### PR TITLE
Fix wildcard cert heading, move routing subdomain

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -159,50 +159,25 @@ OpenShift automatically generates one for you. The generated host name
 is of the form:
 
 ----
-*$routename[-$namespace].$suffix*
+<route-name>[-<namespace>].<suffix>
 ----
 
 The following example shows the OpenShift-generated host name for the above
-configuration of a route without a host added to a namespace *my-namespace*:
+configuration of a route without a host added to a namespace *mynamespace*:
 
 .Generated Host Name
 ====
 
 ----
-no-route-hostname-my-namespace.router.default.svc.cluster.local <1>
+no-route-hostname-mynamespace.router.default.svc.cluster.local <1>
 ----
 <1> The generated host name suffix is the default routing subdomain
 *router.default.svc.cluster.local*.
 ====
 
-=== Custom Default Routing Subdomain
-A cluster administrator can customize the suffix or the default routing
-subdomain for an environment using the
-link:../../admin_guide/master_node_configuration.html#master-configuration-files[master
-configuration file] (the *_/etc/openshift/master/master-config.yaml_* file by
-default). The following example shows how you can set the configured suffix to
-*v3.openshift.test*:
-
-.Master Configuration Snippet
-====
-
-----
-routingConfig:
-  subdomain: v3.openshift.test
-----
-====
-
-With the OpenShift master(s) running the above configuration, the
-generated host name for the example of a host added to a namespace
-*my-namespace* would be:
-
-.Generated Host Name
-====
-
-----
-no-route-hostname.my-namespace.v3.openshift.test
-----
-====
+A cluster administrator can also
+link:../../install_config/install/deploy_router.html#customizing-the-default-routing-subdomain[customize
+the suffix used as the default routing subdomain] for their environment.
 
 == Route Types
 Routes can be either secured or unsecured. Secure routes provide the ability to
@@ -309,11 +284,10 @@ termination.
 [[edge-termination]]
 *Edge Termination*
 
-With edge termination, TLS termination occurs at the
-router, prior to proxying traffic to its destination. TLS
-certificates are served by the front end of the router,
-so they must be configured into the route, otherwise the
-link:../../install_config/install/deploy_router.html#using-wildcard-dns[router's
+With edge termination, TLS termination occurs at the router, prior to proxying
+traffic to its destination. TLS certificates are served by the front end of the
+router, so they must be configured into the route, otherwise the
+link:../../install_config/install/deploy_router.html#using-wildcard-certificates[router's
 default certificate] will be used for TLS termination.
 
 .A Secured Route Using Edge Termination

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -142,7 +142,7 @@ $ oadm router <router_name> --replicas=<number> \
 endif::[]
 
 Multiple instances are created on different hosts according to the
-link:../scheduler.html[scheduler policy].
+link:../../admin_guide/scheduler.html[scheduler policy].
 
 To use a different router image and view the router configuration that would be used:
 
@@ -184,10 +184,44 @@ $ oadm router region-west -o yaml --images=myrepo/somerouter:mytag \
 endif::[]
 
 === High Availability
-You can link:../high_availability.html[set up a highly-available
+You can link:../../admin_guide/high_availability.html[set up a highly-available
 router] on your OpenShift cluster using IP failover.
 
-=== Using Wildcard DNS
+[[customizing-the-default-routing-subdomain]]
+
+=== Customizing the Default Routing Subdomain
+
+You can customize the suffix used as the default routing subdomain for your
+environment using the
+link:../../admin_guide/master_node_configuration.html#master-configuration-files[master
+configuration file] (the *_/etc/openshift/master/master-config.yaml_* file by
+default). The following example shows how you can set the configured suffix to
+*v3.openshift.test*:
+
+.Master Configuration Snippet
+====
+
+----
+routingConfig:
+  subdomain: v3.openshift.test
+----
+====
+
+With the OpenShift master(s) running the above configuration, the
+link:../../architecture/core_concepts/routes.html#route-hostnames[generated host
+name] for the example of a host added to a namespace *mynamespace* would be:
+
+.Generated Host Name
+====
+
+----
+myroute-mynamespace.v3.openshift.test
+----
+====
+
+[[using-wildcard-certificates]]
+
+=== Using Wildcard Certificates
 
 A TLS-enabled route that does not include a certificate uses the router's
 default certificate instead. In most cases, this certificate should be provided by a
@@ -384,13 +418,13 @@ $ oadm router --credentials="$KUBECONFIG" --images=myrepo/myimage:mytag
 == What's Next?
 
 After you have a router deployed, you can learn more about
-link:../router.html[monitoring the HAProxy router].
+link:../../admin_guide/router.html[monitoring the HAProxy router].
 
 If you have not yet done so, you can:
 
-- link:../configuring_authentication.html[Configure authentication]; by default,
-authentication is set to
-link:../configuring_authentication.html#DenyAllPasswordIdentityProvider[Deny
+- link:../../admin_guide/configuring_authentication.html[Configure
+authentication]; by default, authentication is set to
+link:../../admin_guide/configuring_authentication.html#DenyAllPasswordIdentityProvider[Deny
 All].
 - Deploy an link:docker_registry.html[integrated Docker registry].
 - link:first_steps.html[Populate your OpenShift installation] with a useful set


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/856

I moved the existing `routingConfig.subdomain` info out of the Arch topic and into the deploy_router topic (right before the now-correctly-titled Wildcard Certificates section), since it seemed like it fit better in the Admin Guide.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/082515/wildcardcerts_defaultsubdomain/admin_guide/install/deploy_router.html

@sosiouxme @thoraxe WDYT?
