### PR TITLE
metrics: reencrypte route simplified; validations

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -353,7 +353,7 @@ Depending on your installation method, the template may not be present in your
 {product-title} installation. If so, the template can be found at the following GitHub
 location:
 
-https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_examples/files/examples/v1.1/infrastructure-templates/origin/metrics-deployer.yaml
+https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_examples/files/examples/v1.2/infrastructure-templates/origin/metrics-deployer.yaml
 ====
 
 endif::[]
@@ -399,7 +399,7 @@ Data loss will result if the Cassandra persisted volume runs out of sufficient s
 All of the other parameters are optional and allow for greater customization.
 For instance, if you have a custom install in which the Kubernetes master is not
 available under `https://kubernetes.default.svc:443` you can specify the value
-to use instead with the `*HAWKULAR_METRICS_HOSTNAME*` parameter. If you wish to
+to use instead with the `*MASTER_URL*` parameter. If you wish to
 deploy a specific version of the metrics components, you can do so with the `*IMAGE_VERSION*` parameter.
 
 [[deploying-the-metrics-components]]
@@ -422,23 +422,22 @@ The following command sets the Hawkular Metrics route to use
 You must have a persistent volume of sufficient size available.
 
 ----
-$ oc process -f metrics-deployer.yaml -v \
-    HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-    | oc create -f -
+$ oc new-app -f metrics-deployer.yaml \
+    -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com
 ----
 ====
 
 .Deploying without Persistent Storage
 ====
 The following command sets the Hawkular Metrics route to use
-`hawkular-metrics.example.com` and is deployed without persistent storage.
-Remember, this is being deployed without persistent storage, so metrics data loss
+`hawkular-metrics.example.com` and deploy without persistent storage.
+Remember, because this is being deployed without persistent storage, metric data loss
 can occur.
 
 ----
-$ oc process -f metrics-deployer.yaml -v \
-    HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,USE_PERSISTENT_STORAGE=false \
-    | oc create -f -
+$ oc new-app -f metrics-deployer.yaml \
+    -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
+    -p USE_PERSISTENT_STORAGE=false
 ----
 ====
 
@@ -453,12 +452,13 @@ link:../install_config/cluster_metrics.html#metrics-deployer-using-secrets[deplo
 secret].
 ====
 
-By default, the Hawkular Metrics server uses self-signed certificates, which are
-not trusted by a browser or other external services. If you want to provide your
-own trusted certificate to be used for external access, you can do so using a
-route with a
-link:../architecture/core_concepts/routes.html#secured-routes[re-encryption
-termination] after deploying the metrics components.
+By default the Hawkular Metrics server uses an internally-signed certificate which is not
+trusted by browsers or other external services. If you wish to provide your own trusted
+certificate to be used for external access you can do so using a route with
+link:../architecture/core_concepts/routes.html#secured-routes[re-encryption termination].
+
+Creating this new route requires deleting the default route that just passes through to
+an internally-signed certificate:
 
 . First, delete the default route that uses the self-signed certificates:
 +
@@ -466,47 +466,23 @@ termination] after deploying the metrics components.
 $ oc delete route hawkular-metrics
 ----
 
-. Define a new route with a
-link:../architecture/core_concepts/routes.html#secured-routes[re-encryption
-termination]:
+. A new route with link:../architecture/core_concepts/routes.html#secured-routes[re-encryption termination]
+will then need to be created.
 +
 ====
-[source,yaml]
 ----
-apiVersion: v1
-kind: Route
-metadata:
-  name: hawkular-metrics-reencrypt
-spec:
-  host: hawkular-metrics.example.com <1>
-  port:
+$ oc create route reencrypt hawkular-metrics-reencrypt \
+            --hostname hawkular-metrics.example.com \ <1>
+            --key /path/to/key \ <2>
+            --cert /path/to/cert \ <2>
+            --ca-cert /path/to/ca.crt \ <2>
 ifdef::openshift-enterprise[]
-    targetPort: 8444
+            --service hawkular-metrics --port 8444 \
 endif::[]
 ifdef::openshift-origin[]
-    targetPort: 8443
+            --service hawkular-metrics --port 8443 \
 endif::[]
-  to:
-    kind: Service
-    name: hawkular-metrics
-  tls:
-    termination: reencrypt
-    key: |-
-      -----BEGIN PRIVATE KEY-----
-      [...] <2>
-      -----END PRIVATE KEY-----
-    certificate: |-
-      -----BEGIN CERTIFICATE-----
-      [...] <2>
-      -----END CERTIFICATE-----
-    caCertificate: |-
-      -----BEGIN CERTIFICATE-----
-      [...] <2>
-      -----END CERTIFICATE-----
-    destinationCACertificate: |-
-      -----BEGIN CERTIFICATE-----
-      [...] <3>
-      -----END CERTIFICATE-----
+            --dest-ca-cert /path/to/internal-ca.crt <3>
 ----
 <1> The value specified in the *HAWKULAR_METRICS_HOSTNAME* template parameter.
 <2> These need to define the custom certificate you wish to provide.
@@ -519,15 +495,10 @@ the *hawkular-metrics-certificate* secret:
 ----
 $ base64 -d <<< \
     `oc get -o yaml secrets hawkular-metrics-certificate \
-    | grep -i hawkular-metrics-ca.certificate | awk '{print $2}'`
+    | grep -i hawkular-metrics-ca.certificate | awk '{print $2}'` \
+    > /path/to/internal-ca.crt
 ----
 
-. Save your route definition to a file, for example *_metrics-reencrypt.yaml_*,
-and create it:
-+
-----
-$ oc create -f metrics-reencrypt.yaml
-----
 
 [[configuring-openshift-metrics]]
 == Configuring OpenShift


### PR DESCRIPTION
Use the oc create route command to make it a lot simpler to create the
reencrypt route.
Discuss deployer validations.
Make minor wording/terminology fixes.
