### PR TITLE
Dedicated 3.1 Weekly Publishing Schedule - Jan 18, 2016

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -34,6 +34,8 @@ Distros: openshift-enterprise,openshift-dedicated
 Topics:
   - Name: Overview
     File: index
+  - Name: OpenShift v2 vs. OpenShift v3
+    File: v2_vs_v3
   - Name: OpenShift Enterprise 3.1 Release Notes
     File: ose_3_1_release_notes
     Distros: openshift-enterprise

--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -34,8 +34,6 @@ Distros: openshift-enterprise,openshift-dedicated
 Topics:
   - Name: Overview
     File: index
-  - Name: OpenShift v2 vs. OpenShift v3
-    File: v2_vs_v3
   - Name: OpenShift Enterprise 3.1 Release Notes
     File: ose_3_1_release_notes
     Distros: openshift-enterprise
@@ -45,6 +43,8 @@ Topics:
   - Name: xPaaS Release Notes
     File: xpaas_release_notes
     Distros: openshift-enterprise
+  - Name: Comparing OpenShift Enterprise 2 and OpenShift Enterprise 3
+    File: v2_vs_v3
 
 ---
 Name: What's New?

--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -277,6 +277,18 @@ external registry. It uses standard docker pull specification for its name,
 eg `openshift/ruby-20-centos7:2.0`. When no tag is specified it is assumed
 the `latest` will be used.
 
+[NOTE]
+====
+When looking at an example image stream definition, such as the
+link:https://github.com/openshift/origin/blob/master/examples/image-streams/image-streams-centos7.json[example centos image streams],
+you will notice that it will contain definitions of
+ImageStreamTags and references to DockerImages, but nothing related to ImageStreamImages.  This is because the
+ImageStreamImage objects are automatically created in the
+OpenShift server whenever you import or tag an image into the ImageStream.
+You should never have to explicitly define an ImageStreamImage object in any
+ImageStream JSON or YAML that you use to create ImageStreams.
+====
+
 The sample image below is from the *ruby* image stream and was
 retrieved by asking for the `*ImageStreamImage*` with the name
 *ruby@371829c*:

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -335,15 +335,23 @@ indicated files.
 
 |`process`
 |`oc process -f _<template_file_path>_`
-|Transform a project link:../dev_guide/templates.html[template] into a project configuration file.
+|Transform a project link:../dev_guide/templates.html[template] into a project
+configuration file.
+
+|`run`
+|`oc run NAME --image=image [--env="key=value"] [--port=port] +
+[--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [options]`
+|Create and run a particular image, possibly replicated. Create a deployment
+config to manage the created container(s). You can choose to run in the
+foreground for an interactive container execution.
 
 |`export`
 |`oc export _<object_type>_ [--options]`
-|Export resources to be used elsewhere
+|Export resources to be used elsewhere.
 
 |`policy`
 |`oc policy [--options]`
-|Manage authorization policies
+|Manage authorization policies.
 
 |`secrets`
 |`oc secrets [--options] path/to/ssh_key`

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -381,10 +381,10 @@ foreground for an interactive container execution.
 works for builds, build configurations, deployment configurations, and pods.
 
 |`exec`
