### PR TITLE
BUG1383703 - Corrected the path for routes.json,certs and cacerts  for Monitoring Routers section

### DIFF
--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -112,7 +112,7 @@ $ oc env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 Routes are processed by the HAProxy router, and are stored both in memory, on
 disk, and in the HAProxy configuration file. The internal route representation,
 which is passed to the template to generate the HAProxy configuration file, is
-found in the *_/var/lib/containers/router/routes.json_* file. When
+found in the *_/var/lib/haproxy/router/routes.json_* file. When
 troubleshooting a routing issue, view this file to see the data being used to
 drive configuration.
 
@@ -128,9 +128,9 @@ backends use mapping files when mapping incoming requests to a backend.
 Certificates are stored in two places:
 
 - Certificates for edge terminated and re-encrypt terminated routes are stored
-in the *_/var/lib/containers/router/certs_* directory.
+in the *_/var/lib/haproxy/router/certs_* directory.
 - Certificates that are used for connecting to backends for re-encrypt
-terminated routes are stored in the *_/var/lib/containers/router/cacerts_*
+terminated routes are stored in the *_/var/lib/haproxy/router/cacerts_*
 directory.
 
 The files are keyed by the namespace and name of the route. The key,


### PR DESCRIPTION
Changed from _**/var/lib/containers/router/**_ to _**/var/lib/haproxy/router/**_