### PR TITLE
Support for project node selector

### DIFF
--- a/admin_guide/master_node_configuration.adoc
+++ b/admin_guide/master_node_configuration.adoc
@@ -118,6 +118,7 @@ servingInfo:
   certFile: openshift.local.certificates/master/cert.crt
   clientCA: openshift.local.certificates/ca/cert.crt
   keyFile: openshift.local.certificates/master/key.key
+projectNodeSelector: ""
 
 ---
 

--- a/admin_guide/scheduler.adoc
+++ b/admin_guide/scheduler.adoc
@@ -51,6 +51,10 @@ These predicates do not take any configuration parameters or inputs from the use
 ----
 {"name" : "HostName"}
 ----
+**_MatchProjectNodeSelector_** determines fit based on node selector query that is defined in the project. Default project node selector is used if no node selector is explicitly specified in the project.
+----
+{"name" : "MatchProjectNodeSelector"}
+----
 
 === Configurable Predicates
 These predicates can be configured by the user to tweak their functioning.  They can be given any user-defined name.  The type of the predicate is identified by the argument that they take.  Since these are configurable, multiple predicates of the same type (but different configuration parameters) can be combined as long as their user-defined names are different.

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -131,18 +131,18 @@ OpenShift objects at the project level.
 The simplest way to create a new project is:
 
 ****
-`$ osadm new-project _<project_name>_ --display-name=_<display_name>_ --description=_<description>_ --admin=_<admin_username>_`
+`$ osadm new-project _<project_name>_ --display-name=_<display_name>_ --description=_<description>_ --admin=_<admin_username>_ --node-selector=_<node_label_selector>_`
 ****
 
 The following example creates a new project called `test` that appears in the
-Management Console as "OpenShift 3 Sample", with `test-admin` as the project
-admin.
+Management Console as "Openshift 3 Sample", with `test-admin` as the project
+admin and launches any pods onto nodes matching label `environment : test`.
 
 ====
 
 [options="nowrap"]
 ----
-$ osadm new-project test --display-name="OpenShift 3 Sample" --description="This is an example project to demonstrate OpenShift v3" --admin=anypassword:test-admin`
+$ osadm new-project test --display-name="OpenShift 3 Sample" --description="This is an example project to demonstrate OpenShift v3" --admin=anypassword:test-admin --node-selector="environment=test"`
 ----
 ====
 

--- a/dev_guide/projects.adoc
+++ b/dev_guide/projects.adoc
@@ -19,14 +19,14 @@ Each project may have its own:
 [horizontal]
 Resources:: pods, services, replication controllers
 Policies:: who can or cannot perform an action
-Constraints:: quota for the project
+Constraints:: quota for the project, limit pods in a project to a pool of nodes
 
 == Create a Project
 
 To create a new project:
 
 ****
-`$ osadm new-project hello-openshift --description="This is an example project to demonstrate OpenShift v3" --display-name="Hello OpenShift"`
+`$ osadm new-project hello-openshift --description="This is an example project to demonstrate OpenShift v3" --display-name="Hello OpenShift" --node-selector="environment=dev"`
 ****
 
 == View Projects


### PR DESCRIPTION
Project node selector will constrain all pods within a project
to a pool of nodes that satisfies given label selector.
- Cluster admin can optionally specify global default project node selector.
  Either pass '--project-node-selector=[node_label_selector]' flag as command line argument to
  openshift start or pass 'projectNodeSelector: [node_label_selector]' entry in the master config.
  
  [node_label_selector] format: check https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/labels.md
- User can optionally specify node selector for the project.
  REST API: Pass node selector as annotation to the project.
  Example:
  {
  kind: 'Project',
  Annotations: map[string]string{
  'nodeSelector': [node_label_selector]
  }
  ...
  }
  CLI: osadm new-project --node-selector=[node_label_selector]
- Any project with no node selector will use global node selector if present.

trello card: https://trello.com/c/fn4r7ZIH
