### PR TITLE
20160218 overcommit plugin

### DIFF
--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -127,6 +127,70 @@ exist.
 - *BestEffort* containers are treated with the lowest priority. Processes in
 these containers are first to be killed if the system runs out of memory.
 
+[[configuring-masters-for-overcommitment]]
+== Configuring Masters for Overcommitment
+
+Scheduling is based on resources requested, while quota and hard limits refer to
+resource limits, which can be set higher than requested resources. The difference
+between request and limit determines the level of overcommit; for instance, if a
+container is given a memory request of 1Gi and a memory limit of 2Gi, it is
+scheduled based on the 1Gi request being available on the node, but could use
+up to 2Gi; so it is 200% overcommitted.
+
+If {product-title} administrators would like to control the level of overcommit
+and manage container density on nodes, masters can be configured
+to override the ratio between request and limit set on developer
+containers. In conjunction with a link:./limits.html[per-project
+LimitRange] specifying limits and defaults, this adjusts the container
+limit and request to achieve the desired level of overcommit.
+
+This requires configuring the `*ClusterResourceOverride*` admission controller in the
+*_master-config.yaml_* as in the following example (reuse the existing configuration tree
+if it exists, or introduce absent elements as needed):
+
+====
+----
+kubernetesMasterConfig:
+  admissionConfig:
+    pluginConfig:
+      ClusterResourceOverride:   <1>
+        configuration:
+          apiVersion: v1
+          kind: ClusterResourceOverrideConfig
+          memoryRequestToLimitPercent: 25  <2>
+          cpuRequestToLimitPercent: 25     <3>
+          limitCPUToMemoryPercent: 200     <4>
+----
+<1> This is the plug-in name; case matters and anything but an exact match for a plug-in name is ignored.
+<2> (optional, 1-100) If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit.
+<3> (optional, 1-100) If a container CPU limit has been specified or defaulted, the CPU request is overridden to this percentage of the limit.
+<4> (optional, positive integer) If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, with a 100 percentage scaling 1Gi of RAM to equal 1 CPU core. This is processed prior to overriding CPU request (if configured).
+====
+
+After changing the master configuration, a master restart is required.
+
+Note that these overrides have no effect if no limits have
+been set on containers. link:./limits.html[Create a LimitRange
+object] with default limits (per individual project, or in the
+link:./managing_projects.html#modifying-the-template-for-new-projects[project
+template]) in order to ensure that the overrides apply.
+
+Note also that after overrides, the container limits and requests must still
+be validated by any LimitRange objects in the project. It is possible,
+for example, for developers to specify a limit close to the minimum
+limit, and have the request then be overridden below the minimum limit,
+causing the pod to be forbidden. This unfortunate user experience should
+be addressed with future work, but for now, configure this capability
+and LimitRanges with caution.
+
+When configured, overrides can be disabled per-project (for example,
+to allow infrastructure components to be configured independently of
+overrides) by editing the project and adding the following annotation:
+
+----
+quota.openshift.io/cluster-resource-override-enabled: "false"
+----
+
 [[configuring-nodes-for-overcommitment]]
 == Configuring Nodes for Overcommitment
 

--- a/dev_guide/compute_resources.adoc
+++ b/dev_guide/compute_resources.adoc
@@ -279,3 +279,13 @@ To specify compute resources via the CLI:
 $ oc run nginx --image=nginx --limits=cpu=200m,memory=400Mi --requests=cpu=100m,memory=200Mi
 ----
 ====
+
+ifdef::openshift-enterprise,openshift-dedicated,openshift-origin[]
+== Project Resource Limits
+
+link:../admin_guide/limits.html#limits[Resource limits can be
+set per-project] by cluster administrators. Developers do not
+have the ability to create, edit, or delete these limits, but can
+link:../admin_guide/limits.html#viewing-limits[view them] for projects
+they have access to.
+endif::[]

--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -599,9 +599,16 @@ items is required:
 the list of resources in the quota.
 ====
 
-- A link:../dev_guide/compute_resources.html#dev-limit-ranges[limit range] defined
-in your project, where the defaults from the `*LimitRange*` object apply to pods
-created during the deployment process.
+ifdef::openshift-enterprise,openshift-dedicated,openshift-origin[]
+- A link:../admin_guide/limits.html[limit range] defined in your project, where the
+defaults from the `*LimitRange*` object apply to pods created during the
+deployment process.
+endif::[]
+ifdef::openshift-online[]
+- A limit range defined in your project, where the
+defaults from the `*LimitRange*` object apply to pods created during the
+deployment process.
+endif::[]
 
 Otherwise, deploy pod creation will fail, citing a failure to satisfy quota.
 

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -40,7 +40,7 @@ for memory and CPU. The time range displayed is selectable, and these charts
 automatically update every 30 seconds. If there are multiple containers on the
 pod, then you can select a specific container to display its metrics.
 
-If you have link:../admin_guide/limits.html[limit range] defined for the
+If link:../admin_guide/limits.html[resource limits] are defined for your
 project, then you can also see a donut chart for each pod. The donut chart
 displays usage against the resource limit. For example: `145 Available of 200
 MiB`, with the donut chart showing `55 MiB Used`.


### PR DESCRIPTION
The first commit is the main commentary re https://trello.com/c/rRN7m0zv/546-5-override-container-resource-request-based-on-limit

The second commit I tacked on because this links to LimitRange objects and those are defined in limits.html which really IMHO belongs in the admin guide. This should address at least part of https://github.com/openshift/openshift-docs/issues/809 - nevertheless I give separate commits in order to make it easy to hold this back for further consideration if desired.
