### PR TITLE
How to be safe with multiple registry replicas on NFS

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -72,6 +72,8 @@ The registry stores Docker images and metadata. If you simply deploy a pod with
 the registry, it uses an ephemeral volume that is destroyed if the pod exits.
 Any images anyone has built or pushed into the registry would disappear.
 
+==== Production Use
+
 For production use, you should attach a remote volume or
 link:../../admin_guide/persistent_storage/persistent_storage_nfs.html[use persistent storage] using
 `*PersistentVolume*` and `*PersistentVolumeClaim*` objects for storage for the
@@ -83,6 +85,24 @@ $ oc volume deploymentconfigs/docker-registry \
      --add --overwrite --name=registry-storage --mount-path=/registry \
      --source='{"nfs": { "server": "<fqdn>", "path": "/path/to/export"}}'
 ----
+
+There are known issues when using multiple registry replicas with the same NFS
+volume. Due to a client side caching, file system changes are propagated with
+non-zero latency which increases with the size of data blob written. This
+causes problems when pushing image layers while changing replicas in round robin
+fashion. Fortunately there's a simple workaround. Set registry service's
+`sessionAffinity` to `ClientIP`:
+
+----
+$ oc get -o yaml svc docker-registry | \
+      sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
+      oc replace -f -
+----
+
+This ensures that requests from particular docker client will be always handled
+by the same replica.
+
+==== Non-Production use
 
 For non-production use, you can use the `--mount-host=<path>` option to specify
 a directory for the registry to use for persistent storage. The registry volume

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -87,9 +87,10 @@ $ oc volume deploymentconfigs/docker-registry \
 ----
 
 There are link:#known-issues[known issues] when using multiple registry replicas
-with the same NFS volume. We recommend to change docker-registry service's
+with the same NFS volume. We recommend changing the docker-registry service's
 `sessionAffinity` to `ClientAPI` like this:
 
+[[session-affinity-workaround]]
 ----
 $ oc get -o yaml svc docker-registry | \
       sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
@@ -562,26 +563,20 @@ In the `<host>/test/busybox` example above, `test` refers to the project name.
 
 === Image push errors with scaled registry using shared NFS volume
 
-During a build of an image you may see one of the following errors in the output of `oc build-logs BUILD`:
+During a push of an image, you may see one of the following errors:
 
-* `Build error: Failed to push image. Response from registry is: digest invalid: provided digest did not match uploaded content`
-* `Build error: Failed to push image. Response from registry is: blob upload unknown`
+* `digest invalid: provided digest did not match uploaded content`
+* `blob upload unknown`
 
-The error is returned by an internal registry service when Docker tries to push the built
-image to it. Its cause originates in synchronization of file attributes across nodes.
-Factors such as NFS client side caching, network latency, and layer size can
-all contribute to potential errors that might occur when pushing an image using
-the default round-robin load balancing configuration. One possible workaround
-is to set the docker-registry service's `sessionAffinity` to `ClientIP`:
-
-----
-$ oc get -o yaml svc docker-registry | \
-      sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
-      oc replace -f -
-----
-
-This ensures that requests from particular docker client will be always handled
-by the same replica.
+The error is returned by an internal registry service when Docker attempts to
+push the image. Its cause originates in synchronization of file attributes
+across nodes. Factors such as NFS client side caching, network latency, and
+layer size can all contribute to potential errors that might occur when pushing
+an image using the default round-robin load balancing configuration. One
+possible workaround is to link:#session-affinity-workaround[set the
+docker-registry service's `sessionAffinity` to `ClientIP`]. It ensures that
+requests from particular docker client will always be handled by the same
+replica.
 
 == What's Next?
 

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -86,21 +86,15 @@ $ oc volume deploymentconfigs/docker-registry \
      --source='{"nfs": { "server": "<fqdn>", "path": "/path/to/export"}}'
 ----
 
-There are known issues when using multiple registry replicas with the same NFS
-volume. Due to a client side caching, file system changes are propagated with
-non-zero latency which increases with the size of data blob written. This
-causes problems when pushing image layers while changing replicas in round robin
-fashion. Fortunately there's a simple workaround. Set registry service's
-`sessionAffinity` to `ClientIP`:
+There are link:#known-issues[known issues] when using multiple registry replicas
+with the same NFS volume. We recommend to change docker-registry service's
+`sessionAffinity` to `ClientAPI` like this:
 
 ----
 $ oc get -o yaml svc docker-registry | \
       sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
       oc replace -f -
 ----
-
-This ensures that requests from particular docker client will be always handled
-by the same replica.
 
 ==== Non-Production use
 
@@ -563,6 +557,31 @@ not the route name and port. See `oc get imagestreams` for details.
 In the `<host>/test/busybox` example above, `test` refers to the project name.
 ====
 
+
+== Known Issues
+
+=== Image push errors with scaled registry using shared NFS volume
+
+During a build of an image you may see one of the following errors in the output of `oc build-logs BUILD`:
+
+* `Build error: Failed to push image. Response from registry is: digest invalid: provided digest did not match uploaded content`
+* `Build error: Failed to push image. Response from registry is: blob upload unknown`
+
+The error is returned by an internal registry service when Docker tries to push the built
+image to it. Its cause originates in synchronization of file attributes across nodes.
+Factors such as NFS client side caching, network latency, and layer size can
+all contribute to potential errors that might occur when pushing an image using
+the default round-robin load balancing configuration. One possible workaround
+is to set the docker-registry service's `sessionAffinity` to `ClientIP`:
+
+----
+$ oc get -o yaml svc docker-registry | \
+      sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
+      oc replace -f -
+----
+
+This ensures that requests from particular docker client will be always handled
+by the same replica.
 
 == What's Next?
 


### PR DESCRIPTION
Documents a work-around for [#5761](https://github.com/openshift/origin/pull/5761).
Based on [this comment](https://github.com/openshift/origin/pull/5761#issuecomment-154718324).

Needs to be removed once [issue #5795](https://github.com/openshift/origin/issues/5795)
has been resolved.
