### PR TITLE
Follow-up to PR#1926 for REST API Overview

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -461,6 +461,8 @@ Topics:
     File: authentication
   - Name: Managing Images
     File: managing_images
+  - Name: Service Accounts
+    File: service_accounts
 
 ---
 Name: CLI Reference

--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -9,30 +9,37 @@
 :toc-title:
 
 toc::[]
+{nbsp} +
+The {product-title} distribution of Kubernetes includes the
+xref:../rest_api/kubernetes_v1.adoc#rest-api-kubernetes-v1[Kubernetes v1 REST
+API] and the xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[OpenShift
+v1 REST API]. These are RESTful APIs accessible via HTTP(s) on the
+{product-title} master servers.
 
-The {product-title} distribution of Kubernetes includes the xref:../rest_api/kubernetes_v1.adoc#rest-api-kubernetes-v1[Kubernetes v1 REST API]
-and the xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[OpenShift v1 REST API]. These are RESTful APIs accessible via HTTP(s)
-on the {product-title} master servers.
-
-These REST APIs can be used to manage end-user applications, the cluster, and the users of the cluster.
+These REST APIs can be used to manage end-user applications, the cluster, and
+the users of the cluster.
 
 [[rest-api-authentication]]
 == Authentication
 
 API calls must be authenticated with an access token or X.509 certificate. See
-xref:../architecture/additional_concepts/authentication.html#api-authentication[authentication architecture]
-for an overview.
+xref:../architecture/additional_concepts/authentication.html#api-authentication[Authentication]
+in the Architecture documentation for an overview.
 
 This section highlights the token authentication method. With token
-authentication a bearer token must be passed in as an
-link:https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8[HTTP Authorization header].
-There are two types of access tokens, session and service account.
+authentication, a bearer token must be passed in as an
+link:https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8[HTTP
+Authorization header]. There are two types of access tokens: session and service
+account.
 
 [[rest-api-session-tokens]]
 === Session Tokens
-A user session token is short-lived, expiring within 24 hours by default. It
-represents a user. Once logged in, the session token may be obtained with the
-**oc whoami** command.
+
+A _session token_ is short-lived, expiring within 24 hours by default. It
+represents a
+xref:../architecture/additional_concepts/authentication.adoc#users-and-groups[user].
+After logging in, the session token may be obtained with the `oc whoami`
+command:
 
 ----
 $ oc login -u test_user
@@ -43,29 +50,31 @@ dIAo76N-W-GXK3S_w_KsC6DmH3MzP79zq7jbMQvCOUo
 
 [[rest-api-serviceaccount-tokens]]
 === Service Account Tokens
-Service account tokens are long-lived tokens. They are
+
+_Service account tokens_ are long-lived tokens. They are
 link:https://tools.ietf.org/html/rfc7519[JSON Web Token (JWT)] formatted tokens
-and are much longer strings than session tokens. See the Developer Guide for
-xref:../dev_guide/service_accounts.adoc#using-a-service-account-s-credentials-externally[using service account tokens]
-to authenticate using the CLI.
+and are much longer strings than session tokens. See
+xref:../dev_guide/service_accounts.adoc#using-a-service-accounts-credentials-externally[Using
+a Service Account’s Credentials Externally] for steps on using these tokens to
+authenticate using the CLI.
 
 A service account token may be obtained with these commands:
 
-. Create a service account in the current project ("test") named **robot**.
+. Create a service account in the current project (*test*) named *robot*:
 +
 ----
 $ oc create serviceaccount robot
 serviceaccount "robot" created
 ----
 
-. Grant a role to the service account. In this example we assign the **robot**
-service account in the **test** project the **admin** role.
+. Grant a role to the service account. In this example, assign the *robot* service
+account in the *test* project the *admin* role:
 +
 ----
 $ oc policy add-role-to-user admin system:serviceaccounts:test:robot
 ----
 
-. Describe the service account to discover the secret token name.
+. Describe the service account to discover the secret token name:
 +
 ----
 $ oc describe serviceaccount robot
@@ -82,7 +91,7 @@ Tokens:            	robot-token-2dsne
                    	robot-token-9efwm
 ----
 
-. Describe the secret token to get the token value.
+. Describe the secret token to get the token value:
 +
 ----
 $  oc describe secret robot-token-2dsne
@@ -94,39 +103,39 @@ Annotations:	kubernetes.io/service-account.name=robot,kubernetes.io/service-acco
 Type:	kubernetes.io/service-account-token
 
 Data
