### PR TITLE
Make clear that OpenStack instance names can be used in nodeName.

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -77,7 +77,7 @@ contents of the `*kubeletArguments*` and `*nodeName*` sections:
 [source,yaml]
 ----
 nodeName:
-  <instance_ID> <1>
+  <instance_name> <1>
 
 kubeletArguments:
   cloud-provider:
@@ -85,5 +85,5 @@ kubeletArguments:
   cloud-config:
     - "/etc/cloud.conf"
 ----
-<1> ID of OpenStack instance (i.e., the virtual machine)
+<1> Name of the OpenStack instance where the node runs (i.e., name of the virtual machine)
 ====


### PR DESCRIPTION
Instance ID can be interpreted as instance UUID. `nodeName` should be  human-friendlier instance name.
