### PR TITLE
Bz1384752 pvc review

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -12,22 +12,25 @@
 toc::[]
 
 == Overview
-The *StorageClass* resource object is used to describe and classify storage that can be requested, as well as
-provide a means for passing in parameters for *dynamically provisioned storage* on-demand.  StorageClasses can also serve
-as a management mechanism for controlling different levels of storage and access to the storage.  Cluster Administrators (cluster-admin)
-or Storage Administrators (storage-admin) need to define and create the StorageClasses that can then be requested by users without the users needing to have
-any intimate knowledge about the underlying storage volume sources.
+The _StorageClass_ resource object describes and classifies storage that can be
+requested, as well as provides a means for passing parameters for
+*dynamically provisioned storage* on demand. _StorageClass_ objects can also serve as
+a management mechanism for controlling different levels of storage and access
+to the storage. Cluster Administrators (`cluster-admin`) or Storage
+Administrators (`storage-admin`) define and create the _StorageClass_ objects
+that users can request without needing any intimate knowledge about the
+underlying storage volume sources.
 
-The Kubernetes
+The {product-title}
 xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent volume]
-framework enables this functionality and allows administrators to provision a cluster with persistent storage
-and gives users a way to request those resources without having any knowledge of
-the underlying infrastructure.
+framework enables this functionality and allows administrators to provision a
+cluster with persistent storage. The framework also gives users a way to request
+those resources without having any knowledge of the underlying infrastructure.
 
 Many storage types are available for use as persistent volumes in
 {product-title}. While all of them can be statically provisioned by an
-administrator, some types of storage can be created dynamically using the built in provider and plug-in APIs.
-
+administrator, some types of storage are created dynamically using the
+built-in provider and plug-in APIs.
 
 [[available-dynamically-provisioned-plug-ins]]
 == Available Dynamically Provisioned Plug-ins
@@ -50,21 +53,21 @@ configured provider's API to create new storage resources:
 |AWS Elastic Block Store (EBS)
 |`kubernetes.io/aws-ebs`
 |xref:../../install_config/configuring_aws.adoc#install-config-configuring-aws[Configuring for AWS]
-|For dynamic provisioning when using multiple clusters in different zones, each
-node must be tagged with `*Key=KubernetesCluster,Value=clusterid*`.
+|For dynamic provisioning when using multiple clusters in different zones, tag each
+node with `*Key=KubernetesCluster,Value=clusterid*`.
 
 |GCE Persistent Disk (gcePD)
 |`kubernetes.io/gce-pd`
 |xref:../../install_config/configuring_gce.adoc#install-config-configuring-gce[Configuring for GCE]
-|In multi-zone configurations, PVs must be created in the same region/zone as
-the master node. Do this by setting the
+|In multi-zone configurations, persistent volumes (PVs) must be created in the same region/zone as
+the master node. To do this, set the
 `*failure-domain.beta.kubernetes.io/region*` and
 `*failure-domain.beta.kubernetes.io/zone*` PV labels to match the master node.
 
 |GlusterFS
 |`kubernetes.io/glusterfs`
 |link:https://access.redhat.com/documentation/en/red-hat-gluster-storage/3.1/single/container-native-storage-for-openshift-container-platform/[Container Native Storage with GlusterFS]
-|Container Native Storage (CNS) utilizes heketi to manage Gluster Storage
+|Container Native Storage (CNS) utilizes link:https://github.com/heketi/heketi[Heketi] to manage Gluster Storage.
 
 |Ceph RBD
 |`kubernetes.io/rbd`
@@ -76,22 +79,23 @@ the master node. Do this by setting the
 
 [IMPORTANT]
 ====
-For any chosen provisioner plug-ins, any relevant cloud, host or third-party configurations must also
-be set up, per provider required documentation.
+Any chosen provisioner plug-in also requires configuration for the relevant
+cloud, host, or third-party provider as per the relevant documentation.
 ====
 
 [[defining-storage-classes]]
 == Defining a StorageClass
 
-StorageClasses are currently a globally scoped object and need to be created by cluster-admins or
-storage-admins.
-There are currently five plug-ins that are supported. Below sections will
-describe the basic Spec definition for a _StorageClass_ and specific examples for each of the supported plug-in types.
+_StorageClass_ objects are currently a globally scoped object and need to be
+created by `cluster-admin` or `storage-admin` users. There are currently five
+plug-ins that are supported. The following sections describe the basic object
+definition for a _StorageClass_ and specific examples for each of the supported
+plug-in types.
 
 [[basic-spec-defintion]]
