### PR TITLE
fix up "build log level" docs

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -53,8 +53,8 @@ To allow access to build logs, use the following command:
 *STI Build Logs*
 
 link:../architecture/core_objects/builds.html#sti-build[STI builds] by default
-show full output of the `assemble` script and all the errors that happen in the
-mean time. To enable more verbose output, you can pass the `*BUILD_LOGLEVEL*`
+show full output of the *_assemble_* script and all subsequent errors.
+To enable more verbose output, you can pass the `*BUILD_LOGLEVEL*`
 environment variable as part of the `*stiStrategy*` in BuildConfig:
 
 ====
@@ -76,20 +76,17 @@ environment variable as part of the `*stiStrategy*` in BuildConfig:
 <1> Adjust this value to the desired log level.
 ====
 
-NOTE: A platform administrator can increase verbosity for the entire OpenShift
-instance by passing the `--loglevel` flag to the `openshift start` command. The
-STI builder inherits the value of that flag, which increases verbosity for all
-STI build logs.
+NOTE: A platform administrator can set verbosity for the entire OpenShift
+instance by passing the `--loglevel` option to the `openshift start` command.
+If both `--loglevel` and `BUILD_LOGLEVEL` are specified, `BUILD_LOGLEVEL` takes precedence.
 
 Available log levels for STI are as follows:
 
 [horizontal]
-Level 0:: Produces output from containers running the *_assemble_* script and
-all encountered errors. (Default)
-Level 1:: Produces basic information about the executed process
-Level 2:: Produces very detailed information about the executed process
-Level 3:: Produces very detailed information about the executed process, along
-with listing *tar* contents.
+Level 0:: Produces output from containers running the *_assemble_* script and all encountered errors.  This is the default.
+Level 1:: Produces basic information about the executed process.
+Level 2:: Produces very detailed information about the executed process.
+Level 3:: Produces very detailed information about the executed process, and a listing of the archive contents.
 
 == Source Code
 The source code location is one of the required parameters for the


### PR DESCRIPTION
- use consistent markup for the ‘assemble’ script
- reword to prefer "subsequent"
- call ‘--loglevel’ "option", not "flag"
- don't say "increase" verbosity; say "set" instead
- drop "inherit" impl detail
- mention that for ‘BUILD_CONFIG’ vs ‘--loglevel’, ‘BUILD_CONFIG’ wins
- rework level table

@bparees Could you please review?
