### PR TITLE
Set search default tab per product version

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -55,7 +55,7 @@
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
         <div class="row-fluid">
-          <%= render("_templates/_search.html.erb", :distro_key => distro_key) %>
+          <%= render("_templates/_search.html.erb", :distro_key => distro_key, :version => version) %>
         </div>
         <%= render("_templates/_nav_openshift.html.erb", :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim) %>
       </div>

--- a/_templates/_search.html.erb
+++ b/_templates/_search.html.erb
@@ -1,9 +1,11 @@
 <% if distro_key == 'openshift-origin' %>
 <%= render("_templates/_search_origin.html") %>
 <% elsif distro_key == 'openshift-dedicated' %>
-<%= render("_templates/_search_dedicated.html") %>
+<%= render("_templates/_search_dedicated.html", :version => version) %>
 <% elsif distro_key == 'openshift-online' %>
 <%= render("_templates/_search_online.html") %>
+<% elsif distro_key == 'openshift-enterprise' %>
+<%= render("_templates/_search_enterprise.html.erb", :version => version) %>
 <% else %>
 <%= render("_templates/_search_other.html") %>
 <% end %>

--- a/_templates/_search_dedicated.html
+++ b/_templates/_search_dedicated.html
@@ -10,4 +10,4 @@
     s.parentNode.insertBefore(gcse, s);
   })();
 </script>
-<gcse:search></gcse:search>
+<gcse:search defaultToRefinement="Dedicated <%= version %>"></gcse:search>

--- a/_templates/_search_enterprise.html.erb
+++ b/_templates/_search_enterprise.html.erb
@@ -1,0 +1,12 @@
+<script>
+  (function() {
+    var cx = '013769182564158614814:e-dp46b51vk';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search defaultToRefinement="Enterprise <%= version %>"></gcse:search>


### PR DESCRIPTION
This change sets a default tab in search results to correspond to the version of the Enterprise docs being read.
