### PR TITLE
EgressNetworkPolicy clarifications

### DIFF
--- a/admin_guide/managing_pods.adoc
+++ b/admin_guide/managing_pods.adoc
@@ -254,7 +254,7 @@ address.
 === Limiting Pod Access with Egress Firewall
 
 As an {product-title} cluster administrator, you can use egress policy to limit
-the addresses that some or all pods can access from within the cluster, so that:
+the external addresses that some or all pods can access from within the cluster, so that:
 
 - A pod can only talk to internal hosts, and cannot initiate connections to the
 public Internet.
@@ -278,22 +278,19 @@ xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[*ovs-
 ====
 
 Project administrators can neither create `*EgressNetworkPolicy*` objects, nor
-edit the ones you create in their project.
+edit the ones you create in their project. There are also several other
+restrictions on where `*EgressNetworkPolicy*` may be created:
 
-The `default` project (and any other global namespace) cannot have egress
-policy.
+. The `default` project (and any other project that has been made global via
+`oadm pod-network make-projects-global`) cannot have egress policy.
 
-[NOTE]
-====
-If you merge two projects together (via `oadm pod-network join-projects`),
+. If you merge two projects together (via `oadm pod-network join-projects`),
 then you cannot use egress policy in _any_ of the joined projects.
 
-If you make a project global (via `oadm pod-network make-projects-global`),
-then it cannot have an `*EgressNetworkPolicy*`.
+. No project may have more than one egress policy object.
 
-If an allowed network overlaps with a denied network, then the rules are
-checked in order, and the first one that matches is enforced.
-====
+Violating any of these restrictions will result in broken egress policy for the
+project, and may cause all external network traffic to be dropped.
 
 [[admin-guide-config-pod-access]]
 ==== Configuring Pod Access Limits
@@ -340,8 +337,14 @@ To configure pod access limits:
 ----
 +
 When the example above is added in a project, it allows traffic to `1.2.3.0/24`,
-but denies access to all other external IP addresses. This would not affect
-traffic to other pods.
+but denies access to all other external IP addresses. (Traffic to other pods is
+not affected, because the policy only applies to _external_ traffic.)
+
+Note that the rules in an `*EgressNetworkPolicy*` are checked in order, and the
+first one that matches takes effect. So if the two rules in the above example
+were swapped, then traffic would *not* be allowed to `1.2.3.0/24`, because the
+`0.0.0.0/0` rule would be checked first, and it would match and deny all
+traffic.
 
 [[admin-guide-manage-pods-limit-bandwidth]]
 == Limiting the Bandwidth Available to Pods


### PR DESCRIPTION
Some clarifications based on problems @weliang1 ran into while testing:
- be more explicit that it only affects external traffic, not pod-to-pod traffic
- be more explicit about rule ordering
- mention that you can only have a single EgressNetworkPolicy in a namespace
- mention that breaking the rules may result in all egress traffic from the namespace being dropped
- merge together the redundant warnings about global namespaces
