### PR TITLE
Follow-up fixes to OSD 3.1 Mon Feb 01 publish

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -281,8 +281,10 @@ Topics:
     File: get_started_cli
   - Name: Managing CLI Profiles
     File: manage_cli_profiles
-  - Name: CLI Operations
+  - Name: Developer CLI Operations
     File: basic_cli_operations
+  - Name: Administrator CLI Operations
+    File: admin_cli_operations
   - Name: Revision History
     File: revhistory_cli_reference
     Distros: openshift-enterprise,openshift-dedicated

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -17,8 +17,9 @@
 Builds and Image Streams]
 |Added more information on how builds work behind the scenes.
 
-|link:../architecture/additional_concepts/storage.html[Persistent Storage]
-|Added important box about providing high-availability.
+|link:../architecture/additional_concepts/storage.html[Additional Concepts ->
+Persistent Storage]
+|Added an Important box about providing high-availability.
 
 |===
 // end::architecture_mon_feb_01_2016[]

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -1,0 +1,175 @@
+= Administrator CLI Operations
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+This topic provides information on the administrator CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+
+The administrator CLI uses the `oadm` command, and is used for administrator operations. This differs from the link:basic_cli_operations.html[developer CLI], which uses the `oc` command, and is used for basic, project-level operations. 
+
+[[common-operations]]
+
+== Common Operations
+The administrator CLI allows interaction with the various objects that are managed by OpenShift. Many common `oadm` operations are invoked using the following syntax:
+
+----
+$ oadm <action> <option>
+----
+
+This specifies:
+
+- An `<action>` to perform, such as `new-project` or `router`.
+- An available `<option>` to perform the action on as well as a value for the option. Options include `--output` or `--credentials`.
+
+[[basic-admin-cli-operations]]
+
+== Basic CLI Operations
+
+=== `new-project` 
+Creates a new project:
+
+----
+$ oadm new-project <project_name>
+----
+
+=== `policy`
+Manages authorization policies:
+----
+$ oadm policy
+----
+
+=== `groups`
+Manages groups:
+----
+$ oadm groups
+----
+
+[[install-cli-operations]]
+
+== Install CLI Operations
+
+=== `router`
+Installs a router:
+----
+$ oadm router <router_name>
+----
+
+=== `ipfailover`
+Installs an IP failover group for a set of nodes:
+----
+$ oadm ipfailover <ipfailover_config>
+----
+
+=== `registry`
+Installs an integrated Docker registry:
+----
+$ oadm registry
+----
+
+[[maintenance-cli-operations]]
+
+== Maintenance CLI Operations
+
+=== `build-chain`
+Outputs the inputs and dependencies of any builds:
+----
+$ oadm build-chain <image-stream>[:<tag>]
+----
+
+=== `manage-node`
+Manages nodes. For example, list or evacuate pods, or mark them ready:
+----
+$ oadm manage-node
+----
+
+=== `prune`
+Removes older versions of resources from the server:
+----
+$ oadm prune
+----
+
+[[settings-cli-operations]]
+
+== Settings CLI Operations
+
+=== `config`
+Changes kubelet configuration files:
+----
+$ oadm config <subcommand>
+----
+
+=== `create-kubeconfig`
+Creates a basic *_.kubeconfig_* file from client certificates:
+----
+$ oadm create-kubeconfig
+----
+
+=== `create-api-client-config`
+Creates a configuration file for connecting to the server as a user:
+----
+$ oadm create-api-client-config
+----
+
+[[advanced-cli-operations]]
+
+==  Advanced CLI Operations
+
+=== `create-bootstrap-project-template`
+Creates a bootstrap project template:
+----
+$ oadm create-bootstrap-project-template
+----
+
+=== `create-bootstrap-policy-file`
+Creates the default bootstrap policy:
+----
+$ oadm create-bootstrap-policy-file
+----
+
+=== `create-login-template`
+Creates a login template:
+----
+$ oadm create-login-template
+----
+
+=== `overwrite-policy`
+Resets the policy to the default values:
+----
+$ oadm overwrite-policy
+----
+
+=== `create-node-config`
+Creates a configuration bundle for a node:
+----
+$ oadm create-node-config
+----
+
+=== `ca`
+Manages certificates and keys:
+----
+$ oadm ca
+----
+
+[[other-cli-operations]]
+
+== Other CLI Operations
+
+=== `version`
+Displays the version of the indicated object:
+----
+$ oadm version
+----
+
+=== `help`
+Displays help about any command:
+----
+$ oadm help <command>
+----

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -48,20 +48,20 @@ option. Options include `--output` or `--credentials`.
 
 == Basic CLI Operations
 
-=== `new-project`
+=== new-project
 Creates a new project:
 
 ----
 $ oadm new-project <project_name>
 ----
 
-=== `policy`
+=== policy
 Manages authorization policies:
 ----
 $ oadm policy
 ----
 
-=== `groups`
+=== groups
 Manages groups:
 ----
 $ oadm groups
@@ -72,19 +72,19 @@ ifdef::openshift-enterprise[]
 
 == Install CLI Operations
 
-=== `router`
+=== router
 Installs a router:
 ----
 $ oadm router <router_name>
 ----
 
-=== `ipfailover`
+=== ipfailover
 Installs an IP failover group for a set of nodes:
 ----
 $ oadm ipfailover <ipfailover_config>
 ----
 
-=== `registry`
+=== registry
 Installs an integrated Docker registry:
 ----
 $ oadm registry
@@ -95,19 +95,19 @@ endif::[]
 
 == Maintenance CLI Operations
 
-=== `build-chain`
+=== build-chain
 Outputs the inputs and dependencies of any builds:
 ----
 $ oadm build-chain <image-stream>[:<tag>]
 ----
 
-=== `manage-node`
+=== manage-node
 Manages nodes. For example, list or evacuate pods, or mark them ready:
 ----
 $ oadm manage-node
 ----
 
-=== `prune`
+=== prune
 Removes older versions of resources from the server:
 ----
 $ oadm prune
@@ -118,19 +118,19 @@ ifdef::openshift-enterprise[]
 
 == Settings CLI Operations
 
-=== `config`
+=== config
 Changes kubelet configuration files:
 ----
 $ oadm config <subcommand>
 ----
 
-=== `create-kubeconfig`
+=== create-kubeconfig
 Creates a basic *_.kubeconfig_* file from client certificates:
 ----
 $ oadm create-kubeconfig
 ----
 
-=== `create-api-client-config`
+=== create-api-client-config
 Creates a configuration file for connecting to the server as a user:
 ----
 $ oadm create-api-client-config
@@ -140,37 +140,37 @@ $ oadm create-api-client-config
 
 ==  Advanced CLI Operations
 
-=== `create-bootstrap-project-template`
+=== create-bootstrap-project-template
 Creates a bootstrap project template:
 ----
 $ oadm create-bootstrap-project-template
 ----
 
-=== `create-bootstrap-policy-file`
+=== create-bootstrap-policy-file
 Creates the default bootstrap policy:
 ----
 $ oadm create-bootstrap-policy-file
 ----
 
-=== `create-login-template`
+=== create-login-template
 Creates a login template:
 ----
 $ oadm create-login-template
 ----
 
-=== `overwrite-policy`
+=== overwrite-policy
 Resets the policy to the default values:
 ----
 $ oadm overwrite-policy
 ----
 
-=== `create-node-config`
+=== create-node-config
 Creates a configuration bundle for a node:
 ----
 $ oadm create-node-config
 ----
 
-=== `ca`
+=== ca
 Manages certificates and keys:
 ----
 $ oadm ca
@@ -181,13 +181,13 @@ endif::[]
 
 == Other CLI Operations
 
-=== `version`
+=== version
 Displays the version of the indicated object:
 ----
 $ oadm version
 ----
 
-=== `help`
+=== help
 Displays help about any command:
 ----
 $ oadm help <command>

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -11,14 +11,28 @@ toc::[]
 
 == Overview
 
-This topic provides information on the administrator CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+This topic provides information on the administrator CLI operations and their
+syntax. You must link:get_started_cli.html[setup and login] with the CLI before
+you can perform these operations.
 
