### PR TITLE
Bug 1285366: Show multitenant in OSE docs

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -162,6 +162,8 @@ Topics:
     File: configuring_authentication
   - Name: Syncing Groups With LDAP
     File: syncing_groups_with_ldap
+  - Name: Configuring the SDN
+    File: configuring_sdn
   - Name: Configuring for AWS
     File: configuring_aws
   - Name: Configuring for OpenStack
@@ -231,7 +233,7 @@ Topics:
     File: router
   - Name: High Availability
     File: high_availability
-  - Name: Manage Pod Network
+  - Name: Managing Pod Networks
     File: pod_network
   - Name: Self-Provisioned Projects
     File: selfprovisioned_projects

--- a/admin_guide/pod_network.adoc
+++ b/admin_guide/pod_network.adoc
@@ -1,4 +1,4 @@
-= Managing Pod Network
+= Managing Pod Networks
 {product-author}
 {product-version}
 :data-uri:
@@ -10,24 +10,36 @@
 toc::[]
 
 == Overview
-As a cluster administrator of OpenShift, you can manage pod overlay network for the projects.
+When your cluster is link:../install_config/configuring_sdn.html[configured to
+use the *ovs-multitenant* SDN plug-in], you can manage the separate pod overlay
+networks for projects using the administrator CLI.
 
-== Join Project Network
-Allows projects to join existing project network when using the link:../architecture/additional_concepts/sdn.html#multitenant-plugin[multitenant] network plugin.
+[[joining-project-networks]]
+== Joining Project Networks
+
+To join projects to an existing project network:
 
 ----
 $ oadm pod-network join-projects --to=<project1> <project2> <project3>
 ----
-In this case, all the pods and services in _<project2>_ and _<project3>_ can access any pods and services in _<project1>_ and vice versa.
 
-Alternatively, instead of specifying specific project names (e.g., `_<project2>_ _<project3>_`), you can use the `--selector=_<project_selector>_` option.
+In the above example, all the pods and services in `<project2>` and `<project3>`
+can now access any pods and services in `<project1>` and vice versa.
 
-== Make Project Network Global
-Allows projects to access all pods and services in the cluster. Also all pods and services in the cluster can reach the selected projects when using the link:../architecture/additional_concepts/sdn.html#multitenant-plugin[multitenant] network plugin.
+Alternatively, instead of specifying specific project names, you can use the
+`--selector=<project_selector>` option.
+
+[[making-project-networks-global]]
+== Making Project Networks Global
+
+To allow projects to access all pods and services in the cluster and vice versa:
 
 ----
 $ oadm pod-network make-projects-global <project1> <project2>
 ----
-In this case, all the pods and services in _<project1>_ and _<project2>_ can access any pods and services in the cluster and vice versa.
 
-Alternatively, instead of specifying specific project names (e.g., `_<project1>_ _<project2>_`), you can use the `--selector=_<project_selector>_` option.
+In the above example, all the pods and services in `<project1>` and `<project2>`
+can now access any pods and services in the cluster and vice versa.
+
+Alternatively, instead of specifying specific project names, you can use the
+`--selector=<project_selector>` option.

--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -12,8 +12,8 @@ toc::[]
 == Overview
 
 OpenShift uses a software-defined networking (SDN) approach to provide a unified
-cluster network that enables communication between pods across the
-OpenShift cluster. This cluster network is established and maintained by the
+cluster network that enables communication between pods across the OpenShift
+cluster. This pod network is established and maintained by the
 ifdef::openshift-origin[]
 https://github.com/openshift/openshift-sdn[OpenShift SDN],
 endif::[]
@@ -22,35 +22,32 @@ OpenShift SDN,
 endif::[]
 which configures an overlay network using Open vSwitch (OVS).
 
-ifdef::openshift-origin[]
-OpenShift SDN provides two SDN plug-ins for configuring the network:
+OpenShift SDN provides two SDN plug-ins for configuring the pod network:
 
