### PR TITLE
Edits to high availability section

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -10,50 +10,163 @@
 toc::[]
 
 == Overview
-This document describes how to setup high available services on your
+This topic describes how to set up highly-available services on your
 OpenShift cluster.
 
-== IP Failover
-This section describes how to make any IP based network service highly available using virtual IP addresses and IP failover.
+The Kubernetes link:../architecture/core_objects/kubernetes_model.html#replication-controller[replication controller] ensures that the deployment requirements,
+in particular the number of replicas, are satisfied when the appropriate
+resources are available. When run with two or more replicas, the link:../architecture/core_objects/routing.html[router] can be resilient to failures, providing a highly-available service. Depending on how the router instances are discovered (via a service,
+DNS entry, or IP addresses), this could impose operational requirements to
+handle failure cases when one or more router instances are "unreachable".
 
-=== Why IP Failover?
-Within a cluster, the Kubernetes replication controller ensures that the deployment requirements - in particular the number of replicas - are satisfied when the appropriate resources are available.
+For some IP-based traffic services, Virtual IP addresses (VIPs) should always be
+serviced for as long as a single instance is available. This simplifies the
+operational overhead and handles failure cases gracefully.
 
-The link:../architecture/core_objects/routing.html[Router] is one such deployment which can be run with 2 or more replicas to provide a highly available service resilient to individual router instance failures. Depending on how these router instances are discovered (for example via a well-published service or a DNS entry or even IP addresses), this could well impose operational requirements to handle failure cases when 1 or more router instances are "unreachable".
+IMPORTANT: Even though
+a service is highly available, performance can still be affected.
 
-For some IP based traffic services, if we can ensure that the IP addresses are always serviced as long as a single instance is available, this simplifies the operational overhead and handles failure cases gracefully. It is pertinent to note here, that even though the service is highly available, performance could still be impacted.
+Use cases for high-availability include:
 
-=== Use Cases
-  1. As an administrator, I want my cluster to be assigned a resource set
-     and I want the cluster to automatically manage those resources.
-  2. As an administrator, I want my cluster to be assigned a set of virtual
-     IP addresses that the cluster manages and migrates (with zero or
-     minimal downtime) on failure conditions.
-  3. As an addendum to use case #2, the administrator should not be
-     required to perform any manual interaction to update the upstream
-     "discovery" sources (e.g. DNS). The cluster should service all the
-     assigned virtual IPs when atleast a single node is available - and
-     this should be inspite of the fact that the current available
-     resources are not sufficient to reach "critical mass" aka the
-     desired state.
+* As an administrator, I want my cluster to be assigned a resource set and I want the cluster to automatically manage those resources.
+* As an administrator, I want my cluster to be assigned a set of VIPs that the cluster manages and migrates (with zero or minimal downtime) on failure conditions. As an administrator, I should not be required to perform any manual interactions to update the upstream "discovery" sources (e.g. DNS). The cluster should service all the assigned VIPs when at least a single node is available, despite the current available resources not being sufficient to reach the desired state.
 
-=== ipfailover admin command
-The `osadm ipfailover` command helps to setup the VIP failover configuration. An administrator can configure IP failover on an entire cluster or as would normally be the case on a subset of nodes (as defined via a labelled selector). If you are running in production, it is recommended that the labelled selector for the nodes matches atleast 2 nodes to ensure you have failover protection and that you provide a --replicas=<n> value that matches the number of nodes for the given labelled selector.
+You can configure a highly-available router or network setup by running multiple
+instances of the pod and fronting them with a balancing tier. This can be
+something as simple as DNS round robin, or as complex as multiple load-balancing
+layers.
+////
+=== DNS Round Robin [[dns-round-robin]]
 
-Running with the `--help` option will show you the supported options and their description. A small subset of these options pertinent to this document is described in the next section.
+As a simple example, you can create a zone file for a DNS server, such as BIND,
+that maps multiple A records for a single domain name. When clients do a lookup,
+they are given one of the many records, in order, as a round robin scheme.
+
+[NOTE]
+====
+The procedure below uses wildcard DNS with multiple A records to achieve the
+desired round robin. The wildcard could be further distributed into shards with:
 
 ****
-`$ osadm ipfailover --help`
+`*._<shard>_`
 ****
+====
 
-==== ipfailover command syntax
+.To Configure Simple DNS Round Robin:
+. Add a new zone that points to your file:
++
+====
 
