### PR TITLE
Reflow dev_guide/templates and edits for 918

### DIFF
--- a/architecture/core_concepts/templates.adoc
+++ b/architecture/core_concepts/templates.adoc
@@ -87,7 +87,7 @@ application.
 
 Templates can be processed from a definition in a file or
 from an existing OpenShift API object.  Cluster administrators can
-link:../../install_config/install/first_steps.html#creating-quickstart-templates[define
+link:../../install_config/install/first_steps.html#creating-instantapp-templates[define
 standard templates in the API] that are
 available for all users to process, while users can
 link:../../dev_guide/templates.html#uploading-a-template[define their

--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -311,8 +311,8 @@ $ oc new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
 
 === Command Output
 
-The `new-app` command generates OpenShift resources that will build, deploy, and
-run the application being created. Normally, these resources are created in the
+The `new-app` command generates OpenShift objects that will build, deploy, and
+run the application being created. Normally, these objects are created in the
 current project using names derived from the input source repositories or the
 input images. However, `new-app` allows you to modify this behavior.
 
@@ -321,8 +321,8 @@ input images. However, `new-app` allows you to modify this behavior.
 ==== Output Without Creation
 To see a dry-run of what `new-app` will create, you can use the `-o|--output`
 flag with a value of either `yaml` or `json`. You can then use the output to
-preview the resources that will be created, or redirect it to a file that you
-can edit and then use with `oc create` to create the OpenShift resources.
+preview the objects that will be created, or redirect it to a file that you
+can edit and then use with `oc create` to create the OpenShift objects.
 
 .To Output `new-app` Artifacts to a File, Edit Them, Then Create Them Using `oc create`:
 ====
@@ -368,7 +368,7 @@ $ oc new-app https://github.com/openshift/ruby-hello-world -n myproject
 The set of artifacts created by `new-app` depends on the artifacts passed as
 input: source repositories, images, or templates.
 
-.`new-app` Output Resources
+.`new-app` Output Objects
 [cols="2,8",options="header"]
 |===
 
@@ -399,12 +399,12 @@ port. In order to expose a different port, after `new-app` has completed, simply
 use the `oc expose` command to generate additional services.
 
 a|Other
- |Other resources can be generated when instantiating
+ |Other objects can be generated when instantiating
 link:#specifying-a-template[templates].
 
 |===
 
-[[advanced:multiple-components-and-grouping]]
+[[advanced-multiple-components-and-grouping]]
 
 === Advanced: Multiple Components and Grouping
 
@@ -483,40 +483,40 @@ from the global library:
 ====
 
 image::console_select_image.png["Select Builder Image"]
-
+====
++
 [NOTE]
-Only ImageStreamTags which have the 'builder' tag listed in their annotations will appear in this list, as demonstrated here:
-
+====
+Only
+link:../architecture/core_concepts/builds_and_image_streams.html#referencing-images-in-image-streams[image
+stream tags] which have the *builder* tag listed in their annotations will
+appear in this list, as demonstrated here:
+====
++
+====
 ----
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "ruby",
-        "creationTimestamp": null
-      },
-      "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/openshift3/ruby-20-rhel7",
-        "tags": [
-          {
-            "name": "2.0",
-            "annotations": {
-              "description": "Build and run Ruby 2.0 applications",
-              "iconClass": "icon-ruby",
-              "tags": "builder,ruby",<1>
-              "supports": "ruby:2.0,ruby",
-              "version": "2.0"
-            }
-          }
-        ]
-      }
-    },
+kind: "ImageStream"
+apiVersion: "v1"
+metadata:
+  name: "ruby"
+  creationTimestamp: null
+spec:
+  dockerImageRepository: "registry.access.redhat.com/openshift3/ruby-20-rhel7"
+  tags:
+    -
+      name: "2.0"
+      annotations:
+        description: "Build and run Ruby 2.0 applications"
+        iconClass: "icon-ruby"
+        tags: "builder,ruby" <1>
+        supports: "ruby:2.0,ruby"
+        version: "2.0"
 ----
-<1> Including 'builder' here ensures this ImageStreamTag will appear in the web console as a builder.
-
+<1> Including *builder* here ensures this `*ImageStreamTag*` will appear in the
+web console as a builder.
 ====
 
