### PR TITLE
Fixes for OSE 3.1 06/10/16 publish

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -14,14 +14,14 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|xref:../admin_guide/service_accounts.adoc#[Configuring Service Accounts]
-|Fixed callout numbering in the xref:../admin_guide/service_accounts.adoc#managed-service-accounts[Managed Service Accounts] example.
+|link:../admin_guide/service_accounts.html[Configuring Service Accounts]
+|Fixed callout numbering in the link:../admin_guide/service_accounts.html#managed-service-accounts[Managed Service Accounts] example.
 
-|xref:../admin_guide/overcommit.adoc#[Overcommitting]
-|Added instructions on how to make the xref:../admin_guide/overcommit.adoc#reserving-resources-for-system-processes[resource-reserver pod] start automatically.
+|link:../admin_guide/overcommit.html[Overcommitting]
+|Added instructions on how to make the link:../admin_guide/overcommit.html#reserving-resources-for-system-processes[resource-reserver pod] start automatically.
 
-|xref:../admin_guide/scheduler.adoc#[Scheduler]
-|Added a xref:../admin_guide/scheduler.adoc#modifying-scheduler-policy[Modifying Scheduler Policy] section.
+|link:../admin_guide/scheduler.html[Scheduler]
+|Added a link:../admin_guide/scheduler.html#modifying-scheduler-policy[Modifying Scheduler Policy] section.
 
 
 

--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -354,8 +354,8 @@ These are the interfaces that the OpenShift SDN creates:
 
 * `br0`: The OVS bridge device that containers will be attached to.
 OpenShift SDN also configures a set of non-subnet-specific flow rules
