### PR TITLE
Fixes to Quick Install for 3.1

### DIFF
--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -25,16 +25,15 @@ easier by link:#running-an-interactive-installation[interactively gathering the
 data] needed to run on each host. The utility is a self-contained wrapper
 intended for usage on a Red Hat Enterprise Linux 7 host.
 
-In addition to being able to run
-link:#running-an-interactive-installation[interactive installations] from
-scratch, the `atomic-openshift-installer` command can also be run or re-run
-using a predefined installation configuration file. This file can be used with
-the installation utility to:
+In addition to running link:#running-an-interactive-installation[interactive
+installations] from scratch, the `atomic-openshift-installer` command can also
+be run or re-run using a predefined installation configuration file. This file
+can be used with the installation utility to:
 
 - run an link:#running-an-unattended-installation[unattended installation],
-- add hosts to an existing cluster,
+- link:#adding-nodes-or-reinstalling[add nodes] to an existing cluster,
 - link:../../install_config/upgrades.html[upgrade your cluster], or
-- re-install OpenShift completely.
+- link:#adding-nodes-or-reinstalling[reinstall] the OpenShift cluster completely.
 endif::[]
 
 Alternatively, you can use the link:advanced_install.html[advanced installation]
@@ -164,6 +163,11 @@ an unattended installation, the installation fails.
 must be set to *true* for the configuration file to be considered valid.
 <10> If set to *true*, OpenShift services are run in a container on this host
 instead of installed using RPM packages.
+ifdef::openshift-enterprise[]
+Containerized installations are in Technology Preview in OpenShift Enterprise
+3.1.
+endif::[]
+
 ====
 
 [[running-an-unattended-installation]]
@@ -191,7 +195,7 @@ file] at *_~/.config/openshift/installer.cfg.yml_*. Then, run the installation
 utility with the `-u` flag:
 
 ----
-$ atomic-openshift-installer install -u
+$ atomic-openshift-installer -u install
 ----
 
 By default in interactive or unattended mode, the installation utility uses the
@@ -202,33 +206,49 @@ configuration file using the `-c` option, but doing so will require you to
 specify the file location every time you run the installation:
 
 ----
-$ atomic-openshift-installer install -u -c </path/to/file>
+$ atomic-openshift-installer -u -c </path/to/file> install
 ----
 
-After the unattended installation finishs, ensure that you back up the
+After the unattended installation finishes, ensure that you back up the
 *_~/.config/openshift/installer.cfg.yml_* file that was used, as it is required
 if you later want to re-run the installation, add hosts to the cluster, or
 link:../../install_config/upgrades.html[upgrade your cluster]. Then, see
 link:#quick-install-whats-next[What's Next] for the next steps on configuring
 your OpenShift cluster.
 
-[[re-running-the-installation]]
+[[adding-nodes-or-reinstalling]]
 
-== Re-running the Installation
+== Adding Nodes or Reinstalling the Cluster
 
 Whether you began the process using an
 link:#running-an-interactive-installation[interactive] or
 link:#running-an-unattended-installation[unattended] installation, you can
 re-run the installation as long as you have an
 link:#defining-an-installation-configuration-file[installation configuration
-file] at *_~/.config/openshift/installer.cfg.yml_*.
+file] at *_~/.config/openshift/installer.cfg.yml_* (or specify its location with
+the `-c` option).
 
-To re-run an installation, the process is the same as
-link:#running-an-unattended-installation[running an unattended installation]:
+To re-run an installation, use the `install` subcommand again in interactive or
+unattended mode:
 
 ----
-$ atomic-openshift-installer install -u
+$ atomic-openshift-installer install
 ----
+
+The installer will detect your installed environment and allow you to either add
+an additional node or perform a clean install:
+
+====
+----
+Gathering information from hosts...
+Installed environment detected.
+By default the installer only adds new nodes to an installed environment.
+Do you want to (1) only add additional nodes or (2) perform a clean install?:
+----
+====
+
+Choose one of the options and follow the on-screen  instructions to complete
+your desired task.
 
 [[uninstalling-openshift-quick]]
 


### PR DESCRIPTION
Adjusts flags for `install` subcommand, some minor fixes, and adds info about adding nodes.

cc @dgoodwin @smunilla 

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/111115/fix_quick_install31/install_config/install/quick_install.html