-4. Modify the settings in the new application screen to configure the resources
+4. Modify the settings in the new application screen to configure the objects
 to support your application:
 +
 ====
@@ -524,7 +524,7 @@ to support your application:
 image::create_from_image.png["Create from source"]
 ====
 <1> The builder image name and description.
-<2> The application name used for the generated OpenShift resources.
+<2> The application name used for the generated OpenShift objects.
 <3> Routing configuration section for making this application publicly
 accessible.
 <4> Deployment configuration section for customizing
@@ -536,4 +536,4 @@ link:builds.html#build-triggers[build triggers].
 number of running instances of the application.
 <7> The link:../architecture/core_concepts/pods_and_services.html#labels[labels]
 to assign to all items generated for the application. You can add and edit
-labels for all resources here.
+labels for all objects here.

--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -24,22 +24,25 @@ configurations]. A template may also define a set of
 link:../architecture/core_concepts/pods_and_services.html#labels[labels]
 to apply to every object defined in the template.
 
-[[creating-resources-from-a-template]]
-
-== Creating Resources from a Template
-You can create a list of resources from a template using the CLI or, if a template
-has been uploaded to your project or global template library, using the web
-console.
-
-Create a template JSON or YAML file (similar to
-link:../architecture/core_concepts/templates.html[this example]); then
-upload it with the CLI using the following process.
+You can create a list of objects from a template
+link:#creating-from-templates-using-the-cli[using the CLI] or, if a
+link:#uploading-a-template[template has been uploaded] to your project or the
+global template library,
+link:#creating-from-templates-using-the-web-console[using the web console].
 
 [[uploading-a-template]]
 
-=== Uploading a Template
-You can upload a template to your current project's template library by passing
-a JSON or YAML file with the following command:
+== Uploading a Template
+
+If you have a JSON or YAML file that defines a template, for example as seen in
+link:../architecture/core_concepts/templates.html[this example], you can upload
+the template to projects using the CLI. This saves the template to the project
+for repeated use by any user with appropriate access to that project.
+Instructions on link:#writing-templates[writing your own templates] are provided
+later in this topic.
+
+To upload a template to your current project's template library, pass the JSON
+or YAML file with the following command:
 
 ----
 $ oc create -f <filename>
@@ -52,78 +55,13 @@ name of the project:
 $ oc create -f <filename> -n <project>
 ----
 
-The template is now available to be selected for a configuration using the web
-console or the CLI.
+The template is now available for selection using the web console or the CLI.
 
-[[generating-a-list-of-resources]]
+[[creating-from-templates-using-the-web-console]]
 
-=== Generating a List of Resources
-Process the template and return the list of resources to standard output:
+== Creating from Templates Using the Web Console
 
-----
-$ oc process -f <filename>
-----
-
-You can also process an uploaded template by calling the `process` command using:
-
-----
-$ oc process uploaded-template-name
-----
-
-The process command also takes a list of templates you can process to a list of
-resources. In that case, every template will be processed and the resulting list
-of resources will contain objects from all templates passed to a process command:
-
-----
-$ cat <first_template> <second_template> | oc process -f -
-----
-
-Alternatively, you can create from a template without uploading it to the
-template library by processing the template and creating from the same template
-by piping both commands:
-
-----
-$ oc process -f <filename.json> | oc create -f -
-----
-
-You can override any link:../dev_guide/templates.html#parameters[parameter]
-values defined in the file by adding the `-v` option followed by a
-comma-separated list of _<name>_=_<value>_ pairs.
-A parameter reference may appear in any text field inside the template items.
-
-For example, you can override the *`ADMIN_USERNAME`* and *`MYSQL_DATABASE`*
-parameters to create a configuration with customized environment variables:
-
-.Creating list of resources from a template
-====
-
-[options="nowrap"]
-----
-$ oc process -f examples/sample-app/application-template-dockerbuild.json \
-    -v ADMIN_USERNAME=root,MYSQL_DATABASE=admin
-----
-
-====
-
-The JSON file can either be redirected to a file or applied directly without
-uploading the template by piping the process output to the `create` command:
-
-====
-
-[options="nowrap"]
-----
-$ oc process -f examples/sample-app/application-template-dockerbuild.json \
-    -v ADMIN_USERNAME=root,MYSQL_DATABASE=admin \
-    | oc create -f -
-----
-
-====
-
-[[using-the-web-console]]
-
-=== Using the Web Console
-
-To create the resources from an link:#uploading-a-template[uploaded template]
+To create the objects from an link:#uploading-a-template[uploaded template]
 using the web console:
 
 1. While in the desired project, click *Add to Project*:
