### PR TITLE
Document new deployment features

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -11,33 +11,44 @@ toc::[]
 
 == Overview
 
-A deployment in OpenShift is a replication controller based on a user defined
-template called a deployment configuration. Deployments are created manually
-or in response to triggered events.
+{product-title} deployments provide fine-grained management over applications
+based on a user defined template called a deployment configuration.
+The deployment system in response to a deployment configuration will
+create a replication controller to run an application. Replication
+controllers are created manually or in response to triggered events.
 
-The deployment system provides:
+[IMPORTANT]
+====
+Users should never manipulate replication controllers owned by
+deployment configurations. The deployment system makes sure changes to
+deployment configurations are propagated appropriately to replication
+controllers.
+====
 
-- A link:#creating-a-deployment-configuration[deployment configuration], which is a template for deployments.
-- link:#triggers[Triggers] that drive automated deployments in response to events.
-- User-customizable link:#strategies[strategies] to transition from the previous deployment to the new deployment.
-- link:#rolling-back-a-deployment[Rollbacks] to a previous deployment.
-- Manual replication link:#scaling[scaling].
+Features provided by the deployment system:
+
+- A xref:creating-a-deployment-configuration[deployment configuration], which is a template for running applications.
+- xref:triggers[Triggers] that drive automated deployments in response to events.
+- User-customizable xref:strategies[strategies] to transition from the previous version to the new version.
+- xref:rolling-back-a-deployment[Rollbacks] to a previous version either manually or automatically in case of deployment failure.
+- Manual replication xref:scaling[scaling] and autoscaling.
 
 The deployment configuration contains a version number that is incremented
-each time a new deployment is created from that configuration. In addition,
-the cause of the last deployment is added to the configuration.
+each time a new replication controller is created from that configuration.
+In addition, the cause of the last deployed replication controller is added
+to the configuration.
 
 [[creating-a-deployment-configuration]]
 == Creating a Deployment Configuration
 
 A deployment configuration consists of the following key parts:
 
-- A replication controller template which describes the application to be deployed.
-- The default replica count for the deployment.
-- A deployment link:#strategies[strategy] which will be used to execute the deployment.
-- A set of link:#triggers[triggers] which cause deployments to be created automatically.
+- A pod template which describes the application to be deployed.
+- The default replica count for the replication controller.
+- A deployment xref:strategies[strategy] which will be used to deploy the application.
+- A set of xref:triggers[triggers] which cause replication controllers to be created automatically.
 
-Deployment configurations are `*deploymentConfig*` OpenShift API resources
+Deployment configurations are `*deploymentConfig*` {product-title} API resources
 which can be managed with the `oc` command like any other resource. The
 following is an example of a `*deploymentConfig*` resource:
 
@@ -62,8 +73,6 @@ spec:
             - containerPort: 8080
               protocol: "TCP"
   replicas: 5 <2>
-  selector: 
-    name: "frontend"
   triggers: 
     - type: "ConfigChange" <3>
     - type: "ImageChange" <4>
@@ -76,14 +85,21 @@ spec:
           name: "origin-ruby-sample:latest"
   strategy: <5>
     type: "Rolling"
+  paused: false <6>
+  revisionHistoryLimit: 2 <7>
+  minReadySeconds: 0 <8>
+
 ----
 
-<1> The replication controller template named `frontend` describes a simple Ruby application.
-<2> There will be 5 replicas of `frontend` by default.
-<3> A link:#config-change-trigger[configuration change trigger] causes a new deployment to be created any time the replication controller template changes.
-<4> An link:#image-change-trigger[image change trigger] trigger causes a new deployment to be
-created each time a new version of the `origin-ruby-sample:latest` image repository is available.
-<5> The link:#rolling-strategy[Rolling strategy] is the default and may be omitted.
+<1> The pod template of the `frontend` deployment configuration describes a simple Ruby application.
+<2> There will be 5 replicas of `frontend`.
+<3> A xref:config-change-trigger[configuration change trigger] causes a new replication controller to be created any time the pod template changes.
+<4> An xref:image-change-trigger[image change trigger] trigger causes a new replication controller to be
+created each time a new version of the `origin-ruby-sample:latest` image stream tag is available.
+<5> The xref:rolling-strategy[Rolling strategy] is the default way of deploying your pods. May be omitted.
+<6> If true, `paused` makes inert your deployment configuration and subsequent changes to the pod template or new images will not run new deployments.
+<7> Revision history limit is the limit of old replication controllers you want to keep around for rolling back. May be omitted.
+<8> Minimum seconds to wait (after the readiness checks succeed) for a pod to be considered available. May be omitted.
 ====
 
 [[start-deployment]]
