### PR TITLE
install_config/upgrades.adoc: Fix ellipses

### DIFF
--- a/install_config/upgrades.adoc
+++ b/install_config/upgrades.adoc
@@ -202,13 +202,13 @@ Apply the following changes:
 
 ====
 ----
-..
+...
 spec:
  template:
     spec:
       containers:
       - env:
-        ..
+        ...
 ifdef::openshift-enterprise[]
         image: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.0.2.0 <1>
 endif::[]
@@ -216,7 +216,7 @@ ifdef::openshift-origin[]
         image: openshift/origin-haproxy-router:v1.0.6 <1>
 endif::[]
         imagePullPolicy: IfNotPresent
-        ..
+        ...
 ----
 ====
 <1> Adjust the image version to match the version you are upgrading to.
@@ -242,12 +242,13 @@ Apply the following changes:
 
 ====
 ----
+...
 spec:
  template:
     spec:
       containers:
       - env:
-        ..
+        ...
 ifdef::openshift-enterprise[]
         image: registry.access.redhat.com/openshift3/ose-docker-registry:v3.0.2.0 <1>
 endif::[]
@@ -255,7 +256,7 @@ ifdef::openshift-origin[]
         image: openshift/origin-docker-registry:v1.0.4 <1>
 endif::[]
         imagePullPolicy: IfNotPresent
-        ..
+        ...
 ----
 ====
 <1> Adjust the image version to match the version you are upgrading to.
@@ -481,6 +482,7 @@ Apply the following changes:
 
 ====
 ----
+...
 spec:
   replicas: 2
   selector:
@@ -493,9 +495,11 @@ spec:
       updatePeriodSeconds: 1
       updatePercent: -10 <1>
     type: Rolling
-    ..
+    ...
+  template:
+    ...
     spec:
-      ..
+      ...
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccount: router <2>
@@ -561,15 +565,16 @@ Apply the following changes:
 
 ====
 ----
+...
 spec:
   replicas: 2
   selector:
     router: router
-    ..
+    ...
   template:
-    ..
+    ...
     spec:
-      ..
+      ...
       ports:
         - containerPort: 80 <1>
           hostPort: 80


### PR DESCRIPTION
Fix the ellipses in some examples in the upgrade directions:

• Consistently put ellipses at the starts of examples where appropriate.

• Consistently use "..." (as opposed to "..") for ellipses.

• Fix one example of editing the router's deployment controller where the instructions indicate to add an item to the `strategy:` block under the `spec:` block for the deployment controller and then are supposed to indicate to add items to the `spec`: block for the pod spec under the `template:` block under the deployment controller's `spec:` block.  This example had the `template:` omitted, so it looked like the pod spec's `spec:` block was under the `strategy:` block for the deployment controller.  This commit adds the `template:` to make the instructions clearer and more consistent with other examples.
