### PR TITLE
Prevent LD_PRELOAD error

### DIFF
--- a/creating_images/guidelines.adoc
+++ b/creating_images/guidelines.adoc
@@ -305,7 +305,7 @@ start script:
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 envsubst < ${HOME}/passwd.template > /tmp/passwd
-export LD_PRELOAD=libnss_wrapper.so
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
 export NSS_WRAPPER_PASSWD=/tmp/passwd
 export NSS_WRAPPER_GROUP=/etc/group
 ----


### PR DESCRIPTION
This will prevent errors of the library not being found.