### PR TITLE
Enterprise 3.1 Weekly Publishing Schedule - Dec 14, 2015

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -223,7 +223,7 @@ Topics:
     File: manage_scc
   - Name: Scheduler
     File: scheduler
-  - Name: Overcommit
+  - Name: Overcommitting
     File: overcommit
   - Name: Pruning Objects
     File: pruning_resources

--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -309,13 +309,28 @@ $ oc get scc privileged -o json |
 in the first step. The following example runs three instances using the
 *ipfailover* service account:
 +
+ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm router ha-router-us-west --replicas=3  \
-       --selector="ha-router=geo-us-west" --labels="ha-router=geo-us-west" \
-       --credentials="$KUBECONFIG" --service-account=ipfailover
+$ oadm router ha-router-us-west --replicas=3 \
+    --selector="ha-router=geo-us-west" \
+    --labels="ha-router=geo-us-west" \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover
 ----
 ====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm router ha-router-us-west --replicas=3 \
+    --selector="ha-router=geo-us-west" \
+    --labels="ha-router=geo-us-west" \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover
+----
+====
+endif::[]
 +
 [NOTE]
 ====
@@ -338,13 +353,30 @@ below) should be different from the name of the router configuration
 configuration with those names. Specify the VIPs addresses and the port number
 that *ipfailover* should monitor on the desired instances:
 +
+ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm ipfailover ipf-ha-router-us-west --replicas=5  --watch-port=80    \
-     --selector="ha-router=geo-us-west" --virtual-ips="10.245.2.101-105" \
-     --credentials="$KUBECONFIG" --service-account=ipfailover --create
+$ oadm ipfailover ipf-ha-router-us-west \
+    --replicas=5 --watch-port=80 \
+    --selector="ha-router=geo-us-west" \
+    --virtual-ips="10.245.2.101-105" \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover --create
 ----
 ====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm ipfailover ipf-ha-router-us-west \
+    --replicas=5 --watch-port=80 \
+    --selector="ha-router=geo-us-west" \
+    --virtual-ips="10.245.2.101-105" \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover --create
+----
+====
+endif::[]
 
 === Configuring a Highly-available Network Service [[ip-failover]]
 
@@ -465,13 +497,28 @@ of nodes and that they satisfy the label setup in first step. Specify the VIP
 addresses and the port number that *ipfailover* should monitor for the desired
 instances:
 +
+ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm ipfailover ipf-ha-geo-cache --replicas=4 --selector="ha-cache=geo" \
-        --virtual-ips=10.245.2.101-104 --watch-port=9736  \
-	--credentials="$KUBECONFIG" --service-account=ipfailover --create
+$ oadm ipfailover ipf-ha-geo-cache \
+    --replicas=4 --selector="ha-cache=geo" \
+    --virtual-ips=10.245.2.101-104 --watch-port=9736  \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover --create
 ----
 ====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm ipfailover ipf-ha-geo-cache \
+    --replicas=4 --selector="ha-cache=geo" \
+    --virtual-ips=10.245.2.101-104 --watch-port=9736 \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover --create
+----
+====
+endif::[]
 ////
 +
 As an alternative, the following example creates an IP failover configuration on

--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -1,4 +1,4 @@
-= Overcommit
+= Overcommitting
 {product-author}
 {product-version}
 :data-uri:
@@ -11,61 +11,137 @@ toc::[]
 
 == Overview
 
-The scheduler attempts to improve the utilization of compute resources across all nodes in the cluster.
+Containers can specify link:../dev_guide/compute_resources.html[compute resource
+requests and limits]. Requests are used for scheduling your container and
+provide a minimum service guarantee. Limits constrain the amount of compute
+resource that may be consumed on your node.
 
-It places pods on nodes relative to the pods compute resource requests to find a node that provides the best fit.
+The link:../admin_guide/scheduler.html[scheduler] attempts to improve the
+utilization of compute resources across all nodes in the cluster. It places pods
+on nodes relative to the pods' compute resource requests to find a node that
+provides the best fit.
 
+Requests and limits enable administrators to allow and manage the overcommitment
+of resources on a node, which may be desirable in development environments where
+performance is not a concern.
+
+[[requests-and-limits]]
 == Requests and Limits
 
-For each compute resource, a container may specify a resource request and limit.  Scheduling decisions are made based on the request to ensure that a node has enough capacity available to meet the requested value.  If a container specifies limits, but omits requests, the requests are defaulted to the limits.  A container is not able to exceed the specified limit on the node.  The enforcement of limits is dependent upon the compute resource type.  If a container makes no request or limit, the container is scheduled to a node with no resource guarantees.  In practice, the container is able to consume as much of the specified resource as is available with the lowest local priority.  In low resource situations, containers that specify no resource requests are given the lowest quality of service.
+For each compute resource, a container may specify a resource request and limit.
+Scheduling decisions are made based on the request to ensure that a node has
+enough capacity available to meet the requested value. If a container specifies
+limits, but omits requests, the requests are defaulted to the limits. A
+container is not able to exceed the specified limit on the node.
 
+The enforcement of limits is dependent upon the compute resource type. If a
+container makes no request or limit, the container is scheduled to a node with
+no resource guarantees. In practice, the container is able to consume as much of
+the specified resource as is available with the lowest local priority. In low
+resource situations, containers that specify no resource requests are given the
+lowest quality of service.
+
+[[compute-resources]]
 == Compute Resources
 
-The node enforced behavior for compute resources is resource type specific.
+The node-enforced behavior for compute resources is specific to the resource
+type.
 
+[[overcommit-cpu]]
 === CPU
 
