### PR TITLE
--selector option, and re: quick install automatically deploys router and registry

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -235,9 +235,9 @@ Topics:
       - Name: Disconnected Installation
         File: disconnected_install
         Distros: openshift-enterprise
-      - Name: Deploying a Docker Registry
+      - Name: Configure or Deploy a Docker Registry
         File: docker_registry
-      - Name: Deploying a Router
+      - Name: Configure or Deploy a Router
         File: deploy_router
   - Name: Upgrading
     Dir: upgrading

--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -1,5 +1,5 @@
 [[install-config-install-deploy-router]]
-= Deploying a Router
+= Configure or Deploy the Router
 {product-author}
 {product-version}
 :data-uri:
@@ -19,20 +19,20 @@ in your {product-title} installation. {product-title} provides and supports the
 following two router plug-ins:
 
 - The
-xref:../../architecture/core_concepts/routes.adoc#haproxy-template-router[HAProxy
-template router] is the default plug-in. It uses the
+xref:../../architecture/core_concepts/routes.adoc#haproxy-template-router[HAProxy template router] 
+is the default plug-in. It uses the
 ifdef::openshift-enterprise[]
 *openshift3/ose-haproxy-router*
 endif::[]
 ifdef::openshift-origin[]
 *openshift/origin-haproxy-router*
 endif::[]
- image to run an HAProxy instance alongside the template router plug-in inside a
-container on {product-title}. It currently supports HTTP(S) traffic and TLS-enabled
-traffic via SNI. The router's container listens on the host network interface,
-unlike most containers that listen only on private IPs. The router proxies
-external requests for route names to the IPs of actual pods identified by the
-service associated with the route.
+image to run an HAProxy instance alongside the template router plug-in inside a
+container on {product-title}. It currently supports HTTP(S) traffic and
+TLS-enabled traffic via SNI. The router's container listens on the host network
+interface, unlike most containers that listen only on private IPs. The router
+proxies external requests for route names to the IPs of actual pods identified
+by the service associated with the route.
 
 - The xref:../../architecture/core_concepts/routes.adoc#f5-router[F5 router]
 integrates with an existing *F5 BIG-IP®* system in your environment to
@@ -103,13 +103,15 @@ $ oadm policy add-cluster-role-to-user \
 
 [[haproxy-router]]
 == Deploying the Default HAProxy Router
+
 The `oadm router` command is provided with the administrator CLI to simplify the
-tasks of setting up routers in a new installation.
-This command creates the service and deployment configuration objects.
-Just about every form of
-communication between {product-title} components is secured by TLS and uses various
-certificates and authentication methods. Use the `--credentials` option to
-specify what credentials the router should use to contact the master.
+tasks of setting up routers in a new installation. If you followed the
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation], then
+a default router was automatically created for you. The `oadm router` command
+creates the service and deployment configuration objects. Just about every form
+of communication between {product-title} components is secured by TLS and uses
+various certificates and authentication methods. Use the `--credentials` option
+to specify what credentials the router should use to contact the master.
 
 [IMPORTANT]
 ====
@@ -161,6 +163,9 @@ routers deployment configuration and you may want to increase them based on the
 load of the router.
 ====
 
+[[deploy-router-check-default]]
+Checking the Default Router::
+
 ifdef::openshift-enterprise[]
 The default router service account, named *router*, is automatically created during quick and advanced installations. To verify that this account already exists:
 endif::[]
@@ -185,6 +190,9 @@ $ oadm router --dry-run --service-account=router \
 ----
 endif::[]
 
+[[deploy-router-viewing-default]]
+Viewing the Default Router::
+
 To see what the default router would look like if created:
 
 ifdef::openshift-enterprise[]
@@ -201,7 +209,12 @@ $ oadm router -o yaml --service-account=router \
 ----
 endif::[]
 
-To create a router if it does not exist:
+[[deploy-router-create-router]]
+Creating a Router::
+
+The 
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation] 
+process automatically creates a default router. To create a router if it does not exist:
 
 ifdef::openshift-enterprise[]
 ----
@@ -218,8 +231,53 @@ $ oadm router <router_name> --replicas=<number> \
 ----
 endif::[]
 
