### PR TITLE
Additional clarification around docker and persistent storage

### DIFF
--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -61,7 +61,7 @@ ifdef::openshift-enterprise[]
 - Base OS: Red Hat Enterprise Linux (RHEL) 7.1 with "Minimal" installation
 option
 endif::[]
-- Docker 1.6 or later
+- Docker 1.6.2 or later
 - 1 vCPU
 - Minimum 8 GB RAM
 - Minimum 15 GB hard disk space
@@ -212,7 +212,7 @@ endif::[]
 
 *Installing Docker*
 
-Docker version 1.6 or later
+Docker version 1.6.2 or later
 ifdef::openshift-enterprise[]
 from the *rhel-7-server-ose-3.0-rpms* repository
 endif::[]

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -145,7 +145,7 @@ endif::[]
 
 ifdef::openshift-enterprise[]
 
-=== Software Prerequisites 
+=== Software Prerequisites
 *Installing Red Hat Enterprise Linux 7*
 
 A base installation of Red Hat Enterprise Linux (RHEL) 7.1 is required for
@@ -404,6 +404,18 @@ This will destroy any Docker containers or images currently on the host.
 # rm -rf /var/lib/docker/*
 # systemctl restart docker
 ----
+
+[reconfiguring-docker-storage]
+*Reconfiguring Docker Storage*
+
+Should you need to re-configure storage after having created the docker-pool
+you should remove the docker-pool logical volume. If you're using a
+dedicated volume group you should also remove the volume group and any
+associated physical volumes before re-configuring docker-storage-setup
+according to the instructions above.
+
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Logical_Volume_Manager_Administration/index.html[Logical Volume Manager Administration]
+covers LVM management in depth.
 
 
 

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -260,9 +260,9 @@ images or containers. The script reads configuration options from the
 *_/etc/sysconfig/docker-storage-setup_* file and supports three options for
 creating the logical volume:
 
-. *A)* Use an additional block device
-. *B)* Use a specified volume group
-. *C)* Use the remaining free space from the volume group where your root
+- *Option A)* Use an additional block device
+- *Option B)* Use a specified volume group
+- *Option C)* Use the remaining free space from the volume group where your root
 filesystem is located
 
 Option A is the most robust option however it requires adding an additional
@@ -281,23 +281,25 @@ Enterprise Linux 7.
 [IMPORTANT]
 ====
 Before using Docker or OpenShift please verify that the docker-pool logical
-volume is approximately 60% of the space you've allocated. This thin pool
-will automatically grow to fill the remaining space as needed.
+volume is large enough to meet your needs. The docker-pool volume should be
+60% of the available volume group and will grow to fill the volume group
+via LVM monitoring.
 ====
 
 
-. Configure *docker-storage-setup* for your environment. There are three methods
-available based on your storage configuration:
+. Create the docker-pool volume using one of the following three options:
 
-.. [[docker-storage-a]]Use an unpartitioned block device to create a new volume
-group and thinpool. In this example, the `/dev/vdc` device is used to create the
-*docker-vg* volume group:
+** [[docker-storage-a]]*Option A) Use an additional block device*
++
+In *_/etc/sysconfig/docker-storage-setup_* set *DEVS* to the path of the block
+device you wish to use. Set *VG* to the volume group name you wish to create,
+*docker-vg* is a reasonable choice. Run *docker-storage-setup* and review the
+output to ensure the *docker-pool* volume was created.
 +
 ----
 # cat <<EOF > /etc/sysconfig/docker-storage-setup
 DEVS=/dev/vdc
 VG=docker-vg
-SETUP_LVM_THIN_POOL=yes
 EOF
 
 # docker-storage-setup                                                                                                                                                                                                                                [5/1868]
@@ -340,15 +342,16 @@ to zero the first 512 bytes:  dd if=/dev/zero of=/dev/foo7 bs=512 count=1
   Converted docker-vg/docker-pool to thin pool.
   Logical volume "docker-pool" changed.
 ----