-A container is guaranteed the amount of CPU it requests, but it may or may not get more CPU time based on local node conditions.  If a container does not specify a corresponding limit, it is able to consume as much excess CPU is available on the node.  If multiple containers are attempting to use excess CPU, CPU time is distributed based on the amount of CPU requested by each container.  For example, if one container requested 500m of CPU time, and another container requested 250m of CPU time, any extra CPU time available on the node is distributed among the containers in a 2:1 ratio.  If a container specified a limit, it will be throttled to not use more CPU than the specified limit. 
+A container is guaranteed the amount of CPU it requests, but it may or may not
+get more CPU time based on local node conditions. If a container does not
+specify a corresponding limit, it is able to consume excess CPU available on the
+node. If multiple containers are attempting to use excess CPU, CPU time is
+distributed based on the amount of CPU requested by each container.
 
-CPU requests are enforced using the CFS shares support in the Linux kernel.  CPU limits are enforced using the CFS quota support in the Linux kernel over a 100ms measuring interval by default.
+For example, if one container requested 500m of CPU time, and another container
+requested 250m of CPU time, any extra CPU time available on the node is
+distributed among the containers in a 2:1 ratio. If a container specified a
+limit, it will be throttled to not use more CPU than the specified limit.
 
+CPU requests are enforced using the CFS shares support in the Linux kernel. By
+default, CPU limits are enforced using the CFS quota support in the Linux kernel
+over a 100ms measuring interval, though link:#enforcing-cpu-limits[this can be
+disabled].
+
+[[overcommit-memory]]
 === Memory
 
-A container is guaranteed the amount of memory it requests.  A container may use more memory than requested, but once it exceeds its requested amount, it could be killed in a low memory situation on the node.  If a container uses less memory than requested, it will not be killed unless system tasks or daemons need more memory than was accounted for in the nodes resource reservation.  If a container specifies a limit on memory, it is immediately killed if it exceeds the limited amount.
+A container is guaranteed the amount of memory it requests. A container may use
+more memory than requested, but once it exceeds its requested amount, it could
+be killed in a low memory situation on the node.
 
+If a container uses less memory than requested, it will not be killed unless
+system tasks or daemons need more memory than was accounted for in the node's
+resource reservation. If a container specifies a limit on memory, it is
+immediately killed if it exceeds the limited amount.
+
+[[qos-classes]]
 == Quality of Service Classes
 
-A node is overcommitted when it has a pod scheduled that makes no request, or when the sum of limits across all pods on that node exceeds available machine capacity.  In this environment, it is possible that the pods on the node will attempt to use more compute resource than is available at any given point in time.  When this occurs, the node must give priority to one pod over another.  The facility used to make this decision is referred to as a Quality of Service (QoS) Class.
+A node is _overcommitted_ when it has a pod scheduled that makes no request, or
+when the sum of limits across all pods on that node exceeds available machine
+capacity.
 
-For each compute resource, a container is divided into one of 3 QoS classes with decreasing order of priority:
+In an overcommitted environment, it is possible that the pods on the node will
+attempt to use more compute resource than is available at any given point in
+time. When this occurs, the node must give priority to one pod over another. The
+facility used to make this decision is referred to as a Quality of Service (QoS)
+Class.
 
-1. Guaranteed
-2. Burstable
-3. BestEffort
+For each compute resource, a container is divided into one of three QoS classes
+with decreasing order of priority:
 
-If limits and optionally requests are set (not equal to 0) for all resources and they are equal, then the container is classified as Guaranteed.
+.Quality of Service Classes
+[options="header",cols="1,1,5"]
+|===
+|Priority |Class Name |Description
 
-If requests and optionally limits are set (not equal to 0) for all resources, and they are not equal, then the container is classified as Burstable.
+|1 (highest)
+|*Guaranteed*
+|If limits and optionally requests are set (not equal to 0) for all resources
+and they are equal, then the container is classified as *Guaranteed*.
 
-If requests and limits are not set for any of the resources, then the container is classified as BestEffort.
+|2
+|*Burstable*
+|If requests and optionally limits are set (not equal to 0) for all resources,
+and they are not equal, then the container is classified as *Burstable*.
 
-Memory is an incompressible resource, so in low-memory situations, containers are killed that have the lowest priority.
+|3 (lowest)
+|*BestEffort*
+|If requests and limits are not set for any of the resources, then the container
+is classified as *BestEffort*.
+|===
 
-1. BestEffort containers are treated with the lowest priority.  Processes in these containers are first to be killed if the system runs out of memory.
-2. Guaranteed containers are considered top priority, and are guaranteed to only be killed if they exceed their limits, or if the system is under memory pressure and there are no lower priority containers that can be evicted.
-3. Burstable containers under system memory pressure are more likely to be killed once they exceed their requests and no other BestEffort containers exist.
+Memory is an incompressible resource, so in low memory situations, containers
+are killed that have the lowest priority:
 
-== Node configuration
+- *Guaranteed* containers are considered top priority, and are guaranteed to
+only be killed if they exceed their limits, or if the system is under memory
+pressure and there are no lower priority containers that can be evicted.
+- *Burstable* containers under system memory pressure are more likely to be
+killed once they exceed their requests and no other *BestEffort* containers
+exist.
+- *BestEffort* containers are treated with the lowest priority. Processes in
+these containers are first to be killed if the system runs out of memory.
 
-In an overcommitted environment, it's important to properly configure your node to provide best system behavior.
+[[configuring-nodes-for-overcommitment]]
+== Configuring Nodes for Overcommitment
 
-=== Enforcing CPU limits
+In an overcommitted environment, it is important to properly configure your node
+to provide best system behavior.
 
-The node by default will enforce specified CPU limits using the CPU CFS quota support in the kernel.
+[[enforcing-cpu-limits]]
+=== Enforcing CPU Limits
 
-If you do not want to enforce CPU limits on the node, then you can disable its enforcement by modifying the node configuration as follows:
+Nodes by default enforce specified CPU limits using the CPU CFS quota support in
+the Linux kernel. If you do not want to enforce CPU limits on the node, you can
+disable its enforcement by modifying the
+link:../install_config/master_node_configuration.html[node configuration file]
+(the *_node-config.yaml_* file) to include the following:
 
