### PR TITLE
Async publish for OSE 3.1 - 06/03/16

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1158,7 +1158,7 @@ with the `-i option`:
 +
 ----
 # ansible-playbook [-i /path/to/file] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/scaleup.yml
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml
 ----
 
 . After the playbook completes successfully,

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -684,17 +684,9 @@ Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 
 You can override the integrated registry's default configuration, found by
 default at *_/config.yml_* in a running registry's container, with your own
-custom configuration. See
-link:#registry-configuration-reference[registry configuration reference] for more
-information.
-
-[TIP]
-Upstream configuration options in this file may also be overridden using environment
-variables. However, the link:#middleware[middleware section] may **not** be
-overridden using environment variables. See upstream documentation on how to
-link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[override specific configuration options].
-
-=== Deploying Updated Configuration
+custom configuration. See the upstream registry documentation's
+https://docs.docker.com/registry/configuration/[Registry Configuration
+Reference] for the full list of available options.
 
 To enable managing the registry configuration file directly, it
 is recommended that the configuration file be mounted as a
@@ -703,11 +695,8 @@ link:../../dev_guide/secrets.html[secret volume]:
 . link:#deploy-registry[Deploy the registry].
 
 . Edit the registry configuration file locally as needed. The initial YAML file
-deployed on the registry is provided below. See
-link:#registry-configuration-reference[registry configuration reference] for
-supported options.
+deployed on the registry is provided below:
 +
-.Registry configuration file
 ====
 ----
 version: 0.1
@@ -717,7 +706,7 @@ http:
   addr: :5000
 storage:
   cache:
-    blobdescriptor: inmemory
+    layerinfo: inmemory
   filesystem:
     rootdirectory: /registry
   delete:
@@ -732,6 +721,9 @@ middleware:
         pullthrough: true
 ----
 ====
++
+See https://docs.docker.com/registry/configuration/[Registry Configuration
+Reference] for more options.
 
 . Create a new secret called *registry-config* from your custom registry
 configuration file you edited locally:
@@ -795,166 +787,6 @@ $ oc deploy docker-registry --latest
 It is recommended that configuration files be maintained in a source control
 repository.
 ====
-
-[[registry-configuration-reference]]
-=== Registry Configuration Reference
-
-There are many configuration options available in the upstream
-link:https://github.com/docker/distribution[docker distribution]
-library. Not all link:https://docs.docker.com/registry/configuration/[configuration options]
-are supported or enabled. Use this section as a reference.
-
-[TIP]
-Upstream configuration options in this file may also be overridden using environment
-variables. However, the link:#middleware[middleware section] may **not** be
-overridden using environment variables. See upstream documentation on how to
-link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[override specific configuration options].
-
-==== log
-
-link:https://docs.docker.com/registry/configuration/#log[Upstream options] supported.
-Example:
-
-====
-----
-log:
-  level: debug
-  formatter: text
-  fields:
-    service: registry
-    environment: staging
-----
-====
-
-==== hooks
-
-Mail hooks are not supported.
-
-==== storage
-
-The following link:https://docs.docker.com/registry/configuration/#storage[storage drivers]
-are supported:
-
-- link:https://docs.docker.com/registry/storage-drivers/filesystem/[filesystem]
-- link:https://docs.docker.com/registry/storage-drivers/azure/[azure]
-- link:https://docs.docker.com/registry/storage-drivers/s3/[s3] See
-link:#middleware[Middleware] section below for CloudFront configuration
-- link:https://docs.docker.com/registry/storage-drivers/swift/[swift]
-
-General registry storage configuration options are supported. See
-link:https://docs.docker.com/registry/configuration/#maintenance[upstream options]
-for more details.
-
-.General storage configuration options
-====
-----
-storage:
-  delete:
-    enabled: true
-  redirect:
-    disable: false
-  cache:
-    blobdescriptor: inmemory
-  maintenance:
-    uploadpurging:
-      enabled: true
-      age: 168h
-      interval: 24h
-      dryrun: false
-    readonly:
-      enabled: false
-----
-====
-
-==== auth
-
-Auth options should not be altered. The **openshift** extension is the only supported
-option.
-
-----
-auth:
-  openshift:
-    realm: openshift
-----
-
-==== middleware
-
-The **repository** middleware extension should not be altered except for the
-**options** section to disable pull-through cache.
-
-[NOTE]
-The **middleware** section may not be overridden using environment variables.
-
-====
-----
-middleware:
-  repository:
-    - name: openshift
-      options:
-        pullthrough: true
-----
-====
-
-The **cloudfront** link:https://docs.docker.com/registry/configuration/#cloudfront[middleware extension]
-may be added to support AWS CloudFront CDN storage provider.
-
-==== reporting
-
-Unsupported
-
-==== http
-
-While link:https://docs.docker.com/registry/configuration/#http[Upstream options]
-are supported, see link:#securing-the-registry[securing the registry] for
-altering these settings via environment variables. Only the **tls** section
-should be altered, provided below for reference only:
-
-====
-----
-http:
-  addr: :5000
-  tls:
-    certificate: /etc/secrets/registry.crt
-    key: /etc/secrets/registry.key
-----
-====
-
-==== notifications
-
-While link:https://docs.docker.com/registry/configuration/#notifications[Upstream options]
-are supported, see link:../../rest_api/index.html[rest API] for more comprehensive
-integration options. Example:
-
-====
-----
-notifications:
-  endpoints:
-    - name: registry
-      disabled: false
-      url: https://url:port/path
-      headers:
-        Accept:
-          - text/plain
-      timeout: 500
-      threshold: 5
-      backoff: 1000
-----
-====
-
-==== redis
-
-Unsupported
-
-==== health
-
-While link:https://docs.docker.com/registry/configuration/#health[Upstream options]
-are supported, the registry deployment config provides an integrated health check
-at **/healthz**.
-
-==== proxy
-
-Proxy configuration should not be enabled. This functionality is provided by
-the link:#middleware[OpenShift repository middleware extension], **pullthrough: true**.
 
 [[whitelisting-docker-registries]]
 == Whitelisting Docker Registries

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -12,13 +12,13 @@ toc::[]
 
 ifdef::openshift-origin,openshift-origin,openshift-enterprise,openshift-dedicated[]
 == Overview
