### PR TITLE
Updating ruby-20 links and image name so they point to new repo and image

### DIFF
--- a/architecture/openshift_model.adoc
+++ b/architecture/openshift_model.adoc
@@ -82,7 +82,7 @@ Sample image:
                 "OPENSHIFT_BUILD_NAMESPACE=test",
                 "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
                 "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin",
+                "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
                 "APP_ROOT=.",
                 "HOME=/opt/ruby"
             ],
@@ -91,7 +91,7 @@ Sample image:
                 "-c",
                 "tar -C /tmp -xf - \u0026\u0026 /tmp/scripts/assemble"
             ],
-            "Image": "openshift/ruby-20-centos",
+            "Image": "openshift/ruby-20-centos7",
             "WorkingDir": "/opt/ruby/src"
         },
         "DockerVersion": "1.4.1-dev",
@@ -105,7 +105,7 @@ Sample image:
                 "OPENSHIFT_BUILD_NAMESPACE=test",
                 "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
                 "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin",
+                "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
                 "APP_ROOT=.",
                 "HOME=/opt/ruby"
             ],
@@ -182,7 +182,7 @@ Sample ImageRepositoryMapping:
                     "OPENSHIFT_BUILD_NAMESPACE=test",
                     "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
                     "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                    "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin",
+                    "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
                     "APP_ROOT=.",
                     "HOME=/opt/ruby"
                 ],
@@ -223,7 +223,7 @@ Sample ImageRepositoryMapping:
                     "OPENSHIFT_BUILD_NAMESPACE=test",
                     "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
                     "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                    "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin",
+                    "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
                     "APP_ROOT=.",
                     "HOME=/opt/ruby"
                 ],
@@ -231,7 +231,7 @@ Sample ImageRepositoryMapping:
                     "9292/tcp": {}
                 },
                 "Hostname": "f81db8980c62",
-                "Image": "openshift/ruby-20-centos",
+                "Image": "openshift/ruby-20-centos7",
                 "MacAddress": "",
                 "Memory": 0,
                 "MemorySwap": 0,

