### PR TITLE
Fix metric re-encrypted route port for enterprise containers.

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -446,7 +446,12 @@ metadata:
 spec:
   host: hawkular-metrics.example.com <1>
   port:
+ifdef::openshift-enterprise[]
+    targetPort: 8444
+endif::[]
+ifdef::openshift-origin[]
     targetPort: 8443
+endif::[]
   to:
     kind: Service
     name: hawkular-metrics


### PR DESCRIPTION
The port value for the re-encrypting port needs to be different between the enterprise and origin metric containers.

Without this fix people viewing how to setup the re-encrypting route will be entering the wrong port and they will not be able to properly get the route working.
