### PR TITLE
Correct documentation around setting AWS Access keys

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -83,13 +83,13 @@ kubeletArguments:
 
 == Exporting Key Value Access Pairs
 
-Make sure the following environment variables are exported and start or restart OpenShift services on the master and all nodes:
+Make sure the following environment variables are set in /etc/sysconfig/atomic-openshift-master and /etc/sysconfig/atomic-openshift-node, then start or restart OpenShift services on the master and all nodes:
 
 ====
 ----
-export AWS_ACCESS_KEY_ID=<key id>
-export AWS_SECRET_ACCESS_KEY=<secret key>
+AWS_ACCESS_KEY_ID=<key id>
+AWS_SECRET_ACCESS_KEY=<secret key>
 ----
 ====
 
-These access keys are obtained when setting up your AWS instances.
+Access keys are obtained when setting up your AWS IAM user.


### PR DESCRIPTION
Docs say you should export access keys. But that doesn't work.  It needs to be set in the service's environment as specified in the systemd unitfile, which are /etc/sysconfig/atomic-openshift-master and /etc/sysconfig/atomic-openshift-node.

http://stackoverflow.com/questions/34731990/openshift-3-origins-persistent-volume-issue
