### PR TITLE
Bug 1286734: Breakup Upgrading into subdir, add pacemaker_to_native_ha

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -173,7 +173,16 @@ Topics:
       - Name: First Steps
         File: first_steps
   - Name: Upgrading
-    File: upgrades
+    Dir: upgrading
+    Topics:
+      - Name: Overview
+        File: index
+      - Name: Automated Upgrades
+        File: automated_upgrades
+      - Name: Manual Upgrades
+        File: manual_upgrades
+      - Name: Pacemaker to Native HA
+        File: pacemaker_to_native_ha
   - Name: Downgrading
     File: downgrade
     Distros: openshift-enterprise

--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -223,11 +223,11 @@ ifdef::openshift-enterprise,openshift-origin[]
 
 === Updating Cluster Roles
 
-After any link:../../install_config/upgrades.html[OpenShift cluster upgrade],
-the recommended default roles may have been updated. See the Cluster
-Administration documentation for instructions on
-link:../../install_config/upgrades.html#updating-policy-definitions[updating the
-policy definitions] to the new recommendations using:
+After any link:../../install_config/upgrading/index.html[OpenShift cluster
+upgrade], the recommended default roles may have been updated. See
+link:../../install_config/upgrading/manual_upgrades.html#updating-policy-definitions[Updating
+Policy Definitions] for instructions on getting to the new recommendations
+using:
 
 ----
 $ oadm policy reconcile-cluster-roles

--- a/dev_guide/authentication.adoc
+++ b/dev_guide/authentication.adoc
@@ -120,7 +120,7 @@ link:../cli_reference/manage_cli_profiles.html[manage multiple CLI profiles].
 [NOTE]
 ====
 If you have access to administrator credentials but are no longer logged in as
-the link:../architecture/core_concepts/projects_and_users.html#users[default
+the link:/architecture/core_concepts/projects_and_users.html#users[default
 system user] *system:admin*, you can log back in as this user at any time as
 long as the credentials are still present in your
 link:../cli_reference/get_started_cli.html#cli-configuration-files[CLI

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -57,10 +57,10 @@ ifdef::openshift-origin[]
 ====
 If your OpenShift installation was originally performed on a version previous to
 v1.0.8, even if it has since been updated to a newer version, you will need to
-follow these steps outlined in the
-link:upgrades.html#updating-node-certificates[update] document. If the node
-certificate does not contain the IP address of the node, then Heapster will fail
-to retrieve any metrics.
+follow the instructions for node certificates outlined in
+link:../install_config/upgrading/manual_upgrades.html#updating-master-and-node-certificates[Updating
+Master and Node Certificates]. If the node certificate does not contain the IP
+address of the node, then Heapster will fail to retrieve any metrics.
 ====
 endif::[]
 
@@ -404,16 +404,16 @@ ifdef::openshift-origin[]
 
 If you wish to access and manage metrics more directly, you can do so via the Hawkular Metrics API.
 
-The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation] covers 
-how to use the API, but there are a few differences when dealing with the version of Hawkular Metrics 
+The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation] covers
+how to use the API, but there are a few differences when dealing with the version of Hawkular Metrics
 configured for use on OpenShift:
 
 === OpenShift Projects & Hawkular Tenants
 
-Hawkular Metrics is a multi-tenanted application. The way its been configured is that a project in 
+Hawkular Metrics is a multi-tenanted application. The way its been configured is that a project in
 OpenShift corresponds to a tenant in Hawkular Metrics.
 
-As such, when accessing metrics for a project named `MyProject` you will need to set the 
+As such, when accessing metrics for a project named `MyProject` you will need to set the
 link:http://www.hawkular.org/docs/rest/rest-metrics.html#_tenant_header[Hawkular-tenant] header to
 `MyProject`
 
@@ -443,7 +443,7 @@ $ curl -H "Authorization: Bearer XXXXXXXXXXXXXXXXX" \
        -X GET https://${KUBERNETES_MASTER}/api/v1/proxy/namespaces/openshift-infra/services/https:heapster:/validate
 ----
 
-For more information about Heapster and how to access its APIs, please refer the 
+For more information about Heapster and how to access its APIs, please refer the
 link:https://github.com/kubernetes/heapster/[Heapster] project.
 
 endif::[]

--- a/install_config/downgrade.adoc
+++ b/install_config/downgrade.adoc
@@ -13,18 +13,19 @@ toc::[]
 
 == Overview
 
-Following an OpenShift Enterprise link:../install_config/upgrades.html[upgrade],
-it may be desirable in extreme cases to downgrade your cluster to a previous
-version. The following sections outline the required steps for each system in a
-cluster to perform such a downgrade, currently supported for the OpenShift
-Enterprise 3.1 to 3.0 downgrade path.
+Following an OpenShift Enterprise
+link:../install_config/upgrading/index.html[upgrade], it may be desirable in
+extreme cases to downgrade your cluster to a previous version. The following
+sections outline the required steps for each system in a cluster to perform such
+a downgrade, currently supported for the OpenShift Enterprise 3.1 to 3.0
+downgrade path.
 
 [[downgrade-verifying-backups]]
 == Verifying Backups
 
 The Ansible playbook used during the
-link:../install_config/upgrades.html[upgrade process] should have created a
-backup of the *_master-config.yaml_* file and the etcd data directory. Ensure
+link:../install_config/upgrading/index.html[upgrade process] should have created
+a backup of the *_master-config.yaml_* file and the etcd data directory. Ensure
 these exist on your masters and etcd members:
 
 ====

--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -41,7 +41,7 @@ can be used with the installation utility to:
 
 - run an link:#running-an-unattended-installation[unattended installation],
 - link:#adding-nodes-or-reinstalling[add nodes] to an existing cluster,
-- link:../../install_config/upgrades.html[upgrade your cluster], or
+- link:../../install_config/upgrading/index.html[upgrade your cluster], or
 - link:#adding-nodes-or-reinstalling[reinstall] the OpenShift cluster completely.
 endif::[]
 
@@ -121,7 +121,7 @@ After it has finished, ensure that you back up the
 link:#defining-an-installation-configuration-file[installation configuration
 file] that is created, as it is required if you later want to re-run the
 installation, add hosts to the cluster, or
-link:../../install_config/upgrades.html[upgrade your cluster]. Then, see
+link:../../install_config/upgrading/index.html[upgrade your cluster]. Then, see
 link:#quick-install-whats-next[What's Next] for the next steps on configuring
 your OpenShift cluster.
 
@@ -246,7 +246,7 @@ $ atomic-openshift-installer -u -c </path/to/file> install
 After the unattended installation finishes, ensure that you back up the
 *_~/.config/openshift/installer.cfg.yml_* file that was used, as it is required
 if you later want to re-run the installation, add hosts to the cluster, or
