### PR TITLE
Described all router environment variables

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -186,21 +186,46 @@ addresses; because of the NAT configuration, the originating IP address
 
 *Configuration Parameters*
 
-With all the items outlined in this section, you should be able to set environment
+For all the items outlined in this section, you can set environment
 variables on the *deployment config* for the router to alter its configuration.
 
 .Router Configuration Parameters
-[cols="2*", options="header"]
+[cols="3*", options="header"]
 |===
-|Variable | Default
-|`*ROUTER_SYSLOG_ADDRESS*` | ""
-|`*ROUTER_LOG_LEVEL*` | warning
-|`*ROUTER_BACKEND_CHECK_INTERVAL*` | 5000ms
-|`*ROUTER_DEFAULT_CONNECT_TIMEOUT*`| 5s
-|`*ROUTER_DEFAULT_CLIENT_TIMEOUT*`| 30s
-|`*ROUTER_DEFAULT_SERVER_TIMEOUT*`| 30s
-|`*ROUTER_DEFAULT_TUNNEL_TIMEOUT*` | 1h
-|`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s
+|Variable | Default | Description
+|`*DEFAULT_CERTIFICATE*` |  | The contents of a default certificate to use for routes that don't expose a TLS server cert; in PEM format.
+|`*DEFAULT_CERTIFICATE_DIR*` |  | A path to a directory that contains a file named tls.crt. If tls.crt is not a PEM file which also contains a private key, it is first combined with a file named tls.key in the same directory. The PEM-format contents are then used as the default certificate. Only used if DEFAULT_CERTIFICATE or DEFAULT_CERTIFICATE_PATH are not specified.
+|`*DEFAULT_CERTIFICATE_PATH*` |  | A path to default certificate to use for routes that don't expose a TLS server cert; in PEM format. Only used if DEFAULT_CERTIFICATE is not specified.
+|`*EXTENDED_VALIDATION*` | true | Whether to perform an additional extended validation step on all routes admitted by this router.
+|`*NAMESPACE_LABELS*` |  | A label selector to apply to namespaces to watch, empty means all.
+|`*PROJECT_LABELS*` |  | A label selector to apply to projects to watch, emtpy means all.
+|`*RELOAD_SCRIPT*` |  | The path to the reload script to use to reload the router.
+|`*ROUTER_BACKEND_CHECK_INTERVAL*` | 5000ms | Time interval between subsequent "liveness" checks on backends.
+|`*ROUTER_COMPRESSION_MIME*` | "text/html text/plain text/css" | A space separated list of mime types to compress.
+|`*ROUTER_DEFAULT_CLIENT_TIMEOUT*`| 30s | Time interval within which a client has to acknowledge or send data.
+|`*ROUTER_DEFAULT_CONNECT_TIMEOUT*`| 5s | The maximum connect time.
+|`*ROUTER_DEFAULT_SERVER_TIMEOUT*`| 30s | Time interval within which a server has to acknowledge or send data.
+|`*ROUTER_DEFAULT_TUNNEL_TIMEOUT*` | 1h | Time interval to allow TCP or WebSocket connections to remain open.
+|`*ROUTER_ENABLE_COMPRESSION*`| false | If "true", compress responses when possible.
+|`*ROUTER_LOG_LEVEL*` | warning | The log level to send to the syslog server.
+|`*ROUTER_OVERRIDE_HOSTNAME*`|  | If set, override the spec.host value for a route with the template in ROUTER_SUBDOMAIN.
+|`*ROUTER_SERVICE_HTTPS_PORT*` | 443 | Port to listen for https requests.
+|`*ROUTER_SERVICE_HTTP_PORT*` | 80 | Port to listen for http requests.
+|`*ROUTER_SERVICE_NAME*` | public | The name that the router will identify itself with in route statuses.
+|`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router will identify itself with in route statuses.  Required if ROUTER_SERVICE_NAME is used.
+|`*ROUTER_SERVICE_NO_SNI_PORT*` | 10443 | Internal port for some front-end to back-end communication (see note below).
+|`*ROUTER_SERVICE_SNI_PORT*` | 10444 | Internal port for some front-end to back-end communication (see note below).
+|`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s | How long the transmission of an HTTP request can take.
+|`*ROUTER_SUBDOMAIN*`|  | The template that should be used to generate the hostname for a route without spec.host (e.g. '${name}-${namespace}.myapps.mycompany.com').
+|`*ROUTER_SYSLOG_ADDRESS*` |  | Where to send log messages.  Disabled if empty.
+|`*ROUTER_TCP_BALANCE_SCHEME*` | source | How to load-balance multiple endpoints for pass-through routes.  Either "source", "roundrobin", or "leastconn".
+|`*ROUTE_FIELDS*` |  | A field selector to apply to routes to watch, empty means all.
+|`*ROUTE_LABELS*` |  | A label selector to apply to the routes to watch, empty means all.
+|`*STATS_PASSWORD*` |  | The password needed to access router stats (if the router implementation supports it).
+|`*STATS_PORT*` |  | What port to expose statistics on (if the router implementation supports it).  If not set, stats are not exposed.
+|`*STATS_USERNAME*` |  | The username needed to access router stats (if the router implementation supports it).
+|`*TEMPLATE_FILE*` | /var/lib/haproxy/conf/custom/haproxy-config-custom.template | The path to the haproxy template file (in the image).
+|`*RELOAD_INTERVAL*` | 12s | The minimum frequency the router is allowed to reload to accept new changes.
 |===
 
 As an example, you can apply the parameters listed using the example:
@@ -208,6 +233,15 @@ As an example, you can apply the parameters listed using the example:
 ----
 $ oc env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LOG_LEVEL=debug
 ----
+
+[NOTE]
+====
+If you want to run multiple routers on the same machine you must
+change the ports that the router is listening on, and
+`ROUTER_SERVICE_SNI_PORT` and `ROUTER_SERVICE_NO_SNI_PORT`.  These can
+be anything you want as long as they are unique on the machine.  The ports will
+not be exposed externally.
+====
 
 [[f5-router]]
 === F5 Router


### PR DESCRIPTION
Added missing router environment variables to the documentation, and
added descriptons to all of them.

For 3.3 and 3.4.
