### PR TITLE
image related updates for online beta

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -449,9 +449,16 @@ Topics:
         File: decision_server
       - Name: JBoss Data Grid
         File: data_grid
+  - Name: OpenShift V3 Online
+    Dir: online_images
+    Distros: openshift-online
+    Topics:
+      - Name: Overview
+        File: index
   - Name: Revision History
     File: revhistory_using_images
     Distros: openshift-enterprise,openshift-dedicated
+
 
 ---
 Name: REST API Reference

--- a/getting_started/developers/developers_cli.adoc
+++ b/getting_started/developers/developers_cli.adoc
@@ -27,13 +27,73 @@ start by reading about
 ifdef::openshift-enterprise[]
 link:../../release_notes/index.html[what's new].
 endif::[]
-ifdef::openshift-origin[]
+ifdef::openshift-origin,openshift-online[]
 link:../../whats_new/index.html[what's new].
 endif::[]
-This version
 of OpenShift is significantly different from version 2.
 
-The following sections guide you through creating a project that contains a
+That said, similar to version 2, OpenShift provides out of the box for developers
+a set of languages and link:../../using_images/db_images/index.html[databases] with corresponding implementations and tutorials that allow you to kickstart your application
+development.  The support around languages center around the link:../../dev_guide/templates.html#using-the-instantapp-templates[InstantApp Templates].
+InstantApp Templates in turn leverage link:../../using_images/s2i_images/index.html[Builder Images].
+
+|===
+|Language|Implementations and Tutorials
+
+.^|Ruby
+|https://github.com/openshift/rails-ex[Rails]
+
+.^|Python
+|https://github.com/openshift/django-ex[Django]
+
+.^|Node.js
+|https://github.com/openshift/nodejs-ex[Node.js]
+
+.^|PHP
+|https://github.com/openshift/cakephp-ex[CakePHP]
+
+.^|Perl
+|https://github.com/openshift/dancer-ex[Dancer]
+
+.^|Java
+|link:../../using_images/s2i_images/java.html[Maven]
+
+|===
+
+Other OpenShift Docker Images
+
+* https://github.com/openshift/mysql[MySQL]
+
+* https://github.com/openshift/mongodb[MongoDB]
+
+* https://github.com/openshift/postgresql[PostgreSQL]
+
+* https://github.com/openshift/jenkins[Jenkins]
+
+
+ifdef::openshift-enterprise,openshift-dedicated,openshift-online[]
+=== More on Java
+JBoss Middleware has put together a broad range of https://github.com/jboss-openshift/application-templates[OpenShift templates] as well as link:../../using_images/xpaas_images/index.html[images] as part of their xPaaS services.
+
+The technologies available with the xPaaS services in particular include:
+
+* Java EE 6 Application Server provided by JBoss EAP 6
+* Integration and Messaging Services provided by JBoss Fuse and JBoss A-MQ
+* Data Grid Service provided by JBoss Data Grid
+* Real Time Decision Service provided by JBoss BRMS
+* Java Web Server 3.0 provided by Tomcat 7 and Tomcat 8
+
+With each of these offerings, a series of combinations are provided:
+
+* HTTP only vs. HTTP and HTTPS
+* No database required, or the use of either MongoDB, PostgreSQL, or MySQL
+* If desired, integration with A-MQ
+
+// end::moreonjava[]
+
+endif::[]
+
+To help illustrate constructing such applications, the following sections guide you through creating a project that contains a
 sample Node.js application that will serve a welcome page and the current hit
 count (stored in a database).
 
@@ -45,7 +105,9 @@ count (stored in a database).
 
 Before you can get started:
 
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
 - You must be able to access a running instance of
+endif::[]
 ifdef::openshift-enterprise[]
 OpenShift Enterprise.
 endif::openshift-enterprise[]
@@ -55,10 +117,19 @@ endif::openshift-origin[]
 ifdef::openshift-dedicated[]
 OpenShift Dedicated.
 endif::openshift-dedicated[]
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
  If you do not have access, contact your cluster administrator.
+endif::[]
 
-- Your instance must be pre-configured by a cluster administrator with the InstantApp templates and builder images. If they
+ifdef::openshift-online[]
+- You musht register for an account with the https://openshift.com[OpenShift Online Developer Preview.]
+- Your project has been populated with the link:../../dev_guide/templates.html#using-the-instantapp-templates[InstantApp templates] and link:../../using_images/s2i_images/index.html[builder images] that conform to the current
+link:../../using_images/online_images/index.html[set of rules and restrictions] for running in the OpenShift Online Developer Preview offering.
+endif::openshift-online[]
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
+- Your instance must be pre-configured by a cluster administrator with the link:../../dev_guide/templates.html#using-the-instantapp-templates[InstantApp templates] and link:../../using_images/s2i_images/index.html[builder images]. If they
 are not available,
+endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 direct your cluster administrator to the
 link:../../install_config/install/first_steps.html[First Steps] topic.
@@ -72,11 +143,6 @@ https://help.github.com/articles/set-up-git/#next-steps-authenticating-with-gith
 link:../../cli_reference/get_started_cli.html[downloaded and installed].
 
 // end::beforeyoubegin[]
-
-== Tutorial Video
-
-The following video walks you through the rest of this topic:
-https://fix.this.link[Click here to watch]
 
 // tag::forking[]
 
@@ -117,6 +183,7 @@ $ oc new-project <projectname> --description="<description>" --display-name="<di
 After creating the new project, you will be automatically switched to the new
 project namespace.
 
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
 == Uploading a Template
 . Navigate into the *_nodejs-ex/openshift/templates_* subdirectory within your locally-cloned repository:
 +
@@ -128,9 +195,14 @@ $ cd nodejs-ex/openshift/templates
 ----
 $ oc create -f nodejs-mongodb.json
 ----
+endif::[]
 
 == Creating an Application
-To create a new application from the InstantApp template that you uploaded:
+To create a new application from the InstantApp template
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
+that you uploaded
+endif::[]
+:
 
 ----
 $ oc process nodejs-mongodb-example
@@ -234,3 +306,4 @@ Alternatively, do not include `--follow` in the above command, and instead issue
 ----
 $ oc logs -f build/nodejs-ex-n
 ----
+

--- a/getting_started/index.adoc
+++ b/getting_started/index.adoc
@@ -27,5 +27,9 @@ endif::openshift-origin[]
 a|Create a project using the:
 
 * link:../getting_started/developers/developers_console.html[Web Console]
+ifdef::openshift-online[]
+* link:../getting_started/developers/developers_cli.html[CLI]
+* http://tools.jboss.org/features/openshift.html#openshift-3[Eclipse tooling]
+endif::openshift-online[]
 
 |===

--- a/using_images/online_images/index.adoc
+++ b/using_images/online_images/index.adoc
@@ -1,0 +1,39 @@
+= Current restrictions and constraints
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+The OpenShift Online Developer Preview offering scopes the inventory of images it provides out of the box
+with a few contraints in mind.  These constrainst also apply to any images you choose to
+inport into your Project.  The various constraints are enforced via the OpenShift Quota
+system.  See the link:../../dev_guide/compute_resources.html[computing guide] for a description of how this system works.
+
+Now, the specific constraints:
+
+* A memory limit of 2GiB is in place.  The 2 GiB is spread out across the project's pods and containers.
+* Up to 10 pods are allowed.
+* Up to 20 Replication Controllers are allowed.
+* Up to 10 Services are allowed.
+* Up to 16 Secrets are allowed (though some amount of these secrets will be needed by the system's build and deployer service accounts)
+* No templates that map a DockerFile VOLUME to an emptyDir Kubernetes Volume are allowed for now.  The current intent is to lift this restriction and the V3 OpenShift Online Developer Preview offering progresses out of the beta phase.
+* In fact, any Dockerfile VOLUME must be mounted with a Persistent Volume Claim at this time with the V3 OpenShift Online Developer Preview offering.
+* The Project associated with a user can allocate up to 2 Persistent Volume Claims.
+* No images that run as ROOT are allowed.
+* Only the Source-To-Image build strategy is allowed for any BuildConfigs imported into your Project.
+
+If you want to know your Project's current resource usage, you can log into the console and view them from the settings tab of your Project view, or use the CLI command  `oc describe quota [your project's quota object's name]`.
+
+As part of providing a set of templates out of the box, the Online Developer Preview offering has taken various, publicly accessible templates and added a memory limit template parameter with
+a default setting for the deployments.  These default settings were based on tuning exercises of some common developer flows, with the 2 GiB memory limit in mind.
+
+You can change the defaults as you see fit, based on the needs of the specific scenario you want to try.  You'll just have to keep in mind the 2 GiB overall memory limit when adjusting the settings
+of your various deployments.
+
+[NOTE]
+Read about memory limits  link:../../dev_guide/compute_resources.html#memory-limits[here] and template parameters link:../../architecture/core_concepts/templates.html#parameters[here] if you require more details on those concepts.
+
+
+
+


### PR DESCRIPTION
@luciddreamz @abhgupta @sspeiche @danmcp  FYI - my very _initial_ pass at a write up for the documentation for the [online beta image/template curation card](https://trello.com/c/zgWyXOg8/474-8-curating-the-set-of-images-templates)

As I've added a whole new section to Using Images, rather than needing ifdef's, I believe simply limiting the Distros in _build_cfg.yml to online should suffice, but of course correct me as needed.

Otherwise of course content / structure / location are all fair game at this early stage.

PTAL - thx.

@bparees - FYI - this PR starts to delve somewhat (more of a toe tipping really) into documenting (or at least claiming the existence of) the example repos in the official documentation.  DevExp weigh in of course welcomed as well.
