### PR TITLE
Fixed the docs on how to protect the router from packet drops

### DIFF
--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -1093,10 +1093,10 @@ $ oadm policy add-scc-to-user privileged -z router
 You can now create privileged containers. Next, configure the router deployment
 configuration to use the privilege so that the router can set the iptables rules
 it needs. This patch changes the router deployment configuration so that the
-container that is created runs as root:
+container that is created runs as privileged (so gets the right capabilities) and runs as root:
 
 ----
-$ oc patch dc router -p '{"spec":{"template":{"spec":{"containers":[{"name":"router","securityContext":{"privileged":true}}]}}}}'
+$ oc patch dc router -p '{"spec":{"template":{"spec":{"containers":[{"name":"router","securityContext":{"privileged":true}}],"securityContext":{"runAsUser": 0}}}}}'
 ----
 
 *Configure the Router to Use iptables*


### PR DESCRIPTION
The previous docs were missing a piece for how to set up the
deployment config.  This corrects that.  As written, this will only
work with 3.3.  For 3.2 you need to set the environment variable to
'1' not 'true' and then it will work.

For bug 1269488