-node-config.yaml
 ====
 ----
 kubeletArguments:
@@ -74,21 +150,36 @@ kubeletArguments:
 ----
 ====
 
-If CPU limit enforcement is disabled, it's important to understand the impact that will have on your node.  If a container makes a request
-for CPU, it will continue to be enforced by CFS shares in the Linux kernel.  If a container makes no explicit request for CPU, but it does
-specify a limit, the request will default to the specified limit, and be enforced by CFS shares in the Linux kernel.  If a container specifies
-both a request and a limit for CPU, the request will be enforced by CFS shares in the Linux kernel, and the limit will have no impact on the node.
+If CPU limit enforcement is disabled, it is important to understand the impact that will have on your node:
 
-=== Reserving resources for system processes
+- If a container makes a request for CPU, it will continue to be enforced by CFS
+shares in the Linux kernel.
+- If a container makes no explicit request for CPU, but it does specify a limit,
+the request will default to the specified limit, and be enforced by CFS shares
+in the Linux kernel.
+- If a container specifies both a request and a limit for CPU, the request will
+be enforced by CFS shares in the Linux kernel, and the limit will have no
+impact on the node.
 
-The scheduler ensures that there are enough resources for all pods on a node based on the pod requests.  It verifies that the sum of requests of containers on the node is no greater than the node capacity.  It includes all containers started by the node, but not containers or processes started outside the knowledge of the cluster.
+[[reserving-resources-for-system-processes]]
+=== Reserving Resources for System Processes
 
-It is recommended that you reserve some portion of the node capacity to allow for the system daemons that are required to run on your node for your cluster to function (sshd, docker, etc).  In particular, it is recommended
-that you reserve resources for incompressible resources like memory.
+The link:../admin_guide/scheduler.html[scheduler] ensures that there are enough
+resources for all pods on a node based on the pod requests. It verifies that the
+sum of requests of containers on the node is no greater than the node capacity.
+It includes all containers started by the node, but not containers or processes
+started outside the knowledge of the cluster.
 
-If you want to explicitly reserve resources for non-Pod processes, you can create a resource-reserver pod that does nothing but reserve capacity from being scheduled to on the node by the cluster.
+It is recommended that you reserve some portion of the node capacity to allow
+for the system daemons that are required to run on your node for your cluster to
+function (*sshd*, *docker*, etc.). In particular, it is recommended that you
+reserve resources for incompressible resources such as memory.
 
-resource-reserver.yaml
+If you want to explicitly reserve resources for non-pod processes, you can
+create a *resource-reserver* pod that does nothing but reserve capacity from
+being scheduled to on the node by the cluster. For example:
+
+.Definition for a *resource-reserver* Pod
 ====
 ----
 apiVersion: v1
@@ -101,42 +192,60 @@ spec:
     image: gcr.io/google_containers/pause:0.8.0
     resources:
       limits:
-        cpu: 100m <1>        
+        cpu: 100m <1>
         memory: 150Mi <2>
 ----
-<1> The amount of cpu you would like to reserve on a node for host level daemons unknown to the cluster.
-<2> The amount of memory you would like to reserve on a node for host level daemons unknown to the cluster.
+<1> The amount of CPU to reserve on a node for host-level daemons unknown to the
+cluster.
+<2> The amount of memory to reserve on a node for host-level daemons unknown to
+the cluster.
 ====
 
-Place the file in the node config directory, i.e. --config=DIR location.
+You can save your definition to a file, for example *_resource-reserver.yaml_*,
+then place the file in the node configuration directory, for example
+*_/etc/origin/node/_* or the `--config=<dir>` location if otherwise specified.
 
-On start of the node, the node agent will launch the specified container and the remaining capacity for the scheduler to place cluster pods will adjust accordingly.
+With this file in place, on start of the node, the node agent launches the
+specified container, and the remaining capacity for the scheduler to place
+cluster pods adjusts accordingly.
 
-=== Kernel tunable flags
+[[kernel-tunable-flags]]
+=== Kernel Tunable Flags
 
-When the node starts, it ensures that the kernel tunable flags for memory management are set properly.
+When the node starts, it ensures that the kernel tunable flags for memory
+management are set properly. The kernel should never fail memory allocations
+unless it runs out of physical memory.
 
-The kernel should never fail memory allocations unless it runs out of physical memory.  
-
-To ensure this behavior, the node instructs the kernel to always overcommit memory:
+To ensure this behavior, the node instructs the kernel to always overcommit
+memory:
 
 ----
 $ sysctl -w vm.overcommit_memory=1
 ----
 
-The node instructs the kernel to not panic when it runs out of memory.  
-
-Instead the kernel OOM killer should kill processes based on priority.
+The node also instructs the kernel not to panic when it runs out of memory.
+Instead, the kernel OOM killer should kill processes based on priority:
 
 ----
 $ sysctl -w vm.panic_on_oom=0
 ----
 
-=== Disable swap memory
+[NOTE]
+====
+The above flags should already be set on nodes, and no further action is
+required.
+====
 
-It is important to disable the use of swap memory on the node as it makes it difficult for the resource guarantees the scheduler makes during pod placement to hold.  For example, suppose 2 guaranteed pods have reached their memory limit.  Each container would start allocating memory on swap space.  Eventually, if there isn't enough swap space, processes in the pods might get killed.
+[[disabling-swap-memory]]
+=== Disabling Swap Memory
 
-To disable swap memory on each node:
+It is important to disable the use of swap memory on the node as it makes it
+difficult for the resource guarantees that the scheduler makes during pod
+placement to hold. For example, if two guaranteed pods have reached their memory
+limit, each container would start allocating memory on swap space. Eventually,
+if there was not enough swap space, processes in the pods might get killed.
+
+Disable swap memory on each node by running:
 
 ----
 $ swapoff -a

