### PR TITLE
Enterprise 3.0 Weekly Publishing Schedule - Jan 18, 2016

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -66,16 +66,16 @@ No events.
 
 [WARNING]
 ====
-Versions of `oc` prior to 
+Versions of `oc` prior to
 ifdef::openshift-origin[]
-1.0.5 
+1.0.5
 endif::[]
 ifdef::openshift-enterprise[]
 3.0.2.0
 endif::[]
-did not have the ability to negotiate API versions against a server. So if you are using `oc` up to 
+did not have the ability to negotiate API versions against a server. So if you are using `oc` up to
 ifdef::openshift-origin[]
-1.0.4 
+1.0.4
 endif::[]
 ifdef::openshift-enterprise[]
 3.0.1.0
@@ -149,7 +149,7 @@ available varies as described in link:#object-types[object type].
 |`oc edit _<object_type>_/_<object_type_name>_`
 |Edit the desired object type.
 
-|`OSC_EDITOR="_<text_editor>_" oc edit \`
+|`OC_EDITOR="_<text_editor>_" oc edit \`
 `_<object_type>_/_<object_type_name>_`
 |Edit the desired object type with a specified text editor.
 

--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -312,7 +312,7 @@
   $ oc edit dc/my-deployment
 
   // Use an alternative editor
-  $ OSC_EDITOR="nano" oc edit dc/my-deployment
+  $ OC_EDITOR="nano" oc edit dc/my-deployment
 
   // Edit the service 'docker-registry' in JSON using the v1beta3 API format:
   $ oc edit svc/docker-registry --output-version=v1beta3 -o json

--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -23,7 +23,9 @@ provides an overview on how developers can use them.
 {
   "apiVersion": "v1",
   "kind": "Secret",
-  "name": "mysecret",
+  "metadata": {
+    "name": "mysecret"
+  },
   "namespace": "myns",
   "data": { <1>
     "username": "dmFsdWUtMQ0K",


### PR DESCRIPTION
This week's cherry-picked commits for OSE 3.0 update the following books:

**CLI Reference**
- Updated the "CLI Operations" topic to fix references to the outdated `OSC_EDITOR` environment variable to instead refer to the current `OC_EDITOR`.

**Developer Guide**
- Updated the "Secrets" topic to include the `metadata.name` parameter in an example.
