### PR TITLE
dev_guide/builds.adoc: fix name of secret in example.

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -781,7 +781,7 @@ following command:
 ====
 
 ----
-$ oc secrets add serviceaccount/builder secrets/scmsecret
+$ oc secrets add serviceaccount/builder secrets/sshsecret
 ----
 ====
 


### PR DESCRIPTION
The `scmsecret` secret doesn't exist, because we've created secret with name `sshsecret`.

@rhcarvalho PTAL
