### PR TITLE
The path of RPM package is wrong

### DIFF
--- a/admin_guide/aggregate_logging.adoc
+++ b/admin_guide/aggregate_logging.adoc
@@ -64,7 +64,7 @@ Perform the following steps on each node to install and configure *fluentd*
 # export RPM=td-agent-2.2.0-0.x86_64.rpm
 # curl https://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
     -o /tmp/$RPM
-# yum localinstall $RPM
+# yum localinstall /tmp/$RPM
 # /opt/td-agent/embedded/bin/gem install fluent-plugin-kubernetes
 # mkdir -p /etc/td-agent/config.d
 # chown td-agent:td-agent /etc/td-agent/config.d


### PR DESCRIPTION
curl https://packages.treasuredata.com/2/redhat/7/x86_64/$RPM  -o /tmp/$RPM   ==> it will download the RPM package into /tmp folder but the next command 'yum' will try to install the package in wrong folder. 
So I just add tmp folder in front of package name.
==> yum localinstall /tmp/$RPM
