### PR TITLE
Fix NFS links, edits to glusterFS topic

### DIFF
--- a/admin_guide/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/admin_guide/persistent_storage/persistent_storage_glusterfs.adoc
@@ -11,18 +11,21 @@
 toc::[]
 
 == Overview
-OpenShift can utilize persistent storage using Distributed File Systems (DFS) like GlusterFS.  Some familiarity with Kubernetes/Docker is assumed.  Also assumed that there is access to an existing GlusterFS cluster and volume and that the glusterfs-client has been installed on all OpenShift nodes in the cluster.
+OpenShift can utilize persistent storage using Distributed File Systems (DFS)
+like GlusterFS. Some familiarity with Kubernetes and Docker is assumed. It is
+also assumed that there is access to an existing GlusterFS cluster and volume,
+and that *glusterfs-client* has been installed on all OpenShift nodes in the
+cluster.
 
-The Kubernetes link:../../dev_guide/persistent_volumes.html[persistent volume]
+The Kubernetes
+link:../../architecture/additional_concepts/storage.html[persistent volume]
 framework allows administrators to provision a cluster with persistent storage
 and gives users a way to request those resources without having any knowledge of
-the underlying infrastructure.
-
-[NOTE]
-====
-`Persistent Volumes` are not bound to a single project/namespace, they can be shared across the OpenShift environment, where as, `Persistent Volume Claims` are project/namespace specific and can be requested by users.
-====
-
+the underlying infrastructure. Persistent volumes are not bound to a single
+project or namespace; they can be shared across the OpenShift cluster.
+link:../../architecture/additional_concepts/storage.html[Persistent volume
+claims], however, are specific to a project or namespace and can be requested by
+users.
 
 [IMPORTANT]
 ====
@@ -30,153 +33,142 @@ High-availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====
 
-
-[[provisioning]]
+[[gfs-provisioning]]
 
 == Provisioning
 Storage must exist in the underlying infrastructure before it can be mounted as
-a volume in OpenShift. All that is required for GlusterFS is a distinct list of
-servers in the Gluster cluster (endpoints), Gluster Volumes (PersistentVolume) and the `*PersistentVolume*` API.
+a volume in OpenShift. To provision GlusterFS volumes in OpenShift, the
+following are required:
 
+- A distinct list of servers in the Gluster cluster, to be defined as endpoints
+- Existing Gluster volumes, to be defined in the persistent volume object
+- The `*PersistentVolume*` API
 
-[[create-gluster-endpoints]]
+You must also ensure *glusterfs-client* is installed on all OpenShift nodes in the cluster:
 
-=== Create Gluster Endpoints
+----
+# yum install glusterfs-client
+----
+
+[[creating-gluster-endpoints]]
+
+=== Creating Gluster Endpoints
+
+In an endpoints definition, you must define the GlusterFS cluster as
+`*EndPoints*` and include the IP and host name of your Gluster servers with the
+port that you want to use. The port value can be any numeric value within the
+accepted range of ports.
 
 .Persistent Volume Endpoints Definition
 ====
-
-For this example, you will have to define the GlusterFS Cluster as “EndPoints” within Kubernetes/OpenShift platform using a file similar to [endpoints configuration file](gluster-endpoints.json).  You must define the IP/Hostname of your gluster servers and the port that you want to use.  The port value can be any numeric value within the accepted range of ports.
-
-
-[source,json]
+[source,yaml]
 ----
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: glusterfs-cluster
+subsets:
+- addresses:
+  - ip: 192.168.122.221 <1>
+  ports:
+  - port: 1
+- addresses:
+  - ip: 192.168.122.222 <1>
+  ports:
+  - port: 1
+----
+<1> This value must be an actual IP address of a Gluster server, not a fully
+qualified host name. This requirement could change in future releases.
+====
 
-{ 
-   "kind": "Endpoints", 
-   "apiVersion": "v1", 
-   "metadata": { 
-       "name": "glusterfs-cluster" 
-   }, 
-   "subsets": [ 
-       { 
-           "addresses": [ 
-               { 
-                   "IP": "192.168.122.221"
-               } 
-           ], 
-           "ports": [ 
-               { 
-                  "port": 1 
-               } 
-           ] 
-       }, 
-       { 
-           "addresses": [ 
-              { 
-                  "IP": "192.168.122.222"
-              } 
-          ], 
-          "ports": [ 
-              { 
-                  "port": 1 
-              } 
-          ] 
-       } 
-   ] 
-} 
+Save your endpoints definition to a file, for example
+*_gluster-endpoints.yaml_*, then create the endpoints:
+
+====
+----
+$ oc create -f gluster-endpoints.yaml
+endpoints "glusterfs-cluster" created
 ----
 ====
 
