### PR TITLE
More OCP 3.3 release note edits

### DIFF
--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -660,6 +660,15 @@ have previously deployed a
 xref:../../admin_guide/high_availability.adoc#configuring-a-highly-available-routing-service[highly-available
 routing service].
 
+ifdef::openshift-enterprise[]
+[NOTE]
+====
+If you previously customized your HAProxy routing template, then, depending on
+the changes, additional steps may be required due to changes in the routing data
+structure starting in {product-title} 3.3. See xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-routing-data-structure-changes[Routing Data Structure Changes] in the {product-title} 3.3 Release Notes for details.
+====
+endif::[]
+
 ifdef::openshift-origin[]
 [IMPORTANT]
 ====

--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -29,7 +29,7 @@ security, privacy, compliance, and governance requirements.
 [[ocp-33-about-this-release]]
 == About This Release
 
-Red Hat {product-title} version 3.3 is now available. This release is based on
+Red Hat {product-title} version 3.3 (link:https://access.redhat.com/errata/RHBA-2016:1933[RHBA-2016:1933]) is now available. This release is based on
 link:https://github.com/openshift/origin/releases/tag/v1.3.0[OpenShift Origin 1.3]. New features, changes, bug fixes, and known issues that
 pertain to {product-title} 3.3 are included in this topic.
 
@@ -207,222 +207,6 @@ To optimize image and blob lookups for pull-through requests, a small cache is
 kept in the registry to track which image streams have the manifest for the
 requested blobs, avoiding a potentially costly multi-server search.
 
-[[ocp-33-networking]]
-=== Networking
-
-This release adds the following improvements to networking components.
-
-[[ocp-33-controllable-source-ip]]
-==== Controllable Source IP
-
-Platform administrators can now identify a node in the cluster and allocate a
-number of static IP addresses to the node at the host level. If a developer needs
-an unchanging source IP for their application service, they can request access
-to one during the process they use to ask for firewall access. Platform
-administrators can then deploy an egress router from the developer's project,
-leveraging a `*nodeSelector*` in the deployment configuration to ensure the pod
-lands on the host with the pre-allocated static IP address.
-
-The egress pod's deployment declares one of the source IPs, the
-destination IP of the protected service, and a gateway IP to reach the
-destination. After the pod is deployed, the platform administrator can create a
-service to access the egress router pod. They then add that source IP to the
-corporate firewall and close out the ticket. The developer then has access
-information to the egress router service that was created in their project
-(e.g., `service.project.cluster.domainname.com`).
-
-When the developer would like to reach the external, firewalled service, they can
-call out to the ergress router pod's service (e.g.,
-`service.project.cluster.domainname.com`) in their application (e.g., the JDBC
-connection information) rather than the actual protected service url.
-
-[[ocp-33-router-sharding]]
-==== Router Sharding
-
-{product-title} offers a
-xref:../architecture/additional_concepts/sdn.adoc#architecture-additional-concepts-sdn[multi-tenant],
-docker-compliant platform. Thousands of tenants can be placed on the platform,
-some of which may be subsidiary corporations or have drastically different
-affiliations. With such diversity, often times business rules and regulatory
-requirements will dictate that tenants not flow through the same routing tier.
-
-To solve this issue, {product-title} 3.3 introduces
-xref:../architecture/core_concepts/routes.adoc#router-sharding[router sharding].
-With router sharding, a platform administrator can xref:../install_config/router/default_haproxy_router.adoc#using-router-shards[group specific routes or namespaces into shards] and then assign those shards to routers that may be up
-and running on the platform or be external to the platform. This allows tenants
-to have separation of egress traffic at the routing tiers.
-
-[[ocp-33-non-standard-ports]]
-==== Non-Standard Ports
-
-{product-title} has always been able to support non-standard TCP ports via SNI
-routing with SSL. As the internet of things (IoT) has exploded, so to has the
-need to speak to dumb devices or aggregation points without SNI routing. At the
-same time, with more and more people running data sources (such as databases) on
-{product-title}, many more people want to expose ports other than 80 or 433 for
-their applications so that people outside of the platform can leverage their
-service.
-
-Previously, the solution for this in Kubernetes was to leverage NodePorts or
-External IPs. The problem with NodePorts is that only one developer can have the
-port on all the nodes in the cluster. The problem with External IPs is that
-duplications can be common if the administrator is not carefully assigning them
-out.
-
-{product-title} 3.3 solves this problem through xref:../admin_guide/tcp_ingress_external_ports.adoc#admin-guide-unique-external-ips-ingress-traffic[the clever use of edge routers].
-Platform administrators can either select one or more of the nodes (more than
-one for high availability) in the cluster to become edge routers or they can
-just run additional pods on the HAProxy nodes.
-
-For example, a platform administrator can run additional pods that are
-ipfailover pods. A pool of available Ingress IPs are specified that are routable
-to the nodes in the cluster and resolvable externally via the corporate DNS.
-This pool of IP addresses are served out to developers who want to use a port other
-than 80 and 433. In these use cases, there are services outside of the cluster
-trying to connect to services inside the cluster that are running on ports other
-than 80 or 433. This means they are coming into the cluster (ingress) as opposed
-to leaving the cluster (egress). By resolving through the edge routers, the
-cluster can ensure each developers gets their desired port by pairing it with a
-Ingress IP from the available pool rather than giving them a random port.
-
-In order to trigger this allocation of an Ingress IP, the developer declares a
-`*LoadBalancer*` type in their service definition for their application.
-Afterwards, they can use the `oc get <service_name>` command to see what Ingress IP was
-assigned to them. See xref:../dev_guide/getting_traffic_into_cluster.adoc#getting-traffic-into-cluster[Getting Traffic into the Cluster] for details.
-
-[[ocp-33-ab-service-annotation]]
-==== A/B Service Annotation
-
-{product-title} 3.3 adds service lists to routes, making it easier to perform
-A/B testing. Each route can now have multiple services assigned to it, and those
-services can come from different applications or pods. New automation enables
-HAProxy to be able to read weight annotations on the route for the services.
-This enables developers to declare traffic flow (for example, 70% to application
-A and 30% to application B) using the CLI or web console.
-
-[[ocp-33-security]]
-=== Security
-
-This release adds the following improvements to cluster security.
-
-[[ocp-33-scc-profiles-seccomp]]
-==== SCC Profiles for seccomp
-
-The *seccomp* feature in Red Hat Enterprise Linux (RHEL) has been enabled for docker 1.10 or higher. This feature allows containers to define interactions with the kernel using *syscall* filtering. This reduces the risk of a malicious container exploiting a kernel vulnerability, thereby reducing the guest attack surface.
-
-{product-title} adds the ability to create *seccomp* policies with security
-context constraints (SCCs). This allows platform administrators to set SCC
-policies on developers that imposes a filter on their containers for Linux-level
-system calls.
-
-[[ocp-33-kerb-support-oc-client-linux]]
-==== Kerberos Support in oc client for Linux
-
-The `oc` client on Linux can now recognize and handle the `kinit` process of
-generating a Kerberos ticket during developer interactions with the CLI. For
-example:
-
-----
-$ kinit <user>@<domain>
-$ oc login <openshift_master>
-----
-
-[[ocp-33-cert-maintenance]]
-==== Certificate Maintenance
-
-{product-title} leverages TLS encryption and token-based authentication between
-its framework components. In order to accelerate and ease the installation of
-the product, certificates are self-signed during automated installation.
-{product-title} 3.3 adds the ability to update and change those certificates
-that govern the communication between framework components. This allows platform
-administrators to more easily maintain the life cycles of their {product-title}
-installations.
-
-[[ocp-33-cluster-longevity]]
-=== Cluster Longevity
-
-This release adds the following improvements to cluster longevity.
-
-[[ocp-33-pod-eviction]]
-==== Pod Eviction
-
-{product-title} 3.3 allows platform administrators more control over what
-happens over the lifecycle of the workload on the cluster after the process
-(container) is started. By leveraging limits and request setting at deployment
-time, the cluster can determine automatically how the developer wants their
-workload handled in terms of resources. Three positions can be taken:
-
-- If the developer declares no resource requirements (best effort), slack resources
-are offered on the cluster. More importantly, workloads are re-deployed first
-should an individual node become exhausted.
-- If the developer sets minimum resource requirements but does not ask for a very
-specific range of consumption (burstable), their minimum is set while also
-giving them an ability to consume slack resources should any exist. This
-workload is considered more important than best effort in terms of re-deployment
-during a node eviction.
-- If a developer sets the minimum and maximum resource requirements (guaranteed),
-a node with those resources is found and the workload is set as most important
-on the node. These workloads remain as the last survivor on a node should it go
-into a memory starvation situation.
-
-The decision to evict is a configurable setting. Platform
-administrators can turn on the ability to hand a pod (container) back to the
-scheduler for re-deployment on a different node should out of memory errors
-start to occur.
-
-[[ocp-33-scale]]
-==== Scale
-
-1000 nodes per cluster at 250 pods per node (with a
-recommendation of 10 pods per hyper-threaded core) are now supported. See
-xref:../install_config/install/planning.adoc#sizing[Sizing Considerations] for
-more details.
-
-[[ocp-33-idling-unidling]]
-==== Idling and Unidling
-
-{product-title} 3.3 adds an API to idle an application's pods (containers). This
-allows for monitoring solutions to call the API when a threshold to a metric of
-interest is crossed.  At the routing tier, the HAProxy holds the declared route
-URL that is connected to the service open and the pods are shut down. Should
-someone hit this application URL, the pods are re-launched on available
-resources in the cluster and connected to the existing route.
-
-////
-[[ocp-33-storage-labels]]
-==== Storage Labels
-
-{product-title} already included the ability to offer remote persistence block
-and file based storage, and this release adds the ability for developers to
-select a storage provider on the cluster in a more granular manner using storage
-labels. Storage labels help developers call out to a specific provider in a
-simple manner by adding a label request to their persistent volume claim (PVC).
-////
-
-[[ocp-33-framework-services]]
-=== Framework Services
-
-{product-title} provides resource usage metrics and log access to developers based on the Hawkular and Elasticsearch open source projects. This release adds the following improvements to these components.
-
-[[ocp-33-logging-enhancements]]
-==== Logging Enhancements
-
-A new xref:../install_config/aggregate_logging.adoc#configuring-curator[log curator] utility helps platform administrators deal with the storage requirements of
-storing tenant logs over time.
-
-Integration with existing ELK stacks you might already own or be invested in has
-also been enhanced by allowing logs to more easily be sent to multiple
-locations.
-
-[[ocp-33-metrics-installation-enhancements]]
-==== Metrics Installation Enhancement
-
-This release adds network usage attributes to the core metrics tracked for
-tenants. Metrics deployment is also now a core installation feature instead of a
-post-installation activity.  The {product-title} installer now guides you
-through the Ansible playbooks required to successfully deploy metrics, thus
-driving more usage of the feature in the user interface and Red Hat CloudForms.
-
 [[ocp-33-developer-experience]]
 === Developer Experience
 
