### PR TITLE
Remove NFS Attach Example for Docker Registry for Production Use

### DIFF
--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -152,14 +152,6 @@ $ oc volume deploymentconfigs/docker-registry --add --name=registry-storage -t p
      --claim-name=<pvc_name> --overwrite
 ----
 
-Or, to attach an existing NFS volume to the registry:
-
-----
-$ oc volume deploymentconfigs/docker-registry \
-     --add --overwrite --name=registry-storage --mount-path=/registry \
-     --source='{"nfs": { "server": "<fqdn>", "path": "/path/to/export"}}'
-----
-
 [NOTE]
 ====
 See xref:registry_known_issues.adoc#install-config-registry-known-issues[Known Issues] if using a scaled registry with a


### PR DESCRIPTION
The deleted command:
$ oc volume deploymentconfigs/docker-registry \
     --add --overwrite --name=registry-storage --mount-path=/registry \
     --source='{"nfs": { "server": "<fqdn>", "path": "/path/to/export"}}'
does not work because the default docker-registry SCC profile, i.e. restricted, does not allow direct mounting of NFS volumes.

In addition, docker-registry based on NFS does not scale because NFS can not "guarantee" read-after-write consistency, when scaled.

To sum it up, I propose to delete the above command from the documentation from the place where it is described as one of the options for production use.

For additional information refer to bug: https://bugzilla.redhat.com/show_bug.cgi?id=1393568