### PR TITLE
Svc and pkg rename

### DIFF
--- a/admin_guide/cluster_metrics.adoc
+++ b/admin_guide/cluster_metrics.adoc
@@ -55,7 +55,12 @@ kubeletArguments:
 Restart your node to make this setting take effect:
 
 ----
+ifdef::openshift-origin[]
+$ systemctl restart origin-node
+endif::[]
+ifdef::openshift-enterprise[]
 $ systemctl restart atomic-openshift-node
+endif::[]
 ----
 
 Update firewall rules to allow remote access to the read-only port:

--- a/admin_guide/cluster_metrics.adoc
+++ b/admin_guide/cluster_metrics.adoc
@@ -55,7 +55,7 @@ kubeletArguments:
 Restart your node to make this setting take effect:
 
 ----
-$ systemctl restart openshift-node
+$ systemctl restart atomic-openshift-node
 ----
 
 Update firewall rules to allow remote access to the read-only port:

--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -523,10 +523,10 @@ link:#requestheader-master-ca-config[master's identity provider configuration].
 
 ----
 # oadm ca create-signer-cert \
-  --cert='/etc/openshift/master/proxyca.crt' \
-  --key='/etc/openshift/master/proxyca.key' \
+  --cert='/etc/origin/master/proxyca.crt' \
+  --key='/etc/origin/master/proxyca.key' \
   --name='openshift-proxy-signer@1432232228' \
-  --serial='/etc/openshift/master/proxyca.serial.txt'
+  --serial='/etc/origin/master/proxyca.serial.txt'
 ----
 
 Generate a client certificate for the proxy. This can be done using any x509
@@ -534,14 +534,14 @@ certificate tooling. For convenience, the `oadm` CLI can be used:
 
 ----
 # oadm create-api-client-config \
-  --certificate-authority='/etc/openshift/master/proxyca.crt' \
-  --client-dir='/etc/openshift/master/proxy' \
-  --signer-cert='/etc/openshift/master/proxyca.crt' \
-  --signer-key='/etc/openshift/master/proxyca.key' \
-  --signer-serial='/etc/openshift/master/proxyca.serial.txt' \
+  --certificate-authority='/etc/origin/master/proxyca.crt' \
+  --client-dir='/etc/origin/master/proxy' \
+  --signer-cert='/etc/origin/master/proxyca.crt' \
+  --signer-key='/etc/origin/master/proxyca.key' \
+  --signer-serial='/etc/origin/master/proxyca.serial.txt' \
   --user='system:proxy' <1>
 
-# pushd /etc/openshift/master
+# pushd /etc/origin/master
 # cp master.server.crt /etc/pki/tls/certs/localhost.crt <2>
 # cp master.server.key /etc/pki/tls/private/localhost.key
 # cp ca.crt /etc/pki/CA/certs/ca.crt
@@ -555,7 +555,7 @@ name as it will appear in logs.
 <2> When running the authentication proxy on a different host name than the
 master, it is important to generate a certificate that matches the host name
 instead of using the default master certificate as shown above. The value for
-`*masterPublicURL*` in the *_/etc/openshift/master/master-config.yaml_* file
+`*masterPublicURL*` in the *_/etc/origin/master/master-config.yaml_* file
 must be included in the `X509v3 Subject Alternative Name` in the certificate
 that is specified for `*SSLCertificateFile*`. If a new certificate needs to be
 created, the `oadm ca create-server-cert` command can be used.
@@ -628,7 +628,7 @@ LoadModule request_module modules/mod_request.so
   </Location>
 
   <ProxyMatch /oauth/authorize>
-    AuthUserFile /etc/openshift/htpasswd
+    AuthUserFile /etc/origin/htpasswd
     AuthName openshift
     Require valid-user
     RequestHeader set X-Remote-User %{REMOTE_USER}s
@@ -667,15 +667,15 @@ accounts information. In this example, file-backed authentication is used:
 
 ----
 # yum -y install httpd-tools
-# touch /etc/openshift/htpasswd
-# htpasswd -c /etc/openshift/htpasswd <user_name>
+# touch /etc/origin/htpasswd
+# htpasswd -c /etc/origin/htpasswd <user_name>
 ----
 
 *Configuring the Master*
 
 [[requestheader-master-ca-config]]
 The `*identityProviders*` stanza in the
-*_/etc/openshift/master/master-config.yaml_* file must be updated as well:
+*_/etc/origin/master/master-config.yaml_* file must be updated as well:
 
 ----
   identityProviders:
@@ -687,7 +687,7 @@ The `*identityProviders*` stanza in the
       kind: RequestHeaderIdentityProvider
       challengeURL: "https://[MASTER]/challenging-proxy/oauth/authorize?${query}"
       loginURL: "https://[MASTER]/login-proxy/oauth/authorize?${query}"
-      clientCA: /etc/openshift/master/proxyca.crt
+      clientCA: /etc/origin/master/proxyca.crt
       headers:
       - X-Remote-User
 ----
@@ -698,7 +698,7 @@ Finally, restart the following services:
 
 ----
 # systemctl restart httpd
-# systemctl restart openshift-master
+# systemctl restart atomic-openshift-master
 ----
 
 *Verifying the Configuration*

--- a/admin_guide/configuring_authentication.adoc
+++ b/admin_guide/configuring_authentication.adoc
@@ -698,7 +698,12 @@ Finally, restart the following services:
 
 ----
 # systemctl restart httpd
+ifdef::openshift-origin[]
+# systemctl restart origin-master
+endif::[]
+ifdef::openshift-enterprise[]
 # systemctl restart atomic-openshift-master
+endif::[]
 ----
 
 *Verifying the Configuration*

--- a/admin_guide/configuring_aws.adoc
+++ b/admin_guide/configuring_aws.adoc
@@ -35,7 +35,7 @@ Zone = us-east-1c  <1>
 Edit or
 link:master_node_configuration.html#creating-new-configuration-files[create] the
 master configuration file on all masters
-(*_/etc/openshift/master/master-config.yaml_* by default) and update the
+(*_/etc/origin/master/master-config.yaml_* by default) and update the
 contents of the `*apiServerArguments*` and `*controllerArguments*` sections:
 
 ====
@@ -61,7 +61,7 @@ kubernetesMasterConfig:
 Edit or
 link:master_node_configuration.html#creating-new-configuration-files[create] the
 node configuration file on all nodes
