### PR TITLE
Bug 1256963, added link connecting F5 router and Routing from Edge LB topics

### DIFF
--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -208,6 +208,12 @@ $ oadm manage-node <ramp_node_hostname> --schedulable=false
 ----
 ====
 
+[NOTE]
+====
+The xref:../install_config/install/deploy_router.html#deploying-the-f5-router[F5
+router plug-in] integrates with F5 BIG-IP®.
+====
+
 === Configuring a Highly-Available Ramp Node
 You can use {product-title}'s *ipfailover* feature, which uses *keepalived*
 internally, to make the ramp node highly available from *F5 BIG-IP®*'s point of


### PR DESCRIPTION
Most of the work in https://bugzilla.redhat.com/show_bug.cgi?id=1256963 was previously done. However, per the BZ notes, @adellape intended to add a link to the F5 content from the Routing from Edge Load Balancers topic. That is what this work accomplishes, which will allow us to close that bug.
