### PR TITLE
Update audit configuration description

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -689,7 +689,8 @@ Each audit log contains two entries:
 .. The source IP of the request
 .. The HTTP method being invoked
 .. The original user invoking the operation
-.. The impersonated user for the operation
+.. The impersonated user for the operation (`self` meaning himself here)
+.. The impersonated group for the operation (`lookup` meaning user's group)
 .. The namespace of the request or <none>
 .. The URI as requested
 
@@ -700,7 +701,7 @@ Each audit log contains two entries:
 Example output for user *admin* asking for a list of pods:
 
 ----
-AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" ip="127.0.0.1" method="GET" user="admin" as="<self>" namespace="default" uri="/api/v1/namespaces/default/pods"
+AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" ip="127.0.0.1" method="GET" user="admin" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
 AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" response="200"
 ----
 
@@ -712,6 +713,19 @@ AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" response="200"
 
 |`*Enabled*`
 |A boolean to enable or disable audit logs. Default is *false*.
+
+|`*AuditFilePath*`
+|File path where the requests should be logged to. If not set, logs will be printed
+to master logs.
+
+|`*MaximumFileRetentionDays*`
+|Specifies maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
+
+|`*MaximumRetainedFiles*`
+|Specifies Maximum number of old audit log files to retain.
+
+|`*MaximumFileSizeMegabytes*`
+|Specifies maximum size in megabytes of the log file before it gets rotated. Defaults to 100MB.
 
 |===
 


### PR DESCRIPTION
With k8s 1.4 we switched to using upstream audit mechanics, which gave us a few additional options. I've updated the description with those new options.

@ahardin-rh ptal