### PR TITLE
Fix typo in devGuide imagestream docker tag description

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -35,8 +35,8 @@ deployments to behave. The following sections cover a range of these topics.
 Before working with {product-title} image streams and their tags, it will help
 to first understand image tags in the context of Docker generally.
 
-Container images can have names added to them that make it more intuitive what they
-contain, called a _tag_. Using a tag to specify the version of what is contained
+Container images can have names added to them that make it more intuitive to determine
+what they contain, called a _tag_. Using a tag to specify the version of what is contained
 in the image is a common use case. If you have an image named *ruby*, you could
 have a tag named *2.0* for 2.0 version of Ruby, and another named *latest* to
 indicate literally the latest built image in that repository overall.


### PR DESCRIPTION
Before:
`Container images can have names added to them that make it more intuitive what they contain, called a tag. `

After:
`Container images can have names added to them that make it more intuitive to determine what they contain, called a tag.`

Please suggest better wording if preferred.