### PR TITLE
Fixes for OSE 3.2 06/10/16 publish

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -14,16 +14,14 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|xref:../admin_guide/service_accounts.adoc#[Configuring Service Accounts]
-|Fixed callout numbering in the xref:../admin_guide/service_accounts.adoc#managed-service-accounts[Managed Service Accounts] example.
+|link:../admin_guide/service_accounts.html[Configuring Service Accounts]
+|Fixed callout numbering in the link:../admin_guide/service_accounts.html#managed-service-accounts[Managed Service Accounts] example.
 
-|xref:../admin_guide/overcommit.adoc#[Overcommitting]
-|Added instructions on how to make the xref:../admin_guide/overcommit.adoc#reserving-resources-for-system-processes[resource-reserver pod] start automatically.
+|link:../admin_guide/overcommit.html[Overcommitting]
+|Added instructions on how to make the link:../admin_guide/overcommit.html#reserving-resources-for-system-processes[resource-reserver pod] start automatically.
 
-|xref:../admin_guide/scheduler.adoc#[Scheduler]
-|Added a xref:../admin_guide/scheduler.adoc#modifying-scheduler-policy[Modifying Scheduler Policy] section.
-
-
+|link:../admin_guide/scheduler.html[Scheduler]
+|Added a link:../admin_guide/scheduler.html#modifying-scheduler-policy[Modifying Scheduler Policy] section.
 
 |===
 

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -14,14 +14,14 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|xref:../architecture/infrastructure_components/web_console.adoc#project-overviews[Infrastructure Components -> Web Console]
-|Added a Note introducing Cockpit.
+|link:../architecture/infrastructure_components/web_console.html[Infrastructure Components -> Web Console]
+|Added a Note introducing Cockpit to the link:../architecture/infrastructure_components/web_console.html#project-overviews[Project Overviews] section.
 
 |link:../architecture/core_concepts/builds_and_image_streams.html[Core Concepts -> Builds and Image Streams]
 |Added *Reproducibility* to the list of S2I advantages in the link:../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-to-Image (S2I) Build] section.
 
-|xref:../architecture/additional_concepts/authorization.adoc#roles[Additional Concepts -> Authorization]
-|Added a Note box indicating that xref:../architecture/additional_concepts/authorization.adoc#roles[Roles] need to be assigned to administer the setup with an external user.
+|link:../architecture/additional_concepts/authorization.html#roles[Additional Concepts -> Authorization]
+|Added a Note box indicating that link:../architecture/additional_concepts/authorization.html#roles[Roles] need to be assigned to administer the setup with an external user.
 
 
 

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -14,10 +14,8 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|xref:../dev_guide/ssh_environment.adoc[Opening a Remote Shell to Containers]
+|link:../dev_guide/ssh_environment.html[Opening a Remote Shell to Containers]
 |Added a new topic on opening a remote shell to containers.
-
-
 
 |===
 

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -1020,9 +1020,9 @@ satisfy high-availability requirements.
 To deploy the F5 router:
 
 . First,
-xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[establish
+link:../../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[establish
 a tunnel using a ramp node], which allows for the routing of traffic to pods
-through the xref:../../architecture/additional_concepts/sdn.adoc[OpenShift SDN].
+through the link:../../architecture/additional_concepts/sdn.html[OpenShift SDN].
 ifdef::openshift-origin[]
 . Ensure you have link:#creating-the-router-service-account[created the router
 service account].

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -14,24 +14,29 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
+
+.2+|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
+|Added NetworkManager to the
+link:../install_config/install/prerequisites.html#system-requirements[System Requirements]
+section for nodes.
+|Added
+link:../install_config/install/prerequisites.html#prereq-networkmanager[NetworkManager]
+as a prerequisite in the
+link:../install_config/install/prerequisites.html#envirornment-requirements[Environment
+Requirements] section.
+
 |link:../install_config/install/advanced_install.html[Installing -> Advanced Installation]
 |Replaced the `*openshift_docker_log_options*` Ansible variable with `*openshift_docker_options*` in the link:../install_config/install/advanced_install.html#configuring-host-variables[Configuring Host Variables] section.
 
-|xref:../install_config/install/prerequisites.adoc#[Installing -> Prerequisites]
-|Added xref:../install_config/install/prerequisites.adoc#prereq-networkmanager[NetworkManager] as a prerequisite.
+|link:../install_config/install/docker_registry.html[Installing -> Deploying a Docker Registry]
+|Fixed examples in the link:../install_config/install/docker_registry.html#securing-the-registry[Securing the Registry] section to use consistent `--cert` and `--key` values. Also, clarify the origin of the *_ca.crt_* file that must be installed per-node.
 
