### PR TITLE
Add Jenkins kube plugin section

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -182,6 +182,32 @@ as a source image for the build.
 <3> The `output` field defines the resulting, customized Jenkins image
 you can use in deployment configuration instead of the official Jenkins image.
 
+== Using Jenkins Kubernetes plugin to run jobs
+
+The official OpenShift Jenkins includes the pre-installed
+link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes
+Plugin] that allows Jenkins slaves to be dynamically provisioned on multiple
+Docker hosts using Kubernetes and OpenShift.
+
+The Jenkins image entrypoint also provides auto-discovery and auto-configuration
+of the Kubernetes plugins by scanning the project Jenkins is deployed in for
+existing image streams with the label `role` set to `jenkins-slave`.
+
+When an image stream with this label is found, the entrypoint will generate the
+corresponding Kubernetes plugin configuration so you can simply assign your
+Jenkins jobs to run in a Pod running the Docker image provided by the image
+stream.
+
+To use a Docker image as an Jenkins slave, the image has to run the slave agent
+as an entrypoint. For more details about this, refer to the official
+link:https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Launchslaveagentheadlessly[Jenkins
+documentation].
+
+Alternatively, you can use
+link:https://github.com/openshift/origin/blob/master/examples/jenkins-master/jenkins-slave-template.json[this]
+provided OpenShift template, to convert an existing image stream to a Jenkins
+slave.
+
 == Tutorial
 
 For more details on the sample job included in this image, see this link:https://github.com/openshift/origin/blob/master/examples/jenkins/README.md[tutorial].

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -182,30 +182,30 @@ as a source image for the build.
 <3> The `output` field defines the resulting, customized Jenkins image
 you can use in deployment configuration instead of the official Jenkins image.
 
-== Using Jenkins Kubernetes plugin to run jobs
+[[using-the-jenkins-kubernetes-plug-in-to-run-jobs]]
+== Using the Jenkins Kubernetes Plug-in to Run Jobs
 
-The official OpenShift Jenkins includes the pre-installed
-link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes
-Plugin] that allows Jenkins slaves to be dynamically provisioned on multiple
+The official OpenShift Jenkins image includes the pre-installed
+https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes
+plug-in] that allows Jenkins slaves to be dynamically provisioned on multiple
 Docker hosts using Kubernetes and OpenShift.
 
 The Jenkins image entrypoint also provides auto-discovery and auto-configuration
-of the Kubernetes plugins by scanning the project Jenkins is deployed in for
-existing image streams with the label `role` set to `jenkins-slave`.
+of the Kubernetes plug-ins by scanning the project Jenkins is deployed in for
+existing image streams with the label *role* set to *jenkins-slave*.
 
-When an image stream with this label is found, the entrypoint will generate the
-corresponding Kubernetes plugin configuration so you can simply assign your
-Jenkins jobs to run in a Pod running the Docker image provided by the image
-stream.
+When an image stream with this label is found, the entrypoint generates the
+corresponding Kubernetes plug-in configuration so you can assign your Jenkins
+jobs to run in a pod running the Docker image provided by the image stream.
 
-To use a Docker image as an Jenkins slave, the image has to run the slave agent
-as an entrypoint. For more details about this, refer to the official
-link:https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Launchslaveagentheadlessly[Jenkins
+To use a Docker image as an Jenkins slave, the image must run the slave agent as
+an entrypoint. For more details about this, refer to the official
+https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Launchslaveagentheadlessly[Jenkins
 documentation].
 
 Alternatively, you can use
-link:https://github.com/openshift/origin/blob/master/examples/jenkins-master/jenkins-slave-template.json[this]
-provided OpenShift template, to convert an existing image stream to a Jenkins
+https://github.com/openshift/origin/blob/master/examples/jenkins-master/jenkins-slave-template.json[a
+provided OpenShift template] to convert an existing image stream to a Jenkins
 slave.
 
 == Tutorial


### PR DESCRIPTION
Resurrects the commit from https://github.com/openshift/openshift-docs/pull/1580, rebases, continues edits.

This just includes the new "Using the Jenkins Kubernetes Plug-in to Run Jobs" section, as the "Using Jenkins image as Source-To-Image builder" section from https://github.com/openshift/openshift-docs/pull/1580 had already been merged and followed-up on in:

https://github.com/openshift/openshift-docs/pull/1316
https://github.com/openshift/openshift-docs/pull/1725

For downstream (OSE/OSD/Online), still tracking for 3.2 timeframe.

@mfojtik @tnguyen-rh @bparees PTAL