-=== Basic StorageClass Spec Definition
+=== Basic StorageClass Object Definition
 
-.StorageClass Basic Spec Definition
+.StorageClass Basic Object Definition
 ====
 [source,yaml]
 ----
@@ -120,20 +124,21 @@ from plug-in to plug-in.
 [[storage-class-annotations]]
 === StorageClass Annotations
 
-- Setting a _StorageClass_ as the cluster wide default _StorageClass_.  This will enable any Persistent Volume Claim (PVC)
-that does not specify a specific volume to automatically be provisioned via the _default_ StorageClass
+To set a _StorageClass_ as the cluster-wide default: 
 ----
    storageclass.beta.kubernetes.io/is-default-class: "true"
 ----
+This enables any Persistent Volume Claim (PVC) that does not specify a specific
+volume to automatically be provisioned through the _default_ StorageClass
 
-- Setting a _StorageClass_ description
+To set a _StorageClass_ description:
 ----
    kubernetes.io/description: My StorgeClass Description
 ----
 
 
 [[openstack-cinder-spec]]
-=== OpenStack Cinder Spec
+=== OpenStack Cinder Object Defintion
 
 .cinder-storageclass.yaml
 ====
@@ -154,7 +159,7 @@ parameters:
 ====
 
 [[aws-elasticblockstore-ebs]]
-=== AWS ElasticBlockStore (EBS)
+=== AWS ElasticBlockStore (EBS) Object Defintion
 
 .aws-ebs-storageclass.yaml
 ====
@@ -174,15 +179,15 @@ parameters:
 
 ----
 
-<1> io1, gp2, sc1, st1. See AWS docs for details. Default: gp2.
-<2> AWS zone. If not specified, a random zone from those where Kubernetes cluster has a node is chosen.
-<3> only for io1 volumes. I/O operations per second per GiB. AWS volume plug-in multiplies this with size of requested volume to compute IOPS of the volume and caps it at 20 000 IOPS (maximum supported by AWS, see AWS docs).
-<4> denotes whether the EBS volume should be encrypted or not. Valid values are true or false.
-<5> (optional) The full Amazon Resource Name (ARN) of the key to use when encrypting the volume. If none is supplied but encrypted is true, a key is generated by AWS. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
+<1> Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
+<2> AWS zone. If not specified, the zone is randomly selected from zones where {product-title} cluster has a node.
+<3> Only for io1 volumes. I/O operations per second per GiB. The AWS volume plug-in multiplies this with the size of the requested volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which is the maximum supported by AWS. See AWS documentation for further details.
+<4> Denotes whether to encrypt the EBS volume. Valid values are `true` or `false`.
+<5> (optional) The full Amazon Resource Name (ARN) of the key to use when encrypting the volume. If none is supplied but encrypted is true, AWS generates a key. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
 ====
 
 [[gce-persistentdisk-gcePd]]
-=== GCE PersistentDisk (gcePD)
+=== GCE PersistentDisk (gcePD) Object Defintion
 
 .gce-pd-storageclass.yaml
 ====
@@ -196,15 +201,14 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard  <1>
   zone: us-central1-a  <2>
-
 ----
 
-<1> pd-standard or pd-ssd. Default: pd-ssd
-<2> GCE zone. If not specified, a random zone in the same region as controller-manager will be chosen.
+<1> Select either `pd-standard` or `pd-ssd`. The default is `pd-ssd`.
+<2> GCE zone. If not specified, the zone is randomly chosen from zones in the same region as `controller-manager`.
 ====
 
 [[glusterfs]]
-=== GlusterFS
+=== GlusterFS Object Defintion
 
 .glusterfs-storageclass.yaml
 ====
@@ -224,15 +228,15 @@ parameters:
 
 ----
 
