### PR TITLE
Enterprise 3.1 Async Publishing - Feb 04, 2016

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -214,6 +214,8 @@ Topics:
         File: persistent_storage_iscsi
       - Name: Using Fibre Channel
         File: persistent_storage_fibre_channel
+      - Name: Dynamic Provisioning
+        File: dynamically_provisioning_pvs
       - Name: Volume Security
         File: pod_security_context
   - Name: Working with HTTP Proxies

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -82,13 +82,13 @@ kubeletArguments:
 
 == Exporting Key Value Access Pairs
 
-Make sure the following environment variables are exported and start or restart OpenShift services on the master and all nodes:
+Make sure the following environment variables are set in /etc/sysconfig/atomic-openshift-master and /etc/sysconfig/atomic-openshift-node, then start or restart OpenShift services on the master and all nodes:
 
 ====
 ----
-export AWS_ACCESS_KEY_ID=<key id>
-export AWS_SECRET_ACCESS_KEY=<secret key>
+AWS_ACCESS_KEY_ID=<key id>
+AWS_SECRET_ACCESS_KEY=<secret key>
 ----
 ====
 
-These access keys are obtained when setting up your AWS instances.
+Access keys are obtained when setting up your AWS IAM user.

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -18,22 +18,22 @@ volumes as persistent storage] for application data. After AWS is configured
 properly, some additional configurations will need to be completed on the
 OpenShift hosts.
 
-
+[[configuring-aws-variables]]
 == Configuring AWS Variables
+
 To set the required AWS variables, create a *_/etc/aws/aws.conf_* file with
 the following contents on all of your OpenShift hosts, both masters and nodes:
 
 ====
 ----
 [Global]
-Zone = us-east-1c  <1>
+Zone = us-east-1c <1>
 ----
-
-<1> This is the Availability Zone of your AWS Instance and where your EBS Volume resides; this information is obtained from the AWS Managment Console.
+<1> This is the Availability Zone of your AWS Instance and where your EBS Volume
+resides; this information is obtained from the AWS Managment Console.
 ====
 
-
-
+[[aws-configuring-masters]]
 == Configuring Masters
 
 Edit or
@@ -60,6 +60,7 @@ kubernetesMasterConfig:
 ----
 ====
 
+[[aws-configuring-nodes]]
 == Configuring Nodes
 
 Edit or
@@ -78,17 +79,29 @@ kubeletArguments:
 ----
 ====
 
+[[aws-setting-key-value-access-pairs]]
+== Setting Key Value Access Pairs
 
-
-== Exporting Key Value Access Pairs
-
-Make sure the following environment variables are set in /etc/sysconfig/atomic-openshift-master and /etc/sysconfig/atomic-openshift-node, then start or restart OpenShift services on the master and all nodes:
+Make sure the following environment variables are set in the
+ifdef::openshift-enterprise[]
+*_/etc/sysconfig/atomic-openshift-master_* file on masters and the
+*_/etc/sysconfig/atomic-openshift-node_* file on nodes:
+endif::[]
+ifdef::openshift-origin[]
+*_/etc/sysconfig/origin-master_* file on masters and the
+*_/etc/sysconfig/origin-node_* file on nodes:
+endif::[]
 
 ====
 ----
-AWS_ACCESS_KEY_ID=<key id>
-AWS_SECRET_ACCESS_KEY=<secret key>
+AWS_ACCESS_KEY_ID=<key_ID>
+AWS_SECRET_ACCESS_KEY=<secret_key>
 ----
 ====
 
+[NOTE]
+====
 Access keys are obtained when setting up your AWS IAM user.
+====
+
+Then, start or restart OpenShift services on the master and all nodes.

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -64,9 +64,8 @@ kubernetesMasterConfig:
 
 Edit or
 link:../install_config/master_node_configuration.html#creating-new-configuration-files[create]
-the node configuration file on all nodes
-(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` section:
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` section:
 
 ====
 [source,yaml]

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -37,7 +37,6 @@ kubernetesMasterConfig:
   controllerArguments:
     cloud-provider:
       - "gce"
-
 ----
 ====
 
@@ -59,4 +58,4 @@ kubeletArguments:
 ----
 ====
 
-Start or restart the OpenShift services on the master and all nodes.
+Then, start or restart the OpenShift services on the master and all nodes.

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -17,6 +17,7 @@ volumes as persistent storage] for application data. After GCE is configured
 properly, some additional configurations will need to be completed on the
 OpenShift hosts.
 