-link:../../install_config/upgrades.html[upgrade your cluster]. Then, see
+link:../../install_config/upgrading/index.html[upgrade your cluster]. Then, see
 link:#quick-install-whats-next[What's Next] for the next steps on configuring
 your OpenShift cluster.
 

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -1,0 +1,239 @@
+= Performing Automated Cluster Upgrades
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+ifdef::openshift-enterprise[]
+Starting with OpenShift 3.0.2,
+endif::[]
+ifdef::openshift-origin[]
+Starting with Origin 1.0.6,
+endif::[]
+if you installed using the
+link:../../install_config/install/advanced_install.html[advanced installation]
+and the inventory file that was used is available, you can use the upgrade
+playbook to automate the OpenShift cluster upgrade process.
+ifdef::openshift-enterprise[]
+If you installed using the
+link:../../install_config/install/quick_install.html[quick installation] method
+and a *_~/.config/openshift/installer.cfg.yml_* file is available, you can use
+the installation utility to perform the automated upgrade.
+endif::[]
+
+The automated upgrade performs the following steps for you:
+
+* Applies the latest configuration.
+* Upgrades and restart master services.
+* Upgrades and restart node services.
+* Applies the latest cluster policies.
+* Updates the default router if one exists.
+* Updates the default registry if one exists.
+* Updates default image streams and InstantApp templates.
+
+ifdef::openshift-origin[]
+Ensure that you have the latest *openshift-ansible* code checked out, then run
+the playbook utilizing the default *ansible-hosts* file located in
+*_/etc/ansible/hosts_*. If your inventory file is located somewhere else, add
+the `-i` flag to specify the location:
+
+----
+# cd ~/openshift-ansible
+# git pull https://github.com/openshift/openshift-ansible master
+# ansible-playbook \
+    [-i </path/to/inventory/file>] \
+    playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+----
+
+[NOTE]
+====
+The *_v3_0_to_v3_1_* in the above path is a reference to the related OpenShift
+Enterprise versions, however it is also the correct playbook to use when
+upgrading from OpenShift Origin 1.0 to 1.1.
+====
+endif::[]
+
+ifdef::openshift-enterprise[]
+[[preparing-for-an-automated-upgrade]]
+== Preparing for an Automated Upgrade
+
+If you are upgrading from OpenShift Enterprise 3.0 to 3.1, on each master and
+node host you must manually disable the 3.0 channel and enable the 3.1 channel:
+
+====
+----
+# subscription-manager repos --disable="rhel-7-server-ose-3.0-rpms" \
+    --enable="rhel-7-server-ose-3.1-rpms"
+----
+====
+
+For any upgrade path, always ensure that you have the latest version of the
+*atomic-openshift-utils* package, which should also update the
+*openshift-ansible-** packages:
+
+----
+# yum update atomic-openshift-utils
+----
+
+There are two methods for running the automated upgrade:
+link:#upgrading-using-the-installation-utility-to-upgrade[using the installation
+utility] or link:#running-the-upgrade-playbook-directly[running the upgrade
+playbook directly]. Choose and follow one method.
+
+[[upgrading-using-the-installation-utility-to-upgrade]]
+== Using the Installation Utility to Upgrade
+
+If you installed OpenShift using the
+link:../../install_config/install/quick_install.html[quick installation] method,
+you should have an installation configuration file located at
+*_~/.config/openshift/installer.cfg.yml_*. The installation utility requires
+this file to start an upgrade.
+
+[NOTE]
+====
+The installation utility currently only supports upgrading from OpenShift
+Enterprise 3.0 to 3.1. See
+link:#upgrading-to-openshift-enterprise-3-1-asynchronous-releases[Upgrading to
+OpenShift Enterprise 3.1 Asynchronous Releases] for instructions on using
+Ansible directly.
+====
+
+If you have an older format installation configuration file in
+*_~/.config/openshift/installer.cfg.yml_* from an existing OpenShift Enterprise
+3.0 installation, the installation utility will attempt to upgrade the file to
+the new supported format. If you do not have an installation configuration file
+of any format, you can
+link:../../install_config/install/quick_install.html#defining-an-installation-configuration-file[create
+one manually].
+
+To start the upgrade, run the installation utility with the `upgrade`
+subcommand:
+
+----
+# atomic-openshift-installer upgrade
+----
+
+Then, follow the on-screen instructions to upgrade to the latest release. When
+the upgrade finishes, a recommendation will be printed to reboot all hosts.
+After rebooting, continue to
+link:#updating-master-and-node-certificates[Updating Master and Node
+Certificates].
+
+[[running-the-upgrade-playbook-directly]]
+== Running the Upgrade Playbook Directly
+
+Alternatively, you can run the upgrade playbook with Ansible directly, similar
+to the advanced installation method, if you have an inventory file.
+
+[[upgrading-to-openshift-enterprise-3-0-1]]
+=== Upgrading to OpenShift Enterprise 3.1.0
+
+Before running the upgrade, first update your inventory file to change the
+`*deployment_type*` parameter from *enterprise* to *openshift-enterprise*; this
+is required when upgrading from OpenShift Enterprise 3.0 to 3.1:
+
+----
+# sed -i s/deployment_type=enterprise/deployment_type=openshift-enterprise/ </path/to/inventory/file>
+----
+
+Then, run the *_v3_0_to_v3_1_* upgrade playbook. If your inventory file is
+located somewhere other than the default *_/etc/ansible/hosts_*, add the `-i`
+flag to specify the location. If you previously used the
+`atomic-openshift-installer` command to run your installation, you can check
+*_~/.config/openshift/.ansible/hosts_* for the last inventory file that was
+used, if needed.
+
+----
+# ansible-playbook [-i </path/to/inventory/file>] \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+----
+
+When the upgrade finishes, a recommendation will be printed to reboot all hosts.
+After rebooting, continue to
+link:#updating-master-and-node-certificates[Updating Master and Node
+Certificates].
+
+[[upgrading-to-openshift-enterprise-3-1-asynchronous-releases]]
+=== Upgrading to OpenShift Enterprise 3.1 Asynchronous Releases
+
+To apply
+link:../../release_notes/ose_3_1_release_notes.html#ose-31-asynchronous-errata-updates[asynchronous
+errata updates], such as release 3.1.1, to an existing OpenShift Enterprise 3.1
+cluster, first upgrade the *atomic-openshift-utils* package on the Red Hat
+Enterprise Linux 7 system where you will be running Ansible:
+
+----
+# yum update atomic-openshift-utils
+----
+
+Then, run the *_v3_1_minor_* upgrade playbook. If your inventory file is located
+somewhere other than the default *_/etc/ansible/hosts_*, add the `-i` flag to
+specify the location. If you previously used the `atomic-openshift-installer`
+command to run your installation, you can check
+*_~/.config/openshift/.ansible/hosts_* for the last inventory file that was
+used, if needed.
+
+----
+# ansible-playbook [-i </path/to/inventory/file>] \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
+----
+
+When the upgrade finishes, a recommendation will be printed to reboot all hosts.
+After rebooting, continue to link:#verifying-the-upgrade[Verifying the Upgrade].
+endif::[]
+
+include::install_config/upgrading/manual_upgrades.adoc[tag=30to31updatingcerts]
+
+[[verifying-the-upgrade]]
+== Verifying the Upgrade
+
+To verify the upgrade, first check that all nodes are marked as *Ready*:
+
+====
+----
+# oc get nodes
+NAME                 LABELS                                                                STATUS
+master.example.com   kubernetes.io/hostname=master.example.com,region=infra,zone=default   Ready
+node1.example.com    kubernetes.io/hostname=node1.example.com,region=primary,zone=east     Ready
+----
+====
+
+Then, verify that you are running the expected versions of the *docker-registry*
+and *router* images, if deployed:
+
+====
+----
+ifdef::openshift-enterprise[]
+# oc get -n default dc/docker-registry -o json | grep \"image\"
+    "image": "openshift3/ose-docker-registry:v3.1.1.6",
+# oc get -n default dc/router -o json | grep \"image\"
+    "image": "openshift3/ose-haproxy-router:v3.1.1.6",
+endif::[]
+ifdef::openshift-origin[]
+# oc get -n default dc/docker-registry -o json | grep \"image\"
+    "image": "openshift/origin-docker-registry:v1.0.6",
+# oc get -n default dc/router -o json | grep \"image\"
+    "image": "openshift/origin-haproxy-router:v1.0.6",
+endif::[]
+----
+====
+
+After upgrading, you can use the experimental diagnostics tool to look for
+common issues:
+
+====
+----
+# openshift ex diagnostics
+...
+[Note] Summary of diagnostics execution:
+[Note] Completed with no errors or warnings seen.
+----
+====

