### PR TITLE
Existing resources are ignored by osc create

### DIFF
--- a/using_openshift/cli.adoc
+++ b/using_openshift/cli.adoc
@@ -155,7 +155,7 @@ The following table describes the common `osc` operations and provides the gener
 
 |`create`
 |`osc create -f _<file_or_directory_path>_`
-|This command is used to parse a configuration file and create one or more OpenShift objects based on the file contents. The -f flag can be passed multiple times with different file / directory paths. When the flag is passed multiple times, `osc create` iterates through each one, creating the objects described in all of the indicated files.
+|This command is used to parse a configuration file and create one or more OpenShift objects based on the file contents. The -f flag can be passed multiple times with different file / directory paths. When the flag is passed multiple times, `osc create` iterates through each one, creating the objects described in all of the indicated files. Any existing resources are ignored.
 
 |`update`
 |`osc update -f _<file_or_directory_path>_`


### PR DESCRIPTION
Document the fact that osc create -f will skip resource creation if the resource already exists.
