### PR TITLE
Bug 1286893, added info on container log rotation with json-file options

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -34,6 +34,13 @@ all logs.
 
 This topic shows you how to deploy the stack.
 
+[NOTE]
+====
+link:../install_config/install/prerequisites.html#managing-docker-container-logs[Managing
+Docker Container Logs] discusses the use of `json-file` logging driver options
+to manage container logs when they become full.
+====
+
 == Pre-deployment Configuration
 
 Deploying the EFK stack requires:

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -126,6 +126,12 @@ Containerized] for more details.
 ifdef::openshift-enterprise[]
 Containerized installations are supported starting in OSE 3.1.1.
 endif::[]
+
+|`*docker_log_options*`
+|This variable configures container logging options that are supported by
+Docker's `json-file` logging driver. See
+link:../../install_config/install/prerequisites.html#managing-docker-container-logs[Managing
+Docker Container Logs] for available options.
 |===
 
 [[configuring-cluster-variables]]

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -806,6 +806,63 @@ See
 link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Logical_Volume_Manager_Administration/index.html[Logical
 Volume Manager Administration] for more detailed information on LVM management.
 
+[[managing-docker-container-logs]]
+*Managing Docker Container Logs*
+
+Sometimes a container's log file (the
+*_/var/lib/docker/containers/<hash>/<hash>-json.log_* file on the node where the
+container is running) can increase to a problematic size. You can manage this by
+configuring Docker's `json-file` logging driver to restrict the size and number
+of log files.
+
+[options="header"]
+|===
+
+|Option |Purpose
+
+|`--log-opt max-size`
+|Sets the size at which a new log file is created.
+
+|`--log-opt max-file`
+|Sets the file on each host to configure the options.
+|===
+
+For example, to set the maximum file size to 1MB and always keep the last three
+log files, edit the *_/etc/sysconfig/docker_* file to configure `max-size=1M`
+and `max-file=3`:
+====
+----
+OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1M --log-opt max-file=3'
+----
+====
+
+Next, restart the Docker service:
+----
+# systemctl restart docker
+----
+
+[[viewing-available-container-logs]]
+*Viewing Available Container Logs*
+
+Container logs are stored in the *_/var/lib/docker/containers/<hash>/_*
+directory on the node where the container is running. For example:
+====
+----
+# ls -lh /var/lib/docker/containers/f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8/
+total 2.6M
+-rw-r--r--. 1 root root 5.6K Nov 24 00:12 config.json
+-rw-r--r--. 1 root root 649K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log
+-rw-r--r--. 1 root root 977K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log.1
+-rw-r--r--. 1 root root 977K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log.2
+-rw-r--r--. 1 root root 1.3K Nov 24 00:12 hostconfig.json
+drwx------. 2 root root    6 Nov 24 00:12 secrets
+----
+====
+
+See Docker's documentation for additional information on how to
+http://docs.docker.com/engine/reference/logging/overview/#the-json-file-options[Configure
+Logging Drivers].
+
 [[ensuring-host-access]]
 
 == Ensuring Host Access


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1286893

@sosiouxme @nak3 PTAL

As part of these changes, I added docker_log_driver and docker_log_options to the table, but the descriptions need more clarity I think. Thanks!
