### PR TITLE
Replace .sti -> .s2i in docs

### DIFF
--- a/creating_images/s2i.adoc
+++ b/creating_images/s2i.adoc
@@ -63,7 +63,7 @@ executable inside the builder image. S2I supports multiple options providing
 each build in the following order:
 
 1. A script found at the `--scripts-url` URL
-2. A script found in the application source `.sti/bin` directory
+2. A script found in the application source `.s2i/bin` directory
 3. A script found at the default image URL (`io.openshift.s2i.scripts-url` label)
 
 Both the `io.openshift.s2i.scripts-url` label specified in the image and the `--scripts-url` flag

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -200,7 +200,7 @@ link:../creating_images/s2i.html#s2i-scripts[S2I scripts] provided by the
 builder image in one of two ways. Either:
 
 1. Provide an *_assemble_*, *_run_*, and/or *_save-artifacts_* script in the
-*_.sti/bin_* directory of your application source repository, or
+*_.s2i/bin_* directory of your application source repository, or
 
 2. Provide a URL of a directory containing the scripts as part of the strategy
 definition. For example:
@@ -225,7 +225,7 @@ named script(s) provided in the image.
 [NOTE]
 ====
 Files located at the `*scripts*` URL take precedence over files located in
-*_.sti/bin_* of the source repository. See the
+*_.s2i/bin_* of the source repository. See the
 link:../creating_images/s2i.html[S2I Requirements] topic and the
 link:https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#sti-scripts[S2I
 documentation] for information on how S2I scripts are used.
@@ -243,24 +243,24 @@ link:#buildconfig-environment[*BuildConfig* environment] values.
 
 ==== Environment Files
 Source build enables you to set environment values (one per line) inside your
-application, by specifying them in a *_.sti/environment_* file in the source
+application, by specifying them in a *_.s2i/environment_* file in the source
 repository. The environment variables specified in this file are present during
 the build process and in the final Docker image. The complete list of supported
 environment variables is available in the
 link:../using_images/index.html[documentation] for each image.
 
-If you provide a *_.sti/environment_* file in your source repository, S2I reads
+If you provide a *_.s2i/environment_* file in your source repository, S2I reads
 this file during the build. This allows customization of the build behavior as
 the *_assemble_* script may use these variables.
 
 For example, if you want to disable assets compilation for your Rails
 application, you can add `*DISABLE_ASSET_COMPILATION=true*` in the
-*_.sti/environment_* file to cause assets compilation to be skipped during the
+*_.s2i/environment_* file to cause assets compilation to be skipped during the
 build.
 
 In addition to builds, the specified environment variables are also available in
 the running application itself. For example, you can add
-`*RAILS_ENV=development*` to the *_.sti/environment_* file to cause the Rails
+`*RAILS_ENV=development*` to the *_.s2i/environment_* file to cause the Rails
 application to start in `development` mode instead of `production`.
 
 [[buildconfig-environment]]
@@ -1813,7 +1813,7 @@ depends on the build strategy you are using.
 For a `*Source*` build strategy, you must put appropriate shell commands into
 the *_assemble_* script:
 
-.*_.sti/bin/assemble_* File
+.*_.s2i/bin/assemble_* File
 ====
 
 [source,bash]
@@ -1824,7 +1824,7 @@ wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
 ----
 ====
 
-.*_.sti/bin/run_* File
+.*_.s2i/bin/run_* File
 ====
 
 [source,bash]
@@ -1867,7 +1867,7 @@ environment variable defined on the `BuildConfig`, rather than updating the
 
 You can choose between different methods of defining environment variables:
 
