### PR TITLE
accompany mention of etcd in Terminology w/ a cross reference

### DIFF
--- a/whats_new/terminology.adoc
+++ b/whats_new/terminology.adoc
@@ -57,4 +57,4 @@ link:../architecture/core_concepts/pods_and_services.html#pods[pods].
 link:../architecture/infrastructure_components/kubernetes_infrastructure.html#master[_Masters_]
 in OpenShift v3 do the job of the _broker_ layer in OpenShift v2. However, the
 MongoDB and ActiveMQ layers used by the broker in OpenShift v2 are no longer
-necessary because [sysitem]#etcd# is typically installed with each master.
+necessary because the link:../architecture/infrastructure_components/kubernetes_infrastructure.html#master[key-value store] *etcd* is typically installed with each master.


### PR DESCRIPTION
This fixes #538 basically by duplicating the link for the first word in the paragraph.
