### PR TITLE
Fix Recreate deployment strategy inaccuracy

### DIFF
--- a/using_openshift/deployments.adoc
+++ b/using_openshift/deployments.adoc
@@ -104,8 +104,8 @@ The Recreate `strategy` has very basic behavior.
 
 The algorithm for this `strategy` is simply:
 
-1.  Find and disable previous `deployments` (by reducing their replica count to 0)
-2.  Increase the replica count of the new `deployment` to the replica count defined on the deployment configuration
+1.  Increase the replica count of the new `deployment` to the replica count defined on the deployment configuration
+2.  Find and disable previous `deployments` (by reducing their replica count to 0)
 
 ===== Custom strategy
 


### PR DESCRIPTION
Reverse the documented steps for the Recreate strategy to reflect reality.
