### PR TITLE
fixed typo in webhooks

### DIFF
--- a/using_openshift/webhooks.adoc
+++ b/using_openshift/webhooks.adoc
@@ -15,7 +15,7 @@ OpenShift builds can be triggered remotely using webhooks. The following types o
 * https://developer.github.com/webhooks/[GitHub Webhooks]
 * Generic Webhooks
 
-Using the REST API, you can use webhooks to automatically trigger a build, for examplke, when the code changes. You can create builds automatically from a SCM (source code management) repository, or a continuous integration system. Typically, you configure the SCM repository to make the POST request to the build configuration's webhook endpoint.
+Using the REST API, you can use webhooks to automatically trigger a build; for example, when the code changes. You can create builds automatically from a SCM (source code management) repository, or a continuous integration system. Typically, you configure the SCM repository to make the POST request to the build configuration's webhook endpoint.
 
 == Displaying a build configuration's Webhook URLs
 


### PR DESCRIPTION
I'd written "examplke"... oops! Fixed now.
