### PR TITLE
Fix typo in RunOnceDuration example

### DIFF
--- a/admin_guide/limit_runonce_pod_duration.adoc
+++ b/admin_guide/limit_runonce_pod_duration.adoc
@@ -34,7 +34,7 @@ kubernetesMasterConfig:
     pluginOrderOverride:
     - RunOnceDuration <1>
     - NamespaceLifecycle
-    - OriginPodeNodeEnvironment
+    - OriginPodNodeEnvironment
     - LimitRanger
     - ServiceAccount
     - SecurityContextConstraint


### PR DESCRIPTION
Fixes typo in example configuration
