### PR TITLE
Added Azure Block Provisioner

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -327,6 +327,9 @@ Topics:
   - Name: Configuring for GCE
     File: configuring_gce
     Distros: openshift-origin,openshift-enterprise
+  - Name: Configuring for Azure
+    File: configuring_azure
+    Distros: openshift-origin,openshift-enterprise
   - Name: Configuring Persistent Storage
     Dir: persistent_storage
     Distros: openshift-origin,openshift-enterprise
@@ -351,6 +354,8 @@ Topics:
         File: persistent_storage_fibre_channel
       - Name: Dynamic Provisioning and Creating Storage Classes
         File: dynamically_provisioning_pvs
+      - Name: Using Azure Disk
+        File: persistent_storage_azure
       - Name: Volume Security
         File: pod_security_context
       - Name: Selector-Label Volume Binding

--- a/install_config/configuring_azure.adoc
+++ b/install_config/configuring_azure.adoc
@@ -1,0 +1,83 @@
+[[install-config-configuring-azure]]
+= Configuring for Azure
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+{product-title} can be configured to access an
+link:https://azure.microsoft.com/en-us/services/storage/disks/[Azure infrastructure], including
+xref:../install_config/persistent_storage/persistent_storage_azure.adoc#install-config-persistent-storage-persistent-storage-azure[using Azure disk as persistent storage] for application data. After Azure is configured
+properly, some additional configurations will need to be completed on the
+{product-title} hosts.
+
+[[azure-configuring-masters]]
+== Configuring Masters
+
+Edit or
+xref:../install_config/master_node_configuration.adoc#creating-new-configuration-files[create] the
+master configuration file on all masters
+(*_/etc/origin/master/master-config.yaml_* by default) and update the
+contents of the `*apiServerArguments*` and `*controllerArguments*` sections:
+
+====
+[source,yaml]
+----
+kubernetesMasterConfig:
+  ...
+  apiServerArguments:
+    cloud-provider:
+      - "azure"
+      cloud-config:
+        - "/etc/azure/azure.conf"
+  controllerArguments:
+    cloud-provider:
+      - "azure"
+      cloud-config:
+        - "/etc/azure/azure.conf"
+----
+====
+
+[IMPORTANT]
+====
+When triggering a containerized installation, only the directories of
+*_/etc/origin_* and *_/var/lib/origin_* are mounted to the master and node
+container. Therefore, *_master-config.yaml_* should be in *_/etc/origin/master_*
+instead of *_/etc/_*.
+====
+
+[[azure-configuring-nodes]]
+== Configuring Nodes
+
+Edit or
+xref:../install_config/master_node_configuration.adoc#creating-new-configuration-files[create]
+the node configuration file on all nodes (*_/etc/origin/node/node-config.yaml_*
+by default) and update the contents of the `*kubeletArguments*` section:
+
+====
+[source,yaml]
+----
+kubeletArguments:
+  cloud-provider:
+    - "azure"
+    cloud-config:
+      - "/etc/azure/azure.conf"
+
+----
+====
+
+[IMPORTANT]
+====
+When triggering a containerized installation, only the directories of
+*_/etc/origin_* and *_/var/lib/origin_* are mounted to the master and node
+container. Therefore, *_node-config.yaml_* should be in *_/etc/origin/node_*
+instead of *_/etc/_*.
+====
+
+Then, start or restart the {product-title} services on the master and all nodes.

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -68,6 +68,11 @@ the master node. Do this by setting the
 `*failure-domain.beta.kubernetes.io/region*` and
 `*failure-domain.beta.kubernetes.io/zone*` PV labels to match the master node.
 
+|Azure Disk
+|`kubernetes.io/azure-dd`
+|xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[Configuring for Azure]
+|
+
 |===
 
 