-<1> glusterfs-cluster is the endpoint name which includes GlusterFS trusted pool IP addresses. This parameter is mandatory. We need to also create a service for this endpoint, so that the endpoint will be persisted. This service can be without a selector to tell Kubernetes that the endpoints will be added manually. Please note that, glusterfs plug-in looks for the endpoint in the pod namespace, so it is mandatory that the endpoint and service have to be created in Pod's namespace for successful mount of gluster volumes in the pod.
-<2> Gluster REST service/Heketi service url which provision gluster volumes on demand. The general format should be IPaddress:Port and this is a mandatory parameter for GlusterFS dynamic provisioner. If Heketi service is exposed as a routable service in openshift/kubernetes setup, it will have a resolvable fully qualified domain name and heketi service url. link:https://access.redhat.com/documentation/en/red-hat-gluster-storage/3.1/single/container-native-storage-for-openshift-container-platform/[For additional information and configuration]
-<3> Gluster REST service/Heketi user who has access to create volumes in the Gluster Trusted Pool.
-<4> Gluster REST service/Heketi user's password which will be used for authentication to the REST server. This parameter is deprecated in favor of secretNamespace + secretName.
-<5> Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both secretNamespace and secretName are omitted.
+<1> `glusterfs-cluster` is the endpoint name that includes GlusterFS trusted pool IP addresses. This parameter is mandatory. You also need to create a service for this endpoint so that the endpoint remains persistent. This service does not require a selector to tell {product-title} that the endpoints will be added manually. Please note that the `glusterfs` plug-in looks for the endpoint in the pod namespace. This means it is mandatory to create the endpoint and service in the Pod's namespace for a successful mount of gluster volumes in the pod.
+<2> Gluster REST service/Heketi service URL that provisions gluster volumes on demand. The general format should be `{http/https}://{IPaddress}:{Port}`. This is a mandatory parameter for GlusterFS dynamic provisioner. If the Heketi service is exposed as a routable service in the {product-title}, it will have a resolvable fully qualified domain name and Heketi service URL. For additional information and configuration, See link:https://access.redhat.com/documentation/en/red-hat-gluster-storage/3.1/single/container-native-storage-for-openshift-container-platform/[Container-Native Storage for OpenShift Container Platform].
+<3> A boolean value that indicates whether Gluster REST service authentication is enabled on the REST server. If this value is ‘true’, you must supply values for the ‘restuser’ and ‘restuserkey’ parameters.
+<4> Gluster REST service/Heketi user with access to create volumes in the Gluster Trusted Pool.
+<5> Gluster REST service/Heketi user's password used for authentication to the REST server. This parameter is deprecated in favor of `secretNamespace` and `secretName`.
 ====
 
 [[ceph-persistentdisk-cephRBD]]
-=== Ceph RBD
+=== Ceph RBD Object Defintion
 
 .ceph-storageclass.yaml
 ====
@@ -253,7 +257,6 @@ parameters:
   userSecretName: ceph-secret-user  <7>
 
 ----
-
 <1> Ceph monitors, comma delimited. It is required.
 <2> Ceph client ID that is capable of creating images in the pool. Default is "admin".
 <3> Secret Name for `adminId`. It is required. The provided secret must have type "kubernetes.io/rbd".

--- a/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
+++ b/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
@@ -15,8 +15,13 @@ toc::[]
 [[install-config-storage-examples-storage-classes-dynamic-provisioning-overview]]
 == Overview
 
-In these examples we will walk through a few scenarios of various configuratons of xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[StorageClasses] and Dynamic Provisioning using Google Cloud Platform Compute Engine (GCE).
-These examples assume some familiarity with Kubernetes, GCE and Persistent Disks and {product-title} is installed and xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[properly configured to use GCE].
+These examples demonstrate a few configuration scenarios for xref:../../install_config/persistent_storage/storage_classes.adoc#install-config-persistent-storage-storage-classes[StorageClasses] and Dynamic Provisioning using Google Cloud Platform Compute Engine (GCE). These examples
+assume:
+
+- Some familiarity with {product-title}, GCE, and Persistent Disks
+- {product-title} is installed and xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[properly configured to use GCE].
+
+The examples included in this sections are:
 
 - xref:../../install_config/storage_examples/storage_classes_dynamic_provisioning.adoc#example1[Basic Dynamic Provisioning]
 - xref:../../install_config/storage_examples/storage_classes_dynamic_provisioning.adoc#example2[Defaulting Cluster Dynamic Provisioning Behavior]
@@ -25,14 +30,18 @@ These examples assume some familiarity with Kubernetes, GCE and Persistent Disks
 [[example1]]
 == Scenario 1: Basic Dynamic Provisioning with Two Types of _StorageClasses_
 