-(*_/etc/openshift/node-<hostname>/node-config.yaml_* by default) and update the
+(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
 contents of the `*kubeletArguments*` section:
 
 ====

--- a/admin_guide/configuring_gce.adoc
+++ b/admin_guide/configuring_gce.adoc
@@ -22,7 +22,7 @@ After GCE is configured properly, some additional configurations will need to be
 Edit or
 link:master_node_configuration.html#creating-new-configuration-files[create] the
 master configuration file on all masters
-(*_/etc/openshift/master/master-config.yaml_* by default) and update the
+(*_/etc/origin/master/master-config.yaml_* by default) and update the
 contents of the `*apiServerArguments*` and `*controllerArguments*` sections:
 
 ====
@@ -45,7 +45,7 @@ kubernetesMasterConfig:
 Edit or
 link:master_node_configuration.html#creating-new-configuration-files[create] the
 node configuration file on all nodes
-(*_/etc/openshift/node-<hostname>/node-config.yaml_* by default) and update the
+(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
 contents of the `*kubeletArguments*` section:
 
 ====

--- a/admin_guide/configuring_openstack.adoc
+++ b/admin_guide/configuring_openstack.adoc
@@ -41,7 +41,7 @@ are commonly used in OpenStack configuration.
 Edit or
 link:master_node_configuration.html#creating-new-configuration-files[create] the
 master configuration file on all masters
-(*_/etc/openshift/master/master-config.yaml_* by default) and update the
+(*_/etc/origin/master/master-config.yaml_* by default) and update the
 contents of the `*apiServerArguments*` and `*controllerArguments*` sections:
 
 ====
@@ -67,7 +67,7 @@ kubernetesMasterConfig:
 Edit or
 link:master_node_configuration.html#creating-new-configuration-files[create] the
 node configuration file on all nodes
-(*_/etc/openshift/node-<hostname>/node-config.yaml_* by default) and update the
+(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
 contents of the `*kubeletArguments*` section:
 
 ====

--- a/admin_guide/http_proxies.adoc
+++ b/admin_guide/http_proxies.adoc
@@ -22,8 +22,14 @@ files.
 == Configuring Hosts for Proxies
 
 . Add the `*NO_PROXY*`, `*HTTP_PROXY*`, and `*HTTPS_PROXY*` environment variables
+ifdef::openshift-origin[]
+to each host's *_/etc/sysconfig/origin-master_* or
+*_/etc/sysconfig/origin-node_* file depending on the type of host:
+endif::[]
+ifdef::openshift-enterprise[]
 to each host's *_/etc/sysconfig/atomic-openshift-master_* or
 *_/etc/sysconfig/atomic-openshift-node_* file depending on the type of host:
+endif::[]
 +
 ====
 ----
@@ -36,8 +42,14 @@ NO_PROXY=master.hostname.example.com
 . Restart the master or node host as appropriate:
 +
 ----
+ifdef::openshift-origin[]
+# systemctl restart origin-master
+# systemctl restart origin-node
+endif::[]
+ifdef::openshift-enterprise[]
 # systemctl restart atomic-openshift-master
 # systemctl restart atomic-openshift-node
+endif::[]
 ----
 
 [[proxying-docker-pull]]

--- a/admin_guide/http_proxies.adoc
+++ b/admin_guide/http_proxies.adoc
@@ -22,8 +22,8 @@ files.
 == Configuring Hosts for Proxies
 
 . Add the `*NO_PROXY*`, `*HTTP_PROXY*`, and `*HTTPS_PROXY*` environment variables
-to each host's *_/etc/sysconfig/openshift-master_* or
-*_/etc/sysconfig/openshift-node_* file depending on the type of host:
+to each host's *_/etc/sysconfig/atomic-openshift-master_* or
+*_/etc/sysconfig/atomic-openshift-node_* file depending on the type of host:
 +
 ====
 ----
@@ -36,8 +36,8 @@ NO_PROXY=master.hostname.example.com
 . Restart the master or node host as appropriate:
 +
 ----
-# systemctl restart openshift-master
-# systemctl restart openshift-node
+# systemctl restart atomic-openshift-master
+# systemctl restart atomic-openshift-node
 ----
 
 [[proxying-docker-pull]]

--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -32,7 +32,7 @@ ifdef::openshift-enterprise[]
 ====
 ----
 $ oadm router hap --service-account=router --stats-port=0  \
-    --credentials='/etc/openshift/master/openshift-router.kubeconfig'
+    --credentials='/etc/origin/master/openshift-router.kubeconfig'
 ----
 ====
 endif::[]

--- a/admin_guide/routing_from_edge_lb.adoc
+++ b/admin_guide/routing_from_edge_lb.adoc
@@ -152,7 +152,7 @@ interface (e.g., *eth0*):
 ====
 [options="nowrap"]
 ----
-# source /etc/openshift-sdn/config.env
+# source /etc/origin-sdn/config.env
 # subaddr=$(echo $OPENSHIFT_SDN_TAP1_ADDR | cut -d "." -f 1,2,3)
 # export RAMP_SDN_IP=${subaddr}.254
 ----

--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -513,7 +513,7 @@ out the route table normally.
 
 == Reading the Logs
 
-Run: `journalctl -u openshift-node.service --boot | less`
+Run: `journalctl -u atomic-openshift-node.service --boot | less`
 
 Look for the `Output of setup script:` line.  Everything starting with
 '+' below that are the script steps.  Look through that for obvious

--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -512,8 +512,12 @@ out the route table normally.
 
 
 == Reading the Logs
-
+ifdef::openshift-origin[]
+Run: `journalctl -u origin-node.service --boot | less`
+endif::[]
+ifdef::openshift-enterprise[]
 Run: `journalctl -u atomic-openshift-node.service --boot | less`
+endif::[]
 
 Look for the `Output of setup script:` line.  Everything starting with
 '+' below that are the script steps.  Look through that for obvious

--- a/admin_guide/web_console_customization.adoc
+++ b/admin_guide/web_console_customization.adoc
@@ -229,7 +229,7 @@ restart the server after changing this configuration.
 
 You can change the location a console user is sent to when logging out of
 the console by modifying the `*logoutURL*` parameter in the
-*_/etc/openshift/master/master-config.yaml_* file:
+*_/etc/origin/master/master-config.yaml_* file:
 
 ====
 ----

--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -261,7 +261,12 @@ ifdef::openshift-origin[]
 To switch from one SDN plug-in to another, admin needs to:
 
 . Change the *networkPluginName* parameter in both master and node configuration files.
+ifdef::openshift-origin[]
+. Restart origin-master service on master and origin-node service on all nodes.
+endif::[]
+ifdef::openshift-enterprise[]
 . Restart atomic-openshift-master service on master and atomic-openshift-node service on all nodes.
+endif::[]
 
 When switching from ovssubnet to multitenant plug-in, all the existing projects in the cluster
 will be fully isolated (assigned unique VNIDs). Admin can choose to join or unisolate project

--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -86,12 +86,12 @@ Cluster admin will have the option to control these pod network settings on the 
 ----
 ...
 networkConfig:
-  clusterNetworkCIDR: 10.1.0.0/16    # Cluster network for node IP allocation 
+  clusterNetworkCIDR: 10.1.0.0/16    # Cluster network for node IP allocation
   hostSubnetLength: 8                # Number of bits for Pod IP allocation within a node
   networkPluginName: ""              # redhat/openshift-ovs-subnet for flat SDN
 ifdef::openshift-origin[]
-	                             # redhat/openshift-ovs-multitenant for multitenant SDN			
-endif::[] 
+	                             # redhat/openshift-ovs-multitenant for multitenant SDN
+endif::[]
   serviceNetworkCIDR: 172.30.0.0/16  # Service IP allocation for the cluster
 ...
 ----
@@ -171,8 +171,8 @@ networkConfig:
   mtu: 1450              # Maximum transmission unit for the pod overlay network
   networkPluginName: ""  # redhat/openshift-ovs-subnet for flat SDN
 ifdef::openshift-origin[]
-	                 # redhat/openshift-ovs-multitenant for multitenant SDN			
-endif::[] 
+	                 # redhat/openshift-ovs-multitenant for multitenant SDN
+endif::[]
 ...
 ----
 
@@ -261,7 +261,7 @@ ifdef::openshift-origin[]
 To switch from one SDN plug-in to another, admin needs to:
 
 . Change the *networkPluginName* parameter in both master and node configuration files.
-. Restart openshift-master service on master and openshift-node service on all nodes.
+. Restart atomic-openshift-master service on master and atomic-openshift-node service on all nodes.
 
 When switching from ovssubnet to multitenant plug-in, all the existing projects in the cluster
 will be fully isolated (assigned unique VNIDs). Admin can choose to join or unisolate project

--- a/dev_guide/quota.adoc
+++ b/dev_guide/quota.adoc
@@ -214,7 +214,7 @@ services                3       5
 
 When a set of resources are deleted, the synchronization timeframe of resources
 is determined by the `*resource-quota-sync-period*` setting in the
-*_/etc/openshift/master/master-config.yaml_* file. Before your quota usage is
+*_/etc/origin/master/master-config.yaml_* file. Before your quota usage is
 restored, you may encounter problems when attempting to reuse the resources.
 Change the `*resource-quota-sync-period*` setting to have the set of resources
 regenerate at the desired amount of time (in seconds) and for the resources to

--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -62,7 +62,7 @@ the OpenShift container.
 $ sudo docker run -d --name "origin" \
         --privileged --pid=host --net=host \
         -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /var/lib/docker:/var/lib/docker:rw \
-        -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
+        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes \
         openshift/origin start
 ----
 +

--- a/install_config/upgrades.adoc
+++ b/install_config/upgrades.adoc
@@ -145,6 +145,23 @@ upgrade process.
 [[upgrading-masters]]
 
 === Upgrading Masters
+ifdef::openshift-origin[]
+Upgrade your masters first. On each master host, upgrade the *origin-master*
+package:
+
+----
+# yum upgrade origin-master
+----
+
+Then, restart the *origin-master* service and review its logs to ensure
+services have been restarted successfully:
+
+----
+# systemctl restart origin-master
+# journalctl -r -u origin-master
+----
+endif::[]
+ifdef::openshift-enterprise[]
 Upgrade your masters first. On each master host, upgrade the *atomic-openshift-master*
 package:
 
@@ -159,6 +176,7 @@ services have been restarted successfully:
 # systemctl restart atomic-openshift-master
 # journalctl -r -u atomic-openshift-master
 ----
+endif::[]
 
 [[updating-policy-definitions]]
 
@@ -210,16 +228,36 @@ made, or you can automatically apply the new policy by running:
 
 === Upgrading Nodes
 After upgrading your masters, you can upgrade your nodes. When restarting the
+ifdef::openshift-origin[]
+*origin-node* service, there will be a brief disruption of outbound network
+endif::[]
+ifdef::openshift-enterprise[]
 *atomic-openshift-node* service, there will be a brief disruption of outbound network
+endif::[]
 connectivity from running pods to services while the
 link:../architecture/infrastructure_components/kubernetes_infrastructure.html#service-proxy[service
 proxy] is restarted. The length of this disruption should be very short and
 scales based on the number of services in the entire cluster.
 
-On each node host, upgrade all *openshift* packages:
+ifdef::openshift-origin[]
+On each node host, upgrade all *origin* packages:
 
 ----
-# yum upgrade openshift\*
+# yum upgrade origin\*
+----
+
+Then, restart the *origin-node* service:
+
+----
+# systemctl restart origin-node
+----
+endif::[]
+
+ifdef::openshift-enterprise[]
+On each node host, upgrade all *atomic-openshift* packages:
+
+----
+# yum upgrade atomic-openshift\*
 ----
 
 Then, restart the *atomic-openshift-node* service:
@@ -227,6 +265,7 @@ Then, restart the *atomic-openshift-node* service:
 ----
 # systemctl restart atomic-openshift-node
 ----
+endif::[]
 
 As a user with *cluster-admin* privileges, verify that all nodes are showing as
 *Ready*:

--- a/install_config/upgrades.adoc
+++ b/install_config/upgrades.adoc
@@ -145,19 +145,19 @@ upgrade process.
 [[upgrading-masters]]
 
 === Upgrading Masters
-Upgrade your masters first. On each master host, upgrade the *openshift-master*
+Upgrade your masters first. On each master host, upgrade the *atomic-openshift-master*
 package:
 
 ----
-# yum upgrade openshift-master
+# yum upgrade atomic-openshift-master
 ----
 
-Then, restart the *openshift-master* service and review its logs to ensure
+Then, restart the *atomic-openshift-master* service and review its logs to ensure
 services have been restarted successfully:
 
 ----
-# systemctl restart openshift-master
-# journalctl -r -u openshift-master
+# systemctl restart atomic-openshift-master
+# journalctl -r -u atomic-openshift-master
 ----
 
 [[updating-policy-definitions]]
@@ -210,7 +210,7 @@ made, or you can automatically apply the new policy by running:
 
 === Upgrading Nodes
 After upgrading your masters, you can upgrade your nodes. When restarting the
-*openshift-node* service, there will be a brief disruption of outbound network
+*atomic-openshift-node* service, there will be a brief disruption of outbound network
 connectivity from running pods to services while the
 link:../architecture/infrastructure_components/kubernetes_infrastructure.html#service-proxy[service
 proxy] is restarted. The length of this disruption should be very short and
@@ -222,10 +222,10 @@ On each node host, upgrade all *openshift* packages:
 # yum upgrade openshift\*
 ----
 
-Then, restart the *openshift-node* service:
+Then, restart the *atomic-openshift-node* service:
 
 ----
-# systemctl restart openshift-node
+# systemctl restart atomic-openshift-node
 ----
 
 As a user with *cluster-admin* privileges, verify that all nodes are showing as
@@ -684,7 +684,7 @@ upgrade steps].
 *Configuring serviceNetworkCIDR for the SDN*
 
 Add the `*serviceNetworkCIDR*` parameter to the `*networkConfig*` section in
