### PR TITLE
Making Blue-Green Deployments its own topic

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -246,6 +246,8 @@ Topics:
         File: automated_upgrades
       - Name: Manual Upgrades
         File: manual_upgrades
+      - Name: Blue-Green Deployments
+        File: blue_green_deployments       
   - Name: Downgrading
     File: downgrade
     Distros: openshift-enterprise

--- a/install_config/upgrading/blue_green_deployments.adoc
+++ b/install_config/upgrading/blue_green_deployments.adoc
@@ -1,0 +1,174 @@
+[[upgrading-blue-green-deployments]]
+= Blue-Green Deployments
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+This topic serves as an alternative node upgrade method to the approach in
+xref:../../install_config/upgrading/manual_upgrades.adoc#upgrading-nodes[Manual
+Upgrades].
+
+Blue-green deployments are a proven approach to reducing downtime caused while
+upgrading an environment. This is done by creating a parallel environment on
+which the new deployment can be installed. If a problem is detected, and after
+the new deployment is verified, traffic can be switched over with the option to
+rollback.
+
+While blue-green is a valid strategy for deploying just about any software,
+there are always trade-offs. Not all environments have the same uptime
+requirements or the resources to properly perform blue-green deployments. In an
+{product-title} environment, the most suitable candidate for blue-green
+deployments are the nodes. All user processes run on these systems and even
+critical pieces of {product-title} infrastructure are self-hosted there. Uptime
+is most important for these workloads and the additional complexity of
+blue-green deployments can be justified. The exact implementation of this
+approach varies based on your requirements. Often the main challenge is having the
+excess capacity to facilitate such an approach.
+
+ifdef::openshift-enterprise[]
+Another lesser challenge is that the administrator must temporarily share the
+Red Hat software entitlements between the blue-green deployments or provide
+access to the installation content by means of a system such as Red Hat
+Satellite. This can be accomplished by sharing the consumer ID from the previous
+host.
+endif::openshift-enterprise[]
+
+[[blue-green-deployments-preparing-for-upgrade]]
+== Preparing for Upgrade
+
+ifdef::openshift-enterprise[]
+. On the old host:
++
+----
+# subscription-manager identity | grep system
+system identity: 6699375b-06db-48c4-941e-689efd6ce3aa
+----
+
+. On the new host:
++
+----
+# subscription-manager register --consumerid=6699375b-06db-48c4-941e-689efd6ce3aa
+----
++
+[IMPORTANT]
+====
+After a successful deployment, remember to unregister the old host with
+`subscription-manager clean` to prevent the environment from being out of
+compliance.
+====
+endif::openshift-enterprise[]
+
+. xref:../../install_config/upgrading/manual_upgrades.adoc#upgrading-masters[After
+the master and etcd servers have been upgraded], you must ensure that your
+current production nodes are labeled either blue or green. In this example, the
+current installation will be blue and the new environment will be green. On each
+production node in your current installation:
++
+----
+$ oc label --all nodes color=blue
+----
++
+In the case of nodes requiring the uptime guarantees of a blue-green deployment,
+the `-l` flag can be used to match a subset of the environment using a selector.
+
+. Create the new green environment for any nodes that are to be replaced by
+xref:../install/advanced_install.adoc#adding-nodes-advanced[adding an equal
+number of new nodes] to the existing cluster. Ansible can apply the
+`*color=green*` label using the `*openshift_node_labels*` variable for each
+node.
+
+. In order to delay workload scheduling until the nodes are
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[healthy],
+be sure to set the `*openshift_schedulable=false*` variable. After the green
+nodes are in *Ready* state, they can be made schedulable.
+
+. Blue nodes are disabled so that no new pods are run on them:
++
+----
+# oadm manage-node --schedulable=true --selector=color=green
+# oadm manage-node --schedulable=false --selector=color=blue
+----
+
+A common practice is to scale the registry and router pods until they are
+migrated to the green nodes. For these pods, a _canary_ deployment approach is
+commonly used. Scaling them up will make them immediately active on the new
+nodes. Pointing the deployment configuration to the new image initiates a
+rolling update. However, because of node anti-affinity, and the fact that the
+blue nodes are still unschedulable, the deployments to the old nodes will fail.
+At this point, the registry and router deployments can be scaled down to the
+original number of pods. At any given point, the original number of pods is
+still available so no capacity is lost.
+
+[[blue-green-deployments-warming-the-new-nodes]]
+== Warming the New Nodes
+
+In order for pods to be migrated from the blue environment to the green, the
+images must be pulled. Network latency and load on the registry can cause delays
+if there is not sufficient capacity built in to the environment. Often, the best
+way to minimize impact to the running system is to trigger new pod deployments that
+will land on the new nodes. Accomplish this by importing new image streams.
+
+A major release of {product-title} is the motivation for a blue-green
+deployment. At that time, new image streams become available for users of
+Source-to-Image (S2I). Upon import, any builds or deployments configured with
+*ImageChangeTriggers* are automatically created.
+
+[NOTE]
+====
+To continue with the upgrade process,
+xref:../../install_config/upgrading/manual_upgrades.html#updating-the-default-image-streams-and-templates[update
+the default image streams and templates] and
+xref:../../install_config/upgrading/manual_upgrades.html#importing-the-latest-images[import
+the latest images].
+====
+
+It is important to realize that this process can trigger a large number of
+builds. The good news is that the builds are performed on the green nodes and,
+therefore, do not impact any traffic on the blue deployment.
+
+To monitor build progress across all namespaces (projects) in the cluster:
+
+----
+$ oc get events -w --all-namespaces
+----
+
+In large environments, builds rarely completely stop. However, you should see a
+large increase and decrease caused by the administrative import.
+
+Another benefit of triggering the builds is that it does a fairly good job of
+fetching the majority of the ancillary images to all nodes such as the various
+build images, the pod infrastructure image, and deployers. Everything else can
+be moved over using node evacuation and will proceed more quickly as a result.
+
+[[blue-green-deployments-node-evacuation]]
+== Node Evacuation
+
+For larger deployments, it is possible to have other labels that help
+determine how evacuation can be coordinated. The most conservative approach
+for avoiding downtime is to evacuate one node at a time. If services are
+composed of pods using zone anti-affinity, then an entire zone can be
+evacuated at once. It is important to ensure that the storage volumes used are
+available in the new zone as this detail can vary among cloud providers.
+
+ifdef::openshift-origin[]
+In OpenShift Origin 1.2 and later,
+endif::[]
+ifdef::openshift-enterprise[]
+In OpenShift Enterprise 3.2 and later,
+endif::[]
+a node evacuation is triggered whenever the service is stopped. Achieve manual
+evacuation and deletion of all blue nodes at once by:
+
+----
+# oadm manage-node --selector=color=blue --evacuate
+# oc delete node --selector=color=blue
+----

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -431,6 +431,13 @@ xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc
 proxy] is restarted. The length of this disruption should be very short and
 scales based on the number of services in the entire cluster.
 