+[[deploy-router-to-labeled-nodes]]
+Deploying the Router to a Labeled Node::
+
+To deploy the router to any node(s) that match a specified 
+xref:../../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[node label]:
+
+ifdef::openshift-enterprise[]
+----
+$ oadm router <router_name> --replicas=<number> --selector=<label> \
+    --credentials='/etc/origin/master/openshift-router.kubeconfig' \
+    --service-account=router
+----
+
+For example, if you want to create a router named `router` and have it placed on a node labeled with `region=infra`:
+----
+$ oadm router router --replicas=1 --selector='region=infra' \ 
+  --credentials='/etc/origin/master/openshift-router.kubeconfig' \
+  --service-account=router
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+$ oadm router <router_name> --replicas=<number> --selector=<label> \
+    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
+    --service-account=router
+----
+
+For example, if you want to create a router named `router` and have it placed on a node labeled with `region=infra`:
+----
+$ oadm router router --replicas=1 --selector='region=infra' \ 
+  --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
+  --service-account=router
+----
+endif::[]
+
+During 
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation], 
+the `*openshift_hosted_router_selector*` and `*openshift_registry_selector*`
+Ansible settings are set to *region=infra* by default. The default router and
+registry will only be automatically deployed if a node exists that matches the
+*region=infra* label.
+
 Multiple instances are created on different hosts according to the
 xref:../../admin_guide/scheduler.adoc#admin-guide-scheduler[scheduler policy].
+
+[[deploy-router-different-image]]
+Using a Different Router Image::
 
 To use a different router image and view the router configuration that would be used:
 

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -1,5 +1,5 @@
 [[install-config-install-docker-registry]]
-= Deploying a Docker Registry
+= Configure or Deploy a Docker Registry
 {product-author}
 {product-version]
 :data-uri:
@@ -45,14 +45,36 @@ $ oadm registry --config=admin.kubeconfig \//<1>
 ----
 endif::[]
 ifdef::openshift-enterprise[]
+Starting in {product-title} 3.2, 
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installations] 
+automatically handle the initial deployment of the Docker registry and the
+{product-title} router. However, you may need to manually create the registry
+if:
+
+- You did an 
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced install] and did not include the `*openshift_registry_selector*` variable.
++
+Or,
+- For some reason it was not automatically deployed during a quick installation.
++
+Or,
+- You deleted the registry and need to deploy it again.
+
 To deploy the integrated Docker registry, use the `oadm registry` command as a
 user with cluster administrator privileges. For example:
 
 ----
 $ oadm registry --config=/etc/origin/master/admin.kubeconfig \//<1>
     --service-account=registry \//<2>
-    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' <3>
+    --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \//<3>
+    --selector='region=infra' <4>
 ----
+During 
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation], 
+the `*openshift_registry_selector*` and `*openshift_hosted_router_selector*`
+Ansible settings are set to *region=infra* by default. The default router and
+registry will only be automatically deployed if a node exists that matches the
+*region=infra* label.
 endif::[]
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 <1> `--config` is the path to the
@@ -63,6 +85,8 @@ administrator].
 endif::[]
 ifdef::openshift-enterprise[]
 <3> Required to pull the correct image for {product-title}.
+<4> Optionally, you can specify the node location where you want to install the registry by specifying the corresponding 
+xref:../../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[node label].
 endif::[]
 
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]

--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -348,6 +348,6 @@ Now that you have a working {product-title} instance, you can:
 authentication]; by default, authentication is set to
 xref:../../install_config/configuring_authentication.adoc#DenyAllPasswordIdentityProvider[Deny
 All].
-- Deploy an xref:docker_registry.adoc#install-config-install-docker-registry[integrated Docker registry].
-- Deploy a xref:deploy_router.adoc#install-config-install-deploy-router[router].
+- Configure the automatically-deployed xref:docker_registry.adoc#install-config-install-docker-registry[integrated Docker registry].
+- Configure the automatically-deployed xref:deploy_router.adoc#install-config-install-deploy-router[router].
 endif::[]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1350289

Added --selector option to both the Router and Registry topics in the install guide.

Also made changes since the quick install now automatically deploys the docker registry and the router.

We did a lot of digging, and the --selector option does not appear to have been in the docs before. I read the kbase articles linked to in the discussion that sparked this BZ:

https://access.redhat.com/solutions/2293161
https://access.redhat.com/articles/1598953

but I don't think 1598953 is inferring that the --selector option was in the docs, rather that you can set default node selector while installing via Ansible, as per the links provided.

So what I've done is document the --selector option for both router and registry, as well as made some changes to indicate that both router and registry are now automatically deployed if using the quick install, but not the advanced install. For the advanced, the Ansible variables responsible for setting default node selector during installation are already documented:

openshift_hosted_router_selector
openshift_registry_selector

Rendered docs for review here:

http://file.bne.redhat.com/tpoitras/2016/selector/openshift-enterprise/selector-BZ1350289/install_config/install/docker_registry.html

http://file.bne.redhat.com/tpoitras/2016/selector/openshift-enterprise/selector-BZ1350289/install_config/install/deploy_router.html
