### PR TITLE
Executing scl enable <collection> is now not required

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -62,11 +62,11 @@ user, and the administrator user are not created, and the MongoDB daemon starts.
 
 OpenShift uses https://www.softwarecollections.org/[Software Collections] to
 install and launch MongoDB. If you want to execute a MongoDB command inside of a
-running container (for debugging), you must prefix it with the `scl enable
-mongodb24` command, for example:
+running container (for debugging), you must invoke it using bash, to make sure
+the MongoDB collection is enabled, for example:
 
 ----
-$ docker exec -ti CONTAINER scl enable mongodb24 -- mongo
+$ docker exec -ti CONTAINER /bin/bash -c mongo
 ----
 
 To enter a container from the host:
@@ -76,11 +76,6 @@ $ docker exec -it <CONTAINER_ID> /bin/bash
 ----
 
 When you enter the container, the required software collection is automatically enabled.
-
-[NOTE]
-====
-In this case, you are able to run MongoDB commands without invoking the scl commands.
-====
 
 === Environment Variables
 


### PR DESCRIPTION
Since https://github.com/openshift/mongodb/pull/38 one can use bash -c mongo
with running container, without explicitly enabeling a collection.

Related to #472. Sorry for not using a single PR.
