### PR TITLE
There is no "(see the section above)." in the OpenShift docs. That se…

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -137,7 +137,10 @@ repository with the following directory structure:
 This directory contains those binary Jenkins plug-ins you want to copy into Jenkins.
 
 *_plugins.txt_*::
-This file lists the plug-ins you want to install (see the section above).
+This file lists the plug-ins you want to install in the format of:
+```
+pluginId:pluginVersion
+```
 
 *_configuration/jobs_*::
 This directory contains the Jenkins job definitions.


### PR DESCRIPTION
…ction only exists in https://github.com/openshift/jenkins/README.md. Removed that statment and added a short description with no example of the format used in plugins.txt

But maybe this is included automatically from https://github.com/openshift/jenkins ? Then maybe the change needs to be applied there.
