### PR TITLE
Adding basicauth and sshauth secrets

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1025,10 +1025,113 @@ is *dockerhub*:
 == Using Private Repositories for Builds
 
 Supply valid credentials to build an application from a private repository.
-Currently, only SSH key based authentication is supported. The repository keys
-are located in the `$HOME/.ssh/` directory, and are named `id_dsa.pub`,
-`id_ecdsa.pub`, `id_ed25519.pub`, or `id_rsa.pub` by default. Generate SSH key
-credentials with the following command:
+
+Currently two types of authentication are supported: basic username-password
+and SSH key based authentication.
+
+[[basic-authentication]]
+=== Basic Authentication
+
+Basic authentication requires either a combination of `username` and `password`,
+or a `token` to authenticate against the SCM server. A `CA certificate` file,
+or a `.gitconfig` file can be attached.
+
+A link:../dev_guide/secrets.html[`*secret*`] is used to store your keys.
+
+. Create the `*secret*` first before using the username and password to access
+the private repository:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD
+----
+====
+
+.. To create a Basic Authentication Secret with a token:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --password=TOKEN
+----
+====
+
+.. To create a Basic Authentication Secret with a CA certificate file:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --ca-cert=FILENAME
+----
+====
+
+.. To create a Basic Authentication Secret with a `.gitconfig` file:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --gitconfig=FILENAME
+----
+====
+
+. Add the `*secret*` to the builder service account:
++
+====
+----
+$ oc secrets add serviceaccount/builder secrets/basicsecret
+----
+====
+
+. Add a `*sourceSecret*` field to the `*source*` section inside the
+`*BuildConfig*` and set it to the name of the `*secret*` that you created.
+In this case `*basicsecret*`:
++
+====
+
+----
+{
+  "apiVersion": "v1",
+  "kind": "BuildConfig",
+  "metadata": {
+    "name": "sample-build",
+  },
+  "parameters": {
+    "output": {
+      "to": {
+        "name": "sample-image"
+      }
+    },
+    "source": {
+      "git": {
+        "uri": "https://github.com/user/app.git" <1>
+      },
+      "sourceSecret": {
+        "name": "basicsecret"
+      },
+      "type": "Git"
+    },
+    "strategy": {
+      "sourceStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "python-33-centos7:latest"
+        }
+      },
+      "type": "Source"
+    }
+  }
+----
+<1> The URL of private repository, accessed by basic authentication, is usually
+in the `http` or `https` form.
+====
+
+
+[[ssh-key-authentication]]
+=== SSH Key Based Authentication
+
+SSH Key Based Authentication requires a private SSH key. A `.gitconfig` file can
+also be attached.
+
+The repository keys are usually located in the `$HOME/.ssh/` directory, and are named
+`id_dsa.pub`, `id_ecdsa.pub`, `id_ed25519.pub`, or `id_rsa.pub` by default.
+Generate SSH key credentials with the following command:
 
 ====
 
@@ -1050,7 +1153,15 @@ repository:
 +
 ====
 ----
-$ oc secrets new scmsecret ssh-privatekey=$HOME/.ssh/id_rsa
+$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa
+----
+====
+
+.. To create a SSH Based Authentication Secret with a `.gitconfig` file:
++
+====
+----
+$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa --gitconfig=FILENAME
 ----
 ====
 
@@ -1066,8 +1177,8 @@ $ oc secrets add serviceaccount/builder secrets/scmsecret
 
 
 . Add a `*sourceSecret*` field into the `*source*` section inside the
-`*BuildConfig*` and set it to the name of the `*secret*` that you created, in
-this case `*scmsecret*`:
+`*BuildConfig*` and set it to the name of the `*secret*` that you created.
+In this case `*sshsecret*`:
 +
 ====
 
@@ -1089,7 +1200,7 @@ this case `*scmsecret*`:
         "uri": "git@repository.com:user/app.git" <1>
       },
       "sourceSecret": {
-        "name": "scmsecret"
+        "name": "sshsecret"
       },
       "type": "Git"
     },
@@ -1104,6 +1215,51 @@ this case `*scmsecret*`:
     }
   }
 ----
-<1> The URL of private repository is usually in the form
-`git@example.com:<username>/<repository>`.
+<1> The URL of private repository, accessed by a private SSH key, is usually
+in the form `git@example.com:<username>/<repository>.git`.
+====
+
+[[other-authentication]]
+=== Other
+
+In case the cloning of your application is dependent on a `CA certificate`, `.gitconfig`
+file or both, you can create a secret that contains them, add it to the builder service
+account and then your `BuildConfig`.
+
+. Create desired type of `*secret*`:
+
+.. To create a secret from a `.gitconfig`:
++
+====
+----
+$ oc secrets new mysecret .gitconfig=path/to/.gitconfig
+----
+====
+.. To create a secret from a `CA certificate`:
++
+====
+----
+$ oc secrets new mysecret ca.crt=path/to/certificate
+----
+====
+.. To create a secret from a `CA certificate` and `.gitconfig`:
++
+====
+----
+$ oc secrets new mysecret ca.crt=path/to/certificate .gitconfig=path/to/.gitconfig
+----
+====
+
+[NOTE]
+====
+Please note that SSL verification can be turned off, if `sslVerify=false` is set
+in your `.gitconfig` file.
+====
+
+. Add the `*secret*` to the builder service account:
++
+====
+----
+$ oc secrets add serviceaccount/builder secrets/mysecret
+----
 ====

--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -12,11 +12,11 @@ toc::[]
 == Overview
 
 The `Secret` object type provides a mechanism to hold sensitive information such
-as passwords, OpenShift client config files, `dockercfg` files, etc. Secrets
-decouple sensitive content from the pods that use it and can be mounted into
-containers using a volume plug-in or used by the system to perform actions on
-behalf of a pod. This topic discusses important properties of secrets and
-provides an overview on how developers can use them.
+as passwords, OpenShift client config files, `dockercfg` files, private source
+repository credentials, etc. Secrets decouple sensitive content from the pods that
+use it and can be mounted into containers using a volume plug-in or used by the
+system to perform actions on behalf of a pod. This topic discusses important
+properties of secrets and provides an overview on how developers can use them.
 
 ====
 ----
@@ -109,6 +109,9 @@ See link:#examples[Examples].
 === Image Pull Secrets
 See the link:image_pull_secrets.html[Image Pull Secrets] topic for more
 information.
+
+=== Source Clone Secrets
+See the link:builds.html#using-private-repositories-for-builds[Using Private Repositories for Builds] topic for more information.
 
 [[restrictions]]
 


### PR DESCRIPTION
Adding docs for two new subcommands:
- `oc secrets new-basicauth`
- `oc secrets new-sshauth`

Wants sure if there should be a standalone topic in the `dev_guide.adoc`, similarly to `image_pull_secrets.adoc`, cause it would contain the same content then updated `Using Private Repositories for Builds` section in the `builds.adoc`

@csrwng @adellape PTAL
