### PR TITLE
Add documentation for OSE 3.1 to 3.0 downgrade.

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -243,6 +243,9 @@ Topics:
     File: building_dependency_trees
   - Name: Troubleshooting Networking
     File: sdn_troubleshooting
+  - Name: Downgrading to 3.0
+    File: downgrade
+    Distros: openshift-enterprise
 
 ---
 Name: CLI Reference

--- a/admin_guide/downgrade.adoc
+++ b/admin_guide/downgrade.adoc
@@ -1,0 +1,251 @@
+= Downgrading OpenShift Enterprise 3.1 to 3.0
+{product-author}
+{product-version}
+:icons: font
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+:description: Manual steps to revert to OpenShift 3.0 after an upgrade to 3.1.
+:keywords: yum
+
+toc::[]
+
+== Overview
+In extreme cases it may be desirable to downgrade to 3.0 following an upgrade with atomic-openshift-installer, or the openshift-ansible playbooks. The following steps will help to explain the steps that are required on each system in the cluster.
+
+== Step 1: Verify Backups Are In Place
+
+The openshift-ansible upgrade playbooks should have created a backup of the master-config.yaml, and the etcd data directory. Please ensure these exist on your masters/etcd members. In the case of a separate etcd cluster, the backup is likely created on all etcd members, though we'll only need one to recover.
+
+====
+----
+/etc/openshift/master/master-config.yaml.[TIMESTAMP]
+/var/lib/openshift/etcd-backup-[TIMESTAMP]
+----
+====
+
+The rpm downgrade will likely create .rpmsave backups of these files, but it may be a good idea to keep a separate copy of them regardless:
+
+====
+----
+/etc/sysconfig/openshift-master
+/etc/etcd/etcd.conf (if using a separate etcd cluster)
+----
+====
+
+
+== Step 2: Shutdown Cluster
+
+On all masters, nodes, and etcd members (if using a separate etcd cluster), ensure relevant services are stopped.
+
+====
+----
+$ systemctl stop atomic-openshift-master
+$ systemctl stop atomic-openshift-node
+$ systemctl stop etcd
+----
+====
+
+== Step 3: Remove 3.1 Atomic OpenShift RPMs
+
+On each master / node / etcd member:
+
+====
+----
+yum remove atomic-openshift atomic-openshift-clients atomic-openshift-node atomic-openshift-master etcd openvswitch tuned-projects-atomic-openshift-node atomic-openshift-sdn-ovs tuned-profiles-atomic-openshift-node
+----
+====
+
+
+== Step 4: Re-install 3.0 RPMs
+
+Disable 3.1 repositories, and re-enable 3.0 repositories:
+
+====
+----
+$ subscription-manager repos --disable=rhel-7-server-ose-3.1-rpms --enable=rhel-7-server-ose-3.0-rpms
+----
+====
+
+On each OpenShift master:
+
+====
+----
+$ yum install openshift openshift-master openshift-node openshift-sdn-ovs
+----
+====
+
+On each OpenShift node:
+
+====
+----
+$ yum install openshift openshift-node openshift-sdn-ovs
+----
+====
+
+If using a separate etcd cluster, on each etcd member:
+
+====
+----
+$ yum install etcd
+----
+====
+
+
+== Step 5: Restore etcd
+
+=== Create New Etcd Cluster From Backup
+
+For both embedded etcd as well as separate etcd clusters, the first step is to restore the backup by creating a new single node etcd cluster.
+
+Choose a system to be the initial etcd member and restore it's backup and configuration.
+
+WARNING: If you are using embedded non-clustered etcd, please use /var/lib/openshift/openshift.local.etcd for ETCD_DIR in the commands below. If you are using a separate etcd cluster, please use /var/lib/etcd/ for ETCD_DIR.
+
+====
+----
+$ mv $ETCD_DIR /var/lib/etcd.orig
+$ cp -Rp /var/lib/openshift/etcd-backup-20151120093517/ $ETCD_DIR
+$ chcon -R --reference /var/lib/etcd.orig/ $ETCD_DIR
+$ chown -R etcd:etcd $ETCD_DIR
+----
+====
+
+If you are using a separate etcd cluster, you should also restore /etc/etcd/etcd.conf from backup or .rpmsave.
+
+We now create the new single node cluster using etcd's --force-new-cluster option. We can do this with a long complex command using the values from /etc/etcd/etcd.conf, or we can temporarily modify the systemd file and start the service normally.
+
+Edit /usr/lib/systemd/system/etcd.service and add --force-new-cluster:
+
+====
+----
+$ sed -i '/ExecStart/s/"$/  --force-new-cluster"/' /usr/lib/systemd/system/etcd.service
+$ cat /usr/lib/systemd/system/etcd.service  | grep ExecStart
+ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd --force-new-cluster"
+$ systemctl daemon-reload
+$ systemctl start etcd
+----
+====
+
+Verify the etcd service started correctly, then re-edit /usr/lib/systemd/system/etcd.service and remove the --force-new-cluster option.
+
+====
+----
+$ sed -i '/ExecStart/s/ --force-new-cluster//' /usr/lib/systemd/system/etcd.service
+$ cat /usr/lib/systemd/system/etcd.service  | grep ExecStart
+ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd"
+$ systemctl daemon-reload
+$ systemctl restart etcd
+----
+====
+
+Etcd should now be running correctly and will display OpenShift's configuration:
+
+====
+----
+etcdctl --cert-file=/etc/etcd/peer.crt --key-file=/etc/etcd/peer.key --ca-file=/etc/etcd/ca.crt --peers="https://172.16.4.18:2379,https://172.16.4.27:2379" ls /
+----
+====
+
+
+### Add Additional Etcd Members
+
+If you are using a separate etcd cluster additional steps are necessary.
+
+Adjust the default localhost peerURL for the first member so we can add additional members to the cluster.
+
+Get the member ID for the first member:
+
+====
+----
+$ etcdctl --cert-file=/etc/etcd/peer.crt --key-file=/etc/etcd/peer.key --ca-file=/etc/etcd/ca.crt --peers="https://172.18.1.18:2379,https://172.18.9.202:2379,https://172.18.0.75:2379" member list
+----
+====
+
+Update the peerURL. In etcd 2.2 and beyond this can be done with etcdctl member update. On etcd 2.1 and below we must use curl:
+
+====
+----
+$ curl --cacert /etc/etcd/ca.crt --cert /etc/etcd/peer.crt --key /etc/etcd/peer.key https://172.18.1.18:2379/v2/members/511b7fb6cc0001 -XPUT -H "Content-Type: application/json" -d '{"peerURLs":["https://172.18.1.18:2380"]}'
+----
+====
+
+Re-run member list and ensure the peerURLs no longer points to localhost.
+
+Now we add each member to the cluster, one at a time.
+
+WARNING: Each member must be fully added and brought online one at a time.
+
+WARNING: When adding each member to the cluster, the peerURL list must be correct for that point in time, so it will grow by one for each member we add. The etcdctl "member add" command will output the values that need to be set in etcd.conf as you add each member.
+
+For each member, add it to the cluster using the values that can be found in that system's etcd.conf:
+
+====
+----
+$ etcdctl --cert-file=/etc/etcd/peer.crt --key-file=/etc/etcd/peer.key --ca-file=/etc/etcd/ca.crt --peers="https://172.16.4.18:2379,https://172.16.4.27:2379" member add 10.3.9.222 https://172.16.4.27:2380
+Added member named 10.3.9.222 with ID 4e1db163a21d7651 to cluster
+
+ETCD_NAME="10.3.9.222"
+ETCD_INITIAL_CLUSTER="10.3.9.221=https://172.16.4.18:2380,10.3.9.222=https://172.16.4.27:2380"
+ETCD_INITIAL_CLUSTER_STATE="existing"
+----
+====
+
+The output contains the environment variables we need. Edit /etc/etcd/etcd.conf on the member system itself and ensure these settings match.
+
+We are now ready to start etcd on the new member:
+
+====
+----
+$ rm -rf /var/lib/etcd/member
+$ systemctl enable etcd
+$ systemctl start etcd
+----
+====
+
+Ensure the service starts correctly and the etcd cluster is now healthy.
+
+====
+----
+$ etcdctl --cert-file=/etc/etcd/peer.crt --key-file=/etc/etcd/peer.key --ca-file=/etc/etcd/ca.crt --peers="https://172.16.4.18:2379,https://172.16.4.27:2379" member list
+51251b34b80001: name=10.3.9.221 peerURLs=https://172.16.4.18:2380 clientURLs=https://172.16.4.18:2379
+d266df286a41a8a4: name=10.3.9.222 peerURLs=https://172.16.4.27:2380 clientURLs=https://172.16.4.27:2379
+
+$ etcdctl --cert-file=/etc/etcd/peer.crt --key-file=/etc/etcd/peer.key --ca-file=/etc/etcd/ca.crt --peers="https://172.16.4.18:2379,https://172.16.4.27:2379" cluster-health
+cluster is healthy
+member 51251b34b80001 is healthy
+member d266df286a41a8a4 is healthy
+----
+====
+
+Now repeat this process for the next member to add to the cluster.
+
+== Step 6: Bring OpenShift Services Back Online
+
+=== OpenShift Masters
+
+Restore your openshift-master configuration from backup:
+
+====
+----
+$ cp /etc/sysconfig/openshift-master.rpmsave /etc/sysconfig/openshift-master
+$ cp /etc/openshift/master/master-config.yaml.2015-11-20\@08\:36\:51~ /etc/openshift/master/master-config.yaml
+$ systemctl enable openshift-master
+$ systemctl enable openshift-node
+$ systemctl start openshift-master
+$ systemctl start openshift-node
+----
+====
+
+=== OpenShift Nodes
+
+====
+----
+$ systemctl enable openshift-node
+$ systemctl start openshift-node
+----
+====
+
+Your cluster should now be back online.
+


### PR DESCRIPTION
Documents the process of reverting to 3.0 rpms after an upgrade, and restoring
etcd, and various configuration files from backups.

Apologies as this is still a little rough around the edges but I wanted to get review started ASAP so I can get this into line quickly.

Ping @adellape
