### PR TITLE
BZ1268180: added more jobs info

### DIFF
--- a/architecture/core_concepts/deployments.adoc
+++ b/architecture/core_concepts/deployments.adoc
@@ -14,33 +14,32 @@ toc::[]
 
 == Replication Controllers
 
-A replication controller ensures that a specified number of replicas of a pod
-are running at all times. If pods exit or are deleted, the replica controller
-acts to instantiate more up to the desired number. Likewise, if there are more
-running than desired, it deletes as many as necessary to match the number.
+A
+https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/replication-controller.md[replication
+controller] ensures that a specified number of replicas of a pod are running at
+all times. If pods exit or are deleted, the replication controller acts to
+instantiate more up to the defined number. Likewise, if there are more running
+than desired, it deletes as many as necessary to match the defined amount.
 
-The definition of a replication controller consists mainly of:
+A replication controller configuration consists of:
 
 1. The number of replicas desired (which can be adjusted at runtime).
-2. A pod definition for creating a replicated pod.
+2. A pod definition to use when creating a replicated pod.
 3. A selector for identifying managed pods.
 
-The selector is just a set of labels that all of the pods managed by the
-replication controller should have. So that set of labels is included
-in the pod definition that the replication controller instantiates.
-This selector is used by the replication controller to determine how many
+A selector is a set of labels assigned to
+the pods that are managed by the replication controller. These labels are
+included in the pod definition that the replication controller instantiates.
+The replication controller uses the selector to determine how many
 instances of the pod are already running in order to adjust as needed.
 
-It is not the job of the replication controller to perform auto-scaling
-based on load or traffic, as it does not track either; rather, this
-would require its replica count to be adjusted by an external auto-scaler.
+The replication controller does not perform auto-scaling based on load or
+traffic, as it does not track either. Rather, this would require its replica
+count to be adjusted by an external auto-scaler.
 
-Replication controllers are a core Kubernetes object, `*ReplicationController*`.
-The
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/replication-controller.md[Kubernetes documentation]
-has more details on replication controllers.
+Replication controllers are a core Kubernetes object called `*ReplicationController*`.
 
-Here is an example `*ReplicationController*` definition with some omissions and callouts:
+The following is an example `*ReplicationController*` definition:
 
 [source,yaml]
 ----
@@ -70,6 +69,45 @@ spec:
 2. The label selector of the pod to run.
 3. A template for the pod the controller creates.
 4. Labels on the pod should include those from the label selector.
+
+[[jobs]]
+
+== Jobs
+
+A job is similar to a replication controller, in that it's purpose is to create
+pods for specified reasons. The difference is that replication controllers are
+designed for pods that will be continuously running, whereas jobs are for
+one-time pods. A job tracks any successful completions and when the specified
+amount of completions have been reached, the job itself is completed.
+
+The following example runs π to 2000 places, prints it out, then completes:
+
+====
+----
+apiVersion: extensions/v1
+kind: Job
+metadata:
+  name: pi
+spec:
+  selector:
+    matchLabels:
+      app: pi
+  template:
+    metadata:
+      name: pi
+      labels:
+        app: pi
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+----
+====
+
+See the link:../../dev_guide/jobs.html[Jobs] topic for more information on how
+to use jobs.
 
 [[deployments-and-deployment-configurations]]
 

--- a/architecture/core_concepts/deployments.adoc
+++ b/architecture/core_concepts/deployments.adoc
@@ -37,7 +37,7 @@ The replication controller does not perform auto-scaling based on load or
 traffic, as it does not track either. Rather, this would require its replica
 count to be adjusted by an external auto-scaler.
 
-Replication controllers are a core Kubernetes object called `*ReplicationController*`.
+A replication controller is a core Kubernetes object called `*ReplicationController*`.
 
 The following is an example `*ReplicationController*` definition:
 
@@ -74,13 +74,13 @@ spec:
 
 == Jobs
 
-A job is similar to a replication controller, in that it's purpose is to create
+A job is similar to a replication controller, in that its purpose is to create
 pods for specified reasons. The difference is that replication controllers are
 designed for pods that will be continuously running, whereas jobs are for
 one-time pods. A job tracks any successful completions and when the specified
 amount of completions have been reached, the job itself is completed.
 
-The following example runs π to 2000 places, prints it out, then completes:
+The following example computes π to 2000 places, prints it out, then completes:
 
 ====
 ----

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -66,16 +66,16 @@ No events.
 
 [WARNING]
 ====
-Versions of `oc` prior to 
+Versions of `oc` prior to
 ifdef::openshift-origin[]
-1.0.5 
+1.0.5
 endif::[]
 ifdef::openshift-enterprise[]
 3.0.2.0
 endif::[]
-did not have the ability to negotiate API versions against a server. So if you are using `oc` up to 
+did not have the ability to negotiate API versions against a server. So if you are using `oc` up to
 ifdef::openshift-origin[]
-1.0.4 
+1.0.4
 endif::[]
 ifdef::openshift-enterprise[]
 3.0.1.0
