### PR TITLE
Use consistent --cert and --key values for Securing the Registry

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -670,13 +670,19 @@ time="2015-05-27T05:05:53Z" level=info msg="listening on :5000, tls" instance.id
 . Copy the CA certificate to the Docker certificates directory. This must be
 done on all nodes in the cluster:
 +
+====
 ----
-$ sudo mkdir -p /etc/docker/certs.d/172.30.124.220:5000
-$ sudo cp ca.crt /etc/docker/certs.d/172.30.124.220:5000
+$ dcertsdir=/etc/docker/certs.d
+$ destdir_addr=$dcertsdir/172.30.124.220:5000
+$ destdir_name=$dcertsdir/docker-registry.default.svc.cluster.local:5000
 
-$ sudo mkdir -p /etc/docker/certs.d/docker-registry.default.svc.cluster.local:5000
-$ sudo cp ca.crt /etc/docker/certs.d/docker-registry.default.svc.cluster.local:5000
+$ sudo mkdir -p $destdir_addr $destdir_name
+$ sudo cp ca.crt $destdir_addr    //<1>
+$ sudo cp ca.crt $destdir_name
 ----
+<1> The *_ca.crt_* file is a copy
+    of *_/etc/origin/master/ca.crt_* on the master.
+====
 +
 . Remove the `--insecure-registry` option only for this particular registry in
 the *_/etc/sysconfig/docker_* file. Then, reload the daemon and restart the

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -553,6 +553,7 @@ Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 ----
 ====
 
+[[securing-the-registry]]
 == Securing the Registry
 
 Optionally, you can secure the registry so that it serves traffic via TLS:
@@ -585,23 +586,29 @@ create a server certificate for the registry service IP and the
 *docker-registry.default.svc.cluster.local* host name:
 +
 ----
-$ oadm ca create-server-cert --signer-cert=ca.crt \
-    --signer-key=ca.key --signer-serial=ca.serial.txt \
+$ oadm ca create-server-cert \
+    --signer-cert=/etc/origin/master/ca.crt \
+    --signer-key=/etc/origin/master/ca.key \
+    --signer-serial=/etc/origin/master/ca.serial.txt \
     --hostnames='docker-registry.default.svc.cluster.local,172.30.124.220' \
-    --cert=registry.crt --key=registry.key
+    --cert=/etc/secrets/registry.crt \
+    --key=/etc/secrets/registry.key
 ----
 +
 . Create the secret for the registry certificates:
 +
 ----
-$ oc secrets new registry-secret registry.crt registry.key
+$ oc secrets new registry-secret \
+    /etc/secrets/registry.crt \
+    /etc/secrets/registry.key
 ----
 +
-. Add the secret to the registry pod's service account (i.e., the *default*
+. Add the secret to the registry pod's service accounts (including the *default*
 service account):
 +
 ----
-$ oc secrets add serviceaccounts/default secrets/registry-secret
+$ oc secrets add serviceaccounts/registry secrets/registry-secret
+$ oc secrets add serviceaccounts/default  secrets/registry-secret
 ----
 +
 . Add the secret volume to the registry deployment configuration:


### PR DESCRIPTION
Fixes 1249155

@rjhowe Thanks for including the detailed session log in the BZ.  These changes are based on them.  WDYT?  In particular, starting on line 605, the previous text and example was for **one** (the `default`) service account, and now there are **two**.  Is that correct?
