### PR TITLE
Change ascii_binder version and simplify future gem updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'ascii_binder', '=0.0.5'
+gem 'ascii_binder', '~>0.0.6'


### PR DESCRIPTION
In the not-too-distant future, the docs repo will not contain a Gemfile at all; this is a temporary fix to make things work until that is sorted out.
