### PR TITLE
Refine deployment docs, add advanced strategies

### DIFF
--- a/dev_guide/deployments.adoc
+++ b/dev_guide/deployments.adoc
@@ -12,43 +12,49 @@ toc::[]
 
 == Overview
 
-{product-title} deployments provide fine-grained management over applications
-based on a user-defined template called a deployment configuration. The
-deployment system in response to a deployment configuration will create a
-replication controller to run an application. Replication controllers are
-created manually or in response to triggered events.
+{product-title} deployments provide fine-grained management over common 
+user applications. They are described using three separate API objects:
+
+- A deployment configuration, which describes the desired state of a particular component of the application as a pod template.
+- One or more replication controllers, which contain a point in time record of the state of a deployment configuration as a pod template.
+- One or more pods, which represent an instance of a particular version of an application.
 
 [IMPORTANT]
 ====
-Users should never manipulate replication controllers owned by
-deployment configurations. The deployment system makes sure changes to
-deployment configurations are propagated appropriately to replication
-controllers.
+Users should not need to manipulate replication controllers or pods owned
+by deployment configurations. The deployment system makes sure changes to
+deployment configurations are propagated appropriately. If the existing
+deployment strategies are not suited for your use-case and you have the
+need to run manual steps during the lifecycle of your deployment, then you
+should consider creating a custom strategy. See the section below on xref:custom-strategy[custom
+strategies].
 ====
+
+When a user creates a deployment configuration, a replication controller is
+created representing the deployment config's pod template. If the deployment
+configuration changes, a new replication controller is created with the latest
+pod template, and a deployment process runs to scale down the old replication
+controller and scale up the new replication controller.
+
+Instances of your application are automatically added and removed from both
+service load balancers and routers as they are created. As long as your
+application supports graceful shutdown when it receives the TERM signal, you
+can ensure that running user connections are given a chance to complete normally.
+See the section below on graceful termination.
+
 
 Features provided by the deployment system:
 
 - A xref:creating-a-deployment-configuration[deployment configuration], which is a template for running applications.
 - xref:triggers[Triggers] that drive automated deployments in response to events.
-- User-customizable xref:strategies[strategies] to transition from the previous version to the new version.
-- xref:rolling-back-a-deployment[Rollbacks] to a previous version either manually or automatically in case of deployment failure.
-- Manual replication xref:scaling[scaling] and autoscaling.
+- User-customizable xref:strategies[strategies] to transition from the previous version to the new version. A strategy runs inside a pod commonly referred as the deployment process.
+- A set of xref:lifecycle-hooks[hooks] for executing custom behavior in different points during the lifecycle of a deployment.
+- Versioning of your application in order to support xref:rolling-back-a-deployment[rollbacks] either manually or automatically in case of deployment failure.
+- Manual replication xref:scaling[scaling] and xref:pod_autoscaling.adoc[autoscaling].
 
-The deployment configuration contains a version number that is incremented
-each time a new replication controller is created from that configuration.
-In addition, the cause of the last deployed replication controller is added
-to the deployment configuration.
 
 [[creating-a-deployment-configuration]]
 == Creating a Deployment Configuration
-
-A deployment configuration consists of the following key parts:
-
-- A pod template, which describes the application to be deployed.
-- The initial replica count for the replication controller.
-- A deployment xref:strategies[strategy], which will be used to deploy the application.
-- A set of xref:triggers[triggers], which cause replication controllers to be created automatically.
-- A set of xref:lifecycle-hooks[hooks] for executing custom behavior in different points during the lifecycle of a deployment.
 
 Deployment configurations are `*deploymentConfig*` {product-title} API resources
 which can be managed with the `oc` command like any other resource. The
@@ -99,15 +105,15 @@ spec:
 <4> An xref:image-change-trigger[image change trigger] trigger causes a new replication controller to be
 created each time a new version of the `origin-ruby-sample:latest` image stream tag is available.
 <5> The xref:rolling-strategy[Rolling strategy] is the default way of deploying your pods. May be omitted.
-<6> The existing running deployment will not be paused. Pod template or image changes cover the full spectrum of changes on which deployments currently run.
-<7> Revision history limit is the limit of old replication controllers you want to keep around for rolling back. May be omitted. If omitted, old replication controllers will not be cleaned.
+<6> Pause a deployment configuration. This disables the functionality of all triggers and allows for multiple changes on the pod template before actually rolling it out.
+<7> Revision history limit is the limit of old replication controllers you want to keep around for rolling back. May be omitted. If omitted, old replication controllers will not be cleaned up.
 <8> Minimum seconds to wait (after the readiness checks succeed) for a pod to be considered available. The default value is 0.
 ====
 
 [[start-deployment]]
 == Starting a Deployment
 
