### PR TITLE
Fix names of mysql scripts

### DIFF
--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -380,7 +380,7 @@ second the MySQL _slave_ servers.
 
 To tell a MySQL server to act as the master, the `*command*` field in the
 container's definition in the deployment configuration must be set to
-*run-mysqld-master.sh*. This script acts as an alternative entrypoint for the
+*run-mysqld-master*. This script acts as an alternative entrypoint for the
 MySQL image and configures the MySQL server to run as the master in replication.
 
 MySQL replication requires a special user that relays data between the master
@@ -445,7 +445,7 @@ this purpose:
             "name":"server",
             "image":"openshift/mysql-55-centos7",
             "command":[
-              "run-mysqld-master.sh"
+              "run-mysqld-master"
             ],
             "ports":[
               {
@@ -516,7 +516,7 @@ server is started, it will create the database defined by `*MYSQL_DATABASE*` and
 configure the server to replicate this database to slaves.
 
 The example provided defines only one replica of the MySQL master server. This
-causes Kubernetes to start only one instance of the server. Multiple instances
+causes OpenShift to start only one instance of the server. Multiple instances
 (multi-master) is not supported and therefore you can not scale this replication
 controller.
 
@@ -526,7 +526,7 @@ To replicate the database created by the
 link:#creating-the-deployment-configuration-for-mysql-master[MySQL master], a
 deployment configuration is defined in the template. This deployment
 configuration creates a replication controller that launches the MySQL image
-with the `*command*` field set to *run-mysqld-slave.sh*. This alternative
+with the `*command*` field set to *run-mysqld-slave*. This alternative
 entrypoints skips the initialization of the database and configures the MySQL
 server to connect to the *mysql-master* service, which is also defined in
 example template.
@@ -567,7 +567,7 @@ example template.
             "name":"server",
             "image":"openshift/mysql-55-centos7",
             "command":[
-              "run-mysqld-slave.sh"
+              "run-mysqld-slave"
             ],
             "ports":[
               {


### PR DESCRIPTION
MySQL scripts have changed its names in https://github.com/openshift/mysql/pull/106 but it wasn't updated in the documentation.

What this PR is changing:
- `run-mysqld-master.sh` -> `run-mysqld-master`
- `run-mysqld-slave.sh` -> `run-mysqld-slave`
- also replace `Kubernetes` by `OpenShift`
