### PR TITLE
Extend allocatable resources with new kubelet system resource stats

### DIFF
--- a/admin_guide/allocating_node_resources.adoc
+++ b/admin_guide/allocating_node_resources.adoc
@@ -101,6 +101,60 @@ status:
 ----
 ====
 
+[[system-resources-reported-by-node]]
+== System Resources Reported by Node
+
+Starting with {product-title}
+ifdef::openshift-enterprise[]
+3.3,
+endif::[]
+ifdef::openshift-origin[]
+1.3,
+endif::[]
+each node reports system resources utilized by the container runtime and kubelet.
+To better aid your ability to configure `*--system-reserved*` and `*--kube-reserved*`,
+you can introspect corresponding node's resource usage using the node summary API,
+which is accessible at *_<master>/api/v1/nodes/<node>/proxy/stats/summary_*.
+
+For instance, to access the resources from *cluster.node22* node, you can run:
+
+----
+$ curl <certificate details> https://<master>/api/v1/nodes/cluster.node22/proxy/stats/summary
+{
+    "node": {
+        "nodeName": "cluster.node22",
+        "systemContainers": [
+            {
+                "cpu": {
+                    "usageCoreNanoSeconds": 929684480915,
+                    "usageNanoCores": 190998084
+                },
+                "memory": {
+                    "rssBytes": 176726016,
+                    "usageBytes": 1397895168,
+                    "workingSetBytes": 1050509312
+                },
+                "name": "kubelet"
+            },
+            {
+                "cpu": {
+                    "usageCoreNanoSeconds": 128521955903,
+                    "usageNanoCores": 5928600
+                },
+                "memory": {
+                    "rssBytes": 35958784,
+                    "usageBytes": 129671168,
+                    "workingSetBytes": 102416384
+                },
+                "name": "runtime"
+            }
+        ]
+    }
+}
+----
+
+See xref:../rest_api/index.adoc[REST API Overview] for more details about certificate details.
+
 [[allocating-node-scheduler]]
 == Scheduler
 


### PR DESCRIPTION
The PR basically states that the `kubelet` extended its API with information about system resources (container runtime and kubelet itself). At the same time, it can be used to improve decision on the suitable amount of resources allocated for system daemons.
