### PR TITLE
Updates to pod evacuation and overall node sections.

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -10,120 +10,130 @@
 toc::[]
 
 == Overview
-As an OpenShift administrator, you can manage
+You can manage
 link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node[nodes]
 in your instance using the link:../cli_reference/overview.html[CLI].
 
 When you perform node management operations, the CLI interacts with
-link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node[node
-objects] that are representations of nodes. The master uses the information from
-node objects to validate nodes with health checks.
+link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node-object-specification[node
+objects] that are representations of actual node hosts. The
+link:../architecture/infrastructure_components/kubernetes_infrastructure.html#master[master]
+uses the information from node objects to validate nodes with
+link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node[health
+checks].
 
 == Listing Nodes
-Use the following command to list all nodes that are known to your OpenShift
-instance:
+To list all nodes that are known to the master:
 
-****
-`$ oc get nodes`
-****
-
-.Listing All Nodes
 ====
-
+[options="nowrap"]
 ----
 $ oc get nodes
-NAME                 LABELS              STATUS
-node1.example.com    <none>              Ready
-node2.example.com    <none>              NotReady
+NAME                 LABELS                                        STATUS
+node1.example.com    kubernetes.io/hostname=node1.example.com      Ready
+node2.example.com    kubernetes.io/hostname=node2.example.com      Ready
 ----
 ====
 
-Use the following command to list information about a single node, replacing
-`_<node>_` with the full node name:
+To only list information about a single node, replace `_<node>_` with the full
+node name:
 
-****
-`$ oc get node _<node>_`
-****
+----
+$ oc get node <node>
+----
 
-The `STATUS` column in the output of these commands indicates whether the node
-is passing the health checks performed from the master. Nodes can be shown in
-this column with the following conditions:
+The `STATUS` column in the output of these commands can show nodes with the
+following conditions:
 
-.Node Conditions
+.Node Conditions [[node-conditions]]
 [cols="3a,8a",options="header"]
 |===
 
 |Condition |Description
 
 |`Ready`
-|The node has returned `StatusOK` for the health check.
+|The node is passing the health checks performed from the master by returning
+`StatusOK`.
 
 |`NotReady`
-|The health check is not passing.
+|The node is not passing the health checks performed from the master.
+
+|`SchedulingDisabled`
+|Pods cannot be link:#marking-nodes-as-unschedulable-or-schedulable[scheduled
+for placement] on the node.
+
 |===
 
 NOTE: The `STATUS` column can also show `Unknown` for a node if the CLI cannot
 find any node condition.
 
-Use the following command to get more detailed information about a node,
-including the reason for the current condition:
-****
-`$ oc describe node _<node>_`
-****
+To get more detailed information about a specific node, including the reason for
+the current condition:
 
-.Getting a Node Description
+----
+$ oc describe node <node>
+----
+
+For example:
+
 ====
-
 [options="nowrap"]
 ----
-$ oc describe node node2.example.com
-Name:	node2.example.com
+$ oc describe node node1.example.com
+Name:			node1.example.com
+Labels:			kubernetes.io/hostname=node1.example.com
+CreationTimestamp:	Wed, 10 Jun 2015 17:22:34 +0000
 Conditions:
-Kind    Status  LastProbeTime                   LastTransitionTime              Reason                                                              Message
-Ready   None    Tue, 03 Mar 2015 22:53:22 +0000 Tue, 03 Mar 2015 21:27:50 +0000 Node health check failed: kubelet /healthz endpoint returns not ok
+  Type		Status	LastHeartbeatTime			LastTransitionTime			Reason					Message
+  Ready 	True 	Wed, 10 Jun 2015 19:56:16 +0000 	Wed, 10 Jun 2015 17:22:34 +0000 	kubelet is posting ready status
+Addresses:	127.0.0.1
+Capacity:
+ memory:	1017552Ki
+ pods:		100
+ cpu:		2
+Version:
+ Kernel Version:		3.17.4-301.fc21.x86_64
+ OS Image:			Fedora 21 (Twenty One)
+ Container Runtime Version:	docker://1.6.0
+ Kubelet Version:		v0.17.1-804-g496be63
+ Kube-Proxy Version:		v0.17.1-804-g496be63
+ExternalID:			node1.example.com
+Pods:				(2 in total)
+  docker-registry-1-9yyw5
+  router-1-maytv
+No events.
 ----
 ====
 