-+
 
-.. [[docker-storage-b]]Use an existing volume group, in this example *docker-vg*, to create a
-thin-pool:
+** [[docker-storage-b]]*Option B) Use a specified volume group*
++
+In *_/etc/sysconfig/docker-storage-setup_* set *VG* to the desired volume group.
+Run *docker-storage-setup* and review the  output to ensure the *docker-pool*
+volume was created.
 +
 ----
 # cat <<EOF > /etc/sysconfig/docker-storage-setup
 VG=docker-vg
-SETUP_LVM_THIN_POOL=yes
 EOF
 
 # docker-storage-setup
@@ -360,11 +363,14 @@ EOF
   Converted docker-vg/docker-pool to thin pool.
   Logical volume "docker-pool" changed.
 ----
-+
 
-.. [[docker-storage-c]]Create a thin-pool volume from the remaining free space in the volume group
-where your root file system resides by running the *docker-storage-setup*
-command with no arguments.
+
+** [[docker-storage-c]]*Option C) Use the remaining free space from the volume group where your root
+filesystem is located*
++
+Verify that the volume group where your root file system resides has the desired
+free space then run *docker-storage-setup* and review the output to ensure the
+*docker-pool* volume was created.
 +
 ----
 # docker-storage-setup
@@ -376,7 +382,6 @@ command with no arguments.
   Converted rhel/docker-pool to thin pool.
   Logical volume "docker-pool" changed.
 ----
-+
 
 . Verify your configuration. You should have *dm.thinpooldev* value in the
 *_/etc/sysconfig/docker-storage_* file and a *docker-pool* logical volume:

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -259,10 +259,11 @@ configure Docker's storage driver after installing Docker but before creating
 images or containers. The script reads configuration options from the
 *_/etc/sysconfig/docker-storage-setup_* file and supports three options for
 creating the logical volume:
+
 . *A)* Use an additional block device
 . *B)* Use a specified volume group
 . *C)* Use the remaining free space from the volume group where your root
-filesystem is located.
+filesystem is located
 
 Option A is the most robust option however it requires adding an additional
 block device. Options B and C both require leaving free space available when

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -68,6 +68,14 @@ endif::[]
 - An additional minimum 15 GB unallocated space to be configured using
 *docker-storage-setup*; see link:#configuring-docker-storage[Configuring
 Docker Storage] below.
+
+|link:../../admin_guide/persistent_storage_nfs.html[Persistent Storage]
+a| - NFS persistent storage volumes per your application needs. Currently NFS
+is fully supported, however other options are available as
+link:../whats_new/ose_3_0_release_notes.html#technology-preview[Technology
+Preview], see
+link:../../dev_guide/persistent_volumes.html[Using Persistent Volumes] for more information
+
 |===
 
 [[security-warning]]
@@ -237,7 +245,11 @@ accordingly.
 [[configuring-docker-storage]]
 *Configuring Docker Storage*
 
-Docker's default loopback storage mechanism is not supported for production use
+Docker containers and the images they're created from are stored in Docker's
+storage backend. This storage is ephemeral and separate from any persistent
+storage allocated to meet the needs of your applications.
+
+Docker's default loopback storage backend is not supported for production use
 and is only appropriate for proof of concept environments. For production
 environments, you must create a thin-pool logical volume and re-configure Docker
 to use that volume.

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -145,6 +145,7 @@ endif::[]
 
 ifdef::openshift-enterprise[]
 
+=== Software Prerequisites 
 *Installing Red Hat Enterprise Linux 7*
 
 A base installation of Red Hat Enterprise Linux (RHEL) 7.1 is required for
@@ -243,7 +244,7 @@ accordingly.
 ====
 
 [[configuring-docker-storage]]
-*Configuring Docker Storage*
+=== Configuring Docker Storage
 
 Docker containers and the images they are created from are stored in Docker's
 storage backend. This storage is ephemeral and separate from any persistent

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -245,20 +245,27 @@ accordingly.
 [[configuring-docker-storage]]
 *Configuring Docker Storage*
 
