### PR TITLE
Cut over OSE docs to 3.0; remove 'latest' branch from commercial site

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -18,7 +18,7 @@ openshift-online:
   site_name: OpenShift Product Documentation
   branches:
     online:
-      name: Latest Release
+      name: Latest
       dir: online
 openshift-enterprise:
   name: OpenShift Enterprise
@@ -26,12 +26,6 @@ openshift-enterprise:
   site: commercial
   site_name: OpenShift Product Documentation
   branches:
-    master:
-      name: Latest
-      dir: enterprise/latest
-    enterprise-2.2:
-      name: '2.2'
-      dir: enterprise/2.2
     enterprise-3.0:
       name: '3.0'
       dir: enterprise/3.0

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -130,7 +130,7 @@
             <h2>OpenShift Enterprise</h2>
             <div class="list-group">
 <p class="list-group-item-text">Red Hat's private, on-premise cloud application deployment and hosting platform.</p>
-<p><a role="button" class="btn btn-primary" href="enterprise/latest/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> Enterprise Documentation</a></p>
+<p><a role="button" class="btn btn-primary" href="enterprise/3.0/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> Enterprise Documentation</a></p>
             </div>
           </div>
           <div class="col-sm-4 text-center">


### PR DESCRIPTION
@CowboysFan @adellape This PR, in conjunction with a new server rule on docs.openshift.com:
- Removes 'latest' and 'enterprise-2.2' versions of the docs from the commercial site
- Redirects any requests on /enterprise/latest/\* to /enterprise/3.0/*

The redirect rule is already in place. If you try:

http://docs.openshift.com/enterprise/latest

...or any URL under that, the web server will redirect you to the equivalent URL under:

http://docs.openshift.com/enterprise/3.0

When you guys gives this PR the thumbs-up, I'll merge it and rebuild the site.
