### PR TITLE
Remove backticks from section titles in admin_cli & basic_cli

### DIFF
--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -48,20 +48,20 @@ option. Options include `--output` or `--credentials`.
 
 == Basic CLI Operations
 
-=== `new-project`
+=== new-project
 Creates a new project:
 
 ----
 $ oadm new-project <project_name>
 ----
 
-=== `policy`
+=== policy
 Manages authorization policies:
 ----
 $ oadm policy
 ----
 
-=== `groups`
+=== groups
 Manages groups:
 ----
 $ oadm groups
@@ -72,19 +72,19 @@ ifdef::openshift-enterprise[]
 
 == Install CLI Operations
 
-=== `router`
+=== router
 Installs a router:
 ----
 $ oadm router <router_name>
 ----
 
-=== `ipfailover`
+=== ipfailover
 Installs an IP failover group for a set of nodes:
 ----
 $ oadm ipfailover <ipfailover_config>
 ----
 
-=== `registry`
+=== registry
 Installs an integrated Docker registry:
 ----
 $ oadm registry
@@ -95,19 +95,19 @@ endif::[]
 
 == Maintenance CLI Operations
 
-=== `build-chain`
+=== build-chain
 Outputs the inputs and dependencies of any builds:
 ----
 $ oadm build-chain <image-stream>[:<tag>]
 ----
 
-=== `manage-node`
+=== manage-node
 Manages nodes. For example, list or evacuate pods, or mark them ready:
 ----
 $ oadm manage-node
 ----
 
-=== `prune`
+=== prune
 Removes older versions of resources from the server:
 ----
 $ oadm prune
@@ -118,19 +118,19 @@ ifdef::openshift-enterprise[]
 
 == Settings CLI Operations
 
-=== `config`
+=== config
 Changes kubelet configuration files:
 ----
 $ oadm config <subcommand>
 ----
 
-=== `create-kubeconfig`
+=== create-kubeconfig
 Creates a basic *_.kubeconfig_* file from client certificates:
 ----
 $ oadm create-kubeconfig
 ----
 
-=== `create-api-client-config`
+=== create-api-client-config
 Creates a configuration file for connecting to the server as a user:
 ----
 $ oadm create-api-client-config
@@ -140,37 +140,37 @@ $ oadm create-api-client-config
 
 ==  Advanced CLI Operations
 
-=== `create-bootstrap-project-template`
+=== create-bootstrap-project-template
 Creates a bootstrap project template:
 ----
 $ oadm create-bootstrap-project-template
 ----
 
-=== `create-bootstrap-policy-file`
+=== create-bootstrap-policy-file
 Creates the default bootstrap policy:
 ----
 $ oadm create-bootstrap-policy-file
 ----
 
-=== `create-login-template`
+=== create-login-template
 Creates a login template:
 ----
 $ oadm create-login-template
 ----
 
-=== `overwrite-policy`
+=== overwrite-policy
 Resets the policy to the default values:
 ----
 $ oadm overwrite-policy
 ----
 
-=== `create-node-config`
+=== create-node-config
 Creates a configuration bundle for a node:
 ----
 $ oadm create-node-config
 ----
 
-=== `ca`
+=== ca
 Manages certificates and keys:
 ----
 $ oadm ca
@@ -181,13 +181,13 @@ endif::[]
 
 == Other CLI Operations
 
-=== `version`
+=== version
 Displays the version of the indicated object:
 ----
 $ oadm version
 ----
 
-=== `help`
+=== help
 Displays help about any command:
 ----
 $ oadm help <command>

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -10,14 +10,19 @@
 toc::[]
 
 == Overview
-This topic provides information on the developer CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+This topic provides information on the developer CLI operations and their
+syntax. You must link:get_started_cli.html[setup and login] with the CLI before
+you can perform these operations.
 
-The developer CLI uses the `oc` command, and is used for project-level operations. This differs from the link:admin_cli_operations.html[administrator CLI], which uses the `oadm` command, and is used for more advanced, administrator operations.
+The developer CLI uses the `oc` command, and is used for project-level
+operations. This differs from the link:admin_cli_operations.html[administrator
+CLI], which uses the `oadm` command for more advanced, administrator operations.
 
 [[oc-common-operations]]
 
