### PR TITLE
Edits to first_steps & dev_guide quickstart section.

### DIFF
--- a/admin_guide/install/first_steps.adoc
+++ b/admin_guide/install/first_steps.adoc
@@ -6,73 +6,177 @@
 :experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
 
 toc::[]
 
 == Overview
-These steps will help you populate your OpenShift deployment with a useful set of `ImageStreams` and `Templates` that will make it easy for developers to create new applications.  The instructions will create these objects in the `openshift` project which is a default project to which all users have view access.
+You can populate your OpenShift installation with a useful set of Red
+Hat-provided
+link:../../architecture/core_objects/openshift_model.html#imagestream[image
+streams] and link:../../dev_guide/templates.html[templates] to make it easy for
+developers to create new applications. Using the following instructions, these
+objects are created in the *openshift* project, which is a default project to
+which all users have view access.
 
 == Prerequisites
-* You have deployed the OpenShift Docker registry service
-* You are able to run client commands with cluster-admin authority
-* You have cluster-admin privileges.  You will need to run all of these commands as cluster-admin because they operate on the `openshift` project.
+- The link:../docker_registry.html[integrated docker
+registry] service must be deployed in your OpenShift installation.
+- You must be able to run the following CLI commands with
+link:../../architecture/additional_concepts/authorization.html#roles[*cluster-admin*
+privileges], because they operate on the default *openshift*
+link:../../architecture/core_objects/openshift_model.html#project[project].
 
-== Create ImageStreams for OpenShift Images
-The core set of image streams provide images that can be used to build NodeJS, Perl, PHP, Python, and Ruby applications.  It also defines images for MongoDB, MySQL,and PostgreSQL to support data storage.
+== Creating Image Streams for OpenShift Images
+The core set of image streams provide images that can be used to build
+link:../../using_images/sti_images/nodejs.html[*Node.js*],
+link:../../using_images/sti_images/perl.html[*Perl*],
+link:../../using_images/sti_images/php.html[*PHP*],
+link:../../using_images/sti_images/python.html[*Python*], and
+link:../../using_images/sti_images/ruby.html[*Ruby*] applications. It also
+defines images for link:../../using_images/db_images/mongodb.html[*MongoDB*],
+link:../../using_images/db_images/mysql.html[*MySQL*], and
+link:../../using_images/db_images/postgresql.html[*PostgreSQL*] to support data
+storage.
 
-To create the core set of image streams, run:
+To create the core set of image streams, which use CentOS 7 based images:
 
-    $ oc create -f examples/image-streams/image-streams-centos7.json -n openshift
+----
+$ oc create -f \
+    examples/image-streams/image-streams-centos7.json \
+    -n openshift
+----
 
-*Note:* if you are setting up a subscribed system and prefer to use the RHEL7 based images,  run this command instead:
-    
-    $ oc create -f examples/image-streams/image-streams-rhel7.json -n openshift
+Alternatively, if you are using node hosts that are subscribed using Red Hat
+Subscription Management and prefer to use the Red Hat Enterprise Linux (RHEL) 7
+based images:
 
-It is not possible to create both sets of ImageStreams because they use the same name.  If you desire to have both sets of ImageStreams available to users, either create one set in a different Project, or edit one of the files and modify the ImageStream names to make them unique.
+----
+$ oc create -f \
+    examples/image-streams/image-streams-rhel7.json \
+    -n openshift
+----
 
-== Create ImageStreams for JBoss Middleware Images
-The JBoss Middleware image streams provide images for JBoss EAP, JBoss EWS, and JBoss AMQ.  They can be used to build applications for those platforms or run directly as is.
+It is not possible to create both the CentOS and RHEL sets of image streams
+because they use the same names. If you desire to have both sets of image
+streams available to users, either create one set in a different project, or
+edit one of the files and modify the image stream names to make them unique.
 
-    $ oc create -f examples/middleware-streams/jboss-image-streams.json
+ifdef::openshift-enterprise[]
+== Creating Image Streams for xPaaS Middleware Images
+The xPaaS Middleware image streams provide images for
+link:../../using_images/xpaas_images/eap.html[*JBoss EAP*],
+link:../../using_images/xpaas_images/jws.html[*JBoss EWS*], and
+link:../../using_images/xpaas_images/a_mq.html[*JBoss A-MQ*]. They can be used
+to build applications for those platforms or run directly as is.
 
-*Note:* Access to the images referenced by these imagestreams requires a subscription. 
+To create the xPaaS Middleware set of image streams:
 
-== Create Database Service Templates
-The database service templates make it easy to run a database image which can be utilized by other components.  For each database (MongoDB, MySQL, PostgreSQL), two templates are defined.  One uses ephemeral storage in the container which means data stored will be lost if the container is restarted such as because the Pod moves.  This template should be used for demonstration purposes only.  The other template defines a persistent volume for storage, however it requires your OpenShift deployment have persistent volumes configured.
+----
+$ oc create -f \
+    examples/xpaas-streams/jboss-image-streams.json
+    -n openshift
+----
 
