### PR TITLE
Add cluster variables to adv_install

### DIFF
--- a/admin_guide/install/advanced_install.adoc
+++ b/admin_guide/install/advanced_install.adoc
@@ -83,8 +83,20 @@ the remaining instructions.
 
 == Configuring Ansible
 
-The *_/etc/ansible/hosts_* file is Ansible's inventory
-file for the playbook to use during the installation. Replace the contents of the file with your desired configuration.
+The *_/etc/ansible/hosts_* file is Ansible's inventory file for the playbook to
+use during the installation. The inventory file describes the configuration for
+your OpenShift cluster. You must replace the default contents of the file with
+your desired configuration.
+
+The following sections describe commonly-used variables to set in your inventory
+file during an advanced installation, followed by example inventory files you
+can use as a starting point for your installation. The examples describe various
+environment topographies, including
+link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters[using
+multiple masters for high availability]. You can choose an example that matches
+your requirements, modify it to match your own environment, and use it as your
+inventory file when link:#running-the-ansible-installer[running the Ansible
+installer].
 
 [NOTE]
 ====
@@ -96,12 +108,112 @@ link:../../architecture/additional_concepts/networking.html#openshift-sdn[OpenSh
 SDN].
 ====
 
-The following sections describe example *_/etc/ansible/hosts_* files for various environment
-topographies, including example configurations for
-link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters[using multiple
-masters for high availability]. You can choose an example that matches your
-requirements and use as your inventory file when
-link:#running-the-ansible-installer[running the Ansible installer], or modify an example to match your own environment.
+[[configuring-host-variables]]
+
+*Configuring Host Variables*
+
+To assign environment variables to hosts during the Ansible install, indicate
+the desired variables in the *_/etc/ansible/hosts_* file after the host entry in
+the *[masters]* or *[nodes]* sections. For example:
+
+====
+----
+[masters]
+ec2-52-6-179-239.compute-1.amazonaws.com openshift_public_hostname=ose3-master.public.example.com
+----
+====
+
+The following table describes variables for use with the Ansible installer that
+can be assigned to individual host entries:
+
+.Host Variables
+[options="header"]
+|===
+
+|Variable |Purpose
+
+|`*openshift_hostname*`
+|This variable overrides the internal cluster host name for the system. Use this
+when the system's default IP address does not resolve to the system host name.
+
+|`*openshift_public_hostname*`
+|This variable overrides the system's public host name. Use this for cloud
+installations, or for hosts on networks using a network address translation
+(NAT).
+
+|`*openshift_ip*`
+|This variable overrides the cluster internal IP address for the system. Use
+this when using an interface that is not configured with the default route.
+
+|`*openshift_public_ip*`
+|This variable overrides the system's public IP address. Use this for cloud
+installations, or for hosts on networks using a network address translation
+(NAT).
+|===
+
+[[configuring-cluster-variables]]
+
+*Configuring Cluster Variables*
+
+To assign environment variables during the Ansible install that apply more
+globally to your OpenShift cluster overall, indicate the desired variables in
+the *_/etc/ansible/hosts_* file on separate, single lines within the *[OSEv3:vars]*
+section. For example:
+
+====
+----
+[OSEv3:vars]
+
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
+
+osm_default_subdomain=apps.test.example.com
+----
+====
+
+The following table describes variables for use with the Ansible installer that
+can be assigned cluster-wide:
+
+.Cluster Variables
+[options="header", cols="1,2"]
+|===
+
+|Variable |Purpose
+
+|`*ansible_ssh_user*`
+|This variable sets the SSH user for the installer to use and defaults to
+*root*. This user should allow SSH-based authentication
+link:prerequisites.html#ensuring-host-access[without requiring a password]. If
+using SSH key-based authentication, then the key should be managed by an SSH
+agent.
+
+|`*ansible_sudo*`
+|If `*ansible_ssh_user*` is not *root*, this variable must be set to *true* and
+the user must be configured for passwordless *sudo*.
+
+|`*openshift_master_cluster_hostname*`
+|This variable overrides the host name for the cluster, which defaults to the
+host name of the master.
+
+|`*openshift_master_cluster_public_hostname*`
+|This variable overrides the public host name for the cluster, which defaults to
+the host name of the master.
+
+|`*openshift_master_identity_providers*`
+|This variable overrides the link:../configuring_authentication.html[identity
+provider], which defaults to
+link:../configuring_authentication.html#DenyAllPasswordIdentityProvider[Deny
+All].
+
+|`*osm_default_subdomain*`
+|This variable overrides the default subdomain to use for exposed
+link:../../architecture/core_concepts/routes.html[routes].
+
+|`*osm_default_node_selector*`
+|This variable overrides the node selector that projects will use by default
+when placing pods.
+|===
+
+[[configuring-node-host-labels]]
 
 *Configuring Node Host Labels*
 
