### PR TITLE
[do not merge] change references to openshift.local directories to origin.local

### DIFF
--- a/admin_guide/aggregate_logging.adoc
+++ b/admin_guide/aggregate_logging.adoc
@@ -378,7 +378,7 @@ the configuration path and check interval appropriately:
 [source,yaml]
 ----
 podManifestConfig:
-  path: openshift.local.manifests
+  path: origin.local.manifests
   fileCheckIntervalSeconds: 10
 ----
 ====

--- a/admin_guide/master_node_configuration.adoc
+++ b/admin_guide/master_node_configuration.adoc
@@ -50,7 +50,7 @@ the same host) in the specified directory:
 
 [options="nowrap"]
 ----
-$ openshift start --write-config=/openshift.local.config
+$ openshift start --write-config=/origin.local.config
 ----
 
 To create a link:#master-configuration-files[master configuration file] and
@@ -58,7 +58,7 @@ other required files in the specified directory:
 
 [options="nowrap"]
 ----
-$ openshift start master --write-config=/openshift.local.config/master
+$ openshift start master --write-config=/origin.local.config/master
 ----
 
 To create a link:#node-configuration-files[node configuration file] and other
@@ -66,13 +66,13 @@ related files in the specified directory:
 
 [options="nowrap"]
 ----
-$ oadm create-node-config --node-dir=/openshift.local.config/node-<node_hostname> --node=<node_hostname> --hostnames=<hostname>,<ip_address>
+$ oadm create-node-config --node-dir=/origin.local.config/node-<node_hostname> --node=<node_hostname> --hostnames=<hostname>,<ip_address>
 ----
 
 For the `--hostnames` option in the above command, use a comma-delimited list of
 every host name or IP address you want server certificates to be valid for. The
 above command also assumes that certificate files are located in an
-*_openshift.local.config/master/_* directory. If they are not, you can include
+*_origin.local.config/master/_* directory. If they are not, you can include
 options to specify their location. Run the command with the `-h` option to see
 details.
 
@@ -89,21 +89,21 @@ configuration file:
 
 [options="nowrap"]
 ----
-$ openshift start --master-config=/openshift.local.config/master/master-config.yaml --node-config=/openshift.local.config/node-<node_hostname>/node-config.yaml
+$ openshift start --master-config=/origin.local.config/master/master-config.yaml --node-config=/origin.local.config/node-<node_hostname>/node-config.yaml
 ----
 
 To launch a master server using a master configuration file:
 
 [options="nowrap"]
 ----
-$ openshift start master--config=/openshift.local.config/master/master-config.yaml
+$ openshift start master--config=/origin.local.config/master/master-config.yaml
 ----
 
 To launch a node server using a node configuration file:
 
 [options="nowrap"]
 ----
-$ openshift start node --config=/openshift.local.config/node-<node_hostname>/node-config.yaml
+$ openshift start node --config=/origin.local.config/node-<node_hostname>/node-config.yaml
 ----
 
 [[master-configuration-files]]
@@ -158,7 +158,7 @@ etcdConfig:
     certFile: etcd.server.crt
     clientCA: ca.crt
     keyFile: etcd.server.key
-  storageDirectory: /root/openshift.local.etcd
+  storageDirectory: /root/origin.local.etcd
 etcdStorageConfig:
   kubernetesStoragePrefix: kubernetes.io
   kubernetesStorageVersion: v1
@@ -275,5 +275,5 @@ servingInfo:
   certFile: server.crt
   clientCA: node-client-ca.crt
   keyFile: server.key
-volumeDirectory: /root/openshift.local.volumes
+volumeDirectory: /root/origin.local.volumes
 ----

--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -72,8 +72,8 @@ the appropriate CA bundle and client key and certificate to connect to
 OpenShift. Set the following environment variables:
 +
 ----
-# export KUBECONFIG=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
-# export CURL_CA_BUNDLE=/var/lib/openshift/openshift.local.config/master/ca.crt
+# export KUBECONFIG=/var/lib/openshift/origin.local.config/master/admin.kubeconfig
+# export CURL_CA_BUNDLE=/var/lib/openshift/origin.local.config/master/ca.crt
 ----
 +
 NOTE: When running as a user other than `root`, you would also need to make the
@@ -144,9 +144,9 @@ the appropriate CA bundle and client key and certificate to connect to
 OpenShift. Set the following environment variables:
 +
 ----
-$ export KUBECONFIG=`pwd`/openshift.local.config/master/admin.kubeconfig
-$ export CURL_CA_BUNDLE=`pwd`/openshift.local.config/master/ca.crt
-$ sudo chmod +r `pwd`/openshift.local.config/master/admin.kubeconfig
+$ export KUBECONFIG=`pwd`/origin.local.config/master/admin.kubeconfig
+$ export CURL_CA_BUNDLE=`pwd`/origin.local.config/master/ca.crt
+$ sudo chmod +r `pwd`/origin.local.config/master/admin.kubeconfig
 ----
 +
 NOTE: This is just for example purposes; in a production environment, developers would generate their own keys and not have access to the system keys.


### PR DESCRIPTION
When https://github.com/openshift/origin/pull/3930 merges the config location, by default, will now be written as origin.local.*.  This PR updates references to those directories.
