### PR TITLE
Restructure and rewrite of prereqs content

### DIFF
--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -222,11 +222,13 @@ Topics:
     Dir: install
     Distros: openshift-origin,openshift-enterprise
     Topics:
-      - Name: Overview
-        File: index
+      - Name: Planning
+        File: planning
       - Name: Prerequisites
         File: prerequisites
-      - Name: RPM vs Containerized
+      - Name: Host Preparation
+        File: host_preparation
+      - Name: Containerized Services
         File: rpm_vs_containerized
       - Name: Quick Installation
         File: quick_install

--- a/_build_cfg.yml
+++ b/_build_cfg.yml
@@ -228,7 +228,7 @@ Topics:
         File: prerequisites
       - Name: Host Preparation
         File: host_preparation
-      - Name: Containerized Services
+      - Name: Containerized Components
         File: rpm_vs_containerized
       - Name: Quick Installation
         File: quick_install

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -1,0 +1,581 @@
+[[install-config-install-host-preparation]]
+= Host Preparation
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+ifdef::openshift-origin[]
+[NOTE]
+====
+If you are using https://www.vagrantup.com[Vagrant] to run {product-title}, you
+do not need to go through the following sections. These changes are only
+necessary when you are setting up the host yourself. If you are using Vagrant,
+see the
+https://github.com/openshift/origin/blob/master/CONTRIBUTING.html#develop-on-virtual-machine-using-vagrant[Contributing
+Guide], then you can skip directly to trying out the
+xref:../../getting_started/administrators.adoc#try-it-out[sample applications].
+====
+endif::[]
+
+ifdef::openshift-enterprise[]
+
+[[software-prerequisites]]
+== Operating System Requirements
+
+A base installation of RHEL 7.1 or later or RHEL Atomic Host 7.2.4 or later is
+required for master and node hosts. See the following documentation for the
+respective installation instructions, if required:
+
+- https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/index.html[Red
+Hat Enterprise Linux 7 Installation Guide]
+- https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/installation-and-configuration-guide/[Red
+Hat Enterprise Linux Atomic Host 7 Installation and Configuration Guide]
+
+== Host Registration
+
+Each host must be registered using Red Hat Subscription Manager (RHSM) and have
+an active {product-title} subscription attached to access the required
+packages.
+
+. On each host, register with RHSM:
++
+----
+# subscription-manager register --username=<user_name> --password=<password>
+----
+
+. List the available subscriptions:
++
+----
+# subscription-manager list --available
+----
+
+. In the output for the previous command, find the pool ID for an {product-title} subscription and attach it:
++
+----
+# subscription-manager attach --pool=<pool_id>
+----
+
+. Disable all repositories and enable only the required ones:
++
+----
+# subscription-manager repos --disable="*"
+# subscription-manager repos \
+    --enable="rhel-7-server-rpms" \
+    --enable="rhel-7-server-extras-rpms" \
+    --enable="rhel-7-server-ose-3.2-rpms"
+----
+endif::[]
+
+== Installing Base Packages
+
+For RHEL 7 systems:
+
+. Install the following base packages:
++
+----
+# yum install wget git net-tools bind-utils iptables-services bridge-utils bash-completion
+----
+
+. Update the system to the latest packages:
++
+----
+# yum update
+----
+
+ifdef::openshift-enterprise[]
+. Install the following package, which provides {product-title} utilities and pulls in
+other tools required by the
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] and
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
+methods, such as Ansible and related configuration files:
++
+----
+# yum install atomic-openshift-utils
+----
+endif::[]
+
+For RHEL Atomic Host 7 systems:
+
+. Ensure the host is up to date by upgrading to the latest Atomic tree if one is
+available:
++
+----
+# atomic host upgrade
+----
+
+. After the upgrade is completed and prepared for the next boot, reboot the
+host:
++
+----
+# systemctl reboot
+----
+
+
+ifdef::openshift-origin[]
+[[preparing-for-advanced-installations-origin]]
+
+== Preparing for Advanced Installations
+
+If you plan to use the
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
+method, you must install Ansible and clone the *openshift-ansible* repository from
+GitHub, which provides the required playbooks and configuration files.
+
+For convenience, the following steps are provided if you want to use EPEL as a
+package source for Ansible:
+
+. Install the EPEL repository:
++
+----
+# yum -y install \
+    https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+----
+
+. Disable the EPEL repository globally so that it is not accidentally used during
+later steps of the installation:
++
+----
+# sed -i -e "s/^enabled=1/enabled=0/" /etc/yum.repos.d/epel.repo
+----
+
+. Install the packages for Ansible:
++
+----
+# yum -y --enablerepo=epel install ansible pyOpenSSL
+----
+
+To clone the *openshift-ansible* repository:
+
+----
+# cd ~
+# git clone https://github.com/openshift/openshift-ansible
+# cd openshift-ansible
+----
+
+[NOTE]
+====
+Be sure to stay on the *master* branch of the *openshift-ansible* repository
+when running an advanced installation.
+====
+endif::[]
+
+[[installing-docker]]
+== Installing Docker
+
+At this point, you should install Docker on all master and node hosts. This
+allows you to configure your xref:configuring-docker-storage[Docker storage
+options] before installing {product-title}.
+
+. For RHEL 7 systems, install Docker 1.10:
++
+----
+ifdef::openshift-enterprise[]
+# yum install docker-1.10.3
+endif::[]
+ifdef::openshift-origin[]
+# yum install docker
+endif::[]
+----
++
+[NOTE]
+====
+On RHEL Atomic Host 7 systems, Docker should already be installed, configured,
+and running by default.
+====
+
+. Edit the *_/etc/sysconfig/docker_* file and add `--insecure-registry
+172.30.0.0/16` to the `*OPTIONS*` parameter. For example:
++
+----
+OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0/16'
+----
++
+If using the
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[Quick
+Installation] method, you can easily script a complete installation from a
+kickstart or cloud-init setup, change the default configuration file:
++
+----
+# sed -i '/OPTIONS=.*/c\OPTIONS="--selinux-enabled --insecure-registry 172.30.0.0/16"' \
+/etc/sysconfig/docker
+----
++
+[[NOTE]]
+====
+The
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Advanced
+Installation] method automatically changes *_/etc/sysconfig/docker_*.
+====
++
+The `--insecure-registry` option instructs the Docker daemon to trust any Docker
+registry on the indicated subnet, rather than
+xref:docker_registry.adoc#securing-the-registry[requiring a certificate].
++
+[IMPORTANT]
+====
+172.30.0.0/16 is the default value of the `*servicesSubnet*` variable in the
+*_master-config.yaml_* file. If this has changed, then the `--insecure-registry`
+value in the above step should be adjusted to match, as it is indicating the
+subnet for the registry to use. Note that the `*openshift_master_portal_net*`
+variable can be set in the Ansible inventory file and used during the
+xref:advanced_install.adoc#configuring-ansible[advanced installation]
+method to modify the `*servicesSubnet*` variable.
+====
++
+[NOTE]
+====
+After the initial {product-title} installation is complete, you can choose to
+xref:docker_registry.adoc#securing-the-registry[secure the integrated Docker
+registry], which involves adjusting the `--insecure-registry` option
+accordingly.
+====
+
+[[configuring-docker-storage]]
+== Configuring Docker Storage
+
+Docker containers and the images they are created from are stored in Docker's
+storage back end. This storage is ephemeral and separate from any
+xref:../../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[persistent storage] allocated to
+meet the needs of your applications.
+
+.For RHEL Atomic Host
+
+The default storage back end for Docker on RHEL Atomic Host is a thin pool
+logical volume, which is supported for production environments. You must ensure
+that enough space is allocated for this volume per the Docker storage
+requirements mentioned in
+xref:../../install_config/install/prerequisites.adoc#system-requirements[System
+Requirements].
+
+If you do not have enough allocated, see
+https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/getting-started-with-containers/#managing_storage_with_docker_formatted_containers[Managing
+Storage with Docker Formatted Containers] for details on using
+*docker-storage-setup* and basic instructions on storage management in RHEL
+Atomic Host.
+
+.For RHEL
+
+The default storage back end for Docker on RHEL 7 is a thin pool on loopback
+devices, which is not supported for production use and only appropriate for
+proof of concept environments. For production environments, you must create a
+thin pool logical volume and re-configure Docker to use that volume.
+
+You can use the *docker-storage-setup* script included with Docker to create a
+thin pool device and configure Docker's storage driver. This can be done after
+installing Docker and should be done before creating images or containers. The
+script reads configuration options from the
+*_/etc/sysconfig/docker-storage-setup_* file and supports three options for
+creating the logical volume:
+
+- *Option A)* Use an additional block device.
+- *Option B)* Use an existing, specified volume group.
+- *Option C)* Use the remaining free space from the volume group where your root
+file system is located.
+
+Option A is the most robust option, however it requires adding an additional
+block device to your host before configuring Docker storage. Options B and C
+both require leaving free space available when provisioning your host.
+
+. Create the *docker-pool* volume using one of the following three options:
+
+** [[docker-storage-a]]*Option A) Use an additional block device.*
++
+In *_/etc/sysconfig/docker-storage-setup_*, set *DEVS* to the path of the block
+device you wish to use. Set *VG* to the volume group name you wish to create;
+*docker-vg* is a reasonable choice. For example:
++
+====
+----
+# cat <<EOF > /etc/sysconfig/docker-storage-setup
+DEVS=/dev/vdc
+VG=docker-vg
+EOF
+----
+====
++
+Then run *docker-storage-setup* and review the output to ensure the
+*docker-pool* volume was created:
++
+====
+----
+# docker-storage-setup                                                                                                                                                                                                                                [5/1868]
+0
+Checking that no-one is using this disk right now ...
+OK
+
+Disk /dev/vdc: 31207 cylinders, 16 heads, 63 sectors/track
+sfdisk:  /dev/vdc: unrecognized partition table type
+
+Old situation:
+sfdisk: No partitions found
+
+New situation:
+Units: sectors of 512 bytes, counting from 0
+
+   Device Boot    Start       End   #sectors  Id  System
+/dev/vdc1          2048  31457279   31455232  8e  Linux LVM
+/dev/vdc2             0         -          0   0  Empty
+/dev/vdc3             0         -          0   0  Empty
+/dev/vdc4             0         -          0   0  Empty
+Warning: partition 1 does not start at a cylinder boundary
+Warning: partition 1 does not end at a cylinder boundary
+Warning: no primary partition is marked bootable (active)
+This does not matter for LILO, but the DOS MBR will not boot this disk.
+Successfully wrote the new partition table
+
+Re-reading the partition table ...
+
+If you created or changed a DOS partition, /dev/foo7, say, then use dd(1)
+to zero the first 512 bytes:  dd if=/dev/zero of=/dev/foo7 bs=512 count=1
+(See fdisk(8).)
+  Physical volume "/dev/vdc1" successfully created
+  Volume group "docker-vg" successfully created
+  Rounding up size to full physical extent 16.00 MiB
+  Logical volume "docker-poolmeta" created.
+  Logical volume "docker-pool" created.
+  WARNING: Converting logical volume docker-vg/docker-pool and docker-vg/docker-poolmeta to pool's data and metadata volumes.
+  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
+  Converted docker-vg/docker-pool to thin pool.
+  Logical volume "docker-pool" changed.
+----
+====
+
+** [[docker-storage-b]]*Option B) Use an existing, specified volume group.*
++
+In *_/etc/sysconfig/docker-storage-setup_*, set *VG* to the desired volume
+group. For example:
++
+====
+----
+# cat <<EOF > /etc/sysconfig/docker-storage-setup
+VG=docker-vg
+EOF
+----
+====
++
+Then run *docker-storage-setup* and review the output to ensure the
+*docker-pool* volume was created:
++
+====
+----
+# docker-storage-setup
+  Rounding up size to full physical extent 16.00 MiB
+  Logical volume "docker-poolmeta" created.
+  Logical volume "docker-pool" created.
+  WARNING: Converting logical volume docker-vg/docker-pool and docker-vg/docker-poolmeta to pool's data and metadata volumes.
+  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
+  Converted docker-vg/docker-pool to thin pool.
+  Logical volume "docker-pool" changed.
+----
+====
+
+** [[docker-storage-c]]*Option C) Use the remaining free space from the volume
+ group where your root file system is located.*
++
+Verify that the volume group where your root file system resides has the desired
+free space, then run *docker-storage-setup* and review the output to ensure the
+*docker-pool* volume was created:
++
+====
+----
+# docker-storage-setup
+  Rounding up size to full physical extent 32.00 MiB
+  Logical volume "docker-poolmeta" created.
+  Logical volume "docker-pool" created.
+  WARNING: Converting logical volume rhel/docker-pool and rhel/docker-poolmeta to pool's data and metadata volumes.
+  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
+  Converted rhel/docker-pool to thin pool.
+  Logical volume "docker-pool" changed.
+----
+====
+
+. Verify your configuration. You should have a *dm.thinpooldev* value in the
+*_/etc/sysconfig/docker-storage_* file and a *docker-pool* logical volume:
++
+====
+----
+# cat /etc/sysconfig/docker-storage
+DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt
+dm.thinpooldev=/dev/mapper/docker--vg-docker--pool
+
+# lvs
+  LV          VG   Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
+  docker-pool rhel twi-a-t---  9.29g             0.00   0.12
+----
+====
++
+[IMPORTANT]
+====
+Before using Docker or {product-title}, verify that the *docker-pool* logical volume
+is large enough to meet your needs. The *docker-pool* volume should be 60% of
+the available volume group and will grow to fill the volume group via LVM
+monitoring.
+====
+
+. Check if Docker is running:
++
+----
+# systemctl is-active docker
+----
+
+. If Docker has not yet been started on the host, enable and start the service:
++
+----
+# systemctl enable docker
+# systemctl start docker
+----
++
+If Docker is already running, re-initialize Docker:
++
+[WARNING]
+====
+This will destroy any Docker containers or images currently on the host.
+====
++
+----
+# systemctl stop docker
+# rm -rf /var/lib/docker/*
+# systemctl restart docker
+----
++
+If there is any content in *_/var/lib/docker/_*, it must be deleted. Files
+will be present if Docker has been used prior to the installation of {product-title}.
+
+[[reconfiguring-docker-storage]]
+=== Reconfiguring Docker Storage
+
+Should you need to reconfigure Docker storage after having created the
+*docker-pool*, you should first remove the *docker-pool* logical volume. If you
+are using a dedicated volume group, you should also remove the volume group and
+any associated physical volumes before reconfiguring *docker-storage-setup*
+according to the instructions above.
+
+See
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Logical_Volume_Manager_Administration/index.html[Logical
+Volume Manager Administration] for more detailed information on LVM management.
+
+[[managing-docker-container-logs]]
+=== Managing Docker Container Logs
+
+Sometimes a container's log file (the
+*_/var/lib/docker/containers/<hash>/<hash>-json.log_* file on the node where the
+container is running) can increase to a problematic size. You can manage this by
+configuring Docker's `json-file` logging driver to restrict the size and number
+of log files.
+
+[options="header"]
+|===
+
+|Option |Purpose
+
+|`--log-opt max-size`
+|Sets the size at which a new log file is created.
+
+|`--log-opt max-file`
+|Sets the file on each host to configure the options.
+|===
+
+For example, to set the maximum file size to 1MB and always keep the last three
+log files, edit the *_/etc/sysconfig/docker_* file to configure `max-size=1M`
+and `max-file=3`:
+====
+----
+OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1M --log-opt max-file=3'
+----
+====
+
+Next, restart the Docker service:
+----
+# systemctl restart docker
+----
+
+[[viewing-available-container-logs]]
+=== Viewing Available Container Logs
+
+Container logs are stored in the *_/var/lib/docker/containers/<hash>/_*
+directory on the node where the container is running. For example:
+====
+----
+# ls -lh /var/lib/docker/containers/f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8/
+total 2.6M
+-rw-r--r--. 1 root root 5.6K Nov 24 00:12 config.json
+-rw-r--r--. 1 root root 649K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log
+-rw-r--r--. 1 root root 977K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log.1
+-rw-r--r--. 1 root root 977K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log.2
+-rw-r--r--. 1 root root 1.3K Nov 24 00:12 hostconfig.json
+drwx------. 2 root root    6 Nov 24 00:12 secrets
+----
+====
+
+See Docker's documentation for additional information on how to
+http://docs.docker.com/engine/reference/logging/overview/#the-json-file-options[Configure
+Logging Drivers].
+
+[[ensuring-host-access]]
+
+== Ensuring Host Access
+
+ifdef::openshift-origin[]
+The xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method requires
+endif::[]
+ifdef::openshift-enterprise[]
+The xref:quick_install.adoc#install-config-install-quick-install[quick] and xref:advanced_install.adoc#install-config-install-advanced-install[advanced
+installation] methods require
+endif::[]
+a user that has access to all hosts. If you want to run the installer as a
+non-root user, passwordless *sudo* rights must be configured on each destination
+host.
+
+For example, you can generate an SSH key on the host where you will invoke the
+installation process:
+
+----
+# ssh-keygen
+----
+
+Do *not* use a password.
+
+An easy way to distribute your SSH keys is by using a `bash` loop:
+
+----
+# for host in master.example.com \
+    node1.example.com \
+    node2.example.com; \
+    do ssh-copy-id -i ~/.ssh/id_rsa.pub $host; \
+    done
+----
+
+Modify the host names in the above command according to your configuration.
+
+== What's Next?
+
+ifdef::openshift-enterprise[]
+If you are interested in installing {product-title} using the containerized method
+(optional for RHEL but required for RHEL Atomic Host), see
+xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[Containerized Services]
+to prepare your hosts.
+
+When you are ready to proceed, you can install {product-title} using the
+xref:quick_install.adoc#install-config-install-quick-install[quick installation] or
+xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method.
+endif::[]
+
+ifdef::openshift-origin[]
+If you are interested in installing {product-title} using the containerized method
+(optional for Fedora, CentOS, or RHEL but required for RHEL Atomic Host), see
+xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[Containerized Services]
+to prepare your hosts.
+
+If you came here from xref:../../getting_started/administrators.adoc#getting-started-administrators[Getting
+Started for Administrators], you can now continue there by choosing an
+xref:../../getting_started/administrators.adoc#installation-methods[installation
+method]. Alternatively, you can install {product-title} using the
+xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method.
+endif::[]

