### PR TITLE
add intial guidance on openshift start config

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -121,6 +121,8 @@ Topics:
     File: generate_cmd
   - Name: Output build dependencies
     File: output_deps 
+  - Name: Launching Configuration
+    File: master_node_configuration.adoc
 
 ---
 Name: Writing OpenShift Images

--- a/using_openshift/master_node_configuration.adoc
+++ b/using_openshift/master_node_configuration.adoc
@@ -1,0 +1,135 @@
+= Master and Node Configuration
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+`openshift start`, `openshift start master`, and `openshift start node` all take a limited set of arguments that are sufficient for development and experimental purposes, but are insufficient to describe and control the full set of configuration and security options that are necessary in a production environment.  To provide those options, it is necessary to use the dedicated master and node config files.
+
+The config files are fully specifying with no defaulting.  This means that any empty value means that you want to start up with an empty value for that parameter.  It makes it easy to reason about exactly what your configuration is, but it also means that it can be difficult to remember all of the options to specify.  To make this easier, the config files can be created with the `--write-config` flag and can be used via the `--config` flag.
+
+== Create the starting config files
+The `openshift start` command accepts flags that indicate that it should simply write the config file that it would have used and terminate.  This is useful for getting a starting point for the config.  You can do this by running `openshift start --writeconfig --master-config=master.yaml --node-config=node.yaml` or `openshift start master --write-config --config=master.yaml` or `openshift start node --write-config config=node.yaml`.
+
+== Use the config files
+Once you have modified the config file to your liking, you can make use of them by specifying them as an argument.  Keep in mind that if you specify a config file, *none of the other flags you pass in will be respected*.  You can run them like: `openshift start --master-config=master.yaml --node-config=node.yaml` or `openshift start master --config=master.yaml` or `openshift start node config=node.yaml`.
+
+== Stub for discussion of generating the config for a new node
+
+
+== Example master.yaml
+This is an example at a point in time.  You should run `--write-config` to generate a file of your own.
+
+[source]
+---
+apiVersion: v1
+assetConfig:
+  kubernetesPublicURL: https://10.13.137.161:8443
+  logoutURI: ""
+  masterPublicURL: https://10.13.137.161:8443
+  publicURL: https://10.13.137.161:8444
+  servingInfo:
+    bindAddress: 0.0.0.0:8444
+    certFile: openshift.local.certificates/master/cert.crt
+    clientCA: openshift.local.certificates/ca/cert.crt
+    keyFile: openshift.local.certificates/master/key.key
+corsAllowedOrigins:
+- 10.13.137.161:8444
+- 10.13.137.161:8443
+- localhost
+- 127.0.0.1
+dnsConfig:
+  bindAddress: 0.0.0.0:53
+etcdClientInfo:
+  ca: ""
+  certFile: ""
+  keyFile: ""
+  url: http://10.13.137.161:4001
+etcdConfig:
+  masterAddress: 10.13.137.161:4001
+  peerAddress: 0.0.0.0:7001
+  servingInfo:
+    bindAddress: 0.0.0.0:4001
+    certFile: ""
+    clientCA: ""
+    keyFile: ""
+  storageDirectory: openshift.local.etcd
+imageConfig:
+  format: openshift/origin-${component}:${version}
+  latest: false
+kind: MasterConfig
+kubernetesMasterConfig:
+  masterIP: 10.13.137.161
+  servicesSubnet: 172.30.17.0/24
+  staticNodeNames:
+  - deads-dev-01
+masterClients:
+  deployerKubeConfig: openshift.local.certificates/openshift-deployer/.kubeconfig
+  kubernetesKubeConfig: openshift.local.certificates/kube-client/.kubeconfig
+  openshiftLoopbackKubeConfig: openshift.local.certificates/openshift-client/.kubeconfig
+oauthConfig:
+  assetPublicURL: https://10.13.137.161:8444
+  grantConfig:
+    method: auto
+  identityProviders:
+  - provider:
+      apiVersion: v1
+      kind: AllowAllPasswordIdentityProvider
+    usage:
+      challenge: true
+      login: true
+      providerScope: anypassword
+  masterPublicURL: https://10.13.137.161:8443
+  masterURL: https://10.13.137.161:8443
+  proxyCA: ""
+  sessionAuthenticationConfig:
+    sessionMaxAgeSeconds: 300
+    sessionName: ssn
+    sessionSecrets:
+    - e0646b24-d25e-11e4-8bfd-28d2447dc82b
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 3600
+    authorizeTokenMaxAgeSeconds: 300
+policyConfig:
+  bootstrapPolicyFile: openshift.local.policy/policy.json
+  masterAuthorizationNamespace: master
+  openshiftSharedResourcesNamespace: openshift
+servingInfo:
+  bindAddress: 0.0.0.0:8443
+  certFile: openshift.local.certificates/master/cert.crt
+  clientCA: openshift.local.certificates/ca/cert.crt
+  keyFile: openshift.local.certificates/master/key.key
+
+---
+
+=== Stub for discussion of what the different values actually do
+
+== Example node.yaml
+This is an example at a point in time.  You should run `--write-config` to generate a file of your own.
+
+[source]
+---
+allowDisabledDocker: true
+apiVersion: v1
+dnsDomain: local
+dnsIP: 10.13.137.161
+kind: NodeConfig
+masterKubeConfig: openshift.local.certificates/node-deads-dev-01/.kubeconfig
+networkContainerImage: openshift/origin-pod:v0.4.1
+nodeName: deads-dev-01
+recordEvents: false
+servingInfo:
+  bindAddress: 0.0.0.0:10250
+  certFile: openshift.local.certificates/node-deads-dev-01/server.crt
+  clientCA: ""
+  keyFile: openshift.local.certificates/node-deads-dev-01/server.key
+volumeDirectory: openshift.local.volumes
+---
+
+=== Stub for discussion of what the different values actually do

