### PR TITLE
fixed various links and added anchors

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -203,9 +203,9 @@ be doing anything except act as a gateway for the *F5 BIG-IP®* host.
 endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 This
-link:../../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[_ramp
+xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[_ramp
 node_] can be configured as
-link:../../admin_guide/manage_nodes.html#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
+xref:../../admin_guide/manage_nodes.adoc#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
 for pods so that it will not be doing anything except act as a gateway for the
 *F5 BIG-IP®* host.
 endif::[]

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -1018,9 +1018,9 @@ satisfy high-availability requirements.
 To deploy the F5 router:
 
 . First,
-link:../../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[establish
+xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[establish
 a tunnel using a ramp node], which allows for the routing of traffic to pods
-through the link:../../architecture/additional_concepts/sdn.html[OpenShift SDN].
+through the xref:../../architecture/additional_concepts/sdn.adoc[OpenShift SDN].
 ifdef::openshift-origin[]
 . Ensure you have link:#creating-the-router-service-account[created the router
 service account].

--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -46,6 +46,7 @@ the link:../rest_api/kubernetes_v1.html#v1-containerport[host port exposed]. The
 pre-packaged link:../architecture/core_concepts/routes.html#routers[HAProxy
 router] in OpenShift runs in precisely this fashion.
 
+[[establishing-a-tunnel-using-a-ramp-node]
 == Establishing a Tunnel Using a Ramp Node
 In some cases, the previous solution is not possible. For example, an *F5
 BIG-IP®* host cannot run an OpenShift node instance or the OpenShift SDN because

--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -87,7 +87,7 @@ describe` command.
 - The `*NO_PROXY*` environment variable will now accept a CIDR in a number of
 places in the code for controlling which IP ranges bypass the default HTTP proxy
 settings. See
-link:../install_config/http_proxies.html#configuring-hosts-for-proxies[Configuring
+xref:../install_config/http_proxies.adoc#configuring-hosts-for-proxies[Configuring
 Hosts for Proxies] for details.
 
 [[ose-32-security]]


### PR DESCRIPTION
I fixed some links to xrefs, and added some missing anchor tags. Some of this has already made into the Enterprise 3.2 branch, so when cherry picking, it is likely to cause some merge issues.

Remember, xrefs --> links. html --> adoc.