@@ -92,11 +108,11 @@ created each time a new version of the `origin-ruby-sample:latest` image reposit
 You can start a new deployment manually using the web console, or from the CLI:
 
 ----
-$ oc deploy <deployment_config> --latest
+$ oc deploy --latest dc/<name>
 ----
 
 NOTE: If there's already a deployment in progress, the command will display a
-message and a new deployment will not be started.
+message and a new replication controller will not be deployed.
 
 [[viewing-a-deployment]]
 
@@ -105,21 +121,26 @@ message and a new deployment will not be started.
 To get basic information about recent deployments:
 
 ----
-$ oc deploy <deployment_config>
+$ oc rollout history dc/<name>
 ----
 
-This will show details about the latest and recent deployments, including any
-currently running deployment.
-
-For more detailed information about a deployment configuration and the latest deployment:
+This will show details about all recently deployed replication controllers for
+the provided deployment configuration, including any currently running deployment.
+You can view details specific to a revision by using the `--revision` flag:
 
 ----
-$ oc describe dc <deployment_config>
+$ oc rollout history dc/<name> --revision=1
+----
+
+For more detailed information about a deployment configuration and its latest deployment:
+
+----
+$ oc describe dc <name>
 ----
 
 [NOTE]
 ====
-The link:../architecture/infrastructure_components/web_console.html#project-overviews[web console]
+The xref:../architecture/infrastructure_components/web_console.html#project-overviews[web console]
 shows deployments in the *Browse* tab.
 ====
 
@@ -130,12 +151,12 @@ shows deployments in the *Browse* tab.
 To cancel a running or stuck deployment:
 
 ----
-$ oc deploy <deployment_config> --cancel
+$ oc deploy --cancel dc/<name>
 ----
 
 WARNING: The cancellation is a best-effort operation, and may take some time to
-complete. It's possible the deployment will partially or totally complete
-before the cancellation is effective.
+complete. It's possible the replication controller will partially or totally complete
+being deployed before the cancellation is effective.
 
 [[retrying-a-deployment]]
 
@@ -144,93 +165,94 @@ before the cancellation is effective.
 To retry the last failed deployment:
 
 ----
-$ oc deploy <deployment_config> --retry
+$ oc deploy --retry dc/<name>
 ----
 
 If the last deployment didn't fail, the command will display a message and the
 deployment will not be retried.
 
 NOTE: Retrying a deployment restarts the deployment and does not create a new
-deployment version. The restarted deployment will have the same configuration
+deployment revision. The restarted deployment will have the same configuration
 it had when it failed.
 
 [[rolling-back-a-deployment]]
 == Rolling Back a Deployment
 
-Rollbacks revert an application back to a previous deployment and can be
+Rollbacks revert an application back to a previous template and can be
 performed using the REST API, the CLI, or the web console.
 
-To rollback to the last successful deployment:
+To rollback to the last successful deployed revision of your configuration:
 
 ----
-$ oc rollback <deployment_config>
+$ oc rollout undo dc/<name>
 ----
 
-The deployment configuration's template will be reverted to match the
-deployment specified in the rollback command, and a new deployment will be
-started.
+The deployment configuration's template will be reverted to match the deployment
+revision specified in the undo command, and a new replication controller will be started.
+If no revision is specified with --to-revision, then the last successfully deployed
+revision will be used.
 
 Image change triggers on the deployment configuration are disabled as part of
 the rollback to prevent unwanted deployments soon after the rollback is
 complete. To re-enable the image change triggers:
 
 ----
-$ oc deploy <deployment_config> --enable-triggers
+$ oc deploy --enable-triggers dc/<name>
 ----
 
-To roll back to a specific version:
+NOTE: Deployment configurations also support automatically rolling back to the
+last successful revision of the configuration in case the latest template fails
+to deploy. In that case, the latest template that failed to deploy stays intact
+by the system and it's up to users to fix their configurations.
 
-----
-$ oc rollback <deployment_config> --to-version=1
-----
-
-To see what the rollback would look like without performing the rollback:
-
-----
-$ oc rollback <deployment_config> --dry-run
-----
 
 [[viewing-deployment-logs]]
 
 == Viewing Deployment Logs
 
