### PR TITLE
add explanation of scoped tokens

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -349,6 +349,8 @@ Topics:
     Distros: openshift-origin,openshift-enterprise,atomic-*
   - Name: Managing Authorization Policies
     File: manage_authorization_policy
+  - Name: Scoped Tokens
+    File: scoped_tokens
   - Name: Managing Security Context Constraints
     File: manage_scc
     Distros: openshift-origin,openshift-enterprise

--- a/admin_guide/scoped_tokens.adoc
+++ b/admin_guide/scoped_tokens.adoc
@@ -1,0 +1,48 @@
+= Scoped Tokens
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+A user may wish to give another entity the power to act as him, but only in a limited way.
+For example, a project admin may wish to delegate the power to create pods.  One way to do 
+this is to create a scoped token.
+
+A scoped token, is a token that identifies as a given user, but is limited to certain actions 
+by its scope.  Right now, only a cluster-admin can create scoped tokens.
+
+
+== Evaluation
+Scopes are evaluated by converting the set of scopes for a token into a set of PolicyRules.
+The request is then matched against those rules.  The request attributes must match at least 
+one of the scope rules to be passed to the "normal" authorizer for further authorization checks.
+
+
+== Scopes
+=== User Scopes
+User scopes are focused on getting information about a given user.  They are intent-based, so
+the rules are automatically created for you.
+
+ 1. `user:info` - Allows access to information the user: name, groups, etc.
+ 2. `user:check-access` - Allows access to self-localsubjectaccessreviews and self-subjectaccessreviews.
+    Those are the variants where you pass an empty user and groups in your request object.
+
+=== Role Scope
+The role scope is about having the same level of access as a given role filtered by namespace.
+
+ 1. `role:<cluster-role name>:<namespace or * for all>` - Limits the scope to the rules specified
+    by the cluster-role, but only in the namespace specified.
+
+    Caveat: This prevents escalating access.  Even if the role allows access to resources like
+    secrets, rolebindings, and roles, this scope will *deny* access to those resources.  This helps
+    prevent unexpected escalations.  Many people do not think of a role like `edit` as being an escalating
+    role, but with access to a `secret`, it is.
+
+ 1.  `role:<cluster-role name>:<namespace or * for all>:!` - Note the bang.  This is like #1, except that it
+     *does* allow escalating access.


### PR DESCRIPTION
Right now, scoped tokens can only be created by cluster admins.  This severely limits their utility.  We have a card to fix this: https://trello.com/c/Tcabgp9F/696-3-auth-scopes-user-mgmt-of-tokens, but we haven't gotten to it yet.

@wjiangjay 
