### PR TITLE
Document Dockerfile and Binary build sources

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -525,9 +525,42 @@ For example, defining a custom HTTP proxy to be used during build:
 ----
 ====
 
+[[source-code]]
+
+== Git Repository Source Options
+
+The source code location is one of the required parameters for the
+`*BuildConfig*`. The build uses this location and fetches the source code that
+is later built. The source code location definition is part of the
+`*spec*` section in the `*BuildConfig*`:
+
+====
+
+----
+{
+  "source" : {
+    "type" : "Git", <1>
+    "git" : { <2>
+      "uri": "git://github.com/openshift/ruby-hello-world.git"
+    },
+    "contextDir": "app/dir", <3>
+  },
+}
+----
+
+<1> The `*type*` field describes which SCM is used to fetch your source code.
+<2> The `*git*` field contains the URI to the remote Git repository of the
+source code. Optionally, specify the `*ref*` field to check out a specific Git
+reference. A valid `*ref*` can be a SHA1 tag or a branch name.
+<3> The `*contextDir*` field allows you to override the default location inside
+the source code repository where the build looks for the application source
+code. If your application exists inside a sub-directory, you can override the
+default location (the root folder) using this field.
+====
+
 [[using-a-proxy-for-git-cloning]]
 
-== Using a Proxy for Git Cloning
+=== Using a Proxy for Git Cloning
 
 // tag::using-a-proxy-for-git-cloning-1[]
 
@@ -554,6 +587,263 @@ source:
 ====
 
 // end::using-a-proxy-for-git-cloning-1[]
