### PR TITLE
Edits to deployments.adoc file

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -10,30 +10,26 @@
 toc::[]
 
 == Overview
-A deployment in OpenShift is an update to a single replication controller's
-pod template based on triggered events. The `*deployment*` subsystem provides:
+A deployment in OpenShift is an update to a single replication controller's pod
+template based on triggered events. The `*deployment*` subsystem provides:
 
-- A link:#defining-a-deploymentConfig[declarative definition] of a desired deployment configuration which drives automated deployments by the system.
+- A link:#defining-a-deploymentConfig[deploymentconfig] that drives automated deployments by the system.
 - link:#triggers[Triggers] which drive new deployments in response to events.
+- User-customizable link:#strategies[strategies] for deployment rollout behavior, which are responsible for making a deployment live in the cluster.
 - link:#rollbacks[Rollbacks] to a previous deployment.
-- link:#strategies[Strategies] for deployment rollout behavior which are user-customizable.
-- Audit history of deployed pod template configurations.
+- An audit history of deployed pod template configurations.
+
+The deployment configuration has a version parameter value that increases in increments of one each time a new deployment is created from that configuration. In addition, the cause of the last deployment is added to the configuration.
+
+== Defining a deploymentConfig
 
 A `*deploymentConfig*` describes a single link:templates.html[template] and a
 set of link:#triggers[triggers] for when a new deployment should be created.
-A deployment is simply a specially annotated `*replicationController*`. A
-link:#strategies[strategy] is responsible for making a deployment live in the
-cluster.
+A deployment is simply a specially annotated `*replicationController*`.
 
-Each time a new deployment is created, the `*latestVersion*` field of
-`*deploymentConfig*` is incremented. A `*deploymentCause*` is also added to the
-`*deploymentConfig*` describing the change that led to the latest deployment.
-
-== Defining a deploymentConfig
-A `*deploymentConfig*` is a REST object which can be used in a `POST`  to the
-API server to create a new instance. Consider the following simple, but
-complete, configuration which should result in a new deployment every time a
-Docker image tag changes:
+A `*deploymentConfig*` is a REST object, which can be used in a `POST` to the
+API server to create a new instance. The following configuration results in a
+new deployment every time a Docker image tag changes:
 
 ====
 
@@ -95,22 +91,22 @@ Docker image tag changes:
 
 <1> This specification will create a new `*deploymentConfig*` named
 `*frontend*`.
-<2> The Recreate `*strategy*` makes the deployment live by disabling any prior
-`deployment` and increasing the replica count of the new `deployment`.
-<3> A single `*ImageChange*` trigger is defined, which causes a new deployment
-to be created each time the *openshift/origin-ruby-sample:latest* tag value
-changes.
+<2> The link:#strategies[`*Recreate*` strategy] makes the deployment live by
+disabling any prior `deployment` and increasing the replica count of the new
+`deployment`.
+<3> A single `*ImageChange*` trigger, which causes a new deployment to be
+created each time the "repositoryName" and "tag" parameter values change.
 ====
 
 == Strategies
-A `*deploymentConfig*` has a `*strategy*` which is responsible for making new
+A `*deploymentConfig*` has a strategy which is responsible for making new
 deployments live in the cluster. Each application has different requirements for
 availability (and other considerations) during deployments. OpenShift provides
 out-of-the-box strategies to support a variety of deployment scenarios:
 
-*Recreate Strategy* [[recreate-strategy]]
+=== Recreate Strategy [[recreate-strategy]]
 
-The `*Recreate*` `*strategy*` has basic rollout behavior, and supports
+The `*Recreate*` strategy has basic rollout behavior, and supports
 link:#lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
 process.
 
@@ -131,13 +127,13 @@ process.
 <2> `*pre*` and `*post*` are both link:#lifecycle-hooks[lifecycle hooks].
 ====
 
-The algorithm for the `*Recreate*``*strategy*` is:
+The `*Recreate*` strategy order of operations is to:
 
 . Execute any `*pre*` lifecycle hook.
 . Increase the replica count of the new deployment to the replica count
 defined on the deployment configuration.
