### PR TITLE
Rearranged and edited basic cli ops info

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -10,9 +10,9 @@
 toc::[]
 
 == Overview
-This topic provides information on some general CLI operations and their syntax.
-You must link:get_started_cli.html[setup and login] with the CLI before you can
-perform these operations.
+This topic provides information on the CLI operations and their syntax. You must
+link:get_started_cli.html[setup and login] with the CLI before you can perform
+these operations.
 
 == Common Operations
 The CLI allows interaction with the various objects that are managed by
@@ -62,49 +62,106 @@ No events.
 ----
 ====
 
-The following table describes common `oc` operations and their general syntax:
+== Basic CLI Operations
+The following table describes basic `oc` operations and their general syntax:
 
-.Common CLI Operations
+[cols=".^2,.^5,8",options="header"]
+|===
+
+|Operation |Syntax |Description
+
+|`types`
+|`oc types`
+|Display an introduction to some core OpenShift concepts.
+
+|`login`
+|`oc login`
+|Log in to the OpenShift server.
+
+|`logout`
+|`oc logout`
+|End the current session.
+
+|`new-project`
+|`oc new-project _<project_name>_`
+|Create a new project.
+
+|`new-app`
+|`oc new-app .`
+|link:../dev_guide/new_app.html[Creates a new application] based on the source code in the current directory.
+
+|`status`
+|`oc status`
+|Show an overview of the current project.
+
+|`project`
+|`oc project _<project_name>_`
+|Switch to another project. Run without options to display the current project. To view all projects you have access to run `oc projects`.
+
+|===
+
+== Application Modification CLI Operations
+
 [cols=".^2,.^5,8",options="header"]
 |===
 
 |Operation |Syntax |Description
 
 |`get`
-|`oc get _<object_type>_ _<object_name_or_id>_`
-|Returns a list of objects for the specified link:#object-types[object type]. If
+|`oc get _<object_type>_ [_<object_name_or_id>_]`
+|Return a list of objects for the specified link:#object-types[object type]. If
 the optional `_<object_name_or_id>_` is included in the request, then the list
 of results is filtered by that value.
 
 |`describe`
 |`oc describe _<object_type>_ _<object_id>_`
-|Returns information about the specific object returned by the query; a specific
+|Returns information about the specific object returned by the query. A specific
 `_<object_name_or_id>_` must be provided. The actual information that is
 available varies as described in link:#object-types[object type].
 
-|`create`
-|`oc create -f _<file_or_directory_path>_`
-|Parses a configuration file and creates one or more OpenShift objects based on
-the file contents. The `-f` flag can be passed multiple times with different
-file or directory paths. When the flag is passed multiple times, `oc create`
-iterates through each one, creating the objects described in all of the
-indicated files. Any existing resources are ignored.
+.3+|`edit`
+|`oc edit _<object_type>_/_<object_type_name>_`
+|Edit the desired object type.
 
-|`scale`
-|`oc scale _<object_type>_ _<object_id>_ --replicas=_<#_of_replicas>_`
-|Sets the number of desired replicas for a
-link:../architecture/core_concepts/deployments.html#replication-controllers[replication
-controller] or a
-link:../architecture/core_concepts/deployments.html#deployments-and-deployment-configurations[deployment
-configuration] to `_<#_of_replicas>_`.
+|`OSC_EDITOR="_<text_editor>_" oc edit _<object_type>_/_<object_type_name>_`
+|Edit the desired object type with a specified text editor.
 
-|`update`
-|`oc update -f _<file_or_directory_path>_`
-|Attempts to modify an existing object based on the contents of the specified
-configuration file. The -f flag can be passed multiple times with different file
-or directory paths. When the flag is passed multiple times, `oc update`
-iterates through each one, updating the objects described in all of the
-indicated files.
+|`oc edit _<object_type>_/_<object_type_name>_ \ --output-version=_<object_type_version>_ -o _<object_type_format>_`
+|Edit the desired object in a specified format (eg: JSON).
+
+|`env`
+|`oc env _<object_type>_/_<object_type_name>_ _<EN_VAR>_=/_<VALUE>_`
+|Update the desired object type with a new environment variable
+
+|`volume`
+|`oc volume _<object_type>_/_<object_type_name>_ [--option]`
+|Modify a link:../dev_guide/volumes.html[volume].
+
+|`label`
+|`oc label _<object_type>_ _<object_name_or_id>_ _<label>_`
+|Update the labels on a object.
+
+|`expose`
+|`oc expose _<object_type>_ _<object_name_or_id>_`
+|Look up a service and expose it as a route. There is also the ability to
+expose a deployment configuration, replication controller, service, or pod as a
+new service on a specified port. If no labels are specified, the new object will
+re-use the labels from the object it exposes.
+
+.4+|`stop`
+|`oc stop -f _<file_path>_`
+|Gracefully shut down an object by ID or file name. Attempt to shut down and
+delete an object that supports graceful termination.
+
+|`oc stop _<object_type>_ _<object_name_or_id>_`
+|Gracefully shut down an object with the specified ID.
+
+|`oc stop _<object_type>_ -l _<label>_`
+|Gracefully shut down an object with the specified label.
+
+
+|`oc stop all -l _<label>_`
+|Gracefully shut down all objects with the specified label.
 
 |`delete`
 a|`oc delete -f _<file_path>_`
