### PR TITLE
BZ 1259118: Added file on available ports

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -208,6 +208,8 @@ Topics:
     File: sdn_troubleshooting
   - Name: Syncing Groups With LDAP
     File: syncing_groups_with_ldap
+  - Name: Available Ports
+    File: available_ports
 
 ---
 Name: CLI Reference

--- a/admin_guide/available_ports.adoc
+++ b/admin_guide/available_ports.adoc
@@ -1,0 +1,118 @@
+= Available Ports
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+OpenShift infrastructure components communicate with each other using ports,
+which are communication endpoints that are identifiable for specific processes
+or services. This topic is for finding the ports that are required to be open
+between hosts in the event that a firewall is being used between machines.
+
+.Node to Node
+[cols='2,8']
+|===
+| *4789*
+|Required for SDN communication between pods on separate hosts.
+|===
+
+.Nodes to Master
+[cols='2,8']
+|===
+| *53*
+|Required for SDN communication between pods on separate hosts.
+
+| *4789*
+|Required for SDN communication between pods on separate hosts.
+
+| *443* or *8443*
+|Required for node hosts to communicate to the master API, for the node hosts to
+post back status, to receive tasks, and so on.
+|===
+
+.Master to Node
+[cols='2,8']
+|===
+| *4789*
+|Required for SDN communication between pods on separate hosts.
+
+| *10250*
+|The master proxies to node hosts via the Kubelet for `oc` commands.
+|===
+
+.Master to Master
+[cols='2,8']
+|===
+| *53*
+|Provides DNS services.
+
+| *4001*
+|Used for etcd to accept changes in state.
+
+| *4789*
+|Required for SDN communication between pods on separate hosts.
+
+| *7001*
+|etcd requires this port be open between masters for leader election and peering
+connections.
+|===
+
+.External to Master
+[cols='2,8']
+|===
+| *443* or *8443*
+|Required for node hosts to communicate to the master API, for node hosts to
+post back status, to receive tasks, and so on.
+|===
+
+.IaaS Deployments
+[cols='2,8']
+|===
+| *22*
+| Required for SSH by the installer or system administrator.
+
+| *53*
+| For SkyDNS use. Only required to be internally open on master hosts.
+
+| *80* or *443*
+| For HTTP/HTTPS use for the router. Required to be externally open on node hosts, especially on nodes running the router.
+
+| *1936*
+| For router statistics use. Required to be open when running the template
+router to access statistics, and can be open externally or internally to
+connections depending on if you want the statistics to be expressed publicly.
+
+| *4001* or *7001*
+| For etcd use. Only required to be internally open on the master host. *4001*
+is for server-client connections. *7001* is for server-server connections, and
+is only required if you have clustered etcd.
+
+| *4789*
+| For VxLAN use (OpenShift SDN). Required only internally on node hosts.
+
+| *8443*
+| For use by the OpenShift web console, shared with the API server.
+
+| *10250*
+| For use by the Kubelet. Required to be externally open on nodes.
+
+| *24224*
+| For use by Fluentd. Required to be open on master hosts for internal
+connections to node hosts.
+|===
+
+
+== Notes
+
+* In the above examples, port *4789* is used for User Datagram Protocol (UDP).
+* When deployments are using the SDN, the pod network is accessed via a service proxy, unless it is accessing the registry from the same node the registry is deployed on.
+* OpenShift internal DNS cannot be received over SDN. Depending on the detected values of `*openshift_facts*`, or if the `*openshift_ip*` and `*openshift_public_ip*` values are overridden, it will be the computed value of `*openshift_ip*`. For non-cloud deployments, this will default to the IP address associated with the default route on the master host. For cloud deployments, it will default to the IP address associated with the first internal interface as defined by the cloud metadata.
+* The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed values of `*openshift_hostname*` and `*openshift_public_hostname*`.


### PR DESCRIPTION
@adellape @tnguyen-rh @tpoitras @CowboysFan I'm not sure if this is in need of a tech review, as it's pretty much just the KBase article, but this is to do with this BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1259118

As discussed with Bilhar, it might be better to focus on an actual Troubleshooting Guide of sorts after the 3.1 release (and his impending restructure), but an available ports doc is something people have been asking for ( @thoraxe I'm looking at you). 

This is open to suggestion (in case I've done something off), but it's the info from:
- this KBase: https://access.redhat.com/solutions/1520653
- this email thread (internal): http://post-office.corp.redhat.com/archives/openshift-sme/2015-June/msg00543.html
- and made from this GH issue: #684 

Any thoughts?
