### PR TITLE
fix distros for new admin solutions guide

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -347,7 +347,7 @@ Topics:
 ---
 Name: Administrator Solutions
 Dir: admin_solutions
-Distros: openshift-origin,openshift-enterprise
+Distros: openshift-enterprise
 Topics:
   - Name: Overview
     File: index


### PR DESCRIPTION
accidentally had new admin solutions guide set to origin
