### PR TITLE
Need re-encrypting route for cluster metrics using generated self-signed certificates

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -323,14 +323,28 @@ properly.
 ==== Using Generated Self-Signed Certificates
 
 The Metrics Deployer can accept multiple certificates using secrets. If a
-certificate is not passed as a secret, the deployer will generate a self-signed
-certificate to be used instead. For the deployer to generate certificates for
-you, a secret is still required before it can be deployed. In this case, create
-a "dummy" secret that does not specify a certificate value:
+certificate is not passed as a secret, then the deployer generates a self-signed
+certificate instead, forcing users to accept the certificate as a security
+exception.
+
+In order to use official certificates for the web console, you must use a
+link:../install_config/cluster_metrics.html#metrics-reencrypting-route[re-encrypting route].
+This allows the self-signed certificates to remain in use internally,
+while allowing your own certificates to be used for external access. When
+using a re-encrypting route, do not set the certificates as a secret. A
+"dummy" secret named *metrics-deployer* must still exist for the Metrics
+Deployer to generate certificates.
+
+To create a "dummy" secret that does not specify a certificate value:
 
 ----
 $ oc secrets new metrics-deployer nothing=/dev/null
 ----
+
+[CAUTION]
+====
+If you do not use a re-encrypting route when using generated self-signed certificates you will encounter errors.
+====
 
 [[modifying-the-deployer-template]]
 === Modifying the Deployer Template


### PR DESCRIPTION
ping @TheDiemer for tech review, here's a nice-lookin' doc instead of a diff: http://file.bne.redhat.com/~tpoitras/2016/reencryptBZ1342170/openshift-enterprise/selfsigned-BZ1342170/install_config/cluster_metrics.html#metrics-using-secrets-autogenerated

https://bugzilla.redhat.com/show_bug.cgi?id=1342170

Added requirement of using re-encrypting route for cluster metrics that use generated self-signed certs.
