### PR TITLE
Also remove docker-common after a failed setup play

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1311,7 +1311,7 @@ system installation. If you are using virtual machines, start from a fresh
 image. If you are using bare metal machines, run the following on all hosts:
 +
 ----
-# yum -y remove openshift openshift-* etcd docker
+# yum -y remove openshift openshift-* etcd docker docker-common
 
 # rm -rf /etc/origin /var/lib/openshift /etc/etcd \
     /var/lib/etcd /etc/sysconfig/atomic-openshift* /etc/sysconfig/docker* \


### PR DESCRIPTION
/etc/sysconfig/docker is provided by the docker-common package:

```
# rpm -ql docker-common | grep /etc/sysconfig/docker
/etc/sysconfig/docker

```
/etc/sysconfig/docker is removed after a failed initial install but it won't be restored upon a rerun of the play unless the docker-common package is also removed.