### PR TITLE
Changed recommended nfs export options

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -90,17 +90,6 @@ $ oc volume deploymentconfigs/docker-registry \
      --source='{"nfs": { "server": "<fqdn>", "path": "/path/to/export"}}'
 ----
 
-[[session-affinity-workaround]]
-There are link:#registry-known-issues[known issues] when using multiple registry
-replicas with the same NFS volume. We recommend changing the docker-registry
-service's `*sessionAffinity*` to *ClientIP*:
-
-----
-$ oc get -o yaml svc docker-registry | \
-      sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
-      oc replace -f -
-----
-
 [[non-production-use]]
 ==== Non-Production use
 
@@ -957,6 +946,7 @@ During a push of an image, you may see one of the following errors:
 
 * `digest invalid: provided digest did not match uploaded content`
 * `blob upload unknown`
+* `blob upload invalid`
 
 The error is returned by an internal registry service when Docker attempts to
 push the image. Its cause originates in the synchronization of file attributes
@@ -964,10 +954,28 @@ across nodes. Factors such as NFS client side caching, network latency, and
 layer size can all contribute to potential errors that might occur when pushing
 an image using the default round-robin load balancing configuration.
 
-link:#session-affinity-workaround[One possible workaround] is to set the
-*docker-registry* service's `*sessionAffinity*` to *ClientIP*. This ensures that
-requests from a particular Docker client will always be handled by the same
-replica.
+There are two simple steps you can do to minimize probability of such a failure.
+
+1. Ensure that the `*sessionAffinity*` of your `docker-registry` service is set
+to `*ClientIP*`:
++
+----
+$ oc get svc/docker-registry --template='{{.spec.sessionAffinity}}'
+----
++
+Should give you `*ClientIP*` which is the default in recent OpenShift versions.
+If not, change it like this:
++
+----
+$ oc get -o yaml svc/docker-registry | \
+      sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
+      oc replace -f -
+----
++
+2. Ensure that the NFS export line of your registry volume on your NFS server
+has `*sync*` and `*no_wdelay*` options listed. See
+link:../persistent_storage/persistent_storage_nfs.html#nfs-export-settings[NFS
+export settings] for details.
 
 [[registry-whats-next]]
 == What's Next?

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -128,7 +128,7 @@ PVC:
 [[nfs-enforcing-disk-quotas]]
 == Enforcing Disk Quotas
 
-You can uses disk partitions to enforce disk quotas and size constraints. Each
+You can use disk partitions to enforce disk quotas and size constraints. Each
 partition can be its own export. Each export is one PV. OpenShift enforces
 unique names for PVs, but the uniqueness of the NFS volume's server and path is
 up to the administrator.
@@ -318,8 +318,11 @@ exported volume on the NFS server should conform to the following conditions:
 - Each export must be:
 +
 ----
-/<example_fs> *(rw,root_squash)
+/<example_fs> *(rw,root_squash,no_wdelay)
 ----
++
+Where the `no_wdelay` stops the server from delaying the writes which greatly
+improves read-after-write consistency.
 - The firewall must be configured to allow traffic to the mount point. For NFSv4,
 the default port is 2049 (*nfs*). For NFSv3, there are three ports to configure:
 2049 (*nfs*), 20048 (*mountd*), and 111 (*portmapper*).


### PR DESCRIPTION
This aims to prevent from registry push failures.

See the bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1277356 for
details.