-- link:#environment-files[Using the *_.sti/environment_* file] (only for a
+- link:#environment-files[Using the *_.s2i/environment_* file] (only for a
 `*Source*` build strategy)
 - link:#buildconfig-environment[Setting in `*BuildConfig*`]
 - link:../cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations[Providing

--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -93,7 +93,7 @@ configuration, delete, then re-run the process:
 == Configuring S2I Builds for Proxies
 
 S2I builds fetch dependencies from various locations. You can
-link:../dev_guide/builds.html#environment-files[use a *_.sti/environment_* file]
+link:../dev_guide/builds.html#environment-files[use a *_.s2i/environment_* file]
 to specify simple shell variables and OpenShift will react accordingly when
 seeing build images.
 

--- a/using_images/s2i_images/java.adoc
+++ b/using_images/s2i_images/java.adoc
@@ -72,7 +72,7 @@ sti build -e "MAVEN_ARGS=clean test package" <git_repo_URL> fabric8/java-main <t
 ----
 
 |`*JAVA_MAIN*`
-|Specifies the main class of the project. This can also be accomplished from within the *_.sti/environment_* file as a Maven property inside the project (*docker.env.Main*).
+|Specifies the main class of the project. This can also be accomplished from within the *_.s2i/environment_* file as a Maven property inside the project (*docker.env.Main*).
 |
 
 |===

--- a/using_images/s2i_images/nodejs.adoc
+++ b/using_images/s2i_images/nodejs.adoc
@@ -66,7 +66,7 @@ image stream definitions] for all the provided OpenShift images.
 The Node.js image offers environment variables that facilitate developing your application.
 
 To set these environment variables, you can place them into
-link:../../dev_guide/builds.html#environment-files[a *_.sti/environment_* file]
+link:../../dev_guide/builds.html#environment-files[a *_.s2i/environment_* file]
 inside your source code repository, or define them in
 link:../../dev_guide/builds.html#buildconfig-environment[the environment
 section] of the build configuration's `*sourceStrategy*` definition.

--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -67,7 +67,7 @@ The Perl image supports a number of environment variables which can be set to
 control the configuration and behavior of the Perl runtime.
 
 To set these environment variables, you can place them into
-link:../../dev_guide/builds.html#environment-files[a *_.sti/environment_* file]
+link:../../dev_guide/builds.html#environment-files[a *_.s2i/environment_* file]
 inside your source code repository, or define them in
 link:../../dev_guide/builds.html#buildconfig-environment[the environment
 section] of the build configuration's `*sourceStrategy*` definition.

--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -73,7 +73,7 @@ The PHP image supports a number of environment variables which can be set to
 control the configuration and behavior of the PHP runtime.
 
 To set these environment variables, you can place them into
-link:../../dev_guide/builds.html#environment-files[a *_.sti/environment_* file]
+link:../../dev_guide/builds.html#environment-files[a *_.s2i/environment_* file]
 inside your source code repository, or define them in
 link:../../dev_guide/builds.html#buildconfig-environment[the environment
 section] of the build configuration's `*sourceStrategy*` definition.

--- a/using_images/s2i_images/python.adoc
+++ b/using_images/s2i_images/python.adoc
@@ -66,7 +66,7 @@ The Python image supports a number of environment variables which can be set to
 control the configuration and behavior of the Python runtime.
 
 To set these environment variables, you can place them into
-link:../../dev_guide/builds.html#environment-files[a *_.sti/environment_* file]
+link:../../dev_guide/builds.html#environment-files[a *_.s2i/environment_* file]
 inside your source code repository, or define them in
 link:../../dev_guide/builds.html#buildconfig-environment[the environment
 section] of the build configuration's `*sourceStrategy*` definition.

--- a/using_images/s2i_images/ruby.adoc
+++ b/using_images/s2i_images/ruby.adoc
@@ -66,7 +66,7 @@ The Ruby image supports a number of environment variables which can be set to
 control the configuration and behavior of the Ruby runtime.
 
 To set these environment variables, you can place them into
-link:../../dev_guide/builds.html#environment-files[a *_.sti/environment_* file]
+link:../../dev_guide/builds.html#environment-files[a *_.s2i/environment_* file]
 inside your source code repository, or define them in
 link:../../dev_guide/builds.html#buildconfig-environment[the environment
 section] of the build configuration's `*sourceStrategy*` definition.


### PR DESCRIPTION
Fixes https://github.com/openshift/sti-python/issues/106.

@bparees @soltysh PTAL. Safe to point users to use `.s2i` instead of the deprecated `.sti`, correct?
