### PR TITLE
fixed formatting of callouts

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -257,6 +257,7 @@ a new node configuration file] to see the valid options for your installed
 version of OpenShift.
 
 .Sample Node Configuration File
+====
 [source,yaml]
 ----
 allowDisabledDocker: true
@@ -285,13 +286,13 @@ servingInfo:
   keyFile: server.key
 volumeDirectory: /root/openshift.local.volumes
 ----
-
-1. Allows pods to be placed directly on certain set of nodes, or on all nodes 
+<1> Allows pods to be placed directly on certain set of nodes, or on all nodes 
 without going through the scheduler. You can then use pods to perform the same 
 administrative tasks and support the same services on each node.
-2. Specifies the path for the 
+<2> Specifies the path for the 
 link:../architecture/core_concepts/pods_and_services.html#pods[pod manifest file] 
 or directory. If it is a directory, then it is expected to contain one or more 
 manifest files. This is used by the Kubelet to create pods on the node.
-3. This is the interval (in seconds) for checking the manifest file for new 
+<3> This is the interval (in seconds) for checking the manifest file for new 
 data. The interval must be a positive value.
+====


### PR DESCRIPTION
Just noticed that the numbered explanations below the example file weren't formatted properly. Quick formatting fix. 

Applicable for all branches of docs.
