### PR TITLE
Clarify EFK logging requires you to upgrade to latest

### DIFF
--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -265,10 +265,8 @@ endif::[]
 == Upgrading the EFK Logging Stack
 
 If you have previously xref:../../install_config/aggregate_logging.adoc#install-config-aggregate-logging[deployed
-the EFK logging stack] and want to upgrade to the latest logging component
-images, the steps must be performed manually as shown in
-xref:../../install_config/upgrading/manual_upgrades.adoc#manual-upgrading-efk-logging-stack[Manual
-Upgrades].
+the EFK logging stack], you must manually xref:../../install_config/upgrading/manual_upgrades.adoc#manual-upgrading-efk-logging-stack[update]
+to the latest logging components.
 
 [[automated-upgrading-cluster-metrics]]
 == Upgrading Cluster Metrics


### PR DESCRIPTION
This PR modifies documentation to:
- Clarify it is necessary to migrate to the latest EFK stack when installing origin
