### PR TITLE
BZ 1299000 -- Document uploading images to the internal registry

### DIFF
--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -317,7 +317,7 @@ image stream and image name. It uses the following convention for its name:
 `<image stream name>@<name>`.
 
 A `*DockerImage*` is used to reference or retrieve an image for a given
-external registry. It uses standard docker pull specification for its name,
+external registry. It uses standard docker _pull specification_ for its name,
 eg `openshift/ruby-20-centos7:2.0`. When no tag is specified it is assumed
 the `latest` will be used.
 

--- a/creating_images/index.adoc
+++ b/creating_images/index.adoc
@@ -6,3 +6,7 @@
 :experimental:
 
 This guide provides best practices on writing and testing Docker images that can be used on OpenShift.
+ifdef::openshift-enterprise,openshift-origin[]
+Once you have created an image, you can push it to
+the link:../install_config/install/docker_registry.html[internal registry].
+endif::[]

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -101,6 +101,7 @@ $ oc get -o yaml svc docker-registry | \
       oc replace -f -
 ----
 
+[[non-production-use]]
 ==== Non-Production use
 
 For non-production use, you can use the `--mount-host=<path>` option to specify
@@ -169,7 +170,6 @@ $ oadm registry --service-account=registry \
 ----
 endif::[]
 
-[[viewing-logs]]
 
 ==== Setting storage quota
 To protect the storage from being accidentally filled up or to prevent users from abusing the space,
@@ -193,6 +193,80 @@ You may then
 link:../../admin_guide/pruning_resources.html#pruning-images[prune obsoleted images]
 to retrieve some space back.
 
+
+[[maintaining-the-registry-ip-address]]
+=== Maintaining the Registry IP Address
+
+OpenShift refers to the integrated registry by its service IP address,
+so if you decide to delete and recreate the *docker-registry* service,
+you can ensure a completely transparent transition by arranging to
+re-use the old IP address in the new service.
+If a new IP address cannot be avoided, you can minimize cluster
+disruption by rebooting only the masters.
+
+[[re-using-the-address]]
+Re-using the Address::
+
+To re-use the IP address, you must save the IP address of the old *docker-registry*
+service prior to deleting it, and arrange to replace the newly assigned IP address
+with the saved one in the new *docker-registry* service.
+
+// NB: Snarfed from <https://github.com/openshift/openshift-docs/issues/1494>.
+. Make a note of the `ClusterIP` for the service:
++
+----
+$ oc get svc/docker-registry -o yaml | grep clusterIP:
+----
+
+. Delete the service:
++
+----
+$ oc delete svc/docker-registry dc/docker-registry
+----
+
+. Create the registry definition in *_registry.yaml_*,
+replacing `<options>` with, for example, those used in step 3 of the
+instructions in the link:#non-production-use[Non-Production use] section:
++
+----
+$ oadm registry <options> -o yaml > registry.yaml
+----
+
+. Edit *_registry.yaml_*, find the `Service` there,
+and change its `ClusterIP` to the address noted in step 1.
+
+. Create the registry using the modified *_registry.yaml_*:
++
+----
+$ oc create -f registry.yaml
+----
+
+[[rebooting-the-masters]]
+Rebooting the Masters::
+
+If you are unable to re-use the IP address, any operation that uses a link:../../architecture/core_concepts/builds_and_image_streams.html#referencing-images-in-image-streams[pull specification]
+that includes the old IP address will fail.
+To minimize cluster disruption, you must reboot the masters:
++
+----
+ifdef::openshift-origin[]
+# systemctl restart origin-master
+endif::[]
+ifdef::openshift-enterprise[]
+# systemctl restart atomic-openshift-master
+endif::[]
+----
+// Code block snarfed from ../http_proxies.adoc, w/ node-reboot stuff removed.
+// tnguyen opines: It would be nice to #define this somewhere and include it here...
++
+This ensures that the old registry URL, which includes the old IP address,
+is cleared from the cache.
++
+[NOTE]
+We recommend against rebooting the entire cluster because that incurs
+unnecessary downtime for pods and does not actually clear the cache.
+
+[[viewing-logs]]
 == Viewing Logs
 
 To view the logs for the Docker registry, run the `oc logs` indicating the desired pod:
@@ -409,6 +483,9 @@ In the following examples, we use:
 |*<image>*
 |`busybox`
 
+|*<tag>*
+| omitted (defaults to `latest`)
+
 |====
 
 . Pull an arbitrary image:
@@ -419,7 +496,11 @@ $ docker pull docker.io/busybox
 ----
 ====
 
-. Tag the new image with the form `<registry_ip>:<port>/<project>/<image>`:
+. Tag the new image with the form `<registry_ip>:<port>/<project>/<image>`.
+The project name *must* appear in this
+link:../../architecture/core_concepts/builds_and_image_streams.html#referencing-images-in-image-streams[pull specification]
+for OpenShift to
+correctly place and later access the image in the registry.
 +
 ====
 ----


### PR DESCRIPTION
This is for [BZ 1299000](https://bugzilla.redhat.com/show_bug.cgi?id=1299000).
It adds an xref from the Creating Images "Overview" to Install/Config "Docker Registry", highlights the term `pull specification` in Architecture, emphasizes the `<project>` component of the pull specification in the `docker tag` command, and adds a section on the registry's IP address (pulling from https://github.com/openshift/openshift-docs/issues/1494).
