### PR TITLE
Formatting edits to SDN topic, condtionalize multitenant plug-in

### DIFF
--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -20,29 +20,38 @@ endif::[]
 ifdef::openshift-enterprise[]
 OpenShift SDN,
 endif::[]
-which configures an overlay network using Open vSwitch (OVS). Following is a
-detailed discussion of the design and operation of OpenShift SDN, which may be
-useful for troubleshooting.
+which configures an overlay network using Open vSwitch (OVS).
 
-OpenShift SDN provides two SDN plugins for configuring the network:
+ifdef::openshift-origin[]
+OpenShift SDN provides two SDN plug-ins for configuring the network:
 
-* The *ovssubnet* plugin is the original plugin which provides a "flat" pod
+* The *ovssubnet* plug-in is the original plug-in which provides a "flat" pod
 network where every pod can communicate with every other pod and service.
-* The *multitenant* plugin provides isolation between pods based on which
-OpenShift project the pod is assigned to.  Each project receives a unique
+* The *multitenant* plug-in provides isolation between pods based on which
+OpenShift project the pod is assigned to. Each project receives a unique
 Virtual Network ID (VNID) that identifies traffic from pods assigned to the
-project.  Pods from different projects cannot send packets to or receive packets
-from pods and services of a different project.
+project. Pods from different projects cannot send packets to or receive
+packets from pods and services of a different project.
 +
-However, the "default" project (which receives VNID 0) is more privileged in
+However, the *default* project (which receives VNID 0) is more privileged in
 that it is allowed to communicate with all other pods, and all other pods can
-communicate with the "default" project.  This facilitates certain services
-(like the load balancer) that are run in containers themselves and must talk
-to all other containers.
+communicate with the *default* project. This facilitates certain services (like
+the load balancer) that are run in containers themselves and must talk to all
+other containers.
+endif::[]
 
-== Design
+ifdef::openshift-enterprise[]
+OpenShift SDN includes the *ovssubnet* SDN plug-in for configuring the network,
+which provides a "flat" pod network where every pod can communicate with every
+other pod and service.
+endif::[]
 
-=== Master
+Following is a detailed discussion of the design and operation of OpenShift SDN,
+which may be useful for troubleshooting.
+
+[[sdn-design-on-masters]]
+
+== Design on Masters
 
 On an OpenShift master, OpenShift SDN maintains a registry of nodes, stored in
 *etcd*. When the system administrator registers a node, OpenShift SDN allocates
@@ -63,22 +72,28 @@ to have access to any cluster network. Consequently, a master host does not have
 access to containers via the cluster network, unless it is also running as a
 node.
 
-When using the *multitenant* plugin, the OpenShift SDN master also watches for
+ifdef::openshift-origin[]
+When using the *multitenant* plug-in, the OpenShift SDN master also watches for
 the creation and deletion of projects, and assigns VXLAN VNIDs to them, which
 will be used later by the nodes to isolate traffic correctly.
+endif::[]
 
-=== Nodes
+[[sdn-design-on-nodes]]
+
+== Design on Nodes
 
 On a node, OpenShift SDN first registers the local host with the SDN master in
-the aforementioned registry so that the master allocates a subnet to the
-node.
+the aforementioned registry so that the master allocates a subnet to the node.
 
 Next, OpenShift SDN creates and configures six network devices:
 
-* *br0*, the OVS bridge device that containers will be attached to.  OpenShift
-SDN also configures a set of non-subnet-specific flow rules on this bridge. (The
-*multitenant* plugin does this immediately; the *ovssubnet* plugin waits until
-the SDN master announces the creation of the new node subnet.)
+* *br0*, the OVS bridge device that containers will be attached to. OpenShift
+SDN also configures a set of non-subnet-specific flow rules on this bridge.
+ifdef::openshift-origin[]
+The *multitenant* plug-in does this immediately.
+endif::[]
+The *ovssubnet* plug-in waits to do so until the SDN master announces the
+creation of the new node subnet.
 * *lbr0*, a Linux bridge device, which is configured as Docker's bridge and
 given the cluster subnet gateway address (eg, 10.1.x.1/24).
 * *tun0*, an OVS internal port (port 2 on *br0*). This _also_ gets assigned the
@@ -96,29 +111,33 @@ Each time a pod is started on the host, OpenShift SDN:
 
 . moves the host side of the pod's veth interface pair from the *lbr0* bridge
 (where Docker placed it when starting the container) to the OVS bridge *br0*.