+
+
+[#using-private-repositories-for-builds]
+=== Using Private Repositories for Builds
+
+Supply valid credentials to build an application from a private repository.
+
+Currently two types of authentication are supported: basic username-password
+and SSH key based authentication.
+
+[[basic-authentication]]
+==== Basic Authentication
+
+Basic authentication requires either a combination of `username` and `password`,
+or a `token` to authenticate against the SCM server. A `CA certificate` file,
+or a `.gitconfig` file can be attached.
+
+A link:../dev_guide/secrets.html[`*secret*`] is used to store your keys.
+
+. Create the `*secret*` first before using the username and password to access
+the private repository:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD
+----
+====
+
+.. To create a Basic Authentication Secret with a token:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --password=TOKEN
+----
+====
+
+.. To create a Basic Authentication Secret with a CA certificate file:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --ca-cert=FILENAME
+----
+====
+
+.. To create a Basic Authentication Secret with a `.gitconfig` file:
++
+====
+----
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --gitconfig=FILENAME
+----
+====
+
+. Add the `*secret*` to the builder service account:
++
+====
+----
+$ oc secrets add serviceaccount/builder secrets/basicsecret
+----
+====
+
+. Add a `*sourceSecret*` field to the `*source*` section inside the
+`*BuildConfig*` and set it to the name of the `*secret*` that you created.
+In this case `*basicsecret*`:
++
+====
+
+----
+{
+  "apiVersion": "v1",
+  "kind": "BuildConfig",
+  "metadata": {
+    "name": "sample-build",
+  },
+  "parameters": {
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag"
+        "name": "sample-image:latest"
+      }
+    },
+    "source": {
+      "git": {
+        "uri": "https://github.com/user/app.git" <1>
+      },
+      "sourceSecret": {
+        "name": "basicsecret"
+      },
+      "type": "Git"
+    },
+    "strategy": {
+      "sourceStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "python-33-centos7:latest"
+        }
+      },
+      "type": "Source"
+    }
+  }
+----
+<1> The URL of private repository, accessed by basic authentication, is usually
+in the `http` or `https` form.
+====
+
+
+[[ssh-key-authentication]]
+==== SSH Key Based Authentication
+
+SSH Key Based Authentication requires a private SSH key. A `.gitconfig` file can
+also be attached.
+
+The repository keys are usually located in the `$HOME/.ssh/` directory, and are named
+`id_dsa.pub`, `id_ecdsa.pub`, `id_ed25519.pub`, or `id_rsa.pub` by default.
+Generate SSH key credentials with the following command:
+
+====
+
+----
+$ ssh-keygen -t rsa -C "your_email@example.com"
+----
+====
+
+[NOTE]
+====
+For a SSH key to work in OpenShift builds, it must not have a passphrase set. When prompted
+for a passphrase, leave it blank.
+====
+
+Two files are created: the public key and a corresponding private key (one of
+`id_dsa`, `id_ecdsa`, `id_ed25519`, or `id_rsa`). With both of these in place,
+consult your source control management (SCM) system's manual on how to upload
+the public key. The private key will be used to access your private repository.
+
+A link:dev_guide/secrets[`*secret*`]
+is used to store your keys.
+
+. Create the `*secret*` first before using the SSH key to access the private
+repository:
++
+====
+----
+$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa
+----
+====
+
+.. To create a SSH Based Authentication Secret with a `.gitconfig` file:
++
+====
+----
+$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa --gitconfig=FILENAME
+----
+====
+
+. Add the `*secret*` to the builder service account. Each build is run with
+`serviceaccount/builder` role, so you need to give it access your secret with
+following command:
++
+====
+
+----
+$ oc secrets add serviceaccount/builder secrets/scmsecret
+----
+====
+
+. Add a `*sourceSecret*` field into the `*source*` section inside the
+`*BuildConfig*` and set it to the name of the `*secret*` that you created.
+In this case `*sshsecret*`:
++
+====
+
+----
+{
+  "apiVersion": "v1",
+  "kind": "BuildConfig",
+  "metadata": {
+    "name": "sample-build",
+  },
+  "parameters": {
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag"
+        "name": "sample-image:latest"
+      }
+    },
+    "source": {
+      "git": {
+        "uri": "git@repository.com:user/app.git" <1>
+      },
+      "sourceSecret": {
+        "name": "sshsecret"
+      },
+      "type": "Git"
+    },
+    "strategy": {
+      "sourceStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "python-33-centos7:latest"
+        }
+      },
+      "type": "Source"
+    }
+  }
+----
+<1> The URL of private repository, accessed by a private SSH key, is usually
+in the form `git@example.com:<username>/<repository>.git`.
+====
+
+[[other-authentication]]
+==== Other
+
+In case the cloning of your application is dependent on a `CA certificate`, `.gitconfig`
+file or both, you can create a secret that contains them, add it to the builder service
+account and then your `BuildConfig`.
+
+. Create desired type of `*secret*`:
+
+.. To create a secret from a `.gitconfig`:
++
+====
+----
+$ oc secrets new mysecret .gitconfig=path/to/.gitconfig
+----
+====
+.. To create a secret from a `CA certificate`:
++
+====
+----
+$ oc secrets new mysecret ca.crt=path/to/certificate
+----
+====
+.. To create a secret from a `CA certificate` and `.gitconfig`:
++
+====
+----
+$ oc secrets new mysecret ca.crt=path/to/certificate .gitconfig=path/to/.gitconfig
+----
+====
+
+[NOTE]
+====
+Please note that SSL verification can be turned off, if `sslVerify=false` is set
+for the `http` section in your `.gitconfig` file:
+----
+[http]
+        sslVerify=false
+----
+====
+
+. Add the `*secret*` to the builder service account:
++
+====
+----
+$ oc secrets add serviceaccount/builder secrets/mysecret
+----
+====
+
 
 [[starting-a-build]]
 
@@ -659,38 +949,6 @@ Level 2:: Produces very detailed information about the executed process.
 Level 3:: Produces very detailed information about the executed process, and a listing of the archive contents.
 Level 4:: Currently produces the same information as level 3.
 Level 5:: Produces everything mentioned on previous levels and additionally provides docker push messages.