@@ -114,50 +171,153 @@ a|`oc delete -f _<file_path>_`
 `oc delete _<object_type>_ -l _<label>_`
 
 `oc delete all -l _<label>_`
-.^|Deletes the specified OpenShift object. An object configuration can also be
-passed in through STDIN. The `oc delete all -l _<label>_` operation deletes all
-objects matching the specified `_<label>_`, including the
+.^|Delete the specified object. An object configuration can also be passed in
+through STDIN. The `oc delete all -l _<label>_` operation deletes all objects
+matching the specified `_<label>_`, including the
 link:../architecture/core_concepts/deployments.html#replication-controllers[replication
 controller] so that pods are not re-created.
 
-|`expose`
-|`oc expose _<object_type>_ _<object_name_or_id>_`
-|Looks up a service and exposes it as a route. There is also the ability to
-expose a deployment configuration, replication controller, service, or pod as a
-new service on a specified port. If no labels are specified, the new object will
-re-use the labels from the object it exposes.
+|===
+
+== Build and Deployment CLI Operations
+One of the fundamental capabilities of OpenShift is the ability to build
+applications into a container from source. The following table describes the CLI
+operations for working with application builds:
+
+OpenShift provides CLI access to inspect and manipulate
+link:../dev_guide/deployments.html[deployment configurations] using standard
+`oc` resource operations, such as `get`, `create`, and `describe`.
+
+[cols=".^2,.^5,8",options="header"]
+|===
+
+|Operation |Syntax |Description
+
+.3+|`start-build`
+|`oc start-build _<buildConfig_name>_`
+|Manually start the build process with the specified build configuration file.
+
+|`oc start-build --from-build=_<build_name>_`
+|Manually start the build process by specifying the name of a previous build as a starting point.
+
+|`oc start-build _<buildConfig_name>_ --follow`
+
+`oc start-build --from-build=_<build_name>_ --follow`
+|Manually start the build process by specifying either a configuration file or the name of a previous build and retrieves its build logs.
+
+|`build-logs`
+|`oc build-logs _<build_name>_`
+|Retrieve the build logs for the specified build.
+
+|`deploy`
+|`oc deploy _<deploymentconfig>_`
+|View a link:../dev_guide/deployments.html[deployment], or manually start, cancel, or retry a deployment.
+
+|`rollback`
+|`oc rollback _<deployment_name>_`
+|Perform a link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback].
+
+|`new-build`
+|`oc new-build .`
+|Create a build config based on the source code in the current git repository
+(with a public remote) and a Docker image
+
+|`cancel-build`
+|`oc cancel-build _<build_name>_`
+|Stop a build that is in progress.
+
+|`import-image`
+|`oc import-image _<imagestream>_`
+|Import tag and image information from an external Docker image repository.
+
+|`scale`
+|`oc scale _<object_type>_ _<object_id>_ --replicas=_<#_of_replicas>_`
+|Set the number of desired replicas for a
+link:../architecture/core_concepts/deployments.html#replication-controllers[replication
+controller] or a link:../dev_guide/deployments.html[deployment configuration] to
+the number of specified replicas.
+
+|`tag`
+|`oc tag _<current_image>_ _<image_stream>_`
+|Take an existing tag or image from an image stream, or a Docker image pull
+spec, and set it as the most recent image for a tag in one or more other image
+streams.
+
+|===
+
+== Advanced Commands
+
+[cols=".^2,.^5,8",options="header"]
+|===
+
+|Operation |Syntax |Description
+
+|`create`
+|`oc create -f _<file_or_directory_path>_`
+|Parse a configuration file and create one or more OpenShift objects based on
+the file contents. The `-f` flag can be passed multiple times with different
+file or directory paths. When the flag is passed multiple times, `oc create`
+iterates through each one, creating the objects described in all of the
+indicated files. Any existing resources are ignored.
+
+|`update`
+|`oc update -f _<file_or_directory_path>_`
+|Attempt to modify an existing object based on the contents of the specified
+configuration file. The -f flag can be passed multiple times with different file
+or directory paths. When the flag is passed multiple times, `oc update`
+iterates through each one, updating the objects described in all of the
+indicated files.
+
+|`process`
+|`oc process -f _<template_file_path>_`
+|Transform a project link:../dev_guide/templates.html[template] into a project configuration file.
+
+|`export`
+|`oc export _<object_type>_ [--options]`
+|Export resources to be used elsewhere
+
+|`policy`
+|`oc policy [--options]`
+|Manage authorization policies
+
+|`secrets`
+|`oc secrets [--options] path/to/ssh_key`
+|Configure link:../dev_guide/secrets.html[secrets].
+
+|===
+
+== Troubleshooting and Debugging CLI Operations
+
+[cols=".^2,.^5,8",options="header"]
+|===
+
+|Operation |Syntax |Description
 
 
 |`logs`
 |`oc logs -f _<pod_name>_ _<container_name>_`
