### PR TITLE
Docker login steps are missing for exposed registry with both secured and insecured

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -293,3 +293,87 @@ not the route name and port. See `oc get imagestreams` for details.
 ====
 In the `<host>/test/busybox` example above, `test` refers to the project name.
 ====
+
+
+[[access-secure-registry-by-exposing-route]]
+=== Exposing a Secure Registry
+
+Instead of logging in to the registry from within the {product-title} cluster,
+you can gain external access to it by first
+xref:securing-the-registry[securing the registry] and then
+xref:exposing-the-registry[exposing the registry].
+This allows you to log in to the registry from outside the cluster using the
+route address, and to tag and push images using the route host. 
+
+When 
+xref:access-logging-in-to-the-registry[logging in] to the secured and exposed
+registry, make sure you specify the registry in the login command. For example:
+
+----
+docker login -e user@company.com -u f83j5h6 -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 registry.ose-node.openshift.com:443
+----
+
+[[access-insecure-registry-by-exposing-route]]
+=== Exposing a Non-Secure Registry
+
+Instead of securing the registry in order to expose the registry, you can simply
+expose a non-secure registry for non-production {product-title} environments.
+This allows you to have an external route to the registry without using SSL
+certificates.
+
+[WARNING]
+====
+Only non-production environments should expose a non-secure registry to external access.
+====
+
+To expose a non-secure registry:
+
+. Expose the registry:
++
+----
+# oc expose service docker-registry --hostname=<hostname> -n default 
+----
++
+This creates the following JSON file:
++
+----
+apiVersion: v1
+kind: Route
+metadata:
+  creationTimestamp: null
+  labels:
+    docker-registry: default
+  name: docker-registry
+spec:
+  host: registry.example.com
+  port:
+    targetPort: "5000"
+  to:
+    kind: Service
+    name: docker-registry
+status: {}
+----
+. Verify that the route has been created successfully: 
++
+----
+# oc get route
+NAME              HOST/PORT                    PATH      SERVICE           LABELS                    INSECURE POLICY   TLS TERMINATION
+docker-registry   registry.example.com            docker-registry   docker-registry=default
+----
+. Check the health of the registry in your web browser: \http://registry.example.com/healthz 
+
+After exposing the registry, update your *_/etc/sysconfig/docker_* file by
+adding the port number to the `OPTIONS` entry. For example:
+
+----
+OPTIONS='--selinux-enabled --insecure-registry=172.30.0.0/16 --insecure-registry registry.ose-node.openshift.com:443'
+----
+
+When 
+xref:access-logging-in-to-the-registry[logging in] to the non-secured and
+exposed registry, make sure you specify the registry in the login command. For
+example:
+
+----
+docker login -e user@company.com -u f83j5h6 -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 registry.ose-node.openshift.com:443
+----


### PR DESCRIPTION
incorp closed #2710, and updated based on review from Jaspreet Kaur (comment9 in bz): https://bugzilla.redhat.com/show_bug.cgi?id=1360586#c9
