### PR TITLE
Request header example tweaks

### DIFF
--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -484,7 +484,7 @@ the correct client certificate and header:
 ----
 # curl -L -k -H "X-Remote-User: joe" \
   --cert /etc/pki/tls/certs/authproxy.pem
-  --https://ose3-master.example.com:8443/oauth/token/request
+  https://ose3-master.example.com:8443/oauth/token/request
 ----
 
 If you do not supply the client certificate, the request should be denied:

--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -483,7 +483,7 @@ the correct client certificate and header:
 
 ----
 # curl -L -k -H "X-Remote-User: joe" \
-  --cert /etc/pki/tls/certs/authproxy.pem
+  --cert /etc/pki/tls/certs/authproxy.pem \
   https://ose3-master.example.com:8443/oauth/token/request
 ----
 

--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -323,7 +323,7 @@ available.
 # cp ca.crt /etc/pki/CA/certs/ca.crt
 # cat proxy/system\:proxy.crt \
   proxy/system\:proxy.key > \
-  /etc/pki/tls/certs/proxy.pem
+  /etc/pki/tls/certs/authproxy.pem
 # popd
 ----
 
@@ -464,7 +464,7 @@ the Apache VirtualHost:
     provider:
       apiVersion: v1
       kind: RequestHeaderIdentityProvider
-      clientCA: /etc/openshift/master/ca.crt
+      clientCA: /etc/openshift/master/proxy/ca.crt
       headers:
       - X-Remote-User
 ----

--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -464,7 +464,7 @@ the Apache VirtualHost:
     provider:
       apiVersion: v1
       kind: RequestHeaderIdentityProvider
-      clientCA: /etc/openshift/master/proxy/ca.crt
+      clientCA: /etc/openshift/master/proxyca.crt
       headers:
       - X-Remote-User
 ----


### PR DESCRIPTION
First commit fixes verification curl, removing extra '--' in the arguments.

The second commit matches generated certificates with those used in the example configs. This is really minor and I was able to get the configs running by reading through this section. Using the same paths throughout might make for easier setup.
