### PR TITLE
Edited Ruby topic in openshift_sti_images as per NodeJS topic

### DIFF
--- a/openshift_sti_images/nodejs.adoc
+++ b/openshift_sti_images/nodejs.adoc
@@ -28,7 +28,7 @@ RHEL-7 image is not available as trusted build in https://index.docker.io[Docker
 == Installation
 To build NodeJS image, select either a RHEL7 or CentOS7 base image:
 
-=== RHEL-7 base image
+=== RHEL-7 Base Image
 
 ----
 $ git clone https://github.com/openshift/sti-nodejs.git
@@ -36,7 +36,7 @@ $ cd sti-nodejs
 $ make build TARGET=rhel7 VERSION=0.10
 ----
 
-=== CentOS-7 base image
+=== CentOS-7 Base Image
 
 ----
 $ git clone https://github.com/openshift/sti-nodejs.git
@@ -52,14 +52,14 @@ If you omit the `VERSION` parameter, the build/test action is performed on all s
 == Usage
 To build a simple https://github.com/ryanj/node-echo[nodejs-echo-app] NodeJS application, use a standalone https://github.com/openshift/source-to-image[STI] and run the resulting image using http://docker.io[Docker].
 
-=== RHEL-7 base image
+=== RHEL-7 Base Image
 
 ----
 $ sti build https://github.com/ryanj/node-echo.git openshift/nodejs-010-rhel7 nodejs-echo-app
 $ docker run -p 3000:3000 nodejs-echo-app
 ----
 
-=== CentOS-7 base image
+=== CentOS-7 Base Image
 
 ----
 $ sti build https://github.com/ryanj/node-echo.git openshift/nodejs-010-centos7 nodejs-echo-app
@@ -74,14 +74,14 @@ $ curl 127.0.0.1:3000
 == Test
 The OpenShift https://github.com/openshift/sti-nodejs/tree/master/0.10[STI-NodeJS] repository also provides the STI test framework, which tests the functionality of a simple NodeJS application built on top of an STI-NodeJS image.
 
-=== RHEL-7 base image
+=== RHEL-7 Base Image
 
 ----
 $ cd sti-nodejs
 $ make test TARGET=rhel7 VERSION=0.10
 ----
 
-=== CentOS-7 base image
+=== CentOS-7 Base Image
 
 ----
 $ cd sti-nodejs
@@ -95,34 +95,34 @@ If you omit the `VERSION` parameter, the build/test action is performed on all s
 
 == Repository Organization
 
-.Repository organization
+.Repository Organization
 [cols=".^2,.^2,8",options="header"]
 |===
 
 |Location |File |Description
 
 |`/nodejs-version/`
-|`Dockerfile`
-|CentOS7-based Dockerfile.
+|[filename]#Dockerfile#
+|CentOS 7 based Dockerfile.
 
 |`/nodejs-version/`
-|`Dockerfile.rhel7`
-|RHEL7 based Dockerfile.
+|[filename]#Dockerfile.rhel7#
+|RHEL 7 based Dockerfile.
 
 |`/nodejs-version/.sti/bin/`
 |
 |This folder contains scripts that are run by https://github.com/openshift/source-to-image[STI].
 
 |`/nodejs-version/.sti/bin/`
-|`assemble`
+|[filename]#assemble#
 |Installs the sources into the location from which the application will be run, and prepares the application for deployment; for example, installing modules using npm.
 
 |`/nodejs-version/.sti/bin/`
-|`run`
+|[filename]#run#
 |This script is responsible for using the application web server to run the application.
 
 |`/nodejs-version/.sti/bin/`
-|`save-artifacts`
+|[filename]#save-artifacts#
 |This script archives all dependent modules in this image in order to perform an incremental build. An incremental build reuses the build artifacts from a previously-built image to create a new image.
 
 |`nodejs-version/nodejs/`
@@ -133,24 +133,26 @@ If you omit the `VERSION` parameter, the build/test action is performed on all s
 |
 |This folder contains STI test framework with a simple node.js echo server.
 
