### PR TITLE
Incorrect docker-registry label reference

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -184,7 +184,7 @@ spec:
 environment variable with the service IP that is inserted into other
 pods in the same namespace.
 <2> The label selector identifies all pods with the
-*docker-registry=frontend* label attached as its backing pods.
+*docker-registry=default* label attached as its backing pods.
 <3> Virtual IP of the service, allocated automatically at creation from a pool
 of internal IPs.
 <4> Port the service listens on.


### PR DESCRIPTION
The Service Object Definition specifies the label selector `docker-registry: default`, but bullet point # 2 referred to `docker-registry=frontend`.
