### PR TITLE
Outline Online EmptyDir volume restrictions and workaround.

### DIFF
--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -214,7 +214,7 @@ link:../install_config/install/docker_registry.html#securing-the-registry[secure
 with SSL],
 endif::[]
 ifdef::openshift-dedicated[]
-secured with SSL, 
+secured with SSL,
 endif::[]
 cluster administrators must ensure that the Docker daemon on the
 OpenShift nodes is run with the `--insecure-registry` flag pointing to that
@@ -542,3 +542,16 @@ labels for all objects here.
 ====
 To see all of the configuration options, click the "Show advanced build and deployment options" link.
 ====
+
+ifdef::openshift-online[]
+== Troubleshooting
+`*EmptyDir*` volumes are disabled in OpenShift Online at present. In some situations new-app will automatically create or use templates which contain `*EmptyDir*` volumes. In this scenario you will need to use `oc edit` to modify the relevant PodSpec and replace the use of `*EmptyDir*` volumes with a `*PersistentVolumeClaim*`.
+
+When this situations occurs, the error will surface as an event with a message similar to:
+
+----
+Error creating: Pod "redis-1-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.volumes: invalid value 'emptyDir', Details: EmptyDir volumes are not allowed to be used]
+----
+
+To correct the issue, identify the relevant object containing an `emptyDir` volume with `oc export`, and use `oc edit` to replace it with a persistent volume claim. For more information, see documentation on link:./persistent_volumes.html[persistent volumes].
+endif::[]

--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -22,6 +22,13 @@ single machine. Administrators may also allow you to request a
 link:persistent_volumes.html[persistent volume] that is automatically attached
 to your pods.
 
+ifdef::openshift-online[]
+[NOTE]
+====
+`*EmptyDir*` volumes are disabled in OpenShift Online at present, you will need to use persistent volume claims instead for the time being.
+====
+endif::[]
+
 You can use the CLI command `oc volume` to link:#adding-volumes[add],
 link:#updating-volumes[update], or link:#removing-volumes[remove] volumes and
 volume mounts for any object that has a pod template like


### PR DESCRIPTION
EmptyDir volumes are expected to be disabled in Online (potentially for a short
period of time so this patch will likely get reverted someday).

EmptyDir volumes are something a user can explicitly add to their PodSpecs, and
in some cases new-app will automatically do it for them. As such we need to
clarify firstly that this volume type is disabled in Online, how the error will
surface (which can vary depending on if the user is creating a template/DC/RC
vs a pod itself), and how to work around the problem.

This PR depends on the following origin PR: https://github.com/openshift/origin/pull/6659

And is somewhat related to the SCC Docs PR for AllowEmptyDirVolumePlugin: https://github.com/openshift/openshift-docs/pull/1528