@@ -430,9 +214,15 @@ This release adds the following improvements to the developer workflow when
 developing and testing applications on {product-title}.
 
 [[ocp-33-pipelines]]
-==== Pipelines (Technology Preview)
+==== OpenShift Pipelines (Technology Preview)
 
-Previously with CI/CD, it was possible to define small pipeline-like workflows (such as triggering deployments after a new image was built or building an image when upstream source code changed), OpenShift Pipelines (currently in Technology Preview) expose a true first class pipeline execution capability. OpenShift Pipelines are based on the link:https://jenkins.io/solutions/pipeline/[Jenkins Pipeline plug-in]. By integrating Jenkins Pipelines into OpenShift, you can now leverage the full power and flexibility of the Jenkins ecosystem while managing your workflow from within OpenShift.
+Previously with CI/CD, it was possible to define small pipeline-like workflows,
+such as triggering deployments after a new image was built or building an image
+when upstream source code changed. OpenShift Pipelines (currently in xref:ocp-33-technology-preview[Technology Preview]) now expose a true first class pipeline execution capability. OpenShift
+Pipelines are based on the link:https://jenkins.io/solutions/pipeline/[Jenkins
+Pipeline plug-in]. By integrating Jenkins Pipelines into OpenShift, you can now
+leverage the full power and flexibility of the Jenkins ecosystem while managing
+your workflow from within OpenShift.
 
 [NOTE]
 ====
