### PR TITLE
Mention minimum ansible version requirements.

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -36,7 +36,8 @@ continue to link:#installing-ansible[installing Ansible].
 
 The advanced installation method is based on Ansible playbooks and as such
 requires invoking Ansible directly. Consult with your IT department to confirm
-your organization's supported download instructions for Ansible.
+your organization's supported download instructions for Ansible version 1.8.4
+or later.
 
 ifdef::openshift-origin[]
 For convenience, the following steps are provided if you want to use EPEL as a


### PR DESCRIPTION
It was noticed that we don't document the minimum version of ansible in the advanced install docs, users who use versions prior to 1.8.4 won't be able to run this playbook.

See https://github.com/openshift/openshift-ansible/issues/623
