### PR TITLE
Consolidate quota/limit/compute_resource into dev_guide/compute_resource

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -361,8 +361,10 @@ Topics:
   - Name: Overcommitting
     File: overcommit
     Distros: openshift-origin,openshift-enterprise
-  - Name: Quota
+  - Name: Setting Quotas
     File: quota
+  - Name: Setting Limit Ranges
+    File: limits
   - Name: Pruning Objects
     File: pruning_resources
     Distros: openshift-origin,openshift-enterprise
@@ -451,7 +453,7 @@ Topics:
     File: builds
   - Name: Managing Images
     File: managing_images
-  - Name: Compute Resources
+  - Name: Quotas, Limit Ranges, and Compute Resources
     File: compute_resources
   - Name: Deployments
     File: deployments
@@ -463,8 +465,6 @@ Topics:
     File: secrets
   - Name: ConfigMaps
     File: configmaps
-  - Name: Resource Limits
-    File: limits
   - Name: Pod Autoscaling
     File: pod_autoscaling
   - Name: Managing Volumes

--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -1,4 +1,4 @@
-= Resource Limits
+= Setting Limit Ranges
 {product-author}
 {product-version}
 :data-uri:
@@ -6,26 +6,29 @@
 :experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
 
 toc::[]
 
 == Overview
 
-A `*LimitRange*` object enumerates link:compute_resources.html[compute resource
-constraints] in a link:projects.html[project] at the pod and container level.
-This allows you to specify the amount of resources that a pod or container can
-consume.
-
-[[setting-limit-range-constraints]]
-== Setting Limit Range Constraints
+// tag::admin_limits_overview[]
+A limit range, defined by a `*LimitRange*` object, enumerates
+link:../dev_guide/compute_resources.html#dev-compute-resources[compute resource
+constraints] in a link:../dev_guide/projects.html[project] at the pod and
+container level, and specifies the amount of resources that a pod or container
+can consume.
 
 All resource create and modification requests are evaluated against each
 `*LimitRange*` object in the project. If the resource violates any of the
 enumerated constraints, then the resource is rejected. If the resource does not
 set an explicit value, and if the constraint supports a default value, then the
 default value is applied to the resource.
+// end::admin_limits_overview[]
+
 
 [[limit-range-def]]
+// tag::admin_limits_sample_definition[]
 .Limit Range Object Definition
 ====
 
@@ -34,33 +37,33 @@ default value is applied to the resource.
 
 apiVersion: "v1"
 kind: "LimitRange"
-metadata: 
-  name: "limits" <1>
-spec: 
-  limits: 
-    - 
+metadata:
+  name: "resource-limits" <1>
+spec:
+  limits:
+    -
       type: "Pod"
-      max: 
+      max:
         cpu: "2" <2>
         memory: "1Gi" <3>
-      min: 
+      min:
         cpu: "200m" <4>
         memory: "6Mi" <5>
-    - 
+    -
       type: "Container"
-      max: 
+      max:
         cpu: "2" <6>
         memory: "1Gi" <7>
-      min: 
+      min:
         cpu: "100m" <8>
         memory: "4Mi" <9>
-      default: 
+      default:
         cpu: "300m" <10>
         memory: "200Mi" <11>
-      defaultRequest: 
+      defaultRequest:
         cpu: "200m" <12>
         memory: "100Mi" <13>
-      maxLimitRequestRatio: 
+      maxLimitRequestRatio:
         cpu: "10" <14>
 ----
 <1> The name of the limit range document.
@@ -83,10 +86,12 @@ specified.
 <13> The default amount of memory that a container will request to use if not specified.
 <14> The maximum amount of CPU burst that a container can make as a ratio of its limit over request.
 ====
+// end::admin_limits_sample_definition[]
 
 [[container-limits]]
 === Container Limits
 
+// tag::admin_limits_container_limits[]
 *Supported Resources:*
 
 * CPU
@@ -103,38 +108,46 @@ Per container, the following must hold true if specified:
 |Constraint |Behavior
 
 |`*Min*`
