### PR TITLE
Edits for upgrade playbook

### DIFF
--- a/install_config/upgrades.adoc
+++ b/install_config/upgrades.adoc
@@ -29,15 +29,15 @@ should not run mismatched versions longer than necessary to upgrade the entire
 cluster.
 
 ifdef::openshift-enterprise[]
-Starting with OpenShift 3.0.2
+Starting with OpenShift 3.0.2,
 endif::[]
 ifdef::openshift-origin[]
-Starting with Origin 1.0.6
+Starting with Origin 1.0.6,
 endif::[]
-if you have installed via the advanced installer and you have your inventory file
-available you may use the upgrade playbook to automate the upgrade process.
-Please see the link:#upgrade-playbook[Automated Upgrade Playbook] section for
-details on using this new upgrade procedure.
+if you installed using the link:install/advanced_install.html[advanced
+installation] and the inventory file that was used is available, you can use the
+upgrade playbook to automate the upgrade process. link:#upgrade-playbook[Using
+the Automated Upgrade Playbook] provides details on this upgrade procedure.
 
 [NOTE]
 ====
@@ -52,15 +52,93 @@ endif::[]
 not currently cover container-based installations.
 ====
 
+[[upgrade-playbook]]
+== Using the Automated Upgrade Playbook
+ifdef::openshift-enterprise[]
+Starting with OpenShift 3.0.2,
+endif::[]
+ifdef::openshift-origin[]
+Starting with Origin 1.0.6,
+endif::[]
+if you installed using the link:install/advanced_install.html[advanced
+installation] and the inventory file that was used is available, you can use the
+upgrade playbook to automate the upgrade process. This playbook performs the
+following steps for you:
+
+* Applies the latest configuration by re-running the installation playbook.
+* Upgrades and restart master services.
+* Upgrades and restart node services.
+* Applies the latest cluster policies.
+* Updates the default router if one exists.
+* Updates the default registry if one exists.
+* Updates default image streams and InstantApp templates.
+
+[IMPORTANT]
+====
+The upgrade playbook re-runs cluster configuration steps, therefore any settings
+that are not stored in your inventory file will be overwritten. The playbook
+creates a backup of any files that are changed, and you should carefully review
+the differences after the playbook finishes to ensure that your environment is
+configured as expected.
+====
+
+Ensure that you have the latest *openshift-ansible* code checked out, then run the playbook
+utilizing the default *ansible-hosts* file located in *_/etc/ansible/hosts_*. If
+your *_hosts_* file is located somewhere else, add the `-i` flag to specify the
+location:
+
+----
+# cd ~/openshift-ansible
+# git pull https://github.com/openshift/openshift-ansible master
+# ansible-playbook [-i /path/to/hosts/file] playbooks/adhoc/upgrades/upgrade.yml
+----
+
+After the upgrade playbook finishes, verify that all nodes are marked as *Ready*
+and that you are running the expected versions of the *docker-registry* and
+*router* images:
+
+====
+----
+# oc get nodes
+NAME                 LABELS                                                                STATUS
+master.example.com   kubernetes.io/hostname=master.example.com,region=infra,zone=default   Ready
+node1.example.com    kubernetes.io/hostname=node1.example.com,region=primary,zone=east     Ready
+
+ifdef::openshift-enterprise[]
+# oc get -n default dc/router -o json | grep \"image\"
+    "image": "openshift3/ose-haproxy-router:v3.0.2.0",
+# oc get -n default dc/docker-registry -ojson | grep \"image\"
+    "image": "openshift3/ose-docker-registry:v3.0.2.0",
+endif::[]
+ifdef::openshift-origin[]
+# oc get -n default dc/router -o json | grep \"image\"
+    "image": "openshift/origin-haproxy-router:v1.0.6",
+# oc get -n default dc/docker-registry -ojson | grep \"image\"
+    "image": "openshift/origin-docker-registry:v1.0.6",
+endif::[]
+----
+====
+
+After upgrading, you can use the experimental diagnostics tool to look for
+common issues:
+
+====
+----
+# openshift ex diagnostics
+...
+[Note] Summary of diagnostics execution:
+[Note] Completed with no errors or warnings seen.
+----
+====
+
 [[manual-upgrades]]
