### PR TITLE
fix registry service account name and include in oadm registry command

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -51,7 +51,8 @@ privileges:
 
 ----
 $ oadm registry --config=admin.kubeconfig \//<1>
-    --credentials=openshift-registry.kubeconfig <2>
+    --credentials=openshift-registry.kubeconfig \\/<2>
+    --service-account='registry' \//<3>
 ----
 endif::[]
 ifdef::openshift-enterprise[]
@@ -61,8 +62,8 @@ user with cluster administrator privileges. For example:
 ----
 $ oadm registry --config=/etc/origin/master/admin.kubeconfig \//<1>
     --credentials=/etc/origin/master/openshift-registry.kubeconfig \//<2>
-    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \//<3>
-    --service-account='registry' <4>
+    --service-account='registry' \//<3>
+    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' <4>
 ----
 endif::[]
 <1> `--config` is the path to the
@@ -72,9 +73,9 @@ administrator].
 <2> `--credentials` is the path to the
 link:../../cli_reference/manage_cli_profiles.html[CLI configuration file] for
 the *openshift-registry*.
+<3> `--service-account` specifies the user with the *system:registry* role
 ifdef::openshift-enterprise[]
-<3> Required to pull the correct image for OpenShift Enterprise.
-<4> `--service-account` specifies the user with the *system:registry* role
+<4> Required to pull the correct image for OpenShift Enterprise.
 endif::[]
 
 This creates a service and a deployment configuration, both called

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -33,8 +33,8 @@ cannot access the registry directly.
 For example, if you are using `HTPASSWD` authentication:
 
 ----
-# htpasswd /etc/origin/openshift-htpasswd reguser
-# oadm policy add-role-to-user system:registry reguser
+# htpasswd /etc/origin/openshift-htpasswd registry
+# oadm policy add-role-to-user system:registry registry
 ----
 
 For more information, see

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -61,7 +61,8 @@ user with cluster administrator privileges. For example:
 ----
 $ oadm registry --config=/etc/origin/master/admin.kubeconfig \//<1>
     --credentials=/etc/origin/master/openshift-registry.kubeconfig \//<2>
-    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' <3>
+    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \//<3>
+    --service-account='registry' <4>
 ----
 endif::[]
 <1> `--config` is the path to the
@@ -73,6 +74,7 @@ link:../../cli_reference/manage_cli_profiles.html[CLI configuration file] for
 the *openshift-registry*.
 ifdef::openshift-enterprise[]
 <3> Required to pull the correct image for OpenShift Enterprise.
+<4> `--service-account` specifies the user with the *system:registry* role
 endif::[]
 
 This creates a service and a deployment configuration, both called


### PR DESCRIPTION
This is a partial fix for [BZ 1296605](https://bugzilla.redhat.com/show_bug.cgi?id=1296605):

Section 2.5.1 Overview, should use 'registry' not 'reguser' for the registry!

Section 2.5.2 Deploying the Registry, should include the “--service-account=registry” as listed in Section 2.5.1, because following the directions creates a registry that does not utilize a service account.
