### PR TITLE
Document the RunOnceDuration plug-in

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -257,6 +257,8 @@ Topics:
     File: pruning_resources
   - Name: Garbage Collection
     File: garbage_collection
+  - Name: Limit Run-once Pod Duration
+    File: limit_runonce_pod_duration
   - Name: Monitoring Routers
     File: router
   - Name: High Availability

--- a/admin_guide/limit_runonce_pod_duration.adoc
+++ b/admin_guide/limit_runonce_pod_duration.adoc
@@ -1,0 +1,76 @@
+= Limit Run-once Pod Duration
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+OpenShift relies on run-once pods to perform tasks such as link:../dev_guide/deployments.html[deploying a pod] or
+link:../dev_guide/builds.html[performing a build]. Run-once pods are pods that have a RestartPolicy of `Never` or `OnFailure`.
+
+The cluster administrator can use the `RunOnceDuration` admission control plug-in to force a limit on the time that those
+run-once pods can be active. Once the time limit expires, the cluster will try to actively terminate those pods.
+The main reason to have such a limit is to prevent tasks such as builds to run for an excessive amount of time.
+
+== Configuring the RunOnceDuration plug-in
+
+Because the `RunOnceDuration` plug-in is not enabled by default, it must be specified along with default Kubernetes admission
+control plug-ins in the master-config.yaml configuration file.
+
+The plugin configuration can also include the default active deadline for run-once pods. This deadline will be enforced globally
+but can be superseded on per-project basis.
+
+====
+
+[source,yaml]
+----
+kubernetesMasterConfig:
+  admissionConfig:
+    pluginOrderOverride:
+    - RunOnceDuration <1>
+    - NamespaceLifecycle
+    - OriginPodeNodeEnvironment
+    - LimitRanger
+    - ServiceAccount
+    - SecurityContextConstraint
+    - ResourceQuota
+    - SCCExecRestrictions
+    pluginConfig:
+      RunOnceDuration:
+        configuration:
+          apiVersion: v1
+          kind: RunOnceDurationConfig
+          activeDeadlineSecondsOverride: 3600 <2>
+----
+
+<1> Add the plugin to the list of admission control plugins.
+<2> Specify the global default for run-once pods in seconds.
+
+====
+
+== Specifying a custom duration per Project
+
+In addition to specifying a global maximum duration for run-once pods, an administrator can add an annotation (`openshift.io/active-deadline-seconds-override`)
+to a specific project to override the global default.
+
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Project
+metadata:
+  annotations:
+    openshift.io/active-deadline-seconds-override: "1000" <1>
+----
+
+<1> Overrides the default active deadline seconds for run-once pods to 1000 seconds.
+Note that the value of the override must be specified in string form.
+
+====
+


### PR DESCRIPTION
Adds documentation for the RunOnceDuration plugin. 

This should only be able to releases that include the admin guide (origin and enterprise).
