### PR TITLE
Bug 1304954: Updated steps for adding nodes

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -22,6 +22,7 @@ uses the information from node objects to validate nodes with
 link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node[health
 checks].
 
+[[listing-nodes]]
 == Listing Nodes
 To list all nodes that are known to the master:
 
@@ -35,7 +36,7 @@ node2.example.com    kubernetes.io/hostname=node2.example.com      Ready
 ----
 ====
 
-To only list information about a single node, replace `_<node>_` with the full
+To only list information about a single node, replace `<node>` with the full
 node name:
 
 ----
@@ -77,7 +78,6 @@ $ oc describe node <node>
 For example:
 
 ====
-[options="nowrap"]
 ----
 $ oc describe node node1.example.com
 Name:			node1.example.com
@@ -105,70 +105,63 @@ No events.
 ----
 ====
 
+[[adding-nodes]]
 == Adding Nodes
-You can add a node to an existing OpenShift instance using the `oc create`
-command and supplying a definition for a node object. After the newly-created
-node passes the health checks that are performed by the master, pods can be
-scheduled for the node.
 
-.To Add a Node to an Existing OpenShift Instance:
+To add nodes to your existing OpenShift cluster, you can run an Ansible playbook
+that handles installing the node components, generating the required
+certificates, and other important steps. See the
+link:../install_config/install/advanced_install.html#adding-nodes-advanced[advanced
+installation] method for instructions on running the playbook directly.
 
-. Create a definition for the new node.
-.. If you have an existing node object created, you can export the existing
-object to use as a starting point for the new node's
-link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node-object-definition[definition]:
-+
-----
-$ oc export node <node_name> > <filename>
-----
-+
-Modify the new file to meet the desired definition for your new node.
+ifdef::openshift-enterprise[]
+Alternatively, if you used the quick installation method, you can
+link:../install_config/install/quick_install.html#adding-nodes-or-reinstalling-quick[re-run
+the installer to add nodes], which performs the same steps.
+endif::[]
 
-.. If you do not have an existing node object, create a new file from scratch by
-following the
-link:../architecture/infrastructure_components/kubernetes_infrastructure.html#node-object-definition[example
-definition].
-
-. Create the node object using the file you created:
-+
-----
-$ oc create -f <filename>
-----
-+
-At this point, the master begins validating the new node by performing health
-checks.
-
-. Verify that the node was added by checking the output of the following
-command:
-+
-====
-
-----
-$ oc get nodes
-NAME                 LABELS                                        STATUS
-node1.example.com    kubernetes.io/hostname=node1.example.com      Ready
-node2.example.com    kubernetes.io/hostname=node2.example.com      Ready
-node3.example.com    kubernetes.io/hostname=node3.example.com      Ready
-----
-====
-+
-Pods are not scheduled for the node until the node passes the health checks that
-are performed by the master. When the node passes these health checks, it is
-then placed in the `Ready` condition.
-
+[[deleting-nodes]]
 == Deleting Nodes
-When you delete a node with the CLI, although the node object is deleted
-in Kubernetes, the pods that exist on the node itself are not deleted. However,
-the pods cannot be accessed by OpenShift. The behavior around deleting nodes and
-pods with the CLI is under active development.
 
-To delete a node:
+When you delete a node using the CLI, the node object is deleted in Kubernetes,
+but the pods that exist on the node itself are not deleted. Any bare pods not
+backed by a replication controller would be inaccessible to {product-title},
+pods backed by replication controllers would be rescheduled to other available
+nodes, and
+link:../install_config/master_node_configuration.html#node-configuration-files[local
+manifest pods] would need to be manually deleted.
 
+To delete a node from the {product-title} cluster:
+
+. link:#evacuating-pods-on-nodes[Evacuate pods] from the node you are preparing
+to delete.
+
+. Delete the node object:
++
 ----
 $ oc delete node <node>
 ----
 
+. Check that the node has been removed from the node list:
++
+----
+$ oc get nodes
+----
++
+Pods should now be only scheduled for the remaining nodes that are in *Ready*
+state.
+
+. If you want to uninstall all {product-title} content from the node host,
+including all pods and containers, continue to
+link:../install_config/install/advanced_install.html#uninstalling-nodes-advanced[Uninstalling
+Nodes] and follow the procedure using the *_uninstall.yml_* playbook. The
+procedure assumes general understanding of the
+link:../install_config/install/advanced_install.html[advanced installation
+method] using Ansible.
+
+[[updating-labels-on-nodes]]
 == Updating Labels on Nodes
+
 To add or update
 link:../architecture/core_concepts/pods_and_services.html#labels[labels] on a
 node:
