### PR TITLE
Fix image attribution popover

### DIFF
--- a/_templates/_footer_origin.html
+++ b/_templates/_footer_origin.html
@@ -39,12 +39,17 @@
     <div class="row">
       <div class="col-lg-12">
         <div class="attribution">
-          <button type="button" class="btn btn-link" data-container="body" data-toggle="popover" data-placement="top" data-content="
+          <button type="button" class="btn btn-link" data-html="true" data-container="body" data-toggle="popover" data-placement="top" data-content="
             '<a target='_blank' href='https://www.flickr.com/photos/eflon/3655695161/'>Spin</a>' by <a target='_blank' href='https://www.flickr.com/photos/eflon/'>eflon</a>,</br> used under <a target='_blank' href='https://creativecommons.org/licenses/by/2.0/'>CC BY 2.0</a> </br>Color tint added to original">
             Image attribution
           </button>
         </div>
       </div>
     </div>
+    <script>
+    $(function () {
+      $('[data-toggle="popover"]').popover()
+    })
+    </script>
   </div>
 </footer>


### PR DESCRIPTION
- Popover functionality needs to be explicity initialized
  (http://getbootstrap.com/javascript/#callout-popover-opt-in)
- Need to set html=true to render contents properly
