### PR TITLE
Fixing links & cleaning up 09/27/16 OCP 3.3 revhistory

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -29,6 +29,8 @@
 // end::admin_guide_tue_oct_04_2016[]
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::admin_guide_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
@@ -46,7 +48,7 @@
 |Added a Note box about the required `storage:delete:enabled` flag when xref:../admin_guide/pruning_resources.adoc#pruning-images[pruning images].
 
 |xref:../admin_guide/managing_pods.adoc#admin-guide-manage-pods-limit-bandwidth[Cluster Administration -> Managing Pods -> Limiting the Bandwidth Available to Pods]
-|Added details on limiting the bandwidth available to pods via quality-of-service traffic shaping. 
+|Added details on limiting the bandwidth available to pods via quality-of-service traffic shaping.
 
 |xref:../admin_guide/managing_pods.adoc#admin-guide-limit-pod-access-egress[Cluster Administration -> Limit Pod Access with Egress Firewall]
 |Added new topic covering how to limit the IP addresses and traffic that a pod can access.

--- a/admin_solutions/revhistory_admin_solutions.adoc
+++ b/admin_solutions/revhistory_admin_solutions.adoc
@@ -9,15 +9,17 @@
 // do-release: revhist-tables
 == Tue Sep 27 2016
 
-// tag::administrator_solutions_tue_sep_27_2016[]
+{product-title} 3.3 initial release.
+
+// tag::admin_solutions_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
 //Tue Sep 27 2016
 
-|Release of OCP 3.3 Docs
-| This is the first release of the Administrator Solutions guide for OpenShift Container Platform 3.3
+|New guide
+|First release of the Administrator Solutions guide for {product-title} 3.3.
 
 |===
-// end::administrator_solutions_tue_sep_27_2016[]
+// end::admin_solutions_tue_sep_27_2016[]

--- a/architecture/revhistory_architecture.adoc
+++ b/architecture/revhistory_architecture.adoc
@@ -15,10 +15,8 @@
 
 |Affected Topic |Description of Change
 //Tue Oct 04 2016
-|xref:../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[Core Concepts -> Routes]
+.2+|xref:../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[Core Concepts -> Routes]
 |Added a new xref:../architecture/core_concepts/routes.adoc#route-specific-timeouts[Route-specific Timeouts] section.
-
-|xref:../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[Routes]
 |Added xref:../architecture/core_concepts/routes.adoc#haproxy-template-router[Router Configuration Parameters].
 
 |===
@@ -27,6 +25,8 @@
 
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::architecture_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
@@ -34,17 +34,11 @@
 |Affected Topic |Description of Change
 //Tue Sep 27 2016
 
-|xref:../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[Core Concepts -> Routes]
-|Added a new xref:../architecture/core_concepts/routes.adoc#route-specific-timeouts[Route-specific Timeouts] section.
-
 |xref:../architecture/additional_concepts/authentication.adoc#architecture-additional-concepts-authentication[Additional Concepts -> Authentication]
 |Added information about OAuth scopes.
 
 |xref:../architecture/additional_concepts/authorization.adoc#architecture-additional-concepts-authorization[Additional Concepts -> Authorization]
 |Added a xref:../architecture/additional_concepts/authorization.adoc#authorization-determining-what-you-can-do-as-an-authenticated-user[new section] about `oc policy can-i --list`.
-
-|xref:../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[Routes]
-|Added xref:../architecture/core_concepts/routes.adoc#haproxy-template-router[Router Configuration Parameters].
 
 |xref:../architecture/additional_concepts/authorization.adoc#architecture-additional-concepts-authorization[ Additional Concepts -> Authorization]
 |Added a new xref:../architecture/additional_concepts/authorization.adoc#authorization-seccomp[Seccomp] section under Security Context Constraints (SCC) Strategies.
@@ -82,4 +76,3 @@
 |===
 
 // end::architecture_tue_sep_27_2016[]
-

--- a/cli_reference/revhistory_cli_reference.adoc
+++ b/cli_reference/revhistory_cli_reference.adoc
@@ -9,6 +9,8 @@
 // do-release: revhist-tables
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::cli_reference_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
@@ -22,4 +24,3 @@
 |===
 
 // end::cli_reference_tue_sep_27_2016[]
-

--- a/creating_images/revhistory_creating_images.adoc
+++ b/creating_images/revhistory_creating_images.adoc
@@ -9,16 +9,4 @@
 // do-release: revhist-tables
 == Tue Sep 27 2016
 
