### PR TITLE
Extract DocSiteBuilder::Helpers#distro_map into _distro_map.yml file.

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -1,0 +1,22 @@
+---
+openshift-origin:
+  name: OpenShift Origin
+  branches:
+    master:
+      name: Nightly Build
+      dir: latest
+    origin-4:
+      name: Version 4
+      dir: stable
+openshift-online:
+  name: OpenShift Online
+  branches:
+    online:
+      name: Latest Release
+      dir: online
+openshift-enterprise:
+  name: OpenShift Enterprise
+  branches:
+    enterprise-2.2:
+      name: Version 2.2
+      dir: enterprise/v2.2


### PR DESCRIPTION
@nhr Please review.

Note that I did not add caching for the distro_map in the same way it isn't being done for the build_config.  The original code was hardcoded, so caching is probably ok, but I'm not sure I should for the same reasons outlined by the build_config note.  distro_map gets called many times, so it's hitting the yaml file on disk more than necessary, however, in reality, the timings for rake build were unaffected.
