### PR TITLE
Fix incorrect deployment config example

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -73,7 +73,7 @@ following is an example of a `*deploymentConfig*` resource:
           }
         ]
       }
-    }
+    },
     "replicas": 5, <2>
     "selector": {
       "name": "frontend"


### PR DESCRIPTION
Fix incorrect deployment config example as comma was missing after template sections ends before replicas.
