### PR TITLE
Update persistent_storage_nfs.adoc

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -214,6 +214,8 @@ Topics:
         File: persistent_storage_iscsi
       - Name: Using Fibre Channel
         File: persistent_storage_fibre_channel
+      - Name: Dynamic Provisioning
+        File: dynamically_provisioning_pvs
       - Name: Volume Security
         File: pod_security_context
   - Name: Working with HTTP Proxies

--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -8,7 +8,7 @@
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-  <title><%= distro %> <%= version %> | <%= [group_title, subgroup_title, topic_title].compact.join(' | ') %></title>
+  <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css">
   <link href="<%= File.join(css_path, 'docs.css') %>" rel="stylesheet" />
   <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png">
@@ -41,10 +41,10 @@
       <li class="sitename">
         <a href="<%= site_home_path %>"><%= site_name %></a>
       </li>
-      <li class="hidden-xs active">
+      <li class="hidden-xs">
         <%= breadcrumb_root %>
       </li>
-      <li class="hidden-xs active">
+      <li class="hidden-xs">
         <%= breadcrumb_group %>
       </li>
       <%= breadcrumb_subgroup_block %>

--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -47,14 +47,14 @@ link:../../dev_guide/builds.html[Developer's Guide].
 
 For more information on how OpenShift leverages Docker for builds, see the link:https://github.com/openshift/origin/blob/master/docs/builds.md#how-it-works[upstream documentation].
 
-[#docker-build]
+[[docker-build]]
 === Docker Build
 The Docker build strategy invokes the plain
 https://docs.docker.com/engine/reference/commandline/build/[docker build] command,
 and it therefore expects a repository with a *_Dockerfile_* and all required
 artifacts in it to produce a runnable image.
 
-[#source-build]
+[[source-build]]
 === Source-to-Image (S2I) Build
 link:../../creating_images/s2i.html[Source-to-Image (S2I)] is a tool for
 building reproducible Docker images. It produces ready-to-run images by
@@ -98,17 +98,18 @@ their application build.
 Ecosystem:: S2I encourages a shared ecosystem of images where you can leverage
 best practices for your applications.
 
-[#custom-build]
+[[custom-build]]
 === Custom Build
 The Custom build strategy allows developers to define a specific builder image
 responsible for the entire build process. Using your own builder image allows
 you to customize your build process.
 
-The link:../../creating_images/custom.html[Custom builder image] is a plain
-Docker image with embedded build process logic, such as building RPMs or
-building base Docker images. The
-https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder/[openshift/origin-custom-docker-builder]
-image is used by default.
+A link:../../creating_images/custom.html[Custom builder image] is a plain Docker
+image embedded with build process logic, for example for building RPMs or base
+Docker images. The `openshift/origin-custom-docker-builder` image is available
+on the
+https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder[Docker
+Hub] as an example implementation of a Custom builder image.
 
 [[image-streams]]
 

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -599,8 +599,9 @@ spec:
       -----END CERTIFICATE-----
 ----
 
-<1> The `*termination*` field is set to `reencrypt`. Other fields are as in edge termination.
-<2> The `*destinationCaCertificate*` field optionally specifies a CA
-certificate to validate the endpoint certificate, securing the connection
-from the router to the destination.
+<1> The `*termination*` field is set to `reencrypt`. Other fields are as in edge
+termination.
+<2> The `*destinationCaCertificate*` field specifies a CA certificate to
+validate the endpoint certificate, securing the connection from the router to
+the destination. This field is required, but only for re-encryption.
 ====

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -67,7 +67,7 @@ Manages groups:
 $ oadm groups
 ----
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-origin[]
 [[install-cli-operations]]
 
 == Install CLI Operations
@@ -113,7 +113,7 @@ Removes older versions of resources from the server:
 $ oadm prune
 ----
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-origin[]
 [[settings-cli-operations]]
 
 == Settings CLI Operations

--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -455,16 +455,39 @@
 [options="nowrap"]
 ----
   // Create a route based on service nginx. The new route will re-use nginx's labels
-  $ oc expose service nginx
+  $ oc expose svc/nginx
 
   // Create a route and specify your own label and route name
-  $ oc expose service nginx -l name=myroute --name=fromdowntown
+  $ oc expose svc/nginx -l name=myroute --name=fromdowntown
 
   // Create a route and specify a hostname
-  $ oc expose service nginx --hostname=www.example.com
+  $ oc expose svc/nginx --hostname=www.example.com
 
   // Expose a deployment configuration as a service and use the specified port
-  $ oc expose dc ruby-hello-world --port=8080 --generator=service/v1
+  $ oc expose dc/ruby-hello-world --port=8080
+----
+====
+
+
+== Securely expose containers via a route
+
+====
+
+[options="nowrap"]
+----
+  // Create a secure edge terminated route using the specified certificates/keys and hostname
+  // If the certificates/keys are not specified, those from the router will be re-used
+  $ oc create route edge --service=frontend --cert=${MASTER_CONFIG_DIR}/ca.crt \
+                        --key=${MASTER_CONFIG_DIR}/ca.key \
+                        --ca-cert=${MASTER_CONFIG_DIR}/ca.crt \
+                        --hostname=www.example.com
+
+  // Create a secure passthrough terminated route
+  $ oc create route passthrough --service=registry
+
+  // Create a secure reencrypt terminated route in a similar fashion as edge. The only additional
+  // requirement is to specify a destination CA certificate.
+  $ oc create route reencrypt --service=backend --dest-ca-cert=ca.crt
 ----
 ====
 

--- a/contributing_to_docs/templates/rev_history_guide_dirname.adoc
+++ b/contributing_to_docs/templates/rev_history_guide_dirname.adoc
@@ -5,11 +5,11 @@
 :icons:
 :experimental:
 
-== Fri Jan 1 2016
+== Fri Jan 01 2016
 
 OpenShift Enterprise X.Y.Z release (if publishing timed with a product release).
 
-// tag::<guide_dirname>_fri_jan_1_2016[]
+// tag::<guide_dirname>_fri_jan_01_2016[]
 [cols="1,3",options="header"]
 |===
 
@@ -23,7 +23,7 @@ link:../path/to/topic1.html#section-anchor[Full Section Title] section to
 |link:../path/to/topic2.html.html[Full Topic Title]
 |New topic to (include, discuss, detail, etc.) <relevant_reason>.
 |===
-// end::<guide_dirname>_fri_jan_1_2016[]
+// end::<guide_dirname>_fri_jan_01_2016[]
 
 == Mon Jan 11 2016
 

--- a/creating_images/custom.adoc
+++ b/creating_images/custom.adoc
@@ -10,49 +10,100 @@
 toc::[]
 
 == Overview
-link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[Custom
-build] is designed to fill the gap that was created when everybody jumped into
-creating Docker images. Still there is a requirement to produce individual
-artifacts (packages, jars, wars, installable zips, base images etc.) This is
-where Custom build is the perfect match to fill in that gap. Additionally Custom
-build allows implementing any extended build process for example, CI/CD flow
-that runs unit or integration tests. The limit here is just the imagination of
-the custom builder image author.
+By allowing you to define a specific builder image responsible for the entire
+build process, OpenShift's
+link:../dev_guide/builds.html#custom-strategy-options[Custom build strategy] was
+designed to fill a gap created with the increased popularity of creating Docker
+images. When there is a requirement for a build to still produce individual
+artifacts (packages, JARs, WARs, installable ZIPs, and base images, for
+example), a _Custom builder image_ utilizing the Custom build strategy is the
+perfect match to fill that gap.
 
-To fully utilize the power of Custom build one needs to be understand how to
-create a builder image that will be capable of building desired objects.
+A Custom builder image is a plain Docker image embedded with build process
+logic, for example for building RPMs or base Docker images. The
+`openshift/origin-custom-docker-builder` image is available on the
+https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder[Docker
+Hub] as an example implementation of a Custom builder image.
 
+Additionally, the Custom builder allows implementing any extended build process,
+for example a CI/CD flow that runs unit or integration tests. The only limit is
+the imagination of the builder image author.
+
+To fully utilize the power of the Custom build strategy, you must understand how
+to create a Custom builder image that will be capable of building desired
+objects.
+
+[[custom-builder-image]]
 == Custom Builder Image
-The builder image upon invocation receives following environment variables with
-the information needed to proceed with the build:
+
+Upon invocation, a custom builder image will receive the following environment
+variables with the information needed to proceed with the build:
 
 .Custom Builder Environment Variables
-[cols="4a,6a",options="header"]
+[cols="1,3",options="header"]
 |===
 
-|Variable name |Description
+|Variable Name |Description
 
 |`*BUILD*`
-|This variable specifies the entire serialized link:../rest_api/openshift_v1.html#v1-build[Build] object.
-If you need to use a specific API version for serialization, you can set the `buildAPIVersion`
-parameter in the link:../rest_api/openshift_v1.html#v1-buildconfig[Build Config]'s custom
-strategy link:../rest_api/openshift_v1.html#v1-custombuildstrategy[specification].
+|The entire serialized JSON of the `*Build*`
+link:../rest_api/openshift_v1.html#v1-build[object definition]. If you need to
+use a specific API version for serialization, you can set the
+`*buildAPIVersion*` parameter in the
+link:../dev_guide/builds.html#custom-strategy-options[custom strategy
+specification] of the build configuration.
 
 |`*SOURCE_REPOSITORY*`
-|This variable specifies the URL to a repository with sources to build.
+|The URL of a Git repository with source to be built.
+
+|`*SOURCE_URI*`
+|Uses the same value as `*SOURCE_REPOSITORY*`. Either can be used.
+
+|`*SOURCE_CONTEXT_DIR*`
+|Specifies the subdirectory of the Git repository to be used when building. Only
+present if defined.
+
+|`*SOURCE_REF*`
+|The Git reference to be built.
+
+|`*ORIGIN_VERSION*`
+|The version of the OpenShift master that created this build object.
+
+|`*OUTPUT_REGISTRY*`
+|The Docker registry to push the image to.
+
+|`*OUTPUT_IMAGE*`
+|The Docker tag name for the image being built.
+
+|`*PUSH_DOCKERCFG_PATH*`
+|The path to the Docker credentials for running a `docker push` operation.
 
 |`*DOCKER_SOCKET*`
-|This variable specifies the path to the Docker socket, if exposing the Docker socket was enabled on BuildConfig.
+|Specifies the path to the Docker socket, if exposing the Docker socket was
+enabled in the build configuration (if `*exposeDockerSocket*` was set to
+*true*.)
+
 |===
 
-== Custom Builder Workflow
-Although the custom builder image author has a great flexibility in defining the build
-process on its own, still they should follow a few required steps necessary to seamlessly
-run a build inside of OpenShift. The required steps for a custom builder image are following:
+It is recommended that you write your Custom builder image to only read the
+information provided by the `*BUILD*` environment variable, which conforms to an
+OpenShift API version. You can then parse the required information from the
+build definition JSON instead of relying on the other individual environment
+variables provided to the builder image. However, the individual environment
+variables are provided for convenience if you do not want to parse the build
+definition.
 
-. Read the link:../rest_api/openshift_v1.html#v1-build[Build] definition, which
-contains all the necessary information about input parameters for the build.
+[[custom-builder-workflow]]
+== Custom Builder Workflow
+
+Although Custom builder image authors have great flexibility in defining the
+build process, your builder image must still adhere to the following required
+steps necessary for seamlessly running a build inside of OpenShift:
+
+. Read the `*Build*` link:../rest_api/openshift_v1.html#v1-build[object
+definition], which contains all the necessary information about input parameters
+for the build.
 . Run the build process.
-. If your build produces image, push it to the link:../rest_api/openshift_v1.html#v1-build[Build]'s
-output location if the output location is defined. Other output locations can be passed with environment
-variable for now.
+. If your build produces an image, push it to the build's
+link:../rest_api/openshift_v1.html#v1-buildoutput[output location] if it is
+defined. Other output locations can be passed with environment variables.

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1429,23 +1429,25 @@ able to launch a build whenever a `*BuildConfig*` is updated.
 [[using-docker-credentials-for-pushing-and-pulling-images]]
 == Using Docker Credentials for Pushing and Pulling Images
 
-Supply the *_.dockercfg_* file with valid Docker Registry credentials in order to
+Supply the *_.docker/config.json_* file with valid Docker Registry credentials in order to
 push the output image into a private Docker Registry or pull the builder image
 from the private Docker Registry that requires authentication. For the OpenShift
 Docker Registry, you don't have to do this because `*secrets*` are generated
 automatically for you by OpenShift.
 
-The *_.dockercfg_* JSON file is found in your home directory by default and has
+The *_.docker/config.json_* file is found in your home directory by default and has
 the following format:
 
 ====
 [source,json]
 ----
 {
-	"https://index.docker.io/v1/": { <1>
-		"auth": "YWRfbGzhcGU6R2labnRib21ifTE=", <2>
-		"email": "user@example.com" <3>
-	}
+  "auths": {
+    "https://index.docker.io/v1/": { <1>
+      "auth": "YWRfbGzhcGU6R2labnRib21ifTE=", <2>
+      "email": "user@example.com" <3>
+    }
+  }
 }
 ----
 <1> URL of the registry.
@@ -1459,11 +1461,11 @@ command. The file will be created if it does not exist. Kubernetes provides
 link:../dev_guide/secrets.html[`*secret*`] objects, which are used to store your
 configuration and passwords.
 
-. Create the `*secret*` from your local *_.dockercfg_* file:
+. Create the `*secret*` from your local *_.docker/config.json_* file:
 +
 ====
 ----
-$ oc secrets new dockerhub ~/.dockercfg
+$ oc secrets new dockerhub ~/.docker/config.json
 ----
 ====
 +

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -60,57 +60,39 @@ image tag or the source code changes:
 
 .BuildConfig Object Definition
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "kind": "BuildConfig",
-    "apiVersion": "v1",
-    "metadata": {
-      "name": "ruby-sample-build" <1>
-    },
-  "spec": {
-    "triggers": [ <2>
-      {
-        "type": "GitHub",
-        "github": {
-          "secret": "secret101"
-        }
-      },
-      {
-        "type": "Generic",
-        "generic": {
-          "secret": "secret101"
-        }
-      },
-      {
-        "type": "ImageChange"
-      }
-    ],
-    "source": { <3>
-      "type": "Git",
-      "git": {
-        "uri": "git://github.com/openshift/ruby-hello-world.git"
-      },
-      "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example"
-    },
-    "strategy": { <4>
-      "type": "Source",
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "ruby-20-centos7:latest"
-        }
-      }
-    },
-    "output": { <5>
-      "to": {
-        "kind": "ImageStreamTag",
-        "name": "origin-ruby-sample:latest"
-      }
-    }
-  }
-}
+kind: "BuildConfig"
+apiVersion: "v1"
+metadata:
+  name: "ruby-sample-build" <1>
+spec:
+  triggers: <2>
+    -
+      type: "GitHub"
+      github:
+        secret: "secret101"
+    -
+      type: "Generic"
+      generic:
+        secret: "secret101"
+    -
+      type: "ImageChange"
+  source: <3>
+    type: "Git"
+    git:
+      uri: "git://github.com/openshift/ruby-hello-world.git"
+    dockerfile: "FROM openshift/ruby-22-centos7\nUSER example"
+  strategy: <4>
+    type: "Source"
+    sourceStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "ruby-20-centos7:latest"
+  output: <5>
+    to:
+      kind: "ImageStreamTag"
+      name: "origin-ruby-sample:latest"
 ----
 
 <1> This specification will create a new `*BuildConfig*` named
@@ -148,21 +130,15 @@ local image and refresh it from the registry to which the image stream points,
 create a `*BuildConfig*` with the `*forcePull*` flag set to *true*:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Source",
-    "sourceStrategy": {
-      "from": {
-        "kind": "ImageStreamTag",
-        "name": "builder-image:latest" <1>
-      },
-      "forcePull": true <2>
-    }
-  }
-}
+strategy:
+  type: "Source"
+  sourceStrategy:
+    from:
+      kind: "ImageStreamTag"
+      name: "builder-image:latest" <1>
+    forcePull: true <2>
 ----
 
 <1> The builder image being used, where the local version on the node may not be
@@ -182,21 +158,15 @@ previously-built images. To create an incremental build, create a
 `*BuildConfig*` with the following modification to the strategy definition:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Source",
-    "sourceStrategy": {
-      "from": {
-        "kind": "ImageStreamTag",
-        "name": "incremental-image:latest" <1>
-      },
-      "incremental": true <2>
-    }
-  }
-}
+strategy:
+  type: "Source"
+  sourceStrategy:
+    from:
+      kind: "ImageStreamTag"
+      name: "incremental-image:latest" <1>
+    incremental: true <2>
 ----
 
 <1> Specify an image that supports incremental builds. Consult the
@@ -228,21 +198,15 @@ builder image in one of two ways. Either:
 definition. For example:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Source",
-    "sourceStrategy": {
-      "from": {
-        "kind": "ImageStreamTag",
-        "name": "builder-image:latest"
-      },
-      "scripts": "http://somehost.com/scripts_directory" <1>
-    }
-  }
-}
+strategy:
+  type: "Source"
+  sourceStrategy:
+    from:
+      kind: "ImageStreamTag"
+      name: "builder-image:latest"
+    scripts: "http://somehost.com/scripts_directory" <1>
 ----
 
 <1> This path will have *_run_*, *_assemble_*, and *_save-artifacts_* appended
@@ -302,19 +266,14 @@ them also available to the *_run_* script and application code.
 For example disabling assets compilation for your Rails application:
 
 ====
-
+[source,yaml]
 ----
-{
-  "sourceStrategy": {
-    ...
-    "env": [
-      {
-        "name": "DISABLE_ASSET_COMPILATION",
-        "value": "true"
-      }
-    ]
-  }
-}
+sourceStrategy:
+...
+  env:
+    -
+      name: "DISABLE_ASSET_COMPILATION"
+      value: "true"
 ----
 ====
 
@@ -341,7 +300,6 @@ field. It can be simply a different file name other than the default
 subdirectory (for example, *_dockerfiles/app1/_*):
 
 ====
-
 [source,yaml]
 ----
 strategy:
@@ -360,17 +318,12 @@ build. Setting the `*nocache*` option to *true* forces the build to ignore
 cached layers and rerun all steps of the *_Dockerfile_*:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Docker",
-    "dockerStrategy": {
-      "nocache": true
-    }
-  }
-}
+strategy:
+  type: "Docker"
+  dockerStrategy:
+    nocache: true
 ----
 ====
 
@@ -384,19 +337,13 @@ local image and refresh it from the registry to which the image stream points,
 create a `*BuildConfig*` with the `*forcePull*` flag set to *true*:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Docker",
-    "dockerStrategy": {
-      "forcePull": true <1>
-    }
-  }
-}
+strategy:
+  type: "Docker"
+  dockerStrategy:
+    forcePull: true <1>
 ----
-
 <1> This flag causes the local builder image to be ignored, and a fresh version
 to be pulled from the registry to which the image stream points. Setting
 `*forcePull*` to *false* results in the default behavior of honoring the image
@@ -411,9 +358,9 @@ link:../architecture/core_concepts/builds_and_image_streams.html#docker-build[Do
 process and resulting image, you can add environment variables to the
 `*dockerStrategy*` definition of the `*BuildConfig*`.
 
-The environment variables defined there are inserted as a single ENV Dockerfile
-instruction right after the FROM instruction, so that it can be referenced later
-on within the Dockerfile.
+The environment variables defined there are inserted as a single `ENV`
+Dockerfile instruction right after the `FROM` instruction, so that it can be
+referenced later on within the Dockerfile.
 
 The variables are defined during build and stay in the output image, therefore
 they will be present in any container that runs that image as well.
@@ -421,23 +368,16 @@ they will be present in any container that runs that image as well.
 For example, defining a custom HTTP proxy to be used during build and runtime:
 
 ====
-
+[source,yaml]
 ----
-{
-  "dockerStrategy": {
-    ...
-    "env": [
-      {
-        "name": "HTTP_PROXY",
-        "value": "http://myproxy.net:5187/"
-      }
-    ]
-  }
-}
+dockerStrategy:
+...
+  env:
+    -
+      name: "HTTP_PROXY"
+      value: "http://myproxy.net:5187/"
 ----
 ====
-
-
 
 [[custom-strategy-options]]
 
@@ -456,17 +396,12 @@ images from inside the Docker container, the build container must be bound to an
 accessible socket. To do so, set the `*exposeDockerSocket*` option to *true*:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Custom",
-    "customStrategy": {
-      "exposeDockerSocket": true
-    }
-  }
-}
+strategy:
+  type: "Custom"
+  customStrategy:
+    exposeDockerSocket: true
 ----
 ====
 
@@ -483,30 +418,20 @@ secrets to the builder pod.
 Each secret can be mounted at a specific location:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Custom",
-    "customStrategy": {
-      "secrets": [
-        {
-          "secretSource": { <1>
-            "name": "secret1"
-          },
-          "mountPath": "/tmp/secret1" <2>
-        },
-        {
-          "secretSource": {
-            "name": "secret2"
-          },
-          "mountPath": "/tmp/secret2"
-        }
-      ]
-    }
-  }
-}
+strategy:
+  type: "Custom"
+  customStrategy:
+    secrets:
+      -
+        secretSource: <1>
+          name: "secret1"
+        mountPath: "/tmp/secret1" <2>
+      -
+        secretSource:
+          name: "secret2"
+        mountPath: "/tmp/secret2"
 ----
 
 <1> `*secretSource*` is a reference to a secret in the same namespace as the
@@ -526,17 +451,12 @@ it from the registry to which the image stream points, create a `*BuildConfig*`
 with the `*forcePull*` flag set to *true*:
 
 ====
-
-[source,json]
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Custom",
-    "customStrategy": {
-      "forcePull": true <1>
-    }
-  }
-}
+strategy:
+  type: "Custom"
+  customStrategy:
+    forcePull: true <1>
 ----
 
 <1> This flag causes the local builder image to be ignored, and a fresh version
@@ -559,19 +479,15 @@ custom build.
 For example, defining a custom HTTP proxy to be used during build:
 
 ====
-
+[source,yaml]
 ----
-{
-  "customStrategy": {
-    ...
-    "env": [
-      {
-        "name": "HTTP_PROXY",
-        "value": "http://myproxy.net:5187/"
-      }
-    ]
-  }
-}
+customStrategy:
+...
+  env:
+    -
+      name: "HTTP_PROXY"
+      value: "http://myproxy.net:5187/"
+
 ----
 ====
 
@@ -589,21 +505,16 @@ replaces the one in the `*contextDir*` of the Git repository.
 The source definition is part of the `*spec*` section in the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
-  "source" : {
-    "type" : "Git",
-    "git" : { <1>
-      "uri": "git://github.com/openshift/ruby-hello-world.git",
-      "ref": "master"
-    },
-    "contextDir": "app/dir", <2>
-    "dockerfile": "FROM openshift/ruby-22-centos7\nUSER example" <3>
-  },
-}
+source:
+  type: "Git"
+  git: <1>
+    uri: "git://github.com/openshift/ruby-hello-world.git"
+    ref: "master"
+  contextDir: "app/dir" <2>
+  dockerfile: "FROM openshift/ruby-22-centos7\nUSER example" <3>
 ----
-
 <1> The `*git*` field contains the URI to the remote Git repository of the
 source code. Optionally, specify the `*ref*` field to check out a specific Git
 reference. A valid `*ref*` can be a SHA1 tag or a branch name.
@@ -632,15 +543,14 @@ Your source URI must use the HTTP or HTTPS protocol for this to work.
 ====
 
 ====
+[source,yaml]
 ----
-...
 source:
   type: Git
   git:
     uri: "git://github.com/openshift/ruby-hello-world.git"
     httpProxy: http://proxy.example.com
     httpsProxy: https://proxy.example.com
-...
 ----
 ====
 
@@ -712,40 +622,29 @@ $ oc secrets add serviceaccount/builder secrets/basicsecret
 In this case `*basicsecret*`:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "apiVersion": "v1",
-  "kind": "BuildConfig",
-  "metadata": {
-    "name": "sample-build",
-  },
-  "spec": {
-    "output": {
-      "to": {
-        "kind": "ImageStreamTag"
-        "name": "sample-image:latest"
-      }
-    },
-    "source": {
-      "git": {
-        "uri": "https://github.com/user/app.git" <1>
-      },
-      "sourceSecret": {
-        "name": "basicsecret"
-      },
-      "type": "Git"
-    },
-    "strategy": {
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "python-33-centos7:latest"
-        }
-      },
-      "type": "Source"
-    }
-  }
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  name: "sample-build"
+spec:
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "sample-image:latest"
+  source:
+    git:
+      uri: "https://github.com/user/app.git" <1>
+    sourceSecret:
+      name: "basicsecret"
+    type: "Git"
+  strategy:
+    sourceStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "python-33-centos7:latest"
+    type: "Source"
 ----
 <1> The URL of private repository, accessed by basic authentication, is usually
 in the `http` or `https` form.
@@ -815,40 +714,29 @@ $ oc secrets add serviceaccount/builder secrets/sshsecret
 In this case `*sshsecret*`:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "apiVersion": "v1",
-  "kind": "BuildConfig",
-  "metadata": {
-    "name": "sample-build",
-  },
-  "spec": {
-    "output": {
-      "to": {
-        "kind": "ImageStreamTag"
-        "name": "sample-image:latest"
-      }
-    },
-    "source": {
-      "git": {
-        "uri": "git@repository.com:user/app.git" <1>
-      },
-      "sourceSecret": {
-        "name": "sshsecret"
-      },
-      "type": "Git"
-    },
-    "strategy": {
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "python-33-centos7:latest"
-        }
-      },
-      "type": "Source"
-    }
-  }
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  name: "sample-build"
+spec:
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "sample-image:latest"
+  source:
+    git:
+      uri: "git@repository.com:user/app.git" <1>
+    sourceSecret:
+      name: "sshsecret"
+    type: "Git"
+  strategy:
+    sourceStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "python-33-centos7:latest"
+    type: "Source"
 ----
 <1> The URL of private repository, accessed by a private SSH key, is usually
 in the form `git@example.com:<username>/<repository>.git`.
@@ -921,19 +809,14 @@ This source type is valid when the build strategy type is `*Docker*` or
 The source definition is part of the `*spec*` section in the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
- "source" : {
-    "type" : "Dockerfile",
-    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <1>
- },
-}
+source:
+  type: "Dockerfile"
+  dockerfile: "FROM centos:7\nRUN yum install -y httpd" <1>
 ----
-
 <1> The `*dockerfile*` field contains an inline Dockerfile that will be built.
 ====
-
 
 [[binary-source]]
 
@@ -957,20 +840,15 @@ allows changing to a subdirectory within the content before the build executes.
 The source definition is part of the `*spec*` section in the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
- "source" : {
-    "type" : "Binary",
-    "binary": { <1>
-      "asFile": "webapp.war" <2>
-    },
-    "contextDir": "app/dir", <3>
-    "dockerfile": "FROM centos:7\nRUN yum install -y httpd" <4>
- },
-}
+source:
+  type: "Binary"
+  binary: <1>
+    asFile: "webapp.war" <2>
+  contextDir: "app/dir" <3>
+  dockerfile: "FROM centos:7\nRUN yum install -y httpd" <4>
 ----
-
 <1> The `*binary*` field specifies the details of the binary source.
 <2> The `*asFile*` field specifies the name of a file that will be created with
 the binary contents.
@@ -1001,26 +879,29 @@ content (if any) is cloned.
 Image inputs are specified in the `*source*` definition of the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
     source:
       git:
         uri: https://github.com/openshift/ruby-hello-world.git
       images: <1>
-      - from: <2>
+      -
+        from: <2>
           kind: ImageStreamTag
           name: myinputimage:latest
           namespace: mynamespace
         paths: <3>
         - destinationDir: injected/dir <4>
           sourcePath: /usr/lib/somefile.jar <5>
-      - from:
+      -
+        from:
           kind: ImageStreamTag
           name: myotherinputimage:latest
           namespace: myothernamespace
         pullSecret: mysecret <6>
         paths:
-        - destinationDir: injected/dir
+        -
+          destinationDir: injected/dir
           sourcePath: /usr/lib/somefile.jar
 ----
 
