### PR TITLE
admin_guide/manage_scc: update output of oc get scc command

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -43,13 +43,14 @@ To get a current list of SCCs:
 ----
 $ oc get scc
 
-NAME               PRIV      CAPS      SELINUX     RUNASUSER          FSGROUP    SUPGROUP   PRIORITY   READONLYROOTFS   VOLUMES
-anyuid             false     []        MustRunAs   RunAsAny           RunAsAny   RunAsAny   10         false            [awsElasticBlockStore azureFile cephFS cinder configMap downwardAPI emptyDir fc flexVolume flocker gcePersistentDisk gitRepo glusterfs iscsi nfs persistentVolumeClaim rbd secret]
-hostaccess         false     []        MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>     false            [*]
-hostmount-anyuid   false     []        MustRunAs   RunAsAny           RunAsAny   RunAsAny   <none>     false            [*]
-nonroot            false     []        MustRunAs   MustRunAsNonRoot   RunAsAny   RunAsAny   <none>     false            [awsElasticBlockStore azureFile cephFS cinder configMap downwardAPI emptyDir fc flexVolume flocker gcePersistentDisk gitRepo glusterfs iscsi nfs persistentVolumeClaim rbd secret]
-privileged         true      []        RunAsAny    RunAsAny           RunAsAny   RunAsAny   <none>     false            [*]
-restricted         false     []        MustRunAs   MustRunAsRange     RunAsAny   RunAsAny   <none>     false            [awsElasticBlockStore azureFile cephFS cinder configMap downwardAPI emptyDir fc flexVolume flocker gcePersistentDisk gitRepo glusterfs iscsi nfs persistentVolumeClaim rbd secret]
+NAME               PRIV      CAPS      SELINUX     RUNASUSER          FSGROUP     SUPGROUP    PRIORITY   READONLYROOTFS   VOLUMES
+anyuid             false     []        MustRunAs   RunAsAny           RunAsAny    RunAsAny    10         false            [configMap downwardAPI emptyDir persistentVolumeClaim secret]
+hostaccess         false     []        MustRunAs   MustRunAsRange     MustRunAs   RunAsAny    <none>     false            [configMap downwardAPI emptyDir hostPath persistentVolumeClaim secret]
+hostmount-anyuid   false     []        MustRunAs   RunAsAny           RunAsAny    RunAsAny    <none>     false            [configMap downwardAPI emptyDir hostPath persistentVolumeClaim secret]
+hostnetwork        false     []        MustRunAs   MustRunAsRange     MustRunAs   MustRunAs   <none>     false            [configMap downwardAPI emptyDir persistentVolumeClaim secret]
+nonroot            false     []        MustRunAs   MustRunAsNonRoot   RunAsAny    RunAsAny    <none>     false            [configMap downwardAPI emptyDir persistentVolumeClaim secret]
+privileged         true      []        RunAsAny    RunAsAny           RunAsAny    RunAsAny    <none>     false            [*]
+restricted         false     []        MustRunAs   MustRunAsRange     MustRunAs   RunAsAny    <none>     false            [configMap downwardAPI emptyDir persistentVolumeClaim secret]
 ----
 ====
 


### PR DESCRIPTION
Output of the `oc get scc` command was outdated, I've updated it by copy&pasting from [Authorization chapter](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#security-context-constraints).

PTAL @openshift/team-documentation 