@@ -186,7 +179,6 @@ $ oc label -h
 == Listing Pods on Nodes
 To list all or selected pods on one or more nodes:
 
-[options="nowrap"]
 ----
 $ oadm manage-node <node1> <node2> \
     --list-pods [--pod-selector=<pod_selector>] [-o json|yaml]
@@ -199,8 +191,9 @@ $ oadm manage-node --selector=<node_selector> \
     --list-pods [--pod-selector=<pod_selector>] [-o json|yaml]
 ----
 
-== Marking Nodes as Unschedulable or Schedulable
 [[marking-nodes-as-unschedulable-or-schedulable]]
+== Marking Nodes as Unschedulable or Schedulable
+
 By default, healthy nodes with a `Ready` link:#node-conditions[status] are
 marked as schedulable, meaning that new pods are allowed for placement on the
 node. Manually marking a node as unschedulable blocks any new pods from being
@@ -229,11 +222,13 @@ To mark a currently unschedulable node or nodes as schedulable:
 $ oadm manage-node <node1> <node2> --schedulable
 ----
 
-Alternatively, instead of specifying specific node names (e.g., `_<node1>_
-_<node2>_`), you can use the `--selector=_<node_selector>_` option to mark
-selected nodes as schedulable or unschedulable.
+Alternatively, instead of specifying specific node names (e.g., `<node1>
+<node2>`), you can use the `--selector=<node_selector>` option to mark selected
+nodes as schedulable or unschedulable.
 
+[[evacuating-pods-on-nodes]]
 == Evacuating Pods on Nodes
+
 Evacuating pods allows you to migrate all or selected pods from a given node or
 nodes. Nodes must first be
 link:#marking-nodes-as-unschedulable-or-schedulable[marked unschedulable] to
@@ -267,12 +262,13 @@ $ oadm manage-node <node1> <node2> \
     --evacuate --force [--pod-selector=<pod_selector>]
 ----
 
-Alternatively, instead of specifying specific node names (e.g., `_<node1>_
-_<node2>_`), you can use the `--selector=_<node_selector>_` option to evacuate
-pods on selected nodes.
+Alternatively, instead of specifying specific node names (e.g., `<node1>
+<node2>`), you can use the `--selector=<node_selector>` option to evacuate pods
+on selected nodes.
 
 [[configuring-node-resources]]
 == Configuring Node Resources
+
 You can configure node resources by adding kubelet arguments to the node
 configuration file (*_/etc/origin/node/node-config.yaml_*). Add the
 `*kubeletArguments*` section and include any desired options:

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -74,8 +74,7 @@ inventory file when link:#running-the-advanced-installation[running the advanced
 installation].
 
 [[configuring-host-variables]]
-
-*Configuring Host Variables*
+=== Configuring Host Variables
 
 To assign environment variables to hosts during the Ansible installation, indicate
 the desired variables in the *_/etc/ansible/hosts_* file after the host entry in
@@ -91,6 +90,7 @@ ec2-52-6-179-239.compute-1.amazonaws.com openshift_public_hostname=ose3-master.p
 The following table describes variables for use with the Ansible installer that
 can be assigned to individual host entries:
 
+[[advanced-host-variables]]
 .Host Variables
 [options="header"]
 |===
@@ -127,11 +127,10 @@ ifdef::openshift-enterprise[]
 Containerized installations are supported starting in OSE 3.1.1.
 endif::[]
 
-|`*docker_log_options*`
-|This variable configures container logging options that are supported by
-Docker's `json-file` logging driver. See
-link:../../install_config/install/prerequisites.html#managing-docker-container-logs[Managing
-Docker Container Logs] for available options.
+|`*openshift_node_labels*`
+|This variable adds labels to nodes during installation. See
+link:#configuring-node-host-labels[Configuring Node Host Labels] for more
+details.
 
 |`*openshift_node_kubelet_args*`
 |This variable is used to configure `kubeletArguments` on nodes, such as
@@ -146,7 +145,7 @@ invalid if used. These values override other settings in node configuration
 which may cause invalid configurations. Example usage:
 *{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
 
-|`*openshift_router_selector*` 
+|`*openshift_router_selector*`
 |Default node selector for automatically deploying router pods. See
 link:#configuring-node-host-labels[Configuring Node Host Labels] for details.
 
@@ -154,11 +153,16 @@ link:#configuring-node-host-labels[Configuring Node Host Labels] for details.
 |Default node selector for automatically deploying registry pods. See
 link:#configuring-node-host-labels[Configuring Node Host Labels] for details.
 
+|`*docker_log_options*`
+|This variable configures container logging options that are supported by
+Docker's `json-file` logging driver. See
+link:../../install_config/install/prerequisites.html#managing-docker-container-logs[Managing
+Docker Container Logs] for available options.
+
 |===
 
 [[configuring-cluster-variables]]
