### PR TITLE
Added managing_nodes and updated node info in kube_infra.

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -95,6 +95,8 @@ Topics:
     File: console
   - Name: JBoss Tools IDE
     File: jboss_tools
+  - Name: Managing Nodes
+    File: managing_nodes
   - Name: Templates
     File: templates
   - Name: Builds

--- a/architecture/kubernetes_infrastructure.adoc
+++ b/architecture/kubernetes_infrastructure.adoc
@@ -9,43 +9,97 @@
 
 toc::[]
 
-Kubernetes is a system for managing containerized applications across a set of containers or hosts, providing deployment, maintenance, and application-scaling mechanisms. Docker is used to package, instantiate, and run containerized applications. 
+== Overview
+http://kubernetes.io[Kubernetes] is used to manage containerized applications
+across a set of containers or hosts and provide deployment, maintenance, and
+application-scaling mechanisms. Docker is used to package, instantiate, and run
+containerized applications.
 
-A Kubernetes cluster consists of a master and a set of nodes. 
+A Kubernetes cluster consists of a master and a set of nodes.
 
 == Master
+The master is the host or hosts that contain the master components, including
+the API server, controller manager server, and *etcd*. The master manages
+link:#node[nodes] in its Kubernetes cluster and schedules
+link:kubernetes_model.html#pod[pods] to run on nodes.
 
-The Kubernetes master is the host or hosts that contain the master components (API Server, Controller Manger Server, etcd, etc.).
+[cols="1,4"]
+.Master Components
+|===
+|Component |Description
 
-=== API Server
+|API Server
+|The Kubernetes API server validates and configures the data for pods, services,
+and replication controllers. It also assigns pods to nodes and synchronizes pod
+information with service configuration.
 
-The Kubernetes API server serves the main API, and validates and configures the data for pods, services, and replication controllers. The Kuberbetes API server also assigns pods to nodes and synchronizes pod information with service configuration. 
+|*etcd*
+|*etcd* stores the persistent master state while other components watch *etcd*
+for changes to bring themselves into the desired state.
 
-=== etcd
+|Controller Manager Server
+|The controller manager server watches *etcd* for changes to replication
+controller objects and then uses the API to enforce the desired state.
+|===
 
-Persistent master state is stored in etcd. Other components watch etcd for changes and eventually bring themselves into the desired state described in etcd.
+////
+*API Server*
 
-=== Controller Manager Server
+The Kubernetes API server validates and configures the data for pods, services, and replication controllers. It also assigns pods to nodes and synchronizes pod information with service configuration.
 
-The controller manager server watches etcd for changes to replication controller objects and then uses the API to enforce the desired state.
+*etcd*
 
+*etcd* stores the persistent master state while other components watch *etcd* for changes to bring themselves into the desired state.
+
+*Controller Manager Server*
+
+The controller manager server watches *etcd* for changes to replication controller objects and then uses the API to enforce the desired state.
+////
+
+[[node]]
 == Node
+A node provides the runtime environments for containers. Each node in a
+Kubernetes cluster has the required services to be managed by the
+link:#master[master]. Nodes also have the required services to run pods,
+including Docker, a link:#kubelet[kubelet], and a link:#service-proxy[service
+proxy].
 
-Kubernetes validates the node with health checks and ignores it until these health checks are passed. Note that Kubernetes continues to check nodes until they are valid.
+Nodes are created from a cloud provider, or from physical or virtual systema.
+Kubernetes interacts with node objects that are a representation of those nodes.
+The master uses the information from node objects to validate nodes with health
+checks. A node is ignored until it passes the health checks, and the master
+continues checking nodes until they are valid.
 
-Note that kubernetes does not create nodes; rather, a node is instead created by your cloud provider, or from your physical or virtual machines. 
+See the
+https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/node.md#node-management[Kubernetes
+documentation] for more information on node management.
 
-=== Kubelet
+As an OpenShift administrator, you can
+link:../using_openshift/managing_nodes.html[manage nodes] in your instance using
+the CLI.
 
-Each node has a kubelet that updates the node as specified by a container manifest; a YAML file that describes a pod. The kubelet uses a set of manifests to ensure that the containers described start and continue to run. A sample manifest can be found https://cloud.google.com/compute/docs/containers/container_vms#container_manifest[here].
+[[kubelet]]
+*Kubelet*
 
-There are a number of ways that a container manifest can be provided to a kubelet:
+The kubelet on each node updates the node as specified by a container manifest,
+which is a YAML file that describes a pod. The kubelet uses a set of manifests
+to ensure that the described containers are started and that they continue to
+run. A sample manifest can be found in the
+https://cloud.google.com/compute/docs/containers/container_vms#container_manifest[Kubernetes
+documentation].
 
-* A file path on the command line. The file is checked every twenty seconds.
-* A HTTP endpoint passed on the command line. The endpoint is checked every twenty seconds.
-* The kubelet watches an etcd server, such as `[filename]#/registry/hosts/$(hostname -f)#`. Any changes are noticed and acted upon.
-* The kubelet listens for HTTP and respond to a simple API to submit a new manifest.
+There are a number of ways that a container manifest can be provided to a
+kubelet:
 
-=== Service Proxy
+- A file path on the command line that is checked every 20 seconds.
+- An HTTP endpoint passed on the command line that is checked every 20 seconds.
+- The kubelet watching an *etcd* server, such as *_/registry/hosts/$(hostname -f)_*, and acting on any changes.
+- The kubelet listening for HTTP and responding to a simple API to submit a new
+ manifest.
 
