### PR TITLE
Bug 1391231: Add sysctl topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -502,6 +502,9 @@ Topics:
     Distros: openshift-origin,openshift-enterprise
   - Name: Restricting Application Capabilities Using Seccomp
     File: seccomp
+  - Name: Sysctls
+    File: sysctls
+    Distros: openshift-origin,openshift-enterprise
   - Name: Building Dependency Trees
     File: building_dependency_trees
     Distros: openshift-origin,openshift-enterprise

--- a/admin_guide/sysctls.adoc
+++ b/admin_guide/sysctls.adoc
@@ -1,0 +1,168 @@
+[[admin-guide-sysctls]]
+= Sysctls
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+Sysctl settings are exposed via Kubernetes, allowing users to modify certain
+kernel parameters at runtime for namespaces within a container. Only sysctls
+that are namespaced can be set independently on pods; if a sysctl is not
+namespaced (called _node-level_), it cannot be set within {product-title}.
+Moreover, only those sysctls considered _safe_ are whitelisted by default; other
+_unsafe_ sysctls can be manually enabled on the node to be available to the
+user.
+
+ifdef::openshift-enterprise[]
+[NOTE]
+====
+As of {product-title} 3.3.1, sysctl support is a feature in
+link:https://access.redhat.com/support/offerings/techpreview[Technology
+Preview].
+====
+endif::[]
+
+[[undersatnding-sysctls]]
+== Understanding Sysctls
+
+In Linux, the sysctl interface allows an administrator to modify kernel
+parameters at runtime. Parameters are available via the *_/proc/sys/_* virtual
+process file system. The parameters cover various subsystems such as:
+
+- kernel (common prefix: *_kernel._*)
+- networking (common prefix: *_net._*)
+- virtual memory (common prefix: *_vm._*)
+- MDADM (common prefix: *_dev._*)
+
+More subsystems are described in
+link:https://www.kernel.org/doc/Documentation/sysctl/README[Kernel documentation]. To get a list of all parameters, you can run:
+
+----
+$ sudo sysctl -a
+----
+
+[[namespaced-vs-node-level-sysctls]]
+== Namespaced vs Node-Level Sysctls
+
+A number of sysctls are _namespaced_ in today’s Linux kernels. This means that
+they can be set independently for each pod on a node. Being namespaced is a
+requirement for sysctls to be accessible in a pod context within Kubernetes.
+
+The following sysctls are known to be namespaced:
+
+- *_kernel.shm*_*
+- *_kernel.msg*_*
+- *_kernel.sem_*
+- *_fs.mqueue.*_*
+- *_net.*_*
+
+Sysctls that are not namespaced are called _node-level_ and must be set
+manually by the cluster administrator, either by means of the underlying Linux
+distribution of the nodes (e.g., via *_/etc/sysctls.conf_*) or using a DaemonSet
+with privileged containers.
+
+[NOTE]
+====
+Consider marking nodes with special sysctls as tainted. Only schedule pods onto
+them that need those sysctl settings. Use the
+link:http://kubernetes.io/docs/user-guide/kubectl/kubectl_taint/[Kubernetes _taints and toleration_ feature] to implement this.
+====
+
+[[safe-vs-unsafe-sysclts]]
+== Safe vs Unsafe Sysctls
+
+Sysctls are grouped into _safe_ and _unsafe_ sysctls. In addition to proper
+namespacing, a safe sysctl must be properly isolated between pods on the same
+node. This means that setting a safe sysctl for one pod:
+
+- must not have any influence on any other pod on the node,
+- must not allow to harm the node's health, and
+- must not allow to gain CPU or memory resources outside of the resource limits of
+a pod.
+
+By far, most of the namespaced sysctls are not necessarily considered safe.
+
+For {product-title} 3.3.1, the following sysctls are supported (whitelisted) in
+the safe set:
+
+- *_kernel.shm_rmid_forced_*
+- *_net.ipv4.ip_local_port_range_*
+
+This list will be extended in future versions when the kubelet supports better
+isolation mechanisms.
+
+All safe sysctls are enabled by default. All unsafe sysctls are disabled by
+default and must be allowed manually by the cluster administrator on a per-node
+basis. Pods with disabled unsafe sysctls will be scheduled, but will fail to
+launch.
+
+[WARNING]
+====
+Due to their nature of being unsafe, the use of unsafe sysctls is
+at-your-own-risk and can lead to severe problems like wrong behavior of
+containers, resource shortage, or complete breakage of a node.
+====
+
+[[enabling-unsafe-sysctls]]
+== Enabling Unsafe Sysctls
+
+With the warning above in mind, the cluster administrator can allow certain
+unsafe sysctls for very special situations, e.g., high-performance or real-time
+application tuning.
+
+If you want to use unsafe sysctls, cluster administrators must enable them
+individually on nodes. Only namespaced sysctls can be enabled this way.
+
+. Use the `*kubeletArguments*` field in the *_/etc/origin/node/node-config.yaml_*
+file, as described in
+xref:../admin_guide/manage_nodes.adoc#configuring-node-resources[Configuring Node Resources], to set the desired unsafe sysctls:
++
+----
+kubeletArguments:
+  experimental-allowed-unsafe-sysctls:
+    - "kernel.msg*,net.ipv4.route.min_pmtu"
+----
+
+. Restart the node service to apply the changes:
++
+----
+# systemctl restart atomic-openshift-node
+----
+
+[[setting-sysctls-for-a-pod]]
+== Setting Sysctls for a Pod
+
+Sysctls are set on pods using annotations. They apply to all containers in the
+same pod.
+
+Here is an example, with different annotations for safe and unsafe sysctls:
+
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctl-example
+  annotations:
+    security.alpha.kubernetes.io/sysctls: kernel.shm_rmid_forced=1
+    security.alpha.kubernetes.io/unsafe-sysctls: net.ipv4.route.min_pmtu=1000,kernel.msgmax=1 2 3
+spec:
+  ...
+----
+
+[NOTE]
+====
+A pod with the unsafe sysctls specified above will fail to launch on any node
+that has not enabled those two unsafe sysctls explicitly. As with node-level
+sysctls, use the
+link:http://kubernetes.io/docs/user-guide/kubectl/kubectl_taint[taints and
+toleration feature] or
+xref:../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[labels on nodes]
+to schedule those pods onto the right nodes.
+====

