### PR TITLE
Add documentation for PostgreSQL settings

### DIFF
--- a/openshift_images/postgresql.adoc
+++ b/openshift_images/postgresql.adoc
@@ -89,3 +89,10 @@ $ docker stop postgresql_database
 == Volumes
 
 * */var/lib/pgsql/data* - This is the database cluster directory where PostgreSQL stores database files.
+
+== Settings
+PostgreSQL settings can be configured by additional environment variables.
+
+* *POSTGRESQL_MAX_CONNECTIONS* - The maximum number of client connections allowed.
+
+* *POSTGRESQL_SHARED_BUFFERS* - Sets how much memory is dedicated to PostgreSQL to use for caching data.


### PR DESCRIPTION
This is analogous to #246.

These are basically taken over from the v2 cartridge. I don't know
whether it's a good idea to create a new settings section, so feel free
to change that.

Also. I was thinking we could add references to the PostgreSQL settings that are
directly affected by these env vars. These can be seen in the config
template as '${}'-escaped variables. See 9.2/contrib/openshift-custom-postgresql.conf.template file in 
https://github.com/openshift/postgresql/pull/4

Defaults are in the same PR in README.md. Don't know whether to include them or not.
