### PR TITLE
Sync container name in gs/admin

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -68,7 +68,7 @@ This command:
 . After the container is started, you can open a console inside the container:
 +
 ----
-$ sudo docker exec -it openshift-origin bash
+$ sudo docker exec -it origin bash
 ----
 
 If you delete the container, any configuration or stored application definitions


### PR DESCRIPTION
Updating the container name in `docker exec` to match the `--name` given in the recently-updated `docker run` command that precedes it.

@smarterclayton ack?
