### PR TITLE
Bug 1308315 and Bug 1306612 : deleted template and fixed file location

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -144,6 +144,8 @@ link:../architecture/additional_concepts/storage.html#persistent-volumes[persist
 volume] and be able to survive a pod being restarted or recreated. This is ideal
 if you require your metric data to be guarded from data loss.
 
+For cluster metrics to work with persistent storage, ensure that the persistent volume has the *ReadWriteOnce* access mode. If not, the persistent volume claim will not be able to find the persistent volume, and Cassandra will fail to start.
+
 To use persistent storage with the metric components, ensure that a
 link:../architecture/additional_concepts/storage.html#persistent-volumes[persistent
 volume] of sufficient size is available. The creation of
@@ -272,117 +274,23 @@ used to deploy the metrics components.
 By default, the OpenShift installer creates this template, and it can be found
 at the following path:
 
+ifdef::openshift-origin[]
 ====
 ----
-/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/infrastructure-templates/enterprise/metrics-deployer.yaml
+/usr/share/openshift/examples/infrastructure-templates/origin/metrics-deployer.yaml
 ----
 ====
+endif::[]
+ifdef::openshift-enterprise[]
+====
+----
+/usr/share/openshift/examples/infrastructure-templates/enterprise/metrics-deployer.yaml
+----
+====
+endif::[]
+
 
 You will need to save your completed file with the file name *_metrics.yaml_*.
-
-====
-[source,yaml,options="nowrap"]
-----
-apiVersion: "v1"
-kind: "Template"
-metadata:
-  name: metrics-deployer-template
-  annotations:
-    description: "Template for deploying the required Metrics integration. Requires cluster-admin 'metrics-deployer' service account and 'metrics-deployer' secret."
-    tags: "infrastructure"
-labels:
-  metrics-infra: deployer
-  provider: openshift
-  component: deployer
-objects:
--
-  apiVersion: v1
-  kind: Pod
-  metadata:
-    generateName: metrics-deployer-
-  spec:
-    containers:
-    - image: ${IMAGE_PREFIX}metrics-deployer:${IMAGE_VERSION}
-      name: deployer
-      volumeMounts:
-      - name: secret
-        mountPath: /secret
-        readOnly: true
-      - name: empty
-        mountPath: /etc/deploy
-      env:
-        - name: PROJECT
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: IMAGE_PREFIX
-          value: ${IMAGE_PREFIX}
-        - name: IMAGE_VERSION
-          value: ${IMAGE_VERSION}
-        - name: PUBLIC_MASTER_URL
-          value: ${PUBLIC_MASTER_URL}
-        - name: MASTER_URL
-          value: ${MASTER_URL}
-        - name: REDEPLOY
-          value: ${REDEPLOY}
-        - name: USE_PERSISTENT_STORAGE
-          value: ${USE_PERSISTENT_STORAGE}
-        - name: HAWKULAR_METRICS_HOSTNAME
-          value: ${HAWKULAR_METRICS_HOSTNAME}
-        - name: CASSANDRA_NODES
-          value: ${CASSANDRA_NODES}
-        - name: CASSANDRA_PV_SIZE
-          value: ${CASSANDRA_PV_SIZE}
-        - name: METRIC_DURATION
-          value: ${METRIC_DURATION}
-    dnsPolicy: ClusterFirst
-    restartPolicy: Never
-    serviceAccount: metrics-deployer
-    volumes:
-    - name: empty
-      emptyDir: {}
-    - name: secret
-      secret:
-        secretName: metrics-deployer
-parameters:
--
-  description: 'Specify prefix for metrics components; e.g. for "openshift/origin-metrics-deployer:v3.1", set prefix "openshift/origin-"'
-  name: IMAGE_PREFIX
-  value: "openshift/origin-"
--
-  description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:v3.1", set version "v1.1"'
-  name: IMAGE_VERSION
-  value: "latest"
--
-  description: "Internal URL for the master, for authentication retrieval"
-  name: MASTER_URL
-  value: "https://kubernetes.default.svc:443"
--
-  description: "External hostname where clients will reach Hawkular Metrics"
-  name: HAWKULAR_METRICS_HOSTNAME
-  required: true
--
-  description: "If set to true the deployer will try and delete all the existing components before trying to redeploy."
-  name: REDEPLOY
-  value: "false"
--
-  description: "Set to true for persistent storage, set to false to use non persistent storage"
-  name: USE_PERSISTENT_STORAGE
-  value: "true"
--
-  description: "The number of Cassandra Nodes to deploy for the initial cluster"
-  name: CASSANDRA_NODES
-  value: "1"
--
-  description: "The persistent volume size for each of the Cassandra nodes"
-  name: CASSANDRA_PV_SIZE
-  value: "10Gi"
--
-  description: "How many days metrics should be stored for."
-  name: METRIC_DURATION
-  value: "7"
-----
-====
 
 [[deployer-template-parameters]]
 ==== Deployer Template Parameters
@@ -403,8 +311,7 @@ All of the other parameters are optional and allow for greater customization.
 For instance, if you have a custom install in which the Kubernetes master is not
 available under `https://kubernetes.default.svc:443` you can specify the value
 to use instead with the `*HAWKULAR_METRICS_HOSTNAME*` parameter. If you wish to
-deploy a version of the metrics components other than _latest_, you can do so
-with the `*IMAGE_VERSION*` parameter.
+deploy a specific version of the metrics components, you can do so with the `*IMAGE_VERSION*` parameter.
 
 == Deploying the Metric Components
 


### PR DESCRIPTION
As per:
https://bugzilla.redhat.com/show_bug.cgi?id=1308315
https://bugzilla.redhat.com/show_bug.cgi?id=1306612

Added the cluster metrics template example for Origin, and ifdef'd it and the Enterprise example. Also, the file location above. 

Also added the bit in Persistent Storage about the type of pv. 

I'll ask for a review in the BZ.