@@ -155,23 +93,19 @@ defined in the template here.
 <4> link:#templates-labels[Labels] to assign to all items included in the
 template. You can add and edit labels for objects.
 
+[[creating-from-templates-using-the-cli]]
 
-[[modifying-an-uploaded-template]]
+== Creating from Templates Using the CLI
 
-=== Modifying an Uploaded Template
-You can edit a template that has already been uploaded to your project by using
-the following command:
-
-----
-$ oc edit template <template>
-----
+You can use the CLI to process templates and use the configuration that is
+generated to create objects.
 
 [[templates-labels]]
 
 === Labels
 link:../architecture/core_concepts/pods_and_services.html#labels[Labels] are
-used to manage and organize generated resources, such as pods. The labels
-specified in the template are applied to every resource that is generated from
+used to manage and organize generated objects, such as pods. The labels
+specified in the template are applied to every object that is generated from
 the template.
 
 There is also the ability to add labels in the template from the command line.
@@ -180,7 +114,7 @@ There is also the ability to add labels in the template from the command line.
 $ oc process -f <filename> -l name=otherLabel
 ----
 
-[[parameters]]
+[[templates-parameters]]
 
 === Parameters
 The list of parameters that you can override are listed in the
@@ -192,35 +126,130 @@ command and specifying the file to be used:
 $ oc process --parameters -f <filename>
 ----
 
-The following shows the output when listing the parameters for one of the
-https://github.com/openshift/origin/tree/master/examples/sample-app[*_sample-app_*]
-templates:
+Alternatively, if the template is already uploaded:
+
+----
+$ oc process --parameters -n <project> <template_name>
+----
+
+For example, the following shows the output when listing the parameters for one
+of the InstantApp templates in the default *openshift* project:
 
 ====
 ----
-$ oc process --parameters -f \
-    examples/sample-app/application-template-dockerbuild.json
-NAME                DESCRIPTION              GENERATOR           VALUE
-ADMIN_USERNAME      administrator username   expression          admin[A-Z0-9]{3}
-ADMIN_PASSWORD      administrator password   expression          [a-zA-Z0-9]{8}
-MYSQL_USER          database username        expression          user[A-Z0-9]{3}
-MYSQL_PASSWORD      database password        expression          [a-zA-Z0-9]{8}
-MYSQL_DATABASE      database name                                root
+$ oc process --parameters -n openshift rails-postgresql-example
+NAME                         DESCRIPTION                                                                                              GENERATOR           VALUE
+SOURCE_REPOSITORY_URL        The URL of the repository with your application source code                                                                  https://github.com/openshift/rails-ex.git
+SOURCE_REPOSITORY_REF        Set this to a branch name, tag or other ref of your repository if you are not using the default branch
+CONTEXT_DIR                  Set this to the relative path to your project if it is not in the root of your repository
+APPLICATION_DOMAIN           The exposed hostname that will route to the Rails service                                                                    rails-postgresql-example.openshiftapps.com
+GITHUB_WEBHOOK_SECRET        A secret string used to configure the GitHub webhook                                                     expression          [a-zA-Z0-9]{40}
+SECRET_KEY_BASE              Your secret key for verifying the integrity of signed cookies                                            expression          [a-z0-9]{127}
+APPLICATION_USER             The application user that is used within the sample application to authorize access on pages                                 openshift
+APPLICATION_PASSWORD         The application password that is used within the sample application to authorize access on pages                             secret
+DATABASE_SERVICE_NAME        Database service name                                                                                                        postgresql
+POSTGRESQL_USER              database username                                                                                        expression          user[A-Z0-9]{3}
+POSTGRESQL_PASSWORD          database password                                                                                        expression          [a-zA-Z0-9]{8}
+POSTGRESQL_DATABASE          database name                                                                                                                root
+POSTGRESQL_MAX_CONNECTIONS   database max connections                                                                                                     10
+POSTGRESQL_SHARED_BUFFERS    database shared buffers                                                                                                      12MB
 ----
 ====
 
