### PR TITLE
Bug 1368881, added info about the diagnostic for metrics in the Metrics Deployer Validations section

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -220,26 +220,26 @@ xref:../architecture/core_concepts/templates.adoc#architecture-core-concepts-tem
 === Using Secrets
 
 The Metrics Deployer will auto-generate self-signed certificates for use between its
-components and will generate a 
+components and will generate a
 xref:../architecture/core_concepts/routes.adoc#secured-routes[re-encrypting route] to expose
 the Hawkular Metrics service. This route is what allows the web console to access the Hawkular Metrics
 service.
 
 In order for the browser running the web console to trust the connection through this route,
-it must trust the route's certificate. This can be accomplished by 
+it must trust the route's certificate. This can be accomplished by
 xref:metrics-using-secrets-byo-certs[providing your own certificates] signed by a trusted
 Certificate Authority. The Metric Deployer's secret allows you to pass your own certificates
 which it will then use when creating the route.
 
 If you do not wish to provide your own certificates, the router's default certificate will
-be used instead. 
+be used instead.
 
 [[metrics-using-secrets-byo-certs]]
 ==== Providing Your Own Certificates
 
-To provide your own certificate which will be used by the 
+To provide your own certificate which will be used by the
 xref:../architecture/core_concepts/routes.adoc#secured-routes[re-encrypting route],
-you can pass these values as 
+you can pass these values as
 xref:../dev_guide/secrets.adoc#dev-guide-secrets[secrets] to the Metrics Deployer.
 
 The `hawkular-metrics.pem` value needs to contain the certificate in its *_.pem_*
@@ -257,7 +257,7 @@ $ oc secrets new metrics-deployer \
 When these secrets are provided, the deployer uses these values to specify the
 `key`, `certificate` and `caCertificate` values for the re-encrypting route it generated.
 
-For more information, please see the 
+For more information, please see the
 xref:../architecture/core_concepts/routes.adoc#secured-routes[re-encryption
 route documentation].
 
@@ -441,7 +441,7 @@ of the metrics components, use the `*IMAGE_VERSION*` parameter.
 [WARNING]
 ====
 It is highly recommended to not use *latest* for the *IMAGE_VERSION*. The *latest*
-version corresponds to the very latest version available and can cause issues if it brings in a 
+version corresponds to the very latest version available and can cause issues if it brings in a
 newer version not meant to function on the version of {product-title} you are currently running.
 ====
 
@@ -513,6 +513,12 @@ added, for example:
 $ oc new-app -f metrics-deployer.yaml \
     -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
     -p MODE=validate
+----
+
+There is also a diagnostic for metrics:
+
+----
+$ oadm diagnostics MetricsApiProxy
 ----
 
 [[configuring-openshift-metrics]]


### PR DESCRIPTION
The bulk of the content for https://bugzilla.redhat.com/show_bug.cgi?id=1368881 is addressed in https://github.com/openshift/openshift-docs/pull/1984
