### PR TITLE
Document creating a custom SCC

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 Security context constraints allow administrators to control permissions for pods.  To learn
-more about this API type please refer to the 
+more about this API type please refer to the
 link:../architecture/additional_concepts/authorization.html#security-context-constraints[security
 context constraints] (SCCs) architecture documentation.  You may manage SCCs in your instance as normal API
 link:../architecture/core_concepts/overview.html[objects] using
@@ -40,6 +40,39 @@ restricted   false     []        false     MustRunAs   MustRunAsRange
 ----
 ====
 
+[[examining-a-security-context-constraints-object]]
+
+== Examining a Security Context Constraints Object
+
+To examine a particular SCC, use `oc get`, `oc describe`, `oc export`, or `oc edit`.
+
+====
+----
+$ oc edit scc restricted
+allowHostDirVolumePlugin: false
+allowHostNetwork: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: v1
+groups:
+- system:authenticated
+kind: SecurityContextConstraints
+metadata:
+  creationTimestamp: 2015-09-08T07:37:54Z
+  name: restricted <1>
+  resourceVersion: "58"
+  selfLink: /api/v1/securitycontextconstraints/restricted
+  uid: 849d9228-55fc-11e5-976b-080027c5bfa9
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+----
+<1> The SCC name specified in the `oc edit` command.
+====
+
+
 [[creating-new-security-context-constraints]]
 
 == Creating New Security Context Constraints
@@ -63,6 +96,7 @@ users:
 groups:
 - my-admin-group
 ----
+Although this example definition was written by hand, another way is to modify the defintion obtained from link:#examining-a-security-context-constraints-object[examining a particular SCC].
 ====
 
 Then, run `oc create` passing the file to create it:
@@ -169,6 +203,36 @@ users:
 <1> The *e2e-user* added to the users section.
 
 ====
+
+[[grant-a-service-account-access-to-the-privileged-scc]]
+
+=== Grant a Service Account Access to the Privileged SCC
+
+First, create a link:../dev_guide/service_accounts.html[service account].
+For example, to create service account `My_SVCACCT` in project `My_Project`:
+
+====
+----
+$ cat <<EOF | oc create -n My_Project -f -
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: My_SVCACCT <1>
+EOF
+----
+====
+
+Then, add the service account to the `privileged` SCC.
+
+----
+$ oc edit scc privileged
+----
+
+Add the following under `users`:
+
+----
+   - system:serviceaccount:My_Project:My_SVCACCT
+----
 
 [[enable-images-to-run-with-user-in-the-dockerfile]]
 


### PR DESCRIPTION
Rather than introduce a specific section on "custom SCC", we piggyback on the "creating SCC" section, pointing back to a new section "examining SCC".

@rjhowe WDYT?
