### PR TITLE
Do not use no_root_squash for NFS in the example

### DIFF
--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -283,7 +283,7 @@ On the NFS server:
 ====
 ----
 # cat /etc/exports
-/opt/nfs *(rw,sync,no_root_squash)
+/opt/nfs *(rw,sync,root_squash)
 ...
 
 # ls -lZ /opt/nfs -d


### PR DESCRIPTION
The no_root_squash is uncommon and not recommended option.