+[[gce-configuring-masters]]
 == Configuring Masters
 
 Edit or
@@ -40,6 +41,7 @@ kubernetesMasterConfig:
 ----
 ====
 
+[[gce-configuring-nodes]]
 == Configuring Nodes
 
 Edit or
@@ -56,7 +58,5 @@ kubeletArguments:
 
 ----
 ====
-
-
 
 Start or restart the OpenShift services on the master and all nodes.

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -43,10 +43,9 @@ kubernetesMasterConfig:
 == Configuring Nodes
 
 Edit or
-link:../install_config/master_node_configuration.html#creating-new-configuration-files[create] the
-node configuration file on all nodes
-(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` section:
+link:../install_config/master_node_configuration.html#creating-new-configuration-files[create]
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` section:
 
 ====
 [source,yaml]

--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -68,10 +68,10 @@ kubernetesMasterConfig:
 == Configuring Nodes
 
 Edit or
-link:../install_config/master_node_configuration.html#creating-new-configuration-files[create] the
-node configuration file on all nodes
-(*_/etc/origin/node/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` and `*nodeName*` sections:
+link:../install_config/master_node_configuration.html#creating-new-configuration-files[create]
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` and `*nodeName*`
+sections:
 
 ====
 [source,yaml]

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -487,6 +487,11 @@ See more details on
 https://github.com/docker/distribution/blob/master/docs/configuration.md#override-configuration-options[overriding
 registry options].
 +
+. You also need to update the scheme used for the liveness and readiness probes to HTTPS:
+----
+$ oc get dc docker-registry -o yaml | sed -e 's/scheme: HTTP/scheme: HTTPS/g' | oc replace -f -
+----
++
 . Validate the registry is running in TLS mode. Wait until the *docker-registry*
 pod status changes to `Running` and verify the Docker logs for the registry
 container. You should find an entry for `listening on :5000, tls`.

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -436,7 +436,7 @@ Optionally, you can secure the registry so that it serves traffic via TLS:
 +
 ====
 ----
-$ oc get svc docker-registry
+$ oc get svc/docker-registry
 NAME              LABELS                                    SELECTOR                  IP(S)            PORT(S)
 docker-registry   docker-registry=default                   docker-registry=default   172.30.124.220   5000/TCP
 ----
@@ -486,12 +486,15 @@ $ oc env dc/docker-registry \
 See more details on
 https://github.com/docker/distribution/blob/master/docs/configuration.md#override-configuration-options[overriding
 registry options].
+
+. Update the scheme used for the registry's liveness probe from HTTP to HTTPS:
 +
-. You also need to update the scheme used for the liveness and readiness probes to HTTPS:
 ----
-$ oc get dc docker-registry -o yaml | sed -e 's/scheme: HTTP/scheme: HTTPS/g' | oc replace -f -
+$ oc get dc/docker-registry -o yaml \
+    | sed -e 's/scheme: HTTP/scheme: HTTPS/g' \
+    | oc replace -f -
 ----
