### PR TITLE
Updated images doc

### DIFF
--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -134,39 +134,33 @@ a build or a deployment.
 .Image Stream Object Definition
 ====
 
-[source,json]
+[source,yaml]
 ----
-{
-  "kind": "ImageStream",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "origin-ruby-sample",
-    "namespace": "p1",
-    "selfLink": "/osapi/v1/namesapces/p1/imageStreams/origin-ruby-sample",
-    "uid": "480dfe73-f340-11e4-97b5-001c422dcd49",
-    "resourceVersion": "293",
-    "creationTimestamp": "2015-05-05T16:03:34Z",
-    "labels": {
-      "template": "application-template-stibuild"
-    }
-  },
-  "spec": {},
-  "status": {
-    "dockerImageRepository": "172.30.30.129:5000/p1/origin-ruby-sample",
-    "tags": [
-      {
-        "tag": "latest",
-        "items": [
-          {
-            "created": "2015-05-05T16:05:47Z",
-            "dockerImageReference": "172.30.30.129:5000/p1/origin-ruby-sample@sha256:4d3a646b58685449179a0c61ad4baa19a8df8ba668e0f0704b9ad16f5e16e642",
-            "image": "sha256:4d3a646b58685449179a0c61ad4baa19a8df8ba668e0f0704b9ad16f5e16e642"
-          }
-        ]
-      }
-    ]
-  }
-}
+apiVersion: v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/generated-by: OpenShiftNewApp
+  creationTimestamp: 2016-01-29T13:33:49Z
+  generation: 1
+  labels:
+    app: ruby-sample-build
+    template: application-template-stibuild
+  name: origin-ruby-sample
+  namespace: test
+  resourceVersion: "633"
+  selfLink: /oapi/v1/namespaces/test/imagestreams/origin-ruby-sample
+  uid: ee2b9405-c68c-11e5-8a99-525400f25e34
+spec: {}
+status:
+  dockerImageRepository: 172.30.56.218:5000/test/origin-ruby-sample
+  tags:
+  - items:
+    - created: 2016-01-29T13:40:11Z
+      dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d
+      generation: 1
+      image: sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d
+    tag: latest
 ----
 
 ====
@@ -190,80 +184,116 @@ The example `*ImageStreamMapping*` below results in an image being tagged as
 .Image Stream Mapping Object Definition
 ====
 
-[source,json]
+[source,yaml]
 ----
