### PR TITLE
Update console extensions examples

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -17,7 +17,9 @@ using extensions, which let you run scripts and load custom stylesheets when the
 web console loads. You can change the look and feel of nearly any aspect of the
 user interface in this way.
 
+[[loading-custom-scripts-and-stylesheets]]
 == Loading Custom Scripts and Stylesheets
+
 To add scripts and stylesheets, edit the
 link:../install_config/master_node_configuration.html[master configuration
 file]. The scripts and stylesheet files must exist on the Asset Server and are
@@ -58,9 +60,18 @@ stylesheet files when you refresh the page in your browser. You still must
 restart the server when adding new extension stylesheets or scripts, however.
 This setting is only recommended for testing changes and not for production.
 
-The following examples show common ways you can customize the web console.
+The examples in the following sections show common ways you can customize the
+web console.
 
-*Customizing the Logo*
+[NOTE]
+====
+Additional extension examples are available in the
+link:https://github.com/openshift/origin/tree/master/assets/extensions/examples[OpenShift
+Origin] repository on GitHub.
+====
+
+[[customizing-the-logo]]
+=== Customizing the Logo
 
 The following style changes the logo in the web console header:
 
@@ -89,7 +100,8 @@ assetConfig:
 ----
 ====
 
-*Changing Links to Documentation*
+[[changing-links-to-documentation]]
+=== Changing Links to Documentation
 
 Links to external documentation are shown in various sections of the web
 console. The following example changes the URL for two given links to docs:
@@ -114,7 +126,7 @@ assetConfig:
 ====
 
 [[adding-or-changing-links-to-download-the-cli]]
-*Adding or Changing Links to Download the CLI*
+=== Adding or Changing Links to Download the CLI
 
 The *About* page in the web console provides download links for the
 link:../cli_reference/index.html[command line interface (CLI)] tools. These
@@ -159,11 +171,7 @@ assetConfig:
 ----
 ====
 
-[NOTE]
-====
-More extension examples are available in the link:https://github.com/openshift/origin/tree/master/assets/extensions/examples[OpenShift Origin] repository on Github.
-====
-
+[[serving-static-files]]
 == Serving Static Files
 
 You can serve other files from the Asset Server as well. For example, you might
@@ -197,6 +205,7 @@ path. For example:
 ----
 ====
 
+[[enabling-html5-mode]]
 === Enabling HTML5 Mode
 
 The web console has a special mode for supporting certain static web
@@ -256,6 +265,7 @@ oauthConfig:
 Relative paths are resolved relative to the master configuration file. You must
 restart the server after changing this configuration.
 
+[[customizing-the-oauth-error-page]]
 == Customizing the OAuth Error Page
 
 You can also change the page shown when errors occur during authentication.
@@ -285,6 +295,7 @@ oauthConfig:
 Relative paths are resolved relative to the master configuration file. You must
 restart the server after changing this configuration.
 
+[[changing-the-logout-url]]
 == Changing the Logout URL
 
 You can change the location a console user is sent to when logging out of

--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -68,14 +68,14 @@ The following style changes the logo in the web console header:
 ----
 #header-logo {
   background-image: url("https://www.example.com/images/logo.png");
-  width: 160px;
-  height: 10px;
+  width: 190px;
+  height: 20px;
 }
 ----
 ====
 
 Replace the *example.com* URL with a URL to an actual image, and adjust the
-width and height. The ideal height is *10px*.
+width and height. The ideal height is *20px*.
 
 Save the style to a file (for example, *_logo.css_*) and add it to the master
 configuration file:
@@ -86,52 +86,6 @@ assetConfig:
   ...
   extensionStylesheets:
     - /path/to/logo.css
-----
-====
-
-*Changing the Header Color*
-
-The following style changes the header color to dark blue:
-
-====
-----
-.navbar-header {
-  background-color: #2B3856;
-}
-----
-====
-
-Save the style to a file (for example, *_theme.css_*) and add it to the master
-configuration file:
-
-====
-----
-assetConfig:
-  ...
-  extensionStylesheets:
-    - /path/to/theme.css
-----
-====
-
-*Adding a Link to the Header*
-
-The following script adds a link into the web console header:
-
-====
-----
-$(".navbar-iconic").prepend('<li><a href="http://example.com/status/">System Status</a></li>');
-----
-====
-
-Save this script to a file (for example, *_nav-link.js_*) and add it to the
-master configuration file:
-
-====
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/nav-link.js
 ----
 ====
 
@@ -203,6 +157,11 @@ assetConfig:
   extensionScripts:
     - /path/to/cli-links.js
 ----
+====
+
+[NOTE]
+====
+More extension examples are available in the link:https://github.com/openshift/origin/tree/master/assets/extensions/examples[OpenShift Origin] repository on Github.
 ====
 
 == Serving Static Files


### PR DESCRIPTION
Builds on https://github.com/openshift/openshift-docs/pull/1637 which needed a rebase, so I grabbed it and did some follow-up edits. Namely, moved the new Note box further up and turned some examples into actual subsections.

@jwforres @ahardin-rh PTAL. Pretty build:

http://file.rdu.redhat.com/~adellape/031116/console_ext_examples/install_config/web_console_customization.html