-Once registered, users will be able to easily instantiate the various templates, giving them quick access to a database deployment.
+[NOTE]
+====
+Access to the images referenced by these image streams requires the relevant xPaaS Middleware subscriptions.
+====
+endif::[]
 
-To register the core set of database templates, run:
+== Creating Database Service Templates
+The database service templates make it easy to run a database image which can be
+utilized by other components. For each database
+(link:../../using_images/db_images/mongodb.html[*MongoDB*],
+link:../../using_images/db_images/mysql.html[*MySQL*], and
+link:../../using_images/db_images/postgresql.html[*PostgreSQL*]), two templates
+are defined.
 
-    $ oc create -f examples/db-templates -n openshift
+One template uses ephemeral storage in the container which means data stored
+will be lost if the container is restarted, for example if the pod moves. This
+template should be used for demonstration purposes only.
 
+The other template defines a persistent volume for storage, however it requires
+your OpenShift installation to have
+link:../persistent_storage_nfs.html[persistent volumes] configured.
 
-== Create QuickStart Templates
-The QuickStart templates define a full set of components for a running application.  These include:
+To create the core set of database templates:
 
-* BuildConfig to build the application from source located in a GitHub public repository
-* DeploymentConfig to deploy the application image once built
-* Service to provide load balancing for the application Pods
-* Route to provide external access to the application
+----
+$ oc create -f \
+    examples/db-templates -n openshift
+----
 
-Some of the templates also define a database deployment and service so the application can perform database operations.
+After creating the templates, users are able to easily instantiate the various
+templates, giving them quick access to a database deployment.
 
-Once registered, users will be able to easily instantiate full applications using the various language images provided with OpenShift.  They can also customize the template parameters during instantiation so that it builds source from their own repository rather than the sample repository, so this provides a simple starting point for building new applications.
+== Creating QuickStart Templates
+The QuickStart templates define a full set of objects for a running application.
+These include:
 
-To register the basic templates run:
+- link:../../dev_guide/builds.html[Build configurations] to build the
+application from source located in a GitHub public repository
+- link:../../dev_guide/deployments.html[Deployment configurations] to deploy the
+application image after it is built.
+- link:../../architecture/core_objects/kubernetes_model.html#service[Services]
+to provide load balancing for the application
+link:../../architecture/core_objects/kubernetes_model.html#pod[pods].
+- link:../../architecture/core_objects/openshift_model.html#route[Routes] to
+provide external access to the application.
 
-    $ oc create -n openshift -f examples/quickstart-templates
+Some of the templates also define a database deployment and service so the
+application can perform database operations.
 
-There is also a set of templates for creating applications using various JBoss products (EAP, EWS, AMQ) which can be registered by running: 
+After creating the templates, users are able to easily instantiate full
+applications using the various language images provided with OpenShift. They can
+also customize the template parameters during instantiation so that it builds
+source from their own repository rather than the sample repository, so this
+provides a simple starting point for building new applications.
 
-    $ oc create -n openshift -f examples/middleware-templates
+To create the core QuickStart templates:
 
-*Note:* the JBoss Templates require the JBoss ImageStreams which in turn require a valid subscription.
+----
+$ oc create -f \
+    examples/quickstart-templates -n openshift
+----
 
-== Next Steps
+ifdef::openshift-enterprise[]
+There is also a set of templates for creating applications using various xPaaS
+Middleware products (link:../../using_images/xpaas_images/eap.html[*JBoss EAP*],
+link:../../using_images/xpaas_images/jws.html[*JBoss EWS*], and
+link:../../using_images/xpaas_images/a_mq.html[*JBoss A-MQ*]), which can be
+registered by running:
 
-With these artifacts created, you can now log into the web console and follow the create from template flow.  You’ll be able to select any of the database or application templates to create a running database service or application in your project.  Note that some of the application templates define their own database services as well.
+----
+$ oc create -f \
+    examples/xpaas-templates -n openshift
+----
 
-The example applications are all built out of GitHub repositories which are referenced by the templates by default, as seen in the SOURCE_REPOSITORY_URL parameter value.  You can fork those repositories and provide your own SOURCE_REPOSITORY_URL parameter value when creating from the template to experiment with creating your own applications.
+[NOTE]
+====
+The xPaaS Middleware templates require the
+link:#creating-image-streams-for-xpaas-middleware-images[xPaaS Middleware image
+streams], which in turn require the relevant xPaaS Middleware subscriptions.
+====
+endif::[]
 
+== What's Next?
 
