### PR TITLE
Fix reference to section of BuildConfig

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -637,7 +637,7 @@ Level 5:: Produces everything mentioned on previous levels and additionally prov
 The source code location is one of the required parameters for the
 `*BuildConfig*`. The build uses this location and fetches the source code that
 is later built. The source code location definition is part of the
-`*parameters*` section in the `*BuildConfig*`:
+`*spec*` section in the `*BuildConfig*`:
 
 ====
 


### PR DESCRIPTION
There is no "parameters" section, it should be "spec".

@openshift/team-documentation @bparees PTAL
