### PR TITLE
Fixing webhook information regarding secret field

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -628,7 +628,7 @@ Level 0:: Produces output from containers running the *_assemble_* script and al
 Level 1:: Produces basic information about the executed process.
 Level 2:: Produces very detailed information about the executed process.
 Level 3:: Produces very detailed information about the executed process, and a listing of the archive contents.
-Level 4:: Currently produces the same information as level 3. 
+Level 4:: Currently produces the same information as level 3.
 Level 5:: Produces everything mentioned on previous levels and additionally provides docker push messages.
 
 [[source-code]]
@@ -710,10 +710,10 @@ https://developer.github.com/webhooks/[GitHub webhooks] or Generic webhooks.
 
 https://developer.github.com/webhooks/creating/[GitHub webhooks] handle the call
 made by GitHub when a repository is updated. When defining the trigger, you must
-specify a link:../dev_guide/secrets.html[`*secret*`] as part of the URL you supply
-to GitHub when configuring the webhook. The `*secret*` ensures that only you and
-your repository can trigger the build. The following example is a trigger
-definition JSON within the `*BuildConfig*`:
+specify a `*secret*`, which will be part of the URL you supply to GitHub when
+configuring the webhook. The secret ensures the uniqueness of the URL, preventing
+others from triggering the build. The following example is a trigger definition
+JSON within the `*BuildConfig*`:
 
 ====
 
@@ -727,6 +727,15 @@ definition JSON within the `*BuildConfig*`:
 ----
 ====
 
+[NOTE]
+====
+The secret field in webhook trigger configuration is not the same as `*secret*`
+field you encounter when configuring webhook in GitHub UI. The former is to make
+the webhook URL unique and hard to predict, the latter is an optional string field
+used to create HMAC hex digest of the body, which is sent as an `X-Hub-Signature`
+https://developer.github.com/webhooks/#delivery-headers[header].
+====
+
 The payload URL is returned as the GitHub Webhook URL by the `describe` command
 (see link:#describe-buildconfig[below]), and is structured as follows:
 
@@ -737,9 +746,10 @@ http://<openshift_api_host:port>/osapi/v1/namespaces/<namespace>/buildconfigs/<n
 *Generic Webhooks*
 
 Generic webhooks can be invoked from any system capable of making a web
-request. As with a GitHub webhook, you must specify a `*secret*` when defining the
-trigger, and the caller must provide this `*secret*` to trigger the build. The
-following is an example trigger definition JSON within the `*BuildConfig*`:
+request. As with a GitHub webhook, you must specify a `*secret*` which will be
+part of the URL, the caller must use to trigger the build. The secret ensures
+the uniqueness of the URL, preventing others from triggering the build.
+The following is an example trigger definition JSON within the `*BuildConfig*`:
 
 ====
 


### PR DESCRIPTION
This came out from https://github.com/openshift/origin/issues/5789. 
We're having a couple of secrets all over the systems and not always they meant the same thing, in case of webhooks these are totally different from [these secrets](https://docs.openshift.org/latest/dev_guide/secrets.html).

@bparees @adellape ptal
