### PR TITLE
Fix OSE 3.2 revhistory for 05/30/16

### DIFF
--- a/creating_images/revhistory_creating_images.adoc
+++ b/creating_images/revhistory_creating_images.adoc
@@ -14,16 +14,12 @@
 
 |Affected Topic |Description of Change
 //Mon May 30 2016
-|link:../creating_images/s2i.html[S2I Requirements]
+.2+|link:../creating_images/s2i.html[S2I Requirements]
 |Clarified details of link:../creating_images/s2i.html#using-images-with-onbuild-instructions[onbuild behavior with S2I].
-
-|link:../creating_images/s2i.html[S2I Requirements]
 |Added an link:../creating_images/s2i.html#external-references[External References] section with links to an image creation tutorial and the S2I project repository.
 
-n|link:../creating_images/s2i_testing.html[Testing S2I Images]
+|link:../creating_images/s2i_testing.html[Testing S2I Images]
 |Updated the link:../creating_images/s2i_testing.html#using-openshift-build-for-automated-testing[`BuildConfig` example] to use `https` for GitHub access.
-
-
 
 |===
 

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -14,37 +14,34 @@
 
 |Affected Topic |Description of Change
 //Mon May 30 2016
+
+.2+|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
+|Added an Important box to the link:../install_config/install/prerequisites.html#sizing-recommendations[Sizing Recommendations] section advising that oversubscribing the physical resources on a node affects resource guarantees the Kubernetes scheduler makes during pod placement.
+|Added prerequisite information to node host section of link:../install_config/install/prerequisites.html#system-requirements[System Requirements].
+
 |link:../install_config/install/advanced_install.html[Installing -> Advanced Installation]
 |Updated the parameter name `*docker_log_options*` to `*openshift_docker_log_options*` in the link:../install_config/install/advanced_install.html#configuring-host-variables[Host Variables] table.
-
-|link:../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[Routing from Edge Load Balancers]
-|Fixed error in the OpenShift SDN cluster network setup steps for the ramp node.
-
-|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
-|Added prerequisite information to node host section of link:../install_config/install/prerequisites.html#system-requirements[System Requirements].
 
 |link:../install_config/install/disconnected_install.html[Installing -> Disconnected Installation]
 |Fixed some outdated image names.
 
-|link:../install_config/aggregate_logging.html[Aggregating Container Logs]
-|Updated with guidance to use `oc new-app` instead of `oc process | oc create` for logging.
-
-n|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
-|Added an Important box to the link:../install_config/install/prerequisites.html#sizing-recommendations[Sizing Recommendations] section advising that oversubscribing the physical resources on a node affects resource guarantees the Kubernetes scheduler makes during pod placement.
-
-n|link:../install_config/http_proxies.html[Working with HTTP Proxies]
-|Updated the example in the link:../install_config/http_proxies.html#configuring-default-templates-for-proxies[Configuring Default Templates for Proxies] section to use `https` for GitHub access.
-
-|link:../install_config/cluster_metrics.html[Enabling Cluster Metrics]
-|Simplified the link:../install_config/cluster_metrics.html#metrics-reencrypting-route[Using a Re-encrypting Route] section.
+|link:../install_config/install/deploy_router.html[Installing -> Deploying a Router]
+|Added sections describing how to link:../install_config/install/deploy_router.html#creating-router-shards[create] and link:../install_config/install/deploy_router.html#modifying-router-shards[modify] router shards.
 
 |link:../install_config/storage_examples/gluster_backed_registry.html[Persistent Storage Examples -> Backing Docker Registry with GlusterFS Storage]
 |New topic about how to attach a GlusterFS persistent volume to the Docker Registry.
 
-n|link:../install_config/install/deploy_router.html[Installing -> Deploying a Router]
-|Added sections describing how to link:../install_config/install/deploy_router.html#creating-router-shards[create] and link:../install_config/install/deploy_router.html#modifying-router-shards[modify] router shards.
+|link:../install_config/http_proxies.html[Working with HTTP Proxies]
+|Updated the example in the link:../install_config/http_proxies.html#configuring-default-templates-for-proxies[Configuring Default Templates for Proxies] section to use `https` for GitHub access.
 
+|link:../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[Routing from Edge Load Balancers]
+|Fixed error in the OpenShift SDN cluster network setup steps for the ramp node.
 
+|link:../install_config/aggregate_logging.html[Aggregating Container Logs]
+|Updated with guidance to use `oc new-app` instead of `oc process \| oc create` for logging.
+
+|link:../install_config/cluster_metrics.html[Enabling Cluster Metrics]
+|Simplified the link:../install_config/cluster_metrics.html#metrics-reencrypting-route[Using a Re-encrypting Route] section.
 
 |===
 
@@ -147,9 +144,6 @@ future for 3.2 to 3.1.
 
 |link:../install_config/storage_examples/index.html[Persistent Storage Examples]
 |New topic on setting up and configuring common storage use cases.
-
-|link:../install_config/persistent_storage/storage_troubleshooting.html[Persistent Storage Troubleshooting]
-|New topic on resolving common issues encountered when configuring your cluster to use persistent storage.
 
 |link:../install_config/syncing_groups_with_ldap.html[Syncing Groups With LDAP]
 |Added information about alternate `bindPassword/clientSecret` methods.

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -10,26 +10,28 @@ date.
 
 // do-release: revhist-tables
 == Mon May 30 2016
-.Admin Guide
+
+.Architecture
+include::architecture/revhistory_architecture.adoc[tag=architecture_mon_may_30_2016]
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_mon_may_30_2016]
+
+.Cluster Administration
 include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_mon_may_30_2016]
 
-.Using Images
-include::using_images/revhistory_using_images.adoc[tag=using_images_mon_may_30_2016]
+.CLI Reference
+include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_mon_may_30_2016]
 
-.Dev Guide
+.Developer Guide
 include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_mon_may_30_2016]
 
 .Creating Images
 include::creating_images/revhistory_creating_images.adoc[tag=creating_images_mon_may_30_2016]
 
-.Cli Reference
-include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_mon_may_30_2016]
+.Using Images
+include::using_images/revhistory_using_images.adoc[tag=using_images_mon_may_30_2016]
 
-.Install Config
-include::install_config/revhistory_install_config.adoc[tag=install_config_mon_may_30_2016]
-
-.Architecture
-include::architecture/revhistory_architecture.adoc[tag=architecture_mon_may_30_2016]
 
 == Wed May 18 2016
 


### PR DESCRIPTION
The table in Install & Config was broken because of a pipe character that needed canceling. Also spelled out the full names of the books in the Full Revision History.

cc @vikram-redhat 
