### PR TITLE
Bug 1277029: edit link to storage options

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -95,11 +95,17 @@ Any images anyone has built or pushed into the registry would disappear.
 
 ==== Production Use
 
-For production use, you should attach a remote volume or
-link:../../install_config/persistent_storage/persistent_storage_nfs.html[use persistent storage] using
-`*PersistentVolume*` and `*PersistentVolumeClaim*` objects for storage for the
-registry. For example, to attach an existing NFS volume to the registry once it
-has been defined:
+For production use, attach a remote volume or
+link:../../install_config/persistent_storage/index.html[define and use the
+persistent storage method of your choice].
+
+For example, to use an existing persistent volume claim:
+----
+$ oc volume deploymentconfigs/docker-registry --add --name=v1 -t pvc \
+     --claim-name=<pvc_name> --overwrite
+----
+
+Or, to attach an existing NFS volume to the registry:
 
 ----
 $ oc volume deploymentconfigs/docker-registry \


### PR DESCRIPTION
@miheer PR is in regard to BZ 1277029:

https://bugzilla.redhat.com/show_bug.cgi?id=1277029

Can I get an ack this is all that's needed for the BZ? The info from the training docs you've linked in the BZ is in the storage section (from what I can tell), and as there are more than just NFS available now, I thought it best to link to the index rather than the specific NFS topic.
