### PR TITLE
document oc groups

### DIFF
--- a/architecture/additional_concepts/authentication.adoc
+++ b/architecture/additional_concepts/authentication.adoc
@@ -35,8 +35,7 @@ access to link:../core_concepts/overview.html[objects] within a
 link:../core_concepts/projects_and_users.html#projects[project], versus granting
 them to users individually.
 
-Support for developers and administrators to define their own custom groups is
-currently under active development. At this time, the only groups that exist are
+In addition to explictly defined groups, there are also 
 system groups, or _virtual groups_, that are automatically provisioned by
 OpenShift. These can be seen when
 link:../../admin_guide/manage_authorization_policy.html#viewing-cluster-bindings[viewing

--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -318,17 +318,13 @@ API.
   "identities": [
     "anypassword:bob" <2>
   ],
-  "fullName": "Bob User", <3>
-  "groups": [
-    "mygroup" <4>
-  ]
+  "fullName": "Bob User" <3>
 }
 ----
 
 <1> `name` is the user name used when adding roles to a user.
 <2> The values in `identities` are Identity objects that map to this user. May be `null` or empty for users that cannot log in.
 <3> The `fullName` value is an optional display name of user.
-<4> `groups` represent any groups the user belongs to.
 ====
 
 === UserIdentityMapping
@@ -369,3 +365,31 @@ methods to identify the same `*User*`.
 
 <1> `*UserIdentityMapping*` name matches the mapped `*Identity*` name
 ====
+
+=== Group
+A `*Group*` represents a list of users in the system. Groups are granted permissions by
+link:../../admin_guide/manage_authorization_policy.html#managing-role-bindings[adding
+roles to users or to their groups].
+
+.`*Group*` Object Definition
+====
+
+[source,json]
+----
+{
+  "kind": "Group",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "developers", <1>
+    "creationTimestamp": "2015-01-01T01:01:01-00:00"
+  },
+  "users": [
+    "bob" <2>
+  ]
+}
+----
+
+<1> `name` is the group name used when adding roles to a group.
+<2> The values in `users` are the names of User objects that are members of this group.
+====
+

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -295,6 +295,10 @@ indicated files.
 |`oc export _<object_type>_ [--options]`
 |Export resources to be used elsewhere
 
+|`groups`
+|`oc groups [--options]`
+|Create or modify groups.
+
 |`policy`
 |`oc policy [--options]`
 |Manage authorization policies


### PR DESCRIPTION
Document the presence of groups and remove the reference to the `groups` field on the `User` object.