-*_/etc/openshift/master/master-config.yaml_*. This value should match the
+*_/etc/origin/master/master-config.yaml_*. This value should match the
 `*servicesSubnet*` value in the `*kubernetesMasterConfig*` section:
 
 ====
@@ -704,7 +704,7 @@ fields when deployed using the quick or advanced installation methods. This will
 affect future upgrades, so it is important to add those values if they do not
 exist.
 
-Modify the *_/etc/openshift/master/scheduler.json_* file to add the `*kind*` and
+Modify the *_/etc/origin/master/scheduler.json_* file to add the `*kind*` and
 `*apiVersion*` fields:
 
 ====

--- a/whats_new/ose_3_0_release_notes.adoc
+++ b/whats_new/ose_3_0_release_notes.adoc
@@ -479,7 +479,7 @@ managed. (https://bugzilla.redhat.com/show_bug.cgi?id=1242312[BZ#1242312])
 * If the *nfs-utils* package was not installed on a node host, when a user tried
 to add an NFS volume to an application, the mount operation would fail for the
 pod. This bug fix adds the *nfs-utils* package as a dependency for the
-*openshift-node* package so it is installed on all node hosts by default.
+*atomic-openshift-node* package so it is installed on all node hosts by default.
 (https://bugzilla.redhat.com/show_bug.cgi?id=1238565[BZ#1238565])
 * Previously, pruning images associated with an image stream that had been
 removed would fail. This bug fix updates layer pruning to always delete blobs


### PR DESCRIPTION
Handle service and package renames
- openshift-{master,node} -> origin-{master,node} and atomic-openshift-{master,node} for origin and enterprise respectively
- /etc/openshift -> /etc/origin
- /var/lib/openshift -> /var/lib/origin
- /etc/sysconfig/openshift-{master,node} -> /etc/sysconfig/origin-{master,node} and /etc/sysconfig/atomic-openshift-{master,node}  for origin and enterprise respectively
