### PR TITLE
Do not use comma-separated environment variables

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -69,8 +69,11 @@ xref:../../architecture/core_concepts/pods_and_services.adoc#pods[pod] with
 MongoDB running in a container:
 
 ----
-$ oc new-app -e \
-    MONGODB_USER=<username>,MONGODB_PASSWORD=<password>,MONGODB_DATABASE=<database_name>,MONGODB_ADMIN_PASSWORD=<admin_password> \
+$ oc new-app \
+    -e MONGODB_USER=<username> \
+    -e MONGODB_PASSWORD=<password> \
+    -e MONGODB_DATABASE=<database_name> \
+    -e MONGODB_ADMIN_PASSWORD=<admin_password> \
 ifdef::openshift-enterprise[]
     registry.access.redhat.com/rhscl/mongodb-26-rhel7
 endif::[]

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -68,8 +68,10 @@ xref:../../architecture/core_concepts/pods_and_services.adoc#pods[pod] with
 MySQL running in a container:
 
 ----
-$ oc new-app -e \
-    MYSQL_USER=<username>,MYSQL_PASSWORD=<password>,MYSQL_DATABASE=<database_name> \
+$ oc new-app \
+    -e MYSQL_USER=<username> \
+    -e MYSQL_PASSWORD=<password> \
+    -e MYSQL_DATABASE=<database_name> \
 ifdef::openshift-enterprise[]
     registry.access.redhat.com/openshift3/mysql-55-rhel7
 endif::[]

--- a/using_images/db_images/postgresql.adoc
+++ b/using_images/db_images/postgresql.adoc
@@ -77,8 +77,10 @@ xref:../../architecture/core_concepts/pods_and_services.adoc#pods[pod] with
 PostgreSQL running in a container:
 
 ----
-$ oc new-app -e \
-    POSTGRESQL_USER=<username>,POSTGRESQL_PASSWORD=<password>,POSTGRESQL_DATABASE=<database_name> \
+$ oc new-app \
+    -e POSTGRESQL_USER=<username> \
+    -e POSTGRESQL_PASSWORD=<password> \
+    -e POSTGRESQL_DATABASE=<database_name> \
 ifdef::openshift-enterprise[]
     registry.access.redhat.com/rhscl/postgresql-94-rhel7
 endif::[]

--- a/using_images/s2i_images/java.adoc
+++ b/using_images/s2i_images/java.adoc
@@ -98,5 +98,5 @@ To specify the output directory and which modules to build in a multi-module
 project:
 
 ----
-s2i build -e "OUTPUT_DIR=<path/to/myartifact/target>,MAVEN_ARGS=install -pl <my.groupId>:<my.artifactId> -am" <git_repo_URL> fabric8/java-main <target_image_name>
+s2i build -e "OUTPUT_DIR=<path/to/myartifact/target>" -e "MAVEN_ARGS=install -pl <my.groupId>:<my.artifactId> -am" <git_repo_URL> fabric8/java-main <target_image_name>
 ----


### PR DESCRIPTION
Addition to #3107. OpenShift change: openshift/origin#11539.

Replace

```
oc new-app -e X=Y,Z=W
```

with

```
oc new-app -e X=Y -e Z=W
```

because the former will likely be removed from oc.
