### PR TITLE
Formatting/edits to SCC arch info for PR#1307

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -260,10 +260,11 @@ endif::[]
 . The SELinux context of the container.
 . The user ID.
 . The use of host namespaces and networking.
-. Allocating an FSGroup that owns the pod's volumes
+. Allocating an `*FSGroup*` that owns the pod's volumes
 . Configuring allowable supplemental groups
 
-Six SCCs are added to the cluster, by default, and are viewable by cluster administrators using the CLI:
+Six SCCs are added to the cluster by default, and are viewable by cluster
+administrators using the CLI:
 
 ====
 ----
@@ -293,9 +294,9 @@ allowHostPorts: true
 allowPrivilegedContainer: true
 allowedCapabilities: null
 apiVersion: v1
-fsGroup: <6>
+fsGroup: <1>
   type: RunAsAny
-groups: <1>
+groups: <2>
 - system:cluster-admins
 - system:nodes
 kind: SecurityContextConstraints
@@ -308,24 +309,29 @@ metadata:
   creationTimestamp: null
   name: privileged
 priority: null
-runAsUser: <2>
+runAsUser: <3>
   type: RunAsAny
-seLinuxContext: <3>
+seLinuxContext: <4>
   type: RunAsAny
 supplementalGroups: <5>
   type: RunAsAny
-users: <4>
+users: <6>
 - system:serviceaccount:default:registry
 - system:serviceaccount:default:router
 - system:serviceaccount:openshift-infra:build-controller
 ----
 
-<1> The groups that have access to this SCC
-<2> The run as user strategy type which dictates the allowable values for the Security Context
-<3> The SELinux context strategy type which dictates the allowable values for the Security Context
-<4> The users who have access to this SCC
-<5> The supplemental groups strategy which dictates the allowable supplemental groups for the Security Context
-<6> The FSGroup strategy which dictates the allowable values for the Security Context
+<1> The `*FSGroup*` strategy which dictates the allowable values for the
+Security Context
+<2> The groups that have access to this SCC
+<3> The run as user strategy type which dictates the allowable values for the
+Security Context
+<4> The SELinux context strategy type which dictates the allowable values for
+the Security Context
+<5> The supplemental groups strategy which dictates the allowable supplemental
+groups for the Security Context
+<6> The users who have access to this SCC
+
 ====
 
 The `*users*` and `*groups*` fields on the SCC control which SCCs can be used.
@@ -355,7 +361,7 @@ The restricted SCC:
 
 [NOTE]
 ====
-For more information about each SCC please refer to the `kubernetes.io/description`
+For more information about each SCC, see the *kubernetes.io/description*
 annotation available on the SCC.
 ====
 
@@ -386,25 +392,38 @@ values.
 
 ==== RunAsUser
 
-. `MustRunAs` - requires a *runAsUser* to be configured. Uses the configured *runAsUser* as the default.  Validates against the configured *runAsUser*.
-. `MustRunAsRange` - requires min and max to be defined if not pre-allocated. Uses min as the default.  Validates against the entire allowable range.
-. `MustRunAsNonRoot` - requires that the pod be submitted with a non-zero *runAsUser* or have the _USER_ directive defined in the image.  No default provided.
-. `RunAsAny` - no default provided.  Allows any *runAsUser* to be specified.
+. *MustRunAs* - Requires a `*runAsUser*` to be configured. Uses the configured
+`*runAsUser*` as the default. Validates against the configured `*runAsUser*`.
+. *MustRunAsRange* - Requires minimum and maximum values to be defined if not
+using pre-allocated values. Uses the minimum as the default. Validates against
+the entire allowable range.
+. *MustRunAsNonRoot* - Requires that the pod be submitted with a non-zero
+`*runAsUser*` or have the `USER` directive defined in the image. No default
+provided.
+. *RunAsAny* - No default provided. Allows any `*runAsUser*` to be specified.
 
 ==== SELinuxContext
 
-. `MustRunAs` - requires _seLinuxOptions_ to be configured if not using pre-allocated values, uses _seLinuxOptions_ as the default, validates against _seLinuxOptions_.
-. `RunAsAny` - no default provided.  Allows any _seLinuxOptions_ to be specified.
+. *MustRunAs* - Requires `*seLinuxOptions*` to be configured if not using
+pre-allocated values. Uses `*seLinuxOptions*` as the default. Validates against
+`*seLinuxOptions*`.
+. *RunAsAny* - No default provided. Allows any `*seLinuxOptions*` to be
+specified.
 
 ==== SupplementalGroups
 
-. `MustRunAs` - requires at least one range to be specified unless using pre-allocated values.  Uses the min value of the first range as the default.  Validates against all ranges.
-. `RunAsAny` - no default provided.  Allows any _supplementalGroups_ to be specified.
+. *MustRunAs* - Requires at least one range to be specified if not using
+pre-allocated values. Uses the minimum value of the first range as the default.
+Validates against all ranges.
+. *RunAsAny* - No default provided. Allows any `*supplementalGroups*` to be
+specified.
 
 ==== FSGroup
 