@@ -1254,19 +1135,14 @@ To enable more verbose output, pass the `*BUILD_LOGLEVEL*` environment variable
 as part of the `*sourceStrategy*` or `*dockerStrategy*` in a `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
-  "sourceStrategy": {
-    ...
-    "env": [
-      {
-        "name": "BUILD_LOGLEVEL",
-        "value": "2" <1>
-      }
-    ]
-  }
-}
+sourceStrategy:
+...
+  env:
+    -
+      name: "BUILD_LOGLEVEL"
+      value: "2" <1>
 ----
 
 <1> Adjust this value to the desired log level.
@@ -1303,11 +1179,8 @@ The following example shows the part of a `*BuildConfig*` specifying
 
 ====
 ----
-{
-  "spec" : {
-    "completionDeadlineSeconds" : 1800,
-  }
-}
+spec:
+  completionDeadlineSeconds: 1800
 ----
 ====
 
@@ -1337,17 +1210,14 @@ made by GitHub when a repository is updated. When defining the trigger, you must
 specify a `*secret*`, which will be part of the URL you supply to GitHub when
 configuring the webhook. The secret ensures the uniqueness of the URL, preventing
 others from triggering the build. The following example is a trigger definition
-JSON within the `*BuildConfig*`:
+YAML within the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
-  "type": "GitHub",
-  "github": {
-    "secret": "secret101"
-  }
-}
+type: "GitHub"
+github:
+  secret: "secret101"
 ----
 ====
 
@@ -1369,21 +1239,18 @@ http://<openshift_api_host:port>/osapi/v1/namespaces/<namespace>/buildconfigs/<n
 
 *Generic Webhooks*
 
-Generic webhooks can be invoked from any system capable of making a web
-request. As with a GitHub webhook, you must specify a `*secret*` which will be
-part of the URL, the caller must use to trigger the build. The secret ensures
-the uniqueness of the URL, preventing others from triggering the build.
-The following is an example trigger definition JSON within the `*BuildConfig*`:
+Generic webhooks can be invoked from any system capable of making a web request.
+As with a GitHub webhook, you must specify a `*secret*` which will be part of
+the URL, the caller must use to trigger the build. The secret ensures the
+uniqueness of the URL, preventing others from triggering the build. The
+following is an example trigger definition YAML within the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
-  "type": "Generic",
-  "generic": {
-    "secret": "secret101"
-  }
-}
+type: "Generic"
+generic:
+  secret: "secret101"
 ----
 ====
 
@@ -1397,25 +1264,20 @@ http://<openshift_api_host:port>/osapi/v1/namespaces/<namespace>/buildconfigs/<n
 The endpoint can accept an optional payload with the following format:
 
 ====
-
+[source,yaml]
 ----
-{
-  type: 'git',
-  git: {
-    uri: '<url to git repository>',
-    ref: '<optional git reference>',
-    commit: '<commit hash identifying a specific git commit>',
-    author: {
-      name: '<author name>',
-      email: '<author e-mail>',
-    },
-    committer: {
-      name: '<committer name>',
-      email: '<committer e-mail>',
-    },
-    message: '<commit message>'
-  }
-}
+type: "git"
+git:
+  uri: "<url to git repository>"
+  ref: "<optional git reference>"
+  commit: "<commit hash identifying a specific git commit>"
+  author:
+    name: "<author name>"
+    email: "<author e-mail>"
+  committer:
+    name: "<committer name>"
+    email: "<committer e-mail>"
+  message: "<commit message>"
 ----
 ====
 
@@ -1448,15 +1310,12 @@ Configuring an image change trigger requires the following actions:
 trigger on:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "kind": "ImageStream",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "ruby-20-centos7"
-  }
-}
+kind: "ImageStream"
+apiVersion: "v1"
+metadata:
+  name: "ruby-20-centos7"
 ----
 ====
 +
@@ -1469,19 +1328,14 @@ running in OpenShift.
 build strategy to point to the image stream:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Source",
-    "sourceStrategy": {
-      "from": {
-        "kind": "ImageStreamTag",
-        "name": "ruby-20-centos7:latest"
-      },
-    }
-  }
-}
+strategy:
+  type: "Source"
+  sourceStrategy:
+    from:
+      kind: "ImageStreamTag"
+      name: "ruby-20-centos7:latest"
 ----
 ====
 +
@@ -1491,28 +1345,22 @@ the image stream named `ruby-20-centos7` located within this namespace.
 . Define a build with one or more triggers that point to image streams:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "type": "imageChange", <1>
-  "imageChange": {}
-}
-{
-  "type": "imagechange", <2>
-  "imageChange": {
-     "from": {
-       "kind": "ImageStreamTag",
-       "name": "custom-image:latest"
-     }
-  }
-}
+type: "imageChange" <1>
+imageChange: {}
+type: "imagechange" <2>
+imageChange:
+  from:
+    kind: "ImageStreamTag"
+    name: "custom-image:latest"
 ----
-
-<1> An image change trigger that monitors the `*ImageStream*` and
-`*Tag*` as defined by the build strategy's `*from*` field. The `*imageChange*` part
+<1> An image change trigger that monitors the `*ImageStream*` and `*Tag*` as
+defined by the build strategy's `*from*` field. The `*imageChange*` object here
 must be empty.
-<2> An image change trigger that monitors an arbitrary image stream. The `*imageChange*`
-part in this case must include a `*from*` field that references the `*ImageStreamTag*` to monitor.
+<2> An image change trigger that monitors an arbitrary image stream. The
+`*imageChange*` part in this case must include a `*from*` field that references
+the `*ImageStreamTag*` to monitor.
 ====
 
 When using an image change trigger for the strategy image stream, the generated build
@@ -1525,19 +1373,14 @@ strategy will not be updated with a unique image reference.
 In the example above that has an image change trigger for the strategy, the resulting build will be:
 
 ====
-
+[source,yaml]
 ----
-{
-  "strategy": {
-    "type": "Source",
-    "sourceStrategy": {
-      "from": {
-        "kind": "DockerImage",
-        "name": "172.30.17.3:5001/mynamespace/ruby-20-centos7:immutableid"
-      }
-    }
-  }
-}
+strategy:
+  type: "Source"
+  sourceStrategy:
+    from:
+      kind: "DockerImage"
+      name: "172.30.17.3:5001/mynamespace/ruby-20-centos7:immutableid"
 ----
 ====
 
@@ -1567,16 +1410,13 @@ uniquely identifiable images in v1 Docker registries.
 === Configuration Change Triggers
 A configuration change trigger allows a build to be automatically invoked as
 soon as a new `*BuildConfig*` is created. The following is an example trigger
-definition JSON within the `*BuildConfig*`:
+definition YAML within the `*BuildConfig*`:
 
 ====
-
+[source,yaml]
 ----
-{
-  "type": "ConfigChange"
-}
+  type: "ConfigChange"
 ----
-
 ====
 
 [NOTE]
@@ -1599,7 +1439,7 @@ The *_.dockercfg_* JSON file is found in your home directory by default and has
 the following format:
 
 ====
-
+[source,json]
 ----
 {
 	"https://index.docker.io/v1/": { <1>
@@ -1608,7 +1448,6 @@ the following format:
 	}
 }
 ----
-
 <1> URL of the registry.
 <2> Encrypted password.
 <3> Email address for the login.
@@ -1647,21 +1486,15 @@ set it to the name of the `*secret*` that you created, which in the above exampl
 is *dockerhub*:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "spec": {
-    "output": {
-      "to": {
-        "kind": "DockerImage"
-        "name": "private.registry.com/org/private-image:latest"
-      },
-      "pushSecret":{
-        "name": "dockerhub"
-      }
-    }
-  }
-}
+spec:
+  output:
+    to:
+      kind: "DockerImage"
+      name: "private.registry.com/org/private-image:latest"
+    pushSecret:
+      name: "dockerhub"
 ----
 ====
 
@@ -1669,22 +1502,16 @@ is *dockerhub*:
 `*pullSecret*` field, which is part of the build strategy definition:
 +
 ====
-
+[source,yaml]
 ----
-{
-  "strategy": {
-    "sourceStrategy": {
-      "from": {
-        "kind": "DockerImage",
-        "name": "docker.io/user/private_repository"
-       },
-       "pullSecret": {
-        "name": "dockerhub"
-       },
-    },
-    "type": "Source"
-  }
-}
+strategy:
+  sourceStrategy:
+    from:
+      kind: "DockerImage"
+      name: "docker.io/user/private_repository"
+    pullSecret:
+      name: "dockerhub"
+  type: "Source"
 ----
 ====
 
@@ -1711,29 +1538,23 @@ of the build.
 
 .Output to an ImageStreamTag
 ====
-
-[source,json]
+[source,yaml]
 ----
-    "output": {
-      "to": {
-        "kind": "ImageStreamTag"
-        "name": "sample-image:latest"
-      }
-    }
+output:
+  to:
+    kind: "ImageStreamTag"
+    name: "sample-image:latest"
 ----
 ====
 
 .Output to a Docker Push Specification
 ====
-
-[source,json]
+[source,yaml]
 ----
-    "output": {
-      "to": {
-        "kind": "DockerImage"
-        "name": "my-registry.mycompany.com:5000/myimages/myimage:tag"
-      }
-    }
+output:
+  to:
+    kind: "DockerImage"
+    name: "my-registry.mycompany.com:5000/myimages/myimage:tag"
 ----
 ====
 

--- a/dev_guide/integrating_external_services.adoc
+++ b/dev_guide/integrating_external_services.adoc
@@ -59,25 +59,19 @@ endpoints manually:
 ====
 
 ----
-{
-  "kind": "Service",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "external-mysql-service"
-  },
-  "spec": {
-    "ports": [
-      {
-        "name": "mysql",
-        "protocol": "TCP",
-        "port": 3306,
-        "targetPort": 3306,
-        "nodePort": 0
-      }
-    ]
-  },
-  "selector": {} <1>
-}
+  kind: "Service"
+  apiVersion: "v1"
+  metadata:
+    name: "external-mysql-service"
+  spec:
+    ports:
+      -
+        name: "mysql"
+        protocol: "TCP"
+        port: 3306
+        targetPort: 3306
+        nodePort: 0
+  selector: {} <1>
 ----
 
 <1> The `selector` field to leave blank.
@@ -90,23 +84,20 @@ proxy and router the location to send traffic directed to the service:
 ====
 
 ----
-{
-  "kind": "Endpoints",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "external-mysql-service" <1>
-  },
-  "subsets": [ <2>
-    {
-      "addresses":  [
-        { "IP": "10.0.0.0" } <3>
-      ],
-      "ports":  [
-        { "port": 3306, "name": "mysql" } <4>
-      ]
-    }
-  ]
-}
+  kind: "Endpoints"
+  apiVersion: "v1"
+  metadata:
+    name: "external-mysql-service" <1>
+  subsets: <2>
+    -
+      addresses:
+        -
+          IP: "10.0.0.0" <3>
+      ports:
+        -
+          port: 3306 <4>
+          name: "mysql"
+
 ----
 
 <1> The name of the `Service` instance, as defined in the previous step.
@@ -128,63 +119,43 @@ the appropriate containers:
 ====
 
 ----
-{
-  "kind": "DeploymentConfig",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "my-app-deployment"
-  },
-  "spec": { <1>
-    "strategy": {
-      "type": "Rolling",
-      "rollingParams": {
-        "updatePeriodSeconds": 1,
-        "intervalSeconds": 1,
-        "timeoutSeconds": 120
-      }
-    },
-    "replicas": 2,
-    "selector": {
-      "name": "frontend"
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "name": "frontend"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "name": "helloworld",
-            "image": "origin-ruby-sample",
-            "ports": [
-              {
-                "containerPort": 8080,
-                "protocol": "TCP"
-              }
-            ],
-            "env": [
-              {
-                "name": "MYSQL_USER",
-                "value": "${MYSQL_USER}" <2>
-              },
-              {
-                "name": "MYSQL_PASSWORD",
-                "value": "${MYSQL_PASSWORD}" <3>
-              },
-              {
-                "name": "MYSQL_DATABASE",
-                "value": "${MYSQL_DATABASE}" <4>
-              }
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
-
+  kind: "DeploymentConfig"
+  apiVersion: "v1"
+  metadata:
+    name: "my-app-deployment"
+  spec: <1>
+    strategy:
+      type: "Rolling"
+      rollingParams:
+        updatePeriodSeconds: 1
+        intervalSeconds: 1
+        timeoutSeconds: 120
+    replicas: 2
+    selector:
+      name: "frontend"
+    template:
+      metadata:
+        labels:
+          name: "frontend"
+      spec:
+        containers:
+          -
+            name: "helloworld"
+            image: "origin-ruby-sample"
+            ports:
+              -
+                containerPort: 3306
+                protocol: "TCP"
+            env:
+              -
+                name: "MYSQL_USER"
+                value: "${MYSQL_USER}" <2>
+              -
+                name: "MYSQL_PASSWORD"
+                value: "${MYSQL_PASSWORD}" <3>
+              -
+                name: "MYSQL_DATABASE"
+                value: "${MYSQL_DATABASE}" <4>
 ----
 
 <1> Other fields on the `DeploymentConfig` are omitted
@@ -258,25 +229,19 @@ manually:
 ====
 
 ----
-{
-  "kind": "Service",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "example-external-service"
-  },
-  "spec": {
-    "ports": [
-      {
-        "name": "mysql",
-        "protocol": "TCP",
-        "port": 1234,
-        "targetPort": 1234,
-        "nodePort": 0
-      }
-    ]
-  },
-  "selector": {} <1>
-}
+  kind: "Service"
+  apiVersion: "v1"
+  metadata:
+    name: "example-external-service"
+  spec:
+    ports:
+      -
+        name: "mysql"
+        protocol: "TCP"
+        port: 3306
+        targetPort: 3306
+        nodePort: 0
+  selector: {} <1>
 ----
 
 <1> The `selector` field to leave blank.
@@ -289,17 +254,16 @@ to send traffic directed to the service proxy and the router:
 ====
 
 ----
-{
-  "kind": "Endpoints",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "example-external-service" <1>
-  },
-  "subsets": [ <2>
-    "api.mysaas.com:80",
-    "api2.mysaas.com:8080"
-  ]
-}
+kind: "Endpoints"
+apiVersion: "v1"
+metadata:
+  name: "example-external-service" <1>
+subsets: <2>
+- addresses:
+  - ip: "10.10.1.1"
+  ports:
+  - name: "mysql"
+    port: 3306
 ----
 
 ====
@@ -313,62 +277,45 @@ use the service by setting environment variables in the appropriate containers:
 ====
 
 ----
-{
-  "kind": "DeploymentConfig",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "my-app-deployment"
-  },
-  "spec": { <1>
-    "strategy": {
-      "type": "Rolling",
-      "rollingParams": {
-        "updatePeriodSeconds": 1,
-        "intervalSeconds": 1,
-        "timeoutSeconds": 120
-      }
-    },
-    "replicas": 1,
-    "selector": {
-      "name": "frontend"
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "name": "frontend"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "name": "helloworld",
-            "image": "openshift/openshift/origin-ruby-sample",
-            "ports": [
-              {
-                "containerPort": 8080,
-                "protocol": "TCP"
-              }
-            ],
-            "env": [
-              {
-                "name": "SAAS_API_KEY", <2>
-                "value": "<SaaS service API key>"
-              },
-              {
-                "name": "SAAS_USERNAME", <3>
-                "value": "<SaaS service user>"
-              },
-              {
-                "name": "SAAS_PASSPHRASE", <4>
-                "value": "<SaaS service passphrase>"
-              }
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
+---
+  kind: "DeploymentConfig"
+  apiVersion: "v1"
+  metadata:
+    name: "my-app-deployment"
+  spec:  <1>
+    strategy:
+      type: "Rolling"
+      rollingParams:
+        updatePeriodSeconds: 1
+        intervalSeconds: 1
+        timeoutSeconds: 120
+    replicas: 1
+    selector:
+      name: "frontend"
+    template:
+      metadata:
+        labels:
+          name: "frontend"
+      spec:
+        containers:
+          -
+            name: "helloworld"
+            image: "openshift/openshift/origin-ruby-sample"
+            ports:
+              -
+                containerPort: 3306
+                protocol: "TCP"
+            env:
+              -
+                name: "SAAS_API_KEY" <2>
+                value: "<SaaS service API key>"
+              -
+                name: "SAAS_USERNAME" <3>
+                value: "<SaaS service user>"
+              -
+                name: "SAAS_PASSPHRASE" <4>
+                value: "<SaaS service passphrase>"
+
 ----
 
 <1> Other fields on the `DeploymentConfig` are omitted.

--- a/dev_guide/jobs.adoc
+++ b/dev_guide/jobs.adoc
@@ -92,3 +92,29 @@ $ oc scale job pi --replicas=3
 Scaling replication controllers also uses the `oc scale` command with the
 `--replicas` option, but instead changes the `*replicas*` parameter of a
 replication controller configuration.
+
+[[setting-maximum-duration]]
+== Setting Maximum Duration
+
+When defining a `*Job*`, you can define its maximum duration by setting
+the `*activeDeadlineSeconds*` field. It is specified in seconds and is not
+set by default. When not set, there is no maximum duration enforced.
+
+The maximum duration is counted from the time when a first pod gets scheduled in
+the system, and defines how long a job can be active. It tracks overall time of
+an execution and is irrelevant to the number of completions (number of pods needed
+to execute a task). After reaching the specified timeout, the job is terminated
+by OpenShift.
+
+The following example shows the part of a `*Job*` specifying
+`*activeDeadlineSeconds*` field for 30 minutes:
+
+====
+----
+{
+  "spec" : {
+    "activeDeadlineSeconds" : 1800,
+  }
+}
+----
+====

--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -28,35 +28,38 @@ to the router.
 
 Tooling for creating routes is developing. In the web console, they are
 displayed but there is not yet a method to create them. Using the CLI, you
-currently can create only an unsecured route:
+can create both unsecured and secured routes. In the following example, an
+unsecured route will be created:
 
 ----
-$ oc expose service/<name> --hostname=<www.example.com>
+$ oc expose svc/frontend --hostname=www.example.com
 ----
 
-The new route inherits the name from the service unless you specify one.
+The new route will inherit the name from the service unless you specify one
+using the --name flag.
 
-.An Unsecured Route YAML Definition
+.YAML definition of the unsecured route created above
 ====
 [source,yaml]
 ----
 apiVersion: v1
 kind: Route
 metadata:
-  name: route-name
+  name: frontend
 spec:
   host: www.example.com
   to:
     kind: Service
-    name: service-name
+    name: frontend
 ----
 ====
 
 Unsecured routes are the default configuration, and are therefore the simplest
 to set up. However, secured routes offer security for connections to remain
 private. To create a secured HTTPS route encrypted with a key and certificate
-(PEM-format files which you must generate and sign separately), you must
-edit the unsecured route to add TLS termination.
+(PEM-format files which you must generate and sign separately), you can use
+the `create route` command and optionally provide certificates and a key. 
+For more information on secured routes, see link:https://docs.openshift.org/latest/architecture/core_concepts/routes.html#secured-routes[here].
 
 [NOTE]
 ====
@@ -65,22 +68,25 @@ replacement of SSL for HTTPS and other encrypted protocols.
 ====
 
 ----
-$ oc edit route/<name>
+$ oc create route edge --service=frontend --cert=${MASTER_CONFIG_DIR}/ca.crt \
+                        --key=${MASTER_CONFIG_DIR}/ca.key \
+                        --ca-cert=${MASTER_CONFIG_DIR}/ca.crt \
+                        --hostname=www.example.com
 ----
 
-.A Secure Route Using Edge Termination
+.YAML definition of the secured route created above
 ====
 [source,yaml]
 ----
 apiVersion: v1
 kind: Route
 metadata:
-  name: route-name
+  name: frontend
 spec:
   host: www.example.com
   to:
     kind: Service
-    name: service-name
+    name: frontend
   tls:
     termination: edge
     key: |-
@@ -98,7 +104,7 @@ spec:
 ----
 ====
 
-You can specify a secured route without a key and certificate, in which case the
+You can create a secured route without specifying a key and certificate, in which case the
 ifdef::openshift-enterprise,openshift-origin[]
 link:../install_config/install/deploy_router.html#using-wildcard-dns[router's
 default certificate]

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -8,9 +8,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="google-site-verification" content="MCaLEYfZB8HfZSTyMQYZyBeRMXGoKt46uvrwEp-KN3M" />
-    <title>Home | OpenShift Documentation</title>
-    <link href="https:/docs.openshift.com/" rel="canonical" />
+    <meta name="google-site-verification" content="MCaLEYfZB8HfZSTyMQYZyBeRMXGoKt46uvrwEp-KN3M">
+    <title>Home | OpenShift by Red Hat Documentation</title>
+    <link href="https:/docs.openshift.com/" rel="canonical">
     <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png">
     <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="image/png">
     <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->

--- a/index-community.html
+++ b/index-community.html
@@ -8,9 +8,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="google-site-verification" content="9jyGvNki3NSELTYJ7t_XbF-YQZ8jjfm7LqQQGNq4SSg" />
+    <meta name="google-site-verification" content="9jyGvNki3NSELTYJ7t_XbF-YQZ8jjfm7LqQQGNq4SSg">
     <title>Home | OpenShift Origin Documentation</title>
-    <link href="https:/docs.openshift.com/" rel="canonical" />
+    <link href="https:/docs.openshift.org/" rel="canonical">
     <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png">
     <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="image/png">
     <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->
@@ -24,13 +24,6 @@
     <!-- IE8 requires jQuery and Bootstrap JS to load in head to prevent rendering bugs -->
     <!-- IE8 requires jQuery v1.x -->
     <script src="https://assets.openshift.net/content/subdomain.js"></script>
-    <script src='https://www.google.com/jsapi' type='text/javascript'></script>
-    <script type='text/javascript'>
-        google.load('search', '1');
-        google.setOnLoadCallback(function() {
-            google.search.CustomSearchControl.attachAutoCompletionWithOptions('013769182564158614814:lt-zcblgpx4', document.getElementById('cse-search-input'), 'cse-search-form', {'maxCompletions' : 5});
-        }, true);
-    </script>
     <script async src="//www.google-analytics.com/analytics.js" type="text/javascript"></script>
     <script>
      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -495,3 +495,52 @@ specified in `*metricsPublicURL*` and accept that certificate.
 To avoid this issue, use certificates which are configured to be acceptable by
 your browser.
 ====
+
+ifdef::openshift-origin[]
+== Accessing Hawkular Metrics Directly
+
+If you wish to access and manage metrics more directly, you can do so via the Hawkular Metrics API.
+
+The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation] covers 
+how to use the API, but there are a few differences when dealing with the version of Hawkular Metrics 
+configured for use on OpenShift:
+
+=== OpenShift Projects & Hawkular Tenants
+
+Hawkular Metrics is a multi-tenanted application. The way its been configured is that a project in 
+OpenShift corresponds to a tenant in Hawkular Metrics.
+
+As such, when accessing metrics for a project named `MyProject` you will need to set the 
+link:http://www.hawkular.org/docs/rest/rest-metrics.html#_tenant_header[Hawkular-tenant] header to
+`MyProject`
+
+There is also a special tenant named `_system` which contains system level metrics. This will require
+either a `cluster-reader` or `cluster-admin` level privileges to access.
+
+=== Authorization
+
+The Hawkular Metrics service will authenticate the user against OpenShift to determine if the user has
+access to the project it is trying to access.
+
+When accessing the Hawkular Metrics API, you will need to pass a bearer token in the `Authorization` header.
+
+For more information how how to access the Hawkular Metrics in OpenShift, please see the
+link:https://github.com/openshift/origin-metrics/blob/master/docs/hawkular_metrics.adoc[Origin Metrics documentation]
+
+== Accessing Heapster Directly
+
+Heapster has been configured to be only accessible via the
+link:../rest_api/kubernetes_v1.html#proxy-get-requests-to-service[API proxy]. Accessing it will required
+either a cluster-reader or cluster-admin privileges.
+
+For example, to access the Heapster `validate` page, you would need to access it using something similar to:
+
+----
+$ curl -H "Authorization: Bearer XXXXXXXXXXXXXXXXX" \
+       -X GET https://${KUBERNETES_MASTER}/api/v1/proxy/namespaces/openshift-infra/services/https:heapster:/validate
+----
+
+For more information about Heapster and how to access its APIs, please refer the 
+link:https://github.com/kubernetes/heapster/[Heapster] project.
+
+endif::[]

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -843,6 +843,13 @@ Using GitHub as an identity provider requires users to get a token using
 `<master>/oauth/token/request` to use with command-line tools.
 ====
 
+[WARNING]
+====
+Using GitHub as an identity provider allows any GitHub user to authenticate to your server.
+You can limit authentication to members of specific GitHub organizations with the
+`organizations` config attribute, as shown below.
+====
+
 .Master Configuration Using *GitHubIdentityProvider*
 ====
 
@@ -859,6 +866,9 @@ oauthConfig:
       kind: GitHubIdentityProvider
       clientID: ... <5>
       clientSecret: ... <6>
+      organizations: <7>
+      - myorganization1
+      - myorganization2
 ----
 <1> This provider name is prefixed to the GitHub numeric user ID to form an
 identity name. It is also used to build the callback URL.
@@ -873,6 +883,8 @@ link:https://github.com/settings/applications/new[registered GitHub OAuth
 application]. The application must be configured with a callback URL of
 `<master>/oauth2callback/<identityProviderName>`.
 <6> The client secret issued by GitHub.
+<7> Optional list of organizations. If specified, only GitHub users that are members of 
+at least one of the listed organizations will be allowed to log in.
 ====
 
 [[Google]]
@@ -888,6 +900,13 @@ Connect integration].
 ====
 Using Google as an identity provider requires users to get a token using
 `<master>/oauth/token/request` to use with command-line tools.
+====
+
+[WARNING]
+====
+Using Google as an identity provider allows any Google user to authenticate to your server.
+You can limit authentication to members of a specific hosted domain with the
+`hostedDomain` config attribute, as shown below.
 ====
 
 .Master Configuration Using *GoogleIdentityProvider*

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -18,22 +18,22 @@ volumes as persistent storage] for application data. After AWS is configured
 properly, some additional configurations will need to be completed on the
 OpenShift hosts.
 
-
+[[configuring-aws-variables]]
 == Configuring AWS Variables
+
 To set the required AWS variables, create a *_/etc/aws/aws.conf_* file with
 the following contents on all of your OpenShift hosts, both masters and nodes:
 
 ====
 ----
 [Global]
-Zone = us-east-1c  <1>
+Zone = us-east-1c <1>
 ----
-
-<1> This is the Availability Zone of your AWS Instance and where your EBS Volume resides; this information is obtained from the AWS Managment Console.
+<1> This is the Availability Zone of your AWS Instance and where your EBS Volume
+resides; this information is obtained from the AWS Managment Console.
 ====
 
-
-
+[[aws-configuring-masters]]
 == Configuring Masters
 
 Edit or
@@ -60,6 +60,7 @@ kubernetesMasterConfig:
 ----
 ====
 
+[[aws-configuring-nodes]]
 == Configuring Nodes
 
 Edit or
@@ -78,17 +79,29 @@ kubeletArguments:
 ----
 ====
 
+[[aws-setting-key-value-access-pairs]]
+== Setting Key Value Access Pairs
 
-
-== Exporting Key Value Access Pairs
-
-Make sure the following environment variables are set in /etc/sysconfig/atomic-openshift-master and /etc/sysconfig/atomic-openshift-node, then start or restart OpenShift services on the master and all nodes:
+Make sure the following environment variables are set in the
+ifdef::openshift-enterprise[]
+*_/etc/sysconfig/atomic-openshift-master_* file on masters and the
+*_/etc/sysconfig/atomic-openshift-node_* file on nodes:
+endif::[]
+ifdef::openshift-origin[]
+*_/etc/sysconfig/origin-master_* file on masters and the
+*_/etc/sysconfig/origin-node_* file on nodes:
+endif::[]
 
 ====
 ----
-AWS_ACCESS_KEY_ID=<key id>
-AWS_SECRET_ACCESS_KEY=<secret key>
+AWS_ACCESS_KEY_ID=<key_ID>
+AWS_SECRET_ACCESS_KEY=<secret_key>
 ----
 ====
 
+[NOTE]
+====
 Access keys are obtained when setting up your AWS IAM user.
+====
+
+Then, start or restart OpenShift services on the master and all nodes.

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -64,9 +64,8 @@ kubernetesMasterConfig:
 
 Edit or
 link:../install_config/master_node_configuration.html#creating-new-configuration-files[create]
-the node configuration file on all nodes
-(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` section:
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` section:
 
 ====
 [source,yaml]

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -37,7 +37,6 @@ kubernetesMasterConfig:
   controllerArguments:
     cloud-provider:
       - "gce"
-
 ----
 ====
 
@@ -59,4 +58,4 @@ kubeletArguments:
 ----
 ====
 
-Start or restart the OpenShift services on the master and all nodes.
+Then, start or restart the OpenShift services on the master and all nodes.

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -17,6 +17,7 @@ volumes as persistent storage] for application data. After GCE is configured
 properly, some additional configurations will need to be completed on the
 OpenShift hosts.
 
+[[gce-configuring-masters]]
 == Configuring Masters
 
 Edit or
@@ -40,6 +41,7 @@ kubernetesMasterConfig:
 ----
 ====
 
+[[gce-configuring-nodes]]
 == Configuring Nodes
 
 Edit or
@@ -56,7 +58,5 @@ kubeletArguments:
 
 ----
 ====
-
-
 
 Start or restart the OpenShift services on the master and all nodes.

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -43,10 +43,9 @@ kubernetesMasterConfig:
 == Configuring Nodes
 
 Edit or
-link:../install_config/master_node_configuration.html#creating-new-configuration-files[create] the
-node configuration file on all nodes
-(*_/etc/origin/node-<hostname>/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` section:
+link:../install_config/master_node_configuration.html#creating-new-configuration-files[create]
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` section:
 
 ====
 [source,yaml]

--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -68,10 +68,10 @@ kubernetesMasterConfig:
 == Configuring Nodes
 
 Edit or
-link:../install_config/master_node_configuration.html#creating-new-configuration-files[create] the
-node configuration file on all nodes
-(*_/etc/origin/node/node-config.yaml_* by default) and update the
-contents of the `*kubeletArguments*` and `*nodeName*` sections:
+link:../install_config/master_node_configuration.html#creating-new-configuration-files[create]
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` and `*nodeName*`
+sections:
 
 ====
 [source,yaml]

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -565,17 +565,34 @@ first have link:deploy_router.html[deployed a router].
 +
 . link:deploy_router.html[Deploy a router].
 +
-. Create your
-link:../../architecture/core_concepts/routes.html#passthrough-termination[passthrough]
-route with `oc create -f <filename>.json`.  The passthrough route will point to
-the registry service that you have created.
+. Create a
+link:https://docs.openshift.org/latest/architecture/core_concepts/routes.html#secured-routes[passthrough]
+route via `oc create route passthrough` by pointing the `--service` flag to the service
+of the registry. You can optionally provide a route name by passing an argument, otherwise
+the name of the service will be used as the route name.
++
+For example:
 +
 ====
 ----
+$ oc get svc
+NAME              CLUSTER_IP       EXTERNAL_IP   PORT(S)                 SELECTOR                  AGE
+docker-registry   172.30.69.167    <none>        5000/TCP                docker-registry=default   4h
+kubernetes        172.30.0.1       <none>        443/TCP,53/UDP,53/TCP   <none>                    4h
+router            172.30.172.132   <none>        80/TCP                  router=router             4h
+
+$ oc create route passthrough --service=docker-registry --hostname=<host>
+route "docker-registry" created
+----
+====
++
+====
+----
+$ oc get route/docker-registry -o yaml
 apiVersion: v1
 kind: Route
 metadata:
-  name: registry
+  name: docker-registry
 spec:
   host: <host> <1>
   to:

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -505,7 +505,7 @@ $ oc get pods
 POD                       IP           CONTAINER(S)   IMAGE(S)                                  HOST                           LABELS                                                                                  STATUS    CREATED    MESSAGE
 docker-registry-1-da73t   172.17.0.1                                                            openshiftdev.local/127.0.0.1   deployment=docker-registry-4,deploymentconfig=docker-registry,docker-registry=default   Running   38 hours
 
-$ oc log docker-registry-1-da73t | grep tls
+$ oc logs docker-registry-1-da73t | grep tls
 time="2015-05-27T05:05:53Z" level=info msg="listening on :5000, tls" instance.id=deeba528-c478-41f5-b751-dc48e4935fc2
 ----
 ====

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -436,7 +436,7 @@ Optionally, you can secure the registry so that it serves traffic via TLS:
 +
 ====
 ----
