### PR TITLE
DOCKER REPO should be new REGISTRY ip.

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -619,7 +619,7 @@ earlier:
 ----
 # oc get imagestreams -n openshift
 NAME                                 DOCKER REPO                                                      TAGS                                     UPDATED
-jboss-amq-62                          registry.access.redhat.com/jboss-amq-6/amq62-openshift                         1.1,1.1-2,1.1-6 + 2 more...     2 weeks ago
+jboss-amq-62                          $REGISTRY/jboss-amq-6/amq62-openshift                             1.1,1.1-2,1.1-6 + 2 more...     2 weeks ago
 ...
 ----
 ====


### PR DESCRIPTION
The final Docker repo should be new $REGISTRY not registry.access.redhat.com. I think it makes people confused so I correct it.