--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -31,13 +31,12 @@ environment needs to be.
 
 * _Is xref:../../admin_guide/high_availability.adoc#admin-guide-high-availability[high availability]
 required?_ High availability is recommended for fault tolerance. In this
-situation, you might aim to use the xref:multi-masters-using-native-ha][Multiple Masters Using Native HA]
+situation, you might aim to use the xref:multi-masters-using-native-ha[Multiple Masters Using Native HA]
 example as a basis for your environment.
 
-* _Which installation type do you want to use:
-xref:rpm-vs-containerized[RPM or
-containerized]?_ Both installations provide a working 
-{product-title} environment, but you might have a preference for a particular
+* _Which installation type do you want to use: xref:rpm-vs-containerized[RPM or containerized]?_
+Both installations provide a working {product-title} environment, but you might
+have a preference for a particular
 method of installing, managing, and updating your services.
 
 [[installation-methods]]

--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -17,7 +17,7 @@ toc::[]
 For production environments, several factors influence installation. Consider
 the following questions as you read through the documentation:
 
-* _Which installation method do you want to use?_ The xref:environment-scenarios[Installation Methods]
+* _Which installation method do you want to use?_ The xref:installation-methods[Installation Methods]
 section provides some information about the quick and advanced installation
 methods.
 

--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -1,0 +1,232 @@
+[[install-config-install-planning]]
+= Planning
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[inital-planning]]
+== Initial Planning
+
+For production environments, several factors influence installation. Consider
+the following questions as you read through the documentation:
+
+* _Which installation method do you want to use?_ The xref:environment-scenarios[Installation Methods]
+section provides some information about the quick and advanced installation
+methods.
+
+* _How many hosts do you require in the cluster?_ The xref:environment-scenarios[Environment Scenarios]
+section provides multiple examples of Single Master and Multiple Master
+configurations.
+
+* _How many pods are required in your cluster?_ The xref:sizing[Sizing Considerations]
+section provides limits for nodes and pods so you can calculate how large your
+environment needs to be.
+
+* _Is xref:../../admin_guide/high_availability.adoc#admin-guide-high-availability[high availability]
+required?_ High availability is recommended for fault tolerance. In this
+situation, you might aim to use the xref:multi-masters-using-native-ha][Multiple Masters Using Native HA]
+example as a basis for your environment.
+
+* _Which installation type do you want to use:
+xref:rpm-vs-containerized[RPM or
+containerized]?_ Both installations provide a working 
+{product-title} environment, but you might have a preference for a particular
+method of installing, managing, and updating your services.
+
+[[installation-methods]]
+== Installation Methods
+
+Both the quick and advanced installations methods are supported for development and production environments. If you want to quickly get OpenShift Container Platform up and running to try out for the first time, use the quick installer and let the interactive CLI guide you through the configuration options relevant to your environment.
+
+For the most control over your cluster’s configuration, you can use the advanced installation method. This method is particularly suited if you are already familiar with Ansible. However, following along with the OpenShift Container Platform documentation should equip you with enough information to reliably deploy your cluster and continue to manage its configuration post-deployment using the provided Ansible playbooks directly.
+
+If you install initially using the quick installer, you can always further tweak your cluster’s configuration and adjust the number of hosts in the cluster using the same installer tool. If you wanted to later switch to using the advanced method, you can create an inventory file for your configuration and carry on that way.
+
+
+[[sizing]]
+== Sizing Considerations
+Determine how many nodes and pods you require for your {product-title} cluster.
+The following table provides the sizing limits for nodes and pods:
+
+[cols="4,2",options="header"]
+|===
+|Type |Maximum
+
+|Maximum nodes per cluster |300
+
+|Maximum pods per nodes |110
+|===
+
+For example, if you require 2200 pods, you need at least 20 nodes in your
+environment.
+
+This also means the maximum number of pods that can run safely in your
+environment is 33000.
+
+[IMPORTANT]
+====
+Oversubscribing the physical resources on a node affects resource guarantees the
+Kubernetes scheduler makes during pod placement. Learn what measures you can
+take to xref:../../admin_guide/overcommit.adoc#disabling-swap-memory[avoid memory swapping].
+====
+
+[[environment-scenarios]]
+== Environment Scenarios
+
+This section outlines different examples of scenarios for your {product-title}
+environment. Use these scenarios as a basis for planning your own 
+{product-title} cluster.
+
+[NOTE]
+====
+Moving from a single master cluster to multiple masters after installation is
+not supported.
+====
+
+[[single-master-multi-node]]
+=== Single Master and Multiple Nodes
+
+The following table describes an example environment for a single
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master] (with embedded *etcd*)
+and two
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]:
+
+[options="header"]
+|===
+
+|Host Name |Infrastructure Component to Install
+
+|*master.example.com*
+|Master and node
+
+|*node1.example.com*
+.2+.^|Node
+
+|*node2.example.com*
+|===
+
+[[single-master-multi-etcd-multi-node]]
+=== Single Master, Multiple etcd, and Multiple Nodes
+
+The following table describes an example environment for a single
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master],
+three
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[*etcd*]
+hosts, and two
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]:
+
+[options="header"]
+|===
+
+|Host Name |Infrastructure Component to Install
+
+|*master.example.com*
+|Master and node
+
+|*etcd1.example.com*
+.3+.^|*etcd*
+
+|*etcd2.example.com*
+
+|*etcd3.example.com*
+
+|*node1.example.com*
+.2+.^|Node
+
+|*node2.example.com*
+|===
+
+[NOTE]
+====
+When specifying multiple *etcd* hosts, external *etcd* is installed and
+configured. Clustering of {product-title}'s embedded *etcd* is not supported.
+====
+
+[[multi-masters-using-native-ha]]
+=== Multiple Masters Using Native HA
+
+The following describes an example environment for three
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[masters],
+one HAProxy load balancer, three
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[*etcd*]
+hosts, and two
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
+using the `native` HA method:
+
+[options="header"]
+|===
+
+|Host Name |Infrastructure Component to Install
+
+|*master1.example.com*
+.3+.^|Master (clustered using native HA) and node
+
+|*master2.example.com*
+
+|*master3.example.com*
+
+|*lb.example.com*
+|HAProxy to load balance API master endpoints
+
+|*etcd1.example.com*
+.3+.^|*etcd*
+
+|*etcd2.example.com*
+
+|*etcd3.example.com*
+
+|*node1.example.com*
+.2+.^|Node
+
+|*node2.example.com*
+|===
+
+[NOTE]
+====
+When specifying multiple *etcd* hosts, external *etcd* is installed and
+configured. Clustering of {product-title}'s embedded *etcd* is not supported.
+====
+
+[[rpm-vs-containerized]]
+== RPM vs Containerized
+
+An RPM installation installs all services through package
+management and configures services to run within the same user space, while a
+containerized installation configures installs services using container images
+and runs separate services in individual containers. 
+
+The default method for installing {product-title} on
+ifdef::openshift-origin[]
+Fedora, CentOS, or RHEL
+endif::[]
+ifdef::openshift-enterprise[]
+Red Hat Enterprise Linux (RHEL)
+endif::[]
+uses RPMs. Alternatively, you can use the containerized method, which deploys
+containerized {product-title} master and node components. When targeting a RHEL
+Atomic Host system, the containerized method is the only available option, and
+is automatically selected for you based on the detection of the
+*_/run/ostree-booted_* file.
+
+The following table outlines the differences between the RPM and Containerized
+methods:
+
+[cols="4,4,4,",options="header"]
+|===
+|Type |RPM  |Containerized 
+
+|Installation Method |Packages via `yum` |Container images via `docker`
+|Service Management |`systemd` |`docker` and `systemd` units 
+|Operating System | Red Hat Enterprise Linux | Red Hat Enterprise Linux or Red Hat Atomic Host
+|===
+
+The xref:rpm_vs_containerized.adoc[Containerized Installation Preparation]
+section provides more details on configuring your installation to use
+containerized services.

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -11,8 +11,6 @@
 
 toc::[]
 
