### PR TITLE
Add note about nodeName.

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -68,11 +68,14 @@ Edit or
 link:../install_config/master_node_configuration.html#creating-new-configuration-files[create] the
 node configuration file on all nodes
 (*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` section:
+contents of the `*kubeletArguments*` and `*nodeName*` sections:
 
 ====
 [source,yaml]
 ----
+nodeName:
+  <Instance ID of OpenStack instance (=virtual machine)>
+
 kubeletArguments:
   cloud-provider:
     - "openstack"


### PR DESCRIPTION
nodeName must be set to OpenStack InstanceID of the node, otherwise
OpenShift's provider for OpenStack cloud can't be initialized.

This is not always necessary, but it's much easier to document it as
mandatory (or recommended) instead of describing cases where OpenShift could
work event without 'nodeName' in the node config.
