### PR TITLE
Updated volume types link to VolumeSource code location.

### DIFF
--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -130,8 +130,7 @@ character.
 |`--source`
 |Details of volume source as a JSON string. Recommended if the desired volume
 source is not supported by `--type`. See
-link:https://github.com/openshift/origin/blob/master/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go#L179[available
-volume sources].
+link:../rest_api/kubernetes_v1.html#v1-volume[available volume sources]
 |
 
 |`-o, --output`


### PR DESCRIPTION
The current link is pointing to Kubernetes [Volume type](https://github.com/openshift/origin/blob/master/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go#L179). I believe it should be pointed at the [VolumeSource type](https://github.com/openshift/origin/blob/master/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go#L191)
