### PR TITLE
syncing_groups_with_ldap: typo fixes, cleanups

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -10,13 +10,13 @@
 toc::[]
 
 == Overview
-As an OpenShift administrator, grouping users allows you to better manage them,
-change their permissions, or to enhance collaboration. Your organization may
-have already created user groups and stored them in an LDAP server. OpenShift
-can sync those LDAP records with internal OpenShift records, allowing you
-to simply manage your groups in one place. OpenShift currently supports group
-sync with LDAP servers using three common schemas for defining group
-membership: RFC 2307, Active Directory, and augmented Active Directory.
+As an OpenShift administrator, you can use groups to manage users, change their
+permissions, and enhance collaboration. Your organization may have already
+created user groups and stored them in an LDAP server. OpenShift can sync those
+LDAP records with internal OpenShift records, enabling you to manage your groups
+in one place. OpenShift currently supports group sync with LDAP servers using
+three common schemas for defining group membership: RFC 2307, Active Directory,
+and augmented Active Directory.
 
 [NOTE]
 ====
@@ -29,16 +29,14 @@ privileges] to sync groups.
 == Configuring LDAP Sync
 
 Before you can link:#running-ldap-sync[run LDAP sync], you need a sync
-configuration file. This file contains LDAP client configuration details,
-allowing you to:
+configuration file. This file contains LDAP client configuration details:
 
-* Correctly connect to your LDAP server.
+* Configuration for connecting to your LDAP server.
 * Sync configuration options that are dependent on the schema used in your LDAP
 server.
 
 A sync configuration file can also contain an administrator-defined list of name
-mappings, which is useful when deciding which groups in OpenShift to map to the
-groups in your LDAP server.
+mappings that maps OpenShift Group names to groups in your LDAP server.
 
 [[ldap-client-configuration]]
 === LDAP Client Configuration
@@ -55,10 +53,10 @@ ca: my-ldap-ca-bundle.crt <5>
 ----
 <1> The connection protocol, IP address of the LDAP server hosting your
 database, and the port to connect to, formatted as `scheme://host:port`.
-<2> Optionally, specify a distinguished name (DN) to use as the Bind DN.
+<2> Optional distinguished name (DN) to use as the Bind DN.
 OpenShift uses this if elevated privilege is required to retrieve entries for
 the sync operation.
-<3> Optionally, specify a password to use to bind. OpenShift uses this if
+<3> Optional password to use to bind. OpenShift uses this if
 elevated privilege is necessary to retrieve entries for the sync
 operation.
 <4> When `true`, no TLS connection is made to the server. When `false`, secure
@@ -84,7 +82,7 @@ baseDN: ou=users,dc=example,dc=com <1>
 scope: sub <2>
 derefAliases: never <3>
 timeout: 0 <4>
-filter: (objectClass=intOrgPerson) <5>
+filter: (objectClass=inetOrgPerson) <5>
 ----
 <1> The distinguished name (DN) of the branch of the directory where all
 searches will start from. It is required that you specify the top of your
@@ -107,7 +105,7 @@ dereferencing behaviors can be found in the link:#deref-aliases[table below].
 [cols="2a,8a",options="header"]
 |===
 |LDAP Search Scope | Description
-.^|`base`          | Only consider the object at specified by the base DN given for the query.
+.^|`base`          | Only consider the object specified by the base DN given for the query.
 .^|`one`           | Consider all of the objects on the same level in the tree as the base DN for
 the query.
 .^|`sub`           | Consider the entire subtree rooted at the base DN given for the query.
@@ -127,12 +125,12 @@ the query.
 [[user-defined-name-mapping]]
 === User-Defined Name Mapping
 
-A user-defined name mapping explicitly maps the names of OpenShift groups to
+A user-defined name mapping explicitly maps the names of OpenShift Groups to
 unique identifiers that find groups on your LDAP server. The mapping uses normal
 YAML syntax. A user-defined mapping can contain an entry for every group in your
 LDAP server or only a subset of those groups. If there are groups on the LDAP
 server that do not have a user-defined name mapping, the default behavior during
-sync is to use the attribute specified as the group's name.
+sync is to use the attribute specified as the Group's name.
 
 .User-Defined Name Mapping
 ====
