### PR TITLE
correct the link in Upgrade Docker

### DIFF
--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -578,8 +578,7 @@ available:
 ====
 If upgrading to RHEL Atomic Host 7.2.5, this upgrades Docker to version 1.10.
 See the
-xref:../../release_notes/ose_3_2_release_notes.adoc#ose-3-2-1-1-enhancements[{product-title}
-3.2.1.1 release notes] for details and known issues.
+https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-3-2-1-1-enhancements[OpenShift Enterprise 3.2.1.1 release notes] for details and known issues.
 ====
 +
 ----


### PR DESCRIPTION
The link in  in Upgrade Docker is invalid,because there is no release note page of openshift origin。
correct it and link to OpenShift Enterprise release notes。