-The output identifies several parameters that are generated with a pseudo
-regex expression generator when the template is processed.
+The output identifies several parameters that are generated with a regular
+expression-like generator when the template is processed.
+
+[[generating-a-list-of-objects]]
+
+=== Generating a List of Objects
+Using the CLI, you can process a file defining a template to return the list of objects to standard output:
+
+----
+$ oc process -f <filename>
+----
+
+Alternatively, if the template has already been uploaded to the current project:
+
+----
+$ oc process <template_name>
+----
+
+The `process` command also takes a list of templates you can process to a list of
+objects. In that case, every template will be processed and the resulting list
+of objects will contain objects from all templates passed to a process command:
+
+----
+$ cat <first_template> <second_template> | oc process -f -
+----
+
+You can create objects from a template by processing the template and piping the
+output to `oc create`:
+
+----
+$ oc process -f <filename> | oc create -f -
+----
+
+Alternatively, if the template has already been uploaded to the current project:
+
+----
+$ oc process <template> | oc create -f -
+----
+
+You can override any
+link:../dev_guide/templates.html#templates-parameters[parameter] values defined
+in the file by adding the `-v` option followed by a comma-separated list of
+`<name>=<value>` pairs. A parameter reference may appear in any text field
+inside the template items.
+
+For example, in the following the *`POSTGRESQL_USER`* and *`POSTGRESQL_DATABSE`*
+parameters of a template are overridden to output a configuration with
+customized environment variables:
+
+.Creating a List of Objects from a Template
+====
+----
+$ oc process -f my-rails-postgresql \
+    -v POSTGRESQL_USER=bob,POSTGRESQL_DATABSE=mydatabase
+----
+====
+
+The JSON file can either be redirected to a file or applied directly without
+uploading the template by piping the processed output to the `oc create`
+command:
+
+====
+----
+$ oc process -f my-rails-postgresql \
+    -v POSTGRESQL_USER=bob,POSTGRESQL_DATABSE=mydatabase
+    | oc create -f -
+----
+====
+
+[[modifying-an-uploaded-template]]
+
+== Modifying an Uploaded Template
+You can edit a template that has already been uploaded to your project by using
+the following command:
+
+----
+$ oc edit template <template>
+----
 
 [[using-the-instantapp-templates]]
 
-=== Using the InstantApp Templates
+== Using the InstantApp Templates
 OpenShift provides a number of default InstantApp templates to make it easy to
 quickly get started creating a new application for different languages.
 Templates are provided for Rails (Ruby), Django (Python), Node.js, CakePHP
 (PHP), and Dancer (Perl). Your cluster administrator should have created these
-templates in the default *openshift* project so you have access to them. If they
-are not available, direct your cluster administrator to the
+templates in the default, global *openshift* project so you have access to them.
+You can list the available default InstantApp templates with:
+
+----
+$ oc get templates -n openshift
+----
+
+If they are not available, direct your cluster administrator to the
 link:../install_config/install/first_steps.html[First Steps] topic.
 
 By default, the templates build using a public source repository on
@@ -235,7 +264,9 @@ from the template, specifying your fork instead of the default value.
 
 By doing this, the build configuration created by the template will now point to
 your fork of the application code, and you can modify the code and rebuild the
-application at will.
+application at will. A walkthrough of this process using the web console is
+provided in link:../getting_started/developers/developers_console.html[Getting
+Started for Developers: Web Console].
 
 [NOTE]
 ====
@@ -247,12 +278,22 @@ as all database data will be lost if the database pod restarts for any reason.
 ====
 
 [[writing-templates]]
+
 == Writing Templates
