### PR TITLE
Update quota for requests vs limits

### DIFF
--- a/dev_guide/quota.adoc
+++ b/dev_guide/quota.adoc
@@ -28,10 +28,10 @@ The following describes the set of limits that may be enforced by a
 |Resource Name |Description
 
 |`cpu`
-|Total cpu usage across all containers
+|Total requested cpu usage across all containers
 
 |`memory`
-|Total memory usage across all containers
+|Total requested memory usage across all containers
 
 |`pods`
 |Total number of pods
@@ -72,6 +72,82 @@ action, and an appropriate error message is returned to the end-user explaining
 the quota constraint violated, and what their currently observed usage stats are
 in the system.
 
+=== Compute Resources: Requests vs Limits
+
+When allocating compute resources, each container may specify a request and a limit value for either CPU or memory.  The quota tracking system will only cost the request value against the quota usage.  If a resource is tracked by quota, and no request value is provided, the associated entity is rejected as part of admission into the cluster.
+
+For an example, consider the following scenarios relative to tracking quota on CPU:
+
+.Quota tracking based on container requests
+[cols="3a,3a,3a,3a,8a",options="header"]
+|===
+
+|Pod |Container |Requests[CPU] |Limits[CPU] |Result
+
+|pod-x
+|a
+|100m
+|500m
+|The quota usage is incremented 100m
+
+|pod-y
+|b
+|100m
+|none
+|The quota usage is incremented 100m
+
+|pod-y
+|c
+|none
+|500m
+|The quota usage is incremented 500m since request will default to limit.
+
+|pod-z
+|d
+|none
+|none
+|The pod is rejected since it does not enumerate a request.
+
+|===
+
+The rationale for charging quota usage for the requested amount of a resource versus the limit is the belief that a user should only be charged for what they are scheduled against in the cluster.
+
+As a consequence, the user is able to spread its usage of a resource across multiple tiers of service. Let's demonstrate this via an example with a 4 cpu quota.
+
+The quota may be allocated as follows:
+
+.Quota with Burstable resources
+[cols="3a,3a,3a,3a,3a,8a",options="header"]
+|===
+
+|Pod |Container |Requests[CPU] |Limits[CPU] |Quality of Service Tier |Quota Usage
+
+|pod-x
+|a
+|1
+|4
+|Burstable
+|1
+
+|pod-y
+|b
+|2
+|2
+|Guaranteed
+|2
+
+|pod-z
+|c
+|1
+|3
+|Burstable
+|1
+
+|===
+
+The user is restricted from using *BestEffort* CPU containers, but at any point in time, the containers on the node may consume up to 9 CPU cores over a given time period if there is no contention on the node because it
+has **Burstable** containers.  If one wants to restrict the ratio between the request and limit, it is encouraged that the user define a `*LimitRange*` with `*MaxLimitRequestRatio*` to control burst out behavior. This would in effect, let an administrator keep the difference between request and limit more in line with tracked usage if desired.
+
 == Sample Resource Quota File
 
 resource-quota.json
@@ -96,8 +172,8 @@ resource-quota.json
 }
 ----
 <1> The name of this quota document
-<2> The total amount of memory consumed across all containers may not exceed 1Gi.
-<3> The total number of cpu usage consumed across all containers may not exceed 20 Kubernetes compute units.
+<2> The total amount of memory requested across all containers may not exceed 1Gi.
+<3> The total number of cpu requested across all containers may not exceed 20 Kubernetes compute units.
 <4> The total number of pods in the project
 <5> The total number of services in the project
 <6> The total number of replication controllers in the project


### PR DESCRIPTION
OpenShift now has support for differentiating request vs limits for compute resources.

This impacts how quota works, and this updates the documentation to describe the changes.
