### PR TITLE
fix video by changing embed into text link

### DIFF
--- a/getting_started/developers/developers_console.adoc
+++ b/getting_started/developers/developers_console.adoc
@@ -15,9 +15,9 @@ toc::[]
 include::getting_started/developers/developers_cli.adoc[tag=overview]
 include::getting_started/developers/developers_cli.adoc[tag=beforeyoubegin]
 
-The following video walks you through the rest of this topic:
+== Tutorial Video
 
-video::https://access.redhat.com/webassets/avalon/v/developer_console.mp4[width=720]
+The following video walks you through the rest of this topic: https://access.redhat.com/webassets/avalon/v/developer_console.mp4[Click here to watch]
 
 include::getting_started/developers/developers_cli.adoc[tag=forking]
 


### PR DESCRIPTION
Since we cannot currently embed video successfully into our documentation, scaling back the use of the video in the getting started experience to just a text link. Also made it into its own section so it stands out a bit more, now that it's just a 1-liner link. :v: 

@vikram-redhat -- as requested.
