### PR TITLE
document healthcheck fields ‘initialDelaySeconds’ and ‘timeoutSeconds’

### DIFF
--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -48,7 +48,7 @@ The exact timing of a probe is controlled by two fields,
 both expressed in units of seconds:
 
 |====
-| Field | Meaning
+| Field | Description
 
 | `initialDelaySeconds`
 | How long to wait after the container starts to begin the probe.

--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -54,7 +54,7 @@ both expressed in units of seconds:
 | How long to wait after the container starts to begin the probe.
 
 | `timeoutSeconds`
-| How long to wait for the probe to end.
+| How long to wait for the probe to finish.
 If this time is exceeded, OpenShift considers the probe to have failed.
 
 |====

--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -44,6 +44,21 @@ Set a readiness check by configuring the
 
 |===
 
+The exact timing of a probe is controlled by two fields,
+both expressed in units of seconds:
+
+|====
+| Field | Meaning
+
+| `initialDelaySeconds`
+| How long to wait after the pod is deployed to begin the probe.
+
+| `timeoutSeconds`
+| How long to wait for the probe to end.
+If this time is exceeded, OpenShift considers the probe to have failed.
+
+|====
+
 Both probes can be configured in three ways:
 
 *HTTP Checks*

--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -51,7 +51,7 @@ both expressed in units of seconds:
 | Field | Meaning
 
 | `initialDelaySeconds`
-| How long to wait after the pod is deployed to begin the probe.
+| How long to wait after the container starts to begin the probe.
 
 | `timeoutSeconds`
 | How long to wait for the probe to end.

--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -54,7 +54,7 @@ both expressed in units of seconds:
 | How long to wait after the container starts to begin the probe.
 
 | `timeoutSeconds`
-| How long to wait for the probe to finish.
+| How long to wait for the probe to finish (default: `1`).
 If this time is exceeded, OpenShift considers the probe to have failed.
 
 |====

--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -50,10 +50,10 @@ both expressed in units of seconds:
 |====
 | Field | Description
 
-| `initialDelaySeconds`
+| `*initialDelaySeconds*`
 | How long to wait after the container starts to begin the probe.
 
-| `timeoutSeconds`
+| `*timeoutSeconds*`
 | How long to wait for the probe to finish (default: `1`).
 If this time is exceeded, OpenShift considers the probe to have failed.
 


### PR DESCRIPTION
This is for [BZ 1267216](https://bugzilla.redhat.com/show_bug.cgi?id=1267216).

@nak3 PTAL
Pretty rendering: https://github.com/tnguyen-rh/openshift-docs/blob/bz1267216/dev_guide/application_health.adoc
