### PR TITLE
add caution re: port 7001 conflict [BZ1271468]

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -46,6 +46,14 @@ Choose one of the following installation methods that works best for you.
 You can quickly get OpenShift running in a Docker container using images from
 https://hub.docker.com[Docker Hub] on a Linux system.
 
+[CAUTION]
+====
+OpenShift Origin requires access to port 7001. If a service (such as another 
+Kubernetes or etcd service) is already running and occupying this port locally, 
+stop that service before launching the OpenShift container to avoid a port 
+conflict.
+====
+
 *Installing and Starting an All-in-One Server*
 
 . Launch the server in a Docker container:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1271468

Warning about potential port conflict if Kubernetes service is running when attempting to run openshift origin inside a container.