-Developers can define new templates to make it easy to recreate all the resources of their application.  The template will define the resources it creates along with some metadata to guide the creation of those resources.
+You can define new templates to make it easy to recreate all the objects of your
+application.  The template will define the objects it creates along with some
+metadata to guide the creation of those objects.
 
 [[writing-description]]
+
 === Description
-The template description covers information that informs users what your template does and helps them find it when searching in the web console.  In addition to general descriptive information, it includes a set of tags.  Useful tags include the name of the language your template is related to (e.g. 'java', 'php', 'ruby', etc).  In addition the special tag `instant-app` will cause your template to be displayed in the list of Instant Apps on the template selection page of the web console.
+The template description covers information that informs users what your
+template does and helps them find it when searching in the web console. In
+addition to general descriptive information, it includes a set of tags. Useful
+tags include the name of the language your template is related to (e.g., *java*,
+*php*, *ruby*, etc.). In addition, adding the special tag *instant-app* causes
+your template to be displayed in the list of InstantApps on the template
+selection page of the web console.
 
 ====
 ----
@@ -273,12 +314,17 @@ The template description covers information that informs users what your templat
 <1> The name of the template as it will appear to users.
 <2> A description of the template.
 <3> Tags to be associated with the template for searching and grouping.
-<4> An icon to be displayd with your template in the web console.
+<4> An icon to be displayed with your template in the web console.
 ====
 
 [[writing-labels]]
+
 === Labels
-Templates can include a set of labels.  These labels will be added to each object created when the template is instantiated.  Defining a label in this way makes it easy for users to find and manage all the objects created from a particular template.
+Templates can include a set of
+link:../architecture/core_concepts/pods_and_services.html#labels[labels]. These
+labels will be added to each object created when the template is instantiated.
+Defining a label in this way makes it easy for users to find and manage all the
+objects created from a particular template.
 
 ====
 ----
@@ -296,8 +342,15 @@ Templates can include a set of labels.  These labels will be added to each objec
 ====
 
 [[writing-parameters]]
+
 === Parameters
-Parameters allow a value to be supplied by the user or generated when the template is instantiated.  This is useful for generating random passwords or allowing the user to supply a hostname or other user specific value that is required to customize the template.  Parameters can be referenced by placing the value "${PARAMETER_NAME}" in place of any string field in the template.
+
+Parameters allow a value to be supplied by the user or generated when the
+template is instantiated. This is useful for generating random passwords or
+allowing the user to supply a host name or other user-specific value that is
+required to customize the template. Parameters can be referenced by placing
+values in the form *"${PARAMETER_NAME}"* in place of any string field in the
+template.
 
 ====
 ----
@@ -343,18 +396,33 @@ Parameters allow a value to be supplied by the user or generated when the templa
   ...
 }
 ----
-<1> This value will be replaced with the value of the SOURCE_REPOSITORY_URL parameter when the template is instantiated.
-<2> The name of the parameter.  This value is displayed to users and used to reference the parameter within the template.
+<1> This value will be replaced with the value of the `*SOURCE_REPOSITORY_URL*`
+parameter when the template is instantiated.
+<2> The name of the parameter. This value is displayed to users and used to
+reference the parameter within the template.
 <3> A description of the parameter.
-<4> A default value for the parameter which will be used if the user does not override the value when instantiating the template.
-<5> Indicates this parameter is required, meaning the user cannot override it with an empty value and if the parameter does not provide a default or generated value, the user must supply a value.
-<6> A parameter which has its value generated via a link:../architecture/core_concepts/templates.html#parameters[regular expression-like syntax].
-<7> The input to the generator.  In this case the generator will produce a 40 character alphanumeric value including upper and lowercase characters.
+<4> A default value for the parameter which will be used if the user does not
+override the value when instantiating the template.
+<5> Indicates this parameter is required, meaning the user cannot override it
+with an empty value. If the parameter does not provide a default or generated
+value, the user must supply a value.
+<6> A parameter which has its value generated via a
+link:../architecture/core_concepts/templates.html#parameters[regular
+expression-like syntax].
+<7> The input to the generator. In this case, the generator will produce a 40
+character alphanumeric value including upper and lowercase characters.
 ====
 
 [[writing-object-list]]
+
 === Object List
