### PR TITLE
[do not merge] Documented installation with HAProxy as a load balancer

### DIFF
--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -46,6 +46,8 @@ configured for high availability, typically deployed with 2n+1 peer services.
 |Controller Manager Server
 |The controller manager server watches *etcd* for changes to replication
 controller objects and then uses the API to enforce the desired state.
+Can be run as a standalone process. Several such processes create a cluster with
+one active leader at a time.
 
 |Pacemaker
 a|Optional, used when configuring
@@ -62,6 +64,9 @@ http://clusterlabs.org/quickstart-redhat.html[CentOS 7] and
 http://clusterlabs.org/doc/[Fedora].
 endif::[]
 
+Another option is to use http://www.haproxy.org[HAProxy] load balancer to
+switch between API endpoints.
+
 |Virtual IP
 a|Optional, used when configuring
 link:#high-availability-masters[highly-available masters].
@@ -73,7 +78,7 @@ failure, for all OpenShift clients that:
 - do not know how to load balance across multiple masters nor retry failed
 master service connections.
 
-There is one VIP and it is managed by Pacemaker.
+There is one VIP and it is managed by Pacemaker or HAProxy.
 |===
 
 [[high-availability-masters]]
@@ -106,7 +111,7 @@ concepts and apply them towards your existing high availability solutions.
 When using Pacemaker, master components have the following availability:
 
 [cols="1,1,3"]
-.Availability Matrix
+.Availability Matrix with Pacemaker
 |===
 |Role |Style| Notes
 
@@ -129,6 +134,35 @@ When using Pacemaker, master components have the following availability:
 
 .Highly-available Masters Using Pacemaker
 image::ha_master_arch.png[Highly-available Masters Using Pacemaker]
+
+When using HAProxy, an alternative to Pacemaker, the availability table will be
+slightly different:
+
+[cols="1,1,3"]
+.Availability Matrix with HAProxy
+|===
+|Role |Style| Notes
+
+|*etcd*
+|Active-active
+|Fully redundant deployment with load balancing
+
+|API Server
+|Active-active 
+|Managed by HAProxy
+
+|Controller Manager Server
+|Active-passive
+|One instance is elected as a cluster leader at a time
+
+|HAProxy
+|Active-passive
+|Balances load between API master endpoints
+
+|Virtual IP
+|Active-passive
+|One active at a time, managed by HAProxy
+|===
 
 [[node]]
 

--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -78,7 +78,8 @@ failure, for all OpenShift clients that:
 - do not know how to load balance across multiple masters nor retry failed
 master service connections.
 
-There is one VIP and it is managed by Pacemaker or HAProxy.
+There is one VIP and it is managed by Pacemaker or another load balancer such as
+HAProxy.
 |===
 
 [[high-availability-masters]]
@@ -148,7 +149,7 @@ slightly different:
 |Fully redundant deployment with load balancing
 
 |API Server
-|Active-active 
+|Active-active
 |Managed by HAProxy
 
 |Controller Manager Server

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -414,7 +414,7 @@ link:../../architecture/infrastructure_components/kubernetes_infrastructure.html
 |*master1.example.com*
 .3+.^|Master
 (link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters[clustered
-using Pacemaker]) and node
+using Pacemaker or HAProxy]) and node
 
 |*master2.example.com*
 
@@ -451,6 +451,8 @@ You can see these example hosts present in the *[masters]*, *[nodes]*, and
 masters
 nodes
 etcd
+# uncomment following to use HAProxy as a management technology
+#lb
 
 # Set variables common for all OSEv3 hosts
 [OSEv3:vars]
@@ -466,13 +468,19 @@ endif::[]
 # uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
 # openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
 
-# master cluster ha variables using pacemaker or RHEL HA
-openshift_master_cluster_password=openshift_cluster
+# master cluster ha variables using pacemaker, RHEL HA or HAProxy
 openshift_master_cluster_vip=192.168.133.25
 openshift_master_cluster_public_vip=192.168.133.25
 openshift_master_cluster_hostname=openshift-master.example.com
 openshift_master_cluster_public_hostname=openshift-master.example.com
