### PR TITLE
Fix wrong case in BuildDefaults example

### DIFF
--- a/admin_guide/build_defaults_overrides.adoc
+++ b/admin_guide/build_defaults_overrides.adoc
@@ -35,7 +35,7 @@ kubernetesMasterConfig:
           apiVersion: v1
           kind: BuildDefaultsConfig
           gitHTTPProxy: http://my.proxy:8080 <1>
-          gitHTTPSproxy: https://my.proxy:8443 <2>
+          gitHTTPSProxy: https://my.proxy:8443 <2>
           env:
           - name: HTTP_PROXY <3>
             value: http://my.proxy:8080


### PR DESCRIPTION
Example has the wrong case for the gitHTTPSProxy setting.