-$ oc get svc docker-registry
+$ oc get svc/docker-registry
 NAME              LABELS                                    SELECTOR                  IP(S)            PORT(S)
 docker-registry   docker-registry=default                   docker-registry=default   172.30.124.220   5000/TCP
 ----
@@ -486,12 +486,15 @@ $ oc env dc/docker-registry \
 See more details on
 https://github.com/docker/distribution/blob/master/docs/configuration.md#override-configuration-options[overriding
 registry options].
+
+. Update the scheme used for the registry's liveness probe from HTTP to HTTPS:
 +
-. You also need to update the scheme used for the liveness and readiness probes to HTTPS:
 ----
-$ oc get dc docker-registry -o yaml | sed -e 's/scheme: HTTP/scheme: HTTPS/g' | oc replace -f -
+$ oc get dc/docker-registry -o yaml \
+    | sed -e 's/scheme: HTTP/scheme: HTTPS/g' \
+    | oc replace -f -
 ----
-+
+
 . Validate the registry is running in TLS mode. Wait until the *docker-registry*
 pod status changes to `Running` and verify the Docker logs for the registry
 container. You should find an entry for `listening on :5000, tls`.

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -764,6 +764,12 @@ the available volume group and will grow to fill the volume group via LVM
 monitoring.
 ====
 
+. Check if Docker is running:
++
+----
+# systemctl is-active docker
+----
+
 . If Docker has not yet been started on the host, enable and start the service:
 +
 ----
@@ -771,7 +777,7 @@ monitoring.
 # systemctl start docker
 ----
 +
-However, if Docker is already running, re-initialize Docker:
+If Docker is already running, re-initialize Docker:
 +
 [WARNING]
 ====
@@ -783,6 +789,9 @@ This will destroy any Docker containers or images currently on the host.
 # rm -rf /var/lib/docker/*
 # systemctl restart docker
 ----
++
+If there is any content in *_/var/lib/docker/_*, it must be deleted. Files
+will be present if Docker has been used prior to the installation of OpenShift.
 
 [[reconfiguring-docker-storage]]
 *Reconfiguring Docker Storage*

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -849,7 +849,7 @@ endif::[]
 
 ifdef::openshift-origin[]
 If you are interested in installing OpenShift using the containerized method
-(optional for Fedora,, CentOS, or RHEL but required for RHEL Atomic Host), see
+(optional for Fedora, CentOS, or RHEL but required for RHEL Atomic Host), see
 link:../../install_config/install/rpm_vs_containerized.html[RPM vs
 Containerized] to ensure that you understand the differences between the
 installation methods. Then continue with your chosen installation method.

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -1,0 +1,124 @@
+= Dynamically Provisioning Persistent Volumes
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+You can provision your OpenShift cluster with storage dynamically when running
+in a cloud environment. The Kubernetes
+link:../../architecture/additional_concepts/storage.html[persistent volume]
+framework allows administrators to provision a cluster with persistent storage
+and gives users a way to request those resources without having any knowledge of
+the underlying infrastructure.
+
+Many storage types are available for use as persistent volumes in OpenShift.
+While all of them can be statically provisioned by an administrator, some types
+of storage can be created dynamically using an API. These types of storage can
+be provisioned in an OpenShift cluster using the new and experimental dynamic
+storage feature.
+
+[IMPORTANT]
+====
+ifdef::openshift-enterprise[]
+Dynamic provisioning of persistent volumes is currently a Technology Preview
+feature, introduced in OpenShift Enterprise 3.1.1.
+endif::[]
+This feature is experimental and expected to change in the future as it matures
+and feedback is received from users. New ways to provision the cluster are
+planned and the means by which one accesses this feature is going to change.
+Backwards compatibility is not guaranteed.
+====
+
+[[enabling-provisioner-plugins]]
+== Enabling Provisioner Plug-ins
+
+OpenShift provides the following _provisioner plug-ins_, which have generic
+implementations for dynamic provisioning that use the cluster's configured cloud
+provider's API to create new storage resources:
+
+[options="header"]
+|===
+
+|Storage Type |Provisioner Plug-in Name |Required Cloud Configuration
+
+|OpenStack Cinder
+|`kubernetes.io/cinder`
+|link:../../install_config/configuring_openstack.html[Configuring for OpenStack]
+
+|AWS Elastic Block Store (EBS)
+|`kubernetes.io/aws-ebs`
+|link:../../install_config/configuring_aws.html[Configuring for AWS]
+
+|GCE Persistent Disk (gcePD)
+|`kubernetes.io/gce-pd`
+|link:../../install_config/configuring_gce.html[Configuring for GCE]
+|===
+
+[IMPORTANT]
+====
+For any chosen provisioner plug-ins, the relevant cloud configuration must also
+be set up, per *Required Cloud Configuration* in the above table.
+====
+
+When your OpenShift cluster is configured for EBS, GCE, or Cinder, the
+associated provisioner plug-in is implied and automatically enabled. No
+additional OpenShift configuration by the cluster administration is required for
+dynamic provisioning.
+
+For example, if your OpenShift cluster is configured to run in AWS, the EBS
+provisioner plug-in is automatically available for creating
+link:#dynamic-pvs-requesting-storage[dynamically provisioned storage requested
+by a user].
+
+Future provisioner plug-ins will include the many types of storage a single
+provider offers. AWS, for example, has several types of EBS volumes to offer,
+each with its own performance characteristics; there is also an NFS-like storage
+option. More provisioner plug-ins will be implemented for the supported storage
+types available in OpenShift.
+
+[[dynamic-pvs-requesting-storage]]
+== Requesting Dynamically Provisioned Storage
+
+Users can request dynamically provisioned storage by including a storage class
+annotation in their link:../../dev_guide/persistent_volumes.html[persistent
+volume claim]:
+
+.Persistent Volume Claim Requesting Dynamic Storage
+====
+[source,yaml]
+----
+kind: "PersistentVolumeClaim"
+apiVersion: "v1"
+metadata:
+  name: "claim1"
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: "foo" <1>
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "3Gi"
+----
+<1> The value of the `*volume.alpha.kubernetes.io/storage-class*` annotation is
+not meaningful at this time. The presence of the annotation, with any arbitrary
+value, triggers provisioning using the single implied
+link:#enabling-provisioner-plugins[provisioner plug-in per cloud].
+====
+
+[[dynamic-pvs-volume-recycling]]
+== Volume Recycling
+
+Volumes created dynamically by a provisioner have their
+`*persistentVolumeReclaimPolicy*` set to *Delete*. When a persistent volume
+claim is deleted, its backing persistent volume is considered released of its
+claim, and that resource can be reclaimed by the cluster. Dynamic provisioning
+utilizes the provider's API to delete the volume from the provider and then
+removes the persistent volume from the cluster.

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -387,6 +387,7 @@ spec:
   containers:
   - name: ...
   securityContext:
+    type: MustRunAs
     SELinuxOptions: <1>
       user: selinux-user-name
       role: selinux-role-name

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -112,7 +112,7 @@ by a specific amount (e.g, 10Gi) and be matched with a corresponding volume of
 equal or greater capacity.
 
 [[nfs-volume-security]]
-=== Volume Security
+== Volume Security
 This section covers aspects of Security Context Constraints (SCCs), which are described
 elsewhere, see
 link:../../admin_guide/manage_scc.html[managing SCCs] and
@@ -145,7 +145,7 @@ uid=99(nobody) gid=99(nobody) groups=99(nobody)
 then the container will need to match selinux labels, and either run with a UID of 99
 (_nobody_ owner), or with 5555 in its supplemental groups in order to access the directory.
 
-==== User IDs
+=== User IDs
 User ids can be defined in the container image or in the pod spec. The
 link:pod_security_context.html#user-id[pod and storage security] document covers
 controlling storage access based on user ids.
@@ -174,7 +174,7 @@ range checking is required,
 
 To best way to fix this situation is to create a custom SCC.
 
-====== Custom SCC for UserID:
+===== Custom SCC for User IDs
 It's generally considered a good practice to *not* modify the predefined SCCs. The preferred
 approach is to create a custom SCC that better fits an organization's security needs, or
 create a new project that supports the desired user ids. See
@@ -209,7 +209,7 @@ default is a user id was not supplied in the pod spec.
 Now, using `runAsUser: 99`, shown in the pod fragment above, the pod matches the "nfs-scc"
 and is able to run with a UID of 99.
 
-===== Group IDs
+=== Group IDs
 Another way to handle NFS access (assuming it's not a choice to change permissions on the NFS mount)
 is to use supplemental groups. Supplemental groups in Openshift are used for shared storage, of which
 NFS is an exmaple. In contrast, block storage, such as Ceph RBD or iSCSI, use the `fsGroup:` SCC strategy
@@ -258,7 +258,7 @@ priority is 9 compared to nil for other SCCs), the remaining SCCs are examined.
 requirements, has its `supplementalGroups` strategy set to _RunAsAny_, and therefore it
 statisfies the pod, and, thus, the pod will start.
 
-====== Custom SCC for Group IDs
+==== Custom SCC for Group IDs
 If GID range checking is desired, and none of the predefined SCCs are to be edited, then the
 new "nfs-scc" can be modified to support this reqirement, as seen below:
 ```
@@ -310,14 +310,13 @@ spec:
 ...
 # oc rsh nfs-pod1 id
 uid=1000000000 gid=0(root) groups=5555 <3>
-
 ```
 <1> verifying that the "nfs-scc" matched the pod.
 <2> the namespace is _default_
 <3> verififying that the running container has the default user id (1000000000) and
 supplemental groups of 5555
 
-==== SELinux
+=== SELinux
 All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
 This forces the pod to use a selinux policy, which can be defined in the pod spec. See the
 fragment below:
@@ -346,7 +345,6 @@ ausearch -m avc --start recent
 # setsebool -P virt_sandbox_use_nfs on
 The virt_sandbox_use_nfs boolean is defined by the docker-selinux package. If you get an error saying it is not defined, please ensure that this package is installed.
 ...
-
 
 *NOTE:*
 The `accessModes:` section of the PV and the PVC provide no access

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -17,13 +17,13 @@ https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/St
 Some familiarity with Kubernetes and NFS is assumed.
 
 The Kubernetes
-link:../../architecture/additional_concepts/storage.html[persistent volume]
+link:../../architecture/additional_concepts/storage.html[persistent volume (PV)]
 framework allows administrators to provision a cluster with persistent storage
 and gives users a way to request those resources without having any knowledge of
 the underlying infrastructure. Persistent volumes are not bound to a single
 project or namespace; they can be shared across the OpenShift cluster.
 link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[Persistent
-volume claims], however, are specific to a project or namespace and can be
+volume claims (PVC)], however, are specific to a project or namespace and can be
 requested by users.
 
 For a detailed example, see the guide for
@@ -100,7 +100,7 @@ pv0001                   <none>    5368709120   RWO           Available         
 ====
 
 Users can then link:../../dev_guide/persistent_volumes.html[request storage
-using persistent volume claims], which can now utilize your new persistent
+using persistent volume claims (PVC)], which can now utilize your new persistent
 volume.
 
 [[nfs-enforcing-disk-quotas]]
@@ -118,11 +118,303 @@ equal or greater capacity.
 [[nfs-volume-security]]
 
 === Volume Security
-Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in
-the user's namespace and can only be referenced by a pod within that same
-namespace. Any attempt to access a persistent volume across a namespace causes
-the pod to fail.
+This section covers pieces of Security Context Constraints (SCC), which are descr
+ibed elsewhere, 
+see link:../../admin_guide/manage_scc.adoc[managing SCCs] and link:../../architec
+ture/additional_concepts/authorization.adoc#security-context-constraints[SCC conc
+epts].
+The reader is expected to understand the basics of POSIX permissions, process UIDs,
+supplemental groups, and selinux.
 
+Developers request NFS storage by referencing, in the `volumes:` section of their
+ pod spec,
+either a _PersistentVolumeClaim_ by name, or the NFS volume plugin directly. Alth
+ough a Persistent
+Volume resides in a global namespace, a persistent volume claim (PVC) lives in th
+e user's namespace
+(project), and the claim can only be referenced by a pod within that same namespa
+ce.
+
+The *_/etc/exports_* file, on the NFS server, contains the accessible NFS directo
+ries. The target
+NFS directory, which is referenced by the pod in either the `path:` section of th
+e PV spec or
+directly in the pod spec, has the familiar POSIX owner and group ids. The Openshift NFS plugin
+mounts the container's NFS directory with the same POSIX ownership and permissions found on the
+target NFS directory. However, the container is not run with its effective UID equal to the owner
+of the NFS mount, which is the desired behavior.
+
+As an example, if the target NFS directory appears as:
+```
+#on the nfs server:
+# ls -lZ /opt/nfs -d
+drwxrws---. nobody 5555 unconfined_u:object_r:usr_t:s0   /opt/nfs
+
+# id nobody
+uid=99(nobody) gid=99(nobody) groups=99(nobody)
+```
+then the container will need to match selinux labels, and either run with a UID of 99 (_nobody_ owner),
+or with 5555 in its supplemental groups in order to access the directory.
+
+==== User IDs:
+User ids can be defined in the container image or in the pod spec. If a user id is supplied and
+the matching SCC's `runAsUser:` strategy is _MustRunAsRange_ then that id will be validated against
+the min and max user ids defined in that SCC. If min/max user ids are not defined in the SCC then
+the user id is validated against the namespace's `openshift.io/sa.scc.uid-range` value. On the
+other hand, if the user id is omitted then the default UID becomes the matching SCC's `runAsUser:`
+strategy's `uidRangeMin:` value. Or, if a min value is not specified in the SCC, then the first
+number in the namespace's `openshift.io/sa.scc.uid-range` becomes the default user id.
+
+As an example, using the _restricted_ SCC and the _default_ namespace, here are the user ID default
+and allowed values:
+```
+# oc get scc restricted 
+NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
+restricted   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   <none>
+                                                        <1>
+```
+<1> _MustRunAsRange_ enforces UID checking. In comparison, a value of _RunAsAny_ would not trigger UID
+range checking and thus would accept any user id.
+
+So, the _restricted_ SCC requires user id checking, but supplies no user id range (the id min/max values,
+are not visible in `oc get scc` above, but are shown in `oc export scc restricted`). Therefore, the
+user id range must come from the _default_ namespace, seen below:
+```
+# oc export ns default
+...
+kind: Namespace
+metadata:
+  annotations:
+    ...
+    openshift.io/sa.scc.uid-range: 1000000000/10000 <1>
+...
+```
+<1> this range is interpreted as allowing user ids between 1000000000 through and including 1000009999.
+If no user id is specified then the default user id will be the min value of 1000000000.
+
+Getting back to the NFS example above: the container needs it's UID to be 99 (ignoring group ids for
+the moment), so the following fragement can be added to the pod spec:
+```
+spec:
+  containers: <1>
+  - name: ...
+    securityContext:
+      runAsUser: 99  #nobody
+```
+<1> *NOTE:* pods contain a `securtityContext:` specific to each container (shown above) and a global
+`securityContext:` which applies to all containers defined in the pod.
+
+Aassuming the _default_ project and the _restricted_ SCC above, the pod's requested user id of 99
+will, unfortunetely, *not* be allowed and therefore the pod will fail. The pod fails because:
+
+- it requests 99 as its user id,
+- all SCCs available to the pod are examined (roughly in priority order followed by most restrictive)
+to see which SCC will allow a user id of 99 (actually, all policies of the SCCs are checked but the 
+focus here is on user id),
+- since all available SCCs use _MustRunAsRange_ for their `runAsUser:` strategy, uid range checking is 
+required, 
+- 99 is not included in the SCC or namespace's user id range, so the pod fails.
+
+To fix this situation:
+
+- the _restricted_ SCC could be modified to include 99 within the min and max user ids
+(*not* recommended),
+- the _restricted_ SCC could be modified to use _RunAsAny_ for the `runAsUser:` value,
+thus eliminating id range checking (*not* recommended -- containers can run as root),
+- a new SCC could be created with the appropriate user id range (recommended),
+- a new SCC could be created with the `runAsUser:` strategy set to _RunAsAny_
+(*caution:* need to be mindful of containers being able to run as root),
+- the _default_ project's UID range could be changed to allow a user id of 99.
+(not generally advisable since only a single range of user ids can be specified),
+- a new project could be created with the appropriate user id range defined (not covered here).
+
+====== Custom SCC for UserID:
+It's generally considered a good practice to *not* modify the predefined SCCs. The preferred approach
+is to create a custom SCC that better fits an organization's security needs, or create a new project
+that supports the desired user ids. See
+link:../../dev_guide/projects.adoc#create-a-project[projects] on creating a new project.
+
+A custom SCC can be created such that a min and max user id is defined, UID range
+checking is still enforced, and the UID of 99 will be allowed. Here is an example:
+```
+# oc export scc nfs-scc 
+allowHostDirVolumePlugin: false  #the allow* bools are the same as for the restricted scc
+...
+kind: SecurityContextConstraints
+metadata:
+  ...
+  name: nfs-scc <1>
+priority: 9 <2>
+requiredDropCapabilities: null
+runAsUser:
+  type: MustRunAsRange <3>
+  uidRangeMax: 99 <4>
+  uidRangeMin: 99
+...
+```
+<1> the name of this new SCC is "nfs-scc"
+<2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
+Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
+<3> `runAsUser:` is a strategy and it is set to _MustRunAsRange_, which means uid range checking is 
+enforced
+<4> the uid range is 99-99 (a range of one value).
+
+ow, using `runAsUser: 99`, shown in the pod fragment above, the pod to matches the new nfs-scc and is
+able to run with a UID of 99.
+
+===== Group IDs:
+Another way to handle NFS access (assuming it's not a choice to change permissions on the NFS mount)
+is to use supplemental groups. Supplemental groups in Openshift are used for shared storage, of which
+NFS is an exmaple. In contrast, block storage, such as Ceph RBD or iSCSI, use the `fsGroup:` SCC strategy
+and  the `fsGroup:` value in the pod's `securityContext:`. Since the group id on the target NFS directory,
+shown above, is 5555, the pod can define that group id using `suplementalGroups:` under pod's global
+`securityContext:` definition. For example:
+```
+spec:
+  containers:
+    - name: ...
+      #runAsUser: 99 from above has been commented out here
+  securityContext: <1>
+    supplementalGroups: [5555] #an array of GIDs defined globally for the pod
+```
+<1> securityContext here is defined globally to the pod, not under a specific container
+
+Since group id is the focus here, it's worth seeing the ranges defined for the _default_
+project:
+```
+# oc export ns default 
+...
+metadata:
+  annotations:
+    ...
+    openshift.io/sa.scc.supplemental-groups: 1000000000/10000 <1>
+    openshift.io/sa.scc.uid-range: 1000000000/10000
+...
+```
+<1> this is the preallocated range for the group ids. Additionally, the min value of the 
+range (1000000000) will be the GID default when a group id is not specified in the pod or image.
+The suggestion below does not modify the project's allowed group ids, but that could be an
+option for some project admins.
+
+Supplemental groups and ranges work a bit differently from a user id and its single range
+(assume the _default_ namespace and the "nfs-scc" SCC are still being used):
+
+- there can be more than one range of allowed group ids defined in the SCC and/or namespace.
+- the "nfs-sec" SCC (which has its `supplementalGroups:` strategy set as _MustRunAs_) will
+not satisfy the pod's requirements. This is due to the pod defining a group id but "nfs-sec"
+does not contain any group id ranges. Since "nfs-scc" is not the last SCC to be examined (its
+priority is 9 compared to nil for the other SCCs), the remaining SCCs are examined.
+- the _restricted_ SCC, which typically is the last SCC used to attempt to statisy a pod's 
+requirements, has its `supplementalGroups:` strategy set to _RunAsAny_, and therefore statisfies
+the pod, and, thus, the pod will start. Contrasted to user ids, the _restricted_ SCC's `runAsUser:`
+strategy is set to _MustRunAsRange_, which means that _restricted_ will not satisfy the pod's 
+requirements (and neither will the other predefined SCCs available to the pod) and, thus, the
+pod will fail to start. If the _restricted_ SCC were edited (not recommended) to change
+`supplementalGroups:` from _RunAsAny_ to _MustRunAs_, then the pod would not match the constraints
+of _restricted_ either and, thus, would fail. Ths scenario is analogous to the behavior seen
+when a user id of 99 was defined in the pod and the _restricted_ SCC was evaluated.
+
+====== Custom SCC for GroupID:
+If GID range checking is desired, and none of the predefined SCCs are to be edited, then the
+new "nfs-scc" can be modified to support this reqirement, as seen below:
+```
+#after oc edit scc nfs-scc
+...
+# oc export scc nfs-scc 
+...
+groups:
+- system:authenticated
+kind: SecurityContextConstraints
+metadata:
+...
+  name: nfs-scc
+priority: 9
+runAsUser:
+  type: MustRunAsRange <1>
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  ranges: <3>
+  - max: 6000
+    min: 5000
+  type: MustRunAs <2>
+```
+<1> no change for user but the user id is no longer defined in the pod spec, so the default value is used
+<2> _MustRunAs_ triggers gid range checking
+<3> the min and max values are defined in the SCC, therefore the SCC statisfies the need for range checking
+and thus the namespace'a `openshift.io/sa.scc.supplemental-groups` range is not needed.
+
+Only the "nfs-scc" has been changed. The pod spec (fragment shown just above) does not need any changes, 
+and the _default_ namespace also remains the same (its original settings). After creating the pod:
+```
+# oc create -f nfs-pod.yaml
+...
+# oc get pod nfs-pod1 -0 yaml
+...
+metadata:
+  annotations:
+    openshift.io/scc: nfs-scc <1>
+  name: nfs-pod1
+  namespace: default <2>
+...
+spec:
+  containers:
+    ...
+    securityContext:
+      runAsUser: 1000000000 <3>
+ ...
+ securityContext:
+    seLinuxOptions:
+     level: s0:c1,c0
+    supplementalGroups:
+    - 5555 <3>
+...
+# oc rsh nfs-pod1 id
+uid=1000000000 gid=0(root) groups=5555 <3>
+
+```
+<1> the "nfs-scc" matched the pod, which was the goal
+<2> the namespace (project) is still _default_
+<3> verification that the running container has the default user id (1000000000)
+and supplemental groups of 5555
+
+==== SELinux
+All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
+This forces the pod to use a selinux policy, which can be defined in the pod spec. See the
+fragment below:
+```
+spec:
+  containers:
+  - name: ...
+  securityContext:
+    SELinuxOptions: <1>
+      user: selinux-user-name
+      role: selinux-role-name
+      type: selinux-type-label
+      level: selinux-level
+```
+<1> selinux policy is defined in the context of a container, but it can also be set global to the pod.
+
+If selinux is not defined in the pod spec then it defaults to the selinux policy defined in the pod's
+matching SCC, or, if absent in the SCC, then the namespace's `sa.scc.mcs:` value is used. 
+
+...
+An SELinuxContext strategy of MustRunAs with no level set. Admission looks for the openshift.io/sa.scc.mcs annotation to populate the level.
+...
+ausearch -m avc --start recent
+...
+# setsebool -P virt_sandbox_use_nfs on
+The virt_sandbox_use_nfs boolean is defined by the docker-selinux package. If you get an error saying it is not defined, please ensure that this package is installed.
+...
+
+
+*NOTE:*
+The `accessModes:` section of the PV and the PVC provide no access
+enforcement. They are used similarly to labels and match a PVC to a PV, nothing more. For example,
+the NFS PV's `accessModes:` can be set to _ReadOnlyMany_ yet the container, depending on its user
+and group ids could have write access to that PV.
+
+*NOTE:*
 Each NFS volume must be mountable by all nodes in the cluster.
 
 [[nfs-reclaiming-resources]]

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -13,10 +13,10 @@ toc::[]
 == Overview
 
 OpenShift clusters can be provisioned with
-link:../../architecture/additional_concepts/storage.html[persistent storage] using
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS]. Some familiarity with Openshift,
+link:../../architecture/additional_concepts/storage.html[persistent storage] using NFS
+Some familiarity with Openshift,
 link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[persistent volume claims (PVCs)],
-and NFS is beneficial.
+and https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS] is beneficial.
 
 The Openshift persistent volume (PV) framework allows administrators to provision a cluster
 with persistent storage and gives developers the ability to request those resources without
@@ -113,10 +113,12 @@ equal or greater capacity.
 === Volume Security
 This section covers pieces of Security Context Constraints (SCC), which are described
 elsewhere, see
-link:../../admin_guide/manage_scc.adoc[managing SCCs] and link:../../architecture/additional_concepts/authorization.adoc#security-context-constraints
-[SCC concepts].
+link:../../admin_guide/manage_scc.html[managing SCCs] and
+link:../../architecture/additional_concepts/authorization.html#security-context-constraints[SCC concepts].
 The reader is expected to understand the basics of POSIX permissions, process UIDs,
-supplemental groups, and selinux. The
+supplemental groups, and selinux.
+
+*NOTE:* The
 link:pod_security_context.html[pod and storage security] document should be read before
 implementing NFS volumes.
 
@@ -226,7 +228,7 @@ thus eliminating id range checking (*not* recommended -- containers can run as r
 It's generally considered a good practice to *not* modify the predefined SCCs. The preferred approach
 is to create a custom SCC that better fits an organization's security needs, or create a new project
 that supports the desired user ids. See
-link:../../dev_guide/projects.adoc#create-a-project[projects] on creating a new project.
+link:../../dev_guide/projects.html#create-a-project[projects] on creating a new project.
 
 A custom SCC can be created such that a min and max user id is defined, UID range
 checking is still enforced, and the UID of 99 will be allowed. Here is an example:

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -11,120 +11,114 @@
 toc::[]
 
 == Overview
-You can provision your OpenShift cluster with
+
+OpenShift clusters can be provisioned with
 link:../../architecture/additional_concepts/storage.html[persistent storage] using
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS].
-Some familiarity with Kubernetes and NFS is assumed.
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS]. Some familiarity with Openshift,
+link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[persistent volume claims (PVCs)],
+and NFS is beneficial.
 
-The Kubernetes
-link:../../architecture/additional_concepts/storage.html[persistent volume (PV)]
-framework allows administrators to provision a cluster with persistent storage
-and gives users a way to request those resources without having any knowledge of
-the underlying infrastructure. Persistent volumes are not bound to a single
-project or namespace; they can be shared across the OpenShift cluster.
-link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[Persistent
-volume claims (PVC)], however, are specific to a project or namespace and can be
-requested by users.
-
-For a detailed example, see the guide for
-https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress and
-MySQL using NFS].
-
-[IMPORTANT]
-====
-High-availability of storage in the infrastructure is left to the underlying
-storage provider.
-====
-
-[[nfs-provisioning]]
+The Openshift persistent volume (PV) framework allows administrators to provision a cluster
+with persistent storage and gives developers the ability to request those resources without
+having specific knowledge of the underlying infrastructure. Persistent volumes are not bound
+to a single project or namespace; they can be shared across the entire OpenShift cluster.
+Persistent volume claims (PVCs), however, are specific to a project (namespace) and are
+created and used by developers.
 
 == Provisioning
-Storage must exist in the underlying infrastructure before it can be mounted as
-a volume in OpenShift. To provision NFS volumes in OpenShift, all that is
-required is a distinct list of NFS servers and paths and the
-`*PersistentVolume*` API.
 
-You must define your persistent volume in an object definition before creating
-it in OpenShift:
+Storage must exist in the underlying infrastructure before it can be mounted as a volume in
+OpenShift. To provision NFS volumes a list of NFS servers and export paths are all that is
+required.
 
-.Persistent Volume Object Definition Using NFS
-====
-
-[source,yaml]
-----
-apiVersion: "v1"
-kind: "PersistentVolume"
+A PV spec file is usually defined before creating the PV:
+```
+apiVersion: v1
+kind: PersistentVolume
 metadata:
-  name: "pv0001" <1>
+  name: pv0001 <1>
 spec:
   capacity:
-    storage: "5Gi" <2>
+    storage: 5Gi <2>
   accessModes:
-    - "ReadWriteOnce" <3>
+  - ReadWriteOnce <3>
   nfs: <4>
-    path: "/tmp" <5>
-    server: "172.17.0.2" <6>
-  persistentVolumeReclaimPolicy: "Recycle" <7>
-----
-<1> The name of the volume. This will be how it is identified via
-link:../../architecture/additional_concepts/storage.html[persistent volume
-claims] or from pods.
-<2> The amount of storage allocated to this volume.
-<3> This is the policy for restricting read/writes to a shared volume.
-<4> This defines the volume type being used, in this case the *nfs* plug-in.
-<5> The path that is exported by the NFS server.
-<6> The host name or IP address of the NFS server.
-<7> Defines what happens to a volume when released from its claim. Valid options
+    path: /tmp <5>
+    server: 172.17.0.2 <6>
+  persistentVolumeReclaimPolicy: Recycle <7>
+```
+<1> the name of the volume. This is the PV identify in various `oc ... pod` commands.
+<2> the amount of storage allocated to this volume.
+<3> though this appears to be related to controlling access to the volume, in fact, it
+is actually used similarly to labels and used to match a PVC to a PV. Currently, no
+access rules are enforced based on the `accessModes`.
+<4> this defines the volume type being used, in this case the *nfs* plug-in.
+<5> the path that is exported by the NFS server.
+<6> the host name or IP address of the NFS server.
+<7> defines what happens to a volume when released from its claim. Valid options
 are *Retain* (default) and *Recycle*. See
 link:#nfs-reclaiming-resources[Reclaiming Resources].
-====
 
-Save your definition to a file, for example *_nfs-pv.yaml_*, and create the
-persistent volume:
-
-====
-----
+Save the definition to a file, for example *_nfs-pv.yaml_*, and create the persistent
+volume:
+```
 # oc create -f nfs-pv.yaml
 persistentvolume "pv0001" created
-----
-====
+```
 
 Verify that the persistent volume was created:
-
-====
-----
+```
 # oc get pv
 NAME                     LABELS    CAPACITY     ACCESSMODES   STATUS      CLAIM     REASON    AGE
 pv0001                   <none>    5368709120   RWO           Available                       31s
-----
-====
+```
 
