### PR TITLE
BZ 1242725 fixes to incorrect imagestream commands

### DIFF
--- a/install_config/install/first_steps.adoc
+++ b/install_config/install/first_steps.adoc
@@ -26,13 +26,22 @@ endif::[]
 these sets in the *openshift* project, which is a default project to which all
 users have view access.
 
-If you opted out of creating them during an link:advanced_install.html[advanced
-installation], you can use the following instructions to create the objects
+Use the following instructions to create the objects
 yourself. The files are installed on the file system of your master.
+
+[NOTE]
+====
+This topic is only necessary if you installed OpenShift using a method other
+than the link:quick_install.html[quick installation] or the
+link:advanced_install.html[advanced installation]. Image streams and templates
+will be automatically populated in the `openshift` project when using these
+methods.
+====
 
 [[prerequisites]]
 
 == Prerequisites
+////
 ifdef::openshift-enterprise[]
 - You installed OpenShift Enterprise using either the
 link:quick_install.html[quick installation] or
@@ -42,12 +51,18 @@ ifdef::openshift-origin[]
 - You installed OpenShift Origin using the  link:advanced_install.html[advanced
 installation] method.
 endif::[]
+////
 - The link:docker_registry.html[integrated Docker registry] service must be
 deployed in your OpenShift installation.
 - You must be able to run the following CLI commands with
 link:../../architecture/additional_concepts/authorization.html#roles[*cluster-admin*
 privileges], because they operate on the default *openshift*
 link:../../architecture/core_concepts/projects_and_users.html#projects[project].
+- You must have cloned the link:https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_examples/files[repository] that contains the supported imagestreams:
++
+----
+$ git clone https://github.com/openshift/openshift-ansible
+----
 
 [[creating-image-streams-for-openshift-images]]
 
@@ -68,7 +83,7 @@ want to use the Red Hat Enterprise Linux (RHEL) 7 based images:
 
 ----
 $ oc create -f \
-    examples/image-streams/image-streams-rhel7.json \
+    openshift-ansible/roles/openshift_examples/files/examples/image-streams/image-streams-rhel7.json \
     -n openshift
 ----
 
@@ -77,7 +92,7 @@ based images:
 
 ----
 $ oc create -f \
-    examples/image-streams/image-streams-centos7.json \
+    openshift-ansible/roles/openshift_examples/files/examples/image-streams/image-streams-centos7.json \
     -n openshift
 ----
 
@@ -98,7 +113,7 @@ To create the xPaaS Middleware set of image streams:
 
 ----
 $ oc create -f \
-    examples/xpaas-streams/jboss-image-streams.json \
+    openshift-ansible/roles/openshift_examples/files/examples/xpaas-streams/jboss-image-streams.json \
     -n openshift
 ----
 
@@ -132,7 +147,7 @@ To create the core set of database templates:
 
 ----
 $ oc create -f \
-    examples/db-templates -n openshift
+    openshift-ansible/roles/openshift_examples/files/examples/db-templates -n openshift
 ----
 
 After creating the templates, users are able to easily instantiate the various
@@ -173,7 +188,7 @@ To create the core QuickStart templates:
 
 ----
 $ oc create -f \
-    examples/quickstart-templates -n openshift
+    openshift-ansible/roles/openshift_examples/files/examples/quickstart-templates -n openshift
 ----
 
 ifdef::openshift-enterprise[]
@@ -185,7 +200,7 @@ registered by running:
 
 ----
 $ oc create -f \
-    examples/xpaas-templates -n openshift
+    openshift-ansible/roles/openshift_examples/files/examples/xpaas-templates -n openshift
 ----
 
 [NOTE]


### PR DESCRIPTION
As per:

https://bugzilla.redhat.com/show_bug.cgi?id=1242725

@detiber @twiest , it was suggested that the installer team might be the right people to ping about this. So... I've included the two of you.

This fix came because the commands to "Create Image Streams for X" are not working correctly; the file path seems to be wrong. @soltysh suggested the example command is missing the start of the file path and where to find the repo. I've updated the "Prerequisites" section so that the reader clones the repo before the can create any images. Can I get an ack this is all the reader would need to do to solve the BZ? 

I do have some other questions about the topic that could be fixed in this PR though:
1. Does the reader have to download the installer for this to work? It's a little confused, but I feel the topic is saying "if you didn't download OpenShift in the suggested methods, you can use these commands to get some imagestreams", but that brings up if they should have downloaded the installer first. Which brings me to my next point...
2. In the intro, it states that using the quick or advance install methods result in these imagestreams for the openshift project, but then it's a prerequisite that their instance be installed using the quick or advanced install method. Is this really a necessary prerequisite? But maybe that's because...
3. Is the reader running this for each new project they create?
4. Is there a different repo containing the imagestreams for Enterprise and Origin?

I think that's all the questions I have.

Thanks in advance!
