### PR TITLE
Inform about disabling ssl in gitconfig format

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1253,7 +1253,11 @@ $ oc secrets new mysecret ca.crt=path/to/certificate .gitconfig=path/to/.gitconf
 [NOTE]
 ====
 Please note that SSL verification can be turned off, if `sslVerify=false` is set
-in your `.gitconfig` file.
+for the `http` section in your `.gitconfig` file:
+----
+[http]
+        sslVerify=false
+----
 ====
 
 . Add the `*secret*` to the builder service account:


### PR DESCRIPTION
After talking to @xiuwang we decided it would be better to also good to show what the format of the `sslVerify` format look like.

@adellape @CowboysFan PTAL 
