### PR TITLE
Add scheduler kind and apiversion to 3.0.2/1.0.5 upgrade

### DIFF
--- a/install_config/upgrades.adoc
+++ b/install_config/upgrades.adoc
@@ -612,6 +612,29 @@ networkConfig:
 ----
 ====
 
+*Add Scheduler Config API version*
+
+The scheduler configuration file incorrectly lacked `*kind*` and `*apiVersion*`
+fields when deployed with the quick or advanced installer. This will affect
+future upgrades so it's important to add those values if they don't exist.
+
+Modify *_/etc/openshift/master/scheduler.json_* to add the `*kind*` and `*apiVersion*`
+fields.
+
+====
+----
+{
+  "kind": "Policy", <1>
+  "apiVersion": "v1", <2>
+  "predicates": [
+  ...
+}
+----
+====
+<1> Add `*"kind": "Policy",*`
+<2> Add `*"apiVersin": "v1",*`
+
+
 [[upgrade-playbook]]
 == Automated Upgrade Playbook
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
We'll need to add this to 3.1/1.1 upgrade docs too.
