### PR TITLE
Revhistories: adjust cols + spell out book names

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -8,7 +8,7 @@
 == Tue Mar 29 2016
 
 // tag::admin_guide_tue_mar_29_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -8,7 +8,7 @@
 == Tue Mar 29 2016
 
 // tag::architecture_tue_mar_29_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -8,7 +8,7 @@
 == Tue Mar 29 2016
 
 // tag::install_config_tue_mar_29_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -8,7 +8,7 @@
 == Tue Mar 29 2016
 
 // tag::using_images_tue_mar_29_2016[]
-[options="header"]
+[cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -8,17 +8,18 @@
 The following sections aggregate the revision histories of each guide by publish date.
 
 == Tue Mar 29 2016
-.Using Images
-include::using_images/revhistory_using_images.adoc[tag=using_images_tue_mar_29_2016]
-
-.Admin Guide
-include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_tue_mar_29_2016]
-
-.Install Config
-include::install_config/revhistory_install_config.adoc[tag=install_config_tue_mar_29_2016]
 
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_tue_mar_29_2016]
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_tue_mar_29_2016]
+
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_tue_mar_29_2016]
+
+.Using Images
+include::using_images/revhistory_using_images.adoc[tag=using_images_tue_mar_29_2016]
 
 == Tue Mar 22 2016
 .Using Images


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1827 for formatting. The script needs to be updated to set these cols + spell out the books better. I had just done this same cleanup yesterday while I was fixing the OSE 3.1 build for the CP jobs (https://github.com/openshift/openshift-docs/pull/1821).

cc @tpoitras @vikram-redhat 