-== Overview
-
 ifdef::atomic-registry[]
 [NOTE]
 ====
@@ -21,42 +19,15 @@ to an {product-title} deployment. The following is provided for reference.
 ====
 endif::[]
 
-ifdef::openshift-origin[]
-{product-title}
-xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#architecture-infrastructure-components-kubernetes-infrastructure[infrastructure
-components] can be installed across multiple hosts. The following sections
-outline the system requirements and instructions for preparing your environment
-and hosts before installing {product-title}.
-endif::[]
-
-ifdef::openshift-enterprise[]
-{product-title}
-xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#architecture-infrastructure-components-kubernetes-infrastructure[infrastructure
-components] can be installed across multiple hosts. The following sections
-outline the system requirements and instructions for preparing your environment
-and hosts before installing {product-title}.
-endif::[]
-
-[[prerequisites-planning]]
-== Planning
-
-For production environments, several factors that can influence installation
-must be considered prior to deployment:
-
-* What is the number of required hosts required to run the cluster?
-* How many pods are required in your cluster?
-* Is xref:../../admin_guide/high_availability.adoc#admin-guide-high-availability[high availability] required?
-High availability is recommended for fault tolerance.
-* Which installation type do you want to use:
-xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[RPM or
-containerized]?
-
-
 [[system-requirements]]
