### PR TITLE
Conditionalize Java img doc for Origin only.

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -251,6 +251,7 @@ Topics:
         File: python
       - Name: Java
         File: java
+        Distros: openshift-origin
   - Name: Database Images
     Dir: db_images
     Topics:


### PR DESCRIPTION
Per @danmcp, the Java image is not shipping with OSE. Conditionalizing the Java image topic to only show up in the Origin build.

FYI @tpoitras @iocanel 
