### PR TITLE
Add binary source documentation for starting a build

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -975,6 +975,29 @@ Specify the `--follow` flag to stream the build's logs in stdout:
 $ oc start-build <BuildConfigName> --follow
 ----
 
+Specify the `--env` flag to set environment variable for the build:
+
+----
+$ oc start-build <BuildConfigName> --env=RACK_ENV=development
+----
+
+[[starting-a-build-from-binary-source]]
+Users can push the binary contents into a build rather than relying on the
+Git source pull or a Dockerfile. This can be done by specifying one of the
+following options for the `start-build` command:
+
+* `--from-dir=<directory>` specifies a directory that will be archived and used as a binary input for the build.
+* `--from-file=<file>` specifies a single file that will be the only file in the build source.
+* `--from-repo=<local source repository>` specifies a path to a local repository to use as the binary input for a build
+
+For example, the following command sends the contents of a local Git repository
+as an archive from the tag 'v2' and starts the build of it:
+
+----
+$ oc start-build hello-world --from-repo=../hello-world --commit=v2
+----
+
+
 [[canceling-a-build]]
 
 == Canceling a Build


### PR DESCRIPTION
This is a documentation part of: https://trello.com/c/oI1ddWEn/273-5-users-can-push-binary-contents-to-trigger-a-build