-* The *ovssubnet* plug-in is the original plug-in which provides a "flat" pod
+* The *ovs-subnet* plug-in is the original plug-in which provides a "flat" pod
 network where every pod can communicate with every other pod and service.
-* The *multitenant* plug-in provides OpenShift project level isolation for
+* The *ovs-multitenant* plug-in provides OpenShift project level isolation for
 pods and services. Each project receives a unique Virtual Network ID (VNID)
 that identifies traffic from pods assigned to the project. Pods from different
-projects cannot send packets to or receive packets from pods and services of
-a different project.
+projects cannot send packets to or receive packets from pods and services of a
+different project.
 +
-However, projects which receive VNID 0 are more privileged in
-that they are allowed to communicate with all other pods, and all other pods can
-communicate with them. In OpenShift clusters, the *default* project has
-VNID 0. This facilitates certain services like the load balancer, etc. to
-communicate with all other pods in the cluster and vice versa.
-endif::[]
-
-ifdef::openshift-enterprise[]
-OpenShift SDN includes the *ovssubnet* SDN plug-in for configuring the network,
-which provides a "flat" pod network where every pod can communicate with every
-other pod and service.
-endif::[]
+However, projects which receive VNID 0 are more privileged in that they are
+allowed to communicate with all other pods, and all other pods can communicate
+with them. In OpenShift clusters, the *default* project has VNID 0. This
+facilitates certain services like the load balancer, etc. to communicate with
+all other pods in the cluster and vice versa.
 
 Following is a detailed discussion of the design and operation of OpenShift SDN,
 which may be useful for troubleshooting.
 
-[[sdn-design-on-masters]]
+[NOTE]
+====
+Information on configuring the SDN on masters and nodes is available in
+link:../../install_config/configuring_sdn.html[Configuring the SDN].
+====
 
+[[sdn-design-on-masters]]
 == Design on Masters
 
 On an OpenShift master, OpenShift SDN maintains a registry of nodes, stored in
@@ -72,32 +69,11 @@ to have access to any cluster network. Consequently, a master host does not have
 access to pods via the cluster network, unless it is also running as a
 node.
 
-ifdef::openshift-origin[]
-When using the *multitenant* plug-in, the OpenShift SDN master also watches for
-the creation and deletion of projects, and assigns VXLAN VNIDs to them, which
-will be used later by the nodes to isolate traffic correctly.
-endif::[]
-
-=== Master Network Configuration
-
-Cluster admin will have the option to control these pod network settings on the master:
-
-[source,yaml]
-----
-...
-networkConfig:
-  clusterNetworkCIDR: 10.1.0.0/16    # Cluster network for node IP allocation
-  hostSubnetLength: 8                # Number of bits for Pod IP allocation within a node
-  networkPluginName: ""              # redhat/openshift-ovs-subnet for flat SDN
-ifdef::openshift-origin[]
-	                             # redhat/openshift-ovs-multitenant for multitenant SDN
-endif::[]
-  serviceNetworkCIDR: 172.30.0.0/16  # Service IP allocation for the cluster
-...
-----
+When using the *ovs-multitenant* plug-in, the OpenShift SDN master also watches
+for the creation and deletion of projects, and assigns VXLAN VNIDs to them,
+which will be used later by the nodes to isolate traffic correctly.
 
 [[sdn-design-on-nodes]]
-
 == Design on Nodes
 
 On a node, OpenShift SDN first registers the local host with the SDN master in
@@ -105,13 +81,9 @@ the aforementioned registry so that the master allocates a subnet to the node.
 
 Next, OpenShift SDN creates and configures six network devices:
 
-* *br0*, the OVS bridge device that pod containers will be attached to. OpenShift
-SDN also configures a set of non-subnet-specific flow rules on this bridge.
-ifdef::openshift-origin[]
-The *multitenant* plug-in does this immediately.
-endif::[]
-The *ovssubnet* plug-in waits to do so until the SDN master announces the
-creation of the new node subnet.
+* *br0*, the OVS bridge device that pod containers will be attached to.
+OpenShift SDN also configures a set of non-subnet-specific flow rules on this
+bridge. The *ovs-multitenant* plug-in does this immediately.
 * *lbr0*, a Linux bridge device, which is configured as Docker's bridge and
 given the cluster subnet gateway address (eg, 10.1.x.1/24).
 * *tun0*, an OVS internal port (port 2 on *br0*). This _also_ gets assigned the
