### PR TITLE
Add note about generic parameter substitution

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -99,6 +99,10 @@ $ `osc process -f _<filename.json>_ | osc create -f -`
 
 You can override any link:../dev_guide/templates.html#parameters[parameters]
 defined in the JSON file by adding the `-v` option and any desired parameters.
+Note that the usage of the parameters is not restricted to only environment
+variables. You can use the parameter reference in any text field inside the
+template items.
+
 For example, you can override the *`ADMIN_USERNAME`* and *`MYSQL_DATABASE`*
 parameters to create a configuration with customized environment variables:
 


### PR DESCRIPTION
This small fix is part of this Trello card:

https://trello.com/c/50JUEZtO/336-1-as-a-user-i-would-like-to-generically-substitute-template-parameters-composition

It just informs users about generic parameter substitution, which is now possible in all text fields, not just the 'env' field.
