### PR TITLE
Add host variables for advanced install

### DIFF
--- a/admin_guide/install/advanced_install.adoc
+++ b/admin_guide/install/advanced_install.adoc
@@ -105,27 +105,36 @@ link:#running-the-ansible-installer[running the Ansible installer], or modify an
 
 *Configuring Node Host Labels*
 
-To assign link:../../architecture/core_concepts/pods_and_services.html#labels[labels] to node hosts during the Ansible install, indicate the desired labels in the *_/etc/ansible/hosts_* file:
+You can assign
+link:../../architecture/core_concepts/pods_and_services.html#labels[labels] to
+node hosts during the Ansible install by configuring the *_/etc/ansible/hosts_*
+file. Labels are useful for determining the placement of pods onto nodes using
+the link:../scheduler.html#configurable-predicates[scheduler].
 
+To assign labels to a node host during an Ansible install, use the
+`*openshift_node_labels*` variable with the desired labels added to the desired
+node host entry in the [nodes] section:
+
+====
 ----
 [nodes]
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 ----
-
-Labels are useful for determining the placement of pods onto nodes using the link:../scheduler.html#configurable-predicates[scheduler].
+====
 
 *Configuring Host Variables*
 
 To assign environment variables to hosts during the Ansible install, indicate the desired variables in the *_/etc/ansible/hosts_* file:
 
+====
 ----
 [masters]
-ec2-52-6-179-239.compute-1.amazonaws.com
-openshift_public_hostname=ose3-master.public.example.com
+ec2-52-6-179-239.compute-1.amazonaws.com openshift_public_hostname=ose3-master.public.example.com
 ----
+====
 
-The following table describes example environment variables to replace
-in the above example configuration:
+The following table describes example variables for use with the Ansible
+installer to replace in the above example configuration:
 
 [options="header"]
 |===
@@ -133,20 +142,22 @@ in the above example configuration:
 |Variable |Purpose
 
 |`*openshift_hostname*`
-|This variable overrides the internal cluster hostname for the system.
+|This variable overrides the internal cluster host name for the system.
 Use this when the system's default IP address does not resolve to the system
 hostname.
 
 |`*openshift_public_hostname*`
-|This variable overrides the system's external/public hostname. Use this for
-cloud installations, or when using a Network address translation (NAT).
+|This variable overrides the system's public host name. Use this for cloud
+installations, or for hosts on networks using a network address translation
+(NAT).
 
 |`*openshift_ip*`
 |This variable overrides the cluster internal IP address for the system. Use this when using an interface that is not configured with the default route.
 
 |`*openshift_public_ip*`
-|This variable overrides the system's external/public IP address. Use this for
-cloud installations, or when using a Network address translation (NAT).
+|This variable overrides the system's public IP address. Use this for cloud
+installations, or for hosts on networks using a network address translation
+(NAT).
 |===
 
 [[single-master-multi-node]]

--- a/admin_guide/install/advanced_install.adoc
+++ b/admin_guide/install/advanced_install.adoc
@@ -83,22 +83,71 @@ the remaining instructions.
 
 == Configuring Ansible
 
-You must create an *_/etc/ansible/hosts_* file, which is Ansible's inventory
-file for the playbook to use during the installation.
+The *_/etc/ansible/hosts_* file is Ansible's inventory
+file for the playbook to use during the installation. Replace the contents of the file with your desired configuration.
 
-Any hosts you designate as masters during the installation process should also
-be configured as
+[NOTE]
+====
+Before running the Ansible installer, any hosts you intend to designate as
+masters during the installation process should also be configured as
 link:../../admin_guide/manage_nodes.html#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
-nodes. This is so the masters are configured as part of the
+nodes, in order to configure the masters as part of the
 link:../../architecture/additional_concepts/networking.html#openshift-sdn[OpenShift
 SDN].
+====
 
-The following sections describe example inventory files for various environment
-topographies, including configuring
-link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters[multiple
+The following sections describe example *_/etc/ansible/hosts_* files for various environment
+topographies, including example configurations for
+link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters[using multiple
 masters for high availability]. You can choose an example that matches your
-requirements to modify and use as your inventory file when
-link:#running-the-ansible-installer[running the Ansible installer].
+requirements and use as your inventory file when
+link:#running-the-ansible-installer[running the Ansible installer], or modify an example to match your own environment.
+
+*Configuring Node Host Labels*
+
+To assign link:../../architecture/core_concepts/pods_and_services.html#labels[labels] to node hosts during the Ansible install, indicate the desired labels in the *_/etc/ansible/hosts_* file:
+
+----
+[nodes]
+node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
+----
+
+Labels are useful for determining the placement of pods onto nodes using the link:../scheduler.html#configurable-predicates[scheduler].
+
+*Configuring Host Variables*
+
+To assign environment variables to hosts during the Ansible install, indicate the desired variables in the *_/etc/ansible/hosts_* file:
+
+----
+[masters]
+ec2-52-6-179-239.compute-1.amazonaws.com
+openshift_public_hostname=ose3-master.public.example.com
+----
+
+The following table describes example environment variables to replace
+in the above example configuration:
+
+[options="header"]
+|===
+
+|Variable |Purpose
+
+|`*openshift_hostname*`
+|This variable overrides the internal cluster hostname for the system.
+Use this when the system's default IP address does not resolve to the system
+hostname.
+
+|`*openshift_public_hostname*`
+|This variable overrides the system's external/public hostname. Use this for
+cloud installations, or when using a Network address translation (NAT).
+
+|`*openshift_ip*`
+|This variable overrides the cluster internal IP address for the system. Use this when using an interface that is not configured with the default route.
+
+|`*openshift_public_ip*`
+|This variable overrides the system's external/public IP address. Use this for
+cloud installations, or when using a Network address translation (NAT).
+|===
 
 [[single-master-multi-node]]
 


### PR DESCRIPTION
Edits to the advanced installation section as per BZ 1245023.

Basically, edited the Configuring Ansible section to be more accurate and adding the missing information (labels and en vars) for more context.

@detiber I'll ping you in the BZ, but if there's anything you feel missing or not clear, let me know.
