### PR TITLE
Add new-app EmptyDirs line for Origin only.

### DIFF
--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -389,6 +389,16 @@ image stream is created for that image as well.
 a|`*DeploymentConfig*`
 a|A `*DeploymentConfig*` is created either to deploy the output of a build, or a
 specified image.
+ifdef::openshift-origin[]
+The `new-app` command creates link:volumes.html[*EmptyDir* volumes] for all
+Docker volumes that are specified in containers included in the resulting
+`*DeploymentConfig*`.
+endif::[]
+////
+Conditionalizing the above as the change is not included in OSE as of
+3.0.0.1, but looks likely to get picked up in 3.0.1. See
+https://github.com/openshift/origin/pull/3098
+////
 
 a|`*Service*`
 a|The `new-app` command attempts to detect exposed ports in input images. It


### PR DESCRIPTION
Builds on https://github.com/openshift/openshift-docs/pull/677. See https://github.com/openshift/origin/pull/3098.

Adding line about `new-app`-created EmptyDirs for the Origin build but conditionalizing it out of the OSE build til 3.0.1. Tracking in Trello to make sure it's re-included for OSE when appropriate.

@mnagy @bparees If you're good with this, I'll merge it and we can close https://github.com/openshift/openshift-docs/pull/677.
