### PR TITLE
Fix language detection files for Python

### DIFF
--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -137,7 +137,7 @@ a|`php`
 a|*_index.php_*, *_composer.json_*
 
 a|`python`
-a|*_requirements.txt_*, *_config.py_*
+a|*_requirements.txt_*, *_setup.py_*
 
 a|`perl`
 a|*_index.pl_*, *_cpanfile_*


### PR DESCRIPTION
Change introduced in early January via https://github.com/openshift/origin/pull/6587.