-
-*Configuring Cluster Variables*
+=== Configuring Cluster Variables
 
 To assign environment variables during the Ansible install that apply more
 globally to your OpenShift cluster overall, indicate the desired variables in
@@ -303,8 +307,7 @@ re-configured after deployment.
 |===
 
 [[configuring-node-host-labels]]
-
-*Configuring Node Host Labels*
+=== Configuring Node Host Labels
 
 You can assign
 link:../../architecture/core_concepts/pods_and_services.html#labels[labels] to
@@ -349,8 +352,7 @@ node1.example.com openshift_node_labels="{'region':'infra','zone':'default'}"
 ====
 
 [[marking-masters-as-unschedulable-nodes]]
-
-*Marking Masters as Unschedulable Nodes*
+=== Marking Masters as Unschedulable Nodes
 
 Any hosts you designate as masters during the installation process should also
 be configured as nodes by adding them to the *[nodes]* section so that the
@@ -373,8 +375,7 @@ master.example.com openshift_node_labels="{'region':'infra','zone':'default'}" o
 
 
 [[advanced-install-session-options]]
-
-*Configuring Session Options*
+=== Configuring Session Options
 
 link:../../install_config/configuring_authentication.html#session-options[Session
 options] in the OAuth configuration are configurable in the inventory file. By
@@ -416,7 +417,7 @@ openshift_master_session_encryption_secrets=['DONT+USE+THIS+SECRET+b4NV+pmZNSO']
 ====
 
 [[advanced-install-custom-certificates]]
-*Configuring Custom Certificates*
+=== Configuring Custom Certificates
 
 link:../../install_config/certificate_customization.html[Custom serving
 certificates] for the public host names of the OpenShift API and
@@ -495,8 +496,7 @@ openshift_master_overwrite_named_certificates: true
 ====
 
 [[single-master]]
-
-=== Single Master
+== Single Master Examples
 
 You can configure an environment with a single master and multiple nodes, and
 either a single embedded *etcd* or multiple external *etcd* hosts.
@@ -508,7 +508,6 @@ not supported.
 ====
 
 [[single-master-multi-node]]
-
 *Single Master and Multiple Nodes*
 
 The following table describes an example environment for a single
@@ -576,7 +575,6 @@ To use this example, modify the file to match your environment and
 specifications, and save it as *_/etc/ansible/hosts_*.
 
 [[single-master-multi-etcd-multi-node]]
-
 *Single Master, Multiple etcd, and Multiple Nodes*
 
 The following table describes an example environment for a single
@@ -661,8 +659,7 @@ To use this example, modify the file to match your environment and
 specifications, and save it as *_/etc/ansible/hosts_*.
 
 [[multiple-masters]]
-
-=== Multiple Masters
+== Multiple Masters Examples
 
 You can configure an environment with multiple masters, multiple *etcd* hosts,
 and multiple nodes. Configuring
@@ -711,7 +708,6 @@ To configure multiple masters, choose one of the above HA methods, and refer to
 the relevant example section that follows.
 
 [[multi-masters-using-native-ha]]
-
 *Multiple Masters Using Native HA*
 
 The following describes an example environment for three
@@ -841,7 +837,6 @@ leader. The interval can be configured with the `*osm_controller_lease_ttl*`
 variable.
 
 [[multi-masters-using-pacemaker]]
-
 *Multiple Masters Using Pacemaker*
 
 The following describes an example environment for three
@@ -978,7 +973,6 @@ instructions or workarounds.
 
 
 [[configuring-fencing]]
-
 == Configuring Fencing
 
 If you installed OpenShift using a link:#multiple-masters[configuration for
@@ -987,15 +981,15 @@ fencing device. See
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/High_Availability_Add-On_Reference/ch-fencing-HAAR.html[Fencing:
 Configuring STONITH] in the High Availability Add-on for Red Hat Enterprise
 Linux documentation for instructions, then continue to
-link:#verifying-the-installation[Verifying the Installation].
+link:#advanced-verifying-the-installation[Verifying the Installation].
 
-[[verifying-the-installation]]
-
+[[advanced-verifying-the-installation]]
 == Verifying the Installation
 
