### PR TITLE
Add information for auto-generated hostnames

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -332,3 +332,95 @@ certificate to validate the endpoint certificate, securing the connection
 from the router to the destination.
 
 ====
+
+== Route Hostnames
+In order for services to be exposed externally, an OpenShift route allows
+you to associate a service with an externally-reachable hostname.
+This edge hostname is then used to route traffic to the service.
+
+.An Route with a specified host:
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: host-route
+spec:
+  host: www.example.com  <1>
+  to:
+    kind: Service
+    name: service-name
+----
+
+<1> Specifies the externally-reachable hostname used to expose a service.
+====
+
+
+.An Route without a host:
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: nohost-route
+spec:
+  to:
+    kind: Service
+    name: service-name
+----
+
+====
+
+If a hostname is *not* provided as part of the route specification, then
+OpenShift will automatically generate one for you. The generated hostname
+is of the form `*$service[.$namespace].$suffix*`.
+
+The following example shows the OpenShift generated hostname for the above
+configuration of a route without a host added to a namespace `my-namespace`:
+
+.Generated Hostname
+====
+
+[source,yaml]
+----
+service-name.my-namespace.router.openshift.local <1>
+----
+
+<1> The generated hostname suffix is the default routing subdomain `*router.openshift.local*`.
+====
+
+
+=== Custom default routing subdomain
+The suffix or the default routing subdomain can be tailored to your
+environment using the OpenShift master configuration.
+The following example shows how you can set the configured suffix to
+`*v3.openshift.test*`:
+
+
+.OpenShift master configuration snippet (master-config.yaml)
+====
+
+[source,yaml]
+----
+routingConfig:
+  subdomain: v3.openshift.test
+----
+
+
+With the OpenShift master node(s) running the above configuration, the
+generated hostname for our example of a host added to a namespace
+`my-namespace` would be:
+
+.Generated Hostname
+====
+
+[source,yaml]
+----
+service-name.my-namespace.v3.openshift.test
+----
+
+====

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -393,10 +393,9 @@ no-route-hostname.my-namespace.router.openshift.local <1>
 <1> The generated hostname suffix is the default routing subdomain `*router.openshift.local*`.
 ====
 
-
 === Custom default routing subdomain
-The suffix or the default routing subdomain can be tailored to your
-environment using the OpenShift master configuration.
+A cluster administrator can customize the suffix or the default routing
+subdomain for an environment using the OpenShift master configuration.
 The following example shows how you can set the configured suffix to
 `*v3.openshift.test*`:
 

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -366,7 +366,7 @@ spec:
 apiVersion: v1
 kind: Route
 metadata:
-  name: nohost-route
+  name: no-route-hostname
 spec:
   to:
     kind: Service
@@ -377,7 +377,7 @@ spec:
 
 If a hostname is *not* provided as part of the route specification, then
 OpenShift will automatically generate one for you. The generated hostname
-is of the form `*$service[.$namespace].$suffix*`.
+is of the form `*$routename[.$namespace].$suffix*`.
 
 The following example shows the OpenShift generated hostname for the above
 configuration of a route without a host added to a namespace `my-namespace`:
@@ -387,7 +387,7 @@ configuration of a route without a host added to a namespace `my-namespace`:
 
 [source,yaml]
 ----
-service-name.my-namespace.router.openshift.local <1>
+no-route-hostname.my-namespace.router.openshift.local <1>
 ----
 
 <1> The generated hostname suffix is the default routing subdomain `*router.openshift.local*`.
@@ -421,7 +421,7 @@ generated hostname for our example of a host added to a namespace
 
 [source,yaml]
 ----
-service-name.my-namespace.v3.openshift.test
+no-route-hostname.my-namespace.v3.openshift.test
 ----
 
 ====

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -338,7 +338,7 @@ In order for services to be exposed externally, an OpenShift route allows
 you to associate a service with an externally-reachable hostname.
 This edge hostname is then used to route traffic to the service.
 
-.An Route with a specified host:
+.A Route with a specified host:
 ====
 
 [source,yaml]
@@ -358,7 +358,7 @@ spec:
 ====
 
 
-.An Route without a host:
+.A Route without a host:
 ====
 
 [source,yaml]
@@ -410,6 +410,7 @@ routingConfig:
   subdomain: v3.openshift.test
 ----
 
+====
 
 With the OpenShift master node(s) running the above configuration, the
 generated hostname for our example of a host added to a namespace


### PR DESCRIPTION
@bfallonf   PTAL

As we talked, this is documentation for the auto-generated route host names. Also added some info on how the suffix / router subdomain config (@liggitt FYI) changes affects the generated host name - not sure if this is the right place for it but its out there. 

Related issue: #498 
