### PR TITLE
Include documentation for the 'oc set build-secret' command

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -257,6 +257,22 @@ $ oc delete <object_type> -l <label>
 $ oc delete all -l <label>
 ----
 
+=== set
+Modify a specific property of the specified object. 
+
+==== set env
+Sets an environment variable on a deployment configuration or a build configuration:
+----
+$ oc set env dc/mydc VAR1=value1
+----
+
+==== set build-secret
+Sets the name of a secret on a build configuration. The secret may be an image pull or
+push secret or a source repository secret:
+----
+$ oc set build-secret --source bc/mybc mysecret
+----
+
 [[build-and-deployment-cli-operations]]
 
 == Build and Deployment CLI Operations

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -922,6 +922,15 @@ spec:
 <1> The URL of private repository, accessed by basic authentication, is usually
 in the `http` or `https` form.
 ====
++
+You can also use the `*oc set build-secret*` command to set the secret on the
+existing build configuration:
++
+====
+----
+$ oc set build-secret --source bc/sample-build basicsecret
+----
+====
 
 
 [[ssh-key-authentication]]
@@ -1013,6 +1022,15 @@ spec:
 <1> The URL of private repository, accessed by a private SSH key, is usually
 in the form `git@example.com:<username>/<repository>.git`.
 ====
++
+You can also use the `*oc set build-secret*` command to set the secret on the
+existing build configuration:
++
+====
+----
+$ oc set build-secret --source bc/sample-build sshsecret
+----
+====
 
 [[other-authentication]]
 ===== Other
@@ -1074,6 +1092,15 @@ source:
     uri: "https://github.com/openshift/nodejs-ex.git"
   sourceSecret:
     name: "mysecret"
+----
+====
++
+You can also use the `*oc set build-secret*` command to set the secret on the
+existing build configuration:
++
+====
+----
+$ oc set build-secret --source bc/sample-build mysecret
 ----
 ====
 
@@ -2090,6 +2117,15 @@ spec:
       name: "dockerhub"
 ----
 ====
++
+You can also use the `*oc set build-secret*` command to set the push secret on
+the build configuration:
++
+====
+----
+$ oc set build-secret --push bc/sample-build dockerhub
+----
+====
 
 . Pull the builder container image from a private Docker registry by specifying the
 `*pullSecret*` field, which is part of the build strategy definition:
@@ -2107,6 +2143,16 @@ strategy:
   type: "Source"
 ----
 ====
++
+You can also use the `*oc set build-secret*` command to set the pull secret on
+the build configuration:
++
+====
+----
+$ oc set build-secret --pull bc/sample-build dockerhub
+----
+====
+
 
 [NOTE]
 ====


### PR DESCRIPTION
Adds doc to the cli reference (along with a section on 'oc set')
and mentions that you can set the build secret with the CLI in the builds dev guide.
