### PR TITLE
Expand the getting-started guide

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -23,6 +23,9 @@ allow you to quickly get your own OpenShift instance up and running. Depending
 on your environment, you can choose the installation method that works best for
 you.
 
+For deploying a full OpenShift cluster,
+link:../install_config/install/advanced_install.html[see the advanced installation guide].
+
 == Prerequisites
 
 Before choosing an installation method, you must first
@@ -31,63 +34,45 @@ your hosts, which includes verifying system and environment requirements and
 installing and configuring Docker. After ensuring your hosts are properly set
 up, you can continue by choosing one of the following installation methods.
 
+Docker and OpenShift must run on the Linux operating system. If you wish to
+run the server from a Windows or Mac OS X host, you should download and run
+the Origin Vagrant image as described in link:#building-from-source[Method 3].
+
 == Installation Methods
 
 Choose one of the following installation methods that works best for you.
 
 === Method 1: Running in a Docker Container [[running-in-a-docker-container]]
 You can quickly get OpenShift running in a Docker container using images from
-https://hub.docker.com[Docker Hub].
+https://hub.docker.com[Docker Hub] on a Linux system.
 
 *Installing and Starting an All-in-One Server*
 
 . Launch the server in a Docker container:
 +
 ----
-$ docker run -d --name "openshift-origin" --net=host --privileged \
--v /var/run/docker.sock:/var/run/docker.sock \
--v /tmp/openshift:/tmp/openshift \
-openshift/origin start
+$ sudo docker run -d --name "origin" \
+        --privileged --net=host \
+        -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
+        -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
+        openshift/origin start
 ----
-+
-NOTE: The `/tmp/openshift` directory must be created the first time.
 +
 This command:
 +
-- starts OpenShift listening on all interfaces (*0.0.0.0:8443*),
-- starts the web console listening on all interfaces (*0.0.0.0:8443*),
+- starts OpenShift listening on all interfaces on your host (*0.0.0.0:8443*),
+- starts the web console listening on all interfaces at `/console` (*0.0.0.0:8443*),
 - launches an [sysitem]#etcd# server to store persistent data, and
 - launches the Kubernetes system components.
 
 . After the container is started, you can open a console inside the container:
 +
 ----
-$ docker exec -it openshift-origin bash
+$ sudo docker exec -it openshift-origin bash
 ----
 
-. Because OpenShift services are secured by TLS, clients must accept the server
-certificates and present their own client certificate. These certificates are
-generated when the master server is started. You must point `oc` and `curl` at
-the appropriate CA bundle and client key and certificate to connect to
-OpenShift. Set the following environment variables:
-+
-----
-# export KUBECONFIG=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
-# export CURL_CA_BUNDLE=/var/lib/openshift/openshift.local.config/master/ca.crt
-----
-+
-NOTE: When running as a user other than `root`, you would also need to make the
-private client key readable by that user. However, this is just for example
-purposes; in a production environment, developers would generate their own keys
-and not have access to the system keys.
-
-. You can see more about the commands available in
-link:../cli_reference/basic_cli_operations.html[the CLI] (the `oc` command)
-with:
-+
-----
-$ oc help
-----
+If you delete the container, any configuration or stored application definitions
+will also be removed.
 
 *What's Next?*
 
@@ -101,15 +86,24 @@ https://github.com/openshift/origin/releases[Releases] page. These are Linux,
 Windows, or Mac OS X 64-bit binaries; note that the Mac and Windows versions are
 for the CLI only.
 
-The tar file for each platform contains a single binary, `openshift`, which is
-an all-in-one OpenShift installation. The file also contains
-link:../cli_reference/basic_cli_operations.html[the CLI] (the `oc` command).
+The release archives for Linux and Mac OS X contain the server binary `openshift`
+which is an all-in-one OpenShift installation. The archives for all platforms
+include
+link:../cli_reference/basic_cli_operations.html[the CLI] (the `oc` command) and
+the Kubernetes client (the `kubectl` command).
 
 *Installing and Running an All-in-One Server*
 
 . Download the binary from the
 https://github.com/openshift/origin/releases[Releases] page and untar it on your
 local system.
+
+. Add the directory you untarred the release into to your path
++
+----
+$ export PATH=$(pwd):$PATH
+----
++
 
 . Launch the server:
 +
@@ -121,7 +115,7 @@ This command:
 +
 --
 - starts OpenShift listening on all interfaces (*0.0.0.0:8443*),
-- starts the web console listening on all interfaces (*0.0.0.0:8443*),
+- starts the web console listening on all interfaces at `/console` (*0.0.0.0:8443*),
 - launches an [sysitem]#etcd# server to store persistent data, and
 - launches the Kubernetes system components.
 --
@@ -129,21 +123,12 @@ This command:
 The server runs in the foreground until you terminate the process.
 +
 NOTE: This command requires `root` access to create services due to the need to
-modify `iptables`. See
-https://github.com/GoogleCloudPlatform/kubernetes/issues/1859[this Issue] for
-more information.
+modify `iptables` and mount volumes.
 
-. You can see more about the commands available in the binary with:
-+
-----
-$ ./openshift help
-----
-
-. Because OpenShift services are secured by TLS, clients must accept the server
-certificates and present their own client certificate. These certificates are
-generated when the master server is started. You must point `oc` and `curl` at
-the appropriate CA bundle and client key and certificate to connect to
-OpenShift. Set the following environment variables:
+. OpenShift services are secured by TLS. In this path we generate a self-signed
+certificate on startup which must be accepted by your web browser or client.
+You must point `oc` and `curl` at the appropriate CA bundle and client key and
+certificate to connect to OpenShift. Set the following environment variables:
 +
 ----
 $ export KUBECONFIG=`pwd`/openshift.local.config/master/admin.kubeconfig
