### PR TITLE
Update Guardfile for subtoic support; reorg _preview

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -2,7 +2,7 @@ guard 'shell' do
   watch(/^.*\.adoc$/) { |m|
     if not m[0].start_with?('_preview') and not m[0].start_with?('_package')
       full_path      = m[0].split('/')
-      src_group_path = full_path.length == 1 ? '' : full_path[0]
+      src_group_path = full_path.length == 1 ? '' : full_path[0..-2].join('/')
       filename       = full_path[-1][0..-6]
       system("bundle exec rake refresh_page['#{src_group_path}:#{filename}']")
     end


### PR DESCRIPTION
This update makes Guard play nice with the subtopic support. Guard behavior is:
1. You run `bundle exec guard`
2. You modify an `.adoc` file in the repo
3. Guard picks this up and regenerates _only_ that file and _only_ for your current working branch, but for all distros.

To see the resulting change, you will look under the `_preview` dir. Specifically:

```
_preview/<distro_name>/<branch_name>/<filepath>
```

Your file will have been updated for all distros with the correct distro-specific `ifdef` blocks applied.
