### PR TITLE
Documented image resource quotas

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1738,3 +1738,15 @@ You can choose between different methods of defining environment variables:
 - link:../cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations[Providing
 explicitly using `*oc start-build --env*`] (only for builds that are triggered
 manually)
+
+== Troubleshooting
+
+|===
+
+|A build fails with `requested access to the resource is denied`. What does it mean?
+|You have exceeded one of
+link:../dev_guide/quota.html#usage-limits[image quotas] set on your project.
+Consult `oc describe quota` and see the limits applied and storage in use.
+
+|===
+

--- a/dev_guide/quota.adoc
+++ b/dev_guide/quota.adoc
@@ -34,6 +34,15 @@ The following describes the set of limits that may be enforced by a
 |`memory`
 |Total requested memory usage across all containers
 
+|`openshift.io/imagesize` [[imagesize]]<<zero,*>>
+|Maximum size of an image storable in an internal registry
+
+|`openshift.io/imagestreamsize` [[imagestreamsize]]<<zero,*>>
+|Size of images stored in an internal registry under one image stream
+
+|`openshift.io/projectimagessize`
+|Total size of images stored in an internal registry
+
 |`pods`
 |Total number of pods
 
@@ -52,6 +61,9 @@ The following describes the set of limits that may be enforced by a
 |`persistentvolumeclaims`
 |Total number of persistent volume claims
 |===
+
+[[zero]]<<imagesize,*>> The resource is not scoped to a project. Thus it will
+always have usage equal to zero.
 
 == Quota Enforcement
 
@@ -164,10 +176,13 @@ resource-quota.json
     "hard": {
       "memory": "1Gi", <2>
       "cpu": "20", <3>
-      "pods": "10", <4>
-      "services": "5", <5>
-      "replicationcontrollers":"5", <6>
-      "resourcequotas":"1" <7>
+      "openshift.io/imagesize": "5Gi", <4>
+      "openshift.io/imagestreamsize": 15Gi", <5>
+      "openshift.io/projectimagessize": 40Gi", <6>
+      "pods": "10", <7>
+      "services": "5", <8>
+      "replicationcontrollers":"5", <9>
+      "resourcequotas":"1" <10>
     }
   }
 }
@@ -175,10 +190,13 @@ resource-quota.json
 <1> The name of this quota document
 <2> The total amount of memory requested across all containers may not exceed 1Gi.
 <3> The total number of cpu requested across all containers may not exceed 20 Kubernetes compute units.
-<4> The total number of pods in the project
-<5> The total number of services in the project
-<6> The total number of replication controllers in the project
-<7> The total number of resource quota documents in the project
+<4> The size of image uploaded to internal registry may not exceed 5Gi.
+<5> The total size of images in internal registry under one repository (aka image stream) may not exceed 15Gi.
+<6> The total size of images in internal registry within one project may not exceed 40Gi.
+<7> The total number of pods in the project
+<8> The total number of services in the project
+<9> The total number of replication controllers in the project
+<10> The total number of resource quota documents in the project
 ====
 
 == Create a Quota
@@ -198,16 +216,20 @@ $ oc get quota
 NAME
 quota
 $ oc describe quota quota
-Name:                   quota
-Resource                Used    Hard
---------                ----    ----
-cpu                     5       20
-memory                  500Mi   1Gi
-pods                    5       10
-replicationcontrollers  5       5
-resourcequotas          1       1
-services                3       5
+Name:                         quota
+Resource                      Used    Hard
+--------                      ----    ----
+cpu                           5       20
+memory                        500Mi   1Gi
+openshift.io/imagesize        0       5Gi   <1>
+openshift.io/imagestreamsize  0       15Gi  <1>
+openshift.io/projectsize      8542Mi  40Gi
+pods                          5       10
+replicationcontrollers        5       5
+resourcequotas                1       1
+services                      3       5
 ----
+<1> Usage will be always zero because the resource isn't scoped to a namespace.
 
 [[configuring_quota_sync_period]]
 

--- a/dev_guide/quota.adoc
+++ b/dev_guide/quota.adoc
@@ -35,13 +35,13 @@ The following describes the set of limits that may be enforced by a
 |Total requested memory usage across all containers
 
 |`openshift.io/imagesize` [[imagesize]]<<zero,*>>
-|Maximum size of an image storable in an internal registry
+|Maximum size of a single image stored in an internal registry
 
 |`openshift.io/imagestreamsize` [[imagestreamsize]]<<zero,*>>
-|Size of images stored in an internal registry under one image stream
+|Maximum size of image stream's images stored in an internal registry
 
 |`openshift.io/projectimagessize`
-|Total size of images stored in an internal registry
+|Maximum size of all the project's images stored in an internal registry
 
 |`pods`
 |Total number of pods
@@ -190,9 +190,9 @@ resource-quota.json
 <1> The name of this quota document
 <2> The total amount of memory requested across all containers may not exceed 1Gi.
 <3> The total number of cpu requested across all containers may not exceed 20 Kubernetes compute units.
-<4> The size of image uploaded to internal registry may not exceed 5Gi.
-<5> The total size of images in internal registry under one repository (aka image stream) may not exceed 15Gi.
-<6> The total size of images in internal registry within one project may not exceed 40Gi.
+<4> The size of a single image uploaded to internal registry may not exceed 5Gi.
+<5> The size of images of single image stream stored in internal registry may not exceed 15Gi.
+<6> The total size of project's images stored in internal registry may not exceed 40Gi.
 <7> The total number of pods in the project
 <8> The total number of services in the project
 <9> The total number of replication controllers in the project

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -171,6 +171,27 @@ endif::[]
 
 [[viewing-logs]]
 
+==== Setting storage quota
+To protect the storage from being accidentally filled up or to prevent users from abusing the space,
+you may set size constraints on images, image streams and projects.
+
+link:../../dev_guide/quota.html#create-a-quota[Create a quota object] on particular namespace with
+one or more of the following resources:
+
+- `openshift.io/imagesize` - to constrain the maximum size of an image
+- `openshift.io/imagestreamsize` - to limit the total images size tagged in one image stream
+                                   (aka repository)
+- `openshift.io/projectimagessize` - to limit the total images size per project
+
+Once the quota is exceeded, an image push will fail with:
+
+----
+Failed to push image: unknown: requested access to the resource is denied
+----
+
+You may then
+link:../../admin_guide/pruning_resources.html#pruning-images[prune obsoleted images]
+to retrieve some space back.
 
 == Viewing Logs
 


### PR DESCRIPTION
Extended constrainable resources for:
- `openshift.io/imagesize`
- `openshift.io/imagestreamsize`
- `openshift.io/projectimagessize`

Documents and depends on [origin PR#7128](https://github.com/openshift/origin/pull/7128).
