### PR TITLE
Fixing the adhoc uninstall path for origin

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1022,7 +1022,7 @@ ifdef::openshift-enterprise[]
 # ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml
 endif::[]
 ifdef::openshift-origin[]
-# ansible-playbook ~/openshift-ansible/playbooks/adoc/uninstall.yml
+# ansible-playbook ~/openshift-ansible/playbooks/adhoc/uninstall.yml
 endif::[]
 ----
 


### PR DESCRIPTION
Fixing the uninstall path when deploying this as origin.