-+
+
 . Validate the registry is running in TLS mode. Wait until the *docker-registry*
 pod status changes to `Running` and verify the Docker logs for the registry
 container. You should find an entry for `listening on :5000, tls`.

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -1,0 +1,124 @@
+= Dynamically Provisioning Persistent Volumes
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+You can provision your OpenShift cluster with storage dynamically when running
+in a cloud environment. The Kubernetes
+link:../../architecture/additional_concepts/storage.html[persistent volume]
+framework allows administrators to provision a cluster with persistent storage
+and gives users a way to request those resources without having any knowledge of
+the underlying infrastructure.
+
+Many storage types are available for use as persistent volumes in OpenShift.
+While all of them can be statically provisioned by an administrator, some types
+of storage can be created dynamically using an API. These types of storage can
+be provisioned in an OpenShift cluster using the new and experimental dynamic
+storage feature.
+
+[IMPORTANT]
+====
+ifdef::openshift-enterprise[]
+Dynamic provisioning of persistent volumes is currently a Technology Preview
+feature, introduced in OpenShift Enterprise 3.1.1.
+endif::[]
+This feature is experimental and expected to change in the future as it matures
+and feedback is received from users. New ways to provision the cluster are
+planned and the means by which one accesses this feature is going to change.
+Backwards compatibility is not guaranteed.
+====
+
+[[enabling-provisioner-plugins]]
+== Enabling Provisioner Plug-ins
+
+OpenShift provides the following _provisioner plug-ins_, which have generic
+implementations for dynamic provisioning that use the cluster's configured cloud
+provider's API to create new storage resources:
+
+[options="header"]
+|===
+
+|Storage Type |Provisioner Plug-in Name |Required Cloud Configuration
+
+|OpenStack Cinder
+|`kubernetes.io/cinder`
+|link:../../install_config/configuring_openstack.html[Configuring for OpenStack]
+
+|AWS Elastic Block Store (EBS)
+|`kubernetes.io/aws-ebs`
+|link:../../install_config/configuring_aws.html[Configuring for AWS]
+
+|GCE Persistent Disk (gcePD)
+|`kubernetes.io/gce-pd`
+|link:../../install_config/configuring_gce.html[Configuring for GCE]
+|===
+
+[IMPORTANT]
+====
+For any chosen provisioner plug-ins, the relevant cloud configuration must also
+be set up, per *Required Cloud Configuration* in the above table.
+====
+
+When your OpenShift cluster is configured for EBS, GCE, or Cinder, the
+associated provisioner plug-in is implied and automatically enabled. No
+additional OpenShift configuration by the cluster administration is required for
+dynamic provisioning.
+
+For example, if your OpenShift cluster is configured to run in AWS, the EBS
+provisioner plug-in is automatically available for creating
+link:#dynamic-pvs-requesting-storage[dynamically provisioned storage requested
+by a user].
+
+Future provisioner plug-ins will include the many types of storage a single
+provider offers. AWS, for example, has several types of EBS volumes to offer,
+each with its own performance characteristics; there is also an NFS-like storage
+option. More provisioner plug-ins will be implemented for the supported storage
+types available in OpenShift.
+
+[[dynamic-pvs-requesting-storage]]
+== Requesting Dynamically Provisioned Storage
+
+Users can request dynamically provisioned storage by including a storage class
+annotation in their link:../../dev_guide/persistent_volumes.html[persistent
+volume claim]:
+
+.Persistent Volume Claim Requesting Dynamic Storage
+====
+[source,yaml]
+----
+kind: "PersistentVolumeClaim"
+apiVersion: "v1"
+metadata:
+  name: "claim1"
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: "foo" <1>
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "3Gi"
+----
+<1> The value of the `*volume.alpha.kubernetes.io/storage-class*` annotation is
+not meaningful at this time. The presence of the annotation, with any arbitrary
+value, triggers provisioning using the single implied
+link:#enabling-provisioner-plugins[provisioner plug-in per cloud].
+====
+
+[[dynamic-pvs-volume-recycling]]
+== Volume Recycling
+
+Volumes created dynamically by a provisioner have their
+`*persistentVolumeReclaimPolicy*` set to *Delete*. When a persistent volume
+claim is deleted, its backing persistent volume is considered released of its
+claim, and that resource can be reclaimed by the cluster. Dynamic provisioning
+utilizes the provider's API to delete the volume from the provider and then
+removes the persistent volume from the cluster.

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -5,6 +5,39 @@
 :icons:
 :experimental:
 
+== Thu Feb 04 2016
+
+// tag::install_config_thu_feb_04_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../install_config/install/docker_registry.html[Installing -> Deploying a
+Docker Registry]
+|Updated the
+link:../install_config/install/docker_registry.html#securing-the-registry[Securing
+the Registry] section to account for the liveness probe added to new registries
+by default starting in OpenShift Enterprise 3.1.1.
+
+|link:../install_config/configuring_aws.html[Configuring for AWS]
+|Fixed the
+link:../install_config/configuring_aws.html#aws-configuring-nodes[default node
+configuration file path].
+
+|link:../install_config/configuring_gce.html[Configuring for GCE]
+|Fixed the
+link:../install_config/configuring_gce.html#gce-configuring-nodes[default node
+configuration file path].
+
+|link:../install_config/persistent_storage/dynamically_provisioning_pvs.html[Configuring
+Persistent Storage -> Dynamically Provisioning Persistent Volumes]
+|New topic on the experimental feature for allowing users to request dynamically
+provisioned persistent storage based on the configured cloud provider. Available
+in Technology Preview starting in OpenShift Enterprise 3.1.1.
+|===
+// end::install_config_thu_feb_04_2016[]
+
 == Mon Feb 01 2016
 
 //tag::install_config_mon_feb_01_2016[]

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -17,13 +17,18 @@
 Docker Registry]
 |Updated the
 link:../install_config/install/docker_registry.html#securing-the-registry[Securing
