### PR TITLE
Use https:// to access github, and drop .git

### DIFF
--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -455,7 +455,7 @@ service database-test (172.30.17.113:6434 -> 3306)
 
 service frontend-test (172.30.17.236:5432 -> 8080)
   frontend-test deploys origin-ruby-sample:test <-
-    builds git://github.com/openshift/ruby-hello-world.git with docker.io/openshift/ruby-20-centos7:latest
+    builds https://github.com/openshift/ruby-hello-world with docker.io/openshift/ruby-20-centos7:latest
     not built yet
     #1 deployment waiting on image
 

--- a/cli_reference/manage_cli_profiles.adoc
+++ b/cli_reference/manage_cli_profiles.adoc
@@ -106,7 +106,7 @@ service database (172.30.43.12:5434 -> 3306)
 
 service frontend (172.30.159.137:5432 -> 8080)
   frontend deploys origin-ruby-sample:latest <-
-    builds git://github.com/openshift/ruby-hello-world.git with joe-project/ruby-20-centos7:latest
+    builds https://github.com/openshift/ruby-hello-world with joe-project/ruby-20-centos7:latest
     #1 deployed 22 minutes ago - 2 pods
 
 To see more information about a service or deployment, use 'oc describe service <name>' or 'oc describe dc <name>'.

--- a/creating_images/s2i_testing.adoc
+++ b/creating_images/s2i_testing.adoc
@@ -172,7 +172,7 @@ section and creates a new S2I builder image.
     "source": {
       "type": "Git",
       "git": {
-        "uri": "git://github.com/openshift/sti-ruby.git"
+        "uri": "https://github.com/openshift/sti-ruby"
       }
     },
     "strategy": {

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -85,7 +85,7 @@ spec:
   source: <3>
     type: "Git"
     git:
-      uri: "git://github.com/openshift/ruby-hello-world.git"
+      uri: "https://github.com/openshift/ruby-hello-world"
     dockerfile: "FROM openshift/ruby-22-centos7\nUSER example"
   strategy: <4>
     type: "Source"
@@ -581,7 +581,7 @@ The source definition is part of the `*spec*` section in the `*BuildConfig*`:
 source:
   type: "Git"
   git: <1>
-    uri: "git://github.com/openshift/ruby-hello-world.git"
+    uri: "https://github.com/openshift/ruby-hello-world"
     ref: "master"
   contextDir: "app/dir" <2>
   dockerfile: "FROM openshift/ruby-22-centos7\nUSER example" <3>
@@ -632,7 +632,7 @@ Your source URI must use the HTTP or HTTPS protocol for this to work.
 source:
   type: Git
   git:
-    uri: "git://github.com/openshift/ruby-hello-world.git"
+    uri: "https://github.com/openshift/ruby-hello-world"
     httpProxy: http://proxy.example.com
     httpsProxy: https://proxy.example.com
 ----

--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -164,7 +164,7 @@ settings:
 source:
   type: Git
   git:
-    uri: git://github.com/openshift/ruby-hello-world.git
+    uri: https://github.com/openshift/ruby-hello-world
     httpProxy: http://proxy.example.com
     httpsProxy: https://proxy.example.com
 ...

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -160,7 +160,7 @@ metadata:
 spec:
   source:                       <1>
     git:
-      uri: git://github.com/custom/repository.git
+      uri: https://github.com/custom/repository
     type: Git
   strategy:                     <2>
     sourceStrategy:


### PR DESCRIPTION
The git protocol has no transport integrity and allows anyone on the
Internet to trivially MITM it.  This isn't a good thing for source
code, so improve security by using `https://` by default.

(Certificate pinning is a lot better, but that's a harder topic)

Also, drop the redundant `.git` on the end of the URLs.  For github
the project page is the same as the `git clone` URL which is a really
nice feature.
