### PR TITLE
Fixed TOC in all topics to new layout

### DIFF
--- a/architecture/http_remote_command_execution.adoc
+++ b/architecture/http_remote_command_execution.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/architecture/image_registry.adoc
+++ b/architecture/image_registry.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/architecture/kubernetes_infrastructure.adoc
+++ b/architecture/kubernetes_infrastructure.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 

--- a/architecture/kubernetes_model.adoc
+++ b/architecture/kubernetes_model.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 

--- a/architecture/networking.adoc
+++ b/architecture/networking.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/architecture/openshift_model.adoc
+++ b/architecture/openshift_model.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 

--- a/architecture/routing.adoc
+++ b/architecture/routing.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 

--- a/architecture/scm.adoc
+++ b/architecture/scm.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/architecture/ssh_remote_command_execution.adoc
+++ b/architecture/ssh_remote_command_execution.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/image_writers_guide/guidelines.adoc
+++ b/image_writers_guide/guidelines.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/image_writers_guide/sti.adoc
+++ b/image_writers_guide/sti.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/installation/docker.adoc
+++ b/installation/docker.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/installation/prereq.adoc
+++ b/installation/prereq.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/installation/rpm.adoc
+++ b/installation/rpm.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/installation/system_req.adoc
+++ b/installation/system_req.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/using_openshift/console.adoc
+++ b/using_openshift/console.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/using_openshift/templates.adoc
+++ b/using_openshift/templates.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/using_openshift/webhooks.adoc
+++ b/using_openshift/webhooks.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title: 
 
 toc::[]
 

--- a/v2_changes/applications.adoc
+++ b/v2_changes/applications.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 

--- a/v2_changes/carts_vs_images.adoc
+++ b/v2_changes/carts_vs_images.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 

--- a/v2_changes/terminology.adoc
+++ b/v2_changes/terminology.adoc
@@ -4,9 +4,8 @@
 :data-uri:
 :icons:
 :experimental:
-:toc:
-:toc-placement!:
-:toc-title: Topics Covered
+:toc: macro
+:toc-title:
 
 toc::[]
 


### PR DESCRIPTION
Fixed all topics to the new TOC layout by removing the TOC title "Topics Covered"
