### PR TITLE
Fix name of secret in builds doc

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1211,7 +1211,7 @@ In this case `*sshsecret*`:
   "apiVersion": "v1",
   "kind": "BuildConfig",
   "metadata": {
-    "name": "sample-build",
+    "name": "sample-build"
   },
   "spec": {
     "output": {

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1196,7 +1196,7 @@ following command:
 ====
 
 ----
-$ oc secrets add serviceaccount/builder secrets/scmsecret
+$ oc secrets add serviceaccount/builder secrets/sshsecret
 ----
 ====
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1213,7 +1213,7 @@ In this case `*sshsecret*`:
   "metadata": {
     "name": "sample-build",
   },
-  "parameters": {
+  "spec": {
     "output": {
       "to": {
         "name": "sample-image"


### PR DESCRIPTION
The actual secret is named "sshsecret" (see few lines above).
