### PR TITLE
advanced/introduction: Atomic Host cleanup

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -17,17 +17,12 @@ installation_ method for installing OpenShift hosts. Familiarity with Ansible is
 assumed, however you can use this configuration as a reference to create your
 own implementation using the configuration management tool of your choosing.
 
-While RHEL Atomic Host is supported for running containerized OpenShift
-services, the advanced installation method utilizes Ansible, which is not
-available in RHEL Atomic Host, and must therefore be run from
-ifdef::openshift-enterprise[]
-a RHEL 7 system.
-endif::[]
-ifdef::openshift-origin[]
-a supported version of Fedora, CentOS, or RHEL.
-endif::[]
-The host initiating the installation does not need to be intended for inclusion
-in the OpenShift cluster, but it can be.
+The host initiating the installation does not need to be intended for
+inclusion in the OpenShift cluster, but it can be.  Regarding host
+initiation, while Atomic Host variants are supported for running
+containerized OpenShift services, the advanced installation method
+utilizes Ansible; thus you will need to either run Ansible from inside
+a container, or install it via RPM non a non-Atomic Host system.
 
 ifdef::openshift-enterprise[]
 Alternatively, you can use the link:quick_install.html[quick installation]


### PR DESCRIPTION
Let's say "Atomic Host variant" since it exists for Fedora and CentOS
as well.  I'd like to have more of our community docs to point to
CentOS Atomic Host where previously we would just say RHEL Atomic
Host.

Also it's certainly _possible_ to run Ansible from inside Docker on an
Atomic Host system...but we probably shouldn't rathole on that early
in the docs introduction.  If Ansible upstream introduces some docs
(like
http://victorlin.me/posts/2014/11/13/provision-with-ansible-from-inside-docker
) we can link to that.