-the Registry] section to account for the liveness probe added to new registries
-by default starting in OpenShift Enterprise 3.1.1.
+the Registry] section to account for the liveness probe that is now added to new
+registries by default starting in OpenShift Enterprise 3.1.1.
+(https://bugzilla.redhat.com/show_bug.cgi?id=1302956[*BZ#1302956*])
 
-|link:../install_config/configuring_aws.html[Configuring for AWS]
+.2+|link:../install_config/configuring_aws.html[Configuring for AWS]
 |Fixed the
 link:../install_config/configuring_aws.html#aws-configuring-nodes[default node
 configuration file path].
+
+|Corrected instructions on
+link:../install_config/configuring_aws.html#aws-setting-key-value-access-pairs[setting
+access key environment variables].
 
 |link:../install_config/configuring_gce.html[Configuring for GCE]
 |Fixed the
@@ -151,12 +156,13 @@ Custom Certificates] section.
 
 |link:../install_config/install/docker_registry.html[Installing -> Deploying a
 Docker Registry]
-|https://bugzilla.redhat.com/show_bug.cgi?id=1273412[BZ#1273412]: Enhanced the
+|Enhanced the
 link:../install_config/install/docker_registry.html#access[Accessing the
 Registry Directly] section, including organizing all user-related requirements
 under a
 link:../install_config/install/docker_registry.html#access-user-prerequisites[User
 Prerequisites] subsection.
