### PR TITLE
Add an example of how to add secure edge terminated routes.

### DIFF
--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -245,7 +245,7 @@ $ oadm ca create-server-cert --signer-cert=$CA/ca.crt \
 ----
 ====
 
-The router expects the ceritifcate and key to be in PEM format in a single
+The router expects the certificate and key to be in PEM format in a single
 file:
 
 ====
@@ -281,6 +281,74 @@ To remove a passphrase from a keyfile, you can run:
 ----
 # openssl rsa -in <passwordProtectedKey.key> -out <new.key>
 ----
+
+Here is an example of how to use a secure edge terminated route with TLS
+termination occuring on the router before traffic is proxied to the
+destination. The secure edge terminated route specifies the TLS certificate
+and key information. The TLS certificate is served by the router front end.
+
+First, start up a router instance:
+
+----
+# odm router --replicas=1 --credentials=$KUBECONFIG --service-account=router
+----
+
+Next, create a private key, csr and certificate for our edge secured route.
+The instructions on how to do that would be specific to your certificate
+authority and provider. For a simple self-signed certificate for a domain
+named `www.example.test`, see the example shown below:
+
+----
+# sudo openssl genrsa -out example-test.key 2048
+#
+# sudo openssl req -new -key example-test.key -out example-test.csr  \
+  -subj "/C=US/ST=CA/L=Mountain View/O=OS3/OU=Eng/CN=www.example.test"
+#
+# sudo openssl x509 -req -days 366 -in example-test.csr  \
+      -signkey example-test.key -out example-test.crt
+----
+
+Generate a route configuration file using the above certificate and key.
+Make sure to replace servicename `my-service` with the name of your service.
+
+----
+# servicename="my-service"
+# echo "
+apiVersion: v1
+kind: Route
+metadata:
+  name:  secured-edge-route
+spec:
+  host: www.example.test
+  to:
+    kind: Service
+    name: $servicename
+  tls:
+    termination: edge
+    key: |
+$(openssl rsa -in example-test.key | sed 's/^/      /')
+    certificate: |
+$(openssl x509 -in example-test.crt | sed 's/^/      /')
+
+" > example-test-route.yaml
+----
+
+Finally add the route to OpenShift (and the router) via:
+
+----
+# oc create -f example-test-route.yaml
+----
+
+Make sure your DNS entry for `www.example.test` points to your router
+instance(s) and the route to your domain should be available.
+The example below uses curl along with a local resolver to simulate the
+DNS lookup:
+
+----
+# routerip="4.1.1.1"  #  replace with IP address of one of your router instances.
+# curl -k --resolve www.example.test:443:$routerip https://www.example.test/
+----
+
 
 [[using-the-container-network-stack]]
 

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -290,7 +290,7 @@ and key information. The TLS certificate is served by the router front end.
 First, start up a router instance:
 
 ----
-# odm router --replicas=1 --credentials=$KUBECONFIG --service-account=router
+# oadm router --replicas=1 --credentials=$KUBECONFIG --service-account=router
 ----
 
 Next, create a private key, csr and certificate for our edge secured route.

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -259,7 +259,7 @@ From there you can use the `--default-cert` flag:
 ====
 ----
 $ oadm router --default-cert=cloudapps.router.pem \
---images=myrepo/somerouter:mytag --credentials="$KUBECONFIG" --service-account=router
+    --credentials="$KUBECONFIG" --service-account=router
 ----
 ====
 


### PR DESCRIPTION
Adds an example of how to route secure routes (edge-terminate) - aka something to showcase non-wildcard DNS secured routes.
@adellape / @bfallonf   PTAL thx.
