### PR TITLE
Overcommitment resource reservation refine description

### DIFF
--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -212,9 +212,29 @@ You can save your definition to a file, for example *_resource-reserver.yaml_*,
 then place the file in the node configuration directory, for example
 *_/etc/origin/node/_* or the `--config=<dir>` location if otherwise specified.
 +
-With this file in place, on start of the node, the node agent launches the
-specified container, and the remaining capacity for the scheduler to place
-cluster pods adjusts accordingly.
+At the same time node server needs to be configured to read the definition from the
+node configuration directory. If *_/etc/origin/node/_* is specifed, you can set the
+following in the
+link:../install_config/master_node_configuration.html[node configuration file]
+(the *_node-config.yaml_* file):
++
+====
+----
+kubeletArguments:
+  config:
+    - "/etc/origin/node"
+----
+====
++
+With the *_resource-reserver.yaml_* file in place, on start of the node server,
+the node agent launches the specified container,
+and the remaining capacity for the scheduler to place cluster pods adjusts accordingly.
++
+The *resource-reserver* pod is created as any other pod.
+All commands applicable for pods can be used.
++
+To remove the *resource-reserver* pod, you can delete or move *_resource-reserver.yaml_*
+from the node configuration directory.
 
 [[kernel-tunable-flags]]
 === Kernel Tunable Flags


### PR DESCRIPTION
The description is not clear how to actually set the node server to read object specifications from node configuration directory.
