### PR TITLE
Removing vsphere from dynamic provisioning

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -66,11 +66,6 @@ the master node. Do this by setting the
 |link:https://access.redhat.com/documentation/en/red-hat-gluster-storage/3.1/single/container-native-storage-for-openshift-container-platform/[Container Native Storage with GlusterFS]
 |Container Native Storage (CNS) utilizes heketi to manage Gluster Storage
 
-|link:https://www.vmware.com/support/vsphere.html[VMWare vSphere]
-|`kubernetes.io/vsphere-volume`
-|link:http://kubernetes.io/docs/getting-started-guides/vsphere/[Getting Started with vSphere and Kubernetes]
-|
-
 |===
 
 
@@ -229,24 +224,6 @@ parameters:
 <3> Gluster REST service/Heketi user who has access to create volumes in the Gluster Trusted Pool.
 <4> Gluster REST service/Heketi user's password which will be used for authentication to the REST server. This parameter is deprecated in favor of secretNamespace + secretName.
 <5> Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both secretNamespace and secretName are omitted.
-====
-
-[[vsphere]]
-=== vSphere
-
-.vsphere-storageclass.yaml
-====
-[source,yaml]
-----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
-metadata:
-  name: slow
-provisioner: kubernetes.io/vsphere-volume
-parameters:
-  diskformat: thin <1>
-----
-<1>  diskformat: thin, zeroedthick and eagerzeroedthick. See vSphere docs for details. Default: "thin"
 ====
 
 [[moreinfo]]


### PR DESCRIPTION
This PR depends on the [PR](https://github.com/openshift/openshift-docs/pull/3316) that must be merged before this one.

@childsb @screeley44  @openshift/team-documentation PTAL

Target versions: OpenShift 3.4 and above.