### PR TITLE
Split CLI install by OS, add Homebrew for Origin on Mac

### DIFF
--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -16,30 +16,142 @@ lower level tools to interact with each component of your system. This topic
 guides you through getting started with the CLI, including installation and
 logging in to create your first project.
 
+[[cli-prereqs]]
+== Prerequisites
+
+Certain operations require Git to be locally installed on a client. For example,
+the command to create an application using a remote Git repository:
+
+====
+----
+$ oc new-app https://github.com/<your_user>/<your_git_repo>
+----
+====
+
+Before proceeding, install Git on your workstation. See the official
+https://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Git documentation]
+for instructions per your workstation's operating system.
+
 // tag::installcli[]
 
 [[installing-the-cli]]
-
 == Installing the CLI
 
-ifdef::openshift-enterprise[]
-You can download and unpack the CLI from the
-https://access.redhat.com/downloads/content/290[Red Hat Customer Portal] for use on Linux, MacOSX, and Windows clients. After
-logging in with your Red Hat account, you must have an active OpenShift
-Enterprise subscription to access the downloads page.
+Installation options for the CLI vary depending on your operating system. Follow
+the instructions that match the workstation where you will be running CLI
+operations.
 
-https://access.redhat.com/downloads/content/290[*Download the CLI*]
+[[cli-windows]]
+=== For Windows
+
+ifdef::openshift-enterprise[]
+You can download and unpack the CLI for Windows as a *_zip_* archive from the
+https://access.redhat.com/downloads/content/290[Red Hat Customer Portal]. After
+logging in with your Red Hat account, you must have an active OpenShift
+Enterprise subscription to access the downloads page:
+
+https://access.redhat.com/downloads/content/290[*Download the CLI from the Red
+Hat Customer Portal*]
+
+Then, unzip the archive with a ZIP program to a directory on your PATH.
+endif::[]
+
+ifdef::openshift-origin[]
+You can download and unpack the CLI for Windows as a *_zip_* archive from the
+https://github.com/openshift/origin/releases[Releases page] of the OpenShift
+Origin source repository on GitHub:
+
+https://github.com/openshift/origin/releases[*Download the CLI from GitHub*]
+
+Then, unzip the archive with a ZIP program to a directory on your PATH.
+endif::[]
+
+[[cli-mac]]
+=== For Mac OS X
+
+ifdef::openshift-enterprise[]
+You can download and unpack the CLI for Mac OS X as a *_tar.gz_* archive from
+the https://access.redhat.com/downloads/content/290[Red Hat Customer Portal].
+After logging in with your Red Hat account, you must have an active OpenShift
+Enterprise subscription to access the downloads page:
+
+https://access.redhat.com/downloads/content/290[*Download the CLI from the Red
+Hat Customer Portal*]
+
+Then, unpack the archive to a directory on your PATH.
+endif::[]
+
+ifdef::openshift-origin[]
+You can download and unpack the CLI for Mac OS X as a *_zip_* archive from the
+https://github.com/openshift/origin/releases[Releases page] of the OpenShift
+Origin source repository on GitHub:
+
+https://github.com/openshift/origin/releases[*Download the CLI from GitHub*]
+
+Then, unzip the archive with a ZIP program to a directory on your PATH.
+
+[[homebrew]]
+Alternatively, Mac OS X users can install the CLI using
+http://brew.sh/[Homebrew]:
+
+----
+$ brew install openshift-cli
+----
+endif::[]
+
+[[cli-linux]]
+=== For Linux
+
+ifdef::openshift-enterprise[]
+For Red Hat Enterprise Linux (RHEL) 7, you can install the CLI as an RPM using
+Red Hat Subscription Management (RHSM) if you have an active OpenShift
+Enterprise subscription on your Red Hat account:
+
+====
+----
+# subscription-manager register
+# subscription-manager attach --pool=<pool_ID> <1>
+# subscription-manager repos --enable="rhel-7-server-ose-3.1-rpms"
+# yum install atomic-openshift-clients
+----
+<1> Pool ID for an active OpenShift Enterprise subscription
+====
+
+For RHEL, Fedora, and other Linux distributions, you can also download the CLI
+directly from the https://access.redhat.com/downloads/content/290[Red Hat
+Customer Portal] as a *_tar.gz_* archive. After logging in with your Red Hat
+account, you must have an active OpenShift Enterprise subscription to access the
+downloads page.
+
+https://access.redhat.com/downloads/content/290[*Download the CLI from the Red
+Hat Customer Portal*]
+
+Then, unpack the archive to a directory on your PATH:
+
+====
+----
+# tar -xf <file>
+----
+====
+endif::[]
+
+ifdef::openshift-origin[]
+You can download and unpack the CLI for Linux clients as a *_tar.gz_* archive
+from the https://github.com/openshift/origin/releases[Releases page] of the
+OpenShift Origin source repository on GitHub:
+
+https://github.com/openshift/origin/releases[*Download the CLI from GitHub*]
+
+Then, unpack the archive to a directory on your PATH:
+
+====
+----
+# tar -xf <file>
+----
+====
 endif::[]
 
 // end::installcli[]
