### PR TITLE
Cleanup/editing for admin_guide/quota and fix links

### DIFF
--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -6,140 +6,167 @@
 :experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
 
 toc::[]
 
 == Overview
 
-A `ResourceQuota` defines constraints that limit aggregrate resource consumption
-per project.  It can limit the quantity of objects that can be created in a project
-by type, as well as the total amount of link:compute_resources.html[compute resources]
-that may be consumed by resources in that project.
+A resource quota, defined by a `*ResourceQuota*` object, provides constraints
+that limit aggregate resource consumption per project. It can limit the quantity
+of objects that can be created in a project by type, as well as the total amount
+of compute resources that may be consumed by resources in that project.
 
-== Resources managed by quota
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+[NOTE]
+====
+See the link:../dev_guide/compute_resources.html[Developer Guide] for more on
+compute resources.
+====
+endif::[]
 
-The following describes the set of resources that may be managed by a `ResourceQuota`.
+[[resources-managed-by-quota]]
+== Resources Managed by Quota
 
-.Resources managed by quota
+The following describes the set of resources that may be managed by a resource
+quota.
+
 [cols="3a,8a",options="header"]
 |===
 
 |Resource Name |Description
 
-|`configmaps`
-|Total number of configmaps
+|`*cpu*`
+|Across all pods in a non-terminal state, the sum of CPU requests cannot exceed
+this value.
 
-|`cpu`
-|Across all pods in a non-terminal state, the sum of cpu requests cannot exceed this value.
+|`*memory*`
+|Across all pods in a non-terminal state, the sum of memory requests cannot
+exceed this value.
 
-|`memory`
-|Across all pods in a non-terminal state, the sum of memory requests cannot exceed this value.
+|`*requests.cpu*`
+|Across all pods in a non-terminal state, the sum of CPU requests cannot exceed
+this value.
 
-|`requests.cpu`
-|Across all pods in a non-terminal state, the sum of cpu requests cannot exceed this value.
+|`*requests.memory*`
+|Across all pods in a non-terminal state, the sum of memory requests cannot
+exceed this value.
 
-|`requests.memory`
-|Across all pods in a non-terminal state, the sum of memory requests cannot exceed this value.
+|`*limits.cpu*`
+|Across all pods in a non-terminal state, the sum of CPU limits cannot exceed
+this value.
 
-|`limits.cpu`
-|Across all pods in a non-terminal state, the sum of cpu limits cannot exceed this value.
+|`*limits.memory*`
+|Across all pods in a non-terminal state, the sum of memory limits cannot exceed
+this value.
 
-|`limits.memory`
-|Across all pods in a non-terminal state, the sum of memory limits cannot exceed this value.
+|`*configmaps*`
+|The total number of `*ConfigMap*` objects that can exist in the project.
 
-|`configmaps`
-|The total number of config maps that can exist in the project.
+|`*pods*`
+|The total number of pods in a non-terminal state that can exist in the project.
+A pod is in a terminal state if `status.phase in (Failed, Succeeded)` is true.
 
-|`pods`
-|The total number of pods in a non-terminal state that can exist in the project.  A pod is in a terminal state if `status.phase in (Failed, Succeeded)` is true.
-
-|`replicationcontrollers`
+|`*replicationcontrollers*`
 |The total number of replication controllers that can exist in the project.
 
-|`resourcequotas`
+|`*resourcequotas*`
 |The total number of resource quotas that can exist in the project.
 
-|`services`
+|`*services*`
 |The total number of services that can exist in the project.
 
-|`secrets`
+|`*secrets*`
 |The total number of secrets that can exist in the project.
 
-|`persistentvolumeclaims`
+|`*persistentvolumeclaims*`
 |The total number of persistent volume claims that can exist in the project.
 |===
 
+[[quota-scopes]]
 == Quota Scopes
 
