### PR TITLE
Update 'oc rsync' documentation

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -260,7 +260,7 @@ Topics:
     File: persistent_volumes
   - Name: Executing Remote Commands
     File: executing_remote_commands
-  - Name: Copying Local Files to Containers
+  - Name: Copying Files
     File: copy_files_to_container
   - Name: Port Forwarding
     File: port_forwarding

--- a/dev_guide/copy_files_to_container.adoc
+++ b/dev_guide/copy_files_to_container.adoc
@@ -1,4 +1,4 @@
-= Copying local files to a container
+= Copying files to or from a container
 {product-author}
 {product-version}
 :data-uri:
@@ -11,14 +11,14 @@
 toc::[]
 
 == Overview
-You can use the CLI to copy local files to a remote directory in a container. 
+You can use the CLI to copy local files to or from a remote directory in a container.
 
 == Basic Usage
-Support for copying local files to a container is built into
+Support for copying local files to or from a container is built into
 link:../cli_reference/index.html[the CLI]:
 
 ----
-$ oc rsync <local_dir> <pod>:<remote_dir> [-c <container>] 
+$ oc rsync <source> <destination> [-c <container>]
 ----
 
 For example:
@@ -26,28 +26,47 @@ For example:
 ====
 
 ----
+# Copy local directory to a pod directory
 $ oc rsync /home/user/source devpod1234:/src
+
+# Copy pod directory to a local directory
+$ oc rsync devpod1234:/src /home/user/source
 ----
 ====
 
 == Requirements
 
 The `oc rsync` command uses the local `rsync` command if present on the client's machine. This requires
-that the remote container also have the `rsync` command.  If `rsync` is not found locally or in the remote 
+that the remote container also have the `rsync` command.  If `rsync` is not found locally or in the remote
 container, then a tar archive will be created locally and sent to the container where `tar` will be used to
 extract the files. If `tar` is not available in the remote container, then the copy will fail.
 
 [NOTE]
 ====
-On Windows clients, `oc rsync` currently only supports tar.
+The tar copy method does not provide the same functionality as rsync. For example, rsync will create the
+destination directory if it doesn't exist and will only send files that are different between the source
+and the destination.
 
 ====
 
-== Specifying the local directory
+[NOTE]
+====
+In Windows, the cwRsync client should be installed and added to the PATH for use with `oc rsync`
 
-The first argument to the `oc rsync` command must be a local directory. Just as with UNIX rsync, if the directory
-name ends in a slash ('/'), only the contents of the directory are copied to the destination. Otherwise, the directory
-itself is copied to the destination with all its contents.
+====
+
+== Specifying the copy source
+
+The source argument of the `oc rsync` command must point to either a local directory or a pod directory. Individual
+files are not currently supported. When specifying a pod directory the directory name must be prefixed with the pod
+name: `<pod name>:<dir>`.  Just as with UNIX rsync, if the directory name ends in a path separator ('/'), only the
+contents of the directory are copied to the destination. Otherwise, the directory itself is copied to the destination
+with all its contents.
+
+== Specifying the copy destination
+
+The destination argument of the `oc rsync` command must point to a directory. If the directory does not exist, but
+rsync is used for copy, the directory is created for you.
 
 
 == Deleting files at the destination


### PR DESCRIPTION
Updates to match functionality in origin. The copy may happen from
container to pod or from pod to container. Rsync is also now supported
in Windows.
