### PR TITLE
updates for router documentation

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -133,6 +133,8 @@ Topics:
     File: manage_nodes
   - Name: Scheduler
     File: scheduler
+  - Name: Routers
+    File: router
 
 ---
 Name: CLI Reference

--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -1,0 +1,54 @@
+= Routers
+{product-author}
+{product-version]
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+Once you have a running link:../architecture/core_objects/routing.html[Router] you are ready
+to monitor it.  Depending on the underlying router implementation this may be accomplished
+multiple ways.  This document will discuss the HAProxy template router and the different
+components that can be checked to ensure its health.
+
+== Viewing Statistics
+The HAProxy router exposes a web listener for the HAProxy statistics.  You can enter the public
+IP address of the router with the correctly configured port to view the statistics page.  You 
+will be prompted for the admin password.  This password and port were configured during the
+router installation.
+
+== Viewing Logs
+To view a router log, simply run the `osc log` command for the pod.  Keep in mind that since
+the router is running as a plugin process that manages the underlying implementation the log
+that you will see is the log for the plugin, not the actual HAProxy log.  
+
+== Router Internals
+.Routes.json
+
+As routes are processed by the HAProxy router they are stored both in memory, on disk, and in
+the HAProxy configuration file.  In `/var/lib/containers/router/routes.json` you can find the
+internal representation of the routes that is passed to the template to generate the HAProxy
+configuration file.  When troubleshooting a route issue it may help to look at this file to
+see the data that is being used to drive configuration.
+
+.HAProxy Config
+
+In `/var/lib/haproxy/conf/haproxy.conf` you can find the configuration that is being used
+by HAProxy.  Here is where you can view the backends that have been created for specific routes.
+Also, in the same directory you can find the mapping files that are used by the helper 
+frontend and backends when mapping an incoming request to a backend.
+
+.Certificates
+
+Certificates are stored in two places. Certificates that are presented at the edge for edge
+terminated and re-encrypt terminated routes are stored in `/var/lib/containers/router/certs/`.
+Certificates that are used when connecting to backends for re-encrypt terminated routes are
+stored in `/var/lib/containers/router/cacerts/`.  The files are keyed by the namespace and
+name of the route.  You will find that the key, certificate, and CA certificate are 
+concatenated into a single file.  You may use openssl to view the contents of these files.
+
+

--- a/architecture/core_objects/routing.adoc
+++ b/architecture/core_objects/routing.adoc
@@ -272,6 +272,35 @@ from the router to the destination, specific to each implementation. See the
 link:#special-notes[special notes] below.
 ====
 
+[[wildcard-certificates]]
+*Wildcard Certificates*
+
+Based on the implementation, you may be able to use a default certificate. Default certificates
+are useful for implementing a wildcard certificate for the router.  For example, if you have
+many routes that end in example.com you may wish to install a router with a wild card
+certificate for `*.example.com`.
+
+To provide the default certificate to the router you must specify it in the create command with
+the default-cert option. The certificate should be a concatenated file of the key, certificate,
+and any CA certificates that are required by the browser. The certificate should be in a
+form acceptable by the underlying router implementation. In the case of HAProxy it should be a
+PEM based certificate.
+
+****
+`osadm router --credentials="$OPENSHIFTCONFIG" --default-cert=/full/path/to/certificate.pem`
+****
+
+For HAProxy, if a default certificate is provided, it will load it first. The certificate that
+is loaded first will be presented to any route that matches the CN on the certificate and
+any route that is secure but does not match any configured certificates. For example, if
+the default certificate is for `\*.example.com` and a secure route for `www.foo.com` is created
+with no certificates the route will still be written and the router will serve the `*.example.com`
+certficiate. This may result in a browser warning for users since the CN on the certificate
+does not match the url.
+
+If no default certificate is supplied, the HAProxy router will default to a generic, expired
+certificate that is provided in the base image.
+
 [[special-notes]]
 *Special Notes About Secure Routes*
 
@@ -316,23 +345,29 @@ available in OpenShift.
 The HAProxy template router implementation is the reference implementation for a
 template router plug-in. This uses the `openshift/origin-haproxy-router`
 repository to run an HAProxy instance alongside the template router plug-in. To
-test routes, an install script is provided in the *_hack/install-router.sh_*
-file.
-
-The router script requires two parameters: the router ID and the full URL to the
-master. It attempts to create the router based on the generated JSON file if it
-can find the `osc` executable on the path. If it cannot find the executable, it
-creates the JSON file and displays the location. You can then manually run the
-create command.
-
-.Running the Router Script
-====
+test routes, an install command is provided.
 
 ----
-$ hack/install-router.sh router https://10.0.2.15:8443
-Creating router file and starting pod...
-router
+Examples:
+  Check the default router ("router"):
+
+  $ osadm router --dry-run
+
+  See what the router would look like if created:
+
+  $ osadm router -o json
+
+  Create a router if it does not exist:
+
+  $ osadm router router-west --replicas=2 --credentials="$OPENSHIFTCONFIG"
+
+  Use a different router image and see the router configuration:
+
+  $ osadm router region-west -o yaml --images=myrepo/somerouter:mytag
 ----
+
+NOTE: This command is currently being actively developed. It is intended to simplify
+  the tasks of setting up routers in a new installation.
 
 ====
 


### PR DESCRIPTION
This update includes information on setting a default certificate for a router  (used for wildcard certificates), examples of the openshift ex router command, and some notes for administrators.

/cc @ramr - the HA setup is ready to be updated when you get a chance.

PTAL
