### PR TITLE
Make SDN docs more consistent, and up-to-date.

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -53,6 +53,13 @@ networkConfig:
 <4> Service IP allocation for the cluster
 ====
 
+Note that the *serviceNetworkCIDR* and *hostSubnetLength* values cannot be
+changed after the cluster is first created, and *clusterNetworkCIDR* can only be
+changed to be a larger network that still contains the original network. e.g.,
+given the default value of *10.1.0.0/16*, you could change it to *10.0.0.0/15*
+(i.e. *10.0.0.0/16* plus *10.1.0.0/16*) but not to *10.2.0.0/16* (since that
+does not overlap the original value).
+
 [[configuring-the-pod-network-on-nodes]]
 == Configuring the Pod Network on Nodes
 

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -246,9 +246,10 @@ options] in the OAuth configuration. See link:#advanced-install-session-options[
 link:../../architecture/core_concepts/pods_and_services.html#services[services]
 will be created within the
 link:../../architecture/additional_concepts/sdn.html[OpenShift SDN]. This
-defaults to *172.30.0.0/16*, which covers *172.30.0.0* through *172.30.255.255*.
-Setting this variable to override the default can be useful if the default
-subnet interferes with other subnets in use in your environment.
+network block should be a private block and must not conflict
+with any existing network blocks in your infrastructure that pods,
+nodes, or the master may require access to. Defaults to
+*172.30.0.0/16* and *can not* be re-configured after deployment.
 
 |`*openshift_node_kubelet_args*`
 |This variable is used to configure `kubeletArguments` on nodes such as arguments used in
@@ -271,15 +272,18 @@ when placing pods.
 | This variable overrides the
 link:../../architecture/additional_concepts/sdn.html#sdn-design-on-masters[SDN cluster network]
 CIDR block. This is the network from which pod IPs are assigned. This network
-block should be a private block and should not conflict with existing network
-blocks in your infrastructure that pods may require access to. Defaults to
-10.1.0.0/16 and *can not* be re-configured after deployment.
+block should be a private block and must not conflict with existing network
+blocks in your infrastructure that pods, nodes, or the master may require access
+to. Defaults to *10.1.0.0/16* and *can not* be arbitrarily re-configured after deployment,
+although certain changes to it can be made in the
+link:../configuring_sdn.html#configuring-the-pod-network-on-masters[SDN master config].
 
 |`*osm_host_subnet_length*`
 |This variable specifies the size of the per host subnet allocated for pod IPs
 by link:../../architecture/additional_concepts/sdn.html#sdn-design-on-masters[OpenShift SDN].
-Defaults to /8 which means that from the 10.1.0.0/16 cluster network a subnet of
-size /24 is allocated to each host (i.e., 10.1.0.0/24, 10.1.1.0/24, 10.1.2.0/24, and so on).
+Defaults to *8* which means that a subnet of size /24 is allocated to each host
+(i.e., given the default 10.1.0.0/16 cluster network, this will allocate
+10.1.0.0/24, 10.1.1.0/24, 10.1.2.0/24, and so on).
 This *can not* be re-configured after deployment.
 |===
 


### PR DESCRIPTION
- Document that clusterNetworkCIDR can now be changed, sometimes.
- Make the docs for the SDN-related ansible variables more consistent with each other.
- Clarify that the services and cluster networks can't overlap with networks the master and nodes need access to either (not just networks the pods need access to).

finishes up https://bugzilla.redhat.com/show_bug.cgi?id=1197170
