### PR TITLE
perl: /tmp/access_log was replaced by logging to stdout.

### DIFF
--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -123,3 +123,10 @@ $ oc rsh <pod_id>
 
 After you enter into the running container, your current directory is set to
 *_/opt/app-root/src_*, where the source code is located.
+
+== Logs
+Access logs are streamed to standard output and as such they can be viewed via the
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[oc
+logs] command. Error logs are stored in *_/tmp/error_log_* which can be viewed
+using link:../../dev_guide/executing_remote_commands.html[oc exec] to access the
+container.


### PR DESCRIPTION
Related PR: https://github.com/openshift/sti-perl/pull/53

@rhcarvalho @mfojtik @mnagy PTAL

Questions:
1) I've copied&pasted the section from PHP page and now I see that all the paragraph is the one line. Hm, may be I should add more newlines to it? It may simplify editing and diff-ing in future.
2) I also see that near my changes there are if/endif conditions. How I can determine if my change is applied to all of the modifications or only to one of them (let's say openshift-origin)? In other words, may be I also should add if/endif.