-[NOTE]
+Verify that the endpoints were created:
+
 ====
-The `IP` value under `addresses` must be an actual IP Address of the gluster server, not a fully qualified hostname, this could change in future releases.
-====
-
-
-Create the endpoints
-
-        oc create -f gluster-endpoints.json
-
-        [root@ose1 nginx_gluster]# oc create -f gluster-endpoints.json 
-        endpoints/glusterfs-cluster 
-
-
-View created endpoints
-
-        oc get endpoints
-
-        [root@ose1 nginx_gluster]# oc get endpoints 
-        NAME                ENDPOINTS 
-        glusterfs-cluster   192.168.122.221:1,192.168.122.222:1 
-        kubernetes          192.168.122.251:8443 
-
-
-
-
-[[create-persistent-volume]]
-
-=== Create Persistent Volume
-
-.Persistent Volume Object Definition
-====
-
-[source,json]
 ----
-{ 
-   "apiVersion": "v1", 
-   "kind": "PersistentVolume", 
-   "metadata": { 
-       "name": "gluster-default-volume"                 <1>
-   }, 
-   "spec": { 
-       "capacity": { 
-             "storage": "2Gi"                           <2>
-       }, 
-       "accessModes": [ "ReadWriteMany" ], 
-       "glusterfs": {                                   <3>
-             "endpoints": "glusterfs-cluster",          <4>
-             "path": "myVol1",                          <5>
-             "readOnly": false 
-       }, 
-       "persistentVolumeReclaimPolicy": "Recycle" 
-   } 
-}
+$ oc get endpoints
+NAME                ENDPOINTS                             AGE
+docker-registry     10.1.0.3:5000                         4h
+glusterfs-cluster   192.168.122.221:1,192.168.122.222:1   11s
+kubernetes          172.16.35.3:8443                      4d
 ----
-
-<1>   Name of the volume, this will be how it is identified via Persistent Volume Claims or from Pods
-<2>   Amount of storage allocated to this volume
-<3>   This defines the volume type being used, in this case glusterfs plugin
-<4>   A reference to the endpoints object that defines the Gluster cluster
-<5>   This is the gluster volume that will be used (defined on your gluster servers)
-
 ====
 
+[[gfs-creating-persistent-volume]]
 
-Create the Persistent Volume
+=== Creating the Persistent Volume
 
-        oc create -f gluster-nginx-pv.json
+You must define your persistent volume in an object definition before creating
+it in OpenShift:
 
-        [root@ose1 nginx_gluster_pvc]# oc create -f gluster-nginx-pv.json 
-        persistentvolumes/gluster-default-volume 
+.Persistent Volume Object Definition Using GlusterFS
+====
 
+[source,yaml]
+----
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "gluster-default-volume" <1>
+spec:
+  capacity:
+    storage: "2Gi" <2>
+  accessModes:
+    - "ReadWriteMany"
+  glusterfs: <3>
+    endpoints: "glusterfs-cluster" <4>
+    path: "myVol1" <5>
+    readOnly: false
+  persistentVolumeReclaimPolicy: "Recycle"
+----
+<1> The name of the volume. This will be how it is identified via
+link:../../architecture/additional_concepts/storage.html[persistent volume
+claims] or from pods.
+<2> The amount of storage allocated to this volume.
+<3> This defines the volume type being used, in this case the *glusterfs*
+plug-in.
+<4> A reference to the endpoints object that defines the Gluster cluster,
+created in link:#creating-gluster-endpoints[Creating Gluster Endpoints].
+<5> This is the Gluster volume that will be used, as defined on your Gluster
+servers.
+====
 
-View the Persistent Volume
+Save your definition to a file, for example *_gluster-pv.yaml_*, and create the
+persistent volume:
 
-        oc get pv
+====
+----
+# oc create -f gluster-pv.yaml
+persistentvolume "gluster-default-volume" created
+----
+====
 
-        [root@ose1 nginx_gluster_pvc]# oc get pv 
-        NAME                     LABELS    CAPACITY     ACCESSMODES   STATUS      CLAIM     REASON 
-        gluster-default-volume   <none>    2147483648   RWX           Available 
+Verify that the persistent volume was created:
 
