### PR TITLE
Correct path of `scaleup.yml` script in install

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1058,7 +1058,7 @@ with the `-i option`:
 +
 ----
 # ansible-playbook [-i /path/to/file] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/scaleup.yml
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml
 ----
 
 . After the playbook completes successfully,


### PR DESCRIPTION
Ran into this one today. There is no `scaleup.yml` script in the in the `openshift-cluster` folder. There is one in both `openshift-master` and `openshift-node`. From my testing, `openshift-node/scaleup.yml` does the required task. 
