### PR TITLE
Document WEB_CONCURRENCY env var

### DIFF
--- a/using_images/s2i_images/python.adoc
+++ b/using_images/s2i_images/python.adoc
@@ -107,6 +107,11 @@ when the produced image is run. Only affects Django projects.
 |`*PIP_INDEX_URL*`
 | Set this variable to use a custom index URL or mirror to download required packages
 during build process. This only affects packages listed in requirements.txt.
+
+| `*WEB_CONCURRENCY*`
+| Set this to change the default setting for the number of
+http://docs.gunicorn.org/en/stable/settings.html#workers[workers]. By default,
+this is set to the number of available cores times 4.
 |===
 
 [[python-hot-deploy]]


### PR DESCRIPTION
For PR https://github.com/sclorg/s2i-python-container/pull/118
Trello: https://trello.com/c/o6ijZ01e/892-5-update-python-image-to-autoconfigure-based-on-available-memory-evg

Will apply for 3.3.
