### PR TITLE
Document --expire-days and --signer-expire-days options

### DIFF
--- a/install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc
+++ b/install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc
@@ -67,6 +67,15 @@ in this topic they are kept separate.
 [[sssd-phase-1-certificate-generation]]
 == Phase 1: Certificate Generation
 
+[NOTE]
+====
+The undermentioned commands generate certificate files that will be valid for 2
+years (and 5 years for Certification authority (CA) certificate). These
+periods can be altered with `--expire-days` and `--signer-expire-days` options
+but by security reasons it is strongly recommended to not make them greater
+than these values.
+====
+
 . To ensure that communication between the authenticating proxy and
 {product-title} is trustworthy, create a set of Transport Layer Security (TLS)
 certificates to use during the other phases of this setup. In the

--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -756,6 +756,11 @@ xref:requestheader-master-ca-config[master's identity provider configuration].
   --serial='/etc/origin/master/proxyca.serial.txt'
 ----
 
+[NOTE]
+`oadm ca create-signer-cert` generates a certificate that is valid for 5 years.
+This period can be altered with `*--expire-days*` option but by security
+reasons it is strongly recommended to not make it greater than this value.
+
 Generate a client certificate for the proxy. This can be done using any x509
 certificate tooling. For convenience, the `oadm` CLI can be used:
 
@@ -786,6 +791,11 @@ instead of using the default master certificate as shown above. The value for
 must be included in the `X509v3 Subject Alternative Name` in the certificate
 that is specified for `*SSLCertificateFile*`. If a new certificate needs to be
 created, the `oadm ca create-server-cert` command can be used.
+
+[NOTE]
+`oadm create-api-client-config` generates a certificate that is valid for 2 years.
+This period can be altered with `*--expire-days*` option but by security
+reasons it is strongly recommended to not make it greater than this value.
 
 *Configuring Apache*
 

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -939,6 +939,11 @@ The following commands write the relevant launch configuration file(s),
 certificate files, and any other necessary files to the specified
 `--write-config` or `--node-dir` directory.
 
+Generated certificate files will be valid for 2 years. Certification authority
+(CA) certificate will be valid for 5 years. These periods can be altered with
+`--expire-days` and `--signer-expire-days` options but by security reasons
+it is strongly recommended to not make them greater than these values.
+
 To create configuration files for an all-in-one server (a master and a node on
 the same host) in the specified directory:
 

--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -53,6 +53,13 @@ $ oadm ca create-server-cert \
     --key=/etc/secrets/registry.key
 ----
 +
+[NOTE]
+====
+`oadm ca create-server-cert` generates a certificate that is valid for 2 years.
+This period can be altered with `*--expire-days*` option but by security
+reasons it is strongly recommended to not make it greater than this value.
+====
++
 . Create the secret for the registry certificates:
 +
 ----

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -718,6 +718,13 @@ $ oadm ca create-server-cert --signer-cert=$CA/ca.crt \
 ----
 ====
 
+[NOTE]
+====
+`oadm ca create-server-cert` generates a certificate that is valid for 2 years.
+This period can be altered with `*--expire-days*` option but by security
+reasons it is strongly recommended to not make it greater than this value.
+====
+
 The router expects the certificate and key to be in PEM format in a single
 file:
 

--- a/registry_quickstart/administrators/system_configuration.adoc
+++ b/registry_quickstart/administrators/system_configuration.adoc
@@ -141,6 +141,13 @@ $ exit
 ----
 ====
 +
+[NOTE]
+====
+`oadm ca create-server-cert` generates a certificate that is valid for 2 years.
+This period can be altered with `*--expire-days*` option but by security
+reasons it is strongly recommended to not make it greater than this value.
+====
++
 . Copy the generated files to the registry directory and change ownership so the
 atomic-registry service can read the files.
 +


### PR DESCRIPTION
Notes:
- this also touch atomic-registry documentation (BTW, why it looks so poor and code listings aren't readable?)
- I didn't modify `install_config/upgrading/manual_upgrades.adoc` because I'm not sure whether it should be updated

PTAL @mfojtik @openshift/team-documentation

Related to: https://github.com/openshift/origin/pull/11814
Trello card: https://trello.com/c/de9h5mA4/829-3-allow-configuration-of-expiration-date-for-generated-certs