### PR TITLE
Added important box about oc exec not working on privileged containers

### DIFF
--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -60,6 +60,14 @@ $ oc exec $routerPod -- bash -c "$cmd"
 ----
 ====
 
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. Instead,
+you can SSH into a node host, then use the `docker exec` command on the desired
+container.
+====
+
 == Viewing Logs
 To view a router log, run the `oc log` command on the pod. Since the router is
 running as a plug-in process that manages the underlying implementation, the log

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -341,6 +341,14 @@ work for other object types.
 
 |===
 
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. Instead,
+administrators can SSH into a node host, then use the `docker exec`
+command on the desired container.
+====
+
 [[object-types]]
 
 == Object Types

--- a/dev_guide/executing_remote_commands.adoc
+++ b/dev_guide/executing_remote_commands.adoc
@@ -16,9 +16,10 @@ to run general Linux commands for routine operations in the container.
 
 [IMPORTANT]
 ====
-The `oc exec` command does not work when accessing privileged containers. In
-these cases, SSH into the desired host manually, then use the
-`docker exec` command.
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. See the
+link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
+operations topic] for more information.
 ====
 
 == Basic Usage

--- a/dev_guide/executing_remote_commands.adoc
+++ b/dev_guide/executing_remote_commands.adoc
@@ -14,6 +14,13 @@ toc::[]
 You can use the CLI to execute remote commands in a container. This allows you
 to run general Linux commands for routine operations in the container.
 
+[IMPORTANT]
+====
+The `oc exec` command does not work when accessing privileged containers. In
+these cases, SSH into the desired host manually, then use the
+`docker exec` command.
+====
+
 == Basic Usage
 Support for remote container command execution is built into
 link:../cli_reference/overview.html[the CLI]:

--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -91,6 +91,14 @@ To enter a container from the host:
 $ oc exec -it -p <pod> -c <container> /bin/bash
 ----
 
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. See the
+link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
+operations topic] for more information.
+====
+
 When you enter the container, the required software collection is automatically
 enabled.
 

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -88,6 +88,14 @@ To enter a container from the host:
 $ oc exec -it -p <pod> -c <container> /bin/bash
 ----
 
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. See the
+link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
+operations topic] for more information.
+====
+
 When you enter the container, the required software collection is automatically enabled.
 
 === Environment Variables

--- a/using_images/db_images/postgresql.adoc
+++ b/using_images/db_images/postgresql.adoc
@@ -94,6 +94,14 @@ To enter a container from the host:
 $ oc exec -it -p <pod> -c <container> /bin/bash
 ----
 
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. See the
+link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
+operations topic] for more information.
+====
+
 When you enter the container, the required software collection is
 automatically enabled.
 

--- a/using_images/xpaas_images/eap.adoc
+++ b/using_images/xpaas_images/eap.adoc
@@ -53,6 +53,14 @@ However, the JBoss EAP Management CLI (*_EAP_HOME/bin/jboss-cli.sh_*) is still a
 $ oc exec -p <pod> -c <container> - /opt/eap/bin/jboss-cli.sh
 ----
 
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. See the
+link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
+operations topic] for more information.
+====
+
 [WARNING]
 Any configuration changes made using the JBoss EAP Management CLI on a running container will be lost when the container restarts.
 


### PR DESCRIPTION
As per #960 , added an important box about oc exec only working on unprivileged containers. 

There's a few more times the oc exec command is mentioned in the docs, but I think this is the only section worth mentioning it in. Definitely the most important section for it.

@adellape @tnguyen-rh @tpoitras any thoughts?
