### PR TITLE
Fix some of asciibinder warnings

### DIFF
--- a/admin_solutions/authentication.adoc
+++ b/admin_solutions/authentication.adoc
@@ -557,7 +557,7 @@ list of users and verify that users were created successfully:
 ----
 $ oc get users
 NAME       UID                                    FULL NAME   IDENTITIES
-bobsmith   166a2367-33fc-11e6-bb22-4ccc6a0ad630   Bob Smith   ldap_provider:uid=bsmith,ou=users,dc=example,dc=com
+bobsmith   166a2367-33fc-11e6-bb22-4ccc6a0ad630   Bob Smith   ldap_provider:uid=bsmith,ou=users,dc=example,dc=com <1>
 ----
 <1> Identities in {product-title} are comprised of the identity provider name prefixed to the LDAP distinguished name (DN).
 ====

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -1979,7 +1979,7 @@ build hook.
 ====
 
 [[build-hooks-using-the-command-line]]
-==== Using the Command Line
+=== Using the Command Line
 
 The `oc set build-hook` command can be used to set the build hook for a build configuration.
 

--- a/getting_started/developers_cli.adoc
+++ b/getting_started/developers_cli.adoc
@@ -52,7 +52,7 @@ turn leverage xref:../using_images/s2i_images/index.adoc#using-images-s2i-images
 
 [[getting-started-developers-cli-languages]]
 
-// tag::dev-cli-languages
+// tag::dev-cli-languages[]
 
 |===
 |Language|Implementations and Tutorials
@@ -125,7 +125,7 @@ development, but they rely on your development to create a useful application.
 In contrast, Instant Apps like Jenkins are instantly usable.
 ====
 
-// end::dev-cli-languages
+// end::dev-cli-languages[]
 
 [[developers-cli-before-you-begin]]
 

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1078,8 +1078,6 @@ identity name. It is also used to build the callback URL.
 the CLI) are sent a `WWW-Authenticate` challenge header for this provider.
 This uses the link:http://doc.gitlab.com/ce/api/oauth2.html#resource-owner-password-credentials[Resource Owner Password Credentials]
 grant flow to obtain an access token from GitLab.
-<2> *GitLabIdentityProvider* cannot be used to send `WWW-Authenticate`
-challenges.
 <3> When *true*, unauthenticated token requests from web clients (like the web
 console) are redirected to GitLab to log in.
 <4> Controls how mappings are established between this provider's identities and user objects,
@@ -1231,8 +1229,6 @@ identity name. It is also used to build the redirect URL.
 the CLI) are sent a `WWW-Authenticate` challenge header for this provider.
 This requires the OpenID provider to support the
 link:https://tools.ietf.org/html/rfc6749#section-1.3.3[Resource Owner Password Credentials] grant flow.
-<2> *OpenIDIdentityProvider* cannot be used to send `WWW-Authenticate`
-challenges.
 <3> When *true*, unauthenticated token requests from web clients (like the web
 console) are redirected to the authorize URL to log in.
 <4> Controls how mappings are established between this provider's identities and user objects,

--- a/install_config/configuring_pipeline_execution.adoc
+++ b/install_config/configuring_pipeline_execution.adoc
@@ -14,6 +14,8 @@ toc::[]
 
 == Overview
 
+// tag::installconfig_configuring_pipeline_execution[]
+
 The first time a user creates a build configuration using the
 xref:../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline]
 build strategy,
@@ -69,3 +71,5 @@ When a Pipeline build configuration is created,
 no existing service name in the project matches the `*serviceName*` field.
 This means `*serviceName*` must be chosen such that it is unique in the project.
 ====
+
+// end::installconfig_configuring_pipeline_execution[]

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -409,13 +409,13 @@ supplementalGroups:
 ...
 ----
 <1> The `allow*` bools are the same as for the *restricted* SCC.
-<1> Name of the new SCC.
-<2> Numerically larger numbers have greater priority. Nil or omitted is the lowest
+<2> Name of the new SCC.
+<3> Numerically larger numbers have greater priority. Nil or omitted is the lowest
 priority. Higher priority SCCs sort before lower priority SCCs and thus have a
 better chance of matching a new pod.
-<3> `*supplementalGroups*` is a strategy and it is set to *MustRunAs*, which means
+<4> `*supplementalGroups*` is a strategy and it is set to *MustRunAs*, which means
 group ID checking is required.
-<4> Multiple ranges are supported. The allowed group ID range here is 5000 through
+<5> Multiple ranges are supported. The allowed group ID range here is 5000 through
 5999, with the default supplemental group being 5000.
 ====
 

--- a/install_config/storage_examples/binding_pv_by_label.adoc
+++ b/install_config/storage_examples/binding_pv_by_label.adoc
@@ -63,7 +63,7 @@ configuration.
 ====
 
 [[binding-pv-by-label-pv-with-labels]]
-==== Persistent Volume with Labels
+=== Persistent Volume with Labels
 .glusterfs-pv.yaml
 ====
 [source,yaml]
@@ -95,7 +95,7 @@ spec:
 ====
 
 [[binding-pv-by-label-pvc-with-selectors]]
-==== Persistent Volume Claim with Selectors
+=== Persistent Volume Claim with Selectors
 
 A claim with a *selector* stanza (see example below) attempts to match existing,
 unclaimed, and non-prebound PVs. The existence of a PVC selector ignores a PV's
@@ -130,7 +130,7 @@ spec:
 ====
 
 [[binding-pv-by-label-volume-endpoints]]
-==== Volume Endpoints
+=== Volume Endpoints
 
 To attach the PV to the Gluster volume, endpoints should be configured before
 creating our objects.

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -697,7 +697,7 @@ On subsequent deployments, this arranges for the
 MySQL configuration variable `*innodb_use_native_aio*`
 to have value `0`.
 
-1. Increase the `aio-max-nr` kernel resource.
+2. Increase the `aio-max-nr` kernel resource.
 The following example examines the current value of `aio-max-nr` and doubles it.
 +
 ----


### PR DESCRIPTION
I tried to fix annoying warnings from `asciibnder build`. I created a separate commit for each warning and also put the warning into the commit message. Later I can squash commits if you need.
