### PR TITLE
Fix minor typo for destinationCACertificate

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -593,7 +593,7 @@ spec:
     key: [as in edge termination]
     certificate: [as in edge termination]
     caCertificate: [as in edge termination]
-    destinationCaCertificate: |-  <2>
+    destinationCACertificate: |-  <2>
       -----BEGIN CERTIFICATE-----
       [...]
       -----END CERTIFICATE-----
@@ -601,7 +601,7 @@ spec:
 
 <1> The `*termination*` field is set to `reencrypt`. Other fields are as in edge
 termination.
-<2> The `*destinationCaCertificate*` field specifies a CA certificate to
+<2> The `*destinationCACertificate*` field specifies a CA certificate to
 validate the endpoint certificate, securing the connection from the router to
 the destination. This field is required, but only for re-encryption.
 ====

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -464,7 +464,7 @@ spec:
       -----BEGIN CERTIFICATE-----
       [...] <2>
       -----END CERTIFICATE-----
-    destinationCaCertificate: |-
+    destinationCACertificate: |-
       -----BEGIN CERTIFICATE-----
       [...] <3>
       -----END CERTIFICATE-----


### PR DESCRIPTION
- Cuz this error message is heartbreaking:

```
Error from server: error when creating "sample-app.yml": Route
"sample-app-route" is invalid: spec.tls.destinationCACertificate:
Required value
```
