### PR TITLE
Remove MatchProjectNodeSelector predicate from scheduler config

### DIFF
--- a/admin_guide/scheduler.adoc
+++ b/admin_guide/scheduler.adoc
@@ -51,10 +51,6 @@ These predicates do not take any configuration parameters or inputs from the use
 ----
 {"name" : "HostName"}
 ----
-**_MatchProjectNodeSelector_** determines fit based on node selector query that is defined in the project. Default project node selector is used if no node selector is explicitly specified in the project.
-----
-{"name" : "MatchProjectNodeSelector"}
-----
 
 === Configurable Predicates
 These predicates can be configured by the user to tweak their functioning.  They can be given any user-defined name.  The type of the predicate is identified by the argument that they take.  Since these are configurable, multiple predicates of the same type (but different configuration parameters) can be combined as long as their user-defined names are different.
@@ -114,7 +110,6 @@ The default scheduler policy includes the following predicates.
 1. NoDiskConflict
 1. MatchNodeSelector
 1. HostName
-1. MatchProjectNodeSelector
 
 The default scheduler policy includes the following priority functions.  Each of the priority function has a weight of '1' applied to it.
 
@@ -147,8 +142,7 @@ The configuration below specifies the default scheduler configuration, if it wer
 		{"name" : "PodFitsResources"},
 		{"name" : "NoDiskConflict"},
 		{"name" : "MatchNodeSelector"},
-		{"name" : "HostName"},
-		{"name" : "MatchProjectNodeSelector"}
+		{"name" : "HostName"}
 	],
 	"priorities" : [
 		{"name" : "LeastRequestedPriority", "weight" : 1},


### PR DESCRIPTION
Project node selector design/implementation has changed.
MatchProjectNodeSelector is no longer a scheduler predicate.
For more details: https://github.com/openshift/origin/pull/1918

/cc @adellape 
