### PR TITLE
Fix links/formatting/etc in Disconnected Install

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -217,6 +217,7 @@ Topics:
         Distros: openshift-origin,openshift-enterprise
       - Name: Disconnected Installation
         File: disconnected_install
+        Distros: openshift-enterprise
       - Name: Deploying a Docker Registry
         File: docker_registry
       - Name: Deploying a Router

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -13,55 +13,57 @@ toc::[]
 == Overview
 
 Frequently, portions of a datacenter may not have access to the Internet, even
-via proxy servers. Installing OpenShift in these environments is considered a
-disconnected installation.
+via proxy servers. Installing {product-title} in these environments is
+considered a disconnected installation.
 
-An OpenShift Enterprise disconnected installation differs from a regular
+An {product-title} disconnected installation differs from a regular
 installation in two primary ways:
 
-* The OpenShift software channels and repositories are not available via Red Hat’s content distribution network. 
-* OpenShift uses several Dockerized components. Normally, these images are pulled
-directly from Red Hat’s Docker registry. In a disconnected environment, this is
-not possible.
+- The {product-title} software channels and repositories are not available via Red Hat’s
+content distribution network.
+- {product-title} uses several containerized components. Normally, these images
+are pulled directly from Red Hat’s Docker registry. In a disconnected
+environment, this is not possible.
 
-A disconnected installation ensures the OpenShift software is made available to
-the relevant servers, then follows the same installation process as a standard
-connected installation. This topic additionally details how to manually download
-the Docker images and transport them onto the relevant servers. 
+A disconnected installation ensures the {product-title} software is made
+available to the relevant servers, then follows the same installation process as
+a standard connected installation. This topic additionally details how to
+manually download the Docker images and transport them onto the relevant
+servers.
 
-Once installed, in order to use OpenShift, you will need source code in a source
-control repository (for example, Git). This topic assumes that an internal Git
-repository is available that can host source code and this repository is
-accessible from the OpenShift nodes. Installing the source control repository is
-outside the scope of this document.
+Once installed, in order to use {product-title}, you will need source code in a
+source control repository (for example, Git). This topic assumes that an
+internal Git repository is available that can host source code and this
+repository is accessible from the {product-title} nodes. Installing the source
+control repository is outside the scope of this document.
 
-Also, when you try building applications in OpenShift, your build may have some
-external dependencies, such as a Maven Repository or Gem files for Ruby
-applications. By default, Red Hat docker images try to reach out to external
-repositories on the Internet. You can configure OpenShift to use your own
+Also, when you try building applications in {product-title}, your build may have
+some external dependencies, such as a Maven Repository or Gem files for Ruby
+applications. By default, Red Hat Docker images try to reach out to external
+repositories on the Internet. You can configure {product-title} to use your own
 internal repositories. For the purposes of this document, we assume that such
-internal repositories already exist and are accessible from the OpenShift nodes
-hosts. Installing such repositories is outside the scope of this document.
- 
+internal repositories already exist and are accessible from the {product-title}
+nodes hosts. Installing such repositories is outside the scope of this document.
+
 [NOTE]
 ====
 You can also have a
-http://www.redhat.com/en/technologies/linux-platforms/satellite[Satellite]
-server that provides access to Red Hat content via the intranet/LAN. For
-environments with Satellite, you can synchronize the OpenShift software onto
-Satellite for use with the OpenShift servers. 
+http://www.redhat.com/en/technologies/linux-platforms/satellite[Red Hat
+Satellite] server that provides access to Red Hat content via an intranet or
+LAN. For environments with Satellite, you can synchronize the {product-title}
+software onto the Satellite for use with the {product-title} servers.
 
-https://access.redhat.com/documentation/en/red-hat-satellite/[Satellite 6.1]
-also introduces the ability to act as a Docker registry, and it can be used to
-host the OpenShift Dockerized components. Doing so is outside of the scope of
-this document.
+https://access.redhat.com/documentation/en/red-hat-satellite/[Red Hat Satellite
+6.1] also introduces the ability to act as a Docker registry, and it can be used
+to host the {product-title} containerized components. Doing so is outside of the
+scope of this document.
 ====
 
 [[disconnected-prerequisites]]
 == Prerequisites
 
 This document assumes that you understand
