### PR TITLE
Add bash-completion to install packages

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -274,7 +274,7 @@ endif::[]
 . Install the following packages:
 +
 ----
-# yum install wget git net-tools bind-utils iptables-services bridge-utils
+# yum install wget git net-tools bind-utils iptables-services bridge-utils bash-completion
 ----
 
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
This is a minor proposal. 
Since `openshift` package contains bash-completion `/etc/bash_completion.d/{oc,oadm,openshift}`, it would be useful to install `bash-completion` package to use them.
