### PR TITLE
Document HTTPD_START_SERVERS and HTTPD_MAX_REQUEST_WORKERS

### DIFF
--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -86,9 +86,17 @@ the testing of the modules is turned off.
 |This variable specifies a mirror URL which
 cpanminus uses to install dependencies. By default, this URL is not specified.
 
-a|`*PERL_APACHE2_RELOAD*`
-|Set this to *true* to enable automatic reloading of modified Perl modules. By
+|`*PERL_APACHE2_RELOAD*`
+|Set this to `true` to enable automatic reloading of modified Perl modules. By
 default, automatic reloading is turned off.
+
+|`*HTTPD_START_SERVERS*`
+|The https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers[StartServers]
+directive sets the number of child server processes created on startup. Default is 8.
+
+|`*HTTPD_MAX_REQUEST_WORKERS*`
+|Number of simultaneous requests that will be handled by Apache. The default
+is 256, but it will be automatically lowered if memory is limited.
 |===
 
 [[perl-accessing-logs]]
@@ -107,7 +115,7 @@ rsh`] command to access the container.
 == Hot Deploying
 Hot deployment allows you to quickly make and deploy changes to your application
 without having to generate a new S2I build. To enable hot deployment in this
-image, you must set the `*PERL_APACHE2_RELOAD*` environment variable to *true*.
+image, you must set the `*PERL_APACHE2_RELOAD*` environment variable to `true`.
 For example, see the link:../../dev_guide/new_app.html#specifying-environment-variables[`oc new-app`]
 command. You can use the link:../../dev_guide/environment_variables.html#set-environment-variables[`oc env`]
 command to update environment variables of existing objects.


### PR DESCRIPTION
This is for trello card https://trello.com/c/HbqjUI5y/881-3-update-perl-image-to-autoconfigure-based-on-available-memory
Original PR: https://github.com/openshift/s2i-perl/pull/81

I've also made couple of nits regarding the formatting of `true` literal, see https://github.com/openshift/openshift-docs/issues/2093
