### PR TITLE
Update 'oc exec' to 'oc rsh' where sensible

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -76,31 +76,39 @@ $ oc new-app -e \
 
 === Running MongoDB Commands in Containers
 
-OpenShift uses https://www.softwarecollections.org/[Software Collections] to
-install and launch MongoDB. If you want to execute a MongoDB command inside of a
-running container (for debugging), you must invoke it using bash, to make sure
-the MongoDB collection is enabled, for example:
+OpenShift uses https://www.softwarecollections.org/[Software Collections] (SCLs)
+to install and launch MongoDB. If you want to execute a MongoDB command inside of
+a running container (for debugging), you must invoke it using bash.
+
+To do so, first identify the name of the running MongoDB pod. For example, you can
+view the list of pods in your current project:
 
 ----
-$ oc exec -it -p <pod> -c <container> /bin/bash -c mongo
+$ oc get pods
 ----
 
-To enter a container from the host:
+Then, open a remote shell session to the desired pod:
 
 ----
-$ oc exec -it -p <pod> -c <container> /bin/bash
+$ oc rsh <pod>
 ----
 
-[IMPORTANT]
+When you enter the container, the required SCL is automatically enabled.
+
+You can now run *mongo* commands from the bash shell to start a MongoDB
+interactive session and perform normal MongoDB operations. For example, to
+switch to the *sampledb* database and authenticate as the database user:
+
 ====
-link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. See the
-link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
-operations topic] for more information.
+----
+bash-4.2$ mongo -u $MONGODB_USER -p $MONGODB_PASSWORD $MONGODB_DATABASE
+MongoDB shell version: 2.4.9
+connecting to: sampledb
+>
+----
 ====
 
-When you enter the container, the required software collection is automatically
-enabled.
+When you are finished, press *CTRL+D* to leave the MongoDB session.
 
 === Environment Variables
 
@@ -178,54 +186,84 @@ method to change passwords for the database user (`*MONGODB_USER*`) and *admin*
 user is by changing the environment variables `*MONGODB_PASSWORD*` and
 `*MONGODB_ADMIN_PASSWORD*`, respectively.
 
+You can view the current passwords by viewing the pod or deployment
+configuration in the web console or by listing the environment variables with
+the CLI:
+
+----
+$ oc env pod <pod_name> --list
+----
+
 Changing database passwords directly in MongoDB causes a mismatch between the
 values stored in the variables and the actual passwords. Whenever a database
 container starts, it resets the passwords to the values stored in the
 environment variables.
 
-You can change these passwords with:
+To change these passwords, update one or both of the desired environment
+variables for the related deployment configuration(s) using the `oc env`
+command. If multiple deployment configurations utilize these environment
+variables, for example in the case of an application created from a template,
+you must update the variables on each deployment configuration so that the
+passwords are in sync everywhere. This can be done all in the same command:
 
 ----
-$ oc env dc mongodb \
+$ oc env dc <dc_name> [<dc_name_2> ...] \
   MONGODB_PASSWORD=<new_password> \
   MONGODB_ADMIN_PASSWORD=<new_admin_password>
 ----
 
-This triggers the redeployment of the database server if you have a
+[IMPORTANT]
+====
+Depending on your application, there may be other environment variables for
+passwords in other parts of the application that should also be updated to
+match. For example, there could be a more generic `*DATABASE_USER*` variable in
+a front-end pod that should match the database user's password. Ensure that
+passwords are in sync for all required environment variables per your
+application, otherwise your pods may fail to redeploy when triggered.
+====
+
+Updating the environment variables triggers the redeployment of the database
+server if you have a
 link:../../dev_guide/deployments.html#config-change-trigger[configuration change
 trigger]. Otherwise, you must manually start a new deployment in order to apply
 the password changes.
 
-Note that you can change one password but not the other by simply omitting one
-of the arguments to `oc env` above.
+To verify that new passwords are in effect, first open a remote shell session to
+the running MongoDB pod:
 
-You can verify that the new password is in effect with:
-
-====
 ----
-$ oc get pods
-...
-$ oc exec <db_podname> -- bash -c 'mongo -u $MONGODB_USER -p NewPassword $MONGODB_DATABASE --eval "db.version()"'
+$ oc rsh <pod>
 ----
-====
 
-Replace `<db_podname>` with the name of the running MongoDB pod.
+From the bash shell, verify the database user's new password:
 
