### PR TITLE
Add MySQL settings

### DIFF
--- a/openshift_images/mysql.adoc
+++ b/openshift_images/mysql.adoc
@@ -91,3 +91,16 @@ $ docker stop mysql_database
 == Volumes
 
 * */var/lib/mysql/data* - This is the data directory where MySQL stores database files.
+
+== Settings
+MySQL settings can be configured by additional environment variables.
+
+* *MYSQL_LOWER_CASE_TABLE_NAMES* - Sets how the table names are stored and compared
+
+* *MYSQL_MAX_CONNECTIONS* - The maximum permitted number of simultaneous client connections
+
+* *MYSQL_FT_MIN_WORD_LEN* - The minimum length of the word to be included in a FULLTEXT index
+
+* *MYSQL_FT_MAX_WORD_LEN* - The maximum length of the word to be included in a FULLTEXT index
+
+* *MYSQL_AIO* - Controls the *innodb_use_native_aio* setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529


### PR DESCRIPTION
These are basically taken over from the v2 cartridge. I don't know
whether it's a good idea to create a new settings section, so feel free
to change that.

Also. I was thinking we could add references to the MySQL settings that are
directly affected by these env vars. These can be seen in the config
template as '${}'-escaped variables:
https://github.com/openshift/mysql/blob/master/5.5/contrib/my.cnf.template
