### PR TITLE
Adding hostedDomain, extraAuthorizeParameters info back in.

### DIFF
--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -299,12 +299,17 @@ oauthConfig:
       kind: GoogleIdentityProvider
       clientID: ... <4>
       clientSecret: ... <5>
+      hostedDomain: "" <6>
 ----
 <1> This provider name is prefixed to the Google numeric user ID to form an identity name. It is also used to build the redirect URL.
 <2> `*GoogleIdentityProvider*` cannot be used to send `WWW-Authenticate` challenges.
 <3> When `true`, unauthenticated token requests from web clients (like the Management Console) are redirected to Google to log in.
 <4> The client ID of a link:https://console.developers.google.com/[registered Google project]. The project must be configured with a redirect URI of `_<master>_/oauth2callback/_<identityProviderName>_`.
 <5> The client secret issued by Google.
+<6> Optional
+link:https://developers.google.com/identity/protocols/OpenIDConnect#hd-param[hosted
+domain] to restrict sign-in accounts to. If empty, any Google account is allowed
+to authenticate.
 ====
 
 === OpenID Connect [[OpenID]]
@@ -377,7 +382,8 @@ oauthConfig:
 <8> link:http://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint[Token Endpoint] described in the OpenID spec. Must use `https`.
 ====
 
-A custom certificate bundle, extra scopes, and `*userInfo*` URL can also be specified:
+A custom certificate bundle, extra scopes, extra authorization request
+parameters, and `*userInfo*` URL can also be specified:
 
 .Full Master Configuration Using `*OpenIDIdentityProvider*`
 ====
@@ -398,32 +404,41 @@ oauthConfig:
       extraScopes: <2>
       - email
       - profile
+      extraAuthorizeParameters: <3>
+        include_granted_scopes: "true"
       claims:
-        id: <3>
+        id: <4>
         - custom_id_claim
         - sub
-        preferredUsername: <4>
+        preferredUsername: <5>
         - preferred_username
         - email
-        name: <5>
+        name: <6>
         - nickname
         - given_name
         - name
-        email: <6>
+        email: <7>
         - custom_email_claim
         - email
       urls:
         authorize: https://myidp.example.com/oauth2/authorize
         token: https://myidp.example.com/oauth2/token
-        userInfo: https://myidp.example.com/oauth2/userinfo <7>
+        userInfo: https://myidp.example.com/oauth2/userinfo <8>
 ----
-<1> Certificate bundle to use to validate server certificates for the configured URLs. If empty, system trusted roots are used.
-<2> List of scopes to request, in addition to the `openid` scope, during the authorization request.
-<3> List of claims to use as the identity. First non-empty claim is used. At least one claim is required. If none of the listed claims have a value, authentication fails.
-<4> List of claims to use as the preferred user name when provisioning a user for this identity. First non-empty claim is used.
-<5> List of claims to use as the display name. First non-empty claim is used.
-<6> List of claims to use as the email address. First non-empty claim is used.
-<7> link:http://openid.net/specs/openid-connect-core-1_0.html#UserInfo[UserInfo Endpoint] described in the OpenID spec. Must use `https`.
+<1> Certificate bundle to use to validate server certificates for the configured
+URLs. If empty, system trusted roots are used.
+<2> Optional list of scopes to request, in addition to the `openid` scope,
+during the authorization token request.
+<3> Optional map of extra parameters to add to the authorization token request.
+<4> List of claims to use as the identity. First non-empty claim is used. At
+least one claim is required. If none of the listed claims have a value,
+authentication fails.
+<5> List of claims to use as the preferred user name when provisioning a user
+for this identity. First non-empty claim is used.
+<6> List of claims to use as the display name. First non-empty claim is used.
+<7> List of claims to use as the email address. First non-empty claim is used.
+<8> link:http://openid.net/specs/openid-connect-core-1_0.html#UserInfo[UserInfo
+Endpoint] described in the OpenID spec. Must use `https`.
 ====
 
 == Token Options


### PR DESCRIPTION
Adding back in info from https://github.com/openshift/openshift-docs/pull/306 which was accidentally lost during https://github.com/openshift/openshift-docs/pull/312.

@liggitt PTAL.
