### PR TITLE
Enterprise 3.1 Weekly Publishing Schedule - Jan 26, 2016

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -270,8 +270,13 @@ link:../architecture/core_concepts/templates.html[template]
 used to deploy the metrics components.
 
 By default, the OpenShift installer creates this template, and it can be found
-in the following directory:
-*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/infrastructure-templates/enterprise/metrics-deployer.yaml_*
+at the following path:
+
+====
+----
+/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/infrastructure-templates/enterprise/metrics-deployer.yaml
+----
+====
 
 You will need to save your completed file with the file name *_metrics.yaml_*.
 

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -26,11 +26,17 @@ the
 ifdef::openshift-enterprise[]
 link:../install_config/install/quick_install.html[Quick Installation] or
 endif::[]
-link:../install_config/install/advanced_install.html[Advanced Installation] method, the
-link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is used by
-default, which denies access for all user names and passwords. To allow access,
-you must choose a different identity provider and configure the master
-configuration file appropriately (located at
+link:../install_config/install/advanced_install.html[Advanced Installation]
+method, the
+ifdef::openshift-enterprise[]
+link:#DenyAllPasswordIdentityProvider[Deny All]
+endif::[]
+ifdef::openshift-origin[]
+link:#AllowAllPasswordIdentityProvider[Allow All]
+endif::[]
+identity provider is used by default, which denies access for all user names and
+passwords. To allow access, you must choose a different identity provider and
+configure the master configuration file appropriately (located at
 *_/etc/origin/master/master-config.yaml_* by default).
 
 When running a master without a configuration file, the

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1032,8 +1032,14 @@ Now that you have a working OpenShift instance, you can:
 
 - link:../../install_config/configuring_authentication.html[Configure
 authentication]; by default, authentication is set to
+ifdef::openshift-enterprise[]
 link:../../install_config/configuring_authentication.html#DenyAllPasswordIdentityProvider[Deny
 All].
+endif::[]
+ifdef::openshift-origin[]
+link:../../install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider[Allow
+All].
+endif::[]
 - Deploy an link:docker_registry.html[integrated Docker registry].
 - Deploy a link:deploy_router.html[router].
 - link:first_steps.html[Populate your OpenShift installation] with a useful set

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -821,8 +821,14 @@ If you have not yet done so, you can:
 
 - link:../../install_config/configuring_authentication.html[Configure
 authentication]; by default, authentication is set to
+ifdef::openshift-enterprise[]
 link:../../install_config/configuring_authentication.html#DenyAllPasswordIdentityProvider[Deny
 All].
+endif::[]
+ifdef::openshift-origin[]
+link:../../install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider[Allow
+All].
+endif::[]
 - Deploy an link:docker_registry.html[integrated Docker registry].
 - link:first_steps.html[Populate your OpenShift installation] with a useful set
 of Red Hat-provided image streams and templates.

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -674,8 +674,14 @@ After you have a registry deployed, you can:
 
 - link:../../install_config/configuring_authentication.html[Configure
 authentication]; by default, authentication is set to
+ifdef::openshift-enterprise[]
 link:../../install_config/configuring_authentication.html#DenyAllPasswordIdentityProvider[Deny
 All].
+endif::[]
+ifdef::openshift-origin[]
+link:../../install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider[Allow
+All].
+endif::[]
 - Deploy a link:deploy_router.html[router].
 - link:first_steps.html[Populate your OpenShift installation] with a useful set
 of Red Hat-provided image streams and templates.

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -155,6 +155,14 @@ In almost all cases, when referencing VMs you must use host names, and the host
 names that you use must match the output of the `hostname -f` command on each
 node.
 
+[WARNING]
+====
+In your *_/etc/resolv.conf_* file on each node host, ensure that the DNS server
+that has the wildcard entry is not listed as a nameserver or that the wildcard
+domain is not listed in the search list. Otherwise, containers managed by
+OpenShift may fail to resolve host names properly.
+====
+
 [[prereq-network-access]]
 
 === Network Access

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -487,6 +487,9 @@ when running an advanced installation.
 ====
 endif::[]
 
+
+[[installing-docker]]
+
 *Installing Docker*
 
 Docker version 1.8.2 or later must be installed and running on master and node

--- a/install_config/persistent_storage/persistent_storage_ceph_rbd.adoc
+++ b/install_config/persistent_storage/persistent_storage_ceph_rbd.adoc
@@ -14,7 +14,7 @@ toc::[]
 OpenShift can utilize persistent storage using Block Storage
 like Ceph RBD. Some familiarity with Kubernetes and Docker is assumed. It is
 also assumed that there is access to an existing Ceph cluster and volume,
