### PR TITLE
OSC_EDITOR -> OC_EDITOR

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -151,7 +151,7 @@ available varies as described in link:#object-types[object type].
 |`oc edit <object_type>/<object_type_name>`
 |Edit the desired object type.
 
-|`OSC_EDITOR="<text_editor>" oc edit \`
+|`OC_EDITOR="<text_editor>" oc edit \`
 `<object_type>/<object_type_name>`
 |Edit the desired object type with a specified text editor.
 

--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -335,7 +335,7 @@
   $ oc edit dc/my-deployment
 
   // Use an alternative editor
-  $ OSC_EDITOR="nano" oc edit dc/my-deployment
+  $ OC_EDITOR="nano" oc edit dc/my-deployment
 
   // Edit the service 'docker-registry' in JSON using the v1beta3 API format:
   $ oc edit svc/docker-registry --output-version=v1beta3 -o json


### PR DESCRIPTION
Fix references to the outdated `OSC_EDITOR` environment variable to instead refer to the current `OC_EDITOR` variable.

The corresponding code change was https://github.com/openshift/origin/pull/3086.