-To view the logs of the latest deployment for a given deployment configuration:
+To stream the logs of the latest revision for a given deployment configuration:
 
 ----
-$ oc logs dc <deployment_config> [--follow]
+$ oc logs -f dc/<name>
 ----
 
-Logs can be retrieved either while the deployment is running or if it has
-failed. If the deployment was successful, there will be no logs to view.
+If the latest revision is running or failed, `oc logs` will return the logs of the
+process that is responsible for deploying your pods. If it is successful, `oc logs`
+will return the logs from a pod of your application.
 
-You can also view logs from older deployments:
+You can also view logs from older failed deployments, if and only if the old deployment
+exists and hasn't been pruned or deleted manually:
 
 ----
-$ oc logs --version=1 dc <deployment_config>
+$ oc logs --version=1 dc/<name>
 ----
 
-This command returns the logs from the first deployment of the provided
-deployment configuration, if and only if that deployment exists (i.e., it has
-failed and has not been manually deleted or pruned).
+For more options on retrieving logs see:
+
+----
+$ oc logs -h
+----
+
 
 [[triggers]]
 == Triggers
 
-A deployment configuration can contain triggers, which drive the creation of
-new deployments in response to events, both inside and outside OpenShift.
+A deployment configuration can contain triggers, which drive the creation of new
+replication controllers in response to events, only inside {product-title} at the moment.
 
-WARNING: If no triggers are defined on a deployment configuration, deployments
-must be link:#start-deployment[started manually].
+WARNING: If no triggers are defined on a deployment configuration, a ConfigChange
+trigger is added by default. If triggers are defined as an empty field, deployments
+must be xref:start-deployment[started manually].
 
 [[config-change-trigger]]
 === Configuration Change Trigger
 
-The ConfigChange trigger results in a new deployment whenever changes are
-detected to the replication controller template of the deployment configuration.
+The ConfigChange trigger results in a new replication controller whenever changes are
+detected in the pod template of the deployment configuration.
 
 NOTE: If a ConfigChange trigger is defined on a deployment configuration,
-the first deployment will be automatically created soon after the deployment
-configuration itself is created.
+the first replication controller will be automatically created soon after
+the deployment configuration itself is created.
 
 The following is an example of a ConfigChange trigger:
 
@@ -246,7 +268,7 @@ triggers:
 [[image-change-trigger]]
 === Image Change Trigger
 
-The ImageChange trigger results in a new deployment whenever the value of an
+The ImageChange trigger results in a new replication controller whenever the value of an
 image stream tag changes.
 
 The following is an example of an ImageChange trigger:
@@ -278,25 +300,25 @@ deployment is created using the new tag value for the `helloworld` container.
 
 A deployment strategy determines the deployment process, and is defined by the
 deployment configuration. Each application has different requirements for
-availability (and other considerations) during deployments. OpenShift provides
+availability (and other considerations) during deployments. {product-title} provides
 strategies to support a variety of deployment scenarios.
 
