### PR TITLE
Remove doc about plugin order override

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -233,18 +233,6 @@ The number of self-provisioned projects requested by a given user can be limited
 the `*ProjectRequestLimit*`
 link:../install_config/configuring_admission_control.html[admission control plug-in].
 
-The plug-in is not enabled by default. Therefore, it must be specified along
-with default {product-title} admission control plug-ins in the configuration:
-
-[source,yaml]
-----
-admissionConfig:
-  pluginOrderOverride:
-  - OriginNamespaceLifecycle
-  - BuildByStrategy
-  - ProjectRequestLimit
-----
-
 In order to specify limits for users, a configuration must be specified for the
 plug-in. The plug-in configuration takes a list of user label selectors and the
 associated maximum project requests:
@@ -269,8 +257,7 @@ specified, a limit applies to all users. If a maximum number of projects is not
 specified, then an unlimited number of projects are allowed for a specific
 selector.
 
-The following configuration adds `*ProjectRequestLimit*` to the list of
-plug-ins and sets a global limit of 2 projects per user while allowing 10
+The following configuration sets a global limit of 2 projects per user while allowing 10
 projects for users with a label of `level=advanced` and unlimited projects for
 users with a label of `level=admin`.
 
@@ -279,10 +266,6 @@ users with a label of `level=admin`.
 [source, yaml]
 ----
 admissionConfig:
-  pluginOrderOverride:
-  - OriginNamespaceLifecycle
-  - BuildByStrategy
-  - ProjectRequestLimit
   pluginConfig:
     ProjectRequestLimit:
       configuration:

--- a/install_config/configuring_admission_control.adoc
+++ b/install_config/configuring_admission_control.adoc
@@ -24,122 +24,11 @@ system configured defaults. In addition, admission control plug-ins may modify
 related resources as part of request processing to do things such as
 incrementing quota usage.
 
-== Configuring the List of Admission Control Plug-ins
-
-The OpenShift master uses two sets of admission control plug-ins. One set
-controls admission of Kubernetes-specific resources such as `*Pods*`,
-`*ReplicationControllers*`, `*Services*`, and so on. Another set controls
-admission of OpenShift-specific resources such as `*Builds*`, `*Projects*`,
-`*Deployments*`, and so on.
-
-[WARNING]
-====
-The OpenShift master has a default list of plug-ins that are enabled by default for each type of resource (Kubernetes and OpenShift).
-These are required for the proper functioning of the master. It is not recommended to modify these lists unless you strictly know what
-you are doing. Future versions of the product may use a different set of plug-ins and may change their ordering. If you do override the
-default list of plug-ins in the master configuration file, you are responsible for updating it to reflect requirements of newer versions of the
-OpenShift master.
-====
-
-=== Overriding the Default List of Admission Control Plug-ins for OpenShift Resources
-
-The list of admission control plug-ins for OpenShift resources can be configured in the
-link:master_node_configuration.html#master-configuration-files[master-config.yaml] file
-as follows:
-
-[source,yaml]
-----
-admissionControl:
-  pluginOrderOverride:
-  - OriginNamespaceLifecycle
-  - BuildByStrategy
-  - YourPlugin
-----
-
-If the `*pluginOrderOverride*` setting is empty or not present, then the default
-set of plug-ins will be used.
-
-The default list of admission control plug-ins for OpenShift resources is:
-
-[source, yaml]
-----
-- OriginNamespaceLifecycle
-- BuildByStrategy
-----
-
-* `*OriginNamespaceLifecycle*` enforces that a
-link:../architecture/core_concepts/projects_and_users.html#namespaces[namespace]
-must exist before creating resources in it. It also prevents creation of
-resources in a project that is in the process of getting deleted.
-
-* `*BuildByStrategy*` restricts creation of
-link:../architecture/core_concepts/builds_and_image_streams.html#builds[builds]
-and
-link:../dev_guide/builds.html#defining-a-buildconfig[BuildConfigs]
-to a strategy that the current user is
-link:../admin_guide/securing_builds.html[allowed to use].
-
-=== Overriding the Default List of Admission Control Plug-ins for Kubernetes Resources
-
-The list of admission control plug-ins for Kubernetes resources can be
-configured in the
-link:master_node_configuration.html#master-configuration-files[master-config.yaml]
-file as follows:
-
-[source,yaml]
-----
-kubernetesMasterConfig:
-  admissionConfig:
-    pluginOrderOverride:
-    - NamespaceLifecycle
-    - OriginPodNodeEnvironment
-    - YourPlugin
-    - ...
-----
-
-The default list of admission control plug-ins for Kubernetes resources is:
-
-[source, yaml]
-----
-- NamespaceLifecycle
-- OriginPodNodeEnvironment
-- LimitRanger
-- ServiceAccount
-- SecurityContextConstraint
-- ResourceQuota
-- SCCExecRestrictions
-----
-
-* `*NamespaceLifecycle*` enforces that a
-link:../architecture/core_concepts/projects_and_users.html#namespaces[namespace]
-must exist before creating resources in it. It also prevents creation of resources in a project
-that is in the process of getting deleted.
-
-* `*OriginPodNodeEnvironment*` ensures that a
-link:../architecture/core_concepts/pods_and_services.html#pods[pod]'s node selector matches at least one node
-in the cluster.
-
-* `*LimitRanger*` enforces resource usage
-link:../dev_guide/limits.html[limits] for pods created in a given namespace.
-
-* `*ServiceAccount*` ensures that all pods are associated with a valid
-link:../admin_guide/service_accounts.html[service account] and that the
-service account associated with the pod can properly execute it.
-
-* `*SecurityContextConstraint*` ensures that
-link:../architecture/additional_concepts/authorization.html#security-context-constraints[security context constraints]
-that apply to the current user and pod service account are applied to a pod.
-
-* `*ResourceQuota*` enforces the
-link:../admin_guide/quota.html[resource quota] that has been configured for a particular project.
-
-* `*SCCExecRestrictions*` prevents users from remotely executing processes on pods that they cannot create according to current
-link:../architecture/additional_concepts/authorization.html#security-context-constraints[security context constraints].
-
 == Providing Configuration for Admission Control Plug-ins
 
-Certain admission control plug-ins may take an additional configuration file. The configuration for a plug-in may be provided either
-as a file location or an embedded configuration object in
+Certain admission control plug-ins may take an additional configuration file. The 
+configuration for a plug-in may be provided either as a file location or an embedded 
+configuration object in
 link:master_node_configuration.html#master-configuration-files[master-config.yaml].
 
 If specifying a path to a configuration file, use a location field:
@@ -168,3 +57,6 @@ admissionControl:
 
 Each plug-in is responsible for initializing and using the configuration
 provided in the master configuration file.
+
+In general, admission control plugins that require a configuration are effectively
+disabled if no configuration is present for them.


### PR DESCRIPTION
Given that all admission control plugins are now part of the default admission control chain, documentation on how to override this chain is no longer needed and it's preferable that end users do not make changes to this. Changing which plugins are in the chain and their order can lead to all kinds of support issues. 
