### PR TITLE
Fix metadata in developers_console

### DIFF
--- a/getting_started/developers_console.adoc
+++ b/getting_started/developers_console.adoc
@@ -1,6 +1,8 @@
 = Developers: Web Console Walkthrough
 :toc: macro
 :toc-title:
+:data-uri:
+:experimental:
 :prewrap!:
 :description: This is the getting started experience for Developers, focusing on web console usage.
 :keywords: getting started, developers, web console, templates


### PR DESCRIPTION
I had tried adjusting this to the updated [topic template](https://github.com/openshift/openshift-docs/pull/2109), but turns out we need `:data-uri:` for [embedding images](http://asciidoctor.org/docs/render-documents/#managing-images) (there's one "copy.jpg" inline in one spot).

And we need `:experimental:` for `btn:` to work on docs.openshift. Even with it in place, it actually doesn't render on the Customer Portal builds, just looks like normal text. But when it's missing on docs.openshift, it comes through verbatim (`btn:[text]`) and is bad. I think its removal here though was my fault / an over-correct, so putting it back.

cc @vikram-redhat @tpoitras 
