### PR TITLE
Add url configuration directive for keystone auth

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -290,6 +290,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: KeystonePasswordIdentityProvider
+      url: https://keystone_url:5000/v2.0
       domainName: default <5>
       ca: ca.pem <6> 
       certFile: keystone.pem <7> 


### PR DESCRIPTION
Url is needed for configuring keystone authentication, let's mention it.