@@ -395,6 +395,7 @@ syntax:
 |`node` |
 |`pod` |`po`
 |`replicationController` |`rc`
+|`job` |
 |`service` |`svc`
 |`persistentVolume` |`pv`
 |`persistentVolumeClaim` |`pvc`

--- a/dev_guide/jobs.adoc
+++ b/dev_guide/jobs.adoc
@@ -75,7 +75,7 @@ spec:
 
 A job can be scaled up or down by changing the `*parallelism*` parameter
 accordingly. You can also use the `oc scale` command with the `*--replicas`
-option, which, in the case of jobs, modifies the `*parallelism*` paramete.
+option, which, in the case of jobs, modifies the `*parallelism*` parameter.
 
 The following command uses the example job above, and sets the `*parallelism*`
 parameter to three:

--- a/dev_guide/jobs.adoc
+++ b/dev_guide/jobs.adoc
@@ -1,4 +1,4 @@
-= Builds
+= Jobs
 {product-author}
 {product-version}
 :data-uri:
@@ -11,14 +11,17 @@
 toc::[]
 
 == Overview
-A job, in contrast to link:../architecture/core_concepts/deployments.html#replication-controllers[Replication Controller],
-is meant to run one or more pods to completion. A job tracks the overall progress
-by updating its status with information about active, succeeded and failed pods.
-Deleting a Job will cleanup the pods it created.
+A job, in contrast to
+link:../architecture/core_concepts/deployments.html#replication-controllers[a
+replication controller], runs any number of pods to completion. A job tracks the
+overall progress of a task and updates its status with information about active,
+succeeded, and failed pods. Deleting a job will clean up any pods it created.
+Jobs are part of the extensions Kubernetes API, which can be managed with `oc` commands like other
+link:../cli_reference/basic_cli_operations.html#object-types[object types].
 
-Jobs are a core Kubernetes object, `*Job*`. The
-https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/jobs.md[Kubernetes documentation]
-has more details on job.
+See the
+https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/jobs.md[Kubernetes
+documentation] for more information about jobs.
 
 [[creating-a-job]]
 
@@ -26,14 +29,12 @@ has more details on job.
 
 A job configuration consists of the following key parts:
 
-- A pod template which describes the application to be run.
-- Optional parameter specifying how many successful pod completions is needed to
-  finish a job (`*completions*`). If not specified this value defaults to `*parallelism*`.
-- Optional parameter suggesting how many concurrently running pods should execute
-  a job (`*parallelism*`). If not specified this value defaults to 1.
+- A pod template, which describes the application the pod will create.
+- An optional `*parallelism*` parameter, which specifies how many successful pod completions are needed to finish a job. If not specified, this defaults to
+ the value in the `*completions*` parameter.
+- An optional `*completions*` parameter, specifying how many concurrently running pods should execute a job. If not specified, this value defaults to one.
 
-Jobs are part of the extensions Kubernetes API which can be managed with the `oc`
-command like any other resource. The following is an example of a `*job*` resource:
+The following is an example of a `*job*` resource:
 
 ====
 [source,yaml]
@@ -61,9 +62,9 @@ spec:
       restartPolicy: Never
 ----
 
-1. Label selector of the pod to run, it uses the https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/labels.md#label-selectors[generalized label selectors].
-2. Optional parallelism, suggests how many pods a job should run concurrently, defaults to `.spec.Completions`.
-3. Optional completions, informs how many successful pods completions is needed to mark a job completed, defaults to 1.
+1. Label selector of the pod to run. It uses the https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/labels.md#label-selectors[generalized label selectors].
+2. Optional value for how many pods a job should run concurrently, defaults to `*completions*`.
+3. Optional value for how many successful pod completions is needed to mark a job completed, defaults to one.
 4. Template for the pod the controller creates.
 ====
 
@@ -72,10 +73,20 @@ spec:
 
 == Scaling a Job
 
-A job can be scaled up or down, which leads to changing the `*parallelism*` parameter
-up or down accordingly. For example, the following command sets the aforementioned
-parameter to 3.
+A job can be scaled up or down by changing the `*parallelism*` parameter
+accordingly. You can also use the `oc scale` command with the `*--replicas`
+option, which, in the case of jobs, modifies the `*parallelism*` paramete.
 
+The following command uses the example job above, and sets the `*parallelism*`
+parameter to three:
+
+====
 ----
 $ oc scale job pi --replicas=3
 ----
+====
+
+[NOTE]
+Scaling replication controllers also uses the `oc scale` command with the
+`--replicas` option, but instead changes the `*replicas*` parameter of a
+replication controller configuration.


### PR DESCRIPTION
@soltysh As discussed, this is a follow up to #1130 

Two questions:
1. I've added the job object to the CLI doc. Is there a shortened version? Like, rc is replication controller? Jobs is pretty short already, I guess.
2. Under Creating a Job, it mentions the completions parameter defaults to the parallelism parameter, which itself defaults to one. But in the example callouts, it reverses this, and says the parallelism parameter defaults to the completions parameter, which defaults to one. Do you know which it is?

I think that's it for my questions. If you have any other thoughts, please let me know. Thanks!
