### PR TITLE
Followup edits to sync/prune groups

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -21,23 +21,26 @@ membership: RFC 2307, Active Directory, and augmented Active Directory.
 [NOTE]
 ====
 You must have
-link:../architecture/additional_concepts/authorization.html#roles[*cluster-admin* privileges] to sync groups.
+link:../architecture/additional_concepts/authorization.html#roles[*cluster-admin*
+privileges] to sync groups.
 ====
 
 [[configuring-ldap-sync]]
 == Configuring LDAP Sync
 
-Before you can
-link:../admin_guide/syncing_groups_with_ldap.html#running-ldap-synchronization[run LDAP sync], you need a sync configuration
-file. This file contains LDAP client configuration details, allowing you to:
+Before you can link:#running-ldap-sync[run LDAP sync], you need a sync
+configuration file. This file contains LDAP client configuration details,
+allowing you to:
 
 * Correctly connect to your LDAP server.
-* Sync configuration options that are dependent on the schema used in your LDAP server.
+* Sync configuration options that are dependent on the schema used in your LDAP
+server.
 
 A sync configuration file can also contain an administrator-defined list of name
 mappings, which is useful when deciding which groups in OpenShift to map to the
 groups in your LDAP server.
 
+[[ldap-client-configuration]]
 === LDAP Client Configuration
 
 .LDAP Client Configuration
@@ -66,7 +69,9 @@ configured URL. If empty, OpenShift uses system-trusted roots. This only applies
 if `insecure` is set to `false`.
 ====
 
+[[ldap-query-definition]]
 === LDAP Query Definition
+
 Sync configurations consist of LDAP query definitions for the entries that are
 required for synchronization. The specific definition of an LDAP query depends
 on the schema used to store membership information in the LDAP server.
@@ -86,13 +91,11 @@ searches will start from. It is required that you specify the top of your
 directory tree, but you can also specify a subtree in the directory.
 <2> The scope of the search. Valid values are `base`, `one`, or `sub`. If this
 is left undefined, then a scope of `sub` is assumed. Descriptions of the scope
-options can be found in the
-link:../admin_guide/syncing_groups_with_ldap.html#ldap-search[table below].
+options can be found in the link:#ldap-search[table below].
 <3> The behavior of the search with respect to aliases in the LDAP tree. Valid
 values are `never`, `search`, `base`, or `always`. If this is left undefined,
 then the default is to `always` dereference aliases. Descriptions of the
-dereferencing behaviors can be found in the
-link:../admin_guide/syncing_groups_with_ldap.html#deref-aliases[table below].
+dereferencing behaviors can be found in the link:#deref-aliases[table below].
 <4> The time limit allowed for the search by the client, in seconds. A value of
 0 imposes no client-side limit.
 <5> A valid LDAP search filter. If this is left undefined, then the default is
@@ -121,7 +124,9 @@ the query.
 .^|`always`             | Always dereference all aliases found in the LDAP tree.
 |===
 
+[[user-defined-name-mapping]]
 === User-Defined Name Mapping
+
 A user-defined name mapping explicitly maps the names of OpenShift groups to
 unique identifiers that find groups on your LDAP server. The mapping uses normal
 YAML syntax. A user-defined mapping can contain an entry for every group in your
@@ -140,32 +145,35 @@ groupUIDNameMapping:
 ----
 ====
 
+[[running-ldap-sync]]
 == Running LDAP Sync
-Once you've created a
-link:../admin_guide/syncing_groups_with_ldap.html#configuring-ldap-sync[sync configuration file],
-then sync can begin. OpenShift allows administrators to perform a
-number of different sync types with the same server.
+
+Once you have created a link:#configuring-ldap-sync[sync configuration file],
+then sync can begin. OpenShift allows administrators to perform a number of
+different sync types with the same server.
 
 [NOTE]
 ====
-By default, all group synchronization or pruning operations are dry-run, so you must set
-the `--confirm` flag on the `sync-groups` command in order to make changes to
-OpenShift Group records.
+By default, all group synchronization or pruning operations are dry-run, so you
+must set the `--confirm` flag on the `oadm groups sync` command in order to make
+changes to OpenShift group records.
 ====
 
 To sync all groups from the LDAP server with OpenShift:
+
 ----
 $ oadm groups sync --sync-config=config.yaml --confirm
 ----
 
