### PR TITLE
add blurb in docs for pipeline dsl

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -219,6 +219,9 @@ The Jenkins image's list of pre-installed plugins includes a plugin which assist
 an OpenShift server.  A series of build steps, post-build actions, as well as SCM-style polling are provided which equate to administrative
 and operational actions on the OpenShift server and the API artifacts hosted there.
 
+In addition to being accessible from the classic "freestyle" form of Jenkins job, the build steps as of version 1.0.14 of the OpenShift Pipeline Plugin
+are also avaible to Jenkins Pipeline jobs via the DSL extension points provided by the Jenkins Pipeline Plugin.
+
 The https://github.com/openshift/jenkins/tree/master/1/contrib/openshift/configuration/jobs/OpenShift%20Sample[sample Jenkins job] that is pre-configured in the Jenkins image utilizes the OpenShift pipeline plugin and serves as an example of
 how to leverage the plugin for creating CI/CD flows for OpenShift in Jenkins.
 


### PR DESCRIPTION
@bparees and @openshift/team-documentation PTAL

A small blurb in the official docs regarding the new DSL for the plugin.  As has been our convention, the precise details are handled in the README in the git repo for the plugin.
