### PR TITLE
Bug 1315646, fixed broken links

### DIFF
--- a/install_config/install/index.adoc
+++ b/install_config/install/index.adoc
@@ -7,10 +7,10 @@
 :prewrap!:
 
 ifdef::openshift-enterprise[]
-The link:quick_install.html[quick installation] method allows you to use an
-interactive CLI utility to install OpenShift across a set of hosts. The utility
-is a self-contained wrapper intended for usage on a Red Hat Enterprise Linux 7
-host.
+The link:../../install_config/install/quick_install.html[quick installation] method
+allows you to use an interactive CLI utility to install OpenShift across a set
+of hosts. The utility is a self-contained wrapper intended for usage on a Red
+Hat Enterprise Linux 7 host.
 endif::[]
 
 ifdef::openshift-origin[]
@@ -20,11 +20,12 @@ Administrators].
 endif::[]
 
 For production environments, a reference configuration implemented using Ansible
-playbooks is available as the link:advanced_install.html[advanced installation]
+playbooks is available as the
+link:../../install_config/install/advanced_install.html[advanced installation]
 method.
 
 [NOTE]
 ====
 Before beginning either installation method, start with the
-link:prerequisites.html[Prerequisites] topic.
+link:../../install_config/install/prerequisites.html[Prerequisites] topic.
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1315646

The links within the Overview section only seemed to choke in the multi-page HTML view within the portal:
https://access.redhat.com/documentation/en/openshift-enterprise/3.1/installation-and-configuration/chapter-2-installing

They worked fine in the single-page HTML view and within my local build. I updated the link paths to be more complete.