--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -35,7 +35,7 @@ A container is guaranteed the amount of memory it requests.  A container may use
 
 == Quality of Service Classes
 
-A node is overcommmitted when it has a pod scheduled that makes no request, or when the sum of limits across all pods on that node exceeds available machine capacity.  In this environment, it is possible that the pods on the node will attempt to use more compute resource than is available at any given point in time.  When this occurs, the node must give priority to one pod over another.  The facility used to make this decision is referred to as a Quality of Service (QoS) Class.
+A node is overcommitted when it has a pod scheduled that makes no request, or when the sum of limits across all pods on that node exceeds available machine capacity.  In this environment, it is possible that the pods on the node will attempt to use more compute resource than is available at any given point in time.  When this occurs, the node must give priority to one pod over another.  The facility used to make this decision is referred to as a Quality of Service (QoS) Class.
 
 For each compute resource, a container is divided into one of 3 QoS classes with decreasing order of priority:
 
@@ -58,6 +58,26 @@ Memory is an incompressible resource, so in low-memory situations, containers ar
 == Node configuration
 
 In an overcommitted environment, it's important to properly configure your node to provide best system behavior.
+
+=== Enforcing CPU limits
+
+The node by default will enforce specified CPU limits using the CPU CFS quota support in the kernel.
+
+If you do not want to enforce CPU limits on the node, then you can disable its enforcement by modifying the node configuration as follows:
+
+node-config.yaml
+====
+----
+kubeletArguments:
+  cpu-cfs-quota:
+    - "false"
+----
+====
+
+If CPU limit enforcement is disabled, it's important to understand the impact that will have on your node.  If a container makes a request
+for CPU, it will continue to be enforced by CFS shares in the Linux kernel.  If a container makes no explicit request for CPU, but it does
+specify a limit, the request will default to the specified limit, and be enforced by CFS shares in the Linux kernel.  If a container specifies
+both a request and a limit for CPU, the request will be enforced by CFS shares in the Linux kernel, and the limit will have no impact on the node.
 
 === Reserving resources for system processes
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -14,9 +14,9 @@ toc::[]
 A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
 runnable images to be used on OpenShift. There are three build strategies:
 
-- link:../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-To-Image (S2I)]
-- link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[Docker]
-- link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[Custom]
+- Source-To-Image (S2I) (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description], link:#source-to-image-strategy-options[options])
+- Docker (link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description], link:#docker-strategy-options[options])
+- Custom (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description], link:#custom-strategy-options[options])
 
 [[defining-a-buildconfig]]
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -14,9 +14,15 @@ toc::[]
 A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
 runnable images to be used on OpenShift. There are three build strategies:
 
