### PR TITLE
The order of deletion option is wrong in htpasswd command.

### DIFF
--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -157,7 +157,7 @@ $ htpasswd </path/to/users.htpasswd> <user_name>
 To remove a login from the file, run:
 
 ----
-$ htpasswd -D </path/to/users.htpasswd>  <user_name>
+$ htpasswd -D </path/to/users.htpasswd> <user_name>
 ----
 
 .Master Configuration Using *HTPasswdPasswordIdentityProvider*

--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -157,7 +157,7 @@ $ htpasswd </path/to/users.htpasswd> <user_name>
 To remove a login from the file, run:
 
 ----
-$ htpasswd </path/to/users.htpasswd> -D <user_name>
+$ htpasswd -D </path/to/users.htpasswd>  <user_name>
 ----
 
 .Master Configuration Using *HTPasswdPasswordIdentityProvider*


### PR DESCRIPTION
`$ htpasswd </path/to/users.htpasswd> -D <user_name>` shows syntax error  so I just change the order of deletion option "-D" before htpasswd file.