-To sync all groups already in OpenShift that correspond to the LDAP
-server specified in the configuration file:
+To sync all groups already in OpenShift that correspond to the LDAP server
+specified in the configuration file:
+
 ----
 $ oadm groups sync --type=openshift --sync-config=config.yaml --confirm
 ----
 
-To sync a subset of LDAP groups with OpenShift, you can use whitelist
-files, blacklist files, or both:
+To sync a subset of LDAP groups with OpenShift, you can use whitelist files,
+blacklist files, or both:
 
 [NOTE]
 ====
@@ -176,46 +184,59 @@ OpenShift. Your files must contain one unique group identifier per line.
 ====
 
 ----
-$ oadm groups sync --whitelist=whitelist.txt --sync-config=config.yaml --confirm
-$ oadm groups sync --blacklist=blacklist.txt --sync-config=config.yaml --confirm
-$ oadm groups sync group_unique_idenitifer --sync-config=config.yaml --confirm
-$ oadm groups sync group_unique_idenitifer   \
-                           --whitelist=whitelist.txt \
-                           --blacklist=blacklist.txt \
-                           --sync-config=config.yaml --confirm
-$ oadm groups sync --type=openshift --whitelist=whitelist.txt --sync-config=config.yaml --confirm
+$ oadm groups sync --whitelist=<whitelist_file> --sync-config=config.yaml --confirm
+$ oadm groups sync --blacklist=<blacklist_file> --sync-config=config.yaml --confirm
+$ oadm groups sync <group_unique_identifier> --sync-config=config.yaml --confirm
+$ oadm groups sync <group_unique_identifier> \
+                           --whitelist=<whitelist_file> \
+                           --blacklist=<blacklist_file> \
+                           --sync-config=config.yaml \
+                           --confirm
+$ oadm groups sync --type=openshift \
+                           --whitelist=<whitelist_file> \
+                           --sync-config=config.yaml \
+                           --confirm
 ----
 
+[[running-a-group-pruning-job]]
 == Running a Group Pruning Job
-An administrator can also choose to remove groups from OpenShift records if the records on the LDAP
-server that created them are no longer present. The prune job will accept the same sync
-configuration file and white- or black-lists as used for the sync job.
 
-For instance, if groups had previously been syncheonized from LDAP using some `config.yaml`, and some of those
-groups no longer existed on the LDAP server, the following command would determine which groups in OpenShift
-corresponded to the deleted groups in LDAP and then remove them from OpenShift.
+An administrator can also choose to remove groups from OpenShift records if the
+records on the LDAP server that created them are no longer present. The prune
+job will accept the same sync configuration file and white- or black-lists as
+used for the sync job.
+
+For example, if groups had previously been synchronized from LDAP using some
+*_config.yaml_* file, and some of those groups no longer existed on the LDAP
+server, the following command would determine which groups in OpenShift
+corresponded to the deleted groups in LDAP and then remove them from OpenShift:
+
 ----
-$ openshift groups prune --sync-config=config.yaml --confirm
+$ oadm groups prune --sync-config=config.yaml --confirm
 ----
 
+[[sync-examples]]
 == Sync Examples
-This section contains examples for the link:../admin_guide/syncing_groups_with_ldap.html#rfc-2307[RFC 2307],
-link:../admin_guide/syncing_groups_with_ldap.html#active-directory[Active Directory],
-and link:../admin_guide/syncing_groups_with_ldap.html#augmented-active-directory[Augmented Active Directory] schemas.
-All of the following examples synchronize a group named *_admins_* that has two
-members: *_Jane_* and *_Jim_*. Each example explains:
+
+This section contains examples for the link:#sync-ldap-rfc-2307[RFC 2307],
+link:#sync-ldap-active-directory[Active Directory], and
+link:#sync-ldap-augmented-active-directory[Augmented Active Directory] schemas.
+All of the following examples synchronize a group named *admins* that has two
+members: *Jane* and *Jim*. Each example explains:
 
 * How the group and users are added to the LDAP server.
 * What the LDAP sync configuration file looks like.
 * What the resulting group record in OpenShift will be after synchronization.
 
+[[sync-ldap-rfc-2307]]
 === RFC 2307
