### PR TITLE
Finishing the Dedicated admin guide

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -92,6 +92,9 @@ Topics:
   - Name: Setting Up a Cluster
     File: administrators
     Distros: openshift-origin,openshift-enterprise
+  - Name: Administering a Cluster
+    File: dedicated_administrators
+    Distros: openshift-dedicated
   - Name: Developer Preview FAQ
     File: devpreview_faq
     Distros: openshift-online
@@ -376,6 +379,10 @@ Topics:
     File: manage_authorization_policy
   - Name: Scoped Tokens
     File: scoped_tokens
+    Distros: openshift-origin
+  - Name: Managing the Default Image Streams and Templates
+    File: osd_imagestreams_templates
+    Distros: openshift-dedicated
   - Name: Managing Security Context Constraints
     File: manage_scc
     Distros: openshift-*
@@ -457,6 +464,7 @@ Topics:
     Distros: openshift-*
   - Name: Administrator CLI Operations
     File: admin_cli_operations
+    Distros: openshift-enterprise,openshift-dedicated,openshift-origin
   - Name: Revision History
     File: revhistory_cli_reference
     Distros: openshift-enterprise,openshift-dedicated

--- a/admin_guide/index.adoc
+++ b/admin_guide/index.adoc
@@ -5,5 +5,49 @@
 :icons:
 :experimental:
 
-{product-title} Cluster Administration topics cover the day-to-day tasks for managing
+These Cluster Administration topics cover the day-to-day tasks for managing
 your {product-title} cluster and other advanced configuration topics.
+
+ifdef::openshift-dedicated[]
+WHAT IS THE OPENSHIFT DEDICATED ADMINISTRATOR ROLE?::
+As an administrator of an {product-title} cluster, your account has increased
+permissions and access to all user-created projects. If you are new to the role,
+check out the Getting Started topic on
+link:../getting_started/dedicated_administrators.html[Administering an
+{product-title} Cluster] for a quick overview.
+
+[NOTE]
+====
+_Some configuration changes or procedures discussed in this guide may be
+performed only by the OpenShift Operations Team. They are included in this guide for
+informational purposes to help you as an {product-title} cluster administrator
+better understand what configuration options are possible. If you would like to
+request a change to your cluster that you cannot perform using the administrator
+CLI, please open a support case on the https://access.redhat.com/support/[Red
+Hat Customer Portal]._
+====
+
+When your account has the *dedicated-cluster-admin* authorization role
+link:../architecture/additional_concepts/authorization.html[bound] to it, you
+are automatically bound to the *dedicated-project-admin* for any new projects
+that are created by users in the cluster.
+
+You can perform actions associated with a set of
+link:../architecture/additional_concepts/authorization.html#evaluating-authorization[verbs]
+(e.g., `create`) to operate on a set of
+link:../architecture/additional_concepts/authorization.html#evaluating-authorization[resource
+names] (e.g., `templates`). To view the details of these roles and their sets of
+verbs and resources, run the following:
+
+----
+$ oc describe clusterrole/dedicated-cluster-admin
+$ oc describe clusterrole/dedicated-project-admin
+----
+
+The verb names do not necessarily all map directly to `oc` commands, but rather
+equate more generally to the types of CLI operations you can perform. For
+example, having the *list* verb means that you can display a list of all objects
+of a given resource name (e.g., using `oc get`), while *get* means that you can
+display the details of a specific object if you know its name (e.g., using `oc
+describe`).
+endif::[]

--- a/admin_guide/osd_imagestreams_templates.adoc
+++ b/admin_guide/osd_imagestreams_templates.adoc
@@ -1,0 +1,24 @@
+= Managing the Default Image Streams and Templates
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+Your {product-title} cluster by default comes loaded with a core set of image
+streams and templates, which are accessible by all users across the cluster via
+the global *openshift* project. As a cluster administrator, you can add, remove,
+and edit these defaults at your discretion.
+
+The following sections detail the default image streams and templates, and show
+how to modify them or create new ones in the global *openshift* project.
+
+[[dedicated-creating-image-streams-in-the-global-project]]
+== Creating Image Streams in the Global Project
+include::install_config/imagestreams_templates.adoc[tag=installconfig_imagestreams_templates]