-After the installer completes, verify that the master is started and
-nodes are registered and reporting in *Ready* status.
-*On the master host*, run the following as root:
+// tag::verifying-the-installation[]
+After the installation completes, verify that the master is started and nodes
+are registered and reporting in *Ready* status. *On the master host*, run the
+following as root:
 
 ====
 ----
@@ -1007,6 +1001,7 @@ node1.example.com         kubernetes.io/hostname=node1.example.com,region=primar
 node2.example.com         kubernetes.io/hostname=node2.example.com,region=primary,zone=west          Ready
 ----
 ====
+// end::verifying-the-installation[]
 
 *Multiple etcd Hosts*
 
@@ -1084,8 +1079,190 @@ You can verify your installation by consulting the
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Load_Balancer_Administration/ch-haproxy-setup-VSA.html[HAProxy
 Configuration documentation].
 
-[[installer-known-issues]]
+[[adding-nodes-advanced]]
+== Adding Nodes to an Existing Cluster
 
+After your cluster is installed, you can install additional nodes and add them
+to your cluster by running the *_scaleup.yml_* playbook. This playbook queries
+the master, generates and distributes new certificates for the new nodes, then
+runs the configuration playbooks on the new nodes only.
+
+ifdef::openshift-enterprise[]
+This process is similar to re-running the installer in the
+link:../../install_config/install/quick_install.html#adding-nodes-or-reinstalling-quick[quick
+installation method to add nodes], however you have more configuration options
+available when using the advanced method and running the playbooks directly.
+endif::[]
+
+You must have an existing inventory file (for example, *_/etc/ansible/hosts_*)
+that is representative of your current cluster configuration in order to run the
+*_scaleup.yml_* playbook.
+ifdef::openshift-enterprise[]
+If you previously used the `atomic-openshift-installer` command to run your
+installation, you can check *_~/.config/openshift/.ansible/hosts_* for the last
+inventory file that the installer generated and use or modify that as needed as
+your inventory file. You must then specify the file location with `-i` when
+calling `ansible-playbook` later.
+endif::[]
+
+To add nodes to an existing cluster:
+
+. Ensure you have the latest playbooks by updating the *atomic-openshift-utils*
+package:
++
+----
+# yum update atomic-openshift-utils
+----
+
+. Edit your *_/etc/ansible/hosts_* file and add `new_nodes` to the
+*[OSEv3:children]* section:
++
+====
+----
+[OSEv3:children]
+masters
+nodes
+new_nodes
+----
+====
+
+. Then, create a *[new_nodes]* section much like the existing *[nodes]* section,
+specifying host information for any new nodes you want to add. For example:
++
+====
+----
+[nodes]
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
+node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+
+[new_nodes]
+node3.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+----
+====
++
+See link:#advanced-host-variables[Configuring Host Variables] for more options.
+
+. Now run the *_scaleup.yml_* playbook. If your inventory file is located
+somewhere other than the default *_/etc/ansible/hosts_*, specify the location
+with the `-i option`:
++
+----
+# ansible-playbook [-i /path/to/file] \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/scaleup.yml
+----
+
+. After the playbook completes successfully,
+link:#advanced-verifying-the-installation[verify the installation].
+
+. Finally, move any hosts you had defined in the *[new_nodes]* section up into
+the *[nodes]* section (but leave the *[new_nodes]* section definition itself in
+place) so that subsequent runs using this inventory file are aware of the nodes
+but do not handle them as new nodes. For example:
++
+====
+----
+[nodes]
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
+node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+node3.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+
+[new_nodes]
+----
+====
+
+[[uninstalling-advanced]]
+== Uninstalling {product-title}
+
+You can uninstall {product-title} hosts in your cluster by running the
+*_uninstall.yml_* playbook. This playbook deletes {product-title} content
+installed by Ansible, including:
+
+- Configuration
+- Containers
+- Default templates and image streams
+- Images
+- RPM packages
+
+The playbook will delete content for any hosts defined in the inventory file
+that you specify when running the playbook. If you want to uninstall
+{product-title} across all hosts in your cluster, run the playbook using the
+inventory file you used when installing {product-title} initially or ran most
+recently:
+
+----
+ifdef::openshift-enterprise[]
+# ansible-playbook [-i /path/to/file] \
+    /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml
+endif::[]
+ifdef::openshift-origin[]
+# ansible-playbook [-i /path/to/file] \
+    ~/openshift-ansible/playbooks/adhoc/uninstall.yml
+endif::[]
+----
+
+[[uninstalling-nodes-advanced]]
+=== Uninstalling Nodes
+
+You can also uninstall node components from specific hosts using the
+*_uninstall.yml_* playbook while leaving the remaining hosts and cluster alone:
+
+[WARNING]
+====
+This method should only be used when attempting to uninstall specific node hosts
+and not for specific masters or etcd hosts, which would require further
+configuration changes within the cluster.
+====
+
+. First follow the steps in
+link:../../admin_guide/manage_nodes.html#deleting-nodes[Deleting Nodes] to
+remove the node object from the cluster, then continue with the remaining steps
+in this procedure.
+
+. Create a different inventory file that only references those hosts. For
+example, to only delete content from one node:
++
+====
+----
+[OSEv3:children]
+nodes <1>
+
+[OSEv3:vars]
+ansible_ssh_user=root
+ifdef::openshift-enterprise[]
+deployment_type=openshift-enterprise
+endif::[]
+ifdef::openshift-origin[]
+deployment_type=origin
+endif::[]
+
+[nodes]
+node3.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}" <2>
+----
+<1> Only include the sections that pertain to the hosts you are interested in
+uninstalling.
+<2> Only include hosts that you want to uninstall.
+====
+
+. Specify that new inventory file using the `-i` option when running the
+*_uninstall.yml_* playbook:
++
+----
+ifdef::openshift-enterprise[]
+# ansible-playbook -i /path/to/new/file \
+    /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml
+endif::[]
+ifdef::openshift-origin[]
+# ansible-playbook -i /path/to/new/file \
+    ~/openshift-ansible/playbooks/adhoc/uninstall.yml
+endif::[]
+----
+
+When the playbook completes, all {product-title} content should be removed from
+any specified hosts.
+
+[[installer-known-issues]]
 == Known Issues
 
 The following are known issues for specified installation configurations.
