### PR TITLE
Bug 1303505 added info on cluster metrics when advanced installing

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -318,6 +318,12 @@ to the Docker configuration.
 |`*openshift_docker_blocked_registries*`
 |{product-title} adds the specified blocked registry or registries to the Docker
 configuration.
+
+|`*openshift_hosted_metrics_public_url*`
+|This variable sets the host name for integration with the metrics console. The
+default is
+`*https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics*`
+If you alter this variable, ensure the host name is accessible via your router.
 |===
 
 [[advanced-install-configuring-global-proxy]]
@@ -586,6 +592,84 @@ following:
 ----
 openshift_master_named_certificates=[{"certfile": "/root/STAR.openshift.com.crt", "keyfile": "/root/STAR.openshift.com.key", "names": ["custom.openshift.com"]}]
 openshift_master_overwrite_named_certificates=true
+----
+====
+
+[[advanced-install-cluster-metrics]]
+== Configuring Cluster Metrics
+
+Cluster metrics are not set to automatically deploy by default. Set the
+following to enable cluster metrics when using the advanced install:
+
+====
+----
+[OSEv3:vars]
+
+openshift_hosted_metrics_deploy=true
+----
+====
+
+=== Metrics Storage
+
+The `*openshift_hosted_metrics_storage_kind*` variable must be set in order to
+use persistent storage. If `*openshift_hosted_metrics_storage_kind*` is not set,
+then cluster metrics data is stored in an `EmptyDir` volume, which will
+be deleted when the Cassandra pod terminates.
+
+There are three options for enabling cluster metrics storage when using the
+advanced install:
+
+*Option A - NFS Host Group*
+
+When the following variables are set, an NFS volume is created during an
+advanced install with path *<nfs_directory>/<volume_name>* on the host within the
+[nfs] host group. For example, the volume path using these options would be
+*/exports/metrics*:
+
+====
+----
+[OSEv3:vars]
+
+openshift_hosted_metrics_storage_kind=nfs
+openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
+openshift_hosted_metrics_storage_nfs_directory=/exports
+openshift_hosted_metrics_storage_nfs_options='*(rw,root_squash)'
+openshift_hosted_metrics_storage_volume_name=metrics
+openshift_hosted_metrics_storage_volume_size=10Gi
+----
+====
+
+*Option B - External NFS Host*
+
+To use an external NFS volume, one must already exist with a path of
+*<nfs_directory>/<volume_name>* on the storage host.
+
+====
+----
+[OSEv3:vars]
+
+openshift_hosted_metrics_storage_kind=nfs
+openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
+openshift_hosted_metrics_storage_host=nfs.example.com
+openshift_hosted_metrics_storage_nfs_directory=/exports
+openshift_hosted_metrics_storage_volume_name=metrics
+openshift_hosted_metrics_storage_volume_size=10Gi
+----
+====
+
+The remote volume path using the following options would be
+*nfs.example.com:/exports/metrics*.
+
+*Option C - Dynamic*
+
+Use the following variable if your {product-title} environment supports dynamic
+volume provisioning for your cloud platform:
+
+====
+----
+[OSEv3:vars]
+
+#openshift_hosted_metrics_storage_kind=dynamic
 ----
 ====
 


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1303505

@sdodson WDYT?

I'm worried about the following:
- Is the placement in the right place in the right book?
- Am I correct in regards to putting the variable under the [OSEv3:vars] heading?
- I'm not sure how the end part of that you sent me. Where does it belong? In the OPTION C part, or does it apply overall:

https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.ose.example#L363-L365

I think that's all. Thanks for sending me the info!
