### PR TITLE
PersistentVolumes: fix JSON, pod, other tweaks

### DIFF
--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -12,7 +12,7 @@ toc::[]
 == Overview
 
 A *PersistentVolume* object is a storage resource in an OpenShift cluster.  It is provisioned by an administrator
-and made available to users who lay claims to the resource
+and made available to users who lay claims to the resource.
 
 A *PersistentVolumeClaim* object is a request for storage resources by a pod author.  The claim is paired with a
 volume that generally matches the user's request.
@@ -20,7 +20,7 @@ volume that generally matches the user's request.
 == Volume Provisioning
 
 Storage is provisioned by an administrator by creating *PersistentVolume* objects from sources such as GCE Persistent Disks,
-AWS Elastic Block Stores, and NFS mounts
+AWS Elastic Block Stores, and NFS mounts.
 
 == Sample persistent volume file
 
@@ -31,15 +31,15 @@ persistent-volume.json
   "apiVersion": "v1",
   "kind": "PersistentVolume",
   "metadata": {
-    "name": "pv0003"
+    "name": "pv0001"
   },
   "spec": {
     "capacity": {
-        "storage": "5Gi
+        "storage": "5Gi"
     },
-    "accessModes: [ "ReadWriteOnce" ],
+    "accessModes": [ "ReadWriteOnce" ],
     "nfs": {
-        "path": "/tmp"
+        "path": "/tmp",
         "server": "172.17.0.2"
     }
   }
@@ -49,7 +49,7 @@ persistent-volume.json
 
 == Requesting Storage
 
-Pod authors request storage by creating *PersistentVolumeClaim* objects.
+Pod authors request storage by creating *PersistentVolumeClaim* objects in their projects.
 
 == Sample persistent volume claim file
 
@@ -60,7 +60,7 @@ persistent-volume-claim.json
     "apiVersion": "v1",
     "kind": "PersistentVolumeClaim",
     "metadata": {
-    "name": "myclaim"
+        "name": "claim1"
     },
     "spec": {
         "accessModes": [ "ReadWriteOnce" ],
@@ -79,18 +79,18 @@ persistent-volume-claim.json
 
 A *PersistentVolume* is a specific resource.  A *PersistentVolumeClaim* is a request for a resource with specific attributes, such as storage size.
 In between the two is a process that matches a claim to an available volume and binds them together.  This allows the claim to be used
-  as a volume in a pod.  OpenShift finds the volume backing the claim and mounts it into the pod.
+as a volume in a pod.  OpenShift finds the volume backing the claim and mounts it into the pod.
 
 You can tell whether a claim or volume is bound by querying the CLI:
 
 ----
 $ osc get pvc
 NAME        LABELS    STATUS    VOLUME
-myclaim     map[]     Bound     PV0003
+claim1      map[]     Bound     pv0001
 
 $ osc get pv
 NAME                LABELS              CAPACITY            ACCESSMODES         STATUS    CLAIM
-pv0001              map[]               10737418240         RWO                 Bound     yournamespace / myclaim
+pv0001              map[]               5368709120          RWO                 Bound     yournamespace / claim1
 ----
 
 == Claims as Volumes in Pods
@@ -107,27 +107,29 @@ pod-with-claim.json
     "apiVersion": "v1",
     "kind": "Pod",
     "metadata": {
-        "name": "mypod"
-        "labels":[
-            {"name": "frontendhttp"}
-        ]
+        "name": "mypod",
+        "labels": {
+            "name": "frontendhttp"
+        }
     },
     "spec": {
         "containers": [{
             "name": "myfrontend",
-            "image": "dockerfile/nginx",
+            "image": "nginx",
             "ports": [{
                 "containerPort": 80,
                 "name": "http-server"
             }],
             "volumeMounts": [{
                 "mountPath": "/var/www/html",
-                "name": "mypd"
+                "name": "pvol"
             }]
         }],
         "volumes": [{
-            "name": "mypd",
-            "claimName": "myclaim"
+            "name": "pvol",
+            "persistentVolumeClaim": {
+                "claimName": "claim1"
+            }
         }]
     }
 }


### PR DESCRIPTION
The JSON did not parse - needed quotes and commas.
Also the pod definition was missing a crucial line.
