### PR TITLE
Fix paths in 2.7.3 - Creating images streams

### DIFF
--- a/install_config/install/first_steps.adoc
+++ b/install_config/install/first_steps.adoc
@@ -83,7 +83,7 @@ want to use the Red Hat Enterprise Linux (RHEL) 7 based images:
 
 ----
 $ oc create -f \
-    openshift-ansible/roles/openshift_examples/files/examples/image-streams/image-streams-rhel7.json \
+    openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams/image-streams-rhel7.json \
     -n openshift
 ----
 
@@ -92,7 +92,7 @@ based images:
 
 ----
 $ oc create -f \
-    openshift-ansible/roles/openshift_examples/files/examples/image-streams/image-streams-centos7.json \
+    openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams/image-streams-centos7.json \
     -n openshift
 ----
 
@@ -113,7 +113,7 @@ To create the xPaaS Middleware set of image streams:
 
 ----
 $ oc create -f \
-    openshift-ansible/roles/openshift_examples/files/examples/xpaas-streams/jboss-image-streams.json \
+    openshift-ansible/roles/openshift_examples/files/examples/v1.1/xpaas-streams/jboss-image-streams.json \
     -n openshift
 ----
 
@@ -147,7 +147,7 @@ To create the core set of database templates:
 
 ----
 $ oc create -f \
-    openshift-ansible/roles/openshift_examples/files/examples/db-templates -n openshift
+    openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates -n openshift
 ----
 
 After creating the templates, users are able to easily instantiate the various
@@ -188,7 +188,7 @@ To create the core InstantApp templates:
 
 ----
 $ oc create -f \
-    openshift-ansible/roles/openshift_examples/files/examples/quickstart-templates -n openshift
+    openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates -n openshift
 ----
 
 ifdef::openshift-enterprise[]
@@ -200,7 +200,7 @@ registered by running:
 
 ----
 $ oc create -f \
-    openshift-ansible/roles/openshift_examples/files/examples/xpaas-templates -n openshift
+    openshift-ansible/roles/openshift_examples/files/examples/v1.1/xpaas-templates -n openshift
 ----
 
 [NOTE]


### PR DESCRIPTION
The paths referring to OpenShift image streams and templates is deprecated and does not contain the version folder, needs to be updated to include "v1.1" folder, under openshift-ansible/roles/openshift_examples/files/examples/ and before further sub-folders (image streams etc)