-The administrator CLI uses the `oadm` command, and is used for administrator operations. This differs from the link:basic_cli_operations.html[developer CLI], which uses the `oc` command, and is used for basic, project-level operations. 
+The administrator CLI uses the `oadm` command, and is used for administrator
+operations. This differs from the link:basic_cli_operations.html[developer CLI],
+which uses the `oc` command, and is used for basic, project-level operations.
 
-[[common-operations]]
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+Your login may or may not have access to the following administrative commands,
+depending on your account type.
+====
+endif::[]
+
+[[oadm-common-operations]]
 
 == Common Operations
-The administrator CLI allows interaction with the various objects that are managed by OpenShift. Many common `oadm` operations are invoked using the following syntax:
+The administrator CLI allows interaction with the various objects that are
+managed by OpenShift. Many common `oadm` operations are invoked using the
+following syntax:
 
 ----
 $ oadm <action> <option>
@@ -27,13 +41,14 @@ $ oadm <action> <option>
 This specifies:
 
 - An `<action>` to perform, such as `new-project` or `router`.
-- An available `<option>` to perform the action on as well as a value for the option. Options include `--output` or `--credentials`.
+- An available `<option>` to perform the action on as well as a value for the
+option. Options include `--output` or `--credentials`.
 
 [[basic-admin-cli-operations]]
 
 == Basic CLI Operations
 
-=== `new-project` 
+=== `new-project`
 Creates a new project:
 
 ----
@@ -52,6 +67,7 @@ Manages groups:
 $ oadm groups
 ----
 
+ifdef::openshift-enterprise[]
 [[install-cli-operations]]
 
 == Install CLI Operations
@@ -73,6 +89,7 @@ Installs an integrated Docker registry:
 ----
 $ oadm registry
 ----
+endif::[]
 
 [[maintenance-cli-operations]]
 
@@ -96,6 +113,7 @@ Removes older versions of resources from the server:
 $ oadm prune
 ----
 
+ifdef::openshift-enterprise[]
 [[settings-cli-operations]]
 
 == Settings CLI Operations
@@ -157,6 +175,7 @@ Manages certificates and keys:
 ----
 $ oadm ca
 ----
+endif::[]
 
 [[other-cli-operations]]
 

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -10,14 +10,19 @@
 toc::[]
 
 == Overview
-This topic provides information on the developer CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+This topic provides information on the developer CLI operations and their
+syntax. You must link:get_started_cli.html[setup and login] with the CLI before
+you can perform these operations.
 
-The developer CLI uses the `oc` command, and is used for project-level operations. This differs from the link:admin_cli_operations.html[administrator CLI], which uses the `oadm` command, and is used for more advanced, administrator operations.
+The developer CLI uses the `oc` command, and is used for project-level
+operations. This differs from the link:admin_cli_operations.html[administrator
+CLI], which uses the `oadm` command for more advanced, administrator operations.
 
 [[oc-common-operations]]
 
-== Common Operations
-The developer CLI allows interaction with the various objects that are managed by OpenShift. Many common `oc` operations are invoked using the following syntax:
+== Common Operations The developer CLI allows interaction with the various
+objects that are managed by OpenShift. Many common `oc` operations are invoked
+using the following syntax:
 
 ----
 $ oc <action> <object_type> <object_name_or_id>
@@ -26,11 +31,12 @@ $ oc <action> <object_type> <object_name_or_id>
 This specifies:
 
 - An `<action>` to perform, such as `get` or `describe`.
-- The `<object_type>` to perform the action on, such as `service` or the abbreviated `svc`.
+- The `<object_type>` to perform the action on, such as `service` or the
+abbreviated `svc`.
 - The `<object_name_or_id>` of the specified `<object_type>`.
 
-For example, the `oc get` operation returns a complete list of services that
-are currently defined:
+For example, the `oc get` operation returns a complete list of services that are
+currently defined:
 
 ====
 
@@ -72,15 +78,17 @@ endif::[]
 ifdef::openshift-enterprise[]
 3.0.2.0
 endif::[]
-did not have the ability to negotiate API versions against a server. So if you are using `oc` up to
+did not have the ability to negotiate API versions against a server. So if you
+are using `oc` up to
 ifdef::openshift-origin[]
 1.0.4
 endif::[]
 ifdef::openshift-enterprise[]
 3.0.1.0
 endif::[]
-with a server that only supports v1 or higher versions of the API, make sure to pass `--api-version` in order to
-point the `oc` client to the correct API endpoint. For example: `oc get svc --api-version=v1`.
+with a server that only supports v1 or higher versions of the API, make sure to
+pass `--api-version` in order to point the `oc` client to the correct API
+endpoint. For example: `oc get svc --api-version=v1`.
 ====
 
 [[object-types]]
@@ -115,45 +123,48 @@ syntax:
 == Basic CLI Operations
 The following table describes basic `oc` operations and their general syntax:
 
-=== `types`
+=== types
 Display an introduction to some core OpenShift concepts:
 ----
 $ oc types
 ----
 
-=== `login`
+=== login
 Log in to the OpenShift server:
 ----
 $ oc login
 ----
 
-=== `logout`
+=== logout
 End the current session:
 ----
 $ oc logout
 ----
 
-=== `new-project`
+=== new-project
 Create a new project:
 ----
 $ oc new-project <project_name>
 ----
 
-=== `new-app`
+=== new-app
 link:../dev_guide/new_app.html[Creates a new application] based on the source
 code in the current directory:
 ----
 $ oc new-app .
 ----
 
-=== `status`
+=== status
 Show an overview of the current project:
 ----
 $ oc status
 ----
 
-=== `project`
-Switch to another project. Run without options to display the current project. To view all projects you have access to run `oc projects`. Run without options to display the current project. To view all projects you have access to run `oc projects`.
+=== project
+Switch to another project. Run without options to display the current project.
+To view all projects you have access to run `oc projects`. Run without options
+to display the current project. To view all projects you have access to run `oc
+projects`.
 ----
 $ oc project <project_name>
 ----
@@ -162,19 +173,23 @@ $ oc project <project_name>
 
 == Application Modification CLI Operations
 
-=== `get`
-Return a list of objects for the specified link:#object-types[object type]. If the optional `<object_name_or_id>` is included in the request, then the list of results is filtered by that value.
+=== get
+Return a list of objects for the specified link:#object-types[object type]. If
+the optional `<object_name_or_id>` is included in the request, then the list of
+results is filtered by that value.
 ----
 $ oc get <object_type> [<object_name_or_id>]
 ----
 
-=== `describe`
-Returns information about the specific object returned by the query. A specific `<object_name_or_id>` must be provided. The actual information that is available varies as described in link:#object-types[object type].
+=== describe
+Returns information about the specific object returned by the query. A specific
+`<object_name_or_id>` must be provided. The actual information that is available
+varies as described in link:#object-types[object type].
 ----
 $ oc describe <object_type> <object_id>
 ----
 
-=== `edit`
+=== edit
 Edit the desired object type:
 ----
 $ oc edit <object_type>/<object_type_name>
@@ -190,32 +205,39 @@ $ oc edit <object_type>/<object_type_name> \
     -o <object_type_format>
 ----
 
-=== `env`
+=== env
 Update the desired object type with a new environment variable:
 ----
 $ oc env <object_type>/<object_type_name> <var_name>=<value>
 ----
 
-=== `volume`
+=== volume
 Modify a link:../dev_guide/volumes.html[volume]:
 ----
 $ oc volume <object_type>/<object_type_name> [--option]
 ----
 
-=== `label`
+=== label
 Update the labels on a object:
 ----
 $ oc label <object_type> <object_name_or_id> <label>
 ----
 
-=== `expose`
-Look up a service and expose it as a route. There is also the ability to expose a deployment configuration, replication controller, service, or pod as a new service on a specified port. If no labels are specified, the new object will re-use the labels from the object it exposes.
+=== expose
+Look up a service and expose it as a route. There is also the ability to expose
+a deployment configuration, replication controller, service, or pod as a new
+service on a specified port. If no labels are specified, the new object will
+re-use the labels from the object it exposes.
 ----
 $ oc expose <object_type> <object_name_or_id>
 ----
 