-Docker containers and the images they're created from are stored in Docker's
+Docker containers and the images they are created from are stored in Docker's
 storage backend. This storage is ephemeral and separate from any persistent
-storage allocated to meet the needs of your applications.
-
-Docker's default loopback storage backend is not supported for production use
-and is only appropriate for proof of concept environments. For production
-environments, you must create a thin-pool logical volume and re-configure Docker
-to use that volume.
+storage allocated to meet the needs of your applications. The default storage
+backend is loopback which  is not supported for production use and only
+appropriate for proof of concept environments. For production environments
+you must create a thin-pool logical volume and re-configure Docker to use
+that volume.
 
 You can use the *docker-storage-setup* script to create a thin-pool device and
-configure Docker's storage driver after installing Docker but before you start
-using it. The script reads configuration options from the
-*_/etc/sysconfig/docker-storage-setup_* file. Allocate at least 15 GB of space
-for this purpose no matter which option you choose.
+configure Docker's storage driver after installing Docker but before creating
+images or containers. The script reads configuration options from the
+*_/etc/sysconfig/docker-storage-setup_* file and supports three options for
+creating the logical volume:
+. *A)* Use an additional block device
+. *B)* Use a specified volume group
+. *C)* Use the remaining free space from the volume group where your root
+filesystem is located.
+
+Option A is the most robust option however it requires adding an additional
+block device. Options B and C both require leaving free space available when
+provisioning your host.
 
 [NOTE]
 ====
@@ -269,40 +276,18 @@ Atomic Host"] Knowledgebase article for more details about
 Enterprise Linux 7.
 ====
 
-. Configure *docker-storage-setup* for your environment. There are three methods
-available based on your storage configuration:
-[[docker-storage-a]]
-.. [[docker-storage-a]]Create a thin-pool volume from the remaining free space in the volume group
-where your root file system resides by running the *docker-storage-setup*
-command with no arguments; this requires no configuration.
-+
 [IMPORTANT]
 ====
-This method will fail if you do not have unpartitioned space available. Ensure
-before running that the amount of unpartitioned space available is actually
-enough to meet link:#system-requirements[your requirements].
+Before using Docker or OpenShift please verify that the docker-pool logical
+volume is approximately 60% of the space you've allocated. This thin pool
+will automatically grow to fill the remaining space as needed.
 ====
-+
-----
-# docker-storage-setup
-----
-+
-If this method does not work as expected for you, see the
-link:#docker-storage-c[third method below], which may require adding a new
-volume to your host.
-+
-.. [[docker-storage-b]]Use an existing volume group, in this example *docker-vg*, to create a
-thin-pool:
-+
-----
-# cat <<EOF > /etc/sysconfig/docker-storage-setup
-VG=docker-vg
-SETUP_LVM_THIN_POOL=yes
-EOF
 
-# docker-storage-setup
-----
-.. [[docker-storage-c]]Use an unpartitioned block device to create a new volume
+
+. Configure *docker-storage-setup* for your environment. There are three methods
+available based on your storage configuration:
+
+.. [[docker-storage-a]]Use an unpartitioned block device to create a new volume
 group and thinpool. In this example, the `/dev/vdc` device is used to create the
 *docker-vg* volume group:
 +
@@ -313,17 +298,92 @@ VG=docker-vg
 SETUP_LVM_THIN_POOL=yes
 EOF
 
