### PR TITLE
Corrected git for stashing/restoring working branch changes during a build

### DIFF
--- a/_builder_lib/docsitebuilder/helpers.rb
+++ b/_builder_lib/docsitebuilder/helpers.rb
@@ -74,15 +74,18 @@ module DocSiteBuilder
       @stash_needed = `git status --porcelain` !~ /^\s*$/
       if @stash_needed
         puts "\nNOTICE: Stashing uncommited changes and files in working branch."
-        `git stash -a`
+        `git stash -u`
       end
     end
 
     def git_apply_and_drop
       return unless @stash_needed
-      puts "\nNOTICE: Re-applying uncommitted changes and files to working branch."
-      `git stash apply`
-      `git stash drop`
+      puts "\nNOTE: Re-applying uncommitted changes and files to working branch."
+      if system("git stash pop")
+        puts "NOTE: Stash application successful."
+      else
+        puts "ERROR: Could not apply stashed code. Run `git stash apply` manually."
+      end
       @stash_needed = false
     end
 


### PR DESCRIPTION
This should fix an issue encountered by folks when they run `bundle exec rake build` from a working branch when there are uncommitted changes in the repo. Of note, this correctly preserves and restores the following items:
- changed files
- untracked files
- "Added" files (as in, `git add` was run on those files)

Note, however, that files that were `git add`ed, while preserved, will need to be re-added.

I have tested this fix on F21 and OS X; @jcantrill please test this on F20.