-link:../../architecture/index.adoc[OpenShift's overall architecture] and that
+link:../../architecture/index.html[OpenShift's overall architecture] and that
 you have already planned out what the topology of your environment will look
 like.
 
@@ -69,45 +71,44 @@ like.
 == Required Software and Components
 
 In order to pull down the required software repositories and Docker images, you
-will need a RHEL7 server with access to the Internet and at least 100GB of
-additional free space. All steps in this section should be performed on the
-internet-connected server as the root system user.
+will need a Red Hat Enterprise Linux (RHEL) 7 server with access to the Internet
+and at least 100GB of additional free space. All steps in this section should be
+performed on the Internet-connected server as the root system user.
 
 [[disconnected-syncing-repos]]
 === Syncing Repositories
 
-[NOTE]
-====
 Before you sync with the required repositories, you may need to import the
 appropriate GPG key:
-+
-----
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-----
-+
-If the key is not imported, the indicated package is deleted after syncing the repository. 
-====
 
-. Register the server with Red Hat’s customer portal. You will need to use
-the login and password associated with the account that has access to the
-OpenShift subscriptions.
+----
+# rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+----
+
+If the key is not imported, the indicated package is deleted after syncing the repository.
+
+To sync the required repositories:
+
+. Register the server with the Red Hat Customer Portal. You must use the login
+and password associated with the account that has access to the {product-title}
+subscriptions:
 +
 ----
 # subscription-manager register
 ----
 
-. Attach to a subscription that provides OpenShift channels. You can find the
-list of available subscriptions using: 
+. Attach to a subscription that provides {product-title} channels. You can find
+the list of available subscriptions using:
 +
 ----
 # subscription-manager list --available
 ----
 +
-Then, find the pool ID for the subscription that provides OpenShift, and attach
-it:
+Then, find the pool ID for the subscription that provides {product-title}, and
+attach it:
 +
 ----
-# subscription-manager attach --pool=${pool_id}
+# subscription-manager attach --pool=<pool_id>
 # subscription-manager repos --disable="*"
 # subscription-manager repos \
     --enable="rhel-7-server-rpms" \
@@ -116,29 +117,28 @@ it:
 ----
 
 . The `yum-utils` command provides the *reposync* utility, which lets you mirror
-yum repositories, and `createrepo` can create a usable yum repository from a
-directory.
+yum repositories, and `createrepo` can create a usable `yum` repository from a
+directory:
 +
 ----
 # yum -y install yum-utils createrepo docker git
 ----
 +
-You will need up to 110GB of free space in order to sync the software.
-Depending on how restrictive your organization’s policies are, you could
-re-connect this server to the disconnected LAN and use it as the repository
-server. You could use USB-connected storage and transport the software to
-another server that will act as the repository server. This topic covers these
-options.
+You will need up to 110GB of free space in order to sync the software. Depending
+on how restrictive your organization’s policies are, you could re-connect this
+server to the disconnected LAN and use it as the repository server. You could
+use USB-connected storage and transport the software to another server that will
+act as the repository server. This topic covers these options.
 
 . Make a path to where you want to sync the software (either locally or on your
 USB or other device):
 +
 ----
-# mkdir -p /path/to/repos
+# mkdir -p </path/to/repos>
 ----
 
-. Sync the packages and create the repo for each of them. You will need
-to modify the command for the appropriate path you created above:
+. Sync the packages and create the repository for each of them. You will need to
+modify the command for the appropriate path you created above:
 +
 ----
 # for repo in \
@@ -146,12 +146,14 @@ rhel-7-server-rpms rhel-7-server-extras-rpms \
 rhel-7-server-ose-3.1-rpms
 do
   reposync --gpgcheck -lm --repoid=${repo} --download_path=/path/to/repos
-  createrepo -v /path/to/repos/${repo}
+  createrepo -v </path/to/repos/>${repo}
 done
 ----
 
 [[disconnected-syncing-images]]
 === Syncing Images
+
+To sync the Docker images:
 
 . Start the Docker daemon:
 +
@@ -159,7 +161,7 @@ done
 # systemctl start docker
 ----
 
-. Pull all of the required OpenShift dockerized components:
+. Pull all of the required {product-title} containerized components:
 +
 ----
 # docker pull registry.access.redhat.com/openshift3/ose-haproxy-router:v3.1.0.4
@@ -170,8 +172,9 @@ done
 # docker pull registry.access.redhat.com/openshift3/ose-docker-registry:v3.1.0.4
 ----
 
-. Pull all of the required OpenShift Dockerized components for the additional centralized log aggregation and metrics aggregation components:
-
+. Pull all of the required {product-title} containerized components for the
+additional centralized log aggregation and metrics aggregation components:
++
 ----
 # docker pull registry.access.redhat.com/openshift3/logging-deployment
 # docker pull registry.access.redhat.com/openshift3/logging-elasticsearch
@@ -184,14 +187,14 @@ done
 # docker pull registry.access.redhat.com/openshift3/metrics-heapster
 ----
 
-. Pull Red Hat’s certified Source-to-Image (S2I) builder images.
-link:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
-is the process that OpenShift uses to take application code and build it into a
-Docker image to run on the platform.
-
-Any languages, runtimes, or databases that you do not intend to use,
-can be skipped.
-
+. Pull Red Hat’s certified
+link:../../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-to-Image
+(S2I)] builder images. S2I is the process that {product-title} uses to take
+application code and build it into a Docker image to run on the platform.
++
+Any languages, runtimes, or databases that you do not intend to use can be
+skipped:
++
 ----
 # docker pull registry.access.redhat.com/jboss-amq-6/amq-openshift
 # docker pull registry.access.redhat.com/jboss-eap-6/eap-openshift
@@ -208,20 +211,20 @@ can be skipped.
 # docker pull registry.access.redhat.com/openshift3/nodejs-010-rhel7
 ----
 
-[[disconnected-prepare-images-for-export]]
-=== Prepare Images for Export
+[[disconnected-preparing-images-for-export]]
+=== Preparing Images for Export
 
 Docker images can be exported from a system by first saving them to a tarball
-and then transporting them. 
+and then transporting them:
 
 . Make and change into a repository home directory:
 +
 ----
-# mkdir /path/to/repos/images
-# cd /path/to/repos/images
+# mkdir </path/to/repos/images>
+# cd </path/to/repos/images>
 ----
 
-. Export the OpenShift Dockerized components:
+. Export the {product-title} containerized components:
 +
 ----
 # docker save -o ose3-images.tar \
@@ -230,7 +233,7 @@ and then transporting them.
     registry.access.redhat.com/openshift3/ose-sti-builder \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-pod \
-    registry.access.redhat.com/openshift3/ose-docker-registry 
+    registry.access.redhat.com/openshift3/ose-docker-registry
 ----
 
 . If you synchronized the metrics and log aggregation images, export:
@@ -265,17 +268,17 @@ not sync in the previous section:
     registry.access.redhat.com/rhscl/python-27-rhel7 \
     registry.access.redhat.com/rhscl/python-34-rhel7 \
     registry.access.redhat.com/rhscl/ruby-22-rhel7 \
-    registry.access.redhat.com/openshift3/nodejs-010-rhel7 
----- 
+    registry.access.redhat.com/openshift3/nodejs-010-rhel7
+----
 
 [[disconnected-repo-server]]
 == Repository Server
 
-During the installation (and for later updates, should you so choose) you will
-need a webserver to host the repositories. RHEL7 can provide the Apache
+During the installation (and for later updates, should you so choose), you will
+need a webserver to host the repositories. RHEL 7 can provide the Apache
 webserver.
 
-*Option 1*: Re-configure as a Web server
+*Option 1*: Re-configuring as a Web server
 
 If you can re-connect the server where you synchronized the software and images
 to your LAN, then you can simply install Apache on the server:
@@ -289,8 +292,8 @@ Skip to link:#disconnected-placing-the-software[Placing the Software].
 *Option 2*: Building a Repository Server
 
 If you need to build a separate server to act as the repository server, install
-a new RHEL7 system with at least 110GB of space. On this repository server
-during the installation make sure you select the *Basic Web Server* option.
+a new RHEL 7 system with at least 110GB of space. On this repository server
+during the installation, make sure you select the *Basic Web Server* option.
 
 [[disconnected-placing-the-software]]
 === Placing the Software
@@ -298,7 +301,7 @@ during the installation make sure you select the *Basic Web Server* option.
 . If necessary, attach the external storage, and then copy the repository
 files into Apache’s root folder. Note that the below copy step (`cp -a`) should
 be substituted with move (`mv`) if you are repurposing the server you used to
-sync.
+sync:
 +
 ----
 # cp -a /path/to/repos /var/www/html/
@@ -309,7 +312,7 @@ sync.
 . Add the firewall rules:
 +
 ----
-# firewall-cmd --permanent  --add-service=http
+# firewall-cmd --permanent --add-service=http
 # firewall-cmd --reload
 ----
 
@@ -321,27 +324,27 @@ sync.
 ----
 
 [[disconnected-openshift-systems]]
-== OpenShift Systems
+== {product-title} Systems
 
-[[disconnected-build-your-hosts]]
-=== Build Your Hosts
+[[disconnected-building-your-hosts]]
+=== Building Your Hosts
 
 At this point you can perform the initial creation of the hosts that will be
-part of the OpenShift environment. It is recommended to use the latest version
-of Red Hat Enterprise Linux and to perform a minimal installation. You will also
+part of the {product-title} environment. It is recommended to use the latest version
+of RHEL 7 and to perform a minimal installation. You will also
 want to pay attention to the other
-link:../../install_config/install/prerequisites.adoc[OpenShift-specific
+link:../../install_config/install/prerequisites.html[{product-title}-specific
 prerequisites].
 
 Once the hosts are initially built, the repositories can be set up.
 
 [[disconnected-connecting-repos]]
-=== Connecting The Repositories
+=== Connecting the Repositories
 
-On all of the relevant systems that will need OpenShift software components,
-create the required repository definitions. Place the following text in the
-*_/etc/yum.repos.d/ose.repo_* file, replacing `<server_IP>` with the IP or
-hostname of the Apache server hosting the software repositories:
+On all of the relevant systems that will need {product-title} software
+components, create the required repository definitions. Place the following text
+in the *_/etc/yum.repos.d/ose.repo_* file, replacing `<server_IP>` with the IP
+or host name of the Apache server hosting the software repositories:
 
 ====
 ----
@@ -367,77 +370,78 @@ gpgcheck=0
 === Host Preparation
 
 At this point, the systems are ready to continue to be prepared
-link:../../install_config/install/prerequisites.adoc#host-preparation[following
-the OpenShift documentation].
+link:../../install_config/install/prerequisites.html#host-preparation[following
+the {product-title} documentation].
 
 Skip the section titled *Registering the Hosts* and start with *Managing
 Packages*.
 
