### PR TITLE
Fix contrib guide template links

### DIFF
--- a/contributing_to_docs/create_or_edit_content.adoc
+++ b/contributing_to_docs/create_or_edit_content.adoc
@@ -55,8 +55,9 @@ With the local branch created and checked out, you can now edit any content, or 
 
 If you are creating a new topic, it is best to use the topic templates so that all of the required metadata is included:
 
-* For an Overview topic, use the https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/overview_topic_template.adoc[Overview topic template].
-* For all other topics, use the https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/topic_template.adoc[normal topic template].
+* For an Overview topic, use the https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/templates/overview_topic_template.adoc[Overview topic template].
+* For revision history topics, use the https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/templates/rev_history.adoc[Revision History Template].
+* For all other topics, use the https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/templates/topic_template.adoc[normal topic template].
 
 Otherwise, ensure that any new topic contains the required metadata as described in the link:doc_guidelines.adoc[documentation guidelines] topic, including naming and title conventions. 
 


### PR DESCRIPTION
The links to the templates in the new topics guide were wrong, also add a link to the revision history template.
