### PR TITLE
Follow-up to PR#1800, Unit for ES_RAM not specified and default is incorrect

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -279,8 +279,8 @@ Elasticsearch to deploy. Redundancy requires at least three, and more can be
 used for scaling.
 
 |`*ES_INSTANCE_RAM*`, `*ES_OPS_INSTANCE_RAM*`
-|Amount of RAM to reserve per Elasticsearch instance. The default is 8GB, and it
-must be at least 512MB.
+|Amount of RAM to reserve per Elasticsearch instance. The default is 8G (for 8GB), and it
+must be at least 512M. Possible suffixes are G,g,M,m.
 
 |`*ES_NODE_QUORUM*`, `*ES_OPS_NODE_QUORUM*`
 |The quorum required to elect a new master. Should be more than half the intended cluster size.


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1800
