### PR TITLE
Fixed broken xrefs, cleaned up revhistory formatting

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -8,7 +8,7 @@
 == Mon Mar 21 2016
 
 // tag::admin_guide_mon_mar_21_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
@@ -24,7 +24,7 @@
 == Thu Mar 17 2016
 
 // tag::admin_guide_thu_mar_17_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -7,7 +7,7 @@
 == Thu Mar 17 2016
 
 // tag::architecture_thu_mar_17_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
@@ -15,8 +15,6 @@
 
 |link:../architecture/additional_concepts/storage.html[Persistent Storage]
 |In the link:../architecture/additional_concepts/storage.html#pvc-access-modes[Access Modes] section, clarified how a PVC determines what PV to select.
-
-
 
 |===
 

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -7,7 +7,7 @@
 == Thu Mar 17 2016
 
 // tag::dev_guide_thu_mar_17_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
@@ -19,8 +19,6 @@
 |link:../dev_guide/builds.html[Builds]
 
 |In the link:../dev_guide/builds.html#no-cache[No Cache] subsection of the link:../dev_guide/builds.html#docker-strategy-options[Docker Strategy Options] section, spelled `noCache` correctly in the example.
-
-
 
 |===
 

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -8,7 +8,7 @@
 == Mon Mar 21 2016
 
 // tag::install_config_mon_mar_21_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
@@ -24,7 +24,7 @@
 == Thu Mar 17 2016
 
 // tag::install_config_thu_mar_17_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
@@ -142,9 +142,8 @@ Pacemaker to Native HA]
 Pacemaker to native HA.
 
 |link:../install_config/cluster_metrics.html[Enabling Cluster Metrics]
-|Removed the template in the
-link:../install_config/cluster_metrics.html#creating-the-deployer-template[Creating
-the Deployer Template] section and fixed an incorrect file location.
+|Removed the template in the "Creating the Deployer Template" section and fixed
+an incorrect file location.
 
 |link:../install_config/aggregate_logging.html[Aggregating Container Logs]
 |Added a step within the
@@ -370,9 +369,7 @@ a Group Pruning Job] section.
 |Affected Topic |Description of Change
 
 |link:../install_config/cluster_metrics.html[Enabling Cluster Metrics]
-|Fixed the
-link:../install_config/cluster_metrics.html#creating-the-deployer-template[*_metrics-deployer.yaml_*
-file path].
+|Fixed the *_metrics-deployer.yaml_* file path.
 
 |link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
 |Added a link:../install_config/install/prerequisites.html#prereq-dns[Warning
@@ -441,13 +438,11 @@ Logs]
 path to the *_logging-deployer.yaml_* file].
 
 .2+|link:../install_config/cluster_metrics.html[Enabling Cluster Metrics]
-|Added information about
-link:../install_config/cluster_metrics.html#metrics-deployer-secrets[Metrics
-Deployer certificates] and the `nothing=/dev/null` option.
+|Added information about Metrics Deployer certificates and the
+`nothing=/dev/null` option.
 
-|Added clarification about
-link:../install_config/cluster_metrics.html#metrics-deployer-secrets[required
-host names] for the Hawkular Metrics certificate.
+|Added clarification about required host names for the Hawkular Metrics
+certificate.
 |===
 // end::install_config_mon_jan_19_2016[]
 

--- a/release_notes/revhistory_release_notes.adoc
+++ b/release_notes/revhistory_release_notes.adoc
@@ -7,7 +7,7 @@
 == Thu Mar 17 2016
 
 // tag::release_notes_thu_mar_17_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
@@ -16,8 +16,6 @@
 |link:../release_notes/ose_3_1_release_notes.html[OpenShift Enterprise 3.1 Release Notes]
 
 |Changed a known issue to a fix regarding liveness and readiness probes.
-
-
 
 |===
 

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -8,17 +8,17 @@
 == Tue Mar 22 2016
 
 // tag::using_images_tue_mar_22_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
 //Tue Mar 22 2016
 
 |link:../using_images/xpaas_images/eap.html[EAP xPaaS Image 7.0 Beta]
-|Updated the EAP xPaaS image for 7.0 Beta release
+|Updated the EAP xPaaS image for 7.0 Beta release.
 
 |link:../using_images/xpaas_images/sso.html[SSO xPaaS Image TP]
-|Added the Red Hat SSO xPaaS tech preview image documentation
+|New topic for the Red Hat SSO xPaaS Technology Preview image.
 
 |===
 
@@ -27,7 +27,7 @@
 == Mon Mar 21 2016
 
 // tag::using_images_mon_mar_21_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -12,30 +12,30 @@ The following sections aggregate the revision histories of each guide by publish
 include::using_images/revhistory_using_images.adoc[tag=using_images_tue_mar_22_2016]
 
 == Mon Mar 21 2016
-.Admin Guide
-include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_mon_mar_21_2016]
-
-.Install Config
+.Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_mon_mar_21_2016]
+
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_mon_mar_21_2016]
 
 .Using Images
 include::using_images/revhistory_using_images.adoc[tag=using_images_mon_mar_21_2016]
 
 == Thu Mar 17 2016
-.Architecture
-include::architecture/revhistory_architecture.adoc[tag=architecture_thu_mar_17_2016]
-
 .Release Notes
 include::release_notes/revhistory_release_notes.adoc[tag=release_notes_thu_mar_17_2016]
 
-.Dev Guide
-include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_thu_mar_17_2016]
+.Architecture
+include::architecture/revhistory_architecture.adoc[tag=architecture_thu_mar_17_2016]
 
-.Install Config
+.Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_thu_mar_17_2016]
 
-.Admin Guide
+.Cluster Administration
 include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_thu_mar_17_2016]
+
+.Developer Guide
+include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_thu_mar_17_2016]
 
 == Mon Mar 7 2016
 .Architecture


### PR DESCRIPTION
@vikram-redhat This should get the 3.1 Install&Config book back on track on the Portal.

The CP Jenkins job was failing because we changed some IDs but they were still referenced in some older revhistory notes, which were accurate links at the time. For the problem links, I've just made them no longer be links.