-
 == System Requirements
 
+The following sections identify the hardware specifications and system-level
+requirements of all hosts within your {product-title} environment.
+
 ifdef::openshift-enterprise[]
+[[red-hat-subscription]]
+=== Red Hat Subscriptions
 You must have an active {product-title} subscription on your Red Hat
 account to proceed. If you do not, contact your sales representative for more
 information.
@@ -69,10 +40,14 @@ xref:../../release_notes/ose_3_2_release_notes.adoc#ose-3-2-1-1[{product-title}
 ====
 endif::[]
 
+[[hardware]]
+=== Minimum Hardware Requirements
+
 The system requirements vary per host type:
 
 [cols="1,7"]
 |===
+
 |xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[Masters]
 a|- Physical or virtual system, or an instance running on a public or private IaaS.
 ifdef::openshift-origin[]
@@ -120,10 +95,10 @@ Storage in Red Hat Enterprise Linux Atomic Host] for instructions on configuring
 this during or after installation.
 ====
 
-[[host-recommendations]]
-=== Host Recommendations
-The following apply to production environments. Test or sample environments will
-function with the minimum requirements.
+=== Production Level Hardware Requirements
+
+Test or sample environments function with the minimum requirements. For
+production environments, the following recommendations apply:
 
 Master Hosts::
 In a highly-available {product-title} cluster with external etcd, a master host
@@ -140,21 +115,9 @@ hosts as well as a load-balancer between the master hosts, is required.
 Node Hosts::
 The size of a node host depends on the expected size of its workload. As an
 {product-title} cluster administrator, you will need to calculate the expected
-workload, then add about 10% for overhead. For production environments, allocate
-enough resources so that node host failure does not affect your maximum
+workload, then add about 10 per cent for overhead. For production environments,
+allocate enough resources so that node host failure does not affect your maximum
 capacity.
-
-Use the above with the following table to plan the maximum loads for nodes and
-pods:
-
-[cols="4,2",options="header"]
-|===
-|Host |Sizing Recommendation
-
-|Maximum nodes per cluster |300
-
-|Maximum pods per nodes |110
-|===
 
 [IMPORTANT]
 ====
@@ -164,7 +127,6 @@ take to xref:../../admin_guide/overcommit.adoc#disabling-swap-memory[avoid memor
 ====
 
 [[configuring-core-usage]]
-
 === Configuring Core Usage
 
 By default, {product-title} masters and nodes use all available cores in the
@@ -188,8 +150,28 @@ OpenShift in a Docker container], add `-e GOMAXPROCS=1` to the `docker run`
 command when launching the server.
 endif::[]
 
-[[security-warning]]
+[[prereq-selinux]]
+=== SELinux
 
+Security-Enhanced Linux (SELinux) must be enabled on all of the servers before
+installing {product-title} or the installer will fail. Also, configure
+`*SELINUXTYPE=targeted*` in the *_/etc/selinux/config_* file:
+
+----
+# This file controls the state of SELinux on the system.
+# SELINUX= can take one of these three values:
+#     enforcing - SELinux security policy is enforced.
+#     permissive - SELinux prints warnings instead of enforcing.
+#     disabled - No SELinux policy is loaded.
+SELINUX=enforcing
+# SELINUXTYPE= can take one of these three values:
+#     targeted - Targeted processes are protected,
+#     minimum - Modification of targeted policy. Only selected processes are protected.
+#     mls - Multi Level Security protection.
+SELINUXTYPE=targeted
+----
+
+[[security-warning]]
 === Security Warning
 
 {product-title} runs
@@ -212,31 +194,37 @@ context constraints] that control the actions that pods can perform and what it
 has the ability to access.
 
 [[envirornment-requirements]]
-
 == Environment Requirements
 
-The following must be set up in your environment before {product-title} can be
-installed.
+The following section defines the requirements of the environment containing
+your {product-title} configuration. This includes networking considerations
+and access to external services, such as a Git repository access, storage, and
+cloud infrastructure providers.
 
 [[prereq-dns]]
 === DNS
 
-A fully functional DNS environment is a requirement for {product-title} to work
-correctly. Adding entries into the *_/etc/hosts_* file is not enough, because
-that file is not copied into containers running on the platform.
+{product-title} requires a fully functional DNS server in the environment. This
+is ideally a separate host running DNS software and can provide name resolution
+to hosts and containers running on the platform.
 