@@ -440,7 +230,10 @@ See xref:ocp-33-web-console-pipelines[New Features and Enhancements: Web Console
 more details on the new pipelines user interface.
 ====
 
-Pipelines are defined as a new build strategy within {product-title}, meaning you can start, cancel, and view your pipelines in the same way as any other build. Because your pipeline is executed by Jenkins, you can also use the Jenkins console to view and manage your pipeline.
+Pipelines are defined as a new build strategy within {product-title}, meaning
+you can start, cancel, and view your pipelines in the same way as any other
+build. Because your pipeline is executed by Jenkins, you can also use the
+Jenkins console to view and manage your pipeline.
 
 Finally, your pipelines can utilize the link:https://github.com/jenkinsci/openshift-pipeline-plugin[OpenShift Pipeline plug-in] to easily
 perform first class actions in your {product-title} cluster, such as triggering
@@ -682,7 +475,7 @@ Monitoring:: A single page that gives you access to logs, metrics, and events.
 
 A new set of pages have been added dedicated to the new
 xref:ocp-33-web-console-pipelines[OpenShift Pipelines] feature (currently in
-Technology Preview) that allow you to visualize your pipeline's stages, edit the
+xref:ocp-33-technology-preview[Technology Preview]) that allow you to visualize your pipeline's stages, edit the
 configuration, and manually kick off a build. Pipelines paused waiting for
 manual user intervention provide a link to the Jenkins pipeline interface.
 
