### PR TITLE
"oc export" command missing option.

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -403,8 +403,9 @@ If an object definition's metadata includes a namespace field, the field will be
 Rather than writing an entire template from scratch, you can also export existing resources from your project in template form, and then modify the template from there by adding parameters and other customizations.  To export resources in a project, in template form, run:
 
 ----
-$ oc export all --as-template=<template_name>
+$ oc export all --all --as-template=<template_name>
 ----
 
-You can also substitute a particular resource type instead of `*all*`.
+You can also substitute a particular resource type or multiple resources instead of `*all*`. 
+Run `$ oc export -h` for more examples. 
 


### PR DESCRIPTION
Original command example produced error:

```
[root@master ~]# oc export all --as-template=test1
error: you must provide one or more resources by argument or filename
```

To correct this `--all` must be added
