### PR TITLE
Fixed file location for scaleup.yml

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -595,10 +595,10 @@ Availability Add-on for Red Hat Enterprise Linux documentation].
 [[adding-nodes-advanced]]
 == Adding Nodes to an Existing Cluster
 
-After your cluster is installed, you can install additional nodes and add them
-to your cluster by running the *_scaleup.yml_* playbook. This playbook queries
-the master, generates and distributes new certificates for the new nodes, then
-runs the configuration playbooks on the new nodes only.
+After your cluster is installed, you can install additional nodes (including
+masters) and add them to your cluster by running the *_scaleup.yml_* playbook.
+This playbook queries the master, generates and distributes new certificates for
+the new nodes, then runs the configuration playbooks on the new nodes only.
 
 ifdef::openshift-enterprise[]
 This process is similar to re-running the installer in the
@@ -665,11 +665,19 @@ See xref:configuring-host-variables[Configuring Host Variables] for more options
 somewhere other than the default *_/etc/ansible/hosts_*, specify the location
 with the `-i option`:
 +
+For additional nodes:
++
 ----
 # ansible-playbook [-i /path/to/file] \
     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/scaleup.yml
 ----
-
++
+For additional masters:
++ 
+----
+# ansible-playbook [-i /path/to/file] \
+    usr/share/ansible/openshift-ansible/playbooks/byo/openshift-master/scaleup.yml
+----
 . After the playbook completes successfully,
 xref:verifying-the-installation[verify the installation].
 


### PR DESCRIPTION
3.0 docs equivalent of https://github.com/openshift/openshift-docs/pull/2359 (which has already merged)

RE: https://bugzilla.redhat.com/show_bug.cgi?id=1341286
