### PR TITLE
Set the DomainName or DomainID in the OpenStack cloud provider

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -27,6 +27,7 @@ nodes:
 auth-url = <OS_AUTH_URL>
 username = <OS_USERNAME>
 password = <password>
+domain-id = <OS_USER_DOMAIN_ID>
 tenant-id = <OS_TENANT_ID>
 region = <OS_REGION_NAME>
 
@@ -50,14 +51,16 @@ You can set an OpenStack configuration on your {product-title} master and node h
 === Configuring {product-title} for OpenStack with Ansible
 
 During
-xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installations], 
-OpenStack can be configured using 
+xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installations],
+OpenStack can be configured using
 xref:../install_config/install/advanced_install.adoc#advanced-install-configuring-global-proxy[the following parameters], which are configurable in the inventory file:
 
 - `*openshift_cloudprovider_kind*`
 - `*openshift_cloudprovider_openstack_auth_url*`
 - `*openshift_cloudprovider_openstack_username*`
 - `*openshift_cloudprovider_openstack_password*`
+- `*openshift_cloudprovider_openstack_domain_id*`
+- `*openshift_cloudprovider_openstack_domain_name*`
 - `*openshift_cloudprovider_openstack_tenant_id*`
 - `*openshift_cloudprovider_openstack_tenant_name*`
 - `*openshift_cloudprovider_openstack_region*`
@@ -79,6 +82,8 @@ xref:../install_config/install/advanced_install.adoc#advanced-install-configurin
 #openshift_cloudprovider_openstack_auth_url=http://openstack.example.com:35357/v2.0/
 #openshift_cloudprovider_openstack_username=username
 #openshift_cloudprovider_openstack_password=password
+#openshift_cloudprovider_openstack_domain_id=domain_id
+#openshift_cloudprovider_openstack_domain_name=domain_name
 #openshift_cloudprovider_openstack_tenant_id=tenant_id
 #openshift_cloudprovider_openstack_tenant_name=tenant_name
 #openshift_cloudprovider_openstack_region=region


### PR DESCRIPTION
Whereas with the OpenStack keystone v2 authentication API, the username and
the password are enough, the keystone v3 API requires an additional domain
parameter.

This domain parameter was not yet documented, but already [taken into account
by released OpenShift](https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go#L109).

relates to openshift/openshift-ansible#2515
