### PR TITLE
Fix links for CP build of xPaaS 3.1 GA

### DIFF
--- a/using_images/xpaas_images/data_grid.adoc
+++ b/using_images/xpaas_images/data_grid.adoc
@@ -35,7 +35,7 @@ There are several major functionality differences in the OpenShift JBoss Data Gr
 * Library mode is not supported.
 * Only JDBC is supported for a backing cache-store.  Support for remote cache stores are present only for data migration purposes.
 
-[[Clustering]]
+[[jdg-clustering]]
 === Forming a Cluster using the OpenShift JBoss Data Grid xPaaS Images
 
 Clustering is achieved through one of two discovery mechanisms: Kubernetes or DNS.  This
@@ -71,7 +71,7 @@ Once the above is configured images will automatically join the cluster as they 
 however, removing images from an active cluster, and therefore shrinking the cluster,
 is not supported.
 
-[[Endpoints]]
+[[jdg-endpoints]]
 === Endpoints
 
 Clients can access JBoss Data Grid via REST, HotRod, and memcached endpoints defined as usual in the cache's configuration.
@@ -85,7 +85,7 @@ being required to access the cache.
 [IMPORTANT]
 Only caches with an exposed REST endpoint will be accessible outside of OpenShift.
 
-[[Configuring_Caches]]
+[[jdg-configuring-caches]]
 === Configuring Caches
 
 A list of caches may be defined by the *_CACHE_NAMES_* environment variable.  By default the
@@ -99,9 +99,9 @@ each environment variable expecting the cache's name as the prefix.  For instanc
 any configuration applied to this cache must begin with the *_DEFAULT__* prefix.  To define the number of cache entry owners
 for each entry in this cache the *_DEFAULT_CACHE_OWNERS_* environment variable would be used.
 
-A full list of these is found at link:#Cache_Environment_Variables[Cache Environment Variables].
+A full list of these is found at link:#jdg-cache-environment-variables[Cache Environment Variables].
 
-[[Datasources]]
+[[jdg-datasources]]
 === Datasources
 
 Datasources are automatically created based on the value of some environment variables.
@@ -111,6 +111,7 @@ datasources.  It must be set to a comma-separated list of *_<name>_<database_typ
 *_name_* is used as the pool-name in the datasource, *_database_type_* determines which database driver to use,
 and *_PREFIX_* is the prefix used in the names of environment variables, which are used to configure the datasource.
 
+[[jdg-jndi-mappings-for-datasources]]
 ==== JNDI Mappings for Datasources
 
 For each *_<name>-database_type>=PREFIX_* triplet in the *_DB_SERVICE_PREFIX_MAPPING_* environment
@@ -124,6 +125,7 @@ The *_<name>_* parameter can be chosen on your own.  Do not use any special char
 [NOTE]
 The first part (before the equal sign) of the *_DB_SERVICE_PREFIX_MAPPING_* should be lowercase.
 
+[[jdg-database-drivers]]
 ==== Database Drivers
 
 The JBoss Data Grid xPaaS image contains Java drivers for MySQL, PostgreSQL, and MongoDB
@@ -132,11 +134,13 @@ databases deployed.  Datasources are *generated only for MySQL and PostGreSQL da
 [NOTE]
 For MongoDB databases there are no JNDI mappings created because this is not a SQL database.
 
+[[jdg-database-drivers-examples]]
 ==== Examples
 
 The following examples demonstrate how datasources may be defined using the *_DB_SERVICE_PREFIX_MAPPING_*
 environment variable.
 
+[[jdg-single-mapping]]
 ===== Single Mapping
 
 Consider the value *_test-postgresql=TEST_*.
@@ -145,6 +149,7 @@ This will create a datasource named *_java:jboss/datasources/test_postgresql_*. 
 such as username and password, will be expected to be provided as environment variables with the *_TEST__* prefix, such as
 *_TEST_USERNAME_* and *_TEST_PASSWORD_*.
 
+[[jdg-mulitple-mappings]]
 ===== Multiple Mappings
 
 Multiple database mappings may also be specified; for instance, considering the following value for the *_DB_SERVICE_PREFIX_MAPPING_*
