### PR TITLE
Docs for security caveats / ownership claim of hostnames and subdomains.

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -907,6 +907,252 @@ This example uses `curl` with a local resolver to simulate the DNS lookup:
 # curl -k --resolve anyname.example.test:443:$routerip https://anyname.example.test/
 ----
 
+[NOTE]
+====
+For routers that allow wildcard routes (`ROUTER_ALLOW_WILDCARD_ROUTES`
+set to `true`), there are some caveats to the ownership of a subdomain
+associated with a wildcard route.
+
+Prior to wildcard routes, ownership was based on the claims made for a
+host name with the namespace with the oldest route winning against any
+other claimants.
+E.g. route `r1` in namespace `ns1` with a claim for `one.example.test`
+     would win over another route `r2` in namespace `ns2` for the same
+     host name `one.example.test` if route `r1` was older than route `r2`.
+
+In addition, routes in other namespaces were allowed to claim
+non-overlapping hostnames.
+E.g. route `rone` in namespace `ns1` could claim `www.example.test` and
+   another route `rtwo` in namespace `d2` could claim `c3po.example.test`).
+
+This is still the case if there are _NO_ wildcard routes claiming that same
+subdomain (`example.test` in the above example).
+
+A wildcard route will however need to claim all the host names within a
+subdomain (host names of the form `\*.example.test`). A wildcard route's claim
+is allowed or denied based on whether or not the oldest route for that
+subdomain (`example.test`) is in the same namespace as the wildcard route.
+The oldest route in turn can be either a regular route or a wildcard route.
+E.g. if there is already a route `eldest` that exists in the `ns1`
+     namespace, which has claimed a host named `owner.example.test`.
+     And if at a later point in time, a new wildcard route `wildthing`
+     requesting for routes in that subdomain (`example.test`) is added,
+     the claim by the wildcard route will _only_ be allowed if it is the
+     same namespace (`ns1`) as the owning route.
+
+The examples that follow illustrate various different scenarios and where
+claims for wildcard routes will succeed or fail.
+====
+
+In the example below, a router that allows wildcard routes will allow
+non-overlapping claims for hosts in the subdomain `example.test` as long as
+a wildcard route has not claimed a subdomain.
+
+----
+$ oadm router ...
+$ oc env dc/router
+$ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
+
+$ oc project ns1
+$ oc expose service myservice --hostname=owner.example.test
+$ oc expose service myservice --hostname=aname.example.test
+$ oc expose service myservice --hostname=bname.example.test
+
+$ oc project ns2
+$ oc expose service anotherservice --hostname=second.example.test
+$ oc expose service anotherservice --hostname=cname.example.test
+
+$ oc project otherns
+$ oc expose service thirdservice --hostname=emmy.example.test
+$ oc expose service thirdservice --hostname=webby.example.test
+
+----
+
+
+In the example below, a router that allows wildcard routes will not allow
+the claim for `owner.example.test` or `aname.example.test` to succeed
+since the owning namespace is `ns1`.
+
+----
+$ oadm router ...
+$ oc env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
+
+$ oc project ns1
+$ oc expose service myservice --hostname=owner.example.test
+$ oc expose service myservice --hostname=aname.example.test
+
+$ oc project ns2
+$ oc expose service secondservice --hostname=bname.example.test
+$ oc expose service secondservice --hostname=cname.example.test
+
+$ # Router will not allow this claim with a different path name `/p1` as
+$ # namespace `ns1` has an older route claiming host `aname.example.test`.
+$ oc expose service secondservice --hostname=aname.example.test --path="/p1"
+
+$ # Router will not allow this claim as namespace `ns1` has an older route
+$ # claiming host name `owner.example.test`.
+$ oc expose service secondservice --hostname=owner.example.test
+
+$ oc project otherns
+
+$ # Router will not allow this claim as namespace `ns1` has an older route
+$ # claiming host name `aname.example.test`.
+$ oc expose service thirdservice --hostname=aname.example.test
+----
+
+
+In the example below, a router that allows wildcard routes will allow the
+claim for \*.example.test to succeed since the owning namespace is ns1 and
+the wildcard route belongs to that same namespace.
+
+----
+$ oadm router ...
+$ oc env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
+
+$ oc project ns1
+$ oc expose service myservice --hostname=owner.example.test
+
+$ # Reusing the route.yaml from the previous example.
+$ # spec:
+$ #   host: www.example.test
+$ #   wildcardPolicy: Subdomain
+
+$ oc create -f route.yaml   #  router will allow this claim.
+----
+
+
+In the example below, a router that allows wildcard routes will not allow
+the claim for \*.example.test to succeed since the owning namespace is `ns1`
+and the wildcard route belongs to another namespace `cyclone`.
+
+----
+$ oadm router ...
+$ oc env dc/router
+$ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
+
+$ oc project ns1
+$ oc expose service myservice --hostname=owner.example.test
+
+$ # Switch to a different namespace/project.
+$ oc project cyclone
+
+$ # Reusing the route.yaml from a prior example.
+$ # spec:
+$ #   host: www.example.test
+$ #   wildcardPolicy: Subdomain
+
+$ oc create -f route.yaml   #  router will deny (_NOT_ allow) this claim.
+----
+
+
+In a similar vein, once a namespace with a wildcard route claims a
+subdomain, only routes within that namespace can claim any hosts in that
+same subdomain.
+
+In the example below, once a route in namespace `ns1` with a wildcard route
+claims subdomain `example.test`, only routes in the namespace `ns1` will be
+allowed to claim any hosts in that same subdomain.
+
+----
+$ oadm router ...
+$ oc env dc/router
+$ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
+
+$ oc project ns1
+$ oc expose service myservice --hostname=owner.example.test
+
+$ oc project otherns
+
+$ # namespace `otherns` is allowed to claim for other.example.test
+$ oc expose service otherservice --hostname=other.example.test
+
+$ oc project ns1
+
+$ # Reusing the route.yaml from the previous example.
+$ # spec:
+$ #   host: www.example.test
+$ #   wildcardPolicy: Subdomain
+
+$ oc create -f route.yaml   #  Router will allow this claim.
+
+$ #  In addition, route in namespace otherns will lose its claim to host
+$ #  `other.example.test` due to the wildcard route claiming the subdomain.
+
+$ # namespace `ns1` is allowed to claim for deux.example.test
+$ oc expose service mysecondservice --hostname=deux.example.test
+
+$ # namespace `ns1` is allowed to claim for deux.example.test with path /p1
+$ oc expose service mythirdservice --hostname=deux.example.test --path="/p1"
+
+$ oc project otherns
+
+$ # namespace `otherns` is not allowed to claim for deux.example.test
+$ # with a different path '/otherpath'
+$ oc expose service otherservice --hostname=deux.example.test --path="/otherpath"
+
+$ # namespace `otherns` is not allowed to claim for owner.example.test
+$ oc expose service yetanotherservice --hostname=owner.example.test
+
+$ # namespace `otherns` is not allowed to claim for unclaimed.example.test
+$ oc expose service yetanotherservice --hostname=unclaimed.example.test
+
+----
+
+
+In the example below, we show the different scenarios when the owner
+routes are deleted and ownership is passed within and across namespaces.
+While a route claiming host `eldest.example.test` in the namespace `ns1`
+exists, wildcard routes in that namespace can claim subdomain
+`example.test`. When the route for host `eldest.example.test` is deleted,
+the next oldest route `senior.example.test` would become the oldest route
+and would not affect any other routes. But once the route for host
+`senior.example.test` is deleted, the next oldest route
+`junior.example.test` would become the oldest route and block the
+wildcard route claimant.
+
+----
+$ oadm router ...
+$ oc env dc/router
+$ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
+
+$ oc project ns1
+$ oc expose service myservice --hostname=eldest.example.test
+$ oc expose service seniorservice --hostname=senior.example.test
+
+$ oc project otherns
+
+$ # namespace `otherns` is allowed to claim for other.example.test
+$ oc expose service juniorservice --hostname=junior.example.test
+
+$ oc project ns1
+
+$ # Reusing the route.yaml from the previous example.
+$ # spec:
+$ #   host: www.example.test
+$ #   wildcardPolicy: Subdomain
+
+$ oc create -f route.yaml   #  Router will allow this claim.
+
+$ #  In addition, route in namespace otherns will lose its claim to host
+$ #  `junior.example.test` due to the wildcard route claiming the subdomain.
+
+$ # namespace `ns1` is allowed to claim for dos.example.test
+$ oc expose service mysecondservice --hostname=dos.example.test
+
+$ # Delete route for host `eldest.example.test`, the next oldest route is
+$ # the one claiming `senior.example.test`, so route claims are unaffacted.
+$ oc delete route myservice
+
+$ # Delete route for host `senior.example.test`, the next oldest route is
+$ # the one claiming `junior.example.test` in another namespace, so claims
+$ # for a wildcard route would be affected. The route for the host
+$ # `dos.example.test` would be unaffected as there are no other wildcard
+$ # claimants blocking it.
+$ oc delete route seniorservice
+
+----
+
+
 [[using-the-container-network-stack]]
 == Using the Container Network Stack
 


### PR DESCRIPTION
Finish up docs for https://trello.com/c/cyY7odgA/366-complete-up-docs-for-wildcard-subdomain-support-add-security-implications-and-add-more-help-text-to-the-oadm-router-command

@ahardin-rh / @knobunc  PTAL Thx

There's too many examples (and a lot of copy-pasta so would appreciate another set of eyes looking at this - thx) but hopefully they are clear ... 

For 3.4 only.