-        osadm ipfailover [<name>] <options>
-        where:
-            <name> = Name of the IP failover configuration.
-                     Default: generated name (e.g.  ipfailover-1)
-            <options> = One or more options - see subset below.
+----
+#### named.conf
+    zone "v3.rhcloud.com" IN {
+            type master;
+            file "v3.rhcloud.com.zone";
+    };
 
+----
+====
+
+. Define the round robin mappings for the DNS lookup:
++
+====
+
+----
+#### v3.rhcloud.com.zone
+    $ORIGIN v3.rhcloud.com.
+
+    @       IN      SOA     . v3.rhcloud.com. (
+                         2009092001         ; Serial
+                             604800         ; Refresh
+                              86400         ; Retry
+                            1206900         ; Expire
+                                300 )       ; Negative Cache TTL
+            IN      NS      ns1.v3.rhcloud.com.
+    ns1     IN      A       127.0.0.1
+    *       IN      A       10.245.2.2
+            IN      A       10.245.2.3
+
+
+----
+====
+
+. Test the entry. The following example test uses `dig` (available in the
+*bind-utils* package) in a *Vagrant* environment to show multiple answers for
+the same lookup. Performing multiple pings shows the resolution swapping between
+IP addresses:
++
+[options="nowrap"]
+====
+
+----
+
+$ dig hello-openshift.shard1.v3.rhcloud.com
+
+; <<>> DiG 9.9.4-P2-RedHat-9.9.4-16.P2.fc20 <<>> hello-openshift.shard1.v3.rhcloud.com
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 36389
+;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 2
+;; WARNING: recursion requested but not available
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;hello-openshift.shard1.v3.rhcloud.com. IN A
+
+;; ANSWER SECTION:
+hello-openshift.shard1.v3.rhcloud.com. 300 IN A	10.245.2.2
+hello-openshift.shard1.v3.rhcloud.com. 300 IN A	10.245.2.3
+
+;; AUTHORITY SECTION:
+v3.rhcloud.com.		300	IN	NS	ns1.v3.rhcloud.com.
+
+;; ADDITIONAL SECTION:
+ns1.v3.rhcloud.com.	300	IN	A	127.0.0.1
+
+;; Query time: 5 msec
+;; SERVER: 10.245.2.3#53(10.245.2.3)
+;; WHEN: Wed Nov 19 19:01:32 UTC 2014
+;; MSG SIZE  rcvd: 132
+
+$ ping hello-openshift.shard1.v3.rhcloud.com
+PING hello-openshift.shard1.v3.rhcloud.com (10.245.2.3) 56(84) bytes of data.
+...
+^C
+--- hello-openshift.shard1.v3.rhcloud.com ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1000ms
+rtt min/avg/max/mdev = 0.272/0.573/0.874/0.301 ms
+
+$ ping hello-openshift.shard1.v3.rhcloud.com
+[...]
+----
+
+====
+////
+
+== Configuring IP Failover
+
+Using IP failover involves switching to a redundant or stand-by set of IP
+addresses if the initial set fails, and is a more reliable method than DNS round robin.
+
+The `osadm ipfailover` command helps set up the VIP failover configuration. As
+an administrator, you can configure IP failover on an entire cluster, or on a
+subset of nodes, as defined by the labeled selector. If you are running in
+production, match the labeled selector with at least two nodes to ensure you
+have failover protection and provide a `--replicas=<n>` value that matches the
+number of nodes for the given labeled selector:
+
+----
+$ osadm ipfailover [<Ip_failover_config_name>] <options> --replicas=<n>
+----
+
+Alternatively, you can produce a test from a JSON file:
+
+----
+$ osadm ipfailover [<Ip_failover_config_name>] <options> -o json
+----
+
+////
 ==== ipfailover command options (subset)
 The list of command options described here are a subset that are relevant to this document.
 
@@ -75,66 +188,119 @@ The list of command options described here are a subset that are relevant to thi
                                 Default: 80.
             <string> = a string of characters.
             <number> = a number ([0-9]*).
+////
 
-==== Setting up an IP based network service with IP Failover
-The following steps describe how to setup a highly available IP based network service with IP failover in a 3-step operation:
+The `osadm ipfailover` command ensures that a pod with failover runs on each of
+the nodes matching the constraints or label used. This pod uses a VRRP (Virtual
+Router Redundancy Protocol) with link:http://www.keepalived.org/[Keepalived] to ensure that the service on the
+watched port is available, and, if needed, Keepalived will automatically float
+the VIPs if the service is not available.
 