-To verify the *admin* password:
-
-====
 ----
-$ oc exec <db_podname> -- bash -c 'mongo -u admin -p NewAdminPassword admin --eval "db.version()"'
+bash-4.2$ mongo -u $MONGODB_USER -p <new_password> $MONGODB_DATABASE --eval "db.version()"
 ----
-====
 
-In both cases, if the password was changed correctly, you should see this output:
+If the password was changed correctly, you should see output like this:
 
 ====
 ----
 MongoDB shell version: 2.6.9
 connecting to: sampledb
 2.6.9
+----
+====
+
+To verify the *admin* user's new password:
+
+----
+bash-4.2$ mongo -u admin -p <new_admin_password> admin --eval "db.version()"
+----
+
+If the password was changed correctly, you should see output like this:
+
+====
+----
+MongoDB shell version: 2.4.9
+connecting to: admin
+2.4.9
 ----
 ====
 

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -73,30 +73,41 @@ $ oc new-app -e \
 
 === Running MySQL Commands in Containers
 
-OpenShift uses https://www.softwarecollections.org/[Software Collections] to
+OpenShift uses https://www.softwarecollections.org/[Software Collections] (SCLs) to
 install and launch MySQL. If you want to execute a MySQL command inside of a
-running container (for debugging), you must invoke it using bash, to make sure
-the MySQL collection is enabled, for example:
+running container (for debugging), you must invoke it using bash.
+
+To do so, first identify the name of the pod. For example, you can view the list
+of pods in your current project:
 
 ----
-$ oc exec -it -p <pod> -c <container> /bin/bash -c mysql
+$ oc get pods
 ----
 
-To enter a container from the host:
+Then, open a remote shell session to the pod:
 
 ----
-$ oc exec -it -p <pod> -c <container> /bin/bash
+$ oc rsh <pod>
 ----
 
-[IMPORTANT]
+When you enter the container, the required SCL is automatically enabled.
+
+You can now run the *mysql* command from the bash shell to start a MySQL
+interactive session and perform normal MySQL operations. For example, to
+authenticate as the database user:
+
 ====
-link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. See the
-link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
-operations topic] for more information.
+----
+bash-4.2$ mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -h $HOSTNAME $MYSQL_DATABASE
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 4
+Server version: 5.5.37 MySQL Community Server (GPL)
+...
+mysql>
+----
 ====
 
-When you enter the container, the required software collection is automatically enabled.
+When you are finished, enter *quit* or *exit* to leave the MySQL session.
 
 === Environment Variables
 
@@ -173,15 +184,23 @@ database files.
 === Changing Passwords
 
 Passwords are part of the image configuration, therefore the only supported
-method to change passwords for the database user (`*MYSQL_USER*`) and root user
-is by changing the environment variables `*MYSQL_PASSWORD*` and
+method to change passwords for the database user (`*MYSQL_USER*`) and *root*
+user is by changing the environment variables `*MYSQL_PASSWORD*` and
 `*MYSQL_ROOT_PASSWORD*`, respectively.
 
-Whenever `*MYSQL_ROOT_PASSWORD*` is set, it enables remote access for the root
+You can view the current passwords by viewing the pod or deployment
+configuration in the web console or by listing the environment variables with
+the CLI:
+
+----
+$ oc env pod <pod_name> --list
+----
+
+Whenever `*MYSQL_ROOT_PASSWORD*` is set, it enables remote access for the *root*
 user with the given password, and whenever it is unset, remote access for the
-root user is disabled. This does not affect the regular user `*MYSQL_USER*`, who
-always has remote access. This also does not affect local access by the root
-user, who can always login without a password in *localhost*.
+*root* user is disabled. This does not affect the regular user `*MYSQL_USER*`,
+who always has remote access. This also does not affect local access by the
+*root* user, who can always log in without a password in *localhost*.
 
 Changing database passwords through SQL statements or any way other than through
 the environment variables aforementioned causes a mismatch between the values
@@ -189,34 +208,49 @@ stored in the variables and the actual passwords. Whenever a database container
 starts, it resets the passwords to the values stored in the environment
 variables.
 
