### PR TITLE
logging conf: saner way to edit scc

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -135,20 +135,13 @@ $ oc policy add-role-to-user edit \
 ====
 
 . Enable the Fluentd service account, which the deployer will create, that
-requires special privileges to operate Fluentd. Edit the security context:
-+
-====
-----
-$ oc edit scc/privileged
-----
-====
-+
-And add the following user to the file. The following example uses the `logging`
+requires special privileges to operate Fluentd. Add the service account user
+to the security context. The following example uses the `logging`
 project. Be sure to use the project created above in the following example:
 +
 ====
 ----
-- system:serviceaccount:logging:aggregated-logging-fluentd
+$ oadm policy add-scc-to-user privileged system:serviceaccount:logging:aggregated-logging-fluentd
 ----
 ====
 +


### PR DESCRIPTION
It turns out you don't have to `oc edit` to add a user to SCC. This is far easier to explain and harder to do wrong. It applies since the release of 3.1 apparently.
