### PR TITLE
Edit section on daemonsets

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -80,19 +80,20 @@ endif::[]
 
 === Deploying the Registry as a DaemonSet
 
-You may use the `oadm registry` command to deploy the registry as a
-link:http://kubernetes.io/docs/admin/daemons/[DaemonSet] with
-the `--daemonset` option.
+Use the `oadm registry` command to deploy the registry as a DaemonSet with the
+`--daemonset` option.
 
-A link:http://kubernetes.io/docs/admin/daemons/[DaemonSet] will run a pod
-on every node.  For more information on
-link:http://kubernetes.io/docs/admin/daemons/[DaemonSets] please see the
+Daemonsets ensure that when nodes are created, they contain copies of a
+specified pod. When the nodes are removed, the pods are garbage collected.
+
+For more information on DaemonSets, see the
 link:http://kubernetes.io/docs/admin/daemons/[DaemonSet documentation].
 
 [NOTE]
 ====
-Updating of DaemonSets is still a work in progress.
-It is recommended that a DeploymentConfig be used to deploy the registry.
+Using DaemonSets with {product-title} is a work in progress, and the only
+supported process is creating a registry. Currently, using deployment
+configurations to deploy a registry is recommended.
 ====
 
 ifdef::openshift-enterprise,openshift-origin[]


### PR DESCRIPTION
@pweil- As discussed.

As it's still a WIP, and it's the only thing that's supported with Daemonsets, I can't think of a better place to put it. So I just gave your PR some more context.

However, is there any reason why my 3.2 install does not have the --daemonset option for the oadm registry command? Am I missing something?
