### PR TITLE
Re-applying REST API doc fixes after mass 3.3 update

### DIFF
--- a/rest_api/kubernetes_v1.adoc
+++ b/rest_api/kubernetes_v1.adoc
@@ -11207,7 +11207,7 @@ ExecAction describes a "run in container" action.
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|command|Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.|false|string array|
+|command|Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('\|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.|false|string array|
 |===
 
 === v1.FCVolumeSource
@@ -11608,7 +11608,7 @@ NodeSpec describes the attributes that a node is created with.
 |podCIDR|PodCIDR represents the pod IP range assigned to the node.|false|string|
 |externalID|External ID of the node assigned by some machine database (e.g. a cloud provider). Deprecated.|false|string|
 |providerID|ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>|false|string|
-|unschedulable|Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/release-1.3/docs/admin/node.md#manual-node-administration"`|false|boolean|
+|unschedulable|Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/release-1.3/docs/admin/node.md#manual-node-administration|false|boolean|
 |===
 
 === v1.NodeStatus
@@ -12534,4 +12534,3 @@ Represents a vSphere volume resource.
 === any
 
 Represents an untyped JSON map - see the description of the field for more info about the structure of this object.
-

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -12602,7 +12602,7 @@ BuildStatus contains the status of a build
 |message|message is a human-readable message indicating details about why the build has this status.|false|string|
 |startTimestamp|startTimestamp is a timestamp representing the server time when this Build started running in a Pod. It is represented in RFC3339 form and is in UTC.|false|string|
 |completionTimestamp|completionTimestamp is a timestamp representing the server time when this Build was finished, whether that build failed or succeeded.  It reflects the time at which the Pod running the Build terminated. It is represented in RFC3339 form and is in UTC.|false|string|
-|duration|duration contains time.Duration object describing build time.|false|<<time.Duration>>|
+|duration|duration contains time.Duration object describing build time.|false|time.Duration|
 |outputDockerImageReference|outputDockerImageReference contains a reference to the Docker image that will be built by this build. Its value is computed from Build.Spec.Output.To, and should include the registry address, so that it can be used to push and pull the image.|false|string|
 |config|config is an ObjectReference to the BuildConfig this Build is based on.|false|<<v1.ObjectReference>>|
 |===
@@ -13337,7 +13337,7 @@ ExecAction describes a "run in container" action.
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|command|Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.|false|string array|
+|command|Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('\|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.|false|string array|
 |===
 
 === v1.ExecNewPodHook
@@ -14522,14 +14522,14 @@ ProjectList is a list of Project objects.
 
 === v1.ProjectRequest
 :hardbreaks:
-ProjecRequest is the set of options necessary to fully qualify a project request
+ProjectRequest is the set of options necessary to fully qualify a project request
 
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
 |kind|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds|false|string|
-|apiVersion|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#resources|false|string|
-|metadata|Standard object's metadata.|false|<<v1.ObjectMeta>>|
+|apiVersion|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#resources|true|string|
+|metadata|Standard object's metadata.|subfield `name`|<<v1.ObjectMeta>>|
 |displayName|DisplayName is the display name to apply to a project|false|string|
 |description|Description is the description to apply to a project|false|string|
 |===


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/2709.
