### PR TITLE
Adjust for new openshift_docker_log_options inventory var.

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -153,11 +153,11 @@ link:#configuring-node-host-labels[Configuring Node Host Labels] for details.
 |Default node selector for automatically deploying registry pods. See
 link:#configuring-node-host-labels[Configuring Node Host Labels] for details.
 
-|`*docker_log_options*`
+|`*openshift_docker_log_options*`
 |This variable configures container logging options that are supported by
 Docker's `json-file` logging driver. See
 link:../../install_config/install/prerequisites.html#managing-docker-container-logs[Managing
-Docker Container Logs] for available options.
+Docker Container Logs] for available options. Example usage: *['max-size=1M', 'max-file=3']*.
 
 |===
 


### PR DESCRIPTION
Current docs were probably broken regardless as I believe the previous
var was cli_ prefixed. Update for the new preferred var, and
include an example for the new preferred list syntax.

https://bugzilla.redhat.com/show_bug.cgi?id=1319663