-You can start a new deployment manually using the web console, or from the CLI:
+You can start a new deployment process manually using the web console, or from the CLI:
 
 ----
 $ oc deploy --latest dc/<name>
@@ -115,7 +121,7 @@ $ oc deploy --latest dc/<name>
 
 [NOTE]
 ====
-If a deployment is already in progress, the command will display a
+If a deployment process is already in progress, the command will display a
 message and a new replication controller will not be deployed.
 ====
 
@@ -123,14 +129,15 @@ message and a new replication controller will not be deployed.
 
 == Viewing a Deployment
 
-To get basic information about recent deployments:
+To get basic information about all the available revisions of your application:
 
 ----
 $ oc rollout history dc/<name>
 ----
 
 This will show details about all recently created replication controllers for
-the provided deployment configuration, including any currently running deployment.
+the provided deployment configuration, including any currently running deployment
+process.
 
 You can view details specific to a revision by using the `--revision` flag:
 
@@ -138,7 +145,7 @@ You can view details specific to a revision by using the `--revision` flag:
 $ oc rollout history dc/<name> --revision=1
 ----
 
-For more detailed information about a deployment configuration and its latest deployment:
+For more detailed information about a deployment configuration and its latest revision:
 
 ----
 $ oc describe dc <name>
@@ -155,7 +162,7 @@ console] shows deployments in the *Browse* tab.
 
 == Canceling a Deployment
 
-To cancel a running or stuck deployment:
+To cancel a running or stuck deployment process:
 
 ----
 $ oc deploy --cancel dc/<name>
@@ -163,29 +170,30 @@ $ oc deploy --cancel dc/<name>
 
 [WARNING]
 ====
-The cancellation is a best-effort operation, and may take some time to complete.
-The replication controller may partially or totally complete deployment before
-the cancellation is effective. When canceled, the deployment automatically rolls
-back.
+The cancelation is a best-effort operation, and may take some time to complete.
+The replication controller may partially or totally complete its deployment before
+the cancelation is effective. When canceled, the deployment config will be automatically
+rolled back by scaling up the previous running replication controller.
 ====
 
 [[retrying-a-deployment]]
 
 == Retrying a Deployment
 
-To retry the last failed deployment:
+If the current revision of your deployment configuration failed to deploy, you can
+restart the deployment process with:
 
 ----
 $ oc deploy --retry dc/<name>
 ----
 
-If the last deployment did not fail, the command will display a message and the
-deployment will not be retried.
+If the latest revision of it was deployed successfully, the command will display a
+message and the deployment process will not be retried.
 
 [NOTE]
 ====
-Retrying a deployment restarts the deployment and does not create a new
-deployment revision. The restarted deployment will have the same configuration
+Retrying a deployment restarts the deployment process and does not create a new
+deployment revision. The restarted replication controller will have the same configuration
 it had when it failed.
 ====
 
@@ -207,8 +215,8 @@ started. If no revision is specified with `--to-revision`, then the last
 successfully deployed revision will be used.
 
 Image change triggers on the deployment configuration are disabled as part of
-the rollback to prevent unwanted deployments soon after the rollback is
-complete. To re-enable the image change triggers:
+the rollback to prevent accidentaly starting a new deployment process soon after
+the rollback is complete. To re-enable the image change triggers:
 
 ----
 $ oc set triggers dc/<name> --auto
@@ -217,9 +225,9 @@ $ oc set triggers dc/<name> --auto
 [NOTE]
 ====
 Deployment configurations also support automatically rolling back to the
-last successful revision of the configuration in case the latest template fails
-to deploy. In that case, the latest template that failed to deploy stays intact
-by the system and it is up to users to fix their configurations.
+last successful revision of the configuration in case the latest deployment
+process fails. In that case, the latest template that failed to deploy stays
+intact by the system and it is up to users to fix their configurations.
 ====
 
 [[executing-commands-inside-a-container-deployments]]
@@ -286,8 +294,9 @@ If the latest revision is running or failed, `oc logs` will return the logs of
 the process that is responsible for deploying your pods. If it is successful,
 `oc logs` will return the logs from a pod of your application.
 