-|`nodejs-version/test/`
-|`test-app/`
+|`nodejs-version/test/test-app/`
+|
 |Simple node.js echo server used for testing within the STI test framework.
 
 |`nodejs-version/test/`
-|`run`
+|[filename]#run#
 |Script that runs the STI test framework.
 
+|
+|[filename]#Makefile#
+|Creates a utility for simplifying image build and test actions.
+
+|`hack/`
+|
+|This folder contains scripts responsible for building and testing actions performed by the [filename]#Makefile#.
 |===
 
-== Environment variables
+== Environment Variables
 
-* *APP_ROOT* - This variable specifies a relative location to your application inside the
-    application GIT repository. In case your application is located in a
-    sub-folder, you can set this variable to a *./myapplication*.
+* [envvar]#APP_ROOT# - This variable specifies a relative location to your application inside the application GIT repository. If your application is located within a sub-folder, you can set this variable to `./[replaceable]#<test-app>#`.
 
-* *STI_SCRIPTS_URL* - This variable specifies the location of directory, where *assemble*, *run* and
-    *save-artifacts* scripts are downloaded/copied from. By default the scripts
-    in this repository will be used, but users can provide an alternative
-    location and run their own scripts.
+* [envvar]#STI_SCRIPTS_URL# - This variable specifies the location of the directory from which the [filename]#assemble#, [filename]#run#, and [filename]#save-artifacts# scripts are downloaded or copied. By default, OpenShift uses the scripts in this repository; however, you can provide an alternative location and run your own scripts.
 					- Default https://raw.githubusercontent.com/openshift/sti-nodejs/master/0.10/.sti/bin[<nodejs-version>/.sti/bin]

--- a/openshift_sti_images/ruby.adoc
+++ b/openshift_sti_images/ruby.adoc
@@ -13,24 +13,22 @@ toc::[]
 Our OpenShift https://github.com/openshift/sti-ruby/tree/master/2.0[Ruby] image repository contains the sources and Dockerfiles for building various versions of Ruby platform images. The resulting images can be run either by Docker or using https://github.com/openshift/source-to-image[STI].
 
 == Versions
-Current supported versions of Ruby:
-
-* https://github.com/openshift/sti-ruby/tree/master/2.0[2.0]
+Currently, OpenShift only supports version https://github.com/openshift/sti-ruby/tree/master/2.0[2.0] of Ruby.
 
 == Base Images
 
-* RHEL-7
-* CentOS-7
+* RHEL 7
+* CentOS 7
 
 [NOTE]
 ====
-RHEL-7 image is not available as trusted build in https://index.docker.io[Docker Index]. In order to perform build or test action on a RHEL-7 based Ruby image, you need to run the build on properly subscribed RHEL-7 machine.
+RHEL 7 image is not available as trusted build in https://index.docker.io[Docker Index]. In order to perform build or test action on a RHEL 7 based Ruby image, you need to run the build on properly subscribed RHEL 7 machine.
 ====
 
 == Installation
-To build Ruby image, choose between CentOS7 or RHEL7 base image:
+To build a Ruby image, choose between a RHEL 7 or CentOS 7 base image:
 
-=== RHEL-7 base image
+=== RHEL 7 base image
 
 ----
 $ git clone https://github.com/openshift/sti-ruby.git
@@ -38,7 +36,7 @@ $ cd sti-ruby
 $ make build TARGET=rhel7 VERSION=2.0
 ----
 
-=== CentOS-7 base image
+=== CentOS 7 Base Image
 
 ----
 $ git clone https://github.com/openshift/sti-ruby.git
@@ -48,42 +46,43 @@ $ make build VERSION=2.0
 
 [NOTE]
 ====
-By omitting the `VERSION` parameter, the build/test action will be performed on all the supported versions of Ruby. Since we are now supporting only version `2.0`, you can omit this parameter
+If you omit the `VERSION` parameter, the build/test action is performed on all supported versions of Ruby. Since version `2.0` is the only version supported, you can omit this parameter.
 ====
 
 == Usage
