### PR TITLE
Make scheduler ifdefs OSD-friendly

### DIFF
--- a/admin_guide/scheduler.adoc
+++ b/admin_guide/scheduler.adoc
@@ -542,14 +542,15 @@ kubernetesMasterConfig:
 ----
 ====
 
-. Restart OpenShift for the changes to take effect:
-+
+. Restart OpenShift for the changes to take effect.
 ifdef::openshift-origin[]
++
 ----
 # systemctl restart origin-master
 ----
 endif::[]
 ifdef::openshift-enterprise[]
++
 ----
 # systemctl restart atomic-openshift-master
 ----
@@ -627,14 +628,15 @@ kubernetesMasterConfig:
 ----
 ====
 
-. Restart OpenShift for the changes to take effect:
-+
+. Restart OpenShift for the changes to take effect.
 ifdef::openshift-origin[]
++
 ----
 # systemctl restart origin-master
 ----
 endif::[]
 ifdef::openshift-enterprise[]
++
 ----
 # systemctl restart atomic-openshift-master
 ----


### PR DESCRIPTION
Leaving dedicated-3.2 label (which is the distro this is really servicing) off of this because I'm picking it with https://github.com/openshift/openshift-docs/pull/2230 now. Can get picked via Next Release for enterprise + online later.
