### PR TITLE
Fixing L1 title in kube_infra topic.

### DIFF
--- a/architecture/kubernetes_infrastructure.adoc
+++ b/architecture/kubernetes_infrastructure.adoc
@@ -1,4 +1,4 @@
-= Kubernetes Model
+= Kubernetes Infrastructure
 {product-author}
 {product-version}
 :data-uri:


### PR DESCRIPTION
The fix in https://github.com/openshift/openshift-docs/pull/214 highlighted that the L1 title in `kubernetes_infrastuture.adoc` was incorrect. Quickly fixing.
