### PR TITLE
Added guide on upgrading / updating the node OS

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -279,6 +279,8 @@ Topics:
         File: manual_upgrades
       - Name: Blue-Green Deployments
         File: blue_green_deployments
+      - Name: Operating System Updates and Upgrades
+        File: os_upgrades
   - Name: Downgrading
     File: downgrade
     Distros: openshift-enterprise

--- a/install_config/upgrading/os_upgrades.adoc
+++ b/install_config/upgrading/os_upgrades.adoc
@@ -1,0 +1,28 @@
+[[install-config-upgrading-os-upgrades]]
+= Overview
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:prewrap!:
+
+When you need to update or upgrade the Operating System, either
+changing OS versions or just updates to the system software, you need
+to be aware that this can have an impact on the {product-title}
+software running on those machines.
+
+In particular, these updates can affect the `iptables` rules or `ovs`
+flows that {product-title} requires to operate.  To be safe, we
+recommend rebooting the node to ensure that all of the software is
+running the new versions (especially if a new kernel has been
+installed).  A reboot will also make sure that the `docker` and
+{product-title} processes have been restarted, which will force them
+to make sure that all of the rules in other services are correct.
+
+However, if you do not wish to do a reboot of the node, then it is
+possible to just restart the services that are affected, or to
+preserve the `iptables` state.  Both of those are described in the
+xref:../../admin_guide/iptables.adoc[{product-title} iptables] section
+of the admin guide.  The `ovs` flow rules do not need to be saved, but
+restarting the {product-title} node software will fix the flow rules.


### PR DESCRIPTION
This adds recommendations on how to upgrade the OS of, or apply system
updates to, a node so that the iptables rules are not broken.

The purpose of this is both to warn administrators of the risks, but
to also provide a place to point people to in release notes and other
articles.

Fixes bug 1378693

For 3.3 and 3.4.
