### PR TITLE
Add a-o-i errata, rm containerized upgrade notes

### DIFF
--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -212,7 +212,7 @@ used, if needed.
 When the upgrade finishes, a recommendation will be printed to reboot all hosts.
 After rebooting, if you have aggregated logging enable you will need to follow steps outlined in the
 link:#automated-upgrading-efk-logging-stack[Upgrading the EFK Logging Stack] section,
-if you have cluster metrics enabled you will need to follow the setps outlined in the 
+if you have cluster metrics enabled you will need to follow the setps outlined in the
 link:#automated-upgrading-cluster-metrics[Upgrading Cluster Metrics] section,
  otherwise proceed to
 link:#verifying-the-upgrade[Verifying the Upgrade].
@@ -220,11 +220,10 @@ link:#verifying-the-upgrade[Verifying the Upgrade].
 [[upgrading-to-openshift-enterprise-3-2-asynchronous-releases]]
 === Upgrading to OpenShift Enterprise 3.2 Asynchronous Releases
 
-This section will be updated in the future with instructions on how to to apply
-any
+This section will be updated in the future with instructions on how to apply
 link:../../release_notes/ose_3_2_release_notes.html#ose-32-asynchronous-errata-updates[asynchronous
-errata updates] that may be released to an existing OpenShift Enterprise 3.2
-cluster.
+errata updates] released for OpenShift Enterprise 3.2 using an automated
+upgrade.
 endif::[]
 
 ifdef::openshift-origin[]
@@ -245,8 +244,8 @@ Upgrades].
 == Upgrading Cluster Metrics
 
 If you have previously link:../../install_config/cluster_metrics.html[deployed
-cluster metrics] you will need to update to the latest metric components, the steps must 
-be performed manually as shown in 
+cluster metrics] you will need to update to the latest metric components, the steps must
+be performed manually as shown in
 link:../../install_config/upgrading/manual_upgrades.html#manual-upgrading-cluster-metrics[Manual
 Upgrades].
 

--- a/install_config/upgrading/index.adoc
+++ b/install_config/upgrading/index.adoc
@@ -49,18 +49,3 @@ link:../../install_config/upgrading/automated_upgrades.html[automated upgrade].
 Alternatively, you can
 link:../../install_config/upgrading/manual_upgrades.html[upgrade OpenShift
 manually].
-
-[NOTE]
-====
-The Upgrading topics pertains to RPM-based installations only
-ifdef::openshift-enterprise[]
-(i.e., the link:../../install_config/install/quick_install.html[quick] and
-link:../../install_config/install/advanced_install.html[advanced installation]
-methods)
-endif::[]
-ifdef::openshift-origin[]
-(i.e., the link:../../install_config/install/advanced_install.html[advanced
-installation] method)
-endif::[]
- and does not currently cover container-based installations.
-====

--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -717,14 +717,14 @@ OpenShift Enterprise 3.2.
 [[ose-32-known-issues]]
 == Known Issues
 
