### PR TITLE
Revert and xref cleanup for OSE 3.1

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -29,14 +29,14 @@ endif::[]
 link:../install_config/install/advanced_install.html[Advanced Installation]
 method, the
 ifdef::openshift-enterprise[]
-link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is 
+link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is
 used by default, which denies access for all user names and
 passwords. To allow access, you must choose a different identity provider and
 configure the master configuration file appropriately (located at
 *_/etc/origin/master/master-config.yaml_* by default).
 endif::[]
 ifdef::openshift-origin[]
-link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is 
+link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is
 used by default, which allows access for all user names and
 passwords.
 endif::[]
@@ -51,7 +51,7 @@ configuration file.
 
 [NOTE]
 ====
-xref:../architecture/additional_concepts/authorization.adoc#roles[Roles] need
+link:../architecture/additional_concepts/authorization.html#roles[Roles] need
 to be assigned to administer the setup with an external user.
 ====
 
@@ -301,9 +301,9 @@ oauthConfig:
       apiVersion: v1
       kind: KeystonePasswordIdentityProvider
       domainName: default <5>
-      ca: ca.pem <6> 
-      certFile: keystone.pem <7> 
-      keyFile: keystonekey.pem <8> 
+      ca: ca.pem <6>
+      certFile: keystone.pem <7>
+      keyFile: keystonekey.pem <8>
 ----
 <1> This provider name is prefixed to provider user names to form an identity name.
 <2> When *true*, unauthenticated token requests from non-web clients (like the

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -29,14 +29,14 @@ endif::[]
 link:../install_config/install/advanced_install.html[Advanced Installation]
 method, the
 ifdef::openshift-enterprise[]
-link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is
+link:#DenyAllPasswordIdentityProvider[Deny All] identity provider is 
 used by default, which denies access for all user names and
 passwords. To allow access, you must choose a different identity provider and
 configure the master configuration file appropriately (located at
 *_/etc/origin/master/master-config.yaml_* by default).
 endif::[]
 ifdef::openshift-origin[]
-link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is
+link:#AllowAllPasswordIdentityProvider[Allow All] identity provider is 
 used by default, which allows access for all user names and
 passwords.
 endif::[]
@@ -51,7 +51,7 @@ configuration file.
 
 [NOTE]
 ====
-link:../architecture/additional_concepts/authorization.html#roles[Roles] need
+xref:../architecture/additional_concepts/authorization.adoc#roles[Roles] need
 to be assigned to administer the setup with an external user.
 ====
 
@@ -301,9 +301,9 @@ oauthConfig:
       apiVersion: v1
       kind: KeystonePasswordIdentityProvider
       domainName: default <5>
-      ca: ca.pem <6>
-      certFile: keystone.pem <7>
-      keyFile: keystonekey.pem <8>
+      ca: ca.pem <6> 
+      certFile: keystone.pem <7> 
+      keyFile: keystonekey.pem <8> 
 ----
 <1> This provider name is prefixed to provider user names to form an identity name.
 <2> When *true*, unauthenticated token requests from non-web clients (like the
@@ -625,19 +625,8 @@ replaced with the current query string.
 <7> Optional: PEM-encoded certificate bundle. If set, a valid client certificate
 must be presented and validated against the certificate authorities in the
 specified file before the request headers are checked for user names.
-<8> Optional: list of common names (`cn`). If set, a valid client certificate with
-a Common Name (`cn`) in the specified list must be presented before the request headers
-are checked for user names. If empty, any Common Name is allowed. Can only be used in combination
-with `clientCA`.
-<9> Header names to check, in order, for the user identity. The first header containing
-a value is used as the identity. Required, case-insensitive.
-<10> Header names to check, in order, for an email address. The first header containing
-a value is used as the email address. Optional, case-insensitive.
-<11> Header names to check, in order, for a display name. The first header containing
-a value is used as the display name. Optional, case-insensitive.
-<12> Header names to check, in order, for a preferred user name, if different than the immutable
-identity determined from the headers specified in `headers`. The first header containing
-a value is used as the preferred user name when provisioning. Optional, case-insensitive.
+<8> Header names to check, in order, for user names. The first header containing
+a value is used as the user name. Required, case-insensitive.
 ====
 
 .Apache Authentication Using *RequestHeaderIdentityProvider*
@@ -944,73 +933,7 @@ link:#mapping-identities-to-users[as described above].
 link:https://github.com/settings/applications/new[registered GitHub OAuth
 application]. The application must be configured with a callback URL of
 `<master>/oauth2callback/<identityProviderName>`.
-<6> The client secret issued by GitHub. This value may also be provided in an
-link:../install_config/master_node_configuration.html#master-node-configuration-passwords-and-other-data[environment
-variable, external file, or encrypted file].
-<7> Optional list of organizations. If specified, only GitHub users that are members of
-at least one of the listed organizations will be allowed to log in. If the GitHub OAuth
-application configured in *clientID* is not owned by the organization, an organization
-owner must grant third-party access in order to use this option. This can be done during
-the first GitHub login by the organization's administrator, or from the GitHub organization settings.
-====
-
-[[GitLab]]
-
-=== GitLab
-
-Set *GitLabIdentityProvider* in the `*identityProviders*` stanza to use
-https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity provider, using the
-http://doc.gitlab.com/ce/integration/oauth_provider.html[OAuth integration].
-The OAuth provider feature requires GitLab version 7.7.0 or higher.
-
-[NOTE]
-====
-Using GitLab as an identity provider requires users to get a token using
-`<master>/oauth/token/request` to use with command-line tools.
-====
-
-.Master Configuration Using *GitLabIdentityProvider*
-====
-
-----
-oauthConfig:
-  ...
-  identityProviders:
-  - name: gitlab <1>
-    challenge: true <2>
-    login: true <3>
-    mappingMethod: claim <4>
-    provider:
-      apiVersion: v1
-      kind: GitLabIdentityProvider
-      url: ... <5>
-      clientID: ... <6>
-      clientSecret: ... <7>
-      ca: ... <8>
-----
-<1> This provider name is prefixed to the GitLab numeric user ID to form an
-identity name. It is also used to build the callback URL.
-<2> When *true*, unauthenticated token requests from non-web clients (like
-the CLI) are sent a `WWW-Authenticate` challenge header for this provider.
-This uses the http://doc.gitlab.com/ce/api/oauth2.html#resource-owner-password-credentials[Resource Owner Password Credentials]
-grant flow to obtain an access token from GitLab.
-<2> *GitLabIdentityProvider* cannot be used to send `WWW-Authenticate`
-challenges.
-<3> When *true*, unauthenticated token requests from web clients (like the web
-console) are redirected to GitLab to log in.
-<4> Controls how mappings are established between this provider's identities and user objects,
-link:#mapping-identities-to-users[as described above].
-<5> The host URL of a GitLab OAuth provider. This could either be `https://gitlab.com/`
-or any other self hosted instance of GitLab.
-<6> The client ID of a
-link:https://gitlab.com/oauth/applications/new[registered GitLab OAuth
-application]. The application must be configured with a callback URL of
-`<master>/oauth2callback/<identityProviderName>`.
-<7> The client secret issued by GitLab. This value may also be provided in an
-link:../install_config/master_node_configuration.html#master-node-configuration-passwords-and-other-data[environment
-variable, external file, or encrypted file].
-<8> CA is an optional trusted certificate authority bundle to use when making
-requests to the GitLab instance. If empty, the default system roots are used.
+<6> The client secret issued by GitHub.
 ====
 
 [[Google]]
