### PR TITLE
Add PIP_INDEX_URL env var to Python S2I document

### DIFF
--- a/using_images/s2i_images/python.adoc
+++ b/using_images/s2i_images/python.adoc
@@ -102,6 +102,10 @@ during the build. Only affects Django projects.
 |`*DISABLE_MIGRATE*`
 | Set it to a nonempty value to inhibit the execution of `manage.py migrate`
 when the produced image is run. Only affects Django projects.
+
+|`*PIP_INDEX_URL*`
+| Set this variable to use a custom index URL or mirror to download required packages
+during build process. This only affects packages listed in requirements.txt.
 |===
 
 [[python-hot-deploy]]


### PR DESCRIPTION
A new env var PIP_INDEX_URL which allows injection of index URL or
mirror during build process is available for Python images.

This PR is to add the new env var to the docs.

Link: https://github.com/sclorg/s2i-python-container/pull/124

Signed-off-by: Vu Dinh vdinh@redhat.com
