### PR TITLE
Move metrics to 'openshift-metrics' project

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -65,16 +65,16 @@ address of the node, then Heapster will fail to retrieve any metrics.
 ====
 endif::[]
 
-The components for cluster metrics must be deployed to the *openshift-infra*
+The components for cluster metrics must be deployed to the *openshift-metrics*
 project. This allows xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[horizontal pod
 autoscalers] to discover the Heapster service and use it to retrieve metrics
 that can be used for autoscaling.
 
 All of the following commands in this topic must be executed under the
-*openshift-infra* project. To switch to the *openshift-infra* project:
+*openshift-metrics* project. To switch to the *openshift-metrics* project:
 
 ----
-$ oc project openshift-infra
+$ oc project openshift-metrics
 ----
 
 To enable cluster metrics, you must next configure the following:
@@ -112,11 +112,11 @@ API
 ----
 
 . Before it can deploy components, the *metrics-deployer* service account must
-also be granted the `edit` permission for the *openshift-infra* project:
+also be granted the `edit` permission for the *openshift-metrics* project:
 +
 ----
 $ oadm policy add-role-to-user \
-    edit system:serviceaccount:openshift-infra:metrics-deployer
+    edit system:serviceaccount:openshift-metrics:metrics-deployer
 ----
 
 [[heapster-service-account]]
@@ -128,7 +128,7 @@ this, the Heapster service account requires the `cluster-reader` permission:
 
 ----
 $ oadm policy add-cluster-role-to-user \
-    cluster-reader system:serviceaccount:openshift-infra:heapster
+    cluster-reader system:serviceaccount:openshift-metrics:heapster
 ----
 
 [NOTE]
@@ -648,7 +648,7 @@ using something similar to:
 
 ----
 $ curl -H "Authorization: Bearer XXXXXXXXXXXXXXXXX" \
-       -X GET https://${KUBERNETES_MASTER}/api/v1/proxy/namespaces/openshift-infra/services/https:heapster:/validate
+       -X GET https://${KUBERNETES_MASTER}/api/v1/proxy/namespaces/openshift-metrics/services/https:heapster:/validate
 ----
 
 For more information about Heapster and how to access its APIs, please refer the


### PR DESCRIPTION
While preparing the installer for automated installation of metrics components in 1.3/3.3 I ran into the fact that metrics were being deployed into `openshift-infra`. That project is a special project containing many highly privileged components and we should avoid using it. Switch docs to use `openshift-metrics` instead, I'm open to suggestions for a better project name. Logging uses `logging` but i sort of like the `openshift-` prefix.