-You can also view logs from older failed deployments, if and only if the old
-deployment exists and has not been pruned or deleted manually:
+You can also view logs from older failed deployment processes, if and only if
+these processes (old replication controllers and their deployer pods) exist and
+have not been pruned or deleted manually:
 
 ----
 $ oc logs --version=1 dc/<name>
@@ -303,7 +312,7 @@ $ oc logs --help
 == Triggers
 
 A deployment configuration can contain triggers, which drive the creation of
-new deployments in response to events, only inside {product-title} at the moment.
+new deployment processes in response to events inside the cluster.
 
 [WARNING]
 ====
@@ -354,6 +363,7 @@ triggers:
       from:
         kind: "ImageStreamTag"
         name: "origin-ruby-sample:latest"
+        namespace: "myproject"
       containerNames:
         - "helloworld"
 ----
@@ -364,16 +374,33 @@ the trigger is disabled.
 With the above example, when the `latest` tag value of the *origin-ruby-sample*
 image stream changes and the new image value differs from the current image
 specified in the deployment configuration's *helloworld* container, a new
-deployment is created using the new image for the *helloworld* container.
+replication controller is created using the new image for the *helloworld* container.
 
 [NOTE]
 ====
 If an `*ImageChange*` trigger is defined on a deployment configuration (with a
-`*ConfigChange*` trigger or with `automatic=true`) and the `*ImageStreamTag*`
-pointed by the `*ImageChange*` trigger does not exist yet, then the first
-deployment automatically starts as soon as an image is imported or pushed by a
-build to the `*ImageStreamTag*`.
+`*ConfigChange*` trigger and `automatic=false`, or with `automatic=true`) and the
+`*ImageStreamTag*` pointed by the `*ImageChange*` trigger does not exist yet, then
+the initial deployment process will automatically start as soon as an image is
+imported or pushed by a build to the `*ImageStreamTag*`.
 ====
+
+[[deployment-triggers-using-the-command-line]]
+==== Using the Command Line
+
+The `oc set triggers` command can be used to set a deployment trigger for a
+deployment configuration. For the example above, you can set the ImageChangeTrigger
+by using the following command:
+
+----
+$ oc set triggers dc/frontend --from-image=myproject/origin-ruby-sample:latest -c helloworld
+----
+
+For more information see:
+
+----
+$ oc set triggers --help
+----
 
 [[strategies]]
 == Strategies
@@ -396,14 +423,35 @@ no strategy is specified on a deployment configuration.
 [[rolling-strategy]]
 === Rolling Strategy
 
-The rolling strategy performs a rolling update and supports
-xref:lifecycle-hooks[lifecycle hooks] for injecting code into the deployment
-process.
+A rolling deployment slowly replaces instances of the previous version of an application
+with instances of the new version of the application. A rolling deployment typically waits
+for new pods to become *ready* via a *readiness check* before scaling down the old components.
+If a significant issue occurs, the rolling deployment can be aborted.
 
-The rolling deployment strategy waits for pods to pass their
-xref:../dev_guide/application_health.adoc#dev-guide-application-health[readiness
-check] before scaling down old components, and does not allow pods that do not
-pass their readiness check within a configurable timeout.
+[[canary-deployments]]
+=== Canary deployments
+
+All rolling deployments in {product-title} are *canary* deployments - a new version (the canary)
+is tested  before all of the old instances are replaced. If the readiness check never succeeds,
+the canary instance is removed and the deployment configuration will be automatically rolled back.
+The readiness check is part of the application code, and may be as sophisticated as necessary to
+ensure the new instance is ready to be used. If you need to implement more complex checks of the
+application (such as sending real user workloads to the new instance), consider implementing a
+custom deployment or using a blue-green deployment strategy.
+
+
+=== When to use a rolling deployment?
+
+* When you want to take no downtime during an application update.
+* When your application supports having old code and new code running at the same time.
+
+A rolling deployment means you to have both old and new versions of your code running at
+the same time. This typically requires that your application handle xref:n1-compatibility[N-1 compatibility],
+that data stored by the new version can be read and handled (or gracefully ignored) by
+the old version of the code. This can take many forms - data stored on disk, in a database,
+in a temporary cache, or that is part of a user's browser session. While most web
+applications can support rolling deployments, it's important to test and design your
+application to handle it.
 
 The following is an example of the Rolling strategy:
 
@@ -420,8 +468,8 @@ strategy:
     post: {}
 ----
 <1> How long to wait for a scaling event before giving up. Optional; the default is 120.