-|Min[resource] <= container.resources.requests[resource] (required) <= container/resources.limits[resource] (optional)
+|`Min[resource]` less than or equal to `container.resources.requests[resource]`
+(required) less than or equal to `container/resources.limits[resource]`
+(optional)
 
 If the configuration defines a `min` CPU, then the request value must be greater
 than the CPU value. A limit value does not need to be specified.
 
 |`*Max*`
-|container.resources.limits[resource] (required) <= Max[resource]
+|`container.resources.limits[resource]` (required) less than or equal to
+`Max[resource]`
 
 If the configuration defines a `max` CPU, then you do not need to define a
 request value, but a limit value does need to be set that satisfies the maximum
 CPU constraint.
 
 |`*MaxLimitRequestRatio*`
-|MaxLimitRequestRatio[resource] <= ( container.resources.limits[resource] / container.resources.requests[resource])
+|`MaxLimitRequestRatio[resource]` less than or equal to (
+`container.resources.limits[resource]` /
+`container.resources.requests[resource]`)
 
 If a configuration defines a `maxLimitRequestRatio` value, then any new
-containers must have both a request and limit value. Additionally, OpenShift
-calculates a limit to request ratio by dividing the limit by the request. For
-example, if a container has `cpu: 500` in the `limit` value, and `cpu: 100` in
-the `request` value, then its limit to request ratio for `cpu` is `5`. This
-ratio must be less than or equal to the `maxLimitRequestRatio`.
+containers must have both a request and limit value. Additionally,
+{product-title} calculates a limit to request ratio by dividing the limit by the
+request.
 
+For example, if a container has `cpu: 500` in the `limit` value, and
+`cpu: 100` in the `request` value, then its limit to request ratio for `cpu` is
+`5`. This ratio must be less than or equal to the `maxLimitRequestRatio`.
 |===
 
 *Supported Defaults:*
 
-* Default[resource] - defaults container.resources.limit[resource] to specified value if none
-* Default Requests[resource] - defaults container.resources.requests[resource] to specified value if none
+`Default[resource]`:: Defaults `container.resources.limit[resource]` to specified value if none.
+`Default Requests[resource]`:: Defaults `container.resources.requests[resource]` to specified value if none.
+// end::admin_limits_container_limits[]
 
 [[pod-limits]]
 === Pod Limits
 
+// tag::admin_limits_pod_limits[]
 *Supported Resources:*
 
 * CPU
@@ -151,15 +164,21 @@ Across all containers in a pod, the following must hold true:
 |Constraint |Enforced Behavior
 
 |`*Min*`
-|Min[resource] less than or equal to container.resources.requests[resource] (required) less than or equal to container.resources.limits[resource] (optional)
+|`Min[resource]` less than or equal to `container.resources.requests[resource]`
+(required) less than or equal to `container.resources.limits[resource]`
+(optional)
 
 |`*Max*`
-|container.resources.limits[resource] (required) less than or equal to Max[resource]
+|`container.resources.limits[resource]` (required) less than or equal to
+`Max[resource]`
 
 |`*MaxLimitRequestRatio*`
-|MaxLimitRequestRatio[resource] less than or equal to ( container.resources.limits[resource] / container.resources.requests[resource])
+|`MaxLimitRequestRatio[resource]` less than or equal to (
+`container.resources.limits[resource]` /
+`container.resources.requests[resource]`)
 
 |===
+// end::admin_limits_pod_limits[]
 
 [[creating-a-limit-range]]
 == Creating a Limit Range
@@ -168,31 +187,46 @@ To apply a limit range to a project, create a link:#limit-range-def[limit range
 object definition] on your file system to your desired specifications, then run:
 
 ----
-$ oc create -f <limit_range_file>
+$ oc create -f <limit_range_file> -n <project>
 ----
 
 [[viewing-limits]]
 == Viewing Limits
 
-To view limits enforced in a project:
+// tag::admin_limits_viewing[]
+You can view any limit ranges defined in a project by navigating in the web
+console to the project's *Settings* tab.
 
+You can also use the CLI to view limit range details:
+
+. First, get the list of limit ranges defined in the project. For example, for a
+project called *demoproject*:
++
 ====
 ----
