### PR TITLE
Reordered where the external links appear in our documentation.

### DIFF
--- a/creating_images/guidelines.adoc
+++ b/creating_images/guidelines.adoc
@@ -18,11 +18,7 @@ consumable and easy to use on {product-title}.
 
 == General Docker Guidelines
 The following guidelines apply when creating a Docker image in general, and are
-independent of whether the images are used on {product-title}. Also see the following
-references for more comprehensive guidelines:
-
-- Docker documentation - https://docs.docker.com/articles/dockerfile_best-practices/[Best practices for writing Dockerfiles]
-- Project Atomic documentation - http://www.projectatomic.io/docs/docker-image-author-guidance/[Guidance for Docker Image Authors]
+independent of whether the images are used on {product-title}.
 
 *Reuse Images*
 
@@ -237,6 +233,14 @@ For more information on how Volumes are used in {product-title}, see https://git
 NOTE: Even with persistent volumes, each instance of your image has its own
 volume, and the filesystem is not shared between instances.  This means the
 volume cannot be used to share state in a cluster.
+
+*External Guidelines*
+
+See the following references for other guidelines:
+
+- Docker documentation - https://docs.docker.com/articles/dockerfile_best-practices/[Best practices for writing Dockerfiles]
+- Project Atomic documentation - http://www.projectatomic.io/docs/docker-image-author-guidance/[Guidance for Docker Image Authors]
+
 
 == OpenShift-Specific Guidelines
 The following are guidelines that apply when creating Docker images specifically


### PR DESCRIPTION
It was observed that the best place for the external links was not at
the start of the section.  This implements the suggestion to move it
to the end.