-_StorageClasses_ can be used to differentiate and deliniate storage levels and usages, in this case the cluster-admin or storage-admin will set up two distinct classes of storage in GCE.
+_StorageClasses_ can be used to differentiate and delineate storage levels and
+usages. In this case, the `cluster-admin` or `storage-admin` sets up two
+distinct classes of storage in GCE.
 
-- slow:   cheap, efficient and optimized for sequential data operations (slower reading and writing)
-- fast:   optimized for higher rates of random IOPS and sustained throughput (faster reading and writing)
+- `slow`: Cheap, efficient, and optimized for sequential data operations (slower reading and writing)
+- `fast`: Optimized for higher rates of random IOPS and sustained throughput (faster reading and writing)
 
-By creating these _StorageClasses_, the cluster/storage-admin is allowing users to create claims requesting a particular level or service of _StorageClass_.
+By creating these _StorageClasses_, the `cluster-admin` or `storage-admin`
+allows users to create claims requesting a particular level or service of
+_StorageClass_.
 
-.StorageClass Slow Spec Definitions
+.StorageClass Slow Object Definitions
 ====
 [source,yaml]
 ----
@@ -46,12 +55,12 @@ parameters:
   zone: us-east1-d  <4>
 ----
 <1>  Name of the _StorageClass_.
-<2>  The provisioner plug-in to be used, this is a required field for _StorageClasses_.
-<3>  PD type, in this case pd-standard which has a slightly lower cost and rate of sustained IOPS and throughput vs pd-ssd which carries more sustained IOPS and throughput.
+<2>  The provisioner plug-in to be used. This is a required field for _StorageClasses_.
+<3>  PD type. This example uses `pd-standard`, which has a slightly lower cost, rate of sustained IOPS, and throughput versus `pd-ssd`, which carries more sustained IOPS and throughput.
 <4>  The zone is required.
 ====
 
-.StorageClass Fast Spec Definition
+.StorageClass Fast Object Definition
 ====
 [source,yaml]
 ----
@@ -66,7 +75,8 @@ parameters:
 ----
 ====
 
-As a cluster-admin or storage-admin save both definitions to .yaml files, i.e. slow-gce.yaml and fast-gce.yaml and then create the _StorageClasses_.
+As a `cluster-admin` or `storage-admin`, save both definitions as YAML files.
+ For example, `slow-gce.yaml` and `fast-gce.yaml`. Then create the _StorageClasses_.
 
 ====
 ----
@@ -87,13 +97,11 @@ slow       kubernetes.io/gce-pd
 
 [IMPORTANT]
 ====
-cluster-admin or storage-admins are responsible for relaying the correct _StorageClass_ name to the correct users/groups and projects.
+`cluster-admin` or `storage-admin` users are responsible for relaying the correct
+_StorageClass_ name to the correct users, groups, and projects.
 ====
 
-
-As a user, create a new project and claim the _StorageClass_.
-First create the claim yaml definition, save it to a file (i.e. pvc-fast.yaml) and then execute it using _oc create_ command and finally
-check to see if your claim was bound.
+As a regular user, create a new project:
 
 ====
 ----
@@ -103,7 +111,7 @@ check to see if your claim was bound.
 ----
 ====
 
-.Claim for Fast Storage Spec Definition
+Create the claim YAML definition, save it to a file (`pvc-fast.yaml`):
 ====
 [source,yaml]
 ----
@@ -122,6 +130,7 @@ spec:
 ----
 ====
 
+Add the claim with the `oc create` command:
 ====
 ----
 
@@ -131,6 +140,7 @@ persistentvolumeclaim "pvc-engineering" created
 ----
 ====
 
+Check to see if your claim is bound:
 ====
 ----
 
@@ -143,10 +153,11 @@ pvc-engineering   Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi     
 
 [IMPORTANT]
 ====
-Since this claim was created and bound in the _rh-eng_ project, it can be shared by any user in the same project.
+Since this claim was created and bound in the _rh-eng_ project, it can be shared
+by any user in the same project.
 ====
 
-As a cluster/storage-admin, view the Persistent Volume (PV) that was just dynamically provisioned.
+As a `cluster-admin` or `storage-admin` user, view the recent dynamically provisioned Persistent Volume (PV).
 
 ====
 ----
@@ -160,34 +171,36 @@ pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete      
 
 [IMPORTANT]
 ====