-====
+===
 token:		fyJhbGciOiJSUzI1NiIyInR5cCI2IkpXVCJ9...
 ca.crt:		1070 bytes
 namespace:	8 bytes
 ----
 
 The token value may be used as an in an authorization header to
-xref:examples[authenticate API calls], the
-xref:../dev_guide/service_accounts.adoc#using-a-service-account-s-credentials-externally[CLI]
-or in the xref:docker-login[docker login command]. Service accounts may be
-created and deleted as needed with the appropriate role(s) assigned. See the
-xref:../architecture/additional_concepts/authorization.adoc#roles[authorization section]
-for a discussion on roles.
+xref:rest-api-examples[authenticate API calls], the
+xref:../dev_guide/service_accounts.adoc#using-a-service-accounts-credentials-externally[CLI]
+or in the xref:rest-api-docker-login[docker login command]. Service accounts may
+be created and deleted as needed with the appropriate role(s) assigned. See
+xref:../architecture/additional_concepts/authorization.adoc#roles[Authorization]
+in the Architecture documentation for a deeper discussion on roles.
 
 [[rest-api-examples]]
 == Examples
 
 These examples are provided as a reference to provide quick success making REST
-API calls. They use insecure methods. In these examples a simple **GET** call
-is made to xref:../rest_api/openshift_v1.html#get-available-resources[list
+API calls. They use insecure methods. In these examples a simple `GET` call is
+made to xref:../rest_api/openshift_v1.html#get-available-resources[list
 available resources].
 
 [[rest-api-example-curl]]
 === cURL
 
-.Request (insecure)
+.Request (Insecure)
 ====
 ----
 $ curl -X GET -H "Authorization: Bearer <token>" https://openshift.redhat.com:8443/oapi/v1 --insecure
 ----
 ====
 
-.Result (truncated)
+.Result (Truncated)
 ====
 ----
 {
@@ -188,7 +197,7 @@ $ curl -X GET -H "Authorization: Bearer <token>" https://openshift.redhat.com:84
 [[rest-api-example-python]]
 === Python
 
-.Interactive Python API call using "requests" module (insecure)
+.Interactive Python API Call Using "requests" Module (Insecure)
 ====
 ----
 >>> import requests
@@ -204,23 +213,26 @@ $ curl -X GET -H "Authorization: Bearer <token>" https://openshift.redhat.com:84
 [[rest-api-docker-login]]
 === Docker Login
 
-The {product-title} integrated docker registry must be authenticated using either a
-xref:session-tokens[user session] or xref:service-account-tokens[service account] token. The value of the token
-must be used as the value for the **--password** argument. The user and email
-argument values are ignored.
+The {product-title} integrated Docker registry must be authenticated using
+either a xref:rest-api-session-tokens[user session] or
+xref:rest-api-serviceaccount-tokens[service account] token. The value of the
+token must be used as the value for the `--password` argument. The user and
+email argument values are ignored:
 
 ----
-$ docker login -p <token_value> -u unused -e unused REGISTRY[:port]
+$ docker login -p <token_value> -u unused -e unused <registry>[:<port>]
 ----
 
 [[rest-api-websockets]]
 == Websockets and Watching for Changes
 
-The API is designed to work via the link:https://tools.ietf.org/html/rfc6455[websocket protocol].
-API requests may take the form of "one-shot" calls to list resources or by passing
-in query parameter `watch=true`. When watching an endpoint changes to the system
-may be observed through an open endpoint. Using callbacks, dynamic systems may
-be developed that integrate with the API.
+The API is designed to work via the
+link:https://tools.ietf.org/html/rfc6455[websocket protocol]. API requests may
+take the form of "one-shot" calls to list resources or by passing in query
+parameter `watch=true`. When watching an endpoint, changes to the system may be
+observed through an open endpoint. Using callbacks, dynamic systems may be
+developed that integrate with the API.
 
-For more information and examples see the Mozilla Developer Network page on
-link:https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications[Writing WebSocket client applications].
+For more information and examples, see the Mozilla Developer Network page on
+link:https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications[Writing
+WebSocket client applications].


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/1926. Minor edits, mostly formatting.

@aweiteka @openshift/team-documentation PTAL? Pretty builds:

(OSE) http://file.rdu.redhat.com/~adellape/072916/openshift-enterprise/edit_api_1926/rest_api/

(AR) http://file.rdu.redhat.com/~adellape/072916/atomic-registry/edit_api_1926/rest_api/

@aweiteka I noticed this topic references `dev_guide/service_accounts`, which is not currently in AR's User Guide. Did you want it to be?
