### PR TITLE
Version-agnostic link to Customer Portal downloads

### DIFF
--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -22,12 +22,11 @@ logging in to create your first project.
 
 ifdef::openshift-enterprise[]
 You can download and unpack the CLI from the
-https://access.redhat.com/downloads/content/290/ver=3.0.0.0/rhel---7/3.0.0.0/x86_64/product-downloads[Red
-Hat Customer Portal] for use on Linux, MacOSX, and Windows clients. After
+https://access.redhat.com/downloads/content/290[Red Hat Customer Portal] for use on Linux, MacOSX, and Windows clients. After
 logging in with your Red Hat account, you must have an active OpenShift
 Enterprise subscription to access the downloads page.
 
-https://access.redhat.com/downloads/content/290/ver=3.0.0.0/rhel---7/3.0.0.0/x86_64/product-downloads[*Download the CLI*]
+https://access.redhat.com/downloads/content/290[*Download the CLI*]
 endif::[]
 
 ifdef::openshift-origin[]

--- a/cli_reference/overview.adoc
+++ b/cli_reference/overview.adoc
@@ -24,7 +24,7 @@ $ oc <command>
 ifdef::openshift-enterprise[]
 You can download and unpack the CLI with an active OpenShift Enterprise
 subscription from the
-https://access.redhat.com/downloads/content/290/ver=3.0.0.0/rhel---7/3.0.0.0/x86_64/product-downloads[Red
+https://access.redhat.com/downloads/content/290[Red
 Hat Customer Portal].
 endif::[]
 


### PR DESCRIPTION
The link to download the client from the customer portal was pointing to version 3.0.0 specifically. Removed the version from the URL, which should point to the latest available version by default.
