### PR TITLE
clean up "Managing Environment Variables"; add it to Developer's Guide TOC

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -237,6 +237,8 @@ Topics:
     File: building_dependency_trees
   - Name: Downward API
     File: downward_api
+  - Name: Managing Environment Variables
+    File: environment_variables
 
 ---
 Name: Creating Images

--- a/dev_guide/environment_variables.adoc
+++ b/dev_guide/environment_variables.adoc
@@ -1,4 +1,4 @@
-= Environment Variables
+= Managing Environment Variables
 {product-author}
 {product-version}
 :data-uri:
@@ -6,156 +6,159 @@
 :experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
 
 toc::[]
 
 == Overview
 
-OpenShift users can set, unset or list environment variables in pods or pod templates using the
+You can set, unset or list environment variables in pods or pod
+link:../dev_guide/templates.html[templates] using the
 `oc env` command.
 
 == CLI Interface
 
 OpenShift provides the `oc env` command to set or unset environment variables for
-any object that has a pod template, like replication controllers or deployment configurations.
+objects that have a pod template, such as replication controllers or deployment configurations.
 It can also list environment variables in pods or any object that has a pod template.
 
-General syntax:
+The `oc env` command uses the following general syntax:
+
 ----
-$ oc env <resource-selection> <environment-variables> [options]
+$ oc env <object-selection> <environment-variables> [options]
 ----
 
-Users can pick one of the options to select the resource:[[resource-selection]]
+There are several ways to express _<object-selection>_.
+
+[[object-selection]]
 [cols="3*",options="header"]
 |===
 
 |Syntax |Description |Example
 
-|`_<resource_type>_ _<resource_name>_`
-|Selects _<resource_name>_ of type _<resource_type>_
-|deploymentConfig registry
+|`_<object-type>_ _<object-name>_`
+|Selects _<object-name>_ of type _<object-type>_.
+|`dc registry`
 
-|`_<resource_type>_/_<resource_name>_`
-|Selects _<resource_name>_ of type _<resource_type>_
-|deploymentConfig/registry
+|`_<object-type>_/_<object-name>_`
+|Selects _<object-name>_ of type _<object-type>_.
+|`dc/registry`
 
-|`_<resource_type>_ --selector=_<resource_label_selector>_`
-|Selects resources of type _<resource_type>_ that matched the given label selector
-|deploymentConfig --selector="name=registry"
+|`_<object-type>_ --selector=_<object-label-selector>_`
+|Selects objects of type _<object-type>_ that match _<object-label-selector>_.
+|`dc --selector="name=registry"`
 
-|`_<resource_type>_ --all`
-|Selects all resources of type _<resource_type>_
-|deploymentConfig --all
+|`_<object-type>_ --all`
+|Selects all objects of type _<object-type>_.
+|`dc --all`
 
-|`-f, --filename=_<resource_definition_file>_`
-|Filename, directory, or URL to file to use to edit the resource.
-|-f registry-deployment-config.json
+|`-f, --filename=_<ref>_`
+|Look in _<ref>_ -- a filename, directory name, or URL -- for the definition of the object to edit.
+|`-f registry-dc.json`
 |===
 
-Supported common options for set, unset or list environment variables: [[common-options]]
-[cols="3*",options="header"]
+Supported common options for set, unset or list environment variables:
+
+[[common-options]]
+[cols="2",options="header"]
 |===
 
-|Option |Description |Default
+|Option |Description
 
-|`-c, --containers`
-|Select containers by name. It can also take wildcard '*' that matches any character
-|'*'
+|`-c, --containers [<name>]`
+|Select containers by `_<name>_`.  You can use asterisk (`\*`, U+2A) as a wildcard.  If unspecified, `_<name>_` defaults to `*`.
 
-|`-o, --output`
-|Display the changed objects instead of updating them on the server. Supported values:
-json, yaml. Not valid for --list
-|
+|`-o, --output <format>`
+|Display the changed objects in `_<format>_` -- either `json` or `yaml` -- instead of updating them on the server.  This option is incompatible with `--list`.
 
-|`--output-version`
-|Output the changed objects with the given version
-|default api-version
+|`--output-version <api-version>`
+|Output the changed objects with `_<api-version>_` instead of the default API version.
 
-|`--resource-version`
-|Current operation will only succeed if the given resource-version matches with the current resource-version in the object. Only valid when specifying a single resource.
-|
+|`--resource-version <version>`
+|Proceed only if `_<version>_` matches the current resource-version in the object.  This option is valid only when specifying a single object.
 |===
 
 == Set Environment Variables
 
-To set environment variables to the pod templates:
+To set environment variables in the pod templates:
 
 ----
