### PR TITLE
Additions and clarifications to doc guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1,5 +1,5 @@
 [[contributing-to-docs-doc-guidelines]]
-= Documentation guidelines
+= Documentation Guidelines
 :icons:
 :toc: macro
 :toc-title:
@@ -8,7 +8,7 @@
 
 toc::[]
 
-== Topic metadata
+== Topic Metadata
 Every topic file should contain the following metadata at the top, with no line spacing in between, except where noted:
 
 ----
@@ -42,7 +42,7 @@ If using section anchors, they must be all lowercase letters, with no line space
 === Section Title
 ----
 
-== Titles, headings, and filenames
+== Titles, Headings, and Filenames
 There are some general guidelines and conventions we follow for titles,
 headings, and topic filenames. These are described in the following table.
 
@@ -61,7 +61,14 @@ would be appropriate for a topic titled Managing Authorization Policies.
 a|- Use title case in all topic titles and section headings. See
 http://titlecase.com/ for more information.
 - Try to be as descriptive as possible with the topic title or section headings
-without making them unnecessarily too long.
+without making them unnecessarily too long. Use a verb form in headings. Some
+suggestions:
+* Creating
+* Managing
+* Using
+* Understanding
+- Use "Overview" as a heading sparingly. Choose a more descriptive heading
+instead.
 - The content in this repo is used to build docs that publish to multiple
 locations (e.g., docs.openshift.com, docs.openshift.org, and the Red Hat
 Customer Portal). While heading IDs will be created automatically from any
@@ -79,7 +86,7 @@ IDs use the following syntax:
 ----
 |===
 
-== Product name & version attributes
+== Product Name & Version Attributes
 
 When possible, generalize references to the product name and/or version using
 the `{product-title}` and/or `{product-version}` attributes. These attributes
@@ -139,7 +146,9 @@ separated, global use of `{product-version}` across all branches is probably
 less useful, but it is available if you come across a need for it. Just consider
 how it will render across any branches that the content appears in.
 
-== Links, hyperlinks, and cross references
+Do not use markup in headings.
+
+== Links, Hyperlinks, and Cross References
 Links can be used to cross-reference internal topics, or send customers to external information resources for further reading.
 
 In OpenShift docs:
@@ -255,7 +264,7 @@ xref:subtopic
 
 Note: There is no `#` used when linking to a subtopic within the same topic.
 
-== Sharing content between files
+== Sharing Content Between Files
 
 If you want to share content from one topic so that it appears in another topic,
 you can use the `include` directive. See the Asciidoctor documentation for
@@ -267,6 +276,45 @@ If you find that you need to include content from one topic multiple times into
 another topic, see the following usage:
 
 http://asciidoctor.org/docs/user-manual/#include-multiple
+
+== Writing Concepts
+A _concept_ is a topic (full .adoc file) or section (individual heading within a
+topic) that supports the things that users want to do and should not include
+task information like commands or numbered steps. Consider topic/section titles
+with a verb like "Understanding <concept>" if it is solely concept-based.
+
+== Writing Tasks
+A _task_ is a topic (full .adoc file) or section (individual heading within a
+topic) that supports the things that users want to do and includes procedural
+information like commands and numbered steps. Write tasks in the following
+format.
+
+*Task Title*: Use a verb in the task title (for example, Create or Creating).
+
+Include a paragraph explaining why the user must perform this task. This should be 1-2 sentences maximum.
+
+If applicable, include any gotchas (things that could trip up the user or cause the task to fail).
+
+
+*Before You Begin*
+
+* A bulleted list of pre-requisites that MUST be performed before the user can complete this task. Skip if there isn't any related information.
+
+*Procedure*
+
+. Step 1 - One command per step.
+
+. Step 2 - One command per step.
+
+. Step N
+
+*After You Finish*
+
+You can explain any other tasks that MUST be completed after this task. You can skip this if there are none.
+
+*Related Information*
+
+* A bulleted list of links to related information about this task. Skip if there isn't any related information.
 
 == Images
 If you want to link to an image:
@@ -280,7 +328,7 @@ image::<name_of_image>[image]
 
 You only need to specify `<name_of_image>`. The build mechanism automatically specifies the file path.
 
-=== AsciiDoctor diagram extension
+=== AsciiDoctor Diagram Extension
 AsciiDoctor provides a set of http://asciidoctor.org/docs/asciidoctor-diagram/[extensions to embed diagrams] written using http://plantuml.sourceforge.net/[PlantUML], http://www.graphviz.org/[Graphviz], http://ditaa.sourceforge.net/[ditaa], or https://github.com/christiangoltz/shaape[Shaape] syntax inside your AsciiDoc documents. The diagram extension generates an SVG, PNG, or TXT file from the source text. The image file that's generated then gets inserted into the rendered document.
 
 [IMPORTANT]
@@ -310,16 +358,22 @@ For all of the system blocks including table delimiters, use four characters. Fo
 ---- for code blocks
 ....
 
