### PR TITLE
valign callout descriptions

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -98,7 +98,7 @@ License: https://creativecommons.org/licenses/by/2.0/
 @media screen and (min-width: 769px) {
  body {
    margin-bottom: 200px;
- } 
+ }
 }
 @media screen and (max-width: 768px) {
   body, html {
@@ -565,8 +565,8 @@ ol.lowergreek { list-style-type: lower-greek; }
 td.hdlist1 { padding-right: .75em; font-weight: bold; }
 td.hdlist1, td.hdlist2 { vertical-align: top; }
 .literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
-.colist > table tr > td:first-of-type { padding: 0 .75em; line-height: 1; }
-.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+.colist > table tr > td:first-of-type { padding: 0 .75em; line-height: 1; vertical-align: top}
+.colist > table tr > td:last-of-type { padding: 0 0 1em 0; }
 .qanda > ol > li > p > em:only-child { color: #1d4b8f; }
 .thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
 .imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
@@ -645,7 +645,7 @@ span.icon > .fa { cursor: default; }
 .conum[data-value] * { color: white !important; }
 .conum[data-value] + b { display: none; }
 .conum[data-value]:after { content: attr(data-value); }
-pre .conum[data-value] { position: relative; top: -2px; }
+pre .conum[data-value] { text-shadow: 0 0; position: relative; top: -2px; }
 b.conum * { color: inherit !important; }
 .conum:not([data-value]):empty { display: none; }
 .print-only { display: none !important; }


### PR DESCRIPTION
Per @tbielawa suggestion.

Makes multi-line callout descriptions easier to read:

http://file.rdu.redhat.com/~adellape/083016/colist_valign/install_config/install/quick_install.html#defining-an-installation-configuration-file

Also matches the style seen on the Customer Portal builds:

https://access.redhat.com/documentation/en/openshift-enterprise/3.2/single/installation-and-configuration/#defining-an-installation-configuration-file

PTAL @nhr @vikram-redhat @sg00dwin Not sure if this the only spot this would need to be implemented.
