### PR TITLE
Corrected 3.3 release notes regarding registry

### DIFF
--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -246,7 +246,7 @@ quota in the Registry].
 The image size is not always available in the manifest of an uploaded image.
 This is especially the case for images built with Docker 1.10 or higher and
 pushed to a v2 registry. If such an image is pulled with an older Docker daemon,
-the image manifest will be converted by the registry to schema v1 lacking all
+the image manifest will be converted by the registry to *schema 1* lacking all
 the size information. No storage limit set on images will prevent it from being
 uploaded.
 

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -940,7 +940,7 @@ Maintain configuration files in a source control repository.
 === Registry Configuration Reference
 
 There are many configuration options available in the upstream
-link:https://github.com/docker/distribution[docker distribution]
+link:https://github.com/docker/distribution[Docker Distribution]
 library. Not all link:https://docs.docker.com/registry/configuration/[configuration options]
 are supported or enabled. Use this section as a reference.
 
@@ -1058,7 +1058,7 @@ middleware:
 get loaded. These values should not be changed.
 <2> Allow to store
 link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-version-2-schema-2[manifest
-schema v2] during a push to the registry. See xref:middleware-repository-acceptschema2[below] for more details.
+V2 schema 2] during a push to the registry. See xref:middleware-repository-acceptschema2[below] for more details.
 <3> Let the registry act as a proxy for remote blobs. See xref:middleware-repository-pullthrough[below] for more details.
 <4> Prevent blob uploads exceeding size limit defined in targeted project.
 <5> An expiration timeout for limits cached in the registry. The lower the
@@ -1094,7 +1094,7 @@ middleware:
 ----
 <1> A configuration option that can be overridden by the boolean environment
 variable `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ACCEPTSCHEMA2*`, which
-allows for the ability to accept manifest schema v2 on manifest put requests.
+allows for the ability to accept manifest v2 schema 2 on manifest put requests.
 <2> A configuration option that can be overridden by the boolean environment
 variable `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*`, which
 allows the ability to turn quota enforcement on or off. By default, quota
@@ -1126,7 +1126,7 @@ This feature is on by default. However, it can be disabled using a
 xref:docker-registry-configuration-reference-middleware[configuration option].
 
 [[middleware-repository-acceptschema2]]
-===== Manifest Schema v2 Support
+===== Manifest V2 Schema 2 Support
 
 Each image has a manifest describing its blobs, instructions for running it
 and additional metadata. The manifest is versioned which have different
@@ -1135,32 +1135,32 @@ by multiple manifest versions. Each version will have different digest though.
 
 The registry currently supports
 link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#image-manifest-version-2-schema-1[manifest
-v2 schema 1] (*schema1*) and
+v2 schema 1] (*schema 1*) and
 link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-version-2-schema-2[manifest
-v2 schema 2] (*schema2*). The former is being obsoleted but will be supported
+v2 schema 2] (*schema 2*). The former is being obsoleted but will be supported
 for an extended amount of time.
 
 You should be wary of compatibility issues with various Docker clients:
 
-- Docker clients of version 1.9 or older support only *schema1*. Any manifest
+- Docker clients of version 1.9 or older support only *schema 1*. Any manifest
 this client pulls or pushes will be of this legacy schema.
-- Docker clients of version 1.10 support both *schema1* and *schema2*. And by default, it will
+- Docker clients of version 1.10 support both *schema 1* and *schema 2*. And by default, it will
 push the latter to the registry if it supports newer schema.
 
-The registry, storing an image with *schema1* will always return it unchanged
-to the client. *Schema2* will be transferred unchanged only to newer Docker
-client. For the older one, it will be converted on-the-fly to *schema1*.
+The registry, storing an image with *schema 1* will always return it unchanged
+to the client. *Schema 2* will be transferred unchanged only to newer Docker
+client. For the older one, it will be converted on-the-fly to *schema 1*.
 
 This has significant consequences. For example an image pushed to the registry
 by a newer Docker client cannot be pulled by the older Docker by its digest.
-That's because the stored image's manifest is of *schema2* and its digest can
+That's because the stored image's manifest is of *schema 2* and its digest can
 be used to pull only this version of manifest.
 
-For this reason, the registry is configured by default not to store *schema2*.
+For this reason, the registry is configured by default not to store *schema 2*.
 This ensures that any docker client will be able to pull from the registry any
 image pushed there regardless of client's version.
 
