### PR TITLE
Deployment Logs: added slash to syntax

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -198,7 +198,7 @@ $ oc rollback <deployment_config> --dry-run
 To view the logs of the latest deployment for a given deployment configuration:
 
 ----
-$ oc logs dc <deployment_config> [--follow]
+$ oc logs dc/<deployment_config> [--follow]
 ----
 
 Logs can be retrieved either while the deployment is running or if it has
@@ -207,7 +207,7 @@ failed. If the deployment was successful, there will be no logs to view.
 You can also view logs from older deployments:
 
 ----
-$ oc logs --version=1 dc <deployment_config>
+$ oc logs --version=1 dc/<deployment_config>
 ----
 
 This command returns the logs from the first deployment of the provided


### PR DESCRIPTION
RE: https://bugzilla.redhat.com/show_bug.cgi?id=1350002

Example commands were missing a slash. Simple fix.