-You can change these passwords with:
+To change these passwords, update one or both of the desired environment
+variables for the related deployment configuration(s) using the `oc env`
+command. If multiple deployment configurations utilize these environment
+variables, for example in the case of an application created from a template,
+you must update the variables on each deployment configuration so that the
+passwords are in sync everywhere. This can be done all in the same command:
 
 ----
-$ oc env dc mysql \
+$ oc env dc <dc_name> [<dc_name_2> ...] \
   MYSQL_PASSWORD=<new_password> \
   MYSQL_ROOT_PASSWORD=<new_root_password>
 ----
 
-This triggers the redeployment of the database server if you have a
+[IMPORTANT]
+====
+Depending on your application, there may be other environment variables for
+passwords in other parts of the application that should also be updated to
+match. For example, there could be a more generic `*DATABASE_USER*` variable in
+a front-end pod that should match the database user's password. Ensure that
+passwords are in sync for all required environment variables per your
+application, otherwise your pods may fail to redeploy when triggered.
+====
+
+Updating the environment variables triggers the redeployment of the database
+server if you have a
 link:../../dev_guide/deployments.html#config-change-trigger[configuration change
-trigger]. Otherwise, you need to manually start a new deployment in order to
-apply the password changes.
+trigger]. Otherwise, you must manually start a new deployment in order to apply
+the password changes.
 
-Note that you can change one password but not the other by simply omitting one
-of the arguments to `oc env` above.
+To verify that new passwords are in effect, first open a remote shell session to
+the running MySQL pod:
 
-You can verify that the new password is in effect with:
-
-====
 ----
-$ oc get pods
-...
-$ oc exec <db_podname> -- bash -c 'mysql -u $MYSQL_USER -pNewPassword -h mysql $MYSQL_DATABASE -te "SELECT * FROM (SELECT database()) db CROSS JOIN (SELECT user()) u"'
+$ oc rsh <pod>
 ----
-====
 
-Replace `<db_podname>` with the name of the running MySQL pod. If the password
-was changed correctly, you should see a table like this:
+From the bash shell, verify the database user's new password:
+
+----
+bash-4.2$ mysql -u $MYSQL_USER -p<new_password> -h $HOSTNAME $MYSQL_DATABASE -te "SELECT * FROM (SELECT database()) db CROSS JOIN (SELECT user()) u"
+----
+
+If the password was changed correctly, you should see a table like this:
 
 ====
 ----
@@ -228,11 +262,11 @@ was changed correctly, you should see a table like this:
 ----
 ====
 
-To verify the root password:
+To verify the *root* user's new password:
 
 ====
 ----
-$ oc exec <db_podname> -- bash -c 'mysql -u root -pNewAdminPassword -h mysql $MYSQL_DATABASE -te "SELECT * FROM (SELECT database()) db CROSS JOIN (SELECT user()) u"'
+bash-4.2$ mysql -u root -p<new_root_password> -h $HOSTNAME $MYSQL_DATABASE -te "SELECT * FROM (SELECT database()) db CROSS JOIN (SELECT user()) u"
 ----
 ====
 

--- a/using_images/db_images/postgresql.adoc
+++ b/using_images/db_images/postgresql.adoc
@@ -79,31 +79,40 @@ $ oc new-app -e \
 
 === Running PostgreSQL Commands in Containers
 
-OpenShift uses https://www.softwarecollections.org/[Software Collections] to
+OpenShift uses https://www.softwarecollections.org/[Software Collections] (SCLs) to
 install and launch PostgreSQL. If you want to execute a PostgreSQL command
-inside of a running container (for debugging), you must invoke it using bash to
-make sure the PostgreSQL collection is enabled. For example:
+inside of a running container (for debugging), you must invoke it using bash.
+
+To do so, first identify the name of the running PostgreSQL pod. For example,
+you can view the list of pods in your current project:
 
 ----
-$ oc exec -it -p <pod> -c <container> /bin/bash -c psql
+$ oc get pods
 ----
 
-To enter a container from the host:
+Then, open a remote shell session to the desired pod:
 
 ----
-$ oc exec -it -p <pod> -c <container> /bin/bash
+$ oc rsh <pod>
 ----
 
-[IMPORTANT]
+When you enter the container, the required SCL is automatically enabled.
+
+You can now run the *psql* command from the bash shell to start a PostgreSQL
+interactive session and perform normal PostgreSQL operations. For example, to
+authenticate as the database user:
+
 ====
