### PR TITLE
small fixes for GlusterFS and Ceph persistent storage

### DIFF
--- a/install_config/persistent_storage/persistent_storage_ceph_rbd.adoc
+++ b/install_config/persistent_storage/persistent_storage_ceph_rbd.adoc
@@ -33,7 +33,7 @@ High-availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====
 
-[[gfs-provisioning]]
+[[ceph-provisioning]]
 
 == Provisioning
 Storage must exist in the underlying infrastructure before it can be mounted as
@@ -50,7 +50,7 @@ You must also ensure *ceph-fuse* is installed on all OpenShift nodes in the clus
 ----
 
 
-[[gfs-creating-persistent-volume]]
+[[ceph-creating-persistent-volume]]
 
 === Creating the Persistent Volume
 
@@ -70,7 +70,7 @@ spec:
   capacity:
     storage: "2Gi" <2>
   accessModes:
-    - "ReadWriteOnce" <3> 
+    - "ReadWriteOnce" <3>
   rbd: <4>
     monitors:
       - "192.168.122.111:6789" <5>
@@ -78,7 +78,7 @@ spec:
     image: foo
     user: admin
     secretRef:
-      name: "ceph-secret" <6> 
+      name: "ceph-secret" <6>
     fsType: ext4
     readOnly: false
   persistentVolumeReclaimPolicy: "Recycle"
@@ -87,7 +87,7 @@ spec:
 link:../../architecture/additional_concepts/storage.html[persistent volume
 claims] or from pods.
 <2> The amount of storage allocated to this volume.
-<3> This is the access type to the block storage. All block storage is defined to be single user (Non-shared storage).
+<3> This is the access type to the block storage. All block storage is defined to be single user (non-shared storage).
 <4> This defines the volume type being used, in this case the *rbd*
 plug-in.
 <5> This is the Ceph monitor address and port.

--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -68,17 +68,17 @@ kind: Endpoints
 metadata:
   name: glusterfs-cluster
 subsets:
-- addresses:
-  - ip: 192.168.122.221 <1>
-  ports:
-  - port: 1
-- addresses:
-  - ip: 192.168.122.222 <1>
-  ports:
-  - port: 1
+  - addresses:
+      - ip: 192.168.122.221 <1>
+    ports:
+      - port: 1
+  - addresses:
+      - ip: 192.168.122.222 <1>
+    ports:
+      - port: 1
 ----
-<1> This value must be an actual IP address of a Gluster server, not a fully
-qualified host name. This requirement could change in future releases.
+<1> The `*ip*` values must be the actual IP addresses of a Gluster server, not
+fully-qualified host names. This requirement could change in future releases.
 ====
 
 Save your endpoints definition to a file, for example
@@ -166,17 +166,13 @@ Users can then link:../../dev_guide/persistent_volumes.html[request storage
 using persistent volume claims], which can now utilize your new persistent
 volume.
 
-
-
-
 [[gluster-volume-security]]
 
 === Volume Security
-Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in
+Users request storage with a `*PersistentVolumeClaim*`. This claim exists only in
 the user's namespace and can only be referenced by a pod within that same
 namespace. Any attempt to access a persistent volume across a namespace causes
 the pod to fail.
-
 
 Also, each node in the cluster should enable the following SELinux booleans by running the following
 commands on each node:
@@ -191,4 +187,3 @@ commands on each node:
 ====
 
 Additionally, permissions and ownership can be controlled as normal by the Gluster server administrators using normal POSIX compliant security.
-


### PR DESCRIPTION
@bfallonf @tpoitras @adellape PTAL
The fixes are small, but i notice that some of them (e.g., `s/lives/exists/`) should also be applied to the peer persistent storage docs.  One thing that i initially changed, but changed back, was `s/via/from/` as "via" is Latin.  I changed it back because i see "via" used everywhere.
