### PR TITLE
install_config/aglog: fix admin cert location

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1304,8 +1304,9 @@ from June 15, 2016, we can run:
 +
 ====
 ----
-$ curl --key /etc/elasticsearch/keys/admin-key --cert /etc/elasticsearch/keys/admin-cert \
-  --cacert /etc/elasticsearch/keys/admin-ca -XDELETE \
+$ curl --key /etc/elasticsearch/secret/admin-key \
+  --cert /etc/elasticsearch/secret/admin-cert \
+  --cacert /etc/elasticsearch/secret/admin-ca -XDELETE \
   "https://localhost:9200/logging.3b3594fa-2ccd-11e6-acb7-0eb6b35eaee3.2016.06.15"
 ----
 ====


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1373611

This location should be changed in the docs for OCP 3.3 and 3.4.