### PR TITLE
adjust to the more fluid resource limits; other fine tuning

### DIFF
--- a/using_images/devpreview_considerations.adoc
+++ b/using_images/devpreview_considerations.adoc
@@ -15,19 +15,15 @@ toc::[]
 The OpenShift Online 3 Developer Preview offering scopes the inventory of images
 it provides out of the box with a few considerations in mind, which also apply
 to any images you choose to import into your project. These conditions are
-enforced via the OpenShift quota system; see
-link:../dev_guide/compute_resources.html[Compute Resources] for information on
-how this system works.
+enforced via the OpenShift link:../dev_guide/quota.html[Quota] and
+link:../dev_guide/compute_resources.html[Compute Resources] systems.
 
 [[devpreview-current-considerations]]
 == Current Considerations
 
 * A memory limit of 2GiB is in place. The 2 GiB is spread out across the project's
 pods and containers.
-* Up to 10 pods are allowed.
-* Up to 20 replication controllers are allowed.
-* Up to 10 services are allowed.
-* Up to 16 secrets are allowed (though some amount of these secrets will be needed
+* Maximum counts are in place for pods, replication controllers, services, and secrets  (though some amount of these secrets will be needed
 by the system's build and deployer service accounts).
 * Any Dockerfile `VOLUME` instruction must be mounted with either a persistent
 volume claim (PVC) or an EmptyDir at this time.
@@ -52,8 +48,7 @@ $ oc describe quota <your_project_quota_object_name>
 
 As part of providing a set of templates out of the box, various publicly accessible templates
 have been updated with a memory limit
-template parameter with a default setting for the deployments. These default
-settings were based on tuning exercises of some common developer flows, with the
+template parameter with a default setting for the deployments, with the
 2 GiB memory limit in mind.
 
 You can change the defaults when instantiating any given template as you see fit, based on the needs of the specific


### PR DESCRIPTION
@adellape PTAL

Just some minor edits:
1) added a link to Quota section, and treat Quota and Compute Resource as equal / peer concepts
2) some of the limits on resources are still somewhat fluid; for those, rather than note the specific number, just note a limit will be placed on them
3) we backed off of the fine tuned mem limits based on scenario, and now set everyone at 512Mi to aid density and maintenance of the online env.  So adjusted the verbiage to back off the fine tuning slant. 
