### PR TITLE
fix template to new asciibinder standard requirements

### DIFF
--- a/contributing_to_docs/templates/topic_template.adoc
+++ b/contributing_to_docs/templates/topic_template.adoc
@@ -1,13 +1,8 @@
 = Replace with topic title
-{product-author}
-{product-version}
-:icons: font
 :experimental:
 :toc: macro
 :toc-title:
 :prewrap!:
-:description: This should be a clear and concise description of the topic.
-:keywords: comma, separated, keywords, list
 
 toc::[]
 
@@ -21,5 +16,6 @@ Another section in the topic.
 [Link to suggested topic]
 [Link to suggested topic]
 
-////This would be the last section of a topic that serves as a suggestion to what topics customers can go read next. It may or may not be required.
+////
+This would be the last section of a topic that serves as a suggestion to what topics customers can go read next. It may or may not be required.
 ////


### PR DESCRIPTION
Ping @ahardin-rh @adellape @bfallonf @tnguyen-rh @vikram-redhat 

Brice and Vikram and I met with Lee Newson to discuss the build system and how our docs get ported to the portal.

I've modified our standard topic template here. Check it out, it turns out that a lot of the stuff we've been including in all our topic headers is no longer needed, due to advancements in Asciibinder. It's much simpler and leaner now, so please use this one from now on.

It also helps the tooling team!
