### PR TITLE
Remove all_squash

### DIFF
--- a/admin_guide/persistent_storage_nfs.adoc
+++ b/admin_guide/persistent_storage_nfs.adoc
@@ -146,7 +146,7 @@ following:
 - Each export must be:
 
 ----
-/<example_fs> *(rw,all_squash)
+/<example_fs> *(rw)
 ----
 
 - Each export must be owned by *nfsnobody*:


### PR DESCRIPTION
This option causes trouble with both PostgreSQL and MongoDB containers. This has caused problems to our QE (https://bugzilla.redhat.com/show_bug.cgi?id=1260571)

The `all_squash` option was introduced in https://github.com/openshift/openshift-docs/pull/558. @markturansky @sosiouxme, can you please verify my fix is correct? I did test it with both PostgreSQL and MySQL and they work now.

@wzheng1 FYI.
