### PR TITLE
Running a pod with a different service account

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -763,3 +763,22 @@ Labels can only be set to one value, so setting a node selector of `region=west`
 in a pod configuration that has `region=east` as the administrator-set default,
 results in a pod that will never be scheduled.
 ====
+
+[[run-pod-with-different-service-account]]
+== Running a Pod with a Different Service Account
+
+You can run a pod with a service account other than the default:
+
+. Edit the deployment configuration:
++
+----
+$ oc edit dc/<deployment_config>
+----
+. Add the `*serviceAccount*` and `*serviceAccountName*` parameters to the `*spec*` field, and specify the service account you want to use:
++
+----
+spec:
+  securityContext: {}
+  serviceAccount: <service_account>
+  serviceAccountName: <service_account>
+----


### PR DESCRIPTION
Updated dev guide -> deployments with info on how to run a pod with a different service account, as described in this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1364565

http://file.bne.redhat.com/tpoitras/2016/runpod/openshift-enterprise/run-pod-diff-svc-acc-BZ1364565/dev_guide/deployments.html#running-a-pod-with-a-different-service-account
