### PR TITLE
Fix incorrect command for adding new application

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -187,7 +187,7 @@ $ oc new-project test
 . Create a new application based on a Node.js image on the Docker Hub
 +
 ----
-$ oc new-app openshift/deployment-example:v1
+$ oc new-app openshift/deployment-example
 ----
 +
 Note that a service was created and given an IP - this is an address that


### PR DESCRIPTION
If an app is created with `oc new openshift/deployment-example:v1`, then deployment will listen only for changes on `v1` tag and not to the `latest` tag. 

This leads to next few sections of the documention to be incorrect: tagging `v2` as `latest` will not actually trigger a deploment.
