### PR TITLE
Fix typo in "Getting Started for Administrators"

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -68,7 +68,7 @@ This command:
 . After the container is started, you can open a console inside the container:
 +
 ----
-$ sudo docker exec -it openshift-origin bash
+$ sudo docker exec -it origin bash
 ----
 
 If you delete the container, any configuration or stored application definitions


### PR DESCRIPTION
The previous step creates a container named "origin" (not "openshift-origin")
