### PR TITLE
Hawkular Metrics and Heapster Access

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -490,3 +490,52 @@ specified in `*metricsPublicURL*` and accept that certificate.
 To avoid this issue, use certificates which are configured to be acceptable by
 your browser.
 ====
+
+ifdef::openshift-origin[]
+== Accessing Hawkular Metrics Directly
+
+If you wish to access and manage metrics more directly, you can do so via the Hawkular Metrics API.
+
+The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation] covers 
+how to use the API, but there are a few differences when dealing with the version of Hawkular Metrics 
+configured for use on OpenShift:
+
+=== OpenShift Projects & Hawkular Tenants
+
+Hawkular Metrics is a multi-tenanted application. The way its been configured is that a project in 
+OpenShift corresponds to a tenant in Hawkular Metrics.
+
+As such, when accessing metrics for a project named `MyProject` you will need to set the 
+link:http://www.hawkular.org/docs/rest/rest-metrics.html#_tenant_header[Hawkular-tenant] header to
+`MyProject`
+
+There is also a special tenant named `_system` which contains system level metrics. This will require
+either a `cluster-reader` or `cluster-admin` level privileges to access.
+
+=== Authorization
+
+The Hawkular Metrics service will authenticate the user against OpenShift to determine if the user has
+access to the project it is trying to access.
+
+When accessing the Hawkular Metrics API, you will need to pass a bearer token in the `Authorization` header.
+
+For more information how how to access the Hawkular Metrics in OpenShift, please see the
+link:https://github.com/openshift/origin-metrics/blob/master/docs/hawkular_metrics.adoc[Origin Metrics documentation]
+
+== Accessing Heapster Directly
+
+Heapster has been configured to be only accessible via the
+link:../rest_api/kubernetes_v1.html#proxy-get-requests-to-service[API proxy]. Accessing it will required
+either a cluster-reader or cluster-admin privileges.
+
+For example, to access the Heapster `validate` page, you would need to access it using something similar to:
+
+----
+$ curl -H "Authorization: Bearer XXXXXXXXXXXXXXXXX" \
+       -X GET https://${KUBERNETES_MASTER}/api/v1/proxy/namespaces/openshift-infra/services/https:heapster:/validate
+----
+
+For more information about Heapster and how to access its APIs, please refer the 
+link:https://github.com/kubernetes/heapster/[Heapster] project.
+
+endif::[]


### PR DESCRIPTION
We need to add some documentation on how to access Hawkular Metrics and Heapster directly with OpenShift Origin.

This PR adds a brief description at the end of the metrics install guide on how to do so. Not sure if we need to add a separate section somewhere instead of adding it to the install section.
