### PR TITLE
Clarify description of default identity providers

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -29,15 +29,17 @@ endif::[]
 link:../install_config/install/advanced_install.html[Advanced Installation]
 method, the
 ifdef::openshift-enterprise[]
-link:#DenyAllPasswordIdentityProvider[Deny All]
-endif::[]
-ifdef::openshift-origin[]
-link:#AllowAllPasswordIdentityProvider[Allow All]
-endif::[]
-identity provider is used by default, which denies access for all user names and
+link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is 
+used by default, which denies access for all user names and
 passwords. To allow access, you must choose a different identity provider and
 configure the master configuration file appropriately (located at
 *_/etc/origin/master/master-config.yaml_* by default).
+endif::[]
+ifdef::openshift-origin[]
+link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is 
+used by default, which allows access for all user names and
+passwords.
+endif::[]
 
 When running a master without a configuration file, the
 link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is used by


### PR DESCRIPTION
Moved the description of the default identity providers into conditional asciidoc sections for OSE and Origin, so that it fits to the selected providers.