@@ -165,8 +163,8 @@ To sync all groups from the LDAP server with OpenShift:
 $ oadm groups sync --sync-config=config.yaml --confirm
 ----
 
-To sync all groups already in OpenShift that correspond to the LDAP server
-specified in the configuration file:
+To sync all Groups already in OpenShift that correspond to groups in the
+LDAP server specified in the configuration file:
 
 ----
 $ oadm groups sync --type=openshift --sync-config=config.yaml --confirm
@@ -179,7 +177,7 @@ blacklist files, or both:
 ====
 Any combination of blacklist files, whitelist files, or whitelist literals will
 work; whitelist literals can be included directly in the command itself. This
-applies to groups found on LDAP servers, as well as groups already present in
+applies to groups found on LDAP servers, as well as Groups already present in
 OpenShift. Your files must contain one unique group identifier per line.
 ====
 
@@ -208,7 +206,7 @@ used for the sync job.
 
 For example, if groups had previously been synchronized from LDAP using some
 *_config.yaml_* file, and some of those groups no longer existed on the LDAP
-server, the following command would determine which groups in OpenShift
+server, the following command would determine which Groups in OpenShift
 corresponded to the deleted groups in LDAP and then remove them from OpenShift:
 
 ----
@@ -220,13 +218,13 @@ $ oadm groups prune --sync-config=config.yaml --confirm
 
 This section contains examples for the link:#sync-ldap-rfc-2307[RFC 2307],
 link:#sync-ldap-active-directory[Active Directory], and
-link:#sync-ldap-augmented-active-directory[Augmented Active Directory] schemas.
+link:#sync-ldap-augmented-active-directory[augmented Active Directory] schemas.
 All of the following examples synchronize a group named *admins* that has two
 members: *Jane* and *Jim*. Each example explains:
 
 * How the group and users are added to the LDAP server.
 * What the LDAP sync configuration file looks like.
-* What the resulting group record in OpenShift will be after synchronization.
+* What the resulting Group record in OpenShift will be after synchronization.
 
 [[sync-ldap-rfc-2307]]
 === RFC 2307
@@ -236,7 +234,7 @@ server as first-class entries, and group membership is stored in attributes on
 the group. The following snippet of `ldif` defines the users and group for this
 schema:
 
-.LDAP Entries Using RFC2307 Schema: *_rfc2307.ldif_*
+.LDAP Entries Using RFC 2307 Schema: *_rfc2307.ldif_*
 ====
 [source,ldif]
 ----
@@ -280,13 +278,13 @@ the group.
 ====
 
 To sync this group, you must first create the configuration file. The
-RFC2307 schema requires you to provide an LDAP query definition for both user
-and group entries, as well as the attributes to represent them with in the
+RFC 2307 schema requires you to provide an LDAP query definition for both user
+and group entries, as well as the attributes with which to represent them in the
 internal OpenShift records.
 
-For clarity, the group you create in OpenShift should use attributes other than
+For clarity, the Group you create in OpenShift should use attributes other than
 the distinguished name whenever possible for user- or administrator-facing
-fields. For example, identify the users of a group by their e-mail, and use the
+fields. For example, identify the users of a Group by their e-mail, and use the
 name of the group as the common name. The following configuration file creates
 these relationships:
 
@@ -296,7 +294,7 @@ If using user-defined name mappings, your
 link:#rfc2307-with-user-defined-name-mappings[configuration file] will differ.
 ====
 
-.LDAP Sync Configuration Using RFC2307 Schema: *_rfc2307_config.yaml_*
+.LDAP Sync Configuration Using RFC 2307 Schema: *_rfc2307_config.yaml_*
 ====
 [source,yaml]
 ----
@@ -327,10 +325,10 @@ stored.
 LDAP (`ldaps://`) URLs connect using TLS, and insecure LDAP (`ldap://`) URLs are
 upgraded to TLS.
 <3> The attribute that uniquely identifies a group on the LDAP server.
-<4> The attribute to use as the name of the group.
+<4> The attribute to use as the name of the Group.
 <5> The attribute on the group that stores the membership information.
 <6> The attribute that uniquely identifies a user on the LDAP server.
-<7> The attribute to use as the name of the user in the OpenShift group record.
+<7> The attribute to use as the name of the user in the OpenShift Group record.
 ====
 
 To run sync with the *_rfc2307_config.yaml_* file:
