### PR TITLE
OpenStack provider configuration Note that you can use instance_name

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -77,7 +77,7 @@ contents of the `*kubeletArguments*` and `*nodeName*` sections:
 [source,yaml]
 ----
 nodeName:
-  <instance_ID> <1>
+  <instance_ID_or_Name> <1>
 
 kubeletArguments:
   cloud-provider:
@@ -85,5 +85,5 @@ kubeletArguments:
   cloud-config:
     - "/etc/cloud.conf"
 ----
-<1> ID of OpenStack instance (i.e., the virtual machine)
+<1> ID or Name of OpenStack instance (i.e., the virtual machine)
 ====


### PR DESCRIPTION
You can use instance_name of the openstack vm instead of just instance_id (and this 
is actually less awkward to us)