-=== Code blocks
-Code blocks are used to show examples of command screen outputs, or configuration files. When using command blocks always use the actual values for any items that a user would normally replace. Code blocks should represent exactly what a customer would see on their screen. If you need to expand or provide information on what some of the contents of a screen output or configuration file represent, then use callouts to provide that information.
+
+=== Code Blocks
+Code blocks are used to show examples of command screen outputs, or
+configuration files. When using command blocks, always use the actual values for
+any items that a user would normally replace. Code blocks should represent
+exactly what a customer would see on their screen. If you need to expand or
+provide information on what some of the contents of a screen output or
+configuration file represent, then use callouts to provide that information.
 
 Follow these general guidelines when using code blocks:
 
 * Do NOT show replaceables within code blocks.
 
-* Do NOT use any markup in code blocks; code blocks generally do not accept any markup
+* Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
 
-* Try to use callouts to provide information on what the output represents when required
+* Try to use callouts to provide information on what the output represents when required.
 
 For all code blocks, you must include an empty line above a code block.
 
@@ -342,7 +396,27 @@ $ lorem.sh
 ----
 ....
 
-Without the line spaces the content is likely to be not parsed correctly.
+Without the line spaces, the content is likely to be not parsed correctly.
+
+Use this format when embedding callouts into the code block:
+
+----
+code example 1 <1>
+code example 2 <2>
+----
+<1> A note about the first example value.
+<2> A note about the second example value.
+
+For long lines of code that you want to break up among multiple lines, use a
+backslash to show the line break. For example:
+
+----
+$ oc get endpoints --all-namespaces --template \
+    '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
+    {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
+    {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
+----
+
 
 === Inline Code or Commands
 Do NOT show full commands or command syntax inline within a sentence. The next section covers how to show commands and command syntax.
@@ -357,10 +431,10 @@ This renders as:
 
 Use the `GET` operation to do x.
 
-=== Command syntax and examples
+=== Command Syntax and Examples
 The main distinction between showing command syntax and example is that a command syntax should just show customers how to use the command without real values. An example on the other hand should show the command with actual values with an example output of that command, where applicable.
 
-==== Command syntax
+==== Command Syntax
 To markup command syntax, use the code block and wrap the replaceables in <> with the required command parameters, as shown in the following example. Do NOT use commands or command syntax inline with sentences.
 
 ....
@@ -460,7 +534,7 @@ some code block
 
 . Item 3
 
-==== Quick reference
+==== Quick Reference
 .User accounts and info
 [option="header"]
 |===
@@ -499,7 +573,7 @@ Text for admonition
 ====
 ....
 
-== Quick markup reference
+== Quick Markup Reference
 
 |===
 |Convention |Markup |Example rendered output
@@ -517,12 +591,15 @@ a|Use the following syntax for the `oc` command:
 $ oc <action> <object_type> <object_name_or_id>
 ----
 
-|Inline commands, operations, and user input
+|Inline commands, operations, literal values, environment variables, parameters,
+settings, flags, and user input
 a|$$`oc get`$$
 
 $$`GET`$$
 
 $$Answer by typing `Yes` or `No` when prompted.$$
+
+$$Use the `--amend` flag
 a|Use the `oc get` command to get a list of services that are currently defined.
 
 The `GET` operation can be used to do something.
@@ -539,16 +616,7 @@ Use the following command to roll back a deployment, specifying the deployment n
 
 `oc rollback <deployment>`
 
-|System or software configuration parameter or environment variable
-a|$$`*ENVIRONMENT_VARIABLE*`$$
-
-$$`*PARAMETER*`$$
-a|Use the `*IP_ADDRESS*` environment variable for the server IP address.
-
-The `*MAX_PODS*` parameter limits the number of pods you can have.
-
-
-|System term, daemon, service, or software package
+|System term, GUI menu items and buttons, daemon, service, name of field, or software package
 a|$$*system item*$$
 
 $$*daemon*$$
@@ -570,4 +638,8 @@ $$*_directory_*$$
 a|Edit the *_kubeconfig_* file as required and save your changes.
 
 The *_express.conf_* configuration file is located in the *_/usr/share_* directory.
+
+|Emphasis for a term
+|only emphasize $$_first_$$ time
+|only emphasize _first_ time
 |===


### PR DESCRIPTION
@adellape @aheslin @bfallonf @tpoitras @vikram-redhat Here is my first pass at the revised doc guidelines. I really want to remove the guess work from the markdown we use. We were running into a lot of inconsistencies and I think that simplifying things will help. The biggest proposed change in that regard is changing the formatting for environment variables to back-ticks. Other product groups seem to use that convention as well.  Per a conversation with @aheslin I also added in guidelines on writing tasks vs concepts vs user goals, and a few other bits of guidance that I think were missing. Please share your thoughts and let me know if I missed anything.
