### PR TITLE
fix syntax for challengeURL and loginURL for Configuring the Master

### DIFF
--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -690,12 +690,12 @@ The `*identityProviders*` stanza in the
   identityProviders:
   - name: requestheader
     challenge: true
-    challengeURL: "https://[MASTER]/challenging-proxy/oauth/authorize?${query}"
     login: true
-    loginURL: "https://[MASTER]/login-proxy/oauth/authorize?${query}"
     provider:
       apiVersion: v1
       kind: RequestHeaderIdentityProvider
+      challengeURL: "https://[MASTER]/challenging-proxy/oauth/authorize?${query}"
+      loginURL: "https://[MASTER]/login-proxy/oauth/authorize?${query}"
       clientCA: /etc/openshift/master/proxyca.crt
       headers:
       - X-Remote-User


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1268918

simple fix
