### PR TITLE
Condtionalize Git proxy info in dev_guide/builds for Origin only, min…

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -85,7 +85,7 @@ every time a Docker image tag or the source code changes:
 <1> This specification will create a new `*buildConfig*` named
 *ruby-sample-build*.
 <2> You can specify a list of link:#build-triggers[triggers], which cause a new build to be created.
-<3> The `*Source*` section defines the source code repository location. You can
+<3> The `*source*` section defines the source code repository location. You can
 provide additional options, such as `*sourceSecret*` or `*contextDir*` here.
 <4> The `*strategy*` section describes the build strategy used to execute the
 build. You can specify `*Source*`, `*Docker*` and `*Custom*` strategies here.
@@ -134,13 +134,24 @@ of a missing `save-artifacts` script.
 For information on how to create a builder image supporting incremental builds
 see the link:../creating_images/s2i.html[creating images guide].
 
+////
+Remove condition once it's verified in for OSE.
+https://bugzilla.redhat.com/show_bug.cgi?id=1235129
+////
+ifdef::openshift-origin[]
 [[using-a-proxy-for-git-cloning]]
 
 == Using a Proxy for Git Cloning
-If your Git repository can only be accessed via a proxy, you can define the proxy
-to use in the Source section of the BuildConfig.  You can configure both a
-HTTP and HTTPS proxy to use.  Both fields are optional.  Note that your source uri must use the http or 
-https protocol for this to work:
+If your Git repository can only be accessed using a proxy, you can define the
+proxy to use in the `*source*` section of the `*BuildConfig*`. You can configure
+both a HTTP and HTTPS proxy to use. Both fields are optional.
+
+[NOTE]
+====
+Your source URI must use the HTTP or HTTPS protocol for this to work.
+====
+
+====
 
 [source,json]
 ----
@@ -154,9 +165,11 @@ https protocol for this to work:
 }
 ----
 
-<1> Must be be an http or https uri
-<2> Specify the HTTP proxy to use
-<3> Specify the HTTPS proxy to use
+<1> Must be an HTTP or HTTPS URI.
+<2> Specify the HTTP proxy to use.
+<3> Specify the HTTPS proxy to use.
+====
+endif::[]
 
 [[starting-a-build]]
 
@@ -709,7 +722,7 @@ $ oc create -f secret.json
 ----
 ====
 
-. Add a `*sourceSecret*` field into the `*Source*` section inside the
+. Add a `*sourceSecret*` field into the `*source*` section inside the
 buildConfig and set it to the name of the `*secret*` that you created, in this
 case `*scmsecret*`:
 +
@@ -749,5 +762,5 @@ case `*scmsecret*`:
   }
 ----
 <1> The URL of private repository is usually in the form
-`git@example.com:<username>/<repository>`
+`git@example.com:<username>/<repository>`.
 ====


### PR DESCRIPTION
…or edits.

Follow up to https://github.com/openshift/openshift-docs/pull/637.

Also synced up other "source"/"Source" section usage where appropriate. @bparees Can you ack those?
