### PR TITLE
Update imagestream/template offerings by subscription type

### DIFF
--- a/admin_guide/osd_imagestreams_templates.adoc
+++ b/admin_guide/osd_imagestreams_templates.adoc
@@ -12,10 +12,12 @@ toc::[]
 
 == Overview
 
-Your {product-title} cluster by default comes loaded with a core set of image
+Your {product-title} cluster by default comes loaded with sets of image
 streams and templates, which are accessible by all users across the cluster via
 the global *openshift* project. As a cluster administrator, you can add, remove,
 and edit these defaults at your discretion.
+
+include::install_config/imagestreams_templates.adoc[tag=installconfig_imagestreams_templates2]
 
 The following sections detail the default image streams and templates, and show
 how to modify them or create new ones in the global *openshift* project.

--- a/install_config/imagestreams_templates.adoc
+++ b/install_config/imagestreams_templates.adoc
@@ -36,11 +36,90 @@ method automatically creates these sets in the *openshift* project, which is a
 default project to which all users have view access.
 endif::[]
 
-[IMPORTANT]
-====
-Before you consider using this topic, confirm if these image streams and
-templates are already registered in your {product-title} cluster by doing one of the
-following:
+ifdef::openshift-enterprise[]
+[[is-templates-subscriptions]]
+== Offerings by Subscription Type
+
+Depending on the active subscriptions on your Red Hat account, the following
+sets of image streams and templates are provided and supported by Red Hat.
+Contact your Red Hat sales representative for further subscription details.
+
+[[is-templates-core-sub]]
+=== {product-title} Subscription
+
+The core set of image streams and templates are provided and supported with an
+active _{product-title} subscription_. This includes the following technologies:
+endif::[]
+// tag::installconfig_imagestreams_templates2[]
+ifdef::openshift-origin,openshift-dedicated[]
+Image streams and templates are provided for the following technologies:
+endif::[]
+
+[options="header",cols="1,3"]
+|===
+
+|Type |Technology
+
+|Languages & Frameworks
+a|- .NET Core
+- xref:../using_images/s2i_images/nodejs.adoc#using-images-s2i-images-nodejs[Node.js]
+- xref:../using_images/s2i_images/perl.adoc#using-images-s2i-images-perl[Perl]
+- xref:../using_images/s2i_images/php.adoc#using-images-s2i-images-php[PHP]
+- xref:../using_images/s2i_images/python.adoc#using-images-s2i-images-python[Python]
+- xref:../using_images/s2i_images/ruby.adoc#using-images-s2i-images-ruby[Ruby]
+
+|Databases
+a|- xref:../using_images/db_images/mongodb.adoc#using-images-db-images-mongodb[MongoDB]
+- xref:../using_images/db_images/mysql.adoc#using-images-db-images-mysql[MySQL]
+- xref:../using_images/db_images/postgresql.adoc#using-images-db-images-postgresql[PostgreSQL]
+
+ifdef::openshift-enterprise,openshift-dedicated[]
+|Middleware Services
+a|- link:https://access.redhat.com/documentation/en/red-hat-xpaas/version-0/red-hat-xpaas-jboss-web-server-image/[Red Hat JBoss Web Server] (Tomcat)
+- link:https://access.redhat.com/documentation/en/red-hat-xpaas/0/paged/red-hat-xpaas-sso-image/[Red Hat Single Sign-on]
+endif::[]
+
+|Other Services
+a|- xref:../using_images/other_images/jenkins.adoc#using-images-other-images-jenkins[Jenkins]
+ifdef::openshift-enterprise[]
+endif::[]
+|===
+
+ifdef::openshift-enterprise[]
+[[is-templates-xpaas-subs]]
+=== xPaaS Middleware Add-on Subscriptions
+
+Support for xPaaS middleware images are provided by _xPaaS Middleware add-on subscriptions_, which are separate subscriptions for each xPaaS product. If the
+relevant subscription is active on your account, image streams and templates are
+provided and supported for the following technologies:
+endif::[]
+ifdef::openshift-dedicated[]
+The following xPaaS middleware image streams are available for development use only:
+endif::[]
+
+ifdef::openshift-dedicated,openshift-enterprise[]
+[options="header",cols="1,3"]
+|===
+
+|Type |Technology
+
+|Middleware Services
+a|- link:https://access.redhat.com/documentation/en/red-hat-xpaas/version-0/red-hat-xpaas-a-mq-image/[Red Hat JBoss A-MQ]
+- link:https://access.redhat.com/documentation/en/red-hat-xpaas/0/paged/red-hat-xpaas-intelligent-process-server-image/[Red Hat JBoss BPM Suite Intelligent Process Server]
+- link:https://access.redhat.com/documentation/en/red-hat-xpaas/version-0/red-hat-xpaas-decision-server-image/[Red Hat JBoss BRMS Decision Server]
+- link:https://access.redhat.com/documentation/en/red-hat-xpaas/version-0/red-hat-xpaas-data-grid-image/[Red Hat JBoss Data Grid]
+- link:https://access.redhat.com/documentation/en/red-hat-xpaas/version-0/red-hat-xpaas-eap-image/[Red Hat JBoss EAP]
+- link:https://access.redhat.com/documentation/en/red-hat-xpaas/version-0/red-hat-xpaas-fuse-integration-services-image/[Red Hat JBoss Fuse Integration Services]
+|===
+endif::[]
+// end::installconfig_imagestreams_templates2[]
+
+[[is-templates-before-you-begin]]
+== Before You Begin
+
+Before you consider performing the tasks in this topic, confirm if these image
+streams and templates are already registered in your {product-title} cluster by
+doing one of the following:
 
 * Log into the web console and click *Add to Project*.
 * List them for the *openshift* project using the CLI:
@@ -58,45 +137,6 @@ endif::[]
 the default image streams and templates are ever removed or changed, you can
 follow this topic to create the default objects yourself. Otherwise, the
 following instructions are not necessary.
-====
-
-ifdef::openshift-enterprise[]
-The core set of image streams and templates are provided and supported by
-Red Hat with an active {product-title} subscription for the following
-technologies:
-endif::[]
-ifdef::openshift-origin[]
-Image streams and templates are provided for the following technologies:
-endif::[]
-
-[horizontal]
-Languages::
-- xref:../using_images/s2i_images/nodejs.adoc#using-images-s2i-images-nodejs[Node.js]
-- xref:../using_images/s2i_images/perl.adoc#using-images-s2i-images-perl[Perl]
-- xref:../using_images/s2i_images/php.adoc#using-images-s2i-images-php[PHP]
-- xref:../using_images/s2i_images/python.adoc#using-images-s2i-images-python[Python]
-- xref:../using_images/s2i_images/ruby.adoc#using-images-s2i-images-ruby[Ruby]
-Database::
-- xref:../using_images/db_images/mongodb.adoc#using-images-db-images-mongodb[MongoDB]
-- xref:../using_images/db_images/mysql.adoc#using-images-db-images-mysql[MySQL]
-- xref:../using_images/db_images/postgresql.adoc#using-images-db-images-postgresql[PostgreSQL]
-Other Services::
-- xref:../using_images/other_images/jenkins.adoc#using-images-other-images-jenkins[Jenkins]
-
-ifdef::openshift-enterprise[]
-If you also have the relevant xPaaS Middleware subscription active on your
-account, image streams and templates are also provided and supported by Red Hat
-for each of following middleware services:
-
-[horizontal]
-Middleware Services::
-- xref:../using_images/xpaas_images/eap.adoc#using-images-xpaas-images-eap[JBoss EAP]
-- xref:../using_images/xpaas_images/a_mq.adoc#using-images-xpaas-images-a-mq[JBoss A-MQ]
-- xref:../using_images/xpaas_images/jws.adoc#using-images-xpaas-images-jws[JBoss Web Server]
-- xref:../using_images/xpaas_images/fuse.adoc#using-images-xpaas-images-fuse[JBoss Fuse Integration Services]
-- xref:../using_images/xpaas_images/decision_server.adoc#using-images-xpaas-images-decision-server[Decision Server]
-- xref:../using_images/xpaas_images/data_grid.adoc#using-images-xpaas-images-data-grid[JBoss Data Grid]
-endif::[]
 
 [[is-templates-prereqs]]
 == Prerequisites
@@ -148,20 +188,10 @@ endif::[]
 == Creating Image Streams for {product-title} Images
 
 // tag::installconfig_imagestreams_templates[]
-The core set of image streams provide images that can be used to build
-xref:../using_images/s2i_images/nodejs.adoc#using-images-s2i-images-nodejs[*Node.js*],
-xref:../using_images/s2i_images/perl.adoc#using-images-s2i-images-perl[*Perl*],
-xref:../using_images/s2i_images/php.adoc#using-images-s2i-images-php[*PHP*],
-xref:../using_images/s2i_images/python.adoc#using-images-s2i-images-python[*Python*], and
-xref:../using_images/s2i_images/ruby.adoc#using-images-s2i-images-ruby[*Ruby*] applications. It also
-defines images for xref:../using_images/db_images/mongodb.adoc#using-images-db-images-mongodb[*MongoDB*],
-xref:../using_images/db_images/mysql.adoc#using-images-db-images-mysql[*MySQL*], and
-xref:../using_images/db_images/postgresql.adoc#using-images-db-images-postgresql[*PostgreSQL*]
-to support data storage.
-
 ifdef::openshift-enterprise,openshift-origin[]
 If your node hosts are subscribed using Red Hat Subscription Manager and you
-want to use the Red Hat Enterprise Linux (RHEL) 7 based images:
+want to use the core set of image streams that used Red Hat Enterprise Linux
+(RHEL) 7 based images:
 
 ----
 $ oc create -f $IMAGESTREAMDIR/image-streams-rhel7.json -n openshift


### PR DESCRIPTION
Preview:
http://file.rdu.redhat.com/~adellape/101116/jws_sub/install_config/imagestreams_templates.html
- Moved JWS (Tomcat) and SSO up under the core OCP subscription table.
- Added .NET under the core OCP subscription (will link that to the .NET doc when it's merged)
- Added "Red Hat JBoss BPM Suite Intelligent Process Server" to the xPaaS subscription table. Used the name form found on https://www.openshift.com/container-platform/features.html#technologies to match.
