### PR TITLE
Follow-up fixes to OSE 3.1 Mon Feb 01 publish

### DIFF
--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -17,8 +17,9 @@
 Builds and Image Streams]
 |Added more information on how builds work behind the scenes.
 
-|link:../architecture/additional_concepts/storage.html[Persistent Storage]
-|Added important box about providing high-availability.
+|link:../architecture/additional_concepts/storage.html[Additional Concepts ->
+Persistent Storage]
+|Added an Important box about providing high-availability.
 
 |===
 // end::architecture_mon_feb_01_2016[]

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -11,14 +11,28 @@ toc::[]
 
 == Overview
 
-This topic provides information on the administrator CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+This topic provides information on the administrator CLI operations and their
+syntax. You must link:get_started_cli.html[setup and login] with the CLI before
+you can perform these operations.
 
-The administrator CLI uses the `oadm` command, and is used for administrator operations. This differs from the link:basic_cli_operations.html[developer CLI], which uses the `oc` command, and is used for basic, project-level operations. 
+The administrator CLI uses the `oadm` command, and is used for administrator
+operations. This differs from the link:basic_cli_operations.html[developer CLI],
+which uses the `oc` command, and is used for basic, project-level operations.
 
-[[common-operations]]
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+Your login may or may not have access to the following administrative commands,
+depending on your account type.
+====
+endif::[]
+
+[[oadm-common-operations]]
 
 == Common Operations
-The administrator CLI allows interaction with the various objects that are managed by OpenShift. Many common `oadm` operations are invoked using the following syntax:
+The administrator CLI allows interaction with the various objects that are
+managed by OpenShift. Many common `oadm` operations are invoked using the
+following syntax:
 
 ----
 $ oadm <action> <option>
@@ -27,13 +41,14 @@ $ oadm <action> <option>
 This specifies:
 
 - An `<action>` to perform, such as `new-project` or `router`.
-- An available `<option>` to perform the action on as well as a value for the option. Options include `--output` or `--credentials`.
+- An available `<option>` to perform the action on as well as a value for the
+option. Options include `--output` or `--credentials`.
 
 [[basic-admin-cli-operations]]
 
 == Basic CLI Operations
 
-=== `new-project` 
+=== `new-project`
 Creates a new project:
 
 ----
@@ -52,6 +67,7 @@ Manages groups:
 $ oadm groups
 ----
 
+ifdef::openshift-enterprise[]
 [[install-cli-operations]]
 
 == Install CLI Operations
@@ -73,6 +89,7 @@ Installs an integrated Docker registry:
 ----
 $ oadm registry
 ----
+endif::[]
 
 [[maintenance-cli-operations]]
 
@@ -96,6 +113,7 @@ Removes older versions of resources from the server:
 $ oadm prune
 ----
 
+ifdef::openshift-enterprise[]
 [[settings-cli-operations]]
 
 == Settings CLI Operations
@@ -157,6 +175,7 @@ Manages certificates and keys:
 ----
 $ oadm ca
 ----
+endif::[]
 
 [[other-cli-operations]]
 

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -14,7 +14,7 @@ This topic provides information on the developer CLI operations and their syntax
 
 The developer CLI uses the `oc` command, and is used for project-level operations. This differs from the link:admin_cli_operations.html[administrator CLI], which uses the `oadm` command, and is used for more advanced, administrator operations.
 
-[[common-operations]]
+[[oc-common-operations]]
 
 == Common Operations
 The developer CLI allows interaction with the various objects that are managed by OpenShift. Many common `oc` operations are invoked using the following syntax:

--- a/cli_reference/revhistory_cli_reference.adoc
+++ b/cli_reference/revhistory_cli_reference.adoc
@@ -14,8 +14,11 @@
 |Affected Topic |Description of Change
 
 |link:../cli_reference/admin_cli_operations.html[Administrator CLI Operations]
+|New topic providing a reference for administrator CLI commands.
 
-|Added administrator CLI commands reference file and changed format of the developer CLI commands reference file.
+|link:../cli_reference/basic_cli_operations.html[Developer CLI Operations]
+|Changed the format for listing commands from tables to individual subsections
+per command.
 
 |===
 // end::cli_reference_mon_feb_01_2016[]

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -14,7 +14,9 @@
 |Affected Topic |Description of Change
 
 |link:../install_config/configuring_openstack.html[Configuring for OpenStack]
-|Changed `<image_ID` to `<image_name>` for readability.
+|Changed `<instance_ID>` to `<instance_name>` in the
+link:../install_config/configuring_openstack.html#openstack-configuring-nodes[Configuring
+Nodes] section for readability.
 
 |===
 // end::install_config_mon_feb_01_2016[]
@@ -85,9 +87,8 @@ link:../install_config/cluster_metrics.html#creating-the-deployer-template[*_met
 file path].
 
 |link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
-|Added link:../install_config/install/prerequisites.html#prereq-dns[Warning
-admonition] about wildcards and DNS server entries in the *_/etc/resolv.conf_*
-file.
+|Added a link:../install_config/install/prerequisites.html#prereq-dns[Warning
+box] about wildcards and DNS server entries in the *_/etc/resolv.conf_* file.
 
 |link:../install_config/persistent_storage/persistent_storage_ceph_rbd.html[Configuring
 Persistent Storage -> Persistent Storage Using Ceph Rados Block Device (RBD)]
@@ -95,7 +96,7 @@ Persistent Storage -> Persistent Storage Using Ceph Rados Block Device (RBD)]
 
 |link:../install_config/persistent_storage/persistent_storage_nfs.html[Configuring
 Persistent Storage -> Persistent Storage Using NFS]
-|Removed a contradictory Note admonition about NFS and SELinux.
+|Removed a contradictory Note box about NFS and SELinux.
 |===
 // end::install_config_tue_jan_26_2016[]
 

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -14,7 +14,7 @@
 |Affected Topic |Description of Change
 
 |link:../using_images/index.html[Overview]
-|Added more details on which images are supported, which are in tech preview, and their location.
+|Added details on which images are supported and their location.
 
 |===
 // end::using_images_mon_feb_01_2016[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -17,7 +17,7 @@ include::architecture/revhistory_architecture.adoc[tag=architecture_mon_feb_01_2
 include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_mon_feb_01_2016]
 
 .Using Images
-include::using_images/revhistory_using_images.adoc[tag=install_config_mon_feb_01_2016]
+include::using_images/revhistory_using_images.adoc[tag=using_images_mon_feb_01_2016]
 
 .Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_mon_feb_01_2016]


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1507.

Made the `[[common-operations]]` anchor unique between the two CLI reference files (it was causing the CP build to fail), and touched up some minor issues with some revhistories.

Also replaced some "admonition" wording in some earlier revhistory entries to call them a "box" instead. Not sure which is better, but at least they're synced up now on one choice.
