### PR TITLE
Remove extraneous topic link

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -89,8 +89,6 @@ Topics:
     File: overview
   - Name: Command Line Interface
     File: cli
-  - Name: CLI Setup
-    File: kubeconfig
   - Name: Management Console
     File: console
   - Name: JBoss Tools IDE


### PR DESCRIPTION
@CowboysFan or @adellape please review / merge. The "CLI Setup" topic points to kubeconfig, but kubeconfig already has a different entry in the same topic group.
