### PR TITLE
Include note about required hostnames for the custom Metric certificates

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -178,6 +178,8 @@ values as link:../dev_guide/secrets.html[secrets] to the *metrics deployer*.
 [WARNING]
 ====
 By default, the Hawkular Metrics service uses self-signed certificates, which can cause problems when the console accesses it in a web browser. As an alternative, you can specify your own *_hawkular-metrics.pem_* secret to use a certificate that is trusted by the browser.
+
+When supplying your own certificate for the Hawkular Metrics service it *must* contain both the hostname specified for the route as well as the internally used `hawkular-metrics` hostname.
 ====
 
 Optionally, provide your own certificate that is configured to be trusted by your browser by pointing your secret to the certificate's *_.pem_* and certificate authority certificate files:
@@ -203,15 +205,17 @@ The following table contains more advanced configuration options, detailing all 
 |Secret Name |Description
 
 |*_hawkular-metrics.pem_*
-|The *_pem_* file to use for the Hawkular Metrics certificate. This is
-auto-generated if unspecified.
+|The *_pem_* file to use for the Hawkular Metrics certificate. This certificate *must* contain the 
+`hawkular-metrics` hostname as well as the publically available hostname used by the route. This file
+is auto-generated if unspecified.
 
 |*_hawkular-metrics-ca.cert_*
 |The certificate for the CA used to sign the *_hawkular-metrics.pem_*. This
 option is ignored if the *_hawkular-metrics.pem_* option is not specified.
 
 |*_hawkular-cassandra.pem_*
-|The *_.pem_* file to use for the Cassandra certificate. This is auto-generated
+|The *_.pem_* file to use for the Cassandra certificate. This certificate *must* contain the
+`hawkular-cassandra` hostname. This file is auto-generated
 if unspecified.
 
 |*_hawkular-cassandra-ca.cert_*


### PR DESCRIPTION
In reference to https://lists.openshift.redhat.com/openshift-archives/users/2016-January/msg00071.html 

See also https://github.com/openshift/origin-metrics/pull/59
