### PR TITLE
Documented recent image quota restrictions

### DIFF
--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -15,9 +15,9 @@ toc::[]
 // tag::admin_limits_overview[]
 A limit range, defined by a `*LimitRange*` object, enumerates
 link:../dev_guide/compute_resources.html#dev-compute-resources[compute resource
-constraints] in a link:../dev_guide/projects.html[project] at the pod and
-container level, and specifies the amount of resources that a pod or container
-can consume.
+constraints] in a link:../dev_guide/projects.html[project] at the pod,
+container, image and image stream level, and specifies the amount of resources
+that a pod, container, image or image stream can consume.
 
 All resource create and modification requests are evaluated against each
 `*LimitRange*` object in the project. If the resource violates any of the
@@ -28,30 +28,27 @@ default value is applied to the resource.
 
 
 [[limit-range-def]]
-// tag::admin_limits_sample_definition[]
+// tag::admin_limits_sample_definitions[]
 
-.Limit Range Object Definition
+.Core Limit Range Object Definition
 ====
 
 [source,yaml]
 ----
-
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "core-resource-limits" <1>
 spec:
   limits:
-    -
-      type: "Pod"
+    - type: "Pod"
       max:
         cpu: "2" <2>
         memory: "1Gi" <3>
       min:
         cpu: "200m" <4>
         memory: "6Mi" <5>
-    -
-      type: "Container"
+    - type: "Container"
       max:
         cpu: "2" <6>
         memory: "1Gi" <7>
@@ -87,7 +84,34 @@ specified.
 <13> The default amount of memory that a container will request to use if not specified.
 <14> The maximum amount of CPU burst that a container can make as a ratio of its limit over request.
 ====
-// end::admin_limits_sample_definition[]
+
+.OpenShift Limit Range Object Definition
+====
+[source,yaml]
+----
+apiVersion: "v1"
+kind: "LimitRange"
+metadata:
+  name: "openshift-resource-limits"
+spec:
+  limits:
+    - type: openshift.io/Image
+      max:
+        storage: 1Gi <1>
+    - type: openshift.io/ImageStream
+      max:
+        openshift.io/image-tags: 20 <2>
+        openshift.io/images: 30 <3>
+----
+<1> The maximum size of an image that can be pushed to an internal registry.
+<2> The maximum number of unique image tags per image stream's spec.
+<3> The maximum number of unique image references per image stream's status.
+====
+
+Both core and OpenShift resources can be specified in just one limit range
+object. They are seperated here into two examples for clarity.
+// end::admin_limits_sample_definitions[]
+
 
 [[container-limits]]
 === Container Limits
@@ -181,6 +205,110 @@ Across all containers in a pod, the following must hold true:
 |===
 // end::admin_limits_pod_limits[]
 
+[[image-limits]]
+=== Image Limits
+
+// tag::admin_limits_image_limits[]
+
+*Supported Resources:*
+
+* Storage
+
+*Resource type name:*
+
+- `openshift.io/Image`
+
+Per image, the following must hold true if specified:
+
+.Image
+[cols="3a,8a",options="header"]
+|===
+|Constraint |Behavior
+
+|`*Max*`
+|`image.dockerimagemetadata.size` less than or equal to `Max[resource]`
+|===
+
+[NOTE]
+====
+To prevent blobs exceeding the limit from being uploaded to the registry, the
+registry must be configured to enforce quota. An environment varibale
+`*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*` must be set to
+`*true*` which is done by default for new deployments. To update older
+deployment config, refer to
+link:../install_config/upgrading/manual_upgrades.html#enforcing-quota-in-the-registry[Enforcing
+quota in the Registry].
+====
+
+[WARNING]
+====
+The image size isn't always available in the manifest of uploaded image. This
+is especially the case for images built with docker of version 1.10 or higher
+and pushed to v2 registry. If such an image is pulled with older docker daemon,
+the image manifest will be converted by the registry to schema v1 lacking all
+the size information. No storage limit set on images will prevent it from being
+uploaded.
+
+link:https://github.com/openshift/origin/issues/7706[The issue] is being
+addressed.
+====
+
+// end::admin_limits_image_limits[]
+
+[[image-stream-limits]]
+=== Image Stream Limits
+
+// tag::admin_limits_image_stream_limits[]
+
+*Supported Resources:*
+
+* `openshift.io/image-tags`
+* `openshift.io/images`
+
+*Resource type name:*
+
+- `openshift.io/ImageStream`
+
+Per image stream, the following must hold true if specified:
+
+.ImageStream
+[cols="3a,8a",options="header"]
+|===
+|Constraint |Behavior
+
+|`*Max[openshift.io/image-tags]*`
+|`length( uniqueimagetags( imagestream.spec.tags ) )` less than or equal to `Max[openshift.io/image-tags]`
+
+Where `uniqueimagetags` returns unique references to images of given spec tags.
+
+|`*Max[openshift.io/images]*`
+|`length( uniqueimages( imagestream.status.tags ) )` less than or equal to `Max[openshift.io/images]`
+
+Where and `uniqueimages` returns unique image names found in status tags. The
+name equals to image's digest.
+
+|===
+
+==== Counting of image references
+
+Resource `openshift.io/image-tags` represents unique
+link:../dev_guide/managing_images.html#referencing-images-in-image-streams[image
+references]. Possible references are an `*ImageStreamTag*`, an
+`*ImageStreamImage*` and a `*DockerImage*`. They may be created using commands
+`oc tag` and `oc import-image` or by using
+link:../dev_guide/managing_images.html#adding-tag[tag
+tracking]. No distinction is done between internal and external references.
+Each unique reference tagged in the image stream's spec is counted just once
+though. It doesn't restrict pushes to an internal docker registry in any way
+but is useful for tag restriction.
+
+Resource `openshift.io/images` represents unique image names recorded in image
+stream status. It allows to restrict a number of images that can be pushed to
+the internal registry. As in prior case, internal and external references are
+not distinguished.
+
+// end::admin_limits_image_stream_limits[]
+
 [[creating-a-limit-range]]
 == Creating a Limit Range
 
