### PR TITLE
switch terminology (instant app vs. quickstart)

### DIFF
--- a/getting_started/developers/developers_cli.adoc
+++ b/getting_started/developers/developers_cli.adoc
@@ -36,8 +36,8 @@ ifdef::openshift-online[]
 That said, similar to version 2, OpenShift provides out of the box a set of
 languages and link:../../using_images/db_images/index.html[databases] for
 developers with corresponding implementations and tutorials that allow you to
-kickstart your application development. Language support center around the
-link:../../dev_guide/templates.html#using-the-instantapp-templates[Instant App templates], 
+kickstart your application development. Language support centers around the
+link:../../dev_guide/app_tutorials/quickstarts.html[Quickstart templates], 
 which in turn leverage
 link:../../using_images/s2i_images/index.html[builder images].
 


### PR DESCRIPTION
@adellape PTAL - I'm pretty sure this is not the only place where InstantApp vs. Quickstart terminology conversions need to occur, but since I know I created this content for the online dev preview (based on input from @sspeiche) just prior to @bparees 's work with the quickstart tutorial, I knew this at least had to be changed :-)

And of course comments from one and all for further massaging of this content always welcome.
