### PR TITLE
Removes git pre-req

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -607,12 +607,6 @@ connections, and is only required if you have clustered etcd.
 * {product-title} internal DNS cannot be received over SDN. Depending on the detected values of `*openshift_facts*`, or if the `*openshift_ip*` and `*openshift_public_ip*` values are overridden, it will be the computed value of `*openshift_ip*`. For non-cloud deployments, this will default to the IP address associated with the default route on the master host. For cloud deployments, it will default to the IP address associated with the first internal interface as defined by the cloud metadata.
 * The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed values of `*openshift_hostname*` and `*openshift_public_hostname*`.
 
-[[prereq-git]]
-=== Git Access
-
-You must have either Internet access and a GitHub account, or read and write
-access to an internal, HTTP-based Git server.
-
 [[prereq-persistent-storage]]
 === Persistent Storage
 


### PR DESCRIPTION
* Despite installing openshift multiple times, git has never been a
  requirement
* This would be a requirement for the development side, but not for
  installing a cluster.
* Therefore, I think it should be removed
* closes openshift/openshift-docs#3133