-Building simple https://github.com/openshift/sti-ruby/tree/master/2.0/test/test-app[ruby-sample-app] application, using standalone https://github.com/openshift/source-to-image[STI] and running the resulting image by http://docker.io[Docker]
+To build a simple https://github.com/openshift/sti-ruby/tree/master/2.0/test/test-app[ruby-sample-app] Ruby application, use a standalone https://github.com/openshift/source-to-image[STI] and run the resulting image using http://docker.io[Docker]
 
-=== RHEL-7 base image
+=== RHEL 7 Base Image
 
 ----
 $ sti build https://github.com/openshift/sti-ruby.git --contextDir=/2.0/test/test-app/ openshift/ruby-20-rhel7 ruby-sample-app
 $ docker run -p 9292:9292 ruby-sample-app
 ----
 
-=== CentOS-7 base image
+=== CentOS 7 Base Image
 
 ----
 $ sti build https://github.com/openshift/sti-ruby.git --contextDir=/2.0/test/test-app/ openshift/ruby-20-centos7 ruby-sample-app
 $ docker run -p 9292:9292 ruby-sample-app
 ----
 
-To access and test if the application is running run:
+To access and test if the application is running:
+
 ----
 $ curl 127.0.0.1:9292
 ----
 
 == Test
-OpenShift https://github.com/openshift/sti-ruby/tree/master/2.0[STI-Ruby] repository also provides STI test framework, which launches test to check functionality of a simple ruby application built on top of sti-ruby image.
+The OpenShift https://github.com/openshift/sti-ruby/tree/master/2.0[STI-Ruby] repository also provides the STI test framework, which tests the functionality of a simple Ruby application built on top of STI-Ruby image.
 
-=== RHEL-7 base image
+=== RHEL7 Base Image
 
 ----
 $ cd sti-ruby
 $ make test TARGET=rhel7 VERSION=2.0
 ----
 
-=== CentOS-7 base image
+=== CentOS 7 Base Image
 
 ----
 $ cd sti-ruby
@@ -92,43 +91,90 @@ $ make test VERSION=2.0
 
 [NOTE]
 ====
-By omitting the `VERSION` parameter, the build/test action will be performed on all the supported versions of Ruby. Since we are now supporting only version `2.0`, you can omit this parameter
+If you omit the `VERSION` parameter, the build/test action is performed on all supported versions of Ruby. Since version `2.0` is the only version supported, you can omit this parameter.
 ====
 
-== Repository organization
+== Repository Organization
 
-* `/ruby-version/`
-** `Dockerfile` - CentOS7 based Dockerfile.
-** `Dockerfile.rhel7` - RHEL7 based Dockerfile.
-** `.sti/bin/` - This folder contains scripts that are run by https://github.com/openshift/source-to-image[STI]:
-*** `assemble` - Is used to install the sources into location from where the application  will be run and prepare the application for deployment (eg. installing modules using npm, etc..).
-*** `run` - This script is responsible for running the application, by using the application web server.
-** `ruby/` - This folder contains file with commonly used modules.
-** `test/` - This folder is containing STI test framework with simple Rack server echo server.
-*** `test-app/` - Simple Rack server used for testing purposes in the STI test framework.
-*** `run` - Script that runs the STI test framework.
-* `hack/` - Folder contains scripts which are responsible for build and test actions performed by the `Makefile`.
-* `Makefile` - Make utility for simplifying image build and test actions.
+.Repository Organization
+[cols=".^2,.^2,8",options="header"]
+|===
 
-== Image name structure
+|Location |File |Description
 
-*Structure: `openshift/<platform_name>-<platform_version>-<base_builder_image>`*
+|`/ruby-version/`
+|[filename]#Dockerfile#
+|CentOS 7 based Dockerfile.
 
-. Platform_name - Refers to the STI platform; `ruby` is one example
-. Platform_version - The version of the referenced platform, without dots (like `20` for Ruby 2.0)
-. Base_builder_image - The base OS, like `rhel7` or `centos7`
+|`/ruby-version/`
+|[filename]#Dockerfile.rhel7#
+|RHEL 7 based Dockerfile.
 
