### PR TITLE
Single-member vs. multi-member etcd clusters for restore operations

### DIFF
--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -170,6 +170,15 @@ The object types included in `oc export all` are:
 [[cluster-restore]]
 == Cluster Restore
 
+[NOTE]
+====
+This restore operation only works for single-member *etcd* clusters. For
+multiple-member *etcd* clusters, see 
+xref:../install_config/downgrade.adoc#downgrading-restoring-etcd[Restoring *etcd*]. 
+====
+
+To restore the cluster:
+
 . Reinstall {product-title}.
 +
 This should be done in the
@@ -193,7 +202,6 @@ that {product-title} was previously installed.
 # chcon -R --reference $ETCD_DATA_DIR.orig $ETCD_DATA_DIR
 # chown -R etcd:etcd $ETCD_DATA_DIR
 ----
-
 . Create the API objects for the cluster:
 +
 ----


### PR DESCRIPTION
From BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1380614

Not sure if I interpreted this BZ correctly. I'm assuming that "Please add a link to complete etcd restoration procedure" is referring to: https://docs.openshift.com/container-platform/3.3/install_config/downgrade.html#downgrading-restoring-etcd

Please correct me if I'm wrong. I suppose you could also mean that the complete etcd restoration procedure is not yet properly documented. In that case, please point me to where I can get the information to write this procedure.

Also, would this stuff apply to OpenShift Dedicated, or not?

Thank you.