@@ -163,16 +168,17 @@ MySQL datasource configuration, such as the username and password, will be expec
 for example *_TEST_MYSQL_USERNAME_*.  Similarly the PostgreSQL datasource will expect to have environment variables
 defined with the *_CLOUD__* prefix, such as *_CLOUD_USERNAME_*.
 
+[[jdg-datasource-environment-variables]]
 ==== Environment Variables
 
-A full list of datasource environment variables may be found at link:#Datasource_Environment_Variables[Datasource Environment Variables].
+A full list of datasource environment variables may be found at link:#jdg-datasource-environment-variables-list[Datasource Environment Variables].
 
-[[Security_Domains]]
+[[jdg-security-domains]]
 === Security Domains
 
 To configure a new Security Domain the *_SECDOMAIN_NAME_* environment variable must be defined, which will result
 in the creation of a security domain named after the passed in value.  This domain may be configured through the use
-of the link:#Security_Environment_Variables[Security Environment Variables].
+of the link:#jdg-security-environment-variables[Security Environment Variables].
 
 [[Managing-OpenShift-JBoss-Data-Grid-xPaaS-Images]]
 === Managing OpenShift JBoss Data Grid xPaaS Images
@@ -263,9 +269,10 @@ It is recommended that you do not replace the OpenShift placeholders in the JBos
 [NOTE]
 Ensure that you follow the   link:../../creating_images/guidelines.html[guidelines for creating images].
 
-[[Variables]]
+[[jdg-environment-variables]]
 == Environment Variables
 
+[[jdg-information-environment-variables]]
 === Information Environment Variables
 The following information environment variables are designed to convey information about the image and should not be modified by the user:
 
@@ -283,6 +290,7 @@ The following information environment variables are designed to convey informati
 | *_LAUNCH_JBOSS_IN_BACKGROUND_* | Allows the data grid server to be gracefully shutdown even when there is no terminal attached. | *_true_*
 |====================================
 
+[[jdg-configuration-environment-variables]]
 === Configuration Environment Variables
 Configuration environment variables are designed to conveniently adjust the image without requiring a rebuild, and should be set by the user as desired.
 
@@ -315,7 +323,7 @@ Configuration environment variables are designed to conveniently adjust the imag
 | *_USERNAME_* | Username for the JDG user. | Example: *_openshift_*
 |====================================
 
-[[Cache_Environment_Variables]]
+[[jdg-cache-environment-variables]]
 === Cache Environment Variables
 
 The following environment variables all control behavior of individual caches; when defining these values for a particular cache substitute the cache's name for *_CACHE_NAME_*.
@@ -352,7 +360,7 @@ The following environment variables all control behavior of individual caches; w
 | *_<CACHE_NAME>_CACHE_PARTITION_HANDLING_ENABLED_* | If enabled, then the cache will enter degraded mode when it loses too many nodes.  Defaults to *_true_*. | *_false_*
 |================================
 
-[[Datasource_Environment_Variables]]
+[[jdg-datasource-environment-variables-list]]
 === Datasource Environment Variables
 
 Datasource properties may be configured with the following environment variables:
@@ -372,7 +380,7 @@ Datasource properties may be configured with the following environment variables
 | *_<PREFIX>_TX_MAX_POOL_SIZE_* | Defines the maximum pool size option for the datasource. | *_20_*
 |================================
 
-[[Security_Environment_Variables]]
+[[jdg-security-environment-variables]]
 === Security Environment Variables
 
 The following environment variables may be defined to customize the environment's security domain:
@@ -388,7 +396,7 @@ The following environment variables may be defined to customize the environment'
 | *_SECDOMAIN_ROLES_PROPERTIES_* | The name of the properties file containing role definitions.  Defaults to *_roles.properties_*. | *_roles.properties_*
 |================================
 
-[[Exposed_Ports]]
+[[jdg-exposed-ports]]
 == Exposed Ports
 
 The following ports are exposed by default in the JBoss Data Grid xPaaS Image:
