### PR TITLE
Split-horizon and Cluster DNS support

### DIFF
--- a/architecture/additional_concepts/networking.adoc
+++ b/architecture/additional_concepts/networking.adoc
@@ -9,7 +9,7 @@
 
 toc::[]
 
-Kubernetes ensures that each pod is able to network with each other, and
+Kubernetes ensures that pods are able to network with each other, and
 allocates each pod an IP address from an internal network. This ensures all
 containers within the pod behave as if they were on the same host. Giving each
 pod its own IP address means that pods can be treated like physical hosts or
@@ -21,6 +21,62 @@ you have a pod talk to another directly by using the IP address. Instead, we
 recommend that you create a
 link:../core_objects/kubernetes_model.html#service[service], then interact with
 the service.
+
+== OpenShift DNS
+
+If you are running multiple
+link:../core_objects/kubernetes_model.html#service[services], such as frontend
+and backend services for use with multiple pods, in order for the frontend pods
+to communicate with the backend services, environment variables are created for
+username, service-ip, etc. If the service is deleted and recreated, a new IP
+address can be assigned to the service, and requires the frontend pods to be
+recreated in order to pick up the updated values for the service IP environment
+variable. Additionally, the backend service has to be created before any of the
+frontend pods to ensure that the service IP is generated properly and that it
+can be provided to the frontend pods as an environment variable.
+
+For this reason, OpenShift has an built-in DNS so that the services can be
+reached by the service DNS as well as the service IP/port. OpenShift supports
+split DNS by running link:https://github.com/skynetservices/skydns[SkyDNS] on the master that answers DNS queries for
+services. The master listens to port 53 by default.
+
+When the node starts, the following message indicates the Kubelet is correctly
+resolved to the master:
+
+----
+0308 19:51:03.118430    4484 node.go:197] Started Kubelet for node
+openshiftdev.local, server at 0.0.0.0:10250
+I0308 19:51:03.118459    4484 node.go:199]   Kubelet is setting 10.0.2.15 as a
+DNS nameserver for domain "local"
+----
+
+If the second message does not appear, the Kubernetes service may not be available.
+
+On a node host, each Docker container's nameserver has the master added to the
+front, and the default search domain for the container will be
+.`_<pod_namespace>_.local`. The container will then direct any nameserver
+queries to the master before any other nameservers on the node, which is the
+default Docker behavior. The master will answer queries on the ".local" domain
+that have the following form:
+
+----
+<pod_namespace>.local
+<service>.<pod_namespace>.local
+----
+
+This prevents having to restart frontend pods in order to pick up new services,
+which creates a new IP for the service. This also removes the need to use
+environment variables, as pods can use the service DNS. Also, as the DNS does not change, you can reference database services as
+"db.local" in config files. Wildcard lookups are also supported, as any lookups
+resolve to the service IP, and removes the need to create the backend service
+before any of the frontend pods, since the service name (and hence DNS) is
+established upfront.
+
+This DNS structure also covers headless services, where a portal IP is not
+assigned to the service and the kube-proxy does not load-balance or provide
+routing for its endpoints. Service DNS can still be used and responds with
+multiple A records, one for each pod of the service, allowing the client to
+round-robin between each pod.
 
 == OpenShift SDN
 


### PR DESCRIPTION
Initial WIP PR for the dns info. 

@abhgupta @smarterclayton a few thoughts/questions I want to ask:
1. I'm presuming architecture/additional_concepts/networking.adoc is the ideal file. But this may change when I get my head around the concept better
2. I'm also presuming that this is a feature that's included in OpenShift by default and there's nothing needed to implement all this.
3. I'm not seeing anything that's defining what this is including. In the email thread @abhgupta gave me, there's Luke, Brenton, Clayton, and Erik giving a few things it _could_ do, but this is a bit rough and doesn't seem to be solid. Is there a more solid explanation of what's happening with this feature?

Any info is helpful.
Thanks.
