### PR TITLE
[DO NOT MERGE]Fixed order of markup symbols

### DIFF
--- a/architecture/openshift_model.adoc
+++ b/architecture/openshift_model.adoc
@@ -23,17 +23,37 @@ The OpenShift build system provides extensible support for build strategies base
 OpenShift supports pure Docker builds. Using this strategy, users may supply a URL to a Docker context which is used as the basis for a https://docs.docker.com/reference/commandline/cli/#build[Docker build].
 
 ==== Source-to-Image
-Source-to-image (sti) is a tool for building reproducible Docker images. It produces ready-to-run images by injecting a user source into a docker image and assembling a new Docker image which incorporates the base image and built source, and is ready to use with `docker run`. STI supports incremental builds which re-use previously downloaded dependencies, previously built artifacts, etc.
+Source-to-image (STI) is a tool for building reproducible Docker images. It produces ready-to-run images by injecting application source code into a base docker image to create a new Docker image. STI supports incremental builds which re-use previously downloaded dependencies and previously-built artifacts.
 
 ===== So why would you want to use this? There were a few goals for STI.
 
-* Image flexibility: STI allows you to use almost any existing Docker image as the base for your application. STI scripts can be written to layer application code onto almost any existing Docker image, so you can take advantage of the existing ecosystem. (Why only “almost” all images? Currently STI relies on tar/untar to inject application source so the image needs to be able to process tarred content.)
-* Speed: Adding layers as part of a Dockerfile can be slow. With STI the assemble process can perform a large number of complex operations without creating a new layer at each step. In addition, STI scripts can be written to re-use dependencies stored in a previous version of the application image rather than re-downloading them each time the build is run.
-* Patchability: If an underlying image needs to be patched due to a security issue, OpenShift can use STI to rebuild your application on top of the patched builder image.
-* Operational efficiency: By restricting build operations instead of allowing arbitrary actions such as in a Dockerfile, the PaaS operator can avoid accidental or intentional abuses of the build system.
-* Operational security: Allowing users to build arbitrary Dockerfiles exposes the host system to root privilege escalation by a malicious user because the entire docker build process is run as a user with docker privileges. STI restricts the operations performed as a root user, and can run the scripts as an individual user
-* User efficiency: STI prevents developers from falling into a trap of performing arbitrary “yum install” type operations during their application build, which would result in slow development iteration.
-* Ecosystem: Encourages a shared ecosystem of images with best practices you can leverage for your applications.
+* Image flexibility: STI allows you to use almost any existing Docker image as
+the base for your application. STI scripts can be written to layer application
+code onto almost any existing Docker image, so you can take advantage of the
+existing ecosystem. Currently, STI relies on `tar/untar` to inject application
+source code, therefore the base Docker image needs to be able to process tarred
+content.
+* Speed: Adding layers as part of a Dockerfile can be slow. With STI the
+assemble process can perform a large number of complex operations without
+creating a new layer at each step. Additionally, STI scripts can be written to
+re-use dependencies stored in a previous version of the application image rather
+than downloading them again each time the build is run.
+* Patching: If an underlying image needs to be patched due to a security
+issue, OpenShift can use STI to rebuild your application on top of the patched
+builder image.
+* Operational efficiency: By restricting build operations instead of allowing
+arbitrary actions (for example, in a Dockerfile) the PaaS operator can avoid
+accidental or intentional abuses of the build system.
+* Operational security: Allowing users to build arbitrary Dockerfiles exposes
+the host system to root privilege escalation by a malicious user because the
+entire docker build process is run as a user with docker privileges. STI
+restricts the operations performed as a root user, and can run the scripts as an
+individual user.
+* User efficiency: STI prevents developers from falling into a trap of
+performing arbitrary `yum install` type operations during their application
+build, which would result in slow development iteration.
+* Ecosystem: Encourages a shared ecosystem of images with best practices you can
+leverage for your applications.
 
 ==== Custom build
 The custom build strategy is very similar to *Docker build* strategy, but users might customize the builder image that will be used for build execution. The Docker build uses https://registry.hub.docker.com/u/openshift/docker-builder/[openshift/docker-builder] image by default. Using your own builder image allows you to customize your build process.
