### PR TITLE
Updated formatting for command syntax

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -262,26 +262,26 @@ This renders as:
 Use the `GET` operation to do x.
 
 === Command syntax and examples
-The main distinction between showing command syntax and example is that a command syntax should just show customers how to use the command without real values. An example on the other hand should show the command with actual values with an actual output of that command, where applicable.
+The main distinction between showing command syntax and example is that a command syntax should just show customers how to use the command without real values. An example on the other hand should show the command with actual values with an example output of that command, where applicable.
 
 ==== Command syntax
-To markup command syntax, use the sidebar block with the <replaceable> markup and the required command parameters, as shown in the following example. Do NOT use commands or command syntax inline with sentences.
+To markup command syntax, use the code block and wrap the replaceables in <> with the required command parameters, as shown in the following example. Do NOT use commands or command syntax inline with sentences.
 
 ....
 The following command returns a list of objects for the specified object type:
 
-****
-`osc get _<object_type>_ _<object_id>_`
-****
+----
+osc get <object_type> <object_id>
+----
 ....
 
 This would render as follows:
 
 The following command returns a list of objects for the specified object type:
 
-****
-`osc get _<object_type>_ _<object_id>_`
-****
+----
+osc get <object_type> <object_id>
+----
 
 ==== Examples
 As mentioned an example of a command should use actual values and also show an output of the command, as shown in the following example. In some a heading may not be required.


### PR DESCRIPTION
Updated the doc_guidelines topic to remove references to using the sidebar block for command syntax. We will now just use the code block and markup replaceables with <>.
