### PR TITLE
Add note about logging in as system:admin

### DIFF
--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -114,6 +114,8 @@ Using project "aliceproject".
 link:../dev_guide/authentication.html[Additional options] are also available for
 the `oc login` command.
 
+include::dev_guide/authentication.adoc[tag=systemadminlogin]
+
 [[cli-configuration-files]]
 
 == CLI Configuration Files

--- a/cli_reference/manage_cli_profiles.adoc
+++ b/cli_reference/manage_cli_profiles.adoc
@@ -25,7 +25,7 @@ make managing CLI configuration easier by providing short-hand references to
 contexts, user credentials, and cluster details.
 
 After link:get_started_cli.html[logging in with the CLI] for the first time,
-OpenShift creates a *_${HOME}/.kube/config_* file if one does not
+OpenShift creates a *_~/.kube/config_* file if one does not
 already exist. As more authentication and connection details are provided to the
 CLI, either automatically during an `oc login` operation or by
 link:#manually-configuring-cli-profiles[setting them explicitly], the updated
@@ -143,6 +143,8 @@ full CLI configuration, as seen in link:#cli-config-file[the above output].
 
 Additional CLI configuration commands are also available for more
 link:#manually-configuring-cli-profiles[advanced usage].
+
+include::dev_guide/authentication.adoc[tag=systemadminlogin]
 
 [[manually-configuring-cli-profiles]]
 
@@ -316,7 +318,7 @@ variable can be a list of paths, and if so the paths are merged together. When
 a value is modified, it is modified in the file that defines the stanza. When
 a value is created, it is created in the first file that exists. If no files
 in the chain exist, then it creates the last file in the list.
-- Otherwise, the *_${HOME}/.kube/config_* file is used and no
+- Otherwise, the *_~/.kube/config_* file is used and no
 merging takes place.
 {empty} +
 {empty} +

--- a/dev_guide/authentication.adoc
+++ b/dev_guide/authentication.adoc
@@ -14,8 +14,8 @@ toc::[]
 == Web Console Authentication
 When accessing the
 link:../architecture/infrastructure_components/web_console.html[web console]
-from a browser at `_<master-public-addr>_:8443`, you are automatically
-redirected to a login page.
+from a browser at *<master_public_addr>:8443*, you are automatically redirected
+to a login page.
 
 ifdef::openshift-origin[]
 .Web Console Login Page
@@ -50,13 +50,17 @@ some common options:
 
 [options="nowrap"]
 ----
-$ oc login [--username=<username>]  [--password=<password>] [--server=<server>] [--certificate-authority=</path/to/file.crt>|--insecure-skip-tls-verify]
+$ oc login [-u=<username>] \
+  [-p=<password>] \
+  [-s=<server>] \
+  [-n=<project>] \
+  [--certificate-authority=</path/to/file.crt>|--insecure-skip-tls-verify]
 ----
 
 The following table describes these common options:
 
 .Common CLI Configuration Options
-[cols="4,8,8",options="header"]
+[cols="1,2,5",options="header"]
 |===
 
 |Option |Syntax |Description
@@ -64,7 +68,7 @@ The following table describes these common options:
 .^|`-s, --server`
 a|[options="nowrap"]
 ----
-$ oc login --server=<server>
+$ oc login -s=<server>
 |Specifies the host name of the OpenShift server. If a
 server is provided through this flag, the command does not ask for it
 interactively. This flag can also be used if you already have a CLI
@@ -72,13 +76,20 @@ configuration file and want to log in and switch to another server.
 
 .^|`-u, --username` and `-p, --password`
 a|----
-$ oc login --username=<username> --password=<password>
+$ oc login -u=<username> -p=<password>
 ----
 |Allows you to specify the credentials to log in to the OpenShift
 server. If user name or password are provided through these flags, the command
 does not ask for it interactively. These flags can also be used if you already
 have a configuration file with a session token established and want to log in and
 switch to another user name.
+
+.^|`-n, --namespace`
+a|----
+$ oc login -u=<username> -p=<password> -n=<project>
+----
+|A global CLI option which, when used with `oc login`, allows you to specify the
+project to switch to when logging in as a given user.
 
 .^|`--certificate-authority`
 a|[options="nowrap"]
@@ -103,3 +114,22 @@ for user input to confirm (`y/N` kind of input) about connecting insecurely.
 
 CLI configuration files allow you to easily
 link:../cli_reference/manage_cli_profiles.html[manage multiple CLI profiles].
+
+// tag::systemadminlogin[]
+
+[NOTE]
+====
+If you have access to administrator credentials but are no longer logged in as
+the link:../architecture/core_concepts/projects_and_users.html#users[default
+system user] *system:admin*, you can log back in as this user at any time as
+long as the credentials are still present in your
+link:../cli_reference/get_started_cli.html#cli-configuration-files[CLI
+configuration file]. The following command logs in and switches to the *default*
+project:
+
+----
+$ oc login -u system:admin -n default
+----
+====
+
+// end::systemadminlogin[]


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/682
- Created `[NOTE]` box about logging back in as **system:admin** in 3 spots where I thought it might be good to catch folks
- Added `-n` to `oc login` options table.
- Synced up on `~/.kube/config` vs `{$HOME}/.kube/config` usage

@liggitt PTAL