@@ -1137,11 +1060,7 @@ oauthConfig:
 ----
 <1> This provider name is prefixed to the value of the identity claim to form an
 identity name. It is also used to build the redirect URL.
-<2> When *true*, unauthenticated token requests from non-web clients (like
-the CLI) are sent a `WWW-Authenticate` challenge header for this provider.
-This requires the OpenID provider to support the
-https://tools.ietf.org/html/rfc6749#section-1.3.3[Resource Owner Password Credentials] grant flow.
-*OpenIDIdentityProvider* cannot be used to send `WWW-Authenticate`
+<2> *OpenIDIdentityProvider* cannot be used to send `WWW-Authenticate`
 challenges.
 <3> When *true*, unauthenticated token requests from web clients (like the web
 console) are redirected to the authorize URL to log in.

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -989,7 +989,7 @@ $ oc delete oauthclient --selector logging-infra=support
 ----
 
 .. Then, proceed to follow the same steps as done previously in
-xref:../../install_config/aggregate_logging.adoc#deploying-the-efk-stack[Deploying
+link:../../install_config/aggregate_logging.html#deploying-the-efk-stack[Deploying
 the EFK Stack], but ensure that you add `*IMAGE_VERSION*` to the list of
 variables and set it to the appropriate version. For example, for the latest
 3.1.1 image:
@@ -1001,7 +1001,7 @@ $ oc process logging-deployer-template -n openshift \
 ----
 +
 See
-xref:../../install_config/aggregate_logging.adco#deploying-the-efk-stack[Deploying
+link:../../install_config/aggregate_logging.html#deploying-the-efk-stack[Deploying
 the EFK Stack] for the full instructions. After the deployer completes,
 re-attach your persistent volumes you were using previously.
 


### PR DESCRIPTION
The revert is for https://github.com/openshift/openshift-docs/pull/2265/commits/ee670765c24fed6e98adab1f5c979c02591ebe9f which accidentally pulled in some 3.2 stuff. And then some final xref cleanup for enterprise-3.1.
