### PR TITLE
Bug 1366312, remove oc set volume from 3.1 docs

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -465,7 +465,7 @@ as in this example (where we assume storage is mounted at the same path on each 
 ifdef::openshift-origin[]
 ----
 $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
-    oc set volume $dc \
+    oc volume $dc \
           --add --overwrite --name=elasticsearch-storage \
           --type=hostPath --path=/usr/local/es-storage
     oc deploy --latest $dc
@@ -476,7 +476,7 @@ endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 ----
 $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
-    oc set volume $dc \
+    oc volume $dc \
           --add --overwrite --name=elasticsearch-storage \
           --type=hostPath --path=/usr/local/es-storage
     oc scale $dc --replicas=1
@@ -490,7 +490,7 @@ xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[P
 as in the following example:
 
 ----
-$ oc set volume dc/logging-es-<unique> \
+$ oc volume dc/logging-es-<unique> \
           --add --overwrite --name=elasticsearch-storage \
           --type=persistentVolumeClaim --claim-name=logging-es-1
 ----


### PR DESCRIPTION
Reverted these changes from master in https://github.com/openshift/openshift-docs/pull/2677 after applying the work to the wrong branch in https://github.com/openshift/openshift-docs/pull/2654

This PR reapplies the changes directly to enterprise-3.1