-. Find and disable previous deployments by reducing their replica count to `0`.
-. Execute any `post` lifecycle hook
+. Find and disable previous deployments by reducing their replica count to zero.
+. Execute any `post` lifecycle hook.
 
 link:#lifecycle-hooks[Lifecycle hooks] are specified in the `*recreateParams*`
 for the strategy.
@@ -145,10 +141,9 @@ for the strategy.
 IMPORTANT: The `*Abort*` lifecycle hook failure policy is not supported for the
 `*post*` hook in this strategy; any `*post*` hook failure will be ignored.
 
-*Custom Strategy* [[custom-strategy]]
+=== Custom Strategy [[custom-strategy]]
 
-The `*Custom*` `*strategy*` allows users of OpenShift to provide their own
-deployment behavior.
+The `*Custom*` strategy allows you to provide your own deployment behavior:
 
 ====
 
@@ -170,14 +165,13 @@ deployment behavior.
 ----
 ====
 
-With this specification, the *organization/strategy* Docker image carries out
-the `*strategy*` behavior. The optional `*command*` array overrides any `CMD`
-directive specified in the image's *_Dockerfile_*. The optional `*environment*`
-variables provided are added to the execution environment of the `*strategy*`
-process.
+In the above example, the *organization/strategy* Docker image carries out the
+strategy behavior. The optional `*command*` array overrides any `CMD` directive
+specified in the image's *_Dockerfile_*. The optional environment variables
+provided are added to the execution environment of the strategy process.
 
-Additionally, the following environment variables are provided by OpenShift to
-the `*strategy*` process:
+Additionally, OpenShift provides the following environment variables to the
+strategy process:
 
 [cols="4,8",options="header"]
 |===
@@ -190,14 +184,13 @@ the `*strategy*` process:
 |The namespace of the new deployment.
 |===
 
-The replica count of the new deployment will be `0` initially. The
-responsibility of the `*strategy*` is to make the new deployment live using
-whatever logic best serves the needs of the user.
+The replica count of the new deployment will initially be `0`. The
+responsibility of the strategy is to make the new deployment live using the
+logic that best serves the needs of the user.
 
 == Lifecycle Hooks
-Deployment strategies may support lifecycle hooks, which allow you to
-inject behavior into the deployment process at predefined points within the
-strategy. Consider this partially defined hook:
+Deployment strategies support lifecycle hooks, which allow you to inject
+behavior into the deployment process at predefined points within the strategy:
 
 ====
 
@@ -208,32 +201,39 @@ strategy. Consider this partially defined hook:
   "execNewPod": {} <1>
 }
 ----
-<1> `*execNewPod*` is the type of this lifecycle hook, and is
-link:#pod-based-lifecycle-hook[documented separately].
+<1> `*execNewPod*` is link:#pod-based-lifecycle-hook[a pod-based lifecycle hook].
 ====
 
-Every hook has a `*failurePolicy*` which defines the action the strategy should take when a hook failure is encountered. Possible values are:
+Every hook has a `*failurePolicy*`, which defines the action the strategy should
+take when a hook failure is encountered:
 
-[horizontal]
-Abort:: The deployment should be considered a failure if the hook fails.
-Retry:: The hook execution should be retried until it succeeds.
-Ignore:: Any hook failure should be ignored and the deployment should proceeed.
+[cols="2,8"]
+|===
+
+.^|`*Abort*`
+|The deployment should be considered a failure if the hook fails.
+
+.^|`*Retry*`
+|The hook execution should be retried until it succeeds.
+
+.^|`*Ignore*`
+|Any hook failure should be ignored and the deployment should proceeed.
+|===
 
 WARNING: Some hook points for a strategy might support only a subset of
 `*failurePolicy*` values. For example, the `*Recreate*` strategy does not
 currently support the `*Abort*` policy for its `*post*` deployment lifecycle
-hook point. Check the documentation for a given strategy to learn more about its
-support for lifecycle hooks.
+hook point. Check the link:#recreate-strategy[`*Recreate*` strategy] section for
+more information about support for lifecycle hooks.
 
-Hooks have a type specific field which describes how to execute the hook.
+Hooks have a type specific field that describes how to execute the hook.
 Currently `*execNewPod*` is the only supported type.
 
-*Pod-based Lifecycle Hook* [[pod-based-lifecycle-hook]]
+=== Pod-based Lifecycle Hook [[pod-based-lifecycle-hook]]
 
 The `*execNewPod*` hook type executes lifecycle hook code in a new pod derived
