### PR TITLE
Add --env,--from-dir/file/repo for start-build to dev_guide/builds

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1049,10 +1049,12 @@ into JSON format.
 [[starting-a-build]]
 
 == Starting a Build
-Manually invoke a build using the following command:
+
+Manually start a new build from an existing build configuration in your current
+project using the following command:
 
 ----
-$ oc start-build <BuildConfigName>
+$ oc start-build <buildconfig_name>
 ----
 
 Re-run a build using the `--from-build` flag:
@@ -1064,8 +1066,57 @@ $ oc start-build --from-build=<build_name>
 Specify the `--follow` flag to stream the build's logs in stdout:
 
 ----
-$ oc start-build <BuildConfigName> --follow
+$ oc start-build <buildconfig_name> --follow
 ----
+
+Specify the `--env` flag to set any desired environment variable for the build:
+
+----
+$ oc start-build <buildconfig_name> --env=<key>=<value>
+----
+
+Rather than relying on a Git source pull or a Dockerfile for a build, you can
+can also start a build by directly pushing your source, which could be the
+contents of a Git or SVN working directory, a set of prebuilt binary artifacts
+you want to deploy, or a single file. This can be done by specifying one of the
+following options for the `start-build` command:
+
+[cols="1,2",options="header"]
+|===
+|Option |Description
+
+|`--from-dir=<directory>`
+|Specifies a directory that will be archived and used as a binary input for the
+build.
+
+|`--from-file=<file>`
+|Specifies a single file that will be the only file in the build source. The
+file is placed in the root of an empty directory with the same file name.
+
+|`--from-repo=<local_source_repo>`
+|Specifies a path to a local repository to use as the binary input for a build.
+Add the `--commit` option to control which branch, tag, or commit is used for
+the build.
+|===
+
+When passing any of these options directly to the build, the contents are
+streamed to the build and override the current build source settings.
+
+[NOTE]
+====
+Builds triggered from binary input will not preserve the source on the server,
+so rebuilds triggered by base image changes will use the source specified in the
+build configuration.
+====
+
+For example, the following command sends the contents of a local Git repository
+as an archive from the tag `v2` and starts a build:
+
+====
+----
+$ oc start-build hello-world --from-repo=../hello-world --commit=v2
+----
+====
 
 [[canceling-a-build]]
 


### PR DESCRIPTION
Combines @mfojtik's https://github.com/openshift/openshift-docs/pull/1312, @smarterclayton's [comment](https://github.com/openshift/openshift-docs/pull/1312#issuecomment-164574303), and the `start-build` help text.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/021216/start_binarybuild/dev_guide/builds.html#starting-a-build