-{
-  "kind": "ImageStreamMapping",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "origin-ruby-sample",
-    "namespace": "test"
-  },
-  "image": {
-    "metadata": {
-      "name": "a2f15cc10423c165ca221f4a7beb1f2949fb0f5acbbc8e3a0250eb7d5593ae64"
-    },
-    "dockerImageReference": "172.30.17.3:5001/test/origin-ruby-sample:a2f15cc10423c165ca221f4a7beb1f2949fb0f5acbbc8e3a0250eb7d5593ae64",
-    "dockerImageMetadata": {
-      "kind": "DockerImage",
-      "apiVersion": "1.0",
-      "Id": "a2f15cc10423c165ca221f4a7beb1f2949fb0f5acbbc8e3a0250eb7d5593ae64",
-      "Parent": "3bb14bfe4832874535814184c13e01527239633627cdc38f18fa186e73a6b62c",
-      "Created": "2015-01-23T21:47:04Z",
-      "Container": "f81db8980c62d7650683326173a361c3b09f3bc41471918b6319f7df67943b54",
-      "ContainerConfig": {
-        "Hostname": "f81db8980c62",
-        "User": "ruby",
-        "AttachStdout": true,
-        "ExposedPorts": {
-          "9292/tcp": {}
-        },
-        "OpenStdin": true,
-        "StdinOnce": true,
-        "Env": [
-          "OPENSHIFT_BUILD_NAME=4bf65438-a349-11e4-bead-001c42c44ee1",
-          "OPENSHIFT_BUILD_NAMESPACE=test",
-          "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
-          "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-          "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
-          "APP_ROOT=.",
-          "HOME=/opt/ruby"
-        ],
-        "Cmd": [
-          "/bin/sh",
-          "-c",
-          "tar -C /tmp -xf - \u0026\u0026 /tmp/scripts/assemble"
-        ],
-        "Image": "openshift/ruby-20-centos7",
-        "WorkingDir": "/opt/ruby/src"
-      },
-      "DockerVersion": "1.4.1-dev",
-      "Config": {
-        "User": "ruby",
-        "ExposedPorts": {
-          "9292/tcp": {}
-        },
-        "Env": [
-          "OPENSHIFT_BUILD_NAME=4bf65438-a349-11e4-bead-001c42c44ee1",
-          "OPENSHIFT_BUILD_NAMESPACE=test",
-          "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
-          "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-          "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
-          "APP_ROOT=.",
-          "HOME=/opt/ruby"
-        ],
-        "Cmd": [
-          "/tmp/scripts/run"
-        ],
-        "WorkingDir": "/opt/ruby/src"
-      },
-      "Architecture": "amd64",
-      "Size": 11710004
-    },
-    "dockerImageMetadataVersion": "1.0"
-  },
-  "tag": "latest"
-}
+apiVersion: v1
+kind: ImageStreamMapping
+metadata:
+  creationTimestamp: null
+  name: origin-ruby-sample
+  namespace: test
+tag: latest
+image:
+  dockerImageLayers:
+  - name: sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
+    size: 0
+  - name: sha256:ee1dd2cb6df21971f4af6de0f1d7782b81fb63156801cfde2bb47b4247c23c29
+    size: 196634330
+  - name: sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
+    size: 0
+  - name: sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
+    size: 0
+  - name: sha256:ca062656bff07f18bff46be00f40cfbb069687ec124ac0aa038fd676cfaea092
+    size: 177723024
+  - name: sha256:63d529c59c92843c395befd065de516ee9ed4995549f8218eac6ff088bfa6b6e
+    size: 55679776
+  - name: sha256:92114219a04977b5563d7dff71ec4caa3a37a15b266ce42ee8f43dba9798c966
+    size: 11939149
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+      - /usr/libexec/s2i/run
+      Entrypoint:
+      - container-entrypoint
+      Env:
+      - RACK_ENV=production
+      - OPENSHIFT_BUILD_NAMESPACE=test
+      - OPENSHIFT_BUILD_SOURCE=https://github.com/openshift/ruby-hello-world.git
+      - EXAMPLE=sample-app
+      - OPENSHIFT_BUILD_NAME=ruby-sample-build-1
+      - PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - STI_SCRIPTS_URL=image:///usr/libexec/s2i
+      - STI_SCRIPTS_PATH=/usr/libexec/s2i
+      - HOME=/opt/app-root/src
+      - BASH_ENV=/opt/app-root/etc/scl_enable
+      - ENV=/opt/app-root/etc/scl_enable
+      - PROMPT_COMMAND=. /opt/app-root/etc/scl_enable
+      - RUBY_VERSION=2.2
+      ExposedPorts:
+        8080/tcp: {}
+      Labels:
+        build-date: 2015-12-23
+        io.k8s.description: Platform for building and running Ruby 2.2 applications
+        io.k8s.display-name: 172.30.56.218:5000/test/origin-ruby-sample:latest
+        io.openshift.build.commit.author: Ben Parees <bparees@users.noreply.github.com>
+        io.openshift.build.commit.date: Wed Jan 20 10:14:27 2016 -0500
+        io.openshift.build.commit.id: 00cadc392d39d5ef9117cbc8a31db0889eedd442
+        io.openshift.build.commit.message: 'Merge pull request #51 from php-coder/fix_url_and_sti'
+        io.openshift.build.commit.ref: master
+        io.openshift.build.image: centos/ruby-22-centos7@sha256:3a335d7d8a452970c5b4054ad7118ff134b3a6b50a2bb6d0c07c746e8986b28e
+        io.openshift.build.source-location: https://github.com/openshift/ruby-hello-world.git
+        io.openshift.builder-base-version: 8d95148
+        io.openshift.builder-version: 8847438ba06307f86ac877465eadc835201241df
+        io.openshift.expose-services: 8080:http
+        io.openshift.s2i.scripts-url: image:///usr/libexec/s2i
+        io.openshift.tags: builder,ruby,ruby22
+        io.s2i.scripts-url: image:///usr/libexec/s2i
+        license: GPLv2
+        name: CentOS Base Image
+        vendor: CentOS
+      User: "1001"
+      WorkingDir: /opt/app-root/src
+    Container: 86e9a4a3c760271671ab913616c51c9f3cea846ca524bf07c04a6f6c9e103a76
+    ContainerConfig:
+      AttachStdout: true
+      Cmd:
+      - /bin/sh
+      - -c
+      - tar -C /tmp -xf - && /usr/libexec/s2i/assemble
+      Entrypoint:
+      - container-entrypoint
+      Env:
+      - RACK_ENV=production
+      - OPENSHIFT_BUILD_NAME=ruby-sample-build-1
+      - OPENSHIFT_BUILD_NAMESPACE=test
+      - OPENSHIFT_BUILD_SOURCE=https://github.com/openshift/ruby-hello-world.git
+      - EXAMPLE=sample-app
+      - PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - STI_SCRIPTS_URL=image:///usr/libexec/s2i
+      - STI_SCRIPTS_PATH=/usr/libexec/s2i
+      - HOME=/opt/app-root/src
+      - BASH_ENV=/opt/app-root/etc/scl_enable
+      - ENV=/opt/app-root/etc/scl_enable
+      - PROMPT_COMMAND=. /opt/app-root/etc/scl_enable
+      - RUBY_VERSION=2.2
+      ExposedPorts:
+        8080/tcp: {}
+      Hostname: ruby-sample-build-1-build
+      Image: centos/ruby-22-centos7@sha256:3a335d7d8a452970c5b4054ad7118ff134b3a6b50a2bb6d0c07c746e8986b28e
+      OpenStdin: true
+      StdinOnce: true
+      User: "1001"
+      WorkingDir: /opt/app-root/src
+    Created: 2016-01-29T13:40:00Z
+    DockerVersion: 1.8.2.fc21
+    Id: 9d7fd5e2d15495802028c569d544329f4286dcd1c9c085ff5699218dbaa69b43
+    Parent: 57b08d979c86f4500dc8cad639c9518744c8dd39447c055a3517dc9c18d6fccd
+    Size: 441976279
+    apiVersion: "1.0"
+    kind: DockerImage
+  dockerImageMetadataVersion: "1.0"
+  dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d
 ----
 ====
 