-A deployment strategy uses link:../dev_guide/application_health.html[readiness
+A deployment strategy uses xref:../dev_guide/application_health.html[readiness
 checks] to determine if a new pod is ready for use. If a readiness check
-fails, the deployment is stopped.
+fails, the deployment config will retry to run the pod until it times out.
 
-The link:#rolling-strategy[Rolling strategy] is the default strategy used if
+The xref:rolling-strategy[Rolling strategy] is the default strategy used if
 no strategy is specified on a deployment configuration.
 
 [[rolling-strategy]]
 === Rolling Strategy
 
 The rolling strategy performs a rolling update and supports
-link:#lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
+xref:lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
 process.
 
 The rolling deployment strategy waits for pods to pass their
-link:../dev_guide/application_health.html[readiness check] before scaling down
+xref:../dev_guide/application_health.html[readiness check] before scaling down
 old components, and does not allow pods that do not pass their readiness check
 within a configurable timeout.
 
@@ -317,16 +339,16 @@ strategy:
 <1> How long to wait for a scaling event before giving up. Optional; the default is 120.
 <2> `*maxSurge*` is optional and defaults to `25%`; see below.
 <3> `*maxUnavailable*` is optional and defaults to `25%`; see below.
-<4> `*pre*` and `*post*` are both link:#lifecycle-hooks[lifecycle hooks].
+<4> `*pre*` and `*post*` are both xref:lifecycle-hooks[lifecycle hooks].
 ====
 
 The Rolling strategy will:
 
 . Execute any `*pre*` lifecycle hook.
-. Scale up the new deployment based on the surge configuration.
-. Scale down the old deployment based on the max unavailable configuration.
-. Repeat this scaling until the new deployment has reached the desired replica
-count and the old deployment has been scaled to zero.
+. Scale up the new replication controller based on the surge count.
+. Scale down the old replication controller based on the max unavailable count.
+. Repeat this scaling until the new replication controller has reached the desired
+replica count and the old replication controller has been scaled to zero.
 . Execute any `*post*` lifecycle hook.
 
 [IMPORTANT]
@@ -363,7 +385,7 @@ some potential for capacity loss.
 === Recreate Strategy
 
 The Recreate strategy has basic rollout behavior and supports
-link:#lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
+xref:lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
 process.
 
 The following is an example of the Recreate strategy:
@@ -380,7 +402,7 @@ strategy:
 ----
 
 <1> `*recreateParams*` are optional.
-<2> `*pre*` and `*post*` are both link:#lifecycle-hooks[lifecycle hooks].
+<2> `*pre*` and `*post*` are both xref:lifecycle-hooks[lifecycle hooks].
 ====
 
 The Recreate strategy will:
@@ -427,7 +449,7 @@ directive specified in the image's *_Dockerfile_*. The optional environment
 variables provided are added to the execution environment of the strategy
 process.
 
-Additionally, OpenShift provides the following environment variables to the
+Additionally, {product-title} provides the following environment variables to the
 strategy process:
 
 [cols="4,8",options="header"]
@@ -448,7 +470,7 @@ logic that best serves the needs of the user.
 [[lifecycle-hooks]]
 == Lifecycle Hooks
 
-The link:#recreate-strategy[Recreate] and link:#rolling-strategy[Rolling]
+The xref:recreate-strategy[Recreate] and xref:rolling-strategy[Rolling]
 strategies support lifecycle hooks, which allow behavior to be injected into
 the deployment process at predefined points within the strategy:
 
@@ -463,7 +485,7 @@ pre:
   execNewPod: {} <1>
 ----
 
-<1> `*execNewPod*` is link:#pod-based-lifecycle-hook[a pod-based lifecycle hook].
+<1> `*execNewPod*` is xref:pod-based-lifecycle-hook[a pod-based lifecycle hook].
 ====
 
 Every hook has a `*failurePolicy*`, which defines the action the strategy should
@@ -473,7 +495,7 @@ take when a hook failure is encountered:
 |===
 
 .^|`*Abort*`
-|The deployment should be considered a failure if the hook fails.
+|The deployment process will be considered a failure if the hook fails.
 
 .^|`*Retry*`
 |The hook execution should be retried until it succeeds.
@@ -482,15 +504,8 @@ take when a hook failure is encountered:
 |Any hook failure should be ignored and the deployment should proceed.
 |===
 
-WARNING: Some hook points for a strategy might support only a subset of
-failure policy values. For example, the link:#recreate-strategy[Recreate] and
-link:#rolling-strategy[Rolling] strategies do not currently support the
-`*Abort*` policy for a "post" deployment lifecycle hook. Consult the
-documentation for a given strategy for details on any restrictions regarding
-lifecycle hooks.
-
 Hooks have a type-specific field that describes how to execute the hook.
-Currently link:#pod-based-lifecycle-hook[pod-based hooks] are the only
+Currently xref:pod-based-lifecycle-hook[pod-based hooks] are the only
 supported hook type, specified by the `*execNewPod*` field.
 
 [[pod-based-lifecycle-hook]]
@@ -500,7 +515,7 @@ Pod-based lifecycle hooks execute hook code in a new pod derived from the
 template in a deployment configuration.
 
 The following simplified example deployment configuration uses the
-link:#rolling-strategy[Rolling strategy]. Triggers and some other minor details
+xref:rolling-strategy[Rolling strategy]. Triggers and some other minor details
 are omitted for brevity:
 
 ====
@@ -549,7 +564,7 @@ pod will have the following properties:
 
 * The hook command will be `/usr/bin/command arg1 arg2`.
 * The hook container will have the `CUSTOM_VAR1=custom_value1` environment variable.
-* The hook failure policy is `Abort`, meaning the deployment will fail if the hook fails.
+* The hook failure policy is `Abort`, meaning the deployment process will fail if the hook fails.
 * The hook pod will inherit the `data` volume from the deployment configuration pod.
 
 [[deployment-resources]]
@@ -599,7 +614,7 @@ items is required:
 the list of resources in the quota.
 ====
 
-- A link:../dev_guide/compute_resources.html#dev-limit-ranges[limit range] defined
+- A xref:../dev_guide/compute_resources.html#dev-limit-ranges[limit range] defined
 in your project, where the defaults from the `*LimitRange*` object apply to pods
 created during the deployment process.
 
@@ -631,24 +646,24 @@ placement.
 ifdef::openshift-enterprise,openshift-origin[]
 [NOTE]
 ====
-OpenShift administrators can assign labels
-link:../install_config/install/advanced_install.html#configuring-node-host-labels[during
+{product-title} administrators can assign labels
+xref:../install_config/install/advanced_install.html#configuring-node-host-labels[during
 an advanced installation], or