-. adds OpenFlow rules to the OVS database to route traffic addressed
-to the new pod to the correct OVS port.
-. in the case of the *multitenant* plugin, it also adds OpenFlow rules to tag
-traffic coming from the pod with the pod's VNID, and to allow traffic into the
-pod if the traffic's VNID matches the pod's VNID (or is the privileged VNID
-0). (Non-matching traffic is filtered out by a generic rule.)
+. adds OpenFlow rules to the OVS database to route traffic addressed to the new
+pod to the correct OVS port.
+ifdef::openshift-origin[]
+. in the case of the *multitenant* plug-in, adds OpenFlow rules to tag traffic
+coming from the pod with the pod's VNID, and to allow traffic into the pod if
+the traffic's VNID matches the pod's VNID (or is the privileged VNID 0).
+(Non-matching traffic is filtered out by a generic rule.)
+endif::[]
 
 The pod is allocated an IP address in the cluster subnet by Docker itself
-because Docker is told to use the *lbr0* bridge, which OpenShift SDN has assigned
-the cluster gateway address (eg. 10.1.x.1/24).  Note that the *tun0* is also
-assigned the cluster gateway IP address because it is the default gateway for all
-traffic destined for external networks, but these two interfaces do not
-conflict because the *lbr0* interface is only used for IPAM and no OpenShift
-SDN pods are connected to it.
+because Docker is told to use the *lbr0* bridge, which OpenShift SDN has
+assigned the cluster gateway address (eg. 10.1.x.1/24). Note that the *tun0* is
+also assigned the cluster gateway IP address because it is the default gateway
+for all traffic destined for external networks, but these two interfaces do not
+conflict because the *lbr0* interface is only used for IPAM and no OpenShift SDN
+pods are connected to it.
 
 OpenShift SDN nodes also watch for subnet updates from the SDN master. When a new
 subnet is added, the node adds OpenFlow rules on *br0* so that packets with a
 destination IP address the remote subnet go to *vxlan0* (port 1 on *br0*) and thus
-out onto the network. The *ovssubnet* plugin sends all packets across the VXLAN
-with VNID 0, but the *multitenant* plugin uses the appropriate VNID for the
-source container.
+out onto the network.
+ifdef::openshift-origin[]
+The *ovssubnet* plug-in sends all packets across the VXLAN with VNID 0, but the
+*multitenant* plug-in uses the appropriate VNID for the source container.
+endif::[]
 
-==== Packet Flow
+=== Packet Flow
 
 Suppose we have two containers A and B where the peer virtual Ethernet device
 for container A's *eth0* is named *vethA* and the peer for container B's *eth0*
@@ -150,15 +169,19 @@ Finally, if container A connects to an external host, the traffic looks like:
 *_eth0_* _(in A's netns) -> *vethA* -> *br0* -> *tun0* -> (NAT) -> *eth0* (physical device) -> Internet_
 
 Almost all packet delivery decisions are performed with OpenFlow rules in the
-OVS bridge *br0*.  This simplifies the network architecture of the multitenant
-plugin and provides flexible routing and (in the case of the *multitenant*
-plugin) enforceable network isolation.
+OVS bridge *br0*, which simplifies the plug-in network architecture and provides
+flexible routing.
+ifdef::openshift-origin[]
+In the case of the *multitenant* plug-in, this also provides enforceable network
+isolation.
+endif::[]
 
-==== Network Isolation With the multitenant Plugin
+ifdef::openshift-origin[]
+=== Network Isolation With the multitenant Plug-in
 
-When using the *multitenant* plugin, when a packet exits a pod assigned to a
+When using the *multitenant* plug-in, when a packet exits a pod assigned to a
 non-default project, the OVS bridge *br0* tags that packet with the project's
-assigned VNID.  If the packet is directed to another IP address in the node's
+assigned VNID. If the packet is directed to another IP address in the node's
 cluster subnet, the OVS bridge only allows the packet to be delivered to the
 destination pod if the VNIDs match.
 
@@ -172,10 +195,11 @@ owning the cluster subnet.
 
 As described before, VNID 0 is privileged in that traffic with any VNID is
 allowed to enter any pod assigned VNID 0, and traffic with VNID 0 is allowed to
-enter any pod.  Only the "default" OpenShift project is assigned VNID 0; all
+enter any pod. Only the *default* OpenShift project is assigned VNID 0; all
 other projects are assigned unique, isolation-enabled VNIDs.
+endif::[]
 
-==== External Access to the Cluster Network
+=== External Access to the Cluster Network
 
 If a host that is external to OpenShift requires access to the cluster network,
 you have two options:


### PR DESCRIPTION
Minor follow-up edits to https://github.com/openshift/openshift-docs/pull/952 and also conditionalized the multitenant plug-in for now to only appear in the Origin docs, as it is not supported in OSE 3.0.2.

@danwinship @dcbw PTAL

Pretty build (internal), since GH preview won't show any of the conditionalized stuff: [OSE](http://file.rdu.redhat.com/~adellape/092115/condtl_sdnplugins/architecture/additional_concepts/sdn.html) | [Origin](http://file.rdu.redhat.com/~adellape/092115/origin/condtl_sdnplugins/architecture/additional_concepts/sdn.html)
