### PR TITLE
Correct what's new link on dev getting started

### DIFF
--- a/getting_started/developers/developers_cli.adoc
+++ b/getting_started/developers/developers_cli.adoc
@@ -24,7 +24,7 @@ easiest method.
 If this is the first part of the documentation you have read, and you are
 unfamiliar with the core concepts of OpenShift version 3, you might want to
 start by reading about
-link:../../release_notes/index.html[what's new]. This version
+link:../../whats_new/index.html[what's new]. This version
 of OpenShift is significantly different from version 2.
 
 The following sections guide you through creating a project that contains a


### PR DESCRIPTION
Fixes the link to [What's new](https://docs.openshift.org/latest/whats_new/index.html) the [Getting Started for developers](https://docs.openshift.org/latest/getting_started/developers/developers_console.html) 
