### PR TITLE
dev_guide/builds.adoc: mention that pullSecret may be used for all type of strategies

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1478,6 +1478,11 @@ is *dockerhub*:
 ----
 ====
 
+[NOTE]
+====
+This example uses `*pullSecret*` in a Source build, but it is also applicable
+in Docker and Custom builds.
+====
 
 [[build-output]]
 == Build Output


### PR DESCRIPTION
Maybe I missed something but I didn't find where we explicitly talking that `pullSecret` may be used with all of our strategies. As far I can see in the sources, we can use it.

@rhcarvalho PTAL.