-The main portion of the template is the list of objects which will be created when the template is instantiated.  this can be any valid api object such as a BuildConfig, DeploymentConfig, Service, etc.  The object will be created exactly as defined here, with any parameter values substituted in prior to creation.  The definition of these objects can reference parameters defined earlier.
+The main portion of the template is the list of objects which will be created
+when the template is instantiated. This can be any
+link:../architecture/core_concepts/overview.html#[valid API object], such as a
+`*BuildConfig*`, `*DeploymentConfig*`, `*Service*`, etc. The object will be
+created exactly as defined here, with any parameter values substituted in prior
+to creation. The definition of these objects can reference parameters defined
+earlier.
 
 ====
 ----
@@ -386,26 +454,33 @@ The main portion of the template is the list of objects which will be created wh
       }
     }
   ]
-  ...  
+  ...
 }
 
 ----
-<1> The definition of a Service which will be created by this template.
+<1> The definition of a `*Service*` which will be created by this template.
 ====
 
 [NOTE]
 ====
-If an object definition's metadata includes a namespace field, the field will be stripped out of the definition during template instantiation.  This is necessary because all objects created during instantiation are placed into the target namespace, so it would be invalid for the object to declare a different namespace.
+If an object definition's metadata includes a `*namespace*` field, the field
+will be stripped out of the definition during template instantiation. This is
+necessary because all objects created during instantiation are placed into the
+target namespace, so it would be invalid for the object to declare a different
+namespace.
 ====
 
 [[export-as-template]]
-=== Creating a Template from Existing Resources
-Rather than writing an entire template from scratch, you can also export existing resources from your project in template form, and then modify the template from there by adding parameters and other customizations.  To export resources in a project, in template form, run:
+
+=== Creating a Template from Existing Objects
+Rather than writing an entire template from scratch, you can also export
+existing objects from your project in template form, and then modify the
+template from there by adding parameters and other customizations. To export
+objects in a project in template form, run:
 
 ----
 $ oc export all --all --as-template=<template_name>
 ----
 
-You can also substitute a particular resource type or multiple resources instead of `*all*`. 
-Run `$ oc export -h` for more examples. 
-
+You can also substitute a particular resource type or multiple resources instead of `*all*`.
+Run `$ oc export -h` for more examples.