+====
+----
+# oc get pv
+NAME                     LABELS    CAPACITY     ACCESSMODES   STATUS      CLAIM     REASON    AGE
+gluster-default-volume   <none>    2147483648   RWX           Available                       2s
+----
+====
+
+Users can then link:../../dev_guide/persistent_volumes.html[request storage
+using persistent volume claims], which can now utilize your new persistent
+volume.
 
 [IMPORTANT]
 ====
-Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in
-the user's namespace and can only be referenced by a pod within that same
-namespace. Any attempt to access a persistent volume across a namespace causes
-the pod to fail.
+Persistent volume claims only exist in the user's namespace and can only be
+referenced by a pod within that same namespace. Any attempt to access a
+persistent volume from a different namespace causes the pod to fail.
 ====
-
-
-

--- a/admin_guide/persistent_storage/persistent_storage_nfs.adoc
+++ b/admin_guide/persistent_storage/persistent_storage_nfs.adoc
@@ -24,10 +24,15 @@ when using NFS for persistent storage, due to NSFv4's ability to handle SELinux
 labeling.
 ====
 
-The Kubernetes link:../../dev_guide/persistent_volumes.html[persistent volume]
+The Kubernetes
+link:../../architecture/additional_concepts/storage.html[persistent volume]
 framework allows administrators to provision a cluster with persistent storage
 and gives users a way to request those resources without having any knowledge of
-the underlying infrastructure.
+the underlying infrastructure. Persistent volumes are not bound to a single
+project or namespace; they can be shared across the OpenShift cluster.
+link:../../architecture/additional_concepts/storage.html[Persistent volume
+claims], however, are specific to a project or namespace and can be requested by
+users.
 
 For a detailed example, see the guide for
 https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress and
@@ -39,40 +44,73 @@ High-availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====
 
-[[provisioning]]
+[[nfs-provisioning]]
 
 == Provisioning
 Storage must exist in the underlying infrastructure before it can be mounted as
-a volume in OpenShift. All that is required for NFS is a distinct list of
-servers and paths and the `*PersistentVolume*` API.
+a volume in OpenShift. To provision NFS volumes in OpenShift, all that is
+required is a distinct list of NFS servers and paths and the
+`*PersistentVolume*` API.
 
-.Persistent Volume Object Definition
+You must define your persistent volume in an object definition before creating
+it in OpenShift:
+
+.Persistent Volume Object Definition Using NFS
 ====
 
 [source,yaml]
 ----
-{
-  "apiVersion": "v1",
-  "kind": "PersistentVolume",
-  "metadata": {
-    "name": "pv0001"
-  },
-  "spec": {
-    "capacity": {
-        "storage": "5Gi"
-    },
-    "accessModes": [ "ReadWriteOnce" ],
-    "nfs": {
-        "path": "/tmp",
-        "server": "172.17.0.2"
-    },
-    "persistentVolumeReclaimPolicy": "Recycle"
-  }
-}
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "pv0001" <1>
+spec:
+  capacity:
+    storage: "5Gi" <2>
+  accessModes:
+    - "ReadWriteOnce"
+  nfs: <3>
+    path: "/tmp" <4>
+    server: "172.17.0.2" <5>
+  persistentVolumeReclaimPolicy: "Recycle" <6>
+----
+<1> The name of the volume. This will be how it is identified via
+link:../../architecture/additional_concepts/storage.html[persistent volume
+claims] or from pods.
+<2> The amount of storage allocated to this volume.
+<3> This defines the volume type being used, in this case the *nfs* plug-in.
+<4> The path that is exported by the NFS server.
+<5> The host name or IP address of the NFS server.
+<6> Defines what happens to a volume when released from its claim. Valid options
+are *Retain* (default) and *Recycle*. See
+link:#nfs-reclaiming-resources[Reclaiming Resources].
+====
+
+Save your definition to a file, for example *_nfs-pv.yaml_*, and create the
+persistent volume:
+
+====
+----
+# oc create -f nfs-pv.yaml
+persistentvolume "pv0001" created
 ----
 ====
 
-[[enforcing-disk-quotas]]
+Verify that the persistent volume was created:
+
+====
+----
+# oc get pv
+NAME                     LABELS    CAPACITY     ACCESSMODES   STATUS      CLAIM     REASON    AGE
+pv0001                   <none>    5368709120   RWO           Available                       31s
+----
+====
+
+Users can then link:../../dev_guide/persistent_volumes.html[request storage
+using persistent volume claims], which can now utilize your new persistent
+volume.
+
+[[nfs-enforcing-disk-quotas]]
 
 === Enforcing Disk Quotas
 Use disk partitions to enforce disk quotas and size constraints. Each partition