-To configure the {product-title} DNS environment:
+[IMPORTANT]
+Adding entries into the *_/etc/hosts_* file on each host is not enough. This
+file is not copied into containers running on the platform.
 
-- xref:../../install_config/install/prerequisites.adoc#dns-config-prereq[Complete DNS configuration]
-- (Optionally) xref:../../install_config/install/prerequisites.adoc#wildcard-dns-prereq[configure a wildcard for the router]
+Key components of {product-title} run themselves inside of containers and use
+the following process for name resolution:
 
-Key components of {product-title} run themselves inside of containers. By
-default, these containers receive their *_/etc/resolv.conf_* DNS configuration
-file from their host. {product-title} then inserts one DNS value into the pods
+. By default, containers receive their DNS configuration
+file (*_/etc/resolv.conf_*) from their host.
+
+. {product-title} then inserts one DNS value into the pods
 (above the node's nameserver values). That value is defined in the
 *_/etc/origin/node/node-config.yaml_* file by the `*dnsIP*` parameter, which by
 default is set to the address of the host node because the host is using
-*dnsmasq*. If the `*dnsIP*` parameter is omitted from the *_node-config.yaml_*
+*dnsmasq*.
+
+. If the `*dnsIP*` parameter is omitted from the *_node-config.yaml_*
 file, then the value defaults to the kubernetes service IP, which is the first
 nameserver in the pod's *_/etc/resolv.conf_* file.
 
@@ -283,45 +271,38 @@ upgrade process.
 the DNS IP addresses.
 ====
 
-If you do not have a properly functioning DNS environment, you could experience failure with:
+The following is an example set of DNS records for the xref:planning.adoc#single-master-multi-node[Single Master and Multiple Nodes] scenario:
+
+----
+master    A   10.64.33.100
+node1     A   10.64.33.101
+node2     A   10.64.33.102
+----
+
+If you do not have a properly functioning DNS environment, you could experience
+failure with:
 
 - Product installation via the reference Ansible-based scripts
 - Deployment of the infrastructure containers (registry, routers)
-- Access to the {product-title} web console, because it is not accessible via IP address alone
+- Access to the {product-title} web console, because it is not accessible via
+IP address alone
 
 
 [[dns-config-prereq]]
-*Configuring a DNS Environment*
+==== Configuring Hosts to Use DNS
 
-To properly configure your DNS environment for {product-title}:
+Make sure each host in your environment is configured to resolve hostnames from
+your DNS server. The configuration for hosts' DNS resolution depend on whether
+DHCP is enabled. If DHCP is:
 
-. Check the contents of *_/etc/resolv.conf_*:
-+
-----
-$ cat /etc/resolv.conf
-# Generated by NetworkManager
-search ose3.example.com
-nameserver 10.64.33.1
-# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
-----
-. Ensure that the DNS servers listed in *_/etc/resolv.conf_* are able to resolve to the addresses of all the masters and nodes in your {product-title} environment:
-+
-----
-$ dig <node_hostname> @<IP_address> +short
-----
-+
-For example:
-+
-----
-$ dig node1.ose3.example.com @10.64.33.1 +short
-10.64.33.156
-$ dig master.ose3.example.com @10.64.33.1 +short
-10.64.33.37
-----
-. If DHCP is:
-+
-- Disabled, then configure your network interface to be static, and add DNS nameservers to NetworkManager.
-- Enabled, then the NetworkManager dispatch script automatically configures DNS based on the DHCP configuration. Optionally, you can add a value to `*dnsIP*` in the *_node-config.yaml_* file to prepend the pod's *_resolv.conf_* file. The second nameserver is then defined by the host's first nameserver. By default, this will be the IP address of the node host.
+- Disabled, then configure your network interface to be static, and add DNS
+nameservers to NetworkManager.
+
+- Enabled, then the NetworkManager dispatch script automatically configures DNS
+based on the DHCP configuration. Optionally, you can add a value to `*dnsIP*`
+in the *_node-config.yaml_* file to prepend the pod's *_resolv.conf_* file. The
+second nameserver is then defined by the host's first nameserver. By default,
+this will be the IP address of the node host.
 +
 [NOTE]
 ====
@@ -336,9 +317,38 @@ queries SkyDNS first, or to the SkyDNS service or endpoint IP (the Kubernetes
 service IP).
 ====
 
+To properly check that hosts are correctly configured to resolved to your DNS
+server:
+
+. Check the contents of *_/etc/resolv.conf_*:
++
+----
+$ cat /etc/resolv.conf
+# Generated by NetworkManager
+search example.com
+nameserver 10.64.33.1
+# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
+----
++
+In this example, 10.64.33.1 is the address of our DNS server.
+
+. Test the DNS servers listed in *_/etc/resolv.conf_* are able to resolve to the addresses of all the masters and nodes in your {product-title} environment:
++
+----
+$ dig <node_hostname> @<IP_address> +short
+----
++
+For example:
++
+----
+$ dig master.example.com @10.64.33.1 +short
+10.64.33.100
+$ dig node1.example.com @10.64.33.1 +short
+10.64.33.101
+----
 
 [[wildcard-dns-prereq]]
-*Configuring Wildcard DNS*
+==== Configuring a DNS Wildcard
 
 Optionally, configure a wildcard for the router to use, so that you do not need
 to update your DNS configuration when new routes are added.
@@ -366,21 +376,6 @@ domain is not listed in the search list. Otherwise, containers managed by
 {product-title} may fail to resolve host names properly.
 ====
 
-
-[[run-dns-diagnostics]]
-*Running Diagnostics*
-
-To explore your DNS setup and run specific DNS queries, you can use the `host` and `dig` commands (part of the `bind-utils` package). For example, you can query a specific DNS server, or check if recursion is involved.
-
-----
-$ host `hostname`
-ose3-master.example.com has address 172.16.25.41
-
-$ dig ose3-node1.example.com  +short
-172.16.25.45
-----
-
-
 [[prereq-network-access]]
 === Network Access
 
@@ -395,21 +390,24 @@ routable between all of your nodes, and if you configure using a FQDN it should
 resolve on all nodes.
 
 [[prereq-networkmanager]]
-
-*NetworkManager*
+==== NetworkManager
 
 NetworkManager, a program for providing detection and configuration for systems
 to automatically connect to the network, is required.
 
 [[required-ports]]
+==== Required Ports
 
-*Required Ports*
+The {product-title} installation automatically creates a set of internal
+firewall rules on each host using `iptables`. However, if your network
+configuration uses an external firewall, such as a hardware-based firewall, you
+must ensure infrastructure components can communicate with each other through
+specific ports that act as communication endpoints for certain processes or
+services.
 
-{product-title} infrastructure components communicate with each other using
-ports, which are communication endpoints that are identifiable for specific
-processes or services. Ensure the following ports required by {product-title}
-are open between hosts, for example if you have a firewall in your environment.
-Some ports are optional depending on your configuration and usage.
+Ensure the following ports required by {product-title} are open on your network
+and configured to allow access between hosts. Some ports are optional depending
+on your configuration and usage.
 
 .Node to Node
 [cols='2,1,8']
@@ -586,14 +584,12 @@ connections, and is only required if you have clustered etcd.
 * The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed values of `*openshift_hostname*` and `*openshift_public_hostname*`.
 
 [[prereq-git]]
-
 === Git Access
 
 You must have either Internet access and a GitHub account, or read and write
 access to an internal, HTTP-based Git server.
 
 [[prereq-persistent-storage]]
-
 === Persistent Storage
 
 The Kubernetes
@@ -618,33 +614,13 @@ xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install
 Persistent Disks], and
 xref:../../install_config/persistent_storage/persistent_storage_iscsi.adoc#install-config-persistent-storage-persistent-storage-iscsi[iSCSI].
 