-on this bridge. (The `multitenant` plug-in does this immediately; the
-`ovssubnet` plug-in waits until the SDN master announces the creation
+on this bridge. (The `multitenant` plugin does this immediately; the
+`ovssubnet` plugin waits until the SDN master announces the creation
 of the new node subnet.)
 * `lbr0`: A Linux bridge device, which is configured as Docker's bridge and
 given the cluster subnet gateway address (eg, 10.1.x.1/24).
@@ -490,7 +490,7 @@ table=0, priority=100, ip, nw_dst=10.1.0.10    actions=output:12
 table=0, priority=100,arp,arp_tpa=10.1.0.10    actions=output:12
 ....
 
-The SDN networking plug-in configures two entries (one for arp and one
+The SDN networking plugin configures two entries (one for arp and one
 for ip) with `output=1` per peer endpoint (i.e. if there are five
 nodes, then there should be 4 * 2 rules; In the example above we have
 3 nodes total, so there are four entries above).  It also sets up the

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -14,14 +14,14 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|xref:../architecture/infrastructure_components/web_console.adoc#project-overviews[Infrastructure Components -> Web Console]
-|Added a Note introducing Cockpit.
+|link:../architecture/infrastructure_components/web_console.html[Infrastructure Components -> Web Console]
+|Added a Note introducing Cockpit to the link:../architecture/infrastructure_components/web_console.html#project-overviews[Project Overviews] section.
 
 |link:../architecture/core_concepts/builds_and_image_streams.html[Core Concepts -> Builds and Image Streams]
 |Added *Reproducibility* to the list of S2I advantages in the link:../architecture/core_concepts/builds_and_image_streams.html#source-build[Source-to-Image (S2I) Build] section.
 
-|xref:../architecture/additional_concepts/authorization.adoc#roles[Additional Concepts -> Authorization]
-|Added a Note box indicating that xref:../architecture/additional_concepts/authorization.adoc#roles[Roles] need to be assigned to administer the setup with an external user.
+|link:../architecture/additional_concepts/authorization.html[Additional Concepts -> Authorization]
+|Added a Note box indicating that link:../architecture/additional_concepts/authorization.html#roles[Roles] need to be assigned to administer the setup with an external user.
 
 
 

--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -126,7 +126,7 @@ $ bundle exec guard
 This utility will run in the terminal where you started it, so you should leave
 it running and open new terminal windows for other tasks.
 
-4. In your browser, enable the LiveReload plug-in in the same tab where the
+4. In your browser, enable the LiveReload plugin in the same tab where the
 preview file is open; the icon should change color once activated. The following
 message will also display in your terminal window:
 +

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -14,10 +14,8 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|xref:../dev_guide/ssh_environment.adoc[Opening a Remote Shell to Containers]
+|link:../dev_guide/ssh_environment.html[Opening a Remote Shell to Containers]
 |Added a new topic on opening a remote shell to containers.
-
-
 
 |===
 

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -742,9 +742,9 @@ satisfy high-availability requirements.
 To deploy the F5 router:
 
 . First,
-xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[establish
+link:../../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[establish
 a tunnel using a ramp node], which allows for the routing of traffic to pods
-through the xref:../../architecture/additional_concepts/sdn.adoc[OpenShift SDN].
+through the link:../../architecture/additional_concepts/sdn.html[OpenShift SDN].
 ifdef::openshift-origin[]
 . Ensure you have link:#creating-the-router-service-account[created the router
 service account].
@@ -794,10 +794,10 @@ specific profile with appropriate permissions.
 Partition paths allow you to store your OpenShift routing configuration in a
 custom *F5 BIG-IP®* administrative partition, instead of the default */Common*
 partition. You can use custom administrative partitions to secure *F5 BIG-IP®*
-environments. This means that an OpenShift-specific configuration stored in 
+environments. This means that an OpenShift-specific configuration stored in
 *F5 BIG-IP®* system objects reside within a logical container, allowing
 administrators to define access control policies on that specific administrative
-partition. 
+partition.
 
 See the
 link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_0_0/tmos_partitions.html[*F5 BIG-IP®* documentation] for more information about administrative partitions.
@@ -830,6 +830,6 @@ All].
 endif::[]
 - Deploy an link:docker_registry.html[integrated Docker registry].
 ifdef::openshift-origin[]
-- link:../../install_config/imagestreams_templates.html[Populate your OpenShift installation] 
+- link:../../install_config/imagestreams_templates.html[Populate your OpenShift installation]
 with a useful set of Red Hat-provided image streams and templates.
 endif::[]

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -14,21 +14,20 @@
 
 |Affected Topic |Description of Change
 //Fri Jun 10 2016
-|link:../install_config/install/advanced_install.html[Installing -> Advanced Installation]
+
+.2+|link:../install_config/install/advanced_install.html[Installing -> Advanced Installation]
 |Replaced the `*openshift_docker_log_options*` Ansible variable with `*openshift_docker_options*` in the link:../install_config/install/advanced_install.html#configuring-host-variables[Configuring Host Variables] section.
-
-|xref:../install_config/configuring_authentication.adoc#[Configuring Authentication]
-|Added a note on how to obtain the xref:../install_config/configuring_authentication.adoc#HTPasswdPasswordIdentityProvider[`htpasswd`] utility.
-
-|xref:../install_config/install/docker_registry.adoc#[Installing -> Deploying a Docker Registry]
-|Fixed examples in the xref:../install_config/install/docker_registry.adoc#securing-the-registry[Securing the Registry] section to use consistent `--cert` and `--key` values. Also, clarify the origin of the *_ca.crt_* file that must be installed per-node.
-
-|xref:../install_config/web_console_customization.adoc#[Customizing the Web Console]
-|Added that each time a user's token to {product-title} expires, the user is presented with a custom page. Also, added xref:../install_config/web_console_customization.adoc#custom-login-page-example-usage[use cases] for custom login pages.
-|xref:../install_config/install/advanced_install.adoc#configuring-host-variables[Installing -> Advanced Installation]
 |Updated `*openshift_router_selector*` to its new name of `*openshift_hosted_router_selector*`.
 
+|link:../install_config/install/docker_registry.html[Installing -> Deploying a Docker Registry]
+|Fixed examples in the link:../install_config/install/docker_registry.html#securing-the-registry[Securing the Registry] section to use consistent `--cert` and `--key` values. Also, clarify the origin of the *_ca.crt_* file that must be installed per-node.
 
+|link:../install_config/configuring_authentication.html[Configuring Authentication]
+|Added a note on how to obtain the link:../install_config/configuring_authentication.html#HTPasswdPasswordIdentityProvider[`htpasswd`] utility.
+
+|link:../install_config/web_console_customization.html[Customizing the Web Console]
+|Added that each time a user's token to {product-title} expires, the user is presented with a custom page. Also, added link:../install_config/web_console_customization.html#custom-login-page-example-usage[use cases] for custom login pages.
+|link:../install_config/install/advanced_install.html#configuring-host-variables[Installing -> Advanced Installation]
 
 |===
 
@@ -74,8 +73,8 @@ n|link:../install_config/install/prerequisites.html[Installing -> Prerequisites]
 |link:../install_config/install/docker_registry.html[Installing -> Deploying a Docker Registry]
 |Added support information for upstream registry configuration.
 
-n|link:../install_config/http_proxies.html[Working with HTTP Proxies]
-|Updated the example in the xref:../install_config/http_proxies.adoc#configuring-default-templates-for-proxies[Configuring Default Templates for Proxies] section to use `https` for GitHub access.
+|link:../install_config/http_proxies.html[Working with HTTP Proxies]
+|Updated the example in the link:../install_config/http_proxies.html#configuring-default-templates-for-proxies[Configuring Default Templates for Proxies] section to use `https` for GitHub access.
 
 |link:../install_config/storage_examples/gluster_backed_registry.html[Persistent Storage Examples -> Backing Docker Registry with GlusterFS Storage]
 |New topic about how to attach a GlusterFS persistent volume to the Docker Registry.
@@ -141,7 +140,7 @@ an {product-title} persistent store.
 |Updated the link:../install_config/install/docker_registry.html#registry-known-issues[Known Issues] section to note the `no_wdelay` NFS export option.
 
 .2+|link:../install_config/http_proxies.html[Working with HTTP Proxies]
-|Added specific *_/etc/sysconfig_* files to the xref:../install_config/http_proxies.adoc#configuring-hosts-for-proxies[Configuring Hosts for Proxies] section.
+|Added specific *_/etc/sysconfig_* files to the link:../install_config/http_proxies.html#configuring-hosts-for-proxies[Configuring Hosts for Proxies] section.
 
 |Added information explaining that OpenShift does not accept an asterisk as a wildcard attached to a domain suffix.
 
@@ -455,7 +454,7 @@ the Installation] section to run the `oc get nodes` command on the master host.
 
 |link:../install_config/routing_from_edge_lb.html[Routing from Edge Load Balancers]
 |Corrected the *_/run/openshift-sdn/config.env_* path in the
