### PR TITLE
Add recommendation and rationale for labels on app creation; add link to CLI Reference.

### DIFF
--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -68,8 +68,12 @@ path:
 $ osc new-app <myregistry.com>/<mycompany>/<image_name>
 ----
 
-You can also create an application from a remote repository using a label. For 
-example, to create an application from the `ruby-hello-world` remote repository:
+You can also apply a label when creating an application.
+This is recommended, as labels make it easy to collectively select,
+manipulate, and delete objects associated with the application.
+See the link:../cli_reference/basic_cli_operations.html#common-operations[CLI Reference] for more details.
+For example, to apply label `name=hello-world` when creating an
+application from the `ruby-hello-world` remote repository:
 
 ====
 ----


### PR DESCRIPTION
@kargakis @sosiouxme 
I think "osc new-app" is the right place to mention labels in the context of easy deletion, and it mentions not only deletion, but selection and (general) manipulation as well.  WDYT?