-- Source-To-Image (S2I) (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description], link:#source-to-image-strategy-options[options])
-- Docker (link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description], link:#docker-strategy-options[options])
-- Custom (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description], link:#custom-strategy-options[options])
+- Source-To-Image (S2I)
+(link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description],
+link:#source-to-image-strategy-options[options])
+- Docker
+(link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[description],
+link:#docker-strategy-options[options])
+- Custom
+(link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description],
+link:#custom-strategy-options[options])
 
 [[defining-a-buildconfig]]
 
@@ -561,7 +567,7 @@ $ oc start-build <BuildConfigName>
 Re-run a build using the `--from-build` flag:
 
 ----
-$ oc start-build --from-build=<buildName>
+$ oc start-build --from-build=<build_name>
 ----
 
 Specify the `--follow` flag to stream the build's logs in stdout:
@@ -576,33 +582,42 @@ $ oc start-build <BuildConfigName> --follow
 Manually cancel a build using the web console, or with the following CLI command:
 
 ----
-$ oc cancel-build <buildName>
+$ oc cancel-build <build_name>
 ----
 
 [[viewing-build-details]]
 == Viewing Build Details
-View build details using the web console, or with the following CLI command:
+
+You can view build details using the web console or the following CLI command:
 
 ----
-$ oc describe build <buildName>
+$ oc describe build <build_name>
 ----
 
-The output of the describe command includes information such the build source, strategy and output destination.
-If the build uses the Docker or Source strategy, it will also include information about the source revision used
-for the build: commit ID, author, committer, and message.
+The output of the `describe` command includes details such as the build source,
+strategy, and output destination.
 
 [[accessing-build-logs]]
 
 == Accessing Build Logs
-To allow access to build logs, use one of the following commands:
+You can access build logs using the web console or the CLI.
+
+To stream the logs using the build directly:
 
 ----
-// Stream the logs using the build directly
-$ oc logs -f build/<buildName>
-// Stream the logs of the latest build for build config
-$ oc logs -f bc/<buildConfigName>
-// Return the logs of the first build for build config
-$ oc logs --version=1 bc/<buildConfigName>
+$ oc logs -f build/<build_name>
+----
+
+To stream the logs of the latest build for a build configuration:
+
+----
+$ oc logs -f bc/<buildconfig_name>
+----
+
+To return the logs of a given version build for a build configuration:
+
+----
+$ oc logs --version=<number> bc/<buildconfig_name>
 ----
 
 *Log Verbosity*
@@ -1329,15 +1344,20 @@ $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
 ====
 
+[[build-output]]
 == Build Output
 
-Docker and source builds will result in a new Docker image getting created. The image is
-then pushed to the registry specified in the `*output*` section of the `*Build*` specification.
-If the output kind is `*ImageStreamTag*` then the image will be pushed to the OpenShift registry
-and tagged in the specified ImageStream. If the output is of type `*DockerImage*` then the
-name of the output reference will be used as a Docker push specification. The specification may contain
-a registry or will default to DockerHub if no registry is specified. If the output section of the
-build specification is empty, then the image will not be pushed at the end of the build.
+Docker and Source builds result in the creation of a new Docker image. The image
+is then pushed to the registry specified in the `*output*` section of the
+`*Build*` specification.
+
+If the output kind is `*ImageStreamTag*`, then the image will be pushed to the
+integrated OpenShift registry and tagged in the specified image stream. If the
+output is of type `*DockerImage*`, then the name of the output reference will be
+used as a Docker push specification. The specification may contain a registry or
+will default to DockerHub if no registry is specified. If the output section of
+the build specification is empty, then the image will not be pushed at the end
+of the build.
 
 .Output to an ImageStreamTag
 ====
@@ -1353,7 +1373,7 @@ build specification is empty, then the image will not be pushed at the end of th
 ----
 ====
 
-.Output to a Docker push specification
+.Output to a Docker Push Specification
 ====
 
 [source,json]
@@ -1367,26 +1387,58 @@ build specification is empty, then the image will not be pushed at the end of th
 ----
 ====
 
+[[output-image-environment-variables]]
 === Output Image Environment Variables
 
-Docker and source builds set the following environment variables on output images:
+Docker and Source builds set the following environment variables on output
+images:
 
-[horizontal]
-OPENSHIFT_BUILD_NAME:: Name of the build
-OPENSHIFT_BUILD_NAMESPACE:: Namespace of the build
-OPENSHIFT_BUILD_SOURCE:: The source URL of the build
-OPENSHIFT_BUILD_REFERENCE:: The git reference used in the build
-OPENSHIFT_BUILD_COMMIT:: Source commit used in the build
+[options="header"]
+|===
 
+|Variable |Description
+
+|`*OPENSHIFT_BUILD_NAME*`
+|Name of the build
+
+|`*OPENSHIFT_BUILD_NAMESPACE*`
+|Namespace of the build
+
+|`*OPENSHIFT_BUILD_SOURCE*`
+|The source URL of the build
+
+|`*OPENSHIFT_BUILD_REFERENCE*`
+|The Git reference used in the build
+
+|`*OPENSHIFT_BUILD_COMMIT*`
+|Source commit used in the build
+|===
+
+[[output-image-labels]]
 === Output Image Labels
 
-Docker and source builds set the following labels on output images:
+Docker and Source builds set the following labels on output images:
 
-[horizontal]
-io.openshift.build.commit.author:: Author of the source commit used in the build
-io.openshift.build.commit.date:: Date of the source commit used in the build
-io.openshift.build.commit.id:: Hash of the source commit used in the build
-io.openshift.build.commit.message:: Message of the source commit used in the build
-io.openshift.build.commit.ref:: Branch or reference specified in the source
-io.openshift.build.source-location:: Source URL for the build
+[options="header"]
+|===
 
+|Label |Description
+
+|*io.openshift.build.commit.author*
+|Author of the source commit used in the build
+
+|*io.openshift.build.commit.date*
+|Date of the source commit used in the build
+
+|*io.openshift.build.commit.id*
+|Hash of the source commit used in the build
+
+|*io.openshift.build.commit.message*
+|Message of the source commit used in the build
+
+|*io.openshift.build.commit.ref*
+|Branch or reference specified in the source
+
+|*io.openshift.build.source-location*
+|Source URL for the build
+|===

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -579,6 +579,18 @@ Manually cancel a build using the web console, or with the following CLI command
 $ oc cancel-build <buildName>
 ----
 
+[[viewing-build-details]]
+== Viewing Build Details
+View build details using the web console, or with the following CLI command:
+
+----
+$ oc describe build <buildName>
+----
+
+The output of the describe command includes information such the build source, strategy and output destination.
+If the build uses the Docker or Source strategy, it will also include information about the source revision used
+for the build: commit ID, author, committer, and message.
+
 [[accessing-build-logs]]
 
 == Accessing Build Logs
@@ -1316,3 +1328,65 @@ for the `http` section in your `.gitconfig` file:
 $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
 ====
+
+== Build Output
+
+Docker and source builds will result in a new Docker image getting created. The image is
+then pushed to the registry specified in the `*output*` section of the `*Build*` specification.
+If the output kind is `*ImageStreamTag*` then the image will be pushed to the OpenShift registry
+and tagged in the specified ImageStream. If the output is of type `*DockerImage*` then the
+name of the output reference will be used as a Docker push specification. The specification may contain
+a registry or will default to DockerHub if no registry is specified. If the output section of the
+build specification is empty, then the image will not be pushed at the end of the build.
+
+.Output to an ImageStreamTag
+====
+
+[source,json]
+----
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag"
+        "name": "sample-image:latest"
+      }
+    }
+----
+====
+
+.Output to a Docker push specification
+====
+
+[source,json]
+----
+    "output": {
+      "to": {
+        "kind": "DockerImage"
+        "name": "my-registry.mycompany.com:5000/myimages/myimage:tag"
+      }
+    }
+----
+====
+
+=== Output Image Environment Variables
+
+Docker and source builds set the following environment variables on output images:
+
+[horizontal]
+OPENSHIFT_BUILD_NAME:: Name of the build
+OPENSHIFT_BUILD_NAMESPACE:: Namespace of the build
+OPENSHIFT_BUILD_SOURCE:: The source URL of the build
+OPENSHIFT_BUILD_REFERENCE:: The git reference used in the build
+OPENSHIFT_BUILD_COMMIT:: Source commit used in the build
+
+=== Output Image Labels
+
+Docker and source builds set the following labels on output images:
+
+[horizontal]
+io.openshift.build.commit.author:: Author of the source commit used in the build
+io.openshift.build.commit.date:: Date of the source commit used in the build
+io.openshift.build.commit.id:: Hash of the source commit used in the build
+io.openshift.build.commit.message:: Message of the source commit used in the build
+io.openshift.build.commit.ref:: Branch or reference specified in the source
+io.openshift.build.source-location:: Source URL for the build
+

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -19,7 +19,7 @@ server]. Developers and administrators obtain
 link:../architecture/additional_concepts/authentication.html#api-authentication[OAuth
 access tokens] to authenticate themselves to the API.
 
