### PR TITLE
Updated guidelines doc for clarification; removed custom markups

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1,7 +1,4 @@
-= Documentation Guidelines [DRAFT]
-{product-author}
-{product-version}
-:data-uri:
+= Documentation Guidelines [WIP]
 :icons:
 :toc: macro
 :toc-title:
@@ -63,10 +60,12 @@ If using section anchors, they must be all lowercase letters, with no line space
 ----
 
 == Links, hyperlinks, and cross references
+Links can be used to cross-reference internal topics, or send customers to external information resources for further reading. 
 
-Whenever possible the link to another topic should be part of the actual sentence. Avoid creating links as a separate sentence that begins with "See [this topic] for more information on x". 
+=== Internal Cross-References
+Whenever possible the link to another topic should be part of the actual sentence. Avoid creating links as a separate sentence that begins with "See [this topic] for more information on x".
 
-.Examples of recommended method of linking to other topics
+.Markup example of cross-referencing to internal topics
 ----
 Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or
 the link:cli.html#deployment-rollbacks[OpenShift CLI].
@@ -74,7 +73,7 @@ the link:cli.html#deployment-rollbacks[OpenShift CLI].
 Before you can create a domain, you must first link:applications.html#create_app[create an application].
 ----
 
-This example renders like so:
+.Rendered output of cross-referencing to internal topics:
 ====
 Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the link:cli.html#deployment-rollbacks[OpenShift CLI].
 
@@ -82,6 +81,7 @@ Before you can create a domain, you must first link:applications.html#create_app
 ====
 
 For comparison and clarification, the following example shows the previous method of linking to other topics.
+Do not use the old method of linking to internal topics, as shown in the following examples.
 
 .Example of old method of linking to other topics (not recommended)
 ----
@@ -101,6 +101,8 @@ Before you can create a domain, you must first create an application. See link:a
 
 The difference here is that in the first example the link to [create an application] is part of the actual sentence. In the second example, both links are sentences that begin with "See....", which is not recommended.
 
+=== Links to External Websites
+
 If you want to link to a different website, use:
 
 ----
@@ -109,18 +111,11 @@ http://othersite.com/otherpath[friendly descriptor]
 
 TIP: If you want to build a link from a URL _without_ changing the text from the actual URL, just print the URL without adding a `[friendly text]` block at the end; it will automatically be rendered as a link.
 
-If you want to link to another topic in the same topic group directory:
-
-----
-link:<filename>[friendly title]
-----
-
-Do not use the `.adoc` file extension. The document processor will correctly link this to the resulting HTML file.
-
+=== Links to Internal Topics
 There probably are two scenarios for linking to other content:
 
-1. Link to another topic file that exists in a separate topic group, or directory.
-2. Link to another topic file that exists in the same topic group, or directory.
+1. Link to another topic file that exists in the same topic group, or directory.
+2. Link to another topic file that exists in a separate topic group, or directory.
 
 The following examples use the example directory structure shown here:
 ....
@@ -132,7 +127,27 @@ The following examples use the example directory structure shown here:
 /baz/zag.adoc
 ....
 
-If you are working on `bar.adoc` and you want to link to `zig.adoc`, do it this way:
+*Link to topic in same topic group directory*
+
+----
+link:<filename>[friendly title]
+----
+
+Do not use the `.adoc` file extension. The document processor will correctly link this to the resulting HTML file.
+
+For example, using the above syntax, if you are working on `zig.adoc` and want to link to `zag.adoc`, do it this way:
+
+----
+link:zag.html[comment]
+----
+
+*Link to topic in different topic group directory*
+
+----
+link:../dir/<filename>.html[friendly title]
+----
+
+For example, if you are working on `bar.adoc` and you want to link to `zig.adoc`, do it this way:
 
 ----
 link:../baz/zig.html[see the ZIG manual for more]
@@ -143,17 +158,16 @@ link:../baz/zig.html[see the ZIG manual for more]
 You must use the .html extension in order for the link to work correctly.
 ====
 
