### PR TITLE
fix typo for setting up the openshift-origin default authentication

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -21,23 +21,17 @@ access tokens] to authenticate themselves to the API.
 
 As an administrator, you can configure OAuth using the
 link:../install_config/master_node_configuration.html[master configuration file] to specify an
-link:#identity-providers[identity provider]. If you installed OpenShift using
-the
+link:#identity-providers[identity provider].
 ifdef::openshift-enterprise[]
-link:../install_config/install/quick_install.html[Quick Installation] or
-endif::[]
-link:../install_config/install/advanced_install.html[Advanced Installation]
-method, the
-ifdef::openshift-enterprise[]
-link:#DenyAllPasswordIdentityProvider[Deny All]
-endif::[]
-ifdef::openshift-origin[]
-link:#AllowAllPasswordIdentityProvider[Allow All]
-endif::[]
-identity provider is used by default, which denies access for all user names and
-passwords. To allow access, you must choose a different identity provider and
-configure the master configuration file appropriately (located at
+If you installed OpenShift using the
+link:../install_config/install/quick_install.html[Quick Installation]  method,
+the link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is used
+by default, which denies access for all user names and passwords. To allow
+access, you must choose a different identity provider and configure the master
+configuration file appropriately (located at
 *_/etc/origin/master/master-config.yaml_* by default).
+endif::[]
+
 
 When running a master without a configuration file, the
 link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is used by
@@ -883,7 +877,7 @@ link:https://github.com/settings/applications/new[registered GitHub OAuth
 application]. The application must be configured with a callback URL of
 `<master>/oauth2callback/<identityProviderName>`.
 <6> The client secret issued by GitHub.
-<7> Optional list of organizations. If specified, only GitHub users that are members of 
+<7> Optional list of organizations. If specified, only GitHub users that are members of
 at least one of the listed organizations will be allowed to log in.
 ====
 


### PR DESCRIPTION
this fixes the below error which occurs when the user sees the docs as part of origin and not ose.

``````
the Allow All identity provider is used by default, which denies access for all user names and passwords. ```

``````