-Notice that the xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[RECLAIMPOLICY] is _Delete_ by default for all dynamic provisioned volumes, this means that the volume will only last as long as the claim still exists in the system, if the claim was deleted, the volume would also be deleted and all data would be lost.
+Notice the xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[RECLAIMPOLICY]
+is _Delete_ by default for all dynamically provisioned volumes. This means the
+volume only lasts as long as the claim still exists in the system. If you delete
+the claim, the volume is also deleted and all data on the volume is lost.
 ====
 
-
-Lastly, on GCE console, the new disk will be created and ready for a _Pod_ to be created referencing the persistent volume claim to start using the volume.
-
+Finally, check the GCE console. The new disk has been created and is ready for use. 
 
 ====
 ----
-
-
 kubernetes-dynamic-pvc-e9b4fef7-8bf7-11e6-9962-42010af00004 	SSD persistent disk 	10 GB 	us-east1-d
-
 ----
 ====
 
-
-
+Pods can now reference the persistent volume claim and start using the volume.
 
 [[example2]]
 == Scenario 2: How to enable Default _StorageClass_ behavior for a Cluster
 
-In this example, a cluster/storage-admin will enable a _default_ storage class to be used by all other users and projects that do not implicitly specify a _StorageClass_ annotation in their claim.  This will be useful for a cluster-admin or storage-admin that wants to provide easy management of a storage volume without having to setup or communicate specialized _StorageClasses_ across the cluster.
+In this example, a `cluster-admin` or `storage-admin` enables a _default_
+storage class for all other users and projects that do not implicitly specify a
+_StorageClass_ annotation in their claim. This is useful for a `cluster-admin`
+or `storage-admin` to provide easy management of a storage volume without having
+to set up or communicate specialized _StorageClasses_ across the cluster.
 
+This example builds upon <<example1>>. The `cluster-admin` or `storage-admin`
+will create another _StorageClass_ for designation as the _default_
+_StorageClass_.
 
-Building on the previous example, the cluster-admin or storage-admin will create another _StorageClass_ to be designated as the _default_ _StorageClass_.
-
-.Default StorageClass Spec Definition
+.Default StorageClass Object Definition
 ====
 [source,yaml]
 ----
@@ -202,15 +215,17 @@ parameters:
   type: pd-standard
   zone: us-east1-d
 ----
-<1>  Name of the _StorageClass_, has no meaning other than it needs to be unique in the cluster.
-<2>  Annotation that marks this _StorageClass_ as the default class.  You must use the "true" quoted in this version of the api. If annotation is not supplied, it by default implies that this is not the _default_ _StorageClass_.
+<1>  Name of the _StorageClass_, which needs to be unique in the cluster.
+<2>  Annotation that marks this _StorageClass_ as the default class. You must
+use `"true"` quoted in this version of the API. Without this
+annotation, {product-title} considers this not the _default_ _StorageClass_.
 ====
 
-As a cluster-admin or storage-admin save the definition to a .yaml file, (i.e. generic-gce.yaml), and then create the _StorageClasses_.
+As a `cluster-admin` or `storage-admin` save the definition to a YAML file
+(`generic-gce.yaml`), then create the _StorageClasses_:
 
 ====
 ----
-
 # oc create -f generic-gce.yaml
 storageclass "generic" created
 
@@ -219,14 +234,13 @@ NAME       TYPE
 generic    kubernetes.io/gce-pd
 fast       kubernetes.io/gce-pd
 slow       kubernetes.io/gce-pd
-
 ----
 ====
 
-As a user, create a new claim without any _StorageClass_ annotation, by creating the claim yaml definition and saving it to a file (i.e. generic-pvc.yaml), and then execute it and view if the claim was bound.
+As a regular user, create a new claim definition without any _StorageClass_
+annotation and save it to a file (`generic-pvc.yaml`). 
 
-
-.Claim for the _default_ Storage Spec Definition
+._default_ Storage Claim Object Definition
 ====
 [source,yaml]
 ----
@@ -243,6 +257,7 @@ spec:
 ----
 ====
 
+Execute it and check the claim is bound:
 ====
 ----
 
@@ -255,30 +270,29 @@ pvc-engineering    Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi    
 pvc-engineering2   Bound     pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           7s  <1>
 
 ----
-<1> pvc-engineering2 was bound to a dynamically provisioned Volume by _default_.
+<1> `pvc-engineering2` is bound to a dynamically provisioned Volume by _default_.
 ====
 