@@ -695,9 +488,8 @@ page if they are related to a deployment configuration.
 .Project Overview with Pipelines
 image::ocp33-pipelines2.png["Project Overview with Pipelines"]
 
-OpenShift Pipelines are currently in Technology Preview. To enable pipelines in
-the primary navigation of the web console, see
-xref:../install_config/web_console_customization.html#install-config-web-console-customization[Customizing the Web Console].
+Because OpenShift Pipelines are currently in xref:ocp-33-technology-preview[Technology Preview], you must enable pipelines in the primary navigation of the web console to use this feature. See
+xref:../install_config/web_console_customization.adoc#web-console-enable-tech-preview-feature[Enabling Features in Technology Preview] for instructions.
 
 [[ocp-33-web-console-ab-routing]]
 ==== New Concept: A/B Routing
@@ -711,7 +503,7 @@ visualize the percentage of traffic configured to go to each one.
 image::ocp33-abroutes.png["A/B Routes"]
 
 Modifying the route's back end services can be done in the new GUI editor, which
-also lets you change the route’s target ports, path, and TLS settings.
+also lets you change the route's target ports, path, and TLS settings.
 
 [[ocp-33-web-console-deploy-image]]
 ==== Deploy Image
@@ -805,11 +597,244 @@ the images in your image streams, aside from the SHAs. This made it difficult to
 know the specifics of how your image was defined unless you used the CLI. Now,
 for any image stream tag you can see the metadata, cofiguration, and layers.
 
-.Image Stream Details
-image::ocp33-imagedetails.png["Image Stream Details"]
+.Image Stream Tag Details
+image::ocp33-imagedetails.png["Image Stream Tag Details"]
 
