### PR TITLE
Correct endpoints example in External MySQL Database 

### DIFF
--- a/dev_guide/integrating_external_services.adoc
+++ b/dev_guide/integrating_external_services.adoc
@@ -93,7 +93,7 @@ proxy and router the location to send traffic directed to the service:
     -
       addresses:
         -
-          IP: "10.0.0.0" <3>
+          ip: "10.0.0.0" <3>
       ports:
         -
           port: 3306 <4>


### PR DESCRIPTION
 "IP: 10.0.0.0" should be" ip: 10.0.0.0"
in the endpoints example of External MySQL Database section.
