### PR TITLE
Followup to #1274 Add oc create route subcommands docs

### DIFF
--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -490,17 +490,20 @@
 
 [options="nowrap"]
 ----
-  // Create a secure edge terminated route using the specified certificates/keys and hostname
-  // If the certificates/keys are not specified, those from the router will be re-used
-  $ oc create route edge --service=frontend --cert=${MASTER_CONFIG_DIR}/ca.crt \
-                        --key=${MASTER_CONFIG_DIR}/ca.key \
-                        --ca-cert=${MASTER_CONFIG_DIR}/ca.crt \
-                        --hostname=www.example.com
+  // Create a secure edge-terminated route using the specified
+  // certificates/keys and hostname.  If the certificates/keys
+  // are not specified, those from the router will be re-used.
+  $ oc create route edge --service=frontend \
+      --cert=${MASTER_CONFIG_DIR}/ca.crt \
+      --key=${MASTER_CONFIG_DIR}/ca.key \
+      --ca-cert=${MASTER_CONFIG_DIR}/ca.crt \
+      --hostname=www.example.com
 
-  // Create a secure passthrough terminated route
+  // Create a secure passthrough terminated route.
   $ oc create route passthrough --service=registry
 
-  // Create a secure reencrypt terminated route in a similar fashion as edge. The only additional
+  // Create a secure reencrypt-terminated route in
+  // a similar fashion to edge.  The only additional
   // requirement is to specify a destination CA certificate.
   $ oc create route reencrypt --service=backend --dest-ca-cert=ca.crt
 ----

--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -28,17 +28,17 @@ to the router.
 
 Tooling for creating routes is developing. In the web console, they are
 displayed but there is not yet a method to create them. Using the CLI, you
-can create both unsecured and secured routes. In the following example, an
-unsecured route will be created:
+can create both unsecured and secured routes.
+The following example creates an unsecured route:
 
 ----
 $ oc expose svc/frontend --hostname=www.example.com
 ----
 
-The new route will inherit the name from the service unless you specify one
-using the --name flag.
+The new route inherits the name from the service unless you specify one
+using the `--name` option.
 
-.YAML definition of the unsecured route created above
+.YAML Definition of the Unsecured Route Created Above
 ====
 [source,yaml]
 ----
@@ -55,11 +55,13 @@ spec:
 ====
 
 Unsecured routes are the default configuration, and are therefore the simplest
-to set up. However, secured routes offer security for connections to remain
-private. To create a secured HTTPS route encrypted with a key and certificate
+to set up.
+However,
+link:../architecture/core_concepts/routes.html#secured-routes[secured routes]
+offer security for connections to remain private.
+To create a secured HTTPS route encrypted with a key and certificate
 (PEM-format files which you must generate and sign separately), you can use
 the `create route` command and optionally provide certificates and a key. 
-For more information on secured routes, see link:https://docs.openshift.org/latest/architecture/core_concepts/routes.html#secured-routes[here].
 
 [NOTE]
 ====
@@ -68,13 +70,14 @@ replacement of SSL for HTTPS and other encrypted protocols.
 ====
 
 ----
-$ oc create route edge --service=frontend --cert=${MASTER_CONFIG_DIR}/ca.crt \
-                        --key=${MASTER_CONFIG_DIR}/ca.key \
-                        --ca-cert=${MASTER_CONFIG_DIR}/ca.crt \
-                        --hostname=www.example.com
+$ oc create route edge --service=frontend \
+    --cert=${MASTER_CONFIG_DIR}/ca.crt \
+    --key=${MASTER_CONFIG_DIR}/ca.key \
+    --ca-cert=${MASTER_CONFIG_DIR}/ca.crt \
+    --hostname=www.example.com
 ----
 
-.YAML definition of the secured route created above
+.YAML Definition of the Secured Route Created Above
 ====
 [source,yaml]
 ----
@@ -104,7 +107,8 @@ spec:
 ----
 ====
 
-You can create a secured route without specifying a key and certificate, in which case the
+You can create a secured route without specifying a key and certificate,
+in which case the
 ifdef::openshift-enterprise,openshift-origin[]
 link:../install_config/install/deploy_router.html#using-wildcard-dns[router's
 default certificate]

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -414,6 +414,11 @@ $ oc create route edge --service=my-service \
     --hostname=www.example.test \
     --key=example-test.key --cert=example-test.crt
 route "my-service" created
+----
+
+Look at its definition.
+
+----
 $ oc get route/my-service -o yaml
 apiVersion: v1
 kind: Route

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -1066,9 +1066,9 @@ first have link:deploy_router.html[deployed a router].
 +
 . Create a
 link:https://docs.openshift.org/latest/architecture/core_concepts/routes.html#secured-routes[passthrough]
-route via `oc create route passthrough` by pointing the `--service` flag to the service
-of the registry. You can optionally provide a route name by passing an argument, otherwise
-the name of the service will be used as the route name.
+route via the `oc create route passthrough` command,
+specifying the registry as the route's service.
+By default, the name of the created route is the same as the service name.
 +
 For example:
 +
@@ -1080,9 +1080,13 @@ docker-registry   172.30.69.167    <none>        5000/TCP                docker-
 kubernetes        172.30.0.1       <none>        443/TCP,53/UDP,53/TCP   <none>                    4h
 router            172.30.172.132   <none>        80/TCP                  router=router             4h
 
-$ oc create route passthrough --service=docker-registry --hostname=<host>
-route "docker-registry" created
+$ oc create route passthrough    \
+    --service=docker-registry    \//<1>
+    --hostname=<host>
+route "docker-registry" created     <2>
 ----
+<1> Specify the registry as the route's service.
+<2> The route name is identical to the service name.
 ====
 +
 ====


### PR DESCRIPTION
Fixes #1717
Fixes #1274

The bulk of the previous work lies in the example code block.  The only non-code-block change was to the intro blurb.  It's fine.  This particular PR just splits up the example into the `oc create route` command, and the `oc get` command.  Confused?  Me too, that's why we ask @bfallonf @tpoitras @adellape @ahardin-rh @vikram-redhat to PTAL.
