### PR TITLE
take public url for cockpit documentation

### DIFF
--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -128,7 +128,7 @@ ifdef::openshift-enterprise[]
 ====
 http://cockpit-project.org[Cockpit] is automatically installed and enabled in
 {product-title} 3.1 and later to help you monitor your development environment.
-https://access.qa.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/getting-started-with-cockpit/[Red
+https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/getting-started-with-cockpit/[Red
 Hat Enterprise Linux Atomic Host: Getting Started with Cockpit] provides more
 information on using Cockpit.
 ====


### PR DESCRIPTION
Replaced access**.qa**.redhat.com with access.redhat.com to make link work.
New link to cockpit documentation:
https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/7/single/getting-started-with-cockpit/
