### PR TITLE
Fix default node config file path

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -67,7 +67,7 @@ kubernetesMasterConfig:
 Edit or
 link:../install_config/master_node_configuration.html#creating-new-configuration-files[create] the
 node configuration file on all nodes
-(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
+(*_/etc/origin/node/node-config.yaml_* by default) and update the
 contents of the `*kubeletArguments*` and `*nodeName*` sections:
 
 ====


### PR DESCRIPTION
A minor change here: the default path to the node's config file does not contain the node's hostname.