-If you are working on `zig.adoc` and want to link to `zag.adoc`, do it this way:
+*Link to a subtopic within a topic file*
 
-----
-link:zag.html[comment]
-----
-
-This type of linking should be sufficient in most cases. However, you can also link to a subtopic within a topic file:
+To link to a subtopic within a topic file, use the following syntax: 
 
 ----
 link:../baz/zig/#subtopic
 ----
+
+*Link to an image*
+
 
 If you want to link to an image:
 
@@ -212,6 +226,15 @@ For all of the system blocks including table delimiters, use four characters. Fo
 ....
 
 === Code blocks
+Code blocks are used to show examples of command screen outputs, or configuration files. When using command blocks always use the actual values for any items that a user would normally replace. Code blocks should represent exactly what a customer would see on their screen. If you need to expand or provide information on what some of the contents of a screen output or configuration file represent, then use callouts to provide that information.
+
+Follow these general guidelines when using code blocks:
+
+* Do NOT show replaceables within code blocks.
+
+* Do NOT use any markup in code blocks; code blocks generally do not accept any markup
+
+* Try to use callouts to provide information on what the output represents when required
 
 For all code blocks, you must include an empty line above a code block.
 
@@ -236,15 +259,76 @@ $ lorem.sh
 
 Without the line spaces the content is likely to be not parsed correctly.
 
-Also, if you want to render some code inline, use backticks:
+=== Inline Code or Commands
+Do NOT show full commands or command syntax inline within a sentence. See <<Command syntax and examples>> for information on how to show commands and command syntax.
+
+Only use case for inline commands would be general commands and operations, without replaceables and command options. In this case an inline command is marked up using the back ticks:
 
 ....
-"The file can be found at `/dev/null` on your host."
+Use the `GET` operation to do x.
 ....
 
-Which renders as:
+This renders as:
 
-"The file can be found at `/dev/null` on your host."
+Use the `GET` operation to do x.
+
+=== Command syntax and examples
+The main distinction between showing command syntax and example is that a command syntax should just show customers how to use the command without real values. An example on the other hand should show the command with actual values with an actual output of that command, where applicable.
+
+==== Command syntax
+To markup command syntax, use the sidebar block with the <replaceable> markup and the required command parameters, as shown in the following example. Do NOT use commands or command syntax inline with sentences.
+
+....
+The following command returns a list of objects for the specified object type:
+
+****
+`osc get _<object_type>_ _<object_id>_`
+****
+....
+
+This would render as follows:
+
+The following command returns a list of objects for the specified object type:
+
+****
+`osc get _<object_type>_ _<object_id>_`
+****
+
+==== Examples
+As mentioned an example of a command should use actual values and also show an output of the command, as shown in the following example. In some a heading may not be required.
+
+
+....
+In the following example the `osc get` operation returns a complete list of services that are currently defined.
+
+.Example Title
+====
+
+----
+$ osc get se
+NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
+docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
+----
+====
+....
+
+This would render as shown:
+
+In the following example the `osc get` operation returns a complete list of services that are currently defined.
+
+.Example Title
+====
+
+----
+$ osc get se
+NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
+docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
+----
+====
 
 === Lists
 Lists are created as shown in this example:
@@ -291,69 +375,11 @@ some code block
 
 . Item 3
 
-=== Command syntax and examples
-The main distinction between showing command syntax and example is that a command syntax should just show customers how to use the command, with replaceable parameters of that command. Whereas an example should show the command with actual values and the output of that command.
-
-==== Command syntax
-To markup command syntax, use the sidebar block with the [replaceable] markup and the required command parameters, as shown in the following example.
-
-....
-The following command returns a list of objects for the specified object type:
-
-****
-`osc get [replaceable]#<object_type> <object_id>#`
-****
-....
-
-This would render as follows:
-
-The following command returns a list of objects for the specified object type:
-
-****
-`osc get [replaceable]#<object_type> <object_id>#`
-****
-
-==== Examples
-As mentioned an example of a command should use actual values and also show an output of the command, as shown in the following example. In some a heading may not be required.
-
-
-....
-In the following example the `osc get` operation returns a complete list of services that are currently defined.
-
-.Example Title
-====
-
-----
-$ osc get se
-NAME                LABELS                                    SELECTOR            IP                  PORT
-kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
-kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
-docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
-----
-====
-....
-
-This would render as shown:
-
-In the following example the `osc get` operation returns a complete list of services that are currently defined.
-
-.Example Title
-====
-
-----
-$ osc get se
-NAME                LABELS                                    SELECTOR            IP                  PORT
-kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
-kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
-docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
-----
-====
-
 ==== Quick reference
 .User accounts and info
 [option="header"]
 |===
