### PR TITLE
Bug 1283792: in ipfailover example, add callout explaining ‘$KUBECONFIG’

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -309,13 +309,28 @@ $ oc get scc privileged -o json |
 in the first step. The following example runs three instances using the
 *ipfailover* service account:
 +
+ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm router ha-router-us-west --replicas=3  \
-       --selector="ha-router=geo-us-west" --labels="ha-router=geo-us-west" \
-       --credentials="$KUBECONFIG" --service-account=ipfailover
+$ oadm router ha-router-us-west --replicas=3 \
+    --selector="ha-router=geo-us-west" \
+    --labels="ha-router=geo-us-west" \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover
 ----
 ====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm router ha-router-us-west --replicas=3 \
+    --selector="ha-router=geo-us-west" \
+    --labels="ha-router=geo-us-west" \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover
+----
+====
+endif::[]
 +
 [NOTE]
 ====
@@ -338,13 +353,30 @@ below) should be different from the name of the router configuration
 configuration with those names. Specify the VIPs addresses and the port number
 that *ipfailover* should monitor on the desired instances:
 +
+ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm ipfailover ipf-ha-router-us-west --replicas=5  --watch-port=80    \
-     --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" \
-     --credentials="$KUBECONFIG" --service-account=ipfailover --create
+$ oadm ipfailover ipf-ha-router-us-west \
+    --replicas=5 --watch-port=80 \
+    --selector="ha-router=geo-us-west" \
+    --virtual-ips="10.245.2.101-105" \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover --create
 ----
 ====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm ipfailover ipf-ha-router-us-west \
+    --replicas=5 --watch-port=80 \
+    --selector="ha-router=geo-us-west" \
+    --virtual-ips="10.245.2.101-105" \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover --create
+----
+====
+endif::[]
 
 === Configuring a Highly-available Network Service [[ip-failover]]
 
@@ -465,13 +497,28 @@ of nodes and that they satisfy the label setup in first step. Specify the VIP
 addresses and the port number that *ipfailover* should monitor for the desired
 instances:
 +
+ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm ipfailover ipf-ha-geo-cache --replicas=4 --selector="ha-cache=geo" \
-        --virtual-ips=10.245.2.101-104 --watch-port=9736  \
-	--credentials="$KUBECONFIG" --service-account=ipfailover --create
+$ oadm ipfailover ipf-ha-geo-cache \
+    --replicas=4 --selector="ha-cache=geo" \
+    --virtual-ips=10.245.2.101-104 --watch-port=9736  \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover --create
 ----
 ====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm ipfailover ipf-ha-geo-cache \
+    --replicas=4 --selector="ha-cache=geo" \
+    --virtual-ips=10.245.2.101-104 --watch-port=9736 \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover --create
+----
+====
+endif::[]
 ////
 +
 As an alternative, the following example creates an IP failover configuration on


### PR DESCRIPTION
@rjhowe 
PTAL (re https://bugzilla.redhat.com/show_bug.cgi?id=1283792)