@@ -304,143 +334,112 @@ object in any image stream definition that you use to create image streams.
 
 The sample image below is from the *ruby* image stream and was
 retrieved by asking for the `*ImageStreamImage*` with the name
-*ruby@371829c*:
+*ruby@3a335d7*:
 
 .Definition of an Image Object retrieved via ImageStreamImage
 ====
 
-[source,json]
+[source,yaml]
 ----
-{
-    "kind": "ImageStreamImage",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "ruby@371829c",
-        "uid": "a48b40d7-18e2-11e5-9ba2-001c422dcd49",
-        "resourceVersion": "1888",
-        "creationTimestamp": "2015-06-22T13:29:00Z"
-    },
-    "image": {
-        "metadata": {
-            "name": "371829c6d5cf05924db2ab21ed79dd0937986a817c7940b00cec40616e9b12eb",
-            "uid": "a48b40d7-18e2-11e5-9ba2-001c422dcd49",
-            "resourceVersion": "1888",
-            "creationTimestamp": "2015-06-22T13:29:00Z"
-        },
-        "dockerImageReference": "openshift/ruby-20-centos7:latest",
-        "dockerImageMetadata": {
-            "kind": "DockerImage",
-            "apiVersion": "1.0",
-            "Id": "371829c6d5cf05924db2ab21ed79dd0937986a817c7940b00cec40616e9b12eb",
-            "Parent": "8c7059377eaf86bc913e915f064c073ff45552e8921ceeb1a3b7cbf9215ecb66",
-            "Created": "2015-06-20T23:02:23Z",
-            "ContainerConfig": {},
-            "DockerVersion": "1.6.0",
-            "Author": "Jakub Hadvig \u003cjhadvig@redhat.com\u003e",
-            "Config": {
-                "User": "1001",
-                "ExposedPorts": {
-                    "8080/tcp": {}
-                },
-                "Env": [
-                    "PATH=/opt/openshift/src/bin:/opt/openshift/bin:/usr/local/sti:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                    "STI_SCRIPTS_URL=image:///usr/local/sti",
-                    "HOME=/opt/openshift/src",
-                    "BASH_ENV=/opt/openshift/etc/scl_enable",
-                    "ENV=/opt/openshift/etc/scl_enable",
-                    "PROMPT_COMMAND=. /opt/openshift/etc/scl_enable",
-                    "RUBY_VERSION=2.0"
-                ],
-                "Cmd": [
-                    "usage"
-                ],
-                "Image": "8c7059377eaf86bc913e915f064c073ff45552e8921ceeb1a3b7cbf9215ecb66",
-                "WorkingDir": "/opt/openshift/src",
-                "Labels": {
-                    "io.openshift.s2i.scripts-url": "image:///usr/local/sti",
-                    "k8s.io/description": "Platform for building and running Ruby 2.0 applications",
-                    "k8s.io/display-name": "Ruby 2.0",
-                    "openshift.io/expose-services": "8080:http",
-                    "openshift.io/tags": "builder,ruby,ruby20"
-                }
-            },
-            "Architecture": "amd64",
-            "Size": 53950504
-        },
-        "dockerImageMetadataVersion": "1.0"
-    }
-}
+apiVersion: v1
+image:
+  dockerImageLayers:
+  - name: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
+    size: 0
+  - name: sha256:ee1dd2cb6df21971f4af6de0f1d7782b81fb63156801cfde2bb47b4247c23c29
+    size: 196634330
+  - name: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
+    size: 0
+  - name: sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
+    size: 0
+  - name: sha256:ca062656bff07f18bff46be00f40cfbb069687ec124ac0aa038fd676cfaea092
+    size: 177723024
+  - name: sha256:63d529c59c92843c395befd065de516ee9ed4995549f8218eac6ff088bfa6b6e
+    size: 55679776
+  dockerImageMetadata:
+    Architecture: amd64
+    Author: SoftwareCollections.org <sclorg@redhat.com>
+    Config:
+      Cmd:
+      - /bin/sh
+      - -c
+      - $STI_SCRIPTS_PATH/usage
+      Entrypoint:
+      - container-entrypoint
+      Env:
+      - PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - STI_SCRIPTS_URL=image:///usr/libexec/s2i
+      - STI_SCRIPTS_PATH=/usr/libexec/s2i
+      - HOME=/opt/app-root/src
+      - BASH_ENV=/opt/app-root/etc/scl_enable
+      - ENV=/opt/app-root/etc/scl_enable
+      - PROMPT_COMMAND=. /opt/app-root/etc/scl_enable
+      - RUBY_VERSION=2.2
+      ExposedPorts:
+        8080/tcp: {}
+      Image: d9c3abc5456a9461954ff0de8ae25e0e016aad35700594714d42b687564b1f51
+      Labels:
+        build-date: 2015-12-23
+        io.k8s.description: Platform for building and running Ruby 2.2 applications
+        io.k8s.display-name: Ruby 2.2
+        io.openshift.builder-base-version: 8d95148
+        io.openshift.builder-version: 8847438ba06307f86ac877465eadc835201241df
+        io.openshift.expose-services: 8080:http
+        io.openshift.s2i.scripts-url: image:///usr/libexec/s2i
+        io.openshift.tags: builder,ruby,ruby22
+        io.s2i.scripts-url: image:///usr/libexec/s2i
+        license: GPLv2
+        name: CentOS Base Image
+        vendor: CentOS
+      User: "1001"
+      WorkingDir: /opt/app-root/src
+    ContainerConfig: {}
+    Created: 2016-01-26T21:07:27Z
+    DockerVersion: 1.8.2-el7
+    Id: 57b08d979c86f4500dc8cad639c9518744c8dd39447c055a3517dc9c18d6fccd
+    Parent: d9c3abc5456a9461954ff0de8ae25e0e016aad35700594714d42b687564b1f51
+    Size: 430037130
+    apiVersion: "1.0"
+    kind: DockerImage
+  dockerImageMetadataVersion: "1.0"
+  dockerImageReference: centos/ruby-22-centos7@sha256:3a335d7d8a452970c5b4054ad7118ff134b3a6b50a2bb6d0c07c746e8986b28e
+  metadata:
+    creationTimestamp: 2016-01-29T13:17:45Z
+    name: sha256:3a335d7d8a452970c5b4054ad7118ff134b3a6b50a2bb6d0c07c746e8986b28e
+    resourceVersion: "352"
+    uid: af2e7a0c-c68a-11e5-8a99-525400f25e34
+kind: ImageStreamImage
+metadata:
+  creationTimestamp: null
+  name: ruby@3a335d7
+  namespace: openshift
+  selfLink: /oapi/v1/namespaces/openshift/imagestreamimages/ruby@3a335d7
 ----
 ====
