### PR TITLE
Add COMPOSER_MIRROR env var to PHP docs

### DIFF
--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -87,7 +87,7 @@ The following environment variables set their equivalent property value in the
 [cols="4a,6a,6a",options="header"]
 |===
 
-|Variable name |Description |Default
+|Variable Name |Description |Default
 
 |`*ERROR_REPORTING*`
 |Informs PHP of the errors, warnings, and notices for which you would like it to
@@ -127,7 +127,7 @@ The following environment variable sets its equivalent property value in the
 [cols="3a,6a,1a",options="header"]
 |===
 
-|Variable name |Description |Default
+|Variable Name |Description |Default
 
 |`*OPCACHE_MEMORY_CONSUMPTION*`
 |The link:http://php.net/manual/en/book.opcache.php[OPcache] shared memory
@@ -147,13 +147,26 @@ You can also override the entire directory used to load the PHP configuration by
 [cols="3a,6a",options="header"]
 |===
 
-| Variable name | Description
+| Variable Name | Description
 
 |`*PHPRC*`
 |Sets the path to the *_php.ini_* file.
 
 |`*PHP_INI_SCAN_DIR*`
 |Path to scan for additional *_.ini_* configuration files
+|===
+
+You can use a custom composer repository mirror URL to download packages instead of the default 'packagist.org':
+
+.Composer Environment Variables
+[cols="4a,6a,6a",options="header"]
+|===
+
+|Variable Name |Description
+
+|`*COMPOSER_MIRROR*`
+|Set this variable to use a custom Composer repository mirror URL to download required packages during the build process.
+Note: This only affects packages listed in *_composer.json_*.
 |===
 
 [[php-apache-configuration]]


### PR DESCRIPTION
The new COMPOSER_MIRROR is introduced to allow users to use custom
composer repository mirror URL during build process.

Signed-off-by: Vu Dinh vdinh@redhat.com