-
-[[source-code]]
-
-== Source Code
-The source code location is one of the required parameters for the
-`*BuildConfig*`. The build uses this location and fetches the source code that
-is later built. The source code location definition is part of the
-`*spec*` section in the `*BuildConfig*`:
-
-====
-
-----
-{
-  "source" : {
-    "type" : "Git", <1>
-    "git" : { <2>
-      "uri": "git://github.com/openshift/ruby-hello-world.git"
-    },
-    "contextDir": "app/dir", <3>
-  },
-}
-----
-
-<1> The `*type*` field describes which SCM is used to fetch your source code.
-<2> The `*git*` field contains the URI to the remote Git repository of the
-source code. Optionally, specify the `*ref*` field to check out a specific Git
-reference. A valid `*ref*` can be a SHA1 tag or a branch name.
-<3> The `*contextDir*` field allows you to override the default location inside
-the source code repository where the build looks for the application source
-code. If your application exists inside a sub-directory, you can override the
-default location (the root folder) using this field.
-====
 
 [[setting-maximum-duration]]
 == Setting Maximum Duration
@@ -1091,260 +1349,6 @@ is *dockerhub*:
 ----
 ====
 
-[#using-private-repositories-for-builds]
-== Using Private Repositories for Builds
-
-Supply valid credentials to build an application from a private repository.
-
-Currently two types of authentication are supported: basic username-password
-and SSH key based authentication.
-
-[[basic-authentication]]
-=== Basic Authentication
-
-Basic authentication requires either a combination of `username` and `password`,
-or a `token` to authenticate against the SCM server. A `CA certificate` file,
-or a `.gitconfig` file can be attached.
-
-A link:../dev_guide/secrets.html[`*secret*`] is used to store your keys.
-
-. Create the `*secret*` first before using the username and password to access
-the private repository:
-+
-====
-----
-$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD
-----
-====
-
-.. To create a Basic Authentication Secret with a token:
-+
-====
-----
-$ oc secrets new-basicauth basicsecret --password=TOKEN
-----
-====
-
-.. To create a Basic Authentication Secret with a CA certificate file:
-+
-====
-----
-$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --ca-cert=FILENAME
-----
-====
-
-.. To create a Basic Authentication Secret with a `.gitconfig` file:
-+
-====
-----
-$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --gitconfig=FILENAME
-----
-====
-
-. Add the `*secret*` to the builder service account:
-+
-====
-----
-$ oc secrets add serviceaccount/builder secrets/basicsecret
-----
-====
-
-. Add a `*sourceSecret*` field to the `*source*` section inside the
-`*BuildConfig*` and set it to the name of the `*secret*` that you created.
-In this case `*basicsecret*`:
-+
-====
-
-----
-{
-  "apiVersion": "v1",
-  "kind": "BuildConfig",
-  "metadata": {
-    "name": "sample-build",
-  },
-  "parameters": {
-    "output": {
-      "to": {
-        "kind": "ImageStreamTag"
-        "name": "sample-image:latest"
-      }
-    },
-    "source": {
-      "git": {
-        "uri": "https://github.com/user/app.git" <1>
-      },
-      "sourceSecret": {
-        "name": "basicsecret"
-      },
-      "type": "Git"
-    },
-    "strategy": {
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "python-33-centos7:latest"
-        }
-      },
-      "type": "Source"
-    }
-  }
-----
-<1> The URL of private repository, accessed by basic authentication, is usually
-in the `http` or `https` form.
-====
-
-
-[[ssh-key-authentication]]
-=== SSH Key Based Authentication
-
-SSH Key Based Authentication requires a private SSH key. A `.gitconfig` file can
-also be attached.
-
-The repository keys are usually located in the `$HOME/.ssh/` directory, and are named
-`id_dsa.pub`, `id_ecdsa.pub`, `id_ed25519.pub`, or `id_rsa.pub` by default.
-Generate SSH key credentials with the following command:
-
-====
-
-----
-$ ssh-keygen -t rsa -C "your_email@example.com"
-----
-====
-
-[NOTE]
-====
-For a SSH key to work in OpenShift builds, it must not have a passphrase set. When prompted
-for a passphrase, leave it blank.
-====
-
-Two files are created: the public key and a corresponding private key (one of
-`id_dsa`, `id_ecdsa`, `id_ed25519`, or `id_rsa`). With both of these in place,
-consult your source control management (SCM) system's manual on how to upload
-the public key. The private key will be used to access your private repository.
-
-A link:dev_guide/secrets[`*secret*`]
-is used to store your keys.
-
-. Create the `*secret*` first before using the SSH key to access the private
-repository:
-+
-====
-----
-$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa
-----
-====
-
-.. To create a SSH Based Authentication Secret with a `.gitconfig` file:
-+
-====
-----
-$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa --gitconfig=FILENAME
-----
-====
-
-. Add the `*secret*` to the builder service account. Each build is run with
-`serviceaccount/builder` role, so you need to give it access your secret with
-following command:
-+
-====
-
-----
-$ oc secrets add serviceaccount/builder secrets/scmsecret
-----
-====
-
-. Add a `*sourceSecret*` field into the `*source*` section inside the
-`*BuildConfig*` and set it to the name of the `*secret*` that you created.
-In this case `*sshsecret*`:
-+
-====
-
-----
-{
-  "apiVersion": "v1",
-  "kind": "BuildConfig",
-  "metadata": {
-    "name": "sample-build",
-  },
-  "parameters": {
-    "output": {
-      "to": {
-        "kind": "ImageStreamTag"
-        "name": "sample-image:latest"
-      }
-    },
-    "source": {
-      "git": {
-        "uri": "git@repository.com:user/app.git" <1>
-      },
-      "sourceSecret": {
-        "name": "sshsecret"
-      },
-      "type": "Git"
-    },
-    "strategy": {
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "python-33-centos7:latest"
-        }
-      },
-      "type": "Source"
-    }
-  }
-----
-<1> The URL of private repository, accessed by a private SSH key, is usually
-in the form `git@example.com:<username>/<repository>.git`.
-====
-
-[[other-authentication]]
-=== Other
-
-In case the cloning of your application is dependent on a `CA certificate`, `.gitconfig`
-file or both, you can create a secret that contains them, add it to the builder service
-account and then your `BuildConfig`.
-
-. Create desired type of `*secret*`:
-
-.. To create a secret from a `.gitconfig`:
-+
-====
-----
-$ oc secrets new mysecret .gitconfig=path/to/.gitconfig
-----
-====
-.. To create a secret from a `CA certificate`:
-+
-====
-----
-$ oc secrets new mysecret ca.crt=path/to/certificate
-----
-====
-.. To create a secret from a `CA certificate` and `.gitconfig`:
-+
-====
-----
-$ oc secrets new mysecret ca.crt=path/to/certificate .gitconfig=path/to/.gitconfig
-----
-====
-
-[NOTE]
-====
-Please note that SSL verification can be turned off, if `sslVerify=false` is set
-for the `http` section in your `.gitconfig` file:
-----
-[http]
-        sslVerify=false
-----
-====
-
-. Add the `*secret*` to the builder service account:
-+
-====
-----
-$ oc secrets add serviceaccount/builder secrets/mysecret
-----
-====
 
 [[build-output]]
 == Build Output

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -589,7 +589,7 @@ source:
 // end::using-a-proxy-for-git-cloning-1[]
 
 