-=== `delete`
-Delete the specified object. An object configuration can also be passed in through STDIN. The `oc delete all -l <label>` operation deletes all objects matching the specified `<label>`, including the link:../architecture/core_concepts/deployments.html#replication-controllers[replication controller] so that pods are not re-created.
+=== delete
+Delete the specified object. An object configuration can also be passed in
+through STDIN. The `oc delete all -l <label>` operation deletes all objects
+matching the specified `<label>`, including the
+link:../architecture/core_concepts/deployments.html#replication-controllers[replication
+controller] so that pods are not re-created.
 ----
 $ oc delete -f <file_path>
 ----
@@ -232,31 +254,38 @@ $ oc delete all -l <label>
 [[build-and-deployment-cli-operations]]
 
 == Build and Deployment CLI Operations
-One of the fundamental capabilities of OpenShift is the ability to build applications into a container from source.
+One of the fundamental capabilities of OpenShift is the ability to build
+applications into a container from source.
 
-OpenShift provides CLI access to inspect and manipulate link:../dev_guide/deployments.html[deployment configurations] using standard `oc` resource operations, such as `get`, `create`, and `describe`.
+OpenShift provides CLI access to inspect and manipulate
+link:../dev_guide/deployments.html[deployment configurations] using standard
+`oc` resource operations, such as `get`, `create`, and `describe`.
 
-=== `start-build`
+=== start-build
 Manually start the build process with the specified build configuration file:
 ----
 $ oc start-build <buildconfig_name>
 ----
-Manually start the build process by specifying the name of a previous build as a starting point:
+Manually start the build process by specifying the name of a previous build as a
+starting point:
 ----
 $ oc start-build --from-build=<build_name>
 ----
-Manually start the build process by specifying either a configuration file or the name of a previous build and retrieve its build logs:
+Manually start the build process by specifying either a configuration file or
+the name of a previous build and retrieve its build logs:
 ----
 $ oc start-build --from-build=<build_name> --follow
 ----
 ----
 $ oc start-build <buildconfig_name> --follow
 ----
-Wait for a build to complete and exit with a non-zero return code if the build fails:
+Wait for a build to complete and exit with a non-zero return code if the build
+fails:
 ----
 $ oc start-build --from-build=<build_name> --wait
 ----
-Set or override environment variables for the current build without changing the build configuration. Alternatively, use `-e`.
+Set or override environment variables for the current build without changing the
+build configuration. Alternatively, use `-e`.
 ----
 $ oc start-build --env <var_name>=<value>
 ----
@@ -264,7 +293,8 @@ Set or override the default build log level output during the build:
 ----
 $ oc start-build --build-loglevel [0-5]
 ----
-Specify the source code commit identifier the build should use; requires a build based on a Git repository:
+Specify the source code commit identifier the build should use; requires a build
+based on a Git repository:
 ----
 $ oc start-build --commit=<hash>
 ----
@@ -276,11 +306,13 @@ Archive `<dir_name>` and build with it as the binary input:
 ----
 $ oc start-build --from-dir=<dir_name>
 ----
-Use `<file_name>` as the binary input for the build. This file must be the only one in the build source. For example, *_pom.xml_* or *_Dockerfile_*.
+Use `<file_name>` as the binary input for the build. This file must be the only
+one in the build source. For example, *_pom.xml_* or *_Dockerfile_*.
 ----
 $ oc start-build --from-file=<file_name>
 ----
-The path to a local source code repository to use as the binary input for a build:
+The path to a local source code repository to use as the binary input for a
+build:
 ----
 $ oc start-build --from-repo=<path_to_repo>
 ----
@@ -292,53 +324,63 @@ The contents of the post-receive hook to trigger a build:
 ----
 $ oc start-build --git-post-receive=<contents>
 ----
-The path to the Git repository for post-receive; defaults to the current directory:
+The path to the Git repository for post-receive; defaults to the current
+directory:
 ----
 $ oc start-build --git-repository=<path_to_repo>
 ----
-List the webhooks for the specified build configuration or build; accepts `all`, `generic`, or `github`:
+List the webhooks for the specified build configuration or build; accepts `all`,
+`generic`, or `github`:
 ----
 $ oc start-build --list-webhooks
 ----
 
-=== `deploy`
-View a link:../dev_guide/deployments.html[deployment], or manually start, cancel, or retry a deployment:
+=== deploy
+View a link:../dev_guide/deployments.html[deployment], or manually start,
+cancel, or retry a deployment:
 ----
 $ oc deploy <deploymentconfig>
 ----
 
-=== `rollback`
-Perform a link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback]:
+=== rollback
+Perform a
+link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback]:
 ----
 $ oc rollback <deployment_name>
 ----
 
-=== `new-build`
-Create a build config based on the source code in the current Git repository (with a public remote) and a Docker image:
+=== new-build
+Create a build configuration based on the source code in the current Git
+repository (with a public remote) and a Docker image:
 ----
 $ oc new-build .
 ----
 
-=== `cancel-build`
+=== cancel-build
 Stop a build that is in progress:
 ----
 $ oc cancel-build <build_name>
 ----
 
-=== `import-image`
+=== import-image
 Import tag and image information from an external Docker image repository:
 ----
 $ oc import-image <imagestream>
 ----
 
-=== `scale`
-Set the number of desired replicas for a link:../architecture/core_concepts/deployments.html#replication-controllers[replication controller] or a link:../dev_guide/deployments.html[deployment configuration] to the number of specified replicas:
+=== scale
+Set the number of desired replicas for a
+link:../architecture/core_concepts/deployments.html#replication-controllers[replication
+controller] or a link:../dev_guide/deployments.html[deployment configuration] to
+the number of specified replicas:
 ----
 $ oc scale <object_type> <object_id> --replicas=<#_of_replicas>
 ----
 
-=== `tag`
-Take an existing tag or image from an image stream, or a Docker image pull spec, and set it as the most recent image for a tag in one or more other image streams:
+=== tag
+Take an existing tag or image from an image stream, or a Docker image pull spec,
+and set it as the most recent image for a tag in one or more other image
+streams:
 ----
 $ oc tag <current_image> <image_stream>
 ----
@@ -347,26 +389,37 @@ $ oc tag <current_image> <image_stream>
 
 == Advanced Commands
 
-=== `create`
-Parse a configuration file and create one or more OpenShift objects based on the file contents. The `-f` flag can be passed multiple times with different file or directory paths. When the flag is passed multiple times, `oc create` iterates through each one, creating the objects described in all of the indicated files. Any existing resources are ignored.
+=== create
+Parse a configuration file and create one or more OpenShift objects based on the
+file contents. The `-f` flag can be passed multiple times with different file or
+directory paths. When the flag is passed multiple times, `oc create` iterates
+through each one, creating the objects described in all of the indicated files.
+Any existing resources are ignored.
 ----
 $ oc create -f <file_or_dir_path>
 ----
 
-=== `update`
-Attempt to modify an existing object based on the contents of the specified configuration file. The `-f` flag can be passed multiple times with different file or directory paths. When the flag is passed multiple times, `oc update` iterates through each one, updating the objects described in all of the indicated files.
+=== update
+Attempt to modify an existing object based on the contents of the specified
+configuration file. The `-f` flag can be passed multiple times with different
+file or directory paths. When the flag is passed multiple times, `oc update`
+iterates through each one, updating the objects described in all of the
+indicated files.
 ----
 $ oc update -f <file_or_dir_path>
 ----
 
-=== `process`
-Transform a project link:../dev_guide/templates.html[template] into a project configuration file:
+=== process
+Transform a project link:../dev_guide/templates.html[template] into a project
+configuration file:
 ----
 $ oc process -f <template_file_path>
 ----
 
-=== `run`
-Create and run a particular image, possibly replicated. Create a deployment configuration to manage the created container(s). You can choose to run in the foreground for an interactive container execution.
+=== run
+Create and run a particular image, possibly replicated. Create a deployment
+configuration to manage the created container(s). You can choose to run in the
+foreground for an interactive container execution.
 ----
 $ oc run NAME --image=<image> \
     [--port=<port>] \