--- a/getting_started/developers/developers_cli.adoc
+++ b/getting_started/developers/developers_cli.adoc
@@ -28,7 +28,7 @@ link:../../whats_new/overview.html[what's new]. This version
 of OpenShift is significantly different from version 2.
 
 The following sections guide you through creating a project that contains a
-sample NodeJS application that will serve a welcome page and the current hit
+sample Node.js application that will serve a welcome page and the current hit
 count (stored in a database).
 
 // end::overview[]
@@ -50,10 +50,10 @@ endif::openshift-origin[]
 
 - Your instance must be pre-configured by a cluster administrator with the InstantApp templates and builder images. If they
 are not available, direct your cluster administrator to the
-link:../../admin_guide/install/first_steps.html[First Steps] topic.
+link:../../install_config/install/first_steps.html[First Steps] topic.
 - You must have an account on http://www.github.com[GitHub], have https://help.github.com/articles/set-up-git/[Git set up], and
 https://help.github.com/articles/set-up-git/#next-steps-authenticating-with-github-from-git[set up authentication to GitHub from Git].
-- You must have the OpenShift CLI Client
+- You must have the OpenShift CLI
 link:../../cli_reference/get_started_cli.html[downloaded and installed].
 
 // end::beforeyoubegin[]
@@ -62,7 +62,7 @@ link:../../cli_reference/get_started_cli.html[downloaded and installed].
 
 == Forking the Sample Repository
 
-. Visit the https://github.com/openshift/nodejs-ex[NodeJS example] page while you are logged in to Github.
+. Visit the https://github.com/openshift/nodejs-ex[Node.js example] page while you are logged in to Github.
 . https://help.github.com/articles/fork-a-repo/[Fork the repository].
 +
 You are redirected to your new fork.
@@ -101,13 +101,13 @@ $ oc process nodejs-mongodb.json
 ----
 
 Your application is then created, which might take some time. In the case of
-this template, MongoDB is created first, then the NodeJS application is built
+this template, MongoDB is created first, then the Node.js application is built
 using the OpenShift source-to-image (S2I) builder.
 
 You can follow along on the Overview page of the web console to see the new
 resources being created, and watch the progress of the build and deployment. While the MongoDB pod is being created, its status is shown as pending. The MongoDB pod then starts up and displays its newly-assigned IP address.
 
-When the NodeJS pod is running, the build is complete.
+When the Node.js pod is running, the build is complete.
 
 You can also use the `oc get pods` command to check when the pod is up and
 running.

--- a/getting_started/developers/developers_console.adoc
+++ b/getting_started/developers/developers_console.adoc
@@ -23,7 +23,9 @@ include::getting_started/developers/developers_cli.adoc[tag=forking]
 
 == Creating a Project
 
-To create an application, you must first create a new project, then select a quickstart template. From there, OpenShift begins the build process and creates a new deployment.
+To create an application, you must first create a new project, then select an
+InstantApp template. From there, OpenShift begins the build process and creates
+a new deployment.
 
 . Visit the OpenShift web console in your browser. The web console uses a self-signed certificate, so if prompted, continue past a browser warning.
 . Log in using the username and password recommended to you by your administrator.
@@ -52,13 +54,13 @@ After creation, these settings can only be modified from the CLI by using the
 ====
 
 Your application is then created, which might take some time. In the case of
-this template, MongoDB is created first, then the NodeJS application is built
+this template, MongoDB is created first, then the Node.js application is built
 using the OpenShift source-to-image (S2I) builder.
 
 You can follow along on the Overview page of the web console to see the new
 resources being created, and watch the progress of the build and deployment. While the MongoDB pod is being created, its status is shown as pending. The MongoDB pod then starts up and displays its newly-assigned IP address.
 
-When the NodeJS pod is running, the build is complete.
+When the Node.js pod is running, the build is complete.
 
 == Viewing the Running Application
 If your DNS is correctly configured, then your new application can be accessed using a web browser. If you cannot access your application, then speak with your system administrator.

--- a/getting_started/overview.adoc
+++ b/getting_started/overview.adoc
@@ -19,15 +19,15 @@ ifdef::openshift-enterprise[]
 endif::openshift-enterprise[]
 
 ifdef::openshift-origin[]
-.^|link:administrators.html[Platform administrator]
-|link:../getting_started/administrators.html[Quick Install]
+.^|Cluster administrator
+|link:../getting_started/administrators.html[Getting Started for Administrators]
 endif::openshift-origin[]
 
 |Developer
-a|Create a project using the link:../getting_started/developers/developers_console.html[Web console]
+a|Create a project using the link:../getting_started/developers/developers_console.html[web console]
 
 ////
-- link:../getting_started/developers/developers_console.html[Web console]
+- link:../getting_started/developers/developers_console.html[web console]
 - link:../getting_started/developers/developers_cli.html[Command Line]
 ////
 

--- a/install_config/install/first_steps.adoc
+++ b/install_config/install/first_steps.adoc
@@ -153,10 +153,10 @@ $ oc create -f \
 After creating the templates, users are able to easily instantiate the various
 templates, giving them quick access to a database deployment.
 
-[[creating-quickstart-templates]]
+[[creating-instantapp-templates]]
 
-== Creating QuickStart Templates
-The QuickStart templates define a full set of objects for a running application.
+== Creating InstantApp Templates
+The InstantApp templates define a full set of objects for a running application.
 These include:
 
 - link:../../architecture/core_concepts/builds_and_image_streams.html#builds[Build configurations] to build the
@@ -184,7 +184,7 @@ also customize the template parameters during instantiation so that it builds
 source from their own repository rather than the sample repository, so this
 provides a simple starting point for building new applications.
 
-To create the core QuickStart templates:
+To create the core InstantApp templates:
 
 ----
 $ oc create -f \
@@ -225,7 +225,8 @@ endif::[]
 
 With these artifacts created, developers can now
 link:../../dev_guide/authentication.html[log into the web console] and follow
-the flow for link:../../dev_guide/templates.html#using-the-web-console[creating
+the flow for
+link:../../dev_guide/templates.html#creating-from-templates-using-the-web-console[creating
 from a template]. Any of the database or application templates can be selected
 to create a running database service or application in the current project. Note
 that some of the application templates define their own database services as
