### PR TITLE
Added CLI command for stopping a deployment

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -355,3 +355,25 @@ To perform the rollback manually by piping the *JSON* of the new configuration b
 $ osc rollback deployment-1 --output=json | osc update deploymentConfigs deployment -f -
 ----
 ====
+
+*Canceling a Deployment*
+
+Cancelation can be very useful. You might want to cancel a deployment if:
+
+* A deployment was initiated incorrectly, and you want to cancel it before it can do further damage.
+* There is a security fix you need to apply, and you do not want to wait for an ongoing deployment to complete.
+* A deployment or hook implementation is stuck after running for too long, and you cannot initiate a deployment when there is a deployment already running. 
+
+[NOTE]
+====
+By default, the deployment process is restricted to 6 hours. If a deployment is still in progress after 6 hours, then the containers for the deployment pod and any deployment hook pods are all deleted, and these pods are placed in the Failed state. 
+====
+
+Cancel a running or stuck deployment with the following command:
+
+----
+$ osc deploy <config_name> --cancel
+----
+
+After running this command, the deployment eventually shuts down and transitions to a Failed status.
+


### PR DESCRIPTION
Docs trello card: https://trello.com/c/uh3DegFd
Dev trello card: https://trello.com/c/QLdFlyA4

Waiting on dev work to complete but getting a jumpstart on documenting this option to stop a deployment.

@ironcladlou -- I know you're still working on this but I thought I'd get going. Take a look and let me know if I'm missing anything. Can you maybe give me a use case or two for WHY a user would want to stop a deployment?