-Users can then link:../../dev_guide/persistent_volumes.html[request storage
-using persistent volume claims (PVC)], which can now utilize your new persistent
-volume.
+The next step can be to create a persistent volume claim (PV) which will bind to the new PV.
+This is easy to do, as shown in the "nfs-claim.yaml example below:
+```
+#claim yaml file: "nfs-claim.yaml"
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-claim1
+spec:
+  accessModes:
+    - ReadWriteOnce <1>
+  resources:
+    requests:
+      storage: 1Gi <2>
+
+# oc create -f nfs-claim.yaml
+```
+<1> as mentioned above for PVs, the `accessModes` do not enforce security, but rather act as
+labels to match a PV to a PVC.
+<2> this claim will look for PVs offering 1Gi or greater capacity.
+
+*Note:* PVs, and PVCs are not necessary, just convenient and make sharing a volume across a
+project simpler. The NFS specific information contained in the PV spec can also be defined
+directly in a pod spec.
 
 [[nfs-enforcing-disk-quotas]]
-
 === Enforcing Disk Quotas
-Use disk partitions to enforce disk quotas and size constraints. Each partition
-can be its own export. Each export is one persistent volume. Kubernetes enforces
-unique names for persistent volumes, but the uniqueness of the NFS volume's
-server and path is up to the administrator.
+Disk partitions can be used to enforce disk quotas and size constraints. Each partition
+can be its own export. Each export is one persistent volume (PV). Openshift enforces
+unique names for PVs, but the uniqueness of the NFS volume's server and path is up to
+the administrator.
 
-Enforcing quotas in this way allows the end user to request persistent storage
+Enforcing quotas in this way allows the developer to request persistent storage
 by a specific amount (e.g, 10Gi) and be matched with a corresponding volume of
 equal or greater capacity.
 
 [[nfs-volume-security]]
-
 === Volume Security
-This section covers pieces of Security Context Constraints (SCC), which are descr
-ibed elsewhere, 
-see link:../../admin_guide/manage_scc.adoc[managing SCCs] and link:../../architec
-ture/additional_concepts/authorization.adoc#security-context-constraints[SCC conc
-epts].
+This section covers pieces of Security Context Constraints (SCC), which are described
+elsewhere, see
+link:../../admin_guide/manage_scc.adoc[managing SCCs] and link:../../architecture/additional_concepts/authorization.adoc#security-context-constraints
+[SCC concepts].
 The reader is expected to understand the basics of POSIX permissions, process UIDs,
-supplemental groups, and selinux.
+supplemental groups, and selinux. The
+link:pod_security_context.html[pod and storage security] document should be read before
+implementing NFS volumes.
 
 Developers request NFS storage by referencing, in the `volumes:` section of their
  pod spec,

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -21,9 +21,10 @@ and https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/htm
 The Openshift persistent volume (PV) framework allows administrators to provision a cluster
 with persistent storage and gives developers the ability to request those resources without
 having specific knowledge of the underlying infrastructure. Persistent volumes are not bound
-to a single project or namespace; they can be shared across the entire OpenShift cluster.
-Persistent volume claims (PVCs), however, are specific to a project (namespace) and are
-created and used by developers.
+to a single project; they can be shared across the entire OpenShift cluster. Persistent volume
+claims (PVCs), however, are specific to a project and are created and used by developers.
+
+(Note: "project" and "namespace" are used interchangeably throughout this document)
 
 == Provisioning
 
@@ -77,6 +78,7 @@ The next step can be to create a persistent volume claim (PV) which will bind to
 This is easy to do, as shown in the "nfs-claim.yaml example below:
 ```
 #claim yaml file: "nfs-claim.yaml"
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -111,7 +113,7 @@ equal or greater capacity.
 
 [[nfs-volume-security]]
 === Volume Security
-This section covers pieces of Security Context Constraints (SCC), which are described
+This section covers aspects of Security Context Constraints (SCCs), which are described
 elsewhere, see
 link:../../admin_guide/manage_scc.html[managing SCCs] and
 link:../../architecture/additional_concepts/authorization.html#security-context-constraints[SCC concepts].
@@ -122,23 +124,14 @@ supplemental groups, and selinux.
 link:pod_security_context.html[pod and storage security] document should be read before
 implementing NFS volumes.
 
-Developers request NFS storage by referencing, in the `volumes:` section of their
- pod spec,
-either a _PersistentVolumeClaim_ by name, or the NFS volume plugin directly. Alth
-ough a Persistent
-Volume resides in a global namespace, a persistent volume claim (PVC) lives in th
-e user's namespace
-(project), and the claim can only be referenced by a pod within that same namespa
-ce.
+Developers request NFS storage by referencing, in the `volumes` section of their
+pod spec, either a _PersistentVolumeClaim_ by name, or the NFS volume plugin directly.
 
-The *_/etc/exports_* file, on the NFS server, contains the accessible NFS directo
-ries. The target
-NFS directory, which is referenced by the pod in either the `path:` section of th
-e PV spec or
-directly in the pod spec, has the familiar POSIX owner and group ids. The Openshift NFS plugin
-mounts the container's NFS directory with the same POSIX ownership and permissions found on the
-target NFS directory. However, the container is not run with its effective UID equal to the owner
-of the NFS mount, which is the desired behavior.
+The *_/etc/exports_* file, on the NFS server, contains the accessible NFS directories.
+The target NFS directory has the familiar POSIX owner and group ids. The Openshift NFS
+plug-in mounts the container's NFS directory with the same POSIX ownership and permissions
+found on the exported NFS directory. However, the container is not run with its effective
+UID equal to the owner of the NFS mount, which is the desired behavior.
 
 As an example, if the target NFS directory appears as:
 ```
@@ -149,47 +142,16 @@ drwxrws---. nobody 5555 unconfined_u:object_r:usr_t:s0   /opt/nfs
 # id nobody
 uid=99(nobody) gid=99(nobody) groups=99(nobody)
 ```
-then the container will need to match selinux labels, and either run with a UID of 99 (_nobody_ owner),
-or with 5555 in its supplemental groups in order to access the directory.
+then the container will need to match selinux labels, and either run with a UID of 99
+(_nobody_ owner), or with 5555 in its supplemental groups in order to access the directory.
 
-==== User IDs:
-User ids can be defined in the container image or in the pod spec. If a user id is supplied and
-the matching SCC's `runAsUser:` strategy is _MustRunAsRange_ then that id will be validated against
-the min and max user ids defined in that SCC. If min/max user ids are not defined in the SCC then
-the user id is validated against the namespace's `openshift.io/sa.scc.uid-range` value. On the
-other hand, if the user id is omitted then the default UID becomes the matching SCC's `runAsUser:`
-strategy's `uidRangeMin:` value. Or, if a min value is not specified in the SCC, then the first
-number in the namespace's `openshift.io/sa.scc.uid-range` becomes the default user id.
+==== User IDs
+User ids can be defined in the container image or in the pod spec. The
+link:pod_security_context.html#user-id[pod and storage security] document covers
+controlling storage access based on user ids.
 
-As an example, using the _restricted_ SCC and the _default_ namespace, here are the user ID default
-and allowed values:
-```
-# oc get scc restricted 
-NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
-restricted   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   <none>
-                                                        <1>
-```
-<1> _MustRunAsRange_ enforces UID checking. In comparison, a value of _RunAsAny_ would not trigger UID
-range checking and thus would accept any user id.
-
-So, the _restricted_ SCC requires user id checking, but supplies no user id range (the id min/max values,
-are not visible in `oc get scc` above, but are shown in `oc export scc restricted`). Therefore, the
-user id range must come from the _default_ namespace, seen below:
-```
-# oc export ns default
-...
-kind: Namespace
-metadata:
-  annotations:
-    ...
-    openshift.io/sa.scc.uid-range: 1000000000/10000 <1>
-...
-```
-<1> this range is interpreted as allowing user ids between 1000000000 through and including 1000009999.
-If no user id is specified then the default user id will be the min value of 1000000000.
-
-Getting back to the NFS example above: the container needs it's UID to be 99 (ignoring group ids for
-the moment), so the following fragement can be added to the pod spec:
+The container needs it's UID set to 99 (ignoring group ids for the moment), so the
+following fragement can be added to the pod spec:
 ```
 spec:
   containers: <1>
@@ -197,43 +159,32 @@ spec:
     securityContext:
       runAsUser: 99  #nobody
 ```
-<1> *NOTE:* pods contain a `securtityContext:` specific to each container (shown above) and a global
-`securityContext:` which applies to all containers defined in the pod.
+<1> pods contain a `securtityContext` specific to each container (shown above) and a global
+`securityContext` which applies to all containers defined in the pod.
 
-Aassuming the _default_ project and the _restricted_ SCC above, the pod's requested user id of 99
-will, unfortunetely, *not* be allowed and therefore the pod will fail. The pod fails because:
+Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
+will, unfortunetely, *not* be allowed, and therefore the pod will fail. The pod fails because:
 
 - it requests 99 as its user id,
-- all SCCs available to the pod are examined (roughly in priority order followed by most restrictive)
-to see which SCC will allow a user id of 99 (actually, all policies of the SCCs are checked but the 
-focus here is on user id),
-- since all available SCCs use _MustRunAsRange_ for their `runAsUser:` strategy, uid range checking is 
-required, 
+- all SCCs available to the pod are examined to see which SCC will allow a user id of 99
+(actually, all policies of the SCCs are checked but the  focus here is on user id),
+- since all available SCCs use _MustRunAsRange_ for their `runAsUser` strategy, uid
+range checking is required, 
 - 99 is not included in the SCC or namespace's user id range, so the pod fails.
 
-To fix this situation:
-
-- the _restricted_ SCC could be modified to include 99 within the min and max user ids
-(*not* recommended),
-- the _restricted_ SCC could be modified to use _RunAsAny_ for the `runAsUser:` value,
-thus eliminating id range checking (*not* recommended -- containers can run as root),
-- a new SCC could be created with the appropriate user id range (recommended),
-- a new SCC could be created with the `runAsUser:` strategy set to _RunAsAny_
-(*caution:* need to be mindful of containers being able to run as root),
-- the _default_ project's UID range could be changed to allow a user id of 99.
-(not generally advisable since only a single range of user ids can be specified),
-- a new project could be created with the appropriate user id range defined (not covered here).
+To best way to fix this situation is to create a custom SCC.
 
 ====== Custom SCC for UserID:
-It's generally considered a good practice to *not* modify the predefined SCCs. The preferred approach
-is to create a custom SCC that better fits an organization's security needs, or create a new project
-that supports the desired user ids. See
-link:../../dev_guide/projects.html#create-a-project[projects] on creating a new project.
+It's generally considered a good practice to *not* modify the predefined SCCs. The preferred
+approach is to create a custom SCC that better fits an organization's security needs, or
+create a new project that supports the desired user ids. See
+link:../../dev_guide/projects.html#create-a-project[projects] if interested in creating
+a new project.
 
-A custom SCC can be created such that a min and max user id is defined, UID range
-checking is still enforced, and the UID of 99 will be allowed. Here is an example:
+A custom SCC can be created such that a min and max user ids are defined, UID range
+checking is still enforced, and the UID of 99 will be allowed. Here is an exert:
 ```
-# oc export scc nfs-scc 
+# oc export scc nfs-scc <1>
 allowHostDirVolumePlugin: false  #the allow* bools are the same as for the restricted scc
 ...
 kind: SecurityContextConstraints
@@ -241,30 +192,35 @@ metadata:
   ...
   name: nfs-scc <1>
 priority: 9 <2>
-requiredDropCapabilities: null
 runAsUser:
   type: MustRunAsRange <3>
   uidRangeMax: 99 <4>
   uidRangeMin: 99
 ...
 ```
-<1> the name of this new SCC is "nfs-scc"
+<1> the name of the new SCC is "nfs-scc"
 <2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
 Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
 <3> `runAsUser:` is a strategy and it is set to _MustRunAsRange_, which means uid range checking is 
 enforced
-<4> the uid range is 99-99 (a range of one value).
+<4> the uid range is 99-99 (a range of one value). The min value, 99, would become the user id
+default is a user id was not supplied in the pod spec.
 
-ow, using `runAsUser: 99`, shown in the pod fragment above, the pod to matches the new nfs-scc and is
-able to run with a UID of 99.
+Now, using `runAsUser: 99`, shown in the pod fragment above, the pod matches the "nfs-scc"
+and is able to run with a UID of 99.
 
-===== Group IDs:
+===== Group IDs
 Another way to handle NFS access (assuming it's not a choice to change permissions on the NFS mount)
 is to use supplemental groups. Supplemental groups in Openshift are used for shared storage, of which
 NFS is an exmaple. In contrast, block storage, such as Ceph RBD or iSCSI, use the `fsGroup:` SCC strategy
-and  the `fsGroup:` value in the pod's `securityContext:`. Since the group id on the target NFS directory,
-shown above, is 5555, the pod can define that group id using `suplementalGroups:` under pod's global
-`securityContext:` definition. For example:
+and  the `fsGroup:` value in the pod's `securityContext:`.
+
+*NOTE:* this is covered in the
+link:pod_security_context.adoc#supplemental-groups[pod and storage security] document.
+
+Since the group id on the link:#nfs-export[target NFS directory], shown above, is 5555,
+the pod can define that group id using `suplementalGroups` under pod's global
+`securityContext` definition. For example:
 ```
 spec:
   containers:
@@ -287,61 +243,48 @@ metadata:
     openshift.io/sa.scc.uid-range: 1000000000/10000
 ...
 ```
-<1> this is the preallocated range for the group ids. Additionally, the min value of the 
-range (1000000000) will be the GID default when a group id is not specified in the pod or image.
-The suggestion below does not modify the project's allowed group ids, but that could be an
-option for some project admins.
+<1> this is the preallocated range for group ids. Additionally, the min value of the range
+(1000000000) becomes the GID default if a group id is not specified in the pod or image.
+The suggestion below does not modify the project's range of allowed group ids, but that
+could be an option for some projects.
 
-Supplemental groups and ranges work a bit differently from a user id and its single range
-(assume the _default_ namespace and the "nfs-scc" SCC are still being used):
+Assuming the _default_ namespace and the "nfs-scc" SCC are being used:
 
-- there can be more than one range of allowed group ids defined in the SCC and/or namespace.
-- the "nfs-sec" SCC (which has its `supplementalGroups:` strategy set as _MustRunAs_) will
+- the "nfs-sec" SCC (which has its `supplementalGroups` strategy set as _MustRunAs_) will
 not satisfy the pod's requirements. This is due to the pod defining a group id but "nfs-sec"
 does not contain any group id ranges. Since "nfs-scc" is not the last SCC to be examined (its
-priority is 9 compared to nil for the other SCCs), the remaining SCCs are examined.
+priority is 9 compared to nil for other SCCs), the remaining SCCs are examined.
 - the _restricted_ SCC, which typically is the last SCC used to attempt to statisy a pod's 
-requirements, has its `supplementalGroups:` strategy set to _RunAsAny_, and therefore statisfies
-the pod, and, thus, the pod will start. Contrasted to user ids, the _restricted_ SCC's `runAsUser:`
-strategy is set to _MustRunAsRange_, which means that _restricted_ will not satisfy the pod's 
-requirements (and neither will the other predefined SCCs available to the pod) and, thus, the
-pod will fail to start. If the _restricted_ SCC were edited (not recommended) to change
-`supplementalGroups:` from _RunAsAny_ to _MustRunAs_, then the pod would not match the constraints
-of _restricted_ either and, thus, would fail. Ths scenario is analogous to the behavior seen
-when a user id of 99 was defined in the pod and the _restricted_ SCC was evaluated.
+requirements, has its `supplementalGroups` strategy set to _RunAsAny_, and therefore it
+statisfies the pod, and, thus, the pod will start.
 
-====== Custom SCC for GroupID:
+====== Custom SCC for Group IDs
 If GID range checking is desired, and none of the predefined SCCs are to be edited, then the
 new "nfs-scc" can be modified to support this reqirement, as seen below:
 ```
-#after oc edit scc nfs-scc
+#after: oc edit scc nfs-scc
 ...
 # oc export scc nfs-scc 
 ...
-groups:
-- system:authenticated
 kind: SecurityContextConstraints
 metadata:
 ...
   name: nfs-scc
 priority: 9
-runAsUser:
-  type: MustRunAsRange <1>
-seLinuxContext:
-  type: MustRunAs
+...
 supplementalGroups:
-  ranges: <3>
+  ranges: <2>
   - max: 6000
     min: 5000
-  type: MustRunAs <2>
+  type: MustRunAs <1>
 ```
-<1> no change for user but the user id is no longer defined in the pod spec, so the default value is used
-<2> _MustRunAs_ triggers gid range checking
-<3> the min and max values are defined in the SCC, therefore the SCC statisfies the need for range checking
-and thus the namespace'a `openshift.io/sa.scc.supplemental-groups` range is not needed.
+<1> _MustRunAs_ triggers gid range checking
+<2> the min and max values are defined in the SCC, therefore the SCC statisfies the need for
+range checking, and thus the namespace's `openshift.io/sa.scc.supplemental-groups` range is
+not needed.
 
-Only the "nfs-scc" has been changed. The pod spec (fragment shown just above) does not need any changes, 
-and the _default_ namespace also remains the same (its original settings). After creating the pod:
+Only the "nfs-scc" has been changed. The pod spec (fragment shown just above) does not need any
+changes, and the _default_ namespace also remains the same. After creating the pod:
 ```
 # oc create -f nfs-pod.yaml
 ...
@@ -369,10 +312,10 @@ spec:
 uid=1000000000 gid=0(root) groups=5555 <3>
 
 ```
-<1> the "nfs-scc" matched the pod, which was the goal
-<2> the namespace (project) is still _default_
-<3> verification that the running container has the default user id (1000000000)
-and supplemental groups of 5555
+<1> verifying that the "nfs-scc" matched the pod.
+<2> the namespace is _default_
+<3> verififying that the running container has the default user id (1000000000) and
+supplemental groups of 5555
 
 ==== SELinux
 All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -74,7 +74,7 @@ NAME                     LABELS    CAPACITY     ACCESSMODES   STATUS      CLAIM 
 pv0001                   <none>    5368709120   RWO           Available                       31s
 ```
 
-The next step can be to create a persistent volume claim (PV) which will bind to the new PV.
+The next step can be to create a persistent volume claim (PVC) which will bind to the new PV.
 This is easy to do, as shown in the "nfs-claim.yaml example below:
 ```
 #claim yaml file: "nfs-claim.yaml"
@@ -96,7 +96,7 @@ spec:
 labels to match a PV to a PVC.
 <2> this claim will look for PVs offering 1Gi or greater capacity.
 
-*Note:* PVs, and PVCs are not necessary, just convenient and make sharing a volume across a
+*Note:* PVs, and PVCs are not necessary, just convenient, and make sharing a volume across a
 project simpler. The NFS specific information contained in the PV spec can also be defined
 directly in a pod spec.
 
@@ -125,7 +125,7 @@ link:pod_security_context.html[pod and storage security] document should be read
 implementing NFS volumes.
 
 Developers request NFS storage by referencing, in the `volumes` section of their
-pod spec, either a _PersistentVolumeClaim_ by name, or the NFS volume plugin directly.
+pod spec, either a _PersistentVolumeClaim_ by name, or the NFS volume plug-in directly.
 
 The *_/etc/exports_* file, on the NFS server, contains the accessible NFS directories.
 The target NFS directory has the familiar POSIX owner and group ids. The Openshift NFS
@@ -134,6 +134,7 @@ found on the exported NFS directory. However, the container is not run with its 
 UID equal to the owner of the NFS mount, which is the desired behavior.
 
 As an example, if the target NFS directory appears as:
+[[nfs-export]]
 ```
 #on the nfs server:
 # ls -lZ /opt/nfs -d
@@ -143,7 +144,7 @@ drwxrws---. nobody 5555 unconfined_u:object_r:usr_t:s0   /opt/nfs
 uid=99(nobody) gid=99(nobody) groups=99(nobody)
 ```
 then the container will need to match selinux labels, and either run with a UID of 99
-(_nobody_ owner), or with 5555 in its supplemental groups in order to access the directory.
+(_nobody_ owner), or with 5555 in its supplemental groups, in order to access the directory.
 
 === User IDs
 User ids can be defined in the container image or in the pod spec. The
@@ -159,7 +160,7 @@ spec:
     securityContext:
       runAsUser: 99  #nobody
 ```
-<1> pods contain a `securtityContext` specific to each container (shown above) and a global
+<1> pods contain a `securtityContext` specific to each container (shown above), and a global
 `securityContext` which applies to all containers defined in the pod.
 
 Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
@@ -181,6 +182,7 @@ create a new project that supports the desired user ids. See
 link:../../dev_guide/projects.html#create-a-project[projects] if interested in creating
 a new project.
 
+[[nfs-scc]]
 A custom SCC can be created such that a min and max user ids are defined, UID range
 checking is still enforced, and the UID of 99 will be allowed. Here is an exert:
 ```
@@ -198,22 +200,23 @@ runAsUser:
   uidRangeMin: 99
 ...
 ```
-<1> the name of the new SCC is "nfs-scc"
+<1> the name of the new SCC is "nfs-scc".
 <2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
-Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
-<3> `runAsUser:` is a strategy and it is set to _MustRunAsRange_, which means uid range checking is 
-enforced
+Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new
+pod.
+<3> the `runAsUser` strategy is set to _MustRunAsRange_, which means uid range checking is 
+enforced.
 <4> the uid range is 99-99 (a range of one value). The min value, 99, would become the user id
-default is a user id was not supplied in the pod spec.
+default if a user id was not supplied in the pod spec.
 
 Now, using `runAsUser: 99`, shown in the pod fragment above, the pod matches the "nfs-scc"
 and is able to run with a UID of 99.
 
 === Group IDs
