### PR TITLE
Add ntp line as part of HA configuration

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -962,6 +962,9 @@ openshift_master_cluster_public_hostname=openshift-cluster.example.com
 # override the default controller lease ttl
 #osm_controller_lease_ttl=30
 
+# enable ntp on masters to ensure proper failover
+openshift_clock_enabled=true
+
 # host group for masters
 [masters]
 master1.example.com


### PR DESCRIPTION
Our docs are missing a fundamental requirement in HA deployments: https://bugzilla.redhat.com/show_bug.cgi?id=1370229 

This simply adds to the default HA example. 
