### PR TITLE
Clean-up / follow-up on cluster metrics content 

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -167,118 +167,125 @@ $ oc process -f metrics-deployer.yaml -v \
     | oc create -f -
 ----
 
-The size requirement of the Cassandra storage is dependent on the number of pods.
-It is the administrator's responsibility to ensure that the size requirements
-are sufficient for their setup and to monitor usage to ensure that the disk does
-not become full.
+The size requirement of the Cassandra storage is dependent on the number of
+pods. It is the administrator's responsibility to ensure that the size
+requirements are sufficient for their setup and to monitor usage to ensure that
+the disk does not become full.
 
-If you would like to use xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned
-persistent volumes] you must set the `*DYNAMICALLY_PROVISION_STORAGE*`
-xref:../install_config/cluster_metrics.adoc#modifying-the-deployer-template[template
-option] to `true` for the Metrics Deployer.
+If you would like to use xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned persistent volumes] 
+you must set the `*DYNAMICALLY_PROVISION_STORAGE*`
+xref:../install_config/cluster_metrics.adoc#modifying-the-deployer-template[template option] 
+to `true` for the Metrics Deployer.
 
 [[capacity-planning-for-openshift-metrics]]
-=== Capacity Planning for {product-title} Metrics
+=== Capacity Planning for Cluster Metrics
 
-After the metrics deployer runs, `oc get pods` output should look like:
+After the metrics deployer runs, the output of `oc get pods` should resemble the following:
 
 ====
 ----
  # oc get pods -n openshift-infra
- NAME                                          READY             STATUS      RESTARTS          AGE
- hawkular-cassandra-1-l5y4g                    1/1               Running     0                 17h
- hawkular-metrics-1t9so                        1/1               Running     0                 17h
- heapster-febru                                1/1               Running     0                 17h
+ NAME                                READY             STATUS      RESTARTS          AGE
+ hawkular-cassandra-1-l5y4g          1/1               Running     0                 17h
+ hawkular-metrics-1t9so              1/1               Running     0                 17h
+ heapster-febru                      1/1               Running     0                 17h
 ----
 ====
 
-{product-title} metrics uses the Cassandra database as datastore for metrics.
-Currently, Cassandra is deployed with `*MAX_HEAP_SIZE=512M*` and
-`*NEW_HEAP_SIZE=100M*`. It is assumed that these values should cover most of
-{product-title} metrics installations. It is possible to change these values in
-the
-link:https://github.com/openshift/origin-metrics/blob/master/cassandra/Dockerfile[Cassandra
-Docker file] prior to deploying {product-title} metrics.
+{product-title} metrics are stored using the Cassandra database, which is
+deployed with settings of `*MAX_HEAP_SIZE=512M*` and `*NEW_HEAP_SIZE=100M*`.
+These values should cover most  {product-title} metrics installations, but you
+can modify them in the
+ifdef::openshift-origin[]
+link:https://github.com/openshift/origin-metrics/blob/master/cassandra/Dockerfile[Cassandra Dockerfile] 
+endif::openshift-origin[]
+ifdef::openshift-enterprise[]
+Cassandra Dockerfile
+endif::openshift-enterprise[]
+prior to deploying cluster metrics.
 
-By default, metrics data is stored for 7 days.  This is configurable by
-specifying the `*METRIC_DURATION*` parameter in the
-link:https://github.com/openshift/origin-metrics/blob/master/metrics.yaml[*_metrics.yaml_*
-configuration file]. After 7 days, Cassandra begins to purge older metrics data.
-Metrics data for pods and name spaces that were deleted is not automatically
-purged. These metrics are removed once they are 7 days old.
+By default, metrics data is stored for 7 days. You can configure this with the `*METRIC_DURATION*` parameter in the
+ifdef::openshift-origin[]
+link:https://github.com/openshift/origin-metrics/blob/master/metrics.yaml[*_metrics.yaml_* configuration file]. 
+endif::openshift-origin[]
+ifdef::openshift-enterprise[]
+*_metrics.yaml_* configuration file.
+endif::openshift-enterprise[]
+After 7 days, Cassandra begins to purge the oldest metrics data.
+Metrics data for deleted pods and projects is not automatically
+purged; it is only removed once the data is 7 days old.
 
-In a test scenario including 10 nodes and 1,000 pods, 2.5GB of metrics data was
-accumulated over a 24-hour period.
-
-In a test scenario including 120 nodes and 10,000 pods, 25GB of metrics data was
-accumulated over a 24-hour period.
-
-Thus, a capacity planning formula for {product-title} metrics is:
-
+.Data Accumulated by 10 Nodes and 1000 Pods
 ====
