### PR TITLE
Update rolling strategy docs for new tunables

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -311,39 +311,54 @@ The following is an example of the Rolling strategy:
   "type": "Rolling",
   "rollingParams": {
     "timeoutSeconds": 120, <1>
-    "updatePercent": 10, <2>
-    "pre": {}, <3>
+    "maxSurge": "20%", <2>
+    "maxUnavailable": "10%" <3>
+    "pre": {}, <4>
     "post": {}
   }
 }
 ----
 
 <1> How long to wait for a scaling event before giving up. Optional; the default is 120.
-<2> `*updatePercent*` is optional; see below.
-<3> `*pre*` and `*post*` are both link:#lifecycle-hooks[lifecycle hooks].
+<2> `*maxSurge*` is optional and defaults to `25%`; see below.
+<3> `*maxUnavailable*` is optional and defaults to `25%`; see below.
+<4> `*pre*` and `*post*` are both link:#lifecycle-hooks[lifecycle hooks].
 
 The Rolling strategy will:
 
 . Execute any "pre" lifecycle hook.
-. Scale up the new deployment by one.
-. Scale down the old deployment by one.
+. Scale up the new deployment based on the surge configuration.
+. Scale down the old deployment based on the max unavailable configuration.
 . Repeat this scaling until the new deployment has reached the desired replica
 count and the old deployment has been scaled to zero.
 . Execute any "post" lifecycle hook.
 
-IMPORTANT: During scale up, if the replica count of the deployment is greater
-than one, the first replica of the deployment will be validated for readiness
-before fully scaling up the deployment. If the validation of the first replica
-fails, the deployment will be considered a failure.
+IMPORTANT: When scaling down, the rolling strategy waits for pods to become
+ready so it can decide whether further scaling would affect availability. If
+scaled up pods never become ready, the deployment will eventually time out and
+result in a deployment failure.
 
 IMPORTANT: When executing the "post" lifecycle hook, all failures will be
 ignored regardless of the failure policy specified on the hook.
 
-If `*updatePercent*` is provided, then the specified percent of the new
-deployment's replicas will be scaled up and down each interval (rather than
-the default of 1 replica per interval). For example, given an
-`*updatePercent*` of 10, and new deployment with 100 replicas, 10 replicas
-will be scaled up and down each interval.
+`*maxUnavailable*` is the maximum number of pods that can be unavailable
+during the update.
+
+`*maxSurge*` is the maximum number of pods that can be scheduled above the
+original number of pods.
+
+Both fields can be either a percentage (e.g.  `10%`) or an absolute value
+(e.g. `2`). The default value for both is `25%`.
+
+These fields allow the deployment to be tuned for availability and speed. For
+example:
+
+* `*maxUnavailable*=0` and `*maxSurge*=20%` would ensure full capacity is
+maintained during the update and rapid scale up.
+* `*maxUnavailable*=10%` and `*maxSurge*=0` would perform an update using no
+extra capacity (an in-place update).
+* `*maxUnavailable*=10%` and `*maxSurge*=10%` would scale up and down quickly
+with some potential for capacity loss.
 
 [[recreate-strategy]]
 


### PR DESCRIPTION
Document the latest rolling update tunables API.

For https://github.com/openshift/origin/pull/4504