-Once you're confident that all the registry clients support *schema2*, you'll
+Once you're confident that all the registry clients support *schema 2*, you'll
 be safe to enable its support in the registry. See the
 xref:docker-registry-configuration-reference-middleware[middleware
 configuration reference] above for particular option.

--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -251,7 +251,7 @@ Maintain configuration files in a source control repository.
 == Registry Configuration Reference
 
 There are many configuration options available in the upstream
-link:https://github.com/docker/distribution[docker distribution] library. Not
+link:https://github.com/docker/distribution[Docker Distribution] library. Not
 all link:https://docs.docker.com/registry/configuration/[configuration options]
 are supported or enabled. Use this section as a reference when
 xref:advanced-overriding-the-registry-configuration[overriding the registry
@@ -371,7 +371,7 @@ middleware:
 <1> These entries are mandatory. Their presence ensures required components get loaded. These values shouldn't be changed.
 <2> Allow to store
 link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-version-2-schema-2[manifest
-schema v2] during a push to the registry. See xref:middleware-repository-acceptschema2[below] for more details.
+v2 schema 2] during a push to the registry. See xref:middleware-repository-acceptschema2[below] for more details.
 <3> Let the registry act as a proxy for remote blobs. See xref:middleware-repository-pullthrough[below] for more details.
 <4> Prevent blob uploads exceeding size limit defined in targeted project.
 <5> An expiration timeout for limits cached in the registry. The lower the
@@ -407,7 +407,7 @@ middleware:
 ----
 <1> A configuration option that can be overridden by the boolean environment
 variable `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ACCEPTSCHEMA2*`, which
-allows for the ability to accept manifest schema v2 on manifest put requests.
+allows for the ability to accept manifest v2 schema 2 on manifest put requests.
 <2> A configuration option that can be overridden by the boolean environment
 variable `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*`, which
 allows the ability to turn quota enforcement on or off. By default, quota
@@ -439,7 +439,7 @@ This feature is on by default. However, it can be disabled using a
 xref:docker-registry-configuration-reference-middleware[configuration option].
 
 [[middleware-repository-acceptschema2]]
-==== Manifest Schema v2 Support
+==== Manifest V2 Schema 2 Support
 
 Each image has a manifest describing its blobs, instructions for running it
 and additional metadata. The manifest is versioned which have different
@@ -448,32 +448,32 @@ by multiple manifest versions. Each version will have different digest though.
 
 The registry currently supports
 link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#image-manifest-version-2-schema-1[manifest
-v2 schema 1] (*schema1*) and
+v2 schema 1] (*schema 1*) and
 link:https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-version-2-schema-2[manifest
-v2 schema 2] (*schema2*). The former is being obsoleted but will be supported
+v2 schema 2] (*schema 2*). The former is being obsoleted but will be supported
 for an extended amount of time.
 
 You should be wary of compatibility issues with various Docker clients:
 
-- Docker clients of version 1.9 or older support only *schema1*. Any manifest
+- Docker clients of version 1.9 or older support only *schema 1*. Any manifest
 this client pulls or pushes will be of this legacy schema.
-- Docker clients of version 1.10 support both *schema1* and *schema2*. And by default, it will
+- Docker clients of version 1.10 support both *schema 1* and *schema 2*. And by default, it will
 push the latter to the registry if it supports newer schema.
 
-The registry, storing an image with *schema1* will always return it unchanged
-to the client. *Schema2* will be transferred unchanged only to newer Docker
-client. For the older one, it will be converted on-the-fly to *schema1*.
+The registry, storing an image with *schema 1* will always return it unchanged
+to the client. *Schema 2* will be transferred unchanged only to newer Docker
+client. For the older one, it will be converted on-the-fly to *schema 1*.
 
 This has significant consequences. For example an image pushed to the registry
 by a newer Docker client cannot be pulled by the older Docker by its digest.
-That's because the stored image's manifest is of *schema2* and its digest can
+That's because the stored image's manifest is of *schema 2* and its digest can
 be used to pull only this version of manifest.
 
-For this reason, the registry is configured by default not to store *schema2*.
+For this reason, the registry is configured by default not to store *schema 2*.
 This ensures that any docker client will be able to pull from the registry any
 image pushed there regardless of client's version.
 
