### PR TITLE
BZ1336608: Add note regarding secrets and Ceph

### DIFF
--- a/install_config/persistent_storage/persistent_storage_ceph_rbd.adoc
+++ b/install_config/persistent_storage/persistent_storage_ceph_rbd.adoc
@@ -62,6 +62,11 @@ To provision Ceph volumes, the following are required:
 
 Define the authorization key in a secret configuration, which is then converted to base64 for use by {product-title}.
 
+[NOTE]
+====
+In order to use Ceph storage to back a persistent volume, the secret must be created in the same project as the PVC and pod. The secret cannot simply be in the default project.
+====
+
 . Run `ceph auth get-key` on a Ceph MON node to display the key value for the
 `client.admin` user:
 +


### PR DESCRIPTION
Added a note to specify that the secret must be created in the same project as the PVC and pod in order for Ceph storage to work with a PV.