-== Common Operations
-The developer CLI allows interaction with the various objects that are managed by OpenShift. Many common `oc` operations are invoked using the following syntax:
+== Common Operations The developer CLI allows interaction with the various
+objects that are managed by OpenShift. Many common `oc` operations are invoked
+using the following syntax:
 
 ----
 $ oc <action> <object_type> <object_name_or_id>
@@ -26,11 +31,12 @@ $ oc <action> <object_type> <object_name_or_id>
 This specifies:
 
 - An `<action>` to perform, such as `get` or `describe`.
-- The `<object_type>` to perform the action on, such as `service` or the abbreviated `svc`.
+- The `<object_type>` to perform the action on, such as `service` or the
+abbreviated `svc`.
 - The `<object_name_or_id>` of the specified `<object_type>`.
 
-For example, the `oc get` operation returns a complete list of services that
-are currently defined:
+For example, the `oc get` operation returns a complete list of services that are
+currently defined:
 
 ====
 
@@ -72,15 +78,17 @@ endif::[]
 ifdef::openshift-enterprise[]
 3.0.2.0
 endif::[]
-did not have the ability to negotiate API versions against a server. So if you are using `oc` up to
+did not have the ability to negotiate API versions against a server. So if you
+are using `oc` up to
 ifdef::openshift-origin[]
 1.0.4
 endif::[]
 ifdef::openshift-enterprise[]
 3.0.1.0
 endif::[]
-with a server that only supports v1 or higher versions of the API, make sure to pass `--api-version` in order to
-point the `oc` client to the correct API endpoint. For example: `oc get svc --api-version=v1`.
+with a server that only supports v1 or higher versions of the API, make sure to
+pass `--api-version` in order to point the `oc` client to the correct API
+endpoint. For example: `oc get svc --api-version=v1`.
 ====
 
 [[object-types]]
@@ -115,45 +123,48 @@ syntax:
 == Basic CLI Operations
 The following table describes basic `oc` operations and their general syntax:
 
-=== `types`
+=== types
 Display an introduction to some core OpenShift concepts:
 ----
 $ oc types
 ----
 
-=== `login`
+=== login
 Log in to the OpenShift server:
 ----
 $ oc login
 ----
 
-=== `logout`
+=== logout
 End the current session:
 ----
 $ oc logout
 ----
 
-=== `new-project`
+=== new-project
 Create a new project:
 ----
 $ oc new-project <project_name>
 ----
 
-=== `new-app`
+=== new-app
 link:../dev_guide/new_app.html[Creates a new application] based on the source
 code in the current directory:
 ----
 $ oc new-app .
 ----
 
-=== `status`
+=== status
 Show an overview of the current project:
 ----
 $ oc status
 ----
 
-=== `project`
-Switch to another project. Run without options to display the current project. To view all projects you have access to run `oc projects`. Run without options to display the current project. To view all projects you have access to run `oc projects`.
+=== project
+Switch to another project. Run without options to display the current project.
+To view all projects you have access to run `oc projects`. Run without options
+to display the current project. To view all projects you have access to run `oc
+projects`.
 ----
 $ oc project <project_name>
 ----
@@ -162,19 +173,23 @@ $ oc project <project_name>
 
 == Application Modification CLI Operations
 
-=== `get`
-Return a list of objects for the specified link:#object-types[object type]. If the optional `<object_name_or_id>` is included in the request, then the list of results is filtered by that value.
+=== get
+Return a list of objects for the specified link:#object-types[object type]. If
+the optional `<object_name_or_id>` is included in the request, then the list of
+results is filtered by that value.
 ----
 $ oc get <object_type> [<object_name_or_id>]
 ----
 
-=== `describe`
-Returns information about the specific object returned by the query. A specific `<object_name_or_id>` must be provided. The actual information that is available varies as described in link:#object-types[object type].
+=== describe
+Returns information about the specific object returned by the query. A specific
+`<object_name_or_id>` must be provided. The actual information that is available
+varies as described in link:#object-types[object type].
 ----
 $ oc describe <object_type> <object_id>
 ----
 
