### PR TITLE
adding for docs for insecureEdgeTerminatePolicy in reencrypt and passthrough routes 

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -640,6 +640,12 @@ The destination pod is responsible for serving certificates for the
 traffic at the endpoint. This is currently the only method that can support
 requiring client certificates (also known as two-way authentication).
 
+[NOTE]
+====
+passthrough routes can also have an `insecureEdgeTerminationPolicy` the only valid values are 
+`None` or empty (for disabled) or `Redirect`.
+====
+
 [[re-encryption-termination]]
 *Re-encryption Termination*
 
@@ -681,6 +687,11 @@ termination.
 <3> The `*destinationCACertificate*` field specifies a CA certificate to
 validate the endpoint certificate, securing the connection from the router to
 the destination. This field is required, but only for re-encryption.
+====
+
+[NOTE]
+====
+Reencrypt routes can have an insecureEdgeTerminationPolicy with all of the same values as for edge-terminated routes.
 ====
 
 


### PR DESCRIPTION
update to the docs for origin PR:[11953](https://github.com/openshift/origin/pull/11953)