### PR TITLE
Use latest epel-release package in documentation

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -135,7 +135,7 @@ package source for Ansible:
 +
 ----
 # yum -y install \
-    https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ----
 
 . Disable the EPEL repository globally so that it is not accidentally used during


### PR DESCRIPTION
Using specific epel-release versions will demand maintenance in the documentation every time a new release of epel-release is launched. The current release is 7-8, but the documentation refer to 7-5, which does not exist in the repo and is broken.

This commits fix this problem by using the epel-release latest version provided for RHEL 7. This package name will not change when the epel release is updated.