### PR TITLE
Enterprise 3.0 Weekly Publishing Schedule - Dec 14, 2015

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -14,9 +14,9 @@ toc::[]
 A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
 runnable images to be used on OpenShift. There are three build strategies:
 
-- link:../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-To-Image (S2I)]
-- link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[Docker]
-- link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[Custom]
+- Source-To-Image (S2I) (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description], link:#source-to-image-strategy-options[options])
+- Docker (link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description], link:#docker-strategy-options[options])
+- Custom (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description], link:#custom-strategy-options[options])
 
 [[defining-a-buildconfig]]
 

--- a/using_images/xpaas_images/a_mq.adoc
+++ b/using_images/xpaas_images/a_mq.adoc
@@ -79,7 +79,7 @@ configured:
   *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random
   password is generated.
 `*AMQ_ADMIN_USERNAME*`::
-  The username used as an admin authentication to the broker. If no value is specified, a random user name is generated.
+  The user name used as an admin authentication to the broker. If no value is specified, a random user name is generated.
 `*AMQ_ADMIN_PASSWORD*`::
   The password used for authentication to the broker. If no value is specified, a random password is generated.
 `*MQ_PROTOCOL*`::
@@ -115,12 +115,12 @@ application's Git project root. On each commit, the file will be copied to the
 *_conf_* directory in the A-MQ root and its contents used to configure the
 broker.
 
-== Configuring the JBoss A-MQ Persistance Image
+== Configuring the JBoss A-MQ Persistent Image
 
 [[configuring-params]]
 === Application Template Parameters
 
-Basic configuration of the JBoss A-MQ Persistance xPaaS image is performed by specifying
+Basic configuration of the JBoss A-MQ Persistent xPaaS image is performed by specifying
 values of application template parameters. The following parameters can be
 configured:
 
@@ -145,7 +145,7 @@ configured:
   Comma-separated list of topics available by default on the broker on its
   startup.
 `*VOLUME_CAPACITY*`::
-  The size of the persistence storage for database volumes. 
+  The size of the persistent storage for database volumes.
 `*MQ_USERNAME*`::
   The user name used for authentication to the broker. In a standard
   non-containerized JBoss A-MQ, you would specify the user name in the
@@ -157,7 +157,7 @@ configured:
   *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random
   password is generated.
 `*AMQ_ADMIN_USERNAME*`::
-  The username used as an admin authentication to the broker. If no value is specified, a random user name is generated.
+  The user name used as an admin authentication to the broker. If no value is specified, a random user name is generated.
 `*AMQ_ADMIN_PASSWORD*`::
   The password used for authentication to the broker. If no value is specified, a random password is generated.
 `*AMQ_SECRET*`::
@@ -167,8 +167,8 @@ configured:
 `*AMQ_KEYSTORE*`::
   The SSL key store filename. If no value is specified, a random password is generated.
 
-For more information, see 
-link:../../https://github.com/openshift/openshift-docs/blob/master/dev_guide/persistent_volumes.adoc#using-persistent-volumes[Using Persistance Volumes]
+For more information, see
+link:../../dev_guide/persistent_volumes.html#using-persistent-volumes[Using Persistent Volumes].
 
 == Security
 

--- a/using_images/xpaas_images/a_mq.adoc
+++ b/using_images/xpaas_images/a_mq.adoc
@@ -78,6 +78,10 @@ configured:
   non-containerized JBoss A-MQ, you would specify the password in the
   *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random
   password is generated.
+`*AMQ_ADMIN_USERNAME*`::
+  The username used as an admin authentication to the broker. If no value is specified, a random user name is generated.
+`*AMQ_ADMIN_PASSWORD*`::
+  The password used for authentication to the broker. If no value is specified, a random password is generated.
 `*MQ_PROTOCOL*`::
   Comma-separated list of the messaging protocols used by the broker. Available
   options are _amqp_, _mqtt_, _openwire_, and _stomp_. If left empty, all
@@ -91,6 +95,12 @@ configured:
 `*MQ_TOPICS*`::
   Comma-separated list of topics available by default on the broker on its
   startup.
+`*AMQ_SECRET*`::
+  The name of a secret containing SSL related files. If no value is specified, a random password is generated.
+`*AMQ_TRUSTSTORE*`::
+  The SSL trust store filename. If no value is specified, a random password is generated.
+`*AMQ_KEYSTORE*`::
+The SSL key store filename. If no value is specified, a random password is generated.
 
 [[configuring-sti]]
 === Configuration Using S2I
@@ -104,6 +114,61 @@ Custom A-MQ broker configuration can be specified by creating an
 application's Git project root. On each commit, the file will be copied to the
 *_conf_* directory in the A-MQ root and its contents used to configure the
 broker.
+
+== Configuring the JBoss A-MQ Persistance Image
+
+[[configuring-params]]
+=== Application Template Parameters
+
+Basic configuration of the JBoss A-MQ Persistance xPaaS image is performed by specifying
+values of application template parameters. The following parameters can be
+configured:
+
+`*AMQ_RELEASE*`::
+  The JBoss A-MQ release version. This determines which JBoss A-MQ image will be
+  used as a basis for the application. At the moment, only version _6.2_ is
+  available.
+`*APPLICATION_NAME*`::
+  The name of the application used internally in OpenShift. It is used in names
+  of services, pods, and other objects within the application.
+`*MQ_PROTOCOL*`::
+  Comma-separated list of the messaging protocols used by the broker. Available
+  options are _amqp_, _mqtt_, _openwire_, and _stomp_. If left empty, all
+  available protocols will be available. Please note that for integration of the
+  image with Red Hat JBoss Enterprise Application Platform, the _openwire_
+  protocol must be specified, while other protocols can be optionally specified
+  as well.
+`*MQ_QUEUES*`::
+  Comma-separated list of queues available by default on the broker on its
+  startup.
+`*MQ_TOPICS*`::
+  Comma-separated list of topics available by default on the broker on its
+  startup.
+`*VOLUME_CAPACITY*`::
+  The size of the persistence storage for database volumes. 
+`*MQ_USERNAME*`::
+  The user name used for authentication to the broker. In a standard
+  non-containerized JBoss A-MQ, you would specify the user name in the
+  *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random user
+  name is generated.
+`*MQ_PASSWORD*`::
+  The password used for authentication to the broker. In a standard
+  non-containerized JBoss A-MQ, you would specify the password in the
+  *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random
+  password is generated.
+`*AMQ_ADMIN_USERNAME*`::
+  The username used as an admin authentication to the broker. If no value is specified, a random user name is generated.
+`*AMQ_ADMIN_PASSWORD*`::
+  The password used for authentication to the broker. If no value is specified, a random password is generated.
+`*AMQ_SECRET*`::
+  The name of a secret containing SSL related files. If no value is specified, a random password is generated.
+`*AMQ_TRUSTSTORE*`::
+  The SSL trust store filename. If no value is specified, a random password is generated.
+`*AMQ_KEYSTORE*`::
+  The SSL key store filename. If no value is specified, a random password is generated.
+
+For more information, see 
+link:../../https://github.com/openshift/openshift-docs/blob/master/dev_guide/persistent_volumes.adoc#using-persistent-volumes[Using Persistance Volumes]
 
 == Security
 


### PR DESCRIPTION
This week's cherry-picked commits for OSE 3.0:

**Using Images**
- FUSEDOC-818: Updates the "Red Hat JBoss A-MQ xPaaS Image" topic to include missing template parameters, descriptions for the "persistent" templates, and other fixes.

**Developer Guide**
- Updates the "Builds" topic to include more helpful links to build strategy descriptions and options.