@@ -376,19 +429,19 @@ $ oc run NAME --image=<image> \
     [options]
 ----
 
-=== `export`
+=== export
 Export resources to be used elsewhere:
 ----
 $ oc export <object_type> [--options]
 ----
 
-=== `policy`
+=== policy
 Manage authorization policies:
 ----
 $ oc policy [--options]
 ----
 
-=== `secrets`
+=== secrets
 Configure link:../dev_guide/secrets.html[secrets]:
 ----
 $ oc secrets [--options] path/to/ssh_key
@@ -398,37 +451,41 @@ $ oc secrets [--options] path/to/ssh_key
 
 == Troubleshooting and Debugging CLI Operations
 
-=== `logs`
-Retrieve the log output for a specific build, deployment, or pod. This command works for builds, build configurations, deployment configurations, and pods.
+=== logs
+Retrieve the log output for a specific build, deployment, or pod. This command
+works for builds, build configurations, deployment configurations, and pods.
 ----
 $ oc logs -f <pod_name>
 ----
 
-=== `exec`
-Execute a command in an already-running container. You can optionally specify a container ID, otherwise it defaults to the first container.
+=== exec
+Execute a command in an already-running container. You can optionally specify a
+container ID, otherwise it defaults to the first container.
 ----
 $ oc exec <pod_ID> [-c <container_ID>] <command>
 ----
 
-=== `rsh`
+=== rsh
 Open a remote shell session to a container:
 ----
 $ oc rsh <pod_ID>
 ----
 
-=== `rsync`
-Copy contents of local directory to a directory in an already-running pod container. It will default to the first container if none is specified.
+=== rsync
+Copy contents of local directory to a directory in an already-running pod
+container. It will default to the first container if none is specified.
 ----
 $ oc rsync <local_dir> <pod_ID>:<pod_dir> -c <container_ID>
 ----
 
-=== `port-forward`
-link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a pod:
+=== port-forward
+link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a
+pod:
 ----
 $ oc port-forward <pod_ID> <first_port_ID> <second_port_ID>
 ----
 
-=== `proxy`
+=== proxy
 Run a proxy to the Kubernetes API server:
 ----
 $ oc proxy --port=<port_ID> --www=<static_directory>
@@ -438,6 +495,6 @@ $ oc proxy --port=<port_ID> --www=<static_directory>
 ====
 link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
 `oc exec` command does not work when accessing privileged containers. Instead,
-administrators can SSH into a node host, then use the `docker exec`
-command on the desired container.
+administrators can SSH into a node host, then use the `docker exec` command on
+the desired container.
 ====

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -1,4 +1,4 @@
-= CLI Operations
+= Developer CLI Operations
 {product-author}
 {product-version}
 :data-uri:
@@ -10,15 +10,14 @@
 toc::[]
 
 == Overview
-This topic provides information on the CLI operations and their syntax. You must
-link:get_started_cli.html[setup and login] with the CLI before you can perform
-these operations.
+This topic provides information on the developer CLI operations and their syntax. You must link:get_started_cli.html[setup and login] with the CLI before you can perform these operations.
+
+The developer CLI uses the `oc` command, and is used for project-level operations. This differs from the link:admin_cli_operations.html[administrator CLI], which uses the `oadm` command, and is used for more advanced, administrator operations.
 
 [[common-operations]]
 
 == Common Operations
-The CLI allows interaction with the various objects that are managed by
-OpenShift. Many common `oc` operations are invoked using the following syntax:
+The developer CLI allows interaction with the various objects that are managed by OpenShift. Many common `oc` operations are invoked using the following syntax:
 
 ----
 $ oc <action> <object_type> <object_name_or_id>
@@ -26,9 +25,9 @@ $ oc <action> <object_type> <object_name_or_id>
 
 This specifies:
 
-- An `_<action>_` to perform, such as `get` or `describe`.
-- The `_<object_type>_` to perform the action on, such as `service` or the abbreviated `svc`.
-- The `_<object_name_or_id>_` of the specified `_<object_type>_`.
+- An `<action>` to perform, such as `get` or `describe`.
+- The `<object_type>` to perform the action on, such as `service` or the abbreviated `svc`.
+- The `<object_name_or_id>` of the specified `<object_type>`.
 
 For example, the `oc get` operation returns a complete list of services that
 are currently defined:
@@ -84,338 +83,6 @@ with a server that only supports v1 or higher versions of the API, make sure to 
 point the `oc` client to the correct API endpoint. For example: `oc get svc --api-version=v1`.
 ====
 