--- a/admin_guide/service_accounts.adoc
+++ b/admin_guide/service_accounts.adoc
@@ -1,4 +1,4 @@
-= Service Accounts
+= Configuring Service Accounts
 {product-author}
 {product-version}
 :data-uri:

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -15,13 +15,20 @@ This topic provides information on the administrator CLI operations and their
 syntax. You must link:get_started_cli.html[setup and login] with the CLI before
 you can perform these operations.
 
+ifdef::openshift-origin,openshift-enterprise[]
 The `oadm` command is used for administrator CLI operations, which is a symlink
 that can be used on hosts that have the `openshift` binary, such as a master. If
 you are on a workstation that does not have the `openshift` binary, you can also
 use `oc adm` in place of `oadm`, if `oc` is available.
+endif::[]
 
-The administrator CLI differs from the link:basic_cli_operations.html[developer CLI],
-which uses the `oc` command, and is used for basic, project-level operations.
+ifdef::openshift-dedicated[]
+The `oc adm` command (formerly the `oadm` command) is used for administrator CLI
+operations.
+endif::[]
+The administrator CLI differs from the normal set of commands under the
+link:basic_cli_operations.html[developer CLI], which uses the `oc` command, and
+is used more for project-level operations.
 
 ifdef::openshift-dedicated[]
 [NOTE]
@@ -105,18 +112,21 @@ Outputs the inputs and dependencies of any builds:
 ----
 $ oadm build-chain <image-stream>[:<tag>]
 ----
+endif::[]
 
+ifdef::openshift-enterprise,openshift-origin[]
 === manage-node
 Manages nodes. For example, list or evacuate pods, or mark them ready:
 ----
 $ oadm manage-node
 ----
-endif::[]
+
 === prune
 Removes older versions of resources from the server:
 ----
 $ oadm prune
 ----
+endif::[]
 
 ifdef::openshift-enterprise,openshift-origin,atomic-registry[]
 [[settings-cli-operations]]