-|`oc exec -p <pod_ID> \`
-`-c <container_ID> -- <command>`
-|Execute a command in a already-running container. It will default to the first
-container if none is specified.
+|`oc exec <pod_ID> \`
+`[-c <container_ID>] <command>`
+|Execute a command in an already-running container. You can optionally specify a
+container ID, otherwise it defaults to the first container.
 
 |`rsh`
 |`oc rsh <pod_ID>`

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -107,20 +107,22 @@ The following table describes basic `oc` operations and their general syntax:
 |End the current session.
 
 |`new-project`
-|`oc new-project _<project_name>_`
+|`oc new-project <project_name>`
 |Create a new project.
 
 |`new-app`
 |`oc new-app .`
-|link:../dev_guide/new_app.html[Creates a new application] based on the source code in the current directory.
+|link:../dev_guide/new_app.html[Creates a new application] based on the source
+code in the current directory.
 
 |`status`
 |`oc status`
 |Show an overview of the current project.
 
 |`project`
-|`oc project _<project_name>_`
-|Switch to another project. Run without options to display the current project. To view all projects you have access to run `oc projects`.
+|`oc project <project_name>`
+|Switch to another project. Run without options to display the current project.
+To view all projects you have access to run `oc projects`.
 
 |===
 
@@ -134,63 +136,63 @@ The following table describes basic `oc` operations and their general syntax:
 |Operation |Syntax |Description
 
 |`get`
-|`oc get _<object_type>_ [_<object_name_or_id>_]`
+|`oc get <object_type> [<object_name_or_id>]`
 |Return a list of objects for the specified link:#object-types[object type]. If
 the optional `_<object_name_or_id>_` is included in the request, then the list
 of results is filtered by that value.
 
 |`describe`
-|`oc describe _<object_type>_ _<object_id>_`
+|`oc describe <object_type> <object_id>`
 |Returns information about the specific object returned by the query. A specific
 `_<object_name_or_id>_` must be provided. The actual information that is
 available varies as described in link:#object-types[object type].
 
 .3+|`edit`
-|`oc edit _<object_type>_/_<object_type_name>_`
+|`oc edit <object_type>/<object_type_name>`
 |Edit the desired object type.
 
-|`OSC_EDITOR="_<text_editor>_" oc edit \`
-`_<object_type>_/_<object_type_name>_`
+|`OSC_EDITOR="<text_editor>" oc edit \`
+`<object_type>/<object_type_name>`
 |Edit the desired object type with a specified text editor.
 
-|`oc edit _<object_type>_/_<object_type_name>_ \`
-`--output-version=_<object_type_version>_ \`
-`-o _<object_type_format>_`
+|`oc edit <object_type>/<object_type_name> \`
+`--output-version=<object_type_version> \`
+`-o <object_type_format>`
 |Edit the desired object in a specified format (eg: JSON).
 
 |`env`
-|`oc env _<object_type>_/_<object_type_name>_ \`
-`_<EN_VAR>_=/_<VALUE>_`
-|Update the desired object type with a new environment variable
+|`oc env <object_type>/<object_type_name> \`
+`<var_name>=<value>`
+|Update the desired object type with a new environment variable.
 
 |`volume`
-|`oc volume _<object_type>_/_<object_type_name>_ \`
+|`oc volume <object_type>/<object_type_name> \`
 `[--option]`
 |Modify a link:../dev_guide/volumes.html[volume].
 
 |`label`
-|`oc label _<object_type>_ _<object_name_or_id>_ \`
-`_<label>_`
+|`oc label <object_type> <object_name_or_id> \`
+`<label>`
 |Update the labels on a object.
 
 |`expose`
-|`oc expose _<object_type>_ _<object_name_or_id>_`
+|`oc expose <object_type> <object_name_or_id>`
 |Look up a service and expose it as a route. There is also the ability to
 expose a deployment configuration, replication controller, service, or pod as a
 new service on a specified port. If no labels are specified, the new object will
 re-use the labels from the object it exposes.
 
 |`delete`
-a|`oc delete -f _<file_path>_`
+a|`oc delete -f <file_path>`
 
-`oc delete _<object_type>_ _<object_name_or_id>_`
+`oc delete <object_type> <object_name_or_id>`
 
-`oc delete _<object_type>_ -l _<label>_`
+`oc delete <object_type> -l <label>`
 
-`oc delete all -l _<label>_`
+`oc delete all -l <label>`
 .^|Delete the specified object. An object configuration can also be passed in
-through STDIN. The `oc delete all -l _<label>_` operation deletes all objects
-matching the specified `_<label>_`, including the
+through STDIN. The `oc delete all -l <label>` operation deletes all objects
+matching the specified `<label>`, including the
 link:../architecture/core_concepts/deployments.html#replication-controllers[replication
 controller] so that pods are not re-created.
 
@@ -318,7 +320,7 @@ streams.
 |Operation |Syntax |Description
 
 |`create`
-|`oc create -f _<file_or_dir_path>_`
+|`oc create -f <file_or_dir_path>`
 |Parse a configuration file and create one or more OpenShift objects based on
 the file contents. The `-f` flag can be passed multiple times with different
 file or directory paths. When the flag is passed multiple times, `oc create`
@@ -326,7 +328,7 @@ iterates through each one, creating the objects described in all of the
 indicated files. Any existing resources are ignored.
 
 |`update`
-|`oc update -f _<file_or_dir_path>_`
+|`oc update -f <file_or_dir_path>`
 |Attempt to modify an existing object based on the contents of the specified
 configuration file. The `-f` flag can be passed multiple times with different
 file or directory paths. When the flag is passed multiple times, `oc update`
@@ -334,19 +336,23 @@ iterates through each one, updating the objects described in all of the
 indicated files.
 
 |`process`
-|`oc process -f _<template_file_path>_`
+|`oc process -f <template_file_path>`
 |Transform a project link:../dev_guide/templates.html[template] into a project
 configuration file.
 
 |`run`
-|`oc run NAME --image=image [--env="key=value"] [--port=port] +
-[--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [options]`
+|`oc run NAME --image=<image> \`
+`[--port=<port>] \`
+`[--replicas=<replicas>] \`
+`[--dry-run=<bool>] \`
+`[--overrides=<inline-json>] \`
+`[options]`
 |Create and run a particular image, possibly replicated. Create a deployment
-config to manage the created container(s). You can choose to run in the
+configuration to manage the created container(s). You can choose to run in the
 foreground for an interactive container execution.
 
 |`export`
-|`oc export _<object_type>_ [--options]`
+|`oc export <object_type> [--options]`
 |Export resources to be used elsewhere.
 
 |`policy`
@@ -370,32 +376,34 @@ foreground for an interactive container execution.
 
 
 |`logs`
-|`oc logs -f _<pod_name>_`
+|`oc logs -f <pod_name>`
 |Retrieve the log output for a specific build, deployment, or pod. This command
 works for builds, build configurations, deployment configurations, and pods.
 
 |`exec`
-|`oc exec -p _<pod_ID>_ \`
-`-c _<container_ID>_ -- _<command>_`
-|Execute a command in a already-running container. It will default to the first container if none is specified.
+|`oc exec -p <pod_ID> \`
+`-c <container_ID> -- <command>`
+|Execute a command in a already-running container. It will default to the first
+container if none is specified.
 
 |`rsh`
-|`oc rsh _<pod_ID>_`
+|`oc rsh <pod_ID>`
 |Open a remote shell session to a container.
 
 |`rsync`
-|`oc rsync _<local_dir>_ _<pod_ID>_:_<pod_dir>_ \`
-`-c _<container_ID>_`
-|Copy contents of local directory to a directory in an already-running pod container. It will default to the first container if none is specified.
+|`oc rsync <local_dir> <pod_ID>:<pod_dir> \`
+`-c <container_ID>`
+|Copy contents of local directory to a directory in an already-running pod
+container. It will default to the first container if none is specified.
 
 |`port-forward`
-|`oc port-forward _<pod_ID>_ \`
-`_<first_port_ID>_ _<second_port_ID>_`
+|`oc port-forward <pod_ID> \`
+`<first_port_ID> <second_port_ID>`
 |link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a pod.
 
 |`proxy`
-|`oc proxy --port=_<port_ID>_ \`
-`--www=_<static_directory>_`
+|`oc proxy --port=<port_ID> \`
+`--www=<static_directory>`
 |Run a proxy to the Kubernetes API server
 
 |===

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -151,7 +151,7 @@ available varies as described in link:#object-types[object type].
 |`oc edit <object_type>/<object_type_name>`
 |Edit the desired object type.
 
-|`OSC_EDITOR="<text_editor>" oc edit \`
+|`OC_EDITOR="<text_editor>" oc edit \`
 `<object_type>/<object_type_name>`
 |Edit the desired object type with a specified text editor.
 

--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -335,7 +335,7 @@
   $ oc edit dc/my-deployment
 
   // Use an alternative editor
-  $ OSC_EDITOR="nano" oc edit dc/my-deployment
+  $ OC_EDITOR="nano" oc edit dc/my-deployment
 
   // Edit the service 'docker-registry' in JSON using the v1beta3 API format:
   $ oc edit svc/docker-registry --output-version=v1beta3 -o json

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -174,9 +174,8 @@ previously-built images. To create an incremental build, create a
 }
 ----
 
-<1> Specify an image that supports incremental builds. The S2I images provided
-by OpenShift do not implement artifact reuse, so setting `*incremental*`  to
-*true* will have no effect on builds using those builder images.
+<1> Specify an image that supports incremental builds. Consult the
+documentation of the builder image to determine if it supports this behavior.
 <2> This flag controls whether an incremental build is attempted. If the builder
 image does not support incremental builds, the build will still succeed, but you
 will get a log message stating the incremental build was not successful because

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -640,7 +640,9 @@ $ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD -
 ----
 ====
 
-. Add the `*secret*` to the builder service account:
+. Add the `*secret*` to the builder service account. Each build is run with
+`serviceaccount/builder` role, so you need to give it access your secret with
+following command:
 +
 ====
 ----
@@ -836,7 +838,10 @@ for the `http` section in your `.gitconfig` file:
 ----
 ====
 
-. Add the `*secret*` to the builder service account:
+. Add the `*secret*` to the builder service account. Each build is run with
+`serviceaccount/builder` role, so you need to give it access your secret with
+following command:
+
 +
 ====
 ----
@@ -1295,7 +1300,10 @@ $ oc secrets new dockerhub ~/.dockercfg
 This generates a JSON specification of the `*secret*` named *dockerhub* and
 creates the object.
 
-. Once the `*secret*` is created, add it to the builder service account:
+. Once the `*secret*` is created, add it to the builder service account. Each
+build is run with `serviceaccount/builder` role, so you need to give it access
+your secret with following command:
+
 +
 ====
 ----

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -12,16 +12,8 @@
 toc::[]
 
 == Overview
-
-A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build]
-is the process of transforming input parameters into a resulting object. Most
-often, the process is used to transform source code into a runnable image.
-
-Build configurations are characterized by a strategy and one or more sources.
-The strategy determines the aforementioned process, while the sources provide
-its input.
-
-There are three build strategies:
+A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
+runnable images to be used on OpenShift. There are three build strategies:
 
 - Source-To-Image (S2I)
 (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description],
@@ -32,19 +24,6 @@ link:#docker-strategy-options[options])
 - Custom
 (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description],
 link:#custom-strategy-options[options])
-
-And there are three types of build source:
-
-- link:#source-code[Git]
-- link:#dockerfile-source[Dockerfile]
-- link:#binary-source[Binary]
-
-It is up to each build strategy to consider or ignore a certain type of source,
-as well as to determine how it is to be used.
-
-Binary and Git are mutually exclusive source types, while Dockerfile can be used
-by itself or together with Git and Binary.
-
 
 [[defining-a-buildconfig]]
 
@@ -91,8 +70,7 @@ image tag or the source code changes:
       "type": "Git",
       "git": {
         "uri": "git://github.com/openshift/ruby-hello-world.git"
-      },
-      "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example"
+      }
     },
     "strategy": { <4>
       "type": "Source",
@@ -117,11 +95,8 @@ image tag or the source code changes:
 *ruby-sample-build*.
 <2> You can specify a list of link:#build-triggers[triggers], which cause a new
 build to be created.
-<3> The `*source*` section defines the source of the build. The source type
-determines the primary source of input, and can be either `*Git*`, to point to a
-code repository location, `*Dockerfile*`, to build from an inline Dockerfile, or
-`*Binary*`, to accept binary payloads. It is possible to have multiple sources
-at once, refer to the documentation for each source type for details.
+<3> The `*source*` section defines the source code repository location. You can
+provide additional options, such as `*sourceSecret*` or `*contextDir*` here.
 <4> The `*strategy*` section describes the build strategy used to execute the
 build. You can specify `*Source*`, `*Docker*` and `*Custom*` strategies here.
 This above example uses the `*ruby-20-centos7*` Docker image that
@@ -555,41 +530,33 @@ For example, defining a custom HTTP proxy to be used during build:
 
 == Git Repository Source Options
 
-When the `*BuildConfig.spec.source.type*` is `*Git*`, a Git repository is
-required, and an inline Dockerfile is optional.
-
-The source code is fetched from the location specified and, if the
-`*BuildConfig.spec.source.dockerfile*` field is specified, the inline Dockerfile
-replaces the one in the `*contextDir*` of the Git repository.
-
-The source definition is part of the `*spec*` section in the `*BuildConfig*`:
+The source code location is one of the required parameters for the
+`*BuildConfig*`. The build uses this location and fetches the source code that
+is later built. The source code location definition is part of the
+`*spec*` section in the `*BuildConfig*`:
 
 ====
 
 ----
 {
   "source" : {
-    "type" : "Git",
-    "git" : { <1>
-      "uri": "git://github.com/openshift/ruby-hello-world.git",
-      "ref": "master"
+    "type" : "Git", <1>
+    "git" : { <2>
+      "uri": "git://github.com/openshift/ruby-hello-world.git"
     },
-    "contextDir": "app/dir", <2>
-    "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example" <3>
+    "contextDir": "app/dir", <3>
   },
 }
 ----
 
-<1> The `*git*` field contains the URI to the remote Git repository of the
+<1> The `*type*` field describes which SCM is used to fetch your source code.
+<2> The `*git*` field contains the URI to the remote Git repository of the
 source code. Optionally, specify the `*ref*` field to check out a specific Git
 reference. A valid `*ref*` can be a SHA1 tag or a branch name.
-<2> The `*contextDir*` field allows you to override the default location inside
+<3> The `*contextDir*` field allows you to override the default location inside
 the source code repository where the build looks for the application source
 code. If your application exists inside a sub-directory, you can override the
 default location (the root folder) using this field.
-<3> If the optional `*dockerfile*` field is provided, it should be a string
-containing a Dockerfile that overwrites any Dockerfile that may exist in the
-source repository.
 ====
 
 [[using-a-proxy-for-git-cloning]]
@@ -875,81 +842,6 @@ for the `http` section in your `.gitconfig` file:
 ----
 $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
-====
-
-
-[[dockerfile-source]]
-
-== Dockerfile Source
-
-When the `*BuildConfig.spec.source.type*` is `*Dockerfile*`, an inline
-Dockerfile is used as the build input, and no additional sources can be
-provided.
-
-This source type is valid when the build strategy type is `*Docker*` or
-`*Custom*`.
-
-The source definition is part of the `*spec*` section in the `*BuildConfig*`:
-
-====
-
-----
-{
- "source" : {
-    "type" : "Dockerfile",
-    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <1>
- },
-}
-----
-
-<1> The `*dockerfile*` field contains an inline Dockerfile that will be built.
-====
-
-
-[[binary-source]]
-
-== Binary Source
-
-When the `*BuildConfig.spec.source.type*` is `*Binary*`, the build will expect a
-binary as input, and an inline Dockerfile is optional.
-
-The binary is generally assumed to be a tar, gzipped tar, or zip file depending
-on the strategy. For `*Docker*` builds, this is the build context and an
-optional Dockerfile may be specified to override any Dockerfile in the build
-context. For `*Source*` builds, this is assumed to be an archive as described
-above. For `*Source*` and `*Docker*` builds, if `*binary.asFile*` is set the
-build will receive a directory with a single file. The `*contextDir*` field may
-be used when an archive is provided. Custom builds will receive this binary as
-input on standard input (`stdin`).
-
-A binary source potentially extracts content, in which case `*contextDir*`
-allows changing to a subdirectory within the content before the build executes.
-
-The source definition is part of the `*spec*` section in the `*BuildConfig*`:
-
-====
-
-----
-{
- "source" : {
-    "type" : "Binary",
-    "binary": { <1>
-      "asFile": "webapp.war" <2>
-    },
-    "contextDir": "app/dir", <3>
-    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <4>
- },
-}
-----
-
-<1> The `*binary*` field specifies the details of the binary source.
-<2> The `*asFile*` field specifies the name of a file that will be created with
-the binary contents.
-<3> The `*contextDir*` field specifies a subdirectory with the contents of a
-binary archive.
-<4> If the optional `*dockerfile*` field is provided, it should be a string
-containing an inline Dockerfile that potentially replaces one within the
-contents of the binary archive.
 ====
 
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1456,3 +1456,69 @@ Docker and Source builds set the following labels on output images:
 |*io.openshift.build.source-location*
 |Source URL for the build
 |===
+
+
+[[using-external-artifacts]]
+== Using External Artifacts During a Build
+
+It is not recommended to store binary files in a source repository. Therefore
+you may find it necessary to define a build which pulls additional files (such
+as Java jar dependencies) during the build process. How this is done depends on
+the build strategy you are using:
+
+For a `*Source*` build strategy you need to put appropriate shell commands into
+the `assemble` script.
+
+.`.sti/bin/assemble` file
+====
+
+[source,bash]
+----
+#!/bin/sh
+APP_VERSION=1.0
+wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
+----
+====
+
+.`.sti/bin/run` file
+====
+
+[source,bash]
+----
+#!/bin/sh
+exec java -jar app.jar
+----
+====
+
+For more information on how to control which assemble and run script is used by a source bulid,
+see: link:#override-builder-image-scripts[Override Builder Image Scripts]
+
+For a `*Docker*` build strategy you need to modify the `Dockerfile` and invoke
+shell commands with the https://docs.docker.com/engine/reference/builder/#run[`RUN` instruction].
+
+.Excerpt of `Dockerfile`
+====
+
+[source]
+----
+FROM jboss/base-jdk:8
+
+ENV APP_VERSION 1.0
+RUN wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
+
+EXPOSE 8080
+CMD [ "java", "-jar", "app.jar" ]
+----
+====
+
+In practice you may want to use an environment variable for the file location
+so that the specific file to be downloaded can be customized via an environment
+variable defined on the `BuildConfig` rather than updating the assemble script or
+`Dockerfile`.
+
+You could choose between a different ways of defining environment variables:
+
+- link:#environment-files[put into the `.sti/environment` file] (only for a `*Source*` build strategy)
+- link:#buildconfig-environment[set in `*BuildConfig*`]
+- link:../cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations[provide explicitly with `*oc start-build --env*`]
+  (only for builds that are triggered manually)

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -190,7 +190,7 @@ on how to create a builder image supporting incremental builds.
 
 [[override-builder-image-scripts]]
 
-=== Override Builder Image Scripts
+=== Overriding Builder Image Scripts
 
 You can override the *_assemble_*, *_run_*, and *_save-artifacts_*
 link:../creating_images/s2i.html#s2i-scripts[S2I scripts] provided by the
@@ -1456,19 +1456,18 @@ Docker and Source builds set the following labels on output images:
 |Source URL for the build
 |===
 
-
 [[using-external-artifacts]]
 == Using External Artifacts During a Build
 
-It is not recommended to store binary files in a source repository. Therefore
+It is not recommended to store binary files in a source repository. Therefore,
 you may find it necessary to define a build which pulls additional files (such
-as Java jar dependencies) during the build process. How this is done depends on
-the build strategy you are using:
+as Java *_.jar_* dependencies) during the build process. How this is done
+depends on the build strategy you are using.
 
-For a `*Source*` build strategy you need to put appropriate shell commands into
-the `assemble` script.
+For a `*Source*` build strategy, you must put appropriate shell commands into
+the *_assemble_* script:
 
-.`.sti/bin/assemble` file
+.*_.sti/bin/assemble_* File
 ====
 
 [source,bash]
@@ -1479,7 +1478,7 @@ wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
 ----
 ====
 
-.`.sti/bin/run` file
+.*_.sti/bin/run_* File
 ====
 
 [source,bash]
@@ -1489,11 +1488,16 @@ exec java -jar app.jar
 ----
 ====
 
-For more information on how to control which assemble and run script is used by a source bulid,
-see: link:#override-builder-image-scripts[Override Builder Image Scripts]
+[NOTE]
+====
+For more information on how to control which *_assemble_* and *_run_* script is
+used by a Source build, see link:#override-builder-image-scripts[Overriding
+Builder Image Scripts].
+====
 
-For a `*Docker*` build strategy you need to modify the `Dockerfile` and invoke
-shell commands with the https://docs.docker.com/engine/reference/builder/#run[`RUN` instruction].
+For a `*Docker*` build strategy, you must modify the *_Dockerfile_* and invoke
+shell commands with the
+https://docs.docker.com/engine/reference/builder/#run[`RUN` instruction]:
 
 .Excerpt of `Dockerfile`
 ====
@@ -1510,14 +1514,16 @@ CMD [ "java", "-jar", "app.jar" ]
 ----
 ====
 
-In practice you may want to use an environment variable for the file location
-so that the specific file to be downloaded can be customized via an environment
-variable defined on the `BuildConfig` rather than updating the assemble script or
-`Dockerfile`.
+In practice, you may want to use an environment variable for the file location
+so that the specific file to be downloaded can be customized using an
+environment variable defined on the `BuildConfig`, rather than updating the
+*_assemble_* script or *_Dockerfile_*.
 
-You could choose between a different ways of defining environment variables:
+You can choose between different methods of defining environment variables:
 
-- link:#environment-files[put into the `.sti/environment` file] (only for a `*Source*` build strategy)
-- link:#buildconfig-environment[set in `*BuildConfig*`]
-- link:../cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations[provide explicitly with `*oc start-build --env*`]
-  (only for builds that are triggered manually)
+- link:#environment-files[Using the *_.sti/environment_* file] (only for a
+`*Source*` build strategy)
+- link:#buildconfig-environment[Setting in `*BuildConfig*`]
+- link:../cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations[Providing
+explicitly using `*oc start-build --env*`] (only for builds that are triggered
+manually)

--- a/dev_guide/limits.adoc
+++ b/dev_guide/limits.adoc
@@ -11,19 +11,20 @@ toc::[]
 
 == Overview
 
-A `*LimitRange*` object enumerates compute resource constraints in a 
-link:projects.html[project]. This allows you to specify the amount of resources 
+A `*LimitRange*` object enumerates
+link:compute_resources.html[compute resource constraints] in a
+link:projects.html[project]. This allows you to specify the amount of resources
 that a pod or container can consume.
 
 == Constraints
 
-A `*LimitRange*` object enumerates compute resource constraints at a pod and 
+A `*LimitRange*` object enumerates compute resource constraints at a pod and
 container scope in a project.
 
-All resource create and modification requests are evaluated against each 
-`*LimitRange*` object in the project.  If the resource violates any of the 
-enumerated constraints, then the resource is rejected.  If the resource does 
-not set an explicit value, and if the constraint supports a default value, then 
+All resource create and modification requests are evaluated against each
+`*LimitRange*` object in the project.  If the resource violates any of the
+enumerated constraints, then the resource is rejected.  If the resource does
+not set an explicit value, and if the constraint supports a default value, then
 the default value is applied to the resource.
 
 === Container Limits

--- a/dev_guide/quota.adoc
+++ b/dev_guide/quota.adoc
@@ -13,8 +13,9 @@ toc::[]
 
 A *ResourceQuota* object enumerates hard resource usage limits per project. It
 limits the total number of a particular type of object that may be created in
-a project, and the total amount of compute resources that may be consumed by
-resources in that project.
+a project, and the total amount of
+link:compute_resources.html[compute resources]
+that may be consumed by resources in that project.
 
 == Usage Limits
 

--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -23,7 +23,9 @@ properties of secrets and provides an overview on how developers can use them.
 {
   "apiVersion": "v1",
   "kind": "Secret",
-  "name": "mysecret",
+  "metadata": {
+    "name": "mysecret"
+  },
   "namespace": "myns",
   "data": { <1>
     "username": "dmFsdWUtMQ0K",

--- a/release_notes/v2_vs_v3.adoc
+++ b/release_notes/v2_vs_v3.adoc
@@ -1,4 +1,4 @@
-= Comparing OpenShift version 2 and OpenShift version 3
+= Comparing OpenShift Enterprise 2 and OpenShift Enterprise 3
 {product-author}
 {product-version}
 :icons: font
@@ -11,10 +11,16 @@
 toc::[]
 
 == Overview
-While still an application platform, OpenShift v3 is a very different product than OpenShift v2. 
-Many of the same terms are used, and the same functions are performed, but the terminology can be different, and behind the scenes things may be happening very differently.
+OpenShift version 3 (v3) is a very different product than OpenShift version 2 (v2). 
+Many of the same terms are used, and the same functions are performed, but the terminology can be different, and behind the scenes things may be happening very differently. 
+Still, OpenShift remains an application platform.
 
 This topic discusses these differences in detail, in an effort to help OpenShift users in the transition from OpenShift v2 to OpenShift v3.
+
+ifdef::openshift-dedicated[]
+[NOTE]
+OpenShift Dedicated 3 follows the numbering of the product's major version, and uses the same code base as OpenShift Enterprise 3.
+endif::[]
 
 == Architecture Changes
 

--- a/release_notes/v2_vs_v3.adoc
+++ b/release_notes/v2_vs_v3.adoc
@@ -1,0 +1,145 @@
+= Comparing OpenShift version 2 and OpenShift version 3
+{product-author}
+{product-version}
+:icons: font
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+:description: This topic is a list of the differences between OpenShift v2 and OpenShift v3.
+
+toc::[]
+
+== Overview
+While still an application platform, OpenShift v3 is a very different product than OpenShift v2. 
+Many of the same terms are used, and the same functions are performed, but the terminology can be different, and behind the scenes things may be happening very differently.
+
+This topic discusses these differences in detail, in an effort to help OpenShift users in the transition from OpenShift v2 to OpenShift v3.
+
+== Architecture Changes
+
+*Gears vs Containers*
+
+Gears were a core component of OpenShift v2. 
+Technologies such as kernel namespaces, cGroups, and SELinux helped deliver a highly-scalable, secure, containerized application platform to OpenShift users. Gears themselves were a form of container technology.
+
+OpenShift v3 takes the gears idea to the next level. 
+It uses Docker as the next evolution of the v2 container technology. 
+This container architecture is at the core of OpenShift v3.
+
+*Kubernetes*
+
+As applications in OpenShift v2 typically used multiple gears, applications on OpenShift v3 will expectedly use multiple containers. 
+In OpenShift v2, gear orchestration, scheduling, and placement was handled by the OpenShift broker host. 
+OpenShift v3 integrates Kubernetes into the master host to drive container orchestration. 
+
+== Applications
+
+Applications are still the focal point of OpenShift. 
+In OpenShift v2, an application was a single unit, consisting of one web framework of no more than one cartridge type. 
+For example, an application could have one PHP and one MySQL, but it could not have one Ruby, one PHP, and two MySQLs. 
+It also could not be a database cartridge, such as MySQL, by itself.
+
+This limited scoping for applications meant that OpenShift performed seamless linking for all components within an application using environment variables. 
+For example, every web framework knew how to connect to MySQL using the `OPENSHIFT_MYSQL_DB_HOST` and `OPENSHIFT_MYSQL_DB_PORT` variables. 
+However, this linking was limited to within an application, and only worked within cartridges designed to work together. 
+There was nothing to help link across application components, such as sharing a MySQL instance across two applications.
+
+While most other PaaSes limit themselves to web frameworks and rely on external services for other types of components, OpenShift v3 makes even more application topologies possible and manageable.
+
+OpenShift v3 uses the term "application" as a concept that links services together. 
+You can have as many components as you desire, contained and flexibly linked within a link:../architecture/core_concepts/projects_and_users.html#projects[project], and, optionally, labeled to provide grouping or structure. 
+This updated model allows for a standalone MySQL instance, or one shared between JBoss components.
+
+Flexible linking means you can link any two arbitrary components together. 
+As
+long as one component can export environment variables and the second component
+can consume values from those environment variables, and with potential variable
+name transformation, you can link together any two components without having to
+change the images they are based on. 
+So, the best containerized implementation
+of your desired database and web framework can be consumed directly rather than
+you having to fork them both and rework them to be compatible.
+
+This means you can build anything on OpenShift. 
+And that is OpenShift's
+primary aim: to be a container-based platform that lets you build entire
+applications in a repeatable lifecycle.
+
+== Cartridges vs Images
+
+In OpenShift v3, an link:../architecture/core_concepts/containers_and_images.html#docker-images[image] has replaced OpenShift v2's concept of a cartridge.
+
+Cartridges in OpenShift v2 were the focal point for building applications. 
+Each cartridge provided the required libraries, source code, build mechanisms, connection logic, and routing logic along with a preconfigured environment to run the components of your applications.
+
+However, cartridges came with disadvantages. 
+With cartridges, there was no clear distinction between the developer content and the cartridge content, and you did not have ownership of the home directory on each gear of your application. 
+Also, cartridges were not the best distribution mechanism for large binaries. 
+While you could use external dependencies from within cartridges, doing so would lose the benefits of encapsulation.
+
+From a packaging perspective, an image performs more tasks than a cartridge, and provides better encapsulation and flexibility. 
+However, cartridges also included logic for building, deploying, and routing, which do not exist in images. 
+In OpenShift v3, these additional needs are met by link:../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-to-Image (S2I)] and link:../architecture/core_concepts/templates.html[configuring the template].
+
+*Dependencies*
+
+In OpenShift v2, cartridge dependencies were defined with `*Configure-Order*` or `*Requires*` in
+a cartridge manifest. 
+OpenShift v3 uses a declarative model where
+link:../architecture/core_concepts/pods_and_services.html#pods[pods] bring
+themselves in line with a predefined state. 
+Explicit dependencies that are
+applied are done at runtime rather than just install time ordering.
+
+For example, you might require another service to be available before you start. Such a dependency check is always applicable and not just when you create the
+two components. 
+Thus, pushing dependency checks into runtime enables the system
+to stay healthy over time.
+
+*Collection*
+
+Whereas cartridges in OpenShift v2 were colocated within gears, link:../architecture/core_concepts/containers_and_images.html#docker-images[images] in OpenShift v3 are mapped 1:1 with link:../architecture/core_concepts/containers_and_images.html#containers[containers], which use link:../architecture/core_concepts/pods_and_services.html#pods[pods] as their colocation mechanism.
+
+*Source Code*
+
+In OpenShift v2, applications were required to have at least one web framework with one Git repository. 
+In OpenShift v3, you can choose which images are built from source and that source can be located outside of OpenShift itself. 
+Because the source is disconnected from the images, the choice of image and source are distinct operations with source being optional.
+
+*Build*
+
+In OpenShift v2, builds occurred in application gears. 
+This meant downtime for non-scaled applications due to resource constraints. 
+In v3, link:../architecture/core_concepts/builds_and_image_streams.html#builds[builds] happen in separate containers. 
+Also, OpenShift v2 build results used rsync to synchronize gears. 
+In v3, build results are first committed as an immutable image and published to an internal registry. 
+That image is then available to launch on any of the nodes in the cluster, or available to rollback to at a future date.
+
+*Routing*
+
+In OpenShift v2, you had to choose up front as to whether your application was scalable, and whether the routing layer for your application was enabled for high availability (HA). 
+In OpenShift v3, link:../architecture/core_concepts/routes.html[routes] are first-class objects that are HA-capable simply by scaling up your application component to two or more replicas. 
+There is never a need to recreate your application or change its DNS entry.
+
+The routes themselves are disconnected from images. 
+Previously, cartridges defined a default set of routes and you could add additional aliases to your applications. 
+With OpenShift v3, you can use templates to set up any number of routes for an image. 
+These routes let you modify the scheme, host, and paths exposed as desired, with no distinction between system routes and user aliases.
+
+== Broker vs Master
+
+A link:../architecture/infrastructure_components/kubernetes_infrastructure.html#master[master] in OpenShift v3 is similar to a broker host in OpenShift v2. 
+However, the MongoDB and ActiveMQ layers used by the broker in OpenShift v2 are no longer necessary, because *etcd* is typically installed with each master host.
+
+== Domain vs Project
+
+A link:../architecture/core_concepts/projects_and_users.html#projects[project] is essentially a v2 domain.
+
+////
+== Routing and Scaling
+
+
+
+== DNS
+////


### PR DESCRIPTION
This week's cherry-picked commits for OSD 3.1 update the following books:

**Release Notes**
- Added the "Comparing OpenShift Enterprise 2 and OpenShift Enterprise 3" topic.

**Architecture**
- Updated the "Authorization" topic under "Additional Concepts" for the six default SCCs as of OpenShift Enterprise 3.1, as well as other improvements to the "Security Context Constraints" sections.
- Updated the "Builds and Image Streams" to add a Note box clarifying how `ImageStreamImage` objects are created.

**CLI Reference**
- Updated the "CLI Operations" topic to fix references to the outdated `OSC_EDITOR` environment variable to instead refer to the current `OC_EDITOR`.

**Developer Guide**
- In the "Builds" topic:
  - Grouped related sections under a new "Git Repository Source Options" section.
  - Added a Note box to clarify that `pullSecret` may be used with any of the build strategies.
  - Explained consistently the use for the _serviceaccount/builder_ role.
  - Added the "Using External Artifacts During a Build" section.
  - Updated statement about builder images supporting the incremental flag.
- Updated the "Secrets" topic to include the `metadata.name` parameter in an example.

In addition to the PRs included for the weekly publish:
- Reverted a commit from https://github.com/openshift/openshift-docs/pull/1289/commits which should not have been included in OSD 3.1 docs at GA.
- Included commits for the following PRs from a previous publish cycle that did not have the `dedicated-3.1` branch label on them but should have:
  - https://github.com/openshift/openshift-docs/pull/1391
  - https://github.com/openshift/openshift-docs/pull/1379
  - https://github.com/openshift/openshift-docs/pull/1381
