### PR TITLE
updated LDAP group sync/prune references

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -155,13 +155,13 @@ OpenShift Group records.
 
 To sync all groups from the LDAP server with OpenShift:
 ----
-$ openshift ex sync-groups --sync-config=config.yaml --confirm
+$ oadm groups sync --sync-config=config.yaml --confirm
 ----
 
 To sync all groups already in OpenShift that correspond to the LDAP
 server specified in the configuration file:
 ----
-$ openshift ex sync-groups --type=openshift --sync-config=config.yaml --confirm
+$ oadm groups sync --type=openshift --sync-config=config.yaml --confirm
 ----
 
 To sync a subset of LDAP groups with OpenShift, you can use whitelist
@@ -176,14 +176,14 @@ OpenShift. Your files must contain one unique group identifier per line.
 ====
 
 ----
-$ openshift ex sync-groups --whitelist=whitelist.txt --sync-config=config.yaml --confirm
-$ openshift ex sync-groups --blacklist=blacklist.txt --sync-config=config.yaml --confirm
-$ openshift ex sync-groups group_unique_idenitifer --sync-config=config.yaml --confirm
-$ openshift ex sync-groups group_unique_idenitifer   \
+$ oadm groups sync --whitelist=whitelist.txt --sync-config=config.yaml --confirm
+$ oadm groups sync --blacklist=blacklist.txt --sync-config=config.yaml --confirm
+$ oadm groups sync group_unique_idenitifer --sync-config=config.yaml --confirm
+$ oadm groups sync group_unique_idenitifer   \
                            --whitelist=whitelist.txt \
                            --blacklist=blacklist.txt \
                            --sync-config=config.yaml --confirm
-$ openshift ex sync-groups --type=openshift --whitelist=whitelist.txt --sync-config=config.yaml --confirm
+$ oadm groups sync --type=openshift --whitelist=whitelist.txt --sync-config=config.yaml --confirm
 ----
 
 == Sync Examples
@@ -302,7 +302,7 @@ upgraded to TLS.
 
 To run sync with the `rfc2307_config.yaml` file:
 ----
-$ openshift ex sync-groups --sync-config=rfc2307_config.yaml --confirm
+$ oadm groups sync --sync-config=rfc2307_config.yaml --confirm
 ----
 
 The group record that OpenShift creates as a result of the above sync
@@ -371,7 +371,7 @@ user-defined name mapping.
 
 To run sync with the `rfc2307_config_user_defined.yaml` file:
 ----
-$ openshift ex sync-groups --sync-config=rfc2307_config_user_defined.yaml --confirm
+$ oadm groups sync --sync-config=rfc2307_config_user_defined.yaml --confirm
 ----
 
 The group record that OpenShift creates as a result of the above sync
@@ -473,7 +473,7 @@ activeDirectory:
 
 To run sync with the `active_directory_config.yaml` file:
 ----
-$ openshift ex sync-groups --sync-config=active_directory_config.yaml --confirm
+$ oadm groups sync --sync-config=active_directory_config.yaml --confirm
 ----
 
 The group record that OpenShift creates as a result of the above sync
@@ -601,7 +601,7 @@ augmentedActiveDirectory:
 
 To run sync with the `augmented_active_directory_config.yaml` file:
 ----
-$ openshift ex sync-groups --sync-config=augmented_active_directory_config.yaml --confirm
+$ oadm groups sync --sync-config=augmented_active_directory_config.yaml --confirm
 ----
 
 The group record that OpenShift creates as a result of the above sync operation:


### PR DESCRIPTION
upstream pull https://github.com/openshift/origin/pull/6369 promotes `openshift ex sync-groups` to `oadm groups sync`. this pull updates the doc

@adellape PTAL
@deads2k FYI