@@ -113,7 +225,7 @@ the link:../scheduler.html#configurable-predicates[scheduler].
 
 To assign labels to a node host during an Ansible install, use the
 `*openshift_node_labels*` variable with the desired labels added to the desired
-node host entry in the [nodes] section:
+node host entry in the *[nodes]* section. For example:
 
 ====
 ----
@@ -121,44 +233,6 @@ node host entry in the [nodes] section:
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 ----
 ====
-
-*Configuring Host Variables*
-
-To assign environment variables to hosts during the Ansible install, indicate the desired variables in the *_/etc/ansible/hosts_* file:
-
-====
-----
-[masters]
-ec2-52-6-179-239.compute-1.amazonaws.com openshift_public_hostname=ose3-master.public.example.com
-----
-====
-
-The following table describes example variables for use with the Ansible
-installer to replace in the above example configuration:
-
-[options="header"]
-|===
-
-|Variable |Purpose
-
-|`*openshift_hostname*`
-|This variable overrides the internal cluster host name for the system.
-Use this when the system's default IP address does not resolve to the system
-hostname.
-
-|`*openshift_public_hostname*`
-|This variable overrides the system's public host name. Use this for cloud
-installations, or for hosts on networks using a network address translation
-(NAT).
-
-|`*openshift_ip*`
-|This variable overrides the cluster internal IP address for the system. Use this when using an interface that is not configured with the default route.
-
-|`*openshift_public_ip*`
-|This variable overrides the system's public IP address. Use this for cloud
-installations, or for hosts on networks using a network address translation
-(NAT).
-|===
 
 [[single-master-multi-node]]
 
@@ -226,8 +300,8 @@ node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
 ====
 
-Modify the file to match your environment and specifications, and save it as
-*_/etc/ansible/hosts_*.
+To use this example, modify the file to match your environment and
+specifications, and save it as *_/etc/ansible/hosts_*.
 
 [[single-master-multi-etcd-multi-node]]
 
@@ -312,8 +386,8 @@ node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
 ====
 
-Modify the file to match your environment and specifications, and save it as
-*_/etc/ansible/hosts_*.
+To use this example, modify the file to match your environment and
+specifications, and save it as *_/etc/ansible/hosts_*.
 
 [[multi-master-multi-etcd-multi-node]]
 
@@ -414,8 +488,8 @@ node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
 ====
 
-Modify the file to match your environment and specifications, and save it as
-*_/etc/ansible/hosts_*.
+To use this example, modify the file to match your environment and
+specifications, and save it as *_/etc/ansible/hosts_*.
 
 Note the following when using this configuration:
 
@@ -429,7 +503,8 @@ cluster configuration.
 
 == Running the Ansible Installer
 
-You can now run the Ansible installer:
+After you've link:#configuring-ansible[configured Ansible] by defining an
+inventory file in *_/etc/ansible/hosts_*, you can run the Ansible installer:
 
 ----
 # ansible-playbook ~/openshift-ansible/playbooks/byo/config.yml


### PR DESCRIPTION
@bfallonf Inspired by and builds on https://github.com/openshift/openshift-docs/pull/896.

This adds a cluster variables section to doc cluster-wide inventory settings. Or at least, I'm using "cluster variables" in this case to mean variables that apply more generally to the cluster and the overall install, versus the "Configuring Host Variables" which now states that it's more specifically for individual hosts.

Also moves to the node labels section to the end of the 3 subsections, and other minor edits to sync the sections up further.

@detiber @sdodson PTAL. Pretty build (internal):

http://file.rdu.redhat.com/~adellape/082415/more_ansible_config/admin_guide/install/advanced_install.html#configuring-ansible

Was mostly looking through the following (and elsewhere in openshift-ansible) for inspiration as to which to highlight:

https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_master/tasks/main.yml
https://github.com/openshift/openshift-ansible/blob/next/inventory/byo/hosts.example

Some of it's placeholder (like the descriptions for the cluster hostname vars), but wanted to get something started; LMK what you think. Interested in suggestions on which to mention/leave out, or any better descriptions.