@@ -339,7 +337,7 @@ To run sync with the *_rfc2307_config.yaml_* file:
 $ oadm groups sync --sync-config=rfc2307_config.yaml --confirm
 ----
 
-OpenShift creates the following group record as a result of the above sync
+OpenShift creates the following Group record as a result of the above sync
 operation:
 
 .OpenShift Group Created Using *_rfc2307_config.yaml_*
@@ -359,13 +357,13 @@ users: <5>
 - jane.smith@example.com
 - jim.adams@example.com
 ----
-<1> The last time this group was synchronized with the LDAP server, in ISO 6801
+<1> The last time this Group was synchronized with the LDAP server, in ISO 6801
 format.
 <2> The unique identifier for the group on the LDAP server.
-<3> The IP address and host of the LDAP server where this group's record is
+<3> The IP address and host of the LDAP server where this Group's record is
 stored.
-<4> The name of the group as specified by the sync file.
-<5> The users that are members of the group, named as specified by the sync file.
+<4> The name of the Group as specified by the sync file.
+<5> The users that are members of the Group, named as specified by the sync file.
 ====
 
 [[rfc2307-with-user-defined-name-mappings]]
@@ -374,7 +372,7 @@ stored.
 When syncing groups with user-defined name mappings, the configuration file
 changes to contain these mappings as shown below.
 
-.LDAP Sync Configuration Using RFC2307 Schema With User-Defined Name Mappings: `rfc2307_config_user_defined.yaml`
+.LDAP Sync Configuration Using RFC 2307 Schema With User-Defined Name Mappings: *_rfc2307_config_user_defined.yaml_*
 ====
 [source,yaml]
 ----
@@ -402,7 +400,7 @@ rfc2307:
 <1> The user-defined name mapping.
 <2> The unique identifier attribute that is used for the keys in the
 user-defined name mapping.
-<3> The attribute to name OpenShift groups with if their unique identifier is
+<3> The attribute to name OpenShift Groups with if their unique identifier is
 not in the user-defined name mapping.
 ====
 
@@ -412,7 +410,7 @@ To run sync with the *_rfc2307_config_user_defined.yaml_* file:
 $ oadm groups sync --sync-config=rfc2307_config_user_defined.yaml --confirm
 ----
 
-OpenShift creates the following group record as a result of the above sync
+OpenShift creates the following Group record as a result of the above sync
 operation:
 
 .OpenShift Group Created Using *_rfc2307_config_user_defined.yaml_*
@@ -432,7 +430,7 @@ users:
 - jane.smith@example.com
 - jim.adams@example.com
 ----
-<1> The name of the group as specified by the user-defined name mapping.
+<1> The name of the Group as specified by the user-defined name mapping.
 ====
 
 [[sync-ldap-active-directory]]
@@ -482,12 +480,12 @@ returned to the client but not committed to the database.
 To sync this group, you must first create the configuration file. The
 Active Directory schema requires you to provide an LDAP query definition for
 user entries, as well as the attributes to represent them with in the internal
-OpenShift records.
+OpenShift Group records.
 
-For clarity, the group you create in OpenShift should use attributes other
+For clarity, the Group you create in OpenShift should use attributes other
 than the distinguished name whenever possible for user- or administrator-facing
-fields. For example, identify the users of a group by their e-mail, but the
-name of the group is defined by the name of the group on the LDAP server.
+fields. For example, identify the users of a Group by their e-mail, but define
+the name of the Group by the name of the group on the LDAP server.
 The following configuration file creates these relationships:
 
 .LDAP Sync Configuration Using Active Directory Schema: *_active_directory_config.yaml_*
@@ -507,7 +505,7 @@ activeDirectory:
     userNameAttributes: [ mail ] <1>
     groupMembershipAttributes: [ testMemberOf ] <2>
 ----
-<1> The attribute to use as the name of the user in the OpenShift group record.
+<1> The attribute to use as the name of the user in the OpenShift Group record.
 <2> The attribute on the user that stores the membership information.
 ====
 
@@ -517,7 +515,7 @@ To run sync with the *_active_directory_config.yaml_* file:
 $ oadm groups sync --sync-config=active_directory_config.yaml --confirm
 ----
 
