### PR TITLE
Adding documentation regarding how to customize catalog categories

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -335,6 +335,111 @@ endif::[]
 
 endif::[]
 
+[[configuring-catalog-categories]]
+=== Configuring Catalog Categories
+
+Catalog categories organize the display of builder images and templates on
+the Add to Project page.  A builder image or template is grouped in a category
+if it includes a tag with the same name of the category or category alias.
+Categories only display if one or more builder images or templates with matching
+tags are present in the catalog.
+
+[NOTE]
+====
+Significant customizations to the catalog categories may affect the user
+experience and should be done with careful consideration. You may need to update
+this customization in future upgrades if you modify existing category items.
+====
+
+. Create the configuration scripts within a file (for example,
+*_catalog-categories.js_*):
++
+====
+----
+// Add Go to the Languages category
+var category = _.find(window.OPENSHIFT_CONSTANTS.CATALOG_CATEGORIES,
+{ id: 'languages' });
+category.items.splice(2,0,{ // Insert at the third spot
+  // Required.  Must be unique
+  id: "go",
+  // Required
+  label: "Go",
+  // Optional.  If specified, defines a unique icon for this item
+  iconClass: "font-icon icon-go-gopher",
+  // Optional.  If specified, enables matching other tag values to this category
+  // item
+  categoryAliases: [
+    "golang"
+  ]
+});
+
+// Add a Featured category section at the top of the catalog
+window.OPENSHIFT_CONSTANTS.CATALOG_CATEGORIES.unshift({
+  // Required.  Must be unique
+  id: "featured",
+  // Required
+  label: "Featured",
+  // Optional.  If specified, each item in the category will utilize this icon
+  // as a default
+  iconClassDefault: "fa fa-code",
+  items: [
+    {
+      // Required.  Must be unique
+      id: "go",
+      // Required
+      label: "Go",
+      // Optional.  If specified, defines a unique icon for this item
+      iconClass: "font-icon icon-go-gopher",
+      // Optional.  If specified, enables matching other tag values to this
+      // category item
+      categoryAliases: [
+        "golang"
+      ],
+      // Optional.  If specified, will display below the item label
+      description: "An open source programming language developed at Google in
+      2007 by Robert Griesemer, Rob Pike, and Ken Thompson."
+    },
+    {
+      // Required.  Must be unique
+      id: "jenkins",
+      // Required
+      label: "Jenkins",
+      // Optional.  If specified, defines a unique icon for this item
+      iconClass: "font-icon icon-jenkins",
+      // Optional.  If specified, will display below the item label
+      description: "An open source continuous integration tool written in Java."
+    }
+  ]
+});
+----
+====
+
+. Save the file and add it to the master configuration at
+*_/etc/origin/master/master-config.yml_*:
++
+====
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/catalog-categories.js
+----
+====
+
+. Restart the master host:
++
+====
+ifdef::openshift-origin[]
+# systemctl restart origin-master
+endif::[]
+ifdef::openshift-enterprise[]
+# systemctl restart atomic-openshift-master
+endif::[]
+====
+
+endif::[]
+
+
 [[web-console-enable-tech-preview-feature]]
 === Enabling Features in Technology Preview
 


### PR DESCRIPTION
Per https://trello.com/c/62HPyu65/684-0-customizable-template-categories-in-webconsole, this adds documentation on how to customize the categories on the Add to Project page.  Probably should be edited by a more skilled wordsmith than me.