### PR TITLE
Docs about configuring links to docs and downloads on the web console

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -135,6 +135,75 @@ assetConfig:
 ----
 ====
 
+*Changing links to documentation*
+
+Links to external documentation are shown in various sections of the web 
+console. The following example changes the URL for two given links to docs:
+
+====
+----
+window.OPENSHIFT_CONSTANTS.HELP['get_started_cli']      = "https://example.com/doc1.html";
+window.OPENSHIFT_CONSTANTS.HELP['basic_cli_operations'] = "https://example.com/doc2.html";
+----
+====
+
+Save this script to a file, for example *_help-links.js_*, and add it to the
+master configuration file:
+
+====
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/help-links.js
+----
+====
+
+*Adding or changing links to download the CLI*
+
+The "About" page in the web console provides links to where users can download
+the link:../cli_reference/index.html[command line interface (CLI)] tools. These
+links can be configured by providing both the link text and URL, so that you can
+choose to point them directly to file packages, or to an external page that
+points to the actual packages.
+
+For example, to point directly to packages that can be downloaded, where the link
+text is the package platform:
+
+====
+----
+window.OPENSHIFT_CONSTANTS.CLI = {
+  "Linux (32 bits)": "https://<cdn>/openshift-client-tools-linux-32bit.tar.gz",
+  "Linux (64 bits)": "https://<cdn>/openshift-client-tools-linux-64bit.tar.gz",
+  "Windows":         "https://<cdn>/openshift-client-tools-windows.zip",
+  "Mac OS X":        "https://<cdn>/openshift-client-tools-mac.zip"
+};
+----
+====
+
+Or, to point to a page that links the actual download packages, with the "Latest
+Release" link text:
+
+====
+----
+window.OPENSHIFT_CONSTANTS.CLI = {
+  "Latest Release": "https://<cdn>/openshift-client-tools/latest.html"
+};
+----
+====
+
+Save this script to a file, for example *_cli-links.js_*, and add it to the
+master configuration file:
+
+====
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/cli-links.js
+----
+====
+
 == Serving Static Files
 
 You can serve other files from the Asset Server as well. For example, you might


### PR DESCRIPTION
Ref. https://trello.com/c/ejuUQbJd

Documents how to configure the links to external documentation and URL's to download the command line tools.