-{product-title} can build
+OpenShift can build
 link:../../architecture/core_concepts/containers_and_images.html#docker-images[Docker
 images] from your source code, deploy them, and manage their lifecycle. To
-enable this, {product-title} provides an internal,
+enable this, OpenShift provides an internal,
 link:../../architecture/infrastructure_components/image_registry.html#integrated-openshift-registry[integrated
-Docker registry] that can be deployed in your {product-title} environment to
-locally manage images.
+Docker registry] that can be deployed in your OpenShift environment to locally
+manage images.
 endif::[]
 
 [[deploy-registry]]
@@ -63,7 +63,7 @@ link:../../cli_reference/manage_cli_profiles.html[CLI configuration file] for
 the *openshift-registry*.
 endif::[]
 ifdef::openshift-enterprise[]
-<3> Required to pull the correct image for {product-title}.
+<3> Required to pull the correct image for OpenShift Enterprise.
 endif::[]
 
 ifdef::openshift-origin,openshift-origin,openshift-enterprise,openshift-dedicated[]
@@ -684,29 +684,28 @@ Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 
 You can override the integrated registry's default configuration, found by
 default at *_/config.yml_* in a running registry's container, with your own
-link:#registry-configuration-reference[custom configuration].
+custom configuration. See
+link:#registry-configuration-reference[registry configuration reference] for more
+information.
 
-[NOTE]
-====
-Upstream configuration options in this file may also be overridden using
-environment variables. However, the
-link:#docker-registry-configuration-reference-middleware[middleware section] may
-*not* be overridden using environment variables.
-link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[Learn
-how to override specific configuration options].
-====
+[TIP]
+Upstream configuration options in this file may also be overridden using environment
+variables. However, the link:#middleware[middleware section] may **not** be
+overridden using environment variables. See upstream documentation on how to
+link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[override specific configuration options].
 
-[[docker-registry-deploying-updated-configuration]]
 === Deploying Updated Configuration
 
-To enable management of the registry configuration file directly, mount the
-configuration file as a link:../../dev_guide/secrets.html[secret volume]:
+To enable managing the registry configuration file directly, it
+is recommended that the configuration file be mounted as a
+link:../../dev_guide/secrets.html[secret volume]:
 
 . link:#deploy-registry[Deploy the registry].
 
 . Edit the registry configuration file locally as needed. The initial YAML file
-deployed on the registry is provided below.
-link:#registry-configuration-reference[Review supported options].
+deployed on the registry is provided below. See
+link:#registry-configuration-reference[registry configuration reference] for
+supported options.
 +
 .Registry configuration file
 ====
@@ -778,7 +777,8 @@ This procedure will overwrite the currently deployed registry configuration.
 $ oc delete secret registry-config
 ----
 +
-. Recreate the secret to reference the updated configuration file:
+. Recreate the secret to reference the updated configuration file the first
+step:
 +
 ----
 $ oc secrets new registry-config config.yml=</path/to/custom/registry/config.yml>
