### PR TITLE
Add asciibinder package step to travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ rvm:
   - 2.0.0
 gemfile: Gemfile
 after_install: gem list
-script: bundle exec rake build
+script:
+  - bundle exec rake build
+  - bundle exec rake package
 notifications:
   email:
     #recipients:


### PR DESCRIPTION
Responding to a situation where `asciibinder build` passed but `package` failed due to missing file.
