### PR TITLE
Replace the tab with 4 spaces in adoc files

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -121,14 +121,14 @@ $ dig hello-openshift.shard1.v3.rhcloud.com
 ;hello-openshift.shard1.v3.rhcloud.com. IN A
 
 ;; ANSWER SECTION:
-hello-openshift.shard1.v3.rhcloud.com. 300 IN A	10.245.2.2
-hello-openshift.shard1.v3.rhcloud.com. 300 IN A	10.245.2.3
+hello-openshift.shard1.v3.rhcloud.com. 300 IN A    10.245.2.2
+hello-openshift.shard1.v3.rhcloud.com. 300 IN A    10.245.2.3
 
 ;; AUTHORITY SECTION:
-v3.rhcloud.com.		300	IN	NS	ns1.v3.rhcloud.com.
+v3.rhcloud.com.        300    IN    NS    ns1.v3.rhcloud.com.
 
 ;; ADDITIONAL SECTION:
-ns1.v3.rhcloud.com.	300	IN	A	127.0.0.1
+ns1.v3.rhcloud.com.    300    IN    A    127.0.0.1
 
 ;; Query time: 5 msec
 ;; SERVER: 10.245.2.3#53(10.245.2.3)

--- a/admin_guide/manage_authorization_policy.adoc
+++ b/admin_guide/manage_authorization_policy.adoc
@@ -71,204 +71,204 @@ $ oc describe clusterPolicy default
 [options="nowrap"]
 ----
 $ oc describe clusterPolicy default
