### PR TITLE
Update F5 deploy instructions

### DIFF
--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -1368,6 +1368,12 @@ and endpoints and configuring *F5 BIG-IP®* accordingly, running the F5 router i
 this way along with an appropriately configured *F5 BIG-IP®* deployment should
 satisfy high-availability requirements.
 
+The F5 router will also need to be run in privileged mode because route certificates get copied using 'scp'.
+----
+$ oadm policy remove-scc-from-user hostnetwork -z router
+$ oadm policy add-scc-to-user privileged -z router
+----
+
 To deploy the F5 router:
 
 . First,


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1320490. The default deploying mechanism should use the privileged mode for an F5 router.