--- a/install_config/upgrading/index.adoc
+++ b/install_config/upgrading/index.adoc
@@ -1,0 +1,72 @@
+= Overview
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:prewrap!:
+
+When new versions of OpenShift are released, you can upgrade your existing
+cluster to apply the latest enhancements and bug fixes.
+ifdef::openshift-origin[]
+For OpenShift Origin, see the
+https://github.com/openshift/origin/releases[Releases page] on GitHub to review
+the latest changes.
+endif::[]
+ifdef::openshift-enterprise[]
+This includes upgrading from previous minor versions, such as release 3.0 to
+3.1, and applying asynchronous errata updates within a minor version (3.1.z
+releases). See the link:../../release_notes/ose_3_1_release_notes.html[OpenShift
+Enterprise 3.1 Release Notes] to review the latest changes.
+
+[NOTE]
+====
+Due to the core architectural changes between the major versions, OpenShift
+Enterprise 2 environments cannot be upgraded to OpenShift Enterprise 3 and
+require a fresh installation.
+====
+endif::[]
+
+Unless noted otherwise, node and masters within a major version are forward and
+backward compatible, so upgrading your cluster should go smoothly. However, you
+should not run mismatched versions longer than necessary to upgrade the entire
+cluster.
+
+ifdef::openshift-enterprise[]
+If you installed using the
+link:../../install_config/install/quick_install.html[quick] or
+link:../../install_config/install/advanced_install.html[advanced installation]
+and the *_~/.config/openshift/installer.cfg.yml_* or inventory file that was
+used is available,
+endif::[]
+ifdef::openshift-origin[]
+Starting with Origin 1.0.6, if you installed using the
+link:../../install/advanced_install.html[advanced installation] and the
+inventory file that was used is available,
+endif::[]
+you can perform an
+link:../../install_config/upgrading/automated_upgrades.html[automated upgrade].
+Alternatively, you can
+link:../../install_config/upgrading/manual_upgrades.html[upgrade OpenShift
+manually].
+
+[NOTE]
+====
+The Upgrading topics pertains to RPM-based installations only
+ifdef::openshift-enterprise[]
+(i.e., the link:../../install_config/install/quick_install.html[quick] and
+link:../../install_config/install/advanced_install.html[advanced installation]
+methods)
+endif::[]
+ifdef::openshift-origin[]
+(i.e., the link:../../install_config/install/advanced_install.html[advanced
+installation] method)
+endif::[]
+ and does not currently cover container-based installations.
+====
+
+If you are using the
+link:../../install_config/install/advanced_install.html#multiple-masters[Pacemaker
+method] for high availability (HA) masters, you can
+link:../../install_config/upgrading/pacemaker_to_native_ha.html[upgrade to the
+native HA method] either using Ansible playbooks or manually.

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -1,304 +1,20 @@
-= Upgrading OpenShift
+= Performing Manual Cluster Upgrades
 {product-author}
 {product-version}
 :data-uri:
 :icons:
 :experimental:
 :toc: macro
-:toclevels: 3
 :toc-title:
 :prewrap!:
 
 toc::[]
 
 == Overview
-When new versions of OpenShift are released, you can upgrade your existing
-cluster to apply the latest enhancements and bug fixes.
-ifdef::openshift-origin[]
-For OpenShift Origin, see the
-link:https://github.com/openshift/origin/releases[Releases page] on GitHub  to
-review the latest changes.
-endif::[]
-ifdef::openshift-enterprise[]
-This includes upgrading from previous minor versions, such as release 3.0 to
-3.1, and applying asynchronous errata updates within a minor version (3.1.z
-releases). See the link:../release_notes/ose_3_1_release_notes.html[OpenShift
-Enterprise 3.1 Release Notes] to review the latest changes.
 
-[NOTE]
-====
-Due to the core architectural changes between the major versions, OpenShift
-Enterprise 2 environments cannot be upgraded to OpenShift Enterprise 3 and
-require a fresh installation.
-====
-endif::[]
-
-Unless noted otherwise, node and masters within a major version are forward and
-backward compatible, so upgrading your cluster should go smoothly. However, you
-should not run mismatched versions longer than necessary to upgrade the entire
-cluster.
-
-ifdef::openshift-enterprise[]
-If you installed using the link:install/quick_install.html[quick] or
-link:install/advanced_install.html[advanced installation] and the
-*_~/.config/openshift/installer.cfg.yml_* or inventory file that was used is
-available,
-endif::[]
-ifdef::openshift-origin[]
-Starting with Origin 1.0.6, if you installed using the
-link:install/advanced_install.html[advanced installation] and the inventory file
-that was used is available,
-endif::[]
-you can link:#upgrade-playbook[use an automated upgrade process]. Alternatively,
-you can link:#manual-upgrades[upgrade OpenShift manually].
-
-[NOTE]
-====
-This topic pertains to RPM-based installations only
-ifdef::openshift-enterprise[]
-(i.e., the link:install/quick_install.html[quick] and
-link:install/advanced_install.html[advanced installation] methods)
-endif::[]
-ifdef::openshift-origin[]
-(i.e., the link:install/advanced_install.html[advanced installation] method)
-endif::[]
- and does
-not currently cover container-based installations.
-====
-
-[[upgrade-playbook]]
-== Using the Automated Upgrade
-ifdef::openshift-enterprise[]
-Starting with OpenShift 3.0.2,
-endif::[]
-ifdef::openshift-origin[]
-Starting with Origin 1.0.6,
-endif::[]
-if you installed using the link:install/advanced_install.html[advanced
-installation] and the inventory file that was used is available, you can use the
-upgrade playbook to automate the upgrade process.
-ifdef::openshift-enterprise[]
-If you installed using the link:install/quick_install.html[quick installation]
-method and a *_~/.config/openshift/installer.cfg.yml_* file is available, you
-can use the installation utility to perform the automated upgrade.
-endif::[]
-
-The automated upgrade performs the following steps for you:
-
-* Applies the latest configuration by re-running the installation playbook.
-* Upgrades and restart master services.
-* Upgrades and restart node services.
-* Applies the latest cluster policies.
-* Updates the default router if one exists.
-* Updates the default registry if one exists.
-* Updates default image streams and InstantApp templates.
-
-[IMPORTANT]
-====
-The automated upgrade re-runs cluster configuration steps, therefore any
-settings that are not stored in your inventory file will be overwritten. The
-upgrade process creates a backup of any files that are changed, and you should
-carefully review the differences after the upgrade finishes to ensure that your
-environment is configured as expected.
-====
-
-ifdef::openshift-origin[]
-Ensure that you have the latest *openshift-ansible* code checked out, then run
-the playbook utilizing the default *ansible-hosts* file located in
-*_/etc/ansible/hosts_*. If your inventory file is located somewhere else, add
-the `-i` flag to specify the location:
-
-----
-# cd ~/openshift-ansible
-# git pull https://github.com/openshift/openshift-ansible master
-# ansible-playbook \
-    [-i </path/to/inventory/file>] \
-    playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
-----
-
-[NOTE]
-====
-The *_v3_0_to_v3_1_* in the above path is a reference to the related OpenShift
-Enterprise versions, however it is also the correct playbook to use when
-upgrading from OpenShift Origin 1.0 to 1.1.
-====
-endif::[]
-
-ifdef::openshift-enterprise[]
-[[preparing-for-an-automated-upgrade]]
-=== Preparing for an Automated Upgrade
-
-If you are upgrading from OpenShift Enterprise 3.0 to 3.1, on each master and
-node host you must manually disable the 3.0 channel and enable the 3.1 channel:
-
-====
-----
-# subscription-manager repos --disable="rhel-7-server-ose-3.0-rpms" \
-    --enable="rhel-7-server-ose-3.1-rpms"
-----
-====
-
-For any upgrade path, always ensure that you have the latest version of the
-*atomic-openshift-utils* package, which should also update the
-*openshift-ansible-** packages:
-
-----
-# yum update atomic-openshift-utils
-----
-
-There are two methods for running the automated upgrade:
-link:#upgrading-using-the-installation-utility[Using the Installation Utility]
-and link:#upgrading-using-ansible-directly[Using Ansible Directly]. Choose and
-follow one method, then continue to link:#verifying-the-upgrade[Verifying the
-Upgrade].
-
-[[upgrading-using-the-installation-utility]]
-=== Using the Installation Utility
-
-If you installed using the link:install/quick_install.html[quick installation]
-method, you should have an installation configuration file located at
-*_~/.config/openshift/installer.cfg.yml_*. The installation utility requires
-this file to start an upgrade.
-
-[NOTE]
-====
-The installation utility currently only supports upgrading from OpenShift
-Enterprise 3.0 to 3.1. See
-link:#upgrading-to-openshift-enterprise-3-1-asynchronous-releases[Upgrading to
-OpenShift Enterprise 3.1 Asynchronous Releases] for instructions on using
-Ansible directly.
-====
-
-If you have an older format installation configuration file in
-*_~/.config/openshift/installer.cfg.yml_* from an existing OpenShift Enterprise
-3.0 installation, the installation utility will attempt to upgrade the file to
-the new supported format. If you do not have an installation configuration file
-of any format, you can
-link:install/quick_install.html#defining-an-installation-configuration-file[create
-one manually].
-
-To start the upgrade, run the installation utility with the `upgrade`
-subcommand:
-
-----
-# atomic-openshift-installer upgrade
-----
-
-Then, follow the on-screen instructions to upgrade to the latest release. After
-the upgrade finishes, a recommendation will be printed to reboot all hosts.
-
-[[upgrading-using-ansible-directly]]
-=== Using Ansible Directly
-
-Alternatively, you can run the upgrade playbook directly, similar to the
-advanced installation method, if you have an inventory file.
-
-[[upgrading-to-openshift-enterprise-3-0-1]]
-==== Upgrading to OpenShift Enterprise 3.1.0
-
-Before running the upgrade, first update your inventory file to change the
-`*deployment_type*` parameter from *enterprise* to *openshift-enterprise*; this
-is required when upgrading from OpenShift Enterprise 3.0 to 3.1:
-
-----
-# sed -i s/deployment_type=enterprise/deployment_type=openshift-enterprise/ </path/to/inventory/file>
-----
-
-Then, run the *_v3_0_to_v3_1_* upgrade playbook. If your inventory file is
-located somewhere other than the default *_/etc/ansible/hosts_*, add the `-i`
-flag to specify the location. If you previously used the
-`atomic-openshift-installer` command to run your installation, you can check
-*_~/.config/openshift/.ansible/hosts_* for the last inventory file that was
-used, if needed.
-
-----
-# ansible-playbook [-i </path/to/inventory/file>] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
-----
-
-After the upgrade finishes, a recommendation will be printed to reboot all
-hosts.
-
-[[upgrading-to-openshift-enterprise-3-1-asynchronous-releases]]
-==== Upgrading to OpenShift Enterprise 3.1 Asynchronous Releases
-
-To apply
-link:../release_notes/ose_3_1_release_notes.html#ose-31-asynchronous-errata-updates[asynchronous
-errata updates], such as release 3.1.1, to an existing OpenShift Enterprise 3.1
-cluster, first upgrade the *atomic-openshift-utils* package on the Red Hat
-Enterprise Linux 7 system where you will be running Ansible:
-
-----
-# yum update atomic-openshift-utils
-----
-
-Then, run the *_v3_1_minor_* upgrade playbook. If your inventory file is located
-somewhere other than the default *_/etc/ansible/hosts_*, add the `-i` flag to
-specify the location. If you previously used the `atomic-openshift-installer`
-command to run your installation, you can check
-*_~/.config/openshift/.ansible/hosts_* for the last inventory file that was
-used, if needed.
-
-----
-# ansible-playbook [-i </path/to/inventory/file>] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
-----
-
-After the upgrade finishes, a recommendation will be printed to reboot all
-hosts.
-endif::[]
-
-[[verifying-the-upgrade]]
-=== Verifying the Upgrade
-
-To verify the upgrade, first check that all nodes are marked as *Ready*:
-
-====
-----
-# oc get nodes
-NAME                 LABELS                                                                STATUS
-master.example.com   kubernetes.io/hostname=master.example.com,region=infra,zone=default   Ready
-node1.example.com    kubernetes.io/hostname=node1.example.com,region=primary,zone=east     Ready
-----
-====
-
-Then, verify that you are running the expected versions of the *docker-registry*
-and *router* images, if deployed:
-
-====
-----
-ifdef::openshift-enterprise[]
-# oc get -n default dc/docker-registry -o json | grep \"image\"
-    "image": "openshift3/ose-docker-registry:v3.1.1.6",
-# oc get -n default dc/router -o json | grep \"image\"
-    "image": "openshift3/ose-haproxy-router:v3.1.1.6",
-endif::[]
-ifdef::openshift-origin[]
-# oc get -n default dc/docker-registry -o json | grep \"image\"
-    "image": "openshift/origin-docker-registry:v1.0.6",
-# oc get -n default dc/router -o json | grep \"image\"
-    "image": "openshift/origin-haproxy-router:v1.0.6",
-endif::[]
-----
-====
-
-After upgrading, you can use the experimental diagnostics tool to look for
-common issues:
-
-====
-----
-# openshift ex diagnostics
-...
-[Note] Summary of diagnostics execution:
-[Note] Completed with no errors or warnings seen.
-----
-====
-
-[[manual-upgrades]]
-== Upgrading Manually
-
-As an alternative to using the link:#upgrade-playbook[automated upgrade], you
-can manually upgrade your OpenShift cluster. To manually upgrade without
+As an alternative to performing an
+link:../../install_config/upgrading/automated_upgrades.html[automated upgrade],
+you can manually upgrade your OpenShift cluster. To manually upgrade without
 disruption, it is important to upgrade each component as documented in this
 topic.
 
