### PR TITLE
Add in extra warnings for Cassandra and its disk size.

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -154,6 +154,29 @@ link:../architecture/additional_concepts/storage.html#persistent-volumes[persist
 volume] and be able to survive a pod being restarted or recreated. This is ideal
 if you require your metrics data to be guarded from data loss.
 
+The size of the persisted volume can be specified with the `CASSANDRA_PV_SIZE` 
+link:../install_config/cluster_metrics.html#deployer-template-parameters[template parameter]. 
+By default it is set to 10 Gigabytes, which may or may not be sufficient for the size of the cluster you are using. 
+If you require more space, for instance 100 Gigabytes, you could specify it with something like
+this:
+
+----
+$ oc process -f metrics-deployer.yaml -v \
+    HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,CASSANDRA_PV_SIZE=100Gi \
+    | oc create -f -
+----
+
+[WARNING]
+====
+The size requirement of the Cassandra storage is dependent on the cluster size. It is
+the admin's responsibility to make sure that the size requires are sufficent for their setup and
+to monitor usage to make sure that the disk does not become full.
+
+*Data loss will result if the Cassandra persisted volume runs out of sufficient space.*
+====
+
+
+
 For cluster metrics to work with persistent storage, ensure that the persistent
 volume has the *ReadWriteOnce* access mode. If not, the persistent volume claim
 will not be able to find the persistent volume, and Cassandra will fail to
@@ -361,6 +384,16 @@ value should correspond to a fully qualified domain name. You will need to know
 the value of `*HAWKULAR_METRICS_HOSTNAME*` when
 link:../install_config/cluster_metrics.html#configuring-openshift-metrics[configuring
 the console] for metrics access.
+
+If you are using link:..install_config/cluster_metrics.html#metrics-persistent-storage[persistent storage]
+with Cassandra it is the admin's responsibility to set a sufficient disk size for the cluster using
+the `*CASSANDRA_PV_SIZE*` parameter. It is also the admin's responsibility to monitor disk usage to make
+sure that it does not become full.
+
+[WARNING]
+====
+*Data loss will result if the Cassandra persisted volume runs out of sufficient space.*
+====
 
 All of the other parameters are optional and allow for greater customization.
 For instance, if you have a custom install in which the Kubernetes master is not


### PR DESCRIPTION
We need to make it more clear that Cassandra can lose metric data if its persistent volume becomes full.
