### PR TITLE
contributing_to_docs/term_glossary.adoc fixups

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -9,10 +9,11 @@
 
 toc::[]
 
-This topic describes basic guidelines and how to refer to the various components
-of OpenShift in our documentation. The goal is to standardize terminology across
-OpenShift content and be consistent in the usage of our terminology when
-referring to OpenShift components or architecture.
+This topic provides guidelines for referring to the various components of
+OpenShift and objects of a running OpenShift system in our documentation. The
+goal is to standardize terminology across OpenShift content and be consistent in
+the usage of our terminology when referring to OpenShift components or
+architecture.
 
 [NOTE]
 ====
@@ -27,15 +28,21 @@ on GitHub.
 
 Usage: action
 
-Authorization determines whether an _identity_ is allowed to perform any action.
-It consists of _project_, _verb_, and _resource_.
+An action consists of _project_, _verb_, and _resource_:
 
-Action consists of the following:
-
-* *Project* being accessed
-* *Verb* is a get, list, create, or update operation
+* *Project* is the project containing the resource that is to be acted upon.
+* *Verb* is a get, list, create, or update operation.
 * *Resource* is the API endpoint being accessed. This is distinct from the
-resource being touched, such as pods, deployment configs, builds, etc.
+referenced resource itself, which can be a pod, deployment config, build, etc.
+
+''''
+=== apiserver
+
+Usage: apiserver(s) as appropriate
+
+A REST API endpoint for interacting with the system.  New deployments and
+configurations can be created with this endpoint, and the state of the system
+can be interrogated through this endpoint as well.
 
 ''''
 === application
@@ -44,12 +51,10 @@ Usage: _application(s)_ as appropriate; italicized
 
 Although the term _application_ is no longer an official noun in OpenShift,
 customers still create and host applications on OpenShift, and using the term
-within certain contexts is acceptable. For example, it may be a combination of
-one image, a git repo, or a replication controller, and this _application_
-component can be PHP, MySQL, Ruby, JBoss, or something else.
-
-Another example is that _projects_ can run _applications_ but the components
-that make up that _application_ are defined by the user.
+within certain contexts is acceptable. For example, the term _application_ may
+refer to some combination of an image, a Git repository, or a replication
+controller, and this _application_ may be running PHP, MySQL, Ruby, JBoss, or
+something else.
 
 Do *NOT* use the term _application_ in a topic or section heading.
 
@@ -65,7 +70,7 @@ RabbitMQ message queue, as well as a python worker framework._
 _You can check the health of your application by adding probes to the various
 parts._
 
-_Hosting a WordPress application on OpenShift._
+_You can host a WordPress application on OpenShift._
 ====
 ''''
 
@@ -74,7 +79,7 @@ _Hosting a WordPress application on OpenShift._
 Usage: authorization
 
 An authorization determines whether an _identity_ is allowed to perform any
-action. It consists of _project_, _verb_, and _resource_.
+action. It consists of _identity_ and _action_.
 
 ''''
 
@@ -84,6 +89,14 @@ Usage: build(s) as appropriate
 
 ''''
 
+=== cluster
+
+Usage: cluster
+
+The collection of controllers, pods, and services and related DNS and networking
+routing configuration that are defined on the system.
+
+''''
 === container
 
 Usage: container(s) as appropriate
@@ -109,6 +122,16 @@ To avoid confusion, do not refer to an overall OpenShift installation / instance
 cluster as an "OpenShift deployment".
 
 ''''
+=== deployment controller
+
+Usage: deployment controller(s) as appropriate
+
+Kubernetes object that creates a replication controller from a given pod
+template.  If that pod template is modified, the deployment controller creates
+a new replication controller based on the modified pod template and replaces the
+old replication controller with this new one.
+
+''''
 === Dockerfile
 
 Usage: Dockerfile; wrapped with [filename] markup. See
