### PR TITLE
update seccomp runtime/default to docker/default

### DIFF
--- a/admin_guide/seccomp.adoc
+++ b/admin_guide/seccomp.adoc
@@ -66,7 +66,7 @@ the security constraints of an individual system.
 To create your own custom profile, create a file on every node in the
 `seccomp-profile-root` directory.
 +
-If you are using the default *runtime/default* profile, you do not need to
+If you are using the default *docker/default* profile, you do not need to
 create one.
 
 . Configure your nodes to use the *seccomp-profile-root* where your profiles
@@ -98,15 +98,15 @@ default.
 +
 The allowable formats of the *seccompProfiles* field include:
 +
-* *runtime/default*: the default profile for the container runtime (no profile required)
+* *docker/default*: the default profile for the container runtime (no profile required)
 * *unconfined*: unconfined profile, and disables seccomp
 * *localhost/<profile-name>*: the profile installed to the node's local seccomp profile root
 +
-For example, if you are using the default *runtime/default* profile, configure the *restricted* SCC with:
+For example, if you are using the default *docker/default* profile, configure the *restricted* SCC with:
 +
 ----
 seccompProfiles:
-- runtime/default
+- docker/default
 ----
 
 [[seccomp-configuring-openshift-with-custom-seccomp]]


### PR DESCRIPTION
Docs were using the wrong constant for the runtime default profile.  Switched to `docker/default`.

@sttts please review?

