### PR TITLE
Fix trigger name capitalization

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -332,7 +332,7 @@ following is an example trigger definition JSON within the `*BuildConfig*`:
 
 ----
 {
-  "type": "generic",
+  "type": "Generic",
   "generic": {
     "secret": "secret101"
   }
@@ -444,8 +444,7 @@ ImageStream named `ruby-20-centos7` located within this namespace.
 
 ----
 {
-  "type": "imageChange",
-  "imageChange": {}
+  "type": "ImageChange"
 }
 ----
 ====


### PR DESCRIPTION
Should be GitHub, Generic and ImageChange. Names starting with lowercase
are still accepted in v1 but deprecated.

ImageChange do not need extra (empty) parameters.
