### PR TITLE
Bug 1306890 : Added maximum pod and node info

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -38,6 +38,11 @@ maintain state when recreated. Therefore pods should usually be managed by
 higher-level link:deployments.html#replication-controllers[controllers],
 rather than directly by users.
 
+[IMPORTANT]
+====
+The recommended maximum number of pods within an {product-title} cluster is 110.
+====
+
 Below is an example definition of a pod that provides a long-running
 service, which is actually a part of the OpenShift infrastructure: the
 private Docker registry. It demonstrates many features of pods, most of

--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -241,6 +241,11 @@ link:../../install_config/master_node_configuration.html[dedicated node
 configuration files].
 endif::[]
 
+[IMPORTANT]
+====
+The recommended maximum number of nodes is 300.
+====
+
 [[kubelet]]
 
 === Kubelet

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1105,6 +1105,11 @@ your inventory file. You must then specify the file location with `-i` when
 calling `ansible-playbook` later.
 endif::[]
 
+[IMPORTANT]
+====
+The recommended maximum number of nodes is 300.
+====
+
 To add nodes to an existing cluster:
 
 . Ensure you have the latest playbooks by updating the *atomic-openshift-utils*

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -36,6 +36,18 @@ outline the system requirements and instructions for preparing your environment
 and hosts before installing OpenShift.
 endif::[]
 
+[[prerequisites-planning]]
+== Planning
+
+For production environments, several factors that can influence installation
+must be considered prior to deployment:
+
+* What is the number of required hosts required to run the cluster?
+* How many pods are required in your cluster?
+* Is link:../../admin_guide/high_availability.html[high availability] required?
+High availability is recommended for fault tolerance.
+
+
 [[system-requirements]]
 
 == System Requirements
@@ -108,6 +120,12 @@ https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/
 Storage in Red Hat Enterprise Linux Atomic Host] for instructions on configuring
 this during or after installation.
 ====
+
+In general, an {product-title} cluster should have 1 CPU core and 2.5 GB of
+memory, on top of the defaults in the table above, for each 1000 pods. So, the
+recommended size of a cluster of 2000 pods would be 20 CPU cores and 50 GB of
+RAM, as well as the minimum requirements for a master host of 2 CPU cores and 8
+GB of RAM.
 
 [[configuring-core-usage]]
 

--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -280,6 +280,11 @@ method on how to
 link:../../install_config/install/advanced_install.html#adding-nodes-advanced[run
 the playbook for adding new nodes directly].
 
+[IMPORTANT]
+====
+The recommended maximum number of nodes is 300.
+====
+
 To add nodes or reinstall the cluster:
 
 . Re-run the installer with the `install` subcommand in interactive or


### PR DESCRIPTION
@timothysc @jeremyeder As per #1949 and BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1306890

The max-pods stuff seems to be covered here: https://docs.openshift.com/enterprise/3.1/admin_guide/manage_nodes.html#configuring-node-resources

I do have a question about the CPU requirements. Why is it 20+2 and 50+8? Why not 22 and 58? Is there a difference between the two numbers used there? Other than that, if there's anything else, please let me know. 

Thanks for the inital info in the GH issue!
