### PR TITLE
Document the service proxy mode and how to configure it.

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -199,6 +199,29 @@ of internal IPs.
 <5> Port on the backing pods to which the service forwards connections.
 ====
 
+[[proxy-mode]]
+
+OpenShift has two different implementations of the service-routing
+infrastructure. The default implementation is entirely iptables-based,
+and uses probabilistic iptables rewriting rules to distribute incoming
+service connections between the endpoint pods. The older
+implementation uses a userspace process to accept incoming connections
+and then proxy traffic between the client and one of the endpoint
+pods.
+
+The iptables-based implementation is much more efficient, but it
+requires that all endpoints are always able to accept connections; the
+userspace implementation is slower, but can try multiple endpoints in
+turn until it finds one that works. If you have good
+link:../../dev_guide/application_health.html[readiness checks] (or
+generally reliable nodes and pods) then the iptables-based service
+proxy is the best choice. Otherwise, you can enable the
+userspace-based proxy
+link:../../install_config/install/advanced_install.html[when
+installing], or after deploying the cluster by editing the
+link:../../install_config/master_node_configuration.html[node
+configuration file].
+
 The
 https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/services.md[Kubernetes documentation] has more information on services.
 

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -300,6 +300,12 @@ SDN]. Defaults to *9* which means that a subnet of size /23 is allocated to each
 host; for example, given the default 10.128.0.0/14 cluster network, this will
 allocate 10.128.0.0/23, 10.128.2.0/23, 10.128.4.0/23, and so on. This *cannot* be
 re-configured after deployment.
+
+|`*openshift_node_proxy_mode*`
+|This variable specifies the
+link:../../architecture/core_concepts/pods_and_services.html#proxy-mode[service
+proxy implementation] to use: either *iptables* for the pure-iptables
+version (the default), or *userspace* for the userspace proxy.
 |===
 
 [[advanced-install-configuring-global-proxy]]

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -317,9 +317,12 @@ nodeName: node1.example.com
 podManifestConfig: <1>
   path: "/path/to/pod-manifest-file" <2>
   fileCheckIntervalSeconds: 30 <3>
+proxyArguments:
+  proxy-mode:
+  - iptables <4>
 volumeConfig:
   localQuota:
-   perFSGroup: null<4>
+   perFSGroup: null<5>
 servingInfo:
   bindAddress: 0.0.0.0:10250
   bindNetwork: tcp4
@@ -338,7 +341,9 @@ or directory. If it is a directory, then it is expected to contain one or more
 manifest files. This is used by the Kubelet to create pods on the node.
 <3> This is the interval (in seconds) for checking the manifest file for new
 data. The interval must be a positive value.
-<4> Preliminary support for local emptyDir volume quotas, set this value to a resource
+<4> The link:../architecture/core_concepts/pods_and_services.html#proxy-mode[service
+proxy implementation] to use.
+<5> Preliminary support for local emptyDir volume quotas, set this value to a resource
 quantity representing the desired quota per FSGroup, per node. (i.e. 1Gi, 512Mi, etc)
 Currently requires that the *_volumeDirectory_* be on an XFS filesystem mounted
 with the 'gquota' option, and the matching security context contraint's fsGroup


### PR DESCRIPTION
Addresses the docs-related aspects of https://bugzilla.redhat.com/show_bug.cgi?id=1326067

Feel free to rewrite/reorganize this as much as you want. I wanted to provide some base language/information but I don't know if it's stylistically right, etc.

Eventually the discussion of iptables-vs-userspace tradeoffs belongs upstream, and I filed a bug for that (https://github.com/kubernetes/kubernetes.github.io/pull/401) but we don't know when that will land.
