### PR TITLE
syncing_groups, persistent_storage_aws: fix typos

### DIFF
--- a/install_config/persistent_storage/persistent_storage_aws.adoc
+++ b/install_config/persistent_storage/persistent_storage_aws.adoc
@@ -47,7 +47,7 @@ storage provider.
 Storage must exist in the underlying infrastructure before it can be mounted as
 a volume in OpenShift. After ensuring OpenShift is
 link:../../install_config/configuring_aws.html[configured for AWS Elastic Block
-Store], all that is required for Openshift and AWS is an AWS EBS volume ID and
+Store], all that is required for OpenShift and AWS is an AWS EBS volume ID and
 the `*PersistentVolume*` API.
 
 [[aws-creating-persistent-volume]]

--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -15,7 +15,7 @@ change their permissions, or to enhance collaboration. Your organization may
 have already created user groups and stored them in an LDAP server. OpenShift
 can sync those LDAP records with internal OpenShift records, allowing you
 to simply manage your groups in one place. OpenShift currently supports group
-sync with LDAP servers using three common schema for defining group
+sync with LDAP servers using three common schemas for defining group
 membership: RFC 2307, Active Directory, and augmented Active Directory.
 
 [NOTE]
@@ -164,7 +164,7 @@ server specified in the configuration file:
 $ openshift ex sync-groups --type=openshift --sync-config=config.yaml --confirm
 ----
 
-To sync a subset of LDAP groups with Openshift you can use whitelist
+To sync a subset of LDAP groups with OpenShift, you can use whitelist
 files, blacklist files, or both:
 
 [NOTE]


### PR DESCRIPTION
Fix a few typos:

• "Openshift" -> "OpenShift".

• "schema" -> "schemas".
## 

I was going to use the plural form "schemata" but saw we were using "schemas" elsewhere.  I thought about making a PR to change all occurrences of "schemas" to "schemata" but didn't want to get yelled at.