--- a/image_writers_guide/sti_testing.adoc
+++ b/image_writers_guide/sti_testing.adoc
@@ -37,7 +37,7 @@ The easiest way to run the STI image tests locally is to use the generated [file
 ====
 
 ----
-IMAGE_NAME = openshift/ruby-20-centos
+IMAGE_NAME = openshift/ruby-20-centos7
 
 build:
 	docker build -t $(IMAGE_NAME) .
@@ -94,7 +94,7 @@ To set up a STI image builder CI, define a special `CustomBuild` and use the [sy
   "kind": "BuildConfig",
   "apiVersion": "v1beta1",
   "metadata":{
-    "name": "ruby-20-centos-build"
+    "name": "ruby-20-centos7-build"
   },
   "triggers": [
     {
@@ -108,7 +108,7 @@ To set up a STI image builder CI, define a special `CustomBuild` and use the [sy
     "source" : {
       "type" : "Git",
       "git" : {
-        "uri": "git://github.com/openshift/ruby-20-centos.git"
+        "uri": "git://github.com/openshift/sti-ruby.git"
       }
     },
     "strategy": {
@@ -117,13 +117,18 @@ To set up a STI image builder CI, define a special `CustomBuild` and use the [sy
         "image": "openshift/sti-image-builder",
         "exposeDockerSocket": true,
         "env": [
-          { "name": "IMAGE_NAME", "value": "openshift/ruby-20-centos"}
+          { "name": "IMAGE_NAME", "value": "openshift/ruby-20-centos7"}
+          { "name": "CONTEXT_DIR", "value": "/2.0/"}
         ]
       }
     }
   },
+  "output": {
+    "to": "ruby-20-centos7-repository",
+    "tag": "latest",
+  },
   "labels": {
-    "name": "ruby-20-centos-build"
+    "name": "ruby-20-centos7-build"
   }
 }
 ----
@@ -132,7 +137,7 @@ To set up a STI image builder CI, define a special `CustomBuild` and use the [sy
 You can use the `osc create` command to create this `BuildConfig`. After the `BuildConfig` is created, you can start the build using the following command:
 
 ----
-osc start-build ruby-20-centos-build
+osc start-build ruby-20-centos7-build
 ----
 
 If your OpenShift instance is hosted on a public IP address, then the build is triggered each time you push into your STI builder image GitHub repository.

--- a/using_openshift/builds.adoc
+++ b/using_openshift/builds.adoc
@@ -148,14 +148,14 @@ Configuring an image change trigger requires that a few pieces be in place:
 ----
     {
       "metadata":{
-        "name": "ruby-20-centos",
+        "name": "ruby-20-centos7",
       },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
     }
 ----
 +
-This defines an image repository which is tied to a Docker image repository located at `[replaceable]#<system-registry>#/[replaceable]#<namespace>#/ruby-20-centos`. The `[replaceable]#<system-registry>#` is defined as a service with the name `docker-registry` running in OpenShift.
+This defines an image repository which is tied to a Docker image repository located at `[replaceable]#<system-registry>#/[replaceable]#<namespace>#/ruby-20-centos7`. The `[replaceable]#<system-registry>#` is defined as a service with the name `docker-registry` running in OpenShift.
 
 . Next, define a build with a strategy which consumes some upstream image; for example:
 +
@@ -163,12 +163,12 @@ This defines an image repository which is tied to a Docker image repository loca
     "strategy": {
       "type": "STI",
       "stiStrategy": {
-        "image": "172.30.17.3:5001/mynamespace/ruby-20-centos",
+        "image": "172.30.17.3:5001/mynamespace/ruby-20-centos7",
       }
     }
 ----
 +
-In this case, the STI strategy definition is consuming a Docker image repository named `172.30.17.3:5001/mynamespace/ruby-20-centos`. Here, `172.30.17.3:5001` corresponds to the OpenShift system registry service.
+In this case, the STI strategy definition is consuming a Docker image repository named `172.30.17.3:5001/mynamespace/ruby-20-centos7`. Here, `172.30.17.3:5001` corresponds to the OpenShift system registry service.
 
 . Finally, define an image change trigger to tie these pieces together:
 +
@@ -176,22 +176,22 @@ In this case, the STI strategy definition is consuming a Docker image repository
     {
       "type": "imageChange",
        "imageChange": {
-        "image": "172.30.17.3:5001/mynamespace/ruby-20-centos",
+        "image": "172.30.17.3:5001/mynamespace/ruby-20-centos7",
         "from": {
-          "name": "ruby-20-centos"
+          "name": "ruby-20-centos7"
         },
         "tag":"latest"
       }
     }
 ----
 +
-This defines an image change trigger which monitors the `ruby-20-centos` ImageRepository defined earlier. Specifically, it monitors for changes to the `latest` tag in that repository. When a change occurs, a new build is triggered and is supplied with an immutable Docker tag that points to the new image that was just created. Wherever the BuildConfig previously referenced `172.30.17.3:5001/mynamespace/ruby-20-centos` (as defined by the image change trigger's image field), the value is replaced with the new immutable image tag; for example, the newly-created build will have a definition like:
+This defines an image change trigger which monitors the `ruby-20-centos7` ImageRepository defined earlier. Specifically, it monitors for changes to the `latest` tag in that repository. When a change occurs, a new build is triggered and is supplied with an immutable Docker tag that points to the new image that was just created. Wherever the BuildConfig previously referenced `172.30.17.3:5001/mynamespace/ruby-20-centos` (as defined by the image change trigger's image field), the value is replaced with the new immutable image tag; for example, the newly-created build will have a definition like:
 +
 ----
     "strategy": {
       "type": "STI",
       "stiStrategy": {
-        "image": "172.30.17.3:5001/mynamespace/ruby-20-centos:immutableid",
+        "image": "172.30.17.3:5001/mynamespace/ruby-20-centos7:immutableid",
       }
     }
 ----

--- a/using_openshift/generate_cmd.adoc
+++ b/using_openshift/generate_cmd.adoc
@@ -32,7 +32,7 @@ $ openshift ex generate https://github.com/openshift/ruby-hello-world.git
 Use the source from the current directory, but force it to be an STI type of build with a specific
 image
 ----
-$ openshift ex generate --builder-image=openshift/ruby-20-centos
+$ openshift ex generate --builder-image=openshift/ruby-20-centos7
 ----
 
 == Output
@@ -87,7 +87,7 @@ generate will attempt to detect the type of build to perform based on certain fi
 * Dockerfile - All files named Dockerfile are searched in the repository. If multiple files are found, generate will display a message saying that you must select one with the *--context* flag. If only one Dockerfile is found, then generate will assume this is a docker build. 
 ** Note: If Dockerfile(s) are present, but an  STI type of build is desired, the *--builder-image* flag must be specified.
 * STI source files - In the root of the repository, the following files are searched to determine which STI builder to use:
-  ** Gemfile, Rakefile, config.ru - **openshift/ruby-20-centos**
+  ** Gemfile, Rakefile, config.ru - **openshift/ruby-20-centos7**
   ** pom.xml - **openshift/wildfly-8-centos**
   ** config.json, package.json - **openshift/nodejs-0-10-centos**
   


### PR DESCRIPTION
This is a part of work on https://trello.com/c/UJG1mPZf/364-3-v3-ruby-image-image-beta2
Also last step before we cant get rid of the ruby-20-centos repository
