### PR TITLE
Fixing markup & language in builds.adoc

### DIFF
--- a/using_openshift/builds.adoc
+++ b/using_openshift/builds.adoc
@@ -22,33 +22,33 @@ See the link:../architecture/builds.html[Builds] architecture topic for more det
 Builds can be manually invoked using the following command:
 
 ****
-`$ osc start-build [replaceable]#<buildConfigID>#`
+`$ osc start-build _<buildConfigID>_`
 ****
 
 They can also be re-run using the `--from-build` flag:
 
 ****
-`$ osc start-build --from-build=[replaceable]#<buildID>#`
+`$ osc start-build --from-build=_<buildID>_`
 ****
 
 If the `--follow` flag is specified, the build's logs will be streamed in stdout.
 
 ****
-`$ osc start-build [replaceable]#<buildConfigID># --follow`
+`$ osc start-build _<buildConfigID>_ --follow`
 ****
 
 == Canceling a Build
 Builds can be manually canceled using the following command:
 
 ****
-`$ osc cancel-build [replaceable]#<buildID>#`
+`$ osc cancel-build _<buildID>_`
 ****
 
 == Accessing Build Logs
 Builds allow access to their logs using following command:
 
 ****
-`$ osc build-logs [replaceable]#<buildID>#`
+`$ osc build-logs _<buildID>_`
 ****
 
 == Source Code
@@ -116,7 +116,7 @@ creating a GitHub webhook. The payload URL is the URL returned as the GitHub Web
 command (see link:#describe-buildconfig[below]), and is displayed similar to the following:
 
 ****
-`http://[replaceable]#<openshift_api_host:port>#/osapi/v1beta1/buildConfigHooks/[replaceable]#<build-name>#/[replaceable]#<secret>#/github?namespace=[replaceable]#<namespace>#`
+`http://_<openshift_api_host:port>_/osapi/v1beta1/buildConfigHooks/_<build-name>_/_<secret>_/github?namespace=_<namespace>_`
 ****
 
 *Generic Webhooks*
@@ -141,7 +141,7 @@ following is an example trigger definition JSON within the BuildConfig:
 To set up the caller, supply the calling system with the URL of the generic webhook endpoint for your build:
 
 ****
-`http://[replaceable]#<openshift_api_host:port>#/osapi/v1beta/buildConfigHooks/[replaceable]#<build-name>#/[replaceable]#<secret>#/generic?namespace=[replaceable]#<namespace>#`
+`http://_<openshift_api_host:port>_/osapi/v1beta/buildConfigHooks/_<build-name>_/_<secret>_/generic?namespace=_<namespace>_`
 ****
 
 The endpoint can accept an optional payload with the following format:
@@ -169,7 +169,7 @@ The endpoint can accept an optional payload with the following format:
 [#describe-buildconfig]
 *Displaying a BuildConfig's Webhook URLs*
 
-Use the `osc describe buildConfig [replaceable]#<name>#` command to display the Webhook URLs associated with
+Use the `osc describe buildConfig _<name>_` command to display the Webhook URLs associated with
 a build configuration. If no Webhook URLs are displayed, it means that no Webhook trigger is defined for that
 build configuration.
 
@@ -196,8 +196,8 @@ Configuring an image change trigger requires the following actions:
 
 ====
 +
-This defines the image repository that is tied to a Docker image repository located at `[replaceable]#<system-registry>#/[replaceable]#<namespace>#/ruby-20-centos7`.
-The `[replaceable]#<system-registry>#` is defined as a service with the name `docker-registry` running in OpenShift.
+This defines the image repository that is tied to a Docker image repository located at `_<system-registry>_/_<namespace>_/ruby-20-centos7`.
+The `_<system-registry>_` is defined as a service with the name `docker-registry` running in OpenShift.
 
 . Next, define a build with a strategy that consumes some upstream image; for example:
 +


### PR DESCRIPTION
Just tidying up after https://github.com/openshift/openshift-docs/pull/208

Changed old custom markup to new vanilla-style.

Re-worded the new additions slightly.