--- a/getting_started/dedicated_administrators.adoc
+++ b/getting_started/dedicated_administrators.adoc
@@ -1,0 +1,166 @@
+= Administering an {product-title} Cluster
+:data-uri:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+As an administrator of an {product-title} cluster, your account has additional
+permissions and access to all user-created projects in your organization's
+cluster. While logged in to an account with this role, the basic
+link:../cli_reference/basic_cli_operations.html[developer CLI] (the `oc`
+command) allows you increased visibility and management capabilities over
+objects across projects, while the
+link:../cli_reference/admin_cli_operations.html[administrator CLI] (commands
+under the `oc adm` command, and formerly the `oadm` command) open up additional
+operations.
+
+[NOTE]
+====
+While your account does have these increased permissions, the actual cluster
+maintenance and host configuration is still performed by the OpenShift
+Operations Team. If you would like to request a change to your cluster that you
+cannot perform using the administrator CLI, please open a support case on the
+https://access.redhat.com/support/[Red Hat Customer Portal].
+====
+
+[[gs-dedicated-admin-downloading-the-cli]]
+== Downloading the CLI
+
+The `oc` CLI used for both normal developer operations and administrator
+operations is available for download from the *About* page in the web console.
+See link:../cli_reference/get_started_cli.html[Get Started with the CLI] for
+more detailed installation steps.
+
+[[gs-dedicated-admin-logging-in]]
+== Logging In and Verifying Permissions
+
+You can log in as an {product-title} cluster administration via the web console
+or CLI, just as you would if you were an application developer.
+
+When you link:../dev_guide/authentication.html#web-console-authentication[log in
+to the web console], all user-created projects across the cluster are visible
+from the main *Projects* page.
+
+Use the standard `oc login` command to log in with the CLI:
+
+----
+$ oc login <your_instance_url>
+----
+
+All projects are visible using:
+
+----
+$ oc get projects
+----
+
+When your account has the *dedicated-cluster-admin* authorization role
+link:../architecture/additional_concepts/authorization.html#roles[bound] to it,
+you are automatically bound to the *dedicated-project-admin* for any new
+projects that are created by users in the cluster.
+
+To verify if your account has administrator privileges, run the following
+command against a user-created project to view its default
+link:../architecture/additional_concepts/authorization.html[policy bindings]. If
+you are a cluster administrator, you will see your account listed under
+*RoleBinding[dedicated-project-admin]* for the project:
+
+====
+----
+$ oc describe policyBindings :default -n <project_name>
+
+Name:					:default
+Created:				2 weeks ago
+Labels:					<none>
+Annotations:				<none>
+Last Modified:				2016-05-03 05:34:49 -0400 EDT
+Policy:					<none>
+RoleBinding[admin]:
+					Role:			admin
+					Users:			fred@example.com <1>
+					Groups:			<none>
+					ServiceAccounts:	<none>
+					Subjects:		<none>
+RoleBinding[dedicated-project-admin]:
+					Role:			dedicated-project-admin
+					Users:			alice@example.com, bob@example.com <2>
+					Groups:			<none>
+					ServiceAccounts:	<none>
+					Subjects:		<none>
+...
+----
+<1> The *fred@example.com* user is a normal, project-scoped administrator for this
+project.
+<2> The *alice@example.com* and *bob@example.com* users are cluster administrators.
+====
+
+To view details on your increased permissions, and the sets of
+link:../architecture/additional_concepts/authorization.html#evaluating-authorization[verbs
+and resources] associated with the *dedicated-cluster-admin* and
+*dedicated-project-admin* roles, run the following:
+
+----
+$ oc describe clusterrole/dedicated-cluster-admin
+$ oc describe clusterrole/dedicated-project-admin
+----
+
+[[gs-dedicated-admin-granting-permissions]]
+== Granting Permissions to Users or Groups
+
+To grant permissions to other
+link:../architecture/additional_concepts/authentication.html#users-and-groups[users
+or groups], you can add, or _bind_, a role to them using the following commands:
+
+----
+$ oadm policy add-role-to-user <role> <user_name>
+$ oadm policy add-role-to-group <role> <group_name>
+----
+
+See link:../admin_guide/manage_authorization_policy.html[Managing Authorization
+Policies] for more details on these and related authorization tasks.
+
+[[gs-dedicated-admin-creating-service-accounts]]
+== Creating Service Accounts
+
+You can create a
+link:../architecture/core_concepts/projects_and_users.html#users[service
+account] to be able to run applications like Jenkins that make calls back to
+{product-title}.
+
+See the link:../dev_guide/service_accounts.html[Developer Guide] for basic
+service account management tasks, which as a cluster administrator you can
+perform in any user-created project, and see
+link:../admin_guide/service_accounts.html[Configuring Service Accounts] for more
+advanced, cluster-wide settings.
+
+[[gs-dedicated-admin-adding-or-removing-default-image-streams-and-templates]]
+== Adding or Removing Default Image Streams and Templates
+
+See link:../admin_guide/osd_imagestreams_templates.html[Managing the Default
+Image Streams and Templates] for information on the core set of image streams
+and templates provided by default in the global *openshift* project. You can
+also modify, add, or remove these objects from the *openshift* project as a
+cluster administrator.
+
+[[gs-dedicated-admin-managing-quotas-and-limit-ranges]]
+== Managing Quotas and Limit Ranges
+
+As a cluster administrator, you are able to view, create, and modify
+link:../admin_guide/quota.html[quotas] and link:../admin_guide/limits.html[limit
+ranges] on other projects. This allows you to better constrain how compute
+resources and objects are consumed by users across the cluster.
+
+Defaults can be set for quotas and limit ranges for new projects at creation. To
+request such a change, please open a support case on the
+https://access.redhat.com/support/[Red Hat Customer Portal].
+
+[[gs-dedicated-admin-whats-next]]
+== What's Next?
+
+Further explore the link:../admin_guide/index.html[Cluster Administration] guide
+for more reference information on what's possible with your role and what other
+cluster settings can be configured for you by the OpenShift Operations Team.

