### PR TITLE
Make admin_cli Dedicated-worthy

### DIFF
--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -11,14 +11,28 @@ toc::[]
 
 == Overview
 
-This topic provides information on the administrator CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+This topic provides information on the administrator CLI operations and their
+syntax. You must link:get_started_cli.html[setup and login] with the CLI before
+you can perform these operations.
 
-The administrator CLI uses the `oadm` command, and is used for administrator operations. This differs from the link:basic_cli_operations.html[developer CLI], which uses the `oc` command, and is used for basic, project-level operations. 
+The administrator CLI uses the `oadm` command, and is used for administrator
+operations. This differs from the link:basic_cli_operations.html[developer CLI],
+which uses the `oc` command, and is used for basic, project-level operations.
 
-[[common-operations]]
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+Your login may or may not have access to the following administrative commands,
+depending on your account type.
+====
+endif::[]
+
+[[oadm-common-operations]]
 
 == Common Operations
-The administrator CLI allows interaction with the various objects that are managed by OpenShift. Many common `oadm` operations are invoked using the following syntax:
+The administrator CLI allows interaction with the various objects that are
+managed by OpenShift. Many common `oadm` operations are invoked using the
+following syntax:
 
 ----
 $ oadm <action> <option>
@@ -27,13 +41,14 @@ $ oadm <action> <option>
 This specifies:
 
 - An `<action>` to perform, such as `new-project` or `router`.
-- An available `<option>` to perform the action on as well as a value for the option. Options include `--output` or `--credentials`.
+- An available `<option>` to perform the action on as well as a value for the
+option. Options include `--output` or `--credentials`.
 
 [[basic-admin-cli-operations]]
 
 == Basic CLI Operations
 
-=== `new-project` 
+=== `new-project`
 Creates a new project:
 
 ----
@@ -52,6 +67,7 @@ Manages groups:
 $ oadm groups
 ----
 
+ifdef::openshift-enterprise[]
 [[install-cli-operations]]
 
 == Install CLI Operations
@@ -73,6 +89,7 @@ Installs an integrated Docker registry:
 ----
 $ oadm registry
 ----
+endif::[]
 
 [[maintenance-cli-operations]]
 
@@ -96,6 +113,7 @@ Removes older versions of resources from the server:
 $ oadm prune
 ----
 
+ifdef::openshift-enterprise[]
 [[settings-cli-operations]]
 
 == Settings CLI Operations
@@ -157,6 +175,7 @@ Manages certificates and keys:
 ----
 $ oadm ca
 ----
+endif::[]
 
 [[other-cli-operations]]
 

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -14,7 +14,7 @@ This topic provides information on the developer CLI operations and their syntax
 
 The developer CLI uses the `oc` command, and is used for project-level operations. This differs from the link:admin_cli_operations.html[administrator CLI], which uses the `oadm` command, and is used for more advanced, administrator operations.
 
-[[common-operations]]
+[[oc-common-operations]]
 
 == Common Operations
 The developer CLI allows interaction with the various objects that are managed by OpenShift. Many common `oc` operations are invoked using the following syntax:


### PR DESCRIPTION
- Added OSD-only Note box to Overview
- Hid a few sections for cmds that won't be available to OSD admins
- Created unique anchors for the shared "Common Operations" (not OSD-specific)
- Wrapped some lines
