### PR TITLE
logging: use new-app instead of process|create

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -176,8 +176,7 @@ account] and custom roles:
 +
 ====
 ----
-$ oc process logging-deployer-account-template -n openshift \
-     | oc create -f -
+$ oc new-app logging-deployer-account-template
 ----
 ====
 endif::openshift-origin[]
@@ -238,9 +237,10 @@ The EFK stack is deployed link:../dev_guide/templates.html[using a template].
 +
 ====
 ----
-$ oc process logging-deployer-template -n openshift \
-           -v KIBANA_HOSTNAME=kibana.example.com,ES_CLUSTER_SIZE=1,PUBLIC_MASTER_URL=https://localhost:8443 \
-           | oc create -f -
+$ oc new-app logging-deployer-template \
+             --param KIBANA_HOSTNAME=kibana.example.com \
+             --param ES_CLUSTER_SIZE=1 \
+             --param PUBLIC_MASTER_URL=https://localhost:8443
 ----
 ====
 +
@@ -255,7 +255,7 @@ The available parameters are:
 |Description
 
 |`*PUBLIC_MASTER_URL*`
-|(Required with the `oc process` command) The external URL for the master. For
+|(Required with the `oc new-app` command) The external URL for the master. For
 OAuth use.
 
 |`*ENABLE_OPS_CLUSTER*`
@@ -269,11 +269,11 @@ are distinguishable by the *-ops* included in their names and have parallel
 deployment options listed below.
 
 |`*KIBANA_HOSTNAME*`, `*KIBANA_OPS_HOSTNAME*`
-|(Required with the `oc process` command) The external host name for web clients
+|(Required with the `oc new-app` command) The external host name for web clients
 to reach Kibana.
 
 |`*ES_CLUSTER_SIZE*`, `*ES_OPS_CLUSTER_SIZE*`
-|(Required with the `oc process` command) The number of instances of
+|(Required with the `oc new-app` command) The number of instances of
 Elasticsearch to deploy. Redundancy requires at least three, and more can be
 used for scaling.
 
@@ -358,7 +358,7 @@ ifdef::openshift-enterprise[]
 +
 ====
 ----
-$ oc process logging-support-template | oc create -f -
+$ oc new-app logging-support-template
 ----
 ====
 endif::openshift-enterprise[]
@@ -445,7 +445,7 @@ a template to create Elasticsearch deployments:
 
 ====
 ----
-$ oc process logging-es-template | oc create -f -
+$ oc new-app logging-es-template
 ----
 ====
 
@@ -569,7 +569,7 @@ same template as before:
 ====
 ----
 $ oc delete oauthclient/kibana-proxy
-$ oc process logging-support-template | oc create -f -
+$ oc new-app logging-support-template
 ----
 ====
 
@@ -594,7 +594,7 @@ Fix this issue by replacing the OAuth client entry:
 ====
 ----
 $ oc delete oauthclient/kibana-proxy
-$ oc process logging-support-template | oc create -f -
+$ oc new-app logging-support-template
 ----
 ====
 


### PR DESCRIPTION
(For origin and ose-3.2)

@adellape Small changes that simplify some of the steps, conceptually and as less typing.
