### PR TITLE
Add "Viewing Build Details" and "Build Output" sections

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -14,9 +14,15 @@ toc::[]
 A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
 runnable images to be used on OpenShift. There are three build strategies:
 
-- Source-To-Image (S2I) (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description], link:#source-to-image-strategy-options[options])
-- Docker (link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description], link:#docker-strategy-options[options])
-- Custom (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description], link:#custom-strategy-options[options])
+- Source-To-Image (S2I)
+(link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description],
+link:#source-to-image-strategy-options[options])
+- Docker
+(link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description],
+link:#docker-strategy-options[options])
+- Custom
+(link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description],
+link:#custom-strategy-options[options])
 
 [[defining-a-buildconfig]]
 
@@ -561,7 +567,7 @@ $ oc start-build <BuildConfigName>
 Re-run a build using the `--from-build` flag:
 
 ----
-$ oc start-build --from-build=<buildName>
+$ oc start-build --from-build=<build_name>
 ----
 
 Specify the `--follow` flag to stream the build's logs in stdout:
@@ -576,33 +582,42 @@ $ oc start-build <BuildConfigName> --follow
 Manually cancel a build using the web console, or with the following CLI command:
 
 ----
-$ oc cancel-build <buildName>
+$ oc cancel-build <build_name>
 ----
 
 [[viewing-build-details]]
 == Viewing Build Details
-View build details using the web console, or with the following CLI command:
+
+You can view build details using the web console or the following CLI command:
 
 ----
-$ oc describe build <buildName>
+$ oc describe build <build_name>
 ----
 
-The output of the describe command includes information such the build source, strategy and output destination.
-If the build uses the Docker or Source strategy, it will also include information about the source revision used
-for the build: commit ID, author, committer, and message.
+The output of the `describe` command includes details such as the build source,
+strategy, and output destination.
 
 [[accessing-build-logs]]
 
 == Accessing Build Logs
-To allow access to build logs, use one of the following commands:
+You can access build logs using the web console or the CLI.
+
+To stream the logs using the build directly:
 
 ----
-// Stream the logs using the build directly
-$ oc logs -f build/<buildName>
-// Stream the logs of the latest build for build config
-$ oc logs -f bc/<buildConfigName>
-// Return the logs of the first build for build config
-$ oc logs --version=1 bc/<buildConfigName>
+$ oc logs -f build/<build_name>
+----
+
+To stream the logs of the latest build for a build configuration:
+
+----
+$ oc logs -f bc/<buildconfig_name>
+----
+
+To return the logs of a given version build for a build configuration:
+
+----
+$ oc logs --version=<number> bc/<buildconfig_name>
 ----
 
 *Log Verbosity*
@@ -1329,15 +1344,20 @@ $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
 ====
 
+[[build-output]]
 == Build Output
 
-Docker and source builds will result in a new Docker image getting created. The image is
-then pushed to the registry specified in the `*output*` section of the `*Build*` specification.
-If the output kind is `*ImageStreamTag*` then the image will be pushed to the OpenShift registry
-and tagged in the specified ImageStream. If the output is of type `*DockerImage*` then the
-name of the output reference will be used as a Docker push specification. The specification may contain
-a registry or will default to DockerHub if no registry is specified. If the output section of the
-build specification is empty, then the image will not be pushed at the end of the build.
+Docker and Source builds result in the creation of a new Docker image. The image
+is then pushed to the registry specified in the `*output*` section of the
+`*Build*` specification.
+
+If the output kind is `*ImageStreamTag*`, then the image will be pushed to the
+integrated OpenShift registry and tagged in the specified image stream. If the
+output is of type `*DockerImage*`, then the name of the output reference will be
+used as a Docker push specification. The specification may contain a registry or
+will default to DockerHub if no registry is specified. If the output section of
+the build specification is empty, then the image will not be pushed at the end
+of the build.
 
 .Output to an ImageStreamTag
 ====
@@ -1353,7 +1373,7 @@ build specification is empty, then the image will not be pushed at the end of th
 ----
 ====
 
-.Output to a Docker push specification
+.Output to a Docker Push Specification
 ====
 
 [source,json]
@@ -1367,26 +1387,58 @@ build specification is empty, then the image will not be pushed at the end of th
 ----
 ====
 
+[[output-image-environment-variables]]
 === Output Image Environment Variables
 
-Docker and source builds set the following environment variables on output images:
+Docker and Source builds set the following environment variables on output
+images:
 
-[horizontal]
-OPENSHIFT_BUILD_NAME:: Name of the build
-OPENSHIFT_BUILD_NAMESPACE:: Namespace of the build
-OPENSHIFT_BUILD_SOURCE:: The source URL of the build
-OPENSHIFT_BUILD_REFERENCE:: The git reference used in the build
-OPENSHIFT_BUILD_COMMIT:: Source commit used in the build
+[options="header"]
+|===
 
