### PR TITLE
Continuation of Diagnostics Tool Work in PR#1383

### DIFF
--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -31,6 +31,13 @@ connected to.
 [[admin-guide-using-the-diagnostics-tool]]
 == Using the Diagnostics Tool
 
+{product-title} can be deployed in many ways: built from source, included in a
+VM image, in a container image, or as enterprise RPMs. Each method implies a
+different configuration and environment. To minimize environment assumptions,
+the diagnostics were added to the `openshift` binary so that wherever there is
+an {product-title} server or client, the diagnostics can run in the exact same
+environment.
+
 To use the diagnostics tool, preferably on a master host and as cluster
 administrator, run:
 
@@ -46,3 +53,65 @@ issues. For example:
 ----
 $ oc adm diagnostics NodeConfigCheck UnitStatus
 ----
+
+Diagnostics look for configuration files in standard locations:
+
+* Client:
+** As indicated by the `$KUBECONFIG` environment variable variable
+**  *_~/.kube/config file_*
+* Master:
+** *_/etc/origin/master/master-config.yaml_*
+* Node:
+** *_/etc/origin/node/node-config.yaml_*
+
+Non-standard locations can be specified with flags (respectively,
+`--config`, `--master-config`, and `--node-config`). If a configuration file
+is not found or specified, related diagnostics are skipped.
+
+Consult the output with the `--help` flag for all available options.
+
+[[admin-guide-diagnostics-tool-server-environment]]
+== Running Diagnostics in a Server Environment
+
+Master and node diagnostics are most useful in a specific target environment,
+which is a deployment of RPMs with Ansible deployment logic. This provides some
+diagnostic benefits:
+
+* Master and node configuration is based on a configuration file in a standard
+location.
+* Systemd units are configured to manage the server(s).
+* All components log to journald.
+
+Having configuration files where Ansible places them means that you will
+generally not need to specify where to find them. Running `oc adm diagnostics`
+without flags will look for master and node configurations in the standard
+locations and use them if found; this should make the Ansible-installed use case
+as simple as possible. Also, it is easy to specify configuration files that are
+not in the expected locations:
+
+----
+$ oc adm diagnostics --master-config=<file_path> --node-config=<file_path>
+----
+
+Systemd units and logs entries in journald are necessary for the current log
+diagnostic logic. For other deployment types, logs may be going into files, to
+stdout, or may combine node and master. At this time, for these situations, log
+diagnostics are not able to work properly and will be skipped.
+
+[[admin-guide-diagnostics-tool-client-environment]]
+== Running Diagnostics in a Client Environment
+
+You may have access as an ordinary user, and/or as a *cluster-admin* user,
+and/or may be running on a host where {product-title} master or node servers are
+operating. The diagnostics attempt to use as much access as the user has
+available.
+
+A client with ordinary access should be able to diagnose its connection
+to the master and run a diagnostic pod. If multiple users or masters are
+configured, connections will be tested for all, but the diagnostic pod
+only runs against the current user, server, or project.
+
+A client with *cluster-admin* access available (for any user, but only the
+current master) should be able to diagnose the status of infrastructure such as
+nodes, registry, and router. In each case, running `oc adm diagnostics` looks
+for the client configuration in its standard location and uses it if available.

--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -25,7 +25,6 @@ will work through some scenarios that, hopefully, will cover the
 majority of cases.  If your problem is not covered, the tools and
 concepts that are introduced should help guide debugging efforts.
 
-
 == Nomenclature
 
 Cluster:: The set of machines in the cluster.  _i.e._ the Masters
@@ -55,6 +54,7 @@ network.  Only reachable from the client nodes.
 The following diagram shows all of the pieces involved with external access.
 
 image::Topologies.png["External Access to a Pod"]
+
 
 == Debugging External Access to an HTTP Service
 


### PR DESCRIPTION
Continues https://github.com/openshift/openshift-docs/pull/1383

- Moved content out of the Troubleshooting OpenShift SDN page and into the existing Diagnostics Tool page (introduced in 3.3)
- Updated outdated `openshift ex diagnostics` references and replaced with `oc adm diagnostics`

@sosiouxme @adellape PTAL

