### PR TITLE
/tmp/access_log was replaced by logging to stdout.

### DIFF
--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -145,7 +145,7 @@ handled. The *_.htaccess_* file must be located at the root of the application
 source.
 
 == Logs
-This image logs primarily to standard out and as such the logs can be viewed via the link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[oc logs] command.  Access logs are stored in *_/tmp/access_log_* which can be viewed using link:../../dev_guide/executing_remote_commands.html[oc exec] to access the container.
+Access logs are streamed to standard out and as such they can be viewed via the link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[oc logs] command. Error logs are stored in *_/tmp/error_log_* which can be viewed using link:../../dev_guide/executing_remote_commands.html[oc exec] to access the container.
 
 ifdef::openshift-origin[]
 == Hot Deploy


### PR DESCRIPTION
Updated docs to reflect latest changes: https://github.com/openshift/sti-php/pull/64

PTAL @rhcarvalho 