-----
-(((2.5*10^9)/1000)/24)/10^6 = ~0.125 MB/hour per pod.
-----
-====
+In a test scenario including 10 nodes and 1000 pods, a 24 hour period
+accumulated 2.5GB of metrics data. Therefore, the capacity planning formula for
+metrics data in this scenario is:
 
-In a test scenario including 120 nodes and 10,000 pods, 25GB of metrics data was
-accumulated over a 24-hour period.
-
-====
-----
-(((11.410*10^9)/1000)/24)/10^6 = 0.475 MB/hour
-----
+(((2.5 × 10^9^) ÷ 1000) ÷ 24) ÷ 10^6^ = ~0.125 MB/hour per pod.
 ====
 
-[width="80%"]
-|================================================
+.Data Accumulated by 120 Nodes and 10000 Pods
+====
+In a test scenario including 120 nodes and 10000 pods, a 24 hour period
+accumulated 25GB of metrics data. Therefore, the capacity planning formula for
+metrics data in this scenario is:
+
+(((11.410 × 10^9^) ÷ 1000) ÷ 24) ÷ 10^6^ = 0.475 MB/hour
+====
+
+|===
 | |1000 pods| 10000 pods
-| Cassandra load over 24 hours - default metrics parameters   |2.5GB| 11.4GB
-|================================================
 
-These two test cases are presented on the graph below.
+|Cassandra storage data accumulated over 24 hours (default metrics parameters)
+|2.5GB
+|11.4GB
+|===
 
-image::https://raw.githubusercontent.com/ekuric/openshift/master/metrics/1_10kpods.png[1000 pods vs 10000 pods monitored during 24 h]
+ifdef::openshift-origin[]
+These two test cases are presented on the following graph:
 
-If the default value of 7 (days) for `*METRIC_DURATION*` and
-`*METRIC_RESOLUTION*` of 10 (seconds) are preserved, then it is expected that
-storage requirements for the Cassandra pod would be:
+image::https://raw.githubusercontent.com/ekuric/openshift/master/metrics/1_10kpods.png[1000 pods vs 10000 pods monitored during 24 hours]
+endif::openshift-origin[]
 
-[width="80%"]
-|================================================
+If the default value of 7 days for `*METRIC_DURATION*` and 10 seconds for
+`*METRIC_RESOLUTION*` are preserved, then weekly storage requirements for the Cassandra pod would be:
+
+|===
 | |1000 pods | 10000 pods
-| Cassandra storage over 7 days - default metrics parameters | 20GB | 90GB
-|================================================
 
-In the last table, an additional 10% was added to the expected storage space as
-a buffer for unexpected monitored pod usage.
+|Cassandra storage data accumulated over 7 days (default metrics parameters)
+|20GB
+|90GB
+|===
+
+In the previous table, an additional 10% was added to the expected storage space
+as a buffer for unexpected monitored pod usage.
 
 [WARNING]
 ====
-Data loss will result if the Cassandra persisted volume runs out of sufficient space.
+If the Cassandra persisted volume runs out of sufficient space, then data loss
+will occur.
 ====
 
 For cluster metrics to work with persistent storage, ensure that the persistent
-volume has the *ReadWriteOnce* access mode. If not, the persistent volume claim
-will not be able to find the persistent volume, and Cassandra will fail to
-start.
+volume has the *ReadWriteOnce* access mode. If this mode is not active, then the persistent volume claim cannot locate the persistent volume, and Cassandra fails to start.
 
 To use persistent storage with the metric components, ensure that a
-xref:../architecture/additional_concepts/storage.adoc#persistent-volumes[persistent
-volume] of sufficient size is available. The creation of
-xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent
-volume claims] is handled by the
+xref:../architecture/additional_concepts/storage.adoc#persistent-volumes[persistent volume] of sufficient size is available. The creation of
+xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent volume claims] is handled by the
 xref:../install_config/cluster_metrics.adoc#metrics-deployer[Metrics Deployer].
 
 {product-title} metrics also supports
-link:https://github.com/openshift/origin-metrics/blob/master/metrics.yaml#L130[dynamically
-provisioned persistent volumes]. To use this feature with {product-title}
-metrics, it is necessary to add an additional flag to the metrics-deployer:
-`DYNAMICALLY_PROVISION_STORAGE=true`.
-
-At this time, EBS, GCE, and Cinder storage back-ends can be used to
-xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically
-provision persistent volumes].
+ifdef::openshift-origin[]
+link:https://github.com/openshift/origin-metrics/blob/master/metrics.yaml#L130[dynamically-provisioned persistent volumes].
+endif::openshift-origin[]
+ifdef::openshift-enterprise[]
+dynamically-provisioned persistent volumes.
+endif::openshift-enterprise[]
+To use this feature with {product-title} metrics, it is necessary to add an
+additional flag to the metrics-deployer: `DYNAMICALLY_PROVISION_STORAGE=true`.
+You can use EBS, GCE, and Cinder storage back-ends to
+xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provision persistent volumes].
 
 [[metrics-non-persistent-storage]]
 === Non-Persistent Storage