-// tag::creating_images_tue_sep_27_2016[]
-[cols="1,3",options="header"]
-|===
-
-|Affected Topic |Description of Change
-//Tue Sep 27 2016
-
-|Release of OCP 3.3 Docs
-| This is the first release of the doc set for OpenShift Container Platform 3.3
-
-|===
-
-// end::creating_images_tue_sep_27_2016[]
+{product-title} 3.3 initial release.

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -40,14 +40,14 @@
 // end::dev_guide_tue_oct_04_2016[]
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::dev_guide_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
 
 |Affected Topic |Description of Change
 //Tue Sep 27 2016
-
-|===
 
 |xref:../dev_guide/templates.adoc#dev-guide-templates[Templates]
 |Added information about the template message and what it tells users.
@@ -64,23 +64,18 @@
 |xref:../dev_guide/managing_images.adoc#dev-guide-managing-images[Managing Images]
 |Updated to show that `oc tag -d` now matches `oc delete istag` behavior to better match user expectations.
 
-|xref:../dev_guide/deployments.adoc#dev-guide-deployments[Deployments]
+.2+|xref:../dev_guide/deployments.adoc#dev-guide-deployments[Deployments]
 |Added information about new deployment procedures including paused deployments, cleanup policy, `*minReadySeconds*`, and `oc rollout`.
+|Added information about the xref:../dev_guide/deployments.adoc#deployment-hooks-using-the-command-line[`oc set deployment-hook` command].
 
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
+.7+|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
 |Added a xref:../dev_guide/builds.adoc#build-run-policy[Build Run Policy] section.
-
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
 |Added a xref:../dev_guide/builds.adoc#extended-builds[Note box] indicating that extended builds is a technology preview feature.
-
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
 |Added new xref:../dev_guide/builds.adoc#extended-builds[Extended Builds] section discussing how S2I (Source-to-Image) introduces a two-image build process.
-
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
 |Added a `curl` example for webhook invocations within the xref:../dev_guide/builds.adoc#webhook-triggers[Webhook Triggers] section
-
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
 |Added information on xref:../dev_guide/builds.adoc#pipeline-strategy-options[options for the Pipeline build strategy].
+|Edited references to `oc secrets add`.
+|Added information about the ability to cancel multiple builds.
 
 |xref:../dev_guide/service_accounts.adoc#dev-guide-service-accounts[Service Accounts]
 |Edited references to `oc secrets add`.
@@ -88,25 +83,14 @@
 |xref:../dev_guide/managing_images.adoc#dev-guide-managing-images[Managing Images]
 |Edited references to `oc secrets add`.
 
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
-|Edited references to `oc secrets add`.
-
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
-|Added information about the ability to cancel multiple builds.
-
 |xref:../dev_guide/copy_files_to_container.adoc#dev-guide-copy-files-to-container[Copying Files to or from a Container]
 |Added xref:../dev_guide/copy_files_to_container.adoc#continuous-syncing-on-file-change[Continuous Syncing on File Change] section.
-
-|xref:../dev_guide/builds.adoc#dev-guide-builds[Builds]
-|Added information on shallow cloning.
 
 |xref:../dev_guide/secrets.adoc#dev-guide-secrets[Secrets]
 |Added a new xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[Service Serving Certificate Secrets] section.
 
-|xref:../dev_guide/deployments.adoc#dev-guide-deployments[Deployments]
-|Added information about the xref:../dev_guide/deployments.adoc#deployment-hooks-using-the-command-line[`oc set deployment-hook` command].
-
 |xref:../dev_guide/compute_resources.adoc#dev-guide-compute-resources[Quotas and Limit Ranges]
 |Added recent image quota restrictions.
+|===
 
 // end::dev_guide_tue_sep_27_2016[]

--- a/getting_started/revhistory_getting_started.adoc
+++ b/getting_started/revhistory_getting_started.adoc
@@ -9,16 +9,4 @@
 // do-release: revhist-tables
 == Tue Sep 27 2016
 
-// tag::getting_started_tue_sep_27_2016[]
-[cols="1,3",options="header"]
-|===
-
-|Affected Topic |Description of Change
-//Tue Sep 27 2016
-
-|Release of OCP 3.3 Docs
-| This is the first release of the doc set for OpenShift Container Platform 3.3
-
-|===
-
-// end::getting_started_tue_sep_27_2016[]
+{product-title} 3.3 initial release.

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -53,6 +53,8 @@
 // end::install_config_tue_oct_04_2016[]
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::install_config_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
@@ -63,14 +65,14 @@
 |xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[Configuring the SDN]
 |Added that `oc get netnamespace` can be run to check VNIDs.
 