-Another way to handle NFS access (assuming it's not a choice to change permissions on the NFS mount)
+Another way to handle NFS access (assuming it's not a choice to change permissions on the NFS export)
 is to use supplemental groups. Supplemental groups in Openshift are used for shared storage, of which
-NFS is an exmaple. In contrast, block storage, such as Ceph RBD or iSCSI, use the `fsGroup:` SCC strategy
-and  the `fsGroup:` value in the pod's `securityContext:`.
+NFS is an exmaple. In contrast, block storage, such as Ceph RBD or iSCSI, use the `fsGroup` SCC strategy
+and  the `fsGroup` value in the pod's `securityContext`.
 
 *NOTE:* this is covered in the
 link:pod_security_context.adoc#supplemental-groups[pod and storage security] document.
@@ -229,7 +232,7 @@ spec:
   securityContext: <1>
     supplementalGroups: [5555] #an array of GIDs defined globally for the pod
 ```
-<1> securityContext here is defined globally to the pod, not under a specific container
+<1> securityContext must be defined globally to the pod, not under a specific container
 
 Since group id is the focus here, it's worth seeing the ranges defined for the _default_
 project:
@@ -243,15 +246,15 @@ metadata:
     openshift.io/sa.scc.uid-range: 1000000000/10000
 ...
 ```
-<1> this is the preallocated range for group ids. Additionally, the min value of the range
-(1000000000) becomes the GID default if a group id is not specified in the pod or image.
-The suggestion below does not modify the project's range of allowed group ids, but that
-could be an option for some projects.
+<1> the default range for group ids is 1000000000 - 1000009999 (inclusive).
+Additionally, the min value (1000000000) becomes the group default if the SCC's
+`supplementalGroups` strategy is _MustRunAs_, and if a group id is not specified
+in the pod (or image).
 
-Assuming the _default_ namespace and the "nfs-scc" SCC are being used:
+Assuming the _default_ namespace and the custom link:#nfs-scc["nfs-scc"] SCC apply:
 
 - the "nfs-sec" SCC (which has its `supplementalGroups` strategy set as _MustRunAs_) will
-not satisfy the pod's requirements. This is due to the pod defining a group id but "nfs-sec"
+not satisfy the pod's requirements. This is because the pod defines a group id but "nfs-sec"
 does not contain any group id ranges. Since "nfs-scc" is not the last SCC to be examined (its
 priority is 9 compared to nil for other SCCs), the remaining SCCs are examined.
 - the _restricted_ SCC, which typically is the last SCC used to attempt to statisy a pod's 
@@ -260,7 +263,7 @@ statisfies the pod, and, thus, the pod will start.
 
 ==== Custom SCC for Group IDs
 If GID range checking is desired, and none of the predefined SCCs are to be edited, then the
-new "nfs-scc" can be modified to support this reqirement, as seen below:
+custom link:#nfs-scc["nfs-scc"] can be modified to support this reqirement, as seen below:
 ```
 #after: oc edit scc nfs-scc
 ...
@@ -313,11 +316,15 @@ uid=1000000000 gid=0(root) groups=5555 <3>
 ```
 <1> verifying that the "nfs-scc" matched the pod.
 <2> the namespace is _default_
-<3> verififying that the running container has the default user id (1000000000) and
+<3> verifying that the running container has the default user id (1000000000) and
 supplemental groups of 5555
 
 === SELinux
-All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
+*NOTE:* The
+link:pod_security_context.html#selinux[pod and storage security] document covers
+controlling storage access in conjunction with using selinux.
+
+All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext` to _MustRunAs_.
 This forces the pod to use a selinux policy, which can be defined in the pod spec. See the
 fragment below:
 ```
@@ -332,31 +339,36 @@ spec:
       type: selinux-type-label
       level: selinux-level
 ```
-<1> selinux policy is defined in the context of a container, but it can also be set global to the pod.
+<1> selinux policy here is defined in the context of a container, but it can also be set global
+to the pod.
 
-If selinux is not defined in the pod spec then it defaults to the selinux policy defined in the pod's
-matching SCC, or, if absent in the SCC, then the namespace's `sa.scc.mcs:` value is used. 
+If selinux is not supplied in the pod spec then it defaults to the selinux policy defined in the
+pod's matching SCC, or, if absent in the SCC, then the namespace's `sa.scc.mcs:` value is used. 
 
-...
-An SELinuxContext strategy of MustRunAs with no level set. Admission looks for the openshift.io/sa.scc.mcs annotation to populate the level.
-...
+*Note:* if pods are not authorizing, or if the NFS mount is failing due to permissions errors, then
+there is a possibility that selinux enforcement is interfering. One way to check for this is to run:
+```
 ausearch -m avc --start recent
-...
+```
+which examines the log file for AVC (Access Vector Cache) errors.
+
+It is also usually necessary to enable *virt_sandbox_use_nfs*, as seen below:
+```
 # setsebool -P virt_sandbox_use_nfs on
-The virt_sandbox_use_nfs boolean is defined by the docker-selinux package. If you get an error saying it is not defined, please ensure that this package is installed.
-...
+```
+The *virt_sandbox_use_nfs* boolean is defined by the *_docker-selinux_* package. If an error is
+seen indicating that this bool is not defined, then ensure that this package is installed.
 
 *NOTE:*
-The `accessModes:` section of the PV and the PVC provide no access
-enforcement. They are used similarly to labels and match a PVC to a PV, nothing more. For example,
-the NFS PV's `accessModes:` can be set to _ReadOnlyMany_ yet the container, depending on its user
-and group ids could have write access to that PV.
+The `accessModes` section of the PV and the PVC provide no access enforcement. They are used
+similarly to labels and match a PVC to a PV, nothing more. For example, the NFS PV's `accessModes`
+can be set to _ReadOnlyMany_ yet the container, depending on its user and group ids could have
+write access to that PV.
 
 *NOTE:*
 Each NFS volume must be mountable by all nodes in the cluster.
 
 [[nfs-reclaiming-resources]]
-
 == Reclaiming Resources
 NFS implements the Kubernetes *Recyclable* plug-in interface. Automatic
 processes handle reclamation tasks based on policies set on each persistent

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -431,7 +431,7 @@ be validated against a range of allowed ids. If the pod supplies no user id then
 id is the minimum value of the range of allowable user ids.
 
 Getting back to the link:#nfs-example[NFS example], the container needs it's UID set to 99,
-which is shown in the link:#pod-user-id-99[pod fragement above].
+which is shown in the pod fragement above.
 
 Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
 will *not* be allowed, and therefore the pod will fail. The pod fails because:
@@ -488,21 +488,21 @@ able to run with a UID of 99.
 [[selinux]]
 == SELinuxOptions
 
-SELinux labels can be defined in the pod's `*securityContext*` stanza using `level`,
+SELinux labels can be defined in a pod's `*securityContext*` 's `seLinuxOptions` 's `level` stanza,
 shown in the pod spec fragment below:
 ```
 ...
  securityContext: <1>
     seLinuxOptions:
-      level: s0:c1,c0 <2>
+      level: "s0:c123,c456" <2>
 ...
 ```
-<1> `level` can be defined globally for the entire pod, or specifically to each container.
-<2> in addition to `level`, `user`, `role`, `type` can also be specified.
+<1> `level` can be defined globally for the entire pod, or individually for each container.
+<2> `user`, `role`, and `type` are also supported `seLinuxOptions`.
 
 Here are fragements from a SCC and from the _default_ project:
 ```
-... #SCC
+# oc export scc scc-name
 seLinuxContext:
   type: MustRunAs <1>
 ...
@@ -513,121 +513,34 @@ metadata:
     openshift.io/sa.scc.mcs: s0:c1,c0 <2>
 ...
 ```
-<1> _MustRunAs_ should be used in the SCCs so that volume relabeling can be performed by the container.
+<1> _MustRunAs_ causes volume relabeling.
 <2> if the label is not provided in the pod or in the SCC then the default comes from the namespace.
 
-All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
-This forces poda to use MCS labels, which can be defined in the pod spec, or provided as a default.
-
-...
-An SELinuxContext strategy of MustRunAs with no level set. Admission looks for the openshift.io/sa.scc.mcs annotation to populate the level.
+All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext` to _MustRunAs_.
+This forces pods to use MCS labels, which can be defined in the pod spec, the image, or provided
+as a default.
 
 The SCC determines whether or not to require a selinux label and can provide a default label.
-If `*seLinuxContext*` in the SCC is set to _MustRunAs_, and the pod (or image) does not
-define a label then a default, either from the SCC itself or the namespace, is used. If
+If the `seLinuxContext` strategy is set to _MustRunAs_, and the pod (or image) does not
+define a label then a default, either from the SCC itself or from the namespace, is used. If
 `seLinuxContext`  is set to _RunAsAny_ then no default labels are provided, so the container
 determines the final label. In the case of docker, the container will use a unique MCS label,
-which will not likely match the label on existing storage mounts.
-
-Additionally, volumes which support SELinux management,
-will be relabeled so that they are accessible by the specified label and,
+which will not likely match the labeling on existing storage mounts. Volumes which support
+SELinux management will be relabeled so that they are accessible by the specified label and,
 depending on how exclusionary the label is, only that label.
 
 This means two things for unprivileged containers:
 
-* the volume will be given a `*type*` which is accessible by unprivileged containers.
-Usually *svirt_sandbox_file_t*.
-* If a `*level*` is specified, the volume will be labeled with the given MCS label.
+* the volume will be given a `type` which is accessible by unprivileged containers.
+This `type` is usually *svirt_sandbox_file_t*.
+* if a `level` is specified, the volume will be labeled with the given MCS label.
 
 [NOTE]
 ====
 Level and MCS label are used interchangeably in this topic.
 ====
 
-For your volume to be accessible by your pod, the pod must have both categories
-of the volume. So a pod with *s0:c1,c2* will be able to access volumes with
-*s0,c1,c2*, and a volume with *s0* will be accessible by all pods.
+For a volume to be accessible by a pod, the pod must have both categories of the volume.
+So a pod with *s0:c1,c2* will be able to access a volume with *s0:c1,c2*. A volume with
+*s0* will be accessible by all pods.
 
-[WARNING]
-====
-Hard coding MCS labels into your pod definition makes it easy for others to
-determine what MCS label is needed to access the same volume as the defined pod.
-So it is especially important to rely on the MCS labels allocated by OpenShift
-and to use this feature with care.
-====
-
-SELinux options are specified as follows:
-
-====
-[source,yaml]
-----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ebs-web
-spec:
-  containers:
-    - name: web
-      image: nginx
-      ports:
-        - name: web
-          containerPort: 80
-      volumeMounts:
-          - name: ebs-volume
-            mountPath: "/usr/share/nginx/html"
-  securityContext:
-    seLinuxOptions:
-    level: "s0:c123,c456"
-  volumes:
-    - name: ebs-volume
-      awsElasticBlockStore:
-      volumeID: <VOLUME ID>
-----
-====
-
-Currently the list of volumes which support SELinux management includes:
-
-* AWS Elastic Block Store
-* OpenStack Cinder
-* GCE Persistent Disk
-* iSCSI
-* emptyDir
-* Ceph RBD
-* gitRepo
-
-GlusterFS and NFS do not support SELinux management.
-
-== UID and GID Management with NFS and GlusterFS
-As mentioned above, link:persistent_storage_nfs.html[NFS] and
-link:persistent_storage_glusterfs.html[GlusterFS] do not support ownership
-management. This is because they do not allow `chown` and `chmod` on the client
-side. As a result, when you are using NFS and GlusterFS, you must set the
-appropriate ownership on the server side, then use `*supplementalGroups*` to
-match the group. You can also use `*runAsUser*` to match the user ID.
-
-However, there are a few caveats in this setup that you should be aware of.
-
-=== NFS root_squash Option
-NFS usually runs with *root_squash* as a default option. This option tells the
-NFS server to squash any attempt to do something using UID 0 to *nfsnobody*. So
-if you have a container which is running as *root* and it tries to create a
-file, the file will be owned by the *nfsnobody* user.
-
-=== NFS all_squash Option
-If the NFS server you are using was set up with the *all_squash* option turned
-on, you will not be able to create files which are owned by an arbitrary user or
-group. All files will end up being owned by *nfsnobody*.
-
-=== Applications With Strict UID Requirements
-Certain applications, such as MySQL, and PostgreSQL, double-check the ownership
-of the files they create, and they require that the files be owned by the
-application's configured user ID. An application like this cannot be run on an
-NFS server which enables *all_squash*, for example, so you would have to turn
-that off.
-
-=== NetApp NFSv4 vs NFSv3
-NetApp NFSv4 by default enables the *all_squash* option.
-https://library.netapp.com/ecmdocs/ECMP1196993/html/GUID-24367A9F-E17B-4725-ADC1-02D86F56F78E.html[This
-can be turned off]. However, if you are using NFSv4, NetApp will require that
-you setup an authentication system and export `*AUTH_SYSTEM*`. With NFSv3, the
-`*AUTH_SYSTEM*` requirement is not strict.

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -11,7 +11,7 @@
 toc::[]
 
 == Overview
-(Note: "project" and "namespace" are used interchangeably throughout this document)
+(*Note:* "project" and "namespace" are used interchangeably throughout this document)
 
 This topic provides a general guide on pod security as it relates to volume security.
 For information on pod-level security in general, please see

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -11,7 +11,6 @@
 toc::[]
 
 == Overview
-
 This topic provides a general guide on pod security context as it relates to
 volume security. For information on pod security context in general, please see
 link:../../admin_guide/manage_scc.html[Managing Security Context Constraints (SCC)]
@@ -49,7 +48,7 @@ in the pod. User ids can also be global, or specific to each container. Four sta
 control access to volumes:
 link:#fsgroup[`fsGroup`],
 link:#supplemental-groups[`supplementalGroups`],
-link:#run-as-user[`runAsUser`], and
+link:#user-id[`runAsUser`], and
 link:#selinux[`SELinuxOptions`].
 
 [[scc-defaults-ranges]]
@@ -177,14 +176,13 @@ is not required, and if not defined in the pod, is not set.
 [[supplemental-groups]]
 
 == Supplemental Groups
-
 Supplemental groups are regular Linux groups. When a process runs in Linux, it has a UID,
 a GID, and one or more supplemental groups. These attributes can be set for a container's
 main process. The `supplementalGroups` ids are typically used for controlling access to
 _shared_ storage, such as NFS and GlusterFS; whereas, link:#fsgroup[fsGroup] is used for
 controlling access to _block_ storage, such as Ceph-RBD and iSCSI.
 
-[[nfs-export]]
+[[nfs-example]]
 For example, consider the following NFS export:
 ====
 ----
@@ -257,7 +255,6 @@ group ids.
 [[scc-supplemental-groups]]
 
 ==== Supplemental Groups and Custom SCCs
-
 To remedy this situation a custom SCC can be created such that a min and max group id are defined,
 id range checking is enforced, and the group id of 5555 is allowed. It is considered a better
 practice to create new SCCs versus modifying a predefined SCC, or changing the range of allowed
@@ -296,7 +293,6 @@ custom SCC.
 [[fsgroup]]
 
 == FS Group
-
 `*fsGroup*` defines a pod's "file system group" id, which gets added to the container's supplemental
 groups. As mentioned link:#supplemental-groups[above], the `supplementalGroups` id applies to shared
 storage; whereas, the `fsGroup` id is used for block storage.
@@ -332,7 +328,6 @@ fs group ids, then the pod will fail to run.
 
 [[scc-fsgroup]]
 ==== FS Groups and Custom SCCs
-
 To remedy this situation a custom SCC can be created such that a min and max group id are defined,
 id range checking is enforced, and the group id of 5555 is allowed. It is considered a better
 practice to create new SCCs versus modifying a predefined SCC, or changing the range of allowed
@@ -374,53 +369,12 @@ Currently the list of volumes which support block ownership (block) management i
 * Ceph RBD
 * gitRepo
 
-[[run-as-user]]
-
+[[user-id]]
 == User ID
-
 User ids can be defined in the container image or in the pod spec. In the pod spec, a single user
-id can be define global to all containers, or specific to each container (or both a global spec
-and container-specific UIDs for some of the containers). Similar to group ids, user ids may be
-validated according to policies set in the SCC and/or namespace.
-
-If a user id is supplied and the matching SCC's `*runAsUser*` strategy is _MustRunAsRange_ then
-that id will be validated against the min and max user ids defined in that SCC. If the min/max
-ids are not defined in the SCC then the user id is validated against the namespace's
-`openshift.io/sa.scc.uid-range` value. On the other hand, if the user id is omitted then the
-default UID becomes the matching SCC's `*runAsUser*` strategy's `uidRangeMin` value. Or, if a
-min value is not specified in the SCC, then the first number in the namespace's
-`openshift.io/sa.scc.uid-range` becomes the default user id.
-
-As an example, using the _restricted_ SCC and the _default_ namespace, here are the user ID default
-and allowed values:
-```
-# oc get scc restricted 
-NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
-restricted   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   <none>
-                                                        <1>
-```
-<1> _MustRunAsRange_ enforces UID checking. In comparison, a value of _RunAsAny_ would not trigger UID
-range checking and thus would accept any user id.
-
-So, the _restricted_ SCC requires user id checking, but supplies no user id range (the min/max values
-are not visible in `oc get scc` above, but are shown in `oc export scc restricted`). Therefore, the
-user id allowable range comes from the _default_ namespace, seen below:
-```
-# oc export ns default
-...
-kind: Namespace
-metadata:
-  annotations:
-    ...
-    openshift.io/sa.scc.uid-range: 1000000000/10000 <1>
-...
-```
-<1> this range is interpreted as allowing user ids between 1000000000 through and including 1000009999.
-If no user id is specified then the default user id will be the min value of 1000000000.
-
-Getting back to the NFS example above: the container needs it's UID to be 99 (group ids are
-described link:#supplemental-groups[above]), so the following fragement can be added to
-the pod spec:
+id can be define global to all containers, or specific to individual containers (or both). A user
+id is supplied as shown in the pod fragement below:
+[[pod-user-id-99]]
 ```
 spec:
   containers: <1>
@@ -428,9 +382,70 @@ spec:
     securityContext:
       runAsUser: 99  #nobody
 ```
-<1> id 99 is container specific.
+<1> id 99 is container specific. Specifying `securityContext` outside of the container spec makes
+the id global to all containers in the pod.
 
-Aassuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
+Similar to group ids, user ids may be validated according to policies set in the SCC and/or
+namespace. If the SCC's `runAsUser` strategy is set to _RunAsAny_ then any user id defined in
+the pod spec or in the image is allowed.
+
+*Note:* this means an UID of 0 is allowed!
+
+If no user id is supplied in the pod spec (or image), then 0 (root) becomes the default user id.
+
+If, instead, the `runAsUser` strategy is set to _MustRunAsRange_ then a supplied user id will
+be validated against a range of allowed ids. If the supplied id is outside of this range the
+pod will fail to start. If there is no supplied user id (in the pod or image) then the default
+id is the minimum value of the range of allowable user ids.
+
+The range of allowed user ids can be defined in the SCC and/or in the namespace, as shown below:
+```
+# oc export scc <scc-name> <1>
+...
+runAsUser: <2>
+  type: MustRunAsRange <3>
+  uidRangeMax: 100
+  uidRangeMin: 88 <4>
+...
+# oc export ns default <5>
+...
+kind: Namespace
+metadata:
+  annotations:
+    ...
+    openshift.io/sa.scc.uid-range: 1000000000/10000 <6>
+...
+```
+<1> the name of an existing or custom SCC.
+<2> straegy for determining user id rules.
+<3> _MustRunAsRange_ means that a supplied user id must be within a designated range else the pod
+will fail. And, if there is no supplied user id then a default user id, which is the min id in the
+allowed range, will be provided. _RunAsAny_ has no restrictions on user id
+and must be carefully guarded, else it will be easy for containers to run as root.
+<4> the min uid value in the SCC becomes the default. If a min value is not defined in the SCC then
+the namespace is used.
+<5> "default" is the (unfortunate) name of the current project.
+<6> this range is interpreted as allowing user ids between 1000000000 through and including 1000009999.
+This range also defines the default user id when no id is supplied in the pod and no range is defined
+in the SCC. In this case, the default UID is 1000000000, the min value of the namespace's range.
+
+As an example, using the _restricted_ SCC and the _default_ namespace, here are the user ID default
+and allowed values:
+```
+# oc get scc restricted 
+NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
+restricted   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   <none>
+```
+
+The _restricted_ SCC requires user id checking (RUNASUSER set to _MustRunAsRange_), but supplies
+no user id range (the min/max values are not visible in `oc get scc` above, but are shown in
+`oc export scc restricted`). Therefore, the user id's allowable range comes from the _default_
+namespace, shown above, and is 1000000000 - 1000009999 (inclusive).
+
+Getting back to the link:#nfs-example[NFS example, above], the container needs it's UID set to
+99, which is shown in the link:#pod-user-id-99[pod fragement above].
+
+Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
 will, unfortunetely, *not* be allowed and therefore the pod will fail. The pod fails because:
 
 - it requests 99 as its user id,
@@ -448,8 +463,6 @@ To fix this situation:
 - the _restricted_ SCC could be modified to use _RunAsAny_ for the `*runAsUser*` value,
 thus eliminating id range checking (*not* recommended -- containers can run as root),
 - a new SCC could be created with the appropriate user id range (recommended),
-- a new SCC could be created with the `*runAsUser*` strategy set to _RunAsAny_
-(*caution:* need to be mindful of containers being able to run as root),
 - the _default_ project's UID range could be changed to allow a user id of 99.
 (not generally advisable since only a single range of user ids can be specified),
 - a new project could be created with the appropriate user id range defined (not covered here).
@@ -488,10 +501,7 @@ enforced
 Now, using `runAsUser: 99`, shown in the pod fragment above, the pod to matches the new nfs-scc and is
 able to run with a UID of 99.
 
-
-
 [[selinux]]
-
 == SELinuxOptions
 
 SELinux labels can be defined in the pod's `*securityContext*` stanza using `level`,
@@ -604,7 +614,6 @@ Currently the list of volumes which support SELinux management includes:
 GlusterFS and NFS do not support SELinux management.
 
 == UID and GID Management with NFS and GlusterFS
-
 As mentioned above, link:persistent_storage_nfs.html[NFS] and
 link:persistent_storage_glusterfs.html[GlusterFS] do not support ownership
 management. This is because they do not allow `chown` and `chmod` on the client
@@ -615,20 +624,17 @@ match the group. You can also use `*runAsUser*` to match the user ID.
 However, there are a few caveats in this setup that you should be aware of.
 
 === NFS root_squash Option
-
 NFS usually runs with *root_squash* as a default option. This option tells the
 NFS server to squash any attempt to do something using UID 0 to *nfsnobody*. So
 if you have a container which is running as *root* and it tries to create a
 file, the file will be owned by the *nfsnobody* user.
 
 === NFS all_squash Option
-
 If the NFS server you are using was set up with the *all_squash* option turned
 on, you will not be able to create files which are owned by an arbitrary user or
 group. All files will end up being owned by *nfsnobody*.
 
 === Applications With Strict UID Requirements
-
 Certain applications, such as MySQL, and PostgreSQL, double-check the ownership
 of the files they create, and they require that the files be owned by the
 application's configured user ID. An application like this cannot be run on an
@@ -636,7 +642,6 @@ NFS server which enables *all_squash*, for example, so you would have to turn
 that off.
 
 === NetApp NFSv4 vs NFSv3
-
 NetApp NFSv4 by default enables the *all_squash* option.
 https://library.netapp.com/ecmdocs/ECMP1196993/html/GUID-24367A9F-E17B-4725-ADC1-02D86F56F78E.html[This
 can be turned off]. However, if you are using NFSv4, NetApp will require that

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -35,14 +35,13 @@ https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress and
 MySQL using NFS].
 
 Accessing persistent storage requires coordination between the cluster (and/or storage)
-administrator and the end-developer. The cluster admin creates persistent volumes (PV),
-which abstracts the underlying physical storage. The developer creates pods and,
-optionally, persistent volume claims (PVC), which bind to a PV based on matching
-criteria, such as capacity. Granting pods access to PVs involves knowing the group ids
-and/or user id assigned to the actual storage (and thus knowing the group and/or user id
-that need to be defined in the pod), any selinux considerations, and, finally, ensuring
-that these ids are allowed in the range of legal ids defined for the project (namespace)
-and/or in the SCC that matches the requirements of the pod.
+administrator and the end-developer. The cluster admin creates persistent volumes (PVs),
+which abstract the underlying physical storage. The developer creates pods and,
+optionally, persistent volume claims (PVCs), which bind to PVs, based on matching
+criteria, such as capacity. For the admin, granting pods access to PVs involves knowing
+the group ids and/or user id assigned to the actual storage, selinux considerations, and,
+finally, ensuring that these ids are allowed in the range of legal ids defined for the
+project (namespace) and/or the SCC that matches the requirements of the pod.
 
 Group ids, the user id, and selinux values are defined in the `*SecurityContext*` stanza
 in a pod definition. Group ids are global to the pod and apply to all containers defined
@@ -53,21 +52,66 @@ link:#supplemental-groups[`supplementalGroups`],
 link:#run-as-user[`runAsUser`], and
 link:#selinux[`SELinuxOptions`].
 
-==== Defaults and Allowed ID Ranges
-Default values are provided for `supplementalGroups`, `fsGroup`, `runAsUser`, and `SELinuxOptions`
-when not explicity defined in the pod spec (or in the image). Default values are looked for first in
-the pod's matching SCC, and, if not present there, then in the namespace. When an *id* default
-(preallocated value) is required, it is set to the minimum value in the first range of allowable
-values for that particular id.The _MustRunAs_ and _MustRunAsRange_ SCC strategies require defaults.
-A SCC strategy of _RunAsAny_ does not produce defaults. _RunAsAny_ sets the container's UID and GID
-to 0 (root), and does not set any `SELinuxOptions`. 
+[[scc-defaults-ranges]]
 
-Ids may be validated against ranges which are defined in the SCC and/or the project (namespace). 
-Like defaults, ranges of allowed ids are searched for first in the pod's SCC, and if not found there,
-then in the namespace. If the SCC id-related strategy is set to _MustRunAs_ or _MustRunAsRange_,
-then supplied ids, pertinent to that strategy, will be checked to be within the defined range(s).
-If the supplied ids are outside of the ranges then the pod will fail to start. On the other hand,
-an SCC id-related strategy of _RunAsAny_ bypasses id validation.
+==== SCCs, Defaults, and Allowed Ranges
+SCCs control whether or not a pod is given a default user id, fsgroup id, supplemental
+group id, and selinux label; and, whether or not ids supplied in the pod spec (or in the
+image) will be validated against a range of allowable ids. SCCs can also define the range
+of allowed ids, meaning the ids which can be specified in a pod spec (or in an image). If
+range checking is required (see below) and the allowable range is not defined in the SCC,
+then the namespace will determine the id range. So, projects support ranges of allowable ids;
+however, unlike SCCs, projects do not define strategies, such as _MustRunAs_.
+
+If the supplied id (from the pod or image) is not contained in the id ranges then the pod will
+fail to start. Allowable ranges (in a SCC and namespace) are interesting not only because they
+define the boundaries for container/process IDs, but also because the minimum value in the range
+becomes the *default* value for the id in question. For instance, if the minimum value of an id
+range is 100, and the id is absent from the pod spec (and the image), then 100 is provided as
+the default for this id.
+
+Range checking and default id generation only occur when the SCC strategy is set to _MustRunAs_
+or _MustRunAsRange_. A SCC setting of _RunAsAny_ skips id range checking and additionally does
+*not* produce a default id value. So, if the SCC id related strategy is set to _RunAsAny_ then:
+
+- any id defined in the pod spec (or image) is allowed,
+- absence of an id in the pod spec (and in the image) results in an id of 0 (root),
+- (separate from ids) no selinux labels are defined.
+
+For this reason, SCCs with _RunAsAny_ for id related strategies should be protected so that ordinary
+developers do not have access to the SCC.
+
+There are currently six predefined SCCs, seen below:
+```
+# oc get scc
+NAME               PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER          FSGROUP    SUPGROUP    PRIORITY
+anyuid             false     []        false     MustRunAs   RunAsAny           RunAsAny   RunAsAny    10
+hostaccess         false     []        true      MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
+hostmount-anyuid   false     []        true      MustRunAs   RunAsAny           RunAsAny   RunAsAny    <none>
+nonroot            false     []        false     MustRunAs   MustRunAsNonRoot   RunAsAny   RunAsAny    <none>
+privileged         true      []        true      RunAsAny    RunAsAny           RunAsAny   RunAsAny    <none>
+restricted         false     []        false     MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
+```
+Any SCC with a strategy (e.g. "FSGROUP") set to _RunAsAny_ allows arbitrary values for that strategy
+to be defined in the pod spec (and/or image). When this applies to the user id (`runAsUser`) it is
+prudent to restrict access to the SCC to prevent a container from running as root.
+
+Since often a pod will match the _restricted_ SCC it is worth knowing the security this entails.
+The following observations apply to the _restricted_ SCC:
+
+* it confines user ids due to `runAsUser` being set to _MustRunAsRange_ which forces user id validation,
+* since a range of allowable user ids is not defined in the SCC (see `oc export scc restricted`
+for more details), the namespace's `openshift.io/sa.scc.uid-range`) range will be used for range checking
+and for a default id if needed,
+* it causes a default user id to be produced when a user id is not specified in the pod spec (again due
+to `runAsUser` set to _MustRunAsRange_),
+* requires a selinux label (`seLinuxContext` set to _MustRunAs_) which uses the namespace's default
+MCS label,
+* allows arbitrary supplemental group ids since no range checking is required. This is a result of
+both the `supplementalGroups` and `fsGroup` strategies being set to _RunAsAny_,
+* produces no default supplemental groups for the running pod, again due to _RunAsAny_ for the
+two group strategies above. Therefore, if no groups are defined in the pod spec (or in the
+image), the container(s) will have no supplemental groups predefined.
 
 ```
 (THIS ARE NOTES FOR PAUL WEIL AND WILL BE DELETED SOON)
@@ -111,7 +155,8 @@ id: uid=100 gid=0(root) groups=5000
 so now GID is 0, not 99 and not 100....??
 ```
 
-See the examples below:
+Below is the _default_ namespace and a custom SCC, shown to summarize the interactions of
+the SCC and the namespace:
 ```
 oc export ns default <1>
 ...
@@ -122,7 +167,7 @@ metadata:
     openshift.io/sa.scc.uid-range: 1000000000/10000 <5>
 ...
 
-# oc export scc <scc-name>
+# oc export scc a-custom-scc
 ...
 fsGroup:
   type: MustRunAs <6>
@@ -146,28 +191,29 @@ supplementalGroups:
   - min: 5000
     max: 6000
 ```
-<1> "default" is the name of the project (namespace).
-<2> recall that defaults are only used when the corresponding SCC stragtegy is *not* _RunAsAny_.
-<3> this is the selinux default if a value is not defined in the pod spec or in the SCC.
-<4> this is the range of allowable group ids in the container. There can be more than one range
-specified, separated by commas. Two range formats are supported: 1) M/N, where M is the starting
-id and N is the count, so the range becomes M through, and including, M+N-1. 2) M-N, M is again the
-starting id and N is the ending id. The default group id is the starting id in the first range, 1000000000.
-If the SCC does not define a minimum group id then the namespace's default id is applied.
-<5> same as (3) but for user ids. Also, only a single range of ids is supported.
-<6> _MustRunAs_ enforces group id range checking, and provides the container's groups default. Based on
-this scc definition, the default is 5000 (the min id value). If the range was omitted from this scc then
-the default would be 1000000000, from the namespace.
-The other supported type is _RunAsAny_, which does not perform range checking, thus allowing any
-group id, and causes no default id to be used.
-<7> _MustRunAsRange_ enforces user id range checking, and provides a UID default. Based on this scc
-the default UID is 99, the min value. If the min/max were omitted, the default user id would be
-1000000000, derived from the namespace. When a user id range is defined in the scc, and the `runAsUser`
-id in the pod spec equals the min range value, then the container's *GID* is set to the min UID.
-_MustRunAsNonRoot_ and _RunAsAny_ are the other supported types.
+<1> "default" is the (unfortunate) name of the project (namespace).
+<2> recall that defaults are *only* produced when the corresponding SCC stragtegy is *not* _RunAsAny_.
+<3> this is the selinux default when not defined in the pod spec or in the SCC.
+<4> this is the range of allowable group ids. Id validation only occurs when the SCC
+stragtegy is *not* _RunAsAny_. There can be more than one range specified, separated by
+commas. Two range formats are supported: 1) M/N, where M is the starting id and N is the
+count, so the range becomes M through, and including, M+N-1. 2) M-N, M is again the starting
+id and N is the ending id. The default group id is the starting id in the first range, 1000000000
+in the this namespace. If the SCC did not define a minimum group id then the namespace's
+default id is applied.
+<5> same as (4) but for user ids. Also, only a single range of user ids is supported.
+<6> _MustRunAs_ enforces group id range checking and provides the container's groups default. Based
+on this SCC definition, the default is 5000 (the min id value). If the range was omitted from the
+SCC then the default would be 1000000000, from the namespace. The other supported type, _RunAsAny_,
+does not perform range checking, thus allowing any group id, and produces no default groups.
+<7> _MustRunAsRange_ enforces user id range checking and provides a UID default. Based on this SCC
+the default UID is 99, the min value. If the min/max range were omitted from the SCC, the default
+user id would be 1000000000, derived from the namespace. STRANGELY, when a user id range is defined
+in the SCC, and the `runAsUser` id in the pod spec equals the min range value, then the container's
+*GID* is set to the min UID. _MustRunAsNonRoot_ and _RunAsAny_ are the other supported types.
 <8> when set to _MustRunAs_, the container is created with the SCC's selinux options, or the
 MCS default defined in the namespace. A type of _RunAsAny_ indicates that selinux context
-is not required.
+is not required, and if not defined in the pod, is not set.
 <9> The selinux user name, role name, type, and labels can be defined here.
 
 [[supplemental-groups]]
@@ -176,10 +222,9 @@ is not required.
 
 Supplemental groups are regular Linux groups. When a process runs in Linux, it has a UID,
 a GID, and one or more supplemental groups. These attributes can be set for a container's
-main process. The `supplementalGroups` ids are typically used for controlling
-access to _shared_ storage, such as NFS and GlusterFS; whereas, 
-link:#fsgroup[fsGroup] is used for controlling access to _block_ storage, such
-as Ceph-RBD and iSCSI.
+main process. The `supplementalGroups` ids are typically used for controlling access to
+_shared_ storage, such as NFS and GlusterFS; whereas, link:#fsgroup[fsGroup] is used for
+controlling access to _block_ storage, such as Ceph-RBD and iSCSI.
 
 For example, consider the following NFS export:
 
@@ -209,9 +254,9 @@ containers should not run as root, so, in this NFS example, containers which are
 as UID *99* or are not members the group *5555* will not be able to access the NFS export.
 
 Often, the SCC matching the pod does not allow an arbitrary user id to be specified, thus
-using groups is generally a more flexible way to grant storage access to a pod. For example,
-to grant NFS access to the export above, the group *5555* can be defined in the pod spec,
-as shown below (fragment):
+using supplemental groups is a more flexible way to grant storage access to a pod. For example,
+to grant NFS access to the export above, the group *5555* can be defined in the pod spec, as
+shown below (fragment):
 
 ====
 
@@ -239,75 +284,56 @@ spec:
 <2> nfs export path as seen in the container.
 <3> pod global security context: applies to all containers in pod. Note: each container can also define its
 `securityContext`; however, group ids are global to the pod, and cannot be defined for individual containers.
-<4> supplemental groups will contain 5555 which grants GID access to the export.
+<4> supplemental groups, which is an arry of ids, is set to 5555, which grants group access to the export.
 <5> actual nfs export path on the nfs server.
 
-All containers in the above pod, assuming the matching SCC or project allows the group *5555*, will be
+All containers in the above pod (assuming the matching SCC or project allows the group *5555*) will be
 members of the group *5555*, and will have access to the volume, regardless of the container's user id.
+However, the assumption above is critical. Often, the SCC does not define a range of allowable
+group ids but requires group id validation (due to setting `supplementalGroups` to _MustRunAs_; note this
+is not the case for the _restricted_ SCC). And, the namespace will not likely allow a group id of 5555
+(unless the project has been customized for access to this NFS export). So, in this scenario, the above
+pod will fail because its group id of *5555* is not within the SCC's or the namespace's range of allowed
+group ids. 
 
 [[scc-supplemental-groups]]
 
-==== Supplemental Groups: SCC and Project
-All supplemental groups defined in the pod spec may be subject to validation against
-one of more ranges of group ids. These ranges can be defined in the Security Context
-Constraints (SCC) and/or in the project (which is the namespace) of the running pod.
+==== Supplemental Groups and Custom SCCs
 
-SCCs support two aspects related to supplemental groups:
+To remedy this situation a custom SCC can be created such that a min and max group id are defined,
+id range checking is enforced, and the group id of 5555 is allowed. It is considered a better
+practice to create new SCCs versus modifying a predefined SCC, or changing the range of allowed
+ids in the predefined projects.
 
-* whether or not to allow, uncontested, the group ids defined in the pod (or in the image), and,
-* the range of allowed group ids (when id range checking is required).
-
-Projects (namespaces) support multiple ranges of group ids, used to validate the supplied
-`supplementalGroups` ids. Projects do not define policies, such as "MustRunAs".
-
-An SCC's `*supplementalGroups*` strategy expects a type of _MusRunAs_ or _RunAsAny_.
-_RunAsAny_ omits group id validation, and therefore any group id defined in the pod spec
-(or in the image) is allowed. On the other hand, _MustRunAs_ requires all supplied group ids
-to be validated against a range of group ids. This range can be defined in the SCC itself or
-in the namepsace (or in both, but the SCC has precedence over the namespace).
-
-There are currently six predefined SCCs, seen below:
+Here is a fragment of a new SCC:
 ```
-# oc get scc
-NAME               PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER          FSGROUP    SUPGROUP    PRIORITY
-anyuid             false     []        false     MustRunAs   RunAsAny           RunAsAny   RunAsAny    10
-hostaccess         false     []        true      MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
-hostmount-anyuid   false     []        true      MustRunAs   RunAsAny           RunAsAny   RunAsAny    <none>
-nonroot            false     []        false     MustRunAs   MustRunAsNonRoot   RunAsAny   RunAsAny    <none>
-privileged         true      []        true      RunAsAny    RunAsAny           RunAsAny   RunAsAny    <none>
-restricted         false     []        false     MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
-```
-
-
-```
-# oc export scc <scc-name>  #can use *restricted* here, for example
+# oc export scc nfs-scc 
+allowHostDirVolumePlugin: false  #the allow* bools are the same as for the "restricted" scc
 ...
 kind: SecurityContextConstraints
+metadata:
+  ...
+  name: nfs-scc <1>
+priority: 9 <2>
 ...
 supplementalGroups:
-  type: MustRunAs <1>
-  ranges: <2>
-  - max: 6000
-    min: 5000 <3>
-
-# oc export ns default <4>
-...
-metadata:
-  annotations:
-    ...
-    openshift.io/sa.scc.supplemental-groups: 1000000000/10000 <5>
+  type: MustRunAs <3>
+  ranges:
+  -  min: 5000 <4>
+     max: 6000
 ...
 ```
