### PR TITLE
Replace 'openshift cli' with 'osc' in Builds topic.

### DIFF
--- a/using_openshift/builds.adoc
+++ b/using_openshift/builds.adoc
@@ -106,7 +106,7 @@ The endpoint can accept an optional payload with the following format:
 
 ==== Displaying a build configuration's Webhook URLs
 
-Use the `openshift cli describe buildConfig [replaceable]#<name>#` command to display the Webhook URLs associated with a build configuration. If no Webhook URLs are displayed, it means that no Webhook trigger is defined for that build configuration.
+Use the `osc describe buildConfig [replaceable]#<name>#` command to display the Webhook URLs associated with a build configuration. If no Webhook URLs are displayed, it means that no Webhook trigger is defined for that build configuration.
 
 === Image change triggers
 Image change triggers allow your build to be automatically invoked when a new version of an upstream image is available. For example, if a build is based on top of a RHEL image, then you can trigger that build to run anytime the RHEL image changes. As a result, the application image is always running on the latest RHEL base image.


### PR DESCRIPTION
Taking care of the issue described in https://github.com/openshift/openshift-docs/pull/96, since `webhooks.adoc` no longer exists.
