### PR TITLE
Executing scl enable <collection> is now not required

### DIFF
--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -64,11 +64,11 @@ MySQL daemon starts.
 
 OpenShift uses https://www.softwarecollections.org/[Software Collections] to
 install and launch MySQL. If you want to execute a MySQL command inside of a
-running container (for debugging), you must prefix it with the `scl enable
-mysql55` command, for example:
+running container (for debugging), you must invoke it using bash, to make sure
+the MySQL collection is enabled, for example:
 
 ----
-$ docker exec -ti CONTAINER scl enable mysql55 -- mysql -h 127.0.0.1 -u <user> -p <password>
+$ docker exec -ti CONTAINER /bin/bash -c mysql
 ----
 
 To enter a container from the host:
@@ -78,11 +78,6 @@ $ docker exec -it <CONTAINER_ID> /bin/bash
 ----
 
 When you enter the container, the required software collection is automatically enabled.
-
-[NOTE]
-====
-In this case, you are able to run MySQL commands without invoking the scl commands.
-====
 
 === Environment variables
 


### PR DESCRIPTION
Since https://github.com/openshift/mysql/pull/46 one can use bash -c mysql
with running container, without explicitly enabeling a collection. Furthermore,
the unix socket is enabled and no hostname, user and password is not required.
