### PR TITLE
remove nfsnobody from examples and text

### DIFF
--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -142,8 +142,8 @@ scc restricted` for more details), the project's
 `*openshift.io/sa.scc.uid-range*` range will be used for range checking and for
 a default ID, if needed.
 - A default user ID is produced when a user ID is not specified in the pod
-definition due to `*runAsUser*` being set to *MustRunAsRange*.
-- An SELinux label is required (`seLinuxContext` set to _MustRunAs_), which uses
+definition and the matching SCC's `*runAsUser*` is set to *MustRunAsRange*.
+- An SELinux label is required (`seLinuxContext` set to *MustRunAs*), which uses
 the project's default MCS label.
 - Arbitrary supplemental group IDs are allowed because no range checking is
 required. This is a result of both the `*supplementalGroups*` and `*fsGroup*`
@@ -175,8 +175,8 @@ fsGroup:
     max: 6000
 runAsUser:
   type: MustRunAsRange <7>
-  uidRangeMin: 65534
-  uidRangeMax: 65634
+  uidRangeMin: 1000100000
+  uidRangeMax: 1000100999
 seLinuxContext: <8>
   type: MustRunAs
   SELinuxOptions: <9>
@@ -206,11 +206,11 @@ ID value). If the range was omitted from the SCC, then the default would be
 perform range checking, thus allowing any group ID, and produces no default
 groups.
 <7> *MustRunAsRange* enforces user ID range checking and provides a UID default.
-*Based on this SCC, the default UID is 65534 (the minimum value). If the minimum
-*and maximum range were omitted from the SCC, the default user ID would be
-*1000000000 (derived from the project). *MustRunAsNonRoot* and *RunAsAny* are
-*the other supported types. The range of allowed IDs can be defined to include
-*any user IDs required for the target storage.
+Based on this SCC, the default UID is 1000100000 (the minimum value). If the minimum
+and maximum range were omitted from the SCC, the default user ID would be
+1000000000 (derived from the project). *MustRunAsNonRoot* and *RunAsAny* are
+the other supported types. The range of allowed IDs can be defined to include
+any user IDs required for the target storage.
 <8> When set to *MustRunAs*, the container is created with the SCC's SELinux
 options, or the MCS default defined in the project. A type of *RunAsAny*
 indicates that SELinux context is not required, and, if not defined in the pod,
@@ -287,23 +287,14 @@ On the NFS server:
 ...
 
 # ls -lZ /opt/nfs -d
-drwxrws---. nfsnobody 5555 unconfined_u:object_r:usr_t:s0   /opt/nfs
-
-# id nfsnobody
-uid=65534(nfsnobody) gid=65534(nfsnobody) groups=65534(nfsnobody)
+drwx------. 1000100001 5555 unconfined_u:object_r:usr_t:s0   /opt/nfs
 ----
 ====
 
-[NOTE]
-====
-In the above, the owner is 65534 (*nfsnobody*), but the suggestions and examples in
-this topic apply to any non-root owner.
-====
-
-The *_/opt/nfs/_* export is accessible by UID *65534* and the group *5555*. In
-general, containers should not run as root, so in this NFS example, containers
-which are not run as UID *65534* or are not members the group *5555* will not be
-able to access the NFS export.
+The *_/opt/nfs/_* export is accessible by UID *1000100001* and the group *5555*. In
+general, containers should not run as root. So, in this NFS example, containers
+which are not run as UID *1000100001* and are not members the group *5555* will not
+have access to the NFS export.
 
 Often, the SCC matching the pod does not allow a specific user ID to be
 specified, thus using supplemental groups is a more flexible way to grant
@@ -332,7 +323,7 @@ spec:
 ----
 <1> Name of the volume mount. Must match the name in the `*volumes*` section.
 <2> NFS export path as seen in the container.
-<3> Pod global security context. Applies to all containers in the pod. Each
+<3> Pod global security context. Applies to all containers inside the pod. Each
 container can also define its `*securityContext*`, however group IDs are global
 to the pod and cannot be defined for individual containers.
 <4> Supplemental groups, which is an array of IDs, is set to 5555. This grants
@@ -345,10 +336,10 @@ All containers in the above pod (assuming the matching SCC or project allows the
 group *5555*) will be members of the group *5555* and have access to the volume,
 regardless of the container's user ID. However, the assumption above is
 critical. Sometimes, the SCC does not define a range of allowable group IDs but
-requires group ID validation (due to `*supplementalGroups*` set to *MustRunAs*;
-note this is not the case for the *restricted* SCC). The project will not likely
-allow a group ID of *5555*, unless the project has been customized for access to
-this NFS export. So in this scenario, the above pod will fail because its group
+instead requires group ID validation (a result of `*supplementalGroups*` set to *MustRunAs*).
+Note that this is *not* the case for the *_restricted_* SCC. The project will not likely
+allow a group ID of *5555*, unless the project has been customized to access
+this NFS export. So, in this scenario, the above pod will fail because its group
 ID of *5555* is not within the SCC's or the project's range of allowed group
 IDs.
 
@@ -362,8 +353,8 @@ can be created such that:
 - ID range checking is enforced, and
 - the group ID of *5555* is allowed.
 
-It is better to create new SCCs versus modifying a predefined SCC, or changing
-the range of allowed IDs in the predefined projects.
+It is often better to create a new SCC rather than modifying a predefined SCC, or
+changing the range of allowed IDs in the predefined projects.
 
 The easiest way to create a new SCC is to export an existing SCC and customize
 the YAML file to meet the requirements of the new SCC. For example:
@@ -420,7 +411,7 @@ group ID checking is required.
 ====
 
 When the same pod shown earlier runs against this new SCC (assuming, of course,
-the pod has access to the new SCC), it will start because the group *5555*,
+the pod matches the new SCC), it will start because the group *5555*,
 supplied in the pod definition, is now allowed by the custom SCC.
 
 [[fsgroup]]
@@ -509,7 +500,7 @@ fsGroup:
 <1> *MustRunAs* triggers group ID range checking, whereas *RunAsAny* does not
 require range checking.
 <2> The range of allowed group IDs is 5000 through, and including, 5999. Multiple
-ranges are supported. The allowed group ID range here is 5000 through 5999, with
+ranges are supported but not used. The allowed group ID range here is 5000 through 5999, with
 the default `*fsGroup*` being 5000.
 <3> The minimum value (or the entire range) can be omitted from the SCC, and thus
 range checking and generating a default value will defer to the project's
@@ -519,13 +510,12 @@ separate range for `*fsGroup*`.
 ====
 
 When the pod shown above runs against this new SCC (assuming, of course, the pod
-has access to the new SCC), it will start because the group *5555*, supplied in
+matches the new SCC), it will start because the group *5555*, supplied in
 the pod definition, is allowed by the custom SCC. Additionally, the pod will
 "take over" the block device, so when the block storage is viewed by a process
 outside of the pod, it will actually have *5555* as its group ID.
 
-Currently the list of volumes which support block ownership (block) management
-include:
+A list of volumes supporting block ownership include:
 
 * AWS Elastic Block Store
 * OpenStack Cinder
@@ -534,6 +524,11 @@ include:
 * iSCSI
 * emptyDir
 * gitRepo
+
+[NOTE]
+====
+This list is potentially incomplete.
+====
 
 [[user-id]]
 == User IDs
@@ -556,7 +551,7 @@ pod definition, a single user ID can be defined globally to all containers, or
 specific to individual containers (or both). A user ID is supplied as shown in
 the pod definition fragment below:
 
-[[pod-user-id-65534]]
+[[pod-user-id-1000100001]]
 ====
 [source,yaml]
 ----
@@ -564,11 +559,11 @@ spec:
   containers:
   - name: ...
     securityContext:
-      runAsUser: 65534
+      runAsUser: 1000100001
 ----
 ====
 
-ID 65534 in the above is container-specific and matches the owner ID on the
+ID 1000100001 in the above is container-specific and matches the owner ID on the
 export. If the NFS export's owner ID was *54321*, then that number would be used
 in the pod definition. Specifying `*securityContext*` outside of the container
 definition makes the ID global to all containers in the pod.
@@ -584,33 +579,33 @@ This means even a UID of *0* (root) is allowed.
 
 If, instead, the `*runAsUser*` strategy is set to *MustRunAsRange*, then a
 supplied user ID will be validated against a range of allowed IDs. If the pod
-supplies no user ID, then the default ID is the minimum value of the range of
+supplies no user ID, then the default ID is set to the minimum value of the range of
 allowable user IDs.
 
 Returning to the earlier xref:nfs-example[NFS example], the container needs its
-UID set to *65534*, which is shown in the pod fragment above. Assuming the
+UID set to *1000100001*, which is shown in the pod fragment above. Assuming the
 *default* project and the *restricted* SCC, the pod's requested user ID of
-*65534* will *not* be allowed, and therefore the pod will fail. The pod fails
+1000100001 will not be allowed, and therefore the pod will fail. The pod fails
 because:
 
-- it requests *65534* as its user ID,
+- it requests *1000100001* as its user ID,
 - all available SCCs use *MustRunAsRange* for their `*runAsUser*` strategy, so UID
 range checking is required, and
-- *65534* is not included in the SCC or project's user ID range.
+- *1000100001* is not included in the SCC or in the project's user ID range.
 
-To address this situation, the recommended path would be to create a new SCC
+To remedy this situation, a new SCC can be created 
 with the appropriate user ID range. A new project could also be created with the
-appropriate user ID range defined. There are other, less-preferred options:
+appropriate user ID range defined. There are also other, less-preferred options:
 
-- The *restricted* SCC could be modified to include *65534* within its minimum and
+- The *restricted* SCC could be modified to include *1000100001* within its minimum and
 maximum user ID range. This is not recommended as you should avoid modifying the
 predefined SCCs if possible.
 - The *restricted* SCC could be modified to use *RunAsAny* for the `*runAsUser*`
-value, thus eliminating ID range checking. This is strongly not recommended, as
+value, thus eliminating ID range checking. This is *_strongly_* not recommended, as
 containers could run as root.
 - The *default* project's UID range could be changed to allow a user ID of
-*65534*. This is not generally advisable because only a single range of user IDs
-can be specified.
+*1000100001*. This is not generally advisable because only a single range of user IDs
+can be specified, and thus other pods may not run if the range is altered.
 
 [[scc-runasuser]]
 *User IDs and Custom SCCs*
@@ -625,7 +620,7 @@ such that:
 
 - a minimum and maximum user ID is defined,
 - UID range checking is still enforced, and
-- the UID of *65534* will be allowed.
+- the UID of *1000100001* is allowed.
 
 For example:
 
@@ -643,22 +638,22 @@ priority: 9 <3>
 requiredDropCapabilities: null
 runAsUser:
   type: MustRunAsRange <4>
-  uidRangeMax: 65534 <5>
-  uidRangeMin: 65534
+  uidRangeMax: 1000100001 <5>
+  uidRangeMin: 1000100001
 ...
 ----
-<1> The `allow*` bools are the same as for the *restricted* SCC.
+<1> The `allowXX` bools are the same as for the *restricted* SCC.
 <2> The name of this new SCC is *nfs-scc*.
 <3> Numerically larger numbers have greater priority. Nil or omitted is the lowest
 priority. Higher priority SCCs sort before lower priority SCCs, and thus have a
 better chance of matching a new pod.
 <4> The `*runAsUser*` strategy is set to *MustRunAsRange*, which means UID range
 checking is enforced.
-<5> The UID range is 65534 through 65534 (a range of one value).
+<5> The UID range is 1000100001 through 1000100001 (a range of one value).
 ====
 
-Now, with `*runAsUser: 65534*` shown in the previous pod definition fragment,
-the pod matches the new *nfs-scc* and is able to run with a UID of 65534.
+Now, with `*runAsUser: 1000100001*` shown in the previous pod definition fragment,
+the pod matches the new *nfs-scc* and is able to run with a UID of 1000100001.
 
 [[selinuxoptions]]
 == SELinux Options


### PR DESCRIPTION
See trello card: https://trello.com/c/h6C0XCsl/130-update-storage-example-for-volume-security-not-to-use-nfsnobody
@adellape PTAL