-
-As a cluster-admin or storage-admin view the Persistent Volumes that are defined so far.
+As a `cluster-admin` or `storage-admin`, view the Persistent Volumes defined so
+far:
 
 ====
 ----
-
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM                     REASON    AGE
 pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete          Bound     rh-eng/pvc-engineering2             5m <1>
 pvc-ba4612ce-8b4d-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound     mytest/gce-dyn-claim1               21h
 pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound     rh-eng/pvc-engineering              46m <2>
-
 ----
 <1> This PV was bound to our _default_ dynamic volume from the _default_ _StorageClass_.
-<2> This PV was bound to our first PVC from example 1 with our _fast_ _StorageClass_.
+<2> This PV was bound to our first PVC from <<example1>> with our _fast_ _StorageClass_.
 ====
 
-Create a manually provisioned disk using the link:https://cloud.google.com/compute/docs/disks/[GCE] (not dynamically provisioned) and a xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[Persistent Volume] that connects to the new GCE disk.
+Create a manually provisioned disk using
+link:https://cloud.google.com/compute/docs/disks/[GCE] (not dynamically
+provisioned). Then create a xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[Persistent Volume] that connects to the new GCE disk (`pv-manual-gce.yaml`).
 
-
-.Manual PV Spec
+.Manual PV Object Defition
 ====
 [source,yaml]
 ----
@@ -298,26 +312,31 @@ spec:
 ----
 ====
 
-
-Now view the PVs again, notice that a pv-manual-gce volume is Available.
+Execute the object definition file:
 
 ====
 ----
+# oc create -f pv-manual-gce.yaml
+----
+====
 
+Now view the PVs again. Notice that a `pv-manual-gce` volume is _Available_.
+
+====
+----
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM                     REASON    AGE
 pv-manual-gce                              35Gi       RWX           Retain          Available                                       4s
 pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete          Bound       rh-eng/pvc-engineering2             12m
 pvc-ba4612ce-8b4d-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound       mytest/gce-dyn-claim1               21h
 pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound       rh-eng/pvc-engineering              53m
-
 ----
 ====
 
-Now create another claim identical to the PVC above but change the name (no annotation set). Will the claim get satisfied by the _default_ _StorageClass_ or the manually available Volume?
+Now create another claim identical to the `generic-pvc.yaml` PVC definition but
+change the name and do not set an annotation.
 
-
-.Claim Spec Definition
+.Claim Object Definition
 ====
 [source,yaml]
 ----
@@ -331,12 +350,12 @@ spec:
  resources:
    requests:
      storage: 15Gi
-
 ----
 ====
 
-
-Because _default_ _StorageClass_ is enabled in this instance, the manually created PV will not satisfy the claim request, and the user would get a new dynamically provisioned Persistent Volume.
+Because _default_ _StorageClass_ is enabled in this instance, the manually
+created PV does not satisfy the claim request. The user receives a new
+dynamically provisioned Persistent Volume.
 
 ====
 ----
@@ -350,14 +369,15 @@ pvc-engineering3   Bound     pvc-6fa8e73b-8c00-11e6-9962-42010af00004   15Gi    
 ----
 ====
 
+Since the _default_ _StorageClass_ is enabled on this system, you would need to
+create the PV in the _default_ _StorageClass_ for the manually created Persistent
+Volume to get bound to the above claim and not have a new dynamic provisioned
+volume bound to the claim.
 
-[IMPORTANT]
-====
-Since the _default_ _StorageClass_ is enabled on this system, for the manually created Persistent Volume to get bound by the above claim and not have a new dynamic provisioned volume be bound, the PV would need to have been created in the _default_ _StorageClass_.
-====
-
-
-To fix this, the cluster/storage-admin simply needs to create another GCE disk or delete the first manual PV that was created and use a PV spec that assigns a _StorageClass_ annotation to it.
+To fix this, the `cluster-admin` or `storage-admin` user simply needs to create
+another GCE disk or delete the first manual PV and use a PV object definition 
+that assigns a _StorageClass_ annotation (`pv-manual-gce2.yaml`)
+if necessary:
 
 .Manual PV Spec with _default_ StorageClass annotation
 ====
@@ -366,7 +386,7 @@ To fix this, the cluster/storage-admin simply needs to create another GCE disk o
 apiVersion: v1
 kind: PersistentVolume
 metadata:
- name: pv-manual-gce
+ name: pv-manual-gce2
  annotations:
    volume.beta.kubernetes.io/storage-class: generic <1>
 spec:
@@ -379,8 +399,18 @@ spec:
    pdName: the-newly-created-gce-PD
    fsType: ext4
 ----
-<1> PV is annotated with the _generic_ _StorageClass_ that was created previously.
+<1> The annotation for previously created _generic_ _StorageClass_.
 ====
+
+Execute the object definition file:
+
+====
+----
+# oc create -f pv-manual-gce2.yaml
+----
+====
+
+List the PVs:
 
 ====
 ----
@@ -394,12 +424,12 @@ pvc-ba4612ce-8b4d-11e6-9962-42010af00004   5Gi        RWO           Delete      
 pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound       rh-eng/pvc-engineering              53m
 
 ----
-<1> The original manual PV that was created, still unbound and Available since it was not created in the _default_ _StorageClass_.
-<2> The second identical PVC (other than the name) is created and now it is bound to the Available manually created PV pv-manual-gce2.
+<1> The original manual PV, still unbound and Available. This is because it was not created in the _default_ _StorageClass_.
+<2> The second PVC (other than the name) is bound to the Available manually created PV `pv-manual-gce2`.
 ====
 
 
 [IMPORTANT]
 ====
-Notice that all Dynamically Provisioned volumes by default have a RECLAIMPOLICY of _Delete_, meaning once the PVC that is dynamically bound to the PV is deleted the GCE volume is deleted and all data is lost, However, the manually created PV by default has a RECLAIMPOLICY of _Retain_.
+Notice that all dynamically provisioned volumes by default have a _RECLAIMPOLICY_ of _Delete_. Once the PVC dynamically bound to the PV is deleted, the GCE volume is deleted and all data is lost. However, the manually created PV has a default _RECLAIMPOLICY_ of _Retain_.
 ====

--- a/install_config/storage_examples/storage_classes_legacy.adoc
+++ b/install_config/storage_examples/storage_classes_legacy.adoc
@@ -15,18 +15,22 @@ toc::[]
 [[install-config-storage-examples-storage-classes-legacy]]
 == Overview
 
-In this example, a legacy data volume exists and a cluster/storage-admin needs to make it available for consumption and use in a particular project.  By managing with _StorageClasses_, it will decrease the likliehood of other users and projects gaining access to this volume from a claim, as the claim would have to have an exact matching value for the StorageClass annotation.  Also, this example will disable dynamic provisioning.
-This example assumes some familiarity with Kubernetes, GCE and Persistent Disks and {product-title} is xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[properly configured to use GCE].
+In this example, a legacy data volume exists and a `cluster-admin` or
+`storage-admin` needs to make it available for consumption in a particular
+project. Using _StorageClasses_ decreases the likelihood of other users and
+projects gaining access to this volume from a claim because the claim would have
+to have an exact matching value for the _StorageClass_ annotation. This example
+also disables dynamic provisioning. This example assumes:
 
-
+- Some familiarity with {product-title}, GCE, and Persistent Disks
+- {product-title} is xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[properly configured to use GCE].
 
 [[example1]]
 === Scenario 1: Link StorageClass to existing Persistent Volume with Legacy Data
 
+As a `cluster-admin` or `storage-admin`, define and create the _StorageClass_ for historical financial data.
 
-As a cluster/storage-admin, define and create the _StorageClass_ for historical financial data.
-
-.StorageClass finance-history Spec Definitions
+.StorageClass finance-history Object Definitions
 ====
 [source,yaml]
 ----
@@ -43,7 +47,7 @@ parameters: <3>
 <3>  Parameters can simply be left blank, since these are only used for the dynamic provisioner.
 ==== 
 
-As a cluster-admin or storage-admin save the definitions to .yaml file, (i.e. finance-history-storageclass.yaml) and create the StorageClass.
+Save the definitions to a YAML file (`finance-history-storageclass.yaml`) and create the _StorageClass_.
 
 ====
 ----
@@ -55,22 +59,20 @@ storageclass "finance-history" created
 # oc get storageclass
 NAME              TYPE
 finance-history   no-provisioning           
-
 ----
 ====
 
 [IMPORTANT]
 ====
