### PR TITLE
Fix typo

### DIFF
--- a/install_config/storage_examples/shared_storage.adoc
+++ b/install_config/storage_examples/shared_storage.adoc
@@ -343,7 +343,7 @@ spec:
   restartPolicy: Always
   securityContext:
     supplementalGroups:
-    - 100003i <3>
+    - 100003 <3>
   serviceAccount: default
   serviceAccountName: default
   terminationGracePeriodSeconds: 30


### PR DESCRIPTION
$ grep -r 100003 install_config/storage_examples/shared_storage.adoc 
-rw-r--r--. 1 root **100003**  system_u:object_r:usr_t:s0     10 Oct 12 23:27 test2b
<2> the group has ID **100003**.
and either run with a UID of 0, or with **100003** in its supplemental groups range.
      supplementalGroups: [100003] <5>
    - **_100003i_** <3>
    supplementalGroups: [**100003**] <5>