-== Adding a Node
+== Adding Nodes
 You can add a node to an existing OpenShift instance using the `oc create`
-command and supplying a manifest for a node object. After the new node passes
-the health checks that are performed by the master,  pods can begin to be
+command and supplying a specification for a node object. After the newly-created
+node passes the health checks that are performed by the master, pods can be
 scheduled for the node.
 
 .To Add a Node to an Existing OpenShift Instance:
-. Create a file with the following JSON format:
+
+. Create a specification for the new node.
+.. If you have an existing node object created, you can export the existing
+object to use as a starting point for the new node's
+link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node-object-specification[specification]:
 +
-.*_node.json_* file
-====
-
 ----
-{
-  "id": "node3.example.com", <1>
-  "kind": "Node", <2>
-  "apiVersion": "v1beta1", <3>
-  "labels": { <4>
-    "name": "node3",
-  },
-}
+$ oc export node <node_name> > <filename>
 ----
-
-<1> Set the *`id`* parameter to the fully-qualified domain name where the node can be reached.
-This value will be shown in the `NAME` column when running the `oc get nodes`
-command.
-<2> Set the *`kind`* parameter to `Node` to identify this is a manifest for a node
-object.
-<3> Set the *`apiVersion`* parameter to the Kubernetes API version you are using.
-<4> Set any desired labels using the *`labels`* resource.
-====
-
-. Create a node object using the file you created:
 +
-====
+Modify the new file to meet the desired specification for your new node.
 
+.. If you do not have an existing node object, create a new file from scratch by
+following the
+link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node-object-specification[example
+specification].
+
+. Create the node object using the specification file you created:
++
 ----
-$ oc create -f node.json
+$ oc create -f <filename>
 ----
-====
 +
 At this point, the master begins validating the new node by performing health
 checks.
@@ -135,10 +145,10 @@ command:
 
 ----
 $ oc get nodes
-NAME                 LABELS              STATUS
-node1.example.com    <none>              Ready
-node2.example.com    <none>              Ready
-node3.example.com    <none>              Ready
+NAME                 LABELS                                        STATUS
+node1.example.com    kubernetes.io/hostname=node1.example.com      Ready
+node2.example.com    kubernetes.io/hostname=node2.example.com      Ready
+node3.example.com    kubernetes.io/hostname=node3.example.com      Ready
 ----
 ====
 +
@@ -146,76 +156,116 @@ Pods are not scheduled for the node until the node passes the health checks that
 are performed by the master. When the node passes these health checks, it is
 then placed in the `Ready` condition.
 
-== Deleting a Node
-Use the following command to delete a node:
-
-****
-`$ oc delete node _<node>_`
-****
-
-NOTE: When you delete a node with the CLI, although the node object is deleted
+== Deleting Nodes
+When you delete a node with the CLI, although the node object is deleted
 in Kubernetes, the pods that exist on the node itself are not deleted. However,
 the pods cannot be accessed by OpenShift. The behavior around deleting nodes and
 pods with the CLI is under active development.
 
-== Listing Pods on Nodes
-Use the following command to list all or selected pods on one or more nodes:
+To delete a node:
 
-****
-`$ oadm manage-node _<node1>_ _<node2>_ --list-pods [--pod-selector=_<pod_selector>_] [-o json|yaml]`
-****
+----
+$ oc delete node <node>
+----
+
+== Updating Labels on Nodes
+To add or update
+link:../architecture/core_objects/kubernetes_model.html#label[labels] on a node:
+
+----
+$ oc label node <node> <key_1>=<value_1> ... <key_n>=<value_n>
+----
+
+To see more detailed usage:
+
+----
+$ oc label -h
+----
+
+== Listing Pods on Nodes
+To list all or selected pods on one or more nodes:
+
+[options="nowrap"]
+----
+$ oadm manage-node <node1> <node2> \
+    --list-pods [--pod-selector=<pod_selector>] [-o json|yaml]
+----
 
 To list all or selected pods on selected nodes:
 