-[[prereq-selinux]]
-
-=== SELinux
-
-Security-Enhanced Linux (SELinux) must be enabled on all of the servers before
-installing {product-title} or the installer will fail. Also, configure
-`*SELINUXTYPE=targeted*` in the *_/etc/selinux/config_* file:
-
-----
-# This file controls the state of SELinux on the system.
-# SELINUX= can take one of these three values:
-#     enforcing - SELinux security policy is enforced.
-#     permissive - SELinux prints warnings instead of enforcing.
-#     disabled - No SELinux policy is loaded.
-SELINUX=enforcing
-# SELINUXTYPE= can take one of these three values:
-#     targeted - Targeted processes are protected,
-#     minimum - Modification of targeted policy. Only selected processes are protected.
-#     mls - Multi Level Security protection.
-SELINUXTYPE=targeted
-----
-
 [[prereq-cloud-provider-considerations]]
-
 === Cloud Provider Considerations
 
-*Set up the Security Group*
+There are certain aspects to take into consideration if installing {product-title}
+on a cloud provider.
+
+==== Configuring a Security Group
 
 When installing on AWS or OpenStack, ensure that you set up the appropriate
 security groups. These are some ports that you should have in your security
@@ -652,7 +628,6 @@ groups, without which the installation will fail. You may need more depending on
 the cluster configuration you want to install. For more information and to
 adjust your security groups accordingly, see xref:required-ports[Required Ports]
 for more information.
-
 
 [cols="1,2"]
 |===
@@ -692,7 +667,7 @@ a|- tcp/443 from 0.0.0.0/0
 If configuring ELBs for load balancing the masters and/or routers, you also need
 to configure Ingress and Egress security groups for the ELBs appropriately.
 
-*Override Detected IP Addresses and Host Names*
+==== Overriding Detected IP Addresses and Host Names
 
 Some deployments require that the user override the detected host names and IP
 addresses for the hosts. To see the default values, run the `*openshift_facts*`
@@ -782,592 +757,9 @@ For EC2 hosts in particular, they must be deployed in a VPC that has both
 `*DNS host names*` and `*DNS resolution*` enabled, and `*openshift_hostname*`
 should not be overridden.
 
-*Post-Installation Configuration for Cloud Providers*
+==== Post-Installation Configuration for Cloud Providers
 
 Following the installation process, you can configure {product-title} for
 xref:../../install_config/configuring_aws.adoc#install-config-configuring-aws[AWS],
 xref:../../install_config/configuring_openstack.adoc#install-config-configuring-openstack[OpenStack], or
 xref:../../install_config/configuring_gce.adoc#install-config-configuring-gce[GCE].
