### PR TITLE
logging: give a usable IMAGE_PREFIX

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -347,11 +347,11 @@ endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 |*_IMAGE_PREFIX_*
 |The prefix for logging component images. For example, setting the prefix to
-*registry.access.redhat.com/openshift3/ose-* creates *registry.access.redhat.com/openshift3/ose-logging-deployer:latest*.
+*registry.access.redhat.com/openshift3/* creates *registry.access.redhat.com/openshift3/logging-deployer:latest*.
 
 |*_IMAGE_VERSION_*
 |The version for logging component images. For example, setting the version to
-*v3.2* creates *registry.access.redhat.com/openshift3/ose-logging-deployer:v3.2*.
+*v3.3* creates *registry.access.redhat.com/openshift3/logging-deployer:v3.3*.
 endif::openshift-enterprise[]
 
 |*_MODE_* (default: *install*)


### PR DESCRIPTION
The enterprise docs should give an example value for IMAGE_PREFIX that
actually works, especially since we apparently shipped a version of the
deployer template that refers to origin.
