### PR TITLE
Bug 1381336, deploy metrics as the deployer service account.

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -582,7 +582,8 @@ The following command sets the Hawkular Metrics route to use
 You must have a persistent volume of sufficient size available.
 
 ----
-$ oc new-app -f metrics-deployer.yaml \
+$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
+    -f metrics-deployer.yaml \
     -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com
 ----
 ====
@@ -593,7 +594,8 @@ The following command sets the Hawkular Metrics route to use
 *hawkular-metrics.example.com* and deploy without persistent storage.
 
 ----
-$ oc new-app -f metrics-deployer.yaml \
+$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
+    -f metrics-deployer.yaml \
     -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
     -p USE_PERSISTENT_STORAGE=false
 ----
@@ -627,7 +629,8 @@ validation by running the deployer again with the `*MODE=validate*` parameter
 added, for example:
 
 ----
-$ oc new-app -f metrics-deployer.yaml \
+$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
+    -f metrics-deployer.yaml \
     -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
     -p MODE=validate
 ----


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1381336 where the user who deploys metrics could have special scc permissions which could prevent the deployer from functioning properly.

The deployer service account is the more correct user to be handling the deployer pod.