@@ -311,7 +27,7 @@ standard upgrade process.
 ====
 
 [[preparing-for-a-manual-upgrade]]
-=== Preparing for a Manual Upgrade
+== Preparing for a Manual Upgrade
 
 ifdef::openshift-enterprise[]
 If you are upgrading from OpenShift Enterprise 3.0 to 3.1, perform the following
@@ -374,7 +90,7 @@ For any upgrade path, always ensure that you are running the latest kernel:
 ----
 
 [[upgrading-masters]]
-=== Upgrading Masters
+== Upgrading Masters
 ifdef::openshift-origin[]
 Upgrade your masters first. On each master host, upgrade the *origin-master*
 package:
@@ -479,10 +195,10 @@ review its logs to ensure services have been restarted successfully:
 endif::[]
 
 [[updating-policy-definitions]]
-=== Updating Policy Definitions
+== Updating Policy Definitions
 
 After a cluster upgrade, the recommended
-link:../architecture/additional_concepts/authorization.html#roles[default
+link:../../architecture/additional_concepts/authorization.html#roles[default
 cluster roles] may have been updated. To check if an update is recommended for
 your environment, you can run:
 
@@ -557,9 +273,8 @@ endif::[]
     --confirm
 ----
 
-
 [[upgrading-nodes]]
-=== Upgrading Nodes
+== Upgrading Nodes
 
 After upgrading your masters, you can upgrade your nodes. When restarting the
 ifdef::openshift-origin[]
@@ -569,7 +284,7 @@ ifdef::openshift-enterprise[]
 *atomic-openshift-node* service, there will be a brief disruption of outbound network
 endif::[]
 connectivity from running pods to services while the
-link:../architecture/infrastructure_components/kubernetes_infrastructure.html#service-proxy[service
+link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#service-proxy[service
 proxy] is restarted. The length of this disruption should be very short and
 scales based on the number of services in the entire cluster.
 
@@ -646,14 +361,14 @@ node2.example.com       kubernetes.io/hostname=node2.example.com      Ready
 ====
 
 [[upgrading-the-router]]
-=== Upgrading the Router
+== Upgrading the Router
 
 If you have previously
-link:../install_config/install/deploy_router.html[deployed a router], the router
-deployment configuration must be upgraded to apply updates contained in the
-router image. To upgrade your router without disrupting services, you must have
-previously deployed a
-link:../admin_guide/high_availability.html#configuring-a-highly-available-routing-service[highly-available
+link:../../install_config/install/deploy_router.html[deployed a router], the
+router deployment configuration must be upgraded to apply updates contained in
+the router image. To upgrade your router without disrupting services, you must
+have previously deployed a
+link:../../admin_guide/high_availability.html#configuring-a-highly-available-routing-service[highly-available
 routing service].
 
 ifdef::openshift-origin[]
@@ -701,13 +416,13 @@ endif::[]
 You should see one router pod updated and then the next.
 
 [[upgrading-the-registry]]
-=== Upgrading the Registry
+== Upgrading the Registry
 
 The registry must also be upgraded for changes to take effect in the registry
 image. If you have used a `*PersistentVolumeClaim*` or a host mount point, you
-may restart the registry without losing the contents of your registry. The
-link:install/docker_registry.html#storage-for-the-registry[registry
-installation] topic details how to configure persistent storage.
+may restart the registry without losing the contents of your registry.
+link:../../install_config/install/docker_registry.html#storage-for-the-registry[Deploying
+a Docker Registry] details how to configure persistent storage for the registry.
 
 Edit your registry's deployment configuration:
 
@@ -746,14 +461,15 @@ pods that are already running.
 ====
 
 [[updating-the-default-image-streams-and-templates]]
-=== Updating the Default Image Streams and Templates
+== Updating the Default Image Streams and Templates
 
 ifdef::openshift-origin[]