-# docker-storage-setup
+# docker-storage-setup                                                                                                                                                                                                                                [5/1868]
+0
+Checking that no-one is using this disk right now ...
+OK
+
+Disk /dev/vdc: 31207 cylinders, 16 heads, 63 sectors/track
+sfdisk:  /dev/vdc: unrecognized partition table type
+
+Old situation:
+sfdisk: No partitions found
+
+New situation:
+Units: sectors of 512 bytes, counting from 0
+
+   Device Boot    Start       End   #sectors  Id  System
+/dev/vdc1          2048  31457279   31455232  8e  Linux LVM
+/dev/vdc2             0         -          0   0  Empty
+/dev/vdc3             0         -          0   0  Empty
+/dev/vdc4             0         -          0   0  Empty
+Warning: partition 1 does not start at a cylinder boundary
+Warning: partition 1 does not end at a cylinder boundary
+Warning: no primary partition is marked bootable (active)
+This does not matter for LILO, but the DOS MBR will not boot this disk.
+Successfully wrote the new partition table
+
+Re-reading the partition table ...
+
+If you created or changed a DOS partition, /dev/foo7, say, then use dd(1)
+to zero the first 512 bytes:  dd if=/dev/zero of=/dev/foo7 bs=512 count=1
+(See fdisk(8).)
+  Physical volume "/dev/vdc1" successfully created
+  Volume group "docker-vg" successfully created
+  Rounding up size to full physical extent 16.00 MiB
+  Logical volume "docker-poolmeta" created.
+  Logical volume "docker-pool" created.
+  WARNING: Converting logical volume docker-vg/docker-pool and docker-vg/docker-poolmeta to pool's data and metadata volumes.
+  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
+  Converted docker-vg/docker-pool to thin pool.
+  Logical volume "docker-pool" changed.
 ----
++
+
+.. [[docker-storage-b]]Use an existing volume group, in this example *docker-vg*, to create a
+thin-pool:
++
+----
+# cat <<EOF > /etc/sysconfig/docker-storage-setup
+VG=docker-vg
+SETUP_LVM_THIN_POOL=yes
+EOF
+
+# docker-storage-setup
+  Rounding up size to full physical extent 16.00 MiB
+  Logical volume "docker-poolmeta" created.
+  Logical volume "docker-pool" created.
+  WARNING: Converting logical volume docker-vg/docker-pool and docker-vg/docker-poolmeta to pool's data and metadata volumes.
+  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
+  Converted docker-vg/docker-pool to thin pool.
+  Logical volume "docker-pool" changed.
+----
++
+
+.. [[docker-storage-c]]Create a thin-pool volume from the remaining free space in the volume group
+where your root file system resides by running the *docker-storage-setup*
+command with no arguments.
++
+----
+# docker-storage-setup
+  Rounding up size to full physical extent 32.00 MiB
+  Logical volume "docker-poolmeta" created.
+  Logical volume "docker-pool" created.
+  WARNING: Converting logical volume rhel/docker-pool and rhel/docker-poolmeta to pool's data and metadata volumes.
+  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
+  Converted rhel/docker-pool to thin pool.
+  Logical volume "docker-pool" changed.
+----
++
 
 . Verify your configuration. You should have *dm.thinpooldev* value in the
-*_/etc/sysconfig/docker-storage_* file and a *docker-pool* device:
+*_/etc/sysconfig/docker-storage_* file and a *docker-pool* logical volume:
 +
 ====
 ----
 # lvs
-LV                  VG        Attr       LSize  Pool Origin Data%  Meta% Move Log Cpy%Sync Convert
-docker-pool         docker-vg twi-a-tz-- 48.95g             0.00   0.44
+  LV          VG   Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
+  docker-pool rhel twi-a-t---  9.29g             0.00   0.12
 
 # cat /etc/sysconfig/docker-storage
 DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt
@@ -343,6 +403,8 @@ This will destroy any Docker containers or images currently on the host.
 # rm -rf /var/lib/docker/*
 # systemctl restart docker
 ----
+
+
 
 == Host Access for Ansible-based Installations
 

--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -65,6 +65,9 @@ endif::[]
 - 1 vCPU
 - Minimum 8 GB RAM
 - Minimum 15 GB hard disk space
+- An additional minimum 15 GB unallocated space to be configured using
+*docker-storage-setup*; see link:#configuring-docker-storage[Configuring
+Docker Storage] below.
 |===
 
 [[security-warning]]
@@ -113,7 +116,8 @@ A shared network must exist between the master and node hosts.
 
 *Git*
 