--- a/install_config/persistent_storage/persistent_storage_azure.adoc
+++ b/install_config/persistent_storage/persistent_storage_azure.adoc
@@ -1,0 +1,146 @@
+[[install-config-persistent-storage-persistent-storage-azure]]
+= Persistent Storage Using Azure Disk
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+{product-title} supports Azure Disk volumes. You can provision
+your {product-title} cluster with
+xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent storage]
+using link:https://azure.microsoft.com/en-us/services/storage/disks/[Azure]. Some familiarity
+with Kubernetes and Azure is assumed.
+
+[IMPORTANT]
+====
+Before creating persistent volumes using Azure, {product-title} must first be properly
+xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[configured for Azure Disk].
+====
+
+The Kubernetes
+xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent volume]
+framework allows administrators to provision a cluster with persistent storage
+and gives users a way to request those resources without having any knowledge of
+the underlying infrastructure.
+Azure Disk volumes can be
+xref:dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[provisioned dynamically].
+Persistent volumes are not bound to a single
+project or namespace; they can be shared across the {product-title} cluster.
+xref:../../architecture/additional_concepts/storage.adoc#persistent-volume-claims[Persistent
+volume claims], however, are specific to a project or namespace and can be
+requested by users.
+
+
+[IMPORTANT]
+====
+High-availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
+[[azure-provisioning]]
+
+== Provisioning
+Storage must exist in the underlying infrastructure before it can be mounted as
+a volume in {product-title}. After ensuring {product-title} is
+xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[configured for Azure Disk], all that is required for {product-title} and Azure is an Azure
+Disk Name and Disk URI and the `*PersistentVolume*` API.
+
+[[azure-creating-persistent-volume]]
+
+=== Creating the Persistent Volume
+
+[NOTE]
+====
+Azure does not support the 'Recycle' recycling policy.
+====
+
+You must define your persistent volume in an object definition before creating
+it in {product-title}:
+
+.Persistent Volume Object Definition Using Azure
+====
+
+[source,yaml]
+----
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "pv0001" <1>
+spec:
+  capacity:
+    storage: "5Gi" <2>
+  accessModes:
+    - "ReadWriteOnce"
+  azureDisk: <3>
+    diskName: test2.vhd <4>
+    diskURI: https://someacount.blob.core.windows.net/vhds/test2.vhd <5>
+    cachingMode: readwrite  <6>
+    fsType: ext4  <7>
+    readOnly: false  <8>
+----
+<1> The name of the volume. This will be how it is identified via
+xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent volume
+claims] or from pods.
+<2> The amount of storage allocated to this volume.
+<3> This defines the volume type being used, in this case the *azureDisk* plug-in.
+<4> The Name of the data disk in the blob storage.
+<5> The URI the the data disk in the blob storage.
+<6> Host Caching mode: None, Read Only, Read Write.
+<7> File system type to mount, e.g. ext4, xfs, etc.
+<8> Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+====
+
+[IMPORTANT]
+====
+Changing the value of the `*fsType*` parameter after the volume has been
+formatted and provisioned can result in data loss and pod failure.
+====
+
+Save your definition to a file, for example *_azure-pv.yaml_*, and create the
+persistent volume:
+
+====
+----
+# oc create -f azure-pv.yaml
+persistentvolume "pv0001" created
+----
+====
+
+Verify that the persistent volume was created:
+
+====
+----
+# oc get pv
+NAME      LABELS    CAPACITY   ACCESSMODES   STATUS      CLAIM     REASON    AGE
+pv0001    <none>    5Gi        RWO           Available                       2s
+----
+====
+
+Users can then xref:../../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[request storage
+using persistent volume claims], which can now utilize your new persistent volume.
+
+[IMPORTANT]
+====
+Persistent volume claims only exist in the user's namespace and can only be
+referenced by a pod within that same namespace. Any attempt to access a
+persistent volume from a different namespace causes the pod to fail.
+====
+
+[[volume-format-azure]]
+
+=== Volume Format
+Before {product-title} mounts the volume and passes it to a container, it checks
+that it contains a file system as specified by the `*fsType*` parameter in the
+persistent volume definition. If the device is not formatted with the file
+system, all data from the device is erased and the device is automatically
+formatted with the given file system.
+
+This allows using unformatted Azure volumes as persistent volumes, because
+{product-title} formats them before the first use.

--- a/install_config/persistent_storage/storage_classes.adoc
+++ b/install_config/persistent_storage/storage_classes.adoc
@@ -70,6 +70,11 @@ the master node. Do this by setting the
 |`kubernetes.io/vsphere-volume`
 |link:http://kubernetes.io/docs/getting-started-guides/vsphere/[Getting Started with vSphere and Kubernetes]
 |
+|Azure Disk
+|`kubernetes.io/azure-dd`
+|xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[Configuring for Azure]
+|
+
 |===
 
 
@@ -246,6 +251,30 @@ parameters:
   diskformat: thin <1>
 ----
 <1>  diskformat: thin, zeroedthick and eagerzeroedthick. See vSphere docs for details. Default: "thin"
+====
+
+[[azure-disk]]
+=== Azure Disk
+
+.azure-disk-storageclass.yaml
+====
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS  <1>
+  location: eastus  <2>
+  storageAccount: azure_storage_account_name  <3>
+
+----
+
+<1> skuName: Azure storage account Sku tier. Default is empty.
+<2> location: Azure storage account location. Default is empty.
+<3> storageAccount: Azure storage account name. If storage account is not provided, all storage accounts associated with the resource group are searched to find one that matches skuName and location. If storage account is provided, skuName and location are ignored.
 ====
 
 [[moreinfo]]


### PR DESCRIPTION
PTAL @rootfs @mfojtik @openshift/team-documentation
Target versions: 3.3 and 3.4

I know that the file `install_config/persistent_storage/storage_classes.adoc` is currently not used because it's not in the `_topic_map.yml` file as it was removed in [this commit](https://github.com/openshift/openshift-docs/commit/95c8d88057016513175a24ec739e3458c8fddd52).

IMHO, information about `StorageClass` `parameters` present in the file `install_config/persistent_storage/storage_classes.adoc` should be present somewhere in OpenShift documentation, however, I don't know which place is the right one.

Anyway, this PR adds information on Azure block provisioner that was added to Kubernetes in [this PR](https://github.com/kubernetes/kubernetes/pull/30091).