### PR TITLE
Add references to dotnet streams for rhel

### DIFF
--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -800,6 +800,7 @@ ifdef::openshift-enterprise[]
 ====
 ----
 # oc create -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
+# oc create -n openshift -f /usr/share/openshift/examples/image-streams/dotnet_imagestreams.json
 # oc create -n openshift -f /usr/share/openshift/examples/db-templates
 # oc create -n openshift -f /usr/share/openshift/examples/quickstart-templates
 # oc create -n openshift -f /usr/share/openshift/examples/xpaas-streams
@@ -850,7 +851,9 @@ into
 ====
 ----
 $ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.2/image-streams/image-streams-rhel7.json
+$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.2/image-streams/dotnet_imagestreams.json
 $ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.2/image-streams/image-streams-rhel7.json
+$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.2/image-streams/dotnet_imagestreams.json
 ----
 ====
 


### PR DESCRIPTION
The latest installer added .NET image streams for OCP installs. Add them to the upgrade docs.
