### PR TITLE
Guidelines updated to add info re: internal links

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -69,21 +69,32 @@ There are some general guidelines and conventions we follow for titles, headings
 Links can be used to cross-reference internal topics, or send customers to external information resources for further reading. 
 
 === Internal Cross-References
-Whenever possible the link to another topic should be part of the actual sentence. Avoid creating links as a separate sentence that begins with "See [this topic] for more information on x".
+Whenever possible the link to another topic should be part of the actual sentence. Avoid creating links as a separate sentence that begins with "See [this topic] for more information on x". 
+
+[NOTE]
+====
+Use the relative file path (from the file you are editing, to the file you are linking to), even if you are linking to the same directory that you are writing in. This makes search and replace operations to fix broken links much easier. 
+
+For example, if you are writing in *_architecture/core_concepts/deployments.adoc_* and you want to link to *_architecture/core_concepts/routes.adoc_* then you would need to include the path back to the first level of the topic directory: 
+
+----
+link:../../architecture/core_concepts/routes.adoc
+----
+====
 
 .Markup example of cross-referencing to internal topics
 ----
 Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or
-the link:cli.html#deployment-rollbacks[OpenShift CLI].
+the link:../cli_reference/get_started_cli.html#installing-the-cli[OpenShift CLI].
 
-Before you can create a domain, you must first link:applications.html#create_app[create an application].
+Before you can create a domain, you must first link:../dev_guide/new_app.html[create an application].
 ----
 
 .Rendered output of cross-referencing to internal topics:
 ====
-Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the link:cli.html#deployment-rollbacks[OpenShift CLI].
+Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the link:../cli_reference/get_started_cli.html#installing-the-cli[OpenShift CLI].
 
-Before you can create a domain, you must first link:applications.html#create_app[create an application].
+Before you can create a domain, you must first link:../dev_guide/new_app.html[create an application].
 ====
 
 For comparison and clarification, the following example shows the previous method of linking to other topics.


### PR DESCRIPTION
We need to use the full file path when creating internal links within the docs.

This is because our build system doesn't find broken links.

If a file is 3-directories deep in our docs, and the link is broken, then find & replace operations are very tricky when the file might be referred to by a link containing any level of nesting. Example:

link:../getting_started/developers/developers_console.html
link:developers/developers_console.html
link:developers_console.html

If we all agree to use the full file path all the time, then you simply need to do a find & replace / grep operation for one thing, and one thing only.
