### PR TITLE
added syntax info to Securing the Registry

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -356,9 +356,17 @@ $ sudo systemctl daemon-reload
 $ sudo systemctl restart docker
 ----
 +
-. Validate the `docker` client connection. Running `docker push` to the registry
-or `docker pull` from the registry should succeed.  Make sure you have
+. Validate the `docker` client connection. Running
+https://docs.docker.com/reference/commandline/push/[`docker push`]
+to the registry or
+https://docs.docker.com/reference/commandline/pull/[`docker pull`] from the registry should succeed.  Make sure you have
 link:#access[logged into the registry].
++
+----
+$ docker tag|push <registry/image> <internal_registry/project/image>
+----
++
+For example:
 +
 ====
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1245340

Wasn't clear in "Securing the Registry" section of the Docker registry how the syntax for the command example worked. 

Added the syntax, as well as some embedded links to the Docker docs re: use of push and pull commands.

Rendered file:
http://file.bne.redhat.com/~tpoitras/Sept17/dockersyntax-BZ1245340/install_config/install/docker_registry.html#securing-the-registry