-****
-`$ oadm manage-node --selector=_<node_selector>_ --list-pods [--pod-selector=_<pod_selector>_] [-o json|yaml]`
-****
+----
+$ oadm manage-node --selector=<node_selector> \
+    --list-pods [--pod-selector=<pod_selector>] [-o json|yaml]
+----
 
 == Marking Nodes as Unschedulable or Schedulable
-Use the following command to mark the nodes as unschedulable:
+[[marking-nodes-as-unschedulable-or-schedulable]]
+By default, healthy nodes with a `Ready` link:#node-conditions[status] are
+marked as schedulable, meaning that new pods are allowed for placement on the
+node. Manually marking a node as unschedulable blocks any new pods from being
+scheduled on the node. Existing pods on the node are not affected.
 
-****
-`$ oadm manage-node _<node1>_ _<node2>_ --schedulabe=false`
-****
+To mark a node or nodes as unschedulable:
 
-Marking node as unschedulable will block any new pods to be scheduled on the
-node. Existing pods on the node will not get affected.
+----
+$ oadm manage-node <node1> <node2> --schedulable=false
+----
 
-Use the following command to mark the nodes as schedulable:
+For example:
 
-****
-`$ oadm manage-node _<node1>_ _<node2>_ --schedulabe` or
+====
+[options="nowrap"]
+----
+$ oadm manage-node node1.example.com --schedulable=false
+NAME                 LABELS                                        STATUS
+node1.example.com    kubernetes.io/hostname=node1.example.com      Ready,SchedulingDisabled
+----
+====
 
-`$ oadm manage-node _<node1>_ _<node2>_ --schedulabe=true`
-****
+To mark a currently unschedulable node or nodes as schedulable:
 
-Marking node as schedulable will allow any new pods to be scheduled on the
-node.
+----
+$ oadm manage-node <node1> <node2> --schedulable
+----
 
-Instead of specifying the nodes _<node1>_ _<node2>_, you can also use
---selector=_<node_selector>_ to mark selected nodes as schedulabe or
-unschedulable.
+Alternatively, instead of specifying specific node names (e.g., `_<node1>_
+_<node2>_`), you can use the `--selector=_<node_selector>_` option to mark
+selected nodes as schedulable or unschedulable.
 
 == Evacuating Pods on Nodes
-Use the following command to evacuate all or selected pods on one or more nodes:
+Evacuating pods allows you to migrate all or selected pods from a given node or
+nodes. Nodes must first be
+link:#marking-nodes-as-unschedulable-or-schedulable[marked unschedulable] to
+perform pod evacuation.
 
-****
-`$ oadm manage-node _<node1>_ _<node2>_ --evacuate [--pod-selector=_<pod_selector>_]`
-****
+Only pods backed by a
+link:../architecture/core_objects/kubernetes_model.html#replication-controller[replication
+controller] can be evacuated; the replication controllers create new pods on
+other nodes and remove the existing pods from the specified node(s). Bare pods,
+meaning those not backed by a replication controller, are unaffected by default.
 
-Nodes must be marked unschedulable to perform pod evacuation. Only pods backed
-by replication controller will be evacuated. Bare pods will not be touched.
-You can force deletion of bare pods by using --force option:
+To list pods that will be migrated without actually performing the evacuation,
+use the `--dry-run` option:
 
-****
-`$ oadm manage-node _<node1>_ _<node2>_ --evacuate --force [--pod-selector=_<pod_selector>_]`
-****
+----
+$ oadm manage-node <node1> <node2> \
+    --evacuate --dry-run [--pod-selector=<pod_selector>]
+----
 
-You can list pods that will be migrated by using --dry-run option:
+To actually evacuate all or selected pods on one or more nodes:
 
-****
-`$ oadm manage-node _<node1>_ _<node2>_ --evacuate --dry-run [--pod-selector=_<pod_selector>_]`
-****
+----
+$ oadm manage-node <node1> <node2> \
+    --evacuate [--pod-selector=<pod_selector>]
+----
 
-Instead of specifying the nodes _<node1>_ _<node2>_, you can also use
---selector=_<node_selector>_ to evacuate pods on selected nodes.
+You can force deletion of bare pods by using the `--force` option:
+
+----
+$ oadm manage-node <node1> <node2> \
+    --evacuate --force [--pod-selector=<pod_selector>]
+----
+
+Alternatively, instead of specifying specific node names (e.g., `_<node1>_
+_<node2>_`), you can use the `--selector=_<node_selector>_` option to evacuate
+pods on selected nodes.