-from the pod template in a `*deploymentConfig*`. Consider this simplified
-example `*deploymentConfig*` which uses the link:#recreate-strategy[`*Recreate*`
-`*strategy*`].
+from the pod template in a `*deploymentConfig*`. The following example
+`*deploymentConfig*` uses the link:#recreate-strategy[`*Recreate*` strategy].
 
 ====
 
@@ -289,21 +289,20 @@ example `*deploymentConfig*` which uses the link:#recreate-strategy[`*Recreate*`
 
 In this example, the `*pre*` hook will be executed in a new pod using the
 *openshift/origin-ruby-sample* image from the *helloworld* container. The hook
-command will be `/usr/bin/command arg1 arg2`, and the hook pod will have
-`*CUSTOM_VAR1=custom_value1*` in its environment. Because the `*failurePolicy*`
-is `*Abort*`, if the hook fails, the deployment will fail (as supported by the
-`*Recreate*` `*strategy*`).
+command will be `/usr/bin/command arg1 arg2`, and the hook pod will have the
+`*CUSTOM_VAR1=custom_value1*` environment variable. Because the
+`*failurePolicy*` is `*Abort*`, if the hook fails, the deployment will fail (as
+supported by the `*Recreate*` strategy).
 
 == Triggers
 
-A `*deploymentConfig*` contains triggers which drive the creation of new
-deployments in response to events, both inside and outside OpenShift. The
-following trigger types are supported:
+A `*deploymentConfig*` contains triggers, which drive the creation of new
+deployments in response to events, both inside and outside OpenShift.
 
-*_ImageChange_ Triggers* [[image-change-triggers]]
+=== ImageChange Triggers [[image-change-triggers]]
 
 The `*ImageChange*` trigger results in a new deployment whenever the value
-of a Docker `*imageRepository*` tag value changes. Consider an example trigger:
+of a Docker `*imageRepository*` tag value changes:
 
 ====
 
@@ -325,12 +324,11 @@ of a Docker `*imageRepository*` tag value changes. Consider an example trigger:
 disabled.
 ====
 
-In this example, when the `*latest*` tag value for the `*imageRepository*` named
-*openshift/origin-ruby-sample* changes, the containers specified in
-`*containerNames*` for the `*deploymentConfig*` will be updated  with the new
-tag value, and a new deployment will be created.
+Using the above example, when the `*tag*` value for the image is updated, a new
+deployment is created using the updated configuration. Then, the deployment is
+rolled out using the specified strategy.
 
-*_ConfigChange_ Triggers* [[configchange-triggers]]
+=== ConfigChange Triggers [[configchange-triggers]]
 
 The `*ConfigChange*` trigger results in a new deployment whenever changes are
 detected to the `*template*` of the `*deploymentConfig*`:
@@ -346,8 +344,8 @@ detected to the `*template*` of the `*deploymentConfig*`:
 ====
 
 For example, if the REST API is used to modify an environment variable in a
-container within the `*template*`, this trigger will cause a new deployment to
-be created in response to the `*template*` modification.
+container within the `*template*`, this trigger will launch a new deployment in
+response to the `*template*` modification.
 
 == Rollbacks
 Rollbacks revert an application back to a previous deployment and can be


### PR DESCRIPTION
@ironcladlou This PR is in response to https://github.com/openshift/openshift-docs/pull/296 and I waited for https://github.com/openshift/openshift-docs/pull/330 to merge before I made any edits, etc. Can I ask for a quick review? I have a couple of questions as well:
1. In the Overview, it talks about the _latestversion_ and _deploymentCause_, but these parameters aren't in the example given. Should they be?
2. Under the Lifecycle Hooks section, in the Warning box, it says to check to documentation for a strategy to learn about its support for lifecycle hooks. Does this refer to our own docs? Because maybe something might have to be added here.
3. Would you be able to elaborate on the last paragraph of the ImageChange Triggers section? I can understand that when the image is updated (in this case openshift/origin-ruby-sample), then the tag parameter value changes, but I'm not too sure what happens. Does the current deployment get destroyed and a new one is created from the updated image?

Thanks in advance!