@@ -406,7 +414,7 @@ The following ports are exposed by default in the JBoss Data Grid xPaaS Image:
 [IMPORTANT]
 The external hotrod connector is only available if the *_HOTROD_SERVICE_NAME_* environment variables has been defined.
 
-[[Troubleshooting]]
+[[jdg-troubleshooting]]
 == Troubleshooting
 
 In addition to viewing the OpenShift logs, you can troubleshoot a running JBoss Data Grid xPaaS Image container by viewing its logs. These are outputted to the container’s standard out, and are accessible with the following command:

--- a/using_images/xpaas_images/decision_server.adoc
+++ b/using_images/xpaas_images/decision_server.adoc
@@ -137,25 +137,29 @@ It is recommended that you do not replace the OpenShift placeholders in the JBos
 [NOTE]
 Ensure that you follow the   link:../../creating_images/guidelines.html[guidelines for creating images].
 
+[[ds-updating-rules]]
 === Updating Rules
 
 As each image is built from a snapshot of a specific Maven repository, whenever a new rule is added, or an existing rule modified, a new image must be created and deployed for the rule modifications to take effect.
 
-[[Endpoints]]
+[[ds-endpoints]]
 == Endpoints
 
 Clients can access the Decision Server xPaaS Image via multiple endpoints; by default the provided templates include support for REST, HornetQ, and ActiveMQ.
 
+[[ds-rest]]
 === REST
 
 Clients can use the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_BRMS/6.2/html-single/User_Guide/index.html#The_REST_API_for_Managing_the_Realtime_Decision_Server[REST API] in various ways:
 
+[[ds-browser]]
 ==== Browser
 
 . Current server state: http://host/kie-server/services/rest/server
 . List of containers: http://host/kie-server/services/rest/server/containers
 . Specific container state: http://host/kie-server/services/rest/server/containers/HelloRulesContainer
 
+[[ds-java]]
 ==== Java
 
 [source,java]
@@ -169,6 +173,7 @@ RuleServicesClient client =
 ServiceResponse<String> response = client.executeCommands("HelloRulesContainer", myCommands);
 ----
 
+[[ds-command-line]]
 ==== Command Line
 
 [source,bash]
@@ -199,10 +204,12 @@ http://host/kie-server/services/rest/server/containers/instances/HelloRulesConta
 </batch-execution>
 ----
 
+[[ds-jms]]
 === JMS
 
 Client can also use the Java Messaging Service, as demonstrated below:
 
+[[ds-java-hornetq]]
 ==== Java (HornetQ)
 
 [source,java]
@@ -223,6 +230,7 @@ RuleServicesClient client =
 ServiceResponse<String> response = client.executeCommands("HelloRulesContainer", myCommands);
 ----
 
+[[ds-java-activemq]]
 ==== Java (ActiveMQ)
 
 [source,java]
@@ -245,6 +253,7 @@ RuleServicesClient client =
 ServiceResponse<String> response = client.executeCommands("HelloRulesContainer", myCommands);
 ----
 
+[[ds-troubleshooting]]
 == Troubleshooting
 
 In addition to viewing the OpenShift logs, you can troubleshoot a running Decision Server xPaaS Image container by viewing its logs.  These are outputted to the container's standard out, and are accessible with the following command:

--- a/using_images/xpaas_images/fuse.adoc
+++ b/using_images/xpaas_images/fuse.adoc
@@ -28,6 +28,7 @@ There are several major functionality differences:
 
 Additional details on technical differences and support scope are documented in an associated KCS article.
 
+
 == Using Fuse Integration Services
 You can start using Fuse Integration Services by creating application and deploying it to OpenShift. There are two ways to create an application in Fuse Integration Services:
 
@@ -64,7 +65,7 @@ The Maven Archetype catalog includes the following examples:
 
 Begin by selecting the archetype which matches the type of application you would like to create.
 
-==== Simple Workflow to create an application from Maven Archetype Catalog
+==== Simple Workflow to Create an Application from Maven Archetype Catalog
 
 . Use the Maven archetype catalog to create a sample project with the required resources. In order to use archetypes it is important to configure the Maven repositories which holds the archetypes and artifacts you may need:
 
