### PR TITLE
Replace backtick ("``") with "$()"

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -109,7 +109,7 @@ local system.
 . Add the directory you untarred the release into to your path
 +
 ----
-$ export PATH=$(pwd):$PATH
+$ export PATH="$(pwd)":$PATH
 ----
 +
 
@@ -139,9 +139,9 @@ You must point `oc` and `curl` at the appropriate CA bundle and client key and
 certificate to connect to OpenShift. Set the following environment variables:
 +
 ----
-$ export KUBECONFIG=`pwd`/openshift.local.config/master/admin.kubeconfig
-$ export CURL_CA_BUNDLE=`pwd`/openshift.local.config/master/ca.crt
-$ sudo chmod +r `pwd`/openshift.local.config/master/admin.kubeconfig
+$ export KUBECONFIG="$(pwd)"/openshift.local.config/master/admin.kubeconfig
+$ export CURL_CA_BUNDLE="$(pwd)"/openshift.local.config/master/ca.crt
+$ sudo chmod +r "$(pwd)"/openshift.local.config/master/admin.kubeconfig
 ----
 +
 NOTE: This is just for example purposes; in a production environment, developers


### PR DESCRIPTION
> 1. Keep the document consistent:
>    In one place we use "$()" and in others "``".
> 2. "$()" is preferred over "`...`". Read more here:
>    - http://mywiki.wooledge.org/BashFAQ/082
>    - https://github.com/koalaman/shellcheck/wiki/SC2006
> 3. Add quotes around $(pwd) in case one of the directories
>    has at least one white-space character.

It's not a big deal, but improves the document, in my opinion.
cc @openshift/team-documentation @csrwng 