-xref:../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[Establishing
+link:../install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[Establishing
 a Tunnel Using a Ramp Node] section.
 
 |link:../install_config/install/docker_registry.html[Installing -> Deploying a Docker Registry]

--- a/rest_api/kubernetes_v1.adoc
+++ b/rest_api/kubernetes_v1.adoc
@@ -7468,7 +7468,7 @@ ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
 
 === v1.PersistentVolumeSpec
 :hardbreaks:
-FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plug-in. This is an alpha feature and may change in future.
+PersistentVolumeSpec is the specification of a persistent volume.
 
 [options="header"]
 |===
@@ -8112,23 +8112,10 @@ NodeSpec describes the attributes that a node is created with.
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|capacity|A description of the persistent volume's resources and capacity. More info: http://releases.k8s.io/release-1.2/docs/user-guide/persistent-volumes.md#capacity|false|<<any>>|
-|gcePersistentDisk|GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#gcepersistentdisk|false|<<v1.GCEPersistentDiskVolumeSource>>|
-|awsElasticBlockStore|AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#awselasticblockstore|false|<<v1.AWSElasticBlockStoreVolumeSource>>|
-|hostPath|HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#hostpath|false|<<v1.HostPathVolumeSource>>|
-|glusterfs|Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.2/examples/glusterfs/README.md|false|<<v1.GlusterfsVolumeSource>>|
-|nfs|NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#nfs|false|<<v1.NFSVolumeSource>>|
-|rbd|RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/examples/rbd/README.md|false|<<v1.RBDVolumeSource>>|
-|iscsi|ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.|false|<<v1.ISCSIVolumeSource>>|
-|cinder|Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.2/examples/mysql-cinder-pd/README.md|false|<<v1.CinderVolumeSource>>|
-|cephfs|CephFS represents a Ceph FS mount on the host that shares a pod's lifetime|false|<<v1.CephFSVolumeSource>>|
-|fc|FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.|false|<<v1.FCVolumeSource>>|
-|flocker|Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running|false|<<v1.FlockerVolumeSource>>|
-|flexVolume|FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plug-in. This is an alpha feature and may change in future.|false|<<v1.FlexVolumeSource>>|
-|azureFile|AzureFile represents an Azure File Service mount on the host and bind mount to the pod.|false|<<v1.AzureFileVolumeSource>>|
-|accessModes|AccessModes contains all ways the volume can be mounted. More info: http://releases.k8s.io/release-1.2/docs/user-guide/persistent-volumes.md#access-modes|false|<<v1.PersistentVolumeAccessMode>> array|
-|claimRef|ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://releases.k8s.io/release-1.2/docs/user-guide/persistent-volumes.md#binding|false|<<v1.ObjectReference>>|
-|persistentVolumeReclaimPolicy|What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plug-in underlying this persistent volume. More info: http://releases.k8s.io/release-1.2/docs/user-guide/persistent-volumes.md#recycling-policy|false|string|
+|podCIDR|PodCIDR represents the pod IP range assigned to the node.|false|string|
+|externalID|External ID of the node assigned by some machine database (e.g. a cloud provider). Deprecated.|false|string|
+|providerID|ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>|false|string|
+|unschedulable|Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#manual-node-administration|false|boolean|false
 |===
 
 === v1.HTTPGetAction
@@ -8585,26 +8572,10 @@ An Amazon Elastic Block Store (EBS) must already be created, formatted, and resi
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|kind|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.2/docs/devel/api-conventions.md#types-kinds|false|string|
-|apiVersion|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.2/docs/devel/api-conventions.md#resources|false|string|
-|metadata||false|<<v1.ObjectMeta>>|
-|priority|Priority influences the sort order of SCCs when evaluating which SCCs to try first for a given pod request based on access in the Users and Groups fields.  The higher the int, the higher priority.  If scores for multiple SCCs are equal they will be sorted by name.|true|integer (int32)|
-|allowPrivilegedContainer|AllowPrivilegedContainer determines if a container can request to be run as privileged.|true|boolean|
-|defaultAddCapabilities|DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.|true|<<v1.Capability>> array|
-|requiredDropCapabilities|RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.|true|<<v1.Capability>> array|
-|allowedCapabilities|AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field maybe added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.|true|<<v1.Capability>> array|
-|allowHostDirVolumePlugin|AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plug-in|true|boolean|
-|allowHostNetwork|AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.|true|boolean|
-|allowHostPorts|AllowHostPorts determines if the policy allows host ports in the containers.|true|boolean|
-|allowHostPID|AllowHostPID determines if the policy allows host pid in the containers.|true|boolean|
-|allowHostIPC|AllowHostIPC determines if the policy allows host ipc in the containers.|true|boolean|
-|seLinuxContext|SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.|false|<<v1.SELinuxContextStrategyOptions>>|
-|runAsUser|RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.|false|<<v1.RunAsUserStrategyOptions>>|
-|supplementalGroups|SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.|false|<<v1.SupplementalGroupsStrategyOptions>>|
-|fsGroup|FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.|false|<<v1.FSGroupStrategyOptions>>|
-|readOnlyRootFilesystem|ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the SCC should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.|true|boolean|
-|users|The users who have permissions to use this security context constraints|false|string array|
-|groups|The groups that have permission to use this security context constraints|false|string array|
+|volumeID|Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore|true|string|
+|fsType|Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore|true|string|
+|partition|The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).|false|integer (int32)|
+|readOnly|Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore|false|boolean|false
 |===
 
 === v1.Binding
