### PR TITLE
Added using_images/index file back

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -670,7 +670,7 @@ Distros: openshift-*
 Topics:
   - Name: Overview
     File: index
-    Distros: openshift-online
+    Distros: openshift-online,openshift-enterprise,openshift-dedicated
   - Name: Source-to-Image (S2I)
     Dir: s2i_images
     Topics:


### PR DESCRIPTION
@adellape - I can't figure out why this file wasn't in the enterprise and dedicated distros. Any ideas?