-As an administrator, you can configure OAuth using a
+As an administrator, you can configure OAuth using the
 link:../install_config/master_node_configuration.html[master configuration file] to specify an
 link:#identity-providers[identity provider]. If you installed OpenShift using
 the
@@ -44,19 +44,20 @@ configuration file.
 [[identity-providers]]
 
 == Identity Providers
-You can configure the master for authentication using your desired identity
-provider by modifying the link:../install_config/master_node_configuration.html[master
-configuration file]. The following sections detail the identity providers
-supported by OpenShift.
+You can configure the master host for authentication using your desired identity
+provider by modifying the
+link:../install_config/master_node_configuration.html[master configuration
+file]. The following sections detail the identity providers supported by
+OpenShift.
 
 There are three parameters common to all identity providers:
 
 [cols="2a,8a",options="header"]
 |===
 |Parameter     | Description
-.^|`name`      | The provider name is prefixed to provider user names to form an
+|`name`      | The provider name is prefixed to provider user names to form an
 identity name.
-.^|`challenge` | When *true*, unauthenticated token requests from non-web
+|`challenge` | When *true*, unauthenticated token requests from non-web
 clients (like the CLI) are sent a `WWW-Authenticate` challenge header. Not
 supported by all identity providers.
 
@@ -65,9 +66,68 @@ Basic authentication challenges are only sent if a `X-CSRF-Token` header is
 present on the request. Clients that expect to receive Basic `WWW-Authenticate`
 challenges should set this header to a non-empty value.
 
-.^|`login`     | When *true*, unauthenticated token requests from web clients
+|`login`     | When *true*, unauthenticated token requests from web clients
 (like the web console) are redirected to a login page backed by this provider.
 Not supported by all identity providers.
+
+|`mappingMethod`  | Defines how new identities are mapped to users when they login. See link:#mapping-identities-to-users[Mapping Identities to Users] for more information.
+|===
+
+[NOTE]
+When adding or changing identity providers, you can map identities from the new
+provider to existing users by setting the `*mappingMethod*` parameter to
+`*add*`.
+
+[[mapping-identities-to-users]]
+
+=== Mapping Identities to Users
+
+Setting the `*mappingMethod*` parameter in a
+link:../install_config/master_node_configuration.html[master configuration file]
+determines how identities are mapped to users:
+
+====
+----
+...
+oauthConfig:
+  identityProviders:
+  - name: htpasswd_auth
+    challenge: true
+    login: false
+    mappingMethod: "claim"
+...
+----
+====
+
+When set to the default `*claim*` value, OAuth will fail if the identity is
+mapped to a previously-existing user name. The following table outlines the use
+cases for the available `*mappingMethod*` parameter values:
+
+[cols="2,8"]
+|===
+|Parameter  | Description
+
+|`*claim*` | The default value. Provisions a user with the identity's preferred
+user name. Fails if a user with that user name is already mapped to another
+identity.
+
+|`*lookup*` | Looks up an existing identity, user identity mapping, and user,
+but does not automatically provision users or identities. This allows cluster
+administrators to set up identities and users manually, or using an external
+process.
+
+|`*generate*` | Provisions a user with the identity's preferred user name. If a
+user with the preferred user name is already mapped to an existing identity, a
+unique user name is generated. For example, *myuser2*. This method should not be
+used in combination with external processes that require exact matches between
+OpenShift user names and identity provider user names, such as LDAP group
+sync.
+
+|`*add*` | Provisions a user with the identity's preferred user name. If a user
+with that user name already exists, the identity is mapped to the existing user,
+adding to any existing identity mappings for the user. Required when multiple
+identity providers are configured that identify the same set of users and map to
+the same user names.
 |===
 
 [[AllowAllPasswordIdentityProvider]]

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -108,6 +108,35 @@ link:admin_guide/scheduler.html[scheduler configuration]. As an example, you can
 achieve this by dedicating infrastructure nodes to run services such as routers.
 ====
 
+[IMPORTANT]
+====
+It is recommended to use separate distinct *openshift-router* credentials
+with your router. The credentials can be provided using the `--credentials`
+flag to the `oadm router` command. Alternatively, the default cluster
+administrator credentials can be used from the `$KUBECONFIG` environment
+variable.
+
+ifdef::openshift-enterprise[]
+----
+$ oadm router --dry-run --service-account=router \
+    --credentials='/etc/origin/master/openshift-router.kubeconfig' //<1>
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+$ oadm router --dry-run --service-account=router \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} //<1>
+----
+endif::[]
+<1> `--credentials` is the path to the
+link:../../cli_reference/manage_cli_profiles.html[CLI configuration file]
+for the *openshift-router*.
+ifdef::openshift-origin[]
+It is recommended using an *openshift-router* specific profile with
+appropriate permissions.
+endif::[]
+====
+
 First, ensure you have link:#creating-the-router-service-account[created the
 router service account] before deploying a router.
 
@@ -122,7 +151,8 @@ $ oadm router --dry-run \
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router --credentials="$KUBECONFIG" --dry-run --service-account=router
+$ oadm router --dry-run --service-account=router \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"}
 ----
 endif::[]
 
@@ -137,7 +167,8 @@ $ oadm router -o yaml \
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router -o yaml --credentials="$KUBECONFIG" --service-account=router
+$ oadm router -o yaml --service-account=router \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"}
 ----
 endif::[]
 
@@ -153,7 +184,7 @@ endif::[]
 ifdef::openshift-origin[]
 ----
 $ oadm router <router_name> --replicas=<number> \
