### PR TITLE
oc volume accepts --type=configmap

### DIFF
--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -113,7 +113,7 @@ $ oc volume <object_type>/<name> --add [options]
 
 |`-t, --type`
 |Name of the volume source. Supported values: `emptyDir`, `hostPath`, `secret`,
-or `persistentVolumeClaim`.
+`configmap`, or `persistentVolumeClaim`.
 |`emptyDir`
 
 |`-c, --containers`


### PR DESCRIPTION
Add `configmap` to the list of supported values for the `--type` option of the `oc volume` command.

Support for `configmap` was introduced in 3.2.
