### PR TITLE
Edits per 890 for build configchange triggers

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -20,14 +20,14 @@ runnable images to be used on OpenShift. There are three build strategies:
 
 [[defining-a-buildconfig]]
 
-== Defining a buildConfig
+== Defining a BuildConfig
 
 A build configuration describes a single build definition and a set of
 link:#triggers[triggers] for when a new build should be created.
 
-A build configuration is defined by a `*buildConfig*`, which is a REST object
+A build configuration is defined by a `*BuildConfig*`, which is a REST object
 that can be used in a POST to the API server to create a new instance. The
-following example `*buildConfig*` results in a new build every time a Docker
+following example `*BuildConfig*` results in a new build every time a Docker
 image tag or the source code changes:
 
 .BuildConfig Object Definition
@@ -84,7 +84,7 @@ image tag or the source code changes:
 }
 ----
 
-<1> This specification will create a new `*buildConfig*` named
+<1> This specification will create a new `*BuildConfig*` named
 *ruby-sample-build*.
 <2> You can specify a list of link:#build-triggers[triggers], which cause a new
 build to be created.
@@ -113,7 +113,7 @@ build strategy].
 By default, if the builder image specified in the build configuration is
 available locally on the node, that image will be used. However, to override the
 local image and refresh it from the registry to which the image stream points,
-create a `*buildConfig*` with the `*forcePull*` flag set to *true*:
+create a `*BuildConfig*` with the `*forcePull*` flag set to *true*:
 
 ====
 
@@ -147,7 +147,7 @@ stored locally.
 
 S2I can perform incremental builds, which means it reuses artifacts from
 previously-built images. To create an incremental build, create a
-`*buildConfig*` with the following modification to the strategy definition:
+`*BuildConfig*` with the following modification to the strategy definition:
 
 ====
 
@@ -266,7 +266,7 @@ cached layers and rerun all steps of the *_Dockerfile_*:
 By default, if the builder image specified in the build configuration is
 available locally on the node, that image will be used. However, to override the
 local image and refresh it from the registry to which the image stream points,
-create a `*buildConfig*` with the `*forcePull*` flag set to *true*:
+create a `*BuildConfig*` with the `*forcePull*` flag set to *true*:
 
 ====
 
@@ -328,7 +328,7 @@ ifdef::openshift-origin[]
 By default, when setting up the build pod, the build controller checks if the image specified in the build configuration is
 available locally on the node.  If so, that image will be used.  However, to override the
 local image and refresh it from the registry to which the image stream points,
-create a `*buildConfig*` with the `*forcePull*` flag set to *true*:
+create a `*BuildConfig*` with the `*forcePull*` flag set to *true*:
 
 ====
 
@@ -388,7 +388,7 @@ Your source URI must use the HTTP or HTTPS protocol for this to work.
 Manually invoke a build using the following command:
 
 ----
-$ oc start-build <buildConfigName>
+$ oc start-build <BuildConfigName>
 ----
 
 Re-run a build using the `--from-build` flag:
@@ -400,7 +400,7 @@ $ oc start-build --from-build=<buildName>
 Specify the `--follow` flag to stream the build's logs in stdout:
 
 ----
-$ oc start-build <buildConfigName> --follow
+$ oc start-build <BuildConfigName> --follow
 ----
 
 [[canceling-a-build]]
@@ -426,7 +426,7 @@ $ oc build-logs <buildName>
 By default, link:../architecture/core_concepts/builds_and_image_streams.html#builds[source
 builds] show full output of the *_assemble_* script and all subsequent errors.
 To enable more verbose output, pass the `*BUILD_LOGLEVEL*` environment variable
-as part of the `*sourceStrategy*` in a `*buildConfig*`:
+as part of the `*sourceStrategy*` in a `*BuildConfig*`:
 
 ====
 
@@ -464,9 +464,9 @@ Level 5:: Produces everything mentioned on previous levels and additionally prov
 
 == Source Code
 The source code location is one of the required parameters for the
-`*buildConfig*`. The build uses this location and fetches the source code that
+`*BuildConfig*`. The build uses this location and fetches the source code that
 is later built. The source code location definition is part of the
-`*parameters*` section in the `*buildConfig*`:
+`*parameters*` section in the `*BuildConfig*`:
 
 ====
 
@@ -498,7 +498,7 @@ default location (the root folder) using this field.
 There are two ways to make environment variables available to the
 link:../architecture/core_concepts/builds_and_image_streams.html#builds[source build]
 process and resulting \image: link:#environment-files[environment files] and
-link:#buildconfig-environment[buildConfig environment] values.
+link:#buildconfig-environment[*BuildConfig* environment] values.
 
 [[environment-files]]
 
@@ -528,7 +528,7 @@ application to start in `development` mode instead of `production`.
 
 === BuildConfig Environment
 You can add environment variables to the `*sourceStrategy*` definition of the
-`*buildConfig*`. Defined environment variables are visible during the *_assemble_*
+`*BuildConfig*`. Defined environment variables are visible during the *_assemble_*
 script execution and will be defined in the output image, making them also
 available to the *_run_* script and application code.
 
@@ -554,12 +554,13 @@ For example disabling assets compilation for your Rails application:
 [[build-triggers]]
 
 == Build Triggers