@@ -151,19 +136,9 @@ $ export CURL_CA_BUNDLE=`pwd`/openshift.local.config/master/ca.crt
 $ sudo chmod +r `pwd`/openshift.local.config/master/admin.kubeconfig
 ----
 +
-NOTE: This is just for example purposes; in a production environment, developers would generate their own keys and not have access to the system keys.
+NOTE: This is just for example purposes; in a production environment, developers 
+would generate their own keys and not have access to the system keys.
 
-. You can see more about the commands available in the CLI with:
-+
-----
-$ ./oc help
-----
-+
-Or connect from another system with:
-+
-----
-$ ./oc -h <server_hostname_or_IP> [...]
-----
 
 *What's Next?*
 
@@ -177,10 +152,150 @@ GitHub
 https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc#develop-on-virtual-machine-using-vagrant[for
 instructions].
 
+
 == Try It Out
 
-After installing your OpenShift instance, you can try it out by creating an
-end-to-end application, demonstrating the full OpenShift concept chain. See the
+After starting an OpenShift instance, you can try it out by creating an
+end-to-end application demonstrating the full OpenShift concept chain.
+
+NOTE: When running OpenShift in a VM, you will want to ensure your host system can
+access ports 8080 and 8443 inside the container for the examples below.
+
+
+. Log in to the server as a regular user
++
+----
+$ oc login
+Username: test
+Password: test
+----
++
+. Create a new project to hold your application
++
+----
+$ oc new-project test
+----
++
+. Create a new application based on a Node.js image on the Docker Hub
++
+----
+$ oc new-app openshift/deployment-example:v1
+----
++
+Note that a service was created and given an IP - this is an address that
+can be used within the cluster to access the application.
++
+. Display a summary of the resources you created
++
+----
+$ oc status
+----
++
+. The Docker image for your application will be pulled to the local system and
+started. Once it has started it can be accessed on the host. If this is your
+laptop or desktop, open a web browser to the service IP and port that was
+displayed for the application:
++
+----
+http://172.30.192.169:8080 (example)
+----
++
+If you are on a separate system and do not have direct network access to the
+host, SSH to the system and perform a curl command:
++
+----
+$ curl http://172.30.192.169:8080 # (example)
+----
++
+You should see the `v1` text displayed on the page.
+
+Now that your application is deployed, you can trigger a new version of that
+image to be rolled out to your host by tagging the `v2` image. The `new-app`
+command created an image stream which tracks which images you wish to use.
+Use the `tag` command to mark a new image as being desired for deployment:
+
+----
+$ oc tag deployment-example:v2 deployment-example:latest
+----
+
+Your application's deployment config is watching `deployment-example:latest`
+and will trigger a new rolling deployment when the `latest` tag is updated
+to the value from `v2`.
+
+Return to the browser or use curl again and you should see the `v2` text
+displayed on the page.
+
+NOTE: For this next step we'll need to ensure that Docker is able to pull images
+from the host system. Ensure you have completed the instructions about setting the
+`--insecure-registry` flag from link:../install_config/install/prerequisites.html#host-preparation[the prerequisites page].
+
+As a developer, building new Docker images is as important as deploying them.
+OpenShift provides tools for running Docker builds as well as building source
+code from within predefined builder images via the Source-to-Image toolchain.
+
+. Switch to the administrative user and change to the `default` project
++
+----
+$ oc login -u system:admin
+$ oc project default
+----
++
+. Set up an integrated Docker registry for the OpenShift cluster
++
+----
+$ oadm registry --credentials=./openshift.local.config/master/openshift-registry.kubeconfig
+----
++
+It will take a few minutes for the registry image to download and start - use
+`oc status` to know when the registry is started.
+. Change back to the `test` user and `test` project
++
+----
+$ oc login -u test
+$ oc project test
+----
++
+. Create a new application that combines a builder image for Node.js with
+example source code to create a new deployable Node.js image:
++
+----
+$ oc new-app openshift/nodejs-010-centos7~https://github.com/openshift/nodejs-ex.git
+----
++
+A build will be triggered automatically using the provided image and the latest
+commit to the `master` branch of the provided Git repository. To get the status
+of a build, run
++
+----
+$ oc status
+----
++
+which will summarize the build. When the build completes, the resulting Docker
+image will be pushed to the Docker registry.
+. Wait for the deployed image to start, then view the service IP using your
+browser or curl.
+
+You can see more about the commands available in
+link:../cli_reference/basic_cli_operations.html[the CLI] (the `oc` command)
+with:
+
+----
+$ oc help
+----
+
+Or connect to another system with:
+
+----
+$ oc -h <server_hostname_or_IP> [...]
+----
+
+OpenShift includes a web console which helps you visualize your applications
+and perform common creation and management actions. You can use the `test`
+user we created above to log in to the console via `+++https://<server>:8443/console+++`.
+For more information, see
+link:../developers/developers_console.html[the Developer Console guide].
+
+You can also see the
 https://github.com/openshift/origin/blob/master/examples/sample-app[OpenShift 3
-Application Lifecycle Sample] for instructions.
+Application Lifecycle Sample] for a more in-depth walkthrough.
 endif::[]


### PR DESCRIPTION
Moving the steps from the README.md for Origin here so we can consolidate
on one set of documents. Also includes the Ansible installer as an installation
method.
