### PR TITLE
Fix topic title in gluster_backed_registry

### DIFF
--- a/install_config/storage_examples/gluster_backed_registry.adoc
+++ b/install_config/storage_examples/gluster_backed_registry.adoc
@@ -1,4 +1,3 @@
-
 = Backing Docker Registry with GlusterFS Storage
 {product-author}
 {product-version}
@@ -20,7 +19,7 @@ It is assumed that the Docker registry service has already been started and the
 Gluster volume has been created.
 
 [[backing-docker-registry-with-glusterfs-storage-prerequisites]]
-=== Prerequisites
+== Prerequisites
 
 * The link:../install/docker_registry.html#deploy-registry[docker-registry] was deployed *without*
 configuring storage.
@@ -44,7 +43,7 @@ All `oc` commands are executed on the master node as the *admin* user.
 ====
 
 [[create-gfs-pvc]]
-=== Create the Gluster Persistent Volume
+== Create the Gluster Persistent Volume
 
 First, make the Gluster volume available to the registry.
 
@@ -77,7 +76,7 @@ status is *Bound*.
 ====
 
 [[attach-pvc-to-reg]]
-=== Attach the PVC to the Docker Registry
+== Attach the PVC to the Docker Registry
 
 Before moving forward, ensure that the *docker-registry* service is running.
 


### PR DESCRIPTION
The blank line at the start of the topic was making the TOC not appear in the docs.openshift builds, and was breaking the left-nav TOC in the Customer Portal builds (plus all headings that came after it, in the single-page version).

Also some headings were incorrectly subheadings of the Overview, so pulled them up a level.

cc @vikram-redhat @ahardin-rh 
