### PR TITLE
Make the documentation more OpenShift-centric

### DIFF
--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -151,9 +151,9 @@ ifdef::openshift-origin[]
 == Hot Deploy
 Hot deploy works in this image out of the box.
 
-To change your source code in running container, use Docker's link:https://docs.docker.com/reference/commandline/exec/[exec] command:
+To change your source code in a running Pod, use the link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[oc rsh] command to enter the container:
 
-	$ docker exec -it <CONTAINER_ID> /bin/bash
+	$ oc rsh <POD_ID>
 
-After you link:https://docs.docker.com/reference/commandline/exec/[docker exec] into the running container, your current directory is set to `/opt/app-root/src`, where the source code is located.
+After you enter into the running container, your current directory is set to `/opt/app-root/src`, where the source code is located.
 endif::openshift-origin[]

--- a/using_images/s2i_images/ruby.adoc
+++ b/using_images/s2i_images/ruby.adoc
@@ -104,9 +104,11 @@ In order to dynamically pick up changes made in your application source code, yo
 
 *For Ruby on Rails applications*
 
-Run the built Rails image with the `RAILS_ENV=development` environment variable passed to the link:http://docker.io[Docker] `-e` run flag:
+Run the built Rails application with the `RAILS_ENV=development` environment
+variable passed to the running Pod. For an exisiting deployment configuration,
+you can use the link:../../dev_guide/environment_variables.html#set-environment-variables[oc env] command:
 
-	$ docker run -e RAILS_ENV=development -p 8080:8080 rails-app
+	$ oc env dc/rails-app RAILS_ENV=development
 
 
 *For other types of Ruby applications (Sinatra, Padrino, etc.)*
@@ -119,13 +121,11 @@ Your application needs to be built with one of gems that reloads the server ever
 
 Please note that in order to be able to run your application in development mode, you need to modify the link:https://github.com/openshift/source-to-image#anatomy-of-a-builder-image[S2I run script], so the web server is launched by the chosen gem, which checks for changes in the source code.
 
-After you built your application image with your version of link:#s2i-scripts[S2I run script], run the image with the RACK_ENV=development environment variable passed to the link:http://docker.io[Docker] -e run flag:
+After you built your application image with your version of link:#s2i-scripts[S2I run script], run the image with the `RACK_ENV=development` environment variable. See for example link:dev_guide/new_app.html#specifying-environment-variables[oc new-app].
 
-	$ docker run -e RACK_ENV=development -p 8080:8080 sinatra-app
+To change your source code in a running Pod, use the link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[oc rsh] command to enter the container:
 
-To change your source code in running container, use Docker's link:https://docs.docker.com/reference/commandline/exec/[exec] command:
+	$ oc rsh <POD_ID>
 
-	$ docker exec -it <CONTAINER_ID> /bin/bash
-
-After you link:https://docs.docker.com/reference/commandline/exec/[docker exec] into the running container, your current directory is set to `/opt/app-root/src`, where the source code is located.
+After you enter into the running container, your current directory is set to `/opt/app-root/src`, where the source code is located.
 endif::openshift-origin[]


### PR DESCRIPTION
It'd be more appropriate to refer to OC commands instead of Docker.

cc @jhadvig