-    --credentials="$KUBECONFIG" \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
     --service-account=router
 ----
 endif::[]
@@ -173,7 +204,7 @@ endif::[]
 ifdef::openshift-origin[]
 ----
 $ oadm router <router_name> -o <format> --images=<image> \
-    --credentials="$KUBECONFIG" \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
     --service-account=router
 ----
 endif::[]
@@ -193,7 +224,7 @@ ifdef::openshift-origin[]
 ====
 ----
 $ oadm router region-west -o yaml --images=myrepo/somerouter:mytag \
-    --credentials="$KUBECONFIG" \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
     --service-account=router
 ----
 ====
@@ -272,8 +303,8 @@ From there you can use the `--default-cert` flag:
 
 ====
 ----
-$ oadm router --default-cert=cloudapps.router.pem \
-    --credentials="$KUBECONFIG" --service-account=router
+$ oadm router --default-cert=cloudapps.router.pem --service-account=router \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"}
 ----
 ====
 
@@ -304,7 +335,8 @@ and key information. The TLS certificate is served by the router front end.
 First, start up a router instance:
 
 ----
-# oadm router --replicas=1 --credentials=$KUBECONFIG --service-account=router
+# oadm router --replicas=1 --service-account=router  \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"}
 ----
 
 Next, create a private key, csr and certificate for our edge secured route.
@@ -399,7 +431,7 @@ ifdef::openshift-origin[]
 ====
 ----
 $ oadm router \
-    --credentials="$KUBECONFIG" \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
     --service-account=router \
     --host-network=false
 ----
@@ -637,7 +669,7 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
-    --credentials='/etc/origin/master/openshift-router.kubeconfig' \
+    --credentials='/etc/origin/master/openshift-router.kubeconfig' \//<1>
     --service-account=router
 ----
 ====
@@ -653,11 +685,15 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
-    --credentials="$KUBECONFIG" \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \//<1>
     --service-account=router
 ----
 ====
 endif::[]
+<1> `--credentials` is the path to the
+link:../../cli_reference/manage_cli_profiles.html[CLI configuration file]
+for the *openshift-router*. It is recommended using an *openshift-router*
+specific profile with appropriate permissions.
 
 
 === F5 Router Partition Paths

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -104,7 +104,7 @@ specify what credentials the router should use to contact the master.
 Routers directly attach to port 80 and 443 on all interfaces on a host. Restrict
 routers to hosts where port 80/443 is available and not being consumed by
 another service, and set this using node selectors and the
-link:admin_guide/scheduler.html[scheduler configuration]. As an example, you can
+link:../../admin_guide/scheduler.html[scheduler configuration]. As an example, you can
 achieve this by dedicating infrastructure nodes to run services such as routers.
 ====
 

--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -174,18 +174,6 @@ in the user's namespace and can only be referenced by a pod within that same
 namespace. Any attempt to access a persistent volume across a namespace causes
 the pod to fail.
 
-Also, each node in the cluster should enable the following SELinux booleans by
-running the following commands on each node:
-
-====
-----
-
-# setsebool -P virt_use_fusefs 1
-# setsebool -P virt_sandbox_use_fusefs 1
-
-----
-====
-
 Additionally, permissions and ownership can be controlled as normal by the
 Gluster server administrators using normal POSIX compliant security.
 
@@ -198,6 +186,13 @@ To enable writing to GlusterFS volumes with SELinux enforcing on each node, run:
 ----
 $ sudo setsebool -P virt_sandbox_use_fusefs on
 ----
+
+[NOTE]
+====
+`virt_sandbox_use_fusefs` is defined by the `docker-selinux` package.
+If you get an error saying it is not defined, please ensure that this
+package is installed.
+====
 
 The `-P` option makes the bool persistent between reboots.
 

--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -189,8 +189,8 @@ $ sudo setsebool -P virt_sandbox_use_fusefs on
 
 [NOTE]
 ====
-`virt_sandbox_use_fusefs` is defined by the `docker-selinux` package.
-If you get an error saying it is not defined, please ensure that this
+The `virt_sandbox_use_fusefs` boolean is defined by the *docker-selinux*
+package. If you get an error saying it is not defined, please ensure that this
 package is installed.
 ====
 

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -135,6 +135,17 @@ New Tag Deletion Command::
 You can now delete tags from an image stream using the `oc tag <tag_name> -d`
 command.
 
+New Overcommit Abilities::
+You can now create containers that can specify compute resource requests and limits.
+Requests are used for scheduling your container and provide a minimum service guarantee.
+Limits constrain the amount of compute resource that may be consumed on your node.
+
+.For Administrators:
+`*CPU Limits*` are now enforced using CFS quota by default::
+If you wish to disable CFS quota enforcement, you may disable it by modifying your
+`*node-config.yaml*` file to specify a `*kubeletArguments*` stanza where
+`*cpu-cfs-quota*` is set to `*false*`.
+
 .For Developers:
 `*v1beta3*` no Longer Supported::
 Using `*v1beta3*` in configuration files is no longer supported:

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -136,15 +136,15 @@ You can now delete tags from an image stream using the `oc tag <tag_name> -d`
 command.
 
 New Overcommit Abilities::
-You can now create containers that can specify compute resource requests and limits.
-Requests are used for scheduling your container and provide a minimum service guarantee.
-Limits constrain the amount of compute resource that may be consumed on your node.
+You can now create containers that can specify compute resource requests and
+limits. Requests are used for scheduling your container and provide a minimum
+service guarantee. Limits constrain the amount of compute resource that may be
+consumed on your node.
 