-link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. See the
-link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
-operations topic] for more information.
+----
+bash-4.2$ PGPASSWORD=$POSTGRESQL_PASSWORD psql -h postgresql $POSTGRESQL_DATABASE $POSTGRESQL_USER
+psql (9.2.8)
+Type "help" for help.
+
+default=>
+----
 ====
 
-When you enter the container, the required software collection is
-automatically enabled.
+When you are finished, enter *\q* to leave the PostgreSQL session.
 
 === Environment Variables
 
@@ -174,46 +183,86 @@ method to change passwords for the database user (`*POSTGRESQL_USER*`) and
 *postgres* administrator user is by changing the environment variables
 `*POSTGRESQL_PASSWORD*` and `*POSTGRESQL_ADMIN_PASSWORD*`, respectively.
 
+You can view the current passwords by viewing the pod or deployment
+configuration in the web console or by listing the environment variables with
+the CLI:
+
+----
+$ oc env pod <pod_name> --list
+----
+
 Changing database passwords through SQL statements or any way other than through
 the environment variables aforementioned will cause a mismatch between the
 values stored in the variables and the actual passwords. Whenever a database
 container starts, it resets the passwords to the values stored in the
 environment variables.
 
-You can change these passwords with:
+To change these passwords, update one or both of the desired environment
+variables for the related deployment configuration(s) using the `oc env`
+command. If multiple deployment configurations utilize these environment
+variables, for example in the case of an application created from a template,
+you must update the variables on each deployment configuration so that the
+passwords are in sync everywhere. This can be done all in the same command:
 
 ----
-$ oc env dc postgresql \
+$ oc env dc <dc_name> [<dc_name_2> ...] \
   POSTGRESQL_PASSWORD=<new_password> \
   POSTGRESQL_ADMIN_PASSWORD=<new_admin_password>
 ----
 
-This triggers the redeployment of the database server if you have a
+[IMPORTANT]
+====
+Depending on your application, there may be other environment variables for
+passwords in other parts of the application that should also be updated to
+match. For example, there could be a more generic `*DATABASE_USER*` variable in
+a front-end pod that should match the database user's password. Ensure that
+passwords are in sync for all required environment variables per your
+application, otherwise your pods may fail to redeploy when triggered.
+====
+
+Updating the environment variables triggers the redeployment of the database
+server if you have a
 link:../../dev_guide/deployments.html#config-change-trigger[configuration change
 trigger]. Otherwise, you must manually start a new deployment in order to apply
 the password changes.
 
-Note that you can change one password but not the other by simply omitting one
-of the arguments to `oc env` above.
+To verify that new passwords are in effect, first open a remote shell session to
+the running PostgreSQL pod:
 
-You can verify that the new password is in effect with:
-
-====
 ----
-$ oc get pods
-...
-$ oc exec <db_podname> -- bash -c 'PGPASSWORD=NewPassword psql -h postgresql $POSTGRESQL_DATABASE $POSTGRESQL_USER -c "SELECT * FROM (SELECT current_database()) cdb CROSS JOIN (SELECT current_user) cu"'
+$ oc rsh <pod>
 ----
-====
 
-Replace `<db_podname>` with the name of the running PostgreSQL pod. If the
-password was changed correctly, you should see a table like this:
+From the bash shell, verify the database user's new password:
+
+----
+bash-4.2$ PGPASSWORD=<new_password> psql -h postgresql $POSTGRESQL_DATABASE $POSTGRESQL_USER -c "SELECT * FROM (SELECT current_database()) cdb CROSS JOIN (SELECT current_user) cu"
+----
+
+If the password was changed correctly, you should see a table like this:
 
 ====
 ----
  current_database | current_user
 ------------------+--------------
- sampledb         | user
+ default          | django
+(1 row)
+----
+====
+
+From the bash shell, verify the *postgres* administrator user's new password:
+
+----
+bash-4.2$ PGPASSWORD=<new_admin_password> psql -h postgresql $POSTGRESQL_DATABASE postgres -c "SELECT * FROM (SELECT current_database()) cdb CROSS JOIN (SELECT current_user) cu"
+----
+
+If the password was changed correctly, you should see a table like this:
+
+====
+----
+ current_database | current_user
+------------------+--------------
+ default          | postgres
 (1 row)
 ----
 ====

