### PR TITLE
Add whitelisting docker registries

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -781,6 +781,45 @@ It is recommended that configuration files be maintained in a source control
 repository.
 ====
 
+[[whitelisting-docker-registries]]
+== Whitelisting Docker Registries
+
+You can specify a whitelist of docker registries, allowing you to curate a set
+of images and templates that are available for download by OpenShift users. This
+curated set can be placed in one or more docker registries, and then added to
+the whitelist. When using a whitelist, only the specified registries are
+accessible within OpenShift, and all other registries are denied access by
+default.
+
+To configure a whitelist:
+
+. Edit the *_/etc/sysconfig/docker_* file to block all registries:
++
+----
+BLOCK_REGISTRY='--block-registry=all'
+----
++
+You may need to uncomment the `*BLOCK_REGISTRY*` line.
+. In the same file, add registries to which you want to allow access:
++
+----
+ADD_REGISTRY='--add-registry=<registry1> --add-registry=<registry2>'
+----
++
+.Allowing Access to Registries
+====
+----
+ADD_REGISTRY='--add-registry=registry.access.redhat.com'
+----
+====
++
+This example would restrict access to images available on the 
+link:https://access.redhat.com/search/#/container-images[Red Hat Customer Portal].
+
+Once the whitelist is configured, if a user tries to pull from a docker registry
+that is not on the whitelist, they will receive an error message stating that 
+this registry is not allowed.
+
 [[exposing-the-registry]]
 == Exposing the Registry
 


### PR DESCRIPTION
Tagging @rhatdan for Tech Review:

Added details on whitelisting docker registries as per https://bugzilla.redhat.com/show_bug.cgi?id=1307210

Pretty rendered docs build:

http://file.bne.redhat.com/tpoitras/2016/Mar15/openshift-enterprise/whitelisting-BZ1307210/install_config/install/docker_registry.html#whitelisting-docker-registries

Questions:
1. Would this apply to OpenShift Origin as well?
2. Do we really need the = sign in between the --add-registry command and the specified registry? Example from my docs update, based on comment#1 in the BZ: 

ADD_REGISTRY='--add-registry=registry.access.redhat.com

Because on my test machine, my  /etc/sysconfig/docker file already has this line:

ADD_REGISTRY='--add-registry registry.access.redhat.com'
