### PR TITLE
add label --service-account to create ipfailover

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -254,7 +254,7 @@ run on one or more, or even all, of the labeled nodes.
 +
 ====
 ----
-$ oadm ipfailover ipf-ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$KUBECONFIG" --create
+$ oadm ipfailover ipf-ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$KUBECONFIG" --create --service-account=router
 ----
 ====
 


### PR DESCRIPTION
Example: oadm ipfailover ipf-ha-router-us-west --replicas=5 --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" --watch-port=80 --credentials="$KUBECONFIG" --create --service-account=router
