### PR TITLE
Add documentation for Horizontal Pod Autoscaling

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -292,6 +292,8 @@ Topics:
     File: limits
   - Name: Quota
     File: quota
+  - Name: Pod Autoscaling
+    File: pod_autoscaling
   - Name: Managing Volumes
     File: volumes
   - Name: Using Persistent Volumes

--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -1,0 +1,118 @@
+= Pod Autoscaling
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+A *HorizontalPodAutoscaler* object specifies how the system should automatically
+increase or decrease the scale of a *ReplicationController* or *DeploymentConfig*,
+based on metrics collected from the pods that belong to that *ReplicationController*
+or *DeploymentConfig*.
+
+[NOTE]
+====
+Horizontal Pod Autoscaling is currently a Tech Preview feature.
+====
+
+ifdef::openshift-origin,openshift-enterprise[]
+== Requirements for Using Horizontal Pod Autoscalers
+
+In order to use *HorizontalPodAutoscalers*, your cluster admin must have
+link:../install_config/cluster_metrics.html[properly configured cluster metrics].
+endif::openshift-origin,openshift-enterprise[]
+
+== Metrics Supported
+
+The following describes the metrics supported by *HorizontalPodAutoscalers*:
+
+.Metrics
+[cols="3a,8a",options="header"]
+|===
+
+|Metric |Description
+
+|CPU Utilization
+|Percentage of the link:../dev_guide/compute_resources.html#cpu-requests[requested CPU]
+|===
+
+== Scaling
+
+Once a *HorizontalPodAutoscaler* is created, it will begin attempting to query
+Heapster for metrics on the pods.  It may take 1-2 minutes before Heapster obtains
+the initial metrics.  Once metrics are available in heapster, the *HorizontalPodAutoscaler*
+will compute the ratio of the current metric utilization with the desired metric utilization,
+and scale up or down accordingly.  The scaling will occur at a regular interval, but it may take
+1-2 minutes before metrics make their way into Heapster.
+
+For *ReplicationControllers*, this scaling corresponds directly to the replicas of the
+*ReplicationController*.  For *DeploymentConfigs*, this will scale the latest deployment,
+or, if no deployment is present, the *ReplicationController* template in the *DeploymentConfig*
+(note that scaling will occur if the latest deployment is marked as `Complete`).
+
+== Sample Horizontal Pod Autoscaler File
+
+.scaler.yaml
+====
+[source,yaml,options="nowrap"]
+----
+apiVersion: extensions/v1beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend-scaler <1>
+spec:
+  scaleRef:
+    kind: DeploymentConfig <2>
+    name: frontend <3>
+    apiVersion: v1 <4>
+    subresource: scale
+  minReplicas: 1 <5>
+  maxReplicas: 10 <6>
+  cpuUtilization:
+    targetPercentage: 80 <7>
+----
+<1> The name of this horizontal pod autoscaler object
+<2> The kind of object to scale
+<3> The name of the object to scale
+<4> The API version of the object to scale
+<5> The minimum number of replicas to which to scale down
+<6> The maximum number of replicas to which to scale up
+<7> The percentage of the requested CPU that each pod should ideally be using
+====
+
+== Create a Horizontal Pod Autoscaler
+
+To create a horizontal pod autoscaler:
+
+----
+$ oc create -f scaler.yaml
+----
+
+== View a Horizontal Pod Autocaler
+
+To view the status of a horizontal pod autoscaler:
+
+----
+$ oc get hpa
+NAME              REFERENCE                                 TARGET    CURRENT   MINPODS        MAXPODS   AGE
+frontend-scaler   DeploymentConfig/default/frontend/scale   80%       79%       1              10        8d
+$ oc describe hpa frontend-scaler
+Name:                           frontend-scaler
+Namespace:                      default
+Labels:                         <none>
+CreationTimestamp:              Mon, 26 Oct 2015 21:13:47 -0400
+Reference:                      DeploymentConfig/default/frontend/scale
+Target CPU utilization:         80%
+Current CPU utilization:        79%
+Min pods:                       1
+Max pods:                       10
+----
+
+====
+

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -12,17 +12,23 @@ toc::[]
 
 == Overview
 
-As an OpenShift administrator, you can view a cluster's metrics from all
-containers and components in one user interface. The
+The
 link:../architecture/infrastructure_components/kubernetes_infrastructure.html#kubelet[kubelet]
 exposes metrics that can be collected and stored in back-ends by
 link:https://github.com/GoogleCloudPlatform/heapster[Heapster].
+
+As an OpenShift administrator, you can view a cluster's metrics from all
+containers and components in one user interface.  These metrics are also
+used by link:../dev_guide/pod_autoscaling.html[horizontal pod autoscalers]
+in order to determine when and how to scale.
+
 This topic describes using
 link:https://github.com/hawkular/hawkular-metrics[Hawkular Metrics]
 as a metrics engine which stores the data persistently in a
 link:http://cassandra.apache.org/[Cassandra] database. When this is
 configured, CPU and memory-based metrics are viewable from the OpenShift
-web console.
+web console and are available for use by
+link:../dev_guide/pod_autoscaling.html[horizontal pod autoscalers].
 
 Heapster retrieves a list of all nodes from the master server, then contacts
 each node individually through the `/stats` endpoint. From there, Heapster
@@ -47,11 +53,9 @@ endif::[]
 == Before You Begin
 
 The components for cluster metrics must be deployed to the `openshift-infra`
-project. This allows the `horizontal pod autoscaler` to discover the heapster
-service and use it to retrieve metrics that can be used for autoscaling.
-////
-TODO: make a link to the HPA page once it exists.
-////
+project. This allows link:../dev_guide/pod_autoscaling.html[horizontal pod autoscalers]
+to discover the heapster service and use it to retrieve metrics that can be used
+for autoscaling.
 
 All of the following commands in this topic must be executed under the
 `openshift-infra` project. To switch to the `openshift-infra` project:
@@ -215,11 +219,16 @@ option is ignored if the *_hawkular-cassandra.pem_* option is not specified.
 
 |*_heapster_client_ca.cert_*
 |The certificate that generates *_heapster.cert_*. This is required if
-*_heapster.cert_* is specified, otherwise it is auto-generated.
+*_heapster.cert_* is specified.  Otherwise, the main CA for the OpenShift installation
+is used. In order for link:../dev_guide/pod_autoscaling.html[horizontal pod autoscaling]
+to function properly, this should not be overridden.
 
 |*_heapster_allowed_users_*
 |A file containing a comma-separated list of CN to accept from certificates
-signed with the specified CA. By default, this is set to no allowed users.
+signed with the specified CA. By default, this is set to allow the OpenShift service
+proxy to connect.  If you override this, make sure to add `system:master-proxy` to the
+list in order to allow link:../dev_guide/pod_autoscaling.html[horizontal pod autoscaling]
+to function properly.
 
 |===
 


### PR DESCRIPTION
This commit introduces documentation for Horizontal Pod Autoscaling,
and updates the cluster metrics documentation to support the Heapster
setup required for it.
