### PR TITLE
[On QA] BZ 1240377

### DIFF
--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -216,7 +216,7 @@ endif::[]
 . Install the following packages:
 +
 ----
-# yum install wget git net-tools bind-utils iptables-services bridge-utils
+# yum install wget git net-tools bind-utils iptables-services bridge-utils python-virtualenv
 ----
 
 . Update the system to the latest packages:


### PR DESCRIPTION
Added python-virtualenv to the list of prerequisites in step 2 of the Managing Base Packages section, as per BZ requirements.

https://bugzilla.redhat.com/show_bug.cgi?id=1240377