-|xref:../install_config/registry/securing_and_exposing_registry.adoc#install-config-registry-securing-exposing[Installation and Configuration -> Setting up the Registry -> Securing and Exposing the Registry]
-|Added two new sections on Exposing a Secure Registry and Exposing a Non-Secure Registry. 
+|xref:../install_config/registry/securing_and_exposing_registry.adoc#install-config-registry-securing-exposing[Setting up the Registry -> Securing and Exposing the Registry]
+|Added two new sections on Exposing a Secure Registry and Exposing a Non-Secure Registry.
 
 |xref:../install_config/web_console_customization.adoc#install-config-web-console-customization[Customizing the Web Console]
 |Added xref:../install_config/web_console_customization.adoc#configuring-navigation-menus[Configuring Navigation Menus] section.
 
-|xref:../install_config/registry/index.adoc#install-config-registry-overview[Configure or Deploy a Docker Registry]
-|Added troubleshooting guidance on xref:../install_config/install/docker_registry.adoc#known-issue-prune-fails-due-to-delete-disabled[Image Pruning Failures].
+|xref:../install_config/registry/registry_known_issues.adoc#install-config-registry-known-issues[Setting up the Registry -> Known Issues]
+|Added troubleshooting guidance on xref:../install_config/registry/registry_known_issues.adoc#known-issue-prune-fails-due-to-delete-disabled[Image Pruning Failures].
 
 |xref:../install_config/master_node_configuration.adoc#install-config-master-node-configuration[Master and Node Configuration]
 |Added a xref:../install_config/master_node_configuration.adoc#master-node-config-audit-config[Audit Configuration] section.
@@ -90,7 +92,7 @@
 |xref:../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Installing -> Prerequisites]
 |Updated scale recommendations.
 
-|xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Installing -> Advanced Installation] 
+|xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Installing -> Advanced Installation]
 |Updated the xref:../install_config/install/advanced_install.adoc#multiple-masters[Multiple Masters Using HAProxy Inventory File example] with guidance on applying updated node defaults.
 
 |xref:../install_config/upgrading/manual_upgrades.adoc#install-config-upgrading-manual-upgrades[Upgrading -> Performing Manual Cluster Upgrades]
@@ -114,15 +116,14 @@
 |xref:../install_config/upgrading/manual_upgrades.adoc#install-config-upgrading-manual-upgrades[Upgrading -> Performing Manual Cluster Upgrades]
 |Added a new xref:../install_config/upgrading/manual_upgrades.adoc#updating-the-registry-configuration-file[Update Your Configuration File] section.
 
-|xref:../install_config/registry/index.adoc#install-config-registry-overview[Installing -> Configure or Deploy a Docker Registry]
-.2+|Emphasized the new mandatory xref:../install_config/install/docker_registry.adoc#docker-registry-configuration-reference-middleware[middleware] configuration entries.
-|Added a new section about the `error: build error: Failed to push image: EOF` known error.
+|xref:../install_config/registry/extended_registry_configuration.adoc#install-config-registry-extended-configuration[Setting up the Registry -> Extended Registry Configuration]
+|Emphasized the new mandatory xref:../install_config/registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-middleware[middleware] configuration entries.
 
 |xref:../install_config/registry/index.adoc#install-config-registry-overview[Deploying a Docker Registry]
 |Extended the registry configuration file example within the Deploying Updated Configuration section to include the `*blobrepositorycachettl*` option.
 
 |xref:../install_config/storage_examples/binding_pv_by_label.adoc#binding-pv-by-label[Storage Examples -> Binding Persistent Volumes by Labels]
-|New topic providing an end-to-end example for binding persistent volume claims (PVCs) to persistent volumes (PVs) by defining labels in the PV and matching selectors in the PVC. 
+|New topic providing an end-to-end example for binding persistent volume claims (PVCs) to persistent volumes (PVs) by defining labels in the PV and matching selectors in the PVC.
 
 |xref:../install_config/persistent_storage/selector_label_binding.adoc#selector-label-volume-binding[Persistent Storage Examples -> Selector-Label Volume Binding]
 |New topic outlining how to bind persistent volumes claims (PVCs) to persistent volumes (PVs) via *selector* and *label* attributes.
@@ -149,7 +150,7 @@
 |Edited references to `oc secrets add`.
 
 |xref:../install_config/persistent_storage/pod_security_context.adoc#install-config-persistent-storage-pod-security-context[Configuring Persistent Storage -> Volume Security]
-|Fixed formatting of the `oc get project default -o yaml` example output within the xref:../install_config/persistent_storage/pod_security_context.adoc#sccs-defaults-allowed-ranges[SCCs, Defaults, and Allowed Ranges] section. 
+|Fixed formatting of the `oc get project default -o yaml` example output within the xref:../install_config/persistent_storage/pod_security_context.adoc#sccs-defaults-allowed-ranges[SCCs, Defaults, and Allowed Ranges] section.
 
 |xref:../install_config/configuring_authentication.adoc#grant-options[Configuring Authentication]
 |Updated OAuth grant strategies information.

