### PR TITLE
make all kubelet arguments strings

### DIFF
--- a/admin_guide/garbage_collection.adoc
+++ b/admin_guide/garbage_collection.adoc
@@ -62,11 +62,11 @@ configuration file] (the *_/etc/origin/node/node-config.yaml_* file by default).
 ----
 kubeletArguments:
   minimum-container-ttl-duration:
-    - 10s
+    - "10s"
   maximum-dead-containers-per-container:
-    - 2
+    - "2"
   maximum-dead-containers:
-    - 100
+    - "100"
 ----
 ====
 
@@ -136,9 +136,9 @@ Add the section if it does not already exist:
 ----
 kubeletArguments:
   image-gc-high-threshold:
-    - 90
+    - "90"
   image-gc-low-threshold:
-    - 80
+    - "80"
 ----
 ====
 


### PR DESCRIPTION
Replacing all non string arguments with string ones.
