### PR TITLE
Add section about using external artifacts during the build.

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1590,3 +1590,69 @@ Docker and Source builds set the following labels on output images:
 |*io.openshift.build.source-location*
 |Source URL for the build
 |===
+
+
+[[using-external-artifacts]]
+== Using External Artifacts During a Build
+
+It is not recommended to store binary files in a source repository. Therefore
+you may find it necessary to define a build which pulls additional files (such
+as Java jar dependencies) during the build process. How this is done depends on
+the build strategy you are using:
+
+For a `*Source*` build strategy you need to put appropriate shell commands into
+the `assemble` script.
+
+.`.sti/bin/assemble` file
+====
+
+[source,bash]
+----
+#!/bin/sh
+APP_VERSION=1.0
+wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
+----
+====
+
+.`.sti/bin/run` file
+====
+
+[source,bash]
+----
+#!/bin/sh
+exec java -jar app.jar
+----
+====
+
+For more information on how to control which assemble and run script is used by a source bulid,
+see: link:#override-builder-image-scripts[Override Builder Image Scripts]
+
+For a `*Docker*` build strategy you need to modify the `Dockerfile` and invoke
+shell commands with the https://docs.docker.com/engine/reference/builder/#run[`RUN` instruction].
+
+.Excerpt of `Dockerfile`
+====
+
+[source]
+----
+FROM jboss/base-jdk:8
+
+ENV APP_VERSION 1.0
+RUN wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
+
+EXPOSE 8080
+CMD [ "java", "-jar", "app.jar" ]
+----
+====
+
+In practice you may want to use an environment variable for the file location
+so that the specific file to be downloaded can be customized via an environment
+variable defined on the `BuildConfig` rather than updating the assemble script or
+`Dockerfile`.
+
+You could choose between a different ways of defining environment variables:
+
+- link:#environment-files[put into the `.sti/environment` file] (only for a `*Source*` build strategy)
+- link:#buildconfig-environment[set in `*BuildConfig*`]
+- link:../cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations[provide explicitly with `*oc start-build --env*`]
+  (only for builds that are triggered manually)


### PR DESCRIPTION
Document how to use external artifacts during the build.

@rhcarvalho PTAL.

Addressed to the following Trello card: https://trello.com/c/HTVCfQss/777-3-document-binary-build-via-dockerfile-and-custom-assemble
