### PR TITLE
[Bug 1342941] Update web console examples link and rework headings

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -60,18 +60,8 @@ stylesheet files when you refresh the page in your browser. You still must
 restart the server when adding new extension stylesheets or scripts, however.
 This setting is only recommended for testing changes and not for production.
 
-The examples in the following sections show common ways you can customize the
-web console.
-
-[NOTE]
-====
-Additional extension examples are available in the
-link:https://github.com/openshift/origin/tree/master/assets/extensions/examples[OpenShift
-Origin] repository on GitHub.
-====
-
 [[customizing-the-logo]]
-=== Customizing the Logo
+== Customizing the Logo
 
 The following style changes the logo in the web console header:
 
@@ -101,7 +91,7 @@ assetConfig:
 ====
 
 [[changing-links-to-documentation]]
-=== Changing Links to Documentation
+== Changing Links to Documentation
 
 Links to external documentation are shown in various sections of the web
 console. The following example changes the URL for two given links to docs:
@@ -126,7 +116,7 @@ assetConfig:
 ====
 
 [[adding-or-changing-links-to-download-the-cli]]
-=== Adding or Changing Links to Download the CLI
+== Adding or Changing Links to Download the CLI
 
 The *About* page in the web console provides download links for the
 link:../cli_reference/index.html[command line interface (CLI)] tools. These
@@ -334,3 +324,47 @@ Header] and OAuth or
 link:../install_config/configuring_authentication.html#OpenID[OpenID] identity
 providers, which require visiting an external URL to destroy single sign-on
 sessions.
+
+[[web-console-customization-additional-examples]]
+== Additional Examples
+
+For more examples showing common ways you can customize the web console,
+additional extension examples are available in the
+https://github.com/openshift/origin-web-console/tree/master/extensions/examples[*_/extensions/examples/_*]
+directory of the upstream
+https://github.com/openshift/origin-web-console[OpenShift Management Console]
+source repository on GitHub.
+
+The JS file in the directory shows how to add to one of the extension points. In
+addition, several other examples are provided in the
+https://github.com/openshift/origin-web-console/tree/master/app/scripts/extensions[*_/app/scripts/extensions/_*]
+directory. They adhere to the following pattern:
+
+====
+----
+angular
+  .module('openshiftOnlineExtensions')
+  .run([
+    'extensionRegistry',
+    function(extensionRegistry) {
+      extensionRegistry
+        .add('<extension-point-desired>', function(data) {
+          // data may provide contextual information for building nodes
+          // returning type 'node' will be most intuitive if you have
+          // some jQuery experience
+          return [
+            {
+              type: 'dom',
+              node: '<li><a href="link/to/something">Link!</a></li>'
+            }
+          ];
+        });
+    }
+  ]);
+----
+====
+
+If you are familiar with Angular, the extension framework being used is
+available in the OpenShift Origin
+https://github.com/openshift/angular-extension-registry[*angular-extension-registry*]
+repository.


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1342941. Updates the broken link originally in the NOTE box, makes that content is own section at the end of the topic, and pulls up some subheadings up a level.

@benjaminapetersen @ahardin-rh WDYT? Pretty build here:

http://file.rdu.redhat.com/~adellape/060616/console_ext_link/install_config/web_console_customization.html#web-console-customization-additional-examples
