### PR TITLE
Modify nav template headers to prevent jumping to top of page

### DIFF
--- a/_templates/_nav.html.erb
+++ b/_templates/_nav.html.erb
@@ -2,7 +2,7 @@
   <%- navigation.each.with_index do |topic_group, groupidx| -%>
     <%- current_group = topic_group[:id] == group_id -%>
     <li class="nav-header">
-      <a class="" href="#" data-toggle="collapse" data-target="#topicGroup<%= groupidx %>">
+      <a class="" href="javascript:void(0);" data-toggle="collapse" data-target="#topicGroup<%= groupidx %>">
         <span id="tgSpan<%= groupidx %>" class="fa <%= current_group ? 'fa-angle-down' : 'fa-angle-right' %>"></span><%= topic_group[:name] %>
       </a>
       <ul id="topicGroup<%= groupidx %>" class="collapse <%= current_group ? 'in' : '' %> list-unstyled">
@@ -13,7 +13,7 @@
           <%- else -%>
             <%- current_subgroup = topic[:id] == subgroup_id -%>
             <li class="nav-header">
-              <a class="" href="#" data-toggle="collapse" data-target="#topicSubGroup-<%= groupidx %>-<%= topicidx %>">
+              <a class="" href="javascript:void(0);" data-toggle="collapse" data-target="#topicSubGroup-<%= groupidx %>-<%= topicidx %>">
                 <span id="sgSpan-<%= groupidx %>-<%= topicidx %>" class="fa <%= current_subgroup ? 'fa-caret-down' : 'fa-caret-right' %>"></span>&nbsp;<%= topic[:name] %>
               </a>
               <ul id="topicSubGroup-<%= groupidx %>-<%= topicidx %>" class="nav-tertiary list-unstyled collapse<%= current_subgroup ? ' in' : '' %>">


### PR DESCRIPTION
If a user has scrolled down the page and then clicks a heading in the left-hand nav bar, this change will prevent the browser from jumping back to the top of the current page as the result the click.