-.Image Stream Configuration
-image::ocp33-imagedetails2.png["Image Stream Configuration"]
+.Image Stream Tag Configuration
+image::ocp33-imagedetails2.png["Image Stream Tag Configuration"]
+
+[[ocp-33-networking]]
+=== Networking
+
+This release adds the following improvements to networking components.
+
+[[ocp-33-controllable-source-ip]]
+==== Controllable Source IP
+
+Platform administrators can now identify a node in the cluster and allocate a
+number of static IP addresses to the node at the host level. If a developer needs
+an unchanging source IP for their application service, they can request access
+to one during the process they use to ask for firewall access. Platform
+administrators can then deploy an egress router from the developer's project,
+leveraging a `*nodeSelector*` in the deployment configuration to ensure the pod
+lands on the host with the pre-allocated static IP address.
+
+The egress pod's deployment declares one of the source IPs, the
+destination IP of the protected service, and a gateway IP to reach the
+destination. After the pod is deployed, the platform administrator can create a
+service to access the egress router pod. They then add that source IP to the
+corporate firewall and close out the ticket. The developer then has access
+information to the egress router service that was created in their project
+(e.g., `service.project.cluster.domainname.com`).
+
+When the developer would like to reach the external, firewalled service, they can
+call out to the ergress router pod's service (e.g.,
+`service.project.cluster.domainname.com`) in their application (e.g., the JDBC
+connection information) rather than the actual protected service url.
+
+See xref:../admin_guide/managing_pods.adoc#admin-guide-controlling-egress-traffic[Controlling Egress Traffic] for more details.
+
+[[ocp-33-router-sharding]]
+==== Router Sharding
+
+{product-title} offers a
+xref:../architecture/additional_concepts/sdn.adoc#architecture-additional-concepts-sdn[multi-tenant],
+docker-compliant platform. Thousands of tenants can be placed on the platform,
+some of which may be subsidiary corporations or have drastically different
+affiliations. With such diversity, often times business rules and regulatory
+requirements will dictate that tenants not flow through the same routing tier.
+
+To solve this issue, {product-title} 3.3 introduces
+xref:../architecture/core_concepts/routes.adoc#router-sharding[router sharding].
+With router sharding, a platform administrator can xref:../install_config/router/default_haproxy_router.adoc#using-router-shards[group specific routes or namespaces into shards] and then assign those shards to routers that may be up
+and running on the platform or be external to the platform. This allows tenants
+to have separation of egress traffic at the routing tiers.
+
+[[ocp-33-non-standard-ports]]
+==== Non-Standard Ports
+
+{product-title} has always been able to support non-standard TCP ports via SNI
+routing with SSL. As the internet of things (IoT) has exploded, so to has the
+need to speak to dumb devices or aggregation points without SNI routing. At the
+same time, with more and more people running data sources (such as databases) on
+{product-title}, many more people want to expose ports other than 80 or 433 for
+their applications so that people outside of the platform can leverage their
+service.
+
+Previously, the solution for this in Kubernetes was to leverage NodePorts or
+External IPs. The problem with NodePorts is that only one developer can have the
+port on all the nodes in the cluster. The problem with External IPs is that
+duplications can be common if the administrator is not carefully assigning them
+out.
+
+{product-title} 3.3 solves this problem through xref:../admin_guide/tcp_ingress_external_ports.adoc#admin-guide-unique-external-ips-ingress-traffic[the clever use of edge routers].
+Platform administrators can either select one or more of the nodes (more than
+one for high availability) in the cluster to become edge routers or they can
+just run additional pods on the HAProxy nodes.
+
+For example, a platform administrator can run additional pods that are
+ipfailover pods. A pool of available Ingress IPs are specified that are routable
+to the nodes in the cluster and resolvable externally via the corporate DNS.
+This pool of IP addresses are served out to developers who want to use a port other
+than 80 and 433. In these use cases, there are services outside of the cluster
+trying to connect to services inside the cluster that are running on ports other
+than 80 or 433. This means they are coming into the cluster (ingress) as opposed
+to leaving the cluster (egress). By resolving through the edge routers, the
+cluster can ensure each developers gets their desired port by pairing it with a
+Ingress IP from the available pool rather than giving them a random port.
+
+In order to trigger this allocation of an Ingress IP, the developer declares a
+`*LoadBalancer*` type in their service definition for their application.
+Afterwards, they can use the `oc get <service_name>` command to see what Ingress IP was
+assigned to them. See xref:../dev_guide/getting_traffic_into_cluster.adoc#getting-traffic-into-cluster[Getting Traffic into the Cluster] for details.
+
+[[ocp-33-ab-service-annotation]]
+==== A/B Service Annotation
+
+{product-title} 3.3 adds service lists to routes, making it easier to perform
+A/B testing. Each route can now have multiple services assigned to it, and those
+services can come from different applications or pods.
+
+New automation enables HAProxy to be able to read weight annotations on the
+route for the services. This enables developers to declare traffic flow (for
+example, 70% to application A and 30% to application B) using the CLI or web
+console.
+
+[NOTE]
+====
+See xref:ocp-33-web-console-ab-routing[New Features and Enhancements: Web Console] for
+more details on the new A/B routing user interface.
+====
+
+See xref:../dev_guide/routes.adoc#routes-load-balancing-for-AB-testing[Load Balancing for A/B Testing] for more details.
+
+[[ocp-33-security]]
+=== Security
+
+This release adds the following improvements to cluster security.
+
+[[ocp-33-scc-profiles-seccomp]]
+==== SCC Profiles for seccomp
+
+The *seccomp* feature in Red Hat Enterprise Linux (RHEL) has been enabled for docker 1.10 or higher. This feature allows containers to define interactions with the kernel using *syscall* filtering. This reduces the risk of a malicious container exploiting a kernel vulnerability, thereby reducing the guest attack surface.
+
+{product-title} adds the ability to create *seccomp* policies with security
+context constraints (SCCs). This allows platform administrators to set SCC
+policies on developers that imposes a filter on their containers for Linux-level
+system calls.
+
+See the xref:../architecture/additional_concepts/authorization.adoc#authorization-seccomp[Authorization] concept for more details.
+
+[[ocp-33-kerb-support-oc-client-linux]]
+==== Kerberos Support in oc client for Linux
+
+The `oc` client on Linux can now recognize and handle the `kinit` process of
+generating a Kerberos ticket during developer interactions with the CLI. For
+example:
+
+----
+$ kinit <user>@<domain>
+$ oc login <openshift_master>
+----
+
+[[ocp-33-cert-maintenance]]
+==== Certificate Maintenance
+
+{product-title} leverages TLS encryption and token-based authentication between
+its framework components. In order to accelerate and ease the installation of
+the product, certificates are self-signed during automated installation.
+
+{product-title} 3.3 adds the ability to update and change those certificates
+that govern the communication between framework components. This allows platform
+administrators to more easily maintain the life cycles of their {product-title}
+installations.
+
+See xref:../install_config/redeploying_certificates.adoc#install-config-redeploying-certificates[Redeploying Certificates] for more details.
+
+[[ocp-33-cluster-longevity]]
+=== Cluster Longevity
+
+This release adds the following improvements to cluster longevity.
+
+[[ocp-33-pod-eviction]]
+==== Pod Eviction
+
+{product-title} 3.3 allows platform administrators more control over what
+happens over the lifecycle of the workload on the cluster after the process
+(container) is started. By leveraging limits and request setting at deployment
+time, the cluster can determine automatically how the developer wants their
+workload handled in terms of resources. Three positions can be taken:
+
+- If the developer declares no resource requirements (best effort), slack resources
+are offered on the cluster. More importantly, workloads are re-deployed first
+should an individual node become exhausted.
+- If the developer sets minimum resource requirements but does not ask for a very
+specific range of consumption (burstable), their minimum is set while also
+giving them an ability to consume slack resources should any exist. This
+workload is considered more important than best effort in terms of re-deployment
+during a node eviction.
+- If a developer sets the minimum and maximum resource requirements (guaranteed),
+a node with those resources is found and the workload is set as most important
+on the node. These workloads remain as the last survivor on a node should it go
+into a memory starvation situation.
+
+The decision to evict is a configurable setting. Platform
+administrators can turn on the ability to hand a pod (container) back to the
+scheduler for re-deployment on a different node should out of memory errors
+start to occur.
+
+[[ocp-33-scale]]
+==== Scale
+
+1000 nodes per cluster at 250 pods per node (with a
+recommendation of 10 pods per hyper-threaded core) are now supported. See
+xref:../install_config/install/planning.adoc#sizing[Sizing Considerations] for
+more details.
+
+[[ocp-33-idling-unidling]]
+==== Idling and Unidling
+
+{product-title} 3.3 adds an API to idle an application's pods (containers). This
+allows for monitoring solutions to call the API when a threshold to a metric of
+interest is crossed.  At the routing tier, the HAProxy holds the declared route
+URL that is connected to the service open and the pods are shut down. Should
+someone hit this application URL, the pods are re-launched on available
+resources in the cluster and connected to the existing route.
+
+[[ocp-33-storage-labels]]
+==== Storage Labels
+
+{product-title} already included the ability to offer remote persistence block
+and file based storage, and this release adds the ability for developers to
+select a storage provider on the cluster in a more granular manner using storage
+labels. Storage labels help developers call out to a specific provider in a
+simple manner by adding a label request to their persistent volume claim (PVC).
+
+See xref:../install_config/storage_examples/binding_pv_by_label.adoc#binding-pv-by-label[Binding Persistent Volumes by Labels] for exampe usage.
+
+[[ocp-33-framework-services]]
+=== Framework Services
+
+{product-title} provides resource usage metrics and log access to developers based on the Hawkular and Elasticsearch open source projects. This release adds the following improvements to these components.
+
+[[ocp-33-logging-enhancements]]
+==== Logging Enhancements
+
+A new xref:../install_config/aggregate_logging.adoc#configuring-curator[log curator] utility helps platform administrators deal with the storage requirements of
+storing tenant logs over time.
+
+Integration with existing ELK stacks you might already own or be invested in has
+also been enhanced by allowing logs to more easily be sent to multiple
+locations.
+
+[[ocp-33-metrics-installation-enhancements]]
+==== Metrics Installation Enhancement
+
+This release adds network usage attributes to the core metrics tracked for
+tenants. Metrics deployment is also now a core installation feature instead of a
+post-installation activity.  The {product-title} installer now guides you
+through the Ansible playbooks required to successfully deploy metrics, thus
+driving more usage of the feature in the user interface and Red Hat CloudForms.
 
 [[ocp-33-notable-technical-changes]]
 == Notable Technical Changes
