### PR TITLE
Fix anchor, webhook trigger lettercase in dev_guide/builds

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -23,7 +23,7 @@ runnable images to be used on OpenShift. There are three build strategies:
 == Defining a BuildConfig
 
 A build configuration describes a single build definition and a set of
-link:#triggers[triggers] for when a new build should be created.
+link:#build-triggers[triggers] for when a new build should be created.
 
 A build configuration is defined by a `*BuildConfig*`, which is a REST object
 that can be used in a POST to the API server to create a new instance. The
@@ -44,7 +44,7 @@ image tag or the source code changes:
   "spec": {
     "triggers": [ <2>
       {
-        "type": "Github",
+        "type": "GitHub",
         "github": {
           "secret": "secret101"
         }
@@ -582,7 +582,7 @@ definition JSON within the `*BuildConfig*`:
 
 ----
 {
-  "type": "github",
+  "type": "GitHub",
   "github": {
     "secret": "secret101"
   }
@@ -608,7 +608,7 @@ following is an example trigger definition JSON within the `*BuildConfig*`:
 
 ----
 {
-  "type": "generic",
+  "type": "Generic",
   "generic": {
     "secret": "secret101"
   }


### PR DESCRIPTION
Fixed (in one instance) and synced up letter case for the webhook trigger types.
