### PR TITLE
Add in instructions on how to use a re-encrypting route for Hawkular Metrics

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -177,19 +177,32 @@ link:../dev_guide/secrets.html[secrets] and by passing parameters to the
 === Metrics Deployer Secrets
 
 By default, the *metrics deployer* auto-generates self-signed certificates for
-use between components. To provide your own certificates, you can pass these
-values as link:../dev_guide/secrets.html[secrets] to the *metrics deployer*.
+use between components. Since these are self-signed certificates they will not
+be automatically trusted by a web browser and it is advisable to use your own
+certificates for anything being accessed outside of the OpenShift cluster. This
+is especially important for the Hawkular Metrics server as it needs to be accessible 
+in a browser for the console to function.
+
+To provide your own certificates and replace the internally used ones, you 
+can pass these values as link:../dev_guide/secrets.html[secrets] to the 
+*metrics deployer*.
+
+Alternatively you can instead use a 
+link:../install_config/cluster_metrics.html#reencrypting-route[re-encrypting route] which 
+will allow the self-signed certificates to remain used internally while allowing your own 
+certificates to be used for externally access. If you wish to use a re-encrypting route
+you should not set the certificates as a secret.
+ 
 
 [WARNING]
 ====
-By default, the Hawkular Metrics service uses self-signed certificates, which
-can cause problems when the console accesses it in a web browser. As an
-alternative, you can specify your own *_hawkular-metrics.pem_* secret to use a
-certificate that is trusted by the browser.
+Setting the value via secrets will *replace* the internally used certificates and as such these 
+certificates *must* be valid for both the externally used hostnames as well as the externally hostname. For
+`hawkular-metrics` this means the certificate must be value if *'hawkular-metrics'* as well
+as the value specified in *HAWKULAR_METRICS_HOSTNAME*.
 
-When supplying your own certificate for the Hawkular Metrics service, it must
-contain both the host name specified for the route as well as the internally
-used *hawkular-metrics* host name.
+If you are unable to add the internal hostname to your certificate, then you will need to a 
+link:../install_config/cluster_metrics.html#reencrypting-route[re-encrypting route].
 ====
 
 Optionally, provide your own certificate that is configured to be trusted by
@@ -223,7 +236,7 @@ the secrets which can be used by the deployer:
 
 |*_hawkular-metrics.pem_*
 |The *_pem_* file to use for the Hawkular Metrics certificate. This certificate
-must contain the *hawkular-metrics* host name as well as the publicly available
+must contain the *'hawkular-metrics'* host name as well as the publicly available
 host name used by the route. This file is auto-generated if unspecified.
 
 |*_hawkular-metrics-ca.cert_*
@@ -445,6 +458,77 @@ HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,USE_PERSISTENT_STORAGE=fa
 | oc create -f -
 ----
 ====
+
+[[reencrypting-route]]
+== Using a Re-encrypting Route
+
+[NOTE]
+====
+The following section is not required if the *hawkular-metrics.pem* secret was specified
+as a link:../install_config/cluster_metrics.html#metrics-deployer-secrets[deployer secret].
+====
+
+By default the Hawkular Metrics server will be using self-signed certificate which will not
+be trusted by a browser or other external services. If you wish to provide your own trusted
+certificate to be used for external access you can do so using a route with a 
+link:../architecture/core_concepts/routes.html#secured-routes[re-encryption termination].
+
+The creating this new route you will require that the default route which uses self-signed
+certificates be deleted.
+
+[options="nowrap"]
+----
+$ oc delete route hawkular-metrics
+----
+
+A new route with a link:../architecture/core_concepts/routes.html#secured-routes[re-encryption termination]
+will then need to be created.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: hawkular-metrics-reencrypt
+spec:
+  host: hawkular-metrics.example.com <1>
+  port:
+    targetPort: 8443
+  to:
+    kind: Service
+    name: hawkular-metrics
+  tls:
+    termination: reencrypt       
+    key: |-
+      -----BEGIN PRIVATE KEY-----
+      [...] <2>
+      -----END PRIVATE KEY-----
+    certificate: |-
+      -----BEGIN CERTIFICATE-----
+      [...] <2>
+      -----END CERTIFICATE-----
+    caCertificate: |-
+      -----BEGIN CERTIFICATE-----
+      [...] <2>
+      -----END CERTIFICATE-----
+    destinationCaCertificate: |-  
+      -----BEGIN CERTIFICATE-----
+      [...] <3>
+      -----END CERTIFICATE-----
+----
+<1> The value specified in the *HAWKULAR_METRICS_HOSTNAME* template parameter.
+<2> These need to define the custom certificate you wish to provide.
+<3> This needs to correspond to the CA used to sign the internal Hawkular Metrics certificate
+
+The CA used to sign the internal Hawkular Metrics certificate can be found from the 
+*hawkular-metrics-certificate* secret:
+
+[options="nowrap"]
+----
+$ base64 -d <<< `oc get -o yaml secrets hawkular-metrics-certificate | grep -i hawkular-metrics-ca.certificate | awk '{print $2}'`
+----
+
+
 
 [[configuring-openshift-metrics]]
 


### PR DESCRIPTION
Adds in instructions on how to use a re-encrypting route for when dealing with Hawkular Metrics. 

Useful for people who cannot or do not want to have internal hostnames defined in their certificates.

See https://bugzilla.redhat.com/show_bug.cgi?id=1306348