-=== `edit`
+=== edit
 Edit the desired object type:
 ----
 $ oc edit <object_type>/<object_type_name>
@@ -190,32 +205,39 @@ $ oc edit <object_type>/<object_type_name> \
     -o <object_type_format>
 ----
 
-=== `env`
+=== env
 Update the desired object type with a new environment variable:
 ----
 $ oc env <object_type>/<object_type_name> <var_name>=<value>
 ----
 
-=== `volume`
+=== volume
 Modify a link:../dev_guide/volumes.html[volume]:
 ----
 $ oc volume <object_type>/<object_type_name> [--option]
 ----
 
-=== `label`
+=== label
 Update the labels on a object:
 ----
 $ oc label <object_type> <object_name_or_id> <label>
 ----
 
-=== `expose`
-Look up a service and expose it as a route. There is also the ability to expose a deployment configuration, replication controller, service, or pod as a new service on a specified port. If no labels are specified, the new object will re-use the labels from the object it exposes.
+=== expose
+Look up a service and expose it as a route. There is also the ability to expose
+a deployment configuration, replication controller, service, or pod as a new
+service on a specified port. If no labels are specified, the new object will
+re-use the labels from the object it exposes.
 ----
 $ oc expose <object_type> <object_name_or_id>
 ----
 
-=== `delete`
-Delete the specified object. An object configuration can also be passed in through STDIN. The `oc delete all -l <label>` operation deletes all objects matching the specified `<label>`, including the link:../architecture/core_concepts/deployments.html#replication-controllers[replication controller] so that pods are not re-created.
+=== delete
+Delete the specified object. An object configuration can also be passed in
+through STDIN. The `oc delete all -l <label>` operation deletes all objects
+matching the specified `<label>`, including the
+link:../architecture/core_concepts/deployments.html#replication-controllers[replication
+controller] so that pods are not re-created.
 ----
 $ oc delete -f <file_path>
 ----
@@ -232,31 +254,38 @@ $ oc delete all -l <label>
 [[build-and-deployment-cli-operations]]
 
 == Build and Deployment CLI Operations
-One of the fundamental capabilities of OpenShift is the ability to build applications into a container from source.
+One of the fundamental capabilities of OpenShift is the ability to build
+applications into a container from source.
 
-OpenShift provides CLI access to inspect and manipulate link:../dev_guide/deployments.html[deployment configurations] using standard `oc` resource operations, such as `get`, `create`, and `describe`.
+OpenShift provides CLI access to inspect and manipulate
+link:../dev_guide/deployments.html[deployment configurations] using standard
+`oc` resource operations, such as `get`, `create`, and `describe`.
 
-=== `start-build`
+=== start-build
 Manually start the build process with the specified build configuration file:
 ----
 $ oc start-build <buildconfig_name>
 ----
-Manually start the build process by specifying the name of a previous build as a starting point:
+Manually start the build process by specifying the name of a previous build as a
+starting point:
 ----
 $ oc start-build --from-build=<build_name>
 ----
-Manually start the build process by specifying either a configuration file or the name of a previous build and retrieve its build logs:
+Manually start the build process by specifying either a configuration file or
+the name of a previous build and retrieve its build logs:
 ----
 $ oc start-build --from-build=<build_name> --follow
 ----
 ----
 $ oc start-build <buildconfig_name> --follow
 ----
-Wait for a build to complete and exit with a non-zero return code if the build fails:
+Wait for a build to complete and exit with a non-zero return code if the build
+fails:
 ----
 $ oc start-build --from-build=<build_name> --wait
 ----
-Set or override environment variables for the current build without changing the build configuration. Alternatively, use `-e`.
+Set or override environment variables for the current build without changing the
+build configuration. Alternatively, use `-e`.
 ----
 $ oc start-build --env <var_name>=<value>
 ----
@@ -264,7 +293,8 @@ Set or override the default build log level output during the build:
 ----
 $ oc start-build --build-loglevel [0-5]
 ----