@@ -1115,21 +1292,6 @@ image. If you are use bare metal machines:
 # rm -rf /etc/origin /var/lib/openshift /etc/etcd \
     /var/lib/etcd /etc/sysconfig/atomic-openshift* /etc/sysconfig/docker* \
     /root/.kube/config /etc/ansible/facts.d /usr/share/openshift
-----
-
-[[uninstalling-openshift-advanced]]
-
-== Uninstalling OpenShift
-
-You can uninstall OpenShift by running the following Ansible playbook:
-
-----
-ifdef::openshift-enterprise[]
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook ~/openshift-ansible/playbooks/adhoc/uninstall.yml
-endif::[]
 ----
 
 == What's Next?

--- a/install_config/install/index.adoc
+++ b/install_config/install/index.adoc
@@ -7,10 +7,10 @@
 :prewrap!:
 
 ifdef::openshift-enterprise[]
-The link:../../install_config/install/quick_install.html[quick installation] method
-allows you to use an interactive CLI utility to install OpenShift across a set
-of hosts. The utility is a self-contained wrapper intended for usage on a Red
-Hat Enterprise Linux 7 host.
+The link:../../install_config/install/quick_install.html[quick installation]
+method allows you to use an interactive CLI utility to install OpenShift across
+a set of hosts. This installer is a self-contained wrapper intended for usage on
+a Red Hat Enterprise Linux 7 host.
 endif::[]
 
 ifdef::openshift-origin[]

--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -20,15 +20,14 @@ toc::[]
 == Overview
 The _quick installation_ method allows you to use an interactive CLI utility,
 the `atomic-openshift-installer` command, to install OpenShift across a set of
-hosts. The installation utility can deploy OpenShift components on targeted
-hosts by either installing RPMs or running containerized services.
+hosts. This installer can deploy OpenShift components on targeted hosts by
+either installing RPMs or running containerized services.
 
 This installation method is provided to make the installation experience easier
 by link:#running-an-interactive-installation[interactively gathering the data]
-needed to run on each host. The utility is a self-contained wrapper intended for
-usage on a Red Hat Enterprise Linux (RHEL) 7 system. While RHEL Atomic Host is
-supported for running containerized OpenShift services, the installation utility
-is
+needed to run on each host. The installer is a self-contained wrapper intended
+for usage on a Red Hat Enterprise Linux (RHEL) 7 system. While RHEL Atomic Host
+is supported for running containerized OpenShift services, the installer is
 link:../../install_config/install/prerequisites.html#software-prerequisites[provided
 by an RPM] not available by default in RHEL Atomic Host, and must therefore be
 run from a RHEL 7 system. The host initiating the installation does not need to
@@ -37,12 +36,13 @@ be intended for inclusion in the OpenShift cluster, but it can be.
 In addition to running link:#running-an-interactive-installation[interactive
 installations] from scratch, the `atomic-openshift-installer` command can also
 be run or re-run using a predefined installation configuration file. This file