--- a/getting_started/index.adoc
+++ b/getting_started/index.adoc
@@ -7,7 +7,7 @@
 :toc: macro
 :toc-title:
 
-ifdef::openshift-origin,openshift-enterprise[]
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 To get started with OpenShift, find the appropriate topic based on your role:
 
 [option="Getting Started"]
@@ -25,8 +25,14 @@ ifdef::openshift-origin[]
 endif::openshift-origin[]
 
 |Developer
-a|Step through a basic link:../getting_started/developers_console.html[walkthrough
+|Step through a basic link:../getting_started/developers_console.html[walkthrough
 using the web console] and create your first project and application.
+
+ifdef::openshift-dedicated[]
+.^|Cluster administrator
+|Understand your link:../getting_started/dedicated_administrators.html[cluster
+administrator] role.
+endif::openshift-dedicated[]
 
 |===
 endif::openshift-origin,openshift-enterprise[]

--- a/install_config/imagestreams_templates.adoc
+++ b/install_config/imagestreams_templates.adoc
@@ -144,8 +144,9 @@ $ IMAGESTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/
 endif::[]
 
 [[creating-image-streams-for-openshift-images]]
-
 == Creating Image Streams for OpenShift Images
+
+// tag::installconfig_imagestreams_templates[]
 The core set of image streams provide images that can be used to build
 link:../using_images/s2i_images/nodejs.html[*Node.js*],
 link:../using_images/s2i_images/perl.html[*Perl*],
@@ -157,6 +158,7 @@ link:../using_images/db_images/mysql.html[*MySQL*], and
 link:../using_images/db_images/postgresql.html[*PostgreSQL*]
 to support data storage.
 
+ifdef::openshift-enterprise,openshift-origin[]
 If your node hosts are subscribed using Red Hat Subscription Manager and you
 want to use the Red Hat Enterprise Linux (RHEL) 7 based images:
 
@@ -171,10 +173,35 @@ based images:
 $ oc create -f $IMAGESTREAMDIR/image-streams-centos7.json -n openshift
 ----
 
-It is not possible to create both the CentOS and RHEL sets of image streams
-because they use the same names. If you desire to have both sets of image
-streams available to users, either create one set in a different project, or
-edit one of the files and modify the image stream names to make them unique.
+Creating both the CentOS and RHEL sets of image streams is not possible, because
+they use the same names. To have both sets of image streams available to users,
+either create one set in a different project, or edit one of the files and
+modify the image stream names to make them unique.
+endif::[]
+
+ifdef::openshift-dedicated[]
+You can view all default image streams and their definitions using the CLI. To
+get a list of the current objects in the global *openshift* project:
+
+----
+$ oc get imagestreams -n openshift
+----
+
+To view or modify the definition for a specific image stream:
+
+----
+$ oc edit imagestream <imagestream_name> -n openshift
+----
+
+If you define your own image stream, first save it to a file, then create it in
+the *openshift* project using the CLI:
+
+----
+$ oc create -f <file_name> -n openshift
+----
+
+This makes the image stream available to all users across the cluster.
+endif::[]
 
 ifdef::openshift-enterprise[]
 == Creating Image Streams for xPaaS Middleware Images
@@ -200,9 +227,11 @@ xPaaS Middleware subscriptions.
 ====
 endif::[]
 
-[[creating-database-service-templates]]
+ifdef::openshift-enterprise,openshift-origin[]
 
+[[creating-database-service-templates]]
 == Creating Database Service Templates
+
 The database service templates make it easy to run a database image which can be
 utilized by other components. For each database
 (link:../using_images/db_images/mongodb.html[*MongoDB*],
@@ -227,10 +256,11 @@ $ oc create -f $DBTEMPLATES -n openshift
 
 After creating the templates, users are able to easily instantiate the various
 templates, giving them quick access to a database deployment.
+endif::[]
 
 [[creating-instantapp-templates]]
-
 == Creating Instant App and Quickstart Templates
+
 The Instant App and Quickstart templates define a full set of objects for a running application.
 These include:
 
@@ -254,17 +284,19 @@ content. These templates should be used for demonstration purposes only as all
 database data will be lost if the database pod restarts for any reason.
 ====
 
-After creating the templates, users are able to easily instantiate full
-applications using the various language images provided with OpenShift. They can
-also customize the template parameters during instantiation so that it builds
-source from their own repository rather than the sample repository, so this
-provides a simple starting point for building new applications.
+Using these templates, users are able to easily instantiate full applications
+using the various language images provided with OpenShift. They can also
+customize the template parameters during instantiation so that it builds source
+from their own repository rather than the sample repository, so this provides a
+simple starting point for building new applications.
 
+ifdef::openshift-enterprise,openshift-origin[]
 To create the core Instant App and Quickstart templates:
 
 ----
 $ oc create -f $QSTEMPLATES -n openshift
 ----
+endif::[]
 
 ifdef::openshift-enterprise[]
 There is also a set of templates for creating applications using various xPaaS
@@ -296,6 +328,30 @@ database data will be lost if the database pod restarts for any reason.
 ====
 endif::[]
 
+ifdef::openshift-dedicated[]
+You can view all default templates and their definitions using the CLI. To get a
+list of the current objects in the global *openshift* project:
+
+----
+$ oc get templates -n openshift
+----
+
+To view or modify the definition for a specific template:
+
+----
+$ oc edit template <template_name> -n openshift
+----
+
+If you define your own template, first save it to a file, then create it in
+the *openshift* project using the CLI:
+
+----
+$ oc create -f <file_name> -n openshift
+----
+
+This makes the template available to all users across the cluster.
+endif::[]
+
 [[what-s-next]]
 
 == What's Next?
@@ -319,3 +375,4 @@ their own applications.
 You can direct your developers to the
 link:../dev_guide/templates.html#using-the-instantapp-templates[Using the Instant App and Quickstart Templates]
 section in the Developer Guide for these instructions.
+// end::installconfig_imagestreams_templates[]


### PR DESCRIPTION
Finishes putting together a Cluster Admin guide for the dedicated role. Some quick sections in the new dedicated-admin's Getting Started still need filling out, to come very shortly.

@bfallonf @tpoitras @tnguyen-rh @ahardin-rh @vikram-redhat Can you folks take a look at this so far?

Of note:
- The Overview of the new Cluster Administration guide (previously did not exist in the Dedicated docs set):
  http://file.rdu.redhat.com/~adellape/051916/admin_dedicated/admin_guide/index.html
- The above suggests checking out the new Getting Started topic, which serves as an overview of the role and highlights some things you may want to do with it:
  http://file.rdu.redhat.com/~adellape/051916/admin_dedicated/getting_started/dedicated_administrators.html
  You'll notice some of the later sections are not filled out. Planning to provide a quick explanation and command to run, but ultimately link to the topic that describes the task better for more details.
- The CLI Reference "Administrator CLI Operations" topic was also adjusted for accuracy.
- A number of topics are included in the Cluster Admin guide that also include stuff that they can't actually do themselves, and require the Ops team to do for them, but they're included for informational purposes, so they can maybe request a change if they want. For those topics, I've included a NOTE box at the top explaining this. I made it italic and above the TOC in the docs.openshift builds so that they stand out better. For example:
  http://file.rdu.redhat.com/~adellape/051916/admin_dedicated/admin_guide/managing_projects.html
  It actually comes out looking better on the Customer Portal builds, too. Here's a look from a quick test/QA build Lee did the other day:
  ![screenshot from 2016-05-19 19-09-22](https://cloud.githubusercontent.com/assets/3442316/15413098/305a038a-1dfb-11e6-983b-c31bef4bbf52.png)