-By default, the link:install/advanced_install.html[advanced installation] method
-automatically creates default image streams, InstantApp templates, and database
-service templates in the *openshift* project, which is a default project to
-which all users have view access. These objects were created during installation
-from the JSON files located under *_/usr/share/openshift/examples_*.
+By default, the link:../../install_config/install/advanced_install.html[advanced
+installation] method automatically creates default image streams, InstantApp
+templates, and database service templates in the *openshift* project, which is a
+default project to which all users have view access. These objects were created
+during installation from the JSON files located under
+*_/usr/share/openshift/examples_*.
 
 To update these objects, first ensure that you have the latest
 *openshift-ansible* code checked out, which provides the example JSON files:
@@ -765,12 +481,12 @@ To update these objects, first ensure that you have the latest
 endif::[]
 
 ifdef::openshift-enterprise[]
-By default, the link:install/quick_install.html[quick] and
-link:install/advanced_install.html[advanced installation] methods automatically
-create default image streams, InstantApp templates, and database service
-templates in the *openshift* project, which is a default project to which all
-users have view access. These objects were created during installation from the
-JSON files located under the
+By default, the link:../../install_config/install/quick_install.html[quick] and
+link:../../install_config/install/advanced_install.html[advanced installation]
+methods automatically create default image streams, InstantApp templates, and
+database service templates in the *openshift* project, which is a default
+project to which all users have view access. These objects were created during
+installation from the JSON files located under the
 *_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/_*
 directory.
 
@@ -819,10 +535,8 @@ ifdef::openshift-origin[]
 ====
 endif::[]
 
-include::dev_guide/authentication.adoc[tag=systemadminlogin]
-
 [[importing-the-latest-images]]
-=== Importing the Latest Images
+== Importing the Latest Images
 
 After link:#updating-the-default-image-streams-and-templates[updating the
 default image streams], you may also want to ensure that the images within those
@@ -875,107 +589,109 @@ build of those applications after importing the new images using `oc start-build
 <app-name>`.
 ====
 
+// tag::30to31updatingcerts[]
 [[updating-master-and-node-certificates]]
-=== Updating Master and Node Certificates
+== Updating Master and Node Certificates
 
 ifdef::openshift-enterprise[]
-The following steps may be required for any OpenShift instance which
-was originally installed prior to the
-link:../release_notes/ose_3_1_release_notes.adoc[OpenShift Enterprise
-3.1 release].  This may include any and all updates from that version.
+The following steps may be required for any OpenShift cluster that was
+originally installed prior to the
+link:../../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise 3.1
+release]. This may include any and all updates from that version.
 endif::[]
 ifdef::openshift-origin[]
-The following steps may be required for any OpenShift instance which
-was originally installed prior to the
-link:https://github.com/openshift/origin/releases[OpenShift Origin
-1.0.8 release].  This may include any and all updates from that
-version.
+The following steps may be required for any OpenShift cluster that was
+originally installed prior to the
+https://github.com/openshift/origin/releases[OpenShift Origin 1.0.8 release].
+This may include any and all updates from that version.
 endif::[]
 
 [[updating-node-certificates]]
-==== Node Certificates
+=== Node Certificates
 
 ifdef::openshift-enterprise[]
-With the 3.1 release, certificates for each of the kubelet nodes
-were updated to include the IP address of the node. Any node
-certificates generated before the 3.1 release may not contain the IP
-address of the node.
+With the 3.1 release, certificates for each of the kubelet nodes were updated to
+include the IP address of the node. Any node certificates generated before the
+3.1 release may not contain the IP address of the node.
 endif::[]
 ifdef::openshift-origin[]
-With the 1.0.8 release, certificates for each of the kubelet nodes
-were updated to include the IP address of the node. Any node
-certificates generated before the 1.0.8 release may not contain the IP
-address of the node.
+With the 1.0.8 release, certificates for each of the kubelet nodes were updated
+to include the IP address of the node. Any node certificates generated before
+the 1.0.8 release may not contain the IP address of the node.
 endif::[]
 
-If a node is missing the IP address as part of its certificate,
-clients may refuse to connect to the kubelet endpoint. Usually this
-will result in errors regarding the certificate not containing an `IP
-SAN`
+If a node is missing the IP address as part of its certificate, clients may
+refuse to connect to the kubelet endpoint. Usually this will result in errors
+regarding the certificate not containing an `IP SAN`.
 
 In order to remedy this situation, you may need to manually update the
 certificates for your node.
 
-===== Checking the Node's Certificate
+[[checking-the-nodes-certificate]]
+==== Checking the Node's Certificate
 
-The following command can be used to determine which `Subject
-Alternative Names` are present in the node's serving certificate. In
-this example, the `Subject Alternative Names` are: mynode,
-mynode.mydomain.com, 1.2.3.4.
+The following command can be used to determine which Subject Alternative Names
+(SANs) are present in the node's serving certificate. In this example, the
+Subject Alternative Names are *mynode*, *mynode.mydomain.com*, and *1.2.3.4*:
 
+====
 ----
 # openssl x509 -in /etc/origin/node/server.crt -text -noout | grep -A 1 "Subject Alternative Name"
 X509v3 Subject Alternative Name:
 DNS:mynode, DNS:mynode.mydomain.com, IP: 1.2.3.4
 ----
+====
 
-Ensure that the `nodeIP` value set in
-*_/etc/origin/node/node-config.yaml_* is present in the IP values from
-the `Subject Alternative Names` listed in the node's serving
-certificate. If the `nodeIP` is not present then it will need to be
-added to the node's certificate.
+Ensure that the `*nodeIP*` value set in the
+*_/etc/origin/node/node-config.yaml_* file is present in the IP values from the
+Subject Alternative Names listed in the node's serving certificate. If the
+`*nodeIP*` is not present, then it will need to be added to the node's
+certificate.
 
-If the `nodeIP` value is already contained within the `Subject
-Alternative Names`, then no further steps are required.
+If the `*nodeIP*` value is already contained within the Subject Alternative
+Names, then no further steps are required.
 
-You will need to know the `Subject Alternative Names` and `nodeIP`
-value for the following steps.
+You will need to know the Subject Alternative Names and `*nodeIP*` value for the
+following steps.
 
-===== Generating a New Node Certificate
+[[generating-a-new-node-certificate]]
+==== Generating a New Node Certificate
 
-If your current node certificate does not contain the proper IP
-address, then you will need to regenerate a new certificate for your
-node.
+If your current node certificate does not contain the proper IP address, then
+you must regenerate a new certificate for your node.
 
 [IMPORTANT]
-Node certificates will be regenerated on the master (or first master)
-and are then copied into place on node systems.
+====
+Node certificates will be regenerated on the master (or first master) and are
+then copied into place on node systems.
+====
 
-. Create a temporary directory in which to perform the following steps
+. Create a temporary directory in which to perform the following steps:
 +
 ----
 # mkdir /tmp/node_certificate_update
 # cd /tmp/node_certificate_update
 ----
 
-. Export signing options:
+. Export the signing options:
 +
 ----
-# export signing_opts="--signer-cert=/etc/origin/master/ca.crt --signer-key=/etc/origin/master/ca.key --signer-serial=/etc/origin/master/ca.serial.txt"
+# export signing_opts="--signer-cert=/etc/origin/master/ca.crt \
+    --signer-key=/etc/origin/master/ca.key \
+    --signer-serial=/etc/origin/master/ca.serial.txt"
 ----
 
-. Generate the new certificate
+. Generate the new certificate:
 +
-
 ----
 # oadm ca create-server-cert --cert=server.crt \
   --key=server.key $signing_opts \
-  --hostnames=<existing subject alt names>,<nodeIP>
+  --hostnames=<existing_SANs>,<nodeIP>
 ----
 +
-For example, if the `Subject Alternative Names` from before were
-_mynode,mynode.mydomain.com,1.2.3.4_ and the `nodeIP` was 10.10.10.1,
-then you will need to run the following command:
+For example, if the Subject Alternative Names from before were *mynode*,
+*mynode.mydomain.com*, and *1.2.3.4*, and the `*nodeIP*` was 10.10.10.1, then
+you would need to run the following command:
 +
 ----
 # oadm ca create-server-cert --cert=server.crt \
@@ -983,29 +699,26 @@ then you will need to run the following command:
   --hostnames=mynode,mynode.mydomain.com,1.2.3.4,10.10.10.1
 ----
 