-<1> _MustRunAs_ triggers gid range checking; whereas _RunAsAny_ does not require range checking.
-<2> the range of allowed group ids (when range checking is required) is 5000 through, and including, 5999.
-Since the min and max values are defined here (in the SCC), the namespace's
-`openshift.io/sa.scc.supplemental-groups` range (5) is not needed.
-<3> the min value will be used as the default supplemental group if groups are not defined in the pod
-(or in the image).
-<4> _default_ is the name of the project (namespace) associated with the pod.
-<5> this is the namespace's allowed range of group ids, defined here to be 1000000000 through, and
-including, 1000009999. Additionally, the min value of the range (1000000000) will be the default
-supplemental group id (if a min value is not defined in the matching SCC).
+<1> the name of this new SCC is "nfs-scc".
+<2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
+Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
+<3> `supplementalGroups` is a strategy and it is set to _MustRunAs_, which means group id checking
+is required.
+<4> multiple ranges are supported. The allowed group id range here is 5000-5999, with the default
+supplemental group being 5000.
+
+When the same pod shown above runs against this new SCC (assuming, of course, the pod has access to
+the new SCC), it will start because the group *5555*, supplied in the pod spec, is allowed by the
+custom SCC.
 
 [[fsgroup]]
 

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -29,13 +29,11 @@ outside of the first claim's namespace. If the underlying storage needs to be ac
 multiple projects then each project needs its own PV, which can point to the same physical
 storage. In this sense, a bound PV is tied to a namespace. For a detailed PV and PVC example,
 see the guide for
-https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress andMySQL using NFS].
+https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress and MySQL using NFS].
 
-[IMPORTANT]
-====
+*NOTE:*
 High-availability of storage in the infrastructure is left to the underlying
 storage provider.
-====
 
 Accessing persistent storage requires coordination between the cluster (and/or storage)
 administrator and the end-developer. The cluster admin creates persistent volumes (PVs),

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -50,8 +50,7 @@ link:#supplemental-groups[`supplementalGroups`],
 link:#user-id[`runAsUser`], and
 link:#selinux[`SELinuxOptions`].
 
-[[scc-defaults-ranges]]
-
+[[scc]]
 ==== SCCs, Defaults, and Allowed Ranges
 
 (*Note:* "project" and "namespace" are user interchangeably)
@@ -204,8 +203,10 @@ required, and if not defined in the pod, is not set in the container.
 <9> The selinux user name, role name, type, and labels can be defined here.
 
 [[supplemental-groups]]
-
 == Supplemental Groups
+*Note:* the link:#scc[SCC overview], above, should be read before working with supplemental
+groups.
+
 Supplemental groups are regular Linux groups. When a process runs in Linux, it has a UID,
 a GID, and one or more supplemental groups. These attributes can be set for a container's
 main process. The `supplementalGroups` ids are typically used for controlling access to
@@ -235,19 +236,15 @@ uid=99(nobody) gid=99(nobody) groups=99(nobody)
 ----
 ====
 
-The _/opt/nfs/_ export is accessible by UID *99* and the group *5555*. In general,
-containers should not run as root, so, in this NFS example, containers which are not run
-as UID *99* or are not members the group *5555* will not be able to access the NFS export.
+The _/opt/nfs/_ export is accessible by UID *99* and the group *5555*. In general, containers
+should not run as root, so, in this NFS example, containers which are not run as UID *99* or
+are not members the group *5555* will not be able to access the NFS export.
 
 Often, the SCC matching the pod does not allow an arbitrary user id to be specified, thus
 using supplemental groups is a more flexible way to grant storage access to a pod. For example,
 to grant NFS access to the export above, the group *5555* can be defined in the pod spec, as
 shown below (fragment):
-
-====
-
-[source,yaml]
-----
+```
 apiVersion: v1
 kind: Pod
 ...
@@ -264,33 +261,43 @@ spec:
     nfs:
       server: <nfs-server-ip-or-host>
       path: /opt/nfs <5>
-----
-====
+```
 <1> name of the volume mount, must match the name in the `volumes` section.
 <2> nfs export path as seen in the container.
 <3> pod global security context: applies to all containers in pod. Note: each container can also define its
 `securityContext`; however, group ids are global to the pod, and cannot be defined for individual containers.
-<4> supplemental groups, which is an arry of ids, is set to 5555, which grants group access to the export.
+<4> supplemental groups, which is an array of ids, is set to 5555. This grants group access to the export.
 <5> actual nfs export path on the nfs server.
 
 All containers in the above pod (assuming the matching SCC or project allows the group *5555*) will be
 members of the group *5555*, and will have access to the volume, regardless of the container's user id.
-However, the assumption above is critical. Often, the SCC does not define a range of allowable
-group ids but requires group id validation (due to setting `supplementalGroups` to _MustRunAs_; note this
-is not the case for the _restricted_ SCC). And, the namespace will not likely allow a group id of 5555
+However, the assumption above is critical. Sometimes, the SCC does not define a range of allowable group
+ids but requires group id validation (due to `supplementalGroups` set to _MustRunAs_; note this is
+not the case for the _restricted_ SCC). And, the namespace will not likely allow a group id of 5555
 (unless the project has been customized for access to this NFS export). So, in this scenario, the above
 pod will fail because its group id of *5555* is not within the SCC's or the namespace's range of allowed
 group ids. 
 
 [[scc-supplemental-groups]]
-
 ==== Supplemental Groups and Custom SCCs
 To remedy this situation a custom SCC can be created such that a min and max group id are defined,
 id range checking is enforced, and the group id of 5555 is allowed. It is considered a better
 practice to create new SCCs versus modifying a predefined SCC, or changing the range of allowed
-ids in the predefined projects.
+ids in the predefined projects. 
 
-Here is a fragment of a new SCC:
+The easiest way to create a new SCC is to export an existing SCC and customize the yaml file to 
+meet the requirements of the new SCC. For example:
+```
+# oc export SCC restricted >new-scc.yaml <1>
+##edit new-scc.yaml file
+# oc create -f new-scc.yaml <2>
+```
+<1> use the _restricted_ SCC as a template for the new SCC.
+<2> instantiate the new SCC
+
+*Note:* the `oc edit scc` command can be used to modify an instantiated SCC.
+
+Here is a fragment of a new SCC named "nfs-scc":
 ```
 # oc export scc nfs-scc 
 allowHostDirVolumePlugin: false  #the allow* bools are the same as for the "restricted" scc
@@ -308,7 +315,7 @@ supplementalGroups:
      max: 6000
 ...
 ```
-<1> the name of this new SCC is "nfs-scc".
+<1> the name of the new SCC.
 <2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
 Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
 <3> `supplementalGroups` is a strategy and it is set to _MustRunAs_, which means group id checking
@@ -316,13 +323,14 @@ is required.
 <4> multiple ranges are supported. The allowed group id range here is 5000-5999, with the default
 supplemental group being 5000.
 
-When the same pod shown above runs against this new SCC (assuming, of course, the pod has access to
-the new SCC), it will start because the group *5555*, supplied in the pod spec, is allowed by the
-custom SCC.
+When the same pod shown above runs against this new SCC (assuming, of course, the pod has access
+to the new SCC), it will start because the group *5555*, supplied in the pod spec, is now allowed
+by the custom SCC.
 
 [[fsgroup]]
-
 == FS Group
+*Note:* the link:#scc[SCC overview], above, should be read before working with fs group.
+
 `*fsGroup*` defines a pod's "file system group" id, which gets added to the container's supplemental
 groups. As mentioned link:#supplemental-groups[above], the `supplementalGroups` id applies to shared
 storage; whereas, the `fsGroup` id is used for block storage.

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -24,14 +24,13 @@ and gives users a way to request those resources without requiring knowledge of
 the underlying infrastructure. Persistent volumes (PV) are global resources and
 not tied to a specific project (namespace). 
 link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[Persistent
-volume claims (PVC)] are local to the namespace (project), and multiple PVCs within
-the same project can bind to the same PV. However, once a PVC binds to a PV, that
-PV cannot be bound by a claim outside of the first claim's namespace. If the
-underlying storage needs to be accessed by multiple projects then each project needs
-its own PV, which can point to the same physical storage. In this sense, a bound PV
-is tied to a namespace. For a detailed PV and PVC example, see the guide for
-https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress and
-MySQL using NFS].
+volume claims (PVC)] are local to the project, and multiple PVCs within the same project
+can bind to the same PV. However, once a PVC binds to a PV, that PV cannot be bound by a
+claim outside of the first claim's namespace. If the underlying storage needs to be accessed
+by multiple projects then each project needs its own PV, which can point to the same physical
+storage. In this sense, a bound PV is tied to a namespace. For a detailed PV and PVC example,
+see the guide for
+https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress andMySQL using NFS].
 
 Accessing persistent storage requires coordination between the cluster (and/or storage)
 administrator and the end-developer. The cluster admin creates persistent volumes (PVs),
@@ -40,7 +39,7 @@ optionally, persistent volume claims (PVCs), which bind to PVs, based on matchin
 criteria, such as capacity. For the admin, granting pods access to PVs involves knowing
 the group ids and/or user id assigned to the actual storage, selinux considerations, and,
 finally, ensuring that these ids are allowed in the range of legal ids defined for the
-project (namespace) and/or the SCC that matches the requirements of the pod.
+project and/or the SCC that matches the requirements of the pod.
 
 Group ids, the user id, and selinux values are defined in the `*SecurityContext*` stanza
 in a pod definition. Group ids are global to the pod and apply to all containers defined
@@ -54,31 +53,63 @@ link:#selinux[`SELinuxOptions`].
 [[scc-defaults-ranges]]
 
 ==== SCCs, Defaults, and Allowed Ranges
-SCCs control whether or not a pod is given a default user id, fsgroup id, supplemental
+
+(*Note:* "project" and "namespace" are user interchangeably)
+
+SCCs influence whether or not a pod is given a default user id, fsgroup id, supplemental
 group id, and selinux label; and, whether or not ids supplied in the pod spec (or in the
-image) will be validated against a range of allowable ids. SCCs can also define the range
-of allowed ids, meaning the ids which can be specified in a pod spec (or in an image). If
-range checking is required (see below) and the allowable range is not defined in the SCC,
-then the namespace will determine the id range. So, projects support ranges of allowable ids;
-however, unlike SCCs, projects do not define strategies, such as _MustRunAs_.
+image) will be validated against a range of allowable ids. If validation is required and
+fails then the pod will also fail.
 
-If the supplied id (from the pod or image) is not contained in the id ranges then the pod will
-fail to start. Allowable ranges (in a SCC and namespace) are interesting not only because they
-define the boundaries for container/process IDs, but also because the minimum value in the range
-becomes the *default* value for the id in question. For instance, if the minimum value of an id
-range is 100, and the id is absent from the pod spec (and the image), then 100 is provided as
-the default for this id.
-
-Range checking and default id generation only occur when the SCC strategy is set to _MustRunAs_
-or _MustRunAsRange_. A SCC setting of _RunAsAny_ skips id range checking and additionally does
-*not* produce a default id value. So, if the SCC id related strategy is set to _RunAsAny_ then:
+SCCs define strategies, such as `RunAsUser`, `supplementalGroups`, and `fsGroup`. These
+strategies are used to help decide if the pod is authorized. Strategy values set to
+_RunAsAny_ are essentially stating that the pod can do what it wants regarding that
+strategy. Authorization is skipped for that strategy and no Openshift default is produced
+based on that strategy. So ids and selinux labels in the resulting container are based on
+container defaults and not on Openshift policies. Here's a quick summary of _RunAsAny_:
 
 - any id defined in the pod spec (or image) is allowed,
-- absence of an id in the pod spec (and in the image) results in an id of 0 (root),
-- (separate from ids) no selinux labels are defined.
+- absence of an id in the pod spec (and in the image) results in the container assigning an id,
+which is 0 (root) for docker,
+- no selinux labels are defined, so docker will assign a unique (and generally not useful) label.
 
-For this reason, SCCs with _RunAsAny_ for id related strategies should be protected so that ordinary
-developers do not have access to the SCC.
+For these reasons, SCCs with _RunAsAny_ for id related strategies should be protected so
+that ordinary developers do not have access to the SCC.
+
+On the other hand, SCC strategies set to _MustRunAs_ or _MustRunAsRange_ trigger id validation
+(for id related strategies), and cause default values to be supplied by Openshift to the
+container (when those values are not supplied directly in the pod spec or image).
+
+SCCs may define the range of allowed ids (user, groups). If range checking is required
+(e.g., _MustRunAs_) and the allowable range is not defined in the SCC, then the project
+determines the id range. So, projects support ranges of allowable ids; however, unlike SCCs,
+projects do not define strategies, such as `runAsUser`. Allowable ranges are interesting
+not only because they define the boundaries for container IDs, but also because the
+minimum value in the range becomes the *default* value for the id in question. For instance,
+if the SCC id strategy value is _MustRunAs_, and the minimum value of an id range is 100,
+and the id is absent from the pod spec, then 100 is provided as the default for this id.
+
+As part of pod authorization, the SCCs available to a pod are examined (roughly, in priority
+order followed by most restrictive) to best match the requests of the pod. A SCC's strategy's
+type of _RunAsAny_ is less restrictive; wheras a type of _MustRunAs_ is more restrictive. All
+of these strategies are evaluated. To see which SCC was assigned to a pod use the `oc get pod`
+command, below:
+```
+# oc get pod <pod-name> -o yaml 
+...
+metadata:
+  annotations:
+    openshift.io/scc: nfs-scc <1>
+  name: nfs-pod1 <2>
+  namespace: default <3>
+...
+```
+<1> this is the name of the SCC that the pod used (in this case, a custom SCC)
+<2> this is the name of the pod
+<3> this is the name of the project
+
+It can be inobvious which SCC was matched by a pod, so the command above can be very useful
+in understanding the UID, supplemental groups, and selinux re-labeling in a live container.
 
 There are currently six predefined SCCs, seen below:
 ```
@@ -91,23 +122,24 @@ nonroot            false     []        false     MustRunAs   MustRunAsNonRoot   
 privileged         true      []        true      RunAsAny    RunAsAny           RunAsAny   RunAsAny    <none>
 restricted         false     []        false     MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
 ```
-Any SCC with a strategy (e.g. "FSGROUP") set to _RunAsAny_ allows arbitrary values for that strategy
-to be defined in the pod spec (and/or image). When this applies to the user id (`runAsUser`) it is
-prudent to restrict access to the SCC to prevent a container from running as root.
+*Note:* Any SCC with a strategy set to _RunAsAny_ allows arbitrary values for that strategy to be
+defined in the pod spec (and/or image). When this applies to the user id (`runAsUser`) it is prudent
+to restrict access to the SCC to prevent a container from being able to run as root.
 
-Since often a pod will match the _restricted_ SCC it is worth knowing the security this entails.
+Since often a pod matches the _restricted_ SCC it is worth knowing the security this entails.
 The following observations apply to the _restricted_ SCC:
 
-* it confines user ids due to `runAsUser` being set to _MustRunAsRange_ which forces user id validation,
+* it constrains user ids due to the `runAsUser` strategy set to _MustRunAsRange_. This forces user
+id validation.
 * since a range of allowable user ids is not defined in the SCC (see `oc export scc restricted`
-for more details), the namespace's `openshift.io/sa.scc.uid-range`) range will be used for range checking
-and for a default id if needed,
-* it causes a default user id to be produced when a user id is not specified in the pod spec (again due
-to `runAsUser` set to _MustRunAsRange_),
-* requires a selinux label (`seLinuxContext` set to _MustRunAs_) which uses the namespace's default
-MCS label,
-* allows arbitrary supplemental group ids since no range checking is required. This is a result of
-both the `supplementalGroups` and `fsGroup` strategies being set to _RunAsAny_,
+for more details), the namespace's `openshift.io/sa.scc.uid-range`) range will be used for range
+checking and for a default id, if needed.
+* it causes a default user id to be produced when a user id is not specified in the pod spec
+(again due to `runAsUser` set to _MustRunAsRange_).
+* requires a selinux label (`seLinuxContext` set to _MustRunAs_) which uses the namespace's
+default MCS label.
+* allows arbitrary supplemental group ids since no range checking is required. This is a result
+of both the `supplementalGroups` and `fsGroup` strategies being set to _RunAsAny_.
 * produces no default supplemental groups for the running pod, again due to _RunAsAny_ for the
 two group strategies above. Therefore, if no groups are defined in the pod spec (or in the
 image), the container(s) will have no supplemental groups predefined.
@@ -148,16 +180,15 @@ supplementalGroups:
   - min: 5000
     max: 6000
 ```
-<1> "default" is the (unfortunate) name of the project (namespace).
+<1> "default" is the (unfortunate) name of the project.
 <2> recall that defaults are *only* produced when the corresponding SCC stragtegy is *not* _RunAsAny_.
 <3> this is the selinux default when not defined in the pod spec or in the SCC.
-<4> this is the range of allowable group ids. Id validation only occurs when the SCC
-stragtegy is *not* _RunAsAny_. There can be more than one range specified, separated by
-commas. Two range formats are supported: 1) M/N, where M is the starting id and N is the
-count, so the range becomes M through, and including, M+N-1. 2) M-N, M is again the starting
-id and N is the ending id. The default group id is the starting id in the first range, 1000000000
-in the this namespace. If the SCC did not define a minimum group id then the namespace's
-default id is applied.
+<4> this is the range of allowable group ids. Id validation only occurs when the SCC stragtegy is
+*not* _RunAsAny_. There can be more than one range specified, separated by commas. Two range formats
+are supported: 1) _M/N_, where M is the starting id and N is the count, so the range becomes M through,
+and including, M+N-1. 2) _M-N_, M is again the starting id and N is the ending id. The default group id
+is the starting id in the first range, 1000000000 in the this namespace. If the SCC did not define a
+minimum group id then the namespace's default id is applied.
 <5> same as (4) but for user ids. Also, only a single range of user ids is supported.
 <6> _MustRunAs_ enforces group id range checking and provides the container's groups default. Based
 on this SCC definition, the default is 5000 (the min id value). If the range was omitted from the
@@ -165,12 +196,11 @@ SCC then the default would be 1000000000, from the namespace. The other supporte
 does not perform range checking, thus allowing any group id, and produces no default groups.
 <7> _MustRunAsRange_ enforces user id range checking and provides a UID default. Based on this SCC
 the default UID is 99, the min value. If the min/max range were omitted from the SCC, the default
-user id would be 1000000000, derived from the namespace. STRANGELY, when a user id range is defined
-in the SCC, and the `runAsUser` id in the pod spec equals the min range value, then the container's
-*GID* is set to the min UID. _MustRunAsNonRoot_ and _RunAsAny_ are the other supported types.
+user id would be 1000000000, derived from the namespace. _MustRunAsNonRoot_ and _RunAsAny_ are the
+other supported types.
 <8> when set to _MustRunAs_, the container is created with the SCC's selinux options, or the
-MCS default defined in the namespace. A type of _RunAsAny_ indicates that selinux context
-is not required, and if not defined in the pod, is not set.
+MCS default defined in the namespace. A type of _RunAsAny_ indicates that selinux context is not
+required, and if not defined in the pod, is not set in the container.
 <9> The selinux user name, role name, type, and labels can be defined here.
 
 [[supplemental-groups]]
@@ -389,7 +419,7 @@ Similar to group ids, user ids may be validated according to policies set in the
 namespace. If the SCC's `runAsUser` strategy is set to _RunAsAny_ then any user id defined in
 the pod spec or in the image is allowed.
 
-*Note:* this means an UID of 0 is allowed!
+*Note:* this means a UID of 0 is allowed!
 
 If no user id is supplied in the pod spec (or image), then 0 (root) becomes the default user id.
 
@@ -442,11 +472,11 @@ no user id range (the min/max values are not visible in `oc get scc` above, but 
 `oc export scc restricted`). Therefore, the user id's allowable range comes from the _default_
 namespace, shown above, and is 1000000000 - 1000009999 (inclusive).
 
-Getting back to the link:#nfs-example[NFS example, above], the container needs it's UID set to
-99, which is shown in the link:#pod-user-id-99[pod fragement above].
+Getting back to the link:#nfs-example[NFS example], the container needs it's UID set to 99,
+which is shown in the link:#pod-user-id-99[pod fragement above].
 
 Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
-will, unfortunetely, *not* be allowed and therefore the pod will fail. The pod fails because:
+will, unfortunately, *not* be allowed and therefore the pod will fail. The pod fails because:
 
 - it requests 99 as its user id,
 - all SCCs available to the pod are examined (roughly in priority order followed by most restrictive)

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -226,8 +226,8 @@ main process. The `supplementalGroups` ids are typically used for controlling ac
 _shared_ storage, such as NFS and GlusterFS; whereas, link:#fsgroup[fsGroup] is used for
 controlling access to _block_ storage, such as Ceph-RBD and iSCSI.
 
+[[nfs-export]]
 For example, consider the following NFS export:
-
 ====
 ----
 #on an openshift node:
@@ -339,18 +339,24 @@ custom SCC.
 
 == FS Group
 
-`*fsGroup*` defines a pod's "file system group". As mentioned above, whereas
-link:#supplemental-groups[supplementalGroups] apply to shared storage, `fsGroup` is used for
-block storage. It is, in fact, a supplemental group but with some extra functionality. When
-`fsGroup` is specified, it has the following effects on volumes which support ownership
-management (i.e., block volumes):
+`*fsGroup*` defines a pod's "file system group". As mentioned link:#supplemental-groups[above],
+`supplementalGroups` apply to shared storage; whereas, `fsGroup` is used for block storage.
+Block storage, such as Ceph-RBD,  iSCSI, and various cloud storage, is typically dedicated to
+a single pod which has specified the block storage volume, either directly or via a persistent
+volume claim (PVC). Block storage is "_taken over_" by a pod, meaning that user and group ids
+supplied in the pod spec (or image) are applied to the actual, physical block device. Typically,
+block storage is not shared. Sharing block storage requires all pods in the namespace to define
+the same group/user ids, so that when a pod "takes over" the block device, it is still accessible
+to the other pods. 
 
-* the owning group of the volume is set to the specified `fsGroup`,
+The `fsGroup` id is, in fact, a supplemental group set in the container, but brings some extra
+functionality:
+
+* the group of the volume is set to the specified `fsGroup`,
 * newly created files in the volume are owned by `fsGroup`,
 * read and write permissions are given to `fsGroup`,
-* the specified `fsGroup` is added to the pod's list of supplemental groups.
 
-This grants pods with the same `fsGroup` the same access to the volume.
+Using the link:#nfs-export[NFS export above], NOPE. Need CEPH ex
 
 [IMPORTANT]
 ====
@@ -421,17 +427,56 @@ Currently the list of volumes which support ownership (block) management include
 
 == SELinuxOptions
 
-The pod security context allows you to specify SELinux labels with which to run
-containers in your pod. Additionally, volumes which support SELinux management
+SELinux labels can be defined in the pod's `*securityContext*` stanza using `level`,
+shown in the pod spec fragment below:
+```
+...
+ securityContext: <1>
+    seLinuxOptions:
+      level: s0:c1,c0 <2>
+...
+```
+<1> `level` can be defined globally for the entire pod, or specifically to each container.
+<2> in addition to `level`, `user`, `role`, `type` can also be specified.
+
+Here are fragements from a SCC and from the _default_ project:
+```
+... #SCC
+seLinuxContext:
+  type: MustRunAs <1>
+...
+# oc export ns default 
+...
+metadata:
+  annotations:
+    openshift.io/sa.scc.mcs: s0:c1,c0 <2>
+...
+```
+<1> _MustRunAs_ should be used in the SCCs so that volume relabeling can be performed by the container.
+<2> if the label is not provided in the pod or in the SCC then the default comes from the namespace.
+
+All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
+This forces poda to use MCS labels, which can be defined in the pod spec, or provided as a default.
+
+...
+An SELinuxContext strategy of MustRunAs with no level set. Admission looks for the openshift.io/sa.scc.mcs annotation to populate the level.
+
+The SCC determines whether or not to require a selinux label and can provide a default label.
+If `*seLinuxContext*` in the SCC is set to _MustRunAs_, and the pod (or image) does not
+define a label then a default, either from the SCC itself or the namespace, is used. If
+`seLinuxContext`  is set to _RunAsAny_ then no default labels are provided, so the container
+determines the final label. In the case of docker, the container will use a unique MCS label,
+which will not likely match the label on existing storage mounts.
+
+Additionally, volumes which support SELinux management,
 will be relabeled so that they are accessible by the specified label and,
 depending on how exclusionary the label is, only that label.
 
-This means two things:
+This means two things for unprivileged containers:
 
-* If the container is unprivileged the volume will be given a `*type*` which is
-accessible by unprivileged containers. Usually *svirt_sandbox_file_t*.
-* If a `*level*` is specified, the volume will be labeled with the given MCS
-label.
+* the volume will be given a `*type*` which is accessible by unprivileged containers.
+Usually *svirt_sandbox_file_t*.
+* If a `*level*` is specified, the volume will be labeled with the given MCS label.
 
 [NOTE]
 ====
@@ -447,7 +492,7 @@ of the volume. So a pod with *s0:c1,c2* will be able to access volumes with
 Hard coding MCS labels into your pod definition makes it easy for others to
 determine what MCS label is needed to access the same volume as the defined pod.
 So it is especially important to rely on the MCS labels allocated by OpenShift
-and not use this option with care.
+and to use this feature with care.
 ====
 
 SELinux options are specified as follows:

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -11,23 +11,22 @@
 toc::[]
 
 == Overview
-This topic provides a general guide on pod security context as it relates to
-volume security. For information on pod security context in general, please see
+This topic provides a general guide on pod security as it relates to volume security.
+For information on pod-level security in general, please see
 link:../../admin_guide/manage_scc.html[Managing Security Context Constraints (SCC)]
 and
 link:../../architecture/additional_concepts/authorization.html#security-context-constraints[SCC concepts].
 
 As a quick background, the Openshift
 link:../../architecture/additional_concepts/storage.html[persistent volume]
-framework allows administrators to provision a cluster with persistent storage
-and gives users a way to request those resources without requiring knowledge of
-the underlying infrastructure. Persistent volumes (PV) are global resources and
-not tied to a specific project (namespace). 
+framework allows administrators to provision a cluster with persistent storage and gives users
+a way to request those resources without requiring knowledge of the underlying infrastructure.
+Persistent volumes (PV) are global resources and not tied to a specific project (namespace). 
 link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[Persistent
 volume claims (PVC)] are local to the project, and multiple PVCs within the same project
-can bind to the same PV. However, once a PVC binds to a PV, that PV cannot be bound by a
-claim outside of the first claim's namespace. If the underlying storage needs to be accessed
-by multiple projects then each project needs its own PV, which can point to the same physical
+can bind to the same PV. However, once a PVC binds to a PV, that PV cannot be bound by a claim
+outside of the first claim's namespace. If the underlying storage needs to be accessed by
+multiple projects then each project needs its own PV, which can point to the same physical
 storage. In this sense, a bound PV is tied to a namespace. For a detailed PV and PVC example,
 see the guide for
 https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress andMySQL using NFS].
@@ -329,7 +328,7 @@ by the custom SCC.
 
 [[fsgroup]]
 == FS Group
-*Note:* the link:#scc[SCC overview], above, should be read before working with fs groups.
+*Note:* the link:#scc[SCC overview], above, should be read before working with FS groups.
 
 `*fsGroup*` defines a pod's "file system group" id, which gets added to the container's supplemental
 groups. As mentioned link:#supplemental-groups[above], the `supplementalGroups` id applies to shared
@@ -408,9 +407,11 @@ Currently the list of volumes which support block ownership (block) management i
 * gitRepo
 
 [[user-id]]
-== User ID
+== User IDs
+*Note:* the link:#scc[SCC overview], above, should be read before working with user ids.
+
 User ids can be defined in the container image or in the pod spec. In the pod spec, a single user
-id can be define global to all containers, or specific to individual containers (or both). A user
+id can be defined global to all containers, or specific to individual containers (or both). A user
 id is supplied as shown in the pod fragement below:
 [[pod-user-id-99]]
 ```
@@ -431,10 +432,9 @@ be validated against a range of allowed ids. If the pod supplies no user id then
 id is the minimum value of the range of allowable user ids.
 
 Getting back to the link:#nfs-example[NFS example], the container needs it's UID set to 99,
-which is shown in the pod fragement above.
-
-Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
-will *not* be allowed, and therefore the pod will fail. The pod fails because:
+which is shown in the pod fragement above. Assuming the _default_ project and the _restricted_
+SCC, the pod's requested user id of 99 will *not* be allowed, and therefore the pod will fail.
+The pod fails because:
 
 - it requests 99 as its user id,
 - since all available SCCs use _MustRunAsRange_ for their `*runAsUser*` strategy, uid range
@@ -452,7 +452,7 @@ thus eliminating id range checking (*really not* recommended, containers could r
 (not generally advisable since only a single range of user ids can be specified),
 - a new project could be created with the appropriate user id range defined (not covered here).
 
-===== Custom SCC for UserID:
+==== User Ids and Custom SCCs
 It's generally considered a good practice to *not* modify the predefined SCCs. The preferred approach
 is to create a custom SCC that better fits an organization's security needs, or create a new project
 that supports the desired user ids. Or, see

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -31,6 +31,12 @@ storage. In this sense, a bound PV is tied to a namespace. For a detailed PV and
 see the guide for
 https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress andMySQL using NFS].
 
+[IMPORTANT]
+====
+High-availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
 Accessing persistent storage requires coordination between the cluster (and/or storage)
 administrator and the end-developer. The cluster admin creates persistent volumes (PVs),
 which abstract the underlying physical storage. The developer creates pods and,

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -329,7 +329,7 @@ by the custom SCC.
 
 [[fsgroup]]
 == FS Group
-*Note:* the link:#scc[SCC overview], above, should be read before working with fs group.
+*Note:* the link:#scc[SCC overview], above, should be read before working with fs groups.
 
 `*fsGroup*` defines a pod's "file system group" id, which gets added to the container's supplemental
 groups. As mentioned link:#supplemental-groups[above], the `supplementalGroups` id applies to shared
