### PR TITLE
Fix API bug: parameters -> spec

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -694,7 +694,7 @@ In this case `*basicsecret*`:
   "metadata": {
     "name": "sample-build",
   },
-  "parameters": {
+  "spec": {
     "output": {
       "to": {
         "kind": "ImageStreamTag"
@@ -798,7 +798,7 @@ In this case `*sshsecret*`:
   "metadata": {
     "name": "sample-build",
   },
-  "parameters": {
+  "spec": {
     "output": {
       "to": {
         "kind": "ImageStreamTag"
@@ -1420,7 +1420,7 @@ is *dockerhub*:
 
 ----
 {
-  "parameters": {
+  "spec": {
     "output": {
       "to": {
         "kind": "DockerImage"


### PR DESCRIPTION
The examples referred to the wrong field name (used in old beta APIs).