-link:../admin_guide/manage_nodes.html#updating-labels-on-nodes[added to a node
+xref:../admin_guide/manage_nodes.html#updating-labels-on-nodes[added to a node
 after installation].
 ====
 endif::[]
 
 Cluster administrators
 ifdef::openshift-enterprise,openshift-origin[]
-link:../admin_guide/managing_projects.html#using-node-selectors[can set the
+xref:../admin_guide/managing_projects.html#using-node-selectors[can set the
 default node selector]
 endif::[]
 ifdef::openshift-dedicated,openshift-online[]
 can set the default node selector
 endif::[]
 for your project in order to restrict pod placement to
-specific nodes. As an OpenShift developer, you can set a node selector on a pod
+specific nodes. As an {product-title} developer, you can set a node selector on a pod
 configuration to restrict nodes even further.
 
 To add a node selector when creating a pod, edit the pod configuration, and add
@@ -671,7 +686,7 @@ specified labels.
 
 The labels specified here are used in conjunction with the labels
 ifdef::openshift-enterprise,openshift-origin[]
-link:../admin_guide/managing_projects.html#using-node-selectors[added by a
+xref:../admin_guide/managing_projects.html#using-node-selectors[added by a
 cluster administrator].
 endif::[]
 ifdef::openshift-dedicated,openshift-online[]


### PR DESCRIPTION
Contains:
- paused deployment configs (config.spec.paused)

When a deployment config is paused, it stops being reconciled by the controller loops. This is useful for pausing a config (oc rollout pause), making multiple changes to the config and resuming (oc rollout resume) without running any new deployments in the meantime.
- cleanup policy (config.spec.revisionHistoryLimit)

If set, the controller loop will retain that number of older deployments and delete all the rest. For example, I have a dc/foo with dc.status.latestVersion=5 (meaning there are 5 deployments - 1 new and 4 old). If I set dc.spec.revisionHistoryLimit to 1 this means that only one old deployment will be kept around and the rest will be deleted. Note that only old controllers with **zero** replicas will be deleted.

``` shell
$ oc get dc
NAME       REVISION   DESIRED   CURRENT   TRIGGERED BY
database   5          1         0         config
$ oc get rc
NAME         DESIRED   CURRENT   AGE
database-1   0         0         1h
database-2   0         0         1h
database-3   0         0         1h
database-4   0         0         40m
database-5   1         1         34m
$ oc edit dc/database
# Sets revisionHistoryLimit to 1
$ oc get rc
NAME         DESIRED   CURRENT   AGE
database-4   0         0         40m
database-5   1         1         34m
```
- minReadySeconds (config.spec.minReadySeconds)

So far our deployments completed as soon as all the new pods became ready. If minReadySeconds is set, the deployer pod will not mark the deployment as Complete before this number of seconds passes for all ready pods.
- `oc rollout`

`oc rollout pause` for pausing a deployment config

`oc rollout resume` for resuming a deployment config

`oc rollout undo` for rolling back a deployment config (almost identical to `oc rollback`, lacks some of `rollback`'s flags)

`oc rollout history` for viewing any historical data available for a deployment config

Targetted for 1.3
Trello card: https://trello.com/c/Mljldox7/643-8-deployments-downstream-support-for-upstream-features

@mfojtik fyi. Still WIP.