-cluster-admin or storage-admins are responsible for relaying the correct _StorageClass_ name to the correct users/groups and projects.
+`cluster-admin` or `storage-admin` users are responsible for relaying the correct _StorageClass_ name to the correct users, groups, and projects.
 ====
 
+The _StorageClass_ exists. A `cluster-admin` or `storage-admin` can create the
+Persistent Volume (PV) for use with the _StorageClass_. Create a manually
+provisioned disk using link:https://cloud.google.com/compute/docs/disks/[GCE]
+(not dynamically provisioned) and a xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[Persistent Volume] that connects to the new GCE disk (`gce-pv.yaml`).
 
-Now the _StorageClass_ exists, a cluster/storage-admin can create the PersistentVolume (PV) to be used with the _StorageClass_.
-If an existing GCE disk does not already exist to be used, then create a manually provisioned disk using link:https://cloud.google.com/compute/docs/disks/[GCE] (not dynamically provisioned) and a xref:../../install_config/persistent_storage/persistent_storage_gce.adoc#install-config-persistent-storage-persistent-storage-gce[Persistent Volume] that connects to the new GCE disk.
-
-
-
-.Finance History PV Spec
+.Finance History PV Object
 ====
 [source,yaml]
 ----
@@ -90,12 +92,11 @@ spec:
    pdName: the-existing-PD-volume-name-that-contains-the-valuable-data <2>
    fsType: ext4
 ----
-<1>  The StorageClass annotation, that must match exactly.
+<1>  The _StorageClass_ annotation, that must match exactly.
 <2>  The name of the GCE disk that already exists and contains the legacy data.
 ====
 
-
-As a cluster/storage-admin create and view PV and notice we have a pv-finance-history Available and ready for consumption.
+As a `cluster-admin` or `storage-admin`, create and view the PV. 
 
 ====
 ----
@@ -110,10 +111,12 @@ pv-finance-history   35Gi       RWX           Retain          Available         
 ----
 ====
 
+Notice you have a `pv-finance-history` Available and ready for consumption.
 
-As a user, create a PersistentVolumeClaim (PVC) using the correct _StorageClass_ annotation and then view the PVC and PV to see if it is bound.
+As a user, create a Persistent Volume Claim (PVC) as a YAML file and specify the
+correct _StorageClass_ annotation:
 
-.Claim for finance-history Spec Definition
+.Claim for finance-history Object Definition
 ====
 [source,yaml]
 ----
@@ -130,8 +133,10 @@ spec:
    requests:
      storage: 20Gi
 ----
-<1>  The StorageClass annotation, that must match exactly or the claim will go unbound until it is deleted or another _StorageClass_ is created that matches the annotation.
+<1>  The _StorageClass_ annotation, that must match exactly or the claim will go unbound until it is deleted or another _StorageClass_ is created that matches the annotation.
 ====
+
+Create and view the PVC and PV to see if it is bound.
 
 ====
 ----
@@ -153,6 +158,7 @@ pv-finance-history   35Gi       RWX           Retain          Bound       defaul
 
 [IMPORTANT]
 ====
-It is important to note that _StorageClasses_ can be used in the same cluster for both legacy data (no dynamic provisioning) and with xref:../../install_config/storage_examples/storage_classes_dynamic_provisioning.adoc#install-config-storage-examples-storage-classes-dynamic-provisioning[dynamic provisioning].
+You can use _StorageClasses_ in the same cluster for both legacy data (no
+dynamic provisioning) and with xref:../../install_config/storage_examples/storage_classes_dynamic_provisioning.adoc#install-config-storage-examples-storage-classes-dynamic-provisioning[dynamic provisioning].
 ====
 


### PR DESCRIPTION
Review of content as a follow-up PRs #2972 and #3009 

A few notes to check with @screeley44. Scott, any chance you can verify the following:

1. I noticed that the some of definitions use `apiVersion: storage.k8s.io/v1beta1`. Should this be `v1` for the docs instead? Or is this particular apiVersion definition something specific to the SC definitions?
2. It looks like the auth params for the GlusterFS Object Defintion don't match the call-out numbers (3, 4, and 5). Any chance you can check the text for these call-outs and let me know if an edit is required here?
3. I've noticed that we use Kubernetes in a few places instead of OpenShift. E.g. "Some familiarity with Kubernetes, GCE, Persistent Disks". Should we use {product-title} instead? Or do we need to call out  Kubernetes on purpose?