-Once you're confident that all the registry clients support *schema2*, you'll
+Once you're confident that all the registry clients support *schema 2*, you'll
 be safe to enable its support in the registry. See the
 xref:docker-registry-configuration-reference-middleware[middleware
 configuration reference] above for particular option.

--- a/registry_quickstart/administrators/system_configuration.adoc
+++ b/registry_quickstart/administrators/system_configuration.adoc
@@ -84,7 +84,7 @@ $ sudo systemctl restart atomic-registry-console.service
 
 === Registry Configuration
 
-The docker distribution registry configuration is managed by a file mounted on
+The Docker Distribution registry configuration is managed by a file mounted on
 the host at *_/etc/atomic-registry/registry/config.yml_*. See
 xref:registry-configuration-reference-sysconfig[registry configuration reference] for complete settings.
 

--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -1123,7 +1123,7 @@ This release fixes bugs for the following components:
 
 *Image Registry*
 
-* The S3 communication library was not efficient enough to support high loads of data. This caused some pushes to the registry to take relatively long. This bug fix updates both the docker distribution code along with the S3 driver. As a result, docker push operations experience improved stability and performance. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1314381[*BZ#1314381*])
+* The S3 communication library was not efficient enough to support high loads of data. This caused some pushes to the registry to take relatively long. This bug fix updates both the Docker Distribution code along with the S3 driver. As a result, docker push operations experience improved stability and performance. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1314381[*BZ#1314381*])
 
 * A bug in an older registry version prevented it from working with a Swift storage back-end while having the content-offload feature turned off, causing the registry to be unusable in these conditions. This bug fix updates the registry version, which has reworked storage drivers. As a result, the registry is now usable in these conditions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1348031[*BZ#1348031*])
 

--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -149,12 +149,11 @@ link:https://github.com/docker/distribution/blob/master/docs/storage-drivers/gcs
 parameter] to define the name of the GCS bucket to store objects in.
 
 [[ocp-support-docker-distribution-2-4]]
-==== Support for docker distribution 2.4
+==== Support for Docker Distribution 2.4
 
-The {product-title} 3.3 registry provides support for docker distribution
-registry 2.4, and the features will be backported to {product-title} 3.2.
-Version 2.4 of the registry includes a variety of performance and usability
-enhancements, notably:
+The {product-title} 3.3 registry is based on Docker Distribution registry 2.4,
+and its features will be backported to {product-title} 3.2. Version 2.4 of the
+registry includes a variety of performance and usability enhancements, notably:
 
 *Cross-repo Mounting When Pushing Images That Already Exist in the Registry*
 
@@ -171,21 +170,26 @@ proceed, unoptimized, and the client will push the entire blob to the target
 repository from the primary source repository without assistance from the
 secondary source repository.
 
-*Support for the New schema2 Storage Format for Images*
+*Support for the New schema 2 Storage Format for Images*
 
-The image manifest version 2, schema2, allows multi-architecture images via a
-manifest list which references image manifests for one or more platform-specific
-versions of an image (e.g., `amd64` versus `ppc64le`). Schema 2 also supports
-the ability to hash an image's configuration, to create an ID for the image and
-provide docker content-addressable information about the image.
+The image manifest version 2, *schema 2*, introduces the ability to hash an image's
+configuration and thus reduce manifest size, to create an ID for the image,
+and provide content-addressable information about the image.
 
-To preserve compatibility with older docker versions, support for schema 2 must
-be manually enabled:
+Support for consuming *schema 2* from external resources is enabled implicitly.
+However, images pushed to the internal registry will be converted to *schema 1*
+for compatibility with older docker versions. For clusters not in need of
+compatibility preservation, accepting of *schema 2* during pushes can be
+manually enabled:
 
 ----
 $ oc login -u system:admin
 $ oc set env dc/docker-registry -n default REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ACCEPTSCHEMA2=true
 ----
+
+Manifest lists, introduced by *schema 2* to provide support for
+multi-architecture images (e.g., amd64 versus ppc64le), are not yet supported
+in {product-title} 3.3.
 
 [[ocp-33-allow-image-pull-through]]
 ==== Allow Image "Pull-Through" from a Remote Registry


### PR DESCRIPTION
- Schema 2 is supported by default.
- Enable accepting schema 2 on pushes only in case where backwards
  compatibility is not needed.
- Manifest lists are not yet supported.

Signed-off-by: Michal Minář miminar@redhat.com