-can be used with the installation utility to:
+can be used with the installer to:
 
 - run an link:#running-an-unattended-installation[unattended installation],
-- link:#adding-nodes-or-reinstalling[add nodes] to an existing cluster,
+- link:#adding-nodes-or-reinstalling-quick[add nodes] to an existing cluster,
 - link:../../install_config/upgrading/index.html[upgrade your cluster], or
-- link:#adding-nodes-or-reinstalling[reinstall] the OpenShift cluster completely.
+- link:#adding-nodes-or-reinstalling-quick[reinstall] the OpenShift cluster
+completely.
 endif::[]
 
 Alternatively, you can use the link:advanced_install.html[advanced installation]
@@ -54,7 +54,7 @@ ifdef::openshift-enterprise[]
 
 == Before You Begin
 
-The installation utility allows you to install OpenShift
+The installer allows you to install OpenShift
 link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#master[master]
 and
 link:../../architecture/infrastructure_components/kubernetes_infrastructure.html#node[node]
@@ -117,20 +117,20 @@ Then follow the on-screen instructions to install a new OpenShift Enterprise
 cluster.
 
 After it has finished, ensure that you back up the
-*_~/.config/openshift/installer.cfg.yml_* link:#defining-an-installation-configuration-file[installation configuration
+*_~/.config/openshift/installer.cfg.yml_*
+link:#defining-an-installation-configuration-file[installation configuration
 file] that is created, as it is required if you later want to re-run the
 installation, add hosts to the cluster, or
-link:../../install_config/upgrading/index.html[upgrade your cluster]. Then, see
-link:#quick-install-whats-next[What's Next] for the next steps on configuring
-your OpenShift cluster.
+link:../../install_config/upgrading/index.html[upgrade your cluster]. Then,
+link:#quick-verifying-the-installation[verify the installation].
 
 [[defining-an-installation-configuration-file]]
 
 == Defining an Installation Configuration File
 
-The installation utility can use a predefined installation configuration file,
-which contains information about your installation, individual hosts, and
-cluster. When running an link:#running-an-interactive-installation[interactive
+The installer can use a predefined installation configuration file, which
+contains information about your installation, individual hosts, and cluster.
+When running an link:#running-an-interactive-installation[interactive
 installation], an installation configuration file based on your answers is
 created for you in *_~/.config/openshift/installer.cfg.yml_*. The file is
 created if you are instructed to exit the installation to manually modify the
@@ -184,10 +184,10 @@ set it to any user that has *sudo* privileges.
 master and node components.
 <7> Required. Allows the installer to connect to the system and gather facts
 before proceeding with the install.
-<8> Required for unattended installations. If these details are not
-specified, then this information is pulled from the facts gathered by the
-installation utility, and you are asked to confirm the details. If undefined for
-an unattended installation, the installation fails.
+<8> Required for unattended installations. If these details are not specified,
+then this information is pulled from the facts gathered by the installer, and
+you are asked to confirm the details. If undefined for an unattended
+installation, the installation fails.
 <9> Determines the type of services that are installed. At least one of these
 must be set to *true* for the configuration file to be considered valid.
 <10> If set to *true*, containerized OpenShift services are run on target master
@@ -216,27 +216,28 @@ Ensure you have read through the link:#quick-before-you-begin[Before You Begin].
 Unattended installations allow you to define your hosts and cluster
 configuration in an
 link:#defining-an-installation-configuration-file[installation configuration
-file] before running the installation utility so that you do not have to go
-through all of the link:#running-an-interactive-installation[interactive
-installation] questions and answers. It also allows you to resume an interactive
-installation you may have left unfinished, and quickly get back to where you
-left off.
+file] before running the installer so that you do not have to go through all of
+the link:#running-an-interactive-installation[interactive installation]
+questions and answers. It also allows you to resume an interactive installation
+you may have left unfinished, and quickly get back to where you left off.
 
 To run an unattended installation, first define an
 link:#defining-an-installation-configuration-file[installation configuration
-file] at *_~/.config/openshift/installer.cfg.yml_*. Then, run the installation
-utility with the `-u` flag:
+file] at *_~/.config/openshift/installer.cfg.yml_*. Then, run the installer with
+the `-u` flag:
 
 ----
 $ atomic-openshift-installer -u install
 ----
 
-By default in interactive or unattended mode, the installation utility uses the
+By default in interactive or unattended mode, the installer uses the
 configuration file located at *_~/.config/openshift/installer.cfg.yml_* if the
 file exists. If it does not exist, attempting to start an unattended
