### PR TITLE
fine-tune docs on resource limits in deployment strategy

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -190,32 +190,29 @@ responsibility of the strategy is to make the new deployment live using the
 logic that best serves the needs of the user.
 
 === Deployment resources
-A deployment is completed by a pod that consumes resources on a node.
+A deployment is completed by a pod that consumes *resources* (memory and cpu) on a node.
+By default, pods consume unbounded node resources.
+However, if a project specifies default container limits, then pods consume resources up to those limits.
+Another way to limit resource use is to specify resource limits as part of the deployment strategy.
+In the following example, each of `resources`, `cpu`, and `memory` is optional.
 
-In order to control the amount of memory or cpu used during a deployment,
-you can specify resource limits as part of your deployment strategy.
-
-If resources are not specified as part of the deployment, the pods that are
-created during the deployment procedure will consume project default resource
-limits, or used unbounded node resources.
 ====
 
 [source,json]
 ----
 {
   "type": "Recreate",
-  "resources": { <1>
+  "resources": {
     "limits": {
-      "cpu": "100m", <2> 
-      "memory": "256Mi" <3>
+      "cpu": "100m", <1>
+      "memory": "256Mi" <2>
     }
   },
 }
 ----
 
-<1> `*resources*` are optional.
-<2> `*cpu*` is optional, specifies amount of cpu the deployer pod should consume
-<3> `*memory*` is optional, specifies amount of memory the deployer pod should consume
+<1> `*cpu*` is in cpu units; `100m` represents 0.1 cpu units (`100 * 1e-3`)
+<2> `*memory*` is in bytes; `256Mi` represents 268435456 bytes (`256 * 2 ^ 20`)
 ====
 
 == Lifecycle Hooks


### PR DESCRIPTION
- intro blurb
  - invert presentation order: go from less constrained to more constrained
  - factor "optional" blurbs from example call-outs to here
- example
  - don't bother w/ "resources is optional"; renumber accordingly
  - rewrite call-out text to describe example

@derekwaynecarr 
I have a doubt about the interpretation of "100m".  That is based on reading https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/resources.md
only; i don't know how thin a layer OpenShift adds in terms of units and suffix processing.
Could you please scrutinize that portion in particular?

@adellape @CowboysFan 
Relatedly, if OpenShift adds anything, we should probably document that somewhere (am i missing something?); if it adds nothing, we should consider pointing to upstream.