@@ -425,81 +425,28 @@ the id global to all containers in the pod.
 
 Similar to group ids, user ids may be validated according to policies set in the SCC and/or
 namespace. If the SCC's `runAsUser` strategy is set to _RunAsAny_ then any user id defined in
-the pod spec or in the image is allowed.
-
-*Note:* this means a UID of 0 is allowed!
-
-If no user id is supplied in the pod spec (or image), then 0 (root) becomes the default user id.
-
+the pod spec or in the image is allowed. *Note:* this means a UID of 0 (root) is allowed!
 If, instead, the `runAsUser` strategy is set to _MustRunAsRange_ then a supplied user id will
-be validated against a range of allowed ids. If the supplied id is outside of this range the
-pod will fail to start. If there is no supplied user id (in the pod or image) then the default
+be validated against a range of allowed ids. If the pod supplies no user id then the default
 id is the minimum value of the range of allowable user ids.
-
-The range of allowed user ids can be defined in the SCC and/or in the namespace, as shown below:
-```
-# oc export scc <scc-name> <1>
-...
-runAsUser: <2>
-  type: MustRunAsRange <3>
-  uidRangeMax: 100
-  uidRangeMin: 88 <4>
-...
-# oc export ns default <5>
-...
-kind: Namespace
-metadata:
-  annotations:
-    ...
-    openshift.io/sa.scc.uid-range: 1000000000/10000 <6>
-...
-```
-<1> the name of an existing or custom SCC.
-<2> straegy for determining user id rules.
-<3> _MustRunAsRange_ means that a supplied user id must be within a designated range else the pod
-will fail. And, if there is no supplied user id then a default user id, which is the min id in the
-allowed range, will be provided. _RunAsAny_ has no restrictions on user id
-and must be carefully guarded, else it will be easy for containers to run as root.
-<4> the min uid value in the SCC becomes the default. If a min value is not defined in the SCC then
-the namespace is used.
-<5> "default" is the (unfortunate) name of the current project.
-<6> this range is interpreted as allowing user ids between 1000000000 through and including 1000009999.
-This range also defines the default user id when no id is supplied in the pod and no range is defined
-in the SCC. In this case, the default UID is 1000000000, the min value of the namespace's range.
-
-As an example, using the _restricted_ SCC and the _default_ namespace, here are the user ID default
-and allowed values:
-```
-# oc get scc restricted 
-NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
-restricted   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   <none>
-```
-
-The _restricted_ SCC requires user id checking (RUNASUSER set to _MustRunAsRange_), but supplies
-no user id range (the min/max values are not visible in `oc get scc` above, but are shown in
-`oc export scc restricted`). Therefore, the user id's allowable range comes from the _default_
-namespace, shown above, and is 1000000000 - 1000009999 (inclusive).
 
 Getting back to the link:#nfs-example[NFS example], the container needs it's UID set to 99,
 which is shown in the link:#pod-user-id-99[pod fragement above].
 
 Assuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
-will, unfortunately, *not* be allowed and therefore the pod will fail. The pod fails because:
+will *not* be allowed, and therefore the pod will fail. The pod fails because:
 
 - it requests 99 as its user id,
-- all SCCs available to the pod are examined (roughly in priority order followed by most restrictive)
-to see which SCC will allow a user id of 99 (actually, all policies of the SCCs are checked but the 
-focus here is on user id),
-- since all available SCCs use _MustRunAsRange_ for their `*runAsUser*` strategy, uid range checking
-is required, 
-- 99 is not included in the SCC or namespace's user id range, so the pod fails.
+- since all available SCCs use _MustRunAsRange_ for their `*runAsUser*` strategy, uid range
+checking is required, 
+- 99 is not included in the SCC or in namespace's user id range, so the pod fails.
 
 To fix this situation:
 
-- the _restricted_ SCC could be modified to include 99 within the min and max user ids
+- the _restricted_ SCC could be modified to include 99 within its min and max user id range
 (*not* recommended),
 - the _restricted_ SCC could be modified to use _RunAsAny_ for the `*runAsUser*` value,
-thus eliminating id range checking (*not* recommended -- containers can run as root),
+thus eliminating id range checking (*really not* recommended, containers could run as root),
 - a new SCC could be created with the appropriate user id range (recommended),
 - the _default_ project's UID range could be changed to allow a user id of 99.
 (not generally advisable since only a single range of user ids can be specified),