-|[replaceable] markup in command syntax |Description |Substitute value in Example block
+|Markup in command syntax |Description |Substitute value in Example block
 
 |<username>
 |Name of user account
@@ -367,7 +393,7 @@ docker-registry     <none>                                    name=registrypod  
 .Projects and applications
 [option="header"]
 |===
-|[replaceable] markup in command syntax |Description |Substitute value in Example block
+|Markup in command syntax |Description |Substitute value in Example block
 
 |<project>
 |Name of project
@@ -390,41 +416,63 @@ Text for admonition
 
 == Quick markup reference
 
-[cols="4,7"]
 |===
-|Markup |Description
+|Convention |Markup |Example rendered output
 
-|$$`osc get`$$
-|Inline commands, for example:
+|Inline commands, operations, and user input
+a|$$`osc get`$$
 
-Use the `osc get` command to get a list of services that are currently defined.
+$$`GET`$$
 
-|$$[parameter]#MAX_GEARS#$$
-|System or software parameters:
+$$Answer by typing `Yes` or `No` when prompted.$$
+a|Use the `osc get` command to get a list of services that are currently defined.
 
-Set the [parameter]#MAX_GEARS# parameter to the desired value.
+The `GET` operation can be used to do something.
 
-|$$[userinput]#value#$$
-|Values that a user is asked to enter:
+Answer by typing `Yes` or `No` when prompted.
 
-Type [userinput]#Yes# when prompted.
+|System or software variable to be replaced by the user
+a|$$_`<project>`_$$
 
-|$$[replaceable]#<Name>#$$
-a|This represents text that a user must replace with an actual value. For example:
+$$_`<deployment`_$$
 
-`rhc app delete [replaceable]#<App_Name>#`
+a|
+Use the following command to roll back a deployment, specifying the deployment name:
 
-|$$[envar]#<env_var>#$$
-a|This represents a system or software environment variable. For example:
+`osc rollback _<deployment>_`
 
-Use the [envar]#IP_ADDRESS# environment variable for the server IP address.
+This is ONLY used when showing the command syntax using the sidebar block.
 
-|$$[sysitem]#<sys_item>#$$
-a|This represents general system terms, such as [sysitem]#HTTPD#.
+|System or software configuration parameter or environment variable
+a|$$*`ENVIRONMENT_VARIABLE`*$$
 
-|$$[package]#<package>#$$
-a|This represents some software package. For example:
+$$*`PARAMETER`*$$
+a|Use the *`IP_ADDRESS`* environment variable for the server IP address.
 
-Ensure that the [package]#rubygems# package is installed before proceeding.
+The *`MAX_PODS`* parameter limits the number of pods you can have.
+
+
+|System term, daemon, service, or software package
+a|$$*system item*$$
+
+$$*daemon*$$
+
+$$*service*$$
+
+$$*software package*$$
+
+a|*HTTPD* 
+
+*NetworkManager*
+
+*RubyGems*
+
+|Filenames or directory paths
+a|$$*_filename_*$$
+
+$$*_directory_*$$
+a|Edit the *_kubeconfig_* file as required and save your changes.
+
+The *_express.conf_* configuration file is located in the *_/usr/share_* directory.
 |===
 


### PR DESCRIPTION
@adellape Quick sanity check, and please merge if all is good. doc_guidelines file updated to reflect the removal of custom markup. We'll be using the standard AsciiDoc markup in different combinations to achieve our goals. 
