### PR TITLE
Do not use comma-separated template parameters

### DIFF
--- a/dev_guide/new_app.adoc
+++ b/dev_guide/new_app.adoc
@@ -258,7 +258,7 @@ When creating an application based on a xref:templates.adoc#dev-guide-templates[
 ====
 ----
 $ oc new-app ruby-helloworld-sample \
-    -p ADMIN_USERNAME=admin,ADMIN_PASSWORD=mypassword
+    -p ADMIN_USERNAME=admin -p ADMIN_PASSWORD=mypassword
 ----
 ====
 

--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -198,9 +198,9 @@ $ oc process <template> | oc create -f -
 
 You can override any
 xref:../dev_guide/templates.adoc#templates-parameters[parameter] values defined
-in the file by adding the `-v` option followed by a comma-separated list of
-`<name>=<value>` pairs. A parameter reference may appear in any text field
-inside the template items.
+in the file by adding the `-v` option for each `<name>=<value>` pair you want
+to override. A parameter reference may appear in any text field inside the
+template items.
 
 For example, in the following the *`POSTGRESQL_USER`* and *`POSTGRESQL_DATABASE`*
 parameters of a template are overridden to output a configuration with
@@ -210,7 +210,8 @@ customized environment variables:
 ====
 ----
 $ oc process -f my-rails-postgresql \
-    -v POSTGRESQL_USER=bob,POSTGRESQL_DATABASE=mydatabase
+    -v POSTGRESQL_USER=bob \
+    -v POSTGRESQL_DATABASE=mydatabase
 ----
 ====
 
@@ -221,7 +222,8 @@ command:
 ====
 ----
 $ oc process -f my-rails-postgresql \
-    -v POSTGRESQL_USER=bob,POSTGRESQL_DATABASE=mydatabase \
+    -v POSTGRESQL_USER=bob \
+    -v POSTGRESQL_DATABASE=mydatabase \
     | oc create -f -
 ----
 ====

--- a/getting_started/beyond_the_basics.adoc
+++ b/getting_started/beyond_the_basics.adoc
@@ -252,7 +252,9 @@ MongoDB service.
 +
 ----
 $ oc new-app mongodb-persistent \
--p MONGODB_USER=admin,MONGODB_PASSWORD=secret,MONGODB_ADMIN_PASSWORD=super-secret
+-p MONGODB_USER=admin \
+-p MONGODB_PASSWORD=secret \
+-p MONGODB_ADMIN_PASSWORD=super-secret
 ----
 +
 [NOTE]

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -162,8 +162,9 @@ for the size of the cluster you are using. If you require more space, for
 instance 100 GB, you could specify it with something like this:
 
 ----
-$ oc process -f metrics-deployer.yaml -v \
-    HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,CASSANDRA_PV_SIZE=100Gi \
+$ oc process -f metrics-deployer.yaml \
+    -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
+    -v CASSANDRA_PV_SIZE=100Gi \
     | oc create -f -
 ----
 
@@ -793,8 +794,11 @@ ifdef::openshift-origin[]
 To add a second node with 10Gi of storage:
 
 ----
-# oc process hawkular-cassandra-node-pv -v \
-"IMAGE_PREFIX=openshift/origin-,IMAGE_VERSION=devel,PV_SIZE=10Gi,NODE=2"
+# oc process hawkular-cassandra-node-pv \
+    -v IMAGE_PREFIX=openshift/origin- \
+    -v IMAGE_VERSION=devel \
+    -v PV_SIZE=10Gi \
+    -v NODE=2
 ----
 
 To deploy more nodes, simply increase the `NODE` value.

--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -333,8 +333,10 @@ $ oc create route passthrough --service registry-console \
 the URL of the {product-title} OAuth provider, which is typically the master.
 +
 ----
-$ oc new-app -n default --template=registry-console -p \
-           OPENSHIFT_OAUTH_PROVIDER_URL="https://<openshift_oauth_url>:8443",REGISTRY_HOST=$(oc get route docker-registry -n default --template='{{ .spec.host }}'),COCKPIT_KUBE_URL=$(oc get route registry-console -n default --template='https://{{ .spec.host }}')
+$ oc new-app -n default --template=registry-console \
+    -p OPENSHIFT_OAUTH_PROVIDER_URL="https://<openshift_oauth_url>:8443" \
+    -p REGISTRY_HOST=$(oc get route docker-registry -n default --template='{{ .spec.host }}') \
+    -p COCKPIT_KUBE_URL=$(oc get route registry-console -n default --template='https://{{ .spec.host }}')
 ----
 
 . Finally, use a web browser to view the console using the route URI.

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -1398,7 +1398,8 @@ except this time, specify the `MODE=refresh` option:
 ====
 ----
 $ oc new-app -f metrics-deployer.yaml \
-    -p HAWKULAR_METRICS_HOSTNAME=hm.example.com,MODE=refresh <1>
+    -p HAWKULAR_METRICS_HOSTNAME=hm.example.com \
+    -p MODE=refresh <1>
 ----
 <1> In the original deployment command, there was no `MODE=refresh`.
 ====


### PR DESCRIPTION
Replace

```
oc new-app --param X=Y,Z=W
oc process --value X=Y,Z=W
```

with

```
oc new-app --param X=Y --param Z=W
oc process --value X=Y --value Z=W
```

because the former will likely be removed from oc in openshift/origin#11539.
