### PR TITLE
note the change to oc tag -d

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -118,9 +118,15 @@ that prevents the registry client from pulling from such a tag.
 
 [[tag-removal]]
 === Removing Tags from Image Streams
+To remove a tag completely from an image stream run:
 
-You can stop tracking a tag by removing the tag. For example, to stop tracking
-an existing *latest* tag:
+====
+----
+$ oc delete istag/ruby:latest
+----
+====
+
+or:
 
 ====
 ----
@@ -128,18 +134,6 @@ $ oc tag -d ruby:latest
 ----
 ====
 
-However, while the above command removes the tag from the image stream
-definition, it does not remove it from the image stream status. The image stream
-definition is user-defined, whereas the image stream status reflects the
-information the system has from the specification.
-
-To remove a tag completely from an image stream:
-
-====
-----
-$ oc delete istag/ruby:latest
-----
-====
 
 [[referencing-images-in-image-streams]]
 === Referencing Images in Image Streams


### PR DESCRIPTION
`oc tag -d` now matches `oc delete istag` behavior to better match user expectations.
