### PR TITLE
admin_guide/downgrade.adoc style, grammar fixups

### DIFF
--- a/install_config/downgrade.adoc
+++ b/install_config/downgrade.adoc
@@ -344,9 +344,9 @@ The `$ETCD_DIR` location differs between external and embedded etcd.
 . Restore your *_/etc/etcd/etcd.conf_* file from backup or *_.rpmsave_*.
 
 . Create the new single node cluster using etcd's `--force-new-cluster`
-option. You can do this with a long complex command using the values from the
-*_/etc/etcd/etcd.conf_*, or you can temporarily modify the *systemd* file and
-start the service normally.
+option. You can do this with a long complex command using the values from
+*_/etc/etcd/etcd.conf_*, or you can temporarily modify the *systemd* unit file
+and start the service normally.
 +
 To do so, edit the *_/usr/lib/systemd/system/etcd.service_* and add
 `--force-new-cluster`:
@@ -407,7 +407,7 @@ Services Back Online].
 ==== Adding Additional etcd Members
 
 To add additional etcd members to the cluster, you must first adjust the default
-*localhost* `*peerURLs*` for the first member:
+*localhost* peer in the `*peerURLs*` value for the first member:
 
 . Get the member ID for the first member using the `member list` command:
 +
@@ -421,8 +421,8 @@ To add additional etcd members to the cluster, you must first adjust the default
 ----
 ====
 
-. Update the `*peerURLs*` using the `etcdctl member update` command by passing the
-member ID obtained from the previous step:
+. Update the value of `*peerURLs*` using the `etcdctl member update` command by
+passing the member ID obtained from the previous step:
 +
 ====
 ----
@@ -447,8 +447,8 @@ Alternatively, you can use `curl`:
 ----
 ====
 
-. Re-run the `member list` command and ensure the `*peerURLs*` no longer points
-to *localhost*.
+. Re-run the `member list` command and ensure the peer URLs no longer include
+*localhost*.
 
 . Now add each additional member to the cluster, one at a time.
 +


### PR DESCRIPTION
Use appropriate markup for package names, commands and command options, file names, environment variables, and Ansible playbook names.

Consistently use the '#' prompt for commands that require root.

Consistently use "you" (as opposed to "we").

Correct a typo: "it's" to "its".

Change "systemd file" to "systemd unit file" for clarity.

Slightly reword the instructions for updating `peerURLs` for clarity.

Add a few colons and a "that" for clarity.
