### PR TITLE
clean up parameter spec/ref text

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -68,16 +68,16 @@ CLI using the following process:
 You can upload a template to your current project's template library by passing
 a JSON file with the following command:
 
-****
-$ `osc create -f _<filename>_`
-****
+----
+$ osc create -f <filename>
+----
 
 You can upload a template to a different project using the `-n` option with the
 name of the project:
 
-****
-$ `osc create -f _<filename>_ -n _<project>_`
-****
+----
+$ osc create -f <filename> -n <project>
+----
 
 The template is now available to be selected for a configuration using the web
 console or the CLI.
@@ -85,23 +85,22 @@ console or the CLI.
 === Generating a Configuration
 Generate a configuration with the following command:
 
-****
-$ `osc process -f _<filename>_`
-****
+----
+$ osc process -f <filename>
+----
 
 Alternatively, you can create from a template without uploading it to the
 template library by processing the template and creating from the same template
 by piping both commands:
 
-****
-$ `osc process -f _<filename.json>_ | osc create -f -`
-****
+----
+$ osc process -f <filename.json> | osc create -f -
+----
 
 You can override any link:../dev_guide/templates.html#parameters[parameters]
-defined in the JSON file by adding the `-v` option and any desired parameters.
-Note that the usage of the parameters is not restricted to only environment
-variables. You can use the parameter reference in any text field inside the
-template items.
+defined in the JSON file by adding the `-v` option followed by a
+comma-separated list of _<name>_=_<value>_ pairs.
+A parameter reference may appear in any text field inside the template items.
 
 For example, you can override the *`ADMIN_USERNAME`* and *`MYSQL_DATABASE`*
 parameters to create a configuration with customized environment variables:
@@ -109,9 +108,10 @@ parameters to create a configuration with customized environment variables:
 .Generating a Configuration
 ====
 
+[options="nowrap"]
 ----
-$ osc process -f examples/sample-app/application-template-dockerbuild.json -v
-ADMIN_USERNAME=root,MYSQL_DATABASE=admin
+$ osc process -f examples/sample-app/application-template-dockerbuild.json \
+    -v ADMIN_USERNAME=root,MYSQL_DATABASE=admin
 ----
 
 ====
@@ -121,9 +121,11 @@ uploading the template by piping the process output to the `create` command:
 
 ====
 
+[options="nowrap"]
 ----
-$ osc process -f examples/sample-app/application-template-dockerbuild.json -v
-ADMIN_USERNAME=root,MYSQL_DATABASE=admin | osc create -f -
+$ osc process -f examples/sample-app/application-template-dockerbuild.json \
+    -v ADMIN_USERNAME=root,MYSQL_DATABASE=admin \
+    | osc create -f -
 ----
 
 ====
@@ -166,9 +168,9 @@ defined in the template here.
 You can edit a template that has already been uploaded to your project by using
 the following command:
 
-****
-$ `osc edit template _<template>_`
-****
+----
+$ osc edit template <template>
+----
 
 == Labels
 link:../architecture/core_objects/kubernetes_model.html#label[Labels]
@@ -178,18 +180,18 @@ the template.
 
 There is also the ability to add labels in the template from the command line.
 
-****
-`$ osc process -f _<filename>_ -l name=otherLabel`
-****
+----
+$ osc process -f <filename> -l name=otherLabel
+----
 
 == Parameters
 The list of parameters that you can override are listed in the `*parameters*`
 section of the template. You can list them with the CLI by using the following
 command and specifying the file to be used:
 
-****
-`$ osc process --parameters -f _<filename>_`
-****
+----
+$ osc process --parameters -f <filename>
+----
 
 The following shows the output when listing the parameters for one of the
 https://github.com/openshift/origin/tree/master/examples/sample-app[*_sample-app_*]
@@ -198,13 +200,13 @@ templates:
 ====
 
 ----
-$ osc process --parameters -f
-examples/sample-app/application-template-dockerbuild.json NAME
+$ osc process --parameters -f examples/sample-app/application-template-dockerbuild.json NAME
 DESCRIPTION              GENERATOR           VALUE ADMIN_USERNAME
 administrator username   expression          admin[A-Z0-9]{3} ADMIN_PASSWORD
 administrator password   expression          [a-zA-Z0-9]{8} MYSQL_ROOT_PASSWORD
 database password        expression          [a-zA-Z0-9]{8} MYSQL_DATABASE
-database name                                root ----
+database name                                root
+----
 
 ====
 


### PR DESCRIPTION
- describe ‘osc process -v’ arg using replaceables
- simplify description of valid parameter reference context
- add eol backslash for multiline command lines

@mfojtik WDYT?