-$ oc get limits
-NAME
-limits
-
-$ oc describe limits limits
-Name:        limits
-Namespace:   default
-Type         Resource  Min Max Request Limit Limit/Request
-----         --------  --- --- ------- ----- -------------
-Pod          memory    6Mi 1Gi -       -     -
-Pod          cpu       200m  2 -       -     -
-Container    cpu       100m  2 200m    300m  10
-Container    memory    4Mi 1Gi 100Mi   200Mi -
+$ oc get limits -n demoproject
+NAME              AGE
+resource-limits   6d
 ----
 ====
+
+. Then, describe the limit range you are interested in, for example the
+*resource-limits* limit range:
++
+====
+----
+$ oc describe limits resource-limits
+Name:		resource-limits
+Namespace:	demoproject
+Type		Resource	Min	Max	Default Request	Default Limit	Max Limit/Request Ratio
+----		--------	---	---	---------------	-------------	-----------------------
+Pod		cpu		30m	2	-		-		-
+Pod		memory		150Mi	1Gi	-		-		-
+Container	memory		150Mi	1Gi	307Mi		512Mi		-
+Container	cpu		30m	2	60m		1		-
+----
+====
+// end::admin_limits_viewing[]
 
 [[deleting-limits]]
 == Deleting Limits

--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -1,4 +1,4 @@
-= Resource Quota
+= Setting Quotas
 {product-author}
 {product-version}
 :data-uri:
@@ -12,10 +12,12 @@ toc::[]
 
 == Overview
 
+// tag::admin_quota_overview[]
 A resource quota, defined by a `*ResourceQuota*` object, provides constraints
 that limit aggregate resource consumption per project. It can limit the quantity
 of objects that can be created in a project by type, as well as the total amount
 of compute resources that may be consumed by resources in that project.
+// end::admin_quota_overview[]
 
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 [NOTE]
@@ -25,12 +27,14 @@ compute resources.
 ====
 endif::[]
 
-[[resources-managed-by-quota]]
+[[managed-by-quota]]
 == Resources Managed by Quota
 
-The following describes the set of resources that may be managed by a resource
-quota.
+// tag::admin_quota_resources_managed[]
+The following describes the set of compute resources and object types that may be
+managed by a quota.
 
+.Compute Resources Managed by Quota
 [cols="3a,8a",options="header"]
 |===
 
@@ -59,9 +63,13 @@ this value.
 |`*limits.memory*`
 |Across all pods in a non-terminal state, the sum of memory limits cannot exceed
 this value.
+|===
 
-|`*configmaps*`
-|The total number of `*ConfigMap*` objects that can exist in the project.
+.Object Counts Managed by Quota
+[cols="3a,8a",options="header"]
+|===
+
+|Resource Name |Description
 
 |`*pods*`
 |The total number of pods in a non-terminal state that can exist in the project.
@@ -79,20 +87,25 @@ A pod is in a terminal state if `status.phase in (Failed, Succeeded)` is true.
 |`*secrets*`
 |The total number of secrets that can exist in the project.
 
+|`*configmaps*`
+|The total number of `*ConfigMap*` objects that can exist in the project.
+
 |`*persistentvolumeclaims*`
 |The total number of persistent volume claims that can exist in the project.
 |===
+// end::admin_quota_resources_managed[]
 
 [[quota-scopes]]
 == Quota Scopes
 
+// tag::admin_quota_scopes[]
 Each quota can have an associated set of _scopes_. A quota will only
 measure usage for a resource if it matches the intersection of enumerated
 scopes.
 
-Adding a scope to a quota limits the number of resources it supports to those
-that pertain to the scope. Specifying a resource on the quota outside of the
-allowed set would result in a validation error.
+When a scope is added to a quota, it limits the number of resources it supports
+to those that pertain to the scope. Resources specified on the quota outside of
+the allowed set results in a validation error.
 
 [cols="3a,8a",options="header"]
 |===
@@ -128,10 +141,12 @@ to tracking the following resources:
 - `*cpu*`
 - `*requests.cpu*`
 - `*limits.cpu*`
+// end::admin_quota_scopes[]
 
 [[quota-enforcement]]
 == Quota Enforcement
 
