### PR TITLE
Use svc alias for services

### DIFF
--- a/using_openshift/cli.adoc
+++ b/using_openshift/cli.adoc
@@ -197,7 +197,7 @@ OpenShift supports the following object types, some of which have abbreviated sy
 |minion |`mi`
 |pod |`po`
 |replicationController |`rc`
-|service |`se`
+|service |`svc`
 |===
 
 == Common CLI Operations


### PR DESCRIPTION
`se` will be deprecated before Kubernetes hits 1.0
https://github.com/GoogleCloudPlatform/kubernetes/blob/844e375ceb81c0a82f5810f735a5f3986e9c1ef4/pkg/kubectl/kubectl.go#L101
