### PR TITLE
fix up docs for prune operations

### DIFF
--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -16,23 +16,23 @@ from the server that accumulate over periods of use, but are no longer needed.
 == Prune Operations
 The CLI groups prune operations under a common parent command.
 
-****
-`$ oadm prune _<object_type>_ _<options>_`
-****
+----
+$ oadm prune <resource_type> <options>
+----
 
 This specifies:
 
-- The `_<object_type>_` to perform the action on, such as `builds`, `deployments`, or `images`.
-- The `_<options>_` supported to prune that resource type.
+- The `<resource_type>` to perform the action on, such as `builds`, `deployments`, or `images`.
+- The `<options>` supported to prune that resource type.
 
 *Deployments*
 
 In order to prune deployments that are no longer required by the system due to age and status, administrators
 may run the following command:
 
-****
-`$ oadm prune deployments [_<options>_]`
-****
+----
+$ oadm prune deployments [<options>]
+----
 
 .Prune Deployments CLI Configuration Options
 [cols="4,8",options="header"]
@@ -41,47 +41,43 @@ may run the following command:
 |Option |Description
 
 .^|`--confirm`
-|Indicate that pruning should occur, instead of performing a dry-run. (default=false)
+|Indicate that pruning should occur, instead of performing a dry-run.
 
 .^|`--orphans`
-|Prune all deployments whose deployment config no longer exists, status is complete or failed, and replica count is zero. (default=false)
+|Prune all deployments whose deployment config no longer exists, status is complete or failed, and replica count is zero.
 
-.^|`--keep-complete`
-|Per deployment config, keep the last N deployments whose status is complete and replica count is zero. (default=5)
+.^|`--keep-complete=<N>`
+|Per deployment config, keep the last N deployments whose status is complete and replica count is zero. (default `5`)
 
-.^|`--keep-failed`
-|Per deployment config, keep the last N deployments whose status is failed and replica count is zero. (default=1)
+.^|`--keep-failed=<N>`
+|Per deployment config, keep the last N deployments whose status is failed and replica count is zero. (default `1`)
 
-.^|`--keep-younger-than`
-|Do not prune any object that is younger than the specified value relative to the current time. (default=60m)
+.^|`--keep-younger-than=<duration>`
+|Do not prune any resource that is younger than `<duration>` relative to the current time. (default `60m`)
 |===
 
-To perform a prune operation:
-
-====
+To see what a pruning operation would delete:
 
 ----
-$ oadm prune deployments --confirm --orphans=true --keep-complete=5 --keep-failed=1 --keep-younger-than=60m
+$ oadm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
+    --keep-younger-than=60m
 ----
-====
 
-To see what the prune will delete, without actually running the operation:
-
-====
+To actually perform the prune operation:
 
 ----
-$ $ oadm prune deployments --orphans=true --keep-complete=5 --keep-failed=1 --keep-younger-than=60m
+$ oadm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
+    --keep-younger-than=60m --confirm
 ----
-====
 
 *Builds*
 
 In order to prune builds that are no longer required by the system due to age and status, administrators
 may run the following command:
 
-****
-`$ oadm prune builds [_<options>_]`
-****
+----
+$ oadm prune builds [<options>]
+----
 
 .Prune Builds CLI Configuration Options
 [cols="4,8",options="header"]
@@ -90,36 +86,33 @@ may run the following command:
 |Option |Description
 
 .^|`--confirm`
-|Indicate that pruning should occur, instead of performing a dry-run. (default=false)
+|Indicate that pruning should occur, instead of performing a dry-run.
 
 .^|`--orphans`
-|Prune all builds whose build config no longer exists, status is complete, failed, error, or canceled. (default=false)
+|Prune all builds whose build config no longer exists, status is complete, failed, error, or canceled.
 
-.^|`--keep-complete`
-|Per build config, keep the last N builds whose status is complete. (default=5)
+.^|`--keep-complete=<N>`
+|Per build config, keep the last N builds whose status is complete. (default `5`)
 
