### PR TITLE
Removed squash from nfs export instructions

### DIFF
--- a/admin_guide/persistent_storage/persistent_storage_nfs.adoc
+++ b/admin_guide/persistent_storage/persistent_storage_nfs.adoc
@@ -184,13 +184,7 @@ following:
 - Each export must be:
 
 ----
-/<example_fs> *(rw,all_squash)
-----
-
-- Each export must be owned by *nfsnobody*:
-
-----
-chown -R nfsnobody:nfsnobody /<example_fs>
+/<example_fs> *(rw)
 ----
 
 - Each export must have the following permissions:


### PR DESCRIPTION
Squash and chown by nfsnobody are incorrect.  both can be safely removed from the docs.

@eparis @smarterclayton 
