### PR TITLE
Remove README.adoc title ID

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,3 @@
-[[-README]]
 = OpenShift Documentation
 Welcome to the OpenShift documentation GitHub repository that contains the source files for the technical documentation for the following products:
 


### PR DESCRIPTION
This doesn't seem necessary (this topic doesn't get linked to from any actual built docs) and was just messing up the title formatting in the GH render:

![screenshot from 2016-07-29 10-58-17](https://cloud.githubusercontent.com/assets/3442316/17252616/62baeb2a-557b-11e6-93db-e85f229de7ba.png)

cc @vikram-redhat 