-.^|`--keep-failed`
-|Per build config, keep the last N builds whose status is failed, error, or canceled (default=1)
+.^|`--keep-failed=<N>`
+|Per build config, keep the last N builds whose status is failed, error, or canceled (default `1`)
 
-.^|`--keep-younger-than`
-|Do not prune any object that is younger than the specified value relative to the current time. (default=60m)
+.^|`--keep-younger-than=<duration>`
+|Do not prune any resource that is younger than `<duration>` relative to the current time. (default `60m`)
 |===
 
-To perform a prune operation:
-
-====
+To see what a pruning operation would delete:
 
 ----
-$ oadm prune builds --confirm --orphans=true --keep-complete=5 --keep-failed=1 --keep-younger-than=60m
+$ oadm prune builds --orphans --keep-complete=5 --keep-failed=1 \
+    --keep-younger-than=60m
 ----
-====
 
-To see what the prune will delete, without actually running the operation:
-
-====
+To actually perform the prune operation:
 
 ----
-$ $ oadm prune builds --orphans=true --keep-complete=5 --keep-failed=1 --keep-younger-than=60m
+$ oadm prune builds --orphans --keep-complete=5 --keep-failed=1 \
+    --keep-younger-than=60m --confirm
 ----
 ====
 
@@ -128,9 +121,9 @@ $ $ oadm prune builds --orphans=true --keep-complete=5 --keep-failed=1 --keep-yo
 In order to prune images that are no longer required by the system due to age and status, administrators
 may run the following command:
 
-****
-`$ oadm prune images [_<options>_]`
-****
+----
+$ oadm prune images [<options>]
+----
 
 .Prune Images CLI Configuration Options
 [cols="4,8",options="header"]
@@ -142,13 +135,13 @@ may run the following command:
 |The path to a certificate authority file to use when communicating with the OpenShift-managed registries. Defaults to the certificate authority data from the current user's config file.
 
 .^|`--confirm`
-|Indicate that pruning should occur, instead of performing a dry-run. (default=false)
+|Indicate that pruning should occur, instead of performing a dry-run.
 
-.^|`--keep-tag-revisions`
-|For each image stream, keep up to at most the specified number of image revisions per tag. (default=60m)
+.^|`--keep-tag-revisions=<N>`
+|For each image stream, keep up to at most N image revisions per tag. (default `60m`)
 
-.^|`--keep-younger-than`
-|Do not prune any image that is younger than the specified value relative to the current time. Do not prune any image that is referenced by any other object that is younger than the specified value relative to the current time. (default=60m)
+.^|`--keep-younger-than=<duration>`
+|Do not prune any image that is younger than `<duration>` relative to the current time. Do not prune any image that is referenced by any other object that is younger than `<duration>` relative to the current time. (default `60m`)
 |===
 
 OpenShift uses the following logic to determine which images and layers to prune:
@@ -173,20 +166,14 @@ When an image is pruned, all references to the image are removed from all ImageS
 
 Image layers that are no longer referenced by any images are removed as well.
 
-To perform a prune operation:
-
-====
+To see what a pruning operation would delete:
 
 ----
-$ oadm prune images --confirm --keep-tag-revisions=3 --keep-younger-than=60m
+$ oadm prune images --keep-tag-revisions=3 --keep-younger-than=60m
 ----
-====
 
-To see what the prune will delete, without actually running the operation:
-
-====
+To actually perform the prune operation:
 
 ----
-$ $ oadm prune builds --orphans=true --keep-complete=5 --keep-failed=1 --keep-younger-than=60m
+$ oadm prune images --keep-tag-revisions=3 --keep-younger-than=60m --confirm
 ----
-====


### PR DESCRIPTION
- remove extraneous markup
- fix up "would do / actually do" example pairs
- wrap long command lines
- change ***\* blocks to ---- blocks
- don't say "object" or "object type"; instead, say "resource" and "resource type"
- reprhase default=FOO as default `FOO`; remove (default `false`); add <N> et al

@derekwaynecarr 