-. `MustRunAs` - requires at least one range to be specified unless using pre-allocated values.  Uses the min value of the first range as the default.  Validates against the first id in the first range.
-. `RunAsAny` - no default provided.  Allows any _fsGroup_ id to be specified.
+. *MustRunAs* - Requires at least one range to be specified if not using
+pre-allocated values. Uses the minimum value of the first range as the default.
+Validates against the first ID in the first range.
+. *RunAsAny* - No default provided. Allows any `*fsGroup*` ID to be specified.
 
 
 [[admission]]
@@ -431,13 +450,35 @@ the pod:
 on the request.
 . Validate the final settings against the available constraints.
 
-A pod must validate every field against the SCC. Below are examples of just two of the fields that must be validated (note: this is in the context of a strategy using the preallocated values):
-
-. a *FSGroup* SCC strategy of `MustRunAs`: if the pod defines a _fsGroup_ id then that id must equal the default FSGroup id. Otherwise, the pod is not validated by that SCC and the next SCC is evaluated. If the *FSGroup* strategy is `RunAsAny` and the pod omits a _fsGroup_ id then the pod matches the SCC based on FSGroup (though other strategies may not validate and thus cause the pod to fail).
-. a *SupplementalGroups* SCC strategy of `MustRunAs`: if the pod spec defines a _SupplementalGroups_ id(s) then the pod's id(s) must equal one of the ids in the namespace's "openshift.io/sa.scc.supplemental-groups" annotation. Otherwise, the pod is not validated by that SCC and the next SCC is evaluated. If the *SupplementalGroups* setting is `RunAsAny` and the pod spec omits a _SupplementalGroups_ id then the pod matches the SCC based on SupplementalGroups (though other strategies may not validate and thus cause the pod to fail).
-
 If a matching set of constraints is found, then the pod is accepted. If the
 request cannot be matched to an SCC, the pod is rejected.
+
+A pod must validate every field against the SCC. The following are examples for
+just two of the fields that must be validated:
+
+[NOTE]
+====
+These examples are in the context of a strategy using the preallocated values.
+====
+
+*A FSGroup SCC Strategy of MustRunAs*
+
+If the pod defines a `*fsGroup*` ID, then that ID must equal the default
+`*FSGroup*` ID. Otherwise, the pod is not validated by that SCC and the next SCC
+is evaluated. If the `*FSGroup*` strategy is *RunAsAny* and the pod omits a
+`*fsGroup*` ID, then the pod matches the SCC based on `*FSGroup*` (though other
+strategies may not validate and thus cause the pod to fail).
+
+*A SupplementalGroups SCC Strategy of MustRunAs*
+
+If the pod specification defines one or more `*SupplementalGroups*` IDs, then
+the pod's IDs must equal one of the IDs in the namespace's
+*openshift.io/sa.scc.supplemental-groups* annotation. Otherwise, the pod is not
+validated by that SCC and the next SCC is evaluated. If the
+`*SupplementalGroups*` setting is *RunAsAny* and the pod specification omits a
+`*SupplementalGroups*` ID, then the pod matches the SCC based on
+`*SupplementalGroups*` (though other strategies may not validate and thus cause
+the pod to fail).
 
 ==== SCC Prioritization
 
@@ -455,35 +496,66 @@ in their SCC set.  This allows cluster administrators to run pods as any
 user by without specifying a `RunAsUser` on the pod's `SecurityContext`.  The
 administrator may still specify a `RunAsUser` if they wish.
 
-==== Understanding pre-allocated values and Security Context Constraints
+==== Understanding Pre-allocated Values and Security Context Constraints
 
-The admission controller is aware of certain conditions in the security context constraints that trigger it to look up pre-allocated values from a namespace and populate the security context constraint before processing the pod. Each SCC strategy is evaluted independently of other strategies, with the pre-allocated values (where allowed) for each policy aggregated with pod spec values to make the final values for the various ids defined in the running pod.
+The admission controller is aware of certain conditions in the security context
+constraints that trigger it to look up pre-allocated values from a namespace and
+populate the security context constraint before processing the pod. Each SCC
+strategy is evaluated independently of other strategies, with the pre-allocated
+values (where allowed) for each policy aggregated with pod specification values
+to make the final values for the various IDs defined in the running pod.
 
-The following security context constraints cause the admission controller to look for pre-allocated values (when no ranges are defined in the pod spec):
+The following SCCs cause the admission controller to look for pre-allocated
+values when no ranges are defined in the pod specification:
 
