### PR TITLE
Document buildAPIVersion

### DIFF
--- a/creating_images/custom.adoc
+++ b/creating_images/custom.adoc
@@ -34,6 +34,9 @@ the information needed to proceed with the build:
 
 |`*BUILD*`
 |This variable specifies the entire serialized link:../rest_api/openshift_v1.html#v1-build[Build] object.
+If you need to use a specific API version for serialization, you can set the `buildAPIVersion`
+parameter in the link:../rest_api/openshift_v1.html#v1-buildconfig[Build Config]'s custom
+strategy link:../rest_api/openshift_v1.html#v1-custombuildstrategy[specification].
 
 |`*SOURCE_REPOSITORY*`
 |This variable specifies the URL to a repository with sources to build.


### PR DESCRIPTION
This is documentation for https://github.com/openshift/origin/pull/6760 (not yet merged).
Trello: https://trello.com/c/2CrsqGjY/638-5-do-not-pass-internal-build-object-json-serialization-to-builder-container
