### PR TITLE
admin runonce plugin: remove pluginOrderOverride

### DIFF
--- a/admin_guide/limit_runonce_pod_duration.adoc
+++ b/admin_guide/limit_runonce_pod_duration.adoc
@@ -19,11 +19,8 @@ The main reason to have such a limit is to prevent tasks such as builds to run f
 
 == Configuring the RunOnceDuration plug-in
 
-Because the `RunOnceDuration` plug-in is not enabled by default, it must be specified along with default Kubernetes admission
-control plug-ins in the master-config.yaml configuration file.
-
-The plugin configuration can also include the default active deadline for run-once pods. This deadline will be enforced globally
-but can be superseded on per-project basis.
+The plug-in configuration should include the default active deadline for run-once pods. This deadline will be enforced globally
+but can be superseded on a per-project basis.
 
 ====
 
@@ -31,25 +28,15 @@ but can be superseded on per-project basis.
 ----
 kubernetesMasterConfig:
   admissionConfig:
-    pluginOrderOverride:
-    - RunOnceDuration <1>
-    - NamespaceLifecycle
-    - OriginPodNodeEnvironment
-    - LimitRanger
-    - ServiceAccount
-    - SecurityContextConstraint
-    - ResourceQuota
-    - SCCExecRestrictions
     pluginConfig:
       RunOnceDuration:
         configuration:
           apiVersion: v1
           kind: RunOnceDurationConfig
-          activeDeadlineSecondsOverride: 3600 <2>
+          activeDeadlineSecondsOverride: 3600 <1>
 ----
 
-<1> Add the plugin to the list of admission control plugins.
-<2> Specify the global default for run-once pods in seconds.
+<1> Specify the global default for run-once pods in seconds.
 
 ====
 


### PR DESCRIPTION
It's no longer required in origin / OSE 3.2.
Per https://github.com/openshift/origin/pull/8145#issuecomment-203220640