@@ -822,6 +847,148 @@ image::ocp33-imagedetails2.png["Image Stream Configuration"]
 - Kubernetes has been updated to v1.3.0+52492b4.
 - etcd has been updated to 2.3.0+git.
 - OpenShift Enterprise 3.3 requires Docker 1.10.
+
+[[ocp-33-routing-data-structure-changes]]
+*Routing Data Structure Changes*
+
+The underlying data structure that a router template can use has changed in
+{product-title} 3.3. xref:ocp-33-custom-haproxy-template-upgrade[Additional steps] may be needed for an upgrade from 3.2 to
+3.3 if you previously customized your HAProxy routing template.
+
+_Short Summary of Changes_
+
+In the older model, the top level had one map of all services. To get to routes
+in the system, all services had to be iterated over to get to the routes that
+each service holds. In the new model, the top level contains two maps: one for
+all the routes and one for all the services. You can now get to any of them
+without repeated iteration.
+
+_Understanding the New Model_
+
+The new data structure defining the routing back ends consists of two structures
+representing services and routes and one top-level structure that contains a map
+to both.
+
+- `*ServiceUnit*` <- -> `*Service*`
+- `*ServiceAliasConfig*` <- -> `*Route*`
+
+The top-level router template has two maps:
+
+====
+----
+State            map[string]ServiceAliasConfig
+ServiceUnits     map[string]ServiceUnit
+----
+====
+
+In {product-title} 3.3, a route can have many services and any service can be
+part of many routes. The `*ServiceAliasConfig(Route)*` holds a map of
+`*ServiceUnitNames(Service)*` with their corresponding weights. To get to the
+actual `service/ServiceUnit`, you must look up the top-level map
+`*ServiceUnits*`:
+
+====
+----
+type ServiceAliasConfig {
+  ..
+  ..
+  ServiceUnitNames map[string]int32
+}
+----
+====
+
+To quickly go through all the routes as an example:
+
+. Iterate over the `*template.State*` map, which gives all routes represented by `*ServiceAliasConfig*`.
+. Go over all services of a route along with their weights.
+. With each service name, look up the actual service from the `*template.ServiceUnits*` map.
+. Go over endpoints of the service with the `*Endpoints*` field in the `*ServiceUnit*` structure and use those endpoints with the associated weight for the service.
++
+.Example Code
+====
+----
+# get the routes/ServiceAliasConfigs from .State
+{{ range $routeId, $route := .State }}
+  # get the names of all services that this route has, with the corresponding weights
+  {{ range $serviceName, $weight := $route.ServiceUnitNames }}
+    # now look up the top level structure .ServiceUnits to get the actual service object
+    {{ with $service := index $.ServiceUnits $serviceName }}
+      # get endpoints from the service object
+      {{ range $idx, $endpoint := endpointsForAlias $route $service }}
+# print the endpoint
+server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}}...
+----
+====
+
+_Comparing with the Older Model_
+
+To contrast with the older model, previously a service could be part of many
+routes, so there were two basic structures:
+
+- `*ServiceAliasConfig*` corresponded to a `*Route*`.
+- `*ServiceUnit*` corresponded to a `*Service*`, but also held how many `*Routes*` pointed to it.
+
+`*ServiceUnit*` had one special field that contained all the
+`*ServiceAliasConfigs*` (routes) that it was part of:
+
+====
+----
+type ServiceUnit {
+ ..
+ ..
+  ServiceAliasConfigs map[string]ServiceAliasConfig
+}
+----
+====
+
+The top level template had a map of all services in the system. To iterate to routes, you previously had to iterate over services first to get the routes that it was part of. For example:
+
+. Iterate over all `*ServiceUnits*` (services)
+. Iterate over all `*ServiceAliasConfigs*` (routes) that this Service has.
+. Get the route information (header, TLS, etc.) and use the `*Endpoints*` field in the `*ServiceUnit*` to get to the actual back ends.
++
+.Example Code
+====
+----
+{{ range $id, $serviceUnit := .State }}
+  {{ range $routeId, $route := $serviceUnit.ServiceAliasConfigs }}
+    {{ range $idx, $endpoint := endpointsForAlias $route $serviceUnit }}
+server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}}
+----
+====
+
+The older model could not accommodate the idea that a route could contain
+multiple services.
+
+[[ocp-33-custom-haproxy-template-upgrade]]
+_Upgrade Requirements for Customized HAProxy Routing Templates_
+
+If you are upgrading to {product-title} 3.3 but you never changed the default
+HAProxy routing template that came with the image, then no action is required.
+Ensure that the new router image is used so that you can use the latest features
+for the release. If you ever need to change the template, consult this
+documentation.
+
+If you previously customized your HAProxy routing template, then, depending on
+the changes, the following may be required:
+
+* Re-apply the changes on the newer template. Or,
+* Rewrite your existing template using the newer model:
+** Iterating over `*.State*` now gives `*ServiceAliasConfigs*` and not the `*ServiceUnits*`.
+** Each `*ServiceAliasConfig*` now has multiple `*ServiceUnits*` in it stored as
+keys of a map, where the value of each key is the weight associated with the
+service.
+** To get the actual service object, index over another top level object called `*ServiceUnits*`.
+** You can no longer get the list of routes that a service serves; this information
+was not found to be useful. If you use this information for any reason, you must
+construct your own map by iterating over all routes that contain a particular
+service.
+
+It is recommended that the new template is taken as a base and modifications are
+re-applied on it. Then, rebuild the router image. The same applies if you use a
+`*configMap*` to supply the template to the router: you must use the new image
+or rebuild your image either way because the {product-title} executable inside
+the image needs an upgrade, too.
 
 [[ocp-33-manual-endpoints-clusternetworkcidr]]
 *Manually-Created Endpoints Inside ClusterNetworkCIDR*