@@ -141,7 +142,7 @@ $ mvn -Pf8-local-deploy
 
 . Login to OpenShift Web Console. A pod is created for the newly created application. You can view the status of this pod, deployments and services that the application is creating.
 
-==== Authenticating against a registry
+==== Authenticating Against a Registry
 For multi node OpenShift setups, the image created must be pushed to the OpenShift registry. This registry must be reachable from the outside through a route. Authentication against this registry reuses the OpenShift authentication with `oc login`. Assuming that your OpenShift registry is exposed as `registry.openshift.dev:80`, the project image can be deployed to the registry with following command:
 
 ----
@@ -152,7 +153,8 @@ $ mvn docker:push -Ddocker.registry=registry.openshift.dev:80 \
 
 To push changes to the registry, the OpenShift project must exist and the users of Docker image must be connected to the OpenShift project. All the examples uses the property `fabric8.dockerUser` as Docker image user which has `fabric8/` as default (note the trailing slash). When this user is used unaltered an OpenShift project 'fabric8' must exist. This can be created with 'oc new-project fabric8'.
 
-==== Plugin configuration
+[[fuse-plug-in-configuration]]
+==== Plug-in Configuration
 Plugins `docker-maven-plugin` and `fabric8-maven-plugin` are responsible for creating Docker images and OpenShift API objects which can be configured flexibly. The examples from the archetypes introduces some extra properties which can be changed when running Maven:
 
 |===
@@ -171,7 +173,7 @@ Plugins `docker-maven-plugin` and `fabric8-maven-plugin` are responsible for cre
 
 |===
 
-
+[[fuse-using-application-templates]]
 === Using Application Templates
 Applications are created through OpenShift Admin Console and CLI using application templates. If you have a JSON or YAML file that defines a template, you can upload the template to the project using the CLI. This saves the template to the project for repeated use by users with appropriate access to that project. You can add the remote Git repository location to the template using template parameters. This allows you to pull the application source from remote repository and built using source-to-image (s2i) method.
 
@@ -183,7 +185,7 @@ $ oc create -n openshift -f https://raw.githubusercontent.com/jboss-fuse/applica
 
 The *`ImageStreams`* may be created in a namespace other than *`openshift`* by changing it in the command and corresponding template parameter *`IMAGE_STREAM_NAMESPACE`* when creating applications.
 
-==== Simple Workflow to create an application using templates
+==== Simple Workflow to Create an Application Using Templates
 
 . Create an application template using command *`mvn archetype:generate*`. To create an application, upload the template to your current project’s template library with the following command:
 
@@ -235,14 +237,17 @@ The template is now available for selection using the web console or the CLI.
 $ oc get pods
 ----
 
-For more information, see https://docs.openshift.com/enterprise/3.0/dev_guide/templates.html[*Application Templates*]
+For more information, see link:../../dev_guide/templates.html[Application
+Templates]
 
+[[fuse-developing-applications]]
 === Developing Applications
-==== Injecting Kubernetes services into applications
+==== Injecting Kubernetes Services into Applications
 
 You can inject Kubernetes services into applications by labeling the pods and use those labels to select the required pods to provide a logical service. These labels are simple key, value pairs.
 
-===== CDI injection
+[[fuse-cdi-injection]]
+===== CDI Injection
 
 Fabric8 provides a CDI extension that you can use to inject Kubernetes resources into your applications. To use the CDI extension, first add the dependency to the project's *`pom.xml*`.
 
@@ -264,7 +269,7 @@ private String service.
 
 The *`@PortName*` annotation is used to select a specific port by name when multiple ports are defined for a service.
 
-
-===== Using environment variables as properties
+[[fuse-using-environment-variables-as-properties]]
+===== Using Environment Variables as Properties
 
 You can use to access a service by using environment variables to expose the fixed IP address and port. These are, *`SERVICE_HOST*` and *`SERVICE_PORT*`. *`SERVICE_HOST*` is the host (IP) address of the service and *`SERVICE_PORT*` is the port of the service.


### PR DESCRIPTION
Some duplicate IDs were causing the Customer Portal build of the docs to fail.