-
-[[image-pull-policy]]
-
-=== Image Pull Policy
-
-Each container in a pod has a Docker image. Once you have created an image and
-pushed it to a registry, you can then refer to it in the pod.
-
-When OpenShift creates containers, it uses the container's `*imagePullPolicy*`
-to determine if the image should be pulled prior to starting the container.
-There are three possible values for `*imagePullPolicy*`:
-
-- `*Always*` - always pull the image.
-- `*IfNotPresent*` - only pull the image if it does not already exist on the node.
-- `*Never*` - never pull the image.
-
-If a container's `*imagePullPolicy*`
-parameter is not specified, OpenShift sets it based on the image's tag:
-
-. If the tag is *latest*, OpenShift defaults `*imagePullPolicy*` to `*Always*`.
-. Otherwise, OpenShift defaults `*imagePullPolicy*` to `*IfNotPresent*`.
 
 [[importing-tag-and-image-metadata]]
 
 === Importing Tag and Image Metadata
+
 An image stream can be configured to import tag and image metadata from an image
 repository in an external Docker image registry. See
 link:../infrastructure_components/image_registry.html[Image Registry] for more
 details.
 
-[[tag-tracking]]
+[[adding-tag]]
 
-=== Tag Tracking
+=== Adding Tag
+
 An image stream can also be configured so that a tag "tracks" another one. For
 example, you can configure the *latest* tag to always refer to the current image