-Specify the source code commit identifier the build should use; requires a build based on a Git repository:
+Specify the source code commit identifier the build should use; requires a build
+based on a Git repository:
 ----
 $ oc start-build --commit=<hash>
 ----
@@ -276,11 +306,13 @@ Archive `<dir_name>` and build with it as the binary input:
 ----
 $ oc start-build --from-dir=<dir_name>
 ----
-Use `<file_name>` as the binary input for the build. This file must be the only one in the build source. For example, *_pom.xml_* or *_Dockerfile_*.
+Use `<file_name>` as the binary input for the build. This file must be the only
+one in the build source. For example, *_pom.xml_* or *_Dockerfile_*.
 ----
 $ oc start-build --from-file=<file_name>
 ----
-The path to a local source code repository to use as the binary input for a build:
+The path to a local source code repository to use as the binary input for a
+build:
 ----
 $ oc start-build --from-repo=<path_to_repo>
 ----
@@ -292,53 +324,63 @@ The contents of the post-receive hook to trigger a build:
 ----
 $ oc start-build --git-post-receive=<contents>
 ----
-The path to the Git repository for post-receive; defaults to the current directory:
+The path to the Git repository for post-receive; defaults to the current
+directory:
 ----
 $ oc start-build --git-repository=<path_to_repo>
 ----
-List the webhooks for the specified build configuration or build; accepts `all`, `generic`, or `github`:
+List the webhooks for the specified build configuration or build; accepts `all`,
+`generic`, or `github`:
 ----
 $ oc start-build --list-webhooks
 ----
 
-=== `deploy`
-View a link:../dev_guide/deployments.html[deployment], or manually start, cancel, or retry a deployment:
+=== deploy
+View a link:../dev_guide/deployments.html[deployment], or manually start,
+cancel, or retry a deployment:
 ----
 $ oc deploy <deploymentconfig>
 ----
 
-=== `rollback`
-Perform a link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback]:
+=== rollback
+Perform a
+link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback]:
 ----
 $ oc rollback <deployment_name>
 ----
 
-=== `new-build`
-Create a build config based on the source code in the current Git repository (with a public remote) and a Docker image:
+=== new-build
+Create a build configuration based on the source code in the current Git
+repository (with a public remote) and a Docker image:
 ----
 $ oc new-build .
 ----
 
-=== `cancel-build`
+=== cancel-build
 Stop a build that is in progress:
 ----
 $ oc cancel-build <build_name>
 ----
 
-=== `import-image`
+=== import-image
 Import tag and image information from an external Docker image repository:
 ----
 $ oc import-image <imagestream>
 ----
 
-=== `scale`
-Set the number of desired replicas for a link:../architecture/core_concepts/deployments.html#replication-controllers[replication controller] or a link:../dev_guide/deployments.html[deployment configuration] to the number of specified replicas:
+=== scale
+Set the number of desired replicas for a
+link:../architecture/core_concepts/deployments.html#replication-controllers[replication
+controller] or a link:../dev_guide/deployments.html[deployment configuration] to
+the number of specified replicas:
 ----
 $ oc scale <object_type> <object_id> --replicas=<#_of_replicas>
 ----
 
-=== `tag`
-Take an existing tag or image from an image stream, or a Docker image pull spec, and set it as the most recent image for a tag in one or more other image streams:
+=== tag
+Take an existing tag or image from an image stream, or a Docker image pull spec,
+and set it as the most recent image for a tag in one or more other image
+streams:
 ----
 $ oc tag <current_image> <image_stream>
 ----
@@ -347,26 +389,37 @@ $ oc tag <current_image> <image_stream>
 
 == Advanced Commands
 
-=== `create`
-Parse a configuration file and create one or more OpenShift objects based on the file contents. The `-f` flag can be passed multiple times with different file or directory paths. When the flag is passed multiple times, `oc create` iterates through each one, creating the objects described in all of the indicated files. Any existing resources are ignored.
+=== create
+Parse a configuration file and create one or more OpenShift objects based on the
+file contents. The `-f` flag can be passed multiple times with different file or
+directory paths. When the flag is passed multiple times, `oc create` iterates
+through each one, creating the objects described in all of the indicated files.
+Any existing resources are ignored.
 ----
 $ oc create -f <file_or_dir_path>
 ----
 