@@ -119,14 +91,9 @@ cluster subnet gateway address, and is used for external network
 access. OpenShift SDN configures *netfilter* and routing rules to enable access
 from the cluster subnet to the external network via NAT.
 * *vlinuxbr* and *vovsbr*, two Linux peer virtual Ethernet interfaces.
-*vlinuxbr* is added to *lbr0* and *vovsbr* is added to *br0*
-ifdef::openshift-origin[]
-(port 9 in *ovssubnet* plug-in,  port 3 in *multitenant* plug-in)
-endif::[]
-ifndef::openshift-origin[]
-(port 9)
-endif::[]
-, to provide connectivity for containers created directly with Docker outside of OpenShift.
+*vlinuxbr* is added to *lbr0* and *vovsbr* is added to *br0* (port 9 with the
+*ovs-subnet* plug-in and port 3 with the *ovs-multitenant* plug-in) to provide
+connectivity for containers created directly with Docker outside of OpenShift.
 * *vxlan0*, the OVS VXLAN device (port 1 on *br0*), which provides access to
 containers on remote nodes.
 
@@ -136,12 +103,10 @@ Each time a pod is started on the host, OpenShift SDN:
 (where Docker placed it when starting the container) to the OVS bridge *br0*.
 . adds OpenFlow rules to the OVS database to route traffic addressed to the new
 pod to the correct OVS port.
-ifdef::openshift-origin[]
-. in the case of the *multitenant* plug-in, adds OpenFlow rules to tag traffic
-coming from the pod with the pod's VNID, and to allow traffic into the pod if
-the traffic's VNID matches the pod's VNID (or is the privileged VNID 0).
-(Non-matching traffic is filtered out by a generic rule.)
-endif::[]
+. in the case of the *ovs-multitenant* plug-in, adds OpenFlow rules to tag
+traffic coming from the pod with the pod's VNID, and to allow traffic into the
+pod if the traffic's VNID matches the pod's VNID (or is the privileged VNID 0).
+Non-matching traffic is filtered out by a generic rule.
 
 The pod is allocated an IP address in the cluster subnet by Docker itself
 because Docker is told to use the *lbr0* bridge, which OpenShift SDN has
@@ -151,34 +116,17 @@ for all traffic destined for external networks, but these two interfaces do not
 conflict because the *lbr0* interface is only used for IPAM and no OpenShift SDN
 pods are connected to it.
 
-OpenShift SDN nodes also watch for subnet updates from the SDN master. When a new
-subnet is added, the node adds OpenFlow rules on *br0* so that packets with a
-destination IP address the remote subnet go to *vxlan0* (port 1 on *br0*) and thus
-out onto the network.
-ifdef::openshift-origin[]
-The *ovssubnet* plug-in sends all packets across the VXLAN with VNID 0, but the
-*multitenant* plug-in uses the appropriate VNID for the source container.
-endif::[]
+OpenShift SDN nodes also watch for subnet updates from the SDN master. When a
+new subnet is added, the node adds OpenFlow rules on *br0* so that packets with
+a destination IP address the remote subnet go to *vxlan0* (port 1 on *br0*) and
+thus out onto the network. The *ovs-subnet* plug-in sends all packets across the
+VXLAN with VNID 0, but the *ovs-multitenant* plug-in uses the appropriate VNID
+for the source container.
 
-=== Node Network Configuration
+[[sdn-packet-flow]]
+== Packet Flow
 
