### PR TITLE
Remove the Optional repo

### DIFF
--- a/admin_guide/install/prerequisites.adoc
+++ b/admin_guide/install/prerequisites.adoc
@@ -253,7 +253,6 @@ Enterprise subscription and attach it:
 # subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-optional-rpms" \
     --enable="rhel-7-server-ose-3.0-rpms"
 ----
 


### PR DESCRIPTION
In openshift/openshift-ansible#410 dev mentions that current OpenShift Enterprise does not use any content from the _Optional_ RHEL7 repo, so suggesting to remove it from the doc.
