### PR TITLE
Edits to pruning_resources for issues 663 and 847

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -159,7 +159,7 @@ Topics:
     File: manage_scc
   - Name: Scheduler
     File: scheduler
-  - Name: Pruning Resources
+  - Name: Pruning Objects
     File: pruning_resources
   - Name: Monitoring Routers
     File: router

--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -1,4 +1,4 @@
-= Pruning Resources
+= Pruning Objects
 {product-author}
 {product-version}
 :data-uri:
@@ -10,25 +10,38 @@
 toc::[]
 
 == Overview
-This topic provides information on CLI operations and syntax to prune old resources
-from the server that accumulate over periods of use, but are no longer needed.
+Over time, link:../architecture/core_concepts/overview.html[API objects] created
+in OpenShift can accumulate in the
+link:../architecture/infrastructure_components/kubernetes_infrastructure.html#master[etcd
+data store] through normal user operations, such as when building and deploying
+applications.
 
-== Prune Operations
+As an administrator, you can periodically prune older versions of objects from
+your OpenShift instance that are no longer needed. For example, by pruning
+images you can delete older images and layers that are no longer in use, but are
+still taking up disk space. 
+
+[[prune-operations]]
+
+== Basic Prune Operations
 The CLI groups prune operations under a common parent command.
 
 ----
-$ oadm prune <resource_type> <options>
+$ oadm prune <object_type> <options>
 ----
 
 This specifies:
 
-- The `<resource_type>` to perform the action on, such as `builds`, `deployments`, or `images`.
-- The `<options>` supported to prune that resource type.
+- The `<object_type>` to perform the action on, such as `builds`,
+`deployments`, or `images`.
+- The `<options>` supported to prune that object type.
 
-*Deployments*
+[[pruning-deployments]]
 
-In order to prune deployments that are no longer required by the system due to age and status, administrators
-may run the following command:
+== Pruning Deployments
+
+In order to prune deployments that are no longer required by the system due to
+age and status, administrators may run the following command:
 
 ----
 $ oadm prune deployments [<options>]
@@ -44,16 +57,20 @@ $ oadm prune deployments [<options>]
 |Indicate that pruning should occur, instead of performing a dry-run.
 
 .^|`--orphans`
-|Prune all deployments whose deployment config no longer exists, status is complete or failed, and replica count is zero.
+|Prune all deployments whose deployment config no longer exists, status is
+complete or failed, and replica count is zero.
 
 .^|`--keep-complete=<N>`
-|Per deployment config, keep the last N deployments whose status is complete and replica count is zero. (default `5`)
+|Per deployment config, keep the last N deployments whose status is complete and
+replica count is zero. (default `5`)
 
 .^|`--keep-failed=<N>`
-|Per deployment config, keep the last N deployments whose status is failed and replica count is zero. (default `1`)
+|Per deployment config, keep the last N deployments whose status is failed and
+replica count is zero. (default `1`)
 
 .^|`--keep-younger-than=<duration>`
-|Do not prune any resource that is younger than `<duration>` relative to the current time. (default `60m`)
+|Do not prune any object that is younger than `<duration>` relative to the
+current time. (default `60m`)
 |===
 
 To see what a pruning operation would delete:
@@ -70,10 +87,12 @@ $ oadm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m --confirm
 ----
 
-*Builds*
+[[pruning-builds]]
 
-In order to prune builds that are no longer required by the system due to age and status, administrators
-may run the following command:
+== Pruning Builds
+
+In order to prune builds that are no longer required by the system due to age
+and status, administrators may run the following command:
 
 ----
 $ oadm prune builds [<options>]
@@ -89,16 +108,20 @@ $ oadm prune builds [<options>]
 |Indicate that pruning should occur, instead of performing a dry-run.
 
 .^|`--orphans`
-|Prune all builds whose build config no longer exists, status is complete, failed, error, or canceled.
+|Prune all builds whose build config no longer exists, status is complete,
+failed, error, or canceled.
 
 .^|`--keep-complete=<N>`
-|Per build config, keep the last N builds whose status is complete. (default `5`)
+|Per build config, keep the last N builds whose status is complete. (default
+`5`)
 
 .^|`--keep-failed=<N>`
-|Per build config, keep the last N builds whose status is failed, error, or canceled (default `1`)
+|Per build config, keep the last N builds whose status is failed, error, or
+canceled (default `1`)
 
 .^|`--keep-younger-than=<duration>`
-|Do not prune any resource that is younger than `<duration>` relative to the current time. (default `60m`)
+|Do not prune any object that is younger than `<duration>` relative to the
+current time. (default `60m`)
 |===
 
 To see what a pruning operation would delete:
@@ -115,14 +138,27 @@ $ oadm prune builds --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m --confirm
 ----
 
