### PR TITLE
Remove link to 3.1 docs for Dedicated

### DIFF
--- a/index-commercial.html
+++ b/index-commercial.html
@@ -422,13 +422,7 @@
             <h2>OpenShift Dedicated</h2>
             <div class="list-group">
 <p class="list-group-item-text">Red Hat's managed public cloud application deployment and hosting service.</p>
-<div class="btn-group">
-  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
-  <ul class="dropdown-menu" role="menu">
-    <li><a href="dedicated/3.2/"><i class="fa fa-arrow-circle-o-right"></i> Dedicated 3.2</a></li>
-    <li><a href="dedicated/3.1/"><i class="fa fa-arrow-circle-o-right"></i> Dedicated 3.1</a></li>
-  </ul>
-</div>
+<p><a role="button" class="btn btn-primary" href="dedicated/3.2/"><i class="fa fa-arrow-circle-o-right"></i> Dedicated 3.2</a></p>
             </div>
           </div>
           <div class="col-sm-3 text-center">


### PR DESCRIPTION
This change corresponds with site redirects from all dedicated/3.1/\* content to dedicated/3.2/\* content.
