### PR TITLE
GH issue #430: added links to kube docs on liveness checks

### DIFF
--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -11,33 +11,126 @@ toc::[]
 
 == Overview
 
-In software systems, components can become unhealthy due to transient issues (temporary
-connectivity loss), configuration errors, or problems with external dependencies.  Applications
-running in OpenShift have a number of options to detect and handle unhealthy containers:
+In software systems, components can become unhealthy due to transient issues
+(such as temporary connectivity loss), configuration errors, or problems with
+external dependencies. OpenShift applications have a number of options to detect
+and handle unhealthy containers.
 
-<1> Container-level liveness checks
-<2> High-level application health checks
+[[container-health-checks-using-probes]]
 
-== Liveness checks
+== Container Health Checks Using Probes
 
-Each component in a distributed system has a notion of liveness scoped to that component.  Liveness
-is the quality of being correctly configured and operational on an individual level.  To express
-this, OpenShift offers a number of methods to establish container liveness and policies that
-determine how 'dead' containers are handled.
+A probe is a Kuberbetes action that periodically performs diagnostics on a
+running container. Currently, two types of probes exist, each serving a
+different purpose:
 
-// TODO: example of liveness check
+[cols="1,4"]
+|===
 
-== High-level application health checks
+|Liveness Probe
+|A liveness probe checks if the container in which it is configured is still
+running. If the liveness probe fails, the kubelet kills the container, which
+will be subjected to its restart policy. Set a liveness check by configuring the
+`*template.spec.containers.livenessprobe*` stanza of a pod configuration.
 
-Holistic notions of application health that cut across multiple components cannot be handled with
-container scoped liveness checks.  It is possible for each component in a distributed application
-to be healthy and responsive but for the overall system behavior to be unhealthy.  Administrators
-of distributed systems use health checks to test the behavior of a overall health of a system.  A
-typical example of this type of check is a script which performs a test transaction: something
-which exercises the components of the system together and verifies that the high-level behavior of
-the system in the context of the test transaction matches the expected behavior of a health system.
+|Readiness Probe
+|A readiness probe determines if a container is ready to service requests. If
+the readiness probe fails a container, the endpoints controller ensures the
+container has its IP address removed from the endpoints of all services. A
+readiness probe can be used to signal to the endpoints controller that even
+though a container is running, it should not receive any traffic from a proxy.
+Set a readiness check by configuring the
+`*template.spec.containers.readinessprobe*` stanza of a pod configuration.
 
-OpenShift users can specify high-level health checks and control:
+|===
 
-<1> The health check methodology (viz: specify a script to run)
-<2> What action should be taken when a health check has a negative result (viz: create an Event)
+Both probes can be configured in three ways:
+
+*HTTP Checks*
+
+The kubelet uses a web hook to determine the healthiness of the container. The
+check is deemed successful if the hook returns with 200 or 399. The following is
+an example of a readiness check using the HTTP checks method:
+
+.Readiness HTTP check
+====
+----
+...
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 15
+  timeoutSeconds: 1
+...
+----
+====
+
+A HTTP check is ideal for complex applications that can return with a 200 status
+when completely initialized.
+
+*Container Execution Checks*
+
+The kubelet executes a command inside the container. Exiting the check with
+status 0 is considered a success. The following is an example of a liveness
+check using the container execution method:
+
+.Liveness Container Execution Check
+====
+----
+...
+livenessProbe:
+  exec:
+    command:
+    - cat
+    - /tmp/health
+  initialDelaySeconds: 15
+  timeoutSeconds: 1
+...
+----
+====
+
+*TCP Socket Checks*
+
+The kubelet attempts to open a socket to the container. The container is only
+considered healthy if the check can establish a connection. The following is an
+example of a liveness check using the TCP socket check method:
+
+.Liveness TCP Socket Check
+====
+----
+...
+livenessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 15
+  timeoutSeconds: 1
+...
+----
+====
+
+A TCP socket check is ideal for applications that do not start listening until
+initialization is complete.
+
+For more information on health checks, see the
+http://kubernetes.io/v1.0/docs/user-guide/walkthrough/k8s201.html#health-checking[Kubernetes
+documentation].
+
+[[high-level-application-health-checks]]
+
+== High-level Application Health Checks
+
+Holistic notions of application health that cut across multiple components
+cannot be handled with container-scoped liveness checks. Having healthy and
+responsive system components in a distributed application, but in a system with
+overall unhealthy behavior, is possible. Administrators of distributed systems
+use health checks to test the behavior of the overall health of a system.
+
+A typical example is a script that performs a test transaction, exercising the
+components of the system together and verifying that the high-level system
+behavior in the context of the test transaction matches the expected behavior of
+a health system.
+
+OpenShift users can specify high-level health checks and control the health
+check methodology by specifying a script to run, and the action to be taken when
+a health check has a negative result by creating an event.

--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -286,11 +286,14 @@ deployment is created using the new tag value for the `helloworld` container.
 
 == Strategies
 
-A deployment configuration declares a strategy which is responsible for
-executing the deployment process. Each application has different requirements
-for availability (and other considerations) during deployments. OpenShift
-provides out-of-the-box strategies to support a variety of deployment
-scenarios.
+A deployment strategy determines the deployment process, and is defined by the
+deployment configuration. Each application has different requirements for
+availability (and other considerations) during deployments. OpenShift provides
+strategies to support a variety of deployment scenarios.
+
+A deployment strategy uses link:../dev_guide/application_health.html[readiness
+checks] to determine if a new pod is ready for use. If a readiness check
+fails, the deployment is stopped.
 
 The link:#rolling-strategy[Rolling strategy] is the default strategy used if
 no strategy is specified on a deployment configuration.
@@ -299,9 +302,14 @@ no strategy is specified on a deployment configuration.
 
 === Rolling Strategy
 
-The Rolling strategy performs a rolling update and supports
+The rolling strategy performs a rolling update and supports
 link:#lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
 process.
+
+The rolling deployment strategy waits for pods to pass their
+link:../dev_guide/application_health.html[readiness check] before scaling down
+old components, and does not allow pods that do not pass their readiness check
+within a configurable timeout.
 
 The following is an example of the Rolling strategy:
 


### PR DESCRIPTION
@thoraxe @sosiouxme @nak3 I added the links to the Kube docs. I think it's more practical, as I'd just be retyping the Kube docs into our docs. i also cleaned up the doc a little.

If you disagree let me know. I can see the argument for having the examples in there.

Thanks.