-When defining a `*buildConfig*`, you can define triggers to control the
-circumstances in which the `*buildConfig*` should be run. There are two types of
-triggers available:
+When defining a `*BuildConfig*`, you can define triggers to control the
+circumstances in which the `*BuildConfig*` should be run. The following build
+triggers are available:
 
 * link:#webhook-triggers[Webhook]
 * link:#image-change-triggers[Image change]
+* link:#config-change-triggers[Configuration change]
 
 [[webhook-triggers]]
 
@@ -575,7 +576,7 @@ made by GitHub when a repository is updated. When defining the trigger, you must
 specify a link:../dev_guide/secrets.html[`*secret*`] as part of the URL you supply
 to GitHub when configuring the webhook. The `*secret*` ensures that only you and
 your repository can trigger the build. The following example is a trigger
-definition JSON within the `*buildConfig*`:
+definition JSON within the `*BuildConfig*`:
 
 ====
 
@@ -601,7 +602,7 @@ http://<openshift_api_host:port>/osapi/v1/namespaces/<namespace>/buildconfigs/<n
 Generic webhooks can be invoked from any system capable of making a web
 request. As with a GitHub webhook, you must specify a `*secret*` when defining the
 trigger, and the caller must provide this `*secret*` to trigger the build. The
-following is an example trigger definition JSON within the `*buildConfig*`:
+following is an example trigger definition JSON within the `*BuildConfig*`:
 
 ====
 
@@ -647,14 +648,15 @@ The endpoint can accept an optional payload with the following format:
 ----
 ====
 
-[#describe-buildconfig]
+[[describe-buildconfig]]
+
 *Displaying a BuildConfig's Webhook URLs*
 
 Use the following command to display the webhook URLs associated with a build
 configuration:
 
 ----
-$ oc describe buildConfig <name>
+$ oc describe bc <name>
 ----
 
 If the above command does not display any webhook URLs, then no webhook trigger
@@ -788,10 +790,11 @@ once when the image stream tag becomes available and not on subsequent image upd
 to the lack of uniquely identifiable images in v1 Docker registries.
 ====
 
-[[config-change-trigger]]
-=== Config Change Trigger
-A config change trigger allows a build to be automatically invoked as soon as
-a new `*BuildConfig*` is created.
+[[config-change-triggers]]
+=== Configuration Change Triggers
+A configuration change trigger allows a build to be automatically invoked as
+soon as a new `*BuildConfig*` is created. The following is an example trigger
+definition JSON within the `*BuildConfig*`:
 
 ====
 
@@ -805,14 +808,15 @@ a new `*BuildConfig*` is created.
 
 [NOTE]
 ====
-A config change trigger will only work on a new `*BuildConfig*`. In the future, config change
-triggers will launch a build whenever a `*BuildConfig*` is updated.
+Configuration change triggers currently only work when creating a new
+`*BuildConfig*`. In a future release, configuration change triggers will also be
+able to launch a build whenever a `*BuildConfig*` is updated.
 ====
 
 [#using-docker-credentials-for-pushing-and-pulling-images]
 == Using Docker Credentials for Pushing and Pulling Images
 
-Supply the `.dockercfg` file with valid Docker Registry credentials in order to
+Supply the *_.dockercfg_* file with valid Docker Registry credentials in order to
 push the output image into a private Docker Registry or pull the builder image
 from the private Docker Registry that requires authentication. For the OpenShift
 Docker Registry, you don't have to do this because `*secrets*` are generated
@@ -843,7 +847,7 @@ command. The file will be created if it does not exist. Kubernetes provides
 https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md[`*secret*`],
 which are used to store your configuration and passwords.
 
-. Create the `*secret*` from your local `.dockercfg` file:
+. Create the `*secret*` from your local *_.dockercfg_* file:
 +
 ====
 ----
@@ -862,7 +866,7 @@ $ oc secrets add serviceaccount/builder secrets/dockerhub
 ----
 ====
 
-. Add a `PushSecret` field into the `Output` section of the `*buildConfig*` and
+. Add a `*pushSecret*` field into the `*output*` section of the `*BuildConfig*` and
 set it to the name of the `*secret*` that you created, which in the above example
 is *dockerhub*:
 +
@@ -885,7 +889,7 @@ is *dockerhub*:
 ====
 
 . Pull the builder Docker image from a private Docker registry by specifying the
-`PullSecret` field, which is part of the build strategy definition:
+`*pullSecret*` field, which is part of the build strategy definition:
 +
 ====
 
@@ -952,8 +956,8 @@ $ oc secrets add serviceaccount/builder secrets/scmsecret
 
 
 . Add a `*sourceSecret*` field into the `*source*` section inside the
-buildConfig and set it to the name of the `*secret*` that you created, in this
-case `*scmsecret*`:
+`*BuildConfig*` and set it to the name of the `*secret*` that you created, in
+this case `*scmsecret*`:
 +
 ====
 


### PR DESCRIPTION
Follow up for https://github.com/openshift/openshift-docs/pull/890

Minor edits and spells out "configuration change triggers" in a few spots.

@csrwng PTAL

Also includes syncing up everything to use "BuildConfig" instead of "buildConfig". This was really the only topic that used the camelcase style a ton anymore.
