### PR TITLE
Remove online specific links from the docs dropdown menu

### DIFF
--- a/_builder_lib/docsitebuilder/helpers.rb
+++ b/_builder_lib/docsitebuilder/helpers.rb
@@ -214,20 +214,14 @@ module DocSiteBuilder
         <li>
           <a href="https://www.openshift.com/products">Products</a>
         </li>
-        <li>
-          <a href="https://www.openshift.com/products/pricing">Pricing</a>
-        </li>
         <li class="active">
+          <a href="http://docs.openshift.org/latest/welcome/index.html">Documentation</a>
+        </li>
+        <li>
           <a href="https://developers.openshift.com">Developer Portal</a>
         </li>
         <li>
-          <a href="https://help.openshift.com">Help Center</a>
-        </li>
-        <li>
           <a href="https://openshift.uservoice.com">Vote on Features</a>
-        </li>
-        <li>
-          <a href="https://marketplace.openshift.com/">Add-ons</a>
         </li>
         <li>
           <a href="https://blog.openshift.com/">Blog</a>


### PR DESCRIPTION
Updated to look like:

![docs_menu_update](https://cloud.githubusercontent.com/assets/1467629/6027614/5121fa18-abb1-11e4-9046-2553c7b856c6.png)

I debated whether to leave in Help Center since it's pretty heavily focused on v2 help right now.  @nhr thoughts?
