### PR TITLE
Bug 1399418, reverted storage_class to dynamically_provisioning_pvs to fix links

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -350,7 +350,7 @@ Topics:
       - Name: Using Fibre Channel
         File: persistent_storage_fibre_channel
       - Name: Dynamic Provisioning and Creating Storage Classes
-        File: storage_classes
+        File: dynamically_provisioning_pvs
       - Name: Volume Security
         File: pod_security_context
       - Name: Selector-Label Volume Binding
@@ -625,7 +625,7 @@ Topics:
         File: advanced_deployment_strategies
       - Name: Kubernetes Deployments Support
         File: kubernetes_deployments
-        Distros: openshift-enterprise,openshift-origin 
+        Distros: openshift-enterprise,openshift-origin
   - Name: Getting Traffic Into The Cluster
     File: getting_traffic_into_cluster
   - Name: Routes


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1399418

This issue was introduced in https://github.com/openshift/openshift-docs/pull/2972

The work in this PR fixes the broken links that were introduced.

cc @danmacpherson FYI about this work, as your are working on other follow-up edits in:
https://github.com/openshift/openshift-docs/pull/3224