### PR TITLE
Add node kubelet args to cluster vars.

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -196,6 +196,15 @@ defaults to *172.30.0.0/16*, which covers *172.30.0.0* through *172.30.255.255*.
 Setting this variable to override the default can be useful if the default
 subnet interferes with other subnets in use in your environment.
 
+|`*openshift_node_kubelet_args*`
+|This variable is used to configure `kubeletArguments` on nodes such as arguments used in
+link:../../admin_guide/garbage_collection.html[container and image garbage collection].
+`kubeletArguments` are key value pairs that will be passed directly to the Kubelet that
+match the link:http://kubernetes.io/v1.1/docs/admin/kubelet.html[Kubelet's command line
+arguments]. `kubeletArguments` are not migrated or validated and may become invalid if
+used. These values override other settings in node configuration which may cause invalid
+configurations. Example usage: *{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
+
 |`*osm_default_subdomain*`
 |This variable overrides the default subdomain to use for exposed
 link:../../architecture/core_concepts/routes.html[routes].


### PR DESCRIPTION
Add a row for `openshift_node_kubelet_args` with an example.

[Pretty build](http://file.rdu.redhat.com/abutcher/openshift-docs/openshift-enterprise/kubelet-args/install_config/install/advanced_install.html)

https://bugzilla.redhat.com/show_bug.cgi?id=1293413
