### PR TITLE
OpenShift admin command to manage node operations

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -157,3 +157,65 @@ NOTE: When you delete a node with the CLI, although the node object is deleted
 in Kubernetes, the pods that exist on the node itself are not deleted. However,
 the pods cannot be accessed by OpenShift. The behavior around deleting nodes and
 pods with the CLI is under active development.
+
+== Listing Pods on Nodes
+Use the following command to list all or selected pods on one or more nodes:
+
+****
+`$ osadm manage-node _<node1>_ _<node2>_ --list-pods [--pod-selector=_<pod_selector>_] [-o json|yaml]`
+****
+
+To list all or selected pods on selected nodes:
+
+****
+`$ osadm manage-node --selector=_<node_selector>_ --list-pods [--pod-selector=_<pod_selector>_] [-o json|yaml]`
+****
+
+== Marking Nodes as Unschedulable or Schedulable
+Use the following command to mark the nodes as unschedulable:
+
+****
+`$ osadm manage-node _<node1>_ _<node2>_ --schedulabe=false`
+****
+
+Marking node as unschedulable will block any new pods to be scheduled on the
+node. Existing pods on the node will not get affected.
+
+Use the following command to mark the nodes as schedulable:
+
+****
+`$ osadm manage-node _<node1>_ _<node2>_ --schedulabe` or
+
+`$ osadm manage-node _<node1>_ _<node2>_ --schedulabe=true`
+****
+
+Marking node as schedulable will allow any new pods to be scheduled on the
+node.
+
+Instead of specifying the nodes _<node1>_ _<node2>_, you can also use
+--selector=_<node_selector>_ to mark selected nodes as schedulabe or
+unschedulable.
+
+== Evacuating Pods on Nodes
+Use the following command to evacuate all or selected pods on one or more nodes:
+
+****
+`$ osadm manage-node _<node1>_ _<node2>_ --evacuate [--pod-selector=_<pod_selector>_]`
+****
+
+Nodes must be marked unschedulable to perform pod evacuation. Only pods backed
+by replication controller will be evacuated. Bare pods will not be touched.
+You can force deletion of bare pods by using --force option:
+
+****
+`$ osadm manage-node _<node1>_ _<node2>_ --evacuate --force [--pod-selector=_<pod_selector>_]`
+****
+
+You can list pods that will be migrated by using --dry-run option:
+
+****
+`$ osadm manage-node _<node1>_ _<node2>_ --evacuate --dry-run [--pod-selector=_<pod_selector>_]`
+****
+
+Instead of specifying the nodes _<node1>_ _<node2>_, you can also use
+--selector=_<node_selector>_ to evacuate pods on selected nodes.


### PR DESCRIPTION
Supported node operations:
  openshift admin manage-node <nodes>|--selector=<node-selector> --list-pods [--pod-selector=<selector>]
  openshift admin manage-node <nodes>|--selector=<node-selector> --schedulable=<true|false>
  openshift admin manage-node <nodes>|--selector=<node-selector> --evacuate [--dry-run] [--force] [--pod-selector=<selector>]
