### PR TITLE
update binary build doc

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -33,17 +33,21 @@ link:#docker-strategy-options[options])
 (link:../architecture/core_concepts/builds_and_image_streams.html#custom-build[description],
 link:#custom-strategy-options[options])
 
-And there are three types of build source:
+And there are four types of build source:
 
 - link:#source-code[Git]
 - link:#dockerfile-source[Dockerfile]
+- link:#image-source[Image]
 - link:#binary-source[Binary]
 
 It is up to each build strategy to consider or ignore a certain type of source,
 as well as to determine how it is to be used.
 
-Binary and Git are mutually exclusive source types, while Dockerfile can be used
-by itself or together with Git and Binary.
+Binary and Git are mutually exclusive source types, while Dockerfile and Image can be used
+by themselves, with each other, or together with either Git or Binary.
+
+Also, the Binary build source type is unique from the other options in how it is
+specified to the system.  Exactly how is detailed link:#binary-source[below].
 
 
 [[defining-a-buildconfig]]
@@ -846,42 +850,47 @@ source:
 
 == Binary Source
 
-When the `*BuildConfig.spec.source.type*` is `*Binary*`, the build will expect a
-binary as input, and an inline Dockerfile is optional.
+Streaming content in binary format from a local file system to the builder is called a `*binary type build*`.
+The corresponding value of `*BuildConfig.spec.source.type*` is `*Binary*` for such builds.
 
-The binary is generally assumed to be a tar, gzipped tar, or zip file depending
-on the strategy. For `*Docker*` builds, this is the build context and an
-optional Dockerfile may be specified to override any Dockerfile in the build
-context. For `*Source*` builds, this is assumed to be an archive as described
-above. For `*Source*` and `*Docker*` builds, if `*binary.asFile*` is set the
-build context will consist of a single file named by the value of `*binary.asFile*`. 
-The `*contextDir*` field may be used when an archive is provided. Custom builds will 
-receive this binary as input on standard input (`stdin`).
+This source type is unique in that it is leveraged solely based on your use of the `oc start-build`.
 
-A binary source potentially extracts content (if `*asFile*` is not set), in which case `*contextDir*`
-allows changing to a subdirectory within the content before the build executes.
-
-The source definition is part of the `*spec*` section in the `*BuildConfig*`:
-
+[NOTE]
 ====
-[source,yaml]
-----
-source:
-  type: "Binary"
-  binary: <1>
-    asFile: "webapp.war" <2>
-  contextDir: "app/dir" <3>
-  dockerfile: "FROM centos:7\nRUN yum install -y httpd" <4>
-----
-<1> The `*binary*` field specifies the details of the binary source.
-<2> The `*asFile*` field specifies the name of the file that will be created with
-the binary contents.
-<3> The `*contextDir*` field specifies a subdirectory within the extracted contents of a
-binary archive.
-<4> If the optional `*dockerfile*` field is provided, it should be a string
-containing an inline Dockerfile that potentially replaces one within the
-contents of the binary archive.
+Since binary type builds require content to be streamed from the local file system, it is not possible
+to automatically trigger a binary type build (e.g. via an image change trigger) because the binary files could
+not be provided. Similarly, you cannot launch binary type builds from the web console.
 ====
+
+To utilize binary builds, invoke `oc start-build` with one of these options:
+
+1) `--from-file`:  The contents of the file you specify will be sent as a binary stream to the builder.  Then
+the builder will store the data in a file with the same name at the top of the build context.
+
+2) `--from-dir` and `--from-repo`:  The contents will be archived and sent as a binary stream to the builder.
+Then the builder will extract the contents of the archive within the build context directory.
+
+In each of the above cases:
+
+1) If your `*BuildConfig*` already has a `*Binary*` source type defined, it will effectively be ignored and replaced by what the
+client sends.
+
+2) If your `*BuildConfig*` has a `*Git*` source type defined, it will be dynamically disabled, since `*Binary*` and `*Git*` are
+mutually exclusive, and the data in the binary stream provided to the builder will take precedence.
+
+When using `oc new-build --binary=true`, the command ensures that the restrictions associated with binary builds are enforced.
+The resulting `*BuildConfig*` will have a source type of `*Binary*`, meaning that the only valid way to run a build for this `*BuildConfig*`
+will be to use `oc start-build` with one of the `--from` options to provide the requisite binary data.
+
+The `*dockerfile*` and `*contextDir*` link:#source-code[source options] have special meaning with binary builds.
+
+The `*dockerfile*` can be used with any form of `*Binary*` build source.  If `*dockerfile*` is used and the binary stream
+is an archive, its contents serve as a replacement Dockerfile to any Dockerfile in the archive.  If `*dockerfile*` is used, and if the
+`--from-file` argument is used, and the file argument is named "Dockerfile", the value from `*dockerfile*` replaces the value from
+the binary stream. 
+
+In the case of the binary stream encapsulating extracted archive content, the value of the `*contextDir*` field is interpreted as
+a subdirectory within the archive, and if valid, the builder changes into that subdirectory before executing the build.
 
 [[image-source]]
 


### PR DESCRIPTION
@bparees @rhcarvalho @mfojtik @csrwng PTAL

Note, I tried to cross reference the document with what I saw in the code, in particular https://github.com/openshift/origin/blob/master/pkg/build/builder/source.go#L44-L101

As such, it seemed like dockerfile's could be used even if asFile was set.  That is counter to what I at least interpreted the prior version of the documentation implying.  So let's confirm/deny that along with assessing the changes' attempt to make things clearer.