+|Variable |Description
+
+|`*OPENSHIFT_BUILD_NAME*`
+|Name of the build
+
+|`*OPENSHIFT_BUILD_NAMESPACE*`
+|Namespace of the build
+
+|`*OPENSHIFT_BUILD_SOURCE*`
+|The source URL of the build
+
+|`*OPENSHIFT_BUILD_REFERENCE*`
+|The Git reference used in the build
+
+|`*OPENSHIFT_BUILD_COMMIT*`
+|Source commit used in the build
+|===
+
+[[output-image-labels]]
 === Output Image Labels
 
-Docker and source builds set the following labels on output images:
+Docker and Source builds set the following labels on output images:
 
-[horizontal]
-io.openshift.build.commit.author:: Author of the source commit used in the build
-io.openshift.build.commit.date:: Date of the source commit used in the build
-io.openshift.build.commit.id:: Hash of the source commit used in the build
-io.openshift.build.commit.message:: Message of the source commit used in the build
-io.openshift.build.commit.ref:: Branch or reference specified in the source
-io.openshift.build.source-location:: Source URL for the build
+[options="header"]
+|===
 
+|Label |Description
+
+|*io.openshift.build.commit.author*
+|Author of the source commit used in the build
+
+|*io.openshift.build.commit.date*
+|Date of the source commit used in the build
+
+|*io.openshift.build.commit.id*
+|Hash of the source commit used in the build
+
+|*io.openshift.build.commit.message*
+|Message of the source commit used in the build
+
+|*io.openshift.build.commit.ref*
+|Branch or reference specified in the source
+
+|*io.openshift.build.source-location*
+|Source URL for the build
+|===

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -579,6 +579,18 @@ Manually cancel a build using the web console, or with the following CLI command
 $ oc cancel-build <buildName>
 ----
 
+[[viewing-build-details]]
+== Viewing Build Details
+View build details using the web console, or with the following CLI command:
+
+----
+$ oc describe build <buildName>
+----
+
+The output of the describe command includes information such the build source, strategy and output destination.
+If the build uses the Docker or Source strategy, it will also include information about the source revision used
+for the build: commit ID, author, committer, and message.
+
 [[accessing-build-logs]]
 
 == Accessing Build Logs
@@ -1316,3 +1328,65 @@ for the `http` section in your `.gitconfig` file:
 $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
 ====
+
+== Build Output
+
+Docker and source builds will result in a new Docker image getting created. The image is
+then pushed to the registry specified in the `*output*` section of the `*Build*` specification.
+If the output kind is `*ImageStreamTag*` then the image will be pushed to the OpenShift registry
+and tagged in the specified ImageStream. If the output is of type `*DockerImage*` then the
+name of the output reference will be used as a Docker push specification. The specification may contain
+a registry or will default to DockerHub if no registry is specified. If the output section of the
+build specification is empty, then the image will not be pushed at the end of the build.
+
+.Output to an ImageStreamTag
+====
+
+[source,json]
+----
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag"
+        "name": "sample-image:latest"
+      }
+    }
+----
+====
+
+.Output to a Docker push specification
+====
+
+[source,json]
+----
+    "output": {
+      "to": {
+        "kind": "DockerImage"
+        "name": "my-registry.mycompany.com:5000/myimages/myimage:tag"
+      }
+    }
+----
+====
+
+=== Output Image Environment Variables
+
+Docker and source builds set the following environment variables on output images:
+
+[horizontal]
+OPENSHIFT_BUILD_NAME:: Name of the build
+OPENSHIFT_BUILD_NAMESPACE:: Namespace of the build
+OPENSHIFT_BUILD_SOURCE:: The source URL of the build
+OPENSHIFT_BUILD_REFERENCE:: The git reference used in the build
+OPENSHIFT_BUILD_COMMIT:: Source commit used in the build
+
+=== Output Image Labels
+
+Docker and source builds set the following labels on output images:
+
+[horizontal]
+io.openshift.build.commit.author:: Author of the source commit used in the build
+io.openshift.build.commit.date:: Date of the source commit used in the build
+io.openshift.build.commit.id:: Hash of the source commit used in the build
+io.openshift.build.commit.message:: Message of the source commit used in the build
+io.openshift.build.commit.ref:: Branch or reference specified in the source
+io.openshift.build.source-location:: Source URL for the build
+


### PR DESCRIPTION
Pulls in and applies edits to commit from https://github.com/openshift/openshift-docs/pull/1258.

@csrwng Seems like it but can you verify that all this is fine to publish immediately in the OSE 3.1 docs?
