### PR TITLE
clarification quota with build/deployment configs

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -653,6 +653,28 @@ In the following example, each of `resources`, `cpu`, and `memory` is optional.
 <2> `*memory*` is in bytes; `256Mi` represents 268435456 bytes (`256 * 2 ^ 20`)
 ====
 
+However, if a quota has been defined for your project, one of the following two items is required:
+
+* a `resources` element must be set with an explicit `requests` of the form
+
+====
+
+[source,yaml]
+----
+  type: "Recreate"
+  resources: 
+    requests: <1>
+      cpu: "100m"
+      memory: "256Mi"
+----
+<1> The request object contains the list of resources that correspond to the list of resources in the quota.
+====
+
+* your project also has a link:./limits.html[LimitRange] defined, where the defaults from the `LimitRange` will apply to pods
+created during the deployment process
+
+Otherwise, deploy pod creation will fail, citing a failure to satisfy quota.
+
 Deployment resources can be used with the `Recreate`, `Rolling`, or `Custom`
 deployment strategies.
 

--- a/dev_guide/quota.adoc
+++ b/dev_guide/quota.adoc
@@ -243,3 +243,9 @@ The `*resource-quota-sync-period*` setting is designed to balance system
 performance. Reducing the sync period can result in a heavy load on
 the master.
 ====
+
+[[accounting-quota-dc]]
+
+== Accounting for Quota in Deployment Configurations
+
+If a quota has been defined for your project, see link:../dev_guide/deployments.html#deployment-resources[Deployment Resources] for considerations on any deployment configurations.


### PR DESCRIPTION
@derekwaynecarr FYI - I added a section to the quota doc for helping newbies bring up quota for the first time (at least I hit this hiccup).

I didn't see anything equivalent in either the cluster admin/overcommit section, or the resource limits and compute resources sections of the dev guide (granted I skimmed more than read line for line).

I did toy with putting in additional information/examples around limits, but in the end, decided to keep it as simple as possible.

Anyway, PTAL when you get the chance and let me know if you are amenable to such a change (perhaps with some edits) and I'll ping to doc folks to edit/merge, or if you think this is superfluous / covered elsewhere, in which case I'll just nuke the PR / branch.

thanks
