### PR TITLE
Add HA note to arch/storage Overview.

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -26,6 +26,12 @@ link:../core_concepts/pods_and_services.html#pods[pod] that uses the PV. PV
 objects capture the details of the implementation of the storage, be that NFS,
 iSCSI, or a cloud-provider-specific storage system.
 
+[IMPORTANT]
+====
+High-availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
 A `*PersistentVolumeClaim*` (PVC) object represents a request for storage by a
 user. It is similar to a pod in that pods consume node resources and PVCs
 consume PV resources. For example, pods can request specific levels of resources


### PR DESCRIPTION
Per suggestion by @sferich888.

This note appears in the various storage provider-specific topics in the Install & Config guide, but this seemed like a good place to also mention it, in the Overview of the related Arch topic, right after the bit introducing the cluster admin's duties.