-Each quota can have an associated set of scopes.  A quota will only
+Each quota can have an associated set of _scopes_. A quota will only
 measure usage for a resource if it matches the intersection of enumerated
 scopes.
 
-Adding a scope to a quota limits the number of resources it supports
-to those that pertain to the scope.  Specifying a resource on the quota outside
-of the allowed set would result in a validation error.
+Adding a scope to a quota limits the number of resources it supports to those
+that pertain to the scope. Specifying a resource on the quota outside of the
+allowed set would result in a validation error.
 
-.Quota scopes
 [cols="3a,8a",options="header"]
 |===
 
 |Scope |Description
 
-|`Terminating`
+|*Terminating*
 |Match pods where `spec.activeDeadlineSeconds >= 0`
 
-|`NotTerminating`
+|*NotTerminating*
 |Match pods where `spec.activeDeadlineSeconds is nil`
 
-|`BestEffort`
-|Match pods that have best effort quality of service for either `cpu` or `memory`.
+|*BestEffort*
+|Match pods that have best effort quality of service for either `*cpu*` or
+`*memory*`.
 
-|`NotBestEffort`
-|Match pods that do not have best effort quality of service for `cpu` and `memory`.
+|*NotBestEffort*
+|Match pods that do not have best effort quality of service for `*cpu*` and
+`*memory*`.
 |===
 
-A `BestEffort` scope restricts a quota to limit the following resources:
+A *BestEffort* scope restricts a quota to limit the following resources:
 
-1. pods 
+- `*pods*`
 
-A `Terminating`, `NotTerminating`, and `NotBestEffort` scope restricts a quota to tracking the following resources:
+A *Terminating*, *NotTerminating*, and *NotBestEffort* scope restricts a quota
+to tracking the following resources:
 
-1. `pods`
-2. `memory`, `requests.memory`, `limits.memory`
-3. `cpu`, `requests.cpu`, `limits.cpu`
+- `*pods*`
+- `*memory*`
+- `*requests.memory*`
+- `*limits.memory*`
+- `*cpu*`
+- `*requests.cpu*`
+- `*limits.cpu*`
 
+[[quota-enforcement]]
 == Quota Enforcement
 
-After a project quota is first created, the project restricts the ability
-to create any new resources that may violate a quota constraint until it has
-calculated updated usage statistics.
+After a resource quota for a project is first created, the project restricts the
+ability to create any new resources that may violate a quota constraint until it
+has calculated updated usage statistics.
 
-Once a quota is created and usage statistics are up-to-date, the project accepts
+After a quota is created and usage statistics are updated, the project accepts
 the creation of new content. When you create or modify resources, your quota
 usage is incremented immediately upon the request to create or modify the
-resource. When you delete a resource, your quota use is decremented during the
-next full recalculation of quota statistics for the project. When you delete
-resources, a link:#configuring_quota_sync_period[configurable amount of time]
-determines how long it takes to reduce quota usage statistics to their current
-observed system value.
+resource.
+
+When you delete a resource, your quota use is decremented during the next full
+recalculation of quota statistics for the project. When you delete resources, a
+link:#configuring-quota-sync-period[configurable amount of time] determines how
+long it takes to reduce quota usage statistics to their current observed system
+value.
 
 If project modifications exceed a quota usage limit, the server denies the
-action, and an appropriate error message is returned to the end-user explaining
-the quota constraint violated, and what their currently observed usage stats are
-in the system.
+action, and an appropriate error message is returned to the user explaining the
+quota constraint violated, and what their currently observed usage stats are in
+the system.
 
-=== Compute Resources: Requests vs Limits
+[[requests-vs-limits]]
+=== Requests vs Limits
 
 When allocating compute resources, each container may specify a request and a limit value
