### PR TITLE
Added --prune-over-size-limit information to oadm prune images

### DIFF
--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -148,8 +148,8 @@ $ oadm prune builds --orphans --keep-complete=5 --keep-failed=1 \
 
 == Pruning Images
 
-In order to prune images that are no longer required by the system due to age
-and status, administrators may run the following command:
+In order to prune images that are no longer required by the system due to age,
+status, or exceed limits, administrators may run the following command:
 
 ----
 $ oadm prune images [<options>]
@@ -188,6 +188,11 @@ from the current user's config file.
 |Do not prune any image that is younger than `<duration>` relative to the
 current time. Do not prune any image that is referenced by any other object that
 is younger than `<duration>` relative to the current time. (default `60m`)
+
+.^|`--prune-over-size-limit`
+|Prune each image that exceeds the smallest xref:limits.adoc#image-limits[limit]
+defined in the same project. This flag cannot be combined with `--keep-tag-revisions`
+nor `--keep-younger-than`.
 |===
 
 {product-title} uses the following logic to determine which images and layers to
@@ -207,6 +212,16 @@ prune:
 - the `--keep-tag-revisions` most recent items in
  `*stream.status.tags[].items*`.
 
+* Remove any image "managed by {product-title}" (i.e., images with the annotation
+`*openshift.io/image.managed*`) that is exceeding the smallest xref:limits.adoc#image-limits[limit]
+defined in the same project and is not currently referenced by:
+- any running pods.
+- any pending pods.
+- any replication controllers.
+- any deployment configurations.
+- any build configurations.
+- any builds.
+
 * There is no support for pruning from external registries.
 
 * When an image is pruned, all references to the image are removed from all
@@ -214,14 +229,37 @@ image streams that have a reference to the image in `*status.tags*`.
 
 * Image layers that are no longer referenced by any images are removed as well.
 
+[NOTE]
+====
+`--prune-over-size-limit` cannot be combined with `--keep-tag-revisions` nor
+`--keep-younger-than` flags. Doing so will return an information that this
+operation is not allowed.
+====
+
 To see what a pruning operation would delete:
 
+. Keeping up to three tag revisions, and keeping resources (images, image
+streams and pods) younger than sixty minutes:
++
+====
 ----
 $ oadm prune images --keep-tag-revisions=3 --keep-younger-than=60m
 ----
+====
 
-To actually perform the prune operation:
+. Pruning every image that exceeds defined limits:
++
+====
+----
+$ oadm prune images --prune-over-size-limit
+----
+====
+
+To actually perform the prune operation for the previously mentioned options
+accordingly:
 
 ----
 $ oadm prune images --keep-tag-revisions=3 --keep-younger-than=60m --confirm
+
+$ oadm prune images --prune-over-size-limit --confirm
 ----


### PR DESCRIPTION
This is part of this trello: https://trello.com/c/L9Coo2Zi.
The functionality already merged in origin: https://github.com/openshift/origin/pull/9481/

@miminar @adellape ptal