@@ -700,10 +707,9 @@ will be able to write metrics to the system, which can affect performance and
 cause Cassandra disk usage to unpredictably increase.
 ====
 
-The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics
-documentation] covers how to use the API, but there are a few differences when
-dealing with the version of Hawkular Metrics configured for use on
-{product-title}:
+The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation] 
+covers how to use the API, but there are a few differences when dealing with the
+version of Hawkular Metrics configured for use on {product-title}:
 
 [[cluster-metrics-openshift-projects-and-hawkular-tenants]]
 === {product-title} Projects and Hawkular Tenants
@@ -719,6 +725,7 @@ There is also a special tenant named *_system* which contains system level
 metrics. This requires either a *cluster-reader* or *cluster-admin* level
 privileges to access.
 
+[[cluster-metrics-authorization]]
 === Authorization
 
 The Hawkular Metrics service will authenticate the user against {product-title}
@@ -734,6 +741,7 @@ When accessing the Hawkular Metrics API, you must pass a bearer token in the
 *Authorization* header.
 
 ifdef::openshift-origin[]
+[[cluster-metrics-accessing-heapster-directly]]
 == Accessing Heapster Directly
 
 Heapster has been configured to be only accessible via the
@@ -755,35 +763,57 @@ endif::[]
 [[cluster-metrics-scaling-openshift-metrics-pods]]
 == Scaling {product-title} Metrics Pods
 
-One set of metrics pods (cassandra/hawkular/heapster) is able to monitor at
+One set of metrics pods (Cassandra/Hawkular/Heapster) is able to monitor at
 least 10,000 pods.
 
-If there is a need to scale out {product-title} metrics pods, follow
-link:https://github.com/openshift/origin-metrics/blob/master/docs/cassandra_scaling.adoc[these
-instructions]
-
-If persistent storage was used to deploy {product-title} metrics, it is
-necessary to
-xref:../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[create
-a persistent volume (PV)] for the new Cassandra pod to use before scaling out
-the number of {product-title} metrics Cassandra pods. If Cassandra was deployed
-with dynamically provisioned PVs, this step is not necessary.
-
-To scale out the number of {product-title} metrics hawkular pods to two
-replicas, run:
-
-====
-----
-# oc scale -n openshift-infra --replicas=2 rc hawkular-metrics
-----
-====
-
-[IMPORTANT]
+[CAUTION]
 ====
 Pay attention to system load on nodes where {product-title} metrics pods run.
 Use that information to determine if it is necessary to scale out a number of
 {product-title} metrics pods and spread the load across multiple {product-title}
 nodes. Scaling {product-title} metrics heapster pods is not recommended.
+====
+
+[[cluster-metrics-scaling-pods-prereqs]]
+=== Prerequisites
+
+If persistent storage was used to deploy {product-title} metrics, then you must 
+xref:../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[create a persistent volume (PV)] 
+for the new Cassandra pod to use before you can scale out the number of
+{product-title} metrics Cassandra pods. However, if Cassandra was deployed with
+dynamically provisioned PVs, then this step is not necessary.
+
+[[cluster-metrics-scaling-pods-cassandra]]
+=== Scaling the Cassandra Components
+
+The Cassandra nodes use persistent storage, therefore scaling up or down is not possible with replication controllers.
+
+Scaling a Cassandra cluster requires you to use the `hawkular-cassandra-node` template. By default, the Cassandra cluster is a single-node cluster. 
+ifdef::openshift-origin[]
+To add a second node with 10Gi of storage:
+
+----
+# oc process hawkular-cassandra-node-pv -v \
+"IMAGE_PREFIX=openshift/origin-,IMAGE_VERSION=devel,PV_SIZE=10Gi,NODE=2"
+----
+
+To deploy more nodes, simply increase the `NODE` value.
+endif::openshift-origin[]
+
+ifdef::openshift-enterprise[]
+To scale out the number of {product-title} metrics hawkular pods to two
+replicas, run:
+
+----
+# oc scale -n openshift-infra --replicas=2 rc hawkular-metrics
+----
+endif::openshift-enterprise[]
+
+[NOTE]
+====
+If you add a new node to a Cassandra cluster, the data stored in the cluster
+rebalances across the cluster. The same thing happens If you remove a node from
+the Cluster.
 ====
 
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
As per vikram, found some content during release cherry-picking that hadn't been followed up on.

nicely rendered: http://file.bne.redhat.com/tpoitras/2016/metrics/openshift-enterprise/clustermetrics-fix/install_config/cluster_metrics.html#capacity-planning-for-openshift-metrics

ping @adellape @bfallonf peer review?