-
-===== Replace Node Serving Certificates
+[[replace-node-serving-certificates]]
+==== Replace Node Serving Certificates
 
 Back up the existing *_/etc/origin/node/server.crt_* and
-*_/etc/origin/node/server.key_* file for your node:
+*_/etc/origin/node/server.key_* files for your node:
 
 ----
 # mv /etc/origin/node/server.crt /etc/origin/node/server.crt.bak
 # mv /etc/origin/node/server.key /etc/origin/node/server.key.bak
 ----
 
-You will now need to copy the new *_server.crt_* and *_server.key_*
-created in the temporary directory during the previous step.
+You must now copy the new *_server.crt_* and *_server.key_* created in the
+temporary directory during the previous step:
 
-====
 ----
 # mv /tmp/node_certificate_update/server.crt /etc/origin/node/server.crt
 # mv /tmp/node_certificate_update/server.key /etc/origin/node/server.key
 ----
-====
 
-After you have replaced the node's certificate, you will now need to
-restart the node service.
+After you have replaced the node's certificate, restart the node service:
 
 ifdef::openshift-enterprise[]
 ----
@@ -1019,27 +732,28 @@ ifdef::openshift-origin[]
 endif::[]
 
 [[updating-master-certificates]]
-==== Master Certificates
+=== Master Certificates
 
 ifdef::openshift-enterprise[]
-With the 3.1 release, certificates for each of the masters were
-updated to include all names that pods may use to communicate with
-masters. Any master certificates generated before the 3.1 release may
-not contain these additional service names.
+With the 3.1 release, certificates for each of the masters were updated to
+include all names that pods may use to communicate with masters. Any master
+certificates generated before the 3.1 release may not contain these additional
+service names.
 endif::[]
 ifdef::openshift-origin[]
-With the 1.0.8 release, certificates for each of the masters were
-updated to include all names that pods may use to communicate with
-masters. Any master certificates generated before the 1.0.8 release
-may not contain these additional service names.
+With the 1.0.8 release, certificates for each of the masters were updated to
+include all names that pods may use to communicate with masters. Any master
+certificates generated before the 1.0.8 release may not contain these additional
+service names.
 endif::[]
 
+[[checking-the-masters-certificate]]
 ==== Checking the Master's Certificate
 
-The following command can be used to determine which `Subject
-Alternative Names` are present in the master's serving certificate. In
-this example, the `Subject Alternative Names` are: mymaster,
-mymaster.mydomain.com, 1.2.3.4.
+The following command can be used to determine which Subject Alternative Names
+(SANs) are present in the master's serving certificate. In this example, the
+Subject Alternative Names are *mymaster*, *mymaster.mydomain.com*, and
+*1.2.3.4*:
 
 ----
 # openssl x509 -in /etc/origin/master/master.server.crt -text -noout | grep -A 1 "Subject Alternative Name"
@@ -1047,81 +761,107 @@ X509v3 Subject Alternative Name:
 DNS:mymaster, DNS:mymaster.mydomain.com, IP: 1.2.3.4
 ----
 
-Ensure that the following entries are present in the `Subject
-Alternative Names` for the master's serving certificate:
+Ensure that the following entries are present in the Subject Alternative Names
+for the master's serving certificate:
 
-* Kubernetes service IP address ex: 172.30.0.1
-* All master hostnames ex: master1.example.com
-* All master IP addresses ex: 192.168.122.1
-* Public master hostname in clustered environments ex: public-master.example.com
-* kubernetes
-* kubernetes.default
-* kubernetes.default.svc
-* kubernetes.default.svc.cluster.local
-* openshift
-* openshift.default
-* openshift.default.svc
-* openshift.default.svc.cluster.local
+[options="header"]
+|===
+|Entry |Example
 
-If these names are already contained within the `Subject Alternative
-Names`, then no further steps are required.
+|Kubernetes service IP address
+|172.30.0.1
 
-===== Generating a New Master Certificate
+|All master host names
+|*master1.example.com*
 
-If your current master certificate does not contain all names from the
-list above, then you will need to generate a new certificate for your
-master.
+|All master IP addresses
+|192.168.122.1
+
+|Public master host name in clustered environments
+|*public-master.example.com*
+
+|*kubernetes*
+|
+
+|*kubernetes.default*
+|
+
+|*kubernetes.default.svc*
+|
+
+|*kubernetes.default.svc.cluster.local*
+|
+
+|*openshift*
+|
+
+|*openshift.default*
+|
+
+|*openshift.default.svc*
+|
+
+|*openshift.default.svc.cluster.local*
+|
+|===
+
+If these names are already contained within the Subject Alternative Names, then
+no further steps are required.
+
+[[generating-a-new-master-certificate]]
+==== Generating a New Master Certificate
+
+If your current master certificate does not contain all names from the list
+above, then you must generate a new certificate for your master:
 
 . Back up the existing *_/etc/origin/master/master.server.crt_* and
-*_/etc/origin/master/master.server.key_* file for your master:
+*_/etc/origin/master/master.server.key_* files for your master:
 +
 ----
 # mv /etc/origin/master/master.server.crt /etc/origin/master/master.server.crt.bak
 # mv /etc/origin/master/master.server.key /etc/origin/master/master.server.key.bak
 ----
 
-. Export service names
-+
-These names will be used when generating the new certificate.
+. Export the service names. These names will be used when generating the new
+certificate:
 +
 ----
 # export service_names="kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local,openshift,openshift.default,openshift.default.svc,openshift.default.svc.cluster.local"
 ----
 
-. Generate the new certificate
+. You will need the first IP in the services
+subnet (the *kubernetes* service IP) as well as the values of `*masterIP*`,
+`*masterURL*` and `*publicMasterURL*` contained in the
+*_/etc/origin/master/master-config.yaml_* file for the following steps.
 +
-You will need the first IP in the services subnet (kubernetes service
-IP) as well as the values of `masterIP`, `masterURL` and
-`publicMasterURL` contained in
-*_/etc/origin/master/master-config.yaml_* for the following steps.
-+
-The kubernetes service IP can be obtained with:
+The *kubernetes* service IP can be obtained with:
 +
 ----
 # oc get svc/kubernetes --template='{{.spec.clusterIP}}'
 ----
+
+. Generate the new certificate:
 +
 ====
 ----
 # oadm ca create-master-certs \
-  --hostnames=<master hostnames>,<master IP addresses>,<kubernetes service IP>,$service_names \ <1> <2> <3>
-  --master=<internal master address> \ <4>
-  --public-master=<public master address> \ <5>
-  --cert-dir=/etc/origin/master/ \
-  --overwrite=false
+      --hostnames=<master_hostnames>,<master_IP_addresses>,<kubernetes_service_IP>,$service_names \ <1> <2> <3>
+      --master=<internal_master_address> \ <4>
+      --public-master=<public_master_address> \ <5>
+      --cert-dir=/etc/origin/master/ \
+      --overwrite=false
 ----
-<1> Adjust master hostname to match your master hostname. In a clustered environment, add all master hostnames.
-<2> Adjust master IP address to match the value of `masterIP`. In a clustered environment, add all master IP addresses.
-<3> The first IP in the services subnet (Kubernetes service IP).
-<4> Adjust internal master address to match the value of `masterURL`.
-<5> Adjust public master address to match the value of `masterPublicURL`.
+<1> Adjust `<master_hostnames>` to match your master host name. In a clustered
+environment, add all master host names.
+<2> Adjust `<master_IP_addresses>` to match the value of `*masterIP*`. In a
+clustered environment, add all master IP addresses.
+<3> Adjust `<kubernetes_service_IP>` to the first IP in the *kubernetes*
+services subnet.
+<4> Adjust `<internal_master_address>` to match the value of `*masterURL*`.
+<5> Adjust `<public_master_address>` to match the value of `*masterPublicURL*`.
 ====
 
-+
-. Restart master services
-+
-
-Single master deployments:
+. Restart master services. For single master deployments:
 +
 ifdef::openshift-enterprise[]
 ----
@@ -1134,7 +874,7 @@ ifdef::openshift-origin[]
 ----
 endif::[]
 +
-`native` multi-master deployments:
+For native HA multiple master deployments:
 +
 ifdef::openshift-enterprise[]
 ----
@@ -1149,14 +889,17 @@ ifdef::openshift-origin[]
 ----
 endif::[]
 +
