### PR TITLE
Correct name of glusterfs client package

### DIFF
--- a/admin_guide/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/admin_guide/persistent_storage/persistent_storage_glusterfs.adoc
@@ -14,7 +14,7 @@ toc::[]
 OpenShift can utilize persistent storage using Distributed File Systems (DFS)
 like GlusterFS. Some familiarity with Kubernetes and Docker is assumed. It is
 also assumed that there is access to an existing GlusterFS cluster and volume,
-and that *glusterfs-client* has been installed on all OpenShift nodes in the
+and that *glusterfs-fuse* has been installed on all OpenShift nodes in the
 cluster.
 
 The Kubernetes
@@ -44,10 +44,10 @@ following are required:
 - Existing Gluster volumes, to be defined in the persistent volume object
 - The `*PersistentVolume*` API
 
-You must also ensure *glusterfs-client* is installed on all OpenShift nodes in the cluster:
+You must also ensure *glusterfs-fuse* is installed on all OpenShift nodes in the cluster:
 
 ----
-# yum install glusterfs-client
+# yum install glusterfs-fuse
 ----
 
 [[creating-gluster-endpoints]]


### PR DESCRIPTION
glusterfs-client is the name of the Debian package for the Gluster client, glusterfs-fuse is the name for RPM based distros.
