### PR TITLE
s/scmsecret/sshsecret/ in dev_guide/builds

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -807,7 +807,7 @@ following command:
 ====
 
 ----
-$ oc secrets add serviceaccount/builder secrets/scmsecret
+$ oc secrets add serviceaccount/builder secrets/sshsecret
 ----
 ====
 


### PR DESCRIPTION
This had been fixed previously (https://github.com/openshift/openshift-docs/commit/c75036f5571306d4531f0447621bb029fe4b8668) but looks like it was overwritten during a subsequent merge conflict resolution, probably (only happened on this branch AFAICT).
