### PR TITLE
Add steps for dynamic VIP update for ipfailover

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -310,7 +310,7 @@ ensure a higher Service Level Availability (SLA). If there are no constraints on
 the service being setup for failover, it is possible to target the service to
 run on one or more, or even all, of the labeled nodes.
 ====
-
++
 . Finally, configure the VIPs and failover for the nodes labeled with
 *ha-router=geo-us-west* in the first step. Ensure the number of replicas match
 the number of nodes and that they satisfy the label setup in the first step. The
@@ -344,6 +344,11 @@ $ oadm ipfailover ipf-ha-router-us-west \
 ----
 ====
 endif::[]
+
+
+For details on how to dynamically update the virtual IP addresses for a
+highly available, see
+link:#dynamically-updating-vips-for-a-highly-available-service [dynamically updating the virtual IPs]
 
 === Configuring a Highly-available Network Service [[ip-failover]]
 
@@ -471,3 +476,58 @@ Using the above example, you can now use the VIPs 10.245.2.101 through
 instance is "unreachable", perhaps due to a node failure, Keepalived ensures
 that the VIPs automatically float amongst the group of nodes labeled
 "ha-cache=geo" and the service is still reachable via the virtual IP addresses.
+
+[[dynamically-updating-vips-for-a-highly-available-service]]
+
+=== Dynamically Updating Virtual IPs for a Highly-available Service
+The default deployment strategy for the IP failover service is to recreate
+the deployment. In order to dynamically update the virtual IPs for a highly
+available routing service with minimal or no downtime, you will need to
+update the IP failover service deployment config to use a rolling update
+strategy and update the environment variable `OPENSHIFT_HA_VIRTUAL_IPS` with
+the updated list or sets of virtual IP addresses.
+
+The following example shows how to dynamically update the deployment
+strategy and the virtual IP addresses:
++
+ifdef::openshift-enterprise[]
+====
+----
+$ oadm ipfailover ipf-ha-router-us-west \
+    --replicas=5 --watch-port=80 \
+    --selector="ha-router=geo-us-west" \
+    --virtual-ips="10.245.2.101-105" \
+    --credentials=/etc/origin/master/openshift-router.kubeconfig \
+    --service-account=ipfailover --create
+----
+====
+endif::[]
+ifdef::openshift-origin[]
+====
+----
+$ oadm ipfailover ipf-ha-router-us-west \
+    --replicas=5 --watch-port=80 \
+    --selector="ha-router=geo-us-west" \
+    --virtual-ips="10.245.2.101-105" \
+    --credentials="$KUBECONFIG" \
+    --service-account=ipfailover --create
+----
+====
+endif::[]
+----
+$ oc edit dc/ipf-ha-router-us-west
+
+$ #  Update Spec.Strategy.Type from "Recreate" to "Rolling".
+$ #  Example:
+$ #     - Spec:
+$ #       ...
+$ #       Strategy:
+$ #         Type: Rolling
+$ #         ...
+
+$ #  Update the environment variable OPENSHIFT_HA_VIRTUAL_IPS to contain
+$ #  the additional virtual IP addresses.
+$ #  Example:
+$ #     - name: OPENSHIFT_HA_VIRTUAL_IPS
+$ #       value: 10.245.2.101-105,10.245.2.110,10.245.2.201-205
+----

--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -264,7 +264,7 @@ $ oc create serviceaccount ipfailover -n default
 ----
 ====
 
-. Add the *ipfailover* service account in the *default* namespace to the *privileged* SCC: 
+. Add the *ipfailover* service account in the *default* namespace to the *privileged* SCC:
 +
 ====
 ----
@@ -310,7 +310,7 @@ ensure a higher Service Level Availability (SLA). If there are no constraints on
 the service being setup for failover, it is possible to target the service to
 run on one or more, or even all, of the labeled nodes.
 ====
-+
+
 . Finally, configure the VIPs and failover for the nodes labeled with
 *ha-router=geo-us-west* in the first step. Ensure the number of replicas match
 the number of nodes and that they satisfy the label setup in the first step. The
