### PR TITLE
Cleanup F5 ramp node instructions

### DIFF
--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -180,10 +180,7 @@ gateway):
 # plugin="sdn"  #  "multitenant"
 #
 # ipflowopts="cookie=0x999,ip"
-# [ "$plugin" == "multitenant" ] && ipflowopts="cookie=0x999,table=1,priority=40000,ip"
-#
 # arpflowopts="cookie=0x999, table=0, arp"
-# [ "$plugin" == "multitenant" ] && arpflowopts="cookie=0x999, table=1,priority=40000, arp"
 #
 # ovs-ofctl -O OpenFlow13 add-flow br0 \
     "${ipflowopts},nw_src=${TUNNEL_IP1},actions=mod_nw_src:${RAMP_SDN_IP},resubmit(,0)"
@@ -198,11 +195,6 @@ gateway):
 # ovs-ofctl -O OpenFlow13 add-flow br0 \
     "ip,table=5,priority=300,nw_dst=${RAMP_SDN_IP},actions=output:2"
 # ovs-ofctl -O OpenFlow13 add-flow br0 "${ipflowopts},nw_dst=${TUNNEL_IP1},actions=output:2"
-
-# if [ "$plugin" == "multitenant" ]; then
-    ovs-ofctl -O OpenFlow13 add-flow br0 \
-      "cookie=0x999, table=1,priority=40000,ip,nw_dst=${TUNNEL_IP1},actions=output:2"
-  fi
 ----
 ====
 


### PR DESCRIPTION
Cleanup F5 ramp node instructions. 
Fix multitenant plugin openflow rules on the ramp node. These now match up to the sdn plugin rules, so special handling is not required anymore.

@adellape / @bfallonf  PTAL  thx

/cc @zhaozhanqi @knobunc @rajatchopra 
