### PR TITLE
Removing dup. warning

### DIFF
--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -89,12 +89,6 @@ cpanminus uses to install dependencies. By default, this URL is not specified.
 a|`*PERL_APACHE2_RELOAD*`
 |Set this to *true* to enable automatic reloading of modified Perl modules. By
 default, automatic reloading is turned off.
-
-[WARNING]
-====
-You should only use this option while developing or debugging; it is not
-recommended to turn this on in your production environment.
-====
 |===
 
 [[perl-hot-deploy]]


### PR DESCRIPTION
Removing this warning since its a dup. of the one in the `hot deploy` section.
@adellape PTAL