-=== `update`
-Attempt to modify an existing object based on the contents of the specified configuration file. The `-f` flag can be passed multiple times with different file or directory paths. When the flag is passed multiple times, `oc update` iterates through each one, updating the objects described in all of the indicated files.
+=== update
+Attempt to modify an existing object based on the contents of the specified
+configuration file. The `-f` flag can be passed multiple times with different
+file or directory paths. When the flag is passed multiple times, `oc update`
+iterates through each one, updating the objects described in all of the
+indicated files.
 ----
 $ oc update -f <file_or_dir_path>
 ----
 
-=== `process`
-Transform a project link:../dev_guide/templates.html[template] into a project configuration file:
+=== process
+Transform a project link:../dev_guide/templates.html[template] into a project
+configuration file:
 ----
 $ oc process -f <template_file_path>
 ----
 
-=== `run`
-Create and run a particular image, possibly replicated. Create a deployment configuration to manage the created container(s). You can choose to run in the foreground for an interactive container execution.
+=== run
+Create and run a particular image, possibly replicated. Create a deployment
+configuration to manage the created container(s). You can choose to run in the
+foreground for an interactive container execution.
 ----
 $ oc run NAME --image=<image> \
     [--port=<port>] \
@@ -376,19 +429,19 @@ $ oc run NAME --image=<image> \
     [options]
 ----
 
-=== `export`
+=== export
 Export resources to be used elsewhere:
 ----
 $ oc export <object_type> [--options]
 ----
 
-=== `policy`
+=== policy
 Manage authorization policies:
 ----
 $ oc policy [--options]
 ----
 
-=== `secrets`
+=== secrets
 Configure link:../dev_guide/secrets.html[secrets]:
 ----
 $ oc secrets [--options] path/to/ssh_key
@@ -398,37 +451,41 @@ $ oc secrets [--options] path/to/ssh_key
 
 == Troubleshooting and Debugging CLI Operations
 
-=== `logs`
-Retrieve the log output for a specific build, deployment, or pod. This command works for builds, build configurations, deployment configurations, and pods.
+=== logs
+Retrieve the log output for a specific build, deployment, or pod. This command
+works for builds, build configurations, deployment configurations, and pods.
 ----
 $ oc logs -f <pod_name>
 ----
 
-=== `exec`
-Execute a command in an already-running container. You can optionally specify a container ID, otherwise it defaults to the first container.
+=== exec
+Execute a command in an already-running container. You can optionally specify a
+container ID, otherwise it defaults to the first container.
 ----
 $ oc exec <pod_ID> [-c <container_ID>] <command>
 ----
 
-=== `rsh`
+=== rsh
 Open a remote shell session to a container:
 ----
 $ oc rsh <pod_ID>
 ----
 
-=== `rsync`
-Copy contents of local directory to a directory in an already-running pod container. It will default to the first container if none is specified.
+=== rsync
+Copy contents of local directory to a directory in an already-running pod
+container. It will default to the first container if none is specified.
 ----
 $ oc rsync <local_dir> <pod_ID>:<pod_dir> -c <container_ID>
 ----
 
-=== `port-forward`
-link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a pod:
+=== port-forward
+link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a
+pod:
 ----
 $ oc port-forward <pod_ID> <first_port_ID> <second_port_ID>
 ----
 
-=== `proxy`
+=== proxy
 Run a proxy to the Kubernetes API server:
 ----
 $ oc proxy --port=<port_ID> --www=<static_directory>
@@ -438,6 +495,6 @@ $ oc proxy --port=<port_ID> --www=<static_directory>
 ====
 link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
 `oc exec` command does not work when accessing privileged containers. Instead,
-administrators can SSH into a node host, then use the `docker exec`
-command on the desired container.
+administrators can SSH into a node host, then use the `docker exec` command on
+the desired container.
 ====


### PR DESCRIPTION
Customer Portal freaks out when there's literal markup (backticks) in a section title.

FYI @openshift/team-documentation 