+# not needed for HAProxy setup
+openshift_master_cluster_password=openshift_cluster
+# override the default controller lease ttl 
+#osm_controller_lease_ttl=30 
 
+# Specify load balancer host
+#[lb]
+#lb.example.com
 
 # host group for masters
 [masters]
@@ -499,13 +507,22 @@ specifications, and save it as *_/etc/ansible/hosts_*.
 
 Note the following when using this configuration:
 
-- Installing multiple masters requires that you
+- Installing multiple masters with Pacemaker requires that you
 link:#configuring-fencing[configure a fencing device] after running the
 installer.
 - When specifying multiple masters, the installer handles creating and starting
 the high availability (HA) cluster. If during that process the `pcs status`
 command indicates that an HA cluster already exists, the installer skips HA
 cluster configuration.
+- Ansible installer doesn't currently support multiple HAProxy load balancers
+in active-passive setup. Please consult
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Load_Balancer_Administration/ch-lvs-overview-VSA.html[Load Balancer Overview documentation]
+for post-installation amendments or use Pacemaker if you require this capability.
+- In HAProxy setup, controller manager servers run as standalone processes.
+They elect their active leader with a lease stored in *etcd*. The lease expires
+after 30 seconds by default. If a failure happens on an active controller
+server, it will take up to this number of seconds to elect another leader. The
+interval can be configured with *_osm_controller_lease_ttl_* option.
 
 == Running the Ansible Installer
 
@@ -526,8 +543,8 @@ instructions or workarounds.
 == Configuring Fencing
 
 If you installed OpenShift using a
-link:#multi-master-multi-etcd-multi-node[configuration for multiple masters],
-you must configure a fencing device. See
+link:#multi-master-multi-etcd-multi-node[configuration for multiple masters]
+with Pacemaker as a load balancer, you must configure a fencing device. See
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/High_Availability_Add-On_Reference/ch-fencing-HAAR.html[Fencing:
 Configuring STONITH] in the High Availability Add-on for Red Hat Enterprise
 Linux documentation for instructions, then continue to
@@ -581,9 +598,9 @@ of your *etcd* hosts in the following:
 ----
 ====
 
-*Multiple Masters*
+*Multiple Masters with Pacemaker*
 
-If you installed multiple masters:
+If you installed multiple masters with Pacemaker as a load balancer:
 
 . On a master host, determine which host is currently running as the active
 master:
@@ -614,6 +631,16 @@ Red Hat recommends that you also verify your installation by consulting the
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html-single/High_Availability_Add-On_Reference/index.html[High
 Availability Add-on for Red Hat Enterprise Linux documentation].
 
+*Multiple Masters with HAProxy*
+
+If you installed multiple masters with HAProxy as a load balancer:
+
+- Paste url `http://lb.example.com:9000` (modify it according to your *_lb_*
+setup) to your browser and check HAProxy's status.
+
+Verify your installation by consulting the
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Load_Balancer_Administration/ch-haproxy-setup-VSA.html[HAProxy Configuration documentation].
+
 [[installer-known-issues]]
 
 == Known Issues
@@ -631,7 +658,7 @@ https://github.com/GoogleCloudPlatform/kubernetes/issues/10030 for details.
 system installation. If you are using virtual machines, start from a fresh
 image. If you are use bare metal machines:
 +
-. Run the following on a master host:
+. Run the following on a master host with Pacemaker:
 +
 ----
 # pcs cluster destroy --all

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -451,7 +451,8 @@ You can see these example hosts present in the *[masters]*, *[nodes]*, and
 masters
 nodes
 etcd
-# uncomment following to use HAProxy as a management technology
+# Uncomment following to let Ansible configure HAProxy as a management technology.
+# Keep commented if the load balancer is preconfigured.
 #lb
 
 # Set variables common for all OSEv3 hosts
