### PR TITLE
Native HA services for Origin upgrades

### DIFF
--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -114,8 +114,9 @@ Upgrade your masters first:
 # yum upgrade origin-master
 ----
 
-. If you are upgrading from OpenShift Origin 1.0 to 1.1, create the following
-master proxy client certificates:
+. If you are upgrading from OpenShift Origin 1.0 to 1.1:
+
+.. Create the following master proxy client certificates:
 +
 ----
 # cd /etc/origin/master/
@@ -137,18 +138,49 @@ kubernetesMasterConfig:
     keyFile: master.proxy-client.key
 ----
 
-. Enable the following renamed service on master hosts:
+.. Enable the following renamed service(s) on master hosts.
++
+For single master clusters:
 +
 ----
 # systemctl enable origin-master
 ----
++
+For multi-master clusters:
++
+----
+# systemctl enable origin-master-api
+# systemctl enable origin-master-controllers
+----
 
-. For any upgrade path, now restart the *origin-master* service and review its
-logs to ensure services have been restarted successfully:
+. Restart the master service(s) on each master and review logs to ensure they
+restart successfully.
++
+For single master clusters:
 +
 ----
 # systemctl restart origin-master
 # journalctl -r -u origin-master
+----
++
+For multi-master clusters:
++
+----
+# systemctl restart origin-master-controllers
+# systemctl restart origin-master-api
+# journalctl -r -u origin-master-controllers
+# journalctl -r -u origin-master-api
+----
+
+. Because masters also have node components running on them in order to be
+configured as part of the OpenShift SDN, restart the *origin-node* and
+*openvswitch* services:
++
+----
+# systemctl restart origin-node
+# systemctl restart openvswitch
+# journalctl -r -u openvswitch
+# journalctl -r -u origin-node
 ----
 endif::[]
 ifdef::openshift-enterprise[]
@@ -435,10 +467,14 @@ renamed service on the node host:
 # systemctl enable origin-node
 ----
 
-. For any upgrade path, restart the *origin-node* service:
+. Restart the *origin-node* and *openvswitch* services and review the logs to
+ensure they restart successfully:
 +
 ----
 # systemctl restart origin-node
+# systemctl restart openvswitch
+# journalctl -r -u origin-node
+# journalctl -r -u openvswitch
 ----
 
 endif::[]


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/9749

The Origin manual upgrade docs didn't consistently differentiate between non-HA and native HA master services, like the OSE docs do. This updates the Origin docs to get them in sync.

@abutcher What say you? :mag: 
