### PR TITLE
Fix up references to `oc secrets add`

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -685,12 +685,12 @@ $ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD -
 ====
 
 . Add the `*secret*` to the builder service account. Each build is run with
-`serviceaccount/builder` role, so you need to give it access your secret with
+the `builder` role, so you need to give it access your secret with the
 following command:
 +
 ====
 ----
-$ oc secrets add serviceaccount/builder secrets/basicsecret
+$ oc secrets link builder basicsecret
 ----
 ====
 
@@ -776,12 +776,12 @@ $ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa --gitconfi
 ====
 
 . Add the `*secret*` to the builder service account. Each build is run with
-`serviceaccount/builder` role, so you need to give it access your secret with
+the `builder` role, so you need to give it access your secret with the
 following command:
 +
 ====
 ----
-$ oc secrets add serviceaccount/builder secrets/sshsecret
+$ oc secrets link builder sshsecret
 ----
 ====
 
@@ -860,12 +860,12 @@ section in your `.gitconfig` file:
 ====
 
 .  Add the `*secret*` to the builder service account. Each build is run with the
-`serviceaccount/builder` role, so you need to give it access your secret with
+the `builder` role, so you need to give it access your secret with the
 following command:
 +
 ====
 ----
-$ oc secrets add serviceaccount/builder secrets/mysecret
+$ oc secrets link builder mysecret
 ----
 ====
 
@@ -1834,13 +1834,13 @@ This generates a JSON specification of the `*secret*` named *dockerhub* and
 creates the object.
 
 . Once the `*secret*` is created, add it to the builder service account. Each
-build is run with `serviceaccount/builder` role, so you need to give it access
-your secret with following command:
+build is run with the `builder` role, so you need to give it access
+your secret with the following command:
 
 +
 ====
 ----
-$ oc secrets add serviceaccount/builder secrets/dockerhub
+$ oc secrets link builder dockerhub
 ----
 ====
 

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -461,14 +461,14 @@ the name of the service account the pod will use; *default* is the default
 service account:
 
 ----
-$ oc secrets add serviceaccount/default secrets/<pull_secret_name> --for=pull
+$ oc secrets link default <pull_secret_name> --for=pull
 ----
 
 To use a secret for pushing and pulling build images, the secret must be
 mountable inside of a pod. You can do this by running:
 
 ----
-$ oc secrets add serviceaccount/builder secrets/<pull_secret_name>
+$ oc secrets link builder <pull_secret_name>
 ----
 endif::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
 

--- a/dev_guide/service_accounts.adoc
+++ b/dev_guide/service_accounts.adoc
@@ -155,17 +155,13 @@ To allow a secret to be used as an image pull secret by a service account's
 pods, run:
 
 ----
-$ oc secrets add --for=pull \
-    serviceaccount/<serviceaccount-name> \
-    secret/<secret-name>
+$ oc secrets link --for=pull <serviceaccount-name> <secret-name>
 ----
 
 To allow a secret to be mounted by a service account's pods, run:
 
 ----
-$ oc secrets add --for=mount \
-    serviceaccount/<serviceaccount-name> \
-    secret/<secret-name>
+$ oc secrets link --for=mount <serviceaccount-name> <secret-name>
 ----
 
 This example creates and adds secrets to a service account:
@@ -181,9 +177,9 @@ $ oc secrets new-dockercfg my-pull-secret \
     --docker-email=mastermind@example.com
 secret/my-pull-secret
 
-$ oc secrets add serviceaccount/robot secret/secret-plans --for=mount
+$ oc secrets link robot secret-plans --for=mount
 
-$ oc secrets add serviceaccount/robot secret/my-pull-secret --for=pull
+$ oc secrets link robot my-pull-secret --for=pull
 
 $ oc describe serviceaccount robot
 Name:               robot

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -676,8 +676,8 @@ $ oc secrets new registry-secret \
 service account):
 +
 ----
-$ oc secrets add serviceaccounts/registry secrets/registry-secret
-$ oc secrets add serviceaccounts/default  secrets/registry-secret
+$ oc secrets link registry registry-secret
+$ oc secrets link default  registry-secret
 ----
 +
 . Add the secret volume to the registry deployment configuration:


### PR DESCRIPTION
This command has been deprecated in favor of `oc secrets link`.

Signed-off-by: Stephen Gallagher sgallagh@redhat.com

Depends on https://github.com/openshift/origin/pull/9234. [DO_NOT_MERGE] will be removed once that lands.
