### PR TITLE
Update class name in extensions customization example

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -119,7 +119,7 @@ The following script adds a link into the web console header:
 
 ====
 ----
-$(".navbar-utility").prepend('<li><a href="http://example.com/status/">System Status</a></li>');
+$(".navbar-iconic").prepend('<li><a href="http://example.com/status/">System Status</a></li>');
 ----
 ====
 


### PR DESCRIPTION
There were some markup changes with the latest theme redesign. 

`.navbar-utility` was changes to `.navbar-iconic`

So the example on https://docs.openshift.org/latest/install_config/web_console_customization.html to add a link to the header needs to be updated.
