### PR TITLE
fixed the KUBERNETES_MASTER value

### DIFF
--- a/using_images/xpaas_images/fuse.adoc
+++ b/using_images/xpaas_images/fuse.adoc
@@ -89,7 +89,7 @@ $ mvn archetype:generate \
 
 | DOCKER_HOST | Specifies the connection to a Docker daemon used to build an application Docker image | `tcp://10.1.2.2:2375`
 
-| KUBERNETES_MASTER | Specifies the URL for contacting the OpenShift API server | `https://172.28.128.4:8443`
+| KUBERNETES_MASTER | Specifies the URL for contacting the OpenShift API server | `https://10.1.2.2:8443`
 
 | KUBERNETES_DOMAIN | Domain used for creating routes. Your OpenShift API server must be mapped to all hosts of this domain. | `openshift.dev`
 


### PR DESCRIPTION
in the docs to point to the CDK to match the value of docker... not a big deal either way as the docs aren't CDK specific, but just for consistency (and so i can copy/paste directly ) :)
