### PR TITLE
Improve branch previews, add packaging

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,7 +72,7 @@ Through the use of link:#distribution-specific-conditionals[Distribution-Specifi
 * `online` - OpenShift Online most recent release
 * `enterprise-N.N` - OpenShift Enterprise support releases
 
-On a nightly basis, the documentation is rebuilt for each of these branches. In this manner, documentation for released versions of OpenShift will remain the same even as development continues on master. Additionally, any corrections or additions that are "cherry-picked" into the release branches will show up in the release documentation the next day.
+On a nightly basis, the documentation web sites are rebuilt for each of these branches. In this manner, documentation for released versions of OpenShift will remain the same even as development continues on master. Additionally, any corrections or additions that are "cherry-picked" into the release branches will show up in the release documentation the next day.
 
 == Document Set Metadata
 In order to construct the documentation site from these sources, the build system looks at the `_build_cfg.yml` metdata file. The build system _only_ looks in this file for information on which files to include, so any new file submissions must be accompanied by an update to this metadata file.
@@ -158,7 +158,7 @@ Once you've installed the link:#prerequisites[prerequisites] you can fire up the
 $ cd openshift-docs
 $ bundle exec rake build
 ----
-2. Now open the generated HTML file in your browser. It will be under `openshift-docs/_preview` with the same path and filename as the original file. The only difference will be the name ending in '.html' instead of '.adoc'.
+2. Now open the generated HTML file in your browser. It will be under `openshift-docs/_preview/<distro>/<branch>` with the same path and filename as the original file. The only difference will be the name ending in '.html' instead of '.adoc'.
 3. Now start up the `guard` utility:
 + 
 ----
@@ -175,7 +175,7 @@ TIP: This utility will run in the terminal where you started it, so you should l
 That's it. Now any changes that you make to the source file will automatically trigger a rebuild of the target HTML file.
 
 === Clean Up
-The `.gitignore` file is set up to prevent anything under `_preview` from being committed. However, you can reset the environment manually by running:
+The `.gitignore` file is set up to prevent anything under `_preview` and `_package` from being committed. However, you can reset the environment manually by running:
 
 ----
 $ bundle exec rake clean

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,13 @@ task :build, :build_distro do |task,args|
   generate_docs(build_distro)
 end
 
+task :package, :package_site do |task,args|
+  package_site = args[:package_site] || ''
+  Rake::Task["clean"].invoke
+  Rake::Task["build"].invoke
+  package_docs(package_site)
+end
+
 task :refresh_page, :single_page do |task,args|
   generate_docs('',args[:single_page])
 end

--- a/_builder_lib/docsitebuilder/helpers.rb
+++ b/_builder_lib/docsitebuilder/helpers.rb
@@ -55,7 +55,7 @@ module DocSiteBuilder
 
     def git_checkout branch_name
       target_branch = git.branches.local.select{ |b| b.name == branch_name }[0]
-      if not target_branch.current
+      if not target_branch.nil? and not target_branch.current
         target_branch.checkout
       end
     end
@@ -482,6 +482,10 @@ EOF
           else
             next
           end
+        end
+
+        if local_branch =~ /^\(detached from .*\)/
+          local_branch = 'detached'
         end
 
         # Run all distros.

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -1,21 +1,24 @@
 ---
 openshift-origin:
   name: OpenShift Origin
+  site: community
   branches:
     master:
-      name: Jenkins Build
+      name: Latest
       dir: latest
     origin:
-      name: Milestone 4
+      name: Milestone 5
       dir: stable
 openshift-online:
   name: OpenShift Online
+  site: commercial
   branches:
     online:
       name: Latest Release
       dir: online
 openshift-enterprise:
   name: OpenShift Enterprise
+  site: commercial
   branches:
     enterprise-2.2:
       name: Version 2.2


### PR DESCRIPTION
This pull request changes the doc generation routines in important and useful ways.

`build`: This command now builds documentation for every local branch of openshift-docs. It doesn't care whether or not `_distro_map.yml` associates a given branch with a given distro. Under `_preview`, you will always see one directory for each distro:

```
$ ls _preview/
openshift-enterprise  openshift-online  openshift-origin
```

And under each of those, there will be a directory for every local branch:

```
$ ls _preview/openshift-origin/
buildfix  index.html  latest
```

The only way `_distro_map.yml` matters in any of this is that branch-to-dirname substitutions are done for previews. So for instance, the `_preview/openshift-origin/latest` dir is actually the product of the `master` branch. This translation at preview time makes site packaging significantly easier and shouldn't adversely affect doc contributors.

`package`: This is a new rake task that first runs a complete `build` and then selectively copies `distro/branch` paths into the `_package` directory. Under the `_package` directory, content is organized by _site_ and then by branch. To support this, a new `site` key was added to each distro entry in `_distro_map.yml`. Since OpenShift Online and OpenShift Enterprise docs will be served from the same site, they have the same `site` value in the config file. This logic depends upon every branch name being distinct across all distros.

The net result of all of this is more abundant combinations in the `_preview` dir, and a distinct second operation for coalescing the various doc versions into the site groups that we will serve from docs.openshift.org and docs.openshift.com.
