### PR TITLE
Java image, made consistent with other images

### DIFF
--- a/using_images/sti_images/java.adoc
+++ b/using_images/sti_images/java.adoc
@@ -10,64 +10,92 @@
 toc::[]
 
 == Overview
-OpenShift provides https://github.com/openshift/source-to-image[S2I] enabled Java images for building and running Java applications.  These images can be used with the link:../../architecture/core_objects/builds.html#source-build[S2I build strategy].
-This image is intended for use with maven based java standalone projects (that are run via main class).
+OpenShift provides
+link:../../architecture/core_objects/builds.html#source-build[S2I] enabled
+Java images for building and running Java applications.
+ifdef::openshift-origin[]
+The https://github.com/fabric8io/java-main/tree/master/[Java S2I builder image]
+endif::openshift-origin[]
+ifdef::openshift-enterprise[]
+The Java S2I builder image
+endif::openshift-enterprise[]
+assembles your application source with any required dependencies to create a new
+image containing your Java application. This resulting image can be run either
+by OpenShift or by Docker. This image is intended for use with
+https://maven.apache.org[Maven]-based Java standalone projects (that are run via
+main class).
 
 == Versions
-The current version can be found at https://github.com/fabric8io/java-main/tree/master/ and support JDK 1.7 and Maven 3.2.x projects.
+The current version supports JDK 1.7 and Maven 3.2.x projects.
 
-To use this image, you can either access it directly from those registries or push it into your OpenShift docker registry.  In addition, it is recommended that you create an ImageStream that points to the image, either in your docker registry or at the external location.  Your OpenShift resources can then reference the ImageStream.  You can find example ImageStream definitions for all the provided OpenShift images https://github.com/openshift/origin/tree/master/examples/image-streams[here].
+== Images
 
-== Customizing the build
+To use this image, you can either access it directly from those
+link:../../architecture/infrastructure_components/image_registry.html[image registries],
+or push it into your
+link:../../admin_guide/docker_registry.html[OpenShift docker registry].
+Additionally, you can create an
+link:../../architecture/core_objects/openshift_model.html#imagestream[ImageStream]
+that points to the image, either in your docker registry or at the external
+location. Your OpenShift resources can then reference the ImageStream. You
+can find
+https://github.com/openshift/origin/tree/master/examples/image-streams[example]
+ImageStream definitions for all the provided OpenShift images.
 
-By default the image will build the project using maven with the following goals and options:
+== Configuration
 
-.maven default goals and options
+By default, the Java S2I builder image uses Maven to build the project with the
+following goals and options:
+
 ----
-    mvn package dependency:copy-dependencies -Popenshift -DskipTests -e
-----
-
-Which means that it will compile the project, copy all the transitive dependencies into the output directory, without running the tests.
-In addition if the project has a profile named 'openshift' it will be activated for the build.
-
-The user is able to override the default goals and options by specifying the following env vars.
-
-* [envvar]#MAVEN_ARGS# The arguments that are going to be passed to the mvn command.
-
-For example, to package and also run the tests:
-
-.sti build with custom maven arguments
-----
-    sti build -e "MAVEN_ARGS=clean test package" <git repo url> fabric8/java-main <target image name>
+$ mvn package dependency:copy-dependencies -Popenshift -DskipTests -e
 ----
 
-=== Working with multi-module projects
+Based on these defaults, the image compiles the project and copies all the
+transitive dependencies into the output directory without running tests.
+Additionally, if the project has a profile named `*openshift*`, then it is
+activated for the build.
 
-Often a java project is consisted of multiple maven modules. Even though it is the developers responsibility to configure maven accordingly, sometimes its still useful to be able to specify things like:
+You can override these default goals and options by specifying the following environment variables:
 
-* The output directory.
-* Which modules need to be build (explicitly).
+.Java Environment Variables
+[cols="4a,6a,6a",options="header"]
+|===
 
-The later can be done easily by setting the appropriate maven arguments:
+|Variable name |Description |Example
 
-.multi-module build, explicitly specifying module
+|`*MAVEN_ARGS*`
+|The arguments that are passed to the mvn command.
+|To package and also run tests:
 ----
-    sti build -e "MAVEN_ARGS=install -pl my.groupId:my.artifactId -am" <git repo url> fabric8/java-main <target image name>
-----
-
-The command above will tell maven to build the module with groupId 'my.groupId' and 'my.artifactId' along with all its module dependencies.
-
-In this case, we need to know in which directory the maven project will put the artifacts, so that the sti build can pick them up. The default output directory
-is considered 'target' dir inside the sources directory, but it can be overridden using the OUTPUT_DIR env var. For example:
-
-.multi-module build, explicitly specifying module and output directory
-----
-    sti build -e "OUTPUT_DIR=path/to/myartifact/target,MAVEN_ARGS=install -pl my.groupId:my.artifactId -am" <git repo url> fabric8/java-main <target image name>
+sti build -e "MAVEN_ARGS=clean test package" <git_repo_URL> fabric8/java-main <target_image_name>
 ----
 
-=== Specifying the main class
+|`*JAVA_MAIN*`
+|Specifies the main class of the project. This can also be accomplished from within the *_.sti/environment_* file as a Maven property inside the project (*docker.env.Main*).
+|
 
-There are couple of options available for configuring the main class of the project:
+|===
 
-* [envvar]#JAVA_MAIN# as an env var passed to the sti or inside `.sti/environment`
-* #docker.env.Main# as a maven property inside the project.
+=== Working with Multi-module Projects
+
+If a Java project consists of multiple Maven modules, it can be useful to
+explicitly specify the output directory, or which modules to build.
+
+To specify which modules to build in a multi-module project, along with all
+their module dependencies:
+
+----
+sti build -e "MAVEN_ARGS=install -pl <my.groupId>:<my.artifactId> -am" <git_repo_URL> fabric8/java-main <target_image_name>
+----
+
+Specifying the directory where the Maven project outputs the artifacts helps the
+S2I build to pick them up. If unspecified, the default is the
+*_sources/target/_* directory.
+
+To specify the output directory and which modules to build in a multi-module
+project:
+
+----
+sti build -e "OUTPUT_DIR=<path/to/myartifact/target>,MAVEN_ARGS=install -pl <my.groupId>:<my.artifactId> -am" <git_repo_URL> fabric8/java-main <target_image_name>
+----


### PR DESCRIPTION
Docs Trello card: https://trello.com/c/LnGCcW7G
Original Dev PR: https://github.com/openshift/openshift-docs/pull/401

ping @iocanel for tech review. I have questions: 
1. OK so it doesn't look like there's a CentOS-7-based Java image available on DockerHub like there is for all the other images (See https://registry.hub.docker.com/repos/openshift/ ). 

Is there a RHEL 7 image available through Red Hat's subscription?
1. For maven default goals and options, should "-Popenshift" and "-DskipTests" be "-P openshift" and "-D skipTests"?
2. Should OUTPUT_DIR be added to the table of environment variables here?
