### PR TITLE
Remove contradictory note about NFS in 3.0 docs

### DIFF
--- a/admin_guide/persistent_storage_nfs.adoc
+++ b/admin_guide/persistent_storage_nfs.adoc
@@ -16,14 +16,6 @@ link:../architecture/additional_concepts/storage.html[persistent storage] using
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFS].
 Some familiarity with Kubernetes and NFS is assumed.
 
-[NOTE]
-====
-OpenShift requires
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html[NFSv4]
-when using NFS for persistent storage, due to NSFv4's ability to handle SELinux
-labeling.
-====
-
 The Kubernetes link:../dev_guide/persistent_volumes.html[persistent volume]
 framework allows administrators to provision a cluster with persistent storage
 and gives users a way to request those resources without having any knowledge of


### PR DESCRIPTION
This is the same change as 158f5b4 (PR #1364) but for the 3.0 branch. Fixes BZ 1284695 (for the 3.0 docs).

It seems that when that change was made the persistent storage for NFS had moved to a different section, and the change missed that fact and did not update the previous location.

The reason to have this fix in the first place is to avoid confusion. Having the latest version show one thing and an earlier version show a different one is still causing confusion.
