### PR TITLE
Add GitLab OAuth provider documentation

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -875,6 +875,59 @@ application]. The application must be configured with a callback URL of
 <6> The client secret issued by GitHub.
 ====
 
+[[GitLab]]
+
+=== GitLab
+
+Set *GitLabIdentityProvider* in the `*identityProviders*` stanza to use
+https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity provider, using the
+http://doc.gitlab.com/ce/integration/oauth_provider.html[OAuth integration].
+The OAuth provider feature requires GitLab version 7.7.0 or higher.
+
+[NOTE]
+====
+Using GitLab as an identity provider requires users to get a token using
+`<master>/oauth/token/request` to use with command-line tools.
+====
+
+.Master Configuration Using *GitLabIdentityProvider*
+====
+
+----
+oauthConfig:
+  ...
+  identityProviders:
+  - name: gitlab <1>
+    challenge: false <2>
+    login: true <3>
+    mappingMethod: claim <4>
+    provider:
+      apiVersion: v1
+      kind: GitLabIdentityProvider
+      url: ... <5>
+      clientID: ... <6>
+      clientSecret: ... <7>
+      ca: ... <8>
+----
+<1> This provider name is prefixed to the GitLab numeric user ID to form an
+identity name. It is also used to build the callback URL.
+<2> *GitLabIdentityProvider* cannot be used to send `WWW-Authenticate`
+challenges.
+<3> When *true*, unauthenticated token requests from web clients (like the web
+console) are redirected to GitLab to log in.
+<4> Controls how mappings are established between this provider's identities and user objects,
+link:#mapping-identities-to-users[as described above].
+<5> The host URL of a GitLab OAuth provider. This could either be `https://gitlab.com/`
+or any other self hosted instance of GitLab.
+<6> The client ID of a
+link:https://gitlab.com/oauth/applications/new[registered GitLab OAuth
+application]. The application must be configured with a callback URL of
+`<master>/oauth2callback/<identityProviderName>`.
+<7> The client secret issued by GitLab.
+<8> CA is an optional trusted certificate authority bundle to use when making
+requests to the GitLab instance. If empty, the default system roots are used.
+====
+
 [[Google]]
 
 === Google


### PR DESCRIPTION
Documents the GitLab OAuth integration. This feature is an open PR at openshift/origin#6923.