-Examples: 
+|`/ruby-version/.sti/bin/`
+|
+|This folder contains scripts that are run by https://github.com/openshift/source-to-image[STI].
 
-* openshift/ruby-20-centos7
-* openshift/ruby-20-rhel7
+|`/ruby-version/.sti/bin/`
+|[filename]#assemble#
+|Installs the sources into the location from which the application will be run, and prepares the application for deployment; for example, installing modules using npm.
 
-== Environment variables
+|`/ruby-version/.sti/bin/`
+|[filename]#run#
+|This script is responsible for using the application web server to run the application.
 
-* *RACK_ENV* - This variable specifies in what environment should the ruby application be deployed - `production`, `development`, `test`. Each level has different behavior in terms of logging verbosity, error pages, ruby gem installation, etc.
-** *Note* : The application assets are going to be compiled only if the RACK_ENV is set to production
+|`/ruby-version/ruby/`
+|
+|This folder contains files with commonly used modules.
 
-* *RAILS_ENV* - This variable specifies in what environment should the Ruby on Rails application be deployed - `production`, `development`, `test`. Each level has different behavior in terms of logging verbosity, error pages, ruby gem installation, etc.
-** *Note* : The application assets are going to be compiled only if the RAILS_ENV is set to production
+|`/ruby-version/test/`
+|
+|This folder contains STI test framework with a simple Rack server.
 
-* *DISABLE_ASSET_COMPILATION* - This variable indicates that the process of asset compilation will be skipped. Since the process of asset compilation takes place only when the application runs in production environment, it should be used when assets are already compiled.
+|`/ruby-version/test/test-app/`
+|
+|Simple Rack server used for testing within the STI test framework.
+
+|`/ruby-version/test/`
+|[filename]#run#
+|Script that runs the STI test framework.
+
+|
+|[filename]#Makefile#
+|Creates a utility for simplifying image build and test actions.
+
+|`hack/`
+|
+|This folder contains scripts responsible for building and testing actions performed by the [filename]#Makefile#.
+|===
+
+== Image Name Structure
+
+Use the following image name structure:
+
+****
+`openshift/[replaceable]#<platform_name>#-[replaceable]#<platform_version>#-[replaceable]#<base_builder_image>#`
+****
+
+Where:
+
+. [replaceable]#<platform_name># - Refers to the STI platform; for example, `ruby`
+. [replaceable]#<platform_version># - The version of the referenced platform, without dots; for example, `20` for Ruby 2.0
+. [replaceable]#<Base_builder_image># - The base OS, such as `rhel7` or `centos7`
+
+.Example image names:
+====
+
+----
+openshift/ruby-20-centos7
+
+openshift/ruby-20-rhel7
+----
+====
+
+== Environment Variables
+
+* [envvar]#RACK_ENV# - This variable specifies the environment within which the Ruby application is deployed; for example, `production`, `development`, or `test`. Each level has different behavior in terms of logging verbosity, error pages, and ruby gem installation. The application assets are only compiled if [envvar]#RACK_ENV# is set to `production`.
+
+* [envvar]#RAILS_ENV# - This variable specifies the environment within which the Ruby on Rails application is deployed; for example, `production`, `development`, or `test`. Each level has different behavior in terms of logging verbosity, error pages, and ruby gem installation. The application assets are only compiled if [envvar]#RAILS_ENV# is set to `production`.
+
+* [envvar]#DISABLE_ASSET_COMPILATION# - This variable indicates that the process of asset compilation can be skipped. Asset compilation only happens when the application runs in a production environment. Therefore, you can use this variable when assets have already been compiled.


### PR DESCRIPTION
This text originally submitted in https://github.com/openshift/openshift-docs/pull/171 by @jhadvig 

Looks like an older version of the NodeJS topic (which I just cleaned up) was used as a template for this topic.

The content is good, but I've made some basic formatting and grammar edits. This made me look back at what I'd done with NodeJS, which was great, because I found a couple more things there that needed fixing.
