### PR TITLE
pyOpenSSL is required by ansible playbook

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -534,7 +534,7 @@ later steps of the installation:
 . Install the packages for Ansible:
 +
 ----
-# yum -y --enablerepo=epel install ansible
+# yum -y --enablerepo=epel install ansible pyOpenSSL
 ----
 
 To clone the *openshift-ansible* repository:


### PR DESCRIPTION
ansible-playbook ~/openshift-ansible/playbooks/byo/config.yml 
throws 
ImportError: No module named OpenSSL.crypto
