### PR TITLE
Bumped travis RVM ruby version to 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.4
+  - 2.3.1
 gemfile: Gemfile
 after_install: gem list
 script: bundle exec rake build


### PR DESCRIPTION
This solves a specific version requirement for ruby_dep and brings our Travis version up to the Ruby version currently available in Fedora 24.
