### PR TITLE
Include an alternate mobile footer that is position:relative so that it doesn't interfere with the toggle off canvas nav at mobile resolutions.

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -101,8 +101,25 @@ License: https://creativecommons.org/licenses/by/2.0/
  } 
 }
 @media screen and (max-width: 768px) {
-  body {
-    margin-bottom: 300px;
+  body, html {
+    overflow-x: hidden;
+    height: 100%;
+    margin-bottom: 0;
+  }
+  .sidebar {
+    border-right: 1px solid #e7e7e7;
+    background: #fff;
+  }
+  .footer-origin-docs,
+  .footer-openshift {
+    display: none; /* hide absolute positioned footer at mobile */
+  }
+  .visible-xs-block .footer-origin-docs,
+  .visible-xs-block .footer-openshift {
+    /* show alternate footer positioned relative at mobile */
+    display: block;
+    position: relative;
+    margin-top: 50px;
   }
   footer {
     text-align: center;
@@ -119,6 +136,7 @@ License: https://creativecommons.org/licenses/by/2.0/
 }
 
 /* End footer edits */
+
 
 .fa-inverse:hover {
   color: #ccc;

--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -66,6 +66,9 @@
         <%= content %>
       </div>
     </div>
+    <div class="visible-xs-block row row-offcanvas row-offcanvas-left">
+      <%= render((distro_key == 'openshift-origin' ? "_templates/_footer_origin.html.erb" : "_templates/_footer_other.html.erb"), :images_path => images_path) %>
+    </div>
   </div>
   <script type="text/javascript">
     /*<![CDATA[*/

--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -67,7 +67,7 @@
       </div>
     </div>
     <div class="visible-xs-block row row-offcanvas row-offcanvas-left">
-      <%= render((distro_key == 'openshift-origin' ? "_templates/_footer_origin.html.erb" : "_templates/_footer_other.html.erb"), :images_path => images_path) %>
+      <%= render("_templates/_footer.html.erb", :distro_key => distro_key, :images_path => images_path) %>
     </div>
   </div>
   <script type="text/javascript">


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/1629
