### PR TITLE
[DO NOT MERGE] Add :Z flag to volume dir bind mount

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -54,7 +54,7 @@ https://hub.docker.com[Docker Hub] on a Linux system.
 $ sudo docker run -d --name "origin" \
         --privileged --net=host \
         -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
-        -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
+        -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes:Z \
         openshift/origin start
 ----
 +


### PR DESCRIPTION
Add :Z flag to volume dir bind mount so the volume dir has its SELinux
context relabeled. This is necessary so pod containers can write to
volumes.

Fixes https://github.com/openshift/origin/issues/4676
