### PR TITLE
Edits to Custom Builder topic

### DIFF
--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -47,14 +47,14 @@ link:../../dev_guide/builds.html[Developer's Guide].
 
 For more information on how OpenShift leverages Docker for builds, see the link:https://github.com/openshift/origin/blob/master/docs/builds.md#how-it-works[upstream documentation].
 
-[#docker-build]
+[[docker-build]]
 === Docker Build
 The Docker build strategy invokes the plain
 https://docs.docker.com/engine/reference/commandline/build/[docker build] command,
 and it therefore expects a repository with a *_Dockerfile_* and all required
 artifacts in it to produce a runnable image.
 
-[#source-build]
+[[source-build]]
 === Source-to-Image (S2I) Build
 link:../../creating_images/s2i.html[Source-to-Image (S2I)] is a tool for
 building reproducible Docker images. It produces ready-to-run images by
@@ -98,17 +98,18 @@ their application build.
 Ecosystem:: S2I encourages a shared ecosystem of images where you can leverage
 best practices for your applications.
 
-[#custom-build]
+[[custom-build]]
 === Custom Build
 The Custom build strategy allows developers to define a specific builder image
 responsible for the entire build process. Using your own builder image allows
 you to customize your build process.
 
-The link:../../creating_images/custom.html[Custom builder image] is a plain
-Docker image with embedded build process logic, such as building RPMs or
-building base Docker images. The
-https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder/[openshift/origin-custom-docker-builder]
-image is used by default.
+A link:../../creating_images/custom.html[Custom builder image] is a plain Docker
+image embedded with build process logic, for example for building RPMs or base
+Docker images. The `openshift/origin-custom-docker-builder` image is available
+on the
+https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder[Docker
+Hub] as an example implementation of a Custom builder image.
 
 [[image-streams]]
 

--- a/creating_images/custom.adoc
+++ b/creating_images/custom.adoc
@@ -10,49 +10,100 @@
 toc::[]
 
 == Overview
-link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[Custom
-build] is designed to fill the gap that was created when everybody jumped into
-creating Docker images. Still there is a requirement to produce individual
-artifacts (packages, jars, wars, installable zips, base images etc.) This is
-where Custom build is the perfect match to fill in that gap. Additionally Custom
-build allows implementing any extended build process for example, CI/CD flow
-that runs unit or integration tests. The limit here is just the imagination of
-the custom builder image author.
+By allowing you to define a specific builder image responsible for the entire
+build process, OpenShift's
+link:../dev_guide/builds.html#custom-strategy-options[Custom build strategy] was
+designed to fill a gap created with the increased popularity of creating Docker
+images. When there is a requirement for a build to still produce individual
+artifacts (packages, JARs, WARs, installable ZIPs, and base images, for
+example), a _Custom builder image_ utilizing the Custom build strategy is the
+perfect match to fill that gap.
 
-To fully utilize the power of Custom build one needs to be understand how to
-create a builder image that will be capable of building desired objects.
+A Custom builder image is a plain Docker image embedded with build process
+logic, for example for building RPMs or base Docker images. The
+`openshift/origin-custom-docker-builder` image is available on the
+https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder[Docker
+Hub] as an example implementation of a Custom builder image.
 
+Additionally, the Custom builder allows implementing any extended build process,
+for example a CI/CD flow that runs unit or integration tests. The only limit is
+the imagination of the builder image author.
+
+To fully utilize the power of the Custom build strategy, you must understand how
+to create a Custom builder image that will be capable of building desired
+objects.
+
+[[custom-builder-image]]
 == Custom Builder Image
-The builder image upon invocation receives following environment variables with
-the information needed to proceed with the build:
+
+Upon invocation, a custom builder image will receive the following environment
+variables with the information needed to proceed with the build:
 
 .Custom Builder Environment Variables
-[cols="4a,6a",options="header"]
+[cols="1,3",options="header"]
 |===
 
-|Variable name |Description
+|Variable Name |Description
 
 |`*BUILD*`
-|This variable specifies the entire serialized link:../rest_api/openshift_v1.html#v1-build[Build] object.
-If you need to use a specific API version for serialization, you can set the `buildAPIVersion`
-parameter in the link:../rest_api/openshift_v1.html#v1-buildconfig[Build Config]'s custom
-strategy link:../rest_api/openshift_v1.html#v1-custombuildstrategy[specification].
+|The entire serialized JSON of the `*Build*`
+link:../rest_api/openshift_v1.html#v1-build[object definition]. If you need to
+use a specific API version for serialization, you can set the
+`*buildAPIVersion*` parameter in the
+link:../dev_guide/builds.html#custom-strategy-options[custom strategy
+specification] of the build configuration.
 
 |`*SOURCE_REPOSITORY*`
-|This variable specifies the URL to a repository with sources to build.
+|The URL of a Git repository with source to be built.
+
+|`*SOURCE_URI*`
+|Uses the same value as `*SOURCE_REPOSITORY*`. Either can be used.
+
+|`*SOURCE_CONTEXT_DIR*`
+|Specifies the subdirectory of the Git repository to be used when building. Only
+present if defined.
+
+|`*SOURCE_REF*`
+|The Git reference to be built.
+
+|`*ORIGIN_VERSION*`
+|The version of the OpenShift master that created this build object.
+
+|`*OUTPUT_REGISTRY*`
+|The Docker registry to push the image to.
+
+|`*OUTPUT_IMAGE*`
+|The Docker tag name for the image being built.
+
+|`*PUSH_DOCKERCFG_PATH*`
+|The path to the Docker credentials for running a `docker push` operation.
 
 |`*DOCKER_SOCKET*`
-|This variable specifies the path to the Docker socket, if exposing the Docker socket was enabled on BuildConfig.
+|Specifies the path to the Docker socket, if exposing the Docker socket was
+enabled in the build configuration (if `*exposeDockerSocket*` was set to
+*true*.)
+
 |===
 
-== Custom Builder Workflow
-Although the custom builder image author has a great flexibility in defining the build
-process on its own, still they should follow a few required steps necessary to seamlessly
-run a build inside of OpenShift. The required steps for a custom builder image are following:
+It is recommended that you write your Custom builder image to only read the
+information provided by the `*BUILD*` environment variable, which conforms to an
+OpenShift API version. You can then parse the required information from the
+build definition JSON instead of relying on the other individual environment
+variables provided to the builder image. However, the individual environment
+variables are provided for convenience if you do not want to parse the build
+definition.
 
-. Read the link:../rest_api/openshift_v1.html#v1-build[Build] definition, which
-contains all the necessary information about input parameters for the build.
+[[custom-builder-workflow]]
+== Custom Builder Workflow
+
+Although Custom builder image authors have great flexibility in defining the
+build process, your builder image must still adhere to the following required
+steps necessary for seamlessly running a build inside of OpenShift:
+
+. Read the `*Build*` link:../rest_api/openshift_v1.html#v1-build[object
+definition], which contains all the necessary information about input parameters
+for the build.
 . Run the build process.
-. If your build produces image, push it to the link:../rest_api/openshift_v1.html#v1-build[Build]'s
-output location if the output location is defined. Other output locations can be passed with environment
-variable for now.
+. If your build produces an image, push it to the build's
+link:../rest_api/openshift_v1.html#v1-buildoutput[output location] if it is
+defined. Other output locations can be passed with environment variables.


### PR DESCRIPTION
Follow-up for https://github.com/openshift/openshift-docs/pull/1491 plus continued edits to the Custom Builder topic in general. Tried to add more context/clarity in the Overview, and other various clean-up.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/020516/edit_buildapiver_1491/creating_images/custom.html

@mnagy @soltysh @bparees Mind reviewing? I also noticed the list of env vars we show in this topic seems different than the ones in `origin-custom-docker-builder`'s Dockerfile comments:

https://hub.docker.com/r/openshift/origin-custom-docker-builder/~/dockerfile/

What's the current correct set?
