### PR TITLE
Add per-distro search functionality

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -22,7 +22,11 @@
 }
 
 td.gsc-clear-button {
-    display: none;
+  display: none;
+}
+
+div.gsc-option-menu-container > div.gsc-selected-option-container {
+  width: auto !important
 }
 
 /* ------------------------------------------------------------

--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -15,6 +15,16 @@
   background-size: 140px;
   margin-left: 20px;
 }
+
+/* Tweaks for the Google-generated search widget */
+.cse .gsc-control-cse, .gsc-control-cse, table.gsc-search-box td.gsc-input {
+  padding: 0;
+}
+
+td.gsc-clear-button {
+    display: none;
+}
+
 /* ------------------------------------------------------------
 Image: "Spin" https://www.flickr.com/photos/eflon/3655695161/
 Author: eflon https://www.flickr.com/photos/eflon/

--- a/_templates/_search.html.erb
+++ b/_templates/_search.html.erb
@@ -1,0 +1,9 @@
+<% if distro_key == 'openshift-origin' %>
+<%= render("_templates/_search_origin.html") %>
+<% elsif distro_key == 'openshift-dedicated' %>
+<%= render("_templates/_search_dedicated.html") %>
+<% elsif distro_key == 'openshift-online' %>
+<%= render("_templates/_search_online.html") %>
+<% else %>
+<%= render("_templates/_search_other.html") %>
+<% end %>

--- a/_templates/_search_dedicated.html
+++ b/_templates/_search_dedicated.html
@@ -1,0 +1,13 @@
+<script>
+  (function() {
+    var cx = '013769182564158614814:ykypjfbua0a';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+        '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>

--- a/_templates/_search_online.html
+++ b/_templates/_search_online.html
@@ -1,0 +1,13 @@
+<script>
+  (function() {
+    var cx = '013769182564158614814:nh-uallhxiy';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+        '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>

--- a/_templates/_search_origin.html
+++ b/_templates/_search_origin.html
@@ -1,0 +1,12 @@
+<script>
+  (function() {
+    var cx = '013769182564158614814:vdyz7waqya4';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>

--- a/_templates/_search_other.html
+++ b/_templates/_search_other.html
@@ -1,0 +1,12 @@
+<script>
+  (function() {
+    var cx = '013769182564158614814:e-dp46b51vk';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>

--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -54,6 +54,9 @@
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
+        <div class="row-fluid">
+          <%= render("_templates/_search.html.erb", :distro_key => distro_key) %>
+        </div>
         <%= render("_templates/_nav.html.erb", :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim) %>
       </div>
       <div class="col-xs-12 col-sm-9 col-md-9 main">


### PR DESCRIPTION
This PR adds a search field to the documentation page template. Search is primarily limited by distro, and within a given distro, search is further segmented by version. This PR addresses https://github.com/openshift/openshift-docs/issues/1235 and supercedes https://github.com/openshift/openshift-docs/pull/349

@adellape or @vikram-redhat please review.
