### PR TITLE
Add '3.1 Preview' from master branch

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -32,3 +32,6 @@ openshift-enterprise:
     enterprise-3.0:
       name: '3.0'
       dir: enterprise/3.0
+    master:
+      name: '3.1 Preview'
+      dir: enterprise/3.1


### PR DESCRIPTION
This change builds the master branch for the OSE distro and publishes it under /enterprise/3.1 with the title '3.1 Preview'. The use of the master branch prevents us from needing to create the enterprise-3.1 branch and repeatedly merge updates into it as we work towards finalizing the enterprise 3.1 docs. When 3.1 is released, we will cut the official branch and change the distro map file to use it instead of master.

@adellape please review.
