### PR TITLE
add docker login using service account tokens

### DIFF
--- a/registry_quickstart/administrators/system_configuration.adoc
+++ b/registry_quickstart/administrators/system_configuration.adoc
@@ -116,6 +116,9 @@ By default the session token used for **docker login** is 24 hours. This value
 may be extended in the master configuration file **/etc/origin/master/master-config.yaml**.
 In this example the session token expiration is extended to 30 days.
 
+See link:#using-service-account-tokens-for-authentication[below] for using service
+account tokens.
+
 ====
 ----
 tokenConfig:
@@ -128,6 +131,17 @@ Restart the origin service to update the running configuration.
 ----
 $ sudo docker restart origin
 ----
+
+[[using-service-account-tokens-for-authentication]]
+== Using Service Account Tokens for Authentication
+
+Typically long-lived, token-based authentication is desired. As an alternative
+to using user session tokens that expire, users may use
+xref:../../admin_guide/service_accounts.html[service account tokens] to
+authenticate with docker. This is particularly useful when integrating automation.
+See the
+xref:../developers.html#using-service-account-tokens-for-docker-login[quickstart developer guide]
+for instructions.
 
 == Project and Image Sharing Modes
 

--- a/registry_quickstart/developers.adoc
+++ b/registry_quickstart/developers.adoc
@@ -88,3 +88,75 @@ See the {product-title} User Guide for these topics:
 
 * link:../dev_guide/authentication.html[authentication]
 * link:../dev_guide/managing_images.html[managing images]
+
+=== Using Service Account Tokens for Docker Login
+
+For long-lived, token-based authentication, users may create
+xref:../admin_guide/service_accounts.html[service account tokens] to
+authenticate with Docker. This is particularly useful when integrating automation.
+Service accounts must be configured using the CLI. See
+xref:../cli_reference/get_started_cli.html[getting started with the CLI].
+
+. Create a service account in the current project named *push*.
++
+----
+$ oc create serviceaccount push
+----
+
+. Add the registry role to the service account. In this example, we grant the
+service account the *registry-editor* role. We are using the *test* project.
++
+----
+$ oc policy add-role-to-user registry-editor system:serviceaccounts:test:push
+----
+
+. Describe the service account to display the secret token name.
++
+----
+$ oc describe sa push
+Name:		push
+Namespace:	test
+Labels:		<none>
+
+Image pull secrets:	push-dockercfg-39j62
+
+Mountable secrets: 	push-token-5518o
+                   	push-dockercfg-39j62
+
+Tokens:            	push-token-5518o
+                   	push-token-htcxd
+----
+
+. Describe the token to get the secret value.
++
+----
+$ oc describe secret push-token-5518o
+Name:		push-token-5518o
+Namespace:	test
+Labels:		<none>
+Annotations:	kubernetes.io/service-account.name=push,kubernetes.io/service-account.uid=9eb24eeb-12d8-11e6-a276-0afb45fc7af5
+
+Type:	kubernetes.io/service-account-token
+
+Data
+====
+token:		eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+ca.crt:		1066 bytes
+namespace:	8 bytes
+----
+
+. Copy the token value and use as the value to the *--password* argument in the `docker login`
+command. Notice that the values for the username and email arguments are not used, so
+they can be any string.
++
+----
+$ sudo docker login -p eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9... -u unused -e unused REGISTRY_URL:5000
+----
+
+Service accounts may be deleted, which disables further authentication attempts.
+For example, as soon as the service account is deleted, `docker push` will no longer
+succeed if logged in with this service account token.
+
+----
+$ oc delete serviceaccount push
+----


### PR DESCRIPTION
This addresses a common question since `docker login -p $(oc whoami -t) -u unused -e unused REGISTRY:5000` expires every 24 hours by default. I suspect we should incorporate some of this as a separate PR for users who do not want or cannot use openshift to perform docker build.