@@ -217,14 +345,17 @@ resource-limits   6d
 ====
 ----
 $ oc describe limits resource-limits
-Name:		resource-limits
-Namespace:	demoproject
-Type		Resource	Min	Max	Default Request	Default Limit	Max Limit/Request Ratio
-----		--------	---	---	---------------	-------------	-----------------------
-Pod		cpu		30m	2	-		-		-
-Pod		memory		150Mi	1Gi	-		-		-
-Container	memory		150Mi	1Gi	307Mi		512Mi		-
-Container	cpu		30m	2	60m		1		-
+Name:                     limits
+Namespace:                default
+Type                      Resource                 Min  Max Request Limit Limit/Request
+----                      --------                 ---  --- ------- ----- -------------
+Pod                       memory                   6Mi  1Gi -       -     -
+Pod                       cpu                      200m  2  -       -     -
+Container                 cpu                      100m  2  200m    300m  10
+Container                 memory                   4Mi  1Gi 100Mi   200Mi -
+openshift.io/Image        storage                  -    1Gi -       -     -
+openshift.io/ImageStream  openshift.io/image-tags  -    10  -       -     -
+openshift.io/ImageStream  openshift.io/images      -    12  -       -     -
 ----
 ====
 // end::admin_limits_viewing[]

--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -92,6 +92,9 @@ A pod is in a terminal state if `status.phase in (Failed, Succeeded)` is true.
 
 |`*persistentvolumeclaims*`
 |The total number of persistent volume claims that can exist in the project.
+
+|`*openshift.io/imagestreams*`
+|The total number of image streams that can exist in the project.
 |===
 // end::admin_quota_resources_managed[]
 
@@ -191,13 +194,14 @@ explicit limit for those resources.
 
 // tag::admin_quota_object_counts[]
 
-.*_object-counts.yaml_*
+.*_core-object-counts.yaml_*
 ====
