### PR TITLE
Fixed webhook URLs

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -263,7 +263,7 @@ https://developer.github.com/webhooks/[GitHub webhooks] or generic webhooks.
 
 https://developer.github.com/webhooks/creating/[GitHub webhooks] can handle the
 call made by GitHub when a repository is updated. When defining the trigger, you
-can specify a *secret* as part of the URL you supply to GitHub when
+must specify a *secret* as part of the URL you supply to GitHub when
 configuring the webhook. The *secret* ensures that only you and your
 repository can trigger the build. The following example is a trigger definition
 JSON within the `*BuildConfig*`:
@@ -284,13 +284,13 @@ The payload URL is returned as the GitHub Webhook URL by the `describe` command
 (see link:#describe-buildconfig[below]), and is structured as follows:
 
 ****
-`http://_<openshift_api_host:port>_/osapi/v1beta1/buildConfigHooks/_<build-name>_/_<secret>_/github?namespace=_<namespace>_`
+`http://_<openshift_api_host:port>_/osapi/v1/namespaces/_<namespace>_/buildconfigs/_<name>_/webhooks/_<secret>_/github`
 ****
 
 *Generic Webhooks*
 
 Generic webhooks can be invoked from any system capable of making a web
-request. As with a GitHub webhook, you specify a *secret* when defining the
+request. As with a GitHub webhook, you must specify a *secret* when defining the
 trigger, and the caller must provide this *secret* to trigger the build. The
 following is an example trigger definition JSON within the `*BuildConfig*`:
 
@@ -310,7 +310,7 @@ To set up the caller, supply the calling system with the URL of the generic
 webhook endpoint for your build:
 
 ****
-`http://_<openshift_api_host:port>_/osapi/v1beta1/buildConfigHooks/_<build-name>_/_<secret>_/generic?namespace=_<namespace>_`
+`http://_<openshift_api_host:port>_/osapi/v1/namespaces/_<namespace>_/buildconfigs/_<name>_/webhooks/_<secret>_/generic`
 ****
 
 The endpoint can accept an optional payload with the following format:


### PR DESCRIPTION
I've noticed we're using old webhooks URL, updated with this PR.