-OpenShift creates the following group record as a result of the above sync
+OpenShift creates the following Group record as a result of the above sync
 operation:
 
 .OpenShift Group Created Using *_active_directory_config.yaml_*
@@ -537,13 +535,13 @@ users: <5>
 - jane.smith@example.com
 - jim.adams@example.com
 ----
-<1> The last time this group was synchronized with the LDAP server, in ISO 6801
+<1> The last time this Group was synchronized with the LDAP server, in ISO 6801
 format.
 <2> The unique identifier for the group on the LDAP server.
-<3> The IP address and host of the LDAP server where this group's record is
+<3> The IP address and host of the LDAP server where this Group's record is
 stored.
 <4> The name of the group as listed in the LDAP server.
-<5> The users that are members of the group, named as specified by the sync
+<5> The users that are members of the Group, named as specified by the sync
 file.
 ====
 
@@ -603,13 +601,13 @@ member: cn=Jim,ou=users,dc=example,dc=com
 
 To sync this group, you must first create the configuration file. The
 augmented Active Directory schema requires you to provide an LDAP query
-definition for both user entries and group entries, as well as the attributes to
-represent them with in the internal OpenShift records.
+definition for both user entries and group entries, as well as the attributes
+with which to represent them in the internal OpenShift Group records.
 
-For clarity, the group you create in OpenShift should use attributes other
+For clarity, the Group you create in OpenShift should use attributes other
 than the distinguished name whenever possible for user- or administrator-facing
-fields. For example, identify the users of a group by their e-mail,
-and use the name of the group as the common name. The following configuration
+fields. For example, identify the users of a Group by their e-mail,
+and use the name of the Group as the common name. The following configuration
 file creates these relationships.
 
 .LDAP Sync Configuration Using Augmented Active Directory Schema: *_augmented_active_directory_config.yaml_*
@@ -637,8 +635,8 @@ augmentedActiveDirectory:
     groupMembershipAttributes: [ testMemberOf ] <4>
 ----
 <1> The attribute that uniquely identifies a group on the LDAP server.
-<2> The attribute to use as the name of the group.
-<3> The attribute to use as the name of the user in the OpenShift group record.
+<2> The attribute to use as the name of the Group.
+<3> The attribute to use as the name of the user in the OpenShift Group record.
 <4> The attribute on the user that stores the membership information.
 ====
 
@@ -648,7 +646,7 @@ To run sync with the *_augmented_active_directory_config.yaml_* file:
 $ oadm groups sync --sync-config=augmented_active_directory_config.yaml --confirm
 ----
 
-OpenShift creates the following group record as a result of the above sync
+OpenShift creates the following Group record as a result of the above sync
 operation:
 
 .OpenShift Group Created Using *_augmented_active_directory_config.yaml_*
@@ -668,9 +666,9 @@ users: <5>
 - jane.smith@example.com
 - jim.adams@example.com
 ----
-<1> The last time this group was synchronized with the LDAP server, in ISO 6801 format.
+<1> The last time this Group was synchronized with the LDAP server, in ISO 6801 format.
 <2> The unique identifier for the group on the LDAP server.
-<3> The IP address and host of the LDAP server where this group's record is stored.
-<4> The name of the group as specified by the sync file.
-<5> The users that are members of the group, named as specified by the sync file.
+<3> The IP address and host of the LDAP server where this Group's record is stored.
+<4> The name of the Group as specified by the sync file.
+<5> The users that are members of the Group, named as specified by the sync file.
 ====


### PR DESCRIPTION
Use consistent capitalisation for references to OpenShift "Group" objects, as opposed to LDAP "groups" or "groups" in the general sense.

Use consistent styling for file names.

Reword some statements to avoid confusing sentence structures (such as dangling non-participial modifiers, lacking parallelism, or ending a relative clause with a stranded preposition and then following it with a prepositional phrase).

Delete a spurious "at".

Use consistent capitalisation for "augmented Active Directory".

Consistently write "RFC 2307" (as opposed to "RFC2307").

Fix some typos: "intOrgPerson", "idenitifer", "syncheonized", and "Adminstrators".
## 

@stevekuznetsov, should "objectclass" be changed to "objectClass" in LDAPSyncConfigs? AFAICT compliant LDAP servers should not care, and we use "objectClass" elsewhere.
