### PR TITLE
added information about LDAP search paging sizes

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -83,6 +83,7 @@ scope: sub <2>
 derefAliases: never <3>
 timeout: 0 <4>
 filter: (objectClass=inetOrgPerson) <5>
+pageSize: 0 <6>
 ----
 <1> The distinguished name (DN) of the branch of the directory where all
 searches will start from. It is required that you specify the top of your
@@ -98,6 +99,10 @@ dereferencing behaviors can be found in the link:#deref-aliases[table below].
 0 imposes no client-side limit.
 <5> A valid LDAP search filter. If this is left undefined, then the default is
 `(objectClass=*)`.
+<6> The optional maximum size of response pages from the server, measured in LDAP
+entries. If set to 0, no size restrictions will be made on pages of responses.
+Setting paging sizes is necessary when queries return more entries than the 
+client or server allow by default.
 ====
 
 [[ldap-search]]
@@ -308,6 +313,7 @@ rfc2307:
         scope: sub
         derefAliases: never
         filter: (objectclass=groupOfNames)
+        pageSize: 0
     groupUIDAttribute: dn <3>
     groupNameAttributes: [ cn ] <4>
     groupMembershipAttributes: [ member ] <5>
@@ -316,6 +322,7 @@ rfc2307:
         scope: sub
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
+        pageSize: 0
     userUIDAttribute: dn <6>
     userNameAttributes: [ mail ] <7>
 ----
@@ -386,6 +393,7 @@ rfc2307:
         scope: sub
         derefAliases: never
         filter: (objectclass=groupOfNames)
+        pageSize: 0
     groupUIDAttribute: dn <2>
     groupNameAttributes: [ cn ] <3>
     groupMembershipAttributes: [ member ]
@@ -394,6 +402,7 @@ rfc2307:
         scope: sub
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
+        pageSize: 0
     userUIDAttribute: dn
     userNameAttributes: [ mail ]
 ----
@@ -502,6 +511,7 @@ activeDirectory:
         scope: sub
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
+        pageSize: 0
     userNameAttributes: [ mail ] <1>
     groupMembershipAttributes: [ testMemberOf ] <2>
 ----
@@ -624,6 +634,7 @@ augmentedActiveDirectory:
         scope: sub
         derefAliases: never
         filter: (objectclass=groupOfNames)
+        pageSize: 0
     groupUIDAttribute: dn <1>
     groupNameAttributes: [ cn ] <2>
     usersQuery:
@@ -631,6 +642,7 @@ augmentedActiveDirectory:
         scope: sub
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
+        pageSize: 0
     userNameAttributes: [ mail ] <3>
     groupMembershipAttributes: [ testMemberOf ] <4>
 ----


### PR DESCRIPTION
This adds information about the LDAP query paging size parameter exposed by https://github.com/openshift/origin/pull/7309

@liggitt PTAL

@adellape FYI

~~blocked on upstream https://github.com/openshift/origin/pull/7309~~
