### PR TITLE
Update ramp node doc for openshift-sdn cluster network changes

### DIFF
--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -119,9 +119,12 @@ pods.
 # F5_IP=10.3.89.66
 # TUNNEL_IP1=10.3.91.216
 # TUNNEL_IP2=10.3.91.217 <1>
+# CLUSTER_NETWORK=10.128.0.0/1 <2>
 ----
 <1> A second, arbitrary IP address for the ramp node's end of the *ipip*
 tunnel.
+<2> The overlay network CIDR that the OpenShift SDN uses to assign
+    addresses to pods.
 ====
 
 . Delete any old tunnel:
@@ -188,6 +191,14 @@ gateway):
     "${ipflowopts},nw_dst=${RAMP_SDN_IP},actions=mod_nw_dst:${TUNNEL_IP1},resubmit(,0)"
 # ovs-ofctl -O OpenFlow13 add-flow br0 \
     "${arpflowopts}, arp_tpa=${RAMP_SDN_IP}, actions=output:2"
+# ovs-ofctl -O OpenFlow13 add-flow br0 \
+    "${arpflowopts}, priority=200, in_port=2, arp_spa=${RAMP_SDN_IP}, arp_tpa=${CLUSTER_NETWORK}, actions=goto_table:5"
+# ovs-ofctl -O OpenFlow13 add-flow br0 \
+    "arp, table=5, priority=300, arp_tpa=${RAMP_SDN_IP}, actions=output:2"
+# ovs-ofctl -O OpenFlow13 add-flow br0 \
+    "ip,table=5,priority=300,nw_dst=${RAMP_SDN_IP},actions=output:2"
+# ovs-ofctl -O OpenFlow13 add-flow br0 "${ipflowopts},nw_dst=${TUNNEL_IP1},actions=output:2"
+
 # if [ "$plugin" == "multitenant" ]; then
     ovs-ofctl -O OpenFlow13 add-flow br0 \
       "cookie=0x999, table=1,priority=40000,ip,nw_dst=${TUNNEL_IP1},actions=output:2"


### PR DESCRIPTION
Match the new openshift-sdn cluster network network  (10.128.0.0/16) and add openflow rules to get the ramp node working.

@adellape / @bfallonf  PTAL Thx 

@rajatchopra  FYI
