### PR TITLE
Use https:// to access GitHub, and drop .git

### DIFF
--- a/admin_guide/http_proxies.adoc
+++ b/admin_guide/http_proxies.adoc
@@ -112,7 +112,7 @@ settings:
 source:
   type: Git
   git:
-    uri: git://github.com/openshift/ruby-hello-world.git
+    uri: https://github.com/openshift/ruby-hello-world
     httpProxy: http://proxy.example.com
     httpsProxy: https://proxy.example.com
 ...

--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -6,6 +6,20 @@
 :experimental:
 
 // do-release: revhist-tables
+== Thu May 19 2016
+
+// tag::admin_guide_thu_may_19_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../admin_guide/http_proxies.html[Working with HTTP Proxies]
+|Updated the example in the link:../admin_guide/http_proxies.html#configuring-default-templates-for-proxies[Configuring Default Templates for Proxies] section to use `https` for GitHub access.
+
+|===
+// end::admin_guide_thu_may_19_2016[]
+
 == Wed Feb 17 2016
 
 // tag::admin_guide_wed_feb_17_2016[]

--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -223,7 +223,7 @@ The example `*ImageStreamMapping*` below results in an image being tagged as
         "Env": [
           "OPENSHIFT_BUILD_NAME=4bf65438-a349-11e4-bead-001c42c44ee1",
           "OPENSHIFT_BUILD_NAMESPACE=test",
-          "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
+          "OPENSHIFT_BUILD_SOURCE=https://github.com/openshift/ruby-hello-world",
           "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
           "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
           "APP_ROOT=.",
@@ -246,7 +246,7 @@ The example `*ImageStreamMapping*` below results in an image being tagged as
         "Env": [
           "OPENSHIFT_BUILD_NAME=4bf65438-a349-11e4-bead-001c42c44ee1",
           "OPENSHIFT_BUILD_NAMESPACE=test",
-          "OPENSHIFT_BUILD_SOURCE=git://github.com/openshift/ruby-hello-world.git",
+          "OPENSHIFT_BUILD_SOURCE=https://github.com/openshift/ruby-hello-world",
           "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
           "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
           "APP_ROOT=.",

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -6,6 +6,20 @@
 :experimental:
 
 // do-release: revhist-tables
+== Thu May 19 2016
+
+// tag::architecture_thu_may_19_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../architecture/core_concepts/builds_and_image_streams.html[Core Concepts -> Builds and Image Streams]
+|Updated the example in the link:../architecture/core_concepts/builds_and_image_streams.html#image-stream-mappings[Image Stream Mappings] section to use `https` for GitHub access.
+
+|===
+// end::architecture_thu_may_19_2016[]
+
 == Tue May 03 2016
 
 // tag::architecture_tue_may_03_2016[]

--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -239,7 +239,7 @@ service database-test (172.30.17.113:6434 -> 3306)
 
 service frontend-test (172.30.17.236:5432 -> 8080)
   frontend-test deploys origin-ruby-sample:test <-
-    builds git://github.com/openshift/ruby-hello-world.git with docker.io/openshift/ruby-20-centos7:latest
+    builds https://github.com/openshift/ruby-hello-world with docker.io/openshift/ruby-20-centos7:latest
     not built yet
     #1 deployment waiting on image
 

--- a/cli_reference/manage_cli_profiles.adoc
+++ b/cli_reference/manage_cli_profiles.adoc
@@ -106,7 +106,7 @@ service database (172.30.43.12:5434 -> 3306)
 
 service frontend (172.30.159.137:5432 -> 8080)
   frontend deploys origin-ruby-sample:latest <-
-    builds git://github.com/openshift/ruby-hello-world.git with joe-project/ruby-20-centos7:latest
+    builds https://github.com/openshift/ruby-hello-world with joe-project/ruby-20-centos7:latest
     #1 deployed 22 minutes ago - 2 pods
 
 To see more information about a service or deployment, use 'oc describe service <name>' or 'oc describe dc <name>'.

--- a/cli_reference/revhistory_cli_reference.adoc
+++ b/cli_reference/revhistory_cli_reference.adoc
@@ -6,6 +6,23 @@
 :experimental:
 
 // do-release: revhist-tables
+== Thu May 19 2016
+
+// tag::cli_reference_thu_may_19_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../cli_reference/get_started_cli.html[Get Started with the CLI]
+|Updated the example in the link:../cli_reference/get_started_cli.html#projects[Projects] section to use `https` for GitHub access.
+
+|link:../cli_reference/manage_cli_profiles.html[Managing CLI Profiles]
+|Updated the example in the link:../cli_reference/manage_cli_profiles.html#switching-between-cli-profiles[Switching Between CLI Profiles] section to use `https` for GitHub access.
+
+|===
+// end::cli_reference_thu_may_19_2016[]
+
 == Tue Apr 19 2016
 
 // tag::cli_reference_tue_apr_19_2016[]

--- a/creating_images/revhistory_creating_images.adoc
+++ b/creating_images/revhistory_creating_images.adoc
@@ -6,6 +6,20 @@
 :experimental:
 
 // do-release: revhist-tables
+== Thu May 19 2016
+
+// tag::creating_images_thu_may_19_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../creating_images/s2i_testing.html[Testing S2I Images]
+|Updated the example in the link:../creating_images/s2i_testing.html#using-openshift-build-for-automated-testing[Using OpenShift Build for Automated Testing] section to use `https` for GitHub access.
+
+|===
+// end::creating_images_thu_may_19_2016[]
+
 == Tue Jun 23 2015
 
 OpenShift Enterprise 3.0 release.

--- a/creating_images/s2i_testing.adoc
+++ b/creating_images/s2i_testing.adoc
@@ -172,7 +172,7 @@ section and creates a new S2I builder image.
     "source": {
       "type": "Git",
       "git": {
-        "uri": "git://github.com/openshift/sti-ruby.git"
+        "uri": "https://github.com/openshift/sti-ruby"
       }
     },
     "strategy": {

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -62,7 +62,7 @@ image tag or the source code changes:
     "source": { <3>
       "type": "Git",
       "git": {
-        "uri": "git://github.com/openshift/ruby-hello-world.git"
+        "uri": "https://github.com/openshift/ruby-hello-world"
       }
     },
     "strategy": { <4>
@@ -536,7 +536,7 @@ Your source URI must use the HTTP or HTTPS protocol for this to work.
 source:
   type: Git
   git:
-    uri: "git://github.com/openshift/ruby-hello-world.git"
+    uri: "https://github.com/openshift/ruby-hello-world"
     httpProxy: http://proxy.example.com
     httpsProxy: https://proxy.example.com
 ...
@@ -1125,7 +1125,7 @@ is later built. The source code location definition is part of the
   "source" : {
     "type" : "Git", <1>
     "git" : { <2>
-      "uri": "git://github.com/openshift/ruby-hello-world.git"
+      "uri": "https://github.com/openshift/ruby-hello-world"
     },
     "contextDir": "app/dir", <3>
   },

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -6,6 +6,20 @@
 :experimental:
 
 // do-release: revhist-tables
+== Thu May 19 2016
+
+// tag::dev_guide_thu_may_19_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../dev_guide/builds.html[Builds]
+|Updated the examples in the link:../dev_guide/builds.html#defining-a-buildconfig[Defining a BuildConfig], link:../dev_guide/builds.html#source-code[Source Code], and link:../dev_guide/builds.html#using-a-proxy-for-git-cloning[Using a Proxy for Git Cloning] sections to use https for GitHub access.
+
+|===
+// end::dev_guide_thu_may_19_2016[]
+
 == Tue Apr 19 2016
 
 // tag::dev_guide_tue_apr_19_2016[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -9,6 +9,23 @@ The following sections aggregate the revision histories of each guide by publish
 date.
 
 // do-release: revhist-tables
+== Thu May 19 2016
+
+.Architecture
+include::architecture/revhistory_architecture.adoc[tag=architecture_thu_may_19_2016]
+
+.Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_thu_may_19_2016]
+
+.CLI Reference
+include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_thu_may_19_2016]
+
+.Creating Images
+include::creating_images/revhistory_creating_images.adoc[tag=creating_images_thu_may_19_2016]
+
+.Developer Guide
+include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_thu_may_19_2016]
+
 == Tue May 03 2016
 
 .Architecture


### PR DESCRIPTION
This is a manual backport of:

 https://github.com/openshift/openshift-docs/pull/2001

and includes revhistory updates.