@@ -369,7 +389,7 @@ Sample Project:
     "annotations": {
       "description": "This is an example project to demonstrate OpenShift v3"
     }
-  },    
+  },
   "displayName": "Hello OpenShift",
 }
 ----

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -432,9 +432,9 @@ The `GET` operation can be used to do something.
 Answer by typing `Yes` or `No` when prompted.
 
 |System or software variable to be replaced by the user
-a|$$_`<project>`_$$
+a|$$`_<project>_`$$
 
-$$_`<deployment`_$$
+$$`_<deployment>_`$$
 
 a|
 Use the following command to roll back a deployment, specifying the deployment name:
@@ -444,9 +444,9 @@ Use the following command to roll back a deployment, specifying the deployment n
 This is ONLY used when showing the command syntax using the sidebar block.
 
 |System or software configuration parameter or environment variable
-a|$$*`ENVIRONMENT_VARIABLE`*$$
+a|$$`*ENVIRONMENT_VARIABLE*`$$
 
-$$*`PARAMETER`*$$
+$$`*PARAMETER*`$$
 a|Use the *`IP_ADDRESS`* environment variable for the server IP address.
 
 The *`MAX_PODS`* parameter limits the number of pods you can have.

--- a/openshift_sti_images/overview.adoc
+++ b/openshift_sti_images/overview.adoc
@@ -3,4 +3,6 @@
 {product-version}
 :data-uri:
 
-This topic group includes information on the different https://github.com/openshift/source-to-image[STI] supported images available for OpenShift users.
+This topic group includes information on the different
+link:../architecture/openshift_model.html#source-to-image [STI] supported images
+available for OpenShift users.

--- a/openshift_sti_images/overview.adoc
+++ b/openshift_sti_images/overview.adoc
@@ -3,9 +3,9 @@
 {product-version}
 :data-uri:
 
-Source-to-image (STI) is a framework for building reproducible docker images by
-injecting source code into a builder image to create a new docker image.
+link:../image_writers_guide/sti.html[Source-to-image (STI)]  is a framework for
+building reproducible docker images by injecting source code into a builder
+image to create a new docker image.
 
-This topic group includes information on the various
-link:../image_writers_guide/sti.html[STI] supported images available to
-OpenShift users.
+This topic group includes information on the various STI-supported images
+available to OpenShift users.

--- a/openshift_sti_images/overview.adoc
+++ b/openshift_sti_images/overview.adoc
@@ -1,8 +1,8 @@
-= Overview
-{product-author}
-{product-version}
-:data-uri:
+= Overview {product-author} {product-version} :data-uri:
 
-This topic group includes information on the different
-link:../architecture/openshift_model.html#source-to-image [STI] supported images
-available for OpenShift users.
+Source-to-image (STI) is a framework for building reproducible docker images by
+injecting source code into a builder image to create a new docker image.
+
+This topic group includes information on the various
+link:../image_writers_guide/sti.html[STI] supported images available to
+OpenShift users.

--- a/openshift_sti_images/overview.adoc
+++ b/openshift_sti_images/overview.adoc
@@ -1,4 +1,7 @@
-= Overview {product-author} {product-version} :data-uri:
+= Overview
+{product-author}
+{product-version}
+:data-uri:
 
 Source-to-image (STI) is a framework for building reproducible docker images by
 injecting source code into a builder image to create a new docker image.


### PR DESCRIPTION
AlexD found this one, so I fixed it.

The order of markup symbols is important, as per: http://asciidoctor.org/docs/asciidoc-writers-guide/#quoted-text

Updated our doc guidelines Quick markup reference. 

Also replaced a missing angle bracket.