-|Retrieves the log output for a specific pod or container. This command does not
+|Retrieve the log output for a specific pod or container. This command does not
 work for other object types.
 
-|`label`
-|`oc label _<object_type>_ _<object_name_or_id>_ _<label>_`
-|Updates the labels on a object.
+|`exec`
+|`oc exec -p _<pod_ID>_ -c _<container_ID>_ -- _<command>_`
+|Execute a command in a already-running container.
 
-|`deploy`
-|`oc deploy` <deploymentconfig>
-|View a deployment, or manually start, cancel, or retry a deployment.
+|`port-forward`
+|`oc port-forward -p _<pod_ID>_ _<first_port_ID>_ _<second_port_ID>_`
+|link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a pod.
 
-|`stop`
-a|`oc stop -f _<file_path>_`
+|`proxy`
+|`oc proxy --port=_<port_ID>_ --www=_<static_directory>_`
+|Run a proxy to the Kubernetes API server
 
-`oc stop _<object_type>_ _<object_name_or_id>_`
-
-`oc stop _<object_type>_ -l _<label>_`
-
-`oc stop all -l _<label>_`
-.^|Gracefully shuts down an object by ID or file name. Attempts to shut down and
-delete an object that supports graceful termination.
 |===
+
 
 == Object Types
 The CLI supports the following object types, some of which have abbreviated
 syntax:
 
-.Supported Object Types
 [options="header"]
 |===
 
@@ -177,212 +337,3 @@ syntax:
 |`persistentVolume` |`pv`
 |`persistentVolumeClaim` |`pvc`
 |===
