### PR TITLE
Add NPM_MIRROR env var to NodeJS docs

### DIFF
--- a/using_images/s2i_images/nodejs.adoc
+++ b/using_images/s2i_images/nodejs.adoc
@@ -86,6 +86,9 @@ section] of the build configuration's `*sourceStrategy*` definition.
 |`*DEBUG_PORT*`
 |The debug port. Only valid if `*DEV_MODE*` is set to true. Default is 5858.
 
+|`*NPM_MIRROR*`
+|The custom NPM registry mirror URL. All NPM packages will be downloaded from the mirror link during the build process.
+
 |===
 
 [[nodejs-hot-deploying]]


### PR DESCRIPTION
The new NPM_MIRROR env var is introduced to allow users to use
custom NPM registry mirror URL during the build process. The NPM
packages will be downloaded from custom link if provided.

Signed-off-by: Vu Dinh vdinh@redhat.com