-*Images*
+[[pruning-images]]
 
-In order to prune images that are no longer required by the system due to age and status, administrators
-may run the following command:
+== Pruning Images
+
+In order to prune images that are no longer required by the system due to age
+and status, administrators may run the following command:
 
 ----
 $ oadm prune images [<options>]
 ----
+
+[NOTE]
+====
+Currently, to prune images you must first
+link:../cli_reference/get_started_cli.html#basic-setup-and-login[log in to the
+CLI] as a user with an
+link:../architecture/additional_concepts/authentication.html#oauth[access
+token]. The user must also have the
+link:../architecture/additional_concepts/authorization.html#roles[cluster role]
+*system:image-pruner* or greater (for example, *cluster-admin*).
+====
 
 .Prune Images CLI Configuration Options
 [cols="4,8",options="header"]
@@ -131,39 +167,46 @@ $ oadm prune images [<options>]
 |Option |Description
 
 .^|`--certificate-authority`
-|The path to a certificate authority file to use when communicating with the OpenShift-managed registries. Defaults to the certificate authority data from the current user's config file.
+|The path to a certificate authority file to use when communicating with the
+OpenShift-managed registries. Defaults to the certificate authority data from
+the current user's config file.
 
 .^|`--confirm`
 |Indicate that pruning should occur, instead of performing a dry-run.
 
 .^|`--keep-tag-revisions=<N>`
-|For each image stream, keep up to at most N image revisions per tag. (default `60m`)
+|For each image stream, keep up to at most N image revisions per tag. (default
+`60m`)
 
 .^|`--keep-younger-than=<duration>`
-|Do not prune any image that is younger than `<duration>` relative to the current time. Do not prune any image that is referenced by any other object that is younger than `<duration>` relative to the current time. (default `60m`)
+|Do not prune any image that is younger than `<duration>` relative to the
+current time. Do not prune any image that is referenced by any other object that
+is younger than `<duration>` relative to the current time. (default `60m`)
 |===
 
-OpenShift uses the following logic to determine which images and layers to prune:
+OpenShift uses the following logic to determine which images and layers to
+prune:
 
-Remove any image managed by OpenShift (see below) that was created at least `--keep-younger-than` minutes ago and is *not* currently referenced by:
+* Remove any image "managed by OpenShift" (i.e., images with the annotation
+`*openshift.io/image.managed*`) that was created at least
+`--keep-younger-than` minutes ago and is not currently referenced by:
+- any pod created less than `--keep-younger-than` minutes ago.
+- any image stream created less than `--keep-younger-than` minutes ago.
+- any running pods.
+- any pending pods.
+- any replication controllers.
+- any deployment configurations.
+- any build configurations.
+- any builds.
+- the `--keep-tag-revisions` most recent items in
+ `*stream.status.tags[].items*`.
 
-- any pod created less than `--keep-younger-than` minutes ago
-- any image stream created less than `--keep-younger-than` minutes ago
-- any running pods
-- any pending pods
-- any replication controllers
-- any deployment configs
-- any build configs
-- any builds
-- the `--keep-tag-revisions` most recent items in stream.status.tags[].items
+* There is no support for pruning from external registries.
 
-There is no support for pruning from external registries.
+* When an image is pruned, all references to the image are removed from all
+image streams that have a reference to the image in `*status.tags*`.
 
-Images "managed by OpenShift" will have the annotation `openshift.io/image.managed`.
-
-When an image is pruned, all references to the image are removed from all ImageStreams having a reference to the image in `status.tags`.
-
-Image layers that are no longer referenced by any images are removed as well.
+* Image layers that are no longer referenced by any images are removed as well.
 
 To see what a pruning operation would delete:
 


### PR DESCRIPTION
Attempting to:

Fix https://github.com/openshift/openshift-docs/issues/847
Fix https://github.com/openshift/openshift-docs/issues/663
- Added a little more context to the intro, but probably needs more.
- Added NOTE about image pruning requiring token/cluster-role.
- Changed all usage of "resources" to "objects" to sync w/ the rest of the docs, though I left the filename as-is to not break links (although, I don't know anything that's referencing it in the wild, so maybe should sync that, too).
- Minor reworking of the "image prune logic" list.
- Minor formatting changes (created actual headings, hard-wrapped text, etc).

Pretty build for linking (internal):
http://file.rdu.redhat.com/~adellape/081815/fix_847_imgprunetoken/admin_guide/pruning_resources.html

@ncdc Can you take a look? It was a little difficult trying to keep the NOTE box discussion about tokens succinct/helpful. LMK if you have suggestions/corrections there. Also interested if you have any other answer for "Why would I want to prune them?" per https://github.com/openshift/openshift-docs/issues/663 other than, for example, images needlessly taking up space.
