### PR TITLE
Fix issue during new-app deployment when tag specified

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -179,7 +179,7 @@ $ oc new-project test
 . Create a new application based on a Node.js image on the Docker Hub
 +
 ----
-$ oc new-app openshift/deployment-example:v1
+$ oc new-app openshift/deployment-example
 ----
 +
 Note that a service was created and given an IP - this is an address that


### PR DESCRIPTION
If we run new app with tag oc is throw Error stating that reponame may not contain a tag and when we remove **v1** tag it's running as expected. Either it's recent change in oc or may be app repo need update. I am putting this PR to keep in mind may be there is recent change in oc.

```
$ oc new-app openshift/deployment-example:v1
Error: ImageStream "deployment-example" is invalid: spec.dockerImageRepository: invalid value 'openshift/deployment-example:v1', Details: the repository name may not contain a tag
deploymentconfigs/deployment-example
services/deployment-example
```
