### PR TITLE
for ‘v1.ProjectRequest’, declare as required ‘apiVersion’ and ‘metadata.name’

### DIFF
--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -9132,8 +9132,8 @@ A deployment is "triggered" when its configuration is changed or a tag in an Ima
 |===
 |Name|Description|Required|Schema|Default
 |kind|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds|false|string|
-|apiVersion|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources|false|string|
-|metadata||false|<<v1.ObjectMeta>>|
+|apiVersion|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources|true|string|
+|metadata||subfield `name`|<<v1.ObjectMeta>>|
 |displayName|display name to apply to a project|false|string|
 |description|description to apply to a project|false|string|
 |===


### PR DESCRIPTION
This is a replay of  https://github.com/openshift/openshift-docs/pull/926 (same [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1244889), even).  See comments 21 and onward.