@@ -8748,27 +8719,9 @@ GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a 
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|name|Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/identifiers.md#names|true|string|
-|hostPath|HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#hostpath|false|<<v1.HostPathVolumeSource>>|
-|emptyDir|EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#emptydir|false|<<v1.EmptyDirVolumeSource>>|
-|gcePersistentDisk|GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#gcepersistentdisk|false|<<v1.GCEPersistentDiskVolumeSource>>|
-|awsElasticBlockStore|AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#awselasticblockstore|false|<<v1.AWSElasticBlockStoreVolumeSource>>|
-|gitRepo|GitRepo represents a git repository at a particular revision.|false|<<v1.GitRepoVolumeSource>>|
-|secret|Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#secrets|false|<<v1.SecretVolumeSource>>|
-|nfs|NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#nfs|false|<<v1.NFSVolumeSource>>|
-|iscsi|ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/examples/iscsi/README.md|false|<<v1.ISCSIVolumeSource>>|
-|glusterfs|Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/examples/glusterfs/README.md|false|<<v1.GlusterfsVolumeSource>>|
-|persistentVolumeClaim|PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.2/docs/user-guide/persistent-volumes.md#persistentvolumeclaims|false|<<v1.PersistentVolumeClaimVolumeSource>>|
-|rbd|RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/examples/rbd/README.md|false|<<v1.RBDVolumeSource>>|
-|flexVolume|FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plug-in. This is an alpha feature and may change in future.|false|<<v1.FlexVolumeSource>>|
-|cinder|Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.2/examples/mysql-cinder-pd/README.md|false|<<v1.CinderVolumeSource>>|
-|cephfs|CephFS represents a Ceph FS mount on the host that shares a pod's lifetime|false|<<v1.CephFSVolumeSource>>|
-|flocker|Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running|false|<<v1.FlockerVolumeSource>>|
-|downwardAPI|DownwardAPI represents downward API about the pod that should populate this volume|false|<<v1.DownwardAPIVolumeSource>>|
-|fc|FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.|false|<<v1.FCVolumeSource>>|
-|azureFile|AzureFile represents an Azure File Service mount on the host and bind mount to the pod.|false|<<v1.AzureFileVolumeSource>>|
-|configMap|ConfigMap represents a configMap that should populate this volume|false|<<v1.ConfigMapVolumeSource>>|
-|metadata|Metadata represents metadata about the pod that should populate this volume Deprecated: Use downwardAPI instead.|false|<<v1.MetadataVolumeSource>>|
+|endpoints|EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod|true|string|
+|path|Path is the Glusterfs volume path. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod|true|string|
+|readOnly|ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod|false|boolean|false
 |===
 
 === v1.PersistentVolumeClaimStatus

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -9229,7 +9229,7 @@ A SecretSpec specifies a secret and its corresponding mount point for a custom b
 
 === v1.ResourceRequirements
 :hardbreaks:
-FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plug-in. This is an alpha feature and may change in future.
+ResourceRequirements describes the compute resource requirements.
 
 [options="header"]
 |===
@@ -9825,10 +9825,7 @@ VolumeMount describes a mounting of a Volume within a container.
 |reference|if true consider this tag a reference only and do not attempt to import metadata about the image|false|boolean|false
 |===
 
-=== v1.NetNamespace
-:hardbreaks:
-NetNamespace represents a segregated network namespace for an entire cluster. When a group of pods, or a project, or a group of projects get a NetNamespace assigned then the openshift-sdn's multitenant plug-in ensures network layer isolation of traffic from other NetNamespaces.
-
+=== v1.OAuthClient
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
@@ -9840,10 +9837,7 @@ NetNamespace represents a segregated network namespace for an entire cluster. Wh
 |redirectURIs|valid redirection URIs associated with a client|false|string array|
 |===
 
-=== v1.NetNamespaceList
-:hardbreaks:
-NetNamespaceList represents a list of NetNamespace objects. NetNamespace catpures information about a segregated network namespace for an entire cluster. When a group of pods, or a project, or a group of projects get a NetNamespace assigned then the openshift-sdn's multitenant plug-in ensures network layer isolation of traffic from other NetNamespaces.
-
+=== v1.ImageStreamList
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
@@ -10618,27 +10612,9 @@ Examples:
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|name|Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/identifiers.md#names|true|string|
-|hostPath|HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#hostpath|false|<<v1.HostPathVolumeSource>>|
-|emptyDir|EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#emptydir|false|<<v1.EmptyDirVolumeSource>>|
-|gcePersistentDisk|GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#gcepersistentdisk|false|<<v1.GCEPersistentDiskVolumeSource>>|
-|awsElasticBlockStore|AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#awselasticblockstore|false|<<v1.AWSElasticBlockStoreVolumeSource>>|
-|gitRepo|GitRepo represents a git repository at a particular revision.|false|<<v1.GitRepoVolumeSource>>|
-|secret|Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#secrets|false|<<v1.SecretVolumeSource>>|
-|nfs|NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/release-1.2/docs/user-guide/volumes.md#nfs|false|<<v1.NFSVolumeSource>>|
-|iscsi|ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.2/examples/iscsi/README.md|false|<<v1.ISCSIVolumeSource>>|
-|glusterfs|Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/examples/glusterfs/README.md|false|<<v1.GlusterfsVolumeSource>>|
-|persistentVolumeClaim|PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.2/docs/user-guide/persistent-volumes.md#persistentvolumeclaims|false|<<v1.PersistentVolumeClaimVolumeSource>>|
-|rbd|RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.2/examples/rbd/README.md|false|<<v1.RBDVolumeSource>>|
-|flexVolume|FlexVolume represents a generic volume resource that is provisioned/attached using a exec based plug-in. This is an alpha feature and may change in future.|false|<<v1.FlexVolumeSource>>|
-|cinder|Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.2/examples/mysql-cinder-pd/README.md|false|<<v1.CinderVolumeSource>>|
-|cephfs|CephFS represents a Ceph FS mount on the host that shares a pod's lifetime|false|<<v1.CephFSVolumeSource>>|
-|flocker|Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running|false|<<v1.FlockerVolumeSource>>|
-|downwardAPI|DownwardAPI represents downward API about the pod that should populate this volume|false|<<v1.DownwardAPIVolumeSource>>|
-|fc|FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.|false|<<v1.FCVolumeSource>>|
-|azureFile|AzureFile represents an Azure File Service mount on the host and bind mount to the pod.|false|<<v1.AzureFileVolumeSource>>|
-|configMap|ConfigMap represents a configMap that should populate this volume|false|<<v1.ConfigMapVolumeSource>>|
-|metadata|Metadata represents metadata about the pod that should populate this volume Deprecated: Use downwardAPI instead.|false|<<v1.MetadataVolumeSource>>|
+|created|when the event was created|true|string|
+|dockerImageReference|the string that can be used to pull this image|true|string|
+|image|the image|true|string|
 |===
 
 === v1.FinalizerName

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -127,16 +127,16 @@ To customize the official OpenShift Jenkins image, you have two options:
 
 You can use link:../../architecture/core_concepts/builds_and_image_streams.html#source-build[S2I]
 to copy your custom Jenkins Jobs definitions, additional
