### PR TITLE
Add stub revhistories for all books

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -26,6 +26,9 @@ Dir: welcome
 Topics:
   - Name: Welcome
     File: index
+  - Name: Full Revision History
+    File: revhistory_full
+    Distros: openshift-enterprise
 
 ---
 Name: What's New?
@@ -42,6 +45,9 @@ Topics:
     File: carts_vs_images
   - Name: Terminology
     File: terminology
+  - Name: Revision History
+    File: revhistory_whats_new
+    Distros: openshift-enterprise
 
 ---
 Name: Getting Started
@@ -56,6 +62,9 @@ Topics:
         File: developers_console
   - Name: Administrators
     File: administrators
+  - Name: Revision History
+    File: revhistory_getting_started
+    Distros: openshift-enterprise
 
 ---
 Name: Architecture
@@ -91,7 +100,6 @@ Topics:
         File: routes
       - Name: Templates
         File: templates
-
   - Name: Additional Concepts
     Dir: additional_concepts
     Topics:
@@ -115,6 +123,9 @@ Topics:
         File: scm
       - Name: Other API Objects
         File: other_api_objects
+  - Name: Revision History
+    File: revhistory_architecture
+    Distros: openshift-enterprise
 
 ---
 Name: Installation and Configuration
@@ -141,6 +152,9 @@ Topics:
         File: first_steps
   - Name: Upgrading
     File: upgrades
+  - Name: Revision History
+    File: revhistory_install_config
+    Distros: openshift-enterprise
 
 ---
 Name: Administration
@@ -191,6 +205,9 @@ Topics:
     File: web_console_customization
   - Name: Working with HTTP Proxies
     File: http_proxies
+  - Name: Revision History
+    File: revhistory_admin_guide
+    Distros: openshift-enterprise
 
 ---
 Name: CLI Reference
@@ -204,6 +221,9 @@ Topics:
     File: manage_cli_profiles
   - Name: CLI Operations
     File: basic_cli_operations
+  - Name: Revision History
+    File: revhistory_cli_reference
+    Distros: openshift-enterprise
 
 ---
 Name: Developer Guide
@@ -255,6 +275,9 @@ Topics:
     File: downward_api
   - Name: Managing Environment Variables
     File: environment_variables
+  - Name: Revision History
+    File: revhistory_dev_guide
+    Distros: openshift-enterprise
 
 ---
 Name: Creating Images
@@ -272,6 +295,9 @@ Topics:
     File: s2i_testing
   - Name: Custom Builder
     File: custom
+  - Name: Revision History
+    File: revhistory_creating_images
+    Distros: openshift-enterprise
 
 ---
 Name: Using Images
@@ -333,6 +359,9 @@ Topics:
         File: a_mq
       - Name: JBoss Web Server
         File: jws
+  - Name: Revision History
+    File: revhistory_using_images
+    Distros: openshift-enterprise
 
 ---
 Name: REST API Reference
@@ -344,3 +373,6 @@ Topics:
     File: openshift_v1
   - Name: Kubernetes v1
     File: kubernetes_v1
+  - Name: Revision History
+    File: revhistory_rest_api
+    Distros: openshift-enterprise

--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -1,0 +1,10 @@
+= Revision History: Administration
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -1,0 +1,10 @@
+= Revision History: Architecture
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/cli_reference/revhistory_cli_reference.adoc
+++ b/cli_reference/revhistory_cli_reference.adoc
@@ -1,0 +1,10 @@
+= Revision History: CLI Reference
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/creating_images/revhistory_creating_images.adoc
+++ b/creating_images/revhistory_creating_images.adoc
@@ -1,0 +1,10 @@
+= Revision History: Creating Images
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -1,0 +1,10 @@
+= Revision History: Developer Guide
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/getting_started/revhistory_getting_started.adoc
+++ b/getting_started/revhistory_getting_started.adoc
@@ -1,0 +1,10 @@
+= Revision History: Getting Started
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -1,0 +1,10 @@
+= Revision History: Installation and Configuration
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/rest_api/revhistory_rest_api.adoc
+++ b/rest_api/revhistory_rest_api.adoc
@@ -1,0 +1,10 @@
+= Revision History: REST API Reference
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -1,0 +1,10 @@
+= Revision History: Using Images
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -1,0 +1,13 @@
+= Full Revision History
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+The following sections aggregate the revision histories of each guide by publish
+date.
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.

--- a/whats_new/revhistory_whats_new.adoc
+++ b/whats_new/revhistory_whats_new.adoc
@@ -1,0 +1,10 @@
+= Revision History: What's New
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+== Tue Jun 23 2015
+
+OpenShift Enterprise 3.0 release.


### PR DESCRIPTION
- Exposed in downstream distro builds only
- Actual rev notes to be added on individual branches (not master) per distro

[During cherry-pick for enterprise-3.0]
- Updated for OSE 3.0 relevance
- Renamed "All Revision History" to "Full Revision History"