-
-[[host-preparation]]
-
-== Host Preparation
-
-Before installing {product-title}, you must first prepare each host per the following.
-
-ifdef::openshift-origin[]
-[NOTE]
-====
-If you are using https://www.vagrantup.com[Vagrant] to run {product-title}, you
-do not need to go through the following sections. These changes are only
-necessary when you are setting up the host yourself. If you are using Vagrant,
-see the
-https://github.com/openshift/origin/blob/master/CONTRIBUTING.html#develop-on-virtual-machine-using-vagrant[Contributing
-Guide], then you can skip directly to trying out the
-xref:../../getting_started/administrators.adoc#try-it-out[sample applications].
-====
-endif::[]
-
-ifdef::openshift-enterprise[]
-
-
-[[software-prerequisites]]
-
-=== Software Prerequisites
-
-*Installing an Operating System*
-
-A base installation of RHEL 7.1 or later or RHEL Atomic Host 7.2.4 or later is
-required for master and node hosts. See the following documentation for the
-respective installation instructions, if required:
-
-- https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/index.html[Red
-Hat Enterprise Linux 7 Installation Guide]
-- https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/installation-and-configuration-guide/[Red
-Hat Enterprise Linux Atomic Host 7 Installation and Configuration Guide]
-
-*Registering the Hosts*
-
-Each host must be registered using Red Hat Subscription Manager (RHSM) and have
-an active {product-title} subscription attached to access the required
-packages.
-
-. On each host, register with RHSM:
-+
-----
-# subscription-manager register --username=<user_name> --password=<password>
-----
-
-. List the available subscriptions:
-+
-----
-# subscription-manager list --available
-----
-
-. In the output for the previous command, find the pool ID for an {product-title} subscription and attach it:
-+
-----
-# subscription-manager attach --pool=<pool_id>
-----
-
-. Disable all repositories and enable only the required ones:
-+
-----
-# subscription-manager repos --disable="*"
-# subscription-manager repos \
-    --enable="rhel-7-server-rpms" \
-    --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-ose-3.2-rpms"
-----
-endif::[]
-
-*Managing Packages*
-
-For RHEL 7 systems:
-
-. Install the following base packages:
-+
-----
-# yum install wget git net-tools bind-utils iptables-services bridge-utils bash-completion
-----
-
-. Update the system to the latest packages:
-+
-----
-# yum update
-----
-
-ifdef::openshift-enterprise[]
-. Install the following package, which provides {product-title} utilities and pulls in
-other tools required by the
-xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] and
-xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
-methods, such as Ansible and related configuration files:
-+
-----
-# yum install atomic-openshift-utils
-----
-endif::[]
-
-For RHEL Atomic Host 7 systems:
-
-. Ensure the host is up to date by upgrading to the latest Atomic tree if one is
-available:
-+
-----
-# atomic host upgrade
-----
-
-. After the upgrade is completed and prepared for the next boot, reboot the
-host:
-+
-----
-# systemctl reboot
-----
-
-
-ifdef::openshift-origin[]
-[[preparing-for-advanced-installations-origin]]
-
-*Preparing for Advanced Installations*
-
-If you plan to use the
-xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
-method, you must install Ansible and clone the *openshift-ansible* repository from
-GitHub, which provides the required playbooks and configuration files.
-
-For convenience, the following steps are provided if you want to use EPEL as a
-package source for Ansible:
-
-. Install the EPEL repository:
-+
-----
-# yum -y install \
-    https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-----
-
-. Disable the EPEL repository globally so that it is not accidentally used during
-later steps of the installation:
-+
-----
-# sed -i -e "s/^enabled=1/enabled=0/" /etc/yum.repos.d/epel.repo
-----
-
-. Install the packages for Ansible:
-+
-----
-# yum -y --enablerepo=epel install ansible pyOpenSSL
-----
-
-To clone the *openshift-ansible* repository:
-
-----
-# cd ~
-# git clone https://github.com/openshift/openshift-ansible
-# cd openshift-ansible
-----
-
-[NOTE]
-====
-Be sure to stay on the *master* branch of the *openshift-ansible* repository
-when running an advanced installation.
-====
-endif::[]
-
-[[installing-docker]]
-
-*Installing Docker*
-
-At this point, you should install Docker on all master and node hosts. This
-allows you to configure your xref:configuring-docker-storage[Docker storage
-options] before installing {product-title}.
-
-. For RHEL 7 systems, install Docker 1.10:
-+
-----
-ifdef::openshift-enterprise[]
-# yum install docker-1.10.3
-endif::[]
-ifdef::openshift-origin[]
-# yum install docker
-endif::[]
-----
-+
-[NOTE]
-====
-On RHEL Atomic Host 7 systems, Docker should already be installed, configured,
-and running by default.
-====
-
-. Edit the *_/etc/sysconfig/docker_* file and add `--insecure-registry
-172.30.0.0/16` to the `*OPTIONS*` parameter. For example:
-+
-----
-OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0/16'
-----
-+
-If using the
-xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[Quick
-Installation] method, you can easily script a complete installation from a
-kickstart or cloud-init setup, change the default configuration file:
-+
-----
-# sed -i '/OPTIONS=.*/c\OPTIONS="--selinux-enabled --insecure-registry 172.30.0.0/16"' \
-/etc/sysconfig/docker
-----
-+
-[[NOTE]]
-====
-The
-xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Advanced
-Installation] method automatically changes *_/etc/sysconfig/docker_*.
-====
-+
-The `--insecure-registry` option instructs the Docker daemon to trust any Docker
-registry on the indicated subnet, rather than
-xref:docker_registry.adoc#securing-the-registry[requiring a certificate].
-+
-[IMPORTANT]
-====
-172.30.0.0/16 is the default value of the `*servicesSubnet*` variable in the
-*_master-config.yaml_* file. If this has changed, then the `--insecure-registry`
-value in the above step should be adjusted to match, as it is indicating the
-subnet for the registry to use. Note that the `*openshift_master_portal_net*`
-variable can be set in the Ansible inventory file and used during the
-xref:advanced_install.adoc#configuring-ansible[advanced installation]
-method to modify the `*servicesSubnet*` variable.
-====
-+
-[NOTE]
-====
-After the initial {product-title} installation is complete, you can choose to
-xref:docker_registry.adoc#securing-the-registry[secure the integrated Docker
-registry], which involves adjusting the `--insecure-registry` option
-accordingly.
-====
-
-[[configuring-docker-storage]]
-
-=== Configuring Docker Storage
-
-Docker containers and the images they are created from are stored in Docker's
-storage back end. This storage is ephemeral and separate from any
-xref:../../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[persistent storage] allocated to
-meet the needs of your applications.
-
-*For RHEL Atomic Host*
-
-The default storage back end for Docker on RHEL Atomic Host is a thin pool
-logical volume, which is supported for production environments. You must ensure
-that enough space is allocated for this volume per the Docker storage
-requirements mentioned in
-xref:../../install_config/install/prerequisites.adoc#system-requirements[System
-Requirements].
-
-If you do not have enough allocated, see
-https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/getting-started-with-containers/#managing_storage_with_docker_formatted_containers[Managing
-Storage with Docker Formatted Containers] for details on using
-*docker-storage-setup* and basic instructions on storage management in RHEL
-Atomic Host.
-
-*For RHEL*
-
-The default storage back end for Docker on RHEL 7 is a thin pool on loopback
-devices, which is not supported for production use and only appropriate for
-proof of concept environments. For production environments, you must create a
-thin pool logical volume and re-configure Docker to use that volume.
-
-You can use the *docker-storage-setup* script included with Docker to create a
-thin pool device and configure Docker's storage driver. This can be done after
-installing Docker and should be done before creating images or containers. The
-script reads configuration options from the
-*_/etc/sysconfig/docker-storage-setup_* file and supports three options for
-creating the logical volume:
-
-- *Option A)* Use an additional block device.
-- *Option B)* Use an existing, specified volume group.
-- *Option C)* Use the remaining free space from the volume group where your root
-file system is located.
-
-Option A is the most robust option, however it requires adding an additional
-block device to your host before configuring Docker storage. Options B and C
-both require leaving free space available when provisioning your host.
-
-. Create the *docker-pool* volume using one of the following three options:
-
-** [[docker-storage-a]]*Option A) Use an additional block device.*
-+
-In *_/etc/sysconfig/docker-storage-setup_*, set *DEVS* to the path of the block
-device you wish to use. Set *VG* to the volume group name you wish to create;
-*docker-vg* is a reasonable choice. For example:
-+
-====
-----
-# cat <<EOF > /etc/sysconfig/docker-storage-setup
-DEVS=/dev/vdc
-VG=docker-vg
-EOF
-----
-====
-+
-Then run *docker-storage-setup* and review the output to ensure the
-*docker-pool* volume was created:
-+
-====
-----
-# docker-storage-setup                                                                                                                                                                                                                                [5/1868]
-0
-Checking that no-one is using this disk right now ...
-OK
-
-Disk /dev/vdc: 31207 cylinders, 16 heads, 63 sectors/track
-sfdisk:  /dev/vdc: unrecognized partition table type
-
-Old situation:
-sfdisk: No partitions found
-
-New situation:
-Units: sectors of 512 bytes, counting from 0
-
-   Device Boot    Start       End   #sectors  Id  System
-/dev/vdc1          2048  31457279   31455232  8e  Linux LVM
-/dev/vdc2             0         -          0   0  Empty
-/dev/vdc3             0         -          0   0  Empty
-/dev/vdc4             0         -          0   0  Empty
-Warning: partition 1 does not start at a cylinder boundary
-Warning: partition 1 does not end at a cylinder boundary
-Warning: no primary partition is marked bootable (active)
-This does not matter for LILO, but the DOS MBR will not boot this disk.
-Successfully wrote the new partition table
-
-Re-reading the partition table ...
-
-If you created or changed a DOS partition, /dev/foo7, say, then use dd(1)
-to zero the first 512 bytes:  dd if=/dev/zero of=/dev/foo7 bs=512 count=1
-(See fdisk(8).)
-  Physical volume "/dev/vdc1" successfully created
-  Volume group "docker-vg" successfully created
-  Rounding up size to full physical extent 16.00 MiB
-  Logical volume "docker-poolmeta" created.
-  Logical volume "docker-pool" created.
-  WARNING: Converting logical volume docker-vg/docker-pool and docker-vg/docker-poolmeta to pool's data and metadata volumes.
-  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
-  Converted docker-vg/docker-pool to thin pool.
-  Logical volume "docker-pool" changed.
-----
-====
-
-** [[docker-storage-b]]*Option B) Use an existing, specified volume group.*
-+
-In *_/etc/sysconfig/docker-storage-setup_*, set *VG* to the desired volume
-group. For example:
-+
-====
-----
-# cat <<EOF > /etc/sysconfig/docker-storage-setup
-VG=docker-vg
-EOF
-----
-====
-+
-Then run *docker-storage-setup* and review the output to ensure the
-*docker-pool* volume was created:
-+
-====
-----
-# docker-storage-setup
-  Rounding up size to full physical extent 16.00 MiB
-  Logical volume "docker-poolmeta" created.
-  Logical volume "docker-pool" created.
-  WARNING: Converting logical volume docker-vg/docker-pool and docker-vg/docker-poolmeta to pool's data and metadata volumes.
-  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
-  Converted docker-vg/docker-pool to thin pool.
-  Logical volume "docker-pool" changed.
-----
-====
-
-** [[docker-storage-c]]*Option C) Use the remaining free space from the volume
- group where your root file system is located.*
-+
-Verify that the volume group where your root file system resides has the desired
-free space, then run *docker-storage-setup* and review the output to ensure the
-*docker-pool* volume was created:
-+
-====
-----
-# docker-storage-setup
-  Rounding up size to full physical extent 32.00 MiB
-  Logical volume "docker-poolmeta" created.
-  Logical volume "docker-pool" created.
-  WARNING: Converting logical volume rhel/docker-pool and rhel/docker-poolmeta to pool's data and metadata volumes.
-  THIS WILL DESTROY CONTENT OF LOGICAL VOLUME (filesystem etc.)
-  Converted rhel/docker-pool to thin pool.
-  Logical volume "docker-pool" changed.
-----
-====
-
-. Verify your configuration. You should have a *dm.thinpooldev* value in the
-*_/etc/sysconfig/docker-storage_* file and a *docker-pool* logical volume:
-+
-====
-----
-# cat /etc/sysconfig/docker-storage
-DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt
-dm.thinpooldev=/dev/mapper/docker--vg-docker--pool
-
-# lvs
-  LV          VG   Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
-  docker-pool rhel twi-a-t---  9.29g             0.00   0.12
-----
-====
-+
-[IMPORTANT]
-====
-Before using Docker or {product-title}, verify that the *docker-pool* logical volume
-is large enough to meet your needs. The *docker-pool* volume should be 60% of
-the available volume group and will grow to fill the volume group via LVM
-monitoring.
-====
-
-. Check if Docker is running:
-+
-----
-# systemctl is-active docker
-----
-
-. If Docker has not yet been started on the host, enable and start the service:
-+
-----
-# systemctl enable docker
-# systemctl start docker
-----
-+
-If Docker is already running, re-initialize Docker:
-+
-[WARNING]
-====
-This will destroy any Docker containers or images currently on the host.
-====
-+
-----
-# systemctl stop docker
-# rm -rf /var/lib/docker/*
-# systemctl restart docker
-----
-+
-If there is any content in *_/var/lib/docker/_*, it must be deleted. Files
-will be present if Docker has been used prior to the installation of {product-title}.
-
-[[reconfiguring-docker-storage]]
-*Reconfiguring Docker Storage*
-
-Should you need to reconfigure Docker storage after having created the
-*docker-pool*, you should first remove the *docker-pool* logical volume. If you
-are using a dedicated volume group, you should also remove the volume group and
-any associated physical volumes before reconfiguring *docker-storage-setup*
-according to the instructions above.
-
-See
-link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Logical_Volume_Manager_Administration/index.html[Logical
-Volume Manager Administration] for more detailed information on LVM management.
-
-[[managing-docker-container-logs]]
-*Managing Docker Container Logs*
-
-Sometimes a container's log file (the
-*_/var/lib/docker/containers/<hash>/<hash>-json.log_* file on the node where the
-container is running) can increase to a problematic size. You can manage this by
-configuring Docker's `json-file` logging driver to restrict the size and number
-of log files.
-
-[options="header"]
-|===
-
-|Option |Purpose
-
-|`--log-opt max-size`
-|Sets the size at which a new log file is created.
-
-|`--log-opt max-file`
-|Sets the file on each host to configure the options.
-|===
-
-For example, to set the maximum file size to 1MB and always keep the last three
-log files, edit the *_/etc/sysconfig/docker_* file to configure `max-size=1M`
-and `max-file=3`:
-====
-----
-OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1M --log-opt max-file=3'
-----
-====
-
-Next, restart the Docker service:
-----
-# systemctl restart docker
-----
-
-[[viewing-available-container-logs]]
-*Viewing Available Container Logs*
-
-Container logs are stored in the *_/var/lib/docker/containers/<hash>/_*
-directory on the node where the container is running. For example:
-====
-----
-# ls -lh /var/lib/docker/containers/f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8/
-total 2.6M
--rw-r--r--. 1 root root 5.6K Nov 24 00:12 config.json
--rw-r--r--. 1 root root 649K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log
--rw-r--r--. 1 root root 977K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log.1
--rw-r--r--. 1 root root 977K Nov 24 00:15 f088349cceac173305d3e2c2e4790051799efe363842fdab5732f51f5b001fd8-json.log.2
--rw-r--r--. 1 root root 1.3K Nov 24 00:12 hostconfig.json
-drwx------. 2 root root    6 Nov 24 00:12 secrets
-----
-====
-
-See Docker's documentation for additional information on how to
-http://docs.docker.com/engine/reference/logging/overview/#the-json-file-options[Configure
-Logging Drivers].
-
-[[ensuring-host-access]]
-
-=== Ensuring Host Access
-
-ifdef::openshift-origin[]
-The xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method requires
-endif::[]
-ifdef::openshift-enterprise[]
-The xref:quick_install.adoc#install-config-install-quick-install[quick] and xref:advanced_install.adoc#install-config-install-advanced-install[advanced
-installation] methods require
-endif::[]
-a user that has access to all hosts. If you want to run the installer as a
-non-root user, passwordless *sudo* rights must be configured on each destination
-host.
-
-For example, you can generate an SSH key on the host where you will invoke the
-installation process:
-
-----
-# ssh-keygen
-----
-
-Do *not* use a password.
-
-An easy way to distribute your SSH keys is by using a `bash` loop:
-
-----
-# for host in master.example.com \
-    node1.example.com \
-    node2.example.com; \
-    do ssh-copy-id -i ~/.ssh/id_rsa.pub $host; \
-    done
-----
-
-Modify the host names in the above command according to your configuration.
-
-== What's Next?
-
-ifdef::openshift-enterprise[]
-If you are interested in installing {product-title} using the containerized method
-(optional for RHEL but required for RHEL Atomic Host), see
-xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[RPM vs
-Containerized] to ensure that you understand the differences between these
-methods.
-
-When you are ready to proceed, you can install {product-title} using the
-xref:quick_install.adoc#install-config-install-quick-install[quick installation] or
-xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method.
-endif::[]
-
-ifdef::openshift-origin[]
-If you are interested in installing {product-title} using the containerized method
-(optional for Fedora, CentOS, or RHEL but required for RHEL Atomic Host), see
-xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[RPM vs
-Containerized] to ensure that you understand the differences between the
-installation methods. Then continue with your chosen installation method.
-
-If you came here from xref:../../getting_started/administrators.adoc#getting-started-administrators[Getting
-Started for Administrators], you can now continue there by choosing an
-xref:../../getting_started/administrators.adoc#installation-methods[installation
-method]. Alternatively, you can install {product-title} using the
-xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method.
-endif::[]