-installation fails. Alternatively, you can specify a different location for the
-configuration file using the `-c` option, but doing so will require you to
-specify the file location every time you run the installation:
+installation fails.
+
+Alternatively, you can specify a different location for the configuration file
+using the `-c` option, but doing so will require you to specify the file
+location every time you run the installation:
 
 ----
 $ atomic-openshift-installer -u -c </path/to/file> install
@@ -245,32 +246,52 @@ $ atomic-openshift-installer -u -c </path/to/file> install
 After the unattended installation finishes, ensure that you back up the
 *_~/.config/openshift/installer.cfg.yml_* file that was used, as it is required
 if you later want to re-run the installation, add hosts to the cluster, or
-link:../../install_config/upgrading/index.html[upgrade your cluster]. Then, see
-link:#quick-install-whats-next[What's Next] for the next steps on configuring
-your OpenShift cluster.
+link:../../install_config/upgrading/index.html[upgrade your cluster]. Then,
+link:#quick-verifying-the-installation[verify the installation].
 
-[[adding-nodes-or-reinstalling]]
+[[quick-verifying-the-installation]]
+== Verifying the Installation
 
+include::install_config/install/advanced_install.adoc[tag=verifying-the-installation]
+
+Then, see link:#quick-install-whats-next[What's Next] for the next steps on
+configuring your OpenShift cluster.
+
+[[adding-nodes-or-reinstalling-quick]]
 == Adding Nodes or Reinstalling the Cluster
 
-Whether you began the process using an
+You can use the installer to add nodes to your existing cluster, or to reinstall
+the cluster entirely.
+
+If you installed OpenShift using the installer in either
 link:#running-an-interactive-installation[interactive] or
-link:#running-an-unattended-installation[unattended] installation, you can
-re-run the installation as long as you have an
+link:#running-an-unattended-installation[unattended] mode, you can re-run the
+installation as long as you have an
 link:#defining-an-installation-configuration-file[installation configuration
-file] at *_~/.config/openshift/installer.cfg.yml_* (or specify its location with
-the `-c` option).
+file] at *_~/.config/openshift/installer.cfg.yml_* (or specify a different
+location with the `-c` option).
 
-To re-run an installation, use the `install` subcommand again in interactive or
+If you installed using the
+link:../../install_config/install/advanced_install.html[advanced installation]
+method and therefore do not have an installation configuration file, you can
+either try link:#defining-an-installation-configuration-file[creating your own]
+based on your cluster's current configuration, or see the advanced installation
+method on how to
+link:../../install_config/install/advanced_install.html#adding-nodes-advanced[run
+the playbook for adding new nodes directly].
+
+To add nodes or reinstall the cluster:
+
+. Re-run the installer with the `install` subcommand in interactive or
 unattended mode:
-
++
 ----
-$ atomic-openshift-installer install
+$ atomic-openshift-installer [-u] [-c </path/to/file>] install
 ----
 
-The installer will detect your installed environment and allow you to either add
-an additional node or perform a clean install:
-
+. The installer will detect your installed environment and allow you to either
+add an additional node or perform a clean install:
++
 ====
 ----
 Gathering information from hosts...
@@ -279,19 +300,23 @@ By default the installer only adds new nodes to an installed environment.
 Do you want to (1) only add additional nodes or (2) perform a clean install?:
 ----
 ====
++
+Choose one of the options and follow the on-screen instructions to complete your
+desired task.
 
-Choose one of the options and follow the on-screen  instructions to complete
-your desired task.
+[[uninstalling-quick]]
+== Uninstalling {product-title}
 
-[[uninstalling-openshift-quick]]
-
-== Uninstalling OpenShift
-
-You can uninstall OpenShift using the installation utility by running:
+You can uninstall {product-title} on all hosts in your cluster using the
+installer by running:
 
 ----
 $ atomic-openshift-installer uninstall
 ----
+
+See the
+link:../install/advanced_install.html#uninstalling-openshift-advanced[advanced
+installation method] for more options.
 
 [[quick-install-whats-next]]
 

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -26,7 +26,7 @@ ifdef::openshift-enterprise[]
 If you installed using the
 link:../../install_config/install/quick_install.html[quick installation] method
 and a *_~/.config/openshift/installer.cfg.yml_* file is available, you can use
-the installation utility to perform the automated upgrade.
+the installer to perform the automated upgrade.
 endif::[]
 
 The automated upgrade performs the following steps for you:
@@ -124,23 +124,23 @@ For any upgrade path, always ensure that you have the latest version of the
 ----
 
 There are two methods for running the automated upgrade:
-link:#upgrading-using-the-installation-utility-to-upgrade[using the installation
-utility] or link:#running-the-upgrade-playbook-directly[running the upgrade
-playbook directly]. Choose and follow one method.
+link:#upgrading-using-the-installation-utility-to-upgrade[using the installer]
+or link:#running-the-upgrade-playbook-directly[running the upgrade playbook
+directly]. Choose and follow one method.
 
 [[upgrading-using-the-installation-utility-to-upgrade]]
-== Using the Installation Utility to Upgrade
+== Using the Installer to Upgrade
 
 If you installed OpenShift using the
 link:../../install_config/install/quick_install.html[quick installation] method,
 you should have an installation configuration file located at
-*_~/.config/openshift/installer.cfg.yml_*. The installation utility requires
-this file to start an upgrade.
+*_~/.config/openshift/installer.cfg.yml_*. The installer requires this file to
+start an upgrade.
 
 [NOTE]
 ====
-The installation utility currently only supports upgrading from OpenShift
-Enterprise 3.0 to 3.1. See
+The installer currently only supports upgrading from OpenShift Enterprise 3.0 to
+3.1. See
 link:#upgrading-to-openshift-enterprise-3-1-asynchronous-releases[Upgrading to
 OpenShift Enterprise 3.1 Asynchronous Releases] for instructions on using
 Ansible directly.
@@ -148,14 +148,13 @@ Ansible directly.
 
 If you have an older format installation configuration file in
 *_~/.config/openshift/installer.cfg.yml_* from an existing OpenShift Enterprise
-3.0 installation, the installation utility will attempt to upgrade the file to
-the new supported format. If you do not have an installation configuration file
-of any format, you can
+3.0 installation, the installer will attempt to upgrade the file to the new
+supported format. If you do not have an installation configuration file of any
+format, you can
 link:../../install_config/install/quick_install.html#defining-an-installation-configuration-file[create
 one manually].
 
-To start the upgrade, run the installation utility with the `upgrade`
-subcommand:
+To start the upgrade, run the installer with the `upgrade` subcommand:
 
 ----
 # atomic-openshift-installer upgrade

--- a/release_notes/ose_3_1_release_notes.adoc
+++ b/release_notes/ose_3_1_release_notes.adoc
@@ -92,9 +92,9 @@ Job Controller Now Available::
 The job object type is now available, meaning that finite jobs can now be
 executed on the cluster.
 
-Installation Utility Updates::
-Multiple enhancements have been made to the Ansible-based installation
-utility. The utility can now:
+Installer Updates::
+Multiple enhancements have been made to the Ansible-based installer. The
+installer can now:
 * Perform container-based installations. (Fully supported starting in
 link:#ose-3-1-1[OpenShift Enterprise 3.1.1])
 * Install active-active, highly-available clusters.
@@ -549,16 +549,16 @@ properly cached and used for volume management.
 ==== Known Issues
 
 https://bugzilla.redhat.com/show_bug.cgi?id=1293578[*BZ#1293578*]::
-There was an issue with OpenShift Enterprise 3.1.1 where hosts with host names 
+There was an issue with OpenShift Enterprise 3.1.1 where hosts with host names
 that resolved to IP addresses that were not local to the host would run into
-problems with liveness and readiness probes on newly-created HAProxy routers. 
+problems with liveness and readiness probes on newly-created HAProxy routers.
 This was resolved in
 https://access.redhat.com/errata/product/290/ver=3.1/rhel---7/x86_64/RHBA-2016:0293[RHBA-2016:0293]
-by configuring the probes to use *localhost* as the hostname for pods with 
+by configuring the probes to use *localhost* as the hostname for pods with
 `*hostPort*` values.
 
-If you created a router under the affected version, and your liveness or 
-readiness probes unexpectedly fail for your router, then add *host: localhost*: 
+If you created a router under the affected version, and your liveness or
+readiness probes unexpectedly fail for your router, then add *host: localhost*:
 
 ====
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1304954

Removing the old, incorrect steps for adding nodes and adding in info on using the scaleup playbook or installer to add nodes. Still need to check on some things, but here's a WIP. Also coming across general old stuff that needed help, cleaning up as I go.

Pretty builds (internal):

http://file.rdu.redhat.com/~adellape/040716/add_node/admin_guide/manage_nodes.html#adding-nodes

http://file.rdu.redhat.com/~adellape/040716/add_node/install_config/install/quick_install.html#adding-nodes-or-reinstalling-quick

http://file.rdu.redhat.com/~adellape/040716/add_node/install_config/install/advanced_install.html#adding-nodes-advanced

FYI @abutcher 