+
 In the RFC 2307 schema, both users (Jane and Jim) and groups exist on the LDAP
 server as first-class entries, and group membership is stored in attributes on
 the group. The following snippet of `ldif` defines the users and group for this
-schema.
+schema:
 
-.LDAP Entries Using RFC2307 Schema: `rfc2307.ldif`
+.LDAP Entries Using RFC2307 Schema: *_rfc2307.ldif_*
 ====
 [source,ldif]
 ----
@@ -249,7 +270,7 @@ schema.
   objectClass: groupOfNames
   cn: admins
   owner: cn=admin,dc=example,dc=com
-  description: System Adminstrators
+  description: System Administrators
   member: cn=Jane,ou=users,dc=example,dc=com <2>
   member: cn=Jim,ou=users,dc=example,dc=com
 ----
@@ -272,10 +293,10 @@ these relationships:
 [NOTE]
 ====
 If using user-defined name mappings, your
-link:../admin_guide/syncing_groups_with_ldap.html#rfc2307-with-user-defined-name-mappings[configuration file] will differ.
+link:#rfc2307-with-user-defined-name-mappings[configuration file] will differ.
 ====
 
-.LDAP Sync Configuration Using RFC2307 Schema: `rfc2307_config.yaml`
+.LDAP Sync Configuration Using RFC2307 Schema: *_rfc2307_config.yaml_*
 ====
 [source,yaml]
 ----
@@ -312,15 +333,16 @@ upgraded to TLS.
 <7> The attribute to use as the name of the user in the OpenShift group record.
 ====
 
-To run sync with the `rfc2307_config.yaml` file:
+To run sync with the *_rfc2307_config.yaml_* file:
+
 ----
 $ oadm groups sync --sync-config=rfc2307_config.yaml --confirm
 ----
 
-The group record that OpenShift creates as a result of the above sync
+OpenShift creates the following group record as a result of the above sync
 operation:
 
-.OpenShift Group Created Using `rfc2307_config.yaml`
+.OpenShift Group Created Using *_rfc2307_config.yaml_*
 ====
 [source,yaml]
 ----
@@ -346,9 +368,11 @@ stored.
 <5> The users that are members of the group, named as specified by the sync file.
 ====
 
+[[rfc2307-with-user-defined-name-mappings]]
 ==== RFC2307 with User-Defined Name Mappings
-When syncing groups with user-defined name mappings, the
-configuration file changes to contain these mappings as shown below.
+
+When syncing groups with user-defined name mappings, the configuration file
+changes to contain these mappings as shown below.
 
 .LDAP Sync Configuration Using RFC2307 Schema With User-Defined Name Mappings: `rfc2307_config_user_defined.yaml`
 ====
@@ -378,18 +402,20 @@ rfc2307:
 <1> The user-defined name mapping.
 <2> The unique identifier attribute that is used for the keys in the
 user-defined name mapping.
-<3> The attribute to name OpenShift groups with if their unique identifier is not in the user-defined name mapping.
+<3> The attribute to name OpenShift groups with if their unique identifier is
+not in the user-defined name mapping.
 ====
 
-To run sync with the `rfc2307_config_user_defined.yaml` file:
+To run sync with the *_rfc2307_config_user_defined.yaml_* file:
+
 ----
 $ oadm groups sync --sync-config=rfc2307_config_user_defined.yaml --confirm
 ----
 
-The group record that OpenShift creates as a result of the above sync
+OpenShift creates the following group record as a result of the above sync
 operation:
 
-.OpenShift Group Created Using `rfc2307_config_user_defined.yaml`
+.OpenShift Group Created Using *_rfc2307_config_user_defined.yaml_*
 ====
 [source,yaml]
 ----
@@ -409,13 +435,15 @@ users:
 <1> The name of the group as specified by the user-defined name mapping.
 ====
 
+[[sync-ldap-active-directory]]
 === Active Directory
+
 In the Active Directory schema, both users (Jane and Jim) exist in the LDAP
 server as first-class entries, and group membership is stored in attributes on
 the user. The following snippet of `ldif` defines the users and group for this
 schema:
 
-.LDAP Entries Using Active Directory Schema: `active_directory.ldif`
+.LDAP Entries Using Active Directory Schema: *_active_directory.ldif_*
 ====
 [source,ldif]
 ----
