### PR TITLE
add github webook instructions

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1411,6 +1411,17 @@ The payload URL is returned as the GitHub Webhook URL by the `describe` command
 http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/github
 ----
 
+To configure a GitHub Webhook:
+
+. Describe the build configuration to get the webhook URL:
++
+----
+$ oc describe bc <name>
+----
+. Copy the webhook URL.
+. Follow the https://developer.github.com/webhooks/creating/#setting-up-a-webhook[GitHub setup instructions]
+to paste the webhook URL into your GitHub repository settings.
+
 [NOTE]
 ====
 https://gogs.io[Gogs] supports the same webhook payload format as GitHub.


### PR DESCRIPTION
Based on user feedback, we need to make it more clear how to setup a github webhook.
