### PR TITLE
Add ‘spec.volumeName’ to "Requesting Storage" example

### DIFF
--- a/dev_guide/persistent_volumes.adoc
+++ b/dev_guide/persistent_volumes.adoc
@@ -62,6 +62,7 @@ spec:
   resources:
     requests:
       storage: "5Gi"
+  volumeName: "pv0001"
 ----
 ====
 


### PR DESCRIPTION
Suggested by Brennan Vincello bvincell@redhat.com in
https://github.com/openshift/openshift-docs/pull/1910.
