### PR TITLE
Fixed broken xrefs throughout docs

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -150,6 +150,7 @@ $ ping hello-openshift.shard1.v3.rhcloud.com
 ====
 ////
 
+[[configuring-ip-failover]]
 == Configuring IP Failover
 
 Using IP failover involves switching IP addresses to a redundant or stand-by

--- a/admin_guide/scheduler.adoc
+++ b/admin_guide/scheduler.adoc
@@ -22,6 +22,7 @@ independent and exists as a standalone/pluggable solution. It does not modify
 the pod and just creates a binding for the pod that ties the pod to the
 particular node.
 
+[[generic-scheduler]]
 == Generic Scheduler
 The existing generic scheduler is the default platform-provided scheduler
 "engine" that selects a node to host the pod in a 3-step operation:
@@ -30,11 +31,13 @@ The existing generic scheduler is the default platform-provided scheduler
 . Prioritize the filtered list of nodes
 . Select the best fit node
 
+[[filter-the-nodes]]
 === Filter the Nodes
 The available nodes are filtered based on the constraints or requirements
 specified. This is done by running each of the nodes through the list of filter
 functions called 'predicates'.
 
+[[prioritize-filtered-list-nodes]]
 === Prioritize the Filtered List of Nodes
 This is achieved by passing each node through a series of 'priority' functions
 that assign it a score between 0 - 10, with 0 indicating a bad fit and 10
@@ -45,16 +48,19 @@ node score provided by each priority function is multiplied by the "weight"
 provided by all the priority functions. This weight attribute can be used by
 administrators to give higher importance to some priority functions.
 
+[[select-best-fit-node]]
 === Select the Best Fit Node
 The nodes are sorted based on their scores and the node with the highest score
 is selected to host the pod. If multiple nodes have the same high score, then
 one of them is selected at random.
 
+[[available-predicates]]
 == Available Predicates
 There are several predicates provided out of the box in Kubernetes. Some of
 these predicates can be customized by providing certain parameters. Multiple
 predicates can be combined to provide additional filtering of nodes.
 
+[[static-predicates]]
 === Static Predicates
 These predicates do not take any configuration parameters or inputs from the
 user. These are specified in the scheduler configuration using their exact
@@ -125,6 +131,7 @@ nodes's labels, it returns false. Otherwise, it returns true.
 * If "presence" is true, and any of the requested labels do not match any of
 the node's labels, it returns false. Otherwise, it returns true.
 
+[[available-priority-functions]]
 == Available Priority Functions
 A custom set of priority functions can be specified to configure the scheduler.
 There are several priority functions provided out-of-the-box in Kubernetes.
@@ -133,6 +140,7 @@ parameters. Multiple priority functions can be combined and different weights
 can be given to each in order to impact the prioritization. A weight is required
 to be specified and cannot be 0 or negative.
 
+[[static-priority-functions]]
 === Static Priority Functions
 These priority functions do not take any configuration parameters or inputs from
 the user. These are specified in the scheduler configuration using their exact
@@ -165,6 +173,7 @@ configs are provided. It is not required/recommended outside of testing.
 {"name" : "EqualPriority", "weight" : 1}
 ----
 
+[[configurable-priority-functions]]
 === Configurable Priority Functions
 These priority functions can be configured by the user by providing certain
 parameters.  They can be given any user-defined name. The type of the priority
@@ -188,7 +197,7 @@ regardless of its value.
 {"name" : "RackPreferred", "weight" : 1, "argument" : {"labelPreference" : {"label" : "rack"}}}
 ----
 
-
+[[scheduler-policy]]
 == Scheduler Policy
 The selection of the predicate and priority functions defines the policy for the
 scheduler. Administrators can provide a JSON file that specifies the predicates
@@ -238,10 +247,12 @@ xref:scheduler-sample-policies[sample policy configurations].
 xref:../install_config/master_node_configuration.adoc#launching-servers-using-configuration-files[master services]
 for the changes to take effect.
 
+[[use-cases]]
 == Use Cases
 One of the important use cases for scheduling within {product-title} is to
 support flexible affinity and anti-affinity policies.
 ifdef::openshift-enterprise,openshift-origin[]
+[[infrastructure-topological-levels]]
 === Infrastructure Topological Levels
 Administrators can define multiple topological levels for their infrastructure
 (nodes).
@@ -255,6 +266,7 @@ for their infrastructure topology, with three levels usually being adequate
 (eg. regions -> zones -> racks).  Lastly, administrators can specify affinity
 and anti-affinity rules at each of these levels in any combination.
 endif::openshift-enterprise,openshift-origin[]
+[[affinity]]
 === Affinity
 Administrators should be able to configure the scheduler to specify affinity at
 any topological level, or even at multiple levels. Affinity at a particular
