### PR TITLE
Follow-up edits to PR#3229

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -805,17 +805,17 @@ WebSocket connections to timeout frequently on that route.
 
 
 [[wildcard-subdomain-route-policy]]
-== Creating routes specifying a wildcard subdomain policy
+== Creating Routes Specifying a Wildcard Subdomain Policy
 
-A route can specify a wildcard policy as part of its configuration using the
-`wildcardPolicy` field. Any routers which are run with a policy that allows
-wildcard routes, will expose the route appropriately based on the wildcard
-policy.
-To configure HAProxy routers to allow wildcard routes, see
-xref:../../install_config/router/default_haproxy_router.adoc#using-wildcard-routes[using wildcard routes with HAProxy]
+A wildcard policy allows a user to define a route that covers all hosts within a
+domain (when the router is configured to allow it). A route can specify a
+wildcard policy as part of its configuration using the `wildcardPolicy` field.
+Any routers run with a policy allowing wildcard routes will expose the route
+appropriately based on the wildcard policy.
 
+xref:../../install_config/router/default_haproxy_router.adoc#using-wildcard-routes[Learn how to configure HAProxy routers to allow wildcard routes].
 
-.A Route Specifying a subdomain WildcardPolicy
+.A Route Specifying a Subdomain WildcardPolicy
 ====
 [source,yaml]
 ----
@@ -828,8 +828,8 @@ spec:
     kind: Service
     name: service-name
 ----
-<1> Specifies the externally-reachable host name used to expose a service.
-<2> Specifies that the externally-reachable host name should allow all hosts
-    in the subdomain `example.com` (aka `*.example.com` - subdomain for host
-    name `wildcard.example.com`) to reach the exposed service.
+<1> Specifies the externally reachable host name used to expose a service.
+<2> Specifies that the externally reachable host name should allow all hosts
+    in the subdomain `example.com`. `*.example.com` is the subdomain for host
+    name `wildcard.example.com` to reach the exposed service.
 ====

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -825,14 +825,13 @@ DNS lookup:
 
 
 [[using-wildcard-routes]]
-== Using Wildcard Routes (for a subdomain)
+== Using Wildcard Routes (for a Subdomain)
 
-The HAProxy router has support for wildcard routes which can be enabled by
-setting an environment variable `ROUTER_ALLOW_WILDCARD_ROUTES` to `true`.
-Any routes with a wildcard policy of `Subdomain` which pass the router
-admission checks will be serviced by the HAProxy router. And the HAProxy
-router would then expose the associated service (for the route)
-appropriately as per the route's wildcard policy.
+The HAProxy router has support for wildcard routes, which are enabled by setting
+the `ROUTER_ALLOW_WILDCARD_ROUTES` environment variable to `true`. Any routes
+with a wildcard policy of `Subdomain` that pass the router admission checks will
+be serviced by the HAProxy router. Then, the HAProxy router exposes the
+associated service (for the route) per the route's wildcard policy.
 
 ----
 $ oadm router --replicas=0 ...
@@ -840,27 +839,30 @@ $ oc env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
 $ oc scale dc/router --replicas=1
 ----
 
-Here is an example of how to use a secure wildcard edge terminated route
-with TLS termination occurring on the router before traffic is proxied to
-the destination. Traffic sent to any hosts in the subdomain `example.org`
-(aka `*.example.org`) would be proxied to the exposed service.
+.Using a Secure Wildcard Edge Terminated Route
+This example reflects TLS termination occurring on the router before traffic is
+proxied to the destination. Traffic sent to any hosts in the subdomain
+`example.org` (`*.example.org`) is proxied to the exposed service.
+
 The secure edge terminated route specifies the TLS certificate and key
-information. The TLS certificate is served by the router front end for all
-hosts that match the subdomain (`*.example.org`).
+information. The TLS certificate is served by the router front end for all hosts
+that match the subdomain (`*.example.org`).
 
-First, start up a router instance:
-
+. Start up a router instance:
++
 ----
 $ oadm router --replicas=0 --service-account=router
 $ oc env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
 $ oc scale dc/router --replicas=1
 ----
 
-Next, create a private key, csr and certificate for our edge secured route.
-The instructions on how to do that would be specific to your certificate
-authority and provider. For a simple self-signed certificate for a domain
-named `*.example.test`, see the example shown below:
-
+. Create a private key, certificate signing request (CSR), and certificate for the
+edge secured route.
++
+The instructions on how to do this are specific to your certificate authority
+and provider. For a simple self-signed certificate for a domain named
+`*.example.test`, see this example:
++
 ----
 # sudo openssl genrsa -out example-test.key 2048
 #
@@ -871,8 +873,8 @@ named `*.example.test`, see the example shown below:
       -signkey example-test.key -out example-test.crt
 ----
 
-Generate a wildcard route using the above certificate and key.
-
+. Generate a wildcard route using the above certificate and key:
++
 ----
 $ cat > route.yaml  <<REOF
 apiVersion: v1
@@ -892,19 +894,18 @@ spec:
 REOF
 $ oc create -f route.yaml
 ----
-
-Make sure your DNS entry for `*.example.test` points to your router
-instance(s) and the route to your domain should be available.
-The example below uses curl along with a local resolver to simulate the
-DNS lookup:
-
++
+Ensure your DNS entry for `*.example.test` points to your router instance(s) and
+the route to your domain is available.
++
+This example uses `curl` with a local resolver to simulate the DNS lookup:
++
 ----
 # routerip="4.1.1.1"  #  replace with IP address of one of your router instances.
 # curl -k --resolve www.example.test:443:$routerip https://www.example.test/
 # curl -k --resolve abc.example.test:443:$routerip https://abc.example.test/
 # curl -k --resolve anyname.example.test:443:$routerip https://anyname.example.test/
 ----
-
 
 [[using-the-container-network-stack]]
 == Using the Container Network Stack


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/3229

Preview Builds:
http://file.rdu.redhat.com/~ahardin/11162016/PR3229-followup/install_config/router/default_haproxy_router.html#using-wildcard-routes

http://file.rdu.redhat.com/~ahardin/11162016/PR3229-followup/architecture/core_concepts/routes.html#wildcard-subdomain-route-policy

