### PR TITLE
Follow-up fixes to OSE 3.0 Mon Feb 01 publish

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -26,6 +26,12 @@ link:../core_concepts/pods_and_services.html#pods[pod] that uses the PV. PV
 objects capture the details of the implementation of the storage, be that NFS,
 iSCSI, or a cloud-provider-specific storage system.
 
+[IMPORTANT]
+====
+High-availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
 A `*PersistentVolumeClaim*` (PVC) object represents a request for storage by a
 user. It is similar to a pod in that pods consume node resources and PVCs
 consume PV resources. For example, pods can request specific levels of resources

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -17,6 +17,10 @@
 Builds and Image Streams]
 |Added more information on how builds work behind the scenes.
 
+|link:../architecture/additional_concepts/storage.html[Additional Concepts ->
+Persistent Storage]
+|Added an Important box about providing high-availability.
+
 |===
 // end::architecture_mon_feb_01_2016[]
 

--- a/using_images/index.adoc
+++ b/using_images/index.adoc
@@ -10,7 +10,7 @@ link:../architecture/core_concepts/builds_and_image_streams.html#source-build[S2
 (Source-to-Image)], database, and other Docker images that are available for
 OpenShift users.
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
 Red Hat's official container images are provided in the Red Hat Registry at
 https://registry.access.redhat.com[registry.access.redhat.com]. OpenShift's
 supported S2I, database, and Jenkins images are provided in the

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -14,7 +14,7 @@
 |Affected Topic |Description of Change
 
 |link:../using_images/index.html[Overview]
-|Added more details on which images are supported, which are in tech preview, and their location.
+|Added details on which images are supported and their location.
 
 |===
 // end::using_images_mon_feb_01_2016[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -13,10 +13,8 @@ date.
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_mon_feb_01_2016]
 
-
 .Using Images
-include::using_images/revhistory_using_images.adoc[tag=install_config_mon_feb_01_2016]
-
+include::using_images/revhistory_using_images.adoc[tag=using_images_mon_feb_01_2016]
 
 == Tue Jun 23 2015
 


### PR DESCRIPTION
`welcome/revhistory_full.adoc` had a mismatched tag name. 

Also added https://github.com/openshift/openshift-docs/pull/1496, which should have been tagged enterprise-3.0, and updated revhistory accordingly.

FYI @bfallonf 