-- Upgrades from {product-title} 3.1 to 3.2 for are currently only supported for
-clusters using the RPM-based installation method. Administrators with clusters
-using the link:../install_config/install/rpm_vs_containerized.html[containerized
-installation method] should not perform an upgrade at this time, as development
-for this upgrade path is currently in progress. Performing a containerized
-upgrade at this time would be detrimental to your cluster. An asynchronous
-errata update will be released shortly to provide the ability to successfully
-upgrade containerized installations.
+- At the general availability release of {product-title} 3.2, there was a known
+issue with upgrades for
+link:../install_config/install/rpm_vs_containerized.html[containerized
+installation] environments from {product-title} 3.1 to 3.2. Upgrades were only
+supported for clusters using the RPM-based installation method. As of the
+release of the link:#ose-32-relnotes-rhba-2016-1208[RHBA-2016:1208] advisory,
+this issue has been resolved, and containerized upgrades are now supported after
+updating the *atomic-openshift-utils* package.
 (https://bugzilla.redhat.com/show_bug.cgi?id=1331097[*BZ#1331097*],
 https://bugzilla.redhat.com/show_bug.cgi?id=1331380[*BZ#1331380*],
 https://bugzilla.redhat.com/show_bug.cgi?id=1326642[*BZ#1326642*],
@@ -764,8 +764,12 @@ OpenShift Enterprise entitlements for OpenShift Enterprise errata notification
 emails to generate.
 ====
 
-This section will be updated over time to provide notes on enhancements and bug
-fixes for any future asynchronous errata releases of OpenShift Enterprise 3.2.
+This section will continue to be updated over time to provide notes on
+enhancements and bug fixes for future asynchronous errata releases of OpenShift
+Enterprise 3.2. Versioned asynchronous releases, for example with the form
+OpenShift Enterprise 3.2.z, will be detailed in subsections. In addition,
+releases in which the errata text cannot fit in the space provided by the
+advisory will be detailed in subsections that follow.
 
 [IMPORTANT]
 ====
@@ -773,3 +777,155 @@ For any release, always review the instructions on
 link:../install_config/upgrading/index.html[upgrading your {product-title}
 cluster] properly.
 ====
+
+[[ose-32-relnotes-rhba-2016-1208]]
+=== RHBA-2016:1208 - atomic-openshift-utils Bug Fix Update
+
+OpenShift Enterprise bug fix advisory
+https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1208[RHBA-2016:1208],
+providing updated *atomic-openshift-utils* and *openshift-ansible* packages that
+fix several bugs, is now available.
+
+[NOTE]
+====
+The instructions for applying this update are provided in the
+https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1208[Solution]
+section of the advisory.
+====
+
+Space precluded documenting all of the bug fixes in the advisory. This release
+includes the following bug fixes:
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1331346[BZ#1331346]::
+The installer's global proxy configuration support did not correctly configure
+the `*BuildDefaults*` admission controller. The installer has been updated to
+properly configure the `*BuildDefaults*` admission controller.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1337438[BZ#1337438]::
+The installer was incorrectly adding extra single quotes to the
+*_/etc/sysconfig/docker_* file on each run due to an errant newline in the
+Ansible role. This bug fix updates the installer to remove the newline, and as a
+result the extra quotes no longer appear.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1334187[BZ#1334187]::
+Due to *docker-1.9.1-40* packaging changes, it is no longer possible to use `yum
+downgrade` to downgrade from *docker-1.9.1* to *docker-1.8.2* as required for
+OpenShift Enterprise 3.1 and 3.0 installations. The installer has been updated
+to use `yum swap` to perform this downgrade when necessary.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1336780[BZ#1336780]::
+Due to packaging changes in *docker-1.9.1-40*, containerized nodes did not have
+the correct Docker components mounted from the host into the node container.
+This prevented pods from being correctly configured to use the SDN. The missing
+components have been added to the containerized node configuration.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1330934[BZ#1330934]::
+The installer did not properly convert the `*openshift_generate_no_proxy_hosts*`
+Ansible variable to a boolean so it may have been ignored. This bug fix updates
+the installer and the `*openshift_generate_no_proxy_hosts*` variable is now
+properly converted into a boolean ensuring that this variable produces the
+desired effect.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1330935[BZ#1330935]::
+Containerized installations of OpenShift Enterprise (OSE) 3.1 were incorrectly
+receiving configuration defaults intended only to be used with OSE 3.2
+installations. This meant that *dnsmasq* was configured for OSE 3.1 installs
+when it should not have been. This bug fix updates the fixed containerized
+version detection so that the correct default configurations are applied to OSE
+3.1 installations. This means *dnsmasq* will no longer be included by default on
+OSE 3.1 containerized installations. This bug only affected containerized
+installations.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1331097[BZ#1331097]::
+Previously under certain configurations, running the *_config.yml_* playbook
+could fully upgrade a containerized OpenShift Enterprise environment to the
+latest available image versions in configured registries. This bug fix updates
+the *_config.yml_* playbook to ensure images are not updated in these scenarios,
+and as a result the playbook can be run safely without inadvertently upgrading
+images to a newer version.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1331365[BZ#1331365]::
+The quick installer has been updated to help make proxy-related questions more
+clear as to what information is being requested.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1331239[BZ#1331239]::
+The quick installer incorrectly prompted for global proxy configuration settings
+when installing OpenShift Enterprise (OSE) 3.1. The installer has been updated
+to no longer prompt for global proxy settings in OSE 3.0 and 3.1 installations
+because this feature requires OSE 3.2.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1331236[BZ#1331236]::
+Proxy variables previously were not written correctly to Ansible inventories by
+the quick installer. This bug fix updates the quick installer to ensure the
+`*openshift_http_proxy*`, `*openshift_https_proxy*`, `*openshift_no_proxy*`
+variables are written to inventories.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1334895[BZ#1334895]::
+The NetworkManager dispatcher script which configures *dnsmasq* in OpenShift
+Enterprise 3.2 did not account for static network configurations. The dispatcher
+script has been updated to work for static network configurations.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1330920[BZ#1330920]::
+The example Ansible inventories used the incorrect syntax for the
+`*openshift_generate_no_proxy_hosts*` variable. If administrators had copied and
+pasted the example syntax, it would not have taken effect. This bug fix updates
+the example inventories with the correct syntax for setting this variable.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1335063[BZ#1335063]::
+The installer's global proxy configuration incorrectly quoted values in the
+master's *_sysconfig_* files. This meant that containerized installs using proxy
+configurations created by the installer would have failed. The installer has
+been updated to use proper quoting syntax.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1337425[BZ#1337425]::
+The installer uses the `repoquery` command, which is provided by the *yum-utils*
+package and is not in Minimal installations of Red Hat Enterprise Linux 7.x.
+Ansible 1.9 installed this package before calling the command, but it is no
+longer installed starting with Ansible 2.0. This bug fix updates the installer
+to check that the *yum-utils* package is installed, and attempts to install it
+if it is not.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1334639[BZ#1334639]::
+When configuring Ansible variables in inventories using raw booleans,
+installations could fail due to broken master configurations. This bug fix
+updates the installer to ensure that these values are properly converted to the
+master configuration files.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1334148[BZ#1334148]::
+The default for the `*openshift_docker_hosted_registry_insecure*` Ansible
+variable is `true` but if it was set explicitly to `true` in an inventory, the
+installation would product an error. Setting the variable to `false` caused it
+to be ignored. This bug fix updates the installer to respect explicitly setting
+this value.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1329496[BZ#1329496]::
+Previously, the `*osm_default_subdomain*` Ansible variable did not take effect when
+set. This was due to a backwards compatibility issue in the installer. This bug
+fix updates the installer to once again respect setting this variable.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1326045[BZ#1326045]::
+The legacy `*cli_docker_options*` and `*cli_docker_log_options*` Ansible
+variables were not working due to use of an outdated host group that was since
+refactored. The variables were supposed to be migrated to the new format, using
+the `*openshift_docker_options*` and `*openshift_docker_log_options*` variables,
+respectively. This bug fix updates the installer so that the legacy variables
+can be used again.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1326642[BZ#1326642]::
+During an upgrade, if the `*openshift_image_tag*` Ansible variable was set in an
+inventory to an image version that was older than the latest available, the
+latest available version was still set in the *systemd* unit files. This bug fix
+updates the installer to ensure the version set by `*openshift_image_tag*` is
+what actually gets set in the *systemd* unit files.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1336202[BZ#1336202]::
+Upgrades from OpenShift Enterprise (OSE) 3.1 to 3.2 on RPM-based installations
+incorrectly attempted to pull the *openshift3/ose:latest* image. This step is
+only required for containerized installations and has been removed from
+RPM-based installations, eliminating the need to pull an unexpected image.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1331389[BZ#1331389]::
+Previously, the `*cli_docker_additional_registries*` Ansible variable did not
+take effect during an upgrade. This was due to legacy options (`*cli_**`) not
+being migrated during upgrades. This bug fix updates the installer to migrate
+these options correctly.


### PR DESCRIPTION
Adds the BZ summaries for [RHBA-2016:1208](https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1208) (shipped this morning) and removes warnings about containerized 3.1 -> 3.2 upgrade.

Pretty build:

http://file.rdu.redhat.com/~adellape/060716/installer_errata/release_notes/ose_3_2_release_notes.html#ose-32-asynchronous-errata-updates

@ahardin-rh PTAL?
