### PR TITLE
Revert "Document new SCC allowEmptyDirVolumePlugin restriction."

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -34,9 +34,9 @@ To get a current list of SCCs:
 ====
 ----
 $ oc get scc
-NAME               PRIV      CAPS      HOSTDIR   EMPTYDIR   SELINUX     RUNASUSER          FSGROUP    SUPGROUP   PRIORITY
-privileged         true      []        true      true       RunAsAny    RunAsAny           RunAsAny   RunAsAny   <none>
-restricted         false     []        false     false      MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>
+NAME         PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER
+privileged   true      []        true      RunAsAny    RunAsAny
+restricted   false     []        false     MustRunAs   MustRunAsRange
 ----
 ====
 
@@ -50,7 +50,6 @@ To examine a particular SCC, use `oc get`, `oc describe`, `oc export`, or `oc ed
 ----
 $ oc edit scc restricted
 allowHostDirVolumePlugin: false
-allowEmptyDirVolumePlugin: true
 allowHostNetwork: false
 allowHostPorts: false
 allowPrivilegedContainer: false
@@ -199,7 +198,6 @@ user:
 $ oc edit scc privileged
 
 allowHostDirVolumePlugin: true
-allowEmptyDirVolumePlugin: true
 allowPrivilegedContainer: true
 apiVersion: v1
 groups:
@@ -393,20 +391,6 @@ $ oc edit scc restricted
 ----
 
 . Add `*allowHostDirVolumePlugin: true*`.
-
-. Save the changes.
-
-=== Block the emptyDir Volume Plug-in
-
-The use of `emptyDir` volumes is enabled by default, but can be disabled in your cluster if desired.
-
-. Edit the *restricted* SCC:
-+
-----
-$ oc edit scc restricted
-----
-
-. Add `*allowEmptyDirVolumePlugin: false*`.
 
 . Save the changes.
 

--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -269,13 +269,13 @@ administrators using the CLI:
 ====
 ----
 $ oc get scc
-NAME               PRIV      CAPS      HOSTDIR   EMPTYDIR   SELINUX     RUNASUSER          FSGROUP    SUPGROUP   PRIORITY
-anyuid             false     []        false     true       MustRunAs   RunAsAny           RunAsAny   RunAsAny   10
-hostaccess         false     []        true      true       MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>
-hostmount-anyuid   false     []        true      true       MustRunAs   RunAsAny           RunAsAny   RunAsAny   <none>
-nonroot            false     []        false     true       MustRunAs   MustRunAsNonRoot   RunAsAny   RunAsAny   <none>
-privileged         true      []        true      true       RunAsAny    RunAsAny           RunAsAny   RunAsAny   <none>
-restricted         false     []        false     true       MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>
+NAME               PRIV      CAPS      HOSTDIR   SELINUX     RUNASUSER          FSGROUP    SUPGROUP   PRIORITY
+anyuid             false     []        false     MustRunAs   RunAsAny           RunAsAny   RunAsAny   10
+hostaccess         false     []        true      MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>
+hostmount-anyuid   false     []        true      MustRunAs   RunAsAny           RunAsAny   RunAsAny   <none>
+nonroot            false     []        false     MustRunAs   MustRunAsNonRoot   RunAsAny   RunAsAny   <none>
+privileged         true      []        true      RunAsAny    RunAsAny           RunAsAny   RunAsAny   <none>
+restricted         false     []        false     MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>
 ----
 ====
 
@@ -287,7 +287,6 @@ CLI. For example, for the privileged SCC:
 # oc export scc/privileged
 
 allowHostDirVolumePlugin: true
-allowEmptyDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true

--- a/rest_api/kubernetes_v1.adoc
+++ b/rest_api/kubernetes_v1.adoc
@@ -7959,7 +7959,6 @@ NamespaceList is a list of Namespaces.
 |allowPrivilegedContainer|allow containers to run as privileged|true|boolean|false
 |allowedCapabilities|capabilities that are allowed to be added|true|<<v1.Capability>> array|
 |allowHostDirVolumePlugin|allow the use of the host dir volume plugin|true|boolean|false
-|allowEmptyDirVolumePlugin|allow the use of the empty dir volume plugin|true|boolean|false
 |allowHostNetwork|allow the use of the hostNetwork in the pod spec|true|boolean|false
 |allowHostPorts|allow the use of the host ports in the containers|true|boolean|false
 |allowHostPID|allow the use of the host pid in the containers|true|boolean|false


### PR DESCRIPTION
This reverts commit 47ab90a5c314aacb475e5b9c9564e6a5dd37b9f4.

Feature was pulled and replaced with a more generic solution allowing the scc
to control arbitrary volume plugins.