-plug-ins or replace the provided *_config.xml_* file with your own, custom, configuration.
+plugins or replace the provided *_config.xml_* file with your own, custom, configuration.
 
 In order to include your modifications in the Jenkins image, you need to have a Git
 repository with the following directory structure:
 
 *_plugins_*::
-This directory contains those binary Jenkins plug-ins you want to copy into Jenkins.
+This directory contains those binary Jenkins plugins you want to copy into Jenkins.
 
 *_plugins.txt_*::
-This file lists the plug-ins you want to install (see the section above).
+This file lists the plugins you want to install (see the section above).
 
 *_configuration/jobs_*::
 This directory contains the Jenkins job definitions.
@@ -211,20 +211,3 @@ slave.
 == Tutorial
 
 For more details on the sample job included in this image, see this link:https://github.com/openshift/origin/blob/master/examples/jenkins/README.md[tutorial].
-
-ifdef::openshift-origin[]
-== OpenShift Pipeline Plug-in
-
-The Jenkins image's list of pre-installed plug-ins includes a plug-in which assists in the creating of CI/CD workflows that run against
-an OpenShift server.  A series of build steps, post-build actions, as well as SCM-style polling are provided which equate to administrative
-and operational actions on the OpenShift server and the API artifacts hosted there.
-
-In addition to being accessible from the classic "freestyle" form of Jenkins job, the build steps as of version 1.0.14 of the OpenShift Pipeline Plug-in
-are also avaible to Jenkins Pipeline jobs via the DSL extension points provided by the Jenkins Pipeline Plug-in.
-
-The https://github.com/openshift/jenkins/tree/master/1/contrib/openshift/configuration/jobs/OpenShift%20Sample[sample Jenkins job] that is pre-configured in the Jenkins image utilizes the OpenShift pipeline plug-in and serves as an example of
-how to leverage the plug-in for creating CI/CD flows for OpenShift in Jenkins.
-
-See the https://github.com/openshift/jenkins-plugin/[the plug-in's README] for a detailed description of what is available.
-
-endif::openshift-origin[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -13,14 +13,15 @@ date.
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_fri_jun_10_2016]
 
-.Admin Guide
-include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_fri_jun_10_2016]
-
-.Install Config
+.Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_fri_jun_10_2016]
 
-.Dev Guide
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_fri_jun_10_2016]
+
+.Developer Guide
 include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_fri_jun_10_2016]
+
 == Fri Jun 03 2016
 
 .Installation and Configuration


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/2245.

@vikram-redhat This fixes revhistories (xrefs aren't working on docs.openshift) and tidies them up, similar to https://github.com/openshift/openshift-docs/pull/2253.

Also reverts the commit that was trying to update the 3.1 REST API to 3.2, see https://github.com/openshift/openshift-docs/pull/2224#issuecomment-225290680 for explanation.
