### PR TITLE
Update rollback documentation

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -180,10 +180,10 @@ it had when it failed.
 Rollbacks revert an application back to a previous deployment and can be
 performed using the REST API or the CLI.
 
-To rollback to a previous deployment:
+To rollback to the last successful deployment:
 
 ----
-$ oc rollback <deployment>
+$ oc rollback <deployment_config>
 ----
 
 The deployment configuration's template will be reverted to match the
@@ -196,6 +196,18 @@ complete. To re-enable the image change triggers:
 
 ----
 $ oc deploy <deployment_config> --enable-triggers
+----
+
+To roll back to a specific version:
+
+----
+$ oc rollback <deployment_config> --to-version=1
+----
+
+To see what the rollback would look like without performing the rollback:
+
+----
+$ oc rollback <deployment_config> --dry-run
 ----
 
 [[triggers]]


### PR DESCRIPTION
Note that you can still supply a deployment name (for backwards compatibility), but I don't see a good reason to promote that in the latest docs.
