### PR TITLE
Update registry config options

### DIFF
--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -795,9 +795,10 @@ xref:registry-configuration-reference[custom configuration].
 [NOTE]
 ====
 Upstream configuration options in this file may also be overridden using
-environment variables. However, the
-xref:docker-registry-configuration-reference-middleware[middleware section] may
-*not* be overridden using environment variables.
+environment variables. The
+xref:docker-registry-configuration-reference-middleware[middleware section] is
+an exception as there are just a few options that can be overridden using
+environment variables.
 link:https://docs.docker.com/registry/configuration/#override-specific-configuration-options[Learn
 how to override specific configuration options].
 ====
@@ -834,12 +835,17 @@ auth:
   openshift:
     realm: openshift
 middleware:
+  registry:
+    - name: openshift
   repository:
     - name: openshift
       options:
+        acceptschema2: false
         pullthrough: true
         enforcequota: false
         projectcachettl: 1m
+  storage:
+    - name: openshift
 ----
 ====
 
@@ -1010,19 +1016,25 @@ middleware responsible for interaction with {product-title} and image proxying.
 [source,yaml]
 ----
 middleware:
+  registry:
+    - name: openshift <1>
   repository:
-    - name: openshift
+    - name: openshift <1>
       options:
-        pullthrough: true <1>
-        enforcequota: false <2>
-        projectcachettl: 1m <3>
+        acceptschema2: false <2>
+        pullthrough: true <3>
+        enforcequota: false <4>
+        projectcachettl: 1m <5>
+  storage:
+    - name: openshift <1>
 ----
-<1> Let the registry act as a proxy for remote blobs.
-<2> Prevent blob uploads exceeding size limit defined in targeted project. It
-can be overridden using
-`*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*` environment variable.
-It will be set to `*true*` in future versions.
-<3> An expiration timeout for limits cached in the registry. The lower the
+<1> These entries are mandatory. Their presence ensures required components get loaded. These values shouldn't be changed.
+<2> Allow to store
+link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-version-2-schema-2[manifest
+schema v2] during a push to the registry. See xref:middleware-repository-acceptschema2[below] for more details.
+<3> Let the registry act as a proxy for remote blobs. See xref:middleware-repository-pullthrough[below] for more details.
+<4> Prevent blob uploads exceeding size limit defined in targeted project.
+<5> An expiration timeout for limits cached in the registry. The lower the
 value, the less time will it take for the limit changes to propagate to the
 registry. However, the registry will query limits from the server more
 frequently and, as a consequence, pushes will be slower.
@@ -1035,6 +1047,7 @@ provider.
 The *middleware* section may not be overridden using environment variables.
 There are a few exceptions, however. For example:
 ====
+[source,yaml]
 ----
 middleware:
   repository:
@@ -1048,6 +1061,60 @@ middleware:
 <2> A configuration option that can be overridden by the boolean environment variable `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*`, which allows the ability to turn quota enforcement on or off. By default, quota enforcement is off. It overrides {product-title} middleware configuration option. Recognized values are *true* and *false*.
 <3> A configuration option that can be overridden by the environment variable `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_PROJECTCACHETTL*`, specifying an eviction timeout for project quota objects. It takes a valid time duration string (for example, *2m*). If empty, you get the default timeout. If zero (*0m*), caching is disabled.
 ====
+
+[[middleware-repository-pullthrough]]
+===== Image Pullthrough
+
+If enabled, the registry will attempt to fetch requested blob from a remote
+registry unless the blob exists locally. The remote candidates are calculated
+from **DockerImage** entries stored in status of the
+xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+stream], a client pulls from. All the unique remote registry references in
+such entries will be tried in turn until the blob is found. The blob, served
+this way, will not be stored in the registry.
+
+This feature is on by default. However, it can be disabled using a
+xref:docker-registry-configuration-reference-middleware[configuration option].
+
+[[middleware-repository-acceptschema2]]
+===== Manifest schema v2 support
+
+Each image has a manifest describing its blobs, instructions for running it
+and additional metadata. The manifest is versioned which have different
+structure and fields as it evolves over time. The same image can be represented
+by multiple manifest versions. Each version will have different digest though.
+
+The registry currently supports
+link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#image-manifest-version-2-schema-1[manifest
+v2 schema 1] (*schema1*) and
+link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-version-2-schema-2[manifest
+v2 schema 2] (*schema2*). The former is being obsoleted but will be supported
+for an extended amount of time.
+
+You should be wary of compatibility issues with various Docker clients:
+
+- Docker clients of version 1.9 or older support only *schema1*. Any manifest
+this client pulls or pushes will be of this legacy schema.
+- Docker clients of version 1.10 support both *schema1* and *schema2*. And by default, it will
+push the latter to the registry if it supports newer schema.
+
+The registry, storing an image with *schema1* will always return it unchanged
+to the client. *Schema2* will be transferred unchanged only to newer Docker
+client. For the older one, it will be converted on-the-fly to *schema1*.
+
+This has significant consequences. For example an image pushed to the registry
+by a newer Docker client cannot be pulled by the older Docker by its digest.
+That's because the stored image's manifest is of *schema2* and its digest can
+be used to pull only this version of manifest.
+
+For this reason, the registry is configured by default not to store *schema2*.
+This ensures that any docker client will be able to pull from the registry any
+image pushed there regardless of client's version.
+
+Once you're confident that all the registry clients support *schema2*, you'll
+be safe to enable its support in the registry. See the
+xref:docker-registry-configuration-reference-middleware[middleware
+configuration reference] above for particular option.
 
 [[docker-registry-configuration-reference-reporting]]
 ==== Reporting


### PR DESCRIPTION
Update mandatory config options of registry's config file.

This reflects changes brought by openshift/origin#8938

What else need to be documented (not necessarily in this PR):
- introduce manifest schema v2
- make a table of supported configurations of registry version vs docker
  version vs manifest schema version
- document known issues when deployment or build fails due to pulling of
  manifest schema v2 with docker <1.10
- explain when it is (un)safe to accept manifest schema v2
