### PR TITLE
Fixing comma usage and removing a bad analogy

### DIFF
--- a/architecture/core_concepts/containers_and_images.adoc
+++ b/architecture/core_concepts/containers_and_images.adoc
@@ -50,7 +50,7 @@ Docker containers are based on Docker images. A Docker image is a
 binary that includes all of the requirements for running a single Docker
 container, as well as metadata describing its needs and capabilities. You
 can think of it as a packaging technology. Docker containers only
-have access to resources defined in the image, unless you give the
+have access to resources defined in the image unless you give the
 container additional access when creating it. By deploying the same
 image in multiple containers across multiple hosts and load balancing
 between them, {product-title} can provide redundancy and horizontal scaling

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -20,10 +20,9 @@ more xref:containers_and_images.adoc#containers[containers] deployed
 together on one host, and the smallest compute unit that can be defined,
 deployed, and managed.
 
-Pods are the rough equivalent of {product-title} v2 gears, with containers
-the rough equivalent of v2 cartridge instances. Each pod is allocated
-its own internal IP address, therefore owning its entire port space,
-and containers within pods can share their local storage and networking.
+Pods are the rough equivalent of a machine instance (physical or virtual) to a
+container. Each pod is allocated its own internal IP address, therefore owning its entire 
+port space, and containers within pods can share their local storage and networking.
 
 Pods have a lifecycle; they are defined, then they are assigned to run on
 a node, then they run until their container(s) exit or they are removed


### PR DESCRIPTION
The v2 analogy doesn't really ring that true.  And it's not what most people coming to the platform need these days.  I replaced with hopefully a better way to think about pods.