-.For Administrators:
-`*CPU Limits*` are now enforced using CFS quota by default::
-If you wish to disable CFS quota enforcement, you may disable it by modifying your
-`*node-config.yaml*` file to specify a `*kubeletArguments*` stanza where
-`*cpu-cfs-quota*` is set to `*false*`.
+CPU Limits Now Enforced Using CFS Quota by Default::
+If you wish to disable CFS quota enforcement, you may disable it by modifying
+your *_node-config.yaml_* file to specify a `*kubeletArguments*` stanza where
+`*cpu-cfs-quota*` is set to *false*.
 
 .For Developers:
 `*v1beta3*` no Longer Supported::

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -9279,7 +9279,7 @@ Patch is provided to give a concrete name and type to the Kubernetes PATCH reque
 |key|provides key file contents|false|string|
 |caCertificate|provides the cert authority certificate contents|false|string|
 |destinationCACertificate|provides the contents of the ca certificate of the final destination.  When using re-encrypt termination this file should be provided in order to have routers use it for health checks on the secure connection|false|string|
-|insecureEdgeTerminationPolicy|indicates desired behavior for insecure connections to an edge-terminated route (disable, allow or redirect).  If not set, insecure connections will not be allowed|false|string|
+|insecureEdgeTerminationPolicy|indicates desired behavior for insecure connections to an edge-terminated route (None, Allow or Redirect).  If not set, insecure connections will not be allowed|false|string|
 |===
 
 === v1.Role

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -9279,6 +9279,7 @@ Patch is provided to give a concrete name and type to the Kubernetes PATCH reque
 |key|provides key file contents|false|string|
 |caCertificate|provides the cert authority certificate contents|false|string|
 |destinationCACertificate|provides the contents of the ca certificate of the final destination.  When using re-encrypt termination this file should be provided in order to have routers use it for health checks on the secure connection|false|string|
+|insecureEdgeTerminationPolicy|indicates desired behavior for insecure connections to an edge-terminated route (disable, allow or redirect).  If not set, insecure connections will not be allowed|false|string|
 |===
 
 === v1.Role

--- a/using_images/xpaas_images/a_mq.adoc
+++ b/using_images/xpaas_images/a_mq.adoc
@@ -79,7 +79,7 @@ configured:
   *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random
   password is generated.
 `*AMQ_ADMIN_USERNAME*`::
-  The username used as an admin authentication to the broker. If no value is specified, a random user name is generated.
+  The user name used as an admin authentication to the broker. If no value is specified, a random user name is generated.
 `*AMQ_ADMIN_PASSWORD*`::
   The password used for authentication to the broker. If no value is specified, a random password is generated.
 `*MQ_PROTOCOL*`::
@@ -115,12 +115,12 @@ application's Git project root. On each commit, the file will be copied to the
 *_conf_* directory in the A-MQ root and its contents used to configure the
 broker.
 
-== Configuring the JBoss A-MQ Persistance Image
+== Configuring the JBoss A-MQ Persistent Image
 
 [[configuring-params-persistence]]
 === Application Template Parameters
 
-Basic configuration of the JBoss A-MQ Persistance xPaaS image is performed by specifying
+Basic configuration of the JBoss A-MQ Persistent xPaaS image is performed by specifying
 values of application template parameters. The following parameters can be
 configured:
 
@@ -145,7 +145,7 @@ configured:
   Comma-separated list of topics available by default on the broker on its
   startup.
 `*VOLUME_CAPACITY*`::
-  The size of the persistence storage for database volumes. 
+  The size of the persistent storage for database volumes.
 `*MQ_USERNAME*`::
   The user name used for authentication to the broker. In a standard
   non-containerized JBoss A-MQ, you would specify the user name in the
@@ -157,7 +157,7 @@ configured:
   *_AMQ_HOME/opt/user.properties_* file. If no value is specified, a random
   password is generated.
 `*AMQ_ADMIN_USERNAME*`::
-  The username used as an admin authentication to the broker. If no value is specified, a random user name is generated.
+  The user name used as an admin authentication to the broker. If no value is specified, a random user name is generated.
 `*AMQ_ADMIN_PASSWORD*`::
   The password used for authentication to the broker. If no value is specified, a random password is generated.
 `*AMQ_SECRET*`::
@@ -167,8 +167,8 @@ configured:
 `*AMQ_KEYSTORE*`::
   The SSL key store filename. If no value is specified, a random password is generated.
 
-For more information, see 
-link:../../https://github.com/openshift/openshift-docs/blob/master/dev_guide/persistent_volumes.adoc#using-persistent-volumes[Using Persistance Volumes]
+For more information, see
+link:../../dev_guide/persistent_volumes.html#using-persistent-volumes[Using Persistent Volumes].
 
 == Security
 


### PR DESCRIPTION
This week's cherry-picked commits for OSE 3.1 update the following books:

**Installation and Configuration**
- BZ#1215604: Updates the "Configuration Authentication" topic to include information on mapping identities to users.
- Updates the "Persistent Storage Using GlusterFS" topic to remove explicitly setting the `virt_use_fusefs` boolean and to include a note about the docker-selinux package.
- Updates the "Deploying a Router" topic to show and recommend using an **openshift-router**-specific profile and to fix a broken link.

**Cluster Administration**
- BZ#1283792: Updates the "High Availability" topic to show better ipconfig command examples when specifying kubeconfig files.
- Updates the "Overcomitting" topic (and the "xPaaS Release Notes") to clarify that CPU limits are now enforced via CFS quota in OSE 3.1 by default, and how to disable CPU limit enforcement for cluster administrators that want to preserve OSE 3.0.x behavior.

**Developer Guide**
- Updates the "Builds" topic to include more helpful links to build strategy descriptions and options.
- Updates the "Builds" topic to add "Viewing Build Details" and "Build Output" sections.

**Using Images**
- Updates the "Red Hat JBoss A-MQ xPaaS Image" topic to fix typos and a broken link.

**REST API Reference**
- Updates the "OpenShift v1 REST API" topic to include `insecureEdgeTerminationPolicy`.
