### PR TITLE
Clarify how routes claim hostnames

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -322,9 +322,19 @@ In order for services to be exposed externally, an {product-title} route allows
 you to associate a service with an externally-reachable host name. This edge
 host name is then used to route traffic to the service.
 
-When two routes claim the same host, the oldest route wins. If additional routes
-with different path fields are defined in the same namespace, those paths will be
-added. If multiple routes with the same path are used, the oldest takes priority.
+When multiple routes from different namespaces claim the same host,
+the oldest route wins and claims it for the namespace. If additional
+routes with different path fields are defined in the same namespace,
+those paths will be added. If multiple routes with the same path are
+used, the oldest takes priority.
+
+Please note that a consequence of this behavior is that if you have
+two routes for a hostname: an older one and a newer one.  And if
+someone else has a route for the same hostname that they created
+between when you created the other two routes.  Then, if you delete
+your older route, your claim to the hostname will no longer be in effect.
+The other namespace will now claim the hostname and your claim will be
+lost.
 
 .A Route with a Specified Host:
 ====


### PR DESCRIPTION
This clarifies how the oldest route claims a hostname for an entire
namespace.  Other routes in the namespace can divide up the hostname
with different paths.  But other routes in different namespaces that
claim the hostname are ignored.