-for either CPU or memory.  The quota can be configured to quota either value.  If the quota
-has a value specified for `requests.cpu` or `requests.memory`, then it will require that 
-every incoming container makes an explicit request for those resources.  If the quota has a 
-value specified for `limits.cpu` or `limits.memory`, then it will require that every incoming
-container specifies an explicit limit for those resources.
+for either CPU or memory. The quota can be configured to quota either value.
 
-== Sample Resource Quota Files
+If the quota has a value specified for `*requests.cpu*` or `*requests.memory*`,
+then it requires that every incoming container makes an explicit request for
+those resources. If the quota has a value specified for `*limits.cpu*` or
+`*limits.memory*`, then it requires that every incoming container specifies an
+explicit limit for those resources.
 
-object-counts.yaml
+== Sample Resource Quota Definitions
+
+.*_object-counts.yaml_*
 ====
 ----
 apiVersion: v1
@@ -154,14 +181,15 @@ spec:
     secrets: "10" <4>
     services: "10" <5>
 ----
-<1> The total number of config maps that can exist in the project
-<2> The total number of persistent volume claims that can exist in the project
-<3> The total number of replication controllers that can exist in the project
-<4> The total number of secrets that can exist in the project
-<5> The total number of services that can exist in the project
+<1> The total number of `*ConfigMap*` objects that can exist in the project.
+<2> The total number of persistent volume claims (PVCs) that can exist in the
+project.
+<3> The total number of replication controllers that can exist in the project.
+<4> The total number of secrets that can exist in the project.
+<5> The total number of services that can exist in the project.
 ====
 
-compute-resources.yaml
+.*_compute-resources.yaml_*
 ====
 ----
 apiVersion: v1
@@ -176,14 +204,19 @@ spec:
     limits.cpu: "2" <4>
     limits.memory: 2Gi <5>
 ----
-<1> The total number of pods in a non-terminal state that can exist in the project
-<2> Across all pods in a non-terminal state, the sum of cpu requests cannot exceed 1 core
-<3> Across all pods in a non-terminal state, the sum of memory requests cannot exceed 1Gi
-<4> Across all pods in a non-terminal state, the sum of cpu limits cannot exceed 2 cores
-<5> Across all pods in a non-terminal state, the sum of memory limits cannot exceed 2Gi
+<1> The total number of pods in a non-terminal state that can exist in the
+project.
+<2> Across all pods in a non-terminal state, the sum of CPU requests cannot
+exceed 1 core.
+<3> Across all pods in a non-terminal state, the sum of memory requests cannot
+exceed 1Gi.
+<4> Across all pods in a non-terminal state, the sum of CPU limits cannot exceed
+2 cores.
+<5> Across all pods in a non-terminal state, the sum of memory limits cannot
+exceed 2Gi.
 ====
 
-besteffort.yaml
+.*_besteffort.yaml_*
 ====
 ----
 apiVersion: v1
@@ -196,49 +229,76 @@ spec:
   scopes:
   - BestEffort <2>
 ----
-<1> The total number of pods in a non-terminal state with `BestEffort` quality of service that can exist in the project
-<2> Restricts the quota to only matching pods that have `BestEffort` quality of service for either memory or cpu.
+<1> The total number of pods in a non-terminal state with *BestEffort* quality
+of service that can exist in the project.
+<2> Restricts the quota to only matching pods that have *BestEffort* quality of
+service for either memory or CPU.
 ====
 
-== Create a Quota
+[[create-a-quota]]
+== Creating a Quota
 
-To apply a quota to a project:
-
-----
-$ oc create -f resource-quota.json
-----
-
-== View a Quota
-
-To view usage statistics related to any hard limits defined in your quota:
+To create a quota, first define the quota to your specifications in a file, for
+example as seen in
+link:../admin_guide/quota.html#sample-resource-quota-definitions[Sample Resource
+Quota Definitions]. Then, create using that file to apply it to a project:
 
 ----
