### PR TITLE
Set namespace on imagestream/template updates

### DIFF
--- a/admin_guide/upgrades.adoc
+++ b/admin_guide/upgrades.adoc
@@ -280,28 +280,28 @@ expected that you will receive warnings about items that already exist.
 ifdef::openshift-enterprise[]
 ====
 ----
-# oc create -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
-# oc create -f /usr/share/openshift/examples/db-templates
-# oc create -f /usr/share/openshift/examples/quickstart-templates
-# oc create -f /usr/share/openshift/examples/xpaas-streams
-# oc create -f /usr/share/openshift/examples/xpaas-templates
-# oc replace -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
-# oc replace -f /usr/share/openshift/examples/db-templates
-# oc replace -f /usr/share/openshift/examples/quickstart-templates
-# oc replace -f /usr/share/openshift/examples/xpaas-streams
-# oc replace -f /usr/share/openshift/examples/xpaas-templates
+# oc create -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
+# oc create -n openshift -f /usr/share/openshift/examples/db-templates
+# oc create -n openshift -f /usr/share/openshift/examples/quickstart-templates
+# oc create -n openshift -f /usr/share/openshift/examples/xpaas-streams
+# oc create -n openshift -f /usr/share/openshift/examples/xpaas-templates
+# oc replace -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
+# oc replace -n openshift -f /usr/share/openshift/examples/db-templates
+# oc replace -n openshift -f /usr/share/openshift/examples/quickstart-templates
+# oc replace -n openshift -f /usr/share/openshift/examples/xpaas-streams
+# oc replace -n openshift -f /usr/share/openshift/examples/xpaas-templates
 ----
 ====
 endif::[]
 ifdef::openshift-origin[]
 ====
 ----
-# oc create -f /usr/share/openshift/examples/image-streams/image-streams-centos7.json
-# oc create -f /usr/share/openshift/examples/db-templates
-# oc create -f /usr/share/openshift/examples/quickstart-templates
-# oc replace -f /usr/share/openshift/examples/image-streams/image-streams-centos7.json
-# oc replace -f /usr/share/openshift/examples/db-templates
-# oc replace -f /usr/share/openshift/examples/quickstart-templates
+# oc create -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-centos7.json
+# oc create -n openshift -f /usr/share/openshift/examples/db-templates
+# oc create -n openshift -f /usr/share/openshift/examples/quickstart-templates
+# oc replace -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-centos7.json
+# oc replace -n openshift -f /usr/share/openshift/examples/db-templates
+# oc replace -n openshift -f /usr/share/openshift/examples/quickstart-templates
 ----
 ====
 endif::[]


### PR DESCRIPTION
Set the namespace on the imagestream and template update commands. I prefer this over changing the project because i don't want someone to switch to openshift and then forget that they're in openshift project.
