### PR TITLE
Old version is a depricated command resulting following message.

### DIFF
--- a/admin_guide/install/deploy_router.adoc
+++ b/admin_guide/install/deploy_router.adoc
@@ -197,7 +197,7 @@ to create the certificate. For example:
 ====
 ----
 $ CA=/etc/openshift/master
-$ oadm create-server-cert --signer-cert=$CA/ca.crt \
+$ oadm ca create-server-cert --signer-cert=$CA/ca.crt \
       --signer-key=$CA/ca.key --signer-serial=$CA/ca.serial.txt \
       --hostnames='*.cloudapps.example.com' \
       --cert=cloudapps.crt --key=cloudapps.key


### PR DESCRIPTION
Command "create-server-cert" is deprecated, Use 'oadm ca' instead.
