### PR TITLE
[do not merge] update information about OAuth grant strategies

### DIFF
--- a/architecture/additional_concepts/authentication.adoc
+++ b/architecture/additional_concepts/authentication.adoc
@@ -145,11 +145,13 @@ $ oc create -f <(echo '
   "redirectURIs": [
     "http://www.example.com/" <3>
   ]
+  "grantStrategy": "...", <4>
 }')
 ----
 <1> The `name` of the OAuth client is used as the `client_id` parameter when making requests to `_<master>_/oauth/authorize` and `_<master>_/oauth/token`.
 <2> The `secret` is used as the `client_secret` parameter when making requests to `_<master>_/oauth/token`.
 <3> The `redirect_uri` parameter specified in requests to `_<master>_/oauth/authorize` and `_<master>_/oauth/token` must be equal to (or prefixed by) one of the URIs in `redirectURIs`.
+<4> The `grantStrategy` is used to determine what action to take when this client requests tokens and has not yet been granted access by the user. Uses the same values seen in link:./../../install_config/configuring_authentication.html#grant-options[Grant Options].
 ====
 
 *Integrations* [[integrations]]

--- a/architecture/additional_concepts/authentication.adoc
+++ b/architecture/additional_concepts/authentication.adoc
@@ -135,18 +135,15 @@ To register additional clients:
 
 ----
 $ oc create -f <(echo '
-{
-  "kind": "OAuthClient",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "demo" <1>
-  },
-  "secret": "...", <2>
-  "redirectURIs": [
-    "http://www.example.com/" <3>
-  ]
-  "grantStrategy": "...", <4>
-}')
+kind: OAuthClient,
+apiVersion: v1,
+metadata:
+  name: demo <1>
+secret: "...", <2>
+redirectURIs:
+   - http://www.example.com/ <3>
+grantStrategy: "...", <4>
+')
 ----
 <1> The `name` of the OAuth client is used as the `client_id` parameter when making requests to `_<master>_/oauth/authorize` and `_<master>_/oauth/token`.
 <2> The `secret` is used as the `client_secret` parameter when making requests to `_<master>_/oauth/token`.

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1235,9 +1235,13 @@ codes. The default lifetime is five minutes.
 
 == Grant Options
 
-To configure how the OAuth server responds to token requests for a client the
-user has not previously granted permission, set the `*method*` value in the
-`*grantConfig*` stanza. Valid values for `*method*` are:
+When the OAuth server recieves token requests for a client the user has not
+previously granted permission, the action that the OAuth server takes
+is dependent on the OAuth client's grant strategy.
+
+When the OAuth client requesting token does not provide its own grant strategy,
+the server-wide default strategy is used. To configure the default strategy, set the 
+`*method*` value in the `*grantConfig*` stanza. Valid values for `*method*` are:
 
 [horizontal]
 `auto`:: Auto-approve the grant and retry the request.


### PR DESCRIPTION
Updates information about how we handle OAuth client grant strategies, follow-up to https://github.com/openshift/origin/pull/7739

@liggitt PTAL

@adellape FYI, second commit changes a JSON example to YAML as it's infinitely easier to read YAML and YAML also seems to be the de-facto standard for the rest of these docs
