### PR TITLE
Added 'nodeIP' option to node configuration

### DIFF
--- a/admin_guide/master_node_configuration.adoc
+++ b/admin_guide/master_node_configuration.adoc
@@ -273,6 +273,7 @@ masterKubeConfig: node.kubeconfig
 networkConfig:
   mtu: 1450
   networkPluginName: ""
+nodeIP: ""
 nodeName: node1.example.com
 podManifestConfig: <1>
   path: "/path/to/pod-manifest-file" <2>


### PR DESCRIPTION
If nodeIP is provided, this IP will be used for pod traffic routing.