-
-ifdef::openshift-origin[]
-You can download and unpack the CLI from the
-https://github.com/openshift/origin/releases[Releases page] of the OpenShift
-Origin source repository on GitHub.
-
-https://github.com/openshift/origin/releases[*Download the CLI*]
-endif::[]
 
 [[basic-setup-and-login]]
 

--- a/cli_reference/index.adoc
+++ b/cli_reference/index.adoc
@@ -21,19 +21,7 @@ The OpenShift CLI is available using the `oc` command:
 $ oc <command>
 ----
 
-ifdef::openshift-enterprise[]
-You can download and unpack the CLI with an active OpenShift Enterprise
-subscription from the
-https://access.redhat.com/downloads/content/290[Red
-Hat Customer Portal].
-endif::[]
-
 ifdef::openshift-origin[]
-You can download and unpack the CLI from the
-https://github.com/openshift/origin/releases[Releases page] of the OpenShift
-Origin source repository on GitHub.
-endif::[]
-
 [NOTE]
 ====
 The CLI command examples presented through OpenShift documentation use
@@ -41,10 +29,7 @@ The CLI command examples presented through OpenShift documentation use
 you can alternatively substitute `openshift cli` in the examples if you
 have the `openshift` binary.
 ====
+endif::[]
 
-[NOTE]
-====
-Certain operations require Git to be locally installed on a client. For example the command to create an application using a remote Git repository:
-`$ oc new-app \https://gitrepository/app`
-====
-
+See link:../cli_reference/get_started_cli.html[Get Started with the CLI] for
+installation and setup instructions.

--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -102,11 +102,10 @@ https://github.com/openshift/origin/releases[Releases] page. These are Linux,
 Windows, or Mac OS X 64-bit binaries; note that the Mac and Windows versions are
 for the CLI only.
 
-The release archives for Linux and Mac OS X contain the server binary `openshift`
-which is an all-in-one OpenShift installation. The archives for all platforms
-include
-link:../cli_reference/basic_cli_operations.html[the CLI] (the `oc` command) and
-the Kubernetes client (the `kubectl` command).
+The release archives for Linux and Mac OS X contain the server binary
+`openshift` which is an all-in-one OpenShift installation. The archives for all
+platforms include link:../cli_reference/get_started_cli.html[the CLI] (the `oc`
+command) and the Kubernetes client (the `kubectl` command).
 
 *Installing and Running an All-in-One Server*
 
@@ -114,7 +113,7 @@ the Kubernetes client (the `kubectl` command).
 https://github.com/openshift/origin/releases[Releases] page and untar it on your
 local system.
 
-. Add the directory you untarred the release into to your path
+. Add the directory you untarred the release into to your path:
 +
 ----
 $ export PATH="$(pwd)":$PATH
