### PR TITLE
routing_from_edge_lb: Clarify ramp node's role

### DIFF
--- a/admin_guide/routing_from_edge_lb.adoc
+++ b/admin_guide/routing_from_edge_lb.adoc
@@ -53,8 +53,11 @@ BIG-IP®* host cannot run an OpenShift node instance or the OpenShift SDN becaus
 
 Instead, to enable *F5 BIG-IP®* to reach pods, you can choose an existing node
 within the cluster network as a _ramp node_ and establish a tunnel between the
-*F5 BIG-IP®* host and the designated ramp node. The ramp node thus assumes the
-role of a gateway of sorts to the cluster network.
+*F5 BIG-IP®* host and the designated ramp node. Because it is otherwise an
+ordinary OpenShift node, the ramp node has the necessary configuration to route
+traffic to any pod on any node in the cluster network.  The ramp node thus
+assumes the role of a gateway through which the *F5 BIG-IP®* host has access to
+the entire cluster network.
 
 Following is an example of establishing an *ipip* tunnel between an *F5 BIG-IP®*
 host and a designated ramp node.


### PR DESCRIPTION
Clarify and elaborate on the ramp node's role as a gateway to the entire cluster network for F5 BIG-IP.
