### PR TITLE
Be explicit that ingress ipam is non-cloud only

### DIFF
--- a/admin_guide/tcp_ingress_external_ports.adoc
+++ b/admin_guide/tcp_ingress_external_ports.adoc
@@ -12,6 +12,12 @@ toc::[]
 
 == Overview
 
+Note: This feature is only supported in non-cloud deployments.  For
+cloud (GCE/AWS/OpenStack) deployments, services of type
+xref:../dev_guide/getting_traffic_into_cluster.adoc#using-the-loadbalancer[LoadBalancer]
+can be used to automatically deploy a cloud loadbalancer to target the
+service's endpoints.
+
 Cluster administrators can assign a unique external IP address to a service. If
 routed correctly, external traffic can reach that service's endpoints via any
 TCP/UDP port the service exposes. This can be simpler than having to manage the
@@ -48,7 +54,7 @@ Two services have been manually configured with the same external
 IP address of 172.7.7.7.
 
 `MongoDB service A` requests port 27017, and then
-`MongoDB service B` requests the same port; the first request gets the port. 
+`MongoDB service B` requests the same port; the first request gets the port.
 ====
 
 However, port clashes are not an issue for external IPs assigned by the ingress
@@ -81,7 +87,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: egress-1
-spec: 
+spec:
   ports:
   - name: db
     port: 3306


### PR DESCRIPTION
This is for 3.3 and beyond only.
