### PR TITLE
Add \w exp modifier for Origin.

### DIFF
--- a/architecture/core_concepts/templates.adoc
+++ b/architecture/core_concepts/templates.adoc
@@ -134,9 +134,25 @@ In the example above, processing will generate a random password 12
 characters long consisting of all upper and lowercase alphabet letters
 and numbers.
 
+////
+Conditionalizing the following modifiers, as \w is not included in OSE as of
+3.0.0.1, but looks likely to get picked up in 3.0.1. See
+https://github.com/openshift/origin/pull/3477
+////
+
 The syntax available is not a full regular expression syntax. However,
-you can use `\d` and `\a` modifiers:
+you can use
+ifdef::openshift-origin[]
+`\w`, `\d`, and `\a` modifiers:
+endif::[]
+ifdef::openshift-enterprise[]
+`\d` and `\a` modifiers:
+endif::[]
 
-* `[\d]{10}` produces 10 numbers. This is equal to `[0-9]{10}`.
-* `[\a]{10}` produces 10 alphabetical characters. This is equal to `[a-zA-Z]{10}`.
-
+ifdef::openshift-origin[]
+- `[\w]{10}` produces 10 alphabet characters, numbers, and underscores. This
+follows the PCRE standard and is equal to `[a-zA-Z0-9_]{10}`.
+endif::[]
+- `[\d]{10}` produces 10 numbers. This is equal to `[0-9]{10}`.
+- `[\a]{10}` produces 10 alphabetical characters. This is equal to
+`[a-zA-Z]{10}`.


### PR DESCRIPTION
Building off https://github.com/openshift/openshift-docs/pull/656. See https://github.com/openshift/origin/pull/3477.

Adding the `\w` expression for the Origin build but conditionalizing it out of OSE builds for now. Tracking in Trello to make sure it's re-included for OSE when appropriate.

@mfojtik PTAL, and if you're good with this we can close https://github.com/openshift/openshift-docs/pull/656.
