### PR TITLE
Correction of start-build command

### DIFF
--- a/using_openshift/builds.adoc
+++ b/using_openshift/builds.adoc
@@ -12,10 +12,12 @@ toc::[]
 == Overview
 A build is a process of creating runnable image to be used inside OpenShift.
 We defined three types of builds:
+
 * docker build
 * STI build
 * custom build.
-More of this is described link:../architecture/builds[here].
+
+More of this is described link:../architecture/builds.html[here].
 
 == Build logs
 Builds allow access to their logs using following command:

--- a/using_openshift/builds.adoc
+++ b/using_openshift/builds.adoc
@@ -28,7 +28,13 @@ osc build-logs <buildID>
 Build can be manually invoked using following command:
 
 ----
-osc start-build <buildConfigID|buildID>
+osc start-build <buildConfigID>
+----
+
+Build can also be re-run using `--from-build` flag:
+
+----
+osc start-build --from-build=<buildID>
 ----
 
 == Cancel build


### PR DESCRIPTION
Correcting the docs. In order to re-run the build from an older one, user has to use `--from-build` flag 
