### PR TITLE
Github teams doc

### DIFF
--- a/admin_solutions/authentication.adoc
+++ b/admin_solutions/authentication.adoc
@@ -659,10 +659,10 @@ For example, if you defined the callback URL as
 xref:../admin_solutions/authentication.adoc#register-app-on-github[registered previously].
 .. Change `*clientSecret*` to the Client Secret from GitHub that you
 xref:../admin_solutions/authentication.adoc#register-app-on-github[registered previously].
-.. Change `*organizations*` to include a list of one or more GitHub
-organizations to which a user must have membership in order to authenticate. If
+.. Change `*organizations*` or `*teams*` to include a list of one or more GitHub
+organizations or teams to which a user must have membership in order to authenticate. If
 specified, only GitHub users that are members of at least one of the listed
-organizations will be allowed to log in. If this is not specified, then any
+organizations or teams will be allowed to log in. If this is not specified, then any
 person with a valid GitHub account can log in.
 . Save your changes and close the file.
 . Start the {product-title} API server, specifying the configuration file you just

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1015,6 +1015,9 @@ oauthConfig:
       organizations: <7>
       - myorganization1
       - myorganization2
+      teams: <7>
+      - myorganization1/team-a
+      - myorganization2/team-b
 ----
 <1> This provider name is prefixed to the GitHub numeric user ID to form an
 identity name. It is also used to build the callback URL.
@@ -1036,6 +1039,13 @@ at least one of the listed organizations will be allowed to log in. If the GitHu
 application configured in *clientID* is not owned by the organization, an organization
 owner must grant third-party access in order to use this option. This can be done during
 the first GitHub login by the organization's administrator, or from the GitHub organization settings.
+Cannot be used in combination with the `teams` field.
+<8> Optional list of teams. If specified, only GitHub users that are members of
+at least one of the listed teams will be allowed to log in. If the GitHub OAuth
+application configured in *clientID* is not owned by the team's organization, an organization
+owner must grant third-party access in order to use this option. This can be done during
+the first GitHub login by the organization's administrator, or from the GitHub organization settings.
+Cannot be used in combination with the `organizations` field.
 ====
 
 [[GitLab]]


### PR DESCRIPTION
Doc for https://trello.com/c/akzREfyn/836-allow-github-identity-provider-to-require-team-membership added in https://github.com/openshift/origin/pull/11931
1.5 / 3.5 only