### PR TITLE
Adds volumName

### DIFF
--- a/dev_guide/persistent_volumes.adoc
+++ b/dev_guide/persistent_volumes.adoc
@@ -61,6 +61,7 @@ spec:
   resources:
     requests:
       storage: "5Gi"
+  volumeName: "pv0001"
 ----
 ====
 


### PR DESCRIPTION
Corrects issue detailed in this bug:

Docs barely make reference to the ability to specify PV by name
https://bugzilla.redhat.com/show_bug.cgi?id=1327308