-Cluster admin will have the option to control these pod network settings on the node:
-
-[source,yaml]
-----
-...
-networkConfig:
-  mtu: 1450              # Maximum transmission unit for the pod overlay network
-  networkPluginName: ""  # redhat/openshift-ovs-subnet for flat SDN
-ifdef::openshift-origin[]
-	                 # redhat/openshift-ovs-multitenant for multitenant SDN
-endif::[]
-...
-----
-
-=== Packet Flow
-
-Suppose we have two containers A and B where the peer virtual Ethernet device
+Suppose you have two containers, A and B, where the peer virtual Ethernet device
 for container A's *eth0* is named *vethA* and the peer for container B's *eth0*
 is named *vethB*.
 
@@ -209,22 +157,17 @@ Finally, if container A connects to an external host, the traffic looks like:
 
 Almost all packet delivery decisions are performed with OpenFlow rules in the
 OVS bridge *br0*, which simplifies the plug-in network architecture and provides
-flexible routing.
-ifdef::openshift-origin[]
-In the case of the *multitenant* plug-in, this also provides enforceable network
-isolation.
-endif::[]
+flexible routing. In the case of the *ovs-multitenant* plug-in, this also
+provides enforceable link:#network-isolation-multitenant[network isolation].
 
-ifdef::openshift-origin[]
-[[multitenant-plugin]]
+[[network-isolation-multitenant]]
+== Network Isolation
 
-=== Network Isolation With the multitenant Plug-in
-
-When using the *multitenant* plug-in, when a packet exits a pod assigned to a
-non-default project, the OVS bridge *br0* tags that packet with the project's
-assigned VNID. If the packet is directed to another IP address in the node's
-cluster subnet, the OVS bridge only allows the packet to be delivered to the
-destination pod if the VNIDs match.
+You can use the *ovs-multitenant* plug-in to achieve network isolation. When a
+packet exits a pod assigned to a non-default project, the OVS bridge *br0* tags
+that packet with the project's assigned VNID. If the packet is directed to
+another IP address in the node's cluster subnet, the OVS bridge only allows the
+packet to be delivered to the destination pod if the VNIDs match.
 
 If a packet is received from another node via the VXLAN tunnel, the Tunnel ID
 is used as the VNID, and the OVS bridge only allows the packet to be delivered
@@ -237,38 +180,6 @@ owning the cluster subnet.
 As described before, VNID 0 is privileged in that traffic with any VNID is
 allowed to enter any pod assigned VNID 0, and traffic with VNID 0 is allowed to
 enter any pod. Only the *default* OpenShift project is assigned VNID 0; all