--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -91,6 +91,17 @@ a|`*PERL_APACHE2_RELOAD*`
 default, automatic reloading is turned off.
 |===
 
+[[perl-accessing-logs]]
+
+== Accessing Logs
+Access logs are streamed to standard output and as such they can be viewed using
+the
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc
+logs`] command. Error logs are stored in the *_/tmp/error_log_* file, which can
+be viewed using the
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc
+rsh`] command to access the container.
+
 [[perl-hot-deploy]]
 
 == Hot Deploying
@@ -108,8 +119,8 @@ recommended to turn this on in your production environment.
 ====
 
 To change your source code in a running pod, use the
-link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc rsh`]
-command to enter the container:
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc
+rsh`] command to enter the container:
 
 ----
 $ oc rsh <pod_id>
@@ -117,10 +128,3 @@ $ oc rsh <pod_id>
 
 After you enter into the running container, your current directory is set to
 *_/opt/app-root/src_*, where the source code is located.
-
-== Logs
-Access logs are streamed to standard output and as such they can be viewed via the
-link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[oc
-logs] command. Error logs are stored in *_/tmp/error_log_* which can be viewed
-using link:../../dev_guide/executing_remote_commands.html[oc exec] to access the
-container.

--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -124,7 +124,7 @@ The following environment variable sets its equivalent property value in the opc
 |16M
 
 |`*OPCACHE_REVALIDATE_FREQ*`
-|How often to check script timestamps for updates, in seconds. 0 will result in 
+|How often to check script timestamps for updates, in seconds. 0 will result in
 link:http://php.net/manual/en/book.opcache.php[OPcache] checking for updates on every request.
 |2
 |===
@@ -155,10 +155,12 @@ source.
 
 == Accessing Logs
 Access logs are streamed to standard out and as such they can be viewed using
-link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[the
-`oc logs` command]. Error logs are stored in the *_/tmp/error_log_* file, which
-can be viewed using link:../../dev_guide/executing_remote_commands.html[the `oc
-exec` command] to access the container.
+the
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc
+logs`] command. Error logs are stored in the *_/tmp/error_log_* file, which can
+be viewed using the
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc
+rsh`] command to access the container.
 
 [[php-hot-deploy]]
 
@@ -167,7 +169,7 @@ Hot deployment allows you to quickly make and deploy changes to your application
 generate a new S2I build. In order to immediately pick up changes made in your application source
 code, you need to run your built image with the `OPCACHE_REVALIDATE_FREQ=0` environment variable.
 For example, see the link:../../dev_guide/new_app.html#specifying-environment-variables[`oc new-app`]
-command. You can use the link:../../dev_guide/environment_variables.html#set-environment-variables[`oc env`] 
+command. You can use the link:../../dev_guide/environment_variables.html#set-environment-variables[`oc env`]
 command to update environment variables of existing objects.
 
 [WARNING]

--- a/using_images/xpaas_images/eap.adoc
+++ b/using_images/xpaas_images/eap.adoc
@@ -47,19 +47,20 @@ There are several major functionality differences in the OpenShift JBoss EAP xPa
 
 A major difference in managing an OpenShift JBoss EAP xPaaS image is that there is no Management Console exposed for the JBoss EAP installation inside the image. Because images are intended to be immutable, with modifications being written to a non-persistent file system, the Management Console is not exposed.
 
-However, the JBoss EAP Management CLI (*_EAP_HOME/bin/jboss-cli.sh_*) is still accessible from within the container for troubleshooting purposes:
+However, the JBoss EAP Management CLI (*_EAP_HOME/bin/jboss-cli.sh_*) is still
+accessible from within the container for troubleshooting purposes. First open a
+remote shell session to the running pod:
 
 ----
-$ oc exec -p <pod> -c <container> - /opt/eap/bin/jboss-cli.sh
+$ oc rsh <pod_name>
 ----
 
-[IMPORTANT]
-====
-link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. See the
-link:../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[CLI
-operations topic] for more information.
-====
+Then run the following from the remote shell session to launch the JBoss EAP
+Management CLI:
+
+----
+$ /opt/eap/bin/jboss-cli.sh
+----
 
 [WARNING]
 Any configuration changes made using the JBoss EAP Management CLI on a running container will be lost when the container restarts.


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1258348.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/102015/rsh_BZ1258348/using_images/db_images/mongodb.html#running-mongodb-commands-in-containers