--- a/using_openshift/master_node_configuration.adoc
+++ b/using_openshift/master_node_configuration.adoc
@@ -36,18 +36,18 @@ This is an example at a point in time.  You should run `--write-config` to gener
 ---
 apiVersion: v1
 assetConfig:
-  kubernetesPublicURL: https://10.13.137.161:8443
+  kubernetesPublicURL: https://10.0.0.1:8443
   logoutURI: ""
-  masterPublicURL: https://10.13.137.161:8443
-  publicURL: https://10.13.137.161:8444
+  masterPublicURL: https://10.0.0.1:8443
+  publicURL: https://10.0.0.1:8444
   servingInfo:
     bindAddress: 0.0.0.0:8444
     certFile: openshift.local.certificates/master/cert.crt
     clientCA: openshift.local.certificates/ca/cert.crt
     keyFile: openshift.local.certificates/master/key.key
 corsAllowedOrigins:
-- 10.13.137.161:8444
-- 10.13.137.161:8443
+- 10.0.0.1:8444
+- 10.0.0.1:8443
 - localhost
 - 127.0.0.1
 dnsConfig:
@@ -56,9 +56,9 @@ etcdClientInfo:
   ca: ""
   certFile: ""
   keyFile: ""
-  url: http://10.13.137.161:4001
+  url: http://10.0.0.1:4001
 etcdConfig:
-  masterAddress: 10.13.137.161:4001
+  masterAddress: 10.0.0.1:4001
   peerAddress: 0.0.0.0:7001
   servingInfo:
     bindAddress: 0.0.0.0:4001
@@ -71,7 +71,7 @@ imageConfig:
   latest: false
 kind: MasterConfig
 kubernetesMasterConfig:
-  masterIP: 10.13.137.161
+  masterIP: 10.0.0.1
   servicesSubnet: 172.30.17.0/24
   staticNodeNames:
   - hostname.example.org
@@ -80,7 +80,7 @@ masterClients:
   kubernetesKubeConfig: openshift.local.certificates/kube-client/.kubeconfig
   openshiftLoopbackKubeConfig: openshift.local.certificates/openshift-client/.kubeconfig
 oauthConfig:
-  assetPublicURL: https://10.13.137.161:8444
+  assetPublicURL: https://10.0.0.1:8444
   grantConfig:
     method: auto
   identityProviders:
@@ -91,8 +91,8 @@ oauthConfig:
       challenge: true
       login: true
       providerScope: anypassword
