### PR TITLE
Conditionalize Elasticsearch option for Origin only.

### DIFF
--- a/admin_guide/aggregate_logging.adoc
+++ b/admin_guide/aggregate_logging.adoc
@@ -12,6 +12,7 @@ toc::[]
 
 == Overview
 
+ifdef::openshift-origin[]
 As an OpenShift administrator, you may want to view the logs from all containers
 in one user interface. There are two options for aggregating container logs,
 depending on user requirements:
@@ -21,18 +22,34 @@ depending on user requirements:
 
 [IMPORTANT]
 ====
-These solutions are a work in progress. As packaging improvements are made these
-instructions will be simplified.
+These solutions are a work in progress. As packaging improvements are made,
+these instructions will be simplified.
 ====
+endif::[]
+ifdef::openshift-enterprise[]
+As an OpenShift administrator, you may want to view the logs from all containers
+in one user interface. The currently supported method for aggregating container
+logs in OpenShift Enterprise is link:#using-a-centralized-file-system[using a
+centralized file system]. Additional supported methods are planned for inclusion
+in future releases.
+
+[NOTE]
+====
+As packaging improvements are made, these instructions will be simplified.
+====
+endif::[]
 
 [[using-a-centralized-file-system]]
 
 == Using a Centralized File System
 
-This option reads all container logs and forwards them to a central server for
-storage on the file system. This solution requires less resources and requires
-less management than the link:#using-elasticsearch[*Elasticsearch* option], but
-the logs are not indexed and searchable.
+This method reads all container logs and forwards them to a central server for
+storage on the file system.
+ifdef::openshift-origin[]
+This solution requires less resources and requires less management than the
+link:#using-elasticsearch[*Elasticsearch* option], but the logs are not indexed
+and searchable.
+endif::[]
 
 [[installing-fluentd-td-agent-on-nodes]]
 === Installing fluentd (td-agent) on Nodes
@@ -215,6 +232,8 @@ Any errors are logged in the *_/var/log/td-agent/td-agent.log_* file.
 You should now find all the containers' logs available on the master in the
 *_/var/log/td-agent/containers.log_* file.
 
+ifdef::openshift-origin[]
+
 [[using-elasticsearch]]
 
 == Using Elasticsearch
@@ -225,7 +244,7 @@ search capabilities. By storing container logs in *Elasticsearch*, users are
 able to search all content and filter appropriately. This documentation shows
 how to run https://www.elastic.co/products/kibana[*Kibana*].
 
-This option requires more configuration and more resources than the
+This method requires more configuration and more resources than the
 link:#using-a-centralized-file-system[centralized file system option], but makes
 logs more useful for troubleshooting and fault finding.
 
@@ -233,7 +252,7 @@ Enabling aggregated logging to *Elasticsearch* involves:
 
 . link:#creating-an-elasticsearch-cluster[Creating an *Elasticsearch* cluster]
 . link:#creating-logging-pods[Creating logging pods]
-. link:#creating-the-kibana-search[Creating the *Kibana* service]
+. link:#creating-the-kibana-service[Creating the *Kibana* service]
 
 [[creating-an-elasticsearch-cluster]]
 
@@ -428,7 +447,7 @@ yellow open   logstash-2015.06.05   5   1        540            0      251kb    
 If the value for `docs.count` is more than 0, then log records are being
 correctly sent to *Elasticsearch*.
 
-[[creating-the-kibana-search]]
+[[creating-the-kibana-service]]
 
 === Creating the Kibana Service
 
@@ -496,3 +515,5 @@ Create the *Kibana* replication controller and service:
 $ oc create -f path/to/kibana.yaml
 ----
 ====
+
+endif::[]


### PR DESCRIPTION
@jwhonce @jimmidyson PTAL.

Pretty builds (internal): [Enterprise](http://file.rdu.redhat.com/~adellape/070915/enterprise/condt_elasticsearch/admin_guide/aggregate_logging.html) / [Origin](http://file.rdu.redhat.com/~adellape/070915/origin/condt_elasticsearch/admin_guide/aggregate_logging.html)

@vikram-redhat Addresses the anchor issue I commented about in https://github.com/openshift/openshift-docs/pull/712#discussion-diff-34220625.

Fixes https://github.com/openshift/openshift-docs/issues/662.
