### PR TITLE
Revert "Outline Online EmptyDir volume restrictions and workaround."

### DIFF
--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -542,16 +542,3 @@ labels for all objects here.
 ====
 To see all of the configuration options, click the "Show advanced build and deployment options" link.
 ====
-
-ifdef::openshift-online[]
-== Troubleshooting
-`*EmptyDir*` volumes are disabled in OpenShift Online at present. In some situations new-app will automatically create or use templates which contain `*EmptyDir*` volumes. In this scenario you will need to use `oc edit` to modify the relevant PodSpec and replace the use of `*EmptyDir*` volumes with a `*PersistentVolumeClaim*`.
-
-When this situations occurs, the error will surface as an event with a message similar to:
-
-----
-Error creating: Pod "redis-1-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.volumes: invalid value 'emptyDir', Details: EmptyDir volumes are not allowed to be used]
-----
-
-To correct the issue, identify the relevant object containing an `emptyDir` volume with `oc export`, and use `oc edit` to replace it with a persistent volume claim. For more information, see documentation on link:./persistent_volumes.html[persistent volumes].
-endif::[]

--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -27,13 +27,6 @@ single machine. Administrators may also allow you to request a
 link:persistent_volumes.html[persistent volume] that is automatically attached
 to your pods.
 
-ifdef::openshift-online[]
-[NOTE]
-====
-`*EmptyDir*` volumes are disabled in OpenShift Online at present, you will need to use persistent volume claims instead for the time being.
-====
-endif::[]
-
 [NOTE]
 ====
 `*EmptyDir*` volume storage may be restricted by a quota based on the pods FSGroup, if enabled by your cluster administrator.


### PR DESCRIPTION
This reverts commit 67667282962d8ce6946bc94665336a3bb40100fd.

Situation has changed and EmptyDir volumes should be covered by quota and available for use in online by launch.
