### PR TITLE
Add NetworkManager as a dependency

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -95,6 +95,7 @@ ifdef::openshift-enterprise[]
 - Base OS: RHEL 7.1 or later with "Minimal" installation option, or RHEL Atomic
 Host 7.2.4 or later.
 endif::[]
+- NetworkManager 1.0 or later
 - 1 vCPU.
 - Minimum 8 GB RAM.
 - Minimum 15 GB hard disk space for the file system containing *_/var/_*.


### PR DESCRIPTION
NetworkManager is required as of Origin 1.2 / OSE 3.2 in order to provide the dnsmasq functionality. The installer will fail when NetworkManager is not installed.
