### PR TITLE
Secret example metadata should contain name in a "metadata" field

### DIFF
--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -23,7 +23,9 @@ properties of secrets and provides an overview on how developers can use them.
 {
   "apiVersion": "v1",
   "kind": "Secret",
-  "name": "mysecret",
+  "metadata": {
+    "name": "mysecret"
+  },
   "namespace": "myns",
   "data": { <1>
     "username": "dmFsdWUtMQ0K",


### PR DESCRIPTION
Kubernetes v1.1 requires that the name of a secret be placed in the metadata field. The current example secret will fail to create for this reason.

See http://kubernetes.io/v1.1/docs/user-guide/secrets.html