-===== Step 1: Label the nodes for the service
-Strictly speaking, this step can be optional as you can run the service on any of the nodes in your Kubernetes cluster and use Virtual IP addresses (VIPs) that can "float" within those nodes.
+=== Configuring a Highly-available Routing Service
+The following steps describe how to setup a highly-available router environment with IP failover:
 
-However that said, it is recommended you provision certain nodes to run the service and have VIPs that can "float" amongst these nodes. In a complex and possibly bigger cluster, you probably may be already doing something similar so that nodes may be filtered on constraints or requirements specified (e.g. nodes with SSD drives or higher cpu/memory/disk requirements, etc).
+. Label the nodes for the service. This step can be optional if you run the
+service on any of the nodes in your Kubernetes cluster and use VIPs that can
+float within those nodes. This process may already exist within a complex
+cluster, in that nodes may be filtered by any constraints or requirements
+specified (e.g. nodes with SSD drives, or higher cpu/memory/disk requirements,
+etc.).
++
+The following example defines a label as router instances that are servicing
+traffic in the US west geography "ha-router=geo-us-west":
++
+====
+----
+$ osc label nodes openshift-minion-{5,6,7,8,9} "ha-router=geo-us-west"
+----
+====
 
-In our example, let us define this label or constraint as "ha-cache=geo" for our highly available cache service binding/listening on port 9736.
+. Start the router with at least two replicas on nodes matching the labels used in
+the first step. The following example runs three instances:
++
+====
+----
+$ osadm router ha-router-us-west --replicas=3 --selector="ha-router=geo-us-west" --labels="ha-router=geo-us-west" --credentials="$OPENSHIFTCONFIG" --create
+----
+====
++
+Note that the above command runs fewer router replicas than available nodes, so
+that, in the chance of node failures, Kubernetes can still ensure three
+available instances until the number of available nodes labeled
+"ha-router=geo-us-west" is below three. Additionally, the router uses the host
+network as well as ports 80 and 443, so fewer number of replicas are running to
+ensure a higher Service Level Availability (SLA). If there are no constraints on
+the service being setup for failover, it is possible to target the service to
+run on one or more, or even all, of the labeled nodes.
 
-****
-`$ openshift kube label nodes openshift-minion-{6,3,7,9} "ha-cache=geo"`
-****
+. Finally, configure the VIPs and failover for the nodes labeled with "ha-router=geo-us-west" in step one. Ensure the number of replicas match the number of nodes and that they satisfy the label setup in step one. Specify the VIPs addresses and the port number that IP failover should monitor on the desired instances:
++
+====
+----
+$ osadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$OPENSHIFTCONFIG" --create
+----
+====
 
-===== Step 2: Run the geo cache service with 2 or more replicas
-An example configuration for running a
-https://raw.githubusercontent.com/openshift/openshift-docs/master/admin_guide/examples/geo-cache.json[geo-cache]
-service is provided along with this document. The docker image referenced in
-that file `myimages/geo-cache` does not exist and is there purely for reference
-purposes. Edit the
-https://raw.githubusercontent.com/openshift/openshift-docs/master/admin_guide/examples/geo-cache.json[geo-cache.json]
-configuration to replace `myimages/geo-cache` with your favorite cache software
-docker image, change the number of replicas to 4 and ensure the label matches
-the one used in step 1 above `ha-cache=geo`.
+=== Configuring a Highly-Availabile Network Service with IP Failover [[ip-failover]]
 
-****
-`$ osc create -n <your-namespace-here> -f ./examples/geo-cache.json`
-****
+The following steps describe how to set up a highly-available IP-based network
+service with IP failover:
 
-===== Step 3: Configure IP failover for the geo cache service
-The final step is to configure the virtual IPs and failover for the nodes labelled in step 1 (with "ha-cache=geo"). Ensure the number of replicas matches the number of nodes that satisfy the constraint or label we used in step 1.  Specify the virtual IP address and the port number 9736 that IP failover should monitor on those instances.
+. Label the nodes for the service. This step can be optional if you run the
+service on any of the nodes in your Kubernetes cluster and use VIPs that can
+float within those nodes. This process may already exist within a complex
+cluster, in that the nodes may be filtered by any constraints or requirements
+specified (e.g. nodes with SSD drives, or higher cpu/memory/disk requirements,
+etc.).
++
+The following example labels a highly-available cache service that is
+binding/listening on port 9736 as "ha-cache=geo":
++
+====
+----
+$ osc label nodes openshift-minion-{6,3,7,9} "ha-cache=geo"
+----
+====
 
