### PR TITLE
Fix wrong json example for PersistentVolume

### DIFF
--- a/admin_guide/persistent_storage_nfs.adoc
+++ b/admin_guide/persistent_storage_nfs.adoc
@@ -49,8 +49,8 @@ servers and paths and the `*PersistentVolume*` API.
     "nfs": {
         "path": "/tmp",
         "server": "172.17.0.2"
-    }
-    "persistentVolumeReclaimPolicy": "Recycle"  // also "Retain"
+    },
+    "persistentVolumeReclaimPolicy": "Recycle"
   }
 }
 ----


### PR DESCRIPTION
Put a properly formatted json in there that can be copy pasted by the
user.