-[[disconnected-openshift-installation]]
-== OpenShift Installation
+[[disconnected-installing-openshift]]
+== Installing {product-title}
 
-[[disconnected-import-openshift-dockerized-components]]
-=== Import OpenShift Dockerized Components
+[[disconnected-importing-containerized-components]]
+=== Importing {product-title} Containerized Components
 
 To import the relevant components, securely copy the images from the connected
-host to the individual OpenShift hosts:
+host to the individual {product-title} hosts:
 
 ----
-# scp /var/www/html/repos/images/ose3-images.tar root@openshift.host.name:
-# ssh root@openshift.host.name "docker load -i ose3-images.tar"
+# scp /var/www/html/repos/images/ose3-images.tar root@<openshift_host_name>:
+# ssh root@<openshift_host_name> "docker load -i ose3-images.tar"
 ----
 
-If you prefer, you could use `wget` on each OpenShift host to fetch the tar
-file, and then perform the Docker import command locally. Perform the same steps
-for the metrics and logging images, if you synchronized them.
+If you prefer, you could use `wget` on each {product-title} host to fetch the
+tar file, and then perform the Docker import command locally. Perform the same
+steps for the metrics and logging images, if you synchronized them.
 
-On the host that will act as an OpenShift Master, copy and import the builder
-images:
+On the host that will act as an {product-title} master, copy and import the
+builder images:
 
 ----
