### PR TITLE
Fix IDs for multiple includes in upgrade cert steps.

### DIFF
--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -230,6 +230,7 @@ When the upgrade finishes, a recommendation will be printed to reboot all hosts.
 After rebooting, continue to link:#verifying-the-upgrade[Verifying the Upgrade].
 endif::[]
 
+:sect: automated
 include::install_config/upgrading/manual_upgrades.adoc[tag=30to31updatingcerts]
 
 [[verifying-the-upgrade]]

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -589,8 +589,9 @@ build of those applications after importing the new images using `oc start-build
 <app-name>`.
 ====
 
+:sect: manual
 // tag::30to31updatingcerts[]
-[[updating-master-and-node-certificates]]
+[id='{sect}-updating-master-and-node-certificates']
 == Updating Master and Node Certificates
 
 ifdef::openshift-enterprise[]
@@ -606,7 +607,7 @@ https://github.com/openshift/origin/releases[OpenShift Origin 1.0.8 release].
 This may include any and all updates from that version.
 endif::[]
 
-[[updating-node-certificates]]
+[id='{sect}-updating-node-certificates']
 === Node Certificates
 
 ifdef::openshift-enterprise[]
@@ -627,7 +628,7 @@ regarding the certificate not containing an `IP SAN`.
 In order to remedy this situation, you may need to manually update the
 certificates for your node.
 
-[[checking-the-nodes-certificate]]
+[id='{sect}-checking-the-nodes-certificate']
 ==== Checking the Node's Certificate
 
 The following command can be used to determine which Subject Alternative Names
@@ -654,7 +655,7 @@ Names, then no further steps are required.
 You will need to know the Subject Alternative Names and `*nodeIP*` value for the
 following steps.
 
-[[generating-a-new-node-certificate]]
+[id='{sect}-generating-a-new-node-certificate']
 ==== Generating a New Node Certificate
 
 If your current node certificate does not contain the proper IP address, then
@@ -699,7 +700,7 @@ you would need to run the following command:
   --hostnames=mynode,mynode.mydomain.com,1.2.3.4,10.10.10.1
 ----
 
-[[replace-node-serving-certificates]]
+[id='{sect}-replace-node-serving-certificates']
 ==== Replace Node Serving Certificates
 
 Back up the existing *_/etc/origin/node/server.crt_* and
@@ -731,7 +732,7 @@ ifdef::openshift-origin[]
 ----
 endif::[]
 
-[[updating-master-certificates]]
+[id='{sect}-updating-master-certificates']
 === Master Certificates
 
 ifdef::openshift-enterprise[]
@@ -747,7 +748,7 @@ certificates generated before the 1.0.8 release may not contain these additional
 service names.
 endif::[]
 
-[[checking-the-masters-certificate]]
+[id='{sect}-checking-the-masters-certificate']
 ==== Checking the Master's Certificate
 
 The following command can be used to determine which Subject Alternative Names
@@ -808,7 +809,7 @@ for the master's serving certificate:
 If these names are already contained within the Subject Alternative Names, then
 no further steps are required.
 
-[[generating-a-new-master-certificate]]
+[id='{sect}-generating-a-new-master-certificate']
 ==== Generating a New Master Certificate
 
 If your current master certificate does not contain all names from the list


### PR DESCRIPTION
Using the method [here](http://asciidoctor.org/docs/user-manual/#include-multiple) to ensure unique IDs when including the same content across multiple topics.
