### PR TITLE
Allow restricting allowed client certificates for RequestHeaderIdentityProvider

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -602,14 +602,16 @@ oauthConfig:
       challengeURL: "https://www.example.com/challenging-proxy/oauth/authorize?${query}" <5>
       loginURL: "https://www.example.com/login-proxy/oauth/authorize?${query}" <6>
       clientCA: /path/to/client-ca.file <7>
-      headers: <8>
+      clientCommonNames: <8>
+      - my-auth-proxy
+      headers: <9>
       - X-Remote-User
       - SSO-User
-      emailHeaders: <9>
+      emailHeaders: <10>
       - X-Remote-User-Email
-      nameHeaders: <10>
+      nameHeaders: <11>
       - X-Remote-User-Display-Name
-      preferredUsernameHeaders: <11>
+      preferredUsernameHeaders: <12>
       - X-Remote-User-Login
 ----
 <1> This provider name is prefixed to the user name in the request header to
@@ -633,13 +635,17 @@ replaced with the current query string.
 <7> Optional: PEM-encoded certificate bundle. If set, a valid client certificate
 must be presented and validated against the certificate authorities in the
 specified file before the request headers are checked for user names.
-<8> Header names to check, in order, for the user identity. The first header containing
+<8> Optional: list of common names (`cn`). If set, a valid client certificate with 
+a Common Name (`cn`) in the specified list must be presented before the request headers 
+are checked for user names. If empty, any Common Name is allowed. Can only be used in combination
+with `clientCA`.   
+<9> Header names to check, in order, for the user identity. The first header containing
 a value is used as the identity. Required, case-insensitive.
-<9> Header names to check, in order, for an email address. The first header containing
+<10> Header names to check, in order, for an email address. The first header containing
 a value is used as the email address. Optional, case-insensitive.
-<10> Header names to check, in order, for a display name. The first header containing
+<11> Header names to check, in order, for a display name. The first header containing
 a value is used as the display name. Optional, case-insensitive.
-<11> Header names to check, in order, for a preferred user name, if different than the immutable
+<12> Header names to check, in order, for a preferred user name, if different than the immutable
 identity determined from the headers specified in `headers`. The first header containing
 a value is used as the preferred user name when provisioning. Optional, case-insensitive.
 ====


### PR DESCRIPTION
1.2 / 3.2 only

Added in https://github.com/openshift/origin/pull/8443