-  masterPublicURL: https://10.13.137.161:8443
-  masterURL: https://10.13.137.161:8443
+  masterPublicURL: https://10.0.0.1:8443
+  masterURL: https://10.0.0.1:8443
   proxyCA: ""
   sessionAuthenticationConfig:
     sessionMaxAgeSeconds: 300
@@ -124,7 +124,7 @@ This is an example at a point in time.  You should run `--write-config` to gener
 allowDisabledDocker: true
 apiVersion: v1
 dnsDomain: local
-dnsIP: 10.13.137.161
+dnsIP: 10.0.0.1
 kind: NodeConfig
 masterKubeConfig: openshift.local.certificates/node-hostname.example.org/.kubeconfig
 networkContainerImage: openshift/origin-pod:v0.4.1

--- a/using_openshift/master_node_configuration.adoc
+++ b/using_openshift/master_node_configuration.adoc
@@ -15,10 +15,16 @@ toc::[]
 The config files are fully specifying with no defaulting.  This means that any empty value means that you want to start up with an empty value for that parameter.  It makes it easy to reason about exactly what your configuration is, but it also means that it can be difficult to remember all of the options to specify.  To make this easier, the config files can be created with the `--write-config` flag and can be used via the `--config` flag.
 
 == Create the starting config files
-The `openshift start` command accepts flags that indicate that it should simply write the config file that it would have used and terminate.  This is useful for getting a starting point for the config.  You can do this by running `openshift start --writeconfig --master-config=master.yaml --node-config=node.yaml` or `openshift start master --write-config --config=master.yaml` or `openshift start node --write-config config=node.yaml`.
+The `openshift start` command accepts flags that indicate that it should simply write the config file that it would have used and terminate.  This is useful for getting a starting point for the config.  You can do this by running 
+*`openshift start --writeconfig --master-config=master.yaml --node-config=node.yaml`
+* `openshift start master --write-config --config=master.yaml`
+* `openshift start node --write-config config=node.yaml`
 
 == Use the config files
-Once you have modified the config file to your liking, you can make use of them by specifying them as an argument.  Keep in mind that if you specify a config file, *none of the other flags you pass in will be respected*.  You can run them like: `openshift start --master-config=master.yaml --node-config=node.yaml` or `openshift start master --config=master.yaml` or `openshift start node config=node.yaml`.
+Once you have modified the config files to your liking, you can make use of them by specifying them as an argument.  Keep in mind that if you specify a config file, *none of the other flags you pass in will be respected*.  You can run them like: 
+* `openshift start --master-config=master.yaml --node-config=node.yaml`
+* `openshift start master --config=master.yaml`
+* `openshift start node config=node.yaml`
 
 == Stub for discussion of generating the config for a new node
 
@@ -68,7 +74,7 @@ kubernetesMasterConfig:
   masterIP: 10.13.137.161
   servicesSubnet: 172.30.17.0/24
   staticNodeNames:
-  - deads-dev-01
+  - hostname.example.org
 masterClients:
   deployerKubeConfig: openshift.local.certificates/openshift-deployer/.kubeconfig
   kubernetesKubeConfig: openshift.local.certificates/kube-client/.kubeconfig
@@ -120,15 +126,15 @@ apiVersion: v1
 dnsDomain: local
 dnsIP: 10.13.137.161
 kind: NodeConfig
-masterKubeConfig: openshift.local.certificates/node-deads-dev-01/.kubeconfig
+masterKubeConfig: openshift.local.certificates/node-hostname.example.org/.kubeconfig
 networkContainerImage: openshift/origin-pod:v0.4.1
-nodeName: deads-dev-01
+nodeName: hostname.example.org
 recordEvents: false
 servingInfo:
   bindAddress: 0.0.0.0:10250
-  certFile: openshift.local.certificates/node-deads-dev-01/server.crt
+  certFile: openshift.local.certificates/node-hostname.example.org/server.crt
   clientCA: ""
-  keyFile: openshift.local.certificates/node-deads-dev-01/server.key
+  keyFile: openshift.local.certificates/node-hostname.example.org/server.key
 volumeDirectory: openshift.local.volumes
 ---
 


### PR DESCRIPTION
We've added configuration files that can describe how to launch openshift.  This is a very sparse introduction to their existence.  The actual contents of the config files is still changing pretty rapidly, so I haven't added details about the stanzas or their serializations.

@liggitt 
