### PR TITLE
updated kube version

### DIFF
--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -40,7 +40,7 @@ availability] (HA) to ensure that the cluster has no single point of failure.
 ifdef::openshift-enterprise,openshift-dedicated[]
 {product-version}
 endif::[]
-uses Kubernetes 1.2 and Docker 1.9.
+uses Kubernetes 1.3 and Docker 1.9.
 ====
 endif::[]
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1364751

Simple updated mention of underlying rebased kubernetes version 1.3

Didn't find any other instances in the docs that mention what version we use, except one place about restricting anything using version 1.2, which should be fine.

Ping @bfallonf @ahardin-rh @adellape  for peer review: I'm pretty sure this is the simplest update but if anyone else knows somewhere I might have missed (don't think I did) please let me know.
