### PR TITLE
Clarify when cleanup needs to be run

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -144,8 +144,9 @@ ifdef::openshift-enterprise[]
 . Restart the *atomic-openshift-master* service on masters and the
 *atomic-openshift-node* service on nodes.
 endif::[]
-. If the existing plug-in is {product-title} SDN plug-in, then cleanup
-{product-title} SDN specific artifacts:
+. If you are switching from an {product-title} SDN plug-in to a
+third-party plugin, then clean up {product-title} SDN specific
+artifacts:
 ----
 $ oc delete clusternetwork --all
 $ oc delete hostsubnets --all


### PR DESCRIPTION
There is no need to clean up several things when changing between
variants of the OpenShift SDN plugin.