@@ -1076,18 +1243,20 @@ Features Support Scope]
 
 The following features are in Technology Preview:
 
-- OpenShift Pipelines
-- PetSets and Init containers (alpha features in Kubernetes 1.3)
+- xref:ocp-33-pipelines[OpenShift Pipelines]
+- xref:../dev_guide/builds.adoc#extended-builds[Extended Builds]
 - Introduced in OpenShift Enterprise 3.1.1,
-xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamic
-provisioning] of persistent storage volumes from Amazon EBS, Google Compute
+xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamic provisioning] of persistent storage volumes from Amazon EBS, Google Compute
 Disk, OpenStack Cinder storage providers remains in Technology Preview for
 {product-title} 3.3.
 
-////
 [[ocp-33-known-issues]]
 == Known Issues
-////
+
+* Setting the `*forks*` parameter in the *_/etc/ansible/ansible.cfg_* file to 11
+or higher is known to cause {product-title} installations to hang with Ansible
+2.2. The current default is 5. See
+link:http://docs.ansible.com/ansible/intro_configuration.html#forks[http://docs.ansible.com/ansible/intro_configuration.html#forks] for more on this parameter. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1367948[*BZ#1367948*])
 
 [[ocp-33-asynchronous-errata-updates]]
 == Asynchronous Errata Updates


### PR DESCRIPTION
http://file.rdu.redhat.com/~adellape/092616/relnoteedits2/release_notes/ocp_3_3_release_notes.html

Adds:
- Storage Labels
- Extended Builds to Tech Preview
- Routing Data Structure Changes to Notable Technical Changes
- Known Issue for Ansible forks setting
- Additional linking to relevant docs from New Features
- Moved Dev Exp and Web Console up in the New Features list
