### PR TITLE
Removed --node-selector for osc new-project

### DIFF
--- a/dev_guide/projects.adoc
+++ b/dev_guide/projects.adoc
@@ -19,7 +19,7 @@ Each project may have its own:
 [horizontal]
 Resources:: pods, services, replication controllers
 Policies:: who can or cannot perform an action
-Constraints:: quota for the project, limit pods in a project to a pool of nodes
+Constraints:: quota for the project
 
 == Creating a Project [[create-a-project]]
 
@@ -27,7 +27,7 @@ To create a new project:
 
 [options="nowrap"]
 ----
-$ osc new-project <project_name> --description="<description>" --display-name="<display_name>" --node-selector="<label>"
+$ osc new-project <project_name> --description="<description>" --display-name="<display_name>"
 ----
 
 For example:
@@ -36,7 +36,7 @@ For example:
 
 [options="nowrap"]
 ----
-$ osc new-project hello-openshift --description="This is an example project to demonstrate OpenShift v3" --display-name="Hello OpenShift" --node-selector="environment=dev"
+$ osc new-project hello-openshift --description="This is an example project to demonstrate OpenShift v3" --display-name="Hello OpenShift"
 ----
 ====
 


### PR DESCRIPTION
--node-selector is only available with osadm new-project.
