### PR TITLE
Emphasize that a branch/PR should have closely-related changes.

### DIFF
--- a/contributing_to_docs/contributing.adoc
+++ b/contributing_to_docs/contributing.adoc
@@ -15,7 +15,11 @@ There are a few different ways you can contribute to OpenShift documentation:
 * https://github.com/openshift/openshift-docs/issues/new[Create an issue in
 GitHub]
 * If you would like to do the work yourself, or if it is a substantial change,
-then you you should clone the repository, make your changes, and submit a PR
+then you you should clone the repository, make your changes, and submit a PR.
+Each PR should have closely-related changes.
+In particular, it is a good idea to use separate PRs
+for bugfix changes (for an old or current release)
+vs enhancement changes (for an upcoming new release).
 
 *What happens when you submit a PR?*
 

--- a/contributing_to_docs/create_or_edit_content.adoc
+++ b/contributing_to_docs/create_or_edit_content.adoc
@@ -59,6 +59,11 @@ any new content.
 
 The following command creates a new local branch and checks it out
 automatically. Be sure to replace `<working_branch>` with a suitable name.
+Also, be sure that the changes made on this branch are closely related and
+do indeed reflect that name.
+In particular, it is a good idea to use separate PRs
+for bugfix changes (for an old or current release)
+vs enhancement changes (for an upcoming new release).
 
 ----
 $ git checkout -b <working_branch>


### PR DESCRIPTION
This is the result of a discussion on how to make cherry-picking
easier for the One That Merges during the 2015-12-07 (or -08,
depending on your time zone) OpenShift writers' meeting.

@vikram-redhat @bfallonf @tpoitras @adellape 
In two places because the dominant pov for some is "branch", for others, "PR".
