### PR TITLE
Cleanup F5 ramp node instructions

### DIFF
--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -176,9 +176,6 @@ gateway):
 ====
 [options="nowrap"]
 ----
-# # set plugin based on the openshift-sdn plugin used in your cluster.
-# plugin="sdn"  #  "multitenant"
-#
 # ipflowopts="cookie=0x999,ip"
 # arpflowopts="cookie=0x999, table=0, arp"
 #


### PR DESCRIPTION
This is a minor change to complete the cleanup of #1934: there the conditionals for the multitenant plugin were removed, so the plugin type variable is not needed any more. This completes the cleanup.

Related: https://bugzilla.redhat.com/1307052 (this should complete that bz too).
