### PR TITLE
architecture/additional_concepts/authorization: fix number of SCCs

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -314,7 +314,7 @@ ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 . Controlling the usage of volume types
 . Configuring allowable seccomp profiles
 
-Six SCCs are added to the cluster by default, and are viewable by cluster
+Seven SCCs are added to the cluster by default, and are viewable by cluster
 administrators using the CLI:
 
 ====


### PR DESCRIPTION
Documentation says that 6 SCC is added, but actually their 7 (and example below is proving it).

PTAL @openshift/team-documentation