### PR TITLE
BZ-1395986  Explicitly identify when logging stopped reading old logs

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -734,6 +734,14 @@ logs from the beginning of the journal.
 
 [NOTE]
 ====
+As of {product-title} 3.3, Fluentd no longer reads historical log files when using the
+json-file log driver. This is to avoid delays pushing into Elasticsearch the most recent logs
+on clusters that have a large number of log files that are older then the EFK deployment, and to 
+mitigate Curator deleting logs shortly after they are added to Elasticsearch.
+====
+
+[NOTE]
+====
 It may require several minutes, or hours, depending on the size of your
 journal, before any new log entries are available in Elasticsearch, when using
 `journal-read-from-head=true`.


### PR DESCRIPTION
To fix:

https://bugzilla.redhat.com/show_bug.cgi?id=1395986