### PR TITLE
How to disable CPU limits

### DIFF
--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -35,7 +35,7 @@ A container is guaranteed the amount of memory it requests.  A container may use
 
 == Quality of Service Classes
 
-A node is overcommmitted when it has a pod scheduled that makes no request, or when the sum of limits across all pods on that node exceeds available machine capacity.  In this environment, it is possible that the pods on the node will attempt to use more compute resource than is available at any given point in time.  When this occurs, the node must give priority to one pod over another.  The facility used to make this decision is referred to as a Quality of Service (QoS) Class.
+A node is overcommitted when it has a pod scheduled that makes no request, or when the sum of limits across all pods on that node exceeds available machine capacity.  In this environment, it is possible that the pods on the node will attempt to use more compute resource than is available at any given point in time.  When this occurs, the node must give priority to one pod over another.  The facility used to make this decision is referred to as a Quality of Service (QoS) Class.
 
 For each compute resource, a container is divided into one of 3 QoS classes with decreasing order of priority:
 
@@ -58,6 +58,26 @@ Memory is an incompressible resource, so in low-memory situations, containers ar
 == Node configuration
 
 In an overcommitted environment, it's important to properly configure your node to provide best system behavior.
+
+=== Enforcing CPU limits
+
+The node by default will enforce specified CPU limits using the CPU CFS quota support in the kernel.
+
+If you do not want to enforce CPU limits on the node, then you can disable its enforcement by modifying the node configuration as follows:
+
+node-config.yaml
+====
+----
+kubeletArguments:
+  cpu-cfs-quota:
+    - "false"
+----
+====
+
+If CPU limit enforcement is disabled, it's important to understand the impact that will have on your node.  If a container makes a request
+for CPU, it will continue to be enforced by CFS shares in the Linux kernel.  If a container makes no explicit request for CPU, but it does
+specify a limit, the request will default to the specified limit, and be enforced by CFS shares in the Linux kernel.  If a container specifies
+both a request and a limit for CPU, the request will be enforced by CFS shares in the Linux kernel, and the limit will have no impact on the node.
 
 === Reserving resources for system processes
 

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -135,6 +135,17 @@ New Tag Deletion Command::
 You can now delete tags from an image stream using the `oc tag <tag_name> -d`
 command.
 
+New Overcommit Abilities::
+You can now create containers that can specify compute resource requests and limits.
+Requests are used for scheduling your container and provide a minimum service guarantee.
+Limits constrain the amount of compute resource that may be consumed on your node.
+
+.For Administrators:
+`*CPU Limits*` are now enforced using CFS quota by default::
+If you wish to disable CFS quota enforcement, you may disable it by modifying your
+`*node-config.yaml*` file to specify a `*kubeletArguments*` stanza where
+`*cpu-cfs-quota*` is set to `*false*`.
+
 .For Developers:
 `*v1beta3*` no Longer Supported::
 Using `*v1beta3*` in configuration files is no longer supported:


### PR DESCRIPTION
Users have reported that they would like to know how to disable CPU limit enforcement in 3.1.

This change makes the following clear to administrators:
1. that cpu limits are now enforced via CFS quota in 3.1 by default
2. how to disable cpu limit enforcement for users that want to preserve 3.0.x behavior