-[#using-private-repositories-for-builds]
+[[using-private-repositories-for-builds]]
 === Using Private Repositories for Builds
 
 Supply valid credentials to build an application from a private repository.
@@ -1250,7 +1250,7 @@ Configuration change triggers currently only work when creating a new
 able to launch a build whenever a `*BuildConfig*` is updated.
 ====
 
-[#using-docker-credentials-for-pushing-and-pulling-images]
+[[using-docker-credentials-for-pushing-and-pulling-images]]
 == Using Docker Credentials for Pushing and Pulling Images
 
 Supply the *_.dockercfg_* file with valid Docker Registry credentials in order to

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -5,6 +5,7 @@
 :icons:
 :experimental:
 :toc: macro
+:toclevels: 3
 :toc-title:
 :prewrap!:
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -12,8 +12,16 @@
 toc::[]
 
 == Overview
-A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
-runnable images to be used on OpenShift. There are three build strategies:
+
+A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build]
+is the process of transforming input parameters into a resulting object. Most
+often, the process is used to transform source code into a runnable image.
+
+Build configurations are characterized by a strategy and one or more sources.
+The strategy determines the aforementioned process, while the sources provide
+its input.
+
+There are three build strategies:
 
 - Source-To-Image (S2I)
 (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description],
@@ -24,6 +32,19 @@ link:#docker-strategy-options[options])
 - Custom
 (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description],
 link:#custom-strategy-options[options])
+
+And there are three types of build source:
+
+- link:#source-code[Git]
+- link:#dockerfile-source[Dockerfile]
+- link:#binary-source[Binary]
+
+It is up to each build strategy to consider or ignore a certain type of source,
+as well as to determine how it is to be used.
+
+Binary and Git are mutually exclusive source types, while Dockerfile can be used
+by itself or together with Git and Binary.
+
 
 [[defining-a-buildconfig]]
 
@@ -70,7 +91,8 @@ image tag or the source code changes:
       "type": "Git",
       "git": {
         "uri": "git://github.com/openshift/ruby-hello-world.git"
-      }
+      },
+      "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example"
     },
     "strategy": { <4>
       "type": "Source",
@@ -95,8 +117,11 @@ image tag or the source code changes:
 *ruby-sample-build*.
 <2> You can specify a list of link:#build-triggers[triggers], which cause a new
 build to be created.
-<3> The `*source*` section defines the source code repository location. You can
-provide additional options, such as `*sourceSecret*` or `*contextDir*` here.
+<3> The `*source*` section defines the source of the build. The source type
+determines the primary source of input, and can be either `*Git*`, to point to a
+code repository location, `*Dockerfile*`, to build from an inline Dockerfile, or
+`*Binary*`, to accept binary payloads. It is possible to have multiple sources
+at once, refer to the documentation for each source type for details.
 <4> The `*strategy*` section describes the build strategy used to execute the
 build. You can specify `*Source*`, `*Docker*` and `*Custom*` strategies here.
 This above example uses the `*ruby-20-centos7*` Docker image that
@@ -530,33 +555,41 @@ For example, defining a custom HTTP proxy to be used during build:
 
 == Git Repository Source Options
 
-The source code location is one of the required parameters for the
-`*BuildConfig*`. The build uses this location and fetches the source code that
-is later built. The source code location definition is part of the
-`*spec*` section in the `*BuildConfig*`:
+When the `*BuildConfig.spec.source.type*` is `*Git*`, a Git repository is
+required, and an inline Dockerfile is optional.
+
+The source code is fetched from the location specified and, if the
+`*BuildConfig.spec.source.dockerfile*` field is specified, the inline Dockerfile
+replaces the one in the `*contextDir*` of the Git repository.
+
+The source definition is part of the `*spec*` section in the `*BuildConfig*`:
 
 ====
 
 ----
 {
   "source" : {
-    "type" : "Git", <1>
-    "git" : { <2>
-      "uri": "git://github.com/openshift/ruby-hello-world.git"
+    "type" : "Git",
+    "git" : { <1>
+      "uri": "git://github.com/openshift/ruby-hello-world.git",
+      "ref": "master"
     },
-    "contextDir": "app/dir", <3>
+    "contextDir": "app/dir", <2>
+    "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example" <3>
   },
 }
 ----
 
-<1> The `*type*` field describes which SCM is used to fetch your source code.
-<2> The `*git*` field contains the URI to the remote Git repository of the
+<1> The `*git*` field contains the URI to the remote Git repository of the
 source code. Optionally, specify the `*ref*` field to check out a specific Git
 reference. A valid `*ref*` can be a SHA1 tag or a branch name.
-<3> The `*contextDir*` field allows you to override the default location inside
+<2> The `*contextDir*` field allows you to override the default location inside
 the source code repository where the build looks for the application source
 code. If your application exists inside a sub-directory, you can override the
 default location (the root folder) using this field.
+<3> If the optional `*dockerfile*` field is provided, it should be a string
+containing a Dockerfile that overwrites any Dockerfile that may exist in the
+source repository.
 ====
 
 [[using-a-proxy-for-git-cloning]]
@@ -843,6 +876,81 @@ for the `http` section in your `.gitconfig` file:
 ----
 $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
+====
+
+
+[[dockerfile-source]]
+
+== Dockerfile Source
+
+When the `*BuildConfig.spec.source.type*` is `*Dockerfile*`, an inline
+Dockerfile is used as the build input, and no additional sources can be
+provided.
+
+This source type is valid when the build strategy type is `*Docker*` or
+`*Custom*`.
+
+The source definition is part of the `*spec*` section in the `*BuildConfig*`:
+
+====
+
+----
+{
+ "source" : {
+    "type" : "Dockerfile",
+    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <1>
+ },
+}
+----
+
+<1> The `*dockerfile*` field contains an inline Dockerfile that will be built.
+====
+
+
+[[binary-source]]
+
+== Binary Source
+
+When the `*BuildConfig.spec.source.type*` is `*Binary*`, the build will expect a
+binary as input, and an inline Dockerfile is optional.
+
+The binary is generally assumed to be a tar, gzipped tar, or zip file depending
+on the strategy. For `*Docker*` builds, this is the build context and an
+optional Dockerfile may be specified to override any Dockerfile in the build
+context. For `*Source*` builds, this is assumed to be an archive as described
+above. For `*Source*` and `*Docker*` builds, if `*binary.asFile*` is set the
+build will receive a directory with a single file. The `*contextDir*` field may
+be used when an archive is provided. Custom builds will receive this binary as
+input on standard input (`stdin`).
+
+A binary source potentially extracts content, in which case `*contextDir*`
+allows changing to a subdirectory within the content before the build executes.
+
+The source definition is part of the `*spec*` section in the `*BuildConfig*`:
+
+====
+
+----
+{
+ "source" : {
+    "type" : "Binary",
+    "binary": { <1>
+      "asFile": "webapp.war" <2>
+    },
+    "contextDir": "app/dir", <3>
+    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <4>
+ },
+}
+----
+
+<1> The `*binary*` field specifies the details of the binary source.
+<2> The `*asFile*` field specifies the name of a file that will be created with
+the binary contents.
+<3> The `*contextDir*` field specifies a subdirectory with the contents of a
+binary archive.
+<4> If the optional `*dockerfile*` field is provided, it should be a string
+containing an inline Dockerfile that potentially replaces one within the
+contents of the binary archive.
 ====
 
 


### PR DESCRIPTION
Wanted to get the conversation out, still have open questions before the documentation is ready.

Changes:
1. Group together git-specific topics in [dev_guide/builds.html](https://docs.openshift.org/latest/dev_guide/builds.html).
2. Document when and how the "Dockerfile" source field can be used.
3. (Maybe) change the `toclevels` setting to show all subsections in the TOC, to facilitating browsing the document through hyperlinks.
4. ~~Improve `oc new-build` documentation (not here yet).~~
5. Document Binary source

---

Q&A:
1. [Q] Is the Dockerfile source only allowed when `strategy: "Docker"`? Setting `strategy: "Source"`
   fails validation, but `strategy: "Custom"` passes. `oc new-build` only allow `--strategy=source`.
   [A] Currently not allowed with Source strategy, but this restriction should be relaxed.
2. [Q] Can there be two build sources at once? [This comment](https://github.com/openshift/origin/pull/4717/files#diff-43dd40b4c2b85b388a3d9116729032e4R123) suggests so.
   
   ```
   {
     source: {
       type: "Git",
       git: {...},
       dockerfile: "..."
     }
   }
   ```
   
   [A] Yes. Git and Binary are mutually exclusive, Dockerfile is always available.
3. [Q] If it is valid to have `source.git` and `source.dockerfile` set at the same
   time, does it imply that the `type` must be `"Git"`?
   [A] Currently yes, but it should not be the case.
4. [Q] If it is valid to have `source.git` and `source.dockerfile` set at the same
   time, how to achieve that with `oc new-build`?
   [A] `oc new-build <src> -D ...` should work (see https://github.com/openshift/origin/issues/6199)