--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -65,21 +65,22 @@ including Docker, a link:#kubelet[kubelet], and a link:#service-proxy[service
 proxy].
 
 Nodes are created from a cloud provider, or from physical or virtual systems.
-Kubernetes interacts with node objects that are a representation of those nodes.
-The master uses the information from node objects to validate nodes with health
-checks. A node is ignored until it passes the health checks, and the master
-continues checking nodes until they are valid.
+Kubernetes interacts with link:#node-object-specification[node objects] that are
+a representation of those nodes. The master uses the information from node
+objects to validate nodes with health checks. A node is ignored until it passes
+the health checks, and the master continues checking nodes until they are valid.
 
 See the
 https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/node.md#node-management[Kubernetes
 documentation] for more information on node management.
 
-As an OpenShift administrator, you can
-link:../../admin_guide/manage_nodes.html[manage nodes] in your instance using
-the CLI.
+Administrators can link:../../admin_guide/manage_nodes.html[manage nodes] in an
+OpenShift instance using the CLI. To define full configuration and security
+options when launching node servers, use
+link:../../admin_guide/master_node_configuration.html[dedicated node
+configuration files].
 
-[[kubelet]]
-*Kubelet*
+=== Kubelet [[kubelet]]
 
 The kubelet on each node updates the node as specified by a container manifest,
 which is a YAML file that describes a pod. The kubelet uses a set of manifests
@@ -97,9 +98,53 @@ kubelet:
 - The kubelet listening for HTTP and responding to a simple API to submit a new
  manifest.
 
-[[service-proxy]]
-*Service Proxy*
+=== Service Proxy [[service-proxy]]
 
 Each node also runs a simple network proxy that reflects the services defined in
 the API on that node. This allows the node to do simple TCP and UDP stream
 forwarding across a set of back ends.
+
+=== Node Object Specification
+
+The following is an example specification for a node object in Kubernetes:
+
+====
+
+[source,yaml]
+----
+apiVersion: v1 <1>
+kind: Node <2>
+metadata:
+  creationTimestamp: null
+  labels: <3>
+    kubernetes.io/hostname: node1.example.com
+  name: node1.example.com <4>
+spec:
+  externalID: node1.example.com <5>
+status:
+  nodeInfo:
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: ""
+    kubeletVersion: ""
+    machineID: ""
+    osImage: ""
+    systemUUID: ""
+----
+
+<1> *`apiVersion`* defines the API version to use.
+<2> *`kind`* set to `Node` identifies this as a specification for a node
+object.
+<3> *`metadata.labels`* lists any
+link:../core_objects/kubernetes_model.html#label[labels] that have been added to
+the node.
+<4> *`metadata.name`* is a required value that defines the name of the node
+object. This value is shown in the `NAME` column when running the `oc get nodes`
+command.
+<5> *`spec.externalID`* defines the fully-qualified domain name where the node
+can be reached. Defaults to the *`metadata.name`* value when empty.
+====
+
+See the link:../../rest_api/kubernetes_v1.html#v1-node[REST API Reference] for
+more details.


### PR DESCRIPTION
Docs card: https://trello.com/c/SB0nf6lX
Follow-up for https://github.com/openshift/openshift-docs/pull/386

@pravisankar PTAL for tech review. Pretty build for linking:

http://file.rdu.redhat.com/~adellape/061015/card602_managenodes/admin_guide/manage_nodes.html

http://file.rdu.redhat.com/~adellape/061015/card602_managenodes/architecture/infrastructure_components/kubernetes_infrastructure.html#node-object-specification
- Updated per v1 API, latest CLI output, and latest doc guidelines.
- In the "Managing Nodes" topic:
  - Updated the "Adding Nodes" section with some new info, but I think it's likely a stop-gap measure, as I would think for GA the installer could be re-used for adding a new node post-install.
  - Added a small "Updating Labels on Nodes" section.
- In the "Kubernetes Infrastructure" topic:
  - Added the "Node Object Specification" section which includes an example spec from a live node, linking to REST API guide for more details. The "Adding Nodes" procedure also links to this new section to see an example spec.