-for the tag "2.0":
-
-====
-
-[source,json]
-----
-{
-  "kind": "ImageStream",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "ruby"
-  },
-  "spec": {
-    "tags": [
-      {
-        "name": "latest",
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "2.0"
-        }
-      }
-    ]
-  }
-}
-----
-====
-
-You can also do the same using the `oc tag` command:
+for the tag "2.0", to do that use the `oc tag` command:
 
 `oc tag ruby:latest ruby:2.0`
 
 [[tag-removal]]
 
 === Tag Removal
+
 You can stop tracking a tag simply by removing it. For example, you can stop
 tracking the *latest* tag you set above:
 
@@ -460,6 +459,7 @@ to run:
 [[insecure-registries]]
 
 === Importing Images from Insecure Registries
+
 An image stream can be configured to import tag and image metadata from insecure
 image registries, such as those signed with a self-signed certificate or using
 plain HTTP instead of HTTPS.
@@ -493,3 +493,69 @@ link:../../install_config/install/prerequisites.html#host-preparation[Host
 Preparation] for information.
 ====
 endif::[]
+
+Additionally there is an option to specify single tag use insecure repository.
+To do that set `.importPolicy.insecure` in tag's definition to *true*:
+
+====
+[source,yaml]
+----
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: ruby
+  tags:
+  - from:
+      kind: DockerImage
+      name: my.repo.com:5000/myimage
+    name: mytag
+    importPolicy:
+      insecure: "true" <1>
+----
+<1> Set tag ruby:mytag to use insecure connection to that registry.
+====
+
+[[private-registries]]
+
+=== Importing Images from Private Registries
+
+An image stream can be configured to import tag and image metadata from private
+image registries, requiring authentication.
+
+To configure this, you need to create a link:../dev_guide/secrets.html[`*secret*`]
+which is used to store your credentials.
+
+. Create the `*secret*` first before importing image from the private repository:
+
+====
+----
+$ oc secrets new-dockercfg SECRET --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
+----
+====
+
+For other options consult with `oc secrets new --help`.
+
+Once the secret is configured proceed with creating new Image Stream or using
+`oc import-image` command. During the import process OpenShift will pick up the
+secrets and provide to the remote party.
+
+[[image-pull-policy]]
+
+=== Image Pull Policy
+
+Each container in a pod has a Docker image. Once you have created an image and
+pushed it to a registry, you can then refer to it in the pod.
+
+When OpenShift creates containers, it uses the container's `*imagePullPolicy*`
+to determine if the image should be pulled prior to starting the container.
+There are three possible values for `*imagePullPolicy*`:
+
+- `*Always*` - always pull the image.
+- `*IfNotPresent*` - only pull the image if it does not already exist on the node.
+- `*Never*` - never pull the image.
+
+If a container's `*imagePullPolicy*`
+parameter is not specified, OpenShift sets it based on the image's tag:
+
+. If the tag is *latest*, OpenShift defaults `*imagePullPolicy*` to `*Always*`.
+. Otherwise, OpenShift defaults `*imagePullPolicy*` to `*IfNotPresent*`.


### PR DESCRIPTION
@adellape while looking at one bug I found we have outdated the images part of the doc. Here are the modifications I've applied:
- updated all jsons to yamls
- moved Image Pull Policy to the end of the docs, since it's loosely coupled with the docs itself
- updated tag tracking, changed to adding tag
- added private registry access using secrets.

@smarterclayton ptal the secrets part
