### PR TITLE
Revert "Bug 1366312, remove oc set volume from 3.1 docs"

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -463,7 +463,7 @@ as in this example (where we assume storage is mounted at the same path on each 
 ifdef::openshift-origin[]
 ----
 $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
-    oc volume $dc \
+    oc set volume $dc \
           --add --overwrite --name=elasticsearch-storage \
           --type=hostPath --path=/usr/local/es-storage
     oc deploy --latest $dc
@@ -474,7 +474,7 @@ endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 ----
 $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
-    oc volume $dc \
+    oc set volume $dc \
           --add --overwrite --name=elasticsearch-storage \
           --type=hostPath --path=/usr/local/es-storage
     oc scale $dc --replicas=1
@@ -488,7 +488,7 @@ xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[P
 as in the following example:
 
 ----
-$ oc volume dc/logging-es-<unique> \
+$ oc set volume dc/logging-es-<unique> \
           --add --overwrite --name=elasticsearch-storage \
           --type=persistentVolumeClaim --claim-name=logging-es-1
 ----


### PR DESCRIPTION
This reverts commit e07b7cdcf092fd4f2ce308a0ab7b9dba79652f4c.

The commit introduced in https://github.com/openshift/openshift-docs/pull/2654 should be introduced directly to the 3.1 branch and not to master, so reverting and will apply changes in a separate PR.
