### PR TITLE
dev_guide/builds.adoc: mention why we are adding secret to serviceaccount/builder

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -673,7 +673,9 @@ $ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD -
 ----
 ====
 
-. Add the `*secret*` to the builder service account:
+. Add the `*secret*` to the builder service account. Each build is run with
+`serviceaccount/builder` role, so you need to give it access your secret with
+following command:
 +
 ====
 ----
@@ -870,7 +872,10 @@ for the `http` section in your `.gitconfig` file:
 ----
 ====
 
-. Add the `*secret*` to the builder service account:
+. Add the `*secret*` to the builder service account. Each build is run with
+`serviceaccount/builder` role, so you need to give it access your secret with
+following command:
+
 +
 ====
 ----
@@ -1404,7 +1409,10 @@ $ oc secrets new dockerhub ~/.dockercfg
 This generates a JSON specification of the `*secret*` named *dockerhub* and
 creates the object.
 
-. Once the `*secret*` is created, add it to the builder service account:
+. Once the `*secret*` is created, add it to the builder service account. Each
+build is run with `serviceaccount/builder` role, so you need to give it access
+your secret with following command:
+
 +
 ====
 ----


### PR DESCRIPTION
We are describing why we are need to add secret to `serviceaccount/builder` in one case but we don't explain it in other cases. I believe we should explain the reason everywhere. It could be useful when the reader didn't read all the page but just open doc on the desired section (maybe someone referred him here in mailing list).

@rhcarvalho PTAL.
