### PR TITLE
Added Pod Distribution Budget Topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -619,6 +619,8 @@ Topics:
     File: daemonsets
   - Name: Pod Autoscaling
     File: pod_autoscaling
+  - Name: Pod Disruption Budget
+    File: pod_disruption_budget
   - Name: Managing Volumes
     File: volumes
   - Name: Using Persistent Volumes

--- a/dev_guide/pod_disruption_budget.adoc
+++ b/dev_guide/pod_disruption_budget.adoc
@@ -1,0 +1,65 @@
+[[dev-guide-pod-disruption-budget]]
+= Pod Distribution Budget
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+A _Pod Disruption Budget_ is part of the
+link:http://kubernetes.io/docs/admin/disruptions/[Kubernetes] API, which can be
+managed with `oc` commands like other
+xref:../cli_reference/basic_cli_operations.adoc#object-types[object types]. They
+allow the specification of safety constraints on pods during operations, such as
+draining a node for maintenance.
+
+ifdef::openshift-enterprise[]
+[NOTE]
+====
+As of {product-title} 3.4, Pod Disruption Budget is a feature in Technology
+Preview, available only for users with *cluster-admin* privileges.
+====
+endif::[]
+
+[[creating-a-poddisruptionbudget]]
+== Creating a Pod Disruption Budget
+
+A `PodDisruptionBudget` configuration consists of the following key parts:
+
+* A label selector, which is a label query over a set of pods.
+* An availability level, which specifies the minimum number of pods that must be
+ available simultaneously.
+
+The following is an example of a `PodDisruptionBudget` resource:
+
+====
+[source,yaml]
+----
+apiVersion: policy/v1alpha1 <1>
+kind: PodDisruptionBudget
+metadata:
+  name: foo
+spec:
+  selector:  <2>
+    matchLabels:
+      foo: bar
+  minAvailable: 2  <3>
+----
+
+<1> `PodDisruptionBudget` is part of the `policy/v1alpha` API group.
+<2> A label query over a set of resources. The result of `matchLabels` and
+ `matchExpressions` are logically conjoined.
+<3> The minimum number of pods that must be available simultaneously. This can
+be either an integer or a string specifying a percentage (for example, `20%`).
+====
+
+The `PodDisruptionBudget` is considered healthy when there are at least
+`minAvailable` pods running in the system. Every pod above that limit can be
+xref:../admin_guide/out_of_resource_handling.adoc#out-of-resource-eviction-policy[evicted].


### PR DESCRIPTION
Continuation of https://github.com/openshift/openshift-docs/pull/3109

Trello Card: https://trello.com/c/3h8HNJfQ/806-enable-poddisruptionbudget-controller-in-origin