@@ -345,10 +345,10 @@ $ oadm ipfailover ipf-ha-router-us-west \
 ====
 endif::[]
 
-
-For details on how to dynamically update the virtual IP addresses for a
-highly available, see
-link:#dynamically-updating-vips-for-a-highly-available-service [dynamically updating the virtual IPs]
+For details on how to dynamically update the virtual IP addresses for high
+availability, see
+link:#dynamically-updating-vips-for-a-highly-available-service[Dynamically
+Updating Virtual IPs for a Highly-available Service].
 
 === Configuring a Highly-available Network Service [[ip-failover]]
 
@@ -406,7 +406,7 @@ $ oc create serviceaccount ipfailover -n default
 ----
 ====
 
-. Add the *ipfailover* service account in the *default* namespace to the *privileged* SCC: 
+. Add the *ipfailover* service account in the *default* namespace to the *privileged* SCC:
 +
 ====
 ----
@@ -478,17 +478,21 @@ that the VIPs automatically float amongst the group of nodes labeled
 "ha-cache=geo" and the service is still reachable via the virtual IP addresses.
 
 [[dynamically-updating-vips-for-a-highly-available-service]]
-
 === Dynamically Updating Virtual IPs for a Highly-available Service
+
 The default deployment strategy for the IP failover service is to recreate
 the deployment. In order to dynamically update the virtual IPs for a highly
-available routing service with minimal or no downtime, you will need to
-update the IP failover service deployment config to use a rolling update
-strategy and update the environment variable `OPENSHIFT_HA_VIRTUAL_IPS` with
-the updated list or sets of virtual IP addresses.
+available routing service with minimal or no downtime, you must:
 
-The following example shows how to dynamically update the deployment
-strategy and the virtual IP addresses:
+- update the IP failover service deployment configuration to use a rolling update
+strategy, and
+- update the `*OPENSHIFT_HA_VIRTUAL_IPS*` environment variable with the updated
+list or sets of virtual IP addresses.
+
+The following example shows how to dynamically update the deployment strategy
+and the virtual IP addresses:
+
+. Consider an IP failover configuration that was created using the following:
 +
 ifdef::openshift-enterprise[]
 ====
@@ -514,20 +518,39 @@ $ oadm ipfailover ipf-ha-router-us-west \
 ----
 ====
 endif::[]
+
+. Edit the deployment configuration:
++
+====
 ----
 $ oc edit dc/ipf-ha-router-us-west
-
-$ #  Update Spec.Strategy.Type from "Recreate" to "Rolling".
-$ #  Example:
-$ #     - Spec:
-$ #       ...
-$ #       Strategy:
-$ #         Type: Rolling
-$ #         ...
-
-$ #  Update the environment variable OPENSHIFT_HA_VIRTUAL_IPS to contain
-$ #  the additional virtual IP addresses.
-$ #  Example:
-$ #     - name: OPENSHIFT_HA_VIRTUAL_IPS
-$ #       value: 10.245.2.101-105,10.245.2.110,10.245.2.201-205
 ----
+====
+
+. Update the `*spec.strategy.type*` field from `Recreate` to `Rolling`:
++
+====
+----
+spec:
+  replicas: 5
+  selector:
+    ha-router: geo-us-west
+  strategy:
+    recreateParams:
+      timeoutSeconds: 600
+    resources: {}
+    type: Rolling <1>
+----
+<1> Set to `Rolling`.
+====
+
+. Update the `*OPENSHIFT_HA_VIRTUAL_IPS*` environment variable to contain the
+additional virtual IP addresses:
++
+====
+----
+- name: OPENSHIFT_HA_VIRTUAL_IPS
+  value: 10.245.2.101-105,10.245.2.110,10.245.2.201-205 <1>
+----
+<1> `10.245.2.110,10.245.2.201-205` have been added to the list.
+====


### PR DESCRIPTION
Pulls in the commit from https://github.com/openshift/openshift-docs/pull/1951 and continues with edits.

@ramr @bfallonf PTAL. Pretty build:

http://file.rdu.redhat.com/~adellape/050616/failover_edits/failover_edits/admin_guide/high_availability.html#dynamically-updating-vips-for-a-highly-available-service
