### PR TITLE
describe new-project

### DIFF
--- a/using_openshift/cli.adoc
+++ b/using_openshift/cli.adoc
@@ -189,6 +189,12 @@ a|`osc delete -f _<file_path>_`
 == Project CLI Operations
 These advanced operations are used to define and instantiate OpenShift objects at the project level.
 
+The simplest way to create a new project is:
+`openshift ex new-project _<project-name> --display-name=<display-name> --description=<description> --admin=<admin-username>`
+
+
+For example: `openshift ex new-project test --display-name="OpenShift 3 Sample" --description="This is an example project to demonstrate OpenShift v3" --admin=anypassword:test-admin` creates a new project called `test` that appears in the web console as "Openshift 3 Sample", with `test-admin` as the project admin.
+
 .Project CLI Operations
 [cols=".^2,.^5,8",options="header"]
 |===


### PR DESCRIPTION
We've created a new command `openshift ex new-project` to streamline project creation.  It can create the project (without specifying json) and add a project admin to it.

I'm not sure where the best place is for this to live, but this didn't look like too bad a spot.