-
-== Project Operations
-These advanced operations for administrators are used to define and instantiate
-OpenShift objects at the project level.
-
-The simplest way to create a new project is:
-
-----
-$ oc new-project <project_name> --display-name=<display_name>
---description=<description> --admin=<admin_username>
---node-selector=<node_label_selector>
-----
-
-The following example creates a new project called `test` that appears in the
-web console as "OpenShift 3 Sample". `test-admin` is the project administrator
-and, when launched onto nodes, pods receive the matching label of `environment :
-test`:
-
-====
-----
-$ oc new-project test --display-name="OpenShift 3 Sample" --description="This
-is an example project to demonstrate OpenShift v3"
---admin=anypassword:test-admin --node-selector="environment=test"
-----
-====
-
-.Project CLI Operations
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-|`process`
-|`oc process -f _<template_file_path>_`
-|Transforms a project template into a project configuration file.
-
-|`apply`
-|`oc apply -f _<config_file_path>_`
-|Creates all of the OpenShift objects for a given project based on the specified configuration file.
-|===
-
-== Build Operations
-One of the fundamental capabilities of OpenShift is the ability to build
-applications into a container from source. The following table describes the CLI
-operations for working with application builds:
-
-.Build CLI Operations
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-.3+|`start-build`
-|`oc start-build _<buildConfig_name>_`
-|Manually starts the build process with the specified build configuration file.
-
-|`oc start-build --from-build=_<build_name>_`
-|Manually starts the build process by specifying the name of a previous build as a starting point.
-
-|`oc start-build _<buildConfig_name>_ --follow`
-
-`oc start-build --from-build=_<build_name>_ --follow`
-|Manually starts the build process by specifying either a configuration file pr the name of a previous build _and_ retrieves its build logs.
-
-|`cancel-build`
-|`oc cancel-build _<build_name>_`
-|Stops a build that is in progress.
-
-|`build-logs`
-|`oc build-logs _<build_name>_`
-|Retrieves the build logs for the specified build.
-|===
-
-== Deployment Operations
-OpenShift provides CLI access to inspect and manipulate
-link:../dev_guide/deployments.html[deployment configurations] using standard
-`oc` resource operations, such as `get`, `create`, and `describe`.
-
-Use the `oc describe` command to describe a deployment configuration in
-human-readable form:
-
-----
-$ oc describe dc <deployment_config>
-----
-
-The following example describes a deployment configuration called
-`docker-registry`:
-
-====
-
-[options="nowrap"]
-----
-$ oc describe dc docker-registry
-Name:		docker-registry
-Created:	18 hours ago
-Labels:		docker-registry=default
-Latest Version:	1
-Triggers:	Config
-Strategy:	Recreate
-Template:
-	Selector:	docker-registry=default
-	Replicas:	1
-	Containers:
-		NAME		IMAGE					ENV
-		registry	openshift/origin-docker-registry:v0.4.3	OPENSHIFT_CA_DATA=[omitted for space],OPENSHIFT_MASTER=https://10.245.2.2:8443
-Latest Deployment:
-	Name:		docker-registry-1
-	Status:		Complete
-	Selector:	deployment=docker-registry-1,deploymentconfig=docker-registry,docker-registry=default
-	Labels:		docker-registry=default
-	Replicas:	1 current / 1 desired
-	Pods Status:	1 Running / 0 Waiting / 0 Succeeded / 0 Failed
-----
-====
-
-=== Deployment Rollbacks
-
-Rollbacks revert an application back to a previous deployment, and they include
-environment variable and volumes. Therefore, consider the following when deciding whether a rollback is viable or not:
-
-- If security credentials have been recently updated, the previous deployment
-may not have the correct values.
-- If the previous deployment used a custom strategy which is no longer available
-or usable, the deployment may not be deployed correctly.
-
-During a rollback, only the configuration of pods and containers is changed by
-default, while the scaling or trigger settings remain unchanged.
-
-The `-d` or `--dry run` option shows the configuration of the updated deployment
-in an easy to read format without actually executing the rollback. This allows
-you to inspect the output before actually proceeding with the rollback.
-
-Use the `oc rollback` command to revert part of an application back to a
-previous deployment:
-
-----
-$ oc rollback <deployment> [<options>]
-----
-
-.Rollback CLI Configuration Options
-[cols="4,8",options="header"]
-|===
-
-|Option |Description
-
-.^|`--change-triggers`
-|Include the previous deployment's triggers in the rollback.
-
-.^|`--change-strategy`
-|Include the previous deployment's strategy in the rollback.
-
-.^|`-d, --dry-run`
-|Instead of performing the rollback, describe what the rollback will look like in human-readable form.
-
-.^|`-o, --output`
-|Instead of performing the rollback, print the updated deployment configuration in the specified format: `json`\|`yaml`\|`template`\|`templatefile`.
-
-.^|`-t, --template`
-|Template string or path to template file to use when `-o=template` or `-o=templatefile`.
-|===
-
-To perform a rollback:
-
-====
-
-----
-$ oc rollback deployment-1
-----
-====
-
-To see what the rollback will look like without performing the rollback:
-
-====
-
-----
-$ oc rollback deployment-1 --dry-run
-----
-====
-
-To perform the rollback manually by piping the *JSON* of the new configuration back to `oc`:
-
-====
-
-[options="nowrap"]
-----
-$ oc rollback deployment-1 --output=json | oc update deploymentConfigs deployment -f -
-----
-====
-
-*Canceling a Deployment*
-
-Cancelation can be very useful. You might want to cancel a deployment if:
-
-* A deployment was initiated incorrectly, and you want to cancel it before it can do further damage.
-* There is a security fix you need to apply, and you do not want to wait for an ongoing deployment to complete.
-* A deployment or hook implementation is stuck after running for too long, and you cannot initiate a deployment when there is a deployment already running.
-
-[NOTE]
-====
-By default, the deployment process is restricted to 6 hours. If a deployment is still in progress after 6 hours, then the containers for the deployment pod and any deployment hook pods are all deleted, and these pods are placed in the Failed state.
-====
-
-Cancel a running or stuck deployment with the following command:
-
-----
-$ oc deploy <config_name> --cancel
-----
-
-After running this command, the deployment eventually shuts down and transitions to a Failed status.

--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -139,15 +139,15 @@ $ osc describe dc <deployment_config>
 
 == Canceling a Deployment
 
-To cancel a running deployment:
+To cancel a running or stuck deployment:
 
 ----
 $ oc deploy <deployment_config> --cancel
 ----
 
-WARNING: The cancelation is a best-effort operation, and may take some time to
+WARNING: The cancellation is a best-effort operation, and may take some time to
 complete. It's possible the deployment will partially or totally complete
-before the cancelation is effective.
+before the cancellation is effective.
 
 == Retrying a Deployment
 


### PR DESCRIPTION
@vikram-redhat @adellape This is the PR about making the cli operations doc more fluid and without repeated info. I made it more like the `oc` command's output, and added examples, as well as pointed to the more info docs (eg, deployments, builds, templates, etc.) when appropriate.

What do you guys think?