@@ -792,7 +792,8 @@ $ oc deploy docker-registry --latest
 
 [TIP]
 ====
-Maintain configuration files in a source control repository.
+It is recommended that configuration files be maintained in a source control
+repository.
 ====
 
 [[registry-configuration-reference]]
@@ -803,21 +804,15 @@ link:https://github.com/docker/distribution[docker distribution]
 library. Not all link:https://docs.docker.com/registry/configuration/[configuration options]
 are supported or enabled. Use this section as a reference.
 
-[NOTE]
-====
-Upstream configuration options in this file may also be overridden using
-environment variables. However, the
-link:#docker-registry-configuration-reference-middleware[middleware section] may
-*not* be overridden using environment variables.
-link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[Learn
-how to override specific configuration options].
-====
+[TIP]
+Upstream configuration options in this file may also be overridden using environment
+variables. However, the link:#middleware[middleware section] may **not** be
+overridden using environment variables. See upstream documentation on how to
+link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[override specific configuration options].
 
-[[docker-registry-configuration-reference-log]]
 ==== log
 
-link:https://docs.docker.com/registry/configuration/#log[Upstream options] are supported.
-
+link:https://docs.docker.com/registry/configuration/#log[Upstream options] supported.
 Example:
 
 ====
@@ -831,29 +826,26 @@ log:
 ----
 ====
 
-[[docker-registry-configuration-reference-hooks]]
 ==== hooks
 
 Mail hooks are not supported.
 
-[[docker-registry-configuration-reference-storage]]
 ==== storage
 
 The following link:https://docs.docker.com/registry/configuration/#storage[storage drivers]
 are supported:
 
-*  link:https://docs.docker.com/registry/storage-drivers/filesystem[Filesystem]
-*  link:https://docs.docker.com/registry/storage-drivers/azure/[Microsoft Azure]
-*  link:https://docs.docker.com/registry/storage-drivers/s3/[S3]
-+
-link:#docker-registry-configuration-reference-middleware[Learn more about CloudFront configuration].
+- link:https://docs.docker.com/registry/storage-drivers/filesystem/[filesystem]
+- link:https://docs.docker.com/registry/storage-drivers/azure/[azure]
+- link:https://docs.docker.com/registry/storage-drivers/s3/[s3] See
+link:#middleware[Middleware] section below for CloudFront configuration
+- link:https://docs.docker.com/registry/storage-drivers/swift/[swift]
 
-* link:https://docs.docker.com/registry/storage-drivers/swift/[OpenStack Swift]
+General registry storage configuration options are supported. See
+link:https://docs.docker.com/registry/configuration/#maintenance[upstream options]
+for more details.
 
-link:https://docs.docker.com/registry/configuration/#maintenance[General registry storage configuration options] are supported.
-
-
-.General Storage Configuration Options
+.General storage configuration options
 ====
 ----
 storage:
@@ -874,30 +866,24 @@ storage:
 ----
 ====
 
-[[docker-registry-configuration-reference-auth]]
 ==== auth
 
-Auth options should not be altered. The *openshift* extension is the only
-supported option.
+Auth options should not be altered. The **openshift** extension is the only supported
+option.
 
-====
 ----
 auth:
   openshift:
     realm: openshift
 ----
-====
 
-[[docker-registry-configuration-reference-middleware]]
 ==== middleware
 
-The *repository* middleware extension should not be altered except for the
-*options* section to disable pull-through cache.
+The **repository** middleware extension should not be altered except for the
+**options** section to disable pull-through cache.
 
 [NOTE]
-====
-The *middleware* section cannot be overridden using environment variables.
-====
+The **middleware** section may not be overridden using environment variables.
 
 ====
 ----
@@ -909,21 +895,19 @@ middleware:
 ----
 ====
 
-The link:https://docs.docker.com/registry/configuration/#cloudfront[*cloudfront*
-middleware extension] can be added to support AWS, CloudFront CDN storage
-provider.
+The **cloudfront** link:https://docs.docker.com/registry/configuration/#cloudfront[middleware extension]
+may be added to support AWS CloudFront CDN storage provider.
 
-[[docker-registry-configuration-reference-reporting]]
 ==== reporting
 
-Reporting is unsupported.
+Unsupported
 
-[[docker-registry-configuration-reference-http]]
 ==== http
 
-link:https://docs.docker.com/registry/configuration/#http[Upstream options] are
-supported. link:#securing-the-registry[Learn how to alter these settings via
-environment variables]. Only the *tls* section should be altered. For example:
+While link:https://docs.docker.com/registry/configuration/#http[Upstream options]
+are supported, see link:#securing-the-registry[securing the registry] for
+altering these settings via environment variables. Only the **tls** section
+should be altered, provided below for reference only:
 
 ====
 ----
