### PR TITLE
Fix RPM paths in logging topic + revhistory note

### DIFF
--- a/admin_guide/aggregate_logging.adoc
+++ b/admin_guide/aggregate_logging.adoc
@@ -64,7 +64,7 @@ Perform the following steps on each node to install and configure *fluentd*
 # export RPM=td-agent-2.2.0-0.x86_64.rpm
 # curl https://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
     -o /tmp/$RPM
-# yum localinstall $RPM
+# yum localinstall /tmp/$RPM
 # /opt/td-agent/embedded/bin/gem install fluent-plugin-kubernetes
 # mkdir -p /etc/td-agent/config.d
 # chown td-agent:td-agent /etc/td-agent/config.d
@@ -187,7 +187,7 @@ that the nodes are working properly.
 # export RPM=td-agent-2.2.0-0.x86_64.rpm
 # curl https://packages.treasuredata.com/2/redhat/7/x86_64/$RPM \
     -o /tmp/$RPM
-# yum localinstall $RPM
+# yum localinstall /tmp/$RPM
 # mkdir -p /etc/td-agent/config.d
 # chown td-agent:td-agent /etc/td-agent/config.d
 ----

--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -5,6 +5,20 @@
 :icons:
 :experimental:
 
+== Mon Feb 08 2016
+
+// tag::admin_guide_mon_feb_08_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../admin_guide/aggregate_logging.html[Aggregating Container Logs]
+|Fixed RPM package paths for `yum localinstall` commands.
+
+|===
+// end::admin_guide_mon_feb_08_2016[]
+
 == Tue Jun 23 2015
 
 OpenShift Enterprise 3.0 release.

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -13,6 +13,9 @@ date.
 .Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_mon_feb_08_2016]
 
+.Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_mon_feb_08_2016]
+
 == Mon Feb 01 2016
 
 .Architecture


### PR DESCRIPTION
Closes https://github.com/openshift/openshift-docs/pull/1117.

Making change directly on the `enterprise-3.0` branch because this content is no longer pertinent in OSE 3.1.

FYI @tnguyen-rh: Sneaking this in w/ your OSE 3.0 publish today, as it turns out.