@@ -508,8 +455,8 @@ thus eliminating id range checking (*not* recommended -- containers can run as r
 ===== Custom SCC for UserID:
 It's generally considered a good practice to *not* modify the predefined SCCs. The preferred approach
 is to create a custom SCC that better fits an organization's security needs, or create a new project
-that supports the desired user ids. See
-link:../../dev_guide/projects.html#create-a-project[projects] on creating a new project.
+that supports the desired user ids. Or, see
+link:../../dev_guide/projects.html#create-a-project[projects] to create a new project.
 
 A custom SCC can be created such that a min and max user id is defined, UID range
 checking is still enforced, and the UID of 99 will be allowed. Here is an example:
@@ -531,12 +478,11 @@ runAsUser:
 ```
 <1> the name of this new SCC is "nfs-scc"
 <2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
-Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
-<3> `*runAsUser*` is a strategy and it is set to _MustRunAsRange_, which means uid range checking is 
-enforced
+Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod.
+<3> the `runAsUser` strategy is set to _MustRunAsRange_, which means uid range checking is  enforced.
 <4> the uid range is 99-99 (a range of one value).
 
-Now, using `runAsUser: 99`, shown in the pod fragment above, the pod to matches the new nfs-scc and is
+Now, with `runAsUser: 99`, shown in the pod fragment above, the pod matches the new nfs-scc and is
 able to run with a UID of 99.
 
 [[selinux]]

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -14,52 +14,204 @@ toc::[]
 
 This topic provides a general guide on pod security context as it relates to
 volume security. For information on pod security context in general, please see
-link:../../admin_guide/manage_scc.html[Managing Security Context Constraints].
+link:../../admin_guide/manage_scc.html[Managing Security Context Constraints (SCC)]
+and
+link:../../architecture/additional_concepts/authorization.html#security-context-constraints[SCC concepts].
 
-The pod security context (the `*SecurityContext*` stanza in a pod definition)
-provides three parameters which allow you to gain and control access to volumes:
-`*FSGroup*`,`*SupplementalGroups*`, and `*SELinuxOptions*`.
+As a quick background, the Openshift
+link:../../architecture/additional_concepts/storage.html[persistent volume]
+framework allows administrators to provision a cluster with persistent storage
+and gives users a way to request those resources without requiring knowledge of
+the underlying infrastructure. Persistent volumes (PV) are global resources and
+not tied to a specific project (namespace). 
+link:../../architecture/additional_concepts/storage.html#persistent-volume-claims[Persistent
+volume claims (PVC)] are local to the namespace (project), and multiple PVCs within
+the same project can bind to the same PV. However, once a PVC binds to a PV, that
+PV cannot be bound by a claim outside of the first claim's namespace. If the
+underlying storage needs to be accessed by multiple projects then each project needs
+its own PV, which can point to the same physical storage. In this sense, a bound PV
+is tied to a namespace. For a detailed PV and PVC example, see the guide for
+https://github.com/openshift/origin/tree/master/examples/wordpress[WordPress and
+MySQL using NFS].
 
-[IMPORTANT]
-====
-The `FSGroup` and `SELinuxOptions` parameters are generated for your pod if not
-specified. It is recommended that you rely on the automatically generated values
-and not specify your own unless you have a specific use case which requires
-otherwise.
-====
+Accessing persistent storage requires coordination between the cluster (and/or storage)
+administrator and the end-developer. The cluster admin creates persistent volumes (PV),
+which abstracts the underlying physical storage. The developer creates pods and,
+optionally, persistent volume claims (PVC), which bind to a PV based on matching
+criteria, such as capacity. Granting pods access to PVs involves knowing the group ids
+and/or user id assigned to the actual storage (and thus knowing the group and/or user id
+that need to be defined in the pod), any selinux considerations, and, finally, ensuring
+that these ids are allowed in the range of legal ids defined for the project (namespace)
+and/or in the SCC that matches the requirements of the pod.
 
-== SupplementalGroups
+Group ids, the user id, and selinux values are defined in the `*SecurityContext*` stanza
+in a pod definition. Group ids are global to the pod and apply to all containers defined
+in the pod. User ids can also be global, or specific to each container. Four stanzas
+control access to volumes:
+link:#fsgroup[`fsGroup`],
+link:#supplemental-groups[`supplementalGroups`],
+link:#run-as-user[`runAsUser`], and
+link:#selinux[`SELinuxOptions`].
 
-Supplemental groups are regular Linux groups. When a process runs in Linux, it
-has a UID and one or more GIDs. Usually this is just the UID and GIDs of the
-user who started the process, but in the case of containers you have the option
-of setting these attributes for the container's main process.
+==== Defaults and Allowed ID Ranges
+Default values are provided for `supplementalGroups`, `fsGroup`, `runAsUser`, and `SELinuxOptions`
+when not explicity defined in the pod spec (or in the image). Default values are looked for first in
+the pod's matching SCC, and, if not present there, then in the namespace. When an *id* default
+(preallocated value) is required, it is set to the minimum value in the first range of allowable
+values for that particular id.The _MustRunAs_ and _MustRunAsRange_ SCC strategies require defaults.
+A SCC strategy of _RunAsAny_ does not produce defaults. _RunAsAny_ sets the container's UID and GID
+to 0 (root), and does not set any `SELinuxOptions`. 
 
-The `*SupplementalGroups*` option of the pod `*SecurityContext*` stanza enables
-you to specify a list of groups which will be added to the main process of every
-container in the pod. This is useful because it enables you to give your pods
-group based access to volumes.
+Ids may be validated against ranges which are defined in the SCC and/or the project (namespace). 
+Like defaults, ranges of allowed ids are searched for first in the pod's SCC, and if not found there,
+then in the namespace. If the SCC id-related strategy is set to _MustRunAs_ or _MustRunAsRange_,
+then supplied ids, pertinent to that strategy, will be checked to be within the defined range(s).
+If the supplied ids are outside of the ranges then the pod will fail to start. On the other hand,
+an SCC id-related strategy of _RunAsAny_ bypasses id validation.
+
+```
+(THIS ARE NOTES FOR PAUL WEIL AND WILL BE DELETED SOON)
+
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP     SUPGROUP    PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   MustRunAs   MustRunAs   9
+id: uid=99(nobody) gid=99(nogroup) groups=1000000000
+
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP     SUPGROUP   PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   MustRunAs   RunAsAny   9
+id: uid=99(nobody) gid=99(nogroup) groups=1000000000  ##same as above
+
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP    PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   MustRunAs   9
+id: uid=99(nobody) gid=99(nogroup) groups=1000000000  ##same
+
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   9
+id: uid=99(nobody) gid=99(nogroup)  !! both grps RunAsAny means no suppl-grps get defined.
+
+scc: no user min/max
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   9
+id: uid=1000000000 gid=0(root)
+
+scc: no user min/max
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP    PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   MustRunAs   9
+id: uid=1000000000 gid=0(root) groups=1000000000
+
+99 defined in pod:
+uid=99(nobody) gid=99(nogroup) groups=1000000000
+
+what if min defined for fsgroup? suppl-groups? and for runasuser
+uid=99(nobody) gid=99(nogroup) groups=5000
+
+pod set user id = 100, same range in scc:
+NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP    PRIORITY
+nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   MustRunAs   9
+id: uid=100 gid=0(root) groups=5000
+so now GID is 0, not 99 and not 100....??
+```
+
+See the examples below:
+```
+oc export ns default <1>
+...
+metadata:
+  annotations: <2>
+    openshift.io/sa.scc.mcs: s0:c1,c0 <3>
+    openshift.io/sa.scc.supplemental-groups: 1000000000/10000 <4>
+    openshift.io/sa.scc.uid-range: 1000000000/10000 <5>
+...
+
+# oc export scc <scc-name>
+...
+fsGroup:
+  type: MustRunAs <6>
+  ranges:
+  - min: 5000
+    max: 6000
+runAsUser:
+  type: MustRunAsRange <7>
+  uidRangeMin: 99
+  uidRangeMax: 199
+seLinuxContext: <8>
+  type: MustRunAs 
+  SELinuxOptions: <9>
+    user: <selinux-user-name>
+    role: ...
+    type: ...
+    level: ...
+supplementalGroups:
+  type: MustRunAs <6>
+  ranges:
+  - min: 5000
+    max: 6000
+```
+<1> "default" is the name of the project (namespace).
+<2> recall that defaults are only used when the corresponding SCC stragtegy is *not* _RunAsAny_.
+<3> this is the selinux default if a value is not defined in the pod spec or in the SCC.
+<4> this is the range of allowable group ids in the container. There can be more than one range
+specified, separated by commas. Two range formats are supported: 1) M/N, where M is the starting
+id and N is the count, so the range becomes M through, and including, M+N-1. 2) M-N, M is again the
+starting id and N is the ending id. The default group id is the starting id in the first range, 1000000000.
+If the SCC does not define a minimum group id then the namespace's default id is applied.
+<5> same as (3) but for user ids. Also, only a single range of ids is supported.
+<6> _MustRunAs_ enforces group id range checking, and provides the container's groups default. Based on
+this scc definition, the default is 5000 (the min id value). If the range was omitted from this scc then
+the default would be 1000000000, from the namespace.
+The other supported type is _RunAsAny_, which does not perform range checking, thus allowing any
+group id, and causes no default id to be used.
+<7> _MustRunAsRange_ enforces user id range checking, and provides a UID default. Based on this scc
+the default UID is 99, the min value. If the min/max were omitted, the default user id would be
+1000000000, derived from the namespace. When a user id range is defined in the scc, and the `runAsUser`
+id in the pod spec equals the min range value, then the container's *GID* is set to the min UID.
+_MustRunAsNonRoot_ and _RunAsAny_ are the other supported types.
+<8> when set to _MustRunAs_, the container is created with the SCC's selinux options, or the
+MCS default defined in the namespace. A type of _RunAsAny_ indicates that selinux context
+is not required.
+<9> The selinux user name, role name, type, and labels can be defined here.
+
+[[supplemental-groups]]
+
+== Supplemental Groups
+
+Supplemental groups are regular Linux groups. When a process runs in Linux, it has a UID,
+a GID, and one or more supplemental groups. These attributes can be set for a container's
+main process. The `supplementalGroups` ids are typically used for controlling
+access to _shared_ storage, such as NFS and GlusterFS; whereas, 
+link:#fsgroup[fsGroup] is used for controlling access to _block_ storage, such
+as Ceph-RBD and iSCSI.
 
 For example, consider the following NFS export:
 
 ====
 ----
-showmount -e example.com
-Export list for example.com:
-/nfsexport (everyone)
+#on an openshift node:
+#(Note: showmount needs access to the ports used by rpcbind and rpc.mount on the nfs server)
+showmount -e <nfs-server-ip-or-hostname>
+Export list for f21-nfs.vm:
+/opt/nfs  *
 
-# ls -ld /nfsexport # on NFS server
-drwxrwx---. 2 root 1234 4096 Oct 30 15:27 /nfsexport
+#on the nfs server:
+# cat /etc/exports
+/opt/nfs *(rw,sync,no_root_squash)
+...
+
+# ls -lZ /opt/nfs -d
+drwxrws---. nobody 5555 unconfined_u:object_r:usr_t:s0   /opt/nfs
+
+# id nobody
+uid=99(nobody) gid=99(nobody) groups=99(nobody)
 ----
 ====
 
-The above export is only accessible by *root* and the group *1234*. So any pod
-which is not run as *root* and is not a member the group *1234* will not be able
-to access that export. It is often the case that the primary UID in the
-container cannot be controlled or predicted.
+The _/opt/nfs/_ export is accessible by UID *99* and the group *5555*. In general,
+containers should not run as root, so, in this NFS example, containers which are not run
+as UID *99* or are not members the group *5555* will not be able to access the NFS export.
 
-To solve this issue, you can add the group *1234* to `*SupplementalGroups*` as
-in the following example:
+Often, the SCC matching the pod does not allow an arbitrary user id to be specified, thus
+using groups is generally a more flexible way to grant storage access to a pod. For example,
+to grant NFS access to the export above, the group *5555* can be defined in the pod spec,
+as shown below (fragment):
 
 ====
 
@@ -67,88 +219,167 @@ in the following example:
 ----
 apiVersion: v1
 kind: Pod
-metadata:
-  name: nfs-web
+...
 spec:
   containers:
-    - name: web
-      image: nginx
-      ports:
-        - name: web
-          containerPort: 80
-      volumeMounts:
-          - name: nfs
-            mountPath: "/usr/share/nginx/html"
-  securityContext:
-    supplementalGroups: [1234]
+  - name: ...
+    volumeMounts: 
+    - name: nfs <1>
+      mountPath: /usr/share/... <2>
+  securityContext: <3>
+    supplementalGroups: [5555] <4>
   volumes:
-    - name: nfs
-      nfs:
-        server: example.com
-        path: "/nfsexport"
+  - name: nfs <1>
+    nfs:
+      server: <nfs-server-ip-or-host>
+      path: /opt/nfs <5>
 ----
 ====
+<1> name of the volume mount, must match the name in the `volumes` section.
+<2> nfs export path as seen in the container.
+<3> pod global security context: applies to all containers in pod. Note: each container can also define its
+`securityContext`; however, group ids are global to the pod, and cannot be defined for individual containers.
+<4> supplemental groups will contain 5555 which grants GID access to the export.
+<5> actual nfs export path on the nfs server.
 
-All containers in the above pod will be members of the group *1234* and will
-have access to the volume regardless of what user the container runs as. This is
-useful for volumes which do not allow you to change the export's ownership on
-the client, such as NFS and GlusterFS.
+All containers in the above pod, assuming the matching SCC or project allows the group *5555*, will be
+members of the group *5555*, and will have access to the volume, regardless of the container's user id.
 
-== FSGroup
+[[scc-supplemental-groups]]
 
-`*FSGroup*` stands for file system group. It is a supplemental group as defined
-above, but with some extra functionality. If `*FSGroup*` is specified, it will
-have the following effects on volumes which support ownership management:
+==== Supplemental Groups: SCC and Project
+All supplemental groups defined in the pod spec may be subject to validation against
+one of more ranges of group ids. These ranges can be defined in the Security Context
+Constraints (SCC) and/or in the project (which is the namespace) of the running pod.
 
-* The owning group of the volume will be set to the specified `*FSGroup*`.
-* Newly created files in the volume will also be owned by `*FSGroup*`.
-* Read and write permissions will be given to `*FSGroup*`.
-* The specified `*FSGroup*` will be added to the pod's list of supplemental
-groups.
+SCCs support two aspects related to supplemental groups:
 
-This gives your pod, and any other pods with the same `*FSGroup*`, access to the
-volume.
+* whether or not to allow, uncontested, the group ids defined in the pod (or in the image), and,
+* the range of allowed group ids (when id range checking is required).
+
+Projects (namespaces) support multiple ranges of group ids, used to validate the supplied
+`supplementalGroups` ids. Projects do not define policies, such as "MustRunAs".
+
+An SCC's `*supplementalGroups*` strategy expects a type of _MusRunAs_ or _RunAsAny_.
+_RunAsAny_ omits group id validation, and therefore any group id defined in the pod spec
+(or in the image) is allowed. On the other hand, _MustRunAs_ requires all supplied group ids
+to be validated against a range of group ids. This range can be defined in the SCC itself or
+in the namepsace (or in both, but the SCC has precedence over the namespace).
+
+There are currently six predefined SCCs, seen below:
+```
+# oc get scc
+NAME               PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER          FSGROUP    SUPGROUP    PRIORITY
+anyuid             false     []        false     MustRunAs   RunAsAny           RunAsAny   RunAsAny    10
+hostaccess         false     []        true      MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
+hostmount-anyuid   false     []        true      MustRunAs   RunAsAny           RunAsAny   RunAsAny    <none>
+nonroot            false     []        false     MustRunAs   MustRunAsNonRoot   RunAsAny   RunAsAny    <none>
+privileged         true      []        true      RunAsAny    RunAsAny           RunAsAny   RunAsAny    <none>
+restricted         false     []        false     MustRunAs   MustRunAsRange     RunAsAny   RunAsAny    <none>
+```
+
+
+```
+# oc export scc <scc-name>  #can use *restricted* here, for example
+...
+kind: SecurityContextConstraints
+...
+supplementalGroups:
+  type: MustRunAs <1>
+  ranges: <2>
+  - max: 6000
+    min: 5000 <3>
+
+# oc export ns default <4>
+...
+metadata:
+  annotations:
+    ...
+    openshift.io/sa.scc.supplemental-groups: 1000000000/10000 <5>
+...
+```
+<1> _MustRunAs_ triggers gid range checking; whereas _RunAsAny_ does not require range checking.
+<2> the range of allowed group ids (when range checking is required) is 5000 through, and including, 5999.
+Since the min and max values are defined here (in the SCC), the namespace's
+`openshift.io/sa.scc.supplemental-groups` range (5) is not needed.
+<3> the min value will be used as the default supplemental group if groups are not defined in the pod
+(or in the image).
+<4> _default_ is the name of the project (namespace) associated with the pod.
+<5> this is the namespace's allowed range of group ids, defined here to be 1000000000 through, and
+including, 1000009999. Additionally, the min value of the range (1000000000) will be the default
+supplemental group id (if a min value is not defined in the matching SCC).
+
+[[fsgroup]]
+
+== FS Group
+
+`*fsGroup*` defines a pod's "file system group". As mentioned above, whereas
+link:#supplemental-groups[supplementalGroups] apply to shared storage, `fsGroup` is used for
+block storage. It is, in fact, a supplemental group but with some extra functionality. When
+`fsGroup` is specified, it has the following effects on volumes which support ownership
+management (i.e., block volumes):
+
+* the owning group of the volume is set to the specified `fsGroup`,
+* newly created files in the volume are owned by `fsGroup`,
+* read and write permissions are given to `fsGroup`,
+* the specified `fsGroup` is added to the pod's list of supplemental groups.
+
+This grants pods with the same `fsGroup` the same access to the volume.
 
 [IMPORTANT]
 ====
-Again, it is recommended to allow OpenShift to automatically allocate an
-`*FSGroup*` unless you have a specific use case which requires you to override
-it in the pod definition.
+Again, it is recommended to allow OpenShift to automatically allocate an `fsGroup`
+unless a specific use case requires pods to have a group id different from the default.
 ====
 
-`*FSGroup*` can be specified as follows:
+`fsGroup` is defined, as shown in the pod spec fragment below:
 
 ====
 [source,yaml]
 ----
-apiVersion: v1
 kind: Pod
-metadata:
-  name: ebs-web
+...
 spec:
   containers:
-    - name: web
-      image: nginx
-      ports:
-        - name: web
-          containerPort: 80
-      volumeMounts:
-          - name: ebs-volume
-            mountPath: "/usr/share/nginx/html"
-  securityContext:
-    fsGroup: 1234
-  volumes:
-    - name: ebs-volume
-      awsElasticBlockStore:
-      volumeID: <volume_id>
+  - name: ...
+  securityContext: <1>
+    fsGroup: 5555
+  ...
 ----
 ====
+<1> like with `supplementalGroups`, `fsGroup` must be defined globally to the pod, not per container.
 
-The above pod will attach the specified AWS EBS volume to the node, format it if
-needed, mount it, and connect it to the pod. It will then apply the `*FSGroup*`
-to it as detailed above.
+The pod resulting from the spec above will run containers with id *5555* in their list of supplemental
+groups, and thus have group-level access to the target volume.
 
-Currently the list of volumes which support ownership management includes:
+==== FS Group: SCC and Project
+Similar to link:#scc-supplemental-groups[supplementalGroups], an fs group id may be subject to
+validation against one of more ranges of group ids. 
+
+Below is a SCC fragement defining an `fsGroup` strategy of _MustRunAs_, and including a range
+of group ids to validate against:
+```
+# oc export scc <scc-name>  #can use *restricted* here, for example
+...
+kind: SecurityContextConstraints
+...
+fsGroup:
+  type: MustRunAs <1>
+  ranges: <2>
+  - max: 6000
+    min: 5000 <3>
+...
+```
+<1> _MustRunAs_ triggers gid range checking; whereas _RunAsAny_ does not require range checking.
+<2> the range of allowed group ids (when range checking is required) is 5000 through, and including, 5999.
+Since the min and max values are defined here (in the SCC), the namespace's
+`openshift.io/sa.scc.supplemental-groups` range is not needed.
+<3> the min value will be used as the default supplemental group if groups are not defined in the pod
+(or in the image).
+
+This is identicle to the spec for `supplementalGroups` other than the key name being `fsGroup`.
+
+Currently the list of volumes which support ownership (block) management include:
 
 * AWS Elastic Block Store
 * OpenStack Cinder
@@ -158,7 +389,9 @@ Currently the list of volumes which support ownership management includes:
 * Ceph RBD
 * gitRepo
 
-GlusterFS and NFS do not support ownership management.
+*NOTE:* GlusterFS and NFS support shared management.
+
+[[selinux]]
 
 == SELinuxOptions
 
@@ -231,6 +464,121 @@ Currently the list of volumes which support SELinux management includes:
 * gitRepo
 
 GlusterFS and NFS do not support SELinux management.
+
+[[run-as-user]]
+
+== User ID
+
+User ids can be defined in the container image or in the pod spec. In the pod spec, a single user
+id can be define global to all containers, or specific to each container (or both a global spec
+and container-specific UIDs for some of the containers). Similar to group ids, user ids may be
+validated according to policies set in the SCC and/or namespace.
+
+If a user id is supplied and the matching SCC's `*runAsUser*` strategy is _MustRunAsRange_ then
+that id will be validated against the min and max user ids defined in that SCC. If the min/max
+ids are not defined in the SCC then the user id is validated against the namespace's
+`openshift.io/sa.scc.uid-range` value. On the other hand, if the user id is omitted then the
+default UID becomes the matching SCC's `*runAsUser*` strategy's `uidRangeMin` value. Or, if a
+min value is not specified in the SCC, then the first number in the namespace's
+`openshift.io/sa.scc.uid-range` becomes the default user id.
+
+As an example, using the _restricted_ SCC and the _default_ namespace, here are the user ID default
+and allowed values:
+```
+# oc get scc restricted 
+NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
+restricted   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   <none>
+                                                        <1>
+```
+<1> _MustRunAsRange_ enforces UID checking. In comparison, a value of _RunAsAny_ would not trigger UID
+range checking and thus would accept any user id.
+
+So, the _restricted_ SCC requires user id checking, but supplies no user id range (the min/max values
+are not visible in `oc get scc` above, but are shown in `oc export scc restricted`). Therefore, the
+user id allowable range comes from the _default_ namespace, seen below:
+```
+# oc export ns default
+...
+kind: Namespace
+metadata:
+  annotations:
+    ...
+    openshift.io/sa.scc.uid-range: 1000000000/10000 <1>
+...
+```
+<1> this range is interpreted as allowing user ids between 1000000000 through and including 1000009999.
+If no user id is specified then the default user id will be the min value of 1000000000.
+
+Getting back to the NFS example above: the container needs it's UID to be 99 (group ids are
+described link:#supplemental-groups[above]), so the following fragement can be added to
+the pod spec:
+```
+spec:
+  containers: <1>
+  - name: ...
+    securityContext:
+      runAsUser: 99  #nobody
+```
+<1> id 99 is container specific.
+
+Aassuming the _default_ project and the _restricted_ SCC, the pod's requested user id of 99
+will, unfortunetely, *not* be allowed and therefore the pod will fail. The pod fails because:
+
+- it requests 99 as its user id,
+- all SCCs available to the pod are examined (roughly in priority order followed by most restrictive)
+to see which SCC will allow a user id of 99 (actually, all policies of the SCCs are checked but the 
+focus here is on user id),
+- since all available SCCs use _MustRunAsRange_ for their `*runAsUser*` strategy, uid range checking
+is required, 
+- 99 is not included in the SCC or namespace's user id range, so the pod fails.
+
+To fix this situation:
+
+- the _restricted_ SCC could be modified to include 99 within the min and max user ids
+(*not* recommended),
+- the _restricted_ SCC could be modified to use _RunAsAny_ for the `*runAsUser*` value,
+thus eliminating id range checking (*not* recommended -- containers can run as root),
+- a new SCC could be created with the appropriate user id range (recommended),
+- a new SCC could be created with the `*runAsUser*` strategy set to _RunAsAny_
+(*caution:* need to be mindful of containers being able to run as root),
+- the _default_ project's UID range could be changed to allow a user id of 99.
+(not generally advisable since only a single range of user ids can be specified),
+- a new project could be created with the appropriate user id range defined (not covered here).
+
+===== Custom SCC for UserID:
+It's generally considered a good practice to *not* modify the predefined SCCs. The preferred approach
+is to create a custom SCC that better fits an organization's security needs, or create a new project
+that supports the desired user ids. See
+link:../../dev_guide/projects.html#create-a-project[projects] on creating a new project.
+
+A custom SCC can be created such that a min and max user id is defined, UID range
+checking is still enforced, and the UID of 99 will be allowed. Here is an example:
+```
+# oc export scc nfs-scc 
+allowHostDirVolumePlugin: false  #the allow* bools are the same as for the restricted scc
+...
+kind: SecurityContextConstraints
+metadata:
+  ...
+  name: nfs-scc <1>
+priority: 9 <2>
+requiredDropCapabilities: null
+runAsUser:
+  type: MustRunAsRange <3>
+  uidRangeMax: 99 <4>
+  uidRangeMin: 99
+...
+```
+<1> the name of this new SCC is "nfs-scc"
+<2> numerically larger numbers have greater priority, nil or omitted is the lowest priority.
+Higher priority SCCs sort before lower pri SCCs and thus have a better chance of matching a new pod
+<3> `*runAsUser*` is a strategy and it is set to _MustRunAsRange_, which means uid range checking is 
+enforced
+<4> the uid range is 99-99 (a range of one value).
+
+Now, using `runAsUser: 99`, shown in the pod fragment above, the pod to matches the new nfs-scc and is
+able to run with a UID of 99.
+
 
 == UID and GID Management with NFS and GlusterFS
 

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -113,48 +113,6 @@ both the `supplementalGroups` and `fsGroup` strategies being set to _RunAsAny_,
 two group strategies above. Therefore, if no groups are defined in the pod spec (or in the
 image), the container(s) will have no supplemental groups predefined.
 
-```
-(THIS ARE NOTES FOR PAUL WEIL AND WILL BE DELETED SOON)
-
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP     SUPGROUP    PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   MustRunAs   MustRunAs   9
-id: uid=99(nobody) gid=99(nogroup) groups=1000000000
-
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP     SUPGROUP   PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   MustRunAs   RunAsAny   9
-id: uid=99(nobody) gid=99(nogroup) groups=1000000000  ##same as above
-
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP    PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   MustRunAs   9
-id: uid=99(nobody) gid=99(nogroup) groups=1000000000  ##same
-
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   9
-id: uid=99(nobody) gid=99(nogroup)  !! both grps RunAsAny means no suppl-grps get defined.
-
-scc: no user min/max
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP   PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   RunAsAny   9
-id: uid=1000000000 gid=0(root)
-
-scc: no user min/max
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP    PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   MustRunAs   9
-id: uid=1000000000 gid=0(root) groups=1000000000
-
-99 defined in pod:
-uid=99(nobody) gid=99(nogroup) groups=1000000000
-
-what if min defined for fsgroup? suppl-groups? and for runasuser
-uid=99(nobody) gid=99(nogroup) groups=5000
-
-pod set user id = 100, same range in scc:
-NAME      PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER        FSGROUP    SUPGROUP    PRIORITY
-nfs-scc   false     []        false     MustRunAs   MustRunAsRange   RunAsAny   MustRunAs   9
-id: uid=100 gid=0(root) groups=5000
-so now GID is 0, not 99 and not 100....??
-```
-
 Below is the _default_ namespace and a custom SCC, shown to summarize the interactions of
 the SCC and the namespace:
 ```
@@ -339,59 +297,50 @@ custom SCC.
 
 == FS Group
 
-`*fsGroup*` defines a pod's "file system group". As mentioned link:#supplemental-groups[above],
-`supplementalGroups` apply to shared storage; whereas, `fsGroup` is used for block storage.
-Block storage, such as Ceph-RBD,  iSCSI, and various cloud storage, is typically dedicated to
-a single pod which has specified the block storage volume, either directly or via a persistent
-volume claim (PVC). Block storage is "_taken over_" by a pod, meaning that user and group ids
-supplied in the pod spec (or image) are applied to the actual, physical block device. Typically,
-block storage is not shared. Sharing block storage requires all pods in the namespace to define
-the same group/user ids, so that when a pod "takes over" the block device, it is still accessible
-to the other pods. 
+`*fsGroup*` defines a pod's "file system group" id, which gets added to the container's supplemental
+groups. As mentioned link:#supplemental-groups[above], the `supplementalGroups` id applies to shared
+storage; whereas, the `fsGroup` id is used for block storage.
 
-The `fsGroup` id is, in fact, a supplemental group set in the container, but brings some extra
-functionality:
+Block storage, such as Ceph-RBD, iSCSI, and various cloud storage, is typically dedicated to a single
+pod which has requested the block storage volume, either directly or via a persistent volume claim (PVC).
+Unlike shared storage, block storage is *_taken over_* by a pod, meaning that user and group ids supplied
+in the pod spec (or image) are applied to the actual, physical block device. Typically, block storage is
+not shared. Sharing block storage requires that all pods in the namespace define the same group or user
+ids, so that when a pod "takes over" the block device, it is still accessible to the other pods. 
 
-* the group of the volume is set to the specified `fsGroup`,
-* newly created files in the volume are owned by `fsGroup`,
-* read and write permissions are given to `fsGroup`,
-
-Using the link:#nfs-export[NFS export above], NOPE. Need CEPH ex
-
-[IMPORTANT]
-====
-Again, it is recommended to allow OpenShift to automatically allocate an `fsGroup`
-unless a specific use case requires pods to have a group id different from the default.
-====
-
-`fsGroup` is defined, as shown in the pod spec fragment below:
-
-====
-[source,yaml]
-----
+A `fsGroup` definition is shown below in the pod spec fragment:
+```
 kind: Pod
 ...
 spec:
   containers:
   - name: ...
   securityContext: <1>
-    fsGroup: 5555
+    fsGroup: 5555 <2>
   ...
-----
-====
-<1> like with `supplementalGroups`, `fsGroup` must be defined globally to the pod, not per container.
-
-The pod resulting from the spec above will run containers with id *5555* in their list of supplemental
-groups, and thus have group-level access to the target volume.
-
-==== FS Group: SCC and Project
-Similar to link:#scc-supplemental-groups[supplementalGroups], an fs group id may be subject to
-validation against one of more ranges of group ids. 
-
-Below is a SCC fragement defining an `fsGroup` strategy of _MustRunAs_, and including a range
-of group ids to validate against:
 ```
-# oc export scc <scc-name>  #can use *restricted* here, for example
+<1> like with `supplementalGroups`, `fsGroup` must be defined globally to the pod, not per container.
+<2> 5555 will become the group id for the volume's group permissions and for all new files created in
+the volume.
+
+As is true with `supplementalGroups`, all containers in the above pod (assuming the matching SCC or
+project allows the group *5555*) will be members of the group *5555*, and will have access to the
+block volume, regardless of the container's user id. If the pod matches the _restricted_ SCC, whose
+`fsGroup` strategy is _RunAsAny_, then any `fsGroup` id (including 5555) will be accepted. However,
+if the SCC has its `fsGroup` strategy set to _MustRunAs_, and 5555 is not in the allowable range of
+fs group ids, then the pod will fail to run.
+
+[[scc-fsgroup]]
+==== FS Groups and Custom SCCs
+
+To remedy this situation a custom SCC can be created such that a min and max group id are defined,
+id range checking is enforced, and the group id of 5555 is allowed. It is considered a better
+practice to create new SCCs versus modifying a predefined SCC, or changing the range of allowed
+ids in the predefined projects.
+
+Here is a fragment of a new SCC:
+```
+# oc export scc <new-scc>
 ...
 kind: SecurityContextConstraints
 ...
@@ -402,16 +351,20 @@ fsGroup:
     min: 5000 <3>
 ...
 ```
-<1> _MustRunAs_ triggers gid range checking; whereas _RunAsAny_ does not require range checking.
-<2> the range of allowed group ids (when range checking is required) is 5000 through, and including, 5999.
-Since the min and max values are defined here (in the SCC), the namespace's
-`openshift.io/sa.scc.supplemental-groups` range is not needed.
-<3> the min value will be used as the default supplemental group if groups are not defined in the pod
-(or in the image).
+<1> _MustRunAs_ triggers group id range checking; whereas, _RunAsAny_ does not require range checking.
+<2> the range of allowed group ids is 5000 through, and including, 5999. Multiple ranges are supported.
+The allowed group id range here is 5000-5999, with the default fs group being 5000.
+<3> the min value (or the entire range) can be omitted from the SCC and, thus range checking and generating
+a default value will defer to the namespace's `openshift.io/sa.scc.supplemental-groups` range. `fsGroup`
+and `supplementalGroups` use the same group field in the namespace (there is not a separate range for fs
+group).
 
-This is identicle to the spec for `supplementalGroups` other than the key name being `fsGroup`.
+When the pod shown above runs against this new SCC (assuming, of course, the pod has access to
+the new SCC), it will start because the group *5555*, supplied in the pod spec, is allowed by the
+custom SCC. Additionally, the pod will "take over" the block device, so when the block storage is
+viewed by a process outside of the pod, it will actually have 5555 as its group permissions.
 
-Currently the list of volumes which support ownership (block) management include:
+Currently the list of volumes which support block ownership (block) management include:
 
 * AWS Elastic Block Store
 * OpenStack Cinder
@@ -420,121 +373,6 @@ Currently the list of volumes which support ownership (block) management include
 * emptyDir
 * Ceph RBD
 * gitRepo
-
-*NOTE:* GlusterFS and NFS support shared management.
-
-[[selinux]]
-
-== SELinuxOptions
-
-SELinux labels can be defined in the pod's `*securityContext*` stanza using `level`,
-shown in the pod spec fragment below:
-```
-...
- securityContext: <1>
-    seLinuxOptions:
-      level: s0:c1,c0 <2>
-...
-```
-<1> `level` can be defined globally for the entire pod, or specifically to each container.
-<2> in addition to `level`, `user`, `role`, `type` can also be specified.
-
-Here are fragements from a SCC and from the _default_ project:
-```
-... #SCC
-seLinuxContext:
-  type: MustRunAs <1>
-...
-# oc export ns default 
-...
-metadata:
-  annotations:
-    openshift.io/sa.scc.mcs: s0:c1,c0 <2>
-...
-```
-<1> _MustRunAs_ should be used in the SCCs so that volume relabeling can be performed by the container.
-<2> if the label is not provided in the pod or in the SCC then the default comes from the namespace.
-
-All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
-This forces poda to use MCS labels, which can be defined in the pod spec, or provided as a default.
-
-...
-An SELinuxContext strategy of MustRunAs with no level set. Admission looks for the openshift.io/sa.scc.mcs annotation to populate the level.
-
-The SCC determines whether or not to require a selinux label and can provide a default label.
-If `*seLinuxContext*` in the SCC is set to _MustRunAs_, and the pod (or image) does not
-define a label then a default, either from the SCC itself or the namespace, is used. If
-`seLinuxContext`  is set to _RunAsAny_ then no default labels are provided, so the container
-determines the final label. In the case of docker, the container will use a unique MCS label,
-which will not likely match the label on existing storage mounts.
-
-Additionally, volumes which support SELinux management,
-will be relabeled so that they are accessible by the specified label and,
-depending on how exclusionary the label is, only that label.
-
-This means two things for unprivileged containers:
-
-* the volume will be given a `*type*` which is accessible by unprivileged containers.
-Usually *svirt_sandbox_file_t*.
-* If a `*level*` is specified, the volume will be labeled with the given MCS label.
-
-[NOTE]
-====
-Level and MCS label are used interchangeably in this topic.
-====
-
-For your volume to be accessible by your pod, the pod must have both categories
-of the volume. So a pod with *s0:c1,c2* will be able to access volumes with
-*s0,c1,c2*, and a volume with *s0* will be accessible by all pods.
-
-[WARNING]
-====
-Hard coding MCS labels into your pod definition makes it easy for others to
-determine what MCS label is needed to access the same volume as the defined pod.
-So it is especially important to rely on the MCS labels allocated by OpenShift
-and to use this feature with care.
-====
-
-SELinux options are specified as follows:
-
-====
-[source,yaml]
-----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ebs-web
-spec:
-  containers:
-    - name: web
-      image: nginx
-      ports:
-        - name: web
-          containerPort: 80
-      volumeMounts:
-          - name: ebs-volume
-            mountPath: "/usr/share/nginx/html"
-  securityContext:
-    seLinuxOptions:
-    level: "s0:c123,c456"
-  volumes:
-    - name: ebs-volume
-      awsElasticBlockStore:
-      volumeID: <VOLUME ID>
-----
-====
-
-Currently the list of volumes which support SELinux management includes:
-
-* AWS Elastic Block Store
-* OpenStack Cinder
-* GCE Persistent Disk
-* iSCSI
-* emptyDir
-* Ceph RBD
-* gitRepo
-
-GlusterFS and NFS do not support SELinux management.
 
 [[run-as-user]]
 
@@ -650,6 +488,120 @@ enforced
 Now, using `runAsUser: 99`, shown in the pod fragment above, the pod to matches the new nfs-scc and is
 able to run with a UID of 99.
 
+
+
+[[selinux]]
+
+== SELinuxOptions
+
+SELinux labels can be defined in the pod's `*securityContext*` stanza using `level`,
+shown in the pod spec fragment below:
+```
+...
+ securityContext: <1>
+    seLinuxOptions:
+      level: s0:c1,c0 <2>
+...
+```
+<1> `level` can be defined globally for the entire pod, or specifically to each container.
+<2> in addition to `level`, `user`, `role`, `type` can also be specified.
+
+Here are fragements from a SCC and from the _default_ project:
+```
+... #SCC
+seLinuxContext:
+  type: MustRunAs <1>
+...
+# oc export ns default 
+...
+metadata:
+  annotations:
+    openshift.io/sa.scc.mcs: s0:c1,c0 <2>
+...
+```
+<1> _MustRunAs_ should be used in the SCCs so that volume relabeling can be performed by the container.
+<2> if the label is not provided in the pod or in the SCC then the default comes from the namespace.
+
+All predefined SCCs, except for the _privileged_ SCC, set the `seLinuxContext:` to _MustRunAs_.
+This forces poda to use MCS labels, which can be defined in the pod spec, or provided as a default.
+
+...
+An SELinuxContext strategy of MustRunAs with no level set. Admission looks for the openshift.io/sa.scc.mcs annotation to populate the level.
+
+The SCC determines whether or not to require a selinux label and can provide a default label.
+If `*seLinuxContext*` in the SCC is set to _MustRunAs_, and the pod (or image) does not
+define a label then a default, either from the SCC itself or the namespace, is used. If
+`seLinuxContext`  is set to _RunAsAny_ then no default labels are provided, so the container
+determines the final label. In the case of docker, the container will use a unique MCS label,
+which will not likely match the label on existing storage mounts.
+
+Additionally, volumes which support SELinux management,
+will be relabeled so that they are accessible by the specified label and,
+depending on how exclusionary the label is, only that label.
+
+This means two things for unprivileged containers:
+
+* the volume will be given a `*type*` which is accessible by unprivileged containers.
+Usually *svirt_sandbox_file_t*.
+* If a `*level*` is specified, the volume will be labeled with the given MCS label.
+
+[NOTE]
+====
+Level and MCS label are used interchangeably in this topic.
+====
+
+For your volume to be accessible by your pod, the pod must have both categories
+of the volume. So a pod with *s0:c1,c2* will be able to access volumes with
+*s0,c1,c2*, and a volume with *s0* will be accessible by all pods.
+
+[WARNING]
+====
+Hard coding MCS labels into your pod definition makes it easy for others to
+determine what MCS label is needed to access the same volume as the defined pod.
+So it is especially important to rely on the MCS labels allocated by OpenShift
+and to use this feature with care.
+====
+
+SELinux options are specified as follows:
+
+====
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ebs-web
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+      volumeMounts:
+          - name: ebs-volume
+            mountPath: "/usr/share/nginx/html"
+  securityContext:
+    seLinuxOptions:
+    level: "s0:c123,c456"
+  volumes:
+    - name: ebs-volume
+      awsElasticBlockStore:
+      volumeID: <VOLUME ID>
+----
+====
+
+Currently the list of volumes which support SELinux management includes:
+
+* AWS Elastic Block Store
+* OpenStack Cinder
+* GCE Persistent Disk
+* iSCSI
+* emptyDir
+* Ceph RBD
+* gitRepo
+
+GlusterFS and NFS do not support SELinux management.
 
 == UID and GID Management with NFS and GlusterFS
 

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -11,6 +11,8 @@
 toc::[]
 
 == Overview
+(Note: "project" and "namespace" are used interchangeably throughout this document)
+
 This topic provides a general guide on pod security as it relates to volume security.
 For information on pod-level security in general, please see
 link:../../admin_guide/manage_scc.html[Managing Security Context Constraints (SCC)]
@@ -55,9 +57,6 @@ link:#selinux[`SELinuxOptions`].
 
 [[scc]]
 ==== SCCs, Defaults, and Allowed Ranges
-
-(*Note:* "project" and "namespace" are user interchangeably)
-
 SCCs influence whether or not a pod is given a default user id, fsgroup id, supplemental
 group id, and selinux label; and, whether or not ids supplied in the pod spec (or in the
 image) will be validated against a range of allowable ids. If validation is required and

--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -135,6 +135,75 @@ assetConfig:
 ----
 ====
 
+*Changing links to documentation*
+
+Links to external documentation are shown in various sections of the web 
+console. The following example changes the URL for two given links to docs:
+
+====
+----
+window.OPENSHIFT_CONSTANTS.HELP['get_started_cli']      = "https://example.com/doc1.html";
+window.OPENSHIFT_CONSTANTS.HELP['basic_cli_operations'] = "https://example.com/doc2.html";
+----
+====
+
+Save this script to a file, for example *_help-links.js_*, and add it to the
+master configuration file:
+
+====
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/help-links.js
+----
+====
+
+*Adding or changing links to download the CLI*
+
+The "About" page in the web console provides links to where users can download
+the link:../cli_reference/index.html[command line interface (CLI)] tools. These
+links can be configured by providing both the link text and URL, so that you can
+choose to point them directly to file packages, or to an external page that
+points to the actual packages.
+
+For example, to point directly to packages that can be downloaded, where the link
+text is the package platform:
+
+====
+----
+window.OPENSHIFT_CONSTANTS.CLI = {
+  "Linux (32 bits)": "https://<cdn>/openshift-client-tools-linux-32bit.tar.gz",
+  "Linux (64 bits)": "https://<cdn>/openshift-client-tools-linux-64bit.tar.gz",
+  "Windows":         "https://<cdn>/openshift-client-tools-windows.zip",
+  "Mac OS X":        "https://<cdn>/openshift-client-tools-mac.zip"
+};
+----
+====
+
+Or, to point to a page that links the actual download packages, with the "Latest
+Release" link text:
+
+====
+----
+window.OPENSHIFT_CONSTANTS.CLI = {
+  "Latest Release": "https://<cdn>/openshift-client-tools/latest.html"
+};
+----
+====
+
+Save this script to a file, for example *_cli-links.js_*, and add it to the
+master configuration file:
+
+====
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/cli-links.js
+----
+====
+
 == Serving Static Files
 
 You can serve other files from the Asset Server as well. For example, you might

--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -294,6 +294,34 @@ oauthConfig:
 Relative paths are resolved relative to the master configuration file. You must
 restart the server after changing this configuration.
 
+== Customizing the OAuth Error Page
+
+You can also change the page shown when errors occur during authentication.
+Run the following command to create a template you can modify:
+
+====
+----
+$ oadm create-error-template > error-template.html
+----
+====
+
+Edit the file to change the styles or add content.
+You can use the Error and ErrorCode variables in the template.
+
+To use your custom error page, set the following option in the master configuration file:
+
+====
+----
+oauthConfig:
+  ...
+  templates:
+    error: /path/to/error-template.html
+----
+====
+
+Relative paths are resolved relative to the master configuration file. You must
+restart the server after changing this configuration.
+
 == Changing the Logout URL
 
 You can change the location a console user is sent to when logging out of

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -193,69 +193,69 @@ Images can be edited to set fields such as `*labels*` or `*annotations*`.
 [[ose-31-bug-fixes]]
 == Bug Fixes
 
-https://bugzilla.redhat.com/show_bug.cgi?id=1264836[BZ 1264836]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1264836[BZ#1264836]:: Previously,
 the upgrade script used an incorrect image to upgrade the HAProxy router. The
 script now uses the right image.
-https://bugzilla.redhat.com/show_bug.cgi?id=1264765[BZ 1264765]:: Previously, an
+https://bugzilla.redhat.com/show_bug.cgi?id=1264765[BZ#1264765]:: Previously, an
 upgrade would fail when a defined image stream or template did not exist. Now,
 the installation utility skips the incorrectly defined image stream or
 template and continues with the upgrade.
-https://bugzilla.redhat.com/show_bug.cgi?id=1274134[BZ 1274134]:: When using
+https://bugzilla.redhat.com/show_bug.cgi?id=1274134[BZ#1274134]:: When using
 the `oc new-app` command with the `--insecure-registry` option, it would not
 set if the Docker daemon was not running. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1273975[BZ 1273975]:: Using the `oc
+https://bugzilla.redhat.com/show_bug.cgi?id=1273975[BZ#1273975]:: Using the `oc
 edit` command on Windows machines displayed errors with wrapping and file
 changes. These issues have been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1268891[BZ 1268891]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1268891[BZ#1268891]:: Previously,
 creating pods from the same image in the same service and deployment were not
 grouped into another service. Now, pods created with the same image run in the
 same service and deployment, grouped together.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267559[BZ 1267559]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1267559[BZ#1267559]:: Previously,
 using the `oc export` command could produce an error, and the export would
 fail. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1266981[BZ 1266981]:: The recycler
+https://bugzilla.redhat.com/show_bug.cgi?id=1266981[BZ#1266981]:: The recycler
 would previously fail if hidden files or directories would be present. This
 issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1268484[BZ 1268484]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1268484[BZ#1268484]:: Previously,
 when viewing a build to completion on the web console after deleting and
 recreating the same build, no build spinner would show. This issue has been
 fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1269070[BZ 1269070]:: You can now
+https://bugzilla.redhat.com/show_bug.cgi?id=1269070[BZ#1269070]:: You can now
 use custom self-signed certificates for the web console for specific host
 names.
-https://bugzilla.redhat.com/show_bug.cgi?id=1264764[BZ 1264764]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1264764[BZ#1264764]:: Previously,
 the installation utility did not have an option to configure the deployment
 type. Now, you can run the `--deployment-type` option with the installation
 utility to select a type, otherwise the type set in the installation utility
 will be set.
-https://bugzilla.redhat.com/show_bug.cgi?id=1273843[BZ 1273843]:: There was an
+https://bugzilla.redhat.com/show_bug.cgi?id=1273843[BZ#1273843]:: There was an
 issue with the `pip` command not being available in the newest OpenShift
 release. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1274601[BZ 1274601]:: Previously,
+https://bugzilla.redhat.com/show_bug.cgi?id=1274601[BZ#1274601]:: Previously,
 using the `oc exec` command was only available to be used on privileged
 containers. Now, users with permissions to create pods can use the `oc exec`
 command to SSH into privileged containers.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267670[BZ 1267670]:: There was an
+https://bugzilla.redhat.com/show_bug.cgi?id=1267670[BZ#1267670]:: There was an
 issue with using the `iptables` command with the `-w` option to make the
 `iptables` command wait to acquire the *xtables* lock, causing some SDN
 initializations to fail. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1272201[BZ 1272201]:: When installing a clustered etcd and defining variables for IP and etcd
+https://bugzilla.redhat.com/show_bug.cgi?id=1272201[BZ#1272201]:: When installing a clustered etcd and defining variables for IP and etcd
 interfaces when using two network interfaces, the certificate would be populated
 with only the first network, instead of whichever network was desired. The issue
 has now been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1269256[BZ 1269256]:: Using the `GET` `*fieldSelector*` would return a 500 BadRequest error. This issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1268000[BZ 1268000]:: Previously, creating an application from a image stream could result in two builds being initiated. This was caused by the wrong image stream tag being used by the build process. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267231[BZ 1267231]:: The *ose-ha-proxy* router image was missing the `X-Forwarded` headers, causing the Jenkins application to redirect to HTTP instead of HTTPS. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1276548[BZ 1276548]:: Previously, an error was present where the HAProxy router did not expose statistics, even if the port was specified. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1275388[BZ 1275388]:: Previously, some node hosts would not talk to the SDN due to routing table differences. A `*lbr0*` entry was causing traffic to be routed incorrectly. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1265187[BZ 1265187]:: When persistent volume claims (PVC) were created from a template, sometimes the same volume would be mounted to multiple PVCs. At the same time, the volume would show that only one PVC was being used. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1279308[BZ 1279308]:: Previously, using a etcd storage location other than the default, as defined in the master configuration file, would result in an upgrade fail at the "generate etcd backup" stage. This issue has now been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1276599[BZ 1276599]:: Basic authentication passwords can now contain colons.
-https://bugzilla.redhat.com/show_bug.cgi?id=1279744[BZ 1279744]:: Previously, giving `*EmptyDir*` volumes a different default permission setting and group ownership could affect deploying the *postgresql-92-rhel7* image. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1276395[BZ 1276395]:: Previously, an error could occur when trying to perform an HA install using Ansible, due to a problem with SRC files. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1267733[BZ 1267733]:: When installing a etcd cluster with hosts with different network interfaces, the install would fail. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1274239[BZ 1274239]:: Previously, when changing the default project region from *infra* to *primary*, old route and registry pods are stuck in the terminating stage and could not be deleted, meaning that new route and registry pods could not be deployed. The issue has been fixed.
-https://bugzilla.redhat.com/show_bug.cgi?id=1278648[BZ 1278648]:: If, when upgrading to OpenShift Enterprise 3.1, the OpenShift Enterprise repository was not set, a Python error would occur. This issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1269256[BZ#1269256]:: Using the `GET` `*fieldSelector*` would return a 500 BadRequest error. This issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1268000[BZ#1268000]:: Previously, creating an application from a image stream could result in two builds being initiated. This was caused by the wrong image stream tag being used by the build process. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1267231[BZ#1267231]:: The *ose-ha-proxy* router image was missing the `X-Forwarded` headers, causing the Jenkins application to redirect to HTTP instead of HTTPS. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1276548[BZ#1276548]:: Previously, an error was present where the HAProxy router did not expose statistics, even if the port was specified. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1275388[BZ#1275388]:: Previously, some node hosts would not talk to the SDN due to routing table differences. A `*lbr0*` entry was causing traffic to be routed incorrectly. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1265187[BZ#1265187]:: When persistent volume claims (PVC) were created from a template, sometimes the same volume would be mounted to multiple PVCs. At the same time, the volume would show that only one PVC was being used. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1279308[BZ#1279308]:: Previously, using a etcd storage location other than the default, as defined in the master configuration file, would result in an upgrade fail at the "generate etcd backup" stage. This issue has now been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1276599[BZ#1276599]:: Basic authentication passwords can now contain colons.
+https://bugzilla.redhat.com/show_bug.cgi?id=1279744[BZ#1279744]:: Previously, giving `*EmptyDir*` volumes a different default permission setting and group ownership could affect deploying the *postgresql-92-rhel7* image. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1276395[BZ#1276395]:: Previously, an error could occur when trying to perform an HA install using Ansible, due to a problem with SRC files. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1267733[BZ#1267733]:: When installing a etcd cluster with hosts with different network interfaces, the install would fail. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1274239[BZ#1274239]:: Previously, when changing the default project region from *infra* to *primary*, old route and registry pods are stuck in the terminating stage and could not be deleted, meaning that new route and registry pods could not be deployed. The issue has been fixed.
+https://bugzilla.redhat.com/show_bug.cgi?id=1278648[BZ#1278648]:: If, when upgrading to OpenShift Enterprise 3.1, the OpenShift Enterprise repository was not set, a Python error would occur. This issue has been fixed.
 
 [[ose-31-technology-preview]]
 == Technology Preview Features
@@ -269,11 +269,11 @@ Features Support Scope]
 
 The following features are in Technology Preview:
 
-* Binary builds, and the Dockerfile source type for builds. (Fully supported
+* Binary builds and the Dockerfile source type for builds. (Fully supported
 starting in link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
-* Pod autoscaling, using the *HorizontalPodAutoscaler* object. OpenShift
-compares pod CPU usage as a percentage of requested CPU, and scales according
-to up to an indicated threshold. (Fully supported starting in
+* Pod autoscaling, using the `*HorizontalPodAutoscaler*` object. OpenShift
+compares pod CPU usage as a percentage of requested CPU and scales according
+to an indicated threshold. (Fully supported starting in
 link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
 * Support for OpenShift Enterprise running on RHEL Atomic Host. (Fully supported
 starting in link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
@@ -338,21 +338,35 @@ This release includes the following enhancements and bug fixes.
 [[ose-3-1-1-enhancements]]
 ==== Enhancements
 
-Containerized Installations Now Supported::
-In addition to installations using the RPM method, support is now added for
-installing OpenShift Enterprise master and node components as containerized
-services. Both the link:../install_config/install/quick_install.html[quick] and
+Containerized Installations Now Fully Supported::
+Installation of OpenShift Enterprise master and node components as containerized
+services, added as Technology Preview in OpenShift Enterprise 3.1.0, is now
+fully supported as an alternative to the standard RPM method. Both the
+link:../install_config/install/quick_install.html[quick] and
 link:../install_config/install/advanced_install.html[advanced installation]
 methods support use of the containerized method. See
 link:../install_config/install/rpm_vs_containerized.html[RPM vs Containerized]
 for more details on the differences when running as a containerized
 installation.
 
-RHEL Atomic Host Now Supported::
-Red Hat Enterprise Linux (RHEL) Atomic Host 7.1.6 or later is now supported for
-running containerized OpenShift services. See
+RHEL Atomic Host Now Fully Supported::
+Installing OpenShift Enterprise on Red Hat Enterprise Linux (RHEL) Atomic Host
+7.1.6 or later, added as Technology Preview in OpenShift Enterprise 3.1.0, is
+now fully supported for running containerized OpenShift services. See
 link:../install_config/install/prerequisites.html#system-requirements[System
 Requirements] for more details.
+
+Binary Builds and Dockerfile Sources Now Fully Supported::
+link:../dev_guide/builds.html#binary-source[Binary builds] and the
+link:../dev_guide/builds.html#dockerfile-source[Dockerfile source type] for
+builds, added as Technology Preview in OpenShift Enterprise 3.1.0, are now fully
+supported.
+
+Pod Autoscaling Now Fully Supported::
+link:../dev_guide/pod_autoscaling.html[Pod autoscaling] using the
+`*HorizontalPodAutoscaler*` object, added as Technology Preview in OpenShift
+Enterprise 3.1.0, is now fully supported. OpenShift compares pod CPU usage as a
+percentage of requested CPU and scales according to an indicated threshold.
 
 Web Console::
 * When creating an application from source in the web console, you can
@@ -430,9 +444,9 @@ different configurations). See the help text for `openshift-router`.
 The following features have entered into
 https://access.redhat.com/support/offerings/techpreview[Technology Preview]:
 
-* Dynamic provisioning of persistent storage volumes from Amazon EBS, Google
-Compute Disk, OpenStack Cinder storage providers. Documentation to be added
-shortly.
+* link:../install_config/persistent_storage/dynamically_provisioning_pvs.html[Dynamic
+provisioning] of persistent storage volumes from Amazon EBS, Google Compute
+Disk, OpenStack Cinder storage providers.
 
 [[ose-3-1-1-bug-fixes]]
 ==== Bug Fixes


### PR DESCRIPTION
I've tried to cover several security topics under nfs persistent storage. This is just a first stab at attempting to improve the documentation around security and storage. It is likely that much of the nfs security will be moved to other sec docs or to a new sec doc, so that these practices do not need to be repeated for each storage type. However, for now, it seem prudent to make this update available and restructure the best fit for storage & security a bit later.
