### PR TITLE
Cherry-pick: removed duplicate ids for configuring-params

### DIFF
--- a/using_images/xpaas_images/a_mq.adoc
+++ b/using_images/xpaas_images/a_mq.adoc
@@ -117,7 +117,7 @@ broker.
 
 == Configuring the JBoss A-MQ Persistent Image
 
-[[configuring-params]]
+[[configuring-params-persistence]]
 === Application Template Parameters
 
 Basic configuration of the JBoss A-MQ Persistent xPaaS image is performed by specifying


### PR DESCRIPTION
This commit was missing from the `enterprise-3.0` branch. The duplicate `configuring-params` ID caused the Customer Portal build to fail when trying to do the weekly publish (https://github.com/openshift/openshift-docs/pull/1339); this should fix it.
