### PR TITLE
Router Sticky sessions

### DIFF
--- a/architecture/core_objects/routing.adoc
+++ b/architecture/core_objects/routing.adoc
@@ -376,6 +376,17 @@ plug-in and finally into an HAProxy configuration:
 
 .HAProxy Router Data Flow
 image:router_model.png[HAProxy Router Data Flow]
+====
+
+*Sticky Sessions*
+
+Implementing sticky sessions is up to the underlying router configuration.  The default HAProxy
+template implements sticky sessions using the `balance source` directive which balances based
+on the source IP.  In addition, the template router plugin will provide the service name and
+namespace to the underlying implementation.  This can be used for more advanced configuration
+such as implementing stick-tables that synchronize between a set of peers. For details on the
+implementation you may inspect the `haproxy-config.template` located in the `/var/lib/haproxy/conf`
+directory of your router container.
 
 == Highly-available Routers
 You can configure a highly-available router setup by running multiple instances
@@ -390,10 +401,10 @@ that maps multiple A records for a single domain name. When clients do a lookup,
 they are given one of the many records, in order, as a round robin scheme.
 
 [NOTE]
-====
 The procedure below uses wildcard DNS with multiple A records to achieve the
 desired round robin. The wildcard could be further distributed into shards with:
 
+====
 ****
 `*._<shard>_`
 ****
@@ -487,6 +498,7 @@ rtt min/avg/max/mdev = 0.272/0.573/0.874/0.301 ms
 $ ping hello-openshift.shard1.v3.rhcloud.com
 [...]
 ----
+====
 
 == High Availability Router Setup with IP Failover
 The following steps describe how to setup a highly available router environment with IP failover in a 3-step operation:


### PR DESCRIPTION
Fix broken formatting of router doc and add section about haproxy sticky sessions.

In support of https://github.com/openshift/origin/pull/2105
