### PR TITLE
routing_from_edge_lb: use $CLUSTER_NETWORK

### DIFF
--- a/admin_guide/routing_from_edge_lb.adoc
+++ b/admin_guide/routing_from_edge_lb.adoc
@@ -82,7 +82,7 @@ pods.
 +
 ====
 ----
-# tmsh delete net route 10.1.0.0/16 || true
+# tmsh delete net route $CLUSTER_NETWORK || true
 # tmsh delete net self SDN || true
 # tmsh delete net tunnels tunnel SDN || true
 ----


### PR DESCRIPTION
We assign `CLUSTER_NETWORK` and use it to create the route, so use it when deleting the route too.