-other projects are assigned unique, isolation-enabled VNIDs. Admin can optionally
-control the pod network for the project with
-link:../../admin_guide/pod_network.html[oadm pod-network] CLI command.
-endif::[]
-
-=== External Access to the Cluster Network
-
-If a host that is external to OpenShift requires access to the cluster network,
-you have two options:
-
-. Configure the host as an OpenShift node but mark it
-link:../../admin_guide/manage_nodes.html#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
-so that the master does not schedule containers on it.
-. Create a tunnel between your host and a host that is on the cluster network.
-
-Both options are presented as part of a practical use-case in the documentation
-for configuring link:../../install_config/routing_from_edge_lb.html[routing from an
-edge load-balancer to containers within OpenShift SDN].
-
-ifdef::openshift-origin[]
-=== Migration between ovssubnet and multitenant plug-ins
-To switch from one SDN plug-in to another, admin needs to:
-
-. Change the *networkPluginName* parameter in both master and node configuration files.
-ifdef::openshift-origin[]
-. Restart origin-master service on master and origin-node service on all nodes.
-endif::[]
-ifdef::openshift-enterprise[]
-. Restart atomic-openshift-master service on master and atomic-openshift-node service on all nodes.
-endif::[]
-
-When switching from ovssubnet to multitenant plug-in, all the existing projects in the cluster
-will be fully isolated (assigned unique VNIDs). Admin can choose to modify the project
-networks using link:../../admin_guide/pod_network.html[oadm pod-network] CLI command.
-endif::[]
+other projects are assigned unique, isolation-enabled VNIDs. Cluster
+administrators can optionally  link:../../admin_guide/pod_network.html[control
+the pod network] for the project using the administrator CLI.

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -1,0 +1,111 @@
+= Configuring the SDN
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+The link:../architecture/additional_concepts/sdn.html[OpenShift SDN] enables
+communication between pods across the OpenShift cluster, establishing a _pod
+network_. Two link:../architecture/additional_concepts/sdn.html[SDN plug-ins]
+are currently available (*ovs-subnet* and *ovs-multitenant*), which provide
+different methods for configuring the pod network.
+
+For initial link:../install_config/install/advanced_install.html[advanced
+installations], the *ovs-subnet* plug-in is installed and configured by default,
+though it can be
+link:../install_config/install/advanced_install.html#configuring-ansible[overridden
+during installation] using the `*os_sdn_network_plugin_name*` parameter.
+
+ifdef::openshift-enterprise[]
+For initial link:../install_config/install/quick_install.html[quick
+installations], the *ovs-subnet* plug-in is installed and configured by default
+as well, and can be reconfigured post-installation.
+endif::[]
+
+[[configuring-the-pod-network-on-masters]]
+== Configuring the Pod Network on Masters
+
+Cluster administrators can control pod network settings on masters by modifying
+parameters in the `*networkConfig*` section of the
+link:../install_config/master_node_configuration.html[master configuration file]
+(located at *_/etc/origin/master/master-config.yaml_* by default):
+
+====
+[source,yaml]
+----
+networkConfig:
+  clusterNetworkCIDR: 10.1.0.0/16 <1>
+  hostSubnetLength: 8 <2>
+  networkPluginName: "redhat/openshift-ovs-subnet" <3>
+  serviceNetworkCIDR: 172.30.0.0/16 <4>
+----
+<1> Cluster network for node IP allocation
+<2> Number of bits for pod IP allocation within a node
+<3> Set to *redhat/openshift-ovs-subnet* for the *ovs-subnet* plug-in or
+*redhat/openshift-ovs-multitenant* for the *ovs-multitenant* plug-in
+<4> Service IP allocation for the cluster
+====
+
+[[configuring-the-pod-network-on-nodes]]
+== Configuring the Pod Network on Nodes
+
+Cluster administrators can control pod network settings on nodes by modifying
+parameters in the `*networkConfig*` section of the
+link:../install_config/master_node_configuration.html[node configuration file]
+(located at *_/etc/origin/node/node-config.yaml_* by default):
+
+====
+[source,yaml]
+----
+networkConfig:
+  mtu: 1450 <1>
+  networkPluginName: "redhat/openshift-ovs-subnet" <2>
+----
+<1> Maximum transmission unit (MTU) for the pod overlay network
+<2> Set to *redhat/openshift-ovs-subnet* for the *ovs-subnet* plug-in or
+*redhat/openshift-ovs-multitenant* for the *ovs-multitenant* plug-in
+====
+
+[[migrating-between-sdn-plugins]]
+== Migrating Between SDN Plug-ins
+
+If you are already using one SDN plug-in and want to switch to another:
+
+. Change the *`networkPluginName`* parameter on all
+link:#configuring-the-pod-network-on-masters[masters] and
+link:#configuring-the-pod-network-on-nodes[nodes] in their configuration files.
+ifdef::openshift-origin[]
+. Restart the *origin-master* service on masters and the *origin-node* service
+on nodes.
+endif::[]
+ifdef::openshift-enterprise[]
+. Restart the *atomic-openshift-master* service on masters and the
+*atomic-openshift-node* service on nodes.
+endif::[]
+
+When switching from the *ovs-subnet* to the *ovs-multitenant* plug-in, all the
+existing projects in the cluster will be fully isolated (assigned unique VNIDs).
+Cluster administrators can choose to link:../admin_guide/pod_network.html[modify
+the project networks] using the administrator CLI.
+
+[[external-access-to-the-cluster-network]]
+== External Access to the Cluster Network
+
+If a host that is external to OpenShift requires access to the cluster network,
+you have two options:
+
+. Configure the host as an OpenShift node but mark it
+link:../admin_guide/manage_nodes.html#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
+so that the master does not schedule containers on it.
+. Create a tunnel between your host and a host that is on the cluster network.
+
+Both options are presented as part of a practical use-case in the documentation
+for configuring link:../install_config/routing_from_edge_lb.html[routing from an
+edge load-balancer to containers within OpenShift SDN].

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -162,6 +162,13 @@ for more information.
 
 |`*openshift_master_cluster_public_vip*`
 