+// tag::admin_quota_enforcement[]
 After a resource quota for a project is first created, the project restricts the
 ability to create any new resources that may violate a quota constraint until it
 has calculated updated usage statistics.
@@ -142,10 +157,11 @@ usage is incremented immediately upon the request to create or modify the
 resource.
 
 When you delete a resource, your quota use is decremented during the next full
-recalculation of quota statistics for the project. When you delete resources, a
-link:#configuring-quota-sync-period[configurable amount of time] determines how
-long it takes to reduce quota usage statistics to their current observed system
-value.
+recalculation of quota statistics for the project.
+// end::admin_quota_enforcement[]
+A link:#configuring-quota-sync-period[configurable amount of time] determines
+how long it takes to reduce quota usage statistics to their current observed
+system value.
 
 If project modifications exceed a quota usage limit, the server denies the
 action, and an appropriate error message is returned to the user explaining the
@@ -153,19 +169,24 @@ quota constraint violated, and what their currently observed usage stats are in
 the system.
 
 [[requests-vs-limits]]
-=== Requests vs Limits
+== Requests vs Limits
 
-When allocating compute resources, each container may specify a request and a limit value
-for either CPU or memory. The quota can be configured to quota either value.
+// tag::admin_quota_requests_vs_limits[]
+When allocating
+link:../dev_guide/compute_resources.html#dev-compute-resources[compute
+resources], each container may specify a request and a limit value for either
+CPU or memory. The quota can be configured to quota either value.
 
 If the quota has a value specified for `*requests.cpu*` or `*requests.memory*`,
 then it requires that every incoming container makes an explicit request for
 those resources. If the quota has a value specified for `*limits.cpu*` or
 `*limits.memory*`, then it requires that every incoming container specifies an
 explicit limit for those resources.
+// end::admin_quota_requests_vs_limits[]
 
 == Sample Resource Quota Definitions
 
+// tag::admin_quota_sample_definitions[]
 .*_object-counts.yaml_*
 ====
 ----
@@ -234,6 +255,7 @@ of service that can exist in the project.
 <2> Restricts the quota to only matching pods that have *BestEffort* quality of
 service for either memory or CPU.
 ====
+// end::admin_quota_sample_definitions[]
 
 [[create-a-quota]]
 == Creating a Quota
@@ -256,10 +278,15 @@ $ oc create -f resource-quota.json -n demoproject
 [[viewing-a-quota]]
 == Viewing a Quota
 
-To view usage statistics related to any hard limits defined in a quota, first
-get the list of quotas defined in the project. For example, for a project called
-*demoproject*:
+// tag::admin_quota_viewing[]
+You can view usage statistics related to any hard limits defined in a project's
+quota by navigating in the web console to the project's *Settings* tab.
 
+You can also use the CLI to view quota details:
+
+. First, get the list of quotas defined in the project. For example, for a project
+called *demoproject*:
++
 ====
 ----
 $ oc get quota -n demoproject
@@ -270,9 +297,9 @@ object-counts       29m
 ----
 ====
 
-Then, describe the resource quota you are interested in, for example a
-*object-counts* quota:
-
+. Then, describe the quota you are interested in, for example the *object-counts*
+quota:
++
 ====
 ----
 $ oc describe quota object-counts -n demoproject
@@ -287,6 +314,7 @@ secrets			9	10
 services		2	10
 ----
 ====
+// end::admin_quota_viewing[]
 
 [[configuring-quota-sync-period]]
 == Configuring Quota Synchronization Period

--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -50,8 +50,8 @@ A Kubernetes `*Resource*` is something that can be requested by, allocated to,
 or consumed by a pod or container. Examples include memory (RAM), CPU,
 disk-time, and network bandwidth.
 
-See the link:../../dev_guide/limits.html[Developer's Guide] and
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/resources.md[Kubernetes
+See the link:../../dev_guide/compute_resources.html[Developer Guide] and
+http://kubernetes.io/docs/user-guide/compute-resources/[Kubernetes
 documentation] for more information.
 
 == Secret

--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -126,14 +126,8 @@ link:../core_concepts/builds_and_image_streams.html#image-streams[Image
 Streams],
 link:../core_concepts/pods_and_services.html#pods[Pods], and
 link:../core_concepts/pods_and_services.html#services[Services].
