### PR TITLE
updated origin link in deploy-router-check-default

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -78,7 +78,7 @@ ifdef::openshift-enterprise[]
 The default router service account, named *router*, is automatically created during quick and advanced installations. To verify that this account already exists:
 endif::[]
 ifdef::openshift-origin[]
-First, ensure you have xref:../install_config/router/index.adoc#creating-the-router-service-account[created the
+First, ensure you have xref:../../install_config/router/index.adoc#creating-the-router-service-account[created the
 router service account] before deploying a router.
 
 To check if a default router, named *router*, already exists:


### PR DESCRIPTION
The link with the text "created the router service account" was broken on https://docs.openshift.org/latest/install_config/router/default_haproxy_router.html#basic-router-commands