### PR TITLE
add image policy documentation

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -399,6 +399,8 @@ Topics:
     File: service_accounts
   - Name: Managing Authorization Policies
     File: manage_authorization_policy
+  - Name: Image Policy
+    File: image_policy
   - Name: Scoped Tokens
     File: scoped_tokens
     Distros: openshift-enterprise

--- a/admin_guide/image_policy.adoc
+++ b/admin_guide/image_policy.adoc
@@ -1,0 +1,155 @@
+[[admin-guide-image-policy]]
+= Image Policy
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+[[image-policy-overview]]
+== Overview
+
+You can control which images are allowed to run on your cluster using the ImagePolicy
+admission plug-in (currently considered beta).  It allows you to control:
+
+ 1. the source of images: which registries can be used to pull images
+ 2. image resolution: force pods to run with immutable digests to ensure the image does not change due to a re-tag
+ 3. docker image label restrictions: force an image to have or not have particular labels
+ 4. image annotation restrictions: force an image in the integration docker registry to have or not have particular annotations
+
+
+[[image-policy-configuring-the-image-policy-admission-plug-in]]
+== Configuring the ImagePolicy Admission Plug-in
+
+To enable this feature, you'll need to configure the plug-in in `*_master-config.yaml_*`.
+Here is an annotated example file:
+
+====
+
+[source,yaml]
+----
+
+admissionConfig:
+  pluginConfig:
+    openshift.io/ImagePolicy:
+      configuration:
+        kind: ImagePolicyConfig
+        apiVersion: v1
+        resolveImages: AttemptRewrite <1>
+        executionRules: <2>
+        - name: execution-denied
+          # Reject all images that have the annotation images.openshift.io/deny-execution set to true.
+          # This annotation may be set by infrastructure that wishes to flag particular images as dangerous
+          onResources: <3>
+          - resource: pods
+          - resource: builds
+          reject: true <4>
+          matchImageAnnotations: <5>
+          - key: images.openshift.io/deny-execution
+            value: "true"
+          skipOnResolutionFailure: true <6>
+        - name: allow-images-from-internal-registry
+          # allows images from the internal registry and tries to resolve them
+          onResources:
+          - resource: pods
+          - resource: builds
+          matchIntegratedRegistry: true
+        - name: allow-images-from-dockerhub
+          onResources:
+          - resource: pods
+          - resource: builds
+          matchRegistries:
+          - docker.io
+
+----
+
+<1> Try to resolve images to an immutable image digest and update the image pull spec in the pod
+<2> Array of rules to evaluate against incoming resources.  If you only have reject==true rules
+    the default is "allow all".  If you have any accept rule, the default is "deny all".
+<3> Indicates which resources to enforce rules upon.  If nothing is specified, the default is "pods"
+<4> Indicates that if this rule matches, the pod should be rejected
+<5> List of annotations to match on the Image object's metadata
+<6> If you are not able to resolve the image, do not fail the pod
+
+====
+
+[[image-policy-testing-image-policy-admission-plug-in]]
+== Testing the ImagePolicy Admission Plug-in
+
+You can use the `openshift/image-policy-check` to test your configuration.
+For example, use the information above, then test like this:
+
+```
+oc import-image openshift/image-policy-check:latest --confirm
+
+```
+
+Create a pod using this yaml.  The pod should be created.
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-pod
+spec:
+  containers:
+  - image: docker.io/openshift/image-policy-check:latest
+    name: first
+```
+
+Create another pod pointing to a different registry.  The pod should be rejected.
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-pod
+spec:
+  containers:
+  - image: different-registry/openshift/image-policy-check:latest
+    name: first
+```
+
+Create a pod pointing to the internal registry using the imported image.  The pod should be created and
+if you look at the image specification, you should see a digest in place of the tag.
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-pod
+spec:
+  containers:
+  - image: <internal registry IP>:5000/<namespace>/image-policy-check:latest
+    name: first
+```
+
+Create a pod pointing to the internal registry using the imported image.  The pod should be created and
+if you look at the image specification, you should see the tag unmodified.
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-pod
+spec:
+  containers:
+  - image: <internal registry IP>:5000/<namespace>/image-policy-check:v1
+    name: first
+```
+
+Get the digest from `oc get istag/image-policy-check:latest` and use it for 
+`oc annotate images/<digest> images.openshift.io/deny-execution=true`, for example:
+`oc annotate images/sha256:09ce3d8b5b63595ffca6636c7daefb1a615a7c0e3f8ea68e5db044a9340d6ba8 images.openshift.io/deny-execution=true`
+
+Create this pod again, and you should see the pod rejected.
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-pod
+spec:
+  containers:
+  - image: <internal registry IP>:5000/<namespace>/image-policy-check:latest
+    name: first
+```


### PR DESCRIPTION
Adds documentation explaining how to use and test the ImagePolicy admission plugin.

@simon3z fyi
@smarterclayton beta or tech preview?  What's the distinction again?