--- a/install_config/install/rpm_vs_containerized.adoc
+++ b/install_config/install/rpm_vs_containerized.adoc
@@ -1,5 +1,5 @@
 [[install-config-install-rpm-vs-containerized]]
-= RPM vs Containerized
+= Containerized Services
 {product-author}
 {product-version}
 :data-uri:
@@ -13,31 +13,23 @@ toc::[]
 
 == Overview
 
-The default method for installing {product-title} on
-ifdef::openshift-origin[]
-Fedora, CentOS, or RHEL
-endif::[]
-ifdef::openshift-enterprise[]
-Red Hat Enterprise Linux (RHEL)
-endif::[]
-uses RPMs. Alternatively, you can use the containerized method, which deploys
-containerized {product-title} master and node components. When targeting a RHEL
-Atomic Host system, the containerized method is the only available option, and
-is automatically selected for you based on the detection of the
-*_/run/ostree-booted_* file.
+This section explores some of the preparation required to install {product-name}
+as a set of services within containers. This applies to hosts using either Red
+Hat Enterprise Linux or Red Hat Atomic Host.
 
-You can easily deploy environments mixing containerized and RPM based
-installations. For the
+- For the xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation
+method], you can choose between the RPM or containerized method on a per host
+basis during the interactive installation, or set the values manually in an
+xref:../../install_config/install/quick_install.adoc#defining-an-installation-configuration-file[installation
+configuration file].
+
+- For the
 xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation
 method], you can set the Ansible variable `*containerized=true*` in an
 xref:../../install_config/install/advanced_install.adoc#configuring-ansible[inventory
 file] on a cluster-wide or per host basis.
 ifdef::openshift-enterprise[]
-For the xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation
-method], you can choose between the RPM or containerized method on a per host
-basis during the interactive installation, or set the values manually in an
-xref:../../install_config/install/quick_install.adoc#defining-an-installation-configuration-file[installation
-configuration file].
+
 
 [NOTE]
 ====
@@ -48,8 +40,8 @@ Installation] for load balancer requirements using the native HA method.
 ====
 endif::[]
 
-The following sections detail the differences between the RPM and containerized
-methods.
+The following sections detail the preparation for a containerized {product-name}
+installation.
 
 [[containerized-required-images]]
 == Required Images

--- a/install_config/install/rpm_vs_containerized.adoc
+++ b/install_config/install/rpm_vs_containerized.adoc
@@ -1,5 +1,5 @@
 [[install-config-install-rpm-vs-containerized]]
-= Containerized Services
+= Containerized Components
 {product-author}
 {product-version}
 :data-uri:

--- a/install_config/install/rpm_vs_containerized.adoc
+++ b/install_config/install/rpm_vs_containerized.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 == Overview
 
-This section explores some of the preparation required to install {product-name}
+This section explores some of the preparation required to install {product-title}
 as a set of services within containers. This applies to hosts using either Red
 Hat Enterprise Linux or Red Hat Atomic Host.
 
@@ -40,7 +40,7 @@ Installation] for load balancer requirements using the native HA method.
 ====
 endif::[]
 
-The following sections detail the preparation for a containerized {product-name}
+The following sections detail the preparation for a containerized {product-title}
 installation.
 
 [[containerized-required-images]]


### PR DESCRIPTION
Brief summary of proposed changes:
- Created a new Planning section. This is to give users some high level guidance on how to plan the overall structure of their environment and their methods of installation.
- Revised content in the Prereqs section to clarify certain parts
- Separated Host Preparation into its own section on the TOC. This is to distinguish the requirements from the host prep procedures.
- Renamed "RPM vs Containerized" to "Containerized Services". The former sets up the expectation that it will discuss differences between RPM and Containerized installation; however, the content does not reflect this.

Preview of the content here: http://file.bne.redhat.com/~dmacpher/OpenShift/openshift-enterprise/master/install_config/