-<2> `*maxSurge*` is optional and defaults to `25%`; see below.
-<3> `*maxUnavailable*` is optional and defaults to `25%`; see below.
+<2> `*maxSurge*` is optional and defaults to `25%` if not specified; see below.
+<3> `*maxUnavailable*` is optional and defaults to `25%` if not specified; see below.
 <4> `*pre*` and `*post*` are both xref:lifecycle-hooks[lifecycle hooks].
 ====
 
@@ -438,14 +486,8 @@ replica count and the old replication controller has been scaled to zero.
 ====
 When scaling down, the Rolling strategy waits for pods to become ready so it can
 decide whether further scaling would affect availability. If scaled up pods
-never become ready, the deployment will eventually time out and result in a
+never become ready, the deployment process will eventually time out and result in a
 deployment failure.
-====
-
-[IMPORTANT]
-====
-When executing the `*post*` lifecycle hook, all failures will be ignored
-regardless of the failure policy specified on the hook.
 ====
 
 The `*maxUnavailable*` parameter is the maximum number of pods that can be
@@ -463,6 +505,55 @@ during the update and rapid scale up.
 capacity (an in-place update).
 - `*maxUnavailable*=10%` and `*maxSurge*=10%` scales up and down quickly with
 some potential for capacity loss.
+
+Generally, if you want fast rollouts, use *maxSurge*, if you need to take into
+account resource quota and can accept partial unavailability, use *maxUnavailable*.
+
+=== Rolling example
+
+Rolling deployments are the default in {product-title}. To see a rolling update, follow these steps:
+
+1. Create an application based on the example deployment images found in 
+xref:https://hub.docker.com/r/openshift/deployment-example/[DockerHub]:
+
+----
+$ oc new-app openshift/deployment-example
+----
+
+If you have the router installed, make the application available via a route (or use the service IP directly)
+
+----
+$ oc expose svc/deployment-example
+----
+
+Browse to the application at `deployment-example.<project>.<router_domain>` to verify you see the 'v1' image.
+
+2. Scale the deployment config up to three replicas:
+
+----
+$ oc scale dc/deployment-example --replicas=3
+----
+
+3. Trigger a new deployment automatically by tagging a new version of the example as the `latest` tag:
+
+----
+$ oc tag deployment-example:v2 deployment-example:latest
+----
+
+4. In your browser, refresh the page until you see the 'v2' image.
+
+5. If you are using the CLI, the following command will show you how many pods are on version 1 and how many
+are on version 2. In the web console, you should see the pods slowly being added to v2 and removed from v1.
+
+---
+$ oc describe dc deployment-example
+---
+
+During the deployment process, the new replication controller is incrementally scaled up. Once the new pods
+are marked as *ready* (because they pass their readiness check), the deployment process will continue. If the
+pods do not become ready, the process will abort, and the deployment config will be rolled back to its previous
+version.
+
 
 [[recreate-strategy]]
 === Recreate Strategy
@@ -505,8 +596,16 @@ scaling up the deployment. If the validation of the first replica fails, the
 deployment will be considered a failure.
 ====
 
-[[custom-strategy]]
+=== When to use a recreate deployment?
 
+* When you must run migrations or other data transformations before your new code starts
+* When you don't support having new and old versions of your application code running at the same time
+* When you want to use a RWO volume which is not supported being shared between multiple replicas
+
+A recreate deployment incurs downtime, because for a brief period no instances of your application
+are running. However, your old code and new code do not run at the same time.
+
+[[custom-strategy]]
 === Custom Strategy
 
 The Custom strategy allows you to provide your own deployment behavior.
@@ -535,7 +634,7 @@ variables provided are added to the execution environment of the strategy
 process.
 
 Additionally, {product-title} provides the following environment variables to the
-strategy process:
+deployment process:
 
 [cols="4,8",options="header"]
 |===
@@ -551,6 +650,8 @@ strategy process:
 The replica count of the new deployment will initially be zero. The
 responsibility of the strategy is to make the new deployment active using the
 logic that best serves the needs of the user.
+
+For more advanced deployment strategies see xref:advanced-deployment-strategies[below].
 
 [[lifecycle-hooks]]
 == Lifecycle Hooks
@@ -829,3 +930,176 @@ spec:
   serviceAccount: <service_account>
   serviceAccountName: <service_account>
 ----
