### PR TITLE
fix typo

### DIFF
--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -73,7 +73,7 @@ A container is guaranteed the amount of memory it requests. A container may use
 more memory than requested, but once it exceeds its requested amount, it could
 be killed in a low memory situation on the node.
 
-If a container uses less memory than requested, it will not be killed unless
+If a container uses more memory than requested, it will not be killed unless
 system tasks or daemons need more memory than was accounted for in the node's
 resource reservation. If a container specifies a limit on memory, it is
 immediately killed if it exceeds the limited amount.


### PR DESCRIPTION
when a container with request set and no limit set, if it uses more memory than requested, it will not be killed .....