-Each node also runs a simple network proxy. This reflects the services defined in the API on each node and can do simple TCP and UDP stream forwarding (round robin) across a set of backends.
+[[service-proxy]]
+*Service Proxy*
+
+Each node also runs a simple network proxy that reflects the services defined in
+the API on that node. This allows the node to do simple TCP and UDP stream
+forwarding across a set of back ends.

--- a/using_openshift/managing_nodes.adoc
+++ b/using_openshift/managing_nodes.adoc
@@ -1,0 +1,159 @@
+= Managing Nodes
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+As an OpenShift administrator, you can manage
+link:../architecture/kubernetes_infrastructure.html#node[nodes] in your instance
+using the link:cli.html[CLI].
+
+When you perform node management operations, the CLI interacts with
+link:../architecture/kubernetes_infrastructure.html#node[node objects] that are
+representations of nodes. The master uses the information from node objects to
+validate nodes with health checks.
+
+== Listing Nodes
+Use the following command to list all nodes that are known to your OpenShift
+instance:
+
+****
+`$ osc get nodes`
+****
+
+.Listing All Nodes
+====
+
+----
+$ osc get nodes
+NAME                 LABELS              STATUS
+node1.example.com    <none>              Ready
+node2.example.com    <none>              NotReady
+----
+====
+
+Use the following command to list information about a single node, replacing
+`_<node>_` with the full node name:
+
+****
+`$ osc get node _<node>_`
+****
+
+The `STATUS` column in the output of these commands indicates whether the node
+is passing the health checks performed from the master. Nodes can be shown in
+this column with the following conditions:
+
+.Node Conditions
+[cols="3a,8a",options="header"]
+|===
+
+|Condition |Description
+
+|`Ready`
+|The node has returned `StatusOK` for the health check.
+
+|`NotReady`
+|The health check is not passing.
+|===
+
+NOTE: The `STATUS` column can also show `Unknown` for a node if the CLI cannot
+find any node condition.
+
+Use the following command to get more detailed information about a node,
+including the reason for the current condition:
+****
+`$ osc describe node _<node>_`
+****
+
+.Getting a Node Description
+====
+
+[options="nowrap"]
+----
+$ osc describe node node2.example.com
+Name:	node2.example.com
+Conditions:
+Kind    Status  LastProbeTime                   LastTransitionTime              Reason                                                              Message
+Ready   None    Tue, 03 Mar 2015 22:53:22 +0000 Tue, 03 Mar 2015 21:27:50 +0000 Node health check failed: kubelet /healthz endpoint returns not ok
+----
+====
+
+== Adding a Node
+You can add a node to an existing OpenShift instance using the `osc create`
+command and supplying a manifest for a node object. After the new node passes
+the health checks that are performed by the master,  pods can begin to be
+scheduled for the node.
+
+.To Add a Node to an Existing OpenShift Instance:
+. Create a file with the following JSON format:
++
+.*_node.json_* file
+====
+
+----
+{
+  "id": "node3.example.com", <1>
+  "kind": "Node", <2>
+  "apiVersion": "v1beta1", <3>
+  "labels": { <4>
+    "name": "node3",
+  },
+}
+----
+
+<1> Set the *`id`* parameter to the fully-qualified domain name where the node can be reached.
+This value will be shown in the `NAME` column when running the `osc get nodes`
+command.
+<2> Set the *`kind`* parameter to `Node` to identify this is a manifest for a node
+object.
+<3> Set the *`apiVersion`* parameter to the Kubernetes API version you are using.
+<4> Set any desired labels using the *`labels`* resource.
+====
+
+. Create a node object using the file you created:
++
+====
+
+----
+$ osc create -f node.json
+----
+====
++
+At this point, the master begins validating the new node by performing health
+checks.
+
+. Verify that the node was added by checking the output of the following
+command:
++
+====
+
+----
+$ osc get nodes
+NAME                 LABELS              STATUS
+node1.example.com    <none>              Ready
+node2.example.com    <none>              Ready
+node3.example.com    <none>              Ready
+----
+====
++
+Pods are not scheduled for the node until the node passes the health checks that
+are performed by the master. When the node passes these health checks, it is
+then placed in the `Ready` condition.
+
+== Deleting a Node
+Use the following command to delete a node:
+
+****
+`$ osc delete node _<node>_`
+****
+
+NOTE: When you delete a node with the CLI, although the node object is deleted
+in Kubernetes, the pods that exist on the node itself are not deleted. However,
+the pods cannot be accessed by OpenShift. The behavior around deleting nodes and
+pods with the CLI is under active development.


### PR DESCRIPTION
Associated docs card: https://trello.com/c/e2s7kbo5

@CowboysFan This adds the "Managing Nodes" topic under Using OpenShift and updates the "Kubernetes Infrastructure" topic under Architecture for more details about nodes. Note that the placement of the "Managing Nodes" topic is only temporary until we have a better home for administrative tasks.

@pravisankar PTAL for a tech review. I'm particularly interested in feedback on the example JSON in `managing_nodes.adoc` (specifically for `resources` and `labels`) and the Node content in `kubernetes_infrastructure.adoc`.

I also left out `Reachable` from the Node Conditions section in `managing_nodes.adoc` since that topic is focused on CLI usage, and I didn't see a `Reachable` Kind in my `osc describe node <node>` output, only `Ready` (but maybe that was just a problem with my testing). I figure we can go more in depth later on all the conditions in a relevant Architecture topic (where a full list probably belongs anyway) once more of them land. Please let me know either way. Thanks!