@@ -130,7 +153,7 @@ Create a [filename]#Dockerfile# at the root of your repository.
 ''''
 === identity
 
-Usage: image(s)
+Usage: identity or identities as appropriate
 
 Both the username and list of groups the user belongs to.
 
@@ -143,21 +166,21 @@ Usage: image(s)
 
 === Kubelet
 
-Usage: Kubelet(s)
+Usage: Kubelet(s) as appropriate
 
-Kubelets act as agents to control Kubernetes nodes.  They handle
-starting/stopping containers on a node, based on the desired state defined by
-the master.
+The agent that controls a Kubernetes node.  Each node runs a Kubelet, which
+handles starting and stopping containers on a node, based on the desired state
+defined by the master.
 
 ''''
-
 === Kubernetes master
 
-Usage: Kubernetes master
+Usage: Kubernetes master(s) as appropriate
 
-This component is responsible for managing the state of the system, ensuring
-that all containers expected to be running are actually running, and that other
-requests like builds and deployments are serviced.
+The Kubernetes-native equivalent to the link:#project[OpenShift master].
+An OpenShift system runs OpenShift masters, not Kubernetes masters, and
+an OpenShift master provides a superset of the functionality of a Kubernetes
+master, so it is generally preferred to use the term OpenShift master.
 
 ''''
 
@@ -169,7 +192,7 @@ Usage: Deprecated. Use link:#node[node] instead.
 
 === node
 
-Usage: node
+Usage: node(s) as appropriate
 
 A
 http://docs.openshift.org/latest/architecture/infrastructure_components/kubernetes_infrastructure.html#node[node]
@@ -197,11 +220,14 @@ the client tools in OpenShift v2.
 
 === OpenShift master
 
-Usage: OpenShift master
+Usage: OpenShift master(s) as appropriate
 
-OpenShift provides a REST endpoint for interacting with the system.  New
-deployments/configurations are created with the REST API and the state of the
-system can be interrogated through this endpoint as well.
+Provides a REST endpoint for interacting with the system and manages the state
+of the system, ensuring that all containers expected to be running are actually
+running and that other requests such as builds and deployments are serviced.
+New deployments and configurations are created with the REST API, and the state
+of the system can be interrogated through this endpoint as well.  An OpenShift
+master comprises the apiserver, scheduler, and SkyDNS.
 
 ''''
 
@@ -210,14 +236,14 @@ system can be interrogated through this endpoint as well.
 Usage: pod(s) as appropriate
 
 Kubernetes object that groups related Docker containers that need to share
-network, filesystem or memory together for placement on a node.  Multiple
+network, filesystem, or memory together for placement on a node.  Multiple
 instances of a Pod can run to provide scaling and redundancy.
 
 ''''
 
 === project
 
-Usage: project
+Usage: project(s) as appropriate
 
 A http://docs.openshift.org/latest/dev_guide/projects.html[project] allows a
 community of users to organize and manage their content in isolation from other
@@ -227,10 +253,27 @@ communities.
 
 === replication controller
 
-Usage: replication controller
+Usage: replication controller(s) as appropriate
 
 Kubernetes object that ensures N (as specified by the user) instances of a given
 Pod are running at all times.
+
+''''
+=== scheduler
+
+Usage: scheduler(s) as appropriate
+
+Component of the Kubernetes master or OpenShift master that manages the state of
+the system, places pods on nodes, and ensures that all containers that are
+expected to be running are actually running.
+
+''''
+=== SkyDNS
+
+Usage: SkyDNS
+
+Component of the Kubernetes master or OpenShift master that provides
+cluster-wide DNS resolution of internal hostnames for services and pods.
 
 ''''
 === Source-to-Image (S2I)


### PR DESCRIPTION
Rewrite the introductory paragraph to be clearer (guidelines for what?) and more comprehensive (components and objects).

Sort out a mix-up of the definitions of action and authorization.

Try to make the definition of "application" a little clearer, delete a confusing example, and fix an example that was a sentence fragment.

Define "apiserver", "cluster", "deployment controller", "scheduler", and "SkyDNS".

Fix usage for "identity".

Note that "OpenShift master" is generally preferred over "Kubernetes master".

Resolve some inconsistency in usage texts.

Fix some minor punctuation issues and unclear writing throughout.