+[source,yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: object-counts
+  name: core-object-counts
 spec:
   hard:
     configmaps: "10" <1>
@@ -214,12 +218,28 @@ project.
 <5> The total number of services that can exist in the project.
 ====
 
+.*_openshift-object-counts.yaml_*
+====
+[source,yaml]
+----
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: openshift-object-counts
+spec:
+  hard:
+    openshift.io/imagestreams: "10" <1>
+----
+<1> The total number of image streams that can exist in the project.
+====
+
 // end::admin_quota_object_counts[]
 
 // tag::admin_quota_compute_resources[]
 
 .*_compute-resources.yaml_*
 ====
+[source,yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
@@ -249,6 +269,7 @@ exceed 2Gi.
 
 .*_besteffort.yaml_*
 ====
+[source,yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
@@ -303,17 +324,17 @@ $ oc get quota -n demoproject
 NAME                AGE
 besteffort          11m
 compute-resources   2m
-object-counts       29m
+core-object-counts  29m
 ----
 ====
 
-. Then, describe the quota you are interested in, for example the *object-counts*
-quota:
+. Then, describe the quota you are interested in, for example the
+*core-object-counts* quota:
 +
 ====
 ----
-$ oc describe quota object-counts -n demoproject
-Name:			object-counts
+$ oc describe quota core-object-counts -n demoproject
+Name:			core-object-counts
 Namespace:		demoproject
 Resource		Used	Hard
 --------		----	----
@@ -339,6 +360,7 @@ to have the set of resources regenerate at the desired amount of time (in
 seconds) and for the resources to be available again:
 
 ====
+[source,yaml]
 ----
 kubernetesMasterConfig:
   apiLevels:

--- a/admin_solutions/user_role_mgmt.adoc
+++ b/admin_solutions/user_role_mgmt.adoc
@@ -105,7 +105,7 @@ link:../admin_guide/limits.html#container-limits[container limits] and
 link:../admin_guide/limits.html#pod-limits[pod limits] that you can place within
 your project:
 +
-include::admin_guide/limits.adoc[tag=admin_limits_sample_definition]
+include::admin_guide/limits.adoc[tag=admin_limits_sample_definitions]
 +
 * These *_ResourceQuota_* examples explain all the
 link:../admin_guide/quota.html#sample-resource-quota-definitions[Object Counts]

--- a/dev_guide/compute_resources.adoc
+++ b/dev_guide/compute_resources.adoc
@@ -91,7 +91,7 @@ include::admin_guide/limits.adoc[tag=admin_limits_viewing]
 Full limit range definitions can be viewed by running `oc export` on the object.
 The following shows an example limit range definition:
 
-include::admin_guide/limits.adoc[tag=admin_limits_sample_definition]
+include::admin_guide/limits.adoc[tag=admin_limits_sample_definitions]
 
 [[dev-container-limits]]
 === Container Limits

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -747,6 +747,7 @@ link:#registry-configuration-reference[Review supported options].
 +
 .Registry configuration file
 ====
+[source,yaml]
 ----
 version: 0.1
 log:
@@ -768,6 +769,8 @@ middleware:
     - name: openshift
       options:
         pullthrough: true
+        enforcequota: false
+        projectcachettl: 1m
 ----
 ====
 
@@ -858,6 +861,7 @@ link:https://docs.docker.com/registry/configuration/#log[Upstream options] are s
 Example:
 
 ====
+[source,yaml]
 ----
 log:
   level: debug
@@ -892,6 +896,7 @@ link:https://docs.docker.com/registry/configuration/#maintenance[General registr
 
 .General Storage Configuration Options
 ====
+[source,yaml]
 ----
 storage:
   delete:
@@ -918,6 +923,7 @@ Auth options should not be altered. The *openshift* extension is the only
 supported option.
 
 ====
+[source,yaml]
 ----
 auth:
   openshift:
@@ -928,22 +934,35 @@ auth:
 [[docker-registry-configuration-reference-middleware]]
 ==== middleware
 
-The *repository* middleware extension should not be altered except for the
-*options* section to disable pull-through cache.
+The **repository** middleware extension allows to configure OpenShift middleware
+responsible for interaction with OpenShift and image proxying.
 
 [NOTE]
 ====
-The *middleware* section cannot be overridden using environment variables.
+The **middleware** section may not be overridden using environment variables.
+There are few exceptions though.
 ====
 
 ====
+[source,yaml]
 ----
 middleware:
   repository:
     - name: openshift
       options:
-        pullthrough: true
+        pullthrough: true <1>
+        enforcequota: false <2>
+        projectcachettl: 1m <3>
 ----
+<1> Let the registry act as a proxy for remote blobs.
+<2> Prevent blob uploads exceeding size limit defined in targeted project. It
+can be overridden using
+`*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*` environment variable.
+It will be set to `*true*` in future versions.
+<3> An expiration timeout for limits cached in the registry. The lower the
+value, the less time will it take for the limit changes to propagate to the
+registry. On the other hand, registry will query limits from the server more
+frequently and, as a consequence, pushes will be slower.
 ====
 
 The link:https://docs.docker.com/registry/configuration/#cloudfront[*cloudfront*
@@ -963,6 +982,7 @@ supported. link:#securing-the-registry[Learn how to alter these settings via
 environment variables]. Only the *tls* section should be altered. For example:
 
 ====
+[source,yaml]
 ----
 http:
   addr: :5000
@@ -982,6 +1002,7 @@ provides more comprehensive integration options.
 Example:
 
 ====
+[source,yaml]
 ----
 notifications:
   endpoints:

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -390,6 +390,35 @@ upgrade will fail and should be restarted automatically. This will not disrupt
 pods that are already running.
 ====
 
+[[enforcing-quota-in-the-registry]]
+=== Enforcing quota in the Registry
+
+To prevent layer blobs exceeding size limit from being written to registry's
+storage, quota must be enforced. This can be achieved either via a
+link:../install/docker_registry.html#registry-configuration-reference[configuration
+file]:
+
+====
+----
+...
+middleware:
+  repository:
+    - name: openshift
+      options:
+        enforcequota: true
+...
+----
+====
+
+Or with an environment variable
+`*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*`. The environment
+variable is set to `*true*` for the new registry deployments by default.
+Existing deployments need to be modified using:
+
+----
+# oc env dc/docker-registry REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA=true
+----
+
 [[updating-the-default-image-streams-and-templates]]
 == Updating the Default Image Streams and Templates
 


### PR DESCRIPTION
New limit range types:
- `openshift.io/Image` supporting `Max[storage]` limit
- `openshift.io/ImageStream` supporting the new limit resources

New resources for use with `openshift.io/ImageStream`:
- `openshift.io/image-tags`
- `openshift.io/image`

~~Depends on:~~
- ~~Origin PR https://github.com/openshift/origin/pull/8195~~
  - already merged