-`pacemaker` multi-master deployments:
+For Pacemaker HA multiple master deployments:
 +
 ----
 # pcs resource restart master
 ----
++
+After the service restarts, the certificate update is complete.
+// end::30to31updatingcerts[]
 
 [[additional-instructions-per-release]]
-=== Additional Manual Steps Per Release
+== Additional Manual Steps Per Release
 
 Some OpenShift releases may have additional instructions specific to that
 release that must be performed to fully apply the updates across the cluster.
@@ -1165,18 +908,18 @@ you may be required to perform certain steps at key points during the standard
 upgrade process described earlier in this topic.
 
 ifdef::openshift-enterprise[]
-See the link:../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise
+See the link:../../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise
 3.1 Release Notes] to review the latest release notes.
 
 [[manual-step-ose-3-1-0]]
-==== OpenShift Enterprise 3.1.0
+=== OpenShift Enterprise 3.1.0
 
 There are no additional manual steps for these releases that are not already
 mentioned inline during the link:#manual-upgrades[standard manual upgrade
 process].
 
 [[manual-step-ose-3-1-1]]
-==== OpenShift Enterprise 3.1.1
+=== OpenShift Enterprise 3.1.1
 
 There is currently a known issue where new routers created with OpenShift
 Enterprise 3.1.1 require public access to port 1936 due to a newly created
@@ -1194,14 +937,14 @@ endif::[]
 
 ifdef::openshift-origin[]
 [[openshift-origin-1-1-0]]
-==== OpenShift Origin 1.1.0
+=== OpenShift Origin 1.1.0
 
 There are no additional manual steps for this release that are not already
 mentioned inline during the link:#manual-upgrades[standard manual upgrade
 process].
 
 [[openshift-origin-1-0-4]]
-==== OpenShift Origin 1.0.4
+=== OpenShift Origin 1.0.4
 
 The following steps are required for the
 https://github.com/openshift/origin/releases/tag/v1.0.4[OpenShift Origin 1.0.4
@@ -1211,7 +954,7 @@ release].
 
 The default HAProxy router was updated to utilize host ports and requires that a
 service account be created and made a member of the privileged
-link:../admin_guide/manage_scc.html[security context constraint] (SCC).
+link:../../admin_guide/manage_scc.html[security context constraint] (SCC).
 Additionally, "down-then-up" rolling upgrades have been added and is now the
 preferred strategy for upgrading routers.
 
@@ -1309,7 +1052,7 @@ Now upgrade your router per the link:#upgrading-the-router[standard router
 upgrade steps].
 
 [[openshift-origin-1-0-5]]
-==== OpenShift Origin 1.0.5
+=== OpenShift Origin 1.0.5
 
 The following steps are required for the
 https://github.com/openshift/origin/releases[OpenShift Origin 1.0.5
@@ -1319,8 +1062,8 @@ release].
 
 The default HAProxy router was updated to use the host networking stack by
 default instead of the former behavior of
-link:install/deploy_router.html#using-the-container-network-stack[using the
-container network stack], which proxied traffic to the router, which in turn
+link:../../install_config/install/deploy_router.html#using-the-container-network-stack[using
+the container network stack], which proxied traffic to the router, which in turn
 proxied the traffic to the target service and container. This new default
 behavior benefits performance because network traffic from remote clients no
 longer needs to take multiple hops through user space in order to reach the

