### PR TITLE
Modifications from testing and review, including:

### DIFF
--- a/getting_started/basic_walkthrough.adoc
+++ b/getting_started/basic_walkthrough.adoc
@@ -16,7 +16,11 @@ This guide demonstrates how to get a simple project up and running on
 
 The following sections guide you through creating a project that contains a
 sample Node.js application that will serve a welcome page and the current hit
-count (stored in a database) using the {product-title}  web console.
+count (stored in a database) using the {product-title}  web console. This 
+involves creating two xref:../architecture/core_concepts/pods_and_services.adoc#pods[pods]:
+
+- one to host the Node.js application
+- one to host the MongoDB database
 
 The tutorial assumes that you have:
 
@@ -103,27 +107,26 @@ MongoDB pod then starts up and displays its newly-assigned IP address.
 
 In this section, you will configure a GitHub webhook to automatically trigger a
 rebuild of your application whenever you push code changes to your forked
-repository.
+repository. This involves adding the Github webhook URL from your application
+into your Github repository. You obtain this webhook from these locations:
 
-. At the bottom of *Next Steps* page shown after creating your app, you will see a
+- At the bottom of *Next Steps* page shown after creating your app, you will see a
 section titled *Making code changes*. Copy the payload URL from the bottom of
 the page and follow the link to the GitHub project webhook settings page
 provided:
 +
 image::gs-copy-webhook.png[Copy webhook]
-+
-[NOTE]
-====
-You can find your GitHub webhook URL at any time in the web console:
 
-.. From the web console, navigate to the project containing your application.
+- In the {product-title}  web console:
+.. Navigate to the project containing your application.
 .. Click the *[ Browse ]* tab, then click *[ Builds ]*, then click the name of the
 build for your Node.js application.
 .. From the *[ Configuration ]* tab, click image:copy.jpg[] next to *GitHub webhook
 URL* to copy your GitHub webhook.
-====
 
-. Next, in GitHub click *[ Add webhook ]* in the GitHub Webhook settings for your
+Next, add the webhook to the Github repository:
+
+. In GitHub click *[ Add webhook ]* in the GitHub Webhook settings for your
 project. Paste the payload URL into the *Payload URL* field, then click *[ Add
 webhook ]* to finish adding the webhook to your project:
 +

--- a/getting_started/beyond_the_basics.adoc
+++ b/getting_started/beyond_the_basics.adoc
@@ -26,7 +26,11 @@ xref:../getting_started/online_v2_vs_v3.adoc#getting-started-online-v2-vs-v3[wha
 
 The following sections guide you through creating a project that contains a
 sample Node.js application that will serve a welcome page and the current hit
-count (stored in a database).
+count (stored in a database). This 
+involves creating two xref:../architecture/core_concepts/pods_and_services.adoc#pods[pods]:
+
+- one to host the Node.js application
+- one to host the MongoDB database
 
 The tutorial assumes that you have:
 


### PR DESCRIPTION
- Added basic description of the pods used in the example app
- Converted the Github webhook URL locations to a set of list items. Previously, this was instructions to use the URL on the post-creation page with an admonition for the location in the UI. However, due to the previous instructions users might have navigated away from the post-creation page (to Overview). It was easy to overlook the instructions for the location in the web UI.
