### PR TITLE
add oadm policy reconcile-cluster-roles

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -203,6 +203,12 @@ a `*policyBinding*` object named `_<projectname>_:default` with the CLI using a
 JSON file. This allows the project *admin* to bind users to roles that are
 defined only in the `_<projectname>_` local policy.
 
+After a product update, the recommended default roles may be updated.  To check 
+if an update is recommended for your environment, you can run `oadm policy reconcile-cluster-roles`.
+This command will output a list of roles that are out of date and their new values.
+You may either take this output, modify, and apply it yourself or you may run
+`oadm policy reconcile-cluster-roles --confirm` and automatically apply the changes.
+
 [[security-context-constraints]]
 
 == Security Context Constraints


### PR DESCRIPTION
We've added a new command to help update default roles as they change throughout different versions.