@@ -935,14 +919,11 @@ http:
 ----
 ====
 
-[[docker-registry-configuration-reference-notifications]]
 ==== notifications
 
-link:https://docs.docker.com/registry/configuration/#notifications[Upstream
-options] are supported. The link:../../rest_api/index.html[REST API Reference]
-provides more comprehensive integration options.
-
-Example:
+While link:https://docs.docker.com/registry/configuration/#notifications[Upstream options]
+are supported, see link:../../rest_api/index.html[rest API] for more comprehensive
+integration options. Example:
 
 ====
 ----
@@ -960,34 +941,30 @@ notifications:
 ----
 ====
 
-[[docker-registry-configuration-reference-redis]]
 ==== redis
 
-Redis is not supported.
+Unsupported
 
-[[docker-registry-configuration-reference-health]]
 ==== health
 
-link:https://docs.docker.com/registry/configuration/#health[Upstream options]
-are supported. The registry deployment configuration provides an integrated
-health check at */healthz*.
+While link:https://docs.docker.com/registry/configuration/#health[Upstream options]
+are supported, the registry deployment config provides an integrated health check
+at **/healthz**.
 
-[[docker-registry-configuration-reference-proxy]]
 ==== proxy
 
 Proxy configuration should not be enabled. This functionality is provided by
-the link:#docker-registry-configuration-reference-middleware[{product-title}
-repository middleware extension], *pullthrough: true*.
+the link:#middleware[OpenShift repository middleware extension], **pullthrough: true**.
 
 [[whitelisting-docker-registries]]
 == Whitelisting Docker Registries
 
 You can specify a whitelist of docker registries, allowing you to curate a set
-of images and templates that are available for download by {product-title}
-users. This curated set can be placed in one or more docker registries, and then
-added to the whitelist. When using a whitelist, only the specified registries
-are accessible within {product-title}, and all other registries are denied
-access by default.
+of images and templates that are available for download by OpenShift users. This
+curated set can be placed in one or more docker registries, and then added to
+the whitelist. When using a whitelist, only the specified registries are
+accessible within OpenShift, and all other registries are denied access by
+default.
 
 To configure a whitelist:
 

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -6,6 +6,27 @@
 :experimental:
 
 // do-release: revhist-tables
+== Fri Jun 03 2016
+
+// tag::install_config_fri_jun_03_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+//Fri Jun 03 2016
+
+|link:../install_config/install/advanced_install.html[Installing -> Advanced Installation]
+|Updated the location of the *scaleup.yml* playbook in the
+link:../install_config/install/advanced_install.html#adding-nodes-advanced[Adding
+Nodes to an Existing Cluster] section.
+
+|link:../install_config/install/docker_registry.html[Installing -> Deploying a Docker Registry]
+|Removed support information for upstream registry configuration not relevant to
+{product-title}.
+
+|===
+
+// end::install_config_fri_jun_03_2016[]
 == Mon May 30 2016
 
 // tag::install_config_mon_may_30_2016[]
@@ -24,7 +45,7 @@ n|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
 |Added an Important box to the link:../install_config/install/prerequisites.html#sizing-recommendations[Sizing Recommendations] section advising that oversubscribing the physical resources on a node affects resource guarantees the Kubernetes scheduler makes during pod placement.
 
 |link:../install_config/install/docker_registry.html[Installing -> Deploying a Docker Registry]
-|Added support information for upstream link:../install_config/install/docker_registry.html#advanced-overriding-the-registry-configuration[registry configuration].
+|Added support information for upstream registry configuration.
 
 n|link:../install_config/http_proxies.html[Working with HTTP Proxies]
 |Updated the example in the xref:../install_config/http_proxies.adoc#configuring-default-templates-for-proxies[Configuring Default Templates for Proxies] section to use `https` for GitHub access.

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -9,6 +9,11 @@ The following sections aggregate the revision histories of each guide by publish
 date.
 
 // do-release: revhist-tables
+== Fri Jun 03 2016
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_fri_jun_03_2016]
+
 == Mon May 30 2016
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_mon_may_30_2016]


### PR DESCRIPTION
Reverting the "upstream registry" related commits as they should have been labeled for 3.2 instead of 3.1, and also we discovered they need more hardening anyway, so those PRs will go back into Next Release w/ to_followup for more editing. Request from GSS/PM.

Plus another quick fix of an incorrect file location.

FYI @vikram-redhat 
