### PR TITLE
Clean up obsolete docker options

### DIFF
--- a/getting_started/dev_get_started/installation.adoc
+++ b/getting_started/dev_get_started/installation.adoc
@@ -27,7 +27,7 @@ You can quickly get OpenShift running in a Docker container using images from Do
 . Launch the server in a Docker container:
 +
 ----
-$ sudo docker run -d --name "openshift-origin" --net=host --privileged \
+$ docker run -d --name "openshift-origin" --net=host --privileged \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /tmp/openshift:/tmp/openshift \
 openshift/origin start
@@ -45,7 +45,7 @@ This command:
 . After the container is started, you can open a console inside the container:
 +
 ----
-$ sudo docker exec -it openshift-origin bash
+$ docker exec -it openshift-origin bash
 ----
 
 . Because OpenShift services are secured by TLS, clients must accept the server certificates and present their own client certificate. These certificates are generated when the master server is started. You must point `osc` and `curl` at the appropriate CA bundle and client key and certificate to connect to OpenShift. Set the following environment variables:

--- a/getting_started/dev_get_started/setup.adoc
+++ b/getting_started/dev_get_started/setup.adoc
@@ -154,15 +154,15 @@ endif::[]
 # yum install docker
 ----
 
-. Edit the [filename]#/etc/sysconfig/docker# file and add `--insecure-registry 172.30.17.0/24` to the [parameter]#OPTIONS# parameter. For example:
+. Edit the [filename]#/etc/sysconfig/docker# file and add `--insecure-registry 172.30.0.0/16` to the [parameter]#OPTIONS# parameter. For example:
 +
 ----
-OPTIONS=--selinux-enabled -H fd:// --insecure-registry 172.30.17.0/24
+OPTIONS=--selinux-enabled --insecure-registry 172.30.0.0/16
 ----
 +
-The `--insecure-registry` option instructs the Docker daemon to trust any Docker registry on the 172.30.17.0/24 subnet, rather than requiring a certificate.
+The `--insecure-registry` option instructs the Docker daemon to trust any Docker registry on the 172.30.0.0/16 subnet, rather than requiring a certificate.
 +
-NOTE: These instructions assume you have not changed the Kubernetes/OpenShift service subnet configuration from the default value of 172.30.17.0/24.
+NOTE: These instructions assume you have not changed the Kubernetes/OpenShift service subnet configuration from the default value of 172.30.0.0/16.
 
 . OpenShift [sysitem]#firewalld# rules are currently a work in progress. During the Beta 1 phase, properly configure or disable the [sysitem]#firewalld# service. To configure it, add `docker0` to the public zone:
 +


### PR DESCRIPTION
This patch update obsolete options.
1. subnet `172.30.0.0/16` which mentioned [issues/344](https://github.com/openshift/openshift-docs/issues/344)
   -  subnet was widened during the update of 0.4.3 to 0.4.4 ([This commit](https://github.com/smarterclayton/origin/commit/ae95ccc6b38a2914e8dfb6d589b5b24dd37503e4) was merged)
2. `-H fd://` in OPTIONS
   - Latest RHEL or Fedora won't work with this option.
3. Remove `sudo` to run docker
   - Docker should not run with root user.
