### PR TITLE
Distinguish between embedded/external etcd; use ETCD_DATA_DIR in example

### DIFF
--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -89,12 +89,19 @@ a RHEL 7 system, ensure the package is installed:
 +
 Then, create the backup:
 +
+====
 ----
-# etcdctl backup --data-dir /var/lib/origin/openshift.local.etcd \
-    --backup-dir /var/lib/origin/openshift.local.etcd.bak.<date> <1>
+# ETCD_DATA_DIR=/var/lib/origin <1>
+# etcdctl backup \
+    --data-dir $ETCD_DATA_DIR \
+    --backup-dir $ETCD_DATA_DIR.bak.<date> <2>
 ----
-<1> Set the date of the backup in `<date>`, or some unique identifier. The command
-will not make a backup if the `--backup-dir` location already exists.
+<1> This directory is for embedded etcd.
+For external etcd, use *_/var/lib/etcd_* instead.
+<2> Use the date of the backup, or some unique identifier, for `<date>`.
+The command will not make a backup if the `--backup-dir` location
+already exists.
+====
 
 . For any upgrade path, ensure that you are running the latest kernel on
 each RHEL 7 system:


### PR DESCRIPTION
Fixes bug 1349226 (specifically the issue explained in [comment 3](https://bugzilla.redhat.com/show_bug.cgi?id=1349226#c3)).
