### PR TITLE
Add global proxy config doc to Adv Install (WIP)

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -302,6 +302,86 @@ allocate 10.128.0.0/23, 10.128.2.0/23, 10.128.4.0/23, and so on. This *cannot* b
 re-configured after deployment.
 |===
 
+[[advanced-install-configuring-global-proxy]]
+=== Configuring Global Proxy Options
+
+If your hosts require use of a HTTP or HTTPS proxy in order to connect to
+external hosts, there are many components that must be configured to use the
+proxy, including masters, Docker, and builds. Node services only connect to the
+master API requiring no external access and therefore do not need to be
+configured to use a proxy.
+
+In order to simplify this configuration, the following Ansible variables can be
+specified at a cluster or host level to apply these settings uniformly across
+your environment.
+
+[NOTE]
+====
+See link:../../install_config/build_defaults_overrides.html[Configuring
+Global Build Defaults and Overrides] for more information on how the proxy
+environment is defined for builds.
+====
+
+.Cluster Proxy Variables
+[options="header"]
+|===
+
+|Variable |Purpose
+
+|`*openshift_http_proxy*`
+|This variable specifies the `*HTTP_PROXY*` environment variable for masters and
+the Docker daemon.
+
+|`*openshift_https_proxy*`
+|This variable specifices the `*HTTPS_PROXY*` environment variable for masters
+and the Docker daemon.
+
+|`*openshift_no_proxy*`
+|This variable is used to set the `*NO_PROXY*` environment variable for masters
+and the Docker daemon. This value should be set to a comma separated list of
+host names or wildcard host names that should not use the defined proxy. This
+list will be augmented with the list of all defined {product-title} host names
+by default.
+
+|`*openshift_generate_no_proxy_hosts*`
+|This boolean variable specifies whether or not the names of all defined
+OpenShift hosts and `pass:[*.cluster.local]` should be automatically appended to
+the `*NO_PROXY*` list. Defaults to *true*; set it to *false* to override this
+option.
+
+|`*openshift_builddefaults_http_proxy*`
+|This variable defines the `*HTTP_PROXY*` environment variable inserted into
+builds using the `*BuildDefaults*` admission controller. If
+`*openshift_http_proxy*` is set, this variable will inherit that value; you only
+need to set this if you want your builds to use a different value.
+
+|`*openshift_builddefaults_https_proxy*`
+|This variable defines the `*HTTPS_PROXY*` environment variable inserted into
+builds using the `*BuildDefaults*` admission controller. If
+`*openshift_https_proxy*` is set, this variable will inherit that value; you
+only need to set this if you want your builds to use a different value.
+
+|`*openshift_builddefaults_no_proxy*`
+|This variable defines the `*NO_PROXY*` environment variable inserted into
+builds using the `*BuildDefaults*` admission controller. If
+`*openshift_no_proxy*` is set, this variable will inherit that value; you only
+need to set this if you want your builds to use a different value.
+
+|`*openshift_builddefaults_git_http_proxy*`
+|This variable defines the HTTP proxy used by `git clone` operations during a
+build, defined using the `*BuildDefaults*` admission controller. If
+`*openshift_builddefaults_http_proxy*` is set, this variable will inherit that
+value; you only need to set this if you want your `git clone` operations to use
+a different value.
+
+|`*openshift_builddefaults_git_https_proxy*`
+|This variable defines the HTTPS proxy used by `git clone` operations during a
+build, defined using the `*BuildDefaults*` admission controller. If
+`*openshift_builddefaults_https_proxy*` is set, this variable will inherit that
+value; you only need to set this if you want your `git clone` operations to use
+a different value.
+|===
+
 [[configuring-node-host-labels]]
 === Configuring Node Host Labels
 


### PR DESCRIPTION
Pulls in and builds on https://github.com/openshift/openshift-docs/pull/1607. Still WIP til https://github.com/openshift/openshift-ansible/pull/1385 merges. cc @sdodson 

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/041416/global-proxy-config/install_config/install/advanced_install.html#advanced-install-configuring-global-proxy
