### PR TITLE
Revert "OCP 3.3 Weekly Release - 11/Oct/2016"

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -7,22 +7,6 @@
 :experimental:
 
 // do-release: revhist-tables
-== Tue Oct 11 2016
-
-// tag::admin_guide_tue_oct_11_2016[]
-[cols="1,3",options="header"]
-|===
-
-|Affected Topic |Description of Change
-//Tue Oct 11 2016
-|xref:../admin_guide/quota.adoc#admin-guide-quota[Setting Quotas]
-|Added that `*cpu*` and `*requests.cpu*` are the same value and can be used interchangeably, as with `*memory*` and `*requests.memory*`.
-
-
-
-|===
-
-// end::admin_guide_tue_oct_11_2016[]
 == Tue Oct 04 2016
 
 // tag::admin_guide_tue_oct_04_2016[]

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -7,22 +7,6 @@
 :experimental:
 
 // do-release: revhist-tables
-== Tue Oct 11 2016
-
-// tag::dev_guide_tue_oct_11_2016[]
-[cols="1,3",options="header"]
-|===
-
-|Affected Topic |Description of Change
-//Tue Oct 11 2016
-|xref:../dev_guide/copy_files_to_container.adoc#dev-guide-copy-files-to-container[Copying Files to or from a Container]
-|Added a procedure outlining how `oc rsync` can be used to copy database archives from an existing database container to a new database container's persistent volume directory.
-
-
-
-|===
-
-// end::dev_guide_tue_oct_11_2016[]
 == Wed Oct 05 2016
 
 // tag::dev_guide_wed_oct_05_2016[]

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -7,37 +7,6 @@
 :experimental:
 
 // do-release: revhist-tables
-== Tue Oct 11 2016
-
-// tag::install_config_tue_oct_11_2016[]
-[cols="1,3",options="header"]
-|===
-
-|Affected Topic |Description of Change
-//Tue Oct 11 2016
-|xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs]
-|Fixed error in xref:../install_config/aggregate_logging.adoc#deploying-the-efk-stack[Deploying the EFK Stack] section.
-
-|xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#setting-up-for-ldap-failover[Setting up SSSD for LDAP Failover]
-|Corrected steps in the xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#sssd-phase-1-certificate-generation[Certificate Generation] section.
-
-|xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[Configuring the SDN]
-|Added clarifying details to the xref:../install_config/configuring_sdn.adoc#migrating-between-sdn-plugins[Migrating Between SDN Plug-ins] section about when to clean up SDN-specific artifacts.
-
-|xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#setting-up-for-ldap-failover[Advanced LDAP Configuration -> Setting up SSSD for LDAP Failover]
-|Fixed errors in the xref:../install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc#sssd-phase-2-authenticating-proxy-setup[Phase 2: Authenticating Proxy Setup] section.
-
-|xref:../install_config/persistent_storage/persistent_storage_ceph_rbd.adoc#install-config-persistent-storage-persistent-storage-ceph-rbd[Configuring Persistent Storage ->Persistent Storage Using Ceph Rados Block Device (RBD)]
-|Updated the *persistentVolumeReclaimPolicy* setting to *retain* in the xref:../install_config/persistent_storage/persistent_storage_ceph_rbd.adoc#ceph-creating-pv[Persistent Volume Object Definition Using Ceph RBD example].
-
-|xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[Installing -> Advanced Installation]
-|Replaced `*ansible_sudo*` with `*ansible_become*`.
-
-
-
-|===
-
-// end::install_config_tue_oct_11_2016[]
 == Tue Oct 04 2016
 
 // tag::install_config_tue_oct_04_2016[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -10,15 +10,6 @@ The following sections aggregate the revision histories of each guide by publish
 date.
 
 // do-release: revhist-tables
-== Tue Oct 11 2016
-.Developer Guide
-include::dev_guide/revhistory_dev_guide.adoc[tag=dev_guide_tue_oct_11_2016]
-
-.Cluster Administration
-include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_tue_oct_11_2016]
-
-.Installation and Configuration
-include::install_config/revhistory_install_config.adoc[tag=install_config_tue_oct_11_2016]
 
 == Wed Oct 05 2016
 


### PR DESCRIPTION
Reverts openshift/openshift-docs#3024 - for some reason only the rev history notes went in, not the actual commits.
