### PR TITLE
Updating examples to use /etc/origin/master/htpasswd

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -709,7 +709,7 @@ LoadModule request_module modules/mod_request.so
   </Location>
 
   <ProxyMatch /oauth/authorize>
-    AuthUserFile /etc/origin/htpasswd
+    AuthUserFile /etc/origin/master/htpasswd
     AuthName openshift
     Require valid-user
     RequestHeader set X-Remote-User %{REMOTE_USER}s
@@ -748,8 +748,8 @@ accounts information. In this example, file-backed authentication is used:
 
 ----
 # yum -y install httpd-tools
-# touch /etc/origin/htpasswd
-# htpasswd -c /etc/origin/htpasswd <user_name>
+# touch /etc/origin/master/htpasswd
+# htpasswd -c /etc/origin/master/htpasswd <user_name>
 ----
 
 *Configuring the Master*

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -749,7 +749,7 @@ accounts information. In this example, file-backed authentication is used:
 ----
 # yum -y install httpd-tools
 # touch /etc/origin/master/htpasswd
-# htpasswd -c /etc/origin/master/htpasswd <user_name>
+# htpasswd /etc/origin/master/htpasswd <user_name>
 ----
 
 *Configuring the Master*

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -141,7 +141,7 @@ section. For example:
 ----
 [OSEv3:vars]
 
-openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/htpasswd'}]
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
 osm_default_subdomain=apps.test.example.com
 ----
@@ -501,7 +501,7 @@ deployment_type=origin
 endif::[]
 
 # uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
-#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/htpasswd'}]
+#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
 # host group for masters
 [masters]
@@ -580,7 +580,7 @@ deployment_type=origin
 endif::[]
 
 # uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
-#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/htpasswd'}]
+#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
 # host group for masters
 [masters]
@@ -721,7 +721,7 @@ endif::[]
 
 # Uncomment the following to enable htpasswd authentication; defaults to
 # DenyAllPasswordIdentityProvider.
-#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/htpasswd'}]
+#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
 # Native high availbility cluster method with optional load balancer.
 # If no lb group is defined installer assumes that a load balancer has
@@ -845,7 +845,7 @@ endif::[]
 
 # Uncomment the following to enable htpasswd authentication; defaults to
 # DenyAllPasswordIdentityProvider.
-#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/htpasswd'}]
+#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
 # Pacemaker high availability cluster method.
 # Pacemaker HA environment must be able to self provision the


### PR DESCRIPTION
As part of openshift/openshift-ansible#1312
- Update examples to use /etc/origin/master/htpasswd
- The -c parameter is not needed to add users to existing htpasswd
