### PR TITLE
Incorrect Binary deployment directory for tomcat STI image is deploym…

### DIFF
--- a/using_images/xpaas_images/jws.adoc
+++ b/using_images/xpaas_images/jws.adoc
@@ -6,7 +6,7 @@
 :experimental:
 :toc: macro
 :toc-title:
-
+d
 toc::[]
 
 == Overview
@@ -46,7 +46,7 @@ The S2I process for the JBoss Web Server xPaaS images works as follows:
 By default the `package` goal is used with the `openshift` profile, including the system properties for skipping tests (`*-DskipTests*`) and enabling the Red Hat GA repository (`*-Dcom.redhat.xpaas.repo.redhatga*`).
 +
 The results of a successful Maven build are copied to *_/opt/webserver/webapps_*. This includes all WAR files from the source repository directory specified by the `*$ARTIFACT_DIR*` environment variable. The default value of `*$ARTIFACT_DIR*` is the *_target_* directory.
-. All WAR files from the *_deployment_* source repository directory are copied to *_/opt/webserver/webapps_*.
+. All WAR files from the *_deployments_* source repository directory are copied to *_/opt/webserver/webapps_*.
 . All files in the *_configuration_* source repository directory are copied to *_/opt/webserver/conf_*.
 +
 [NOTE]


### PR DESCRIPTION
…ents not deployment

Binary deployment directory for tomcat STI image is deployments not deployement.
It is a good thing, because it the same thing for EAP/Wildfly
