### PR TITLE
haproxy.conf is actually haproxy.config

### DIFF
--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -21,7 +21,7 @@ The HAProxy router exposes a web listener for the HAProxy statistics. Enter the
 router's public IP address and the correctly configured port (*1936* by default)
 to view the statistics page, and enter the administrator password when prompted.
 This password and port are configured during the router installation, but they
-can be found by viewing the *_haproxy.conf_* file on the container.
+can be found by viewing the *_haproxy.config_* file on the container.
 
 == Disabling Statistics View
 By default the HAProxy statistics are exposed on port *1936* (with a
@@ -86,7 +86,7 @@ drive configuration.
 *HAProxy configuration*
 
 You can find the HAProxy configuration and the backends that have been created
-for specific routes in the *_/var/lib/haproxy/conf/haproxy.conf_* file. The
+for specific routes in the *_/var/lib/haproxy/conf/haproxy.config_* file. The
 mapping files are found in the same directory. The helper frontend and
 backends use mapping files when mapping incoming requests to a backend.
 


### PR DESCRIPTION
Verified on Origin I just installed.
Specified in https://github.com/openshift/origin/blob/master/images/router/haproxy/reload-haproxy

Not sure it's `.config` true for all downstream versions, or was `.conf` once.
- This doc said `.conf` since it was [created on May 1, 2015 ](https://github.com/openshift/openshift-docs/commit/6bf2d08a0c81d8a25c69ebe62890a43c6ea63cf3).
- https://github.com/openshift/origin/commit/dc24caa88e97c349c384e0333b31768098cab4fe renamed on Dec 9, 2014 haproxy-base/conf/haproxy_template.conf → haproxy/conf/haproxy-config.template; I haven't found where haproxy_template.conf was actually used then.
