### PR TITLE
Link and ifdef fixes to web_console

### DIFF
--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -52,19 +52,22 @@ configuration file parameter `corsAllowedOrigins`].
 endif::[]
 
 ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
-[[web-console-cli-downloads]]
 
+[[web-console-cli-downloads]]
 == CLI Downloads
-You can download and unpack the CLI from the
-link:../install_config/web_console_customization.html#adding-or-changing-links-to-download-the-cli[*About*
-page on the web console] for use on Linux, MacOSX, and Windows clients
+You can download and unpack the CLI from the *About* page on the web console for
+use on Linux, MacOSX, and Windows clients.
 ifdef::openshift-enterprise,openshift-origin[]
-if your cluster administrator has enabled it
-endif::[]
-:
+Cluster administrators can
+link:../../install_config/web_console_customization.html#adding-or-changing-links-to-download-the-cli[customize
+these links further].
+endif::openshift-enterprise,openshift-origin[]
 
 image::about_page.png["About Page"]
 
+endif::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
+
+[[browser-requirements]]
 == Browser Requirements
 
 The following browser versions and operating systems can be used to access the
@@ -158,9 +161,7 @@ controller].
 ifdef::openshift-enterprise[]
 [NOTE]
 ====
-This feature is currently in
-link:../../whats_new/ose_3_0_release_notes.html#technology-preview[Technology
-Preview] and not intended for production use.
+This feature is currently in Technology Preview and not intended for production use.
 ====
 endif::[]
 


### PR DESCRIPTION
Path to web_console_customization.html was off, and the ifdefs needed some help for the CP build to pass. Also moved the web_console_customization.html link to within an enterpris&origin ifdef, because dedicated&online can't link to it.

cc @ahardin-rh 
