### PR TITLE
Follow-up to Note gogs support for github webhook (PR#1943)

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1396,8 +1396,9 @@ http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<na
 
 [NOTE]
 ====
-https://gogs.io[Gogs] supports the same webhook payload format as GitHub.  Therefore, if you are using a Gogs server
-you can define a GitHub webhook trigger on your BuildConfig and trigger it via your Gogs server also.
+https://gogs.io[Gogs] supports the same webhook payload format as GitHub.
+Therefore, if you are using a Gogs server, you can define a GitHub webhook
+trigger on your `*BuildConfig*` and trigger it via your Gogs server also.
 ====
 
 
@@ -1655,7 +1656,7 @@ for running unit tests as above. To control the image entry point,
 or if the image does not have `*/bin/sh*`, use `*command*` and/or `*args*`.
 +
 [NOTE]
-==== 
+====
 The additional `-i` flag was introduced to improve the experience
 working with CentOS and RHEL images, and may be removed in a future release.
 ====
@@ -1710,7 +1711,7 @@ postCommit:
 This form is equivalent to appending the arguments to `*command*`.
 
 [NOTE]
-==== 
+====
 Providing both `*script*` and `*command*` simultaneously creates an invalid
 build hook.
 ====


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1943
