### PR TITLE
fixed order of symbols in the doc_guidelines quick markup reference

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -432,9 +432,9 @@ The `GET` operation can be used to do something.
 Answer by typing `Yes` or `No` when prompted.
 
 |System or software variable to be replaced by the user
-a|$$_`<project>`_$$
+a|$$`_<project>_`$$
 
-$$_`<deployment`_$$
+$$`_<deployment>_`$$
 
 a|
 Use the following command to roll back a deployment, specifying the deployment name:
@@ -444,12 +444,12 @@ Use the following command to roll back a deployment, specifying the deployment n
 This is ONLY used when showing the command syntax using the sidebar block.
 
 |System or software configuration parameter or environment variable
-a|$$*`ENVIRONMENT_VARIABLE`*$$
+a|$$`*ENVIRONMENT_VARIABLE*`$$
 
-$$*`PARAMETER`*$$
-a|Use the *`IP_ADDRESS`* environment variable for the server IP address.
+$$`*PARAMETER*`$$
+a|Use the `*IP_ADDRESS*` environment variable for the server IP address.
 
-The *`MAX_PODS`* parameter limits the number of pods you can have.
+The `*MAX_PODS*` parameter limits the number of pods you can have.
 
 
 |System term, daemon, service, or software package


### PR DESCRIPTION
AlexD found this issue, and I did the update.

The order of vanilla markup symbols matters, as per: http://asciidoctor.org/docs/asciidoc-writers-guide/#quoted-text

Backticks are always on the outside, then asterisks, and underscores always on the inside.

I also replaced a missing angle bracket.
