### PR TITLE
Fix a format error of url

### DIFF
--- a/creating_images/s2i.adoc
+++ b/creating_images/s2i.adoc
@@ -52,7 +52,7 @@ See the following diagram for the basic S2I build workflow:
 .Build Workflow
 image::s2i-flow.png[S2I workflow]
 
-* Run build's responsibility is to untar the sources, scripts and artifacts (if such exist) and invoke the `assemble` script. If this is the second run (after catching `tar`/`/bin/sh` not found error) it is responsible only for invoking `assemble` script, since both scripts and sources are already there.
+* Run build's responsibility is to untar the sources, scripts and artifacts (if such exist) and invoke the `assemble` script. If this is the second run (after catching `tar` or `/bin/sh` not found error) it is responsible only for invoking `assemble` script, since both scripts and sources are already there.
 
 
 [[s2i-scripts]]
@@ -70,8 +70,8 @@ each build in the following order:
 Both the `io.openshift.s2i.scripts-url` label specified in the image and the `--scripts-url` flag
 can take one of the following form:
 
-- `image://path_to_scripts_dir` - absolute path inside the image to a directory where the S2I scripts are located
-- `$$file://path_to_scripts_dir$$` - relative or absolute path to a directory on the host where the S2I scripts are located
+- `image:///path_to_scripts_dir` - absolute path inside the image to a directory where the S2I scripts are located
+- `$$file:///path_to_scripts_dir$$` - relative or absolute path to a directory on the host where the S2I scripts are located
 - `http(s)://path_to_scripts_dir` - URL to a directory where the S2I scripts are located
 
 NOTE: In case where the scripts are already placed inside the image (using `--scripts-url`


### PR DESCRIPTION
`image://path_to_scripts_dir` should be `image:///path_to_scripts_dir`.
`file://path_to_scripts_dir` should be `file:///path_to_scripts_dir`.
"**tar** or **/bin/sh**" is clearer than "**tar**/**/bin/sh**".
