### PR TITLE
add minimal artifacts for Atomic registry distro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'ascii_binder', '~>0.0.6'
+gem 'ascii_binder', '~>0.1.1.1'

--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -75,6 +75,7 @@ Topics:
 ---
 Name: Getting Started
 Dir: getting_started
+Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
@@ -93,8 +94,19 @@ Topics:
     File: revhistory_getting_started
     Distros: openshift-enterprise,openshift-dedicated,openshift-online
 ---
+Name: Registry Quickstart
+Dir: registry_quickstart
+Distros: atomic-registry
+Topics:
+  - Name: Developers
+    File: developers
+  - Name: Administrators
+    File: administrators
+
+---
 Name: Architecture
 Dir: architecture
+Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
@@ -302,6 +314,7 @@ Topics:
 ---
 Name: CLI Reference
 Dir: cli_reference
+Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
@@ -320,6 +333,7 @@ Topics:
 ---
 Name: Developer Guide
 Dir: dev_guide
+Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
@@ -391,6 +405,7 @@ Topics:
 ---
 Name: Creating Images
 Dir: creating_images
+Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
@@ -411,6 +426,7 @@ Topics:
 ---
 Name: Using Images
 Dir: using_images
+Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
@@ -491,6 +507,10 @@ Topics:
     File: openshift_v1
   - Name: Kubernetes v1
     File: kubernetes_v1
+<<<<<<< 2034eb52857754024ee14c1ce9ca02ec4c8959f5
   - Name: Revision History
     File: revhistory_rest_api
     Distros: openshift-enterprise,openshift-dedicated,openshift-online
+=======
+    Distros: openshift-*
+>>>>>>> add minimal artifacts for Atomic registry distro

--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -507,10 +507,6 @@ Topics:
     File: openshift_v1
   - Name: Kubernetes v1
     File: kubernetes_v1
-<<<<<<< 2034eb52857754024ee14c1ce9ca02ec4c8959f5
   - Name: Revision History
     File: revhistory_rest_api
     Distros: openshift-enterprise,openshift-dedicated,openshift-online
-=======
-    Distros: openshift-*
->>>>>>> add minimal artifacts for Atomic registry distro

--- a/registry_quickstart/administrators.adoc
+++ b/registry_quickstart/administrators.adoc
@@ -1,0 +1,64 @@
+= Getting Started for Administrators
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+== Prerequisites
+
+* Docker
+* `atomic` CLI (optional). This is part of any Red Hat-based system, Fedora, Centos, Red Hat Enterprise Linux, including Atomic host variants.
+* Storage for images. By default registry images will use local storage at /var/lib/origin/volumes It is recommended that external storage be provided at this mountpoint or configure the registry for cloud storage.
+
+== Deploy the Registry
+
+. **Install**. This will create configuration files and certificates in /etc/origin , create systemd files and pull down the docker images.
++
+----
+$ sudo atomic install projectatomic/atomic-registry-quickstart
+----
++
+. **Configure**. Optionally edit configuration file /etc/origin/master/master-config.yaml Refer to documentation to configure the authentication identity provider. or customizing certificates. NOTE: Once the registry is running you may load any configuration changes using the systemd service manager, sudo systemctl restart atomic-openshift-master.service
+. **Run**. Start the origin service and launch the registry and web UI services.
++
+----
+$ sudo atomic run projectatomic/atomic-registry-quickstart
+----
++
+Launch the registry web UI using a browser: link:#[https://SERVER]. By default, any username and password will authenticate and have basic user priviledges.
+
+== Configure
+
+There are several setup steps that should be performed. These steps assume access to the CLI.
+
+=== Working with the Command Line Interface (CLI)
+
+The CLI client is not installed on the host system but it is available by entering the origin-master container on the Atomic Registry host system. The client may be installed on a remote system. See documentation for installing and using the remote CLI client.
+
+----
+$ sudo docker exec -it origin-master bash
+# oc whoami
+system:admin
+----
+
+The *system:admin* user is a special user that should only be used for local cluster-administration tasks.
+
+. Configure an identity provider. Edit */etc/origin/master/master-config.yaml* and restart the *atomic-openshift-master* service. Refer to link:#[authentication documentation] for supported identity providers, configuration details and examples. Hint: Integrating with GitHub authentication is a fairly straightforward option.
++
+    sudo systemctl restart atomic-openshift-master.service
++
+. Create an admin user. All authenticated users are assigned a basic user role by default. Choose at least one user to be an administrator. Replace USERNAME with a real user.
++
+    oadm policy add-cluster-role-to-user cluster-admin USERNAME
++
+. Configure registry storage. TODO
+
+
+*What's Next?*
+
+Now that you have {product-title} successfully running in your environment,
+try it out by logging in, uploading and sharing an image.

--- a/registry_quickstart/developers.adoc
+++ b/registry_quickstart/developers.adoc
@@ -1,0 +1,38 @@
+= Getting Started for Developers
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+:description: The getting started experience for developers.
+:keywords: getting started, developers, registry
+
+== Using the Registry
+
+. Launch the registry in a web browser. Depending on the configuration you may see images you have access to.
+. Create a project. This is a namespace and will be part of the image name in the form of *<registry_hostname>/<project_name>/<image_name>*. You will be the administrator of projects you create.
+
+=== Docker Commands
+
+Images are pushed and pulled from the docker command line. The docker command line reference is found on the bottom of the web interface overview page.
+
+. Copy the *docker login* command from the web interface and paste it into a terminal window.
++
+----
+$ sudo docker login -p <token> -u unused -e unused <hostname>:5000
+----
++
+. Tag an image. Here we tag a *centos* base image into the registry using the project name we created above.
++
+----
+$ sudo docker tag centos <registry_hostname>/<project_name>/<image_name>
+----
++
+. Push the image to the registry.
++
+----
+$ sudo docker push <registry_hostname>/<project_name>/<image_name>
+----


### PR DESCRIPTION
This enables a basic build of the atomic registry distro.

It depends on #1693 and the Asciibinder distro key expansion feature in v0.1.1.1+.
See https://github.com/redhataccess/ascii_binder/pull/29 and https://github.com/redhataccess/ascii_binder/pull/25 