@@ -446,7 +474,7 @@ mail: jim.adams@example.com
 testMemberOf: admins
 ----
 <1> The user's group memberships are listed as attributes on the user, and the
-group does not exist as an entry on the server. The `testMemberOf` attribute
+group does not exist as an entry on the server. The `*testMemberOf*` attribute
 cannot be a literal attribute on the user; it can be created during search and
 returned to the client but not committed to the database.
 ====
@@ -462,7 +490,7 @@ fields. For example, identify the users of a group by their e-mail, but the
 name of the group is defined by the name of the group on the LDAP server.
 The following configuration file creates these relationships:
 
-.LDAP Sync Configuration Using Active Directory Schema: `active_directory_config.yaml`
+.LDAP Sync Configuration Using Active Directory Schema: *_active_directory_config.yaml_*
 ====
 [source,yaml]
 ----
@@ -483,15 +511,16 @@ activeDirectory:
 <2> The attribute on the user that stores the membership information.
 ====
 
-To run sync with the `active_directory_config.yaml` file:
+To run sync with the *_active_directory_config.yaml_* file:
+
 ----
 $ oadm groups sync --sync-config=active_directory_config.yaml --confirm
 ----
 
-The group record that OpenShift creates as a result of the above sync
+OpenShift creates the following group record as a result of the above sync
 operation:
 
-.OpenShift Group Created Using `active_directory_config.yaml`
+.OpenShift Group Created Using *_active_directory_config.yaml_*
 ====
 [source,yaml]
 ----
@@ -514,17 +543,19 @@ format.
 <3> The IP address and host of the LDAP server where this group's record is
 stored.
 <4> The name of the group as listed in the LDAP server.
-<5> The users that are members of the group, named as specified by the
-sync file.
+<5> The users that are members of the group, named as specified by the sync
+file.
 ====
 
+[[sync-ldap-augmented-active-directory]]
 === Augmented Active Directory
+
 In the augmented Active Directory schema, both users (Jane and Jim) and groups
 exist in the LDAP server as first-class entries, and group membership is stored
 in attributes on the user. The following snippet of `ldif` defines the users and
 group for this schema:
 
-.LDAP Entries Using Augmented Active Directory Schema: `augmented_active_directory.ldif`
+.LDAP Entries Using Augmented Active Directory Schema: *_augmented_active_directory.ldif_*
 ====
 [source,ldif]
 ----
@@ -562,7 +593,7 @@ dn: cn=admins,ou=groups,dc=example,dc=com <2>
 objectClass: groupOfNames
 cn: admins
 owner: cn=admin,dc=example,dc=com
-description: System Adminstrators
+description: System Administrators
 member: cn=Jane,ou=users,dc=example,dc=com
 member: cn=Jim,ou=users,dc=example,dc=com
 ----
@@ -581,7 +612,7 @@ fields. For example, identify the users of a group by their e-mail,
 and use the name of the group as the common name. The following configuration
 file creates these relationships.
 
-.LDAP Sync Configuration Using Augmented Active Directory Schema:  `augmented_active_directory_config.yaml`
+.LDAP Sync Configuration Using Augmented Active Directory Schema: *_augmented_active_directory_config.yaml_*
 ====
 [source,yaml]
 ----
@@ -611,14 +642,16 @@ augmentedActiveDirectory:
 <4> The attribute on the user that stores the membership information.
 ====
 
-To run sync with the `augmented_active_directory_config.yaml` file:
+To run sync with the *_augmented_active_directory_config.yaml_* file:
+
 ----
 $ oadm groups sync --sync-config=augmented_active_directory_config.yaml --confirm
 ----
 
-The group record that OpenShift creates as a result of the above sync operation:
+OpenShift creates the following group record as a result of the above sync
+operation:
 
-.OpenShift Group Created Using `augmented_active_directory_config.yaml`
+.OpenShift Group Created Using *_augmented_active_directory_config.yaml_*
 ====
 [source,yaml]
 ----


### PR DESCRIPTION
Various clean-up as follow-up to https://github.com/openshift/openshift-docs/pull/1118 and https://github.com/openshift/openshift-docs/pull/1363. A few broken links, minor edits, formatting, fixed an instance of remaining `openshift` cmd usage.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/010416/openshiftprune/install_config/syncing_groups_with_ldap.html

cc @stevekuznetsov 
