### PR TITLE
Edits to rollback sections as per trello card #533

### DIFF
--- a/using_openshift/cli.adoc
+++ b/using_openshift/cli.adoc
@@ -238,20 +238,24 @@ OpenShift provides CLI access to inspect and manipulate deployment configuration
 The syntax to describe a deployment configuration in human-readable form is:
 
 ****
-`openshift cli deploymentConfigs describe [replaceable]#<deployment config>#`
+`osc deploymentConfigs describe [replaceable]#<deployment config>#`
 ****
 
 === Deployment Rollbacks
-Use the `osc rollback` command to revert part of an application back to a previous deployment.
 
-When you run this command your deployment configuration will be updated to match the provided deployment. By default, only the pod and container configuration will be changed, and scaling or trigger settings are left as-is. Note that environment variables and volumes are included in rollbacks; if you've recently updated security credentials in your environment, then your previous deployment may not have the correct values.
+Rollbacks revert an application back to a previous deployment. Note that environment variables and volumes are included in rollbacks, so there are a variety of considerations to make when deciding whether a rollback is viable, such as:
 
-If you would like to review the outcome of the rollback, then use `--dry-run` to print a human-readable representation of the updated deployment configuration instead of executing the rollback. This is useful if you're not quite sure what the outcome will be.
+* If security credentials have been recently updated, the previous deployment may not have the correct values.
+* If the previous deployment used a custom strategy, which is no longer available or usable, the deployment may not be deployed correctly.
 
-The syntax for `rollback` is:
+By default, only the pod and container configuration will be changed and scaling or trigger settings will be left as-is.
+
+Using the `-d`, or `--dry-run` option prints a human-readable representation of the updated deployment configuration instead of executing the rollback. This is useful for inspecting a desired outcome before an actual rollback.
+
+Use the `osc rollback` command to revert part of an application back to a previous deployment. The syntax for `rollback` is:
 
 ****
-`openshift cli rollback [replaceable]#<deployment># [replaceable]#[options]#`
+`osc rollback [replaceable]#<deployment># [replaceable]#[options]#`
 ****
 
 .Rollback CLI Configuration Options

--- a/using_openshift/deployments.adoc
+++ b/using_openshift/deployments.adoc
@@ -183,12 +183,4 @@ This `trigger` will cause a new `deployment` to be created in response to the `t
 
 == Rollbacks
 
-Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the link:cli.html#deployment-rollbacks[OpenShift CLI].
-
-When a rollback is performed, a deployment configuration will be updated to match a provided deployment. Note that environment variables and volumes are included in rollbacks, so there are a variety of considerations to make when deciding whether a rollback is viable:
-
-* If security credentials in the environment have been recently updated, the previous deployment may not have the correct values.
-* If the previous deployment used a custom strategy which is no longer available or usable, the deployment may not be rolled out correctly.
-
-Both the REST API and OpenShift CLI provide a means for users to dry-run rollbacks in order to assess whether a specific rollback is viable prior to committing the new deployment. See the link:cli.html#deployment-rollbacks[CLI documentation] for more details.
-
+Rollbacks revert an application back to a previous deployment and can be performed using the REST API or the OpenShift CLI. See the link:cli.html#deployment-rollbacks[CLI documentation] for more details.


### PR DESCRIPTION
@ironcladlou Hello. I made a few changes to this content. Mainly draggin most of the information into one place, but also making sure that rollback information was still featured in the deployments section. I have a question or two though:
1. When giving the example of the command syntax, it says "openshift cli rollback ...", but the examples use "osc rollback ...". Should this be one or the other?
2. You say that "only the pod and container configuration will be changed", but before that there's the line that environment variables and volumes are included in rollbacks. Is this right? Or are these settings included in container configuration or something. Also, I can't find any information on volumes. Would you be able to elaborate on what they are exactly?
3. I'm wondering if we can include an example for the --template option as well. I'm guessing it's about using a already existing file to rollback to, but I'm wondering what that command would look like.

Thanks in advance!
