### PR TITLE
do not edit default SCC info

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -73,6 +73,12 @@ seLinuxContext:
 ====
 
 
+[NOTE]
+====
+In order to preserve customized SCCs during upgrades editing settings on the default SCCs
+other than priority, users, and groups is not recommended.
+====
+
 [[creating-new-security-context-constraints]]
 
 == Creating New Security Context Constraints
@@ -100,7 +106,6 @@ users:
 groups:
 - my-admin-group
 ----
-Although this example definition was written by hand, another way is to modify the definition obtained from link:#examining-a-security-context-constraints-object[examining a particular SCC].
 ====
 
 Then, run `oc create` passing the file to create it:
@@ -145,6 +150,12 @@ To update an existing SCC:
 $ oc edit scc <scc_name>
 ----
 
+[NOTE]
+====
+In order to preserve customized SCCs during upgrades editing settings on the default SCCs
+other than priority, users, and groups is not recommended.
+====
+
 == Updating the default Security Context Constraints
 
 Default SCCs will be created when the master is started if they are missing. To reset SCCs
@@ -165,6 +176,12 @@ use the `--confirm` option to persist the data.
 ====
 If you would like to reset priorities and grants you may use the `--additive-only=false`
 option.
+====
+
+[NOTE]
+====
+If you have customized settings other than priority, users, or groups in an SCC you will lose those
+settings when you reconcile.
 ====
 
 [[how-do-i]]
@@ -285,11 +302,7 @@ special steps should be required to run `*ping*`.
 
 To provide additional capabilities:
 
-. Create a new SCC or edit the *privileged* SCC:
-+
-----
-$ oc edit scc <name>
-----
+. Create a new SCC
 
 . Add the allowed capability using the `*allowedCapabilities*` field.
 
@@ -302,6 +315,12 @@ $ oc edit scc <name>
 
 To modify your cluster so that it does not pre-allocate UIDs, allows containers
 to run as any user, and prevents privileged containers:
+
+[NOTE]
+====
+In order to preserve customized SCCs during upgrades editing settings on the default SCCs
+other than priority, users, and groups is not recommended.
+====
 
 . Edit the *restricted* SCC:
 +


### PR DESCRIPTION
@adellape - adds info blocks that recommend not changing default SCCs since they may be reset during the upgrade process when reconcile is run
