### PR TITLE
fixed some kubernetes nav stuff in using

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -89,8 +89,8 @@ Topics:
     File: overview
   - Name: Command Line Interface
     File: cli
-  - Name: CLI Setup
-    File: kubeconfig
+  - Name: Managing CLI Profiles
+    File: managing_cli_profiles
   - Name: Management Console
     File: console
   - Name: JBoss Tools IDE
@@ -103,8 +103,6 @@ Topics:
     File: deployments
   - Name: Integrating External Services
     File: integrating_external_services
-  - Name: Kubernetes
-    File: kubeconfig
   - Name: Authorization
     File: authorization
   - Name: Linking

--- a/using_openshift/cli.adoc
+++ b/using_openshift/cli.adoc
@@ -91,7 +91,7 @@ Multiple `.kubeconfig` files are allowed; they are loaded at runtime and merged 
 .  The `.kubeconfig` file in the current directory
 .  The `.kubeconfig` file inside the `.kube` directory in the user's home: `~/.kube/.kubeconfig`
 
-For more details about `.kubeconfig` files, see link:../using_openshift/kubeconfig.html[CLI Setup].
+For more details about `.kubeconfig` files, see link:../using_openshift/managing_cli_profiles.html[Managing CLI Profiles].
 
 == CLI Object Types
 OpenShift supports the following object types, some of which have abbreviated syntax that you can use with `osc`.

--- a/using_openshift/managing_cli_profiles.adoc
+++ b/using_openshift/managing_cli_profiles.adoc
@@ -1,4 +1,4 @@
-= CLI Setup
+= Managing CLI Profiles
 {product-author}
 {product-version}
 :data-uri:
@@ -10,7 +10,7 @@
 toc::[]
 
 == Overview
-The .kubeconfig file allows you to easily switch between multiple clusters. This file contains a series of authentication mechanisms and cluster connection information associated with nicknames. It also introduces the concept of a tuple of user authentication and cluster connection information called a "context", which is also associated with a nickname. A tuple is a data structure consisting of multiple parts.
+The .kubeconfig file allows you to configure different profiles for the CLI, and easily switch between multiple clusters. This file contains a series of authentication mechanisms and cluster connection information associated with nicknames. It also introduces the concept of a tuple of user authentication and cluster connection information called a "context", which is also associated with a nickname. A tuple is a data structure consisting of multiple parts.
 
 Multiple .kubeconfig files are allowed; they are loaded at runtime and merged together along with override options specified from the command line; see the loading and merging rules.
 
@@ -27,32 +27,32 @@ The following flags are valid for all of the .kubeconfig operations: --local, --
 
 |Operation |Syntax |Description
 
-.^|`openshift ex config set-credentials`
-.^|`openshift ex config set-credentials <name> --auth-path=<path_to_authfile> --client-certificate=<path_to_cert> --client-key=<path_to_key> --token=<string>`
+|`openshift ex config set-credentials`
+|`openshift ex config set-credentials <name> --auth-path=<path_to_authfile> --client-certificate=<path_to_cert> --client-key=<path_to_key> --token=<string>`
 |Sets a user entry in .kubeconfig. If the referenced name already exists, the specified information will be merged in.
 
-.^|`openshift ex config set-cluster`
-.^|`openshift ex config set-cluster <name> --server=<server> --skip-tls=<bool> --certificate-authority=<path_to_CA> --api-version=<string>`
+|`openshift ex config set-cluster`
+|`openshift ex config set-cluster <name> --server=<server> --skip-tls=<bool> --certificate-authority=<path_to_CA> --api-version=<string>`
 |Sets a cluster entry in .kubeconfig. If the referenced name already exists, the specified information will be merged in.
 
-.^|`openshift ex config set-context`
-.^|`openshift ex config set-context <name> --user=<string> --cluster=<string> --namespace=<string>`
+|`openshift ex config set-context`
+|`openshift ex config set-context <name> --user=<string> --cluster=<string> --namespace=<string>`
 |Sets a config entry in .kubeconfig. If the referenced name already exists, the specified information will be merged in.
 
-.^|`openshift ex config use-context`
-.^|`openshift ex config use-context <name>`
+|`openshift ex config use-context`
+|`openshift ex config use-context <name>`
 |Sets current-context to the specified name.
 
-.^|`openshift ex config set`
-.^|`openshift ex config set <property-name> <property-value>`
+|`openshift ex config set`
+|`openshift ex config set <property-name> <property-value>`
 |Sets arbitrary value in the .kubeconfig file.
 
-.^|`openshift ex config unset`
-.^|`openshift ex config unset <property-name>`
+|`openshift ex config unset`
+|`openshift ex config unset <property-name>`
 |Unsets arbitrary value in the .kubeconfig file.
 
-.^|`openshift ex config view`
-.^|`openshift ex config view --local=<true> --global=<false> --kubeconfig=<specific_filename> --merged`
+|`openshift ex config view`
+|`openshift ex config view --local=<true> --global=<false> --kubeconfig=<specific_filename> --merged`
 |Displays the result of the specified .kubeconfig file.
 |===
 
@@ -132,4 +132,4 @@ The rules for loading and merging .kubeconfig files are straightforward but nume
 ** If cluster info and a value for the attribute is present, then use it.
 ** If you don't have a server location, then there is an error.
 . Users are built using the same rules as cluster info, except that you can only have one authentication technique per user. The command line flags are: `auth-path`, `client-certificate`, `client-key`, and `token`. If there are two conflicting techniques, then this fails.
-. If you are missing information or are unsure, use the default values and follow prompts for authentication information. 
+. If you are missing information or are unsure, use the default values and follow prompts for authentication information.


### PR DESCRIPTION
hey @CowboysFan -- i made those changes as per our IRC conversation.

I cannot, however, figure out how to make the text in those command examples wrap inside kubeconfig.adoc and my attempt to google an answer was fruitless.

Do you have any ideas there? I copied the table formatting from cli.adoc and I did try your suggestion with regards to the 2,5,8 in the column definition but it didn't change anything. I think this really comes down to the fact that the text is not wrapping properly for whatever reason. This might be the first table we've made with really long command examples in there, so it's the first time we are seeing this?
