### PR TITLE
Remove outdated example of oc process

### DIFF
--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -673,9 +673,6 @@
 
   // Convert template.json into resource list
   $ cat template.json | oc process -f -
-
-  // Combine multiple templates into single resource list
-  $ cat template.json second_template.json | oc process -f -
 ----
 ====
 


### PR DESCRIPTION
The feature has been removed in https://github.com/openshift/origin/commit/6eaf7a2690b72c352b417c62209911e462b96b9c (OpenShift 1.3+)

Complements #3303.

@bparees FYI
@openshift/team-documentation PTAL