### PR TITLE
Add persistent gluster and restructure persistent storage

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -167,8 +167,13 @@ Topics:
     File: high_availability
   - Name: Self-Provisioned Projects
     File: selfprovisioned_projects
-  - Name: Persistent Storage Using NFS
-    File: persistent_storage_nfs
+  - Name: Persistent Storage
+    Dir: persistent_storage
+    Topics:
+      - Name: Using NFS
+        File: persistent_storage_nfs
+      - Name: Using GlusterFS
+        File: persistent_storage_glusterfs
   - Name: IPtables
     File: iptables
   - Name: Native Container Routing

--- a/admin_guide/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/admin_guide/persistent_storage/persistent_storage_glusterfs.adoc
@@ -1,0 +1,182 @@
+= Persistent Storage Using GlusterFS
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+OpenShift can utilize persistent storage using Distributed File Systems (DFS) like GlusterFS.  Some familiarity with Kubernetes/Docker is assumed.  Also assumed that there is access to an existing GlusterFS cluster and volume and that the glusterfs-client has been installed on all OpenShift nodes in the cluster.
+
+The Kubernetes link:../../dev_guide/persistent_volumes.html[persistent volume]
+framework allows administrators to provision a cluster with persistent storage
+and gives users a way to request those resources without having any knowledge of
+the underlying infrastructure.
+
+[NOTE]
+====
+`Persistent Volumes` are not bound to a single project/namespace, they can be shared across the OpenShift environment, where as, `Persistent Volume Claims` are project/namespace specific and can be requested by users.
+====
+
+
+[IMPORTANT]
+====
+High-availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
+
+[[provisioning]]
+
+== Provisioning
+Storage must exist in the underlying infrastructure before it can be mounted as
+a volume in OpenShift. All that is required for GlusterFS is a distinct list of
+servers in the Gluster cluster (endpoints), Gluster Volumes (PersistentVolume) and the `*PersistentVolume*` API.
+
+
+[[create-gluster-endpoints]]
+
+=== Create Gluster Endpoints
+
+.Persistent Volume Endpoints Definition
+====
+
+For this example, you will have to define the GlusterFS Cluster as “EndPoints” within Kubernetes/OpenShift platform using a file similar to [endpoints configuration file](gluster-endpoints.json).  You must define the IP/Hostname of your gluster servers and the port that you want to use.  The port value can be any numeric value within the accepted range of ports.
+
+
+[source,json]
+----
+
+{ 
+   "kind": "Endpoints", 
+   "apiVersion": "v1", 
+   "metadata": { 
+       "name": "glusterfs-cluster" 
+   }, 
+   "subsets": [ 
+       { 
+           "addresses": [ 
+               { 
+                   "IP": "192.168.122.221"
+               } 
+           ], 
+           "ports": [ 
+               { 
+                  "port": 1 
+               } 
+           ] 
+       }, 
+       { 
+           "addresses": [ 
+              { 
+                  "IP": "192.168.122.222"
+              } 
+          ], 
+          "ports": [ 
+              { 
+                  "port": 1 
+              } 
+          ] 
+       } 
+   ] 
+} 
+----
+====
+
+[NOTE]
+====
+The `IP` value under `addresses` must be an actual IP Address of the gluster server, not a fully qualified hostname, this could change in future releases.
+====
+
+
+Create the endpoints
+
+        oc create -f gluster-endpoints.json
+
+        [root@ose1 nginx_gluster]# oc create -f gluster-endpoints.json 
+        endpoints/glusterfs-cluster 
+
+
+View created endpoints
+
+        oc get endpoints
+
+        [root@ose1 nginx_gluster]# oc get endpoints 
+        NAME                ENDPOINTS 
+        glusterfs-cluster   192.168.122.221:1,192.168.122.222:1 
+        kubernetes          192.168.122.251:8443 
+
+
+
+
+[[create-persistent-volume]]
+
+=== Create Persistent Volume
+
+.Persistent Volume Object Definition
+====
+
+[source,json]
+----
+{ 
+   "apiVersion": "v1", 
+   "kind": "PersistentVolume", 
+   "metadata": { 
+       "name": "gluster-default-volume"                 <1>
+   }, 
+   "spec": { 
+       "capacity": { 
+             "storage": "2Gi"                           <2>
+       }, 
+       "accessModes": [ "ReadWriteMany" ], 
+       "glusterfs": {                                   <3>
+             "endpoints": "glusterfs-cluster",          <4>
+             "path": "myVol1",                          <5>
+             "readOnly": false 
+       }, 
+       "persistentVolumeReclaimPolicy": "Recycle" 
+   } 
+}
+----
+
+<1>   Name of the volume, this will be how it is identified via Persistent Volume Claims or from Pods
+<2>   Amount of storage allocated to this volume
+<3>   This defines the volume type being used, in this case glusterfs plugin
+<4>   A reference to the endpoints object that defines the Gluster cluster
+<5>   This is the gluster volume that will be used (defined on your gluster servers)
+
+====
+
+
+Create the Persistent Volume
+
+        oc create -f gluster-nginx-pv.json
+
+        [root@ose1 nginx_gluster_pvc]# oc create -f gluster-nginx-pv.json 
+        persistentvolumes/gluster-default-volume 
+
+
+View the Persistent Volume
+
+        oc get pv
+
+        [root@ose1 nginx_gluster_pvc]# oc get pv 
+        NAME                     LABELS    CAPACITY     ACCESSMODES   STATUS      CLAIM     REASON 
+        gluster-default-volume   <none>    2147483648   RWX           Available 
+
+
+[IMPORTANT]
+====
+Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in
+the user's namespace and can only be referenced by a pod within that same
+namespace. Any attempt to access a persistent volume across a namespace causes
+the pod to fail.
+====
+
+
+

--- a/admin_guide/persistent_storage/persistent_storage_nfs.adoc
+++ b/admin_guide/persistent_storage/persistent_storage_nfs.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 You can provision your OpenShift cluster with
-link:../architecture/additional_concepts/storage.html[persistent storage] using
+link:../../architecture/additional_concepts/storage.html[persistent storage] using
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS].
 Some familiarity with Kubernetes and NFS is assumed.
 
@@ -24,7 +24,7 @@ when using NFS for persistent storage, due to NSFv4's ability to handle SELinux
 labeling.
 ====
 
-The Kubernetes link:../dev_guide/persistent_volumes.html[persistent volume]
+The Kubernetes link:../../dev_guide/persistent_volumes.html[persistent volume]
 framework allows administrators to provision a cluster with persistent storage
 and gives users a way to request those resources without having any knowledge of
 the underlying infrastructure.


### PR DESCRIPTION
Trying to add some details about Persistent Storage for Gluster - and rather than have a .adoc file side by side with the persistent_storage_nfs.adoc, thought it made more sense to subdir this topic, assuming we might have other volume type provider examples in the near future (ceph, cinder, etc...).  Not sure this is the correct approach, let me know what you think.
