### PR TITLE
Master config param, podEvictionTimeout: "<time.Duration>"

### DIFF
--- a/admin_guide/master_node_configuration.adoc
+++ b/admin_guide/master_node_configuration.adoc
@@ -168,6 +168,7 @@ kubeletClientInfo:
 kubernetesMasterConfig:
   masterCount: 1
   masterIP: 10.0.2.15
+  podEvictionTimeout: 5m
   schedulerConfigFile: ""
   servicesSubnet: 172.30.0.0/16
   staticNodeNames: []


### PR DESCRIPTION
PodEvictionTimeout controls grace peroid for deleting pods on failed nodes.
Takes time duration string (e.g. '300ms' or '2m30s').
Valid time units are 'ns', 'us', 'ms', 's', 'm', 'h'.
