### PR TITLE
adminguide: Use https for external RPM repos where available

### DIFF
--- a/admin_guide/aggregate_logging.adoc
+++ b/admin_guide/aggregate_logging.adoc
@@ -62,7 +62,7 @@ Perform the following steps on each node to install and configure *fluentd*
 ====
 ----
 # export RPM=td-agent-2.2.0-0.x86_64.rpm
-# curl http://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
+# curl https://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
     -o /tmp/$RPM
 # yum localinstall $RPM
 # /opt/td-agent/embedded/bin/gem install fluent-plugin-kubernetes
@@ -178,7 +178,7 @@ that the nodes are working properly.
 ====
 ----
 # export RPM=td-agent-2.2.0-0.x86_64.rpm
-# curl http://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
+# curl https://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
     -o /tmp/$RPM
 # yum localinstall $RPM
 # mkdir -p /etc/td-agent/config.d

--- a/admin_guide/install/advanced_install.adoc
+++ b/admin_guide/install/advanced_install.adoc
@@ -66,7 +66,7 @@ Install the EPEL repository:
 
 ----
 # yum -y install \
-    http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+    https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 ----
 
 Disable the EPEL repository so that it is not accidentally used during later


### PR DESCRIPTION
At least `dl.fedoraproject.org` and `packages.treasuredata.com`
support TLS.
