### PR TITLE
Add origin to condtls for admin_cli

### DIFF
--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -67,7 +67,7 @@ Manages groups:
 $ oadm groups
 ----
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-origin[]
 [[install-cli-operations]]
 
 == Install CLI Operations
@@ -113,7 +113,7 @@ Removes older versions of resources from the server:
 $ oadm prune
 ----
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-origin[]
 [[settings-cli-operations]]
 
 == Settings CLI Operations


### PR DESCRIPTION
When removing these sections for Dedicated, accidentally also hid them for Origin.

**revhistory note:**

None needed, just keeping the file updated across branches.
