### PR TITLE
Bug 1215604: Notify admins about multiple users when changing auth methods

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -19,7 +19,7 @@ server]. Developers and administrators obtain
 link:../architecture/additional_concepts/authentication.html#api-authentication[OAuth
 access tokens] to authenticate themselves to the API.
 
-As an administrator, you can configure OAuth using a
+As an administrator, you can configure OAuth using the
 link:../install_config/master_node_configuration.html[master configuration file] to specify an
 link:#identity-providers[identity provider]. If you installed OpenShift using
 the
@@ -44,19 +44,20 @@ configuration file.
 [[identity-providers]]
 
 == Identity Providers
-You can configure the master for authentication using your desired identity
-provider by modifying the link:../install_config/master_node_configuration.html[master
-configuration file]. The following sections detail the identity providers
-supported by OpenShift.
+You can configure the master host for authentication using your desired identity
+provider by modifying the
+link:../install_config/master_node_configuration.html[master configuration
+file]. The following sections detail the identity providers supported by
+OpenShift.
 
 There are three parameters common to all identity providers:
 
 [cols="2a,8a",options="header"]
 |===
 |Parameter     | Description
-.^|`name`      | The provider name is prefixed to provider user names to form an
+|`name`      | The provider name is prefixed to provider user names to form an
 identity name.
-.^|`challenge` | When *true*, unauthenticated token requests from non-web
+|`challenge` | When *true*, unauthenticated token requests from non-web
 clients (like the CLI) are sent a `WWW-Authenticate` challenge header. Not
 supported by all identity providers.
 
@@ -65,9 +66,68 @@ Basic authentication challenges are only sent if a `X-CSRF-Token` header is
 present on the request. Clients that expect to receive Basic `WWW-Authenticate`
 challenges should set this header to a non-empty value.
 
-.^|`login`     | When *true*, unauthenticated token requests from web clients
+|`login`     | When *true*, unauthenticated token requests from web clients
 (like the web console) are redirected to a login page backed by this provider.
 Not supported by all identity providers.
+
+|`mappingMethod`  | Defines how new identities are mapped to users when they login. See link:#mapping-identities-to-users[Mapping Identities to Users] for more information.
+|===
+
+[NOTE]
+When adding or changing identity providers, you can map identities from the new
+provider to existing users by setting the `*mappingMethod*` parameter to
+`*add*`.
+
+[[mapping-identities-to-users]]
+
+=== Mapping Identities to Users
+
+Setting the `*mappingMethod*` parameter in a
+link:../install_config/master_node_configuration.html[master configuration file]
+determines how identities are mapped to users:
+
+====
+----
+...
+oauthConfig:
+  identityProviders:
+  - name: htpasswd_auth
+    challenge: true
+    login: false
+    mappingMethod: "claim"
+...
+----
+====
+
+When set to the default `*claim*` value, OAuth will fail if the identity is
+mapped to a previously-existing user name. The following table outlines the use
+cases for the available `*mappingMethod*` parameter values:
+
+[cols="2,8"]
+|===
+|Parameter  | Description
+
+|`*claim*` | The default value. Provisions a user with the identity's preferred
+user name. Fails if a user with that user name is already mapped to another
+identity.
+
+|`*lookup*` | Looks up an existing identity, user identity mapping, and user,
+but does not automatically provision users or identities. This allows cluster
+administrators to set up identities and users manually, or using an external
+process.
+
+|`*generate*` | Provisions a user with the identity's preferred user name. If a
+user with the preferred user name is already mapped to an existing identity, a
+unique user name is generated. For example, *myuser2*. This method should not be
+used in combination with external processes that require exact matches between
+OpenShift user names and identity provider user names, such as LDAP group
+sync.
+
+|`*add*` | Provisions a user with the identity's preferred user name. If a user
+with that user name already exists, the identity is mapped to the existing user,
+adding to any existing identity mappings for the user. Required when multiple
+identity providers are configured that identify the same set of users and map to
+the same user names.
 |===
 
 [[AllowAllPasswordIdentityProvider]]


### PR DESCRIPTION
As per:

https://bugzilla.redhat.com/show_bug.cgi?id=1215604

Added note box warning admins about the implications of changing auth methods. 

@liggitt @jianlinliu I'll comment in the BZ, can I get an ack this is all that's needed for this BZ? Thanks.
