### PR TITLE
clarify limitrange behavior

### DIFF
--- a/dev_guide/limits.adoc
+++ b/dev_guide/limits.adoc
@@ -74,16 +74,16 @@ Across all containers in a pod, the following must hold true:
 [cols="3a,8a",options="header"]
 |===
 
-|Constraint |Behavior
+|Constraint |Enforced Behavior
 
 |`*Min*`
-|Min[resource] <= container.resources.requests[resource] (required) <= container/resources.limits[resource] (optional)
+|Min[resource] less than or equal to container.resources.requests[resource] (required) less than or equal to container.resources.limits[resource] (optional)
 
 |`*Max*`
-|container.resources.limits[resource] (required) <= Max[resource]
+|container.resources.limits[resource] (required) less than or equal to Max[resource]
 
 |`*MaxLimitRequestRatio*`
-|MaxLimitRequestRatio[resource] <= ( container.resources.limits[resource] / container.resources.requests[resource])
+|MaxLimitRequestRatio[resource] less than or equal to ( container.resources.limits[resource] / container.resources.requests[resource])
 
 |===
 [[limit-range-def]]


### PR DESCRIPTION
three fixes:

1) changed a / to a .
2) replaced <= with "lesser or equal to" because <= was being converted to a left-arrow symbol, so it was not clear it was intended as a mathematical expression.  In addition the table itself didn't really provide enough context to understand the content of the table was a mathematical constraint, so i think converting to pure english makes it clearer.
3) also updated the column heading to make it clearer what the column represents.

@derekwaynecarr ptal.
@openshift/team-documentation ptal
