### PR TITLE
Bug 1337328 : Added text mongodb variable

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -162,15 +162,19 @@ MongoDB settings can be configured with the following environment variables:
 
 |`*MONGODB_NOPREALLOC*`
 |Disable data file preallocation.
-|true
+|`*true*`
 
 |`*MONGODB_SMALLFILES*`
 |Set MongoDB to use a smaller default data file size.
-|true
+|`*true*`
 
 |`*MONGODB_QUIET*`
 |Runs MongoDB in a quiet mode that attempts to limit the amount of output.
-|true
+|`*true*`
+
+|`*MONGODB_TEXT_SEARCH_ENABLED*`
+|(MongoDB version 2.4 only) Enables the https://docs.mongodb.org/v2.6/core/index-text/#text-search-text-command[text search] feature.
+|`*false*`
 |===
 
 === Volume Mount Points


### PR DESCRIPTION
@bparees @mfojtik As per email.

I've pretty much just added the variable to the table with a link to the text section of the Mongo docs. I don't think this warrants its own section explaining it. Let me know if you disagree.

Any other thoughts?