+|`*os_sdn_network_plugin_name*`
+|This variable configures which
+link:../../architecture/additional_concepts/sdn.html[OpenShift SDN plug-in] to
+use for the pod network, which defaults to *redhat/openshift-ovs-subnet* for the
+standard SDN plug-in. Set the variable to *redhat/openshift-ovs-multitenant* to
+use the multitenant plug-in.
+
 |`*openshift_master_identity_providers*`
 |This variable overrides the
 link:../../install_config/configuring_authentication.html[identity provider], which
@@ -179,6 +186,15 @@ options] in the OAuth configuration. See link:#advanced-install-session-options[
 |`*openshift_master_session_auth_secrets*`
 
 |`*openshift_master_session_encryption_secrets*`
+
+|`*openshift_master_portal_net*`
+|This variable configures the subnet in which
+link:../../architecture/core_concepts/pods_and_services.html#services[services]
+will be created within the
+link:../../architecture/additional_concepts/sdn.html[OpenShift SDN]. This
+defaults to *172.30.0.0/16*, which covers *172.30.0.0* through *172.30.255.255*.
+Setting this variable to override the default can be useful if the default
+subnet interferes with other subnets in use in your environment.
 
 |`*osm_default_subdomain*`
 |This variable overrides the default subdomain to use for exposed

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -418,13 +418,14 @@ the actual remote IP address.
 
 [NOTE]
 ====
-On OpenShift cluster with
-link:../../architecture/additional_concepts/sdn.html#multitenant-plugin[multi-tenant
-network isolation], router on a non-default namespace with `--host-network=false`
-option will load all routes in the cluster but routes across the namespaces will not
-be reachable due to network isolation. With `--host-network=true` option, routes
-will bypass the container network and it can access any pod in the cluster.
-If isolation is needed in this case, then don't add routes across the namespaces.
+On OpenShift clusters using
+link:../../architecture/additional_concepts/sdn.html#network-isolation-multitenant[multi-tenant
+network isolation], routers on a non-default namespace with the
+`--host-network=false` option will load all routes in the cluster, but routes
+across the namespaces will not be reachable due to network isolation. With the
+`--host-network=true` option, routes bypass the container network and it can
+access any pod in the cluster. If isolation is needed in this case, then do not
+add routes across the namespaces.
 ====
 
 == Deploying a Customized HAProxy Router


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1285366

Various cleanup to SDN topics
Create new config SDN topic in admin_guide

cc @thoraxe @danwinship @dcbw @pravisankar 

Moves any actual configuration steps from the arch topic into the new admin_guide topic. Also syncs up on calling the plug-ins **ovs-subnet** and **ovs-multitenant** in prose. It felt closer to the actual plug-in names without calling them **redhat/openshift-ovs-subnet** and **redhat/openshift-ovs-multitenant** every time. They were previously being referred to as **ovssubnet** (no `-`) and plain **multitenant**. LMK if there's any issue with that.

Pretty builds (internal):

http://file.rdu.redhat.com/~adellape/112515/uncondtl_multitenant/architecture/additional_concepts/sdn.html

http://file.rdu.redhat.com/~adellape/112515/uncondtl_multitenant/install_config/configuring_sdn.html

(`os_sdn_network_plugin_name` parameter) http://file.rdu.redhat.com/~adellape/112515/uncondtl_multitenant/install_config/install/advanced_install.html#configuring-ansible

http://file.rdu.redhat.com/~adellape/112515/uncondtl_multitenant/admin_guide/pod_network.html
