### PR TITLE
Reflect default resource requests for router pods in documentation

### DIFF
--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -128,6 +128,18 @@ appropriate permissions.
 endif::[]
 ====
 
+[IMPORTANT]
+====
+Router pods created using `oadm router` have default resource requests
+that a node must satisfy for the router pod to be deployed. In an
+effort to increase the reliability of infrastructure components, the default
+resource requests are used to increase the QoS tier of the router pods above
+pods without resource requests. The default values represent the observed minimum
+resources required for a basic router to be deployed and can be edited in the
+routers deployment configuration and you may want to increase them based on the 
+load of the router.
+====
+
 ifdef::openshift-enterprise[]
 The default router service account, named *router*, is automatically created during quick and advanced installations. To verify that this account already exists:
 endif::[]


### PR DESCRIPTION
Pull request https://github.com/openshift/origin/pull/8495 added default
resource request values for a router pod and that should be
mentioned in the documentation.