-and that *ceph-fuse* has been installed on all OpenShift nodes in the
+and that *ceph-common* package has been installed on all OpenShift nodes in the
 cluster.
 
 The Kubernetes
@@ -43,10 +43,10 @@ following are required:
 - Existing Ceph volumes, to be defined in the persistent volume object
 - The `*PersistentVolume*` API
 
-You must also ensure *ceph-fuse* is installed on all OpenShift nodes in the cluster:
+You must also ensure *ceph-common* package is installed on all OpenShift nodes in the cluster:
 
 ----
-# yum install ceph ceph-common
+# yum install ceph-common
 ----
 
 

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -16,14 +16,6 @@ link:../../architecture/additional_concepts/storage.html[persistent storage] usi
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS].
 Some familiarity with Kubernetes and NFS is assumed.
 
-[NOTE]
-====
-OpenShift requires
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFSv4]
-when using NFS for persistent storage, due to NSFv4's ability to handle SELinux
-labeling.
-====
-
 The Kubernetes
 link:../../architecture/additional_concepts/storage.html[persistent volume]
 framework allows administrators to provision a cluster with persistent storage

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -5,6 +5,34 @@
 :icons:
 :experimental:
 
+== Tue Jan 26 2016
+
+// tag::install_config_tue_jan_26_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../install_config/cluster_metrics.html[Enabling Cluster Metrics]
+|Fixed the
+link:../install_config/cluster_metrics.html#creating-the-deployer-template[*_metrics-deployer.yaml_*
+file path].
+
+|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
+|Added link:../install_config/install/prerequisites.html#prereqs-dns[Warning
+admonition] about wildcards and DNS server entries in the *_/etc/resolv.conf_*
+file.
+
+|link:../install_config/persistent_storage/persistent_storage_ceph_rbd.html[Configuring
+Persistent Storage -> Persistent Storage Using Ceph Rados Block Device (RBD)]
+|Fixed the *ceph-common* package name.
+
+|link:../install_config/persistent_storage/persistent_storage_nfs.html[Configuring
+Persistent Storage -> Persistent Storage Using NFS]
+|Removed a contradictory Note admonition about NFS and SELinux.
+|===
+// end::install_config_tue_jan_26_2016[]
+
 == Mon Jan 19 2016
 
 // tag::install_config_mon_jan_19_2016[]

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -5,6 +5,20 @@
 :icons:
 :experimental:
 
+== Tue Jan 26 2016
+
+// tag::using_images_tue_jan_26_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../using_images/xpaas_images/fuse.html[xPaaS Middleware Images -> Red Hat
+JBoss Fuse Integration Services]
+|Fixed the `*KUBERNETES_MASTER*` value.
+|===
+// end::using_images_tue_jan_26_2016[]
+
 == Thu Nov 19 2015
 
 OpenShift Enterprise 3.1 release.

--- a/using_images/xpaas_images/fuse.adoc
+++ b/using_images/xpaas_images/fuse.adoc
@@ -89,7 +89,7 @@ $ mvn archetype:generate \
 
 | DOCKER_HOST | Specifies the connection to a Docker daemon used to build an application Docker image | `tcp://10.1.2.2:2375`
 
-| KUBERNETES_MASTER | Specifies the URL for contacting the OpenShift API server | `https://172.28.128.4:8443`
+| KUBERNETES_MASTER | Specifies the URL for contacting the OpenShift API server | `https://10.1.2.2:8443`
 
 | KUBERNETES_DOMAIN | Domain used for creating routes. Your OpenShift API server must be mapped to all hosts of this domain. | `openshift.dev`
 

--- a/welcome/revhistory_all.adoc
+++ b/welcome/revhistory_all.adoc
@@ -8,6 +8,15 @@
 The following sections aggregate the revision histories of each guide by publish
 date.
 
+== Tue Jan 26 2016
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_tue_jan_26_2016]
+
+.Using Images
+include::using_images/revhistory_using_images.adoc[tag=using_images_tue_jan_26_2016]
+
+
 == Mon Jan 19 2016
 
 .Release Notes


### PR DESCRIPTION
This week's cherry-picked commits for OSE 3.1 update the following books:

**Installation and Configuration**
- Updated "Enabling Cluster Metrics" to fix the metrics-deployer.yaml file path.
- Updated "Prerequisites" to add Warning admonition about DNS server entries in /etc/resolv.conf.
- Updated "Persistent Storage Using Ceph Rados Block Device" to fix a package name.
- Updated "Persistent Storage Using NFS" to remove a contradictory Note admonition about NFS and SELinux.

**Using Images**
- Updated "Red Hat JBoss Fuse Integration Services" to fix the KUBERNETES_MASTER value.