+
+[[advanced-deployment-strategies]]
+=== Advanced deployment strategies
+
+=== Blue-Green Deployment
+
+Blue-Green deployments involve running two versions of an application at the same time and moving production traffic from the old version to the new version ([more about blue-green deployments](http://martinfowler.com/bliki/BlueGreenDeployment.html)). There are several ways to implement a blue-green deployment in {product-title}.
+
+
+=== When to use a Blue-Green deployment?
+
+* When you want to test a new version of your application in a production environment before moving traffic to it
+
+Blue-Green deployments make switching between two different versions of your application easy. However, since
+many applications depend on persistent data you'll need to have an application that supports xref:n1-compatibility[N-1 compatibility]
+if you share a database, or implement a live data migration between your database, store, or disk if you choose to
+create two copies of your data layer.
+
+
+=== Blue-Green deployment example
+
+In order to maintain control over two distinct groups of instances (old and new versions of the code) the blue-green deployment is best represented with multiple deployment configs.
+
+=== Using a route and two services
+
+A route points to a service, and can be changed to point to a different service at any time. As a developer, you may test the new version of your code by connecting to the new service before your production traffic is routed to it. Routes are intended for web (HTTP and HTTPS) traffic and so this technique is best suited for web applications.
+
+1. Create two copies of the example application
+
+---
+$ oc new-app openshift/deployment-example:v1 --name=example-green
+$ oc new-app openshift/deployment-example:v2 --name=example-blue
+---
+
+This will create two independent application components - one running the `v1` image under the `example-green` service, and one using the `v2` image under the `example-blue` service.
+
+2. Create a route that points to the old service:
+
+---
+$ oc expose svc/example-green --name=bluegreen-example
+---
+
+Browse to the application at `bluegreen-example.<project>.<router_domain>` to verify you see the `v1` image.
+
+Note: On versions of {product-title} older than v1.0.3 (OSE v3.0.1), this command will generate a route at `example-green.<project>.<router_domain>`, not the above location.
+
+3. Edit the route and change the service name to `example-blue`:
+
+---
+$ oc patch route/bluegreen-example -p '{"spec":{"to":{"name":"example-blue"}}}'
+---
+
+4. In your browser, refresh the page until you see the 'v2' image.
+
+
+=== A/B Deployment
+
+A/B deployments generally imply running two (or more) versions of the application code or application configuration at the same time for testing or experimentation purposes. The simplest form of an A/B deployment is to divide production traffic between two or more distinct *shards* -- a single group of instances with homogenous configuration and code. More complicated A/B deployments may involve a specialized proxy or load balancer that assigns traffic to specific shards based on information about the user or application (all "test" users get sent to the B shard, but regular users get sent to the A shard). A/B deployments can be considered similar to A/B testing, although an A/B deployment implies multiple versions of code and configuration, where as A/B testing often uses one codebase with application specific checks.
+
+
+=== When to use an A/B deployment?
+
+* When you want to test multiple versions of code or configuration, but are not planning to roll one out in preference to the other
+* When you want to have different configuration in different regions
+
+An A/B deployment groups different configuration and code -- multiple shards -- together under a single logical endpoint. Generally, these deployments, if they access persistent data, should properly deal with N-1 compatibility (the more shards you have, the more possible versions you have running). Use this pattern when you need separate internal configuration and code, but end users should not be aware of the changes.
+
+
+=== A/B deployment example
+
+All A/B deployments are composite deployment types consisting of multiple deployment configs.
+
+=== One service, multiple deployment configs
+
+{product-title}, through labels and deployment configurations, can support multiple simultaneous shards being exposed through the same service. To the consuming user, the shards are invisible. An example of the simplest possible sharding is described below:
+
+1. Create the first shard of the application based on the example deployment images:
+
+---
+$ oc new-app openshift/deployment-example --name=ab-example-a --labels=ab-example=true SUBTITLE="shard A"
+---
+
+2. Edit the newly created shard to set a label `ab-example=true` that will be common to all shards:
+
+---
+$ oc edit dc/ab-example-a
+---
+
+In the editor, add the line `ab-example: "true"` underneath `spec.selector` and `spec.template.metadata.labels` alongside the existing `deploymentconfig=ab-example-a` label. Save and exit the editor.
+
+3. Trigger a re-deployment of the first shard to pick up the new labels:
+
+---
+$ oc deploy ab-example-a --latest
+---
+
+4. Create a service that uses the common label:
+
+---
+$ oc expose dc/ab-example-a --name=ab-example --selector=ab-example=true
+---
+
+If you have the router installed, make the application available via a route (or use the service IP directly)
+
+---
+$ oc expose svc/ab-example
+---
+
+Browse to the application at `ab-example.<project>.<router_domain>` to verify you see the 'v1' image.
+
+5. Create a second shard based on the same source image as the first shard but different tagged version, and set a unique value:
+
+---
+$ oc new-app openshift/deployment-example:v2 --name=ab-example-b --labels=ab-example=true SUBTITLE="shard B" COLOR="red"
+---
+
+6. Edit the newly created shard to set a label `ab-example=true` that will be common to all shards:
+
+---
+$ oc edit dc/ab-example-b
+---
+
+In the editor, add the line `ab-example: "true"` underneath `spec.selector` and `spec.template.metadata.labels` alongside the existing `deploymentconfig=ab-example-b` label. Save and exit the editor.
+
+7. Trigger a re-deployment of the second shard to pick up the new labels:
+
+---
+$ oc deploy ab-example-b --latest
+---
+
+8. At this point, both sets of pods are being served under the route. However, since both browsers (by leaving a connection open) and the router (by default through a cookie) will attempt to preserve your connection to a backend server, you may not see both shards being returned to you. To force your browser to one or the other shard, use the scale command:
+
+---
+$ oc scale dc/ab-example-a --replicas=0
+---
+
+Refreshing your browser should show "v2" and "shard B" (in red)
+
+---
+$ oc scale dc/ab-example-a --replicas=1; oc scale dc/ab-example-b --replicas=0
+---
+
+Refreshing your browser should show "v1" and "shard A" (in blue)
+
+If you trigger a deployment on either shard, only the pods in that shard will be affected. You can easily trigger a deployment by changing the `SUBTITLE` environment variable in either deployment config `oc edit dc/ab-example-a` or `oc edit dc/ab-example-b`. You can add additional shards by repeating steps 5-7.
+
+Note: these steps will be simplified in future versions of {product-title}.
+
+
+=== Shard proxy / Traffic splitter
+
+In production environments, you may want to precisely control the distribution of traffic that lands on a particular shard. When dealing with large numbers of instances, you can use the relative scale of individual shards to implement percentage based traffic. That combines well with a *proxy shard*, which forwards or splits the traffic it receives to a separate service or application running elsewhere.
+
+In the simplest configuration, the proxy would forward requests unchanged. In more complex setups, you may wish to duplicate the incoming requests and send to both a separate cluster as well as to a local instance of the application, and compare the result. Other patterns include keeping the caches of a DR installation warm, or sampling incoming traffic for analysis purposes.
+
+While an implementation is beyond the scope of this example, any TCP (or UDP) proxy could be run under the desired shard. Use the `oc scale` command to alter the relative number of instances serving requests under the proxy shard. For more complex traffic management, you may consider customizing the {product-title} router with proportional balancing capabilities.
+
+
+[[n1-compatibility]]
+=== N-1 Compatibility
+
+Applications that have new code and old code running at the same time must be careful to ensure that data written by the new code can be read by the old code. This is sometimes called *schema evolution* and is a complex problem. For some applications the period of time that old code and new code is running side by side is short and so bugs or some failed user transactions are acceptable. For others, the failure pattern may result in the entire application becoming non-functional.
+
+One way to validate N-1 compatibility is to use an A/B deployment - run the old code and new code at the same time in a controlled fashion in a test environment, and verify that traffic that flows to the new deployment does not cause failures in the old deployment.
+
+[[graceful-termination]]
+=== Graceful Termination
+
+{product-title} and Kubernetes give application instances time to shut down before removing them from load balancing rotations. However, applications must ensure they cleanly terminate user connections as well before they exit.
+
+On shutdown, {product-title} will send a TERM signal to the processes in the container. Application code, on receiving SIGTERM, should stop accepting new connections. This will ensure that load balancers route traffic to other active instances. The application code should then wait until all open connections are closed (or gracefully terminate individual connections at the next opportunity) before exiting.
+
+After the graceful termination period expires, a process that has not exited will be sent the KILL signal which immediately ends the process. The `terminationGracePeriodSeconds` attribute of a `Pod` or pod template controls the graceful termination period (default 30 seconds) and may be customized per application as necessary.


### PR DESCRIPTION
@mfojtik I would like this merged before we proceed with https://trello.com/c/oAlPryPh/793-3-need-to-document-how-to-use-upstream-deployments

@smarterclayton this squashes https://github.com/openshift/origin/blob/master/examples/deployment/README.md in openshift-docs.
