### PR TITLE
OSE 3.1 revhistory for PR#2612

### DIFF
--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -15,7 +15,7 @@
 
 |Affected Topic |Description of Change
 //Mon Aug 15 2016
-|xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs] 
+|xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs]
 |Added information on log locations within Kibana to the xref:../install_config/aggregate_logging.html#deploying-the-efk-stack[Deploying the EFK Stack] section.
 
 
@@ -31,11 +31,19 @@
 
 |Affected Topic |Description of Change
 //Mon Aug 08 2016
+
+|xref:../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Installing -> Prerequisites]
+|Updated Important boxes in the
+xref:../install_config/install/prerequisites.adoc#system-requirements[System
+Requirements] and
+xref:../install_config/install/prerequisites.adoc#installing-docker[Installing
+Docker] sections with more specific details regarding Docker versions
+and `yum update`.
+(https://bugzilla.redhat.com/show_bug.cgi?id=1341142[*BZ#1341142*])
+
 |xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs]
 |Added that NFS is a not suitable for Lucene storage, NFS is not supported, and how to
 use local storage.
-
-
 
 |===
 

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -11,13 +11,14 @@ date.
 
 // do-release: revhist-tables
 == Mon Aug 15 2016
-.Install Config
+.Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_mon_aug_15_2016]
+
 == Mon Aug 08 2016
-.Install Config
+.Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_mon_aug_08_2016]
 
-.Dev Guide
+.Developer Guide
 include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_mon_aug_08_2016]
 == Mon Aug 01 2016
 .Installation and Configuration


### PR DESCRIPTION
Retroactively adding this revhistory note for https://github.com/openshift/openshift-docs/pull/2612, a change I had made directly to the enterprise-3.1 branch.