-ifdef::openshift-enterprise,openshift-origin[]
-<6> The *Settings* tab provides general information about your project, as well
-as the link:../../admin_guide/quota.html[quota] and
-link:../../dev_guide/limits.html[resource limits] that are set on your project.
-endif::openshift-enterprise,openshift-origin[]
-ifdef::openshift-dedicated,openshift-online[]
-<6> The *Settings* tab provides general information about your project, as well
-as the quota and link:../../dev_guide/limits.html[resource limits] that are set
+<6> The *Settings* tab provides general information about your project, as well as
+the link:../../dev_guide/compute_resources.html[quota and limits] that are set
 on your project.
 endif::openshift-dedicated,openshift-online[]
 <7> When you click on one of your objects in the *Overview* page, the *Details*

--- a/dev_guide/compute_resources.adoc
+++ b/dev_guide/compute_resources.adoc
@@ -1,4 +1,4 @@
-= Compute Resources
+= Quotas, Limit Ranges, and Compute Resources
 {product-author}
 {product-version}
 :data-uri:
@@ -6,20 +6,124 @@
 :experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
 
 toc::[]
 
 == Overview
 
-Each container running on a node consumes compute resources, which are measurable quantities that can be requested, allocated, and consumed.
+Using link:#dev-quotas[quotas] and link:#dev-limit-ranges[limit ranges], cluster
+administrators can set constraints to limit the number of objects or amount of
+compute resources that are used in your project. This helps cluster
+administrators better manage and allocate resources across all projects, and
+ensure that no projects are using more than is appropriate for the cluster size.
 
-When authoring a pod configuration file, you can optionally specify how much CPU and memory (RAM) each container needs in order to better schedule pods in the cluster and ensure satisfactory performance.
+As a developer, you can also
+set link:#dev-compute-resources[requests and limits on compute resources] at the
+pod and container level.
 
-CPU is measured in units called millicores. Each node in a cluster inspects the operating system to determine the amount of CPU cores on the node, then multiplies that value by 1000 to express its total capacity. For example, if a node has 2 cores, the node's CPU capacity would be represented as 2000m. If you wanted to use 1/10 of a single core, it would be represented as 100m.
+The following sections help you understand how to check on your quota and limit
+range settings, what sorts of things they can constrain, and how you can request
+or limit compute resources in your own pods and containers.
 
