### PR TITLE
registry setup - fix first image push

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -305,6 +305,15 @@ $ docker pull docker.io/busybox
 $ docker tag docker.io/busybox 172.30.124.220:5000/openshift/busybox
 ----
 ====
++
+[NOTE]
+====
+Your regular user should have the **system:image-builder** role for the specified
+project, which allows to write/push an image. Otherwise, the `docker push` in
+the next step will fail.
+To test, you can just link:../../dev_guide/projects.html#create-a-project[create
+a new project] to push the busybox image.
+====
 
 . Push the newly-tagged image to your registry:
 +


### PR DESCRIPTION
If we follow the steps to push the first image to the registry, it won't work because the regular user does not have write access to the imagestreams of the "openshift" project.

This PR just adds a note explaining that the regular user needs the `system:image-builder` role for the project, and suggesting to create a new project for this test.