-. A *RunAsUser* strategy of `MustRunAsRange` with no min/max set.  Admission will look for the "openshift.io/sa.scc.uid-range" annotation to populate range fields.
-. An *SELinuxContext* strategy of `MustRunAs` with no level set.  Admission will look for the "openshift.io/sa.scc.mcs" annotation to populate the level.
-. A *FSGroup* strategy of `MustRunAs`.  Admission will look for the "openshift.io/sa.scc.supplemental-groups" annotation.
-. A *SupplementalGroups* strategy of `MustRunAs`.  Admission will look for the "openshift.io/sa.scc.supplemental-groups" annotation.
+. A `*RunAsUser*` strategy of *MustRunAsRange* with no minimum or maximum set.
+Admission looks for the *openshift.io/sa.scc.uid-range* annotation to populate
+range fields.
+. An `*SELinuxContext*` strategy of *MustRunAs* with no level set. Admission
+looks for the *openshift.io/sa.scc.mcs* annotation to populate the level.
+. A `*FSGroup*` strategy of *MustRunAs*. Admission looks for the
+*openshift.io/sa.scc.supplemental-groups* annotation.
+. A `*SupplementalGroups*` strategy of *MustRunAs*. Admission looks for the
+*openshift.io/sa.scc.supplemental-groups* annotation.
 
-During the generation phase, the security context provider will default any values that are not specifically set in the pod.  Defaulting is based on the strategy being used:
+During the generation phase, the security context provider will default any
+values that are not specifically set in the pod. Defaulting is based on the
+strategy being used:
 
-. *RunAsAny* and *MustRunAsNonRoot* strategies do not provide default values. Thus, if the pod needs a field defined (eg. a group id) this field must be defined inside the pod spec.
-. *MustRunAs* (single value) strategies provide a default value which is always used. As an example, for group IDs: even if the pod spec defines its own id value, the namespace's default field will also appear in the pod's groups.
-. *MustRunAsRange* and *MustRunAs* (range based) strategies provide the min value of the range. As with a single value `MustRunAs` strategy, the namespace's default value will appear in the running pod.
-If a range based strategy is configurable with multiple ranges it will provide the min value of the first configured range.
+. `*RunAsAny*` and `*MustRunAsNonRoot*` strategies do not provide default
+values. Thus, if the pod needs a field defined (for example, a group ID), this
+field must be defined inside the pod specification.
+. `*MustRunAs*` (single value) strategies provide a default value which is
+always used. As an example, for group IDs: even if the pod specification defines
+its own ID value, the namespace's default field will also appear in the pod's
+groups.
+. `*MustRunAsRange*` and `*MustRunAs*` (range-based) strategies provide the
+minimum value of the range. As with a single value `*MustRunAs*` strategy, the
+namespace's default value will appear in the running pod. If a range-based
+strategy is configurable with multiple ranges, it will provide the minimum value
+of the first configured range.
 
 [NOTE]
 ====
-*FSGroup* and *SupplementalGroups* strategies will fall back to the "openshift.io/sa.scc.uid-range" annotation if the "openshift.io/sa.scc.supplemental-groups" annotation does not exist on the namespace.  If neither exist the SCC will fail to create.
+`*FSGroup*` and `*SupplementalGroups*` strategies fall back to the
+*openshift.io/sa.scc.uid-range* annotation if the
+*openshift.io/sa.scc.supplemental-groups* annotation does not exist on the
+namespace. If neither exist, the SCC will fail to create.
 ====
 
 [NOTE]
 ====
-By default the annotation based *FSGroup* strategy will configure itself with a single range based on the min value for the annotation.  For example, if your annotation reads `1/3` the *FSGroup* strategy will configure itself with a min and max of 1.  If you would like to allow more groups to be accepted for the FSGroup field you may configure a custom SCC that does not use the annotation.
+By default, the annotation-based `*FSGroup*` strategy configures itself with a
+single range based on the minimum value for the annotation. For example, if your
+annotation reads *1/3*, the `*FSGroup*` strategy will configure itself with a
+minimum and maximum of *1*. If you want to allow more groups to be accepted for
+the `*FSGroup*` field, you can configure a custom SCC that does not use the
+annotation.
 ====
 
 [NOTE]
 ====
-The "openshift.io/sa.scc.supplemental-groups" accepts a comma delimited list of blocks in the format of `<start>/<length` or `<start>-<end>`.  The "openshift.io/sa.scc.uid-range" accepts only a single block.
+The *openshift.io/sa.scc.supplemental-groups* annotation accepts a comma
+delimited list of blocks in the format of `<start>/<length` or `<start>-<end>`.
+The *openshift.io/sa.scc.uid-range* annotation accepts only a single block.
 ====


### PR DESCRIPTION
Follow-up edits for https://github.com/openshift/openshift-docs/pull/1307, mostly formatting and syncing up on markup used.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/011716/edit_scc_1307/architecture/additional_concepts/authorization.html#security-context-constraints

cc @jeffvance @erinboyd @pweil- 
