### PR TITLE
Add Origin 1.2 docs to community site

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -9,6 +9,9 @@ openshift-origin:
     master:
       name: Latest
       dir: latest
+    enterprise-3.2:
+      name: '1.2'
+      dir: '1.2'
 openshift-online:
   name: OpenShift Online
   author: OpenShift Documentation Project <dev@lists.openshift.redhat.com>

--- a/index-community.html
+++ b/index-community.html
@@ -53,8 +53,14 @@
 
          <div class="inner cover">
            <h1 class="cover-heading">Documentation</h1>
-           <p class="lead"><strong>OpenShift Origin</strong> is an application platform where developers and teams can build, test, deploy, and run their applications. OpenShift Origin also serves as the upstream code base upon which <a href="http://www.openshift.com">OpenShift Online</a> and <a href="https://www.openshift.com/products/enterprise">OpenShift Enterprise</a> are built.</p>
-           <p class="lead"><a role="button" class="btn btn-lg btn-primary" href="latest/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> Origin Latest Docs</a></p>
+           <p class="lead"><strong>OpenShift Origin</strong> is an application platform where developers and teams can build, test, deploy, and run their applications. OpenShift Origin also serves as the upstream code base upon which <a href="http://www.openshift.com">OpenShift Online</a> and <a href="https://www.openshift.com/container-platform/">OpenShift Container Platform</a> are built.</p>
+           <div class="btn-group">
+             <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
+             <ul class="dropdown-menu" role="menu">
+               <li><a href="latest/"><i class="fa fa-arrow-circle-o-right"></i> Origin Latest</a></li>
+               <li><a href="1.2/"><i class="fa fa-arrow-circle-o-right"></i> Origin 1.2</a></li>
+             </ul>
+           </div>
          </div>
 
          <div class="mastfoot">


### PR DESCRIPTION
As long as Origin releases are feature-identical to subsequent commercial releases, we can build and publish Origin docs based on the commercial docs branches. This PR uses this approach to add Origin 1.2 docs to the community docs site.

@vikram-redhat @adellape please review.
