### PR TITLE
Bug 1305403 -- env vars to override route hostname

### DIFF
--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -85,7 +85,9 @@ endif::[]
 [[haproxy-router]]
 == Deploying the Default HAProxy Router
 The `oadm router` command is provided with the administrator CLI to simplify the
-tasks of setting up routers in a new installation. Just about every form of
+tasks of setting up routers in a new installation.
+This command creates the service and deployment configuration objects.
+Just about every form of
 communication between OpenShift components is secured by TLS and uses various
 certificates and authentication methods. Use the `--credentials` option to
 specify what credentials the router should use to contact the master.
@@ -234,36 +236,67 @@ router] on your OpenShift cluster using IP failover.
 
 === Customizing the Default Routing Subdomain
 
+You can customize the routing subdomain by
+either modifying the master configuration file,
+or by setting environment variables in the deployment configuration.
+
+Modifying the master configuration file::
 You can customize the suffix used as the default routing subdomain for your
 environment using the
 link:../../install_config/master_node_configuration.html#master-configuration-files[master
 configuration file] (the *_/etc/origin/master/master-config.yaml_* file by
 default). The following example shows how you can set the configured suffix to
 *v3.openshift.test*:
-
++
 .Master Configuration Snippet
 ====
-
 ----
 routingConfig:
   subdomain: v3.openshift.test
 ----
 ====
-
++
 [NOTE]
 ====
 This change requires a restart of the master if it is running.
 ====
-
++
 With the OpenShift master(s) running the above configuration, the
 link:../../architecture/core_concepts/routes.html#route-hostnames[generated host
 name] for the example of a host added to a namespace *mynamespace* would be:
-
++
 .Generated Host Name
 ====
-
 ----
 myroute-mynamespace.v3.openshift.test
+----
+====
+
+Setting environment variables in the deployment configuration::
+
+You can use the `oc env` command to set environment variables
+on the router's deployment configuration object.
+Two variables control whether or not the route-specified hostname
+is overridden, and if overridden, the format of the subdomain name.
+Their influence depends on whether or not a route has a hostname
+specified in its `*spec.host*` parameter.
+
+`ROUTER_OVERRIDE_HOSTNAME`:::
+When a route *has* a hostname, if the value of `ROUTER_OVERRIDE_HOSTNAME`
+is unset or has value `false`, OpenShift accepts that hostname.
+Otherwise, it uses `ROUTER_SUBDOMAIN` (see next).
+
+`ROUTER_SUBDOMAIN`:::
+When a route *has no* hostname, the router uses the `ROUTER_SUBDOMAIN` value
+as a template to automatically generate a name for the route upon its admission.
++
+====
+The following example modifies the deployment configuration named `router` to
+use a custom template, and arranges to propagate the change through the cluster.
+----
+$ oc env dc/router \
+    ROUTER_OVERRIDE_HOSTNAME=true \
+    ROUTER_SUBDOMAIN='${name}-${namespace}.apps.example.com'
 ----
 ====
 


### PR DESCRIPTION
@ramr 
This is the first part of bug 1305403 (the second part, router sharding proper, will be in another PR).  WDYT?
