### PR TITLE
automatic service serving cert signer

### DIFF
--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -116,6 +116,21 @@ Pull Secrets] for more information.
 See link:builds.html#using-private-repositories-for-builds[Using Private
 Repositories for Builds] for more information.
 
+[[service-serving-certificate-secrets]]
+=== Service Serving Certificate Secrets
+
+To secure communication to your service, you can have the cluster generate a signed
+serving certificate/key pair into a secret in your namespace.  To do this, set the
+"*service.alpha.openshift.io/serving-cert-secret-name*" to the name you want to use
+for your secret.  Your PodSpec can then mount that secret and when it is available
+your pod will run.  The certificate will be good for the internal service DNS name:
+`*<service.name>.<service.namespace>.svc*`.  The certificate and key are in PEM format, 
+stored in `*tls.crt*` and `*tls.key*` respectively.
+
+Other pods can trust cluster-created certificates (which are only signed for internal
+DNS names), by using the CA bundle in the `*/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt*`
+file that is automatically mounted in their pod.
+
 [[secrets-restrictions]]
 == Restrictions
 


### PR DESCRIPTION
Adds documentation for the service serving certificate signer.

@smarterclayton how should we indicate that this is an alpha feature?
