### PR TITLE
Updated Getting Started sections, including Origin install methods.

### DIFF
--- a/getting_started/installation.adoc
+++ b/getting_started/installation.adoc
@@ -10,67 +10,135 @@
 toc::[]
 
 == Overview
-OpenShift can be installed using either RPMs or Docker images. However, for OpenShift 3 Beta 1 only the RPM installation method is available. Docker images for OpenShift components will be distributed in a later beta release.
+ifdef::openshift-origin[]
+The following sections detail the available installation methods for OpenShift. Choose a method that works best for you. Before continuing, ensure that you have gone through the link:setup.html[Setup] topic, which includes installing and configuring Docker properly.
+endif::[]
 
-NOTE: Before continuing with the following instructions, ensure that your systems have been properly link:setup.html[set up].
+ifdef::openshift-enterprise[]
+During the Beta 1 phase, you can install OpenShift using RPMs. Before continuing, ensure that you have gone through the link:setup.html[Setup] topic, which includes installing and configuring Docker properly.
+endif::[]
 
-== Using RPMs
+ifdef::openshift-origin[]
+== Running in a Docker Container
+You can quickly get OpenShift running in a Docker container using images from Docker Hub.
+
+*Installing and Starting an All-in-One Server*
+
+. Launch the server in a Docker container:
++
+----
+$ sudo docker run -d --name "openshift-origin" --net=host --privileged \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v /tmp/openshift:/tmp/openshift \
+openshift/origin start
+----
++
+NOTE: The `/tmp/openshift` directory must be created the first time.
++
+This command:
++
+* starts OpenShift listening on all interfaces (https://0.0.0.0:8443),
+* starts the Management Console listening on all interfaces (https://0.0.0.0:8444),
+* launches an [sysitem]#etcd# server to store persistent data, and
+* launches the Kubernetes system components.
+
+. After the container is started, you can open a console inside the container:
++
+----
+$ sudo docker exec -it openshift-origin bash
+----
+
+. Because OpenShift services are secured by TLS, clients must accept the server certificates and present their own client certificate. These certificates are generated when the master server is started. You must point `osc` and `curl` at the appropriate CA bundle and client key and certificate to connect to OpenShift. Set the following environment variables:
++
+----
+# export KUBECONFIG=/var/lib/openshift/openshift.local.certificates/admin/.kubeconfig
+# export CURL_CA_BUNDLE=/var/lib/openshift/openshift.local.certificates/admin/root.crt
+----
++
+NOTE: When running as a user other than `root`, you would also need to make the private client key readable by that user. However, this is just for example purposes; in a production environment, developers would generate their own keys and not have access to the system keys.
+
+. You can see more about the commands available in the link:../using_openshift/cli.html[CLI] (the `osc` command) with:
++
+----
+# osc help
+----
+
+*What's Next?*
+
+Now that you have OpenShift successfully running in your environment, link:try_it_out.html[try it out] by walking through a sample application lifecycle.
+endif::[]
+
+ifdef::openshift-origin[]
+== Downloading the Binary
+Red Hat periodically publishes binaries to GitHub, which you can download on the OpenShift Origin repository's https://github.com/openshift/origin/releases[Releases] page. These are Linux, Windows, or Mac OS X 64-bit binaries; note that the Mac and Windows versions are for the CLI only.
+
+The `tar` file for each platform contains a single binary, `openshift`, which is an all-in-one OpenShift installation. The file also contains the link:../using_openshift/cli.html[CLI] (the `osc` command).
+
+*Installing and Running an All-in-One Server*
+
+. Download and untar the binary from the https://github.com/openshift/origin/releases[Releases] page on your local system.
+
+. Launch the server:
++
+----
+$ sudo ./openshift start
+----
++
+This command:
++
+* starts OpenShift listening on all interfaces (https://0.0.0.0:8443),
+* starts the Management Console listening on all interfaces (https://0.0.0.0:8444),
+* launches an [sysitem]#etcd# server to store persistent data, and
+* launches the Kubernetes system components.
++
+The server runs in the foreground until you terminate the process.
++
+NOTE: This command requires `root` access to create services due to the need to modify `iptables`. See https://github.com/GoogleCloudPlatform/kubernetes/issues/1859[this Issue] for more information.
+
+. You can see more about the commands available in the binary with:
++
+----
+$ ./openshift help
+----
+
+. Because OpenShift services are secured by TLS, clients must accept the server certificates and present their own client certificate. These certificates are generated when the master server is started. You must point `osc` and `curl` at the appropriate CA bundle and client key and certificate to connect to OpenShift. Set the following environment variables:
++
+----
+$ export KUBECONFIG=`pwd`/openshift.local.certificates/admin/.kubeconfig
+$ export CURL_CA_BUNDLE=`pwd`/openshift.local.certificates/admin/root.crt
+$ sudo chmod +r `pwd`/openshift.local.certificates/admin/key.key
+----
++
+NOTE: This is just for example purposes; in a production environment, developers would generate their own keys and not have access to the system keys.
+
+. You can see more about the commands available in the CLI with:
++
+----
+$ ./osc help
+----
++
+Or connect from another system with:
++
+----
+$ ./osc -h <server_hostname_or_IP> [...]
+----
+
+*What's Next?*
+
+Now that you have OpenShift successfully running in your environment, link:try_it_out.html[try it out] by walking through a sample application lifecycle.
+endif::[]
+
+ifdef::openshift-origin[]
+== Building from Source
+You can build OpenShift from source locally or using https://www.vagrantup.com/[Vagrant]. See the OpenShift Origin repository https://github.com/openshift/origin#start-developing[README] on GitHub for more information.
+endif::[]
+
+== Installing RPMs
+
 ifdef::openshift-origin[]
 Installation packages for OpenShift Origin will be made available soon.
 endif::[]
 
 ifdef::openshift-enterprise[]
-To install OpenShift using RPM packages, first consult your Red Hat account representative for more details on gaining access to the appropriate repositories during the OpenShift Enterprise 3.0 Beta period.
+To install using RPM packages, consult your Red Hat account representative for more details on gaining access to the appropriate repositories during the OpenShift Enterprise 3.0 Beta period.
 endif::[]
-
-*Installing and Starting the Master*
-
-Configure the master host with the appropriate yum repository for OpenShift. Then, install the [package]#openshift-master# and [package]#openshift-sdn# packages:
-
-----
-# yum install openshift-master openshift-sdn
-----
-
-The [package]#openshift-master# package installs everything you need to start the OpenShift master and use the OpenShift link:../using_openshift/cli.html[command line interface] (the `osc` command). The [package]#openshift-sdn# package installs the SDN (which uses link:http://www.openvswitch.org/[Open vSwitch]) used to create the network overlay for communications between nodes.
-
-To start the master, run the `openshift start master` command. Set the `--nodes` option to the host names of your node hosts.
-
-----
-# openshift start master --nodes=<node1_hostname>,<node2_hostname>
-----
-
-This command:
-
-* starts OpenShift listening on all interfaces (https://0.0.0.0:8443),
-* starts the OpenShift web console listening on all interfaces (https://0.0.0.0:8444),
-* launches an etcd server to store persistent data, and
-* launches the Kubernetes system components.
-
-The web console makes API calls from the browser to the detected master IP address. If that address is not accessible to web console users, specify the IP or hostname to use by passing the `--public-master` option to `openshift start master`.
-
-The server runs in the foreground until you terminate the process.
-
-*Installing and Starting the Nodes*
-
-Configure each node host with the appropriate yum repository for OpenShift. Then, install the [package]#openshift-node# package:
-
-----
-# yum install openshift-node
-----
-
-NOTE: Currently, nodes must be started as the root user so the Kubernetes proxy can manipulate the iptables rules to expose service ports. However, the link:../using_openshift/cli.html[OpenShift CLI] does not need to be run as root.
-
-To start the nodes, run the `openshift start node` command on each node host. Set the `--master` option to the host name of the master.
-
-----
-# openshift start node --master=<master_IP>
-----
-
-The server runs in the foreground until you terminate the process.
-
-*What's Next?*
-
-Now that you have a master and nodes running in your OpenShift environment, link:try_it_out.html[try it out] by walking through a sample application lifecycle.
-
-== Using Docker Images
-Starting in a later beta release, you will be able to install OpenShift using Docker images. Images will be made available for OpenShift platform components such as masters, etcd, nodes, and routers.

--- a/getting_started/installation.adoc
+++ b/getting_started/installation.adoc
@@ -126,9 +126,7 @@ $ ./osc -h <server_hostname_or_IP> [...]
 *What's Next?*
 
 Now that you have OpenShift successfully running in your environment, link:try_it_out.html[try it out] by walking through a sample application lifecycle.
-endif::[]
 
-ifdef::openshift-origin[]
 == Building from Source
 You can build OpenShift from source locally or using https://www.vagrantup.com/[Vagrant]. See the OpenShift Origin repository https://github.com/openshift/origin#start-developing[README] on GitHub for more information.
 endif::[]

--- a/getting_started/setup.adoc
+++ b/getting_started/setup.adoc
@@ -48,14 +48,14 @@ endif::[]
 
 *Security Warning*
 
-OpenShift runs Docker containers on your system, and in some cases, such as build operations and the registry service, it does so using privileged containers. Furthermore, those containers access your host's Docker daemon and perform `docker build` and `docker push` operations. As such, you should be aware of the inherent security risks associated with performing `docker run` operations on arbitrary images as they effectively have root access. This is particularly relevant when running the OpenShift nodes directly on your host system.
+OpenShift runs Docker containers on your system, and in some cases, such as build operations and the registry service, it does so using privileged containers. Furthermore, those containers access your host's Docker daemon and perform `docker build` and `docker push` operations. As such, you should be aware of the inherent security risks associated with performing `docker run` operations on arbitrary images as they effectively have root access.
 
 For more information, see these articles:
 
 - http://opensource.com/business/14/7/docker-security-selinux
 - https://docs.docker.com/articles/security/
 
-The OpenShift security model will continue to evolve and tighten as we head towards production-ready code.
+OpenShift will increase the security constraints on containers in later beta releases.
 
 == Environment Requirements
 *DNS*

--- a/getting_started/setup.adoc
+++ b/getting_started/setup.adoc
@@ -9,53 +9,86 @@
 
 toc::[]
 
-== System Requirements
-OpenShift components can be installed across multiple hosts. For Beta 1, you can deploy a link:../architecture/kubernetes_infrastructure.html#master[master] on one host, and two link:../architecture/kubernetes_infrastructure.html#node[nodes] on two separate hosts.
-
-The following sections describe the system requirements per component type.
-
-*Masters*
-
-Master hosts must meet the following system requirements:
-
-- Physical or virtual system
+== Overview
 ifdef::openshift-origin[]
-- Base OS: Fedora 21, CentOS 7, or Red Hat Enterprise Linux Server 7.0
+OpenShift components can be installed across multiple hosts. The following sections outline the system requirements and instructions for preparing your environment and hosts before installing OpenShift.
+endif::[]
+
+ifdef::openshift-enterprise[]
+OpenShift components can be installed across multiple hosts. During the Beta 1 phase, we recommend installing a  link:../architecture/kubernetes_infrastructure.html#master[master] on one host, and two link:../architecture/kubernetes_infrastructure.html#node[nodes] on two separate hosts.
+endif::[]
+
+== System Requirements
+The system requirements vary per host type:
+
+[cols="1,7"]
+|===
+|Masters a|- Physical or virtual system
+ifdef::openshift-origin[]
+- Base OS: Fedora 21, CentOS 7, or RHEL 7.1 Beta ("Minimal" installation option)
 endif::[]
 ifdef::openshift-enterprise[]
-- Base OS: Red Hat Enterprise Linux Server 7.0
+- Base OS: RHEL 7.1 Beta ("Minimal" installation option)
 endif::[]
 - 2 vCPU
 - Minimum 8 GB RAM
 - Minimum 30 GB hard disk space
 
-*Nodes*
-
-Node hosts must meet the following system requirements:
-
-- Physical or virtual system, or an instance running on a public IaaS
+| Nodes a| - Physical or virtual system, or an instance running on a public IaaS
 ifdef::openshift-origin[]
-- Base OS: Fedora 21, CentOS 7, or Red Hat Enterprise Linux Server 7.0
+- Base OS: Fedora 21, CentOS 7, or RHEL 7.1 Beta ("Minimal" installation option)
 endif::[]
 ifdef::openshift-enterprise[]
-- Base OS: Red Hat Enterprise Linux Server 7.0
+- Base OS: RHEL 7.1 Beta ("Minimal" installation option)
 endif::[]
 - 1 vCPU
 - Minimum 8 GB RAM
 - Minimum 15 GB hard disk space
+|===
 
-*Other Beta Requirements*
+*Security Warning*
 
-- You must have a GitHub account or a local (on premise) Git server.
-- A shared network must exist between the master and node components.
+OpenShift runs Docker containers on your system, and in some cases, such as build operations and the registry service, it does so using privileged containers. Furthermore, those containers access your host's Docker daemon and perform `docker build` and `docker push` operations. As such, you should be aware of the inherent security risks associated with performing `docker run` operations on arbitrary images as they effectively have root access. This is particularly relevant when running the OpenShift nodes directly on your host system.
 
-== Prerequisites
-Whether installing OpenShift using RPM packages or Docker images, you must first satisfy the following prerequisites.
+For more information, see these articles:
+
+- http://opensource.com/business/14/7/docker-security-selinux
+- https://docs.docker.com/articles/security/
+
+The OpenShift security model will continue to evolve and tighten as we head towards production-ready code.
+
+== Environment Requirements
+*DNS*
+
+A wildcard for a DNS zone must ultimately resolve to the IP address of the OpenShift link:../architecture/routing.html[router]. During the Beta 1 phase, this guide ensures that the router ends up on the OpenShift master host.
+
+Create a wildcard DNS entry for `cloudapps`, or something similar, that has a low TTL and points to the public IP address of the master. For example:
+
+----
+*.cloudapps.example.com. 300 IN  A 192.168.133.2
+----
+
+In almost all cases, when referencing VMs you must use host names, and the host names that you use must match the output of the `hostname -f` command on each node. By extension, you must at least have all host name and IP mappings in [filename]#/etc/hosts# files or forward DNS should work.
+
+*Networking*
+
+A shared network must exist between the master and node hosts.
+
+*Git*
+
+You must have either Internet access and a GitHub account, or read and write access to an internal, HTTP-based Git server.
+
+== Host Preparation
+Before installing OpenShift, you must first prepare each host per the following.
+
+ifdef::openshift-origin[]
+NOTE: If you are using https://www.vagrantup.com[Vagrant] to run OpenShift Origin, you can do not need to go through the following sections. These changes are only necessary when you are setting up the host system yourself. If you are using Vagrant, see the https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc#develop-on-virtual-machine-using-vagrant[Contributing Guide], then you can skip directly to trying out the link:try_it_out.html[sample applications].
+endif::[]
 
 ifdef::openshift-enterprise[]
 *Installing Red Hat Enterprise Linux 7*
 
-As mentioned in the system requirements, a base installation of Red Hat Enterprise Linux (RHEL) 7.0 is required for master or node hosts. See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/index.html[Red Hat Enterprise Linux 7 Installation Guide] for more information on installing RHEL 7.0.
+As mentioned in the system requirements, a base installation of Red Hat Enterprise Linux (RHEL) 7.1 Beta is required for master or node hosts. See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7-Beta/html/Installation_Guide/index.html[Red Hat Enterprise Linux 7.1 Beta Installation Guide] for more information.
 
 *Registering with Red Hat Network*
 
@@ -75,30 +108,35 @@ Each system must be registered to Red Hat Network (RHN) and have a RHEL subscrip
 # subscription-manager repos --enable=rhel-7-server-rpms
 ----
 
-. At this point, you can update the system to the latest RHEL base packages:
+endif::[]
+
+*Managing Base Packages*
+
+. Remove [sysitem]#NetworkManager#:
++
+----
+# yum remove NetworkManager*
+----
+
+. Install the following packages:
++
+----
+# yum install wget git vim-enhanced net-tools bind-utils \
+tmux iptables-services bridge-utils
+----
+
+. Update the system to the latest packages:
 +
 ----
 # yum update
 ----
-endif::[]
-
-*Security Warning*
-
-OpenShift runs Docker containers on your system, and in some cases, such as build operations and the registry service, it does so using privileged containers. Furthermore, those containers access your host's Docker daemon and perform `docker build` and `docker push` operations. As such, you should be aware of the inherent security risks associated with performing `docker run` operations on arbitrary images as they effectively have root access. This is particularly relevant when running the OpenShift nodes directly on your host system.
-
-For more information, see these articles:
-
-- http://opensource.com/business/14/7/docker-security-selinux
-- https://docs.docker.com/articles/security/
-
-The OpenShift security model will continue to evolve and tighten as we head towards production ready code.
 
 *Installing Docker*
 
 Docker must be installed and running on master and node hosts before installing OpenShift.
 
 ifdef::openshift-enterprise[]
-. In RHEL 7.0, Docker is provided in the RHEL Extras repository; first, ensure the RHEL Extras repository is enabled:
+. In RHEL 7, Docker is provided in the RHEL Extras repository; first, ensure the RHEL Extras repository is enabled:
 +
 ----
 # subscription-manager repos --enable=rhel-7-server-extras-rpms
@@ -119,9 +157,9 @@ OPTIONS=--selinux-enabled -H fd:// --insecure-registry 172.30.17.0/24
 +
 The `--insecure-registry` option instructs the Docker daemon to trust any Docker registry on the 172.30.17.0/24 subnet, rather than requiring a certificate.
 +
-NOTE: These instructions assume you have not changed the kubernetes/openshift service subnet configuration from the default value of 172.30.17.0/24.
+NOTE: These instructions assume you have not changed the Kubernetes/OpenShift service subnet configuration from the default value of 172.30.17.0/24.
 
-. OpenShift [sysitem]#firewalld# rules are currently a work in progress. In Beta 1, properly configure or disable the [service]#firewalld# service. To configure it, add `docker0` to the public zone:
+. OpenShift [sysitem]#firewalld# rules are currently a work in progress. During the Beta 1 phase, properly configure or disable the [sysitem]#firewalld# service. To configure it, add `docker0` to the public zone:
 +
 ----
 # firewall-cmd --zone=trusted --change-interface=docker0
@@ -135,13 +173,44 @@ Alternatively, stop and disable the service:
 # systemctl disable firewalld
 ----
 
-. You can now enable and start the [service]#Docker# service:
+. Enable and start the [service]#Docker# service:
 +
 ----
 # systemctl enable docker
 # systemctl start docker
 ----
 
+. Add `iptables` port rules for OpenShift by editing the [filename]#/etc/sysconfig/iptables# file. During the Beta 1 phase, the port range is wide open, but it will be significantly closed in future releases. In between the following rules:
++
+----
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+----
++
+Add these rules:
++
+----
+ -A INPUT -p tcp -m state --state NEW -m tcp --dport 10250 -j ACCEPT
+ -A INPUT -p tcp -m state --state NEW -m tcp --dport 8443:8444 -j ACCEPT
+ -A INPUT -p tcp -m state --state NEW -m tcp --dport 7001 -j ACCEPT
+ -A INPUT -p tcp -m state --state NEW -m tcp --dport 4001 -j ACCEPT
+ -A INPUT -p tcp -m state --state NEW -m tcp --dport 443 -j ACCEPT
+ -A INPUT -p tcp -m state --state NEW -m tcp --dport 80 -j ACCEPT
+----
+
+. Enable the [sysitem]#iptables# service:
++
+----
+# systemctl enable iptables
+----
+
+. Restart the [sysitem]#iptables# and [sysitem]#docker# services:
++
+----
+# systemctl restart iptables
+# systemctl restart docker
+----
+
 *What's Next?*
 
-Now that your hosts are properly set up, you can link:installation.html[install OpenShift].
+Now that your environment and hosts are properly set up, you can link:installation.html[install OpenShift].

--- a/getting_started/try_it_out.adoc
+++ b/getting_started/try_it_out.adoc
@@ -13,7 +13,7 @@ toc::[]
 After link:setup.html[setting up] and link:installation.html[installing] OpenShift, you can start creating applications on your instance by trying out the following examples.
 
 == Sample Application Lifecycle
-Create an end-to-end application in this walkthrough, demonstrating the full OpenShift concept chain.
+To create an end-to-end application, demonstrating the full OpenShift concept chain, see the https://github.com/openshift/origin/blob/master/examples/sample-app/README.md[OpenShift 3 Application Lifecycle Sample].
 
 == Create an Application Using Red Hat Images
 Use Linux Container images provided by Red Hat to build and deploy an application on OpenShift.


### PR DESCRIPTION
These updates are mostly about getting the Origin setup/install docs closer to useful (still needs steps for adding additional nodes). I've removed the RPM install method for now (for both Enterprise and Origin) as it's still a WIP (which does get into SDN/additional nodes); will submit that for Enterprise in a later PR.

Some of the additions to the Setup sections were based on https://github.com/openshift/training/blob/master/beta-1-setup.md.

Also placeholder is linking to the upstream sample-app README for now in the Try It Out section. An openshift-docs version of that also still incoming (trying to make the flow from Setup/Installation --> Try It Out make sense / work for any of the install methods, if possible).

@smarterclayton @nhr @CowboysFan PTAL.
