### PR TITLE
Repositioned web console browser requirments information

### DIFF
--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -62,6 +62,42 @@ endif::[]
 
 image::about_page.png["About Page"]
 
+== Browser Requirements
+
+The following browser versions and operating systems can be used to access the
+web console. Browser support is divided into tiers:
+
+. Tier 1: Browser and operating system combinations that are fully tested and fully
+supported. Red Hat Engineering is committed to fixing issues with browsers on
+this tier.
+
+. Tier 2: Browser and operating system combinations that are partially tested, and are
+likely to work. Limited support is provided for this tier. Red Hat Engineering
+will attempt to fix issues with browsers on this tier.
+
+[cols="1,3,1"]
+.Browser Requirements
+|===
+|Browser (Latest Stable) |Operating System |Support Tier
+
+|Firefox
+|Fedora 23, Windows 8
+|Tier 1
+
+|Internet Explorer
+|Windows 8
+|Tier 1
+
+|Chrome
+|Fedora 23, Windows 8, and MacOSX
+|Tier 1
+
+|Safari
+|MacOSX, iPad 2, iPhone 4
+|Tier 1
+
+|===
+
 [[project-overviews]]
 
 == Project Overviews

--- a/dev_guide/authentication.adoc
+++ b/dev_guide/authentication.adoc
@@ -22,6 +22,10 @@ ifdef::openshift-origin[]
 image::login_page.png["Web Console Login Page"]
 endif::[]
 
+Review the
+link:../architecture/infrastructure_components/web_console.html[browser versions
+and operating systems] that can be used to access the web console.
+
 You can provide your login credentials on this page to obtain a token to make
 API calls. After logging in, you can navigate your projects using the
 link:../architecture/infrastructure_components/web_console.html[web console].

--- a/getting_started/developers/developers_console.adoc
+++ b/getting_started/developers/developers_console.adoc
@@ -17,39 +17,9 @@ include::getting_started/developers/developers_cli.adoc[tag=beforeyoubegin]
 
 == Browser Requirements
 
-The following browser versions and operating systems can be used to access the
-Web Console. Browser support is divided into tiers:
-
-. Tier 1: Browser and operating system combinations that are fully tested and fully
-supported. Red Hat Engineering is committed to fixing issues with browsers on
-this tier.
-
-. Tier 2: Browser and operating system combinations that are partially tested, and are
-likely to work. Limited support is provided for this tier. Red Hat Engineering
-will attempt to fix issues with browsers on this tier.
-
-[cols="1,3,1"]
-.Browser Requirements
-|===
-|Browser |Operating System |Support Tier
-
-|Firefox, Latest Stable
-|Fedora 23, Windows 8
-|Tier 1
-
-|IE, Latest Stable
-|Windows 8
-|Tier 1
-
-|Chrome, Latest Stable
-|Fedora 23, Windows 8, and MacOSX
-|Tier 1
-
-|Safari, Latest Stable
-|MacOSX, iPad 2, iPhone 4
-|Tier 1
-
-|===
+Review the
+link:../../architecture/infrastructure_components/web_console.html[browser versions
+and operating systems] that can be used to access the web console.
 
 == Tutorial Video
 


### PR DESCRIPTION
- Moved Browser Requirements section to the Architecture section
- Added pointers to that content in the Dev Guide and Getting Started books

Follow-up to https://github.com/openshift/openshift-docs/pull/1874
