### PR TITLE
Removed unnecessary save-artifacts link and fixed the naming of save-artifacts script

### DIFF
--- a/creating_images/sti.adoc
+++ b/creating_images/sti.adoc
@@ -86,7 +86,7 @@ or `io.s2i.destination` label applies only to sources and artifacts.
 and places them into appropriate directories inside the image. The workflow for
 this script is:
 
-. Restore build artifacts. If you want to support incremental builds, make sure to define link:#save-artifacts[*_save-artifacts_*] as well.
+. Restore build artifacts. If you want to support incremental builds, make sure to define *_save-artifacts_* as well.
 . Place the application source in the desired location.
 . Build the application artifacts.
 . Install the artifacts into locations appropriate for them to run.
@@ -95,9 +95,9 @@ this script is:
 (required)
 |The *_run_* script executes your application.
 
-|*_save-artifact_*
+|*_save-artifacts_*
 (optional)
-|The *_save-artifact_* script gathers all dependencies that can speed up the
+|The *_save-artifacts_* script gathers all dependencies that can speed up the
 build processes that follow. For example:
 
 - For Ruby, *gems* is installed by Bundler.


### PR DESCRIPTION
@bfallonf fixed the link, by removing it completely, it didn't make sense there. I've also noticed we name `save-artifacts` script improperly (missing 's' at the end) - fixed that as well.