@@ -264,6 +276,7 @@ of applications by allowing administrators to ensure that peer pods do not end
 up being too geographically separated. If no node is available within the same
 affinity group to host the pod, then the pod will not get scheduled.
 
+[[anti-affinity]]
 === Anti Affinity
 Administrators should be able to configure the scheduler to specify
 anti-affinity at any topological level, or even at multiple levels.
@@ -417,6 +430,7 @@ priorities:
 
 ----
 
+[[scheduler-extensibility]]
 == Scheduler Extensibility
 As is the case with almost everything else in Kubernetes/{product-title}, the
 scheduler is built using a plug-in model and the current implementation itself
@@ -425,12 +439,14 @@ is a plug-in. There are two ways to extend the scheduler functionality:
 * Enhancements
 * Replacement
 
+[[enhancements]]
 === Enhancements
 The scheduler functionality can be enhanced by adding new predicates and
 priority functions. They can either be contributed upstream or maintained
 separately. These predicates and priority functions would need to be registered
 with the scheduler factory and then specified in the scheduler policy file.
 
+[[replacement]]
 === Replacement
 Since the scheduler is a plug-in, it can be replaced in favor of an alternate
 implementation. The scheduler code has a clean separation that watches new pods

--- a/admin_solutions/authentication.adoc
+++ b/admin_solutions/authentication.adoc
@@ -126,16 +126,16 @@ Additionally, this basic configuration has no access control of its own; all
 LDAP users matching the configured filter are able to log into {product-title}.
 
 With the
-xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#[SSSD failover setup],
+xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#setting-up-for-ldap-failover[SSSD failover setup],
 FreeIPA and Active Directory can also set rules to specifically restrict which
 users can and cannot access {product-title}.
 
 The following three advanced topics begin where this basic LDAP authentication
 topic ends, and describe the setup for a fault-tolerant authentication system:
 
-. xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#[Setting up SSSD for LDAP Failover]
-. xref:../install_config/advanced_ldap_configuration/configuring_form_based_authentication.adoc#[Configuring Form-Based Authentication]
-. xref:../install_config/advanced_ldap_configuration/configuring_extended_ldap_attributes.adoc#[Configuring Extended LDAP Attributes]
+. xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#setting-up-for-ldap-failover[Setting up SSSD for LDAP Failover]
+. xref:../install_config/advanced_ldap_configuration/configuring_form_based_authentication.adoc#configuring-form-based-authentication[Configuring Form-Based Authentication]
+. xref:../install_config/advanced_ldap_configuration/configuring_extended_ldap_attributes.adoc#configuring-extended-ldap-attributes[Configuring Extended LDAP Attributes]
 ====
 
 [[config-ldap-auth-on-master]]

--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -196,7 +196,7 @@ $ oc rollback <deployment_config> --dry-run
 
 You can add a command to a container, which modifies the container's startup
 behavior by overruling the image's `ENTRYPOINT`. This is different from a
-xref:../dev_guide/deployments.html#pod-based-lifecycle-hook[lifecycle hook],
+xref:../dev_guide/deployments.adoc#pod-based-lifecycle-hook[lifecycle hook],
 which instead can be run once per deployment at a specified time.
 
 Add the `*command*` parameters to the `*spec*` field of the deployment

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -46,11 +46,10 @@ If you installed using the
 xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced
 installation] method and therefore do not have an installation configuration
 file, you can either try
-xref:../install_config/install/advanced_install.adoc#defining-an-installation-configuration-file[creating your own] based on
+xref:../install_config/install/quick_install.adoc#defining-an-installation-configuration-file[creating your own] based on
 your cluster's current configuration, or see the advanced installation method on
 how to
-xref:../install_config/install/advanced_install.adoc#adding-nodes-advanced[run
-the playbook for adding new nodes directly].
+xref:adding-nodes-advanced[run the playbook for adding new nodes directly].
 ////
 
 [IMPORTANT]
@@ -89,7 +88,7 @@ cluster by running the *_scaleup.yml_* playbook. This playbook queries the
 master, generates and distributes new certificates for the new hosts, then runs
 the configuration playbooks on the new hosts only. Before running the
 *_scaleup.yml_* playbook, complete all prerequisite
-xref:../install_config/install/prerequisites.html#host-preparation[host
+xref:../install_config/install/prerequisites.adoc#host-preparation[host
 preparation] steps.
 
 

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -963,7 +963,7 @@ OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0/16'
 ----
 +
 If using the
-xref:../install_config/install/quick_install.adoc#install-config-install-quick-install[Quick
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[Quick
 Installation] method, you can easily script a complete installation from a
 kickstart or cloud-init setup, change the default configuration file:
 +
@@ -975,7 +975,7 @@ kickstart or cloud-init setup, change the default configuration file:
 [[NOTE]]
 ====
 The
-xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Advanced
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Advanced
 Installation] method automatically changes *_/etc/sysconfig/docker_*.
 ====
 +

--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -210,7 +210,7 @@ $ oadm manage-node <ramp_node_hostname> --schedulable=false
 
 [NOTE]
 ====
-The xref:../install_config/install/deploy_router.html#deploying-the-f5-router[F5
+The xref:../install_config/install/deploy_router.adoc#deploying-the-f5-router[F5
 router plug-in] integrates with F5 BIG-IP®.
 ====
 

--- a/install_config/upgrading/blue_green_deployments.adoc
+++ b/install_config/upgrading/blue_green_deployments.adoc
@@ -81,7 +81,7 @@ In the case of nodes requiring the uptime guarantees of a blue-green deployment,
 the `-l` flag can be used to match a subset of the environment using a selector.
 
 . Create the new green environment for any nodes that are to be replaced by
-xref:../install/advanced_install.adoc#adding-nodes-advanced[adding an equal
+xref:../../install_config/adding_hosts_to_existing_cluster.adoc#adding-nodes-advanced[adding an equal
 number of new nodes] to the existing cluster. Ansible can apply the
 `*color=green*` label using the `*openshift_node_labels*` variable for each
 node.
@@ -125,9 +125,9 @@ Source-to-Image (S2I). Upon import, any builds or deployments configured with
 [NOTE]
 ====
 To continue with the upgrade process,
-xref:../../install_config/upgrading/manual_upgrades.html#updating-the-default-image-streams-and-templates[update
+xref:../../install_config/upgrading/manual_upgrades.adoc#updating-the-default-image-streams-and-templates[update
 the default image streams and templates] and
-xref:../../install_config/upgrading/manual_upgrades.html#importing-the-latest-images[import
+xref:../../install_config/upgrading/manual_upgrades.adoc#importing-the-latest-images[import
 the latest images].
 ====
 

--- a/registry_quickstart/administrators/index.adoc
+++ b/registry_quickstart/administrators/index.adoc
@@ -124,7 +124,7 @@ $ sudo systemctl restart docker.service
 
 Here are some topics you may follow to explore {product-title}:
 
-* xref:../developers.adoc#[Login with docker and push an image].
-* Complete the xref:system_configuration.adoc#[system configuration].
-* Create xref:../../admin_guide/service_accounts.adoc#[service accounts] to use
+* xref:../developers.adoc#registry-quickstart-developers[Login with docker and push an image].
+* Complete the xref:system_configuration.adoc#registry-quickstart-administrators-system-configuration[system configuration].
+* Create xref:../../admin_guide/service_accounts.adoc#admin-guide-service-accounts[service accounts] to use
 in automation.

--- a/registry_quickstart/administrators/system_configuration.adoc
+++ b/registry_quickstart/administrators/system_configuration.adoc
@@ -47,7 +47,7 @@ to manage container lifecycle. Here we restart the atomic-registry-master servic
 $ sudo systemctl restart atomic-registry-master.service
 ----
 
-The xref:index.html#service-components[three services] may be restarted
+The xref:index.adoc#service-components[three services] may be restarted
 independently.
 
 === Master Configuration
@@ -63,9 +63,9 @@ $ sudo systemctl restart atomic-registry-master.service
 
 Global configuration items managed by this configuration file include:
 
-* xref:../../install_config/configuring_authentication.adoc#[Configure authentication]
+* xref:../../install_config/configuring_authentication.adoc#install-config-configuring-authentication[Configure authentication]
   by integrating with an identity provider
-* Manage xref:../../admin_guide/managing_projects.adoc#[project namespace self-provisioning]
+* Manage xref:../../admin_guide/managing_projects.adoc#admin-guide-managing-projects[project namespace self-provisioning]
 
 Master log level is determined using the service unit configuration file mounted
 on the host at *_/etc/sysconfig/atomic-registry-master_*.
@@ -86,7 +86,7 @@ $ sudo systemctl restart atomic-registry-console.service
 
 The docker distribution registry configuration is managed by a file mounted on
 the host at *_/etc/atomic-registry/registry/config.yml_*. See
-xref:registry-configuration-reference[registry configuration reference] for complete settings.
+xref:registry-configuration-reference-sysconfig[registry configuration reference] for complete settings.
 
 Environment variables for this service are managed by a file mounted on the host
 at *_/etc/sysconfig/atomic-registry_*.
@@ -96,6 +96,8 @@ Configuration changes require a service restart.
 ----
 $ sudo systemctl restart atomic-registry.service
 ----
+
+[[registry-configuration-reference-sysconfig]]
 
 include::install_config/install/docker_registry.adoc[tags=registry-configuration-reference]
 
