### PR TITLE
Update path of openshift origin

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -563,9 +563,9 @@ of your *etcd* hosts in the following:
 ----
 # etcdctl -C \
     https://etcd1.example.com:2379,https://etcd2.example.com:2379,https://etcd3.example.com:2379 \
-    --ca-file=/etc/openshift/master/master.etcd-ca.crt \
-    --cert-file=/etc/openshift/master/master.etcd-client.crt \
-    --key-file=/etc/openshift/master/master.etcd-client.key cluster-health
+    --ca-file=/etc/origin/master/master.etcd-ca.crt \
+    --cert-file=/etc/origin/master/master.etcd-client.crt \
+    --key-file=/etc/origin/master/master.etcd-client.key cluster-health
 ----
 ====
 
@@ -575,9 +575,9 @@ of your *etcd* hosts in the following:
 ----
 # etcdctl -C \
     https://etcd1.example.com:2379,https://etcd2.example.com:2379,https://etcd3.example.com:2379 \
-    --ca-file=/etc/openshift/master/master.etcd-ca.crt \
-    --cert-file=/etc/openshift/master/master.etcd-client.crt \
-    --key-file=/etc/openshift/master/master.etcd-client.key member list
+    --ca-file=/etc/origin/master/master.etcd-ca.crt \
+    --cert-file=/etc/origin/master/master.etcd-client.crt \
+    --key-file=/etc/origin/master/master.etcd-client.key member list
 ----
 ====
 
@@ -642,7 +642,7 @@ image. If you are use bare metal machines:
 ----
 # yum -y remove openshift openshift-* etcd docker
 
-# rm -rf /etc/openshift /var/lib/openshift /etc/etcd \
+# rm -rf /etc/origin /var/lib/openshift /etc/etcd \
     /var/lib/etcd /etc/sysconfig/openshift* /etc/sysconfig/docker* \
     /root/.kube/config /etc/ansible/facts.d /usr/share/openshift
 ----


### PR DESCRIPTION
Updates path references to default /etc/origin.

Following default installation, I was not able to get the command running but quick glance revealed the path is different.
