### PR TITLE
Add RUBYGEM_MIRROR env var to Ruby S2I images document

### DIFF
--- a/using_images/s2i_images/ruby.adoc
+++ b/using_images/s2i_images/ruby.adoc
@@ -111,6 +111,11 @@ link:https://github.com/puma/puma#clustered-mode[clustered mode] (when Puma runs
 more than two processes). If not explicitly set, the default behavior sets
 `*PUMA_WORKERS*` to a value that is appropriate for the memory available to the
 container and the number of cores on the host.
+
+|`*RUBYGEM_MIRROR*`
+|Set this variable to use a custom RubyGems mirror URL to download required gem
+packages during the build process.
+Note: This environment variable is only available for Ruby 2.2+ images.
 |===
 
 [[ruby-hot-deploy]]


### PR DESCRIPTION
A new env var RUBYGEM_MIRROR is added to Ruby S2I images (2.2+).

This env var will allow users to use custom RubyGems mirror URL
during build process.

Signed-off-by: Vu Dinh vdinh@redhat.com
