### PR TITLE
Bug 1392204 added verification steps for console

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1145,7 +1145,21 @@ node1.example.com           Ready                      165d
 node2.example.com           Ready                      165d
 ----
 ====
+
+To verify that the web console is installed correctly, use the master host name and the console port number to access the console with a web browser.
+
+For example, for a master host with a hostname of `master.openshift.com` and using the default port of `8443`, the web console would be found at:
+
+----
+https://master.openshift.com:8443/console
+----
+
 // end::verifying-the-installation[]
+
+[NOTE]
+====
+The default port for the console is `8443`. If this was changed during the installation, the port can be found at *openshift_master_console_port* in the *_/etc/ansible/hosts_* file. 
+====
 
 *Multiple etcd Hosts*
 


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1392204

Added steps to the install docs for verifying that the console is up and running. 

If it's not obvious, there's an include field around the section that puts it into both the quick and advanced docs.

@gaurav-nelson can i ask for a peer review plz?