### PR TITLE
Add Google Custom Search to OpenShift docs

### DIFF
--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -55,6 +55,21 @@
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
         <%= render("_templates/_nav.html.erb", :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim) %>
+        <script type="text/javascript">
+          /*<![CDATA[*/
+          (function() {
+            var cx = '013697484710004864066:xqntrlazi_8';
+            var gcse = document.createElement('script');
+            gcse.type = 'text/javascript';
+            gcse.async = true;
+            gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+                '//cse.google.com/cse.js?cx=' + cx;
+            var s = document.getElementsByTagName('script')[0];
+            s.parentNode.insertBefore(gcse, s);
+          })();
+          /*]]>*/
+        </script>
+        <gcse:search linkTarget="_top"></gcse:search>
       </div>
       <div class="col-xs-12 col-sm-9 col-md-9 main">
         <div class="page-header">


### PR DESCRIPTION
We might want to change the custom search code to transfer the ownership of the search engine settings.

It is configured to index and search `docs.openshift.org/latest/*`.

Closes #1235
