### PR TITLE
Update Node.js image documentation to include hot deploy.

### DIFF
--- a/using_images/s2i_images/nodejs.adoc
+++ b/using_images/s2i_images/nodejs.adoc
@@ -63,5 +63,55 @@ https://github.com/openshift/origin/tree/master/examples/image-streams[example
 image stream definitions] for all the provided OpenShift images.
 
 == Configuration
-The Node.js image does not offer any environment variable based configuration
-settings.
+The Node.js image offers environment variables that facilitate developing your application.
+
+To set these environment variables, you can place them into
+link:../../dev_guide/builds.html#environment-files[a *_.sti/environment_* file]
+inside your source code repository, or define them in
+link:../../dev_guide/builds.html#buildconfig-environment[the environment
+section] of the build configuration's `*sourceStrategy*` definition.
+
+.Development Mode Environment Variables
+[cols="3a,6a",options="header"]
+|===
+
+| Variable name | Description
+
+|`*DEV_MODE*`
+| Enables hot deploy, and opens debug port. Additionally, indicates to tooling that the image is in development mode. To enable, set to true. Default is false.
+
+|`*DEBUG_PORT*`
+|The debug port. Only valid if DEV_MODE is set to true. Default is 5858.
+
+|===
+
+== Hot Deploying
+
+Hot deployment allows you to quickly make and deploy changes to your application
+without having to generate a new S2I build. In order to immediately pick up
+changes made in your application source code, you must run your built image with
+the `*DEV_MODE=true*` environment variable.
+
+For example, see the
+link:../../dev_guide/new_app.html#specifying-environment-variables[`oc new-app`]
+command. You can use the
+link:../../dev_guide/environment_variables.html#set-environment-variables[`oc
+env`] command to update environment variables of existing objects.
+
+[WARNING]
+====
+You should only use this option while developing or debugging; it is not
+recommended to turn this on in your production environment.
+====
+
+To change your source code in a running pod, use the
+link:../../cli_reference/basic_cli_operations.html#troubleshooting-and-debugging-cli-operations[`oc
+rsh`] command to enter the container:
+
+----
+$ oc rsh <pod_id>
+----
+
+After you enter into the running container, your current directory is set to
+*_/opt/app-root/src_*, where the source code is located.
+


### PR DESCRIPTION
Aligns the Node.js image documentation with the [PHP image documentation](https://github.com/openshift/openshift-docs/blob/master/using_images/s2i_images/php.adoc#php-hot-deploy) based on changes made in [this PR, introducing development mode/hot deploy](https://github.com/openshift/sti-nodejs/pull/77).
