### PR TITLE
Add anchor to Installing Docker

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -487,6 +487,9 @@ when running an advanced installation.
 ====
 endif::[]
 
+
+[[installing-docker]]
+
 *Installing Docker*
 
 Docker version 1.8.2 or later must be installed and running on master and node


### PR DESCRIPTION
Needed so we can reference the required Docker version from other places
(like developer docs in origin).
