### PR TITLE
fixed example formatting for ldap sync doc

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -182,18 +182,24 @@ OpenShift. Your files must contain one unique group identifier per line.
 ====
 
 ----
-$ oadm groups sync --whitelist=<whitelist_file> --sync-config=config.yaml --confirm
-$ oadm groups sync --blacklist=<blacklist_file> --sync-config=config.yaml --confirm
-$ oadm groups sync <group_unique_identifier> --sync-config=config.yaml --confirm
-$ oadm groups sync <group_unique_identifier> \
-                           --whitelist=<whitelist_file> \
-                           --blacklist=<blacklist_file> \
-                           --sync-config=config.yaml \
-                           --confirm
-$ oadm groups sync --type=openshift \
-                           --whitelist=<whitelist_file> \
-                           --sync-config=config.yaml \
-                           --confirm
+$ oadm groups sync --whitelist=<whitelist_file> \
+                   --sync-config=config.yaml    \
+                   --confirm
+$ oadm groups sync --blacklist=<blacklist_file> \
+                   --sync-config=config.yaml    \
+                   --confirm
+$ oadm groups sync <group_unique_identifier>    \
+                   --sync-config=config.yaml    \
+                   --confirm
+$ oadm groups sync <group_unique_identifier>    \
+                   --whitelist=<whitelist_file> \
+                   --blacklist=<blacklist_file> \
+                   --sync-config=config.yaml    \
+                   --confirm
+$ oadm groups sync --type=openshift             \
+                   --whitelist=<whitelist_file> \
+                   --sync-config=config.yaml    \
+                   --confirm
 ----
 
 [[running-a-group-pruning-job]]


### PR DESCRIPTION
@adellape as seen on [this](https://access.redhat.com/documentation/en/openshift-enterprise/version-3.1/installation-and-configuration/#sync-examples) page, the example invocations of the command are not well formatted. Many don't fit on one line and the rest don't seem to have a good reason to be indented as they are. Hopefully with these changes it will be easier to look at these examples.
