### PR TITLE
Explain how to disable builds by strategy using policy

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -171,6 +171,8 @@ Topics:
     File: iptables
   - Name: Native Container Routing
     File: native_container_routing
+  - Name: Securing Builds by Strategy
+    File: securing_builds
 
 ---
 Name: CLI Reference

--- a/admin_guide/securing_builds.adoc
+++ b/admin_guide/securing_builds.adoc
@@ -1,0 +1,152 @@
+= Securing Builds by Build Strategy
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+Builds in OpenShift are run in privileged containers that have access to the Docker daemon socket. As a security
+measure, it is recommended to limit who can run builds and the strategy that is used for those builds. Docker and Custom
+builds are inherently less safe than Source builds, given that they can execute any code in the build with
+potentially full access to the node's Docker socket.
+
+By default, project administrators (`admin` role) and project editors (`edit` role) are granted
+permission to use all build strategies (Docker, Source-to-Image, and Custom).
+
+Who can build with what build strategy can be controlled via an
+link:../architecture/additional_concepts/authorization.html[authorization policy].
+Each build strategy has a corresponding build subresource. Granting permission to `create` on the
+build subresource will allow the user to create builds of that type.
+
+.Build strategy subresources
+[cols="1,1",options="header"]
+|===
+
+|Strategy |Resource
+
+|Docker
+|builds/docker
+
+|Source-To-Image
+|builds/source
+
+|Custom
+|builds/custom
+
+|===
+
+
+
+== Disabling a build strategy globally
+To prevent access to a particular build strategy globally, login as cluster administrator and edit
+each of the default roles:
+
+----
+$ oc edit clusterrole admin
+$ oc edit clusterrole edit
+----
+
+For each role, remove the line that corresponds to the resource of the strategy to disable:
+
+.Disable the Docker build strategy for admin
+=====
+
+----
+kind: ClusterRole
+metadata:
+  name: admin
+...
+
+rules:
+- attributeRestrictions: null
+  resources:
+  - builds/custom
+  - builds/docker <1>
+  - builds/source
+  - pods/exec
+  - pods/portforward
+
+...
+
+----
+<1> Delete this line to disable Docker builds globally for users with the admin role.
+
+=====
+
+
+== Allowing only certain users to create builds with a particular strategy
+
+To allow only a set of specific users to create builds with a particular strategy:
+
+1. link:#disabling-a-build-strategy-globally[Remove the build strategy resource from the default admin and edit roles].
+1. Create a separate role for that build strategy
++
+[#create-separate-role]
+.Create a separate role for the docker build strategy
+====
+
+Create a file that defines the new cluster role (dockerstrategy.yaml):
+
+----
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: dockerbuilder
+rules:
+- resources:
+  - builds/docker
+  verbs:
+  - create
+----
+
+
+As cluster administrator, create the cluster role:
+
+----
+$ oc create -f  dockerstrategy.yaml
+----
+
+====
+
+1. Assign the cluster role to an individual user
++
+.Assign role dockerbuilder to devuser
+====
+
+----
+$ oadm policy add-cluster-role-to-user dockerbuilder devuser
+----
+
+====
+
+
+[WARNING]
+====
+Granting access to a user a cluster level to the builds/docker subresource means that the user
+will be able to create builds with the Docker strategy in any project in which they can create builds.
+
+====
+
+
+== Allowing only certain users in a specific project to create builds with a particular strategy
+
+Similar to granting the build strategy role to a user globally:
+
+1. link:#disabling-a-build-strategy-globally[Remove the build strategy resource from the default admin and edit roles].
+1. link:#create-separate-role[Create a separate role for that build strategy]
+1. Assign the role to an individual user in a project
++
+.Assign role dockerbuilder to devuser in project devproject
+====
+
+----
+$ oadm policy add-role-to-user dockerbuilder devuser -n devproject
+----
+
+====


### PR DESCRIPTION
Documents how to disable a build strategy globally and how to grant access only to specified users or to users within a project.
