### PR TITLE
Older oc versions didnt support API negotiation

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -64,6 +64,26 @@ No events.
 ----
 ====
 
+[WARNING]
+====
+Versions of `oc` prior to 
+ifdef::openshift-origin[]
+1.0.5 
+endif::[]
+ifdef::openshift-enterprise[]
+3.0.2.0
+endif::[]
+did not have the ability to negotiate API versions against a server. So if you are using `oc` up to 
+ifdef::openshift-origin[]
+1.0.4 
+endif::[]
+ifdef::openshift-enterprise[]
+3.0.1.0
+endif::[]
+with a server that only supports v1 or higher versions of the API, make sure to pass `--api-version` in order to
+point the `oc` client to the correct API endpoint. For example: `oc get svc --api-version=v1`.
+====
+
 [[basic-cli-operations]]
 
 == Basic CLI Operations


### PR DESCRIPTION
@liggitt This fixes https://github.com/openshift/origin/issues/5254. I checked that recent versions do api negotiation correctly. So any other topics we could add this warning, or is it good enough?