-Memory is measured in bytes. In addition, it may be used with SI suffices (E, P, T, G, M, K, m) or their power-of-two-equivalents (Ei, Pi, Ti, Gi, Mi, Ki).
+[[dev-quotas]]
+== Quotas
+
+include::admin_guide/quota.adoc[tag=admin_quota_overview]
+
+[NOTE]
+====
+Quotas are set by cluster administrators and are scoped to a given project.
+====
+
+[[dev-viewing-quotas]]
+=== Viewing Quotas
+
+include::admin_guide/quota.adoc[tag=admin_quota_viewing]
+
+Full quota definitions can be viewed by running `oc export` on the object. The
+following show some sample quota definitions:
+
+include::admin_guide/quota.adoc[tag=admin_quota_sample_definitions]
+
+[[dev-managed-by-quota]]
+=== Resources Managed by Quota
+
+include::admin_guide/quota.adoc[tag=admin_quota_resources_managed]
+
+[[dev-quota-scopes]]
+=== Quota Scopes
+
+include::admin_guide/quota.adoc[tag=admin_quota_scopes]
+
+[[dev-quota-enforcement]]
+=== Quota Enforcement
+
+include::admin_guide/quota.adoc[tag=admin_quota_enforcement]
+If project modifications exceed a quota usage limit, the server denies the
+action. An appropriate error message is returned explaining the quota constraint
+violated, and what your currently observed usage stats are in the system.
+
+[[dev-requests-vs-limits]]
+=== Requests vs Limits
+
+include::admin_guide/quota.adoc[tag=admin_quota_requests_vs_limits]
+
+See link:#dev-compute-resources[Compute Resources] for more on setting requests
+and limits in pods and containers.
+
+[[dev-limit-ranges]]
+== Limit Ranges
+
+include::admin_guide/limits.adoc[tag=admin_limits_overview]
+
+[NOTE]
+====
+Limit ranges are set by cluster administrators and are scoped to a given
+project.
+====
+
+[[dev-viewing-limit-ranges]]
+=== Viewing Limit Ranges
+
+include::admin_guide/limits.adoc[tag=admin_limits_viewing]
+
+Full limit range definitions can be viewed by running `oc export` on the object.
+The following shows an example limit range definition:
+
+include::admin_guide/limits.adoc[tag=admin_limits_sample_definition]
+
+[[dev-container-limits]]
+=== Container Limits
+
+include::admin_guide/limits.adoc[tag=admin_limits_container_limits]
+
+[[dev-pod-limits]]
+=== Pod Limits
+
+include::admin_guide/limits.adoc[tag=admin_limits_pod_limits]
+
+[[dev-compute-resources]]
+== Compute Resources
+
+Each container running on a node consumes compute resources, which are
+measurable quantities that can be requested, allocated, and consumed.
+
+When authoring a pod configuration file, you can optionally specify how much CPU
+and memory (RAM) each container needs in order to better schedule pods in the
+cluster and ensure satisfactory performance.
+
+CPU is measured in units called millicores. Each node in a cluster inspects the
+operating system to determine the amount of CPU cores on the node, then
+multiplies that value by 1000 to express its total capacity. For example, if a
+node has 2 cores, the node's CPU capacity would be represented as 2000m. If you
+wanted to use 1/10 of a single core, it would be represented as 100m.
+
+Memory is measured in bytes. In addition, it may be used with SI suffices (E, P,
+T, G, M, K, m) or their power-of-two-equivalents (Ei, Pi, Ti, Gi, Mi, Ki).
 
 ====
+[source,yaml]
 ----
 apiVersion: v1
 kind: Pod
@@ -41,66 +145,23 @@ spec:
 <4> The container limits 400Mi memory.
 ====
 
-== CPU Requests
+[[dev-cpu-requests]]
+=== CPU Requests
 
-Each container in a pod can specify the amount of CPU it requests on a node. The scheduler uses CPU requests to find a node with an appropriate fit for a container. The CPU request represents a minimum amount of CPU that your container may consume, but if there is no contention for CPU, it can use all available CPU on the node. If there is CPU contention on the node, CPU requests provide a relative weight across all containers on the system for how much CPU time the container may use. On the node, CPU requests map to Kernel CFS shares to enforce this behavior.
+Each container in a pod can specify the amount of CPU it requests on a node. The
+scheduler uses CPU requests to find a node with an appropriate fit for a
+container.
 
-== CPU Limits
+The CPU request represents a minimum amount of CPU that your container may
+consume, but if there is no contention for CPU, it can use all available CPU on
+the node. If there is CPU contention on the node, CPU requests provide a
+relative weight across all containers on the system for how much CPU time the
+container may use.
 
-Each container in a pod can specify the amount of CPU it is limited to use on a node. CPU limits control the maximum amount of CPU that your container may use independent of contention on the node. If a container attempts to exceed the specified limit, the system will throttle the container. This allows the container to have a consistent level of service independent of the number of pods scheduled to the node.
+On the node, CPU requests map to Kernel CFS shares to enforce this behavior.
 