@@ -107,7 +109,7 @@ The service endpoints are secured by certificates that are mounted on the host a
 === Master
 
 The installer generates self-signed certificates during installation. See
-xref:../../install_config/certificate_customization.adoc#[certificate customization]
+xref:../../install_config/certificate_customization.adoc#install-config-certificate-customization[certificate customization]
 for customizing the API master certificates.
 
 === Registry
@@ -205,7 +207,7 @@ $ sudo systemctl restart docker.service
 By default the session token used for `docker login` is 24 hours. This
 requires users to run `docker login` every day. This value may be extended in
 the master configuration file *_/etc/atomic-registry/master/master-config.yaml_*.
-See xref:#using-service-account-tokens-for-authentication[below] for using
+See xref:using-service-account-tokens-for-authentication[below] for using
 long-lived service account tokens.
 
 In this example the session token expiration is extended to 30 days.
@@ -228,17 +230,17 @@ $ sudo systemctl restart atomic-registry-master.service
 
 Typically long-lived, token-based authentication is desired. As an alternative
 to using user session tokens that expire, users may use
-xref:../../admin_guide/service_accounts.html[service account tokens] to
+xref:../../admin_guide/service_accounts.adoc#admin-guide-service-accounts[service account tokens] to
 authenticate with docker. This is particularly useful when integrating automation.
 See the
-xref:../developers.html#using-service-account-tokens-for-docker-login[quickstart developer guide]
+xref:../developers.adoc#using-service-account-tokens-for-docker-login[quickstart developer guide]
 for instructions.
 
 == Data Persistence and Backup
 
 The data that should be persisted is the configuration, image data and the
 master database. The required directories are mounted from the container onto
-the host. See xref:index.html#service-components[Service Components table] for
+the host. See xref:index.adoc#service-components[Service Components table] for
 specific paths.
 
 == CLI
@@ -257,5 +259,5 @@ Using project "default" on server "https://localhost:8443".
 ----
 ====
 
-See xref:../../cli_reference/index.adoc#[CLI reference] for how to download the
+See xref:../../cli_reference/index.adoc#cli-reference-index[CLI reference] for how to download the
 remote CLI client and using the CLI.

--- a/registry_quickstart/developers.adoc
+++ b/registry_quickstart/developers.adoc
@@ -86,8 +86,8 @@ is used inconsistently.
 
 See the {product-title} User Guide for these topics:
 
-* xref:../dev_guide/authentication.adoc#[authentication]
-* xref:../dev_guide/managing_images.adoc#[managing images]
+* xref:../dev_guide/authentication.adoc#dev-guide-authentication[authentication]
+* xref:../dev_guide/managing_images.adoc#dev-guide-managing-images[managing images]
 
 [[using-service-account-tokens-for-docker-login]]
 === Using Service Account Tokens for Docker Login

--- a/registry_quickstart/index.adoc
+++ b/registry_quickstart/index.adoc
@@ -15,9 +15,9 @@ To get started with {product-title}, find the appropriate topic based on your ro
 |I am a... |Links to relevant topics
 
 .^|Administrator
-|xref:administrators/index.adoc#[Quick Install]
+|xref:administrators/index.adoc#registry-quickstart-administrators-index[Quick Install]
 
 |User
-.^|xref:developers.adoc#[Using the Registry]
+.^|xref:developers.adoc#registry-quickstart-developers[Using the Registry]
 
 |===

--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -23,7 +23,7 @@ the users of the cluster.
 == Authentication
 
 API calls must be authenticated with an access token or X.509 certificate. See
-xref:../architecture/additional_concepts/authentication.html#api-authentication[Authentication]
+xref:../architecture/additional_concepts/authentication.adoc#api-authentication[Authentication]
 in the Architecture documentation for an overview.
 
 This section highlights the token authentication method. With token
@@ -120,10 +120,10 @@ in the Architecture documentation for a deeper discussion on roles.
 [[rest-api-examples]]
 == Examples
 
-These examples are provided as a reference to provide quick success making REST
-API calls. They use insecure methods. In these examples a simple `GET` call is
-made to xref:../rest_api/openshift_v1.html#get-available-resources[list
-available resources].
+These examples are provided as a reference to provide quick success making 
+REST API calls. They use insecure methods. In these examples a simple `GET` 
+call is made to 
+xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[list available resources].
 
 [[rest-api-example-curl]]
 === cURL


### PR DESCRIPTION
Man, there were heaps! :weary: 

Tagging @adellape & @aweiteka - Tons of these broken links were in the "registry_quickstart", which it seems is only related to atomic-registry. Going forward, please be sure to verify xref links using the script authored by @vikram-redhat [1] so that broken links in the atomic registry quickstart do not affect the OpenShift docs team. Thank you.

[1] https://gitlab.cee.redhat.com/vigoyal/openshift-release-script/blob/master/check-links.sh