-You must have either Internet access and a GitHub account, or read and write access to an internal, HTTP-based Git server.
+You must have either Internet access and a GitHub account, or read and write
+access to an internal, HTTP-based Git server.
 
 == Host Preparation
 Before installing OpenShift, you must first prepare each host per the following.
@@ -230,29 +234,52 @@ registry], which involves adjusting the `--insecure-registry` option
 accordingly.
 ====
 
+[[configuring-docker-storage]]
 *Configuring Docker Storage*
 
 Docker's default loopback storage mechanism is not supported for production use
 and is only appropriate for proof of concept environments. For production
-environments, you must create a thin-pool logical volume and re-configure docker
+environments, you must create a thin-pool logical volume and re-configure Docker
 to use that volume.
 
 You can use the *docker-storage-setup* script to create a thin-pool device and
 configure Docker's storage driver after installing Docker but before you start
 using it. The script reads configuration options from the
-*_/etc/sysconfig/docker-storage-setup_* file.
+*_/etc/sysconfig/docker-storage-setup_* file. Allocate at least 15 GB of space
+for this purpose no matter which option you choose.
 
-. Configure *docker-storage-setup* for your environment. There are three options
+[NOTE]
+====
+See the https://access.redhat.com/articles/1492923["Managing Storage with Docker
+Formatted Containers on Red Hat Enterprise Linux and Red Hat Enterprise Linux
+Atomic Host"] Knowledgebase article for more details about
+*docker-storage-setup* and basic instructions on storage management in Red Hat
+Enterprise Linux 7.
+====
+
+. Configure *docker-storage-setup* for your environment. There are three methods
 available based on your storage configuration:
-
-.. Create a thin-pool volume from the remaining free space in the volume group
-where your root file system resides; this requires no configuration:
+[[docker-storage-a]]
+.. [[docker-storage-a]]Create a thin-pool volume from the remaining free space in the volume group
+where your root file system resides by running the *docker-storage-setup*
+command with no arguments; this requires no configuration.
++
+[IMPORTANT]
+====
+This method will fail if you do not have unpartitioned space available. Ensure
+before running that the amount of unpartitioned space available is actually
+enough to meet link:#system-requirements[your requirements].
+====
 +
 ----
 # docker-storage-setup
 ----
-
-.. Use an existing volume group, in this example *docker-vg*, to create a
++
+If this method does not work as expected for you, see the
+link:#docker-storage-c[third method below], which may require adding a new
+volume to your host.
++
+.. [[docker-storage-b]]Use an existing volume group, in this example *docker-vg*, to create a
 thin-pool:
 +
 ----
@@ -260,12 +287,12 @@ thin-pool:
 VG=docker-vg
 SETUP_LVM_THIN_POOL=yes
 EOF
+
 # docker-storage-setup
 ----
-
-.. Use an unpartitioned block device to create a new volume group and thinpool.
-In this example, the `/dev/vdc` device is used to create the *docker-vg* volume
-group:
+.. [[docker-storage-c]]Use an unpartitioned block device to create a new volume
+group and thinpool. In this example, the `/dev/vdc` device is used to create the
+*docker-vg* volume group:
 +
 ----
 # cat <<EOF > /etc/sysconfig/docker-storage-setup
@@ -273,6 +300,7 @@ DEVS=/dev/vdc
 VG=docker-vg
 SETUP_LVM_THIN_POOL=yes
 EOF
+
 # docker-storage-setup
 ----
 
@@ -295,7 +323,7 @@ dm.thinpooldev=/dev/mapper/docker--vg-docker--pool
 +
 [WARNING]
 ====
-This will destroy any docker containers or images currently on the host.
+This will destroy any Docker containers or images currently on the host.
 ====
 +
 ----


### PR DESCRIPTION
Builds upon #674 
- Clarifies differences between docker storage and persistent storage
- Re-orders docker-storage-setup options such that adding an additional block device is first
- Updated example output