--- a/install_config/upgrading/pacemaker_to_native_ha.adoc
+++ b/install_config/upgrading/pacemaker_to_native_ha.adoc
@@ -1,0 +1,356 @@
+= Upgrading from Pacemaker to Native HA
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+If you are using the Pacemaker method for high availability (HA) masters, you
+can upgrade to the native HA method either using Ansible playbooks or
+manually. Both methods are described in the following sections.
+
+[[pm-native-playbooks]]
+== Using Ansible Playbooks
+
+These steps assume that cluster has been upgraded to OpenShift Enterprise 3.1
+using either the
+link:../../install_config/upgrading/manual_upgrades.html[manual] or
+link:../../install_config/upgrading/automated_upgrades.html[automated] method.
+
+[WARNING]
+====
+Playbooks used for the Pacemaker to native HA upgrade will re-run cluster
+configuration steps, therefore any settings that are not stored in your
+inventory file will be overwritten. Back up any configuration files that have
+been modified since installation before beginning this upgrade.
+====
+
+[[pm-native-playbooks-modifying-the-ansible-inventory]]
+=== Modifying the Ansible Inventory
+
+Your original Ansible inventory file's Pacemaker configuration contains a VIP
+and a cluster host name which should resolve to this VIP. Native HA requires a
+cluster host name which resolves to the load balancer being used.
+
+Consider the following example configuration:
+
+====
+----
+# Pacemaker high availability cluster method.
+# Pacemaker HA environment must be able to self provision the
+# configured VIP. For installation openshift_master_cluster_hostname
+# must resolve to the configured VIP.
+#openshift_master_cluster_method=pacemaker
+#openshift_master_cluster_password=openshift_cluster
+#openshift_master_cluster_vip=192.168.133.35
+#openshift_master_cluster_public_vip=192.168.133.35
+#openshift_master_cluster_hostname=openshift-cluster.example.com
+#openshift_master_cluster_public_hostname=openshift-cluster.example.com
+----
+====
+
+Remove or comment the above section in your inventory file. Then, add the
+following section, modifying the host names to match your current cluster host
+names:
+
+====
+----
+# Native high availability cluster method with optional load balancer.
+# If no lb group is defined, the installer assumes that a load balancer has
+# been preconfigured. For installation the value of
+# openshift_master_cluster_hostname must resolve to the load balancer
+# or to one or all of the masters defined in the inventory if no load
+# balancer is present.
+openshift_master_cluster_method=native
+openshift_master_cluster_hostname=openshift-cluster.example.com
+openshift_master_cluster_public_hostname=openshift-cluster.example.com
+----
+====
+
+Native HA requires a load balancer to balance the master API (port 8443). When
+modifying your inventory file, specify an `[lb]` group and add `lb` to the
+`[OSEv3:children]` section if you would like the playbooks to configure an
+HAProxy instance as the load balancer. This instance must be on a separate host
+from the masters and nodes:
+
+====
+----
+[OSEv3:children]
+masters
+nodes
+lb
+...
+[lb]
+lb1.example.com <1>
+----
+<1> Host name of the HAProxy load balancer.
+====
+
+Any external load balancer may be used in place of the default HAProxy host, but
+it must be pre-configured and allow API traffic to masters on port 8443.
+
+[[pm-native-playbooks-destroying-the-pacemaker-cluster]]
+==== Destroying the Pacemaker Cluster
+
+On any master, run the following to destroy the Pacemaker cluster.
+
+[WARNING]
+====
+After the Pacemaker cluster has been destroyed, the OpenShift cluster will be in
+outage until the remaining steps are completed.
+====
+
+----
+# pcs cluster destroy --all
+----
+
+[[pm-native-playbooks-updating-dns]]
+=== Updating DNS
+
+Modify your cluster host name DNS entries such that the host name used resolves
+to the load balancer that will be used with native HA.
+
+In the link:#pm-native-playbooks-modifying-the-ansible-inventory[earlier example
+configuration], *openshift-cluster.example.com* resolves to 192.168.133.35. DNS
+must be modified such that *openshift-cluster.example.com* now resolves to the
+load balancer host or to the master API balancer in an alternative load
+balancing solution.
+
+[[pm-native-playbooks-running-the-ansible-playbook]]
+=== Running the Ansible Playbook
+
+You can now run the following Ansible playbook:
+
+[WARNING]
+====
+Back up any configuration files that have been modified since installation before
+beginning this upgrade.
+====
+
+----
+# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+----
+
+After the playbook finishes successfully, your upgrade to the native HA method
+is complete. Restore any configuration files if you backed up any that had been
+modified since installation, and restart any relevant OpenShift services, if
+necessary.
+
+[[pm-native-manual]]
+== Manually Upgrading
+
+These steps assume that cluster has been upgraded to OpenShift Enterprise 3.1
+using either the
+link:../../install_config/upgrading/manual_upgrades.html[manual] or
+link:../../install_config/upgrading/automated_upgrades.html[automated] method.
+They also assume that you are bringing your own load balancer which has been
+configured to balance the master API on port 8443.
+
+[[pm-native-manual-creating-unit-and-system-configuration-for-new-services]]
+=== Creating Unit and System Configuration for New Services
+
+The Systemd unit files for the *atomic-openshift-master-api* and
+*atomic-openshift-master-controllers* services are not yet provided by
+packaging. Ansible creates unit and system configuration when installing with
+the native HA method.
+
+Therefore, create the following files:
+
+ifdef::openshift-origin[]
+[NOTE]
+====
+*atomic-openshift* can be replaced with *origin* in all steps to target the
+**origin* deployment type.
+====
+endif::[]
+
+.*_/usr/lib/systemd/system/atomic-openshift-master-api.service_* File
+====
+----
+[Unit]
+Description=Atomic OpenShift Master API
+Documentation=https://github.com/openshift/origin
+After=network.target
+After=etcd.service
+Before=atomic-openshift-node.service
+Requires=network.target
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/sysconfig/atomic-openshift-master-api
+Environment=GOTRACEBACK=crash
+ExecStart=/usr/bin/openshift start master api --config=${CONFIG_FILE} $OPTIONS
+LimitNOFILE=131072
+LimitCORE=infinity
+WorkingDirectory=/var/lib/origin/
+SyslogIdentifier=atomic-openshift-master-api
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=atomic-openshift-node.service
+----
+====
+
+.*_/usr/lib/systemd/system/atomic-openshift-master-controllers.service_* File
+====
+----
+[Unit]
+Description=Atomic OpenShift Master Controllers
+Documentation=https://github.com/openshift/origin
+After=network.target
+After=atomic-openshift-master-api.service
+Before=atomic-openshift-node.service
+Requires=network.target
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/sysconfig/atomic-openshift-master-controllers
+Environment=GOTRACEBACK=crash
+ExecStart=/usr/bin/openshift start master controllers --config=${CONFIG_FILE} $OPTIONS
+LimitNOFILE=131072
+LimitCORE=infinity
+WorkingDirectory=/var/lib/origin/
+SyslogIdentifier=atomic-openshift-master-controllers
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=atomic-openshift-node.service
+----
+====
+
+.*_/etc/sysconfig/atomic-openshift-master-api_* File
+====
+----
+OPTIONS=--loglevel=2
+CONFIG_FILE=/etc/origin/master/master-config.yaml
+
+# Proxy configuration
+# Origin uses standard HTTP_PROXY environment variables. Be sure to set
+# NO_PROXY for your master
+#NO_PROXY=master.example.com
+#HTTP_PROXY=http://USER:PASSWORD@IPADDR:PORT
+#HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
+----
+====
+
+.*_/etc/sysconfig/atomic-openshift-master-controllers_* File
+====
+----
+OPTIONS=--loglevel=2
+CONFIG_FILE=/etc/origin/master/master-config.yaml
+
+# Proxy configuration
+# Origin uses standard HTTP_PROXY environment variables. Be sure to set
+# NO_PROXY for your master
+#NO_PROXY=master.example.com
+#HTTP_PROXY=http://USER:PASSWORD@IPADDR:PORT
+#HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
+----
+====
+
+Then, reload Systemd to pick up your changes:
+
+----
+# systemctl daemon-reload
+----
+
+[[pm-native-manual-destroying-the-pacemaker-cluster]]
+=== Destroying the Pacemaker Cluster
+
+On any master, run the following to destroy the Pacemaker cluster.
+
+[WARNING]
+====
+After the Pacemaker cluster has been destroyed, the OpenShift cluster will be
+in outage until the remaining steps are completed.
+====
+
+----
+# pcs cluster destroy --all
+----
+
+[[pm-native-manual-updating-dns]]
+=== Updating DNS
+
+Modify your cluster host name DNS entries such that the host name used resolves
+to the load balancer that will be used with native HA.
+
+For example, if the cluster host name is *openshift-cluster.example.com* and it
+resolved to a VIP of 192.168.133.35, then DNS must be modified such that
+*openshift-cluster.example.com* now resolves to the master API balancer.
+
+[[pm-native-manual-modyfing-master-and-node-configuration]]
+=== Modifying Master and Node Configuration
+
+Edit the master configuration in the *_/etc/origin/master/master-config.yaml_*
+file and ensure that `*kubernetesMasterConfig.masterCount*` is updated to the
+total number of masters. Perform this step on all masters:
+
+.*_/etc/origin/master/master-config.yaml_* File
+====
+----
+...
+kubernetesMasterConfig:
+  apiServerArguments:
+    controllerArguments:
+      masterCount: 3 <1>
+...
+----
+<1> Update this value to the total number of masters.
+====
+
+Edit the node configuration in the *_/etc/orign/node/node-config.yaml_* file and
+remove the `*dnsIP*` setting. OpenShift will use the Kubernetes service IP as
+the `*dnsIP*` by default. Perform this step on all nodes:
+
+.*_/etc/origin/node/node-config.yaml_* File
+====
+----
+...
+allowDisabledDocker: false
+apiVersion: v1
+dnsDomain: cluster.local
+dnsIP: 10.6.102.3 <1>
+dockerConfig:
+  execHandlerName: ""
+...
+----
+<1> Remove this line.
+====
+
+[[pm-native-manual-starting-the-api-service]]
+==== Starting the API Service
+
+Start and enable the API service on all masters:
+
+----
+# systemctl start atomic-openshift-master-api
+# systemctl enable atomic-openshift-master-api
+----
+
+[[pm-native-manual-starting-the-controller-service]]
+==== Starting the Controller Service
+
+Start and enable the controllers service on all masters:
+
+----
+# systemctl start atomic-openshift-master-controllers
+# systemctl enable atomic-openshift-master-controllers
+----
+
+After the service restarts, your upgrade to the native HA method is complete.
+
+[[pm-native-manual-modifying-the-ansible-inventory]]
+=== Modifying the Ansible Inventory
+
+Optionally, modify your Ansible inventory file for future runs per the
+instructions above in
+link:#pm-native-playbooks-modifying-the-ansible-inventory[the playbooks method].

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -34,9 +34,9 @@ specific to this release.
 
 [IMPORTANT]
 ====
-For any release, always review link:../install_config/upgrades.html[Installation
+For any release, always review link:../install_config/upgrading/index.html[Installation
 and Configuration] for instructions on
-link:../install_config/upgrades.html[upgrading your OpenShift cluster] properly,
+link:../install_config/upgrading/index.html[upgrading your OpenShift cluster] properly,
 including any additional steps that may be required for a specific release.
 ====
 
@@ -320,8 +320,8 @@ asynchronous errata release of OpenShift Enterprise 3.1.
 
 [IMPORTANT]
 ====
-For any release, always review the Administrator Guide for instructions on
-link:../install_config/upgrades.html[upgrading your OpenShift cluster] properly.
+For any release, always review the instructions on
+link:../install_config/upgrading/index.html[upgrading your OpenShift cluster] properly.
 ====
 
 [[ose-3-1-1]]
@@ -330,7 +330,7 @@ link:../install_config/upgrades.html[upgrading your OpenShift cluster] properly.
 OpenShift Enterprise release 3.1.1
 (https://access.redhat.com/errata/product/290/ver=3.1/rhel---7/x86_64/RHSA-2016:0070[RHSA-2016:0070])
 is now available. Ensure that you follow the instructions on
-link:../install_config/upgrades.html#upgrading-to-openshift-enterprise-3-1-asynchronous-releases[upgrading
+link:../install_config/upgrading/automated_upgrades.html#upgrading-to-openshift-enterprise-3-1-asynchronous-releases[upgrading
 your OpenShift cluster] to this asynchronous release properly.
 
 This release includes the following enhancements and bug fixes.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1286734
Trello: https://trello.com/c/UWdkkRcp

Builds on https://gist.github.com/abutcher/8104a1b65820b59e511e to add the `pacemaker_to_native_ha` topic.

Also, the Upgrading topic was getting enormous, so this breaks it into a subdir w/ multiple topics.

cc @openshift/team-documentation in case you have feedback (note that the xrefs haven't been updated yet, but you get the basic structure/idea).

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/020916/breakup_upgrading/install_config/upgrading/index.html

TODO:
- [ ] Request redirect for `install_config/upgrades.html` -> `install_config/upgrading/index.html`
- [x] Verify/fix xrefs outside of the new `upgrading` dir.