-== Memory Requests
-
-By default, a container is able to consume as much memory on the node as possible. In order to improve placement of pods in the cluster, specify the amount of memory required for a container to run. The scheduler will then take available node memory capacity into account prior to binding your pod to a node. A container is still able to consume as much memory on the node as possible even when specifying a request.
-
-== Memory Limits
-
-If you specify a memory limit, you can constrain the amount of memory the container can use. For example, if you specify a limit of 200Mi, a container will be limited to using that amount of memory on the node. If the container exceeds the specified memory limit, it will be terminated and potentially restarted dependent upon the container restart policy.
-
-== Quality of Service Tiers
-
-A compute resource is classified with a quality of service based on the specified request and limit value.
-
-[cols="3,8",options="header"]
-|===
-|*Quality of Service*
-|*Description*
-
-|*BestEffort*
-|Provided when a request and limit are not specified.
-
-|*Burstable*
-|Provided when a request is specified that is less than an optionally specified limit.
-
-|*Guaranteed*
-|Provided when a limit is specified that is equal to an optionally specified request.
-|===
-
-A container may have a different quality of service for each compute resource. For example, a container can have *Burstable* CPU and *Guaranteed* memory qualities of service.  
-
-The quality of service has an impact on what happens if the resource is compressible or not. CPU is a compressible resource, whereas memory is an incompressible resource.
-
-With CPU Resources: ::
-- A *BestEffort* CPU container is able to consume as much CPU as is available on a node with the lowest priority.
-- A *Burstable* CPU container is guaranteed to get the minimum amount of CPU requested, but it may or may not get additional CPU time. Excess CPU resources are distributed based on the amount requested across all containers on the node.
-- A *Guaranteed* CPU container is guaranteed to get the amount requested and no more, even if there are additional CPU cycles available. This provides a consistent level of performance independent of other activity on the node.
-
-With Memory Resources: ::
-- A *BestEffort* memory container is able to consume as much memory as is available on the node, but the scheduler is subject to placing that container on a node with too few memory to meet a need. In addition, a *BestEffort* memory container has the greatest chance of being killed if there is an out of memory event on the node.
-- A *Burstable* memory container is scheduled on the node to get the amount of memory requested, but it may consume more. If there is an out of memory event on the node, *Burstable* containers are killed after *BestEffort* containers when attempting to recover memory.
-- A *Guaranteed* memory container gets the amount of memory requested, but no more. In the event of an out of memory event, it will only be killed if there are no more *BestEffort* or *Burstable* memory containers on the system.
-
-== Specifying Compute Resources via CLI
-
-To specify compute resources via the CLI:
-
-====
-----
-$ oc run nginx --image=nginx --limits=cpu=200m,memory=400Mi --requests=cpu=100m,memory=200Mi
-----
-====
-
-== Viewing Compute Resources
+[[viewing-compute-resources]]
+=== Viewing Compute Resources
 
 To view compute resources for a pod:
 
@@ -113,15 +174,15 @@ Image(s):     nginx
 Node:       /
 Labels:       run=nginx
 Status:       Pending
-Reason:       
-Message:      
-IP:       
+Reason:
+Message:
+IP:
 Replication Controllers:  nginx (1/1 replicas created)
 Containers:
   nginx:
-    Container ID: 
+    Container ID:
     Image:    nginx
-    Image ID:   
+    Image ID:
     QoS Tier:
       cpu:  Burstable
       memory: Burstable
@@ -135,5 +196,86 @@ Containers:
     Ready:    False
     Restart Count:  0
     Environment Variables:
+----
+====
+
+[[dev-cpu-limits]]
+=== CPU Limits
+
+Each container in a pod can specify the amount of CPU it is limited to use on a node. CPU limits control the maximum amount of CPU that your container may use independent of contention on the node. If a container attempts to exceed the specified limit, the system will throttle the container. This allows the container to have a consistent level of service independent of the number of pods scheduled to the node.
+
+[[dev-memory-requests]]
+=== Memory Requests
+
+By default, a container is able to consume as much memory on the node as possible. In order to improve placement of pods in the cluster, specify the amount of memory required for a container to run. The scheduler will then take available node memory capacity into account prior to binding your pod to a node. A container is still able to consume as much memory on the node as possible even when specifying a request.
+
+[[dev-memory-limits]]
+=== Memory Limits
+
+If you specify a memory limit, you can constrain the amount of memory the container can use. For example, if you specify a limit of 200Mi, a container will be limited to using that amount of memory on the node. If the container exceeds the specified memory limit, it will be terminated and potentially restarted dependent upon the container restart policy.
+
+[[quality-of-service-tiers]]
+=== Quality of Service Tiers
+
+A compute resource is classified with a _quality of service_ (QoS) based on the
+specified request and limit value.
+
+[cols="3,8",options="header"]
+|===
+|*Quality of Service*
+|*Description*
+
+|*BestEffort*
+|Provided when a request and limit are not specified.
+
+|*Burstable*
+|Provided when a request is specified that is less than an optionally specified
+limit.
+
+|*Guaranteed*
+|Provided when a limit is specified that is equal to an optionally specified
+request.
+|===
+
+A container may have a different quality of service for each compute resource.
+For example, a container can have *Burstable* CPU and *Guaranteed* memory
+qualities of service.
+
+The quality of service has an impact on what happens if the resource is
+compressible or not. CPU is a compressible resource, whereas memory is an
+incompressible resource.
+
+With CPU Resources: ::
+- A *BestEffort* CPU container is able to consume as much CPU as is available on a
+node with the lowest priority.
+- A *Burstable* CPU container is guaranteed to get the minimum amount of CPU
+requested, but it may or may not get additional CPU time. Excess CPU resources
+are distributed based on the amount requested across all containers on the node.
+- A *Guaranteed* CPU container is guaranteed to get the amount requested and no
+more, even if there are additional CPU cycles available. This provides a
+consistent level of performance independent of other activity on the node.
+
+With Memory Resources: ::
+- A *BestEffort* memory container is able to consume as much memory as is
+available on the node, but the scheduler is subject to placing that container on
+a node with too few memory to meet a need. In addition, a *BestEffort* memory
+container has the greatest chance of being killed if there is an out of memory
+event on the node.
+- A *Burstable* memory container is scheduled on the node to get the amount of
+memory requested, but it may consume more. If there is an out of memory event on
+the node, *Burstable* containers are killed after *BestEffort* containers when
+attempting to recover memory.
+- A *Guaranteed* memory container gets the amount of memory requested, but no
+more. In the event of an out of memory event, it will only be killed if there
+are no more *BestEffort* or *Burstable* memory containers on the system.
+
+[[specifying-compute-resources-via-cli]]
+=== Specifying Compute Resources via CLI
+
+To specify compute resources via the CLI:
+
+====
+----
+$ oc run nginx --image=nginx --limits=cpu=200m,memory=400Mi --requests=cpu=100m,memory=200Mi
 ----
 ====

--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -672,9 +672,9 @@ items is required:
 the list of resources in the quota.
 ====
 
-- A link:../dev_guide/limits.html[limit range] defined in your project, where the
-defaults from the `*LimitRange*` object apply to pods created during the
-deployment process.
+- A link:../dev_guide/compute_resources.html#dev-limit-ranges[limit range] defined
+in your project, where the defaults from the `*LimitRange*` object apply to pods
+created during the deployment process.
 
 Otherwise, deploy pod creation will fail, citing a failure to satisfy quota.
 

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -40,7 +40,7 @@ for memory and CPU. The time range displayed is selectable, and these charts
 automatically update every 30 seconds. If there are multiple containers on the
 pod, then you can select a specific container to display its metrics.
 
-If you have link:../dev_guide/limits.html[resource limits] defined for your
+If you have link:../admin_guide/limits.html[limit range] defined for the
 project, then you can also see a donut chart for each pod. The donut chart
 displays usage against the resource limit. For example: `145 Available of 200
 MiB`, with the donut chart showing `55 MiB Used`.

--- a/install_config/configuring_admission_control.adoc
+++ b/install_config/configuring_admission_control.adoc
@@ -120,7 +120,7 @@ link:../architecture/core_concepts/pods_and_services.html#pods[pod]'s node selec
 in the cluster.
 
 * `*LimitRanger*` enforces resource usage
-link:../dev_guide/limits.html[limits] for pods created in a given namespace.
+link:../admin_guide/limits.html[limits] for pods created in a given namespace.
 
 * `*ServiceAccount*` ensures that all pods are associated with a valid
 link:../admin_guide/service_accounts.html[service account] and that the


### PR DESCRIPTION
Also moves dev_guide/limits to admin_guide

Note that this leaves admin_guide/quota and admin_guide/limits in tact, but shares a lot of the content that is applicable to end-users into the dev_guide topic.

Pretty build (internal):

http://file.rdu.redhat.com/~adellape/051116/share_quota_devadmin/dev_guide/compute_resources.html