+With these artifacts created, developers can now
+link:../../dev_guide/authentication.html[log into the web console] and follow
+the flow for link:../../dev_guide/templates.html#using-the-web-console[creating
+from a template]. Any of the database or application templates can be selected
+to create a running database service or application in the current project. Note
+that some of the application templates define their own database services as
+well.
+
+The example applications are all built out of https://github.com[GitHub]
+repositories which are referenced in the templates by default, as seen in the
+`*SOURCE_REPOSITORY_URL*` parameter value. Those repositories can be forked, and
+the fork can be provided as the `*SOURCE_REPOSITORY_URL*` parameter value when
+creating from the templates. This allows developers to experiment with creating
+their own applications.
+
+You can direct your developers to the
+link:../../dev_guide/templates.html#using-the-quickstart-templates[Using the
+QuickStart Templates] section in the Developer Guide for these instructions.

--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -6,6 +6,7 @@
 :experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
 
 toc::[]
 
@@ -17,7 +18,7 @@ parameterized list that is used by OpenShift to create a list of resources,
 including services, pods, routes, buildconfigs, etc. A template also defines a
 set of labels to apply to every resource created by the template.
 
-.Sample Template JSON File:
+.Template Object Definition
 ====
 
 ----
@@ -198,22 +199,40 @@ https://github.com/openshift/origin/tree/master/examples/sample-app[*_sample-app
 templates:
 
 ====
-
 ----
-$ oc process --parameters -f examples/sample-app/application-template-dockerbuild.json NAME
-DESCRIPTION              GENERATOR           VALUE ADMIN_USERNAME
-administrator username   expression          admin[A-Z0-9]{3} ADMIN_PASSWORD
-administrator password   expression          [a-zA-Z0-9]{8} MYSQL_ROOT_PASSWORD
-database password        expression          [a-zA-Z0-9]{8} MYSQL_DATABASE
-database name                                root
+$ oc process --parameters -f \
+    examples/sample-app/application-template-dockerbuild.json
+NAME                DESCRIPTION              GENERATOR           VALUE
+ADMIN_USERNAME      administrator username   expression          admin[A-Z0-9]{3}
+ADMIN_PASSWORD      administrator password   expression          [a-zA-Z0-9]{8}
+MYSQL_USER          database username        expression          user[A-Z0-9]{3}
+MYSQL_PASSWORD      database password        expression          [a-zA-Z0-9]{8}
+MYSQL_DATABASE      database name                                root
 ----
-
 ====
 
 The output identifies several parameters that are generated with a regex
 expression generator when the template is processed.
 
 == Using the QuickStart Templates
-OpenShift provides a number of templates in the box to make it easy to quickly get started creating a new application for different languages.  Templates are provided for Rails(Ruby), Django(Python), NodeJS, CakePHP(PHP), and Dancer(Perl).  Your administrator should have registered these templates in the `openshift` project so you have access to them.  If not, direct him or her to the link:../admin_guide/install/first_steps.html[first steps] guide.
+OpenShift provides a number of default QuickStart templates to make it easy to
+quickly get started creating a new application for different languages.
+Templates are provided for Rails (Ruby), Django (Python), Node.js, CakePHP
+(PHP), and Dancer (Perl). Your cluster administrator should have created these
+templates in the default *openshift* project so you have access to them. If they
+are not available, direct your cluster administrator to the
+link:../admin_guide/install/first_steps.html[First Steps] topic.
 
-By default, the templates will build using a public source repository on GitHub that contains the necessary application code.  In order to be able to modify the source and build your own version of the application, you will need to fork the repository referenced by the template's default `SOURCE_REPOSITORY_URL` parameter.  You should then override the value of that parameter when creating from the template.  By doing this, the BuildConfig created by the template will now point to your fork of the application code and you can modify the code and rebuild the application at will.
+By default, the templates build using a public source repository on
+https://github.com[GitHub] that contains the necessary application code. In
+order to be able to modify the source and build your own version of the
+application, you must:
+
+. Fork the repository referenced by the template's default
+`*SOURCE_REPOSITORY_URL*` parameter.
+. Override the value of the `*SOURCE_REPOSITORY_URL*` parameter when creating
+from the template, specifying your fork instead of the default value.
+
+By doing this, the build configuration created by the template will now point to
+your fork of the application code, and you can modify the code and rebuild the
+application at will.


### PR DESCRIPTION
Follow-up edits to https://github.com/openshift/openshift-docs/pull/532.

Since the xPaaS topics under "Using Images" only appear in the Enterprise build, I conditionalized out the new xPaaS streams/templates sections from the Origin build. So right now they only appear in the Enterprise build. Let me know if they should definitely appear in both (though the Origin admin in that case would need xPaaS subscriptions, I take it).

Pretty build to see the Enterprise-only bits (and for easy linking):

http://file.rdu.redhat.com/~adellape/061815/enterprise/firststeps_edits/admin_guide/install/first_steps.html

Pretty build for Origin:

http://file.rdu.redhat.com/~adellape/061815/origin/firststeps_edits/admin_guide/install/first_steps.html

And pretty build for the QS Templates section in Dev Guide:

http://file.rdu.redhat.com/~adellape/061815/origin/firststeps_edits/dev_guide/templates.html#using-the-quickstart-templates

@bparees PTAL
