### PR TITLE
expose registry externally

### DIFF
--- a/admin_guide/install/docker_registry.adoc
+++ b/admin_guide/install/docker_registry.adoc
@@ -358,6 +358,100 @@ Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 ----
 ====
 
+== Exposing the Registry
+
+If you wish to expose your internal registry externally it is recommended that you run a
+link:#securing-the-registry[secure registry].  In order to expose the registry you must
+first have link:deploy_router.html[deployed a router].
+
+. link:#deploy-registry[Deploy the registry].
++
+. link:#securing-the-registry[Secure the registry]
++
+. link:deploy_router.html[Deploy a router]
++
+. Create your link:../../architecture/core_concepts/routes.html#passthrough-termination[passthrough]
+route with `oc create -f <filename>.json`.  The passthrough route will
+point to the registry service that you have created.
++
+====
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: registry
+spec:
+  host: <host> <1>
+  to:
+    kind: Service
+    name: docker-registry <2>
+  tls:
+    termination: passthrough <3>
+----
+<1> The host for your route.  You must be able to resolve this name externally via DNS to the
+router's IP address.
+<2> The service name for your registry.
+<3> Specify this route as a passthrough route.
+====
++
+[NOTE]
+====
+Passthrough is currently the only type of route supported for exposting the secure registry.
+====
++
+. Next, you must trust the certificates being used for the registry on your host system.
+The certificates referenced were created when you secured your registry.
++
+====
+----
+$ sudo mkdir -p /etc/docker/certs.d/<host>
+$ sudo cp <ca certificate file> /etc/docker/certs.d/<host>
+$ sudo systemctl restart docker
+----
+====
++
+. link:#access[Log in to the registry] using the information from securing the registry.  However,
+this time point to the host name used in the route rather than your service IP.  You should
+now be able to tag and push images using the route host.
++
+----
+$ oc get imagestreams -n test
+NAME      DOCKER REPO   TAGS      UPDATED
+
+$ docker pull busybox
+$ docker tag busybox <host>/test/busybox
+$ docker push <host>/test/busybox
+The push refers to a repository [<host>/test/busybox] (len: 1)
+8c2e06607696: Image already exists
+6ce2e90b0bc7: Image successfully pushed
+cf2616975b4a: Image successfully pushed
+Digest: sha256:6c7e676d76921031532d7d9c0394d0da7c2906f4cb4c049904c4031147d8ca31
+
+$ docker pull <host>/test/busybox
+latest: Pulling from <host>/test/busybox
+cf2616975b4a: Already exists
+6ce2e90b0bc7: Already exists
+8c2e06607696: Already exists
+Digest: sha256:6c7e676d76921031532d7d9c0394d0da7c2906f4cb4c049904c4031147d8ca31
+Status: Image is up to date for <host>/test/busybox:latest
+
+$ oc get imagestreams -n test
+NAME      DOCKER REPO                       TAGS      UPDATED
+busybox   172.30.11.215:5000/test/busybox   latest    2 seconds ago
+----
++
+[NOTE]
+====
+Your image streams will have the IP address and port of the registry service, NOT the route name and port.
+See `oc get imagestreams` for details.
+====
++
+[NOTE]
+====
+In this example, in the url `<host>/test/busybox`, `test` refers to the project name.
+====
+
+
 == What's Next?
 
 After you have a registry deployed, you can:


### PR DESCRIPTION
This details how to expose a secure registry externally via a route

Some items of note:
1.  I tested with the vagrant environment by using the private network and pushing from my local machine into the vagrant environment where OpenShift was running
2.  In order to work properly I needed to have the localhost system trust the ca cert for the registry.  It was not possible to just add this to `docker/certs.d` it had to be added to the system itself
3.  Once pushed, the imagestreams retain the ip/port of the service, not the router so pods that reference them must use that ip/port NOT the ip/port that it was pushed with from the external machine.

@smarterclayton @ncdc @liggitt @etsauer @thesteve0 @jwhonce 

```
# On Vagrant 
# setup registry as secure (already in docs)
# update the vagrant machine for secure registry mode, 
# copying cert, trusting them, removing the --insecure-registry option 
# (already in docs except the system wide trust piece)

# On the local host
# pull in the ca.crt, trust it, restart docker (documented in this PR)
[pweil@localhost openshift-docs]$ docker login -u test -e test@example.com -p <token> www.myregistry.com:443
Login Succeeded
[pweil@localhost openshift-docs]$ docker pull pweil/hello-nginx-docker
[pweil@localhost openshift-docs]$ docker tag pweil/hello-nginx-docker www.myregistry.com:443/test/hello-nginx-docker
[pweil@localhost openshift-docs]$ docker push www.myregistry.com:443/test/hello-nginx-docker
The push refers to a repository [www.myregistry.com:443/test/hello-nginx-docker] (len: 1)
...snip...
Digest: sha256:216c53a6e81248009c8532724545279e9413128e140531e5446a855ffc853198

### On Vagrant
[vagrant@openshiftdev ~]$ oc get imagestreams
NAME                 DOCKER REPO                                  TAGS      UPDATED
hello-nginx-docker   172.30.73.233:5000/test/hello-nginx-docker   latest    13 seconds ago

[vagrant@openshiftdev origin]$ cat ~/hello-nginx-docker/openshift/nginx_pod.json | grep image
        "image": "172.30.73.233:5000/test/hello-nginx-docker",
[vagrant@openshiftdev origin]$ oc create -f ~/hello-nginx-docker/openshift/nginx_pod.json
[vagrant@openshiftdev origin]$ oc get pods
NAME                 READY     STATUS    RESTARTS   AGE
hello-nginx-docker   1/1       Running   0          16s
```

Full notes from testing: https://gist.github.com/pweil-/9cf7159e75c01ea3074f
