### PR TITLE
Fix egress router pod example

### DIFF
--- a/admin_guide/managing_pods.adoc
+++ b/admin_guide/managing_pods.adoc
@@ -172,7 +172,7 @@ metadata:
   labels:
     name: egress-1
   annotations:
-    pod.network.openshift.io/assign-macvlan: true
+    pod.network.openshift.io/assign-macvlan: "true"
 spec:
   containers:
   - name: egress-router
@@ -199,7 +199,8 @@ address of 192.168.12.99
 
 The `pod.network.openshift.io/assign-macvlan annotation` creates a Macvlan
 network interface on the primary network interface, and then moves it into the
-pod's network name space before starting the *egress-router* container.
+pod's network name space before starting the *egress-router* container. (Note
+the quotes around `"true"`; you'll get an error if you forget them.)
 
 The pod contains a single container, using the *openshift/origin-egress-router*
 image, and that container is run privileged so that it can configure the Macvlan


### PR DESCRIPTION
The example egress router pod yaml gives an error if you try to use it.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1387645

This should go into 3.3 and 3.4 please.