@@ -465,18 +466,30 @@ ifdef::openshift-origin[]
 deployment_type=origin
 endif::[]
 
-# uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
-# openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
+# Uncomment the following to enable htpasswd authentication; defaults to
+# DenyAllPasswordIdentityProvider.
+#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
 
-# master cluster ha variables using pacemaker, RHEL HA or HAProxy
-openshift_master_cluster_vip=192.168.133.25
-openshift_master_cluster_public_vip=192.168.133.25
-openshift_master_cluster_hostname=openshift-master.example.com
-openshift_master_cluster_public_hostname=openshift-master.example.com
-# not needed for HAProxy setup
-openshift_master_cluster_password=openshift_cluster
-# override the default controller lease ttl 
-#osm_controller_lease_ttl=30 
+# Master cluster native ha variables with an optional load balancer. If no lb group is defined
+# installer assumes that a load balancer has been preconfigured. For installation the value of
+# openshift_master_cluster_hostname must resolve to the load balancer or to one or all of the
+# masters defined in the inventory if no load balancer is present.
+#openshift_master_cluster_ha=native
+#openshift_master_cluster_hostname=openshift-ansible.test.example.com
+#openshift_master_cluster_public_hostname=openshift-ansible.test.example.com
+
+# Master cluster ha variables when using pacemaker or RHEL HA. Pacemaker HA environment must be able
+# to self provision the configured VIP. For installation openshift_master_cluster_hostname must
+# resolve to the configured VIP.
+#openshift_master_cluster_ha=pacemaker
+#openshift_master_cluster_password=openshift_cluster
+#openshift_master_cluster_vip=192.168.133.25
+#openshift_master_cluster_public_vip=192.168.133.25
+#openshift_master_cluster_hostname=openshift-ansible.test.example.com
+#openshift_master_cluster_public_hostname=openshift-ansible.test.example.com
+
+# override the default controller lease ttl
+#osm_controller_lease_ttl=30
 
 # Specify load balancer host
 #[lb]

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -399,12 +399,20 @@ specifications, and save it as *_/etc/ansible/hosts_*.
 
 === Multiple Masters, Multiple etcd, and Multiple Nodes
 
+There are two high availability methods Ansible supports. `pacemaker` and
+`native`. The former configures Pacemaker as a load balancer for Masters. The
+latter method uses and configures HAProxy instead. You must choose a single
+host and add it into `lb` host group if you want Ansible to configure HAProxy
+for you. If no `lb` is specified, a preconfigured load balancer will be
+assumed.
+
 The following describes an example environment for three
 link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#master[masters],
 three
 link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#master[*etcd*]
 hosts, and two
-link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#node[nodes]:
+link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#node[nodes]
+using *pacemaker* HA method:
 
 [options="header"]
 |===
@@ -414,7 +422,7 @@ link:../../architecture/infrastructure_components/kubernetes_infrastructure.html
 |*master1.example.com*
 .3+.^|Master
 (link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters[clustered
-using Pacemaker or HAProxy]) and node
+using Pacemaker]) and node
 
 |*master2.example.com*
 
@@ -439,8 +447,10 @@ When specifying multiple *etcd* hosts, external *etcd* is installed and
 configured. Clustering of OpenShift's embedded *etcd* is not supported.
 ====
 
-You can see these example hosts present in the *[masters]*, *[nodes]*, and
-*[etcd]* sections of the following example inventory file:
+There would haven been an additional host *lb.example.com* hosting HAProxy if
+*native* HA method had been used. You can see these example hosts present
+in the *[masters]*, *[nodes]*, and *[etcd]* sections of the following example
+inventory file:
 
 .Multiple Masters, Multiple etcd, and Multiple Nodes Inventory File
 ====


### PR DESCRIPTION
Extended advanced install section for HAProxy bits using Ansible.

Modified masters components section acccordingly and added availability
matrix for HAProxy setup.

Depends on [openshift-ansible PR#608](https://github.com/openshift/openshift-ansible/pull/608)
