### PR TITLE
Document "osc resize", including examples.

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -91,9 +91,9 @@ iterates through each one, creating the objects described in all of the
 indicated files. Any existing resources are ignored.
 
 |`resize`
-|`osc resize _<object_type>_ _<object_id>_ _<#_of_replicas>_`
-|Resizes a replication controller either directly or indirectly via a deployment
-configuration; `_<#_of_replicas>_` must be provided.
+|`osc resize _<object_type>_ _<object_id>_ --replicas=_<#_of_replicas>_`
+|Sets the number of desired replicas for a replication controller or a
+deployment configuration to `_<#_of_replicas>_`.
 
 |`update`
 |`osc update -f _<file_or_directory_path>_`

--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -17,6 +17,7 @@ template based on triggered events. The `*deployment*` subsystem provides:
 - link:#triggers[Triggers] which drive new deployments in response to events.
 - User-customizable link:#strategies[strategies] for deployment rollout behavior, which are responsible for making a deployment live in the cluster.
 - link:#rollbacks[Rollbacks] to a previous deployment.
+- Replication link:#resizing[resizing].
 - An audit history of deployed pod template configurations.
 
 The deployment configuration has a version parameter value that increases in increments of one each time a new deployment is created from that configuration. In addition, the cause of the last deployment is added to the configuration.
@@ -381,3 +382,16 @@ Rollbacks revert an application back to a previous deployment and can be
 performed using the REST API or the CLI. See the
 link:../cli_reference/basic_cli_operations.html#deployment-operations[CLI
 Reference] for more details.
+
+== Resizing
+In addition to rollbacks, you can exercise fine-grained control over
+the number of replicas by using the `osc resize` command.
+For example, the following command sets the replicas in the deployment
+configuration `frontend` to 3.
+
+----
+$ osc resize dc frontend --replicas=3
+----
+
+The number of replicas eventually propagates to the desired and current
+state of the deployment configured by the deployment configuration `frontend`.


### PR DESCRIPTION
@kargakis 

The change in the op table is to avoid "direct" / "indirect",
which is distracting, at best.
Mentioning it in Deployments seems like a good idea.

Ref: https://trello.com/c/gROeg5Wj/620
