### PR TITLE
Update F5 routing docs with information on creating SNAT pools and using them ...

### DIFF
--- a/admin_guide/routing_from_edge_lb.adoc
+++ b/admin_guide/routing_from_edge_lb.adoc
@@ -78,17 +78,19 @@ the ramp node's IP addresses, respectively, on a shared, internal network.
 pods.
 ====
 
-. Delete any old route, self, and tunnel:
+. Delete any old route, self, tunnel and SNAT pool:
 +
 ====
 ----
 # tmsh delete net route $CLUSTER_NETWORK || true
 # tmsh delete net self SDN || true
 # tmsh delete net tunnels tunnel SDN || true
+# tmsh delete ltm snatpool SDN_snatpool || true
 ----
 ====
 
-. Create the new tunnel, self, and route:
+. Create the new tunnel, self, route and SNAT pool and use the SNAT pool
+  in the virtual servers:
 +
 ====
 [options="nowrap"]
@@ -99,6 +101,9 @@ pods.
 # tmsh create net self SDN \{ address \
     ${TUNNEL_IP1}/24 allow-service all vlan SDN \}
 # tmsh create net route $CLUSTER_NETWORK interface SDN
+# tmsh create ltm snatpool SDN_snatpool members add { $TUNNEL_IP1 }
+# tmsh modify ltm virtual  ose-vserver source-address-translation { type snat pool SDN_snatpool }
+# tmsh modify ltm virtual  https-ose-vserver source-address-translation { type snat pool SDN_snatpool }
 ----
 ====
 
@@ -135,6 +140,7 @@ interface (e.g., *eth0*):
 # ip addr add $TUNNEL_IP2 dev tun1
 # ip link set tun1 up
 # ip route add $TUNNEL_IP1 dev tun1
+# ping -c 5 $TUNNEL_IP1
 ----
 ====
 


### PR DESCRIPTION
Update F5 routing docs with additional information on creating SNAT pools 
and using that pool in the F5 virtual servers. This makes the F5 virtual
servers use the tunnel IP and allows replies (packets from the pods) to
flow back to the F5 virtual servers.

@adellape / @bfallonf  PTAL  Thx
