### PR TITLE
Changing example to a matching configuration for docker-registry pvc

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -78,7 +78,7 @@ persistent storage method of your choice].
 
 For example, to use an existing persistent volume claim:
 ----
-$ oc volume deploymentconfigs/docker-registry --add --name=v1 -t pvc \
+$ oc volume deploymentconfigs/docker-registry --add --name=registry-storage -t pvc \
      --claim-name=<pvc_name> --overwrite
 ----
 


### PR DESCRIPTION
The provided example for docker-registry using a PVC is not correct and references a volume-named called v1 where the correct name is docker-registry.
This is error prone.