-== Manual Upgrades
+== Upgrading Manually
 To manually upgrade your OpenShift cluster without disruption, it is important
 to upgrade components as documented in this topic. Before you begin your
 upgrade, familiarize yourself with the entire procedure.
 link:#additional-instructions-per-release[Specific releases] may require
 additional steps to be performed at key points during the standard upgrade
 process.
-
 
 [[upgrading-masters]]
 
@@ -418,7 +496,7 @@ endif::[]
 The default HAProxy router was updated to utilize host ports and requires that a
 service account be created and made a member of the privileged
 link:../admin_guide/manage_scc.html[security context constraint] (SCC).
-Additionally, 'down-then-up' rolling upgrades have been added and is now the
+Additionally, "down-then-up" rolling upgrades have been added and is now the
 preferred strategy for upgrading routers.
 
 After upgrading your master and nodes but before updating to the newer router,
@@ -638,76 +716,3 @@ fields.
 ====
 <1> Add `*"kind": "Policy",*`
 <2> Add `*"apiVersin": "v1",*`
-
-
-[[upgrade-playbook]]
-== Automated Upgrade Playbook
-ifdef::openshift-enterprise[]
-Starting with OpenShift 3.0.2
-endif::[]
-ifdef::openshift-origin[]
-Starting with Origin 1.0.6
-endif::[]
-if you have installed via the advanced installer and you have your inventory file
-available you may use the upgrade playbook to automate the upgrade process. This
-playbook will perform the following steps for you:
-
- * Applies latest configuration by re-running the installation playbook
- * Upgrade and restart master services
- * Upgrade and restart node services
- * Applies the latest cluster policies
- * Updates the default router if one exists
- * Updates the default registry if one exists
- * Updates ImageStreams and InstantApp templates
-
-[NOTE]
-====
-The upgrade playbook will re-run cluster configuration steps and any settings
-that are not stored in your inventory file will be overwritten. A backup of any
-files changed will be made and you should carefully review the differences
-to ensure that your environment is configured as expected.
-====
-
-=== Using the upgrade playbook
-Ensure that you have the latest ansible code checked out and run the playbook
-utilizing the default ansible-hosts file located in _/etc/ansible/hosts_. If
-your hosts file is located somewhere else add the `-i` flag to specify the
-location.
-
-----
-# cd ~/openshift-ansible
-# git pull https://github.com/openshift/openshift-ansible master
-# ansible-playbook playbooks/adhoc/upgrades/upgrade.yaml
-----
-
-Verify that all nodes are marked as ready and that you're running the expected
-versions of the docker-registry and router.
-
-----
-# oc get nodes
-NAME                      LABELS                                                           STATUS
-master.example.com   kubernetes.io/hostname=master.example.com,region=infra,zone=default   Ready
-node1.example.com    kubernetes.io/hostname=node1.example.com,region=primary,zone=east     Ready
-ifdef::openshift-enterprise[]
-# oc get -n default dc/router -o json | grep \"image\"
-    "image": "openshift3/ose-haproxy-router:v3.0.2.0",
-# oc get -n default dc/docker-registry -ojson | grep \"image\"
-    "image": "openshift3/ose-docker-registry:v3.0.2.0",
-----
-endif::[]
-ifdef::openshift-origin[]
-# oc get -n default dc/router -o json | grep \"image\"
-    "image": "openshift/origin-haproxy-router:v1.0.6",
-# oc get -n default dc/docker-registry -ojson | grep \"image\"
-    "image": "openshift/origin-docker-registry:v1.0.6",
-----
-endif::[]
-
-After upgrading you may wish to use the experimental diagnostics tool to look for common issues.
-
-----
-# openshift ex diagnostics
-...
-[Note] Summary of diagnostics execution:
-[Note] Completed with no errors or warnings seen.
-----


### PR DESCRIPTION
Minor style edits for https://github.com/openshift/openshift-docs/pull/1000, moves the upgrade playbook section up before the manual steps, and fixes a s/yaml/yml/ issue.