-****
-`$ osadm ipfailover ha-geo-cache --replicas=4 --selector="ha-cache=geo" --virtual-ips=10.245.2.101-104 --watch-port=9736 --credentials="$OPENSHIFTCONFIG" --create`
-****
+. Run the geo cache service with two or more replicas. An example configuration
+for running a geo-cache service
+https://raw.githubusercontent.com/openshift/openshift-docs/master/admin_guide/examples/geo-cache.json[is
+provided here].
++
+IMPORTANT: Be sure to replace the `myimages/geo-cache` docker image referenced in the
+file with your intended image. Also, change the number of replicas to the
+desired amount and ensure the label matches the one used in step one.
++
+----
+$ osc create -n <namespace> -f ./examples/geo-cache.json
+----
 
-==== Internals
-The osadm ipfailover command ensures that an ipfailover sidecar pod runs on each of the nodes matching the constraints or label we used in step 1. This ipfailover sidecar pod uses VRRP (Virtual Router Reduncy Protocol) within keepalived to monitor that the service on the watched port is available and keepalived will automatically float the VIPs in event of the service not being available.
+. Finally, configure the VIPs and failover for the nodes labeled with
+"ha-cache=geo" in step one. Ensure the number of replicas match the number of
+nodes and that they satisfy the label setup in step one. Specify the VIP
+addresses and the port number that IP failover should monitor for the desired
+instances:
++
+====
+----
+$ osadm ipfailover ha-geo-cache --replicas=4 --selector="ha-cache=geo" --virtual-ips=10.245.2.101-104 --watch-port=9736 --credentials="$OPENSHIFTCONFIG" --create
+----
+====
+////
++
+As an alternative, the following example creates an IP failover configuration on
+a selection of nodes labeled "my-ha-service=har-reporter" (on 4 nodes with 7
+VIPs monitoring a service listening on port 4242:
++
+====
+----
+$ osadm ipfailover harreporter --selector="my-ha-service=har-reporter" --virtual-ips="10.245.2.42,10.245.2.100-104,10.245.2.142,10.245.2.242" --watch-port=4242 --replicas=7 --create
+----
+====
+////
 
-In our example, we can now use the VIPs 10.245.2.101 through 10.245.2.104 to send traffic to the geo-cache service. If a particular geo-cache instance is "unreachable" (as an example due to a node failure), keepalived will float the VIPs automatically float amongst group of nodes we labelled "ha-cache=geo" and the service would still be reachable via those virtual IP addresses.
-
-== Examples
-
-See what the IP failover configuration would look like if it is created:
-
-****
-`$ osadm ipfailover <options ...> -o json`
-****
-
-
-Create an IP failover configuration if it does not already exist:
-
-****
-`$ osadm ipfailover --virtual-ips="1.2.3.4-5,6.7.8.9,10.11.12.13-15" --create`
-****
-
-
-Create an IP failover configuration on a selection of nodes labelled "my-ha-service=har-reporter" (on 4 nodes with 7 virtual IPs monitoring a service listening on port 4242.
-
-****
-`$ osadm ipfailover harreporter --selector="my-ha-service=har-reporter" --virtual-ips="10.245.2.42,10.245.2.100-104,10.245.2.142,10.245.2.242" --watch-port=4242 --replicas=7 --create`
-****
+Using the above example, you can now use the VIPs 10.245.2.101 through
+10.245.2.104 to send traffic to the geo-cache service. If a particular geo-cache
+instance is "unreachable", perhaps due to a node failure, Keepalived ensures
+that the VIPs automatically float amongst the group of nodes labeled
+"ha-cache=geo" and the service is still reachable via the virtual IP addresses.

--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -10,16 +10,21 @@
 toc::[]
 
 == Overview
-This topic describes how to set up highly-available services on your
-OpenShift cluster.
+This topic describes how to set up highly-available services on your OpenShift
+cluster.
 
-The Kubernetes link:../architecture/core_objects/kubernetes_model.html#replication-controller[replication controller] ensures that the deployment requirements,
-in particular the number of replicas, are satisfied when the appropriate
-resources are available. When run with two or more replicas, the link:../architecture/core_objects/routing.html[router] can be resilient to failures, providing a highly-available service. Depending on how the router instances are discovered (via a service,
-DNS entry, or IP addresses), this could impose operational requirements to
-handle failure cases when one or more router instances are "unreachable".
+The Kubernetes
+link:../architecture/core_objects/kubernetes_model.html#replication-controller[replication
+controller] ensures that the deployment requirements, in particular the number
+of replicas, are satisfied when the appropriate resources are available. When
+run with two or more replicas, the
+link:../architecture/core_objects/routing.html[router] can be resilient to
+failures, providing a highly-available service. Depending on how the router
+instances are discovered (via a service, DNS entry, or IP addresses), this could
+impose operational requirements to handle failure cases when one or more router
+instances are "unreachable".
 
-For some IP-based traffic services, Virtual IP addresses (VIPs) should always be
+For some IP-based traffic services, virtual IP addresses (VIPs) should always be
 serviced for as long as a single instance is available. This simplifies the
 operational overhead and handles failure cases gracefully.
 
@@ -28,8 +33,8 @@ a service is highly available, performance can still be affected.
 
 Use cases for high-availability include:
 
-* As an administrator, I want my cluster to be assigned a resource set and I want the cluster to automatically manage those resources.
-* As an administrator, I want my cluster to be assigned a set of VIPs that the cluster manages and migrates (with zero or minimal downtime) on failure conditions. As an administrator, I should not be required to perform any manual interactions to update the upstream "discovery" sources (e.g. DNS). The cluster should service all the assigned VIPs when at least a single node is available, despite the current available resources not being sufficient to reach the desired state.
+* I want my cluster to be assigned a resource set and I want the cluster to automatically manage those resources.
+* I want my cluster to be assigned a set of VIPs that the cluster manages and migrates (with zero or minimal downtime) on failure conditions, and I should not be required to perform any manual interactions to update the upstream "discovery" sources (e.g., DNS). The cluster should service all the assigned VIPs when at least a single node is available, despite the current available resources not being sufficient to reach the desired state.
 
 You can configure a highly-available router or network setup by running multiple
 instances of the pod and fronting them with a balancing tier. This can be
@@ -203,7 +208,7 @@ The following steps describe how to setup a highly-available router environment 
 service on any of the nodes in your Kubernetes cluster and use VIPs that can
 float within those nodes. This process may already exist within a complex
 cluster, in that nodes may be filtered by any constraints or requirements
-specified (e.g. nodes with SSD drives, or higher cpu/memory/disk requirements,
+specified (e.g., nodes with SSD drives, or higher CPU/memory/disk requirements,
 etc.).
 +
 The following example defines a label as router instances that are servicing
@@ -211,7 +216,7 @@ traffic in the US west geography "ha-router=geo-us-west":
 +
 ====
 ----
-$ osc label nodes openshift-minion-{5,6,7,8,9} "ha-router=geo-us-west"
+$ osc label nodes openshift-node-{5,6,7,8,9} "ha-router=geo-us-west"
 ----
 ====
 
@@ -241,7 +246,7 @@ $ osadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-w
 ----
 ====
 
-=== Configuring a Highly-Availabile Network Service with IP Failover [[ip-failover]]
+=== Configuring a Highly-availabile Network Service [[ip-failover]]
 
 The following steps describe how to set up a highly-available IP-based network
 service with IP failover:
@@ -250,7 +255,7 @@ service with IP failover:
 service on any of the nodes in your Kubernetes cluster and use VIPs that can
 float within those nodes. This process may already exist within a complex
 cluster, in that the nodes may be filtered by any constraints or requirements
-specified (e.g. nodes with SSD drives, or higher cpu/memory/disk requirements,
+specified (e.g., nodes with SSD drives, or higher CPU/memory/disk requirements,
 etc.).
 +
 The following example labels a highly-available cache service that is
@@ -258,7 +263,7 @@ binding/listening on port 9736 as "ha-cache=geo":
 +
 ====
 ----
-$ osc label nodes openshift-minion-{6,3,7,9} "ha-cache=geo"
+$ osc label nodes openshift-node-{6,3,7,9} "ha-cache=geo"
 ----
 ====
 

--- a/architecture/core_objects/routing.adoc
+++ b/architecture/core_objects/routing.adoc
@@ -523,6 +523,4 @@ The final step is to configure the virtual IPs and failover for the nodes labell
 ////
 
 == High Availability
-It is possible to set up a highly-available router or network on your OpenShift cluster using IP failover.
-
-See the link:../../admin_guide/high_availability.html[High Availability topic] for more information.
+You can link:../../admin_guide/high_availability.html[set up a highly-available router or network service] on your OpenShift cluster using IP failover.

--- a/architecture/core_objects/routing.adoc
+++ b/architecture/core_objects/routing.adoc
@@ -107,7 +107,7 @@ file.
 
 ====
 
-IMPORTANT: While both secure and unsecure routes are possible with an OpenShift instance, Red Hat recommends a secure routing service.
+Unsecure routes are likely faster to set up, as they are the default configuration, but secure routes offer greater security for information to remain private.
 
 == Path Based Routes
 Path based routes specify a path component that can be compared against a URL. This implies that the traffic for the route is HTTP based. Routers should match routes based on the most specific path to the least. However, this depends on your implementation. The following table shows example routes and their accessibility:
@@ -345,29 +345,32 @@ template router plug-in. This uses the `openshift/origin-haproxy-router`
 repository to run an HAProxy instance alongside the template router plug-in. To
 test routes, an install command is provided.
 
-----
-Examples:
-  Check the default router ("router"):
 
-  $ osadm router --dry-run
+Check the default router ("router"):
 
-  See what the router would look like if created:
+****
+$ `osadm router --dry-run`
+****
 
-  $ osadm router -o json
+See what the router would look like if created:
 
-  Create a router if it does not exist:
+****
+$ `osadm router -o json`
+****
 
-  $ osadm router router-west --replicas=2 --credentials="$OPENSHIFTCONFIG"
+Create a router if it does not exist:
 
-  Use a different router image and see the router configuration:
+****
+$ `osadm router router-west --replicas=2 --credentials="$OPENSHIFTCONFIG"`
+****
 
-  $ osadm router region-west -o yaml --images=myrepo/somerouter:mytag
-----
+Use a different router image and see the router configuration:
 
-NOTE: This command is currently being actively developed. It is intended to simplify
-  the tasks of setting up routers in a new installation.
+****
+$ `osadm router region-west -o yaml --images=myrepo/somerouter:mytag`
+****
 
-====
+NOTE: This command is currently being actively developed. It is intended to simplify the tasks of setting up routers in a new installation.
 
 The following diagram illustrates how data flows from the master through the
 plug-in and finally into an HAProxy configuration:
@@ -375,13 +378,14 @@ plug-in and finally into an HAProxy configuration:
 .HAProxy Router Data Flow
 image:router_model.png[HAProxy Router Data Flow]
 
+////
 == Highly-available Routers
 You can configure a highly-available router setup by running multiple instances
 of the router pod and fronting them with a balancing tier. This can be something
 as simple as DNS round robin or as complex as multiple load-balancing layers.
 
-[[dns-round-robin]]
-*DNS Round Robin*
+
+=== DNS Round Robin [[dns-round-robin]]
 
 As a simple example, you can create a zone file for a DNS server, such as BIND,
 that maps multiple A records for a single domain name. When clients do a lookup,
@@ -486,7 +490,8 @@ $ ping hello-openshift.shard1.v3.rhcloud.com
 [...]
 ----
 
-== High Availability Router Setup with IP Failover
+====
+
 The following steps describe how to setup a highly available router environment with IP failover in a 3-step operation:
 
 === Step 1: Label the infrastructures nodes for the service (router)
@@ -515,3 +520,9 @@ The final step is to configure the virtual IPs and failover for the nodes labell
 ****
 `$ osadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$OPENSHIFTCONFIG" --create`
 ****
+////
+
+== High Availability
+It is possible to set up a highly-available router or network on your OpenShift cluster using IP failover.
+
+See the link:../../admin_guide/high_availability.html[High Availability topic] for more information.


### PR DESCRIPTION
@ramr Hi. This is an initial edit of this PR:

https://github.com/openshift/openshift-docs/pull/337

Can i ask for a quick tech review? I'd hate to have changed anything and take away the meaning. I do have a few questions though:
1. Under the "Configuring IP Failover" section it talks about the --replicas=<n> option, but that isn't given in the example, or the help output (that I took out...). Should this be in one of the examples? Is it at home in the example command immediately after the sentence it talks about it?
2. This question's a bit long, so I hope it makes sense. I took out your edits to the routing.doc, and put in a paragraph taking the reader to the high_availability doc, my reason being that this is duplicate information. I did, however, leave in the parts of the routing.doc that discuss DNS round-robin. If there are two separate ways to setup HAness, should they both be in the same doc? Should the DNS round-robin section be in the high_availability doc as well? I originally thought that IP Failover and High Availability were two interchangeable terms, but after seeing the routing.doc now I'm not so sure...
3. Keepalived is mentioned a few times in this doc, and I'd like to link out to another resource, but I can't find much about how Keepalived and how it works with OpenShift. Is this the best resource for Keepalived: http://www.keepalived.org/

Hope the questions make sense. Thanks for the info in advance!