+(https://bugzilla.redhat.com/show_bug.cgi?id=1273412[*BZ#1273412*])
 
 |link:../install_config/downgrade.html[Downgrading OpenShift]
 |New topic for downgrading from OpenShift Enterprise 3.1 to 3.0.

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -193,69 +193,69 @@ Images can be edited to set fields such as `*labels*` or `*annotations*`.
 [[ose-31-bug-fixes]]
 == Bug Fixes
 
-https://bugzilla.redhat.com/show_bug.cgi?id=1264836[BZ 1264836]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1264836[BZ#1264836]:: Previously,
 the upgrade script used an incorrect image to upgrade the HAProxy router. The
 script now uses the right image.
-https://bugzilla.redhat.com/show_bug.cgi?id=1264765[BZ 1264765]:: Previously, an
+https://bugzilla.redhat.com/show_bug.cgi?id=1264765[BZ#1264765]:: Previously, an
 upgrade would fail when a defined image stream or template did not exist. Now,
 the installation utility skips the incorrectly defined image stream or
 template and continues with the upgrade.
-https://bugzilla.redhat.com/show_bug.cgi?id=1274134[BZ 1274134]:: When using
+https://bugzilla.redhat.com/show_bug.cgi?id=1274134[BZ#1274134]:: When using
 the `oc new-app` command with the `--insecure-registry` option, it would not
 set if the Docker daemon was not running. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1273975[BZ 1273975]:: Using the `oc
+https://bugzilla.redhat.com/show_bug.cgi?id=1273975[BZ#1273975]:: Using the `oc
 edit` command on Windows machines displayed errors with wrapping and file
 changes. These issues have been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1268891[BZ 1268891]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1268891[BZ#1268891]:: Previously,
 creating pods from the same image in the same service and deployment were not
 grouped into another service. Now, pods created with the same image run in the
 same service and deployment, grouped together.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267559[BZ 1267559]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1267559[BZ#1267559]:: Previously,
 using the `oc export` command could produce an error, and the export would
 fail. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1266981[BZ 1266981]:: The recycler
+https://bugzilla.redhat.com/show_bug.cgi?id=1266981[BZ#1266981]:: The recycler
 would previously fail if hidden files or directories would be present. This
 issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1268484[BZ 1268484]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1268484[BZ#1268484]:: Previously,
 when viewing a build to completion on the web console after deleting and
 recreating the same build, no build spinner would show. This issue has been
 fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1269070[BZ 1269070]:: You can now
+https://bugzilla.redhat.com/show_bug.cgi?id=1269070[BZ#1269070]:: You can now
 use custom self-signed certificates for the web console for specific host
 names.
-https://bugzilla.redhat.com/show_bug.cgi?id=1264764[BZ 1264764]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1264764[BZ#1264764]:: Previously,
 the installation utility did not have an option to configure the deployment
 type. Now, you can run the `--deployment-type` option with the installation
 utility to select a type, otherwise the type set in the installation utility
 will be set.
-https://bugzilla.redhat.com/show_bug.cgi?id=1273843[BZ 1273843]:: There was an
+https://bugzilla.redhat.com/show_bug.cgi?id=1273843[BZ#1273843]:: There was an
 issue with the `pip` command not being available in the newest OpenShift
 release. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1274601[BZ 1274601]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1274601[BZ#1274601]:: Previously,
 using the `oc exec` command was only available to be used on privileged
 containers. Now, users with permissions to create pods can use the `oc exec`
 command to SSH into privileged containers.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267670[BZ 1267670]:: There was an
+https://bugzilla.redhat.com/show_bug.cgi?id=1267670[BZ#1267670]:: There was an
 issue with using the `iptables` command with the `-w` option to make the
 `iptables` command wait to acquire the *xtables* lock, causing some SDN
 initializations to fail. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1272201[BZ 1272201]:: When installing a clustered etcd and defining variables for IP and etcd
+https://bugzilla.redhat.com/show_bug.cgi?id=1272201[BZ#1272201]:: When installing a clustered etcd and defining variables for IP and etcd
 interfaces when using two network interfaces, the certificate would be populated
 with only the first network, instead of whichever network was desired. The issue
 has now been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1269256[BZ 1269256]:: Using the `GET` `*fieldSelector*` would return a 500 BadRequest error. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1268000[BZ 1268000]:: Previously, creating an application from a image stream could result in two builds being initiated. This was caused by the wrong image stream tag being used by the build process. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267231[BZ 1267231]:: The *ose-ha-proxy* router image was missing the `X-Forwarded` headers, causing the Jenkins application to redirect to HTTP instead of HTTPS. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1276548[BZ 1276548]:: Previously, an error was present where the HAProxy router did not expose statistics, even if the port was specified. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1275388[BZ 1275388]:: Previously, some node hosts would not talk to the SDN due to routing table differences. A `*lbr0*` entry was causing traffic to be routed incorrectly. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1265187[BZ 1265187]:: When persistent volume claims (PVC) were created from a template, sometimes the same volume would be mounted to multiple PVCs. At the same time, the volume would show that only one PVC was being used. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1279308[BZ 1279308]:: Previously, using a etcd storage location other than the default, as defined in the master configuration file, would result in an upgrade fail at the "generate etcd backup" stage. This issue has now been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1276599[BZ 1276599]:: Basic authentication passwords can now contain colons.
-https://bugzilla.redhat.com/show_bug.cgi?id=1279744[BZ 1279744]:: Previously, giving `*EmptyDir*` volumes a different default permission setting and group ownership could affect deploying the *postgresql-92-rhel7* image. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1276395[BZ 1276395]:: Previously, an error could occur when trying to perform an HA install using Ansible, due to a problem with SRC files. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267733[BZ 1267733]:: When installing a etcd cluster with hosts with different network interfaces, the install would fail. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1274239[BZ 1274239]:: Previously, when changing the default project region from *infra* to *primary*, old route and registry pods are stuck in the terminating stage and could not be deleted, meaning that new route and registry pods could not be deployed. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1278648[BZ 1278648]:: If, when upgrading to OpenShift Enterprise 3.1, the OpenShift Enterprise repository was not set, a Python error would occur. This issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1269256[BZ#1269256]:: Using the `GET` `*fieldSelector*` would return a 500 BadRequest error. This issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1268000[BZ#1268000]:: Previously, creating an application from a image stream could result in two builds being initiated. This was caused by the wrong image stream tag being used by the build process. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1267231[BZ#1267231]:: The *ose-ha-proxy* router image was missing the `X-Forwarded` headers, causing the Jenkins application to redirect to HTTP instead of HTTPS. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1276548[BZ#1276548]:: Previously, an error was present where the HAProxy router did not expose statistics, even if the port was specified. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1275388[BZ#1275388]:: Previously, some node hosts would not talk to the SDN due to routing table differences. A `*lbr0*` entry was causing traffic to be routed incorrectly. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1265187[BZ#1265187]:: When persistent volume claims (PVC) were created from a template, sometimes the same volume would be mounted to multiple PVCs. At the same time, the volume would show that only one PVC was being used. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1279308[BZ#1279308]:: Previously, using a etcd storage location other than the default, as defined in the master configuration file, would result in an upgrade fail at the "generate etcd backup" stage. This issue has now been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1276599[BZ#1276599]:: Basic authentication passwords can now contain colons.
+https://bugzilla.redhat.com/show_bug.cgi?id=1279744[BZ#1279744]:: Previously, giving `*EmptyDir*` volumes a different default permission setting and group ownership could affect deploying the *postgresql-92-rhel7* image. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1276395[BZ#1276395]:: Previously, an error could occur when trying to perform an HA install using Ansible, due to a problem with SRC files. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1267733[BZ#1267733]:: When installing a etcd cluster with hosts with different network interfaces, the install would fail. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1274239[BZ#1274239]:: Previously, when changing the default project region from *infra* to *primary*, old route and registry pods are stuck in the terminating stage and could not be deleted, meaning that new route and registry pods could not be deployed. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1278648[BZ#1278648]:: If, when upgrading to OpenShift Enterprise 3.1, the OpenShift Enterprise repository was not set, a Python error would occur. This issue has been fixed.
 
 [[ose-31-technology-preview]]
 == Technology Preview Features
@@ -269,11 +269,11 @@ Features Support Scope]
 
 The following features are in Technology Preview:
 
-* Binary builds, and the Dockerfile source type for builds. (Fully supported
+* Binary builds and the Dockerfile source type for builds. (Fully supported
 starting in link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
-* Pod autoscaling, using the *HorizontalPodAutoscaler* object. OpenShift
-compares pod CPU usage as a percentage of requested CPU, and scales according
-to up to an indicated threshold. (Fully supported starting in
+* Pod autoscaling, using the `*HorizontalPodAutoscaler*` object. OpenShift
+compares pod CPU usage as a percentage of requested CPU and scales according
+to an indicated threshold. (Fully supported starting in
 link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
 * Support for OpenShift Enterprise running on RHEL Atomic Host. (Fully supported
 starting in link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
@@ -338,21 +338,35 @@ This release includes the following enhancements and bug fixes.
 [[ose-3-1-1-enhancements]]
 ==== Enhancements
 
-Containerized Installations Now Supported::
-In addition to installations using the RPM method, support is now added for
-installing OpenShift Enterprise master and node components as containerized
-services. Both the link:../install_config/install/quick_install.html[quick] and
+Containerized Installations Now Fully Supported::
+Installation of OpenShift Enterprise master and node components as containerized
+services, added as Technology Preview in OpenShift Enterprise 3.1.0, is now
+fully supported as an alternative to the standard RPM method. Both the
+link:../install_config/install/quick_install.html[quick] and
 link:../install_config/install/advanced_install.html[advanced installation]
 methods support use of the containerized method. See
 link:../install_config/install/rpm_vs_containerized.html[RPM vs Containerized]
 for more details on the differences when running as a containerized
 installation.
 
-RHEL Atomic Host Now Supported::
-Red Hat Enterprise Linux (RHEL) Atomic Host 7.1.6 or later is now supported for
-running containerized OpenShift services. See
+RHEL Atomic Host Now Fully Supported::
+Installing OpenShift Enterprise on Red Hat Enterprise Linux (RHEL) Atomic Host
+7.1.6 or later, added as Technology Preview in OpenShift Enterprise 3.1.0, is
+now fully supported for running containerized OpenShift services. See
 link:../install_config/install/prerequisites.html#system-requirements[System
 Requirements] for more details.
+
+Binary Builds and Dockerfile Sources Now Fully Supported::
+link:../dev_guide/builds.html#binary-source[Binary builds] and the
+link:../dev_guide/builds.html#dockerfile-source[Dockerfile source type] for
+builds, added as Technology Preview in OpenShift Enterprise 3.1.0, are now fully
+supported.
+
+Pod Autoscaling Now Fully Supported::
+link:../dev_guide/pod_autoscaling.html[Pod autoscaling] using the
+`*HorizontalPodAutoscaler*` object, added as Technology Preview in OpenShift
+Enterprise 3.1.0, is now fully supported. OpenShift compares pod CPU usage as a
+percentage of requested CPU and scales according to an indicated threshold.
 
 Web Console::
 * When creating an application from source in the web console, you can
@@ -430,9 +444,9 @@ different configurations). See the help text for `openshift-router`.
 The following features have entered into
 https://access.redhat.com/support/offerings/techpreview[Technology Preview]:
 
-* Dynamic provisioning of persistent storage volumes from Amazon EBS, Google
-Compute Disk, OpenStack Cinder storage providers. Documentation to be added
-shortly.
+* link:../install_config/persistent_storage/dynamically_provisioning_pvs.html[Dynamic
+provisioning] of persistent storage volumes from Amazon EBS, Google Compute
+Disk, OpenStack Cinder storage providers.
 
 [[ose-3-1-1-bug-fixes]]
 ==== Bug Fixes

--- a/release_notes/revhistory_release_notes.adoc
+++ b/release_notes/revhistory_release_notes.adoc
@@ -5,6 +5,23 @@
 :icons:
 :experimental:
 
+== Thu Feb 04 2016
+
+// tag::release_notes_thu_feb_04_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise 3.1
+Release Notes]
+|Updated the
+link:../release_notes/ose_3_1_release_notes.html#ose-3-1-1-enhancements[OpenShift
+Enterprise 3.1.1 Enhancements] section to more clearly identify the features
+that came out of Technology Preview.
+|===
+// end::release_notes_thu_feb_04_2016[]
+
 == Thu Jan 28 2016
 
 OpenShift Enterprise 3.1.1 release.

--- a/release_notes/revhistory_release_notes.adoc
+++ b/release_notes/revhistory_release_notes.adoc
@@ -13,12 +13,20 @@
 
 |Affected Topic |Description of Change
 
-|link:../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise 3.1
+.2+|link:../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise 3.1
 Release Notes]
 |Updated the
 link:../release_notes/ose_3_1_release_notes.html#ose-3-1-1-enhancements[OpenShift
 Enterprise 3.1.1 Enhancements] section to more clearly identify the features
 that came out of Technology Preview.
+
+|Updated the
+link:../release_notes/ose_3_1_release_notes.html#ose-3-1-1-technology-preview-features[OpenShift
+Enterprise 3.1.1 Technology Preview Features] section to add a link to the new
+link:../install_config/persistent_storage/dynamically_provisioning_pvs.html[Dynamically
+Provisioning Persistent Volumes] topic.
+|
+
 |===
 // end::release_notes_thu_feb_04_2016[]
 

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -8,6 +8,14 @@
 The following sections aggregate the revision histories of each guide by publish
 date.
 
+== Thu Feb 04 2016
+
+.Release Notes
+include::release_notes/revhistory_release_notes.adoc[tag=release_notes_thu_feb_04_2016]
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_thu_feb_04_2016]
+
 == Mon Feb 01 2016
 
 .Architecture


### PR DESCRIPTION
Async publish to get some post-3.1.1 follow-up items in quickly.

**Release Notes**

_OpenShift Enterprise 3.1 Release Notes:_
Updated the OpenShift Enterprise 3.1.1 Enhancements section to more clearly identify the features that came out of Technology Preview.
Updated the OpenShift Enterprise 3.1.1 Technology Preview Features section to add a link to the new Dynamically Provisioning Persistent Volumes topic.

**Installation and Configuration**

_Installing → Deploying a Docker Registry_
Updated the Securing the Registry section to account for the liveness probe that is now added to new registries by default starting in OpenShift Enterprise 3.1.1. (BZ#1302956)

_Configuring for AWS_
Fixed the default node configuration file path.
Corrected instructions on setting access key environment variables.

_Configuring for GCE_
Fixed the default node configuration file path.

_Configuring Persistent Storage → Dynamically Provisioning Persistent Volumes_
New topic on the experimental feature for allowing users to request dynamically provisioned persistent storage based on the configured cloud provider. Available in Technology Preview starting in OpenShift Enterprise 3.1.1.