-$ oc env <<resource-selection>> KEY_1=VAL_1 ... KEY_N=VAL_N [<<set-env-options>>] [<<common-options>>]
+$ oc env <object-selection> KEY_1=VAL_1 ... KEY_N=VAL_N [<set-env-options>] [<common-options>]
 ----
 
-Set environment options: [[set-env-options]]
+Set environment options:
+
+[[set-env-options]]
 [cols="2*",options="header"]
 |===
 
 |Option |Description
 
 |`-e, --env=_<KEY>_=_<VAL>_`
-|Set given key value pairs of environment variables
+|Set given key value pairs of environment variables.
 
 |`--overwrite`
-|Confirm updating existing environment variables
+|Confirm updating existing environment variables.
 |===
 
-Some examples:
+In the following example, both commands modify environment variable `STORAGE` in the deployment config `registry`.
+The first adds, with value `/data`.
+The second updates, with value `/opt`.
 
-Add environment variable 'STORAGE' with value '/data' for deployment config 'registry':
 ----
 $ oc env dc/registry STORAGE=/data
-----
-
-Update environment variable 'STORAGE' with value '/opt' for deployment config 'registry':
-----
 $ oc env dc/registry --overwrite STORAGE=/opt
 ----
 
-Set some of the local shell environment into a replication controller 'r1' on the server:
+The following example finds environment variables in the current shell whose names begin with `RAILS_` and adds them to the replication controller `r1` on the server:
 ----
 $ env | grep RAILS_ | oc env rc/r1 -e -
 ----
 
-Output a YAML object with updated environment 'STORAGE=/local' for
-replication controller 'rc.json' on disk and not alter the object on the server:
+The following example does not modify the replication controller defined in file `rc.json`.
+Instead, it writes a YAML object with updated environment `STORAGE=/local` to new file `rc.yaml`.
 ----
-$ oc env -f rc.json STORAGE=/opt -o yaml
-----
-
-== UnSet Environment Variables
-
-To unset environment variables from the pod templates:
-
-----
-$ oc env <<resource-selection>> KEY_1- ... KEY_N- [<<common-options>>]
+$ oc env -f rc.json STORAGE=/opt -o yaml > rc.yaml
 ----
 
-Some examples:
+== Unset Environment Variables
 
-Remove environment variables 'ENV1', 'ENV2' from deployment config 'd1':
+To unset environment variables in the pod templates:
+
+----
+$ oc env <object-selection> KEY_1- ... KEY_N- [<common-options>]
+----
+
+[IMPORTANT]
+====
+The trailing hyphen (`-`, U+2D) is required.
+====
+
+This example removes environment variables `ENV1` and `ENV2` from deployment config `d1`:
+
 ----
 $ oc env dc/d1 ENV1- ENV2-
 ----
 
-Remove environment variable 'ENV' from all replication controllers:
+This removes environment variable `ENV` from all replication controllers:
 ----
 $ oc env rc --all ENV-
 ----
 
-Remove environment variable 'ENV' from container 'c1' for replication controller 'r1':
+This removes environment variable `ENV` from container `c1` for replication controller `r1`:
 ----
 $ oc env rc r1 --containers='c1' ENV-
 ----
 
 == List Environment Variables
 
-To list environment variables for pods or pod templates:
+To list environment variables in pods or pod templates:
 
 ----
-$ oc env <<resource-selection>> --list [<<common-options>>]
+$ oc env <object-selection> --list [<common-options>]
 ----
 
-Some examples:
-
-List all environment variables for pod 'p1':
+This example lists all environment variables for pod `p1`:
 ----
 $ oc env pod/p1 --list
 ----


### PR DESCRIPTION
- prefix title w/ "Managing"
- add ‘:prewrap!:’
- do ‘s/like/such as/’
- expand general syntax intro blurb; add blank line between it and following codeblock
- add link to templates (dev guide)
- prefer "you" to "[OpenShift] users"
- use hyphen, not underscore, as inter-word separator in replaceables
- avoid "any object that has", use "objects that have" instead
- avoid "resource"; use "object" instead
- don't write <<replaceable>>, just use <replaceable>
- add newlines to position anchor at bol
- replace bloaty "deploymentConfig" w/ succinct "dc"
- add replaceables to common options table; reword desciptions
- rewrite section "Set Environment Variables"
- rewrite blurbs in section "UnSet Environment Variables"
- do ‘s/UnSet/Unset/’
- drop third column in common options table; fold ‘-c’ default value into ‘-c’ description
- add admonition re trailing hyphen for unsetting env vars
- rewrite section "List Environment Variables"
- refine object selection table; use em-dash in common options table
- (_build_cfg.yml): add "Managing Environment Variables" to "Developer Guide"