@@ -84,7 +122,7 @@ Enforcing quotas in this way allows the end user to request persistent storage
 by a specific amount (e.g, 10Gi) and be matched with a corresponding volume of
 equal or greater capacity.
 
-[[volume-security]]
+[[nfs-volume-security]]
 
 === Volume Security
 Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in
@@ -94,7 +132,7 @@ the pod to fail.
 
 Each NFS volume must be mountable by all nodes in the cluster.
 
-[[reclaiming-resources]]
+[[nfs-reclaiming-resources]]
 
 == Reclaiming Resources
 NFS implements the Kubernetes *Recyclable* plug-in interface. Automatic
@@ -107,17 +145,17 @@ released from their claim (i.e, after the user's `*PersistentVolumeClaim*` bound
 to the volume is deleted). Once recycled, the NFS volume can be bound to a new
 claim.
 
-[[automation]]
+[[nfs-automation]]
 
 == Automation
 As discussed, clusters can be provisioned with persistent storage using NFS in
 the following way:
 
-- Disk partitions can be used to link:#enforcing-disk-quotas[enforce storage
+- Disk partitions can be used to link:#nfs-enforcing-disk-quotas[enforce storage
 quotas].
-- Security can be enforced by link:#volume-security[restricting volumes] to the
-namespace that has a claim to them.
-- link:#reclaiming-resources[Reclamation of discarded resources] can be
+- Security can be enforced by link:#nfs-volume-security[restricting volumes] to
+the namespace that has a claim to them.
+- link:#nfs-reclaiming-resources[Reclamation of discarded resources] can be
 configured for each persistent volume.
 
 They are many ways that you can use scripts to automate the above tasks. You can

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -136,7 +136,7 @@ status of the volume.
 ifdef::openshift-origin[]
 OpenShift Origin currently supports the following `*PersistentVolume*` plug-ins:
 
-- link:../../admin_guide/persistent_storage_nfs.html[NFS]
+- link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[NFS]
 - link:../../rest_api/kubernetes_v1.html#v1-gcepersistentdiskvolumesource[GCE
 Persistent Disks]
 - link:../../rest_api/kubernetes_v1.html#v1-awselasticblockstorevolumesource[AWS
@@ -156,7 +156,7 @@ ifdef::openshift-enterprise[]
 OpenShift Enterprise currently supports the following `*PersistentVolume*`
 plug-ins:
 
-- link:../../admin_guide/persistent_storage_nfs.html[NFS]
+- link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[NFS]
 - link:../../rest_api/kubernetes_v1.html#v1-hostpathvolumesource[HostPath]
 (single node testing only)
 

--- a/dev_guide/persistent_volumes.adoc
+++ b/dev_guide/persistent_volumes.adoc
@@ -20,7 +20,7 @@ ifdef::openshift-enterprise[]
 [NOTE]
 ====
 Persistent volume plug-ins other than the supported
-link:../admin_guide/persistent_storage_nfs.html[NFS] plug-in, such as
+link:../admin_guide/persistent_storage/persistent_storage_nfs.html[NFS] plug-in, such as
 link:../rest_api/kubernetes_v1.html#v1-awselasticblockstorevolumesource[AWS
 Elastic Block Stores (EBS)],
 link:../rest_api/kubernetes_v1.html#v1-gcepersistentdiskvolumesource[GCE
@@ -32,7 +32,7 @@ currently in
 link:../whats_new/ose_3_0_release_notes.html#technology-preview[Technology
 Preview]. The Administrator Guide provides instructions on provisioning an
 OpenShift cluster with
-link:../admin_guide/persistent_storage_nfs.html[persistent storage using NFS].
+link:../admin_guide/persistent_storage/persistent_storage_nfs.html[persistent storage using NFS].
 ====
 endif::[]
 
@@ -41,7 +41,7 @@ ifdef::openshift-origin[]
 ====
 The Administrator Guide provides instructions on provisioning an
 OpenShift cluster with
-link:../admin_guide/persistent_storage_nfs.html[persistent storage using NFS].
+link:../admin_guide/persistent_storage/persistent_storage_nfs.html[persistent storage using NFS].
 ====
 endif::[]
 

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -73,7 +73,7 @@ the registry, it uses an ephemeral volume that is destroyed if the pod exits.
 Any images anyone has built or pushed into the registry would disappear.
 
 For production use, you should attach a remote volume or
-link:../../admin_guide/persistent_storage_nfs.html[use persistent storage] using
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[use persistent storage] using
 `*PersistentVolume*` and `*PersistentVolumeClaim*` objects for storage for the
 registry. For example, to attach an existing NFS volume to the registry once it
 has been defined:

--- a/install_config/install/first_steps.adoc
+++ b/install_config/install/first_steps.adoc
@@ -140,7 +140,7 @@ template should be used for demonstration purposes only.
 
 The other template defines a persistent volume for storage, however it requires
 your OpenShift installation to have
-link:../../admin_guide/persistent_storage_nfs.html[persistent volumes]
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[persistent volumes]
 configured.
 
 To create the core set of database templates:

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -87,14 +87,14 @@ needs, giving users a way to request those resources without having any
 knowledge of the underlying infrastructure.
 
 ifdef::openshift-enterprise[]
-Currently link:../../admin_guide/persistent_storage_nfs.html[NFS is fully
+Currently link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[NFS is fully
 supported], however other options are available as
 link:../../whats_new/ose_3_0_release_notes.html#technology-preview[Technology
 Preview].
 endif::[]
 ifdef::openshift-origin[]
 The Administrator Guide provides instructions on provisioning an OpenShift
-cluster with link:../../admin_guide/persistent_storage_nfs.html[persistent
+cluster with link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[persistent
 storage using NFS].
 endif::[]
 

--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -246,7 +246,7 @@ data will be lost.
 which means the data will survive a pod restart. Using persistent volumes
 requires a persistent volume pool be defined in the OpenShift deployment.
 Cluster administrator instructions for setting up the pool are located
-link:../../admin_guide/persistent_storage_nfs.html[here].
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[here].
 
 
 You can find instructions for instantiating templates by following these

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -265,7 +265,7 @@ data will be lost.
 means the data will survive a pod restart. Using persistent volumes requires a
 persistent volume pool be defined in the OpenShift deployment. Cluster
 administrator instructions for setting up the pool are located
-link:../../admin_guide/persistent_storage_nfs.html[here].
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[here].
 
 
 You can find instructions for instantiating templates by following these
@@ -458,9 +458,9 @@ this purpose:
 
 Since we claimed a persistent volume in this deployment configuration to have
 all data persisted for the MySQL master server, you must ask your cluster
-administrator to create a
-link:../../admin_guide/persistent_storage_nfs.html#provisioning[persistent
-volume] that you can claim the storage from.
+administrator to
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html#nfs-provisioning[create
+a persistent volume] that you can claim the storage from.
 
 After the deployment configuration is created and the pod with MySQL master
 server is started, it will create the database defined by `*MYSQL_DATABASE*` and

--- a/using_images/db_images/postgresql.adoc
+++ b/using_images/db_images/postgresql.adoc
@@ -235,7 +235,7 @@ redeploy, all data will be lost.
 which means the data will survive a pod restart. Using persistent volumes
 requires a persistent volume pool be defined in the OpenShift deployment.
 Cluster administrator instructions for setting up the pool are located
-link:../../admin_guide/persistent_storage_nfs.html[here].
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[here].
 
 You can find instructions for instantiating templates by following these
 link:../../dev_guide/templates.html#creating-resources-from-a-template[instructions].

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -116,7 +116,7 @@ data will be lost.
 means the data will survive a pod restart. Using persistent volumes requires a
 persistent volume pool be defined in the OpenShift deployment. Cluster
 administrator instructions for setting up the pool are located
-link:../../admin_guide/persistent_storage_nfs.html[here].
+link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[here].
 
 You can find instructions for instantiating templates by following these
 link:../../dev_guide/templates.html#creating-resources-from-a-template[instructions].

--- a/whats_new/ose_3_0_release_notes.adoc
+++ b/whats_new/ose_3_0_release_notes.adoc
@@ -78,7 +78,8 @@ images].
 link:../architecture/infrastructure_components/web_console.html#jvm-console[JVM
 Console].
 - Using link:../dev_guide/persistent_volumes.html[persistent volume] plug-ins
-other than the supported link:../admin_guide/persistent_storage_nfs.html[NFS]
+other than the supported
+link:../admin_guide/persistent_storage/persistent_storage_nfs.html[NFS]
 plug-in, such as
 link:../rest_api/kubernetes_v1.html#v1-awselasticblockstorevolumesource[AWS
 Elastic Block Stores (EBS)],


### PR DESCRIPTION
Follows up on https://github.com/openshift/openshift-docs/pull/924

Fixes links to the recently-moved NFS topic elsewhere in the docs, and various edits to the new GlusterFS topic, including changing the examples from JSON to YAML.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/100715/nfs_links_post924/admin_guide/persistent_storage/persistent_storage_glusterfs.html

@screeley44 PTAL?
