### PR TITLE
OCP 3.1 weekly release - 10/24/16

### DIFF
--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -7,6 +7,22 @@
 :experimental:
 
 // do-release: revhist-tables
+== Mon Oct 24 2016
+
+// tag::admin_guide_mon_oct_24_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+//Mon Oct 24 2016
+|xref:../admin_guide/service_accounts.adoc#admin-guide-service-accounts[Configuring Service Accounts]
+|Added a xref:../admin_guide/service_accounts.adoc#service-accounts-and-secrets[Service Accounts and Secrets] heading.
+
+
+
+|===
+
+// end::admin_guide_mon_oct_24_2016[]
 == Tue Aug 23 2016
 
 // tag::admin_guide_tue_aug_23_2016[]

--- a/admin_guide/service_accounts.adoc
+++ b/admin_guide/service_accounts.adoc
@@ -126,9 +126,13 @@ policyConfig:
 ----
 ====
 
-Set `limitSecretReferences` field in xref:../install_config/master_node_configuration.adoc#master-configuration-files[master configuration]
-file to `true` to require pod secret references to be whitelisted by their service accounts.
-Set its value to `false` to allow pods to reference any secret in the namespace.
+[[service-accounts-and-secrets]]
+== Service Accounts and Secrets
+
+Set the `*limitSecretReferences*` field in the
+*_/etc/origin/master/master-config.yml_* file on the master to `true` to require
+pod secret references to be whitelisted by their service accounts. Set its value
+to `false` to allow pods to reference any secret in the project.
 
 ====
 ----

--- a/contributing_to_docs/contributing.adoc
+++ b/contributing_to_docs/contributing.adoc
@@ -108,7 +108,12 @@ All OpenShift content development occurs on the `master`, or *working* branch. T
 
 [[how-it-all-comes-together]]
 == How it all comes together
-The documentation build system reads the `_build_cfg.yml_` metadata file to construct the content from the source files and publish to the relevant product site at https://docs.openshift.com. The build system _only_ reads this file to determine which topic files to include. Therefore, all new topics that are created must be included in the `_build_cfg.yml_` metadata file in order to be processed by the build system.
+The documentation build system reads the `&#95;topic&#95;map.yml` metadata file
+to construct the content from the source files and publish to the relevant
+product site at https://docs.openshift.com. The build system _only_ reads this
+file to determine which topic files to include. Therefore, all new topics that
+are created must be included in the `&#95;topic&#95;map.yml` metadata file in
+order to be processed by the build system.
 
 === Metadata file format
 The format of this file is as indicated:

--- a/contributing_to_docs/create_or_edit_content.adoc
+++ b/contributing_to_docs/create_or_edit_content.adoc
@@ -100,8 +100,13 @@ $ git push origin <working_branch>
 == Submit PR to merge your work
 When you have pushed your changes to your GitHub account, you can submit a PR to have your work from your GitHub fork to the `master` branch of the OpenShift documentation repository. The documentation team will review the work, will advise of any further changes that may or may not be required, and finally merge your work.
 
-1. Go to your forked GitHub repository on the GitHub website, and you should see your local branch that includes all of your work.
-2. Click on *Pull Request* to submit the PR against the `master` branch of the `openshift-docs` repository.
+1. Go to your forked GitHub repository on the GitHub website, and you should see
+your local branch that includes all of your work.
+2. Click on *Pull Request* to submit the PR against the `master` branch of the
+`openshift-docs` repository.
+3. Attach labels to your *Pull Request* to indicate to the DOCS team which branches your PR might apply to. Some requests may only apply to the origin distro (origin-only), and some may only apply to a specific version of the enterprise (branch/enterprise-3.0, branch/enterprise-3.1, branch/enterprise-3.2, branch/enterprise-3.3) or dedicated (branch/dedicated) or online (branch/online) docs. If a request applies to multiple versions of a distro, then specify the minimum version (branch/enterprise-3.1 and above, for example).
+
+*If you don't have permissions to apply labels, please make sure to leave that information as a comment.*
 
 == Confirm your changes have been merged
 When your PR has been merged into the `master` branch, you should confirm and then sync your local and GitHub repositories with the `master` branch.

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -695,6 +695,13 @@ Enterprise subscription and attach it:
 # subscription-manager attach --pool=<pool_id>
 ----
 +
+[NOTE]
+====
+When finding the pool ID, the related subscription name might include either
+"OpenShift Enterprise" or "OpenShift Container Platform", due to the product
+name change introduced with version 3.3.
+====
++
 If you plan to configure
 xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#high-availability-masters[multiple
 masters] with the xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] using the

--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -8,6 +8,21 @@
 
 // do-release: revhist-tables
 
+== Mon Oct 24 2016
+
+// tag::install_config_mon_oct_24_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+//Mon Oct 24 2016
+|xref:../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Installing -> Prerequisites]
+|Aded Note box to the xref:../install_config/install/prerequisites.adoc#software-prerequisites[Software Prerequisites] section about subscription names.
+
+|===
+
+// end::install_config_mon_oct_24_2016[]
+
 == Mon Oct 17 2016
 
 // tag::install_config_mon_oct_17_2016[]

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -482,10 +482,6 @@ installation from the JSON files located under the
 *_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/_*
 directory.
 
-<<<<<<< HEAD
-To update these objects, first update the packages that provide the example JSON
-files. On a master host, install or update to the latest version of the
-=======
 [NOTE]
 ====
 Because RHEL Atomic Host 7 cannot use *yum* to update packages, the following
@@ -495,7 +491,6 @@ steps must take place on a RHEL 7 system.
 . Update the packages that provide the example JSON files. On a subscribed Red
 Hat Enterprise Linux 7 system where you can run the CLI as a user with
 *cluster-admin* permissions, install or update to the latest version of the
->>>>>>> fa2b6bd... Bug 1337879, added manual upgrade steps to get the latest templates from *openshift-ansible-roles*
 *atomic-openshift-utils* package, which should also update the
 *openshift-ansible-* packages:
 +
@@ -506,16 +501,9 @@ Hat Enterprise Linux 7 system where you can run the CLI as a user with
 The *openshift-ansible-roles* package provides the latest example JSON files.
 endif::[]
 
-<<<<<<< HEAD
-Now update the global *openshift* project by running the following commands as a
-user with *cluster-admin* privileges. It is expected that you will receive
-warnings about items that already exist.
-
-=======
 . Update the global *openshift* project by running the following commands.
 Receiving warnings about items that already exist is expected.
 +
->>>>>>> fa2b6bd... Bug 1337879, added manual upgrade steps to get the latest templates from *openshift-ansible-roles*
 ifdef::openshift-enterprise[]
 ====
 ----

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -11,6 +11,10 @@ date.
 
 // do-release: revhist-tables
 
+== Mon Oct 24 2016
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_mon_oct_24_2016]
+
 == Tue Oct 17 2016
 .Installation and Configuration
 include::install_config/revhistory_install_config.adoc[tag=install_config_mon_oct_17_2016]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -12,6 +12,9 @@ date.
 // do-release: revhist-tables
 
 == Mon Oct 24 2016
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_mon_oct_24_2016]
+
 .Cluster Administration
 include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_mon_oct_24_2016]
 


### PR DESCRIPTION
Weekly release plus:
- Manually adds https://github.com/openshift/openshift-docs/pull/3057/commits/2e749999e833f89ce5a0555d05419ad622344077 to 3.1
- Fixes an old merge conflicts that's been hanging around related to https://github.com/openshift/openshift-docs/pull/2498
