### PR TITLE
router sa and scc reset

### DIFF
--- a/admin_guide/install/deploy_router.adoc
+++ b/admin_guide/install/deploy_router.adoc
@@ -49,18 +49,34 @@ communication between OpenShift components is secured by TLS and uses various
 certificates and authentication methods. Use the `--credentials` option to
 specify what credentials the router should use to contact the master.
 
+The first step of setting up the ha-proxy router is to create a service account to run the router.
+This service account must have permissions to a link:../../admin_guide/manage_scc.html[security context constraint]
+that allows it to specify host ports.
+
+To create the service account and add it to an SCC:
+
+----
+echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' | oc create -f -
+
+oc edit scc <name>
+
+add the service account in the form of system:serviceaccount:<namespace>:<name> to the users section
+of the SCC.  Example system:serviceaccount:default:router.
+----
+
 To check if the default router, named *router*, already exists:
 
 ifdef::openshift-enterprise[]
 ----
 $ oadm router --dry-run \
     --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
-    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}'
+    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
+    --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router --credentials="$KUBECONFIG" --dry-run
+$ oadm router --credentials="$KUBECONFIG" --dry-run --service-account=router
 ----
 endif::[]
 
@@ -70,12 +86,13 @@ ifdef::openshift-enterprise[]
 ----
 $ oadm router -o yaml \
     --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
-    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}'
+    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
+    --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router -o yaml --credentials="$KUBECONFIG"
+$ oadm router -o yaml --credentials="$KUBECONFIG" --service-account=router
 ----
 endif::[]
 
@@ -85,13 +102,15 @@ ifdef::openshift-enterprise[]
 ----
 $ oadm router <router_name> --replicas=<number> \
     --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
-    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}'
+    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
+    --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
 $ oadm router <router_name> --replicas=<number> \
-    --credentials="$KUBECONFIG"
+    --credentials="$KUBECONFIG" \
+    --service-account=router
 ----
 endif::[]
 
@@ -103,13 +122,15 @@ To use a different router image and view the router configuration that would be 
 ifdef::openshift-enterprise[]
 ----
 $ oadm router <router_name> -o <format> --images=<image> \
-    --credentials='/etc/openshift/master/openshift-router.kubeconfig'
+    --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
+    --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
 $ oadm router <router_name> -o <format> --images=<image> \
-    --credentials="$KUBECONFIG"
+    --credentials="$KUBECONFIG" \
+    --service-account=router
 ----
 endif::[]
 
@@ -120,7 +141,8 @@ ifdef::openshift-enterprise[]
 ====
 ----
 $ oadm router region-west -o yaml --images=myrepo/somerouter:mytag \
-    --credentials='/etc/openshift/master/openshift-router.kubeconfig'
+    --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
+    --service-account=router
 ----
 ====
 endif::[]
@@ -128,7 +150,8 @@ ifdef::openshift-origin[]
 ====
 ----
 $ oadm router region-west -o yaml --images=myrepo/somerouter:mytag \
-    --credentials="$KUBECONFIG"
+    --credentials="$KUBECONFIG" \
+    --service-account=router
 ----
 ====
 endif::[]
@@ -168,7 +191,7 @@ From there you can use the `--default-cert` flag:
 ====
 ----
 $ oadm router --default-cert=cloudapps.router.pem \
---images=myrepo/somerouter:mytag --credentials="$KUBECONFIG"
+--images=myrepo/somerouter:mytag --credentials="$KUBECONFIG" --service-account=router
 ----
 ====
 

--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -106,6 +106,13 @@ To update an existing SCC:
 $ oc edit scc <scc_name>
 ----
 
+== Updating the default Security Context Constraints
+
+If you would like to reset your security context constraints to the default settings for any reason
+you may delete the existing security context constraints and restart your master.  The default
+security context constraints will only be recreated if no security context constraints exist in the
+system.
+
 [[how-do-i]]
 
 == How Do I?


### PR DESCRIPTION
@adellape - this outlines the new requirement to create a service account for a router used during installation and how to reset your default SCCs in case you ever want to pick up new defaults (ie. upgrading your SCCs to whatever the latest defaults are).

/cc @sdodson 