--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -1366,8 +1366,7 @@ namespaced (called _node-level_), it cannot be set within {product-title}.
 These whitelisted sysctls are considered _safe_ and supported because they
 cannot be misused to influence other containers, for example by blocking
 resources like memory outside of the pods' defined memory limits. If a
-namespaced sysctl is not whitelisted, it is considered _unsafe_ and not
-supported.
+namespaced sysctl is not whitelisted, it is considered _unsafe_.
 
 [IMPORTANT]
 ====
@@ -1378,50 +1377,8 @@ link:https://bugzilla.redhat.com/show_bug.cgi?id=1373119#c9[BZ#1373119] for
 details.
 ====
 
-You can use annotations to set safe sysctls on pods, for example:
-
-----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: safe-sysctl-example
-  annotations:
-    security.alpha.kubernetes.io/sysctls: kernel.shm_rmid_forced=1
-----
-
-If you want to use unsafe (and unsupported) namespaced sysctls, cluster
-administrators must enable them individually on nodes:
-
-. Use the `*kubeletArguments*` field in the *_/etc/origin/node/node-config.yaml_*
-file, as described in
-xref:../admin_guide/manage_nodes.adoc#configuring-node-resources[Configuring Node Resources], to set the desired unsafe sysctls:
-+
-----
-kubeletArguments:
-  experimental-allowed-unsafe-sysctls:
-    - "kernel.msg*,net.ipv4.route.min_pmtu"
-----
-
-. Restart the node service to apply the changes:
-+
-----
-# systemctl restart atomic-openshift-node
-----
-
-. Users can then set the unsafe sysctls in pods using annotations, for example:
-+
-----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: unsafe-sysctl-example
-  annotations:
-    security.alpha.kubernetes.io/unsafe-sysctls: net.ipv4.route.min_pmtu=1000,kernel.msgmax=1 2 3
-----
-
-See link:http://kubernetes.io/docs/admin/sysctls/[Kubernetes documentation] for
-more details on safe and unsafe sysctl usage. {product-title} documentation will
-be updated in an upcoming revision for more information on this feature.
+See xref:../admin_guide/sysctls.adoc#admin-guide-sysctls[Sysctls] for more
+details and usage information.
 
 [[ocp-3-3-1-3-bug-fixes]]
 ==== Bug Fixes


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1391231

New topic, based on upstream Kube doc:

http://file.rdu.redhat.com/~adellape/111616/sysctl/admin_guide/sysctls.html

Updated 3.3.1 release note on this Tech Preview feature, moved some of the content to the new dedicated topic (and linked to it):

http://file.rdu.redhat.com/~adellape/111616/sysctl/release_notes/ocp_3_3_release_notes.html#ocp-3-3-1-3-technology-preview

@sttts @ahardin-rh PTAL.