--- a/release_notes/revhistory_release_notes.adoc
+++ b/release_notes/revhistory_release_notes.adoc
@@ -38,6 +38,8 @@
 // end::release_notes_tue_oct_04_2016[]
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::release_notes_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
@@ -45,8 +47,8 @@
 |Affected Topic |Description of Change
 //Tue Sep 27 2016
 
-|Release of OCP 3.3 Docs
-| This is the first release of the doc set for OpenShift Container Platform 3.3
+|xref:../release_notes/ocp_3_3_release_notes.adoc#release-notes-ocp-3-3-release-notes[{product-title} 3.3 Release Notes]
+|Added release notes for initial release.
 
 |===
 

--- a/rest_api/revhistory_rest_api.adoc
+++ b/rest_api/revhistory_rest_api.adoc
@@ -7,9 +7,19 @@
 :experimental:
 
 // do-release: revhist-tables
-== Tue Sep 27 2016
+== Tue Oct 04 2016
 
+// tag::rest_api_tue_oct_04_2016[]
+[cols="1,3",options="header"]
+|===
 |Affected Topic |Description of Change
 //Tue Sep 27 2016
 |xref:../rest_api/index.adoc#rest-api-index[Overview]
 |Updated the `oc whoami --token` command to show the shorter flag of `oc whoami --t`.
+|===
+
+// end::rest_api_tue_oct_04_2016[]
+
+== Tue Sep 27 2016
+
+{product-title} 3.3 initial release.

--- a/using_images/revhistory_using_images.adoc
+++ b/using_images/revhistory_using_images.adoc
@@ -9,6 +9,8 @@
 // do-release: revhist-tables
 == Tue Sep 27 2016
 
+{product-title} 3.3 initial release.
+
 // tag::using_images_tue_sep_27_2016[]
 [cols="1,3",options="header"]
 |===
@@ -19,7 +21,7 @@
 |xref:../using_images/s2i_images/python.adoc#using-images-s2i-images-python[Source-to-Image (S2I) -> Python]
 |Added the `*PIP_INDEX_URL*` environment variable to the xref:../using_images/s2i_images/python.adoc#using-images-python-configuration[Configuration] section.
 
-|xref:../using_images/db_images/mysql.adoc#using-images-db-images-mysql[MySQL]
+|xref:../using_images/db_images/mysql.adoc#using-images-db-images-mysql[Database Images -> MySQL]
 |Updated the Additional MySQL Settings table in the xref:../using_images/db_images/mysql.adoc#mysql-environment-variables[Environment Variables] section with new variables.
 
 

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -36,37 +36,33 @@ include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_tue_oct_04_2016
 .Developer Guide
 include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_tue_oct_04_2016]
 
+.REST API Reference
+include::rest_api/revhistory_rest_api.adoc[tag=rest_api_tue_oct_04_2016]
+
 == Tue Sep 27 2016
 
-[cols="1,3",options="header"]
-|===
-
-|Affected Topic |Description of Change
-//Tue Sep 27 2016
-
-.Rest Api
-include::rest_api/revhistory_rest_api.adoc[tag=rest_api_tue_sep_27_2016]
+{product-title} 3.3 initial release.
 
 .Release Notes
 include::release_notes/revhistory_release_notes.adoc[tag=release_notes_tue_sep_27_2016]
 
-.Admin Solutions
-include::admin_solutions/revhistory_admin_solutions.adoc[tag=admin_solutions_tue_sep_27_2016]
-
-.Admin Guide
-include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_tue_sep_27_2016]
-
-.Install Config
-include::install_config/revhistory_install_config.adoc[tag=install_config_tue_sep_27_2016]
-
-.Cli Reference
-include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_tue_sep_27_2016]
-
-.Dev Guide
-include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_tue_sep_27_2016]
-
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_tue_sep_27_2016]
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_tue_sep_27_2016]
+
+.Administrator Solutions
+include::admin_solutions/revhistory_admin_solutions.adoc[tag=admin_solutions_tue_sep_27_2016]
+
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_tue_sep_27_2016]
+
+.CLI Reference
+include::cli_reference/revhistory_cli_reference.adoc[tag=cli_reference_tue_sep_27_2016]
+
+.Developer Guide
+include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_tue_sep_27_2016]
 
 .Using Images
 include::using_images/revhistory_using_images.adoc[tag=using_images_tue_sep_27_2016]


### PR DESCRIPTION
@vikram-redhat There were some broken tables and tags/links that were messing things up so I've sorted that out. Also did some minor clean-up and synced up the styling for the "`<version_number>` initial release" revision note to look like how we did it in 3.1 and 3.2 (just for consistency, hope that's not a big deal).