+[NOTE]
+====
+xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[Blue-green
+deployments] are another proven approach to reducing downtime caused while
+updating an environment.
+====
+
 One at at time for each node that is not also a master, you must disable
 scheduling and evacuate its pods to other nodes, then upgrade packages and
 restart services.
@@ -1658,149 +1665,3 @@ common issues:
 [Note] Completed with no errors or warnings seen.
 ----
 ====
-
-[[manual-upgrades-advanced-topics]]
-== Advanced Topics
-
-Blue-green deployments are a proven approach to reducing downtime caused while
-updating an environment. This is done by creating a parallel environment on
-which the new deployment can be installed. If a problem is detected and after
-the new deployment is verified, traffic can be switched over with the option to
-rollback.
-
-While blue-green is a valid strategy for deploying just about any software,
-there are always trade-offs to be made. Not all environments have the same
-uptime requirements or the resources to properly perform blue-green deployments.
-In an {product-title} environment the most suitable candidate for blue-green
-deployments are the Nodes. Uptime is most important for these workloads and the
-additional complexity of blue-green deployments can be justified. Often the main
-challenge is having the excess capacity to facilitate such an approach.
-
-ifdef::openshift-enterprise[]
-Another lesser challenge is that the administrator will have to temporarily
-share the entitlements between the blue-green deployments or provide access to
-the installation content by means of a system such as Red Hat Satellite. This
-can be accomplished by sharing the consumer ID from the previous host.
-
-On the old host:
-----
-# subscription-manager identity | grep system
-system identity: 6699375b-06db-48c4-941e-689efd6ce3aa
-----
-
-On the new host:
-----
-# subscription-manager register --consumerid=6699375b-06db-48c4-941e-689efd6ce3aa
-----
-
-[IMPORTANT]
-====
-After a successful deployment, remember to unregister the old host with
-`*subscription-manager clean*` to prevent the environment from being out of
-compliance.
-====
-
-endif::openshift-enterprise[]
-
-[[manual-upgrades-preparing-for-upgrade]]
-=== Preparing for Upgrade
-
-xref:#upgrading-masters[After the master and etcd servers have been upgraded],
-you need to ensure that your current production nodes are labeled either blue or
-green. In this example, the current installation will be blue and the new
-environment will be green.
-
-----
-$ oc label --all nodes color=blue
-----
-
-In the case of nodes requiring the uptime guarantees of a blue-green deployment,
-the `-l` flag can be used to match a subset of the environment using a selector.
-
-Next, xref:../install/advanced_install.adoc#adding-nodes-advanced[the green
-environment] should be created for any nodes that are to be replaced. Ansible
-can apply the `*color=green*` using the `*openshift_node_labels*` variable for
-each node.
-
-In order to delay workload scheduling until the nodes are
-xref:../dev_guide/application_health.adoc#dev-guide-application-health[healthy],
-be sure to set the `*openshift_schedulable=false*` variable.
-
-Once the green nodes are in *Ready* state, they can be made schedulable. Then,
-blue nodes are disabled so that no new pods are run on them.
-
-----
-# oadm manage-node --schedulable=true --selector=color=green
-# oadm manage-node --schedulable=false --selector=color=blue
-----
-
-A common practice is to scale the registry and router pods until they are
-migrated to the green nodes. For these pods, a _canary_ deployment approach is
-commonly used. Scaling them up will make them immediately active on the new
-nodes. Pointing the deployment configuration to the new image initiates a
-rolling update. However, because of node anti-affinity, and the fact that the
-blue nodes are still unschedulable, the deployments to the old nodes will fail.
-At this point, the registry and router deployments can be scaled down to the
-original number of pods. At any given point, the original number of pods is
-still available so no capacity is lost.
-
-[[manual-upgrades-warming-the-new-nodes]]
-=== Warming the New Nodes
-
-In order for pods to be migrated from the blue environment to the green, the
-images must be pulled. Network latency and load on the registry can cause delays
-if there is not sufficient capacity built in to the environment. Often, the best
-way to minimize impact to the running system is to trigger new pod deployments that
-will land on the new nodes. Accomplish this by importing new *ImageStreams*.
-
-A major release of {product-title} is the motivation for a
-blue-green deployment. At that time, new *ImageStreams* become
-available for users of Source-to-Image. Upon import, any builds or deployments
-configured with *ImageChangeTriggers* are automatically created.
-
-It is important to realize that this process can trigger a large number of
-builds. The good news is that the builds are performed on the green nodes and,
-therefore, do not impact any traffic on the blue deployment.
-
-Monitor build progress:
-
-----
-$ oc get events -w --all-namespaces
-----
-
-In large environments, builds rarely completely stop. However, you should see a
-large increase and decrease caused by the administrative import.
-
-Another benefit of triggering the builds is that it does a fairly good job of
-fetching the majority of the ancillary images to all nodes such as the various
-build images, the pod infrastructure image, and deployers. Everything else can
-be moved over using node evacuation and will proceed more quickly as a result.
-
-[[manual-upgrades-node-evacuation]]
-=== Node Evacuation
-
-For larger deployments, it is possible to have other labels that help
-determine how evacuation can be coordinated. The most conservative approach
-for avoiding downtime is to evacuate one node at a time. If services are
-composed of pods using zone anti-affinity, then an entire zone can be
-evacuated at once. It is important to ensure that the storage volumes used are
-available in the new zone as this detail can vary among cloud providers.
-
-In OpenShift Enterprise 3.2 and later, a node evacuation is triggered whenever
-the service is stopped. Achieve manual evacuation and deletion of all blue nodes
-at once by:
-
-----
-# oadm manage-node --selector=color=blue --evacuate
-# oc delete node --selector=color=blue
-----
-
-[[manual-upgrades-summary]]
-=== Summary
-
-In the {product-title} environment, the most suitable candidate for blue-green
-deployments is the node tier. All user processes run on these systems and even
-critical pieces of {product-title} infrastructure are self-hosted there. Uptime
-is most important for these workloads and the additional complexity of
-blue-green deployments can be justified. The exact implementation of this
-approach varies based on your requirements.


### PR DESCRIPTION
After some discussion with @adellape, we agree it may be best to make the Blue-Green Deployments content its own topic under Upgrading.

Original work is here:
https://github.com/openshift/openshift-docs/pull/2287
https://github.com/openshift/openshift-docs/pull/2511