-Name:					default
-Created:				5 days ago
-Labels:					<none>
-Annotations:				<none>
-Last Modified:				2016-03-17 13:25:27 -0400 EDT
-admin					Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[configmaps endpoints persistentvolumeclaims pods pods/attach pods/exec pods/log pods/portforward pods/proxy replicationcontrollers replicationcontrollers/scale secrets serviceaccounts services services/proxy]
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/custom builds/docker builds/log builds/source deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments generatedeploymentconfigs imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags localresourceaccessreviews localsubjectaccessreviews processedtemplates projects resourceaccessreviews rolebindings roles routes subjectaccessreviews templateconfigs templates]
-					[create delete deletecollection get list patch update watch]	[]				[]			[autoscaling]			[horizontalpodautoscalers]
-					[create delete deletecollection get list patch update watch]	[]				[]			[batch]				[jobs]
-					[create delete deletecollection get list patch update watch]	[]				[]			[extensions]			[daemonsets horizontalpodautoscalers jobs replicationcontrollers/scale]
-					[get list watch]						[]				[]			[]				[bindings configmaps endpoints events imagestreams/status limitranges minions namespaces namespaces/status nodes persistentvolumeclaims persistentvolumes pods pods/log pods/status policies policybindings replicationcontrollers replicationcontrollers/status resourcequotas resourcequotas/status resourcequotausages routes/status securitycontextconstraints serviceaccounts services]
-					[get update]							[]				[]			[]				[imagestreams/layers]
-					[update]							[]				[]			[]				[routes/status]
-basic-user				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get]								[]				[~]			[]				[users]
-					[list]								[]				[]			[]				[projectrequests]
-					[get list]							[]				[]			[]				[clusterroles]
-					[list]								[]				[]			[]				[projects]
-					[create]							[]				IsPersonalSubjectAccessReview	[]			[]				[localsubjectaccessreviews subjectaccessreviews]
-cluster-admin				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[*]								[]				[]			[*]				[*]
-					[*]								[*]				[]			[]				[]
-cluster-reader				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[bindings buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/details builds/log clusternetworks clusterpolicies clusterpolicybindings clusterrolebindings clusterroles configmaps deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments endpoints events generatedeploymentconfigs groups hostsubnets identities images imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/status imagestreamtags limitranges localresourceaccessreviews localsubjectaccessreviews minions namespaces netnamespaces nodes oauthclientauthorizations oauthclients persistentvolumeclaims persistentvolumes pods pods/log policies policybindings processedtemplates projectrequests projects replicationcontrollers resourceaccessreviews resourcequotas resourcequotausages rolebindings roles routes routes/status securitycontextconstraints serviceaccounts services subjectaccessreviews templateconfigs templates useridentitymappings users]
-					[get list watch]						[]				[]			[autoscaling]			[horizontalpodautoscalers]
-					[get list watch]						[]				[]			[batch]				[jobs]
-					[get list watch]						[]				[]			[extensions]			[daemonsets horizontalpodautoscalers jobs replicationcontrollers/scale]
-					[create]							[]				[]			[]				[resourceaccessreviews subjectaccessreviews]
-					[get]								[]				[]			[]				[nodes/metrics]
-					[create get]							[]				[]			[]				[nodes/stats]
-					[get]								[*]				[]			[]				[]
-cluster-status				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get]								[/api /api/* /apis /apis/* /healthz /healthz/* /oapi /oapi/* /osapi /osapi/ /version]					[]			[]		[]
-edit					Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[configmaps endpoints persistentvolumeclaims pods pods/attach pods/exec pods/log pods/portforward pods/proxy replicationcontrollers replicationcontrollers/scale secrets serviceaccounts services services/proxy]
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/custom builds/docker builds/log builds/source deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments generatedeploymentconfigs imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags processedtemplates routes templateconfigs templates]
-					[create delete deletecollection get list patch update watch]	[]				[]			[autoscaling]			[horizontalpodautoscalers]
-					[create delete deletecollection get list patch update watch]	[]				[]			[batch]				[jobs]
-					[create delete deletecollection get list patch update watch]	[]				[]			[extensions]			[daemonsets horizontalpodautoscalers jobs replicationcontrollers/scale]
-					[get list watch]						[]				[]			[]				[bindings configmaps endpoints events imagestreams/status limitranges minions namespaces namespaces/status nodes persistentvolumeclaims persistentvolumes pods pods/log pods/status projects replicationcontrollers replicationcontrollers/status resourcequotas resourcequotas/status resourcequotausages routes/status securitycontextconstraints serviceaccounts services]
-					[get update]							[]				[]			[]				[imagestreams/layers]
-registry-admin				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags]
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[localresourceaccessreviews localsubjectaccessreviews resourceaccessreviews rolebindings roles subjectaccessreviews]
-					[get update]							[]				[]			[]				[imagestreams/layers]
-					[get list watch]						[]				[]			[]				[policies policybindings]
-					[get]								[]				[]			[]				[namespaces projects]
-registry-editor				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get]								[]				[]			[]				[namespaces projects]
-					[create delete deletecollection get list patch update watch]	[]				[]			[]				[imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags]
-					[get update]							[]				[]			[]				[imagestreams/layers]
-registry-viewer				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreamtags]
-					[get]								[]				[]			[]				[imagestreams/layers namespaces projects]
-self-provisioner			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create]							[]				[]			[]				[projectrequests]
-system:build-controller			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[builds]
-					[update]							[]				[]			[]				[builds]
-					[create]							[]				[]			[]				[builds/custom builds/docker builds/source]
-					[get]								[]				[]			[]				[imagestreams]
-					[create delete get list]					[]				[]			[]				[pods]
-					[create patch update]						[]				[]			[]				[events]
-system:daemonset-controller		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[extensions]			[daemonsets]
-					[list watch]							[]				[]			[]				[pods]
-					[list watch]							[]				[]			[]				[nodes]
-					[update]							[]				[]			[extensions]			[daemonsets/status]
-					[create delete]							[]				[]			[]				[pods]
-					[create]							[]				[]			[]				[pods/binding]
-					[create patch update]						[]				[]			[]				[events]
-system:deployer				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list]							[]				[]			[]				[replicationcontrollers]
-					[get update]							[]				[]			[]				[replicationcontrollers]
-					[create get list watch]						[]				[]			[]				[pods]
-					[get]								[]				[]			[]				[pods/log]
-					[update]							[]				[]			[]				[imagestreamtags]
-system:deployment-controller		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[replicationcontrollers]
-					[get update]							[]				[]			[]				[replicationcontrollers]
-					[create delete get list update]					[]				[]			[]				[pods]
-					[create patch update]						[]				[]			[]				[events]
-system:discovery			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get]								[/api /api/* /apis /apis/* /oapi /oapi/* /osapi /osapi/ /version]							[]			[]			[]
-system:hpa-controller			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[extensions autoscaling]	[horizontalpodautoscalers]
-					[update]							[]				[]			[extensions autoscaling]	[horizontalpodautoscalers/status]
-					[get update]							[]				[]			[extensions ]			[replicationcontrollers/scale]
-					[get update]							[]				[]			[]				[deploymentconfigs/scale]
-					[create patch update]						[]				[]			[]				[events]
-					[list]								[]				[]			[]				[pods]
-					[proxy]								[]				[https:heapster:]	[]				[services]
-system:image-builder			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get update]							[]				[]			[]				[imagestreams/layers]
-					[update]							[]				[]			[]				[builds/details]
-system:image-pruner			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[delete]							[]				[]			[]				[images]
-					[get list]							[]				[]			[]				[buildconfigs builds deploymentconfigs images imagestreams pods replicationcontrollers]
-					[update]							[]				[]			[]				[imagestreams/status]
-system:image-puller			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get]								[]				[]			[]				[imagestreams/layers]
-system:image-pusher			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get update]							[]				[]			[]				[imagestreams/layers]
-system:job-controller			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[extensions batch]		[jobs]
-					[update]							[]				[]			[extensions batch]		[jobs/status]
-					[list watch]							[]				[]			[]				[pods]
-					[create delete]							[]				[]			[]				[pods]
-					[create patch update]						[]				[]			[]				[events]
-system:master				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[*]								[]				[]			[*]				[*]
-system:namespace-controller		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[delete get list watch]						[]				[]			[]				[namespaces]
-					[update]							[]				[]			[]				[namespaces/finalize namespaces/status]
-					[delete deletecollection get list]				[]				[]			[*]				[*]
-system:node				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create]							[]				[]			[]				[localsubjectaccessreviews subjectaccessreviews]
-					[get list watch]						[]				[]			[]				[services]
-					[create get list watch]						[]				[]			[]				[nodes]
-					[update]							[]				[]			[]				[nodes/status]
-					[create patch update]						[]				[]			[]				[events]
-					[get list watch]						[]				[]			[]				[pods]
-					[create delete get]						[]				[]			[]				[pods]
-					[update]							[]				[]			[]				[pods/status]
-					[get]								[]				[]			[]				[configmaps secrets]
-					[get]								[]				[]			[]				[persistentvolumeclaims persistentvolumes]
-					[get]								[]				[]			[]				[endpoints]
-system:node-admin			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[nodes]
-					[proxy]								[]				[]			[]				[nodes]
-					[*]								[]				[]			[]				[nodes/log nodes/metrics nodes/proxy nodes/stats]
-system:node-proxier			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[endpoints services]
-system:node-reader			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[nodes]
-					[get]								[]				[]			[]				[nodes/metrics]
-					[create get]							[]				[]			[]				[nodes/stats]
-system:oauth-token-deleter		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[delete]							[]				[]			[]				[oauthaccesstokens oauthauthorizetokens]
-system:pv-binder-controller		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[persistentvolumes]
-					[create delete get update]					[]				[]			[]				[persistentvolumes]
-					[update]							[]				[]			[]				[persistentvolumes/status]
-					[list watch]							[]				[]			[]				[persistentvolumeclaims]
-					[get update]							[]				[]			[]				[persistentvolumeclaims]
-					[update]							[]				[]			[]				[persistentvolumeclaims/status]
-system:pv-provisioner-controller	Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[persistentvolumes]
-					[create delete get update]					[]				[]			[]				[persistentvolumes]
-					[update]							[]				[]			[]				[persistentvolumes/status]
-					[list watch]							[]				[]			[]				[persistentvolumeclaims]
-					[get update]							[]				[]			[]				[persistentvolumeclaims]
-					[update]							[]				[]			[]				[persistentvolumeclaims/status]
-system:pv-recycler-controller		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[persistentvolumes]
-					[create delete get update]					[]				[]			[]				[persistentvolumes]
-					[update]							[]				[]			[]				[persistentvolumes/status]
-					[list watch]							[]				[]			[]				[persistentvolumeclaims]
-					[get update]							[]				[]			[]				[persistentvolumeclaims]
-					[update]							[]				[]			[]				[persistentvolumeclaims/status]
-					[list watch]							[]				[]			[]				[pods]
-					[create delete get]						[]				[]			[]				[pods]
-					[create patch update]						[]				[]			[]				[events]
-system:registry				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[delete get]							[]				[]			[]				[images]
-					[get]								[]				[]			[]				[imagestreamimages imagestreams imagestreams/secrets imagestreamtags]
-					[update]							[]				[]			[]				[imagestreams]
-					[create]							[]				[]			[]				[imagestreammappings]
-					[list]								[]				[]			[]				[resourcequotas]
-system:replication-controller		Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[replicationcontrollers]
-					[get update]							[]				[]			[]				[replicationcontrollers]
-					[update]							[]				[]			[]				[replicationcontrollers/status]
-					[list watch]							[]				[]			[]				[pods]
-					[create delete]							[]				[]			[]				[pods]
-					[create patch update]						[]				[]			[]				[events]
-system:router				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[list watch]							[]				[]			[]				[endpoints routes]
-					[update]							[]				[]			[]				[routes/status]
-system:sdn-manager			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create delete get list watch]					[]				[]			[]				[hostsubnets]
-					[create delete get list watch]					[]				[]			[]				[netnamespaces]
-					[get list watch]						[]				[]			[]				[nodes]
-					[create get]							[]				[]			[]				[clusternetworks]
-system:sdn-reader			Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[hostsubnets]
-					[get list watch]						[]				[]			[]				[netnamespaces]
-					[get list watch]						[]				[]			[]				[nodes]
-					[get]								[]				[]			[]				[clusternetworks]
-					[get list watch]						[]				[]			[]				[namespaces]
-system:webhook				Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[create get]							[]				[]			[]				[buildconfigs/webhooks]
-view					Verbs								Non-Resource URLs		Extension			Resource Names		API Groups			Resources
-					[get list watch]						[]				[]			[]				[bindings buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/log configmaps deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments endpoints events generatedeploymentconfigs imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/status imagestreamtags limitranges minions namespaces namespaces/status nodes persistentvolumeclaims persistentvolumes pods pods/log pods/status processedtemplates projects replicationcontrollers replicationcontrollers/status resourcequotas resourcequotas/status resourcequotausages routes routes/status securitycontextconstraints serviceaccounts services templateconfigs templates]
-					[get list watch]						[]				[]			[autoscaling]			[horizontalpodautoscalers]
-					[get list watch]						[]				[]			[batch]				[jobs]
-					[get list watch]						[]				[]			[extensions]			[daemonsets horizontalpodautoscalers jobs]
+Name:                    default
+Created:                5 days ago
+Labels:                    <none>
+Annotations:                <none>
+Last Modified:                2016-03-17 13:25:27 -0400 EDT
+admin                    Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create delete deletecollection get list patch update watch]    []                []            []                [configmaps endpoints persistentvolumeclaims pods pods/attach pods/exec pods/log pods/portforward pods/proxy replicationcontrollers replicationcontrollers/scale secrets serviceaccounts services services/proxy]
+                    [create delete deletecollection get list patch update watch]    []                []            []                [buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/custom builds/docker builds/log builds/source deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments generatedeploymentconfigs imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags localresourceaccessreviews localsubjectaccessreviews processedtemplates projects resourceaccessreviews rolebindings roles routes subjectaccessreviews templateconfigs templates]
+                    [create delete deletecollection get list patch update watch]    []                []            [autoscaling]            [horizontalpodautoscalers]
+                    [create delete deletecollection get list patch update watch]    []                []            [batch]                [jobs]
+                    [create delete deletecollection get list patch update watch]    []                []            [extensions]            [daemonsets horizontalpodautoscalers jobs replicationcontrollers/scale]
+                    [get list watch]                        []                []            []                [bindings configmaps endpoints events imagestreams/status limitranges minions namespaces namespaces/status nodes persistentvolumeclaims persistentvolumes pods pods/log pods/status policies policybindings replicationcontrollers replicationcontrollers/status resourcequotas resourcequotas/status resourcequotausages routes/status securitycontextconstraints serviceaccounts services]
+                    [get update]                            []                []            []                [imagestreams/layers]
+                    [update]                            []                []            []                [routes/status]
+basic-user                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get]                                []                [~]            []                [users]
+                    [list]                                []                []            []                [projectrequests]
+                    [get list]                            []                []            []                [clusterroles]
+                    [list]                                []                []            []                [projects]
+                    [create]                            []                IsPersonalSubjectAccessReview    []            []                [localsubjectaccessreviews subjectaccessreviews]
+cluster-admin                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [*]                                []                []            [*]                [*]
+                    [*]                                [*]                []            []                []
+cluster-reader                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [bindings buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/details builds/log clusternetworks clusterpolicies clusterpolicybindings clusterrolebindings clusterroles configmaps deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments endpoints events generatedeploymentconfigs groups hostsubnets identities images imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/status imagestreamtags limitranges localresourceaccessreviews localsubjectaccessreviews minions namespaces netnamespaces nodes oauthclientauthorizations oauthclients persistentvolumeclaims persistentvolumes pods pods/log policies policybindings processedtemplates projectrequests projects replicationcontrollers resourceaccessreviews resourcequotas resourcequotausages rolebindings roles routes routes/status securitycontextconstraints serviceaccounts services subjectaccessreviews templateconfigs templates useridentitymappings users]
+                    [get list watch]                        []                []            [autoscaling]            [horizontalpodautoscalers]
+                    [get list watch]                        []                []            [batch]                [jobs]
+                    [get list watch]                        []                []            [extensions]            [daemonsets horizontalpodautoscalers jobs replicationcontrollers/scale]
+                    [create]                            []                []            []                [resourceaccessreviews subjectaccessreviews]
+                    [get]                                []                []            []                [nodes/metrics]
+                    [create get]                            []                []            []                [nodes/stats]
+                    [get]                                [*]                []            []                []
+cluster-status                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get]                                [/api /api/* /apis /apis/* /healthz /healthz/* /oapi /oapi/* /osapi /osapi/ /version]                    []            []        []
+edit                    Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create delete deletecollection get list patch update watch]    []                []            []                [configmaps endpoints persistentvolumeclaims pods pods/attach pods/exec pods/log pods/portforward pods/proxy replicationcontrollers replicationcontrollers/scale secrets serviceaccounts services services/proxy]
+                    [create delete deletecollection get list patch update watch]    []                []            []                [buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/custom builds/docker builds/log builds/source deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments generatedeploymentconfigs imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags processedtemplates routes templateconfigs templates]
+                    [create delete deletecollection get list patch update watch]    []                []            [autoscaling]            [horizontalpodautoscalers]
+                    [create delete deletecollection get list patch update watch]    []                []            [batch]                [jobs]
+                    [create delete deletecollection get list patch update watch]    []                []            [extensions]            [daemonsets horizontalpodautoscalers jobs replicationcontrollers/scale]
+                    [get list watch]                        []                []            []                [bindings configmaps endpoints events imagestreams/status limitranges minions namespaces namespaces/status nodes persistentvolumeclaims persistentvolumes pods pods/log pods/status projects replicationcontrollers replicationcontrollers/status resourcequotas resourcequotas/status resourcequotausages routes/status securitycontextconstraints serviceaccounts services]
+                    [get update]                            []                []            []                [imagestreams/layers]
+registry-admin                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create delete deletecollection get list patch update watch]    []                []            []                [imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags]
+                    [create delete deletecollection get list patch update watch]    []                []            []                [localresourceaccessreviews localsubjectaccessreviews resourceaccessreviews rolebindings roles subjectaccessreviews]
+                    [get update]                            []                []            []                [imagestreams/layers]
+                    [get list watch]                        []                []            []                [policies policybindings]
+                    [get]                                []                []            []                [namespaces projects]
+registry-editor                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get]                                []                []            []                [namespaces projects]
+                    [create delete deletecollection get list patch update watch]    []                []            []                [imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/secrets imagestreamtags]
+                    [get update]                            []                []            []                [imagestreams/layers]
+registry-viewer                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreamtags]
+                    [get]                                []                []            []                [imagestreams/layers namespaces projects]
+self-provisioner            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create]                            []                []            []                [projectrequests]
+system:build-controller            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [builds]
+                    [update]                            []                []            []                [builds]
+                    [create]                            []                []            []                [builds/custom builds/docker builds/source]
+                    [get]                                []                []            []                [imagestreams]
+                    [create delete get list]                    []                []            []                [pods]
+                    [create patch update]                        []                []            []                [events]
+system:daemonset-controller        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            [extensions]            [daemonsets]
+                    [list watch]                            []                []            []                [pods]
+                    [list watch]                            []                []            []                [nodes]
+                    [update]                            []                []            [extensions]            [daemonsets/status]
+                    [create delete]                            []                []            []                [pods]
+                    [create]                            []                []            []                [pods/binding]
+                    [create patch update]                        []                []            []                [events]
+system:deployer                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list]                            []                []            []                [replicationcontrollers]
+                    [get update]                            []                []            []                [replicationcontrollers]
+                    [create get list watch]                        []                []            []                [pods]
+                    [get]                                []                []            []                [pods/log]
+                    [update]                            []                []            []                [imagestreamtags]
+system:deployment-controller        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [replicationcontrollers]
+                    [get update]                            []                []            []                [replicationcontrollers]
+                    [create delete get list update]                    []                []            []                [pods]
+                    [create patch update]                        []                []            []                [events]
+system:discovery            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get]                                [/api /api/* /apis /apis/* /oapi /oapi/* /osapi /osapi/ /version]                            []            []            []
+system:hpa-controller            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            [extensions autoscaling]    [horizontalpodautoscalers]
+                    [update]                            []                []            [extensions autoscaling]    [horizontalpodautoscalers/status]
+                    [get update]                            []                []            [extensions ]            [replicationcontrollers/scale]
+                    [get update]                            []                []            []                [deploymentconfigs/scale]
+                    [create patch update]                        []                []            []                [events]
+                    [list]                                []                []            []                [pods]
+                    [proxy]                                []                [https:heapster:]    []                [services]
+system:image-builder            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get update]                            []                []            []                [imagestreams/layers]
+                    [update]                            []                []            []                [builds/details]
+system:image-pruner            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [delete]                            []                []            []                [images]
+                    [get list]                            []                []            []                [buildconfigs builds deploymentconfigs images imagestreams pods replicationcontrollers]
+                    [update]                            []                []            []                [imagestreams/status]
+system:image-puller            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get]                                []                []            []                [imagestreams/layers]
+system:image-pusher            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get update]                            []                []            []                [imagestreams/layers]
+system:job-controller            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            [extensions batch]        [jobs]
+                    [update]                            []                []            [extensions batch]        [jobs/status]
+                    [list watch]                            []                []            []                [pods]
+                    [create delete]                            []                []            []                [pods]
+                    [create patch update]                        []                []            []                [events]
+system:master                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [*]                                []                []            [*]                [*]
+system:namespace-controller        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [delete get list watch]                        []                []            []                [namespaces]
+                    [update]                            []                []            []                [namespaces/finalize namespaces/status]
+                    [delete deletecollection get list]                []                []            [*]                [*]
+system:node                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create]                            []                []            []                [localsubjectaccessreviews subjectaccessreviews]
+                    [get list watch]                        []                []            []                [services]
+                    [create get list watch]                        []                []            []                [nodes]
+                    [update]                            []                []            []                [nodes/status]
+                    [create patch update]                        []                []            []                [events]
+                    [get list watch]                        []                []            []                [pods]
+                    [create delete get]                        []                []            []                [pods]
+                    [update]                            []                []            []                [pods/status]
+                    [get]                                []                []            []                [configmaps secrets]
+                    [get]                                []                []            []                [persistentvolumeclaims persistentvolumes]
+                    [get]                                []                []            []                [endpoints]
+system:node-admin            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [nodes]
+                    [proxy]                                []                []            []                [nodes]
+                    [*]                                []                []            []                [nodes/log nodes/metrics nodes/proxy nodes/stats]
+system:node-proxier            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [endpoints services]
+system:node-reader            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [nodes]
+                    [get]                                []                []            []                [nodes/metrics]
+                    [create get]                            []                []            []                [nodes/stats]
+system:oauth-token-deleter        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [delete]                            []                []            []                [oauthaccesstokens oauthauthorizetokens]
+system:pv-binder-controller        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [persistentvolumes]
+                    [create delete get update]                    []                []            []                [persistentvolumes]
+                    [update]                            []                []            []                [persistentvolumes/status]
+                    [list watch]                            []                []            []                [persistentvolumeclaims]
+                    [get update]                            []                []            []                [persistentvolumeclaims]
+                    [update]                            []                []            []                [persistentvolumeclaims/status]
+system:pv-provisioner-controller    Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [persistentvolumes]
+                    [create delete get update]                    []                []            []                [persistentvolumes]
+                    [update]                            []                []            []                [persistentvolumes/status]
+                    [list watch]                            []                []            []                [persistentvolumeclaims]
+                    [get update]                            []                []            []                [persistentvolumeclaims]
+                    [update]                            []                []            []                [persistentvolumeclaims/status]
+system:pv-recycler-controller        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [persistentvolumes]
+                    [create delete get update]                    []                []            []                [persistentvolumes]
+                    [update]                            []                []            []                [persistentvolumes/status]
+                    [list watch]                            []                []            []                [persistentvolumeclaims]
+                    [get update]                            []                []            []                [persistentvolumeclaims]
+                    [update]                            []                []            []                [persistentvolumeclaims/status]
+                    [list watch]                            []                []            []                [pods]
+                    [create delete get]                        []                []            []                [pods]
+                    [create patch update]                        []                []            []                [events]
+system:registry                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [delete get]                            []                []            []                [images]
+                    [get]                                []                []            []                [imagestreamimages imagestreams imagestreams/secrets imagestreamtags]
+                    [update]                            []                []            []                [imagestreams]
+                    [create]                            []                []            []                [imagestreammappings]
+                    [list]                                []                []            []                [resourcequotas]
+system:replication-controller        Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [replicationcontrollers]
+                    [get update]                            []                []            []                [replicationcontrollers]
+                    [update]                            []                []            []                [replicationcontrollers/status]
+                    [list watch]                            []                []            []                [pods]
+                    [create delete]                            []                []            []                [pods]
+                    [create patch update]                        []                []            []                [events]
+system:router                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [list watch]                            []                []            []                [endpoints routes]
+                    [update]                            []                []            []                [routes/status]
+system:sdn-manager            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create delete get list watch]                    []                []            []                [hostsubnets]
+                    [create delete get list watch]                    []                []            []                [netnamespaces]
+                    [get list watch]                        []                []            []                [nodes]
+                    [create get]                            []                []            []                [clusternetworks]
+system:sdn-reader            Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [hostsubnets]
+                    [get list watch]                        []                []            []                [netnamespaces]
+                    [get list watch]                        []                []            []                [nodes]
+                    [get]                                []                []            []                [clusternetworks]
+                    [get list watch]                        []                []            []                [namespaces]
+system:webhook                Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [create get]                            []                []            []                [buildconfigs/webhooks]
+view                    Verbs                                Non-Resource URLs        Extension            Resource Names        API Groups            Resources
+                    [get list watch]                        []                []            []                [bindings buildconfigs buildconfigs/instantiate buildconfigs/instantiatebinary buildconfigs/webhooks buildlogs builds builds/clone builds/log configmaps deploymentconfigrollbacks deploymentconfigs deploymentconfigs/log deploymentconfigs/scale deployments endpoints events generatedeploymentconfigs imagestreamimages imagestreamimports imagestreammappings imagestreams imagestreams/status imagestreamtags limitranges minions namespaces namespaces/status nodes persistentvolumeclaims persistentvolumes pods pods/log pods/status processedtemplates projects replicationcontrollers replicationcontrollers/status resourcequotas resourcequotas/status resourcequotausages routes routes/status securitycontextconstraints serviceaccounts services templateconfigs templates]
+                    [get list watch]                        []                []            [autoscaling]            [horizontalpodautoscalers]
+                    [get list watch]                        []                []            [batch]                [jobs]
+                    [get list watch]                        []                []            [extensions]            [daemonsets horizontalpodautoscalers jobs]
 ----
 ====
 
@@ -286,75 +286,75 @@ $ oc describe clusterPolicyBindings :default
 [options="nowrap"]
 ----
 $ oc describe clusterPolicyBindings :default
-Name:						:default
-Created:					4 hours ago
-Labels:						<none>
-Last Modified:					2015-06-10 17:22:26 +0000 UTC
-Policy:						<none>
+Name:                        :default
+Created:                    4 hours ago
+Labels:                        <none>
+Last Modified:                    2015-06-10 17:22:26 +0000 UTC
+Policy:                        <none>
 RoleBinding[basic-users]:
-						Role:	basic-user
-						Users:	[]
-						Groups:	[system:authenticated]
+                        Role:    basic-user
+                        Users:    []
+                        Groups:    [system:authenticated]
 RoleBinding[cluster-admins]:
-						Role:	cluster-admin
-						Users:	[]
-						Groups:	[system:cluster-admins]
+                        Role:    cluster-admin
+                        Users:    []
+                        Groups:    [system:cluster-admins]
 RoleBinding[cluster-readers]:
-						Role:	cluster-reader
-						Users:	[]
-						Groups:	[system:cluster-readers]
+                        Role:    cluster-reader
+                        Users:    []
+                        Groups:    [system:cluster-readers]
 RoleBinding[cluster-status-binding]:
-						Role:	cluster-status
-						Users:	[]
-						Groups:	[system:authenticated system:unauthenticated]
+                        Role:    cluster-status
+                        Users:    []
+                        Groups:    [system:authenticated system:unauthenticated]
 RoleBinding[self-provisioners]:
-						Role:	self-provisioner
-						Users:	[]
-						Groups:	[system:authenticated]
+                        Role:    self-provisioner
+                        Users:    []
+                        Groups:    [system:authenticated]
 RoleBinding[system:build-controller]:
-						Role:	system:build-controller
-						Users:	[system:serviceaccount:openshift-infra:build-controller]
-						Groups:	[]
+                        Role:    system:build-controller
+                        Users:    [system:serviceaccount:openshift-infra:build-controller]
+                        Groups:    []
 RoleBinding[system:deployment-controller]:
-						Role:	system:deployment-controller
-						Users:	[system:serviceaccount:openshift-infra:deployment-controller]
-						Groups:	[]
+                        Role:    system:deployment-controller
+                        Users:    [system:serviceaccount:openshift-infra:deployment-controller]
+                        Groups:    []
 RoleBinding[system:masters]:
-						Role:	system:master
-						Users:	[]
-						Groups:	[system:masters]
+                        Role:    system:master
+                        Users:    []
+                        Groups:    [system:masters]
 RoleBinding[system:node-proxiers]:
-						Role:	system:node-proxier
-						Users:	[]
-						Groups:	[system:nodes]
+                        Role:    system:node-proxier
+                        Users:    []
+                        Groups:    [system:nodes]
 RoleBinding[system:nodes]:
-						Role:	system:node
-						Users:	[]
-						Groups:	[system:nodes]
+                        Role:    system:node
+                        Users:    []
+                        Groups:    [system:nodes]
 RoleBinding[system:oauth-token-deleters]:
-						Role:	system:oauth-token-deleter
-						Users:	[]
-						Groups:	[system:authenticated system:unauthenticated]
+                        Role:    system:oauth-token-deleter
+                        Users:    []
+                        Groups:    [system:authenticated system:unauthenticated]
 RoleBinding[system:registrys]:
-						Role:	system:registry
-						Users:	[]
-						Groups:	[system:registries]
+                        Role:    system:registry
+                        Users:    []
+                        Groups:    [system:registries]
 RoleBinding[system:replication-controller]:
-						Role:	system:replication-controller
-						Users:	[system:serviceaccount:openshift-infra:replication-controller]
-						Groups:	[]
+                        Role:    system:replication-controller
+                        Users:    [system:serviceaccount:openshift-infra:replication-controller]
+                        Groups:    []
 RoleBinding[system:routers]:
-						Role:	system:router
-						Users:	[]
-						Groups:	[system:routers]
+                        Role:    system:router
+                        Users:    []
+                        Groups:    [system:routers]
 RoleBinding[system:sdn-readers]:
-						Role:	system:sdn-reader
-						Users:	[]
-						Groups:	[system:nodes]
+                        Role:    system:sdn-reader
+                        Users:    []
+                        Groups:    [system:nodes]
 RoleBinding[system:webhooks]:
-						Role:	system:webhook
-						Users:	[]
-						Groups:	[system:authenticated system:unauthenticated]
+                        Role:    system:webhook
+                        Users:    []
+                        Groups:    [system:authenticated system:unauthenticated]
 ----
 ====
 
@@ -389,27 +389,27 @@ in it.
 [options="nowrap"]
 ----
 $ oc describe policyBindings :default -n joe-project
-Name:					:default
-Created:				About a minute ago
-Labels:					<none>
-Last Modified:				2015-06-10 21:55:06 +0000 UTC
-Policy:					<none>
+Name:                    :default
+Created:                About a minute ago
+Labels:                    <none>
+Last Modified:                2015-06-10 21:55:06 +0000 UTC
+Policy:                    <none>
 RoleBinding[admins]:
-					Role:	admin
-					Users:	[joe]
-					Groups:	[]
+                    Role:    admin
+                    Users:    [joe]
+                    Groups:    []
 RoleBinding[system:deployers]:
-					Role:	system:deployer
-					Users:	[system:serviceaccount:joe-project:deployer]
-					Groups:	[]
+                    Role:    system:deployer
+                    Users:    [system:serviceaccount:joe-project:deployer]
+                    Groups:    []
 RoleBinding[system:image-builders]:
-					Role:	system:image-builder
-					Users:	[system:serviceaccount:joe-project:builder]
-					Groups:	[]
+                    Role:    system:image-builder
+                    Users:    [system:serviceaccount:joe-project:builder]
+                    Groups:    []
 RoleBinding[system:image-pullers]:
-					Role:	system:image-puller
-					Users:	[]
-					Groups:	[system:serviceaccounts:joe-project]
+                    Role:    system:image-puller
+                    Users:    []
+                    Groups:    [system:serviceaccounts:joe-project]
 ----
 ====
 
@@ -503,27 +503,27 @@ You can then view the local bindings and verify the addition in the output:
 [options="nowrap"]
 ----
 $ oc describe policyBindings :default -n joe-project
-Name:					:default
-Created:				5 minutes ago
-Labels:					<none>
-Last Modified:				2015-06-10 22:00:44 +0000 UTC
-Policy:					<none>
+Name:                    :default
+Created:                5 minutes ago
+Labels:                    <none>
+Last Modified:                2015-06-10 22:00:44 +0000 UTC
+Policy:                    <none>
 RoleBinding[admins]:
-					Role:	admin
-					Users:	[alice joe] <1>
-					Groups:	[]
+                    Role:    admin
+                    Users:    [alice joe] <1>
+                    Groups:    []
 RoleBinding[system:deployers]:
-					Role:	system:deployer
-					Users:	[system:serviceaccount:joe-project:deployer]
-					Groups:	[]
+                    Role:    system:deployer
+                    Users:    [system:serviceaccount:joe-project:deployer]
+                    Groups:    []
 RoleBinding[system:image-builders]:
-					Role:	system:image-builder
-					Users:	[system:serviceaccount:joe-project:builder]
-					Groups:	[]
+                    Role:    system:image-builder
+                    Users:    [system:serviceaccount:joe-project:builder]
+                    Groups:    []
 RoleBinding[system:image-pullers]:
-					Role:	system:image-puller
-					Users:	[]
-					Groups:	[system:serviceaccounts:joe-project]
+                    Role:    system:image-puller
+                    Users:    []
+                    Groups:    [system:serviceaccounts:joe-project]
 
 ----
 

--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -81,25 +81,25 @@ For example:
 ====
 ----
 $ oc describe node node1.example.com
-Name:			node1.example.com
-Labels:			kubernetes.io/hostname=node1.example.com
-CreationTimestamp:	Wed, 10 Jun 2015 17:22:34 +0000
+Name:            node1.example.com
+Labels:            kubernetes.io/hostname=node1.example.com
+CreationTimestamp:    Wed, 10 Jun 2015 17:22:34 +0000
 Conditions:
-  Type		Status	LastHeartbeatTime			LastTransitionTime			Reason					Message
-  Ready 	True 	Wed, 10 Jun 2015 19:56:16 +0000 	Wed, 10 Jun 2015 17:22:34 +0000 	kubelet is posting ready status
-Addresses:	127.0.0.1
+  Type        Status    LastHeartbeatTime            LastTransitionTime            Reason                    Message
+  Ready     True     Wed, 10 Jun 2015 19:56:16 +0000     Wed, 10 Jun 2015 17:22:34 +0000     kubelet is posting ready status
+Addresses:    127.0.0.1
 Capacity:
- memory:	1017552Ki
- pods:		100
- cpu:		2
+ memory:    1017552Ki
+ pods:        100
+ cpu:        2
 Version:
- Kernel Version:		3.17.4-301.fc21.x86_64
- OS Image:			Fedora 21 (Twenty One)
- Container Runtime Version:	docker://1.6.0
- Kubelet Version:		v0.17.1-804-g496be63
- Kube-Proxy Version:		v0.17.1-804-g496be63
-ExternalID:			node1.example.com
-Pods:				(2 in total)
+ Kernel Version:        3.17.4-301.fc21.x86_64
+ OS Image:            Fedora 21 (Twenty One)
+ Container Runtime Version:    docker://1.6.0
+ Kubelet Version:        v0.17.1-804-g496be63
+ Kube-Proxy Version:        v0.17.1-804-g496be63
+ExternalID:            node1.example.com
+Pods:                (2 in total)
   docker-registry-1-9yyw5
   router-1-maytv
 No events.

--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -63,35 +63,35 @@ edit`. For example, to examine the *restricted* SCC:
 ----
 $ oc describe scc restricted
 
-Name:						restricted
-Priority:					<none>
+Name:                        restricted
+Priority:                    <none>
 Access:
-  Users:					<none>
-  Groups:					system:authenticated
+  Users:                    <none>
+  Groups:                    system:authenticated
 Settings:
-  Allow Privileged:				false
-  Default Add Capabilities:			<none>
-  Required Drop Capabilities:			<none>
-  Allowed Capabilities:				<none>
-  Allowed Volume Types:				awsElasticBlockStore,azureFile,cephFS,cinder,configMap,downwardAPI,emptyDir,fc,flexVolume,flocker,gcePersistentDisk,gitRepo,glusterfs,iscsi,nfs,persistentVolumeClaim,rbd,secret
-  Allow Host Network:				false
-  Allow Host Ports:				false
-  Allow Host PID:				false
-  Allow Host IPC:				false
-  Read Only Root Filesystem:			false
+  Allow Privileged:                false
+  Default Add Capabilities:            <none>
+  Required Drop Capabilities:            <none>
+  Allowed Capabilities:                <none>
+  Allowed Volume Types:                awsElasticBlockStore,azureFile,cephFS,cinder,configMap,downwardAPI,emptyDir,fc,flexVolume,flocker,gcePersistentDisk,gitRepo,glusterfs,iscsi,nfs,persistentVolumeClaim,rbd,secret
+  Allow Host Network:                false
+  Allow Host Ports:                false
+  Allow Host PID:                false
+  Allow Host IPC:                false
+  Read Only Root Filesystem:            false
   Run As User Strategy: MustRunAsRange
-    UID:					<none>
-    UID Range Min:				<none>
-    UID Range Max:				<none>
+    UID:                    <none>
+    UID Range Min:                <none>
+    UID Range Max:                <none>
   SELinux Context Strategy: MustRunAs
-    User:					<none>
-    Role:					<none>
-    Type:					<none>
-    Level:					<none>
+    User:                    <none>
+    Role:                    <none>
+    Type:                    <none>
+    Level:                    <none>
   FSGroup Strategy: RunAsAny
-    Ranges:					<none>
+    Ranges:                    <none>
   Supplemental Groups Strategy: RunAsAny
-    Ranges:					<none>
+    Ranges:                    <none>
 ====
 
 ifdef::openshift-enterprise,openshift-origin[]

--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -379,15 +379,15 @@ core-object-counts  29m
 ====
 ----
 $ oc describe quota core-object-counts -n demoproject
-Name:			core-object-counts
-Namespace:		demoproject
-Resource		Used	Hard
---------		----	----
-configmaps		3	10
-persistentvolumeclaims	0	4
-replicationcontrollers	3	20
-secrets			9	10
-services		2	10
+Name:            core-object-counts
+Namespace:        demoproject
+Resource        Used    Hard
+--------        ----    ----
+configmaps        3    10
+persistentvolumeclaims    0    4
+replicationcontrollers    3    20
+secrets            9    10
+services        2    10
 ----
 ====
 // end::admin_quota_viewing[]

--- a/admin_solutions/user_role_mgmt.adoc
+++ b/admin_solutions/user_role_mgmt.adoc
@@ -82,11 +82,11 @@ resource-quota      39m
 ====
 ----
 $ oc describe quota resource-quota -n awesomeproject
-Name:			resource-quota
-Namespace:		awesomeproject
-Resource		Used	Hard
---------		----	----
-pods     		3	10
+Name:            resource-quota
+Namespace:        awesomeproject
+Resource        Used    Hard
+--------        ----    ----
+pods             3    10
 ----
 ====
 +

--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -55,14 +55,14 @@ sets for the *admin* and *basic-user* xref:roles[default roles]:
 
 [options="nowrap"]
 ----
-admin			Verbs					Resources															Resource Names	Extension
-			[create delete get list update watch]	[projects resourcegroup:exposedkube resourcegroup:exposedopenshift resourcegroup:granter secrets]				[]
-			[get list watch]			[resourcegroup:allkube resourcegroup:allkube-status resourcegroup:allopenshift-status resourcegroup:policy]			[]
-basic-user		Verbs					Resources															Resource Names	Extension
-			[get]					[users]																[~]
-			[list]					[projectrequests]														[]
-			[list]					[projects]															[]
-			[create]				[subjectaccessreviews]														[]		IsPersonalSubjectAccessReview
+admin            Verbs                    Resources                                                            Resource Names    Extension
+            [create delete get list update watch]    [projects resourcegroup:exposedkube resourcegroup:exposedopenshift resourcegroup:granter secrets]                []
+            [get list watch]            [resourcegroup:allkube resourcegroup:allkube-status resourcegroup:allopenshift-status resourcegroup:policy]            []
+basic-user        Verbs                    Resources                                                            Resource Names    Extension
+            [get]                    [users]                                                                [~]
+            [list]                    [projectrequests]                                                        []
+            [list]                    [projects]                                                            []
+            [create]                [subjectaccessreviews]                                                        []        IsPersonalSubjectAccessReview
 ----
 ====
 
@@ -74,13 +74,13 @@ to various users and groups:
 [options="nowrap"]
 ----
 RoleBinding[admins]:
-				Role:	admin
-				Users:	[alice system:admin]
-				Groups:	[]
+                Role:    admin
+                Users:    [alice system:admin]
+                Groups:    []
 RoleBinding[basic-user]:
-				Role:	basic-user
-				Users:	[joe]
-				Groups:	[devel]
+                Role:    basic-user
+                Users:    [joe]
+                Groups:    [devel]
 ----
 ====
 

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -60,13 +60,13 @@ about a specific object:
 [options="nowrap"]
 ----
 $ oc describe svc docker-registry
-Name:			docker-registry
-Labels:			docker-registry=default
-Selector:		docker-registry=default
-IP:			172.30.78.158
-Port:			<unnamed>	5000/TCP
-Endpoints:		10.128.0.2:5000
-Session Affinity:	None
+Name:            docker-registry
+Labels:            docker-registry=default
+Selector:        docker-registry=default
+IP:            172.30.78.158
+Port:            <unnamed>    5000/TCP
+Endpoints:        10.128.0.2:5000
+Session Affinity:    None
 No events.
 ----
 ====

--- a/creating_images/s2i_testing.adoc
+++ b/creating_images/s2i_testing.adoc
@@ -83,12 +83,12 @@ your image name.
 IMAGE_NAME = openshift/ruby-20-centos7
 
 build:
-	docker build -t $(IMAGE_NAME) .
+    docker build -t $(IMAGE_NAME) .
 
 .PHONY: test
 test:
-	docker build -t $(IMAGE_NAME)-candidate .
-	IMAGE_NAME=$(IMAGE_NAME)-candidate test/run
+    docker build -t $(IMAGE_NAME)-candidate .
+    IMAGE_NAME=$(IMAGE_NAME)-candidate test/run
 ----
 ====
 

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -493,14 +493,14 @@ For example:
 $ oc import-image my-ruby --from=docker.io/openshift/ruby-20-centos7 --confirm
 The import completed successfully.
 
-Name:			my-ruby
-Created:		Less than a second ago
-Labels:			<none>
-Annotations:		openshift.io/image.dockerRepositoryCheck=2016-05-06T20:59:30Z
-Docker Pull Spec:	172.30.94.234:5000/demo-project/my-ruby
+Name:            my-ruby
+Created:        Less than a second ago
+Labels:            <none>
+Annotations:        openshift.io/image.dockerRepositoryCheck=2016-05-06T20:59:30Z
+Docker Pull Spec:    172.30.94.234:5000/demo-project/my-ruby
 
-Tag	Spec					Created			PullSpec							Image
-latest	docker.io/openshift/ruby-20-centos7	Less than a second ago	docker.io/openshift/ruby-20-centos7@sha256:772c5bf9b2d1e8...	<same>
+Tag    Spec                    Created            PullSpec                            Image
+latest    docker.io/openshift/ruby-20-centos7    Less than a second ago    docker.io/openshift/ruby-20-centos7@sha256:772c5bf9b2d1e8...    <same>
 ----
 ====
 +

--- a/dev_guide/service_accounts.adoc
+++ b/dev_guide/service_accounts.adoc
@@ -123,13 +123,13 @@ These can be seen by describing the service account:
 $ oc describe serviceaccount robot
 Name:               robot
 Labels:             <none>
-Image pull secrets:	robot-dockercfg-624cx
+Image pull secrets:    robot-dockercfg-624cx
 
-Mountable secrets: 	robot-token-uzkbh
-                   	robot-dockercfg-624cx
+Mountable secrets:     robot-token-uzkbh
+                       robot-dockercfg-624cx
 
-Tokens:            	robot-token-8bhpp
-                   	robot-token-uzkbh
+Tokens:                robot-token-8bhpp
+                       robot-token-uzkbh
 ----
 ====
 
@@ -188,15 +188,15 @@ $ oc secrets add serviceaccount/robot secret/my-pull-secret --for=pull
 $ oc describe serviceaccount robot
 Name:               robot
 Labels:             <none>
-Image pull secrets:	robot-dockercfg-624cx
-                   	my-pull-secret
+Image pull secrets:    robot-dockercfg-624cx
+                       my-pull-secret
 
-Mountable secrets: 	robot-token-uzkbh
-                   	robot-dockercfg-624cx
-                   	secret-plans
+Mountable secrets:     robot-token-uzkbh
+                       robot-dockercfg-624cx
+                       secret-plans
 
-Tokens:            	robot-token-8bhpp
-                   	robot-token-uzkbh
+Tokens:                robot-token-8bhpp
+                       robot-token-uzkbh
 ----
 ====
 
@@ -252,15 +252,15 @@ For example:
 ====
 ----
 $ oc describe secret robot-token-uzkbh -n top-secret
-Name:		robot-token-uzkbh
-Labels:		<none>
-Annotations:	kubernetes.io/service-account.name=robot,kubernetes.io/service-account.uid=49f19e2e-16c6-11e5-afdc-3c970e4b7ffe
+Name:        robot-token-uzkbh
+Labels:        <none>
+Annotations:    kubernetes.io/service-account.name=robot,kubernetes.io/service-account.uid=49f19e2e-16c6-11e5-afdc-3c970e4b7ffe
 
-Type:	kubernetes.io/service-account-token
+Type:    kubernetes.io/service-account-token
 
 Data
 
-token:	eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+token:    eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 
 $ oc login --token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 Logged into "https://server:8443" as "system:serviceaccount:top-secret:robot" using the token provided.

--- a/getting_started/dedicated_administrators.adoc
+++ b/getting_started/dedicated_administrators.adoc
@@ -74,24 +74,24 @@ you are a cluster administrator, you will see your account listed under
 ----
 $ oc describe policyBindings :default -n <project_name>
 
-Name:					:default
-Created:				2 weeks ago
-Labels:					<none>
-Annotations:				<none>
-Last Modified:				2016-05-03 05:34:49 -0400 EDT
-Policy:					<none>
+Name:                    :default
+Created:                2 weeks ago
+Labels:                    <none>
+Annotations:                <none>
+Last Modified:                2016-05-03 05:34:49 -0400 EDT
+Policy:                    <none>
 RoleBinding[admin]:
-					Role:			admin
-					Users:			fred@example.com <1>
-					Groups:			<none>
-					ServiceAccounts:	<none>
-					Subjects:		<none>
+                    Role:            admin
+                    Users:            fred@example.com <1>
+                    Groups:            <none>
+                    ServiceAccounts:    <none>
+                    Subjects:        <none>
 RoleBinding[dedicated-project-admin]:
-					Role:			dedicated-project-admin
-					Users:			alice@example.com, bob@example.com <2>
-					Groups:			<none>
-					ServiceAccounts:	<none>
-					Subjects:		<none>
+                    Role:            dedicated-project-admin
+                    Users:            alice@example.com, bob@example.com <2>
+                    Groups:            <none>
+                    ServiceAccounts:    <none>
+                    Subjects:        <none>
 ...
 ----
 <1> The *fred@example.com* user is a normal, project-scoped administrator for this

--- a/install_config/storage_examples/gluster_example.adoc
+++ b/install_config/storage_examples/gluster_example.adoc
@@ -320,52 +320,52 @@ More details are shown in the `oc describe pod` command:
 ====
 ----
 # oc describe pod gluster-pod1
-Name:				gluster-pod1
-Namespace:			default   <1>
-Image(s):			busybox
-Node:				rhel7.2-dev/192.168.122.177
-Start Time:			Tue, 22 Mar 2016 10:55:57 -0700
-Labels:				name=gluster-pod1
-Status:				Running
+Name:                gluster-pod1
+Namespace:            default   <1>
+Image(s):            busybox
+Node:                rhel7.2-dev/192.168.122.177
+Start Time:            Tue, 22 Mar 2016 10:55:57 -0700
+Labels:                name=gluster-pod1
+Status:                Running
 Reason:
 Message:
-IP:				10.1.0.2  <2>
-Replication Controllers:	<none>
+IP:                10.1.0.2  <2>
+Replication Controllers:    <none>
 Containers:
   gluster-pod1:
-    Container ID:	docker://acc0c80c28a5cd64b6e3f2848052ef30a21ee850d27ef5fe959d11da4e5a3f4f
-    Image:		busybox
-    Image ID:		docker://964092b7f3e54185d3f425880be0b022bfc9a706701390e0ceab527c84dea3e3
+    Container ID:    docker://acc0c80c28a5cd64b6e3f2848052ef30a21ee850d27ef5fe959d11da4e5a3f4f
+    Image:        busybox
+    Image ID:        docker://964092b7f3e54185d3f425880be0b022bfc9a706701390e0ceab527c84dea3e3
     QoS Tier:
-      cpu:		BestEffort
-      memory:		BestEffort
-    State:		Running
-      Started:		Tue, 22 Mar 2016 10:56:00 -0700
-    Ready:		True
-    Restart Count:	0
+      cpu:        BestEffort
+      memory:        BestEffort
+    State:        Running
+      Started:        Tue, 22 Mar 2016 10:56:00 -0700
+    Ready:        True
+    Restart Count:    0
     Environment Variables:
 Conditions:
-  Type		Status
-  Ready 	True
+  Type        Status
+  Ready     True
 Volumes:
   gluster-vol1:
-    Type:	PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
-    ClaimName:	gluster-claim  <3>
-    ReadOnly:	false
+    Type:    PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
+    ClaimName:    gluster-claim  <3>
+    ReadOnly:    false
   default-token-rbi9o:
-    Type:	Secret (a secret that should populate this volume)
-    SecretName:	default-token-rbi9o
+    Type:    Secret (a secret that should populate this volume)
+    SecretName:    default-token-rbi9o
 
 Events:                        <4>
-  FirstSeen	LastSeen	Count	From			SubobjectPath	Reason		Message
-  ─────────	────────	─────	────			─────────────	──────		───────
-  2m		2m		1	{scheduler }				Scheduled	Successfully assigned gluster-pod1 to rhel7.2-dev
-  2m		2m		1	{kubelet rhel7.2-dev}	implicitly required container POD	Pulled		Container image "openshift3/ose-pod:v3.1.1.6" already present on machine
-  2m		2m		1	{kubelet rhel7.2-dev}	implicitly required container POD	Created		Created with docker id d5c66b4f3aaa
-  2m		2m		1	{kubelet rhel7.2-dev}	implicitly required container POD	Started		Started with docker id d5c66b4f3aaa
-  2m		2m		1	{kubelet rhel7.2-dev}	spec.containers{gluster-pod1}		Pulled		Container image "busybox" already present on machine
-  2m		2m		1	{kubelet rhel7.2-dev}	spec.containers{gluster-pod1}		Created		Created with docker id acc0c80c28a5
-  2m		2m		1	{kubelet rhel7.2-dev}	spec.containers{gluster-pod1}		Started		Started with docker id acc0c80c28a5
+  FirstSeen    LastSeen    Count    From            SubobjectPath    Reason        Message
+  ─────────    ────────    ─────    ────            ─────────────    ──────        ───────
+  2m        2m        1    {scheduler }                Scheduled    Successfully assigned gluster-pod1 to rhel7.2-dev
+  2m        2m        1    {kubelet rhel7.2-dev}    implicitly required container POD    Pulled        Container image "openshift3/ose-pod:v3.1.1.6" already present on machine
+  2m        2m        1    {kubelet rhel7.2-dev}    implicitly required container POD    Created        Created with docker id d5c66b4f3aaa
+  2m        2m        1    {kubelet rhel7.2-dev}    implicitly required container POD    Started        Started with docker id d5c66b4f3aaa
+  2m        2m        1    {kubelet rhel7.2-dev}    spec.containers{gluster-pod1}        Pulled        Container image "busybox" already present on machine
+  2m        2m        1    {kubelet rhel7.2-dev}    spec.containers{gluster-pod1}        Created        Created with docker id acc0c80c28a5
+  2m        2m        1    {kubelet rhel7.2-dev}    spec.containers{gluster-pod1}        Started        Started with docker id acc0c80c28a5
 ----
 <1> The project (namespace) name.
 <2> The IP address of the {product-title} node running the pod.

--- a/install_config/storage_examples/shared_storage.adoc
+++ b/install_config/storage_examples/shared_storage.adoc
@@ -241,51 +241,51 @@ More details are shown in the `oc describe pod` command:
 ====
 ----
 [root@ose70 nfs]# oc describe pod nginx-nfs-pod
-Name:				nginx-nfs-pod
-Namespace:			default <1>
-Image(s):			fedora/nginx
-Node:				ose70.rh7/192.168.234.148 <2>
-Start Time:			Mon, 21 Mar 2016 09:59:47 -0400
-Labels:				name=nginx-nfs-pod
-Status:				Running
+Name:                nginx-nfs-pod
+Namespace:            default <1>
+Image(s):            fedora/nginx
+Node:                ose70.rh7/192.168.234.148 <2>
+Start Time:            Mon, 21 Mar 2016 09:59:47 -0400
+Labels:                name=nginx-nfs-pod
+Status:                Running
 Reason:
 Message:
-IP:				10.1.0.4
-Replication Controllers:	<none>
+IP:                10.1.0.4
+Replication Controllers:    <none>
 Containers:
   nginx-nfs-pod:
-    Container ID:	docker://a3292104d6c28d9cf49f440b2967a0fc5583540fc3b062db598557b93893bc6f
-    Image:		fedora/nginx
-    Image ID:		docker://403d268c640894cbd76d84a1de3995d2549a93af51c8e16e89842e4c3ed6a00a
+    Container ID:    docker://a3292104d6c28d9cf49f440b2967a0fc5583540fc3b062db598557b93893bc6f
+    Image:        fedora/nginx
+    Image ID:        docker://403d268c640894cbd76d84a1de3995d2549a93af51c8e16e89842e4c3ed6a00a
     QoS Tier:
-      cpu:		BestEffort
-      memory:		BestEffort
-    State:		Running
-      Started:		Mon, 21 Mar 2016 09:59:49 -0400
-    Ready:		True
-    Restart Count:	0
+      cpu:        BestEffort
+      memory:        BestEffort
+    State:        Running
+      Started:        Mon, 21 Mar 2016 09:59:49 -0400
+    Ready:        True
+    Restart Count:    0
     Environment Variables:
 Conditions:
-  Type		Status
-  Ready 	True
+  Type        Status
+  Ready     True
 Volumes:
   nfsvol:
-    Type:	PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
-    ClaimName:	nfs-pvc <3>
-    ReadOnly:	false
+    Type:    PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
+    ClaimName:    nfs-pvc <3>
+    ReadOnly:    false
   default-token-a06zb:
-    Type:	Secret (a secret that should populate this volume)
-    SecretName:	default-token-a06zb
+    Type:    Secret (a secret that should populate this volume)
+    SecretName:    default-token-a06zb
 Events: <4>
-  FirstSeen	LastSeen	Count	From			SubobjectPath				Reason		Message
-  ─────────	────────	─────	────			─────────────				──────		───────
-  4m		4m		1	{scheduler }							Scheduled	Successfully assigned nginx-nfs-pod to ose70.rh7
-  4m		4m		1	{kubelet ose70.rh7}	implicitly required container POD	Pulled		Container image "openshift3/ose-pod:v3.1.0.4" already present on machine
-  4m		4m		1	{kubelet ose70.rh7}	implicitly required container POD	Created		Created with docker id 866a37108041
-  4m		4m		1	{kubelet ose70.rh7}	implicitly required container POD	Started		Started with docker id 866a37108041
-  4m		4m		1	{kubelet ose70.rh7}	spec.containers{nginx-nfs-pod}		Pulled		Container image "fedora/nginx" already present on machine
-  4m		4m		1	{kubelet ose70.rh7}	spec.containers{nginx-nfs-pod}		Created		Created with docker id a3292104d6c2
-  4m		4m		1	{kubelet ose70.rh7}	spec.containers{nginx-nfs-pod}		Started		Started with docker id a3292104d6c2
+  FirstSeen    LastSeen    Count    From            SubobjectPath                Reason        Message
+  ─────────    ────────    ─────    ────            ─────────────                ──────        ───────
+  4m        4m        1    {scheduler }                            Scheduled    Successfully assigned nginx-nfs-pod to ose70.rh7
+  4m        4m        1    {kubelet ose70.rh7}    implicitly required container POD    Pulled        Container image "openshift3/ose-pod:v3.1.0.4" already present on machine
+  4m        4m        1    {kubelet ose70.rh7}    implicitly required container POD    Created        Created with docker id 866a37108041
+  4m        4m        1    {kubelet ose70.rh7}    implicitly required container POD    Started        Started with docker id 866a37108041
+  4m        4m        1    {kubelet ose70.rh7}    spec.containers{nginx-nfs-pod}        Pulled        Container image "fedora/nginx" already present on machine
+  4m        4m        1    {kubelet ose70.rh7}    spec.containers{nginx-nfs-pod}        Created        Created with docker id a3292104d6c2
+  4m        4m        1    {kubelet ose70.rh7}    spec.containers{nginx-nfs-pod}        Started        Started with docker id a3292104d6c2
 
 
 ----
@@ -450,51 +450,51 @@ More details are shown in the `oc describe pod` command:
 ====
 ----
 [root@ose70 nfs]# oc describe pod busybox-nfs-pod
-Name:				busybox-nfs-pod
-Namespace:			default
-Image(s):			busybox
-Node:				ose70.rh7/192.168.234.148
-Start Time:			Mon, 21 Mar 2016 10:19:46 -0400
-Labels:				name=busybox-nfs-pod
-Status:				Running
+Name:                busybox-nfs-pod
+Namespace:            default
+Image(s):            busybox
+Node:                ose70.rh7/192.168.234.148
+Start Time:            Mon, 21 Mar 2016 10:19:46 -0400
+Labels:                name=busybox-nfs-pod
+Status:                Running
 Reason:
 Message:
-IP:				10.1.0.5
-Replication Controllers:	<none>
+IP:                10.1.0.5
+Replication Controllers:    <none>
 Containers:
   busybox-nfs-pod:
-    Container ID:	docker://346d432e5a4824ebf5a47fceb4247e0568ecc64eadcc160e9bab481aecfb0594
-    Image:		busybox
-    Image ID:		docker://17583c7dd0dae6244203b8029733bdb7d17fccbb2b5d93e2b24cf48b8bfd06e2
+    Container ID:    docker://346d432e5a4824ebf5a47fceb4247e0568ecc64eadcc160e9bab481aecfb0594
+    Image:        busybox
+    Image ID:        docker://17583c7dd0dae6244203b8029733bdb7d17fccbb2b5d93e2b24cf48b8bfd06e2
     QoS Tier:
-      cpu:		BestEffort
-      memory:		BestEffort
-    State:		Running
-      Started:		Mon, 21 Mar 2016 10:19:48 -0400
-    Ready:		True
-    Restart Count:	0
+      cpu:        BestEffort
+      memory:        BestEffort
+    State:        Running
+      Started:        Mon, 21 Mar 2016 10:19:48 -0400
+    Ready:        True
+    Restart Count:    0
     Environment Variables:
 Conditions:
-  Type		Status
-  Ready 	True
+  Type        Status
+  Ready     True
 Volumes:
   nfsvol-2:
-    Type:	PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
-    ClaimName:	nfs-pvc
-    ReadOnly:	false
+    Type:    PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
+    ClaimName:    nfs-pvc
+    ReadOnly:    false
   default-token-32d2z:
-    Type:	Secret (a secret that should populate this volume)
-    SecretName:	default-token-32d2z
+    Type:    Secret (a secret that should populate this volume)
+    SecretName:    default-token-32d2z
 Events:
-  FirstSeen	LastSeen	Count	From			SubobjectPath				Reason		Message
-  ─────────	────────	─────	────			─────────────				──────		───────
-  4m		4m		1	{scheduler }							Scheduled	Successfully assigned busybox-nfs-pod to ose70.rh7
-  4m		4m		1	{kubelet ose70.rh7}	implicitly required container POD	Pulled		Container image "openshift3/ose-pod:v3.1.0.4" already present on machine
-  4m		4m		1	{kubelet ose70.rh7}	implicitly required container POD	Created		Created with docker id 249b7d7519b1
-  4m		4m		1	{kubelet ose70.rh7}	implicitly required container POD	Started		Started with docker id 249b7d7519b1
-  4m		4m		1	{kubelet ose70.rh7}	spec.containers{busybox-nfs-pod}	Pulled		Container image "busybox" already present on machine
-  4m		4m		1	{kubelet ose70.rh7}	spec.containers{busybox-nfs-pod}	Created		Created with docker id 346d432e5a48
-  4m		4m		1	{kubelet ose70.rh7}	spec.containers{busybox-nfs-pod}	Started		Started with docker id 346d432e5a48
+  FirstSeen    LastSeen    Count    From            SubobjectPath                Reason        Message
+  ─────────    ────────    ─────    ────            ─────────────                ──────        ───────
+  4m        4m        1    {scheduler }                            Scheduled    Successfully assigned busybox-nfs-pod to ose70.rh7
+  4m        4m        1    {kubelet ose70.rh7}    implicitly required container POD    Pulled        Container image "openshift3/ose-pod:v3.1.0.4" already present on machine
+  4m        4m        1    {kubelet ose70.rh7}    implicitly required container POD    Created        Created with docker id 249b7d7519b1
+  4m        4m        1    {kubelet ose70.rh7}    implicitly required container POD    Started        Started with docker id 249b7d7519b1
+  4m        4m        1    {kubelet ose70.rh7}    spec.containers{busybox-nfs-pod}    Pulled        Container image "busybox" already present on machine
+  4m        4m        1    {kubelet ose70.rh7}    spec.containers{busybox-nfs-pod}    Created        Created with docker id 346d432e5a48
+  4m        4m        1    {kubelet ose70.rh7}    spec.containers{busybox-nfs-pod}    Started        Started with docker id 346d432e5a48
 ----
 ====
 

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -781,16 +781,16 @@ Update each image stream one at a time:
 # oc import-image -n openshift nodejs
 The import completed successfully.
 
-Name:			nodejs
-Created:		10 seconds ago
-Labels:			<none>
-Annotations:		openshift.io/image.dockerRepositoryCheck=2016-07-05T19:20:30Z
-Docker Pull Spec:	172.30.204.22:5000/openshift/nodejs
+Name:            nodejs
+Created:        10 seconds ago
+Labels:            <none>
+Annotations:        openshift.io/image.dockerRepositoryCheck=2016-07-05T19:20:30Z
+Docker Pull Spec:    172.30.204.22:5000/openshift/nodejs
 
-Tag	Spec								Created		PullSpec						Image
-latest	4								9 seconds ago	registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest	570ad8ed927fd5c2c9554ef4d9534cef808dfa05df31ec491c0969c3bd372b05
-4	registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest		9 seconds ago	<same>							570ad8ed927fd5c2c9554ef4d9534cef808dfa05df31ec491c0969c3bd372b05
-0.10	registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest	9 seconds ago	<same>							a1ef33be788a28ec2bdd48a9a5d174ebcfbe11c8e986d2996b77f5bccaaa4774
+Tag    Spec                                Created        PullSpec                        Image
+latest    4                                9 seconds ago    registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest    570ad8ed927fd5c2c9554ef4d9534cef808dfa05df31ec491c0969c3bd372b05
+4    registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest        9 seconds ago    <same>                            570ad8ed927fd5c2c9554ef4d9534cef808dfa05df31ec491c0969c3bd372b05
+0.10    registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest    9 seconds ago    <same>                            a1ef33be788a28ec2bdd48a9a5d174ebcfbe11c8e986d2996b77f5bccaaa4774
 ----
 ====
 

--- a/registry_quickstart/developers.adoc
+++ b/registry_quickstart/developers.adoc
@@ -116,35 +116,35 @@ $ oc policy add-role-to-user registry-editor system:serviceaccounts:test:push
 +
 ----
 $ oc describe sa push
-Name:		push
-Namespace:	test
-Labels:		<none>
+Name:        push
+Namespace:    test
+Labels:        <none>
 
-Image pull secrets:	push-dockercfg-39j62
+Image pull secrets:    push-dockercfg-39j62
 
-Mountable secrets: 	push-token-5518o
-                   	push-dockercfg-39j62
+Mountable secrets:     push-token-5518o
+                       push-dockercfg-39j62
 
-Tokens:            	push-token-5518o
-                   	push-token-htcxd
+Tokens:                push-token-5518o
+                       push-token-htcxd
 ----
 
 . Describe the token to get the secret value.
 +
 ----
 $ oc describe secret push-token-5518o
-Name:		push-token-5518o
-Namespace:	test
-Labels:		<none>
-Annotations:	kubernetes.io/service-account.name=push,kubernetes.io/service-account.uid=9eb24eeb-12d8-11e6-a276-0afb45fc7af5
+Name:        push-token-5518o
+Namespace:    test
+Labels:        <none>
+Annotations:    kubernetes.io/service-account.name=push,kubernetes.io/service-account.uid=9eb24eeb-12d8-11e6-a276-0afb45fc7af5
 
-Type:	kubernetes.io/service-account-token
+Type:    kubernetes.io/service-account-token
 
 Data
 ====
-token:		eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
-ca.crt:		1066 bytes
-namespace:	8 bytes
+token:        eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+ca.crt:        1066 bytes
+namespace:    8 bytes
 ----
 
 . Copy the token value and use as the value to the *--password* argument in the `docker login`

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -10289,16 +10289,16 @@ There are five different ways to configure the hook. As an example, all forms be
 
 1. Shell script:
 
-	      "postCommit": {
+          "postCommit": {
          "script": "rake test --verbose",
-	      }
+          }
 
     The above is a convenient form which is equivalent to:
 
-	      "postCommit": {
-		      "command": ["/bin/sh", "-ic"],
-	        "args":    ["rake test --verbose"]
-	      }
+          "postCommit": {
+              "command": ["/bin/sh", "-ic"],
+            "args":    ["rake test --verbose"]
+          }
 
 2. Command as the image entrypoint:
 
@@ -10312,8 +10312,8 @@ There are five different ways to configure the hook. As an example, all forms be
 3. Pass arguments to the default entrypoint:
 
        "postCommit": {
-		      "args": ["rake", "test", "--verbose"]
-	      }
+              "args": ["rake", "test", "--verbose"]
+          }
 
     This form is only useful if the image entrypoint can handle arguments.
 


### PR DESCRIPTION
Spaces, it is aligned to view code with any editor, including the web
page view (such as in the GitHub code). When use tabs, the view on the
page is chaos, and it is terrible to mix tabs and spaces.
