### PR TITLE
Adding documentation for external es from fluentd

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -635,3 +635,43 @@ to see if it is defined in multiple places:
 $ oc get route  --all-namespaces --selector logging-infra=support
 ----
 ====
+
+== External Elasticsearch instance with Fluentd
+
+It is possible to configure the Fluentd pod created with aggregated logging to
+connect to an externally hosted Elasticsearch instance.
+
+Fluentd knows where to send its logs to based on the `ES_HOST`, `ES_PORT`,
+`OPS_HOST` and `OPS_PORT` environment variables.  If you have an external
+Elasticsearch instance that will contain both application and operations logs,
+ensure that `ES_HOST` and `OPS_HOST` are the same and that `ES_PORT` and
+`OPS_PORT` are also the same.  Fluentd is configured to send its application logs
+to the `ES_HOST` destination and all of its operations logs to `OPS_HOST`.
+
+If your externally hosted Elasticsearch does not make use of TLS you will need to
+update the `*_CLIENT_CERT`, `*_CLIENT_KEY` and `*_CA` variables to be empty. If
+it uses TLS but not Mutual TLS, update the `*_CLIENT_CERT` and `*_CLIENT_KEY`
+variables to be empty and patch or recreate the `logging-fluentd` secret with
+the appropriate `*_CA` for communicating with your Elasticsearch.  If it uses
+Mutual TLS as the provided Elasticsearch does, you will just need to patch or
+recreate the `logging-fluentd` secret with your client key, client cert, and CA.
+
+ifdef::openshift-origin[]
+Since Fluentd is deployed by means of a DaemonSet you will need to update the
+`logging-fluentd-template` template, delete your current DaemonSet and recreate
+it with `oc new-app logging-fluentd-template` after seeing all previous Fluentd
+pods have terminated.
+endif::openshift-origin[]
+
+ifdef::openshift-enterprise[]
+You can use `oc edit dc/logging-fluentd` to update your Fluentd configuration.
+It is advised that you first scale down your number of replicas to 0 before
+editing the DeploymentConfig.
+enddef::openshift-enterprise[]
+
+[NOTE]
+====
+If you are not using the provided Kibana and Elasticsearch images, you will not
+have the same multi-tenant capabilities and your data will not be restricted by
+user access to a particular project.
+====


### PR DESCRIPTION
I've seen questions regarding how to do this a few times so adding documentation here.  This is different than sending a copy of all our logs to a second Elasticsearch cluster (es_copy functionality)

@sosiouxme @adellape PTAL

Also, should there be verbiage regarding the supported level of TLS?
