### PR TITLE
Reword "osc resize" description.[WIP]

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -84,7 +84,7 @@ The following table describes common `osc` operations and their general syntax:
 
 |`resize`
 |`osc resize _<object_type>_ _<object_id>_ _<#_of_replicas>_`
-|Resizes a replication controller either directly or indirectly via a deployment configuration; `_<#_of_replicas>_` must be provided.
+|Sets the number of desired replicas for a replication controller or a deployment configuration to `_<#_of_replicas>_`.
 
 |`update`
 |`osc update -f _<file_or_directory_path>_`


### PR DESCRIPTION
According to an IRC chat w/ decarr, the "osc resize" concept currently
only applies to the "replication controller" resource (a "deployment
configuration" resource is a replication controller underneath), but
might in the future also apply to "number of jobs".

When the OBJECT-TYPE possibilities expand beyond ‘rc’ and ‘dc’, this
description will need to be revised.
