### PR TITLE
add docs about self-provisioned projects

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -137,6 +137,8 @@ Topics:
     File: router
   - Name: High Availability
     File: high_availability
+  - Name: Self-Provisioned Projects
+    File: selfprovisioned_projects
 
 ---
 Name: CLI Reference

--- a/admin_guide/selfprovisioned_projects.adoc
+++ b/admin_guide/selfprovisioned_projects.adoc
@@ -1,0 +1,40 @@
+= Self-Provisioned Projects
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+In some cases, it is desirable to allow users to create projects for themselves without administrator intervention.  To make this simpler, a user accessible endpoint is present that will provision a project according to a template.  This endpoint is made accessible via: `osc new-project <project-name>`.
+
+== Configuration
+=== New project template
+The API server creates new auto-provisioned projects based on a template that it finds based on the `projectRequestTemplate` property of the master-config.yaml.  The property is in the form "namespace/templatename", by default "openshift/project-request".  If the template does not exist, the API server will create a default template that creates a project with the requested name and assigns the requesting user to the "admin" role for that project.  If the property is empty, then no action is taken and self-provisioning will fail.
+
+If you want to change the way the shape of self-provisioned projects, you can change the template.  The API will substitute the following parameters into the template:
+
+ .  PROJECT_NAME - name of the project
+
+ .  PROJECT_DISPLAYNAME = display name of the project (defaults to PROJECT_NAME)
+
+ .  PROJECT_DESCRIPTION = description of the project (defaults to PROJECT_DISPLAYNAME)
+
+ .  PROJECT_ADMIN_USER = name of the requesting user
+
+
+
+=== Permissions
+Access to this API is granted via the `self-provisioner` role and the `self-provisioners` cluster role binding.  By default, it is available to all authenticated users.  
+
+=== Disabling auto-provisioning
+Deleting the `self-provisioners` cluster role binding will deny permissions for auto-provisioning new projects.  If you remove this permission, you should consider setting the `projectRequestMessage` option inside of the master-config.yaml file with instructions for how users can request a project.  That field is a string that will be presented to user in the webui and the cli when they attempt to self-provision a project.  Some common examples are:
+
+ .  Call Bob at (555) 867-5309 to request a project
+
+ .  Fill out the project request form located at https://internal.example.com/openshift-project-request
+ 


### PR DESCRIPTION
Information about customizing `osc new-project`

@sosiouxme This also describes a mechanism for cluster-admins to describe how users can request projects.
