### PR TITLE
change default kubeconfig location

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -225,7 +225,7 @@ the first step. The following example runs three instances:
 +
 ====
 ----
-$ oadm router ha-router-us-west --replicas=3 --selector="ha-router=geo-us-west" --labels="ha-router=geo-us-west" --credentials="$OPENSHIFTCONFIG" --create
+$ oadm router ha-router-us-west --replicas=3 --selector="ha-router=geo-us-west" --labels="ha-router=geo-us-west" --credentials="$KUBECONFIG" --create
 ----
 ====
 +
@@ -242,7 +242,7 @@ run on one or more, or even all, of the labeled nodes.
 +
 ====
 ----
-$ oadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$OPENSHIFTCONFIG" --create
+$ oadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$KUBECONFIG" --create
 ----
 ====
 
@@ -288,7 +288,7 @@ instances:
 +
 ====
 ----
-$ oadm ipfailover ha-geo-cache --replicas=4 --selector="ha-cache=geo" --virtual-ips=10.245.2.101-104 --watch-port=9736 --credentials="$OPENSHIFTCONFIG" --create
+$ oadm ipfailover ha-geo-cache --replicas=4 --selector="ha-cache=geo" --virtual-ips=10.245.2.101-104 --watch-port=9736 --credentials="$KUBECONFIG" --create
 ----
 ====
 ////

--- a/architecture/core_objects/routing.adoc
+++ b/architecture/core_objects/routing.adoc
@@ -305,7 +305,7 @@ form acceptable by the underlying router implementation. In the case of HAProxy 
 PEM based certificate.
 
 ****
-`oadm router --credentials="$OPENSHIFTCONFIG" --default-cert=/full/path/to/certificate.pem`
+`oadm router --credentials="$KUBECONFIG" --default-cert=/full/path/to/certificate.pem`
 ****
 
 For HAProxy, if a default certificate is provided, it will load it first. The certificate that
@@ -379,7 +379,7 @@ $ `oadm router -o json`
 Create a router if it does not exist:
 
 ****
-$ `oadm router router-west --replicas=2 --credentials="$OPENSHIFTCONFIG"`
+$ `oadm router router-west --replicas=2 --credentials="$KUBECONFIG"`
 ****
 
 Use a different router image and see the router configuration:
@@ -539,14 +539,14 @@ It is worth noting here that we are running a lesser number of replicas for the 
 Additionally, it is worth mentioning here that the router uses the host network (and ports 80 and 443) and hence we are running a lesser number of replicas to ensure a higher service level availability (SLA). If there are no constraints on the service being setup for failover, we could just as well target the service to run on one or more or even all of the labeled nodes.
 
 ****
-`$ oadm router ha-router-us-west --replicas=3 --labels="ha-router=geo-us-west" --credentials="$OPENSHIFTCONFIG" --create`
+`$ oadm router ha-router-us-west --replicas=3 --labels="ha-router=geo-us-west" --credentials="$KUBECONFIG" --create`
 ****
 
 === Step 3: Configure IP failover for the service (router)
 The final step is to configure the virtual IPs and failover for the nodes labeled in step 1 (with "ha-router=geo-us-west"). Ensure the number of replicas matches the number of nodes that satisfy the constraint or label we used in step 1. Specify the virtual IP address and the port that the IP failover should monitor (port 80 for the router) on those instances.
 
 ****
-`$ oadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$OPENSHIFTCONFIG" --create`
+`$ oadm ipfailover ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$KUBECONFIG" --create`
 ****
 ////
 

--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -90,7 +90,7 @@ nicknames.
 As described in the previous section, the `oc login` command automatically
 creates and manages CLI configuration files. All information gathered by the
 command is stored in a configuration file located in
-*_~/.config/openshift/.config_*. The current CLI configuration can be viewed using the following command:
+*_~/.kube/config_*. The current CLI configuration can be viewed using the following command:
 
 .Viewing the CLI Configuration
 ====

--- a/cli_reference/manage_cli_profiles.adoc
+++ b/cli_reference/manage_cli_profiles.adoc
@@ -23,7 +23,7 @@ make managing CLI configuration easier by providing short-hand references to
 contexts, user credentials, and cluster details.
 
 After link:get_started_cli.html[logging in with the CLI] for the first time,
-OpenShift creates a *_${HOME}/.config/openshift/config_* file if one does not
+OpenShift creates a *_${HOME}/.kube/config_* file if one does not
 already exist. As more authentication and connection details are provided to the
 CLI, either automatically during an `oc login` operation or by
 link:#manually-configuring-cli-profiles[setting them explicitly], the updated
@@ -305,12 +305,12 @@ configuration follows these rules:
 following hierarchy and merge rules:
 - If the `--config` option is set, then only that file is loaded. The flag may
 only be set once and no merging takes place.
-- If `*$OPENSHIFTCONFIG*` environment variable is set, then it is used. The
+- If `*$KUBECONFIG*` environment variable is set, then it is used. The
 variable can be a list of paths, and if so the paths are merged together. When
 a value is modified, it is modified in the file that defines the stanza. When
 a value is created, it is created in the first file that exists. If no files
 in the chain exist, then it creates the last file in the list.
-- Otherwise, the *_${HOME}/.config/openshift/config_* file is used and no
+- Otherwise, the *_${HOME}/.kube/config_* file is used and no
 merging takes place.
 {empty} +
 {empty} +

--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -71,7 +71,7 @@ the appropriate CA bundle and client key and certificate to connect to
 OpenShift. Set the following environment variables:
 +
 ----
-# export OPENSHIFTCONFIG=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
+# export KUBECONFIG=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
 # export CURL_CA_BUNDLE=/var/lib/openshift/openshift.local.config/master/ca.crt
 ----
 +
@@ -143,7 +143,7 @@ the appropriate CA bundle and client key and certificate to connect to
 OpenShift. Set the following environment variables:
 +
 ----
-$ export OPENSHIFTCONFIG=`pwd`/openshift.local.config/master/admin.kubeconfig
+$ export KUBECONFIG=`pwd`/openshift.local.config/master/admin.kubeconfig
 $ export CURL_CA_BUNDLE=`pwd`/openshift.local.config/master/ca.crt
 $ sudo chmod +r `pwd`/openshift.local.config/master/admin.kubeconfig
 ----


### PR DESCRIPTION
Changes the kubeconfig location to match kubernetes.

Merge after https://github.com/openshift/origin/pull/3104
