### PR TITLE
Include links to build strategy options in listing

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -14,9 +14,9 @@ toc::[]
 A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
 runnable images to be used on OpenShift. There are three build strategies:
 
-- link:../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-To-Image (S2I)]
-- link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[Docker]
-- link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[Custom]
+- Source-To-Image (S2I) (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description], link:#source-to-image-strategy-options[options])
+- Docker (link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description], link:#docker-strategy-options[options])
+- Custom (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description], link:#custom-strategy-options[options])
 
 [[defining-a-buildconfig]]
 


### PR DESCRIPTION
This change enhances the navigability of the Developer Guide for Builds.

We already link to the broader explanation of each build strategy in each strategy options subsection, so for me it is natural that when listing the strategies in the overview we should be able to click and go to the usage options (in the same page).

![selection_003](https://cloud.githubusercontent.com/assets/88819/11593793/8745c180-9aa6-11e5-869f-45e44c644a4f.png)