-[[basic-cli-operations]]
-
-== Basic CLI Operations
-The following table describes basic `oc` operations and their general syntax:
-
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-|`types`
-|`oc types`
-|Display an introduction to some core OpenShift concepts.
-
-|`login`
-|`oc login`
-|Log in to the OpenShift server.
-
-|`logout`
-|`oc logout`
-|End the current session.
-
-|`new-project`
-|`oc new-project <project_name>`
-|Create a new project.
-
-|`new-app`
-|`oc new-app .`
-|link:../dev_guide/new_app.html[Creates a new application] based on the source
-code in the current directory.
-
-|`status`
-|`oc status`
-|Show an overview of the current project.
-
-|`project`
-|`oc project <project_name>`
-|Switch to another project. Run without options to display the current project.
-To view all projects you have access to run `oc projects`.
-
-|===
-
-[[application-modification-cli-operations]]
-
-== Application Modification CLI Operations
-
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-|`get`
-|`oc get <object_type> [<object_name_or_id>]`
-|Return a list of objects for the specified link:#object-types[object type]. If
-the optional `_<object_name_or_id>_` is included in the request, then the list
-of results is filtered by that value.
-
-|`describe`
-|`oc describe <object_type> <object_id>`
-|Returns information about the specific object returned by the query. A specific
-`_<object_name_or_id>_` must be provided. The actual information that is
-available varies as described in link:#object-types[object type].
-
-.3+|`edit`
-|`oc edit <object_type>/<object_type_name>`
-|Edit the desired object type.
-
-|`OC_EDITOR="<text_editor>" oc edit \`
-`<object_type>/<object_type_name>`
-|Edit the desired object type with a specified text editor.
-
-|`oc edit <object_type>/<object_type_name> \`
-`--output-version=<object_type_version> \`
-`-o <object_type_format>`
-|Edit the desired object in a specified format (eg: JSON).
-
-|`env`
-|`oc env <object_type>/<object_type_name> \`
-`<var_name>=<value>`
-|Update the desired object type with a new environment variable.
-
-|`volume`
-|`oc volume <object_type>/<object_type_name> \`
-`[--option]`
-|Modify a link:../dev_guide/volumes.html[volume].
-
-|`label`
-|`oc label <object_type> <object_name_or_id> \`
-`<label>`
-|Update the labels on a object.
-
-|`expose`
-|`oc expose <object_type> <object_name_or_id>`
-|Look up a service and expose it as a route. There is also the ability to
-expose a deployment configuration, replication controller, service, or pod as a
-new service on a specified port. If no labels are specified, the new object will
-re-use the labels from the object it exposes.
-
-|`delete`
-a|`oc delete -f <file_path>`
-
-`oc delete <object_type> <object_name_or_id>`
-
-`oc delete <object_type> -l <label>`
-
-`oc delete all -l <label>`
-.^|Delete the specified object. An object configuration can also be passed in
-through STDIN. The `oc delete all -l <label>` operation deletes all objects
-matching the specified `<label>`, including the
-link:../architecture/core_concepts/deployments.html#replication-controllers[replication
-controller] so that pods are not re-created.
-
-|===
-
-[[build-and-deployment-cli-operations]]
-
-== Build and Deployment CLI Operations
-One of the fundamental capabilities of OpenShift is the ability to build
-applications into a container from source. The following table describes the CLI
-operations for working with application builds:
-
-OpenShift provides CLI access to inspect and manipulate
-link:../dev_guide/deployments.html[deployment configurations] using standard
-`oc` resource operations, such as `get`, `create`, and `describe`.
-
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-.15+|`start-build`
-|`oc start-build <buildconfig_name>`
-|Manually start the build process with the specified build configuration file.
-
-|`oc start-build --from-build=<build_name>`
-|Manually start the build process by specifying the name of a previous build as
-a starting point.
-
-|`oc start-build <buildconfig_name> --follow`
-
-`oc start-build \`
-`--from-build=<build_name> --follow`
-|Manually start the build process by specifying either a configuration file or
-the name of a previous build and retrieve its build logs.
-
-|`oc start-build \`
-`--from-build=<build_name> --wait`
-|Wait for a build to complete and exit with a non-zero return code if the build
-fails.
-
-|`oc start-build --env <var_name>=<value>`
-|Set or override environment variables for the current build without changing
-the build configuration. Alternatively, use `-e`.
-
-|`oc start-build --build-loglevel [0-5]`
-|Set or override the default build log level output during the build.
-
-|`oc start-build --commit=<hash>`
-|Specify the source code commit identifier the build should use; requires a
-build based on a Git repository.
-
-|`oc start-build --from-build=<build_name>`
-|Re-run build with name `<build_name>`.
-
-|`oc start-build --from-dir=<dir_name>`
-|Archive `<dir_name>` and build with it as the binary input.
-
-|`oc start-build --from-file=<file_name>`
-|Use <file_name> as the binary input for the build. This file must be the only
-one in the build source. For example, *_pom.xml_* or *_Dockerfile_*.
-
-|`oc start-build --from-repo=<path_to_repo>`
-|The path to a local source code repository to use as the binary input for a build.
-
-|`oc start-build --from-webhook=<webhook_URL>`
-|Specify a webhook URL for an existing build configuration to trigger.
-
-|`oc start-build --git-post-receive=<contents>`
-|The contents of the post-receive hook to trigger a build.
-
-|`oc start-build --git-repository=<path_to_repo>`
-|The path to the Git repository for post-receive; defaults to the current directory.
-
-|`oc start-build --list-webhooks`
-|List the webhooks for the specified build configuration or build; accepts
-`all`, `generic`, or `github`.
-
-|`deploy`
-|`oc deploy <deploymentconfig>`
-|View a link:../dev_guide/deployments.html[deployment], or manually start,
-cancel, or retry a deployment.
-
-|`rollback`
-|`oc rollback <deployment_name>`
-|Perform a
-link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback].
-
-|`new-build`
-|`oc new-build .`
-|Create a build config based on the source code in the current Git repository
-(with a public remote) and a Docker image
-
-|`cancel-build`
-|`oc cancel-build <build_name>`
-|Stop a build that is in progress.
-
-|`import-image`
-|`oc import-image <imagestream>`
-|Import tag and image information from an external Docker image repository.
-
-|`scale`
-|`oc scale <object_type> <object_id> \`
-`--replicas=<#_of_replicas>`
-|Set the number of desired replicas for a
-link:../architecture/core_concepts/deployments.html#replication-controllers[replication
-controller] or a link:../dev_guide/deployments.html[deployment configuration] to
-the number of specified replicas.
-
-|`tag`
-|`oc tag <current_image> <image_stream>`
-|Take an existing tag or image from an image stream, or a Docker image pull
-spec, and set it as the most recent image for a tag in one or more other image
-streams.
-
-|===
-
-[[advanced-commands]]
-
-== Advanced Commands
-
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-|`create`
-|`oc create -f <file_or_dir_path>`
-|Parse a configuration file and create one or more OpenShift objects based on
-the file contents. The `-f` flag can be passed multiple times with different
-file or directory paths. When the flag is passed multiple times, `oc create`
-iterates through each one, creating the objects described in all of the
-indicated files. Any existing resources are ignored.
-
-|`update`
-|`oc update -f <file_or_dir_path>`
-|Attempt to modify an existing object based on the contents of the specified
-configuration file. The `-f` flag can be passed multiple times with different
-file or directory paths. When the flag is passed multiple times, `oc update`
-iterates through each one, updating the objects described in all of the
-indicated files.
-
-|`process`
-|`oc process -f <template_file_path>`
-|Transform a project link:../dev_guide/templates.html[template] into a project
-configuration file.
-
-|`run`
-|`oc run NAME --image=<image> \`
-`[--port=<port>] \`
-`[--replicas=<replicas>] \`
-`[--dry-run=<bool>] \`
-`[--overrides=<inline-json>] \`
-`[options]`
-|Create and run a particular image, possibly replicated. Create a deployment
-configuration to manage the created container(s). You can choose to run in the
-foreground for an interactive container execution.
-
-|`export`
-|`oc export <object_type> [--options]`
-|Export resources to be used elsewhere.
-
-|`policy`
-|`oc policy [--options]`
-|Manage authorization policies.
-
-|`secrets`
-|`oc secrets [--options] path/to/ssh_key`
-|Configure link:../dev_guide/secrets.html[secrets].
-
-|===
-
-[[troubleshooting-and-debugging-cli-operations]]
-
-== Troubleshooting and Debugging CLI Operations
-
-[cols=".^2,.^5,8",options="header"]
-|===
-
-|Operation |Syntax |Description
-
-
-|`logs`
-|`oc logs -f <pod_name>`
-|Retrieve the log output for a specific build, deployment, or pod. This command
-works for builds, build configurations, deployment configurations, and pods.
-
-|`exec`
-|`oc exec <pod_ID> \`
-`[-c <container_ID>] <command>`
-|Execute a command in an already-running container. You can optionally specify a
-container ID, otherwise it defaults to the first container.
-
-|`rsh`
-|`oc rsh <pod_ID>`
-|Open a remote shell session to a container.
-
-|`rsync`
-|`oc rsync <local_dir> <pod_ID>:<pod_dir> \`
-`-c <container_ID>`
-|Copy contents of local directory to a directory in an already-running pod
-container. It will default to the first container if none is specified.
-
-|`port-forward`
-|`oc port-forward <pod_ID> \`
-`<first_port_ID> <second_port_ID>`
-|link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a pod.
-
-|`proxy`
-|`oc proxy --port=<port_ID> \`
-`--www=<static_directory>`
-|Run a proxy to the Kubernetes API server
-
-|===
-
-[IMPORTANT]
-====
-link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. Instead,
-administrators can SSH into a node host, then use the `docker exec`
-command on the desired container.
-====
-
 [[object-types]]
 
 == Object Types
@@ -442,3 +109,335 @@ syntax:
 |`persistentVolume` |`pv`
 |`persistentVolumeClaim` |`pvc`
 |===
+
+[[basic-cli-operations]]
+
+== Basic CLI Operations
+The following table describes basic `oc` operations and their general syntax:
+
+=== `types`
+Display an introduction to some core OpenShift concepts:
+----
+$ oc types
+----
+
+=== `login`
+Log in to the OpenShift server:
+----
+$ oc login
+----
+
+=== `logout`
+End the current session:
+----
+$ oc logout
+----
+
+=== `new-project`
+Create a new project:
+----
+$ oc new-project <project_name>
+----
+
+=== `new-app`
+link:../dev_guide/new_app.html[Creates a new application] based on the source
+code in the current directory:
+----
+$ oc new-app .
+----
+
+=== `status`
+Show an overview of the current project:
+----
+$ oc status
+----
+
+=== `project`
+Switch to another project. Run without options to display the current project. To view all projects you have access to run `oc projects`. Run without options to display the current project. To view all projects you have access to run `oc projects`.
+----
+$ oc project <project_name>
+----
+
+[[application-modification-cli-operations]]
+
+== Application Modification CLI Operations
+
+=== `get`
+Return a list of objects for the specified link:#object-types[object type]. If the optional `<object_name_or_id>` is included in the request, then the list of results is filtered by that value.
+----
+$ oc get <object_type> [<object_name_or_id>]
+----
+
+=== `describe`
+Returns information about the specific object returned by the query. A specific `<object_name_or_id>` must be provided. The actual information that is available varies as described in link:#object-types[object type].
+----
+$ oc describe <object_type> <object_id>
+----
+
+=== `edit`
+Edit the desired object type:
+----
+$ oc edit <object_type>/<object_type_name>
+----
+Edit the desired object type with a specified text editor:
+----
+$ OC_EDITOR="<text_editor>" oc edit <object_type>/<object_type_name>
+----
+Edit the desired object in a specified format (eg: JSON):
+----
+$ oc edit <object_type>/<object_type_name> \
+    --output-version=<object_type_version> \
+    -o <object_type_format>
+----
+
+=== `env`
+Update the desired object type with a new environment variable:
+----
+$ oc env <object_type>/<object_type_name> <var_name>=<value>
+----
+
+=== `volume`
+Modify a link:../dev_guide/volumes.html[volume]:
+----
+$ oc volume <object_type>/<object_type_name> [--option]
+----
+
+=== `label`
+Update the labels on a object:
+----
+$ oc label <object_type> <object_name_or_id> <label>
+----
+
+=== `expose`
+Look up a service and expose it as a route. There is also the ability to expose a deployment configuration, replication controller, service, or pod as a new service on a specified port. If no labels are specified, the new object will re-use the labels from the object it exposes.
+----
+$ oc expose <object_type> <object_name_or_id>
+----
+
+=== `delete`
+Delete the specified object. An object configuration can also be passed in through STDIN. The `oc delete all -l <label>` operation deletes all objects matching the specified `<label>`, including the link:../architecture/core_concepts/deployments.html#replication-controllers[replication controller] so that pods are not re-created.
+----
+$ oc delete -f <file_path>
+----
+----
+$ oc delete <object_type> <object_name_or_id>
+----
+----
+$ oc delete <object_type> -l <label>
+----
+----
+$ oc delete all -l <label>
+----
+
+[[build-and-deployment-cli-operations]]
+
+== Build and Deployment CLI Operations
+One of the fundamental capabilities of OpenShift is the ability to build applications into a container from source.
+
+OpenShift provides CLI access to inspect and manipulate link:../dev_guide/deployments.html[deployment configurations] using standard `oc` resource operations, such as `get`, `create`, and `describe`.
+
+=== `start-build`
+Manually start the build process with the specified build configuration file:
+----
+$ oc start-build <buildconfig_name>
+----
+Manually start the build process by specifying the name of a previous build as a starting point:
+----
+$ oc start-build --from-build=<build_name>
+----
+Manually start the build process by specifying either a configuration file or the name of a previous build and retrieve its build logs:
+----
+$ oc start-build --from-build=<build_name> --follow
+----
+----
+$ oc start-build <buildconfig_name> --follow
+----
+Wait for a build to complete and exit with a non-zero return code if the build fails:
+----
+$ oc start-build --from-build=<build_name> --wait
+----
+Set or override environment variables for the current build without changing the build configuration. Alternatively, use `-e`.
+----
+$ oc start-build --env <var_name>=<value>
+----
+Set or override the default build log level output during the build:
+----
+$ oc start-build --build-loglevel [0-5]
+----
+Specify the source code commit identifier the build should use; requires a build based on a Git repository:
+----
+$ oc start-build --commit=<hash>
+----
+Re-run build with name `<build_name>`:
+----
+$ oc start-build --from-build=<build_name>
+----
+Archive `<dir_name>` and build with it as the binary input:
+----
+$ oc start-build --from-dir=<dir_name>
+----
+Use `<file_name>` as the binary input for the build. This file must be the only one in the build source. For example, *_pom.xml_* or *_Dockerfile_*.
+----
+$ oc start-build --from-file=<file_name>
+----
+The path to a local source code repository to use as the binary input for a build:
+----
+$ oc start-build --from-repo=<path_to_repo>
+----
+Specify a webhook URL for an existing build configuration to trigger:
+----
+$ oc start-build --from-webhook=<webhook_URL>
+----
+The contents of the post-receive hook to trigger a build:
+----
+$ oc start-build --git-post-receive=<contents>
+----
+The path to the Git repository for post-receive; defaults to the current directory:
+----
+$ oc start-build --git-repository=<path_to_repo>
+----
+List the webhooks for the specified build configuration or build; accepts `all`, `generic`, or `github`:
+----
+$ oc start-build --list-webhooks
+----
+
+=== `deploy`
+View a link:../dev_guide/deployments.html[deployment], or manually start, cancel, or retry a deployment:
+----
+$ oc deploy <deploymentconfig>
+----
+
+=== `rollback`
+Perform a link:../dev_guide/deployments.html#rolling-back-a-deployment[rollback]:
+----
+$ oc rollback <deployment_name>
+----
+
+=== `new-build`
+Create a build config based on the source code in the current Git repository (with a public remote) and a Docker image:
+----
+$ oc new-build .
+----
+
+=== `cancel-build`
+Stop a build that is in progress:
+----
+$ oc cancel-build <build_name>
+----
+
+=== `import-image`
+Import tag and image information from an external Docker image repository:
+----
+$ oc import-image <imagestream>
+----
+
+=== `scale`
+Set the number of desired replicas for a link:../architecture/core_concepts/deployments.html#replication-controllers[replication controller] or a link:../dev_guide/deployments.html[deployment configuration] to the number of specified replicas:
+----
+$ oc scale <object_type> <object_id> --replicas=<#_of_replicas>
+----
+
+=== `tag`
+Take an existing tag or image from an image stream, or a Docker image pull spec, and set it as the most recent image for a tag in one or more other image streams:
+----
+$ oc tag <current_image> <image_stream>
+----
+
+[[advanced-commands]]
+
+== Advanced Commands
+
+=== `create`
+Parse a configuration file and create one or more OpenShift objects based on the file contents. The `-f` flag can be passed multiple times with different file or directory paths. When the flag is passed multiple times, `oc create` iterates through each one, creating the objects described in all of the indicated files. Any existing resources are ignored.
+----
+$ oc create -f <file_or_dir_path>
+----
+
+=== `update`
+Attempt to modify an existing object based on the contents of the specified configuration file. The `-f` flag can be passed multiple times with different file or directory paths. When the flag is passed multiple times, `oc update` iterates through each one, updating the objects described in all of the indicated files.
+----
+$ oc update -f <file_or_dir_path>
+----
+
+=== `process`
+Transform a project link:../dev_guide/templates.html[template] into a project configuration file:
+----
+$ oc process -f <template_file_path>
+----
+
+=== `run`
+Create and run a particular image, possibly replicated. Create a deployment configuration to manage the created container(s). You can choose to run in the foreground for an interactive container execution.
+----
+$ oc run NAME --image=<image> \
+    [--port=<port>] \
+    [--replicas=<replicas>] \
+    [--dry-run=<bool>] \
+    [--overrides=<inline-json>] \
+    [options]
+----
+
+=== `export`
+Export resources to be used elsewhere:
+----
+$ oc export <object_type> [--options]
+----
+
+=== `policy`
+Manage authorization policies:
+----
+$ oc policy [--options]
+----
+
+=== `secrets`
+Configure link:../dev_guide/secrets.html[secrets]:
+----
+$ oc secrets [--options] path/to/ssh_key
+----
+
+[[troubleshooting-and-debugging-cli-operations]]
+
+== Troubleshooting and Debugging CLI Operations
+
+=== `logs`
+Retrieve the log output for a specific build, deployment, or pod. This command works for builds, build configurations, deployment configurations, and pods.
+----
+$ oc logs -f <pod_name>
+----
+
+=== `exec`
+Execute a command in an already-running container. You can optionally specify a container ID, otherwise it defaults to the first container.
+----
+$ oc exec <pod_ID> [-c <container_ID>] <command>
+----
+
+=== `rsh`
+Open a remote shell session to a container:
+----
+$ oc rsh <pod_ID>
+----
+
+=== `rsync`
+Copy contents of local directory to a directory in an already-running pod container. It will default to the first container if none is specified.
+----
+$ oc rsync <local_dir> <pod_ID>:<pod_dir> -c <container_ID>
+----
+
+=== `port-forward`
+link:../dev_guide/port_forwarding.html[Forward one or more local ports] to a pod:
+----
+$ oc port-forward <pod_ID> <first_port_ID> <second_port_ID>
+----
+
+=== `proxy`
+Run a proxy to the Kubernetes API server:
+----
+$ oc proxy --port=<port_ID> --www=<static_directory>
+----
+
+[IMPORTANT]
+====
+link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
+`oc exec` command does not work when accessing privileged containers. Instead,
+administrators can SSH into a node host, then use the `docker exec`
+command on the desired container.
+====

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -20,7 +20,8 @@ CLI], which uses the `oadm` command for more advanced, administrator operations.
 
 [[oc-common-operations]]
 
-== Common Operations The developer CLI allows interaction with the various
+== Common Operations
+The developer CLI allows interaction with the various
 objects that are managed by OpenShift. Many common `oc` operations are invoked
 using the following syntax:
 

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -14,7 +14,7 @@ This topic provides information on the developer CLI operations and their syntax
 
 The developer CLI uses the `oc` command, and is used for project-level operations. This differs from the link:admin_cli_operations.html[administrator CLI], which uses the `oadm` command, and is used for more advanced, administrator operations.
 
-[[common-operations]]
+[[oc-common-operations]]
 
 == Common Operations
 The developer CLI allows interaction with the various objects that are managed by OpenShift. Many common `oc` operations are invoked using the following syntax:

--- a/cli_reference/revhistory_cli_reference.adoc
+++ b/cli_reference/revhistory_cli_reference.adoc
@@ -5,6 +5,24 @@
 :icons:
 :experimental:
 
+== Mon Feb 01 2016
+
+//tag::cli_reference_mon_feb_01_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../cli_reference/admin_cli_operations.html[Administrator CLI Operations]
+|New topic providing a reference for administrator CLI commands.
+
+|link:../cli_reference/basic_cli_operations.html[Developer CLI Operations]
+|Changed the format for listing commands from tables to individual subsections
+per command.
+
+|===
+// end::cli_reference_mon_feb_01_2016[]
+
 == Mon Dec 21 2015
 
 OpenShift Dedicated 3.1 release.

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -12,8 +12,16 @@
 toc::[]
 
 == Overview
-A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build] is a process of creating
-runnable images to be used on OpenShift. There are three build strategies:
+
+A link:../architecture/core_concepts/builds_and_image_streams.html#builds[build]
+is the process of transforming input parameters into a resulting object. Most
+often, the process is used to transform source code into a runnable image.
+
+Build configurations are characterized by a strategy and one or more sources.
+The strategy determines the aforementioned process, while the sources provide
+its input.
+
+There are three build strategies:
 
 - Source-To-Image (S2I)
 (link:../architecture/core_concepts/builds_and_image_streams.html#source-build[description],
@@ -24,6 +32,19 @@ link:#docker-strategy-options[options])
 - Custom
 (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description],
 link:#custom-strategy-options[options])
+
+And there are three types of build source:
+
+- link:#source-code[Git]
+- link:#dockerfile-source[Dockerfile]
+- link:#binary-source[Binary]
+
+It is up to each build strategy to consider or ignore a certain type of source,
+as well as to determine how it is to be used.
+
+Binary and Git are mutually exclusive source types, while Dockerfile can be used
+by itself or together with Git and Binary.
+
 
 [[defining-a-buildconfig]]
 
@@ -70,7 +91,8 @@ image tag or the source code changes:
       "type": "Git",
       "git": {
         "uri": "git://github.com/openshift/ruby-hello-world.git"
-      }
+      },
+      "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example"
     },
     "strategy": { <4>
       "type": "Source",
@@ -95,8 +117,11 @@ image tag or the source code changes:
 *ruby-sample-build*.
 <2> You can specify a list of link:#build-triggers[triggers], which cause a new
 build to be created.
-<3> The `*source*` section defines the source code repository location. You can
-provide additional options, such as `*sourceSecret*` or `*contextDir*` here.
+<3> The `*source*` section defines the source of the build. The source type
+determines the primary source of input, and can be either `*Git*`, to point to a
+code repository location, `*Dockerfile*`, to build from an inline Dockerfile, or
+`*Binary*`, to accept binary payloads. It is possible to have multiple sources
+at once, refer to the documentation for each source type for details.
 <4> The `*strategy*` section describes the build strategy used to execute the
 build. You can specify `*Source*`, `*Docker*` and `*Custom*` strategies here.
 This above example uses the `*ruby-20-centos7*` Docker image that
@@ -529,33 +554,41 @@ For example, defining a custom HTTP proxy to be used during build:
 
 == Git Repository Source Options
 
-The source code location is one of the required parameters for the
-`*BuildConfig*`. The build uses this location and fetches the source code that
-is later built. The source code location definition is part of the
-`*spec*` section in the `*BuildConfig*`:
+When the `*BuildConfig.spec.source.type*` is `*Git*`, a Git repository is
+required, and an inline Dockerfile is optional.
+
+The source code is fetched from the location specified and, if the
+`*BuildConfig.spec.source.dockerfile*` field is specified, the inline Dockerfile
+replaces the one in the `*contextDir*` of the Git repository.
+
+The source definition is part of the `*spec*` section in the `*BuildConfig*`:
 
 ====
 
 ----
 {
   "source" : {
-    "type" : "Git", <1>
-    "git" : { <2>
-      "uri": "git://github.com/openshift/ruby-hello-world.git"
+    "type" : "Git",
+    "git" : { <1>
+      "uri": "git://github.com/openshift/ruby-hello-world.git",
+      "ref": "master"
     },
-    "contextDir": "app/dir", <3>
+    "contextDir": "app/dir", <2>
+    "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example" <3>
   },
 }
 ----
 
-<1> The `*type*` field describes which SCM is used to fetch your source code.
-<2> The `*git*` field contains the URI to the remote Git repository of the
+<1> The `*git*` field contains the URI to the remote Git repository of the
 source code. Optionally, specify the `*ref*` field to check out a specific Git
 reference. A valid `*ref*` can be a SHA1 tag or a branch name.
-<3> The `*contextDir*` field allows you to override the default location inside
+<2> The `*contextDir*` field allows you to override the default location inside
 the source code repository where the build looks for the application source
 code. If your application exists inside a sub-directory, you can override the
 default location (the root folder) using this field.
+<3> If the optional `*dockerfile*` field is provided, it should be a string
+containing a Dockerfile that overwrites any Dockerfile that may exist in the
+source repository.
 ====
 
 [[using-a-proxy-for-git-cloning]]
@@ -846,6 +879,81 @@ following command:
 ----
 $ oc secrets add serviceaccount/builder secrets/mysecret
 ----
+====
+
+
+[[dockerfile-source]]
+
+== Dockerfile Source
+
+When the `*BuildConfig.spec.source.type*` is `*Dockerfile*`, an inline
+Dockerfile is used as the build input, and no additional sources can be
+provided.
+
+This source type is valid when the build strategy type is `*Docker*` or
+`*Custom*`.
+
+The source definition is part of the `*spec*` section in the `*BuildConfig*`:
+
+====
+
+----
+{
+ "source" : {
+    "type" : "Dockerfile",
+    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <1>
+ },
+}
+----
+
+<1> The `*dockerfile*` field contains an inline Dockerfile that will be built.
+====
+
+
+[[binary-source]]
+
+== Binary Source
+
+When the `*BuildConfig.spec.source.type*` is `*Binary*`, the build will expect a
+binary as input, and an inline Dockerfile is optional.
+
+The binary is generally assumed to be a tar, gzipped tar, or zip file depending
+on the strategy. For `*Docker*` builds, this is the build context and an
+optional Dockerfile may be specified to override any Dockerfile in the build
+context. For `*Source*` builds, this is assumed to be an archive as described
+above. For `*Source*` and `*Docker*` builds, if `*binary.asFile*` is set the
+build will receive a directory with a single file. The `*contextDir*` field may
+be used when an archive is provided. Custom builds will receive this binary as
+input on standard input (`stdin`).
+
+A binary source potentially extracts content, in which case `*contextDir*`
+allows changing to a subdirectory within the content before the build executes.
+
+The source definition is part of the `*spec*` section in the `*BuildConfig*`:
+
+====
+
+----
+{
+ "source" : {
+    "type" : "Binary",
+    "binary": { <1>
+      "asFile": "webapp.war" <2>
+    },
+    "contextDir": "app/dir", <3>
+    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <4>
+ },
+}
+----
+
+<1> The `*binary*` field specifies the details of the binary source.
+<2> The `*asFile*` field specifies the name of a file that will be created with
+the binary contents.
+<3> The `*contextDir*` field specifies a subdirectory with the contents of a
+binary archive.
+<4> If the optional `*dockerfile*` field is provided, it should be a string
+containing an inline Dockerfile that potentially replaces one within the
+contents of the binary archive.
 ====
 
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -330,12 +330,15 @@ build strategy].
 
 === Dockerfile Path
 
-Docker builds normally use a Dockerfile named *_Dockerfile_*, located at the root
-of the context (identified by the `*BuildConfig.spec.source.contextDir*` field).
-The `*dockerfilePath*` field allows the build to use a different path to locate your Dockerfile.
-The path must be relative to the `*BuildConfig.spec.source.contextDir*` field.
-It could be just a different name for your Dockerfile (*_MyDockerfile_* for example),
-or a path to a Dockerfile in a subdirectory (*_dockerfiles/app1_* for example):
+By default, Docker builds use a Dockerfile (named *_Dockerfile_*) located at the
+root of the context specified in the `*BuildConfig.spec.source.contextDir*`
+field.
+
+The `*dockerfilePath*` field allows the build to use a different path to
+locate your Dockerfile, relative to the `*BuildConfig.spec.source.contextDir*`
+field. It can be simply a different file name other than the default
+*_Dockerfile_* (for example, *_MyDockerfile_*), or a path to a Dockerfile in a
+subdirectory (for example, *_dockerfiles/app1/_*):
 
 ====
 
@@ -344,7 +347,7 @@ or a path to a Dockerfile in a subdirectory (*_dockerfiles/app1_* for example):
 strategy:
   type: Docker
   dockerStrategy:
-    dockerfilePath: dockerfiles/app1
+    dockerfilePath: dockerfiles/app1/
 ----
 ====
 
@@ -977,7 +980,6 @@ binary archive.
 containing an inline Dockerfile that potentially replaces one within the
 contents of the binary archive.
 ====
-
 
 [[starting-a-build]]
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -326,6 +326,28 @@ The following options are specific to the
 link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[Docker
 build strategy].
 
+[[dockerfile-path]]
+
+=== Dockerfile Path
+
+Docker builds normally use a Dockerfile named *_Dockerfile_*, located at the root
+of the context (identified by the `*BuildConfig.spec.source.contextDir*` field).
+The `*dockerfilePath*` field allows the build to use a different path to locate your Dockerfile.
+The path must be relative to the `*BuildConfig.spec.source.contextDir*` field.
+It could be just a different name for your Dockerfile (*_MyDockerfile_* for example),
+or a path to a Dockerfile in a subdirectory (*_dockerfiles/app1_* for example):
+
+====
+
+[source,yaml]
+----
+strategy:
+  type: Docker
+  dockerStrategy:
+    dockerfilePath: dockerfiles/app1
+----
+====
+
 [[no-cache]]
 
 === No Cache

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -5,6 +5,29 @@
 :icons:
 :experimental:
 
+== Mon Feb 01 2016
+
+// tag::dev_guide_mon_feb_01_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+.4+|link:../dev_guide/builds.html[Builds]
+|Added the link:../dev_guide/builds.html#dockerfile-path[Dockerfile Path]
+section.
+
+|Added the link:../dev_guide/builds.html#dockerfile-source[Dockerfile Source]
+section.
+
+|Added the link:../dev_guide/builds.html#binary-source[Binary Source] section.
+
+|Updated the
+link:../dev_guide/builds.html#viewing-build-details[Viewing Build Details]
+section to note information included for Docker or Source strategy builds.
+|===
+// end::dev_guide_mon_feb_01_2016[]
+
 == Mon Dec 21 2015
 
 OpenShift Dedicated 3.1 release.

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -10284,6 +10284,7 @@ ObjectReference contains enough information to let you inspect or modify the ref
 |noCache|if true, indicates that the Docker build must be executed with the --no-cache=true flag|false|boolean|false
 |env|additional environment variables you want to pass into a builder container|false|<<v1.EnvVar>> array|
 |forcePull|forces the source build to pull the image if true|false|boolean|false
+|dockerfilePath|path of the Dockerfile to use for building the Docker image, relative to the contextDir, if set|false|string|
 |===
 
 === v1.DeploymentTriggerPolicy

--- a/using_images/index.adoc
+++ b/using_images/index.adoc
@@ -9,3 +9,17 @@ Use these topics to discover the different
 link:../architecture/core_concepts/builds_and_image_streams.html#source-build[S2I
 (Source-to-Image)], database, and other Docker images that are available for
 OpenShift users.
+
+ifdef::openshift-enterprise[]
+Red Hat's official container images are provided in the Red Hat Registry at
+https://registry.access.redhat.com[registry.access.redhat.com]. OpenShift's
+supported S2I, database, and Jenkins images are provided in the
+https://access.redhat.com/search/#/container-images?q=openshift3&p=1&sort=relevant&rows=12&srch=any&documentKind=ImageRepository[*openshift3*
+repository] in the Red Hat Registry. For example,
+`registry.access.redhat.com/openshift3/nodejs-010-rhel7` for the Node.js image.
+
+The xPaaS middleware images are provided in their respective product
+repositories on the Red Hat Registry, but suffixed with a *-openshift*. For
+example, `registry.access.redhat.com/jboss-eap-6/eap64-openshift` for
+the JBoss EAP image.
+endif::[]

--- a/using_images/index.adoc
+++ b/using_images/index.adoc
@@ -10,7 +10,7 @@ link:../architecture/core_concepts/builds_and_image_streams.html#source-build[S2
 (Source-to-Image)], database, and other Docker images that are available for
 OpenShift users.
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
 Red Hat's official container images are provided in the Red Hat Registry at
 https://registry.access.redhat.com[registry.access.redhat.com]. OpenShift's
 supported S2I, database, and Jenkins images are provided in the

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -5,6 +5,20 @@
 :icons:
 :experimental:
 
+== Mon Feb 01 2016
+
+//tag::using_images_mon_feb_01_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../using_images/index.html[Overview]
+|Added details on which images are supported and their location.
+
+|===
+// end::using_images_mon_feb_01_2016[]
+
 == Wed Jan 27 2016
 
 // tag::using_images_wed_jan_27_2016[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -13,6 +13,12 @@ date.
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_mon_feb_01_2016]
 
+.CLI Reference
+include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_mon_feb_01_2016]
+
+.Using Images
+include::using_images/revhistory_using_images.adoc[tag=using_images_mon_feb_01_2016]
+
 == Wed Jan 27 2016
 
 .Using Images

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -16,6 +16,9 @@ include::architecture/revhistory_architecture.adoc[tag=architecture_mon_feb_01_2
 .CLI Reference
 include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_mon_feb_01_2016]
 
+.Developer Guide
+include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_mon_feb_01_2016]
+
 .Using Images
 include::using_images/revhistory_using_images.adoc[tag=using_images_mon_feb_01_2016]
 


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1509.

Added commits from a few PRs that should have been labeled dedicated-3.1:

https://github.com/openshift/openshift-docs/pull/1423
https://github.com/openshift/openshift-docs/pull/1328

And a few follow-up commits to make those 2 PRs Dedicated-worthy:

https://github.com/openshift/openshift-docs/pull/1512
https://github.com/openshift/openshift-docs/pull/1511

These ones were also added because there were issues with backticks in titles on the Portal:

https://github.com/openshift/openshift-docs/pull/1516
https://github.com/openshift/openshift-docs/pull/1520

Also includes 3 commits from the OSE 3.1.1 release last week that I had meant to pick into dedicated-3.1, but hadn't done yet.

And all revhistories were updated accordingly.

FYI @bfallonf 
