### PR TITLE
this is a boolean and not a string

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -646,7 +646,7 @@ metadata:
       name: my.repo.com:5000/myimage
     name: mytag
     importPolicy:
-      insecure: "true" <1>
+      insecure: true <1>
 ----
 <1> Set tag *mytag* to use insecure connection to that registry.
 ====


### PR DESCRIPTION
insecure is a boolean, the doc uses an example where it has a string value.

Signed-off-by: Christoph Görn <goern@redhat.com>