### PR TITLE
fix broken anchors, which is preventing builds to the portal (found s…

### DIFF
--- a/getting_started/developers_cli.adoc
+++ b/getting_started/developers_cli.adoc
@@ -33,6 +33,10 @@ xref:../whats_new/index.adoc#whats-new-index[what's new].
 endif::[]
 This version of {product-title} is significantly different from version 2 (v2).
 
+// end::overview[]
+
+// tag::overview-online[]
+
 ifdef::openshift-online[]
 Similar to xref:../getting_started/online_v2_vs_v3.adoc#getting-started-online-v2-vs-v3[{product-title} v2],
 endif::[]
@@ -44,7 +48,11 @@ application development. Language support centers around the
 xref:../dev_guide/app_tutorials/quickstarts.adoc#dev-guide-app-tutorials-quickstarts[Quickstart templates], which in
 turn leverage xref:../using_images/s2i_images/index.adoc#using-images-s2i-images-index[builder images].
 
+// end::overview-online[]
+
 [[getting-started-developers-cli-languages]]
+
+// tag::dev-cli-languages
 
 |===
 |Language|Implementations and Tutorials
@@ -117,11 +125,12 @@ development, but they rely on your development to create a useful application.
 In contrast, Instant Apps like Jenkins are instantly usable.
 ====
 
-// end::overview[]
+// end::dev-cli-languages
+
+[[developers-cli-before-you-begin]]
 
 // tag::beforeyoubegin[]
 
-[[developers-cli-before-you-begin]]
 == Before You Begin
 
 Before you can get started:
@@ -159,6 +168,7 @@ xref:../cli_reference/get_started_cli.adoc#cli-reference-get-started-cli[downloa
 
 // end::beforeyoubegin[]
 
+[[developers-cli-video]]
 == Tutorial Video
 
 The following video walks you through the rest of this topic:
@@ -166,9 +176,10 @@ https://access.redhat.com/videos/2481041[Click here to watch]
 
 image::dev-cli-video-thumb.png[CLI Getting Started Experience, 579, 246, link="https://access.redhat.com/videos/2481041"]
 
+[[developers-cli-forking-the-sample-repository]]
+
 // tag::forking[]
 
-[[developers-cli-forking-the-sample-repository]]
 == Forking the Sample Repository
 
 . Visit the https://github.com/openshift/ruby-ex[Ruby example] page while you are logged in to GitHub.

--- a/getting_started/developers_console.adoc
+++ b/getting_started/developers_console.adoc
@@ -11,8 +11,17 @@
 toc::[]
 
 include::getting_started/developers_cli.adoc[tag=overview]
+include::getting_started/developers_cli.adoc[tag=overview-online]
+
+[[getting-started-developers-console-languages]]
+
+include::getting_started/developers_cli.adoc[tag=dev-cli-languages]
+
+[[developers-console-before-you-begin]]
+
 include::getting_started/developers_cli.adoc[tag=beforeyoubegin]
 
+[[developers-console-browser-reqs]]
 == Browser Requirements
 
 Review the
@@ -20,6 +29,7 @@ xref:../architecture/infrastructure_components/web_console.adoc#architecture-inf
 and operating systems] that can be used to access the web console.
 
 ifdef::openshift-enterprise,openshift-dedicated,openshift-origin[]
+[[developers-console-video]]
 == Tutorial Video
 
 The following video walks you through the rest of this topic:
@@ -31,6 +41,7 @@ ifdef::openshift-enterprise,openshift-dedicated,openshift-origin[]
 
 include::getting_started/developers_cli.adoc[tag=forking]
 
+[[developers-console-creating-a-project]]
 == Creating a Project
 
 To create an application, you must first create a new project, then select an
@@ -45,6 +56,7 @@ creates a new deployment.
 +
 The web console's welcome screen loads.
 
+[[developers-console-creating-an-application]]
 == Creating an Application
 
 The Select Image or Template page gives you the option to create from a publicly
@@ -70,6 +82,7 @@ While the Ruby pod is being created, its status is shown as pending. The Ruby
 pod then starts up and displays its newly-assigned IP address. When the Ruby pod
 is running, the build is complete.
 
+[[developers-console-view-app]]
 == Viewing the Running Application
 If your DNS is correctly configured, then your new application can be accessed using a web browser. If you cannot access your application, then speak with your system administrator.
 
@@ -77,6 +90,8 @@ To view your new application:
 
 . In the web console, view the overview page to determine the web address for the application. For example, under *SERVICE: RUBY-EX* you should see something similar to: `ruby-ex-my-test.example.openshiftapps.com`.
 . Visit the web address for your new application.
+
+[[developers-console-configure-auto-builds]]
 
 // tag::deploycode1[]
 
@@ -110,6 +125,8 @@ The next time you push a code change to your forked repository, your application
 
 // end::deploycode2[]
 
+[[developers-console-write-code-change]]
+
 // tag::deploycode3[]
 
 == Writing a Code Change
@@ -128,6 +145,8 @@ Now going forward, all you need to do is push code updates and {product-title}
 handles the rest.
 
 // end::deploycode3[]
+
+[[developers-console-manually-rebuild-images]]
 
 === Manually Rebuilding Images
 

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -43,7 +43,7 @@ The automated upgrade performs the following steps for you:
 [IMPORTANT]
 ====
 Ensure that you have met all
-xref:../install_config/install/prerequisites.adoc#install-config-install-prerequisites[prerequisites]
+xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[prerequisites]
 before proceeding with an upgrade. Failure to do so can result in a failed
 upgrade.
 ====

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -27,7 +27,7 @@ standard upgrade process.
 [IMPORTANT]
 ====
 Ensure that you have met all
-xref:../install_config/install/prerequisites.adoc#install-config-install-prerequisites[prerequisites]
+xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[prerequisites]
 before proceeding with an upgrade. Failure to do so can result in a failed
 upgrade.
 ====


### PR DESCRIPTION
…ome broken xrefs, too, fixed those as well)

Jenkins was throwing errors trying to push the getting started guide due to redundant anchor names, which were due to some anchors being inside the tagged sections. Fixed it now.