-# scp /var/www/html/images/ose3-builder-images.tar root@openshift.masterhost.name: 
-# ssh root@openshift.masterhost.name "docker load -i ose3-builder-images.tar"
+# scp /var/www/html/images/ose3-builder-images.tar root@<openshift_master_host_name>:
+# ssh root@<openshift_master_host_name> "docker load -i ose3-builder-images.tar"
 ----
 
-[[disconnected-run-the-openshift-installer]]
-=== Run the OpenShift Installer
+[[disconnected-running-the-openshift-installer]]
+=== Running the {product-title} Installer
 
 You can now choose to follow the
-link:../../install_config/install/quick_install.adoc[quick] or
-link:../../install_config/install/advanced_install.adoc[advanced] OpenShift
-installation instructions in the documentation. 
+link:../../install_config/install/quick_install.html[quick] or
+link:../../install_config/install/advanced_install.html[advanced]
+{product-title} installation instructions in the documentation.
 
-[[disconnected-create-the-internal-docker-registry]]
-=== Create the Internal Docker Registry
+[[disconnected-creating-the-internal-docker-registry]]
+=== Creating the Internal Docker Registry
 
-You now need to link:../../install_config/install/docker_registry.adoc[create
+You now need to link:../../install_config/install/docker_registry.html[create
 the internal Docker registry].
 
 [[disconnected-post-installation-changes]]
 == Post-Installation Changes
 
 In one of the previous steps, the S2I images were imported into the Docker
-daemon running on one of the OpenShift Master hosts. In a connected
-installation these images would be pulled from Red Hat’s registry on demand.
+daemon running on one of the {product-title} master hosts. In a connected
+installation, these images would be pulled from Red Hat’s registry on demand.
 Since the Internet is not available to do this, the images must be made
 available in another Docker registry.
 
-OpenShift provides an internal registry for storing the images that are built
-as a result of the S2I process, but it can also be used to hold the S2I builder
-images. The following steps assume you did not customize the service IP subnet
-(172.30.0.0/16) or the Docker registry port (5000).
+{product-title} provides an internal registry for storing the images that are
+built as a result of the S2I process, but it can also be used to hold the S2I
+builder images. The following steps assume you did not customize the service IP
+subnet (172.30.0.0/16) or the Docker registry port (5000).
 
-[[disconnected-re-tag-s2i-builder-images]]
-=== Re-tag S2I Builder Images
+[[disconnected-re-tagging-s2i-builder-images]]
+=== Re-tagging S2I Builder Images
 
-. On the Master host where you imported the S2I builder images, obtain the
-service address of your docker registry that you installed on the master:
+. On the master host where you imported the S2I builder images, obtain the
+service address of your Docker registry that you installed on the master:
 +
 ----
 # export REGISTRY=$(oc get service docker-registry -t '{{.spec.clusterIP}}{{"\n"}}')
 ----
 
-. Next, tag all of the builder images before pushing them into the OpenShift Docker registry:
+. Next, tag all of the builder images before pushing them into the
+{product-title} Docker registry:
 +
 ----
 # docker tag registry.access.redhat.com/jboss-amq-6/amq-openshift $REGISTRY:5000/openshift/amq-openshift
@@ -452,77 +456,82 @@ service address of your docker registry that you installed on the master:
 # docker tag registry.access.redhat.com/rhscl/python-27-rhel7 $REGISTRY:5000/openshift/python-27-rhel7
 # docker tag registry.access.redhat.com/rhscl/python-34-rhel7 $REGISTRY:5000/openshift/python-34-rhel7
 # docker tag registry.access.redhat.com/rhscl/ruby-22-rhel7 $REGISTRY:5000/openshift/ruby-22-rhel7
-# docker tag registry.access.redhat.com/openshift3/nodejs-010-rhel7 $REGISTRY:5000/openshift/nodejs-010-rhel7 
+# docker tag registry.access.redhat.com/openshift3/nodejs-010-rhel7 $REGISTRY:5000/openshift/nodejs-010-rhel7
 ----
 
-[[disconnected-create-an-admin-user]]
-=== Create an Administrative User
+[[disconnected-creating-an-admin-user]]
+=== Creating an Administrative User
 
-Pushing the Docker images into OpenShift’s Docker registry requires a user with
-administrator privileges. Because the default OpenShift system administrator
-does not have a standard authorization token, they cannot be used to log in to
-the Docker registry.
+Pushing the Docker images into {product-title}'s Docker registry requires a user
+with *cluster-admin* privileges. Because the default OpenShift system
+administrator does not have a standard authorization token, they cannot be used
+to log in to the Docker registry.
 
-Create a new user account in the authentication system you are using with
-OpenShift. For example, if you are using local htpasswd-based authentication:
+To create an administrative user:
 
+. Create a new user account in the authentication system you are using with
+{product-title}. For example, if you are using local `htpasswd`-based
+authentication:
++
 ----
-# htpasswd -b /etc/openshift/openshift-passwd <username> <password>
+# htpasswd -b /etc/openshift/openshift-passwd <admin_username> <password>
 ----
 
-The external authentication system now has a user account, but a user must log
-in to OpenShift before an account is created in the internal database. Log in to
-OpenShift for this account to be created. This assumes you are using the
-self-signed certificates generated by OpenShift during the installation:
-
+. The external authentication system now has a user account, but a user must log
+in to {product-title} before an account is created in the internal database. Log
+in to {product-title} for this account to be created. This assumes you are using
+the self-signed certificates generated by {product-title} during the
+installation:
++
 ----
 # oc login --certificate-authority=/etc/origin/master/ca.crt \
-    -u adminuser https://openshift.master.host:8443
+    -u <admin_username> https://<openshift_master_host>:8443
 ----
 
-Get the user’s authentication token:
-
+. Get the user’s authentication token:
++
 ----
 # MYTOKEN=$(oc whoami -t)
 # echo $MYTOKEN
 iwo7hc4XilD2KOLL4V1O55ExH2VlPmLD-W2-JOd6Fko
 ----
 
-[[disconnected-modify-the-securitry-policies]]
-=== Modify the Security Policies
+[[disconnected-modifying-the-securitry-policies]]
+=== Modifying the Security Policies
 
-. Using `oc login` switches to the new user. Switch back to the OpenShift system
-administrator in order to make policy changes:
+. Using `oc login` switches to the new user. Switch back to the {product-title}
+system administrator in order to make policy changes:
 +
 ----
 # oc login -u system:admin
 ----
 
-. In order to push images into the OpenShift Docker registry, an account must
-have the `image-builder` security role. Add this to your OpenShift admin user:
+. In order to push images into the {product-title} Docker registry, an account
+must have the `image-builder` security role. Add this to your {product-title}
+administrative user:
 +
 ----
 # oadm policy add-role-to-user system:image-builder <admin_username>
 ----
 
-. Next, add the administrative role to the user in the openshift project. This
-allows the admin user to edit the openshift project, and, in this
+. Next, add the administrative role to the user in the *openshift* project. This
+allows the administrative user to edit the *openshift* project, and, in this
 case, push the Docker images:
 +
 ----
 # oadm policy add-role-to-user admin <admin_username> -n openshift
 ----
 
-[[disconnected-edit-the-imagestream-definitions]]
-=== Edit the Imagestream Definitions
+[[disconnected-editing-the-image-stream-definitions]]
+=== Editing the Image Stream Definitions
 
-The `openshift` project is where all of the imagestreams for builder images are
+The *openshift* project is where all of the image streams for builder images are
 created by the installer. They are loaded by the installer from the
-*_/usr/share/openshift/examples_* directory. Change all of the
-definitions by deleting the imagestreams which had been loaded into OpenShift’s
-database, then re-create them.
+*_/usr/share/openshift/examples_* directory. Change all of the definitions by
+deleting the image streams which had been loaded into {product-title}'s
+database, then re-create them:
 
-. Delete the existing imagestreams:
+. Delete the existing image streams:
 +
 ----
 # oc delete is -n openshift --all
@@ -530,9 +539,11 @@ database, then re-create them.
 
 . Make a backup of the files in *_/usr/share/openshift/examples/_* if you
 desire. Next, edit the file *_image-streams-rhel7.json_* in the
-*_/usr/share/openshift/examples/image-streams_* folder. You will find an
-imagestream section for each of the builder images. Edit the `spec` stanza to
-point to your internal docker registry. For example:
+*_/usr/share/openshift/examples/image-streams_* folder. You will find an image
+stream section for each of the builder images. Edit the `*spec*` stanza to point
+to your internal Docker registry.
++
+For example, change:
 +
 ====
 ----
@@ -541,7 +552,7 @@ point to your internal docker registry. For example:
 ----
 ====
 +
-changes to
+to:
 +
 ====
 ----
@@ -550,37 +561,34 @@ changes to
 ----
 ====
 +
-[NOTE]
-====
-The repository name (`rhscl`) was changed to `openshift`. You will need to
-ensure the change, regardless of whether the repository is `rhscl`,
-`openshift3`, or another directory. Every definition should have the following
+In the above, the repository name was changed from *rhscl* to *openshift*. You
+will need to ensure the change, regardless of whether the repository is *rhscl*,
+*openshift3*, or another directory. Every definition should have the following
 format:
-
-----
-<REGISTRY_IP>:5000/openshift/<IMAGENAME>
-----
-====
 +
-Repeat this change for every imagestream in the file. Ensure you use the correct
-IP address that you determined earlier. When you are finished, save and exit.
-Repeat the same process for the JBoss imagestreams in
-*_/usr/share/openshift/examples/xpaas-streams/jboss-image-streams.json_*.
+----
+<registry_ip>:5000/openshift/<image_name>
+----
++
+Repeat this change for every image stream in the file. Ensure you use the
+correct IP address that you determined earlier. When you are finished, save and
+exit. Repeat the same process for the JBoss image streams in the
+*_/usr/share/openshift/examples/xpaas-streams/jboss-image-streams.json_* file.
 
-. Load the updated imagestream definitions:
+. Load the updated image stream definitions:
 +
 ----
 # oc create -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json -n openshift
 # oc create -f /usr/share/openshift/examples/xpaas-streams/jboss-image-streams.json -n openshift
 ----
 
-[[disconnected-load-the-docker-images]]
-=== Load the Docker Images
+[[disconnected-loading-the-docker-images]]
+=== Loading the Docker Images
 
 At this point the system is ready to load the Docker images.
 
-. Log in to the Docker registry using the token and registry service IP
-obtained earlier:
+. Log in to the Docker registry using the token and registry service IP obtained
+earlier:
 +
 ----
 # docker login -u adminuser -e mailto:adminuser@abc.com \
@@ -602,22 +610,24 @@ obtained earlier:
 # docker push $REGISTRY:5000/openshift/python-27-rhel7
 # docker push $REGISTRY:5000/openshift/python-34-rhel7
 # docker push $REGISTRY:5000/openshift/ruby-22-rhel7
-# docker push $REGISTRY:5000/openshift/nodejs-010-rhel7 
+# docker push $REGISTRY:5000/openshift/nodejs-010-rhel7
 ----
 
-. Verify the that all the imagestreams now have the tags populated:
+. Verify the that all the image streams now have the tags populated:
 +
 ====
 ----
 # oc get imagestreams -n openshift
 NAME                                 DOCKER REPO                                                      TAGS                                     UPDATED
-jboss-amq-62                          registry.access.redhat.com/jboss-amq-6/amq62-openshift                         1.1,1.1-2,1.1-6 + 2 more...     2 weeks ago            
+jboss-amq-62                          registry.access.redhat.com/jboss-amq-6/amq62-openshift                         1.1,1.1-2,1.1-6 + 2 more...     2 weeks ago
 ...
 ----
 ====
 
-[[disconnected-install-a-router]]
-== Install a Router
+[[disconnected-installing-a-router]]
+== Installing a Router
 
-At this point the OpenShift environment is almost ready for use. It is likely
-that you will want to link:../../install_config/install/deploy_router.html [install and configure a router].
+At this point, the {product-title} environment is almost ready for use. It is
+likely that you will want to
+link:../../install_config/install/deploy_router.html[install and configure a
+router].


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1595. Started off just fixing some broken links (mostly s/adoc/html/g) so that the Customer Portal build would finish, but also:
- Conditionalized to only show up for OSE build (not Origin or Atomic-*), because it uses RHSM
- Fixed some broken formatting (e.g., ordered list numbering)
- Turned all headings into gerund form
- Used `{product-title}` where appropriate
- s/Dockerized/containerized/g
- Other minor changes for style consistencies (e.g., s/imagestreams/image streams/)

FYI @bfallonf 
