### PR TITLE
LDAP removed (objectclass=inetOrgPerson) filter when userUIDAttribute = DN

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -322,7 +322,6 @@ rfc2307:
         baseDN: "ou=groups,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
         pageSize: 0
     groupUIDAttribute: dn <3>
     groupNameAttributes: [ cn ] <4>
@@ -331,7 +330,6 @@ rfc2307:
         baseDN: "ou=users,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
         pageSize: 0
     userUIDAttribute: dn <6>
     userNameAttributes: [ mail ] <7>
@@ -343,10 +341,16 @@ stored.
 <2> When `true`, no TLS connection is made to the server. When `false`, secure
 LDAP (`ldaps://`) URLs connect using TLS, and insecure LDAP (`ldap://`) URLs are
 upgraded to TLS.
-<3> The attribute that uniquely identifies a group on the LDAP server.
+<3> The attribute that uniquely identifies a group on the LDAP server. 
+You cannot specify `groupsQuery` filters when using DN for groupUIDAttribute.
+For fine-grained filtering, use the 
+xref:../install_config/syncing_groups_with_ldap.adoc#running-ldap-sync[whitelist / blacklist method].
 <4> The attribute to use as the name of the Group.
 <5> The attribute on the group that stores the membership information.
-<6> The attribute that uniquely identifies a user on the LDAP server.
+<6> The attribute that uniquely identifies a user on the LDAP server. You
+cannot specify `usersQuery` filters when using DN for userUIDAttribute. For
+fine-grained  filtering, use the 
+xref:../install_config/syncing_groups_with_ldap.adoc#running-ldap-sync[whitelist / blacklist method].
 <7> The attribute to use as the name of the user in the {product-title} Group record.
 ====
 
@@ -404,7 +408,6 @@ rfc2307:
         baseDN: "ou=groups,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
         pageSize: 0
     groupUIDAttribute: dn <2>
     groupNameAttributes: [ cn ] <3>
@@ -413,18 +416,23 @@ rfc2307:
         baseDN: "ou=users,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
         pageSize: 0
-    userUIDAttribute: dn
+    userUIDAttribute: dn <4>
     userNameAttributes: [ mail ]
     tolerateMemberNotFoundErrors: false
     tolerateMemberOutOfScopeErrors: false
 ----
 <1> The user-defined name mapping.
 <2> The unique identifier attribute that is used for the keys in the
-user-defined name mapping.
+user-defined name mapping. You cannot specify `groupsQuery` filters when using
+DN for groupUIDAttribute. For fine-grained filtering, use the 
+xref:../install_config/syncing_groups_with_ldap.adoc#running-ldap-sync[whitelist / blacklist method].
 <3> The attribute to name {product-title} Groups with if their unique identifier is
 not in the user-defined name mapping.
+<4> The attribute that uniquely identifies a user on the LDAP server. You
+cannot specify `usersQuery` filters when using DN for userUIDAttribute. For
+fine-grained  filtering, use the 
+xref:../install_config/syncing_groups_with_ldap.adoc#running-ldap-sync[whitelist / blacklist method].
 ====
 
 To run sync with the *_rfc2307_config_user_defined.yaml_* file:
@@ -553,7 +561,6 @@ rfc2307:
         baseDN: "ou=groups,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
     groupUIDAttribute: dn
     groupNameAttributes: [ cn ]
     groupMembershipAttributes: [ member ]
@@ -561,8 +568,7 @@ rfc2307:
         baseDN: "ou=users,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
-    userUIDAttribute: dn
+    userUIDAttribute: dn <3>
     userNameAttributes: [ mail ]
     tolerateMemberNotFoundErrors: true <1>
     tolerateMemberOutOfScopeErrors: true <2>
@@ -575,6 +581,10 @@ found.
 the user scope given in the `usersQuery` base DN, and members outside the member
 query scope are ignored. The default behavior for the sync job is to fail if a
 member of a group is out of scope.
+<3> The attribute that uniquely identifies a user on the LDAP server. You
+cannot specify `usersQuery` filters when using DN for userUIDAttribute. For
+fine-grained  filtering, use the 
+xref:../install_config/syncing_groups_with_ldap.adoc#running-ldap-sync[whitelist / blacklist method].
 ====
 
 To run sync with the *_rfc2307_config_tolerating.yaml_* file:
@@ -798,7 +808,6 @@ augmentedActiveDirectory:
         baseDN: "ou=groups,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
         pageSize: 0
     groupUIDAttribute: dn <1>
     groupNameAttributes: [ cn ] <2>
@@ -811,7 +820,10 @@ augmentedActiveDirectory:
     userNameAttributes: [ mail ] <3>
     groupMembershipAttributes: [ testMemberOf ] <4>
 ----
-<1> The attribute that uniquely identifies a group on the LDAP server.
+<1> The attribute that uniquely identifies a group on the LDAP server. You
+cannot specify `groupsQuery` filters when using DN for groupUIDAttribute. For
+fine-grained filtering, use the 
+xref:../install_config/syncing_groups_with_ldap.adoc#running-ldap-sync[whitelist / blacklist method].
 <2> The attribute to use as the name of the Group.
 <3> The attribute to use as the name of the user in the {product-title} Group record.
 <4> The attribute on the user that stores the membership information.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1381674

Update to Install guide.

Removed mention of a couple filters that don't exist now due to this commit: 
https://github.com/openshift/ose/commit/9351adc9cb35ee67ab82659c165dcb4f3799e33d 

There are no filters allowed when using DN for groupUIDAttribute and userUIDAttribute.  Now recommending use of whitelist / blacklist method.
