### PR TITLE
Capture use of some variables in article titles

### DIFF
--- a/_builder_lib/docsitebuilder/helpers.rb
+++ b/_builder_lib/docsitebuilder/helpers.rb
@@ -706,7 +706,7 @@ EOF
               # Because we render only the body of the article with AsciiDoctor, the full article title
               # would be lost in conversion. So, read it out of the raw asciidoc and pass it in to our
               # page renderer
-              article_title  = topic_adoc.split("\n")[0].gsub(/^\=\s+/, '').gsub(/\s+$/, '')
+              article_title  = topic_adoc.split("\n")[0].gsub(/^\=\s+/, '').gsub(/\s+$/, '').gsub(/\{product-title\}/, distro_config["name"]).gsub(/\{product-version\}/, branch_config["name"])
 
               topic_html     = Asciidoctor.render topic_adoc, :header_footer => false, :safe => :unsafe, :attributes => page_attrs
               dir_depth = ''


### PR DESCRIPTION
The `welcome/index.adoc` page uses the `{product-title}` and `{product-version}` attributes in its article title. Because we are not relying on the AsciiDoctor library to handle the rendering of article titles, I needed to extend our own article title-handling logic to do this substitution as necessary.

Be advised that this will _only_ capture the use of the two aforementioned attributes. No other attributes are supported in the article titles.
