### PR TITLE
Update Docker container run settings for quick install

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -48,10 +48,9 @@ https://hub.docker.com[Docker Hub] on a Linux system.
 
 [CAUTION]
 ====
-OpenShift Origin requires access to port 7001. If a service (such as another 
-Kubernetes or etcd service) is already running and occupying this port locally, 
-stop that service before launching the OpenShift container to avoid a port 
-conflict.
+OpenShift Origin listens on ports 53, 7001, and 8443. If another service is
+already listening on those ports you must stop that service before launching
+the OpenShift container.
 ====
 
 *Installing and Starting an All-in-One Server*
@@ -60,8 +59,8 @@ conflict.
 +
 ----
 $ sudo docker run -d --name "origin" \
-        --privileged --net=host \
-        -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
+        --privileged --pid=host --net=host \
+        -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /var/lib/docker:/var/lib/docker:rw \
         -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
         openshift/origin start
 ----


### PR DESCRIPTION
--pid=host is required, and /sys must not be readonly in order for
the proxy to set hairpin mode.

Also indicate the other ports openshift listens on.