-|xref:../install_config/configuring_authentication.adoc#[Configuring Authentication]
-|Added a note on how to obtain the xref:../install_config/configuring_authentication.adoc#HTPasswdPasswordIdentityProvider[`htpasswd`] utility.
+|link:../install_config/configuring_authentication.html[Configuring Authentication]
+|Added a note on how to obtain the link:../install_config/configuring_authentication.html#HTPasswdPasswordIdentityProvider[`htpasswd`] utility.
 
-|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
-|Added NetworkManager as a system requirement for nodes.
-
-|xref:../install_config/install/docker_registry.adoc#[Installing -> Deploying a Docker Registry]
-|Fixed examples in the xref:../install_config/install/docker_registry.adoc#securing-the-registry[Securing the Registry] section to use consistent `--cert` and `--key` values. Also, clarify the origin of the *_ca.crt_* file that must be installed per-node.
-
-|xref:../install_config/web_console_customization.adoc#[Customizing the Web Console]
-|Added that each time a user's token to {product-title} expires, the user is presented with a custom page. Also, added xref:../install_config/web_console_customization.adoc#custom-login-page-example-usage[use cases] for custom login pages.
-|xref:../install_config/install/advanced_install.adoc#configuring-host-variables[Installing -> Advanced Installation]
+|link:../install_config/web_console_customization.html[Customizing the Web Console]
+|Added that each time a user's token to {product-title} expires, the user is presented with a custom page. Also, added link:../install_config/web_console_customization.html#custom-login-page-example-usage[use cases] for custom login pages.
+|link:../install_config/install/advanced_install.html#configuring-host-variables[Installing -> Advanced Installation]
 |Updated `*openshift_router_selector*` to its new name of `*openshift_hosted_router_selector*`.
 
 

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -220,11 +220,9 @@ used, if needed.
 ----
 
 When the upgrade finishes, a recommendation will be printed to reboot all hosts.
-After rebooting, if you have aggregated logging enable you will need to follow steps outlined in the
-link:#automated-upgrading-efk-logging-stack[Upgrading the EFK Logging Stack] section,
-if you have cluster metrics enabled you will need to follow the setps outlined in the
-link:#automated-upgrading-cluster-metrics[Upgrading Cluster Metrics] section,
- otherwise proceed to
+After rebooting, continue to
+link:#automated-upgrading-efk-logging-stack[Upgrading the EFK Logging Stack] if
+you have aggregated logging enabled, otherwise proceed to
 link:#verifying-the-upgrade[Verifying the Upgrade].
 
 [[upgrading-to-openshift-enterprise-3-2-asynchronous-releases]]
@@ -249,16 +247,6 @@ the EFK logging stack] and want to upgrade to the latest logging component
 images, the steps must be performed manually as shown in
 link:../../install_config/upgrading/manual_upgrades.html#manual-upgrading-efk-logging-stack[Manual
 Upgrades].
-
-[[automated-upgrading-cluster-metrics]]
-== Upgrading Cluster Metrics
-
-If you have previously link:../../install_config/cluster_metrics.html[deployed
-cluster metrics] you will need to update to the latest metric components, the steps must
-be performed manually as shown in
-link:../../install_config/upgrading/manual_upgrades.html#manual-upgrading-cluster-metrics[Manual
-Upgrades].
-
 
 [[verifying-the-upgrade]]
 == Verifying the Upgrade

--- a/install_config/upgrading/index.adoc
+++ b/install_config/upgrading/index.adoc
@@ -49,3 +49,15 @@ link:../../install_config/upgrading/automated_upgrades.html[automated upgrade].
 Alternatively, you can
 link:../../install_config/upgrading/manual_upgrades.html[upgrade OpenShift
 manually].
+
+ifdef::openshift-enterprise[]
+[IMPORTANT]
+====
+Starting with
+link:../../release_notes/ose_3_2_release_notes.html#ose-32-relnotes-rhba-2016-1208[RHBA-2016:1208],
+upgrades from {product-title} 3.1 to 3.2 are supported for clusters using the
+containerized installation method. See
+link:../../release_notes/ose_3_2_release_notes.html#ose-32-known-issues[Known
+Issues].
+====
+endif::[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -13,14 +13,15 @@ date.
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_fri_jun_10_2016]
 
-.Admin Guide
-include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_fri_jun_10_2016]
-
-.Install Config
+.Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_fri_jun_10_2016]
 
-.Dev Guide
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_fri_jun_10_2016]
+
+.Developer Guide
 include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_fri_jun_10_2016]
+
 == Wed Jun 08 2016
 
 .Installation and Configuration


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/2244.

@vikram-redhat This fixes the broken revhistory stuff on the docs.openshift build. It also spells out the book names in `welcome/revhistory_full` and combines some of the revhistory notes when multiple apply to the same topic (mainly in install_config).

Also this reverts https://github.com/openshift/openshift-docs/pull/2227. It was my fault that it was still included in Next Release and subsequently (re)picked yesterday. I had added that milestone and then already manually picked it w/ the related installer errata that shipped other day, and I meant to come back and update the milestone, but forgot.