@@ -239,5 +240,5 @@ creating from the templates. This allows developers to experiment with creating
 their own applications.
 
 You can direct your developers to the
-link:../../dev_guide/templates.html#using-the-quickstart-templates[Using the
-QuickStart Templates] section in the Developer Guide for these instructions.
+link:../../dev_guide/templates.html#using-the-instantapp-templates[Using the
+InstantApp Templates] section in the Developer Guide for these instructions.

--- a/using_images/xpaas_images/a_mq.adoc
+++ b/using_images/xpaas_images/a_mq.adoc
@@ -49,7 +49,7 @@ To use the Red Hat xPaaS middleware images in your OpenShift project, you must
 first
 link:../../install_config/install/first_steps.html#creating-image-streams-for-xpaas-middleware-images[install
 the image streams] and
-link:../../install_config/install/first_steps.html#creating-quickstart-templates[Source-to-Image
+link:../../install_config/install/first_steps.html#creating-instantapp-templates[Source-to-Image
 (S2I) application templates].
 
 == Configuring the JBoss A-MQ Image

--- a/using_images/xpaas_images/eap.adoc
+++ b/using_images/xpaas_images/eap.adoc
@@ -57,7 +57,12 @@ The following is a list of unsupported configurations specific to the JBoss EAP 
 
 == Installing the JBoss EAP xPaaS Image Streams and Application Templates
 
-To use the Red Hat xPaaS middleware images in your OpenShift project, you must first link:../../install_config/install/first_steps.html#creating-image-streams-for-xpaas-middleware-images[install the image streams] and link:../../install_config/install/first_steps.html#creating-quickstart-templates[Source-to-Image (S2I) application templates].
+To use the Red Hat xPaaS middleware images in your OpenShift project, you must
+first
+link:../../install_config/install/first_steps.html#creating-image-streams-for-xpaas-middleware-images[install
+the image streams] and
+link:../../install_config/install/first_steps.html#creating-instantapp-templates[Source-to-Image
+(S2I) application templates].
 
 [[Making-Configuration-Changes-EAP]]
 == Running and Configuring the JBoss EAP xPaaS Image

--- a/using_images/xpaas_images/jws.adoc
+++ b/using_images/xpaas_images/jws.adoc
@@ -26,7 +26,12 @@ A major functionality difference compared to the regular release of JBoss Web Se
 
 == Installing the JBoss Web Server xPaaS Image Streams and Application Templates
 
-To use the Red Hat xPaaS middleware images in your OpenShift project, you must first link:../../install_config/install/first_steps.html#creating-image-streams-for-xpaas-middleware-images[install the image streams] and link:../../install_config/install/first_steps.html#creating-quickstart-templates[Source-to-Image (S2I) application templates].
+To use the Red Hat xPaaS middleware images in your OpenShift project, you must
+first
+link:../../install_config/install/first_steps.html#creating-image-streams-for-xpaas-middleware-images[install
+the image streams] and
+link:../../install_config/install/first_steps.html#creating-instantapp-templates[Source-to-Image
+(S2I) application templates].
 
 [NOTE]
 The JBoss Web Server xPaaS application templates are distributed as two sets: one set for Tomcat 7, and another for Tomcat 8.


### PR DESCRIPTION
Still WIP, but:
- Builds on and edits https://github.com/openshift/openshift-docs/pull/918 (includes new Writing Templates section)
- Finally gets back to my comment in https://github.com/openshift/openshift-docs/pull/486#issuecomment-111630242 about re-structuring the topic overall to be more clear-cut between CLI and web console capabilities
- Syncs up vocabulary and links around "InstantApp" instead of "QuickStart" (other than the quickstart-templates path for now)
- Syncs up vocabulary around "objects" instead of "resources" (which we're trying to save for when talking about limits/cpu/memory)
- Converting JSON examples to YAML

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/082815/edit_918_writingtemplates/dev_guide/templates.html
