### PR TITLE
Dockument docker-storage-setup for enterprise configs

### DIFF
--- a/getting_started/dev_get_started/setup.adoc
+++ b/getting_started/dev_get_started/setup.adoc
@@ -162,6 +162,83 @@ OPTIONS=--selinux-enabled --insecure-registry 172.30.0.0/16
 +
 The `--insecure-registry` option instructs the Docker daemon to trust any Docker registry on the 172.30.0.0/16 subnet, rather than requiring a certificate.
 +
+
+ifdef::openshift-enterprise[]
+
+*Configuring Docker Storage*
+
+Docker's default loopback storage mechanism is not supported for production use and is only
+appropriate for proof of concept environments. For production environments you must create a
+thin-pool logical volume and re-configure docker to use that volume. You can use the
+`docker-storage-setup` package to create a thin-pool device and configure docker's storage driver
+after installing docker but before you start using it.
+
+. In RHEL 7, `docker-storage-setup` is provided in the RHEL Extras repository; first, ensure the
+RHEL Extras repository is enabled:
++
+----
+# subscription-manager repos --enable=rhel-7-server-extras-rpms
+----
+
+. Install `docker-storage-setup`
++
+----
+# yum install docker-storage-setup
+----
+
+. Configure `docker-storage-setup` for your environment, there's three options
+based on your storage configuration.
+.. Create a thin-pool volume from the remaining free space in the volume group where your root
+filesystem resides, this requires no configuration.
++
+----
+docker-storage-setup
+----
+
+.. Use an existing volume group to create a thin-pool, in this example `docker-vg`.
++
+----
+echo <<EOF > /etc/sysconfig/docker-storage-setup
+VG=docker-vg
+SETUP_LVM_THIN_POOL=yes
+EOF
+docker-storage-setup
+----
+.. Use an unpartitioned block device to create a new volume group and thinpool, in this example
+`/dev/vdc` will be used to create `docker-vg`
++
+----
+cat <<EOF > /etc/sysconfig/docker-storage-setup
+DEVS=/dev/vdc
+VG=docker-vg
+SETUP_LVM_THIN_POOL=yes
+EOF
+docker-storage-setup
+----
+
+. Verify your configuration, you should have dm.thinpooldev value in `/etc/sysconfig/docker-storage`
+and a `docker-pool` device
++
+----
+# lvs
+LV                  VG        Attr       LSize  Pool Origin Data%  Meta% Move Log Cpy%Sync Convert
+docker-pool         docker-vg twi-a-tz-- 48.95g             0.00   0.44
+
+# cat /etc/sysconfig/docker-storage
+DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=/dev/mapper/docker--vg-docker--pool
+----
+
+. Re-initialize docker -- this will destroy and docker containers or images currently on the host.
++
+----
+# systemctl stop docker
+# rm -rf /var/lib/docker/*
+# systemctl restart docker
+----
+endif::[]
+
+*Configure Firewall Rules*
+
 NOTE: These instructions assume you have not changed the Kubernetes/OpenShift service subnet configuration from the default value of 172.30.0.0/16.
 
 . OpenShift [sysitem]#firewalld# rules are currently a work in progress. During the Beta 1 phase, properly configure or disable the [sysitem]#firewalld# service. To configure it, add `docker0` to the public zone:


### PR DESCRIPTION
RHEL storage teams have indicated that they will not support lvm loopback devices so we must use dm.thinpooldev for supported configurations.