-$ oc get quota
-NAME
-quota
-$ oc describe quota quota
-Name:                         quota
-Resource                      Used    Hard
---------                      ----    ----
-cpu                           5       20
-memory                        500Mi   1Gi
-pods                          5       10
-replicationcontrollers        5       5
-resourcequotas                1       1
-services                      3       5
+$ oc create -f <resource_quota_definition> [-n <project_name>]
 ----
 
-[[configuring_quota_sync_period]]
+For example:
 
-== Configuring the Quota Synchronization Period
+----
+$ oc create -f resource-quota.json -n demoproject
+----
 
-When a set of resources are deleted, the synchronization timeframe of resources
+[[viewing-a-quota]]
+== Viewing a Quota
+
+To view usage statistics related to any hard limits defined in a quota, first
+get the list of quotas defined in the project. For example, for a project called
+*demoproject*:
+
+====
+----
+$ oc get quota -n demoproject
+NAME                AGE
+besteffort          11m
+compute-resources   2m
+object-counts       29m
+----
+====
+
+Then, describe the resource quota you are interested in, for example a
+*object-counts* quota:
+
+====
+----
+$ oc describe quota object-counts -n demoproject
+Name:			object-counts
+Namespace:		demoproject
+Resource		Used	Hard
+--------		----	----
+configmaps		3	10
+persistentvolumeclaims	0	4
+replicationcontrollers	3	20
+secrets			9	10
+services		2	10
+----
+====
+
+[[configuring-quota-sync-period]]
+== Configuring Quota Synchronization Period
+
+When a set of resources are deleted, the synchronization time frame of resources
 is determined by the `*resource-quota-sync-period*` setting in the
-*_/etc/origin/master/master-config.yaml_* file. Before your quota usage is
-restored, you may encounter problems when attempting to reuse the resources.
-Change the `*resource-quota-sync-period*` setting to have the set of resources
-regenerate at the desired amount of time (in seconds) and for the resources to
-be available again:
+*_/etc/origin/master/master-config.yaml_* file.
+
+Before quota usage is restored, a user may encounter problems when attempting to
+reuse the resources. You can change the `*resource-quota-sync-period*` setting
+to have the set of resources regenerate at the desired amount of time (in
+seconds) and for the resources to be available again:
 
 ====
 ----
@@ -253,18 +313,22 @@ kubernetesMasterConfig:
 ----
 ====
 
+After making any changes, restart the master service to apply them.
+
 Adjusting the regeneration time can be helpful for creating resources and
 determining resource usage when automation is used.
 
 [NOTE]
 ====
 The `*resource-quota-sync-period*` setting is designed to balance system
-performance. Reducing the sync period can result in a heavy load on
-the master.
+performance. Reducing the sync period can result in a heavy load on the master.
 ====
 
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 [[accounting-quota-dc]]
-
 == Accounting for Quota in Deployment Configurations
 
-If a quota has been defined for your project, see link:../dev_guide/deployments.html#deployment-resources[Deployment Resources] for considerations on any deployment configurations.
+If a quota has been defined for your project, see
+link:../dev_guide/deployments.html#deployment-resources[Deployment Resources]
+for considerations on any deployment configurations.
+endif::[]


### PR DESCRIPTION
General clean-up and editing to this topic, but also follows up on https://github.com/openshift/openshift-docs/pull/1919 (which moved the topic from the Dev Guide to the Admin Guide) to fix a broken link or two introduced by the move.

Also:
- Hides references to configmap for the OSE 3.1 builds for now. Will reintroduce for OSE 3.2 in a separate PR.
- Hide links to the Dev Guide in the Atomic Registry build, since AR doesn't have a Dev Guide.

cc @derekwaynecarr @aweiteka 

Pretty builds:

Openshift Origin - http://file.rdu.redhat.com/~adellape/042916/openshift-origin/fix-admin-quota/admin_guide/quota.html

Atomic Registry - http://file.rdu.redhat.com/~adellape/042916/atomic-registry/fix-admin-quota/admin_guide/quota.html