@@ -178,7 +177,7 @@ NOTE: When running OpenShift in a VM, you will want to ensure your host system c
 access ports 8080 and 8443 inside the container for the examples below.
 
 
-. Log in to the server as a regular user
+. Log in to the server as a regular user:
 +
 ----
 $ oc login
@@ -186,13 +185,13 @@ Username: test
 Password: test
 ----
 +
-. Create a new project to hold your application
+. Create a new project to hold your application:
 +
 ----
 $ oc new-project test
 ----
 +
-. Create a new application based on a Node.js image on the Docker Hub
+. Create a new application based on a Node.js image on the Docker Hub:
 +
 ----
 $ oc new-app openshift/deployment-example
@@ -201,7 +200,7 @@ $ oc new-app openshift/deployment-example
 Note that a service was created and given an IP - this is an address that
 can be used within the cluster to access the application.
 +
-. Display a summary of the resources you created
+. Display a summary of the resources you created:
 +
 ----
 $ oc status
@@ -217,7 +216,7 @@ http://172.30.192.169:8080 (example)
 ----
 +
 If you are on a separate system and do not have direct network access to the
-host, SSH to the system and perform a curl command:
+host, SSH to the system and perform a `curl` command:
 +
 ----
 $ curl http://172.30.192.169:8080 # (example)
@@ -238,7 +237,7 @@ Your application's deployment config is watching `deployment-example:latest`
 and will trigger a new rolling deployment when the `latest` tag is updated
 to the value from `v2`.
 
-Return to the browser or use curl again and you should see the `v2` text
+Return to the browser or use `curl` again and you should see the `v2` text
 displayed on the page.
 
 NOTE: For this next step we'll need to ensure that Docker is able to pull images
@@ -249,14 +248,14 @@ As a developer, building new Docker images is as important as deploying them.
 OpenShift provides tools for running Docker builds as well as building source
 code from within predefined builder images via the Source-to-Image toolchain.
 
-. Switch to the administrative user and change to the `default` project
+. Switch to the administrative user and change to the `default` project:
 +
 ----
 $ oc login -u system:admin
 $ oc project default
 ----
 +
-. Set up an integrated Docker registry for the OpenShift cluster
+. Set up an integrated Docker registry for the OpenShift cluster:
 +
 ----
 $ oadm registry --credentials=./openshift.local.config/master/openshift-registry.kubeconfig
@@ -264,7 +263,8 @@ $ oadm registry --credentials=./openshift.local.config/master/openshift-registry
 +
 It will take a few minutes for the registry image to download and start - use
 `oc status` to know when the registry is started.
-. Change back to the `test` user and `test` project
+
+. Change back to the `test` user and `test` project:
 +
 ----
 $ oc login -u test
@@ -280,7 +280,7 @@ $ oc new-app openshift/nodejs-010-centos7~https://github.com/openshift/nodejs-ex
 +
 A build will be triggered automatically using the provided image and the latest
 commit to the `master` branch of the provided Git repository. To get the status
-of a build, run
+of a build, run:
 +
 ----
 $ oc status
@@ -288,8 +288,9 @@ $ oc status
 +
 which will summarize the build. When the build completes, the resulting Docker
 image will be pushed to the Docker registry.
+
 . Wait for the deployed image to start, then view the service IP using your
-browser or curl.
+browser or `curl`.
 
 You can see more about the commands available in
 link:../cli_reference/basic_cli_operations.html[the CLI] (the `oc` command)


### PR DESCRIPTION
Per https://github.com/openshift/origin/issues/6689.

Pretty builds (internal):

http://file.rdu.redhat.com/~adellape/012216/homebrew_cli/cli_reference/get_started_cli.html#installing-the-cli

http://file.rdu.redhat.com/~adellape/012216/homebrew_cli/getting_started/administrators.html#downloading-the-binary

@smarterclayton PTAL.
