### PR TITLE
Prefer short flag for whoami -t

### DIFF
--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -44,7 +44,7 @@ command:
 ----
 $ oc login -u test_user
 Using project "test".
-$ oc whoami --token
+$ oc whoami -t
 dIAo76N-W-GXK3S_w_KsC6DmH3MzP79zq7jbMQvCOUo
 ----
 


### PR DESCRIPTION
In light of https://github.com/openshift/origin/pull/11150, we should prefer the short flag for `oc whoami -t`
