### PR TITLE
Updates for OCP 3.4 cluster upgrades (automated + manual)

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -38,8 +38,8 @@ Distros: openshift-enterprise,openshift-dedicated
 Topics:
   - Name: Overview
     File: index
-  - Name: OpenShift Container Platform 3.3 Release Notes
-    File: ocp_3_3_release_notes
+  - Name: OpenShift Container Platform 3.4 Release Notes
+    File: ocp_3_4_release_notes
     Distros: openshift-enterprise
   - Name: Latest Product Updates
     File: osd_latest_product_updates

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -2,8 +2,8 @@
 = Disconnected Installation
 {product-author}
 {product-version}
-:latest-tag: v3.3.1.5
-:latest-int-tag: 3.3.1
+:latest-tag: v3.4.0.37
+:latest-int-tag: 3.4.0
 :data-uri:
 :icons:
 :experimental:

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -2,7 +2,7 @@
 = Performing Automated In-place Cluster Upgrades
 {product-author}
 {product-version}
-:latest-tag: v3.3.1.5
+:latest-tag: v3.4.0.37
 :data-uri:
 :icons:
 :experimental:
@@ -28,8 +28,8 @@ endif::[]
 The automated upgrade performs the following steps for you:
 
 * Applies the latest configuration.
-* Upgrades and restart master services.
-* Upgrades and restart node services.
+* Upgrades master and etcd components and restarts services.
+* Upgrades node components and restarts services.
 * Applies the latest cluster policies.
 * Updates the default router if one exists.
 * Updates the default registry if one exists.
@@ -66,7 +66,7 @@ To upgrade from OpenShift Origin 1.0 to 1.1, run the following playbook:
 
 ----
 # ansible-playbook \
-    [-i </path/to/inventory/file>] \
+    -i </path/to/inventory/file> \
     playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
 ----
 
@@ -89,7 +89,7 @@ run the following playbook:
 
 ----
 # ansible-playbook \
-    [-i </path/to/inventory/file>] \
+    -i </path/to/inventory/file> \
     playbooks/byo/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
 ----
 
@@ -110,32 +110,47 @@ ifdef::openshift-enterprise[]
 
 [IMPORTANT]
 ====
-Before upgrading your cluster to {product-title} 3.3, the cluster must be
+Before upgrading your cluster to {product-title} 3.4, the cluster must be
 already upgraded to the
-link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-32-asynchronous-errata-updates[latest asynchronous release of version 3.2]. Cluster upgrades cannot span more than one
-minor version at a time, so if your cluster is at version 3.0 or 3.1, you must
-first upgrade incrementally (e.g., 3.0 to 3.1, then 3.1 or 3.2).
+link:https://docs.openshift.com/container-platform/3.3/release_notes/ocp_3_3_release_notes.html#ocp-33-asynchronous-errata-updates[latest asynchronous release of version 3.3]. Cluster upgrades cannot span more than one
+minor version at a time, so if your cluster is at a version earlier than 3.3,
+you must first upgrade incrementally (e.g., 3.1 to 3.2, then 3.2 to 3.3).
 ====
 
 To prepare for an automated upgrade:
 
-. If you are upgrading from version 3.2 to 3.3, manually disable the 3.2 channel and enable the 3.3 channel on each master and node host:
+. If you are upgrading from {product-title} 3.3 to 3.4, manually disable the 3.3
+channel and enable the 3.4 channel on each master and node host:
 +
 ----
-# subscription-manager repos --disable="rhel-7-server-ose-3.2-rpms" \
-    --enable="rhel-7-server-ose-3.3-rpms"\
+# subscription-manager repos --disable="rhel-7-server-ose-3.3-rpms" \
+    --enable="rhel-7-server-ose-3.4-rpms"\
     --enable="rhel-7-server-extras-rpms"
 # yum clean all
 ----
+
 . For any upgrade path, always ensure that you have the latest version of the
-*atomic-openshift-utils* package, which should also update the
+*atomic-openshift-utils* package on each RHEL 7 system, which also updates the
 *openshift-ansible-** packages:
 +
 ----
 # yum update atomic-openshift-utils
 ----
-. Lastly, you must be logged in as a cluster administrative user on the master
-host for the upgrade to succeed:
+
+. Install or update to the following latest available **-excluder* packages on
+each RHEL 7 system, which helps ensure your systems stay on the correct versions
+of *atomic-openshift* and *docker* packages when you are not trying to upgrade,
+according to the {product-title} version:
++
+----
+# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
+----
++
+These packages add entries to the `exclude` directive in the host's
+*_/etc/yum.conf_* file.
+
+. You must be logged in as a cluster administrative user on the master host for
+the upgrade to succeed:
 +
 ----
 $ oc login
@@ -159,8 +174,8 @@ you should have an installation configuration file located at
 start an upgrade.
 
 The installer supports upgrading between minor versions of {product-title}
-(one minor version at a time, e.g., 3.2 to 3.3) as well as between
-xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-asynchronous-errata-updates[asynchronous errata updates] within a minor version (e.g., 3.3.z).
+(one minor version at a time, e.g., 3.3 to 3.4) as well as between
+xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-asynchronous-errata-updates[asynchronous errata updates] within a minor version (e.g., 3.4.z).
 
 If you have an older format installation configuration file in
 *_~/.config/openshift/installer.cfg.yml_* from an installation of a previous
@@ -172,6 +187,14 @@ xref:../../install_config/install/quick_install.adoc#defining-an-installation-co
 To start an upgrade with the quick installer:
 
 . Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
+
+. Run the following command on each host to remove the *atomic-openshift* packages
+from the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder unexclude
+----
+
 . Run the installer with the `upgrade` subcommand:
 +
 ----
@@ -179,10 +202,18 @@ To start an upgrade with the quick installer:
 ----
 . Then, follow the on-screen instructions to upgrade to the latest release.
 // tag::automated_upgrade_after_reboot[]
-. When the upgrade finishes, a recommendation will be printed to reboot all hosts.
-After rebooting, if there are no additional features enabled, you can
-xref:verifying-the-upgrade[verify the upgrade]. Otherwise, the next step depends
-on what features are enabled.
+. Run the following command on each host to add the *atomic-openshift* packages
+back to the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder exclude
+----
+
+. After all master and node upgrades have completed, a recommendation will be
+printed to reboot all hosts. After rebooting, if there are no additional
+features enabled, you can xref:verifying-the-upgrade[verify the upgrade].
+Otherwise, the next step depends on what additional features have you previously
+enabled.
 +
 [cols="1,4"]
 |===
@@ -197,66 +228,178 @@ on what features are enabled.
 // end::automated_upgrade_after_reboot[]
 
 [[running-the-upgrade-playbook-directly]]
-== Running the Upgrade Playbook Directly
+== Running Upgrade Playbooks Directly
 
-You can run the automated upgrade playbook using Ansible directly, similar
-to the advanced installation method, if you have an inventory file.
+You can run automated upgrade playbooks using Ansible directly, similar to the
+advanced installation method, if you have an inventory file. Playbooks can be
+run using the `ansible-playbook` command.
 
-The same *_v3_3_* upgrade playbook can be used to upgrade either of the
-following to the latest 3.3 release:
+The same *_v3_4_* upgrade playbooks can be used for either of the following
+scenarios:
 
-- xref:upgrading-to-ocp-3-3[Existing {product-title} 3.2 clusters]
-- xref:upgrading-to-ocp-3-3-asynchronous-releases[Existing {product-title} 3.3 clusters]
+- Upgrading existing {product-title} 3.3 clusters to 3.4
+- Upgrading existing {product-title} 3.4 clusters to the latest
+xref:../../release_notes/ocp_3_4_release_notes.html#ocp-34-asynchronous-errata-updates[asynchronous
+errata updates]
 
-[[upgrading-to-ocp-3-3]]
-=== Upgrading to {product-title} 3.3
+[[upgrading-control-plane-nodes-separate-phases]]
+=== Upgrading the Control Plane and Nodes in Separate Phases
 
-To run an upgrade from {product-title} 3.2 to 3.3:
+An {product-title} cluster can be upgraded in one or more phases. You can choose
+whether to upgrade all hosts in one phase by running a single Ansible playbook,
+or upgrade the _control plane_ (master components) and nodes in multiple phases
+using separate playbooks.
+
+[NOTE]
+====
+Instructions on the full upgrade process and when to call these playbooks are
+described in xref:upgrading-to-ocp-3-4[Upgrading to the Latest {product-title}
+3.4 Release].
+====
+
+When upgrading in separate phases, the control plane phase includes upgrading:
+
+- etcd
+- master components
+- Docker on any stand-alone etcd hosts
+
+It does does not include:
+
+- node services running on masters
+- Docker running on masters
+- node services running on stand-alone nodes
+
+When upgrading only the nodes, the control plane must already be upgraded. The
+node phase includes upgrading:
+
+- node services running on masters and stand-alone nodes
+- Docker running on masters and nodes
+
+[[customizing-node-upgrades]]
+=== Customizing Node Upgrades
+
+Whether upgrading in a single or multiple phases, you can customize how the node
+portion of the upgrade progresses by passing certain Ansible variables to an
+upgrade playbook using the `-e` option.
+
+[NOTE]
+====
+Instructions on the full upgrade process and when to call these playbooks are
+described in xref:upgrading-to-ocp-3-4[Upgrading to the Latest {product-title}
+3.4 Release].
+====
+
+The `openshift_upgrade_nodes_serial` variable can be set to an integer or
+percentage to control how many node hosts are upgraded at the same time. The
+default is `1`, upgrading nodes one at a time.
+
+For example, to upgrade 20 percent of the total number of detected nodes at a
+time:
+
+----
+$ ansible-playbook -i <path/to/inventory/file> \
+    </path/to/upgrade/playbook> \
+    -e openshift_upgrade_nodes_serial="20%"
+----
+
+The `openshift_upgrade_nodes_label` variable allows you to specify that only
+nodes with a certain label are upgraded. This can also be combined with the
+`openshift_upgrade_nodes_serial` variable.
+
+For example, to only upgrade nodes in the *group1* region, two at a time:
+
+----
+$ ansible-playbook -i <path/to/inventory/file> \
+    </path/to/upgrade/playbook> \
+    -e openshift_upgrade_nodes_serial="2" \
+    -e openshift_upgrade_nodes_label="region=group1"
+----
+
+See xref:../../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[Manging
+Nodes] for more on node labels.
+
+[[upgrading-to-ocp-3-4]]
+=== Upgrading to the Latest {product-title} 3.4 Release
+
+To upgrade an existing {product-title} 3.3 or 3.4 cluster to the latest 3.4
+release:
 
 . Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-. Ensure the `*deployment_type*` parameter in your inventory file is set to
+
+. Run the following command on each host to remove the *atomic-openshift* packages
+from the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder unexclude
+----
+
+. Ensure the `deployment_type` parameter in your inventory file is set to
 `openshift-enterprise`.
+
 . If you have multiple masters configured and want to enable rolling, full system
-restarts of the hosts, you can set the `*openshift_rolling_restart_mode*`
+restarts of the hosts, you can set the `openshift_rolling_restart_mode`
 parameter in your inventory file to `system`. Otherwise, the default value
 *services* performs rolling service restarts on HA masters, but does not reboot
 the systems. See
 xref:../install/advanced_install.adoc#configuring-cluster-variables[Configuring
 Cluster Variables] for details.
-. Run the *_v3_3_* upgrade playbook. If your inventory file is located somewhere
-other than the default *_/etc/ansible/hosts_*, add the `-i` flag to specify the
-location. If you previously used the `atomic-openshift-installer` command to run
-your installation, you can check *_~/.config/openshift/hosts_* (previously
-located at *_~/.config/openshift/.ansible/hosts_*) for the last inventory file
-that was used, if needed.
+
+. At this point, you can choose to run the upgrade in a single or multiple phases.
+See xref:upgrading-control-plane-nodes-separate-phases[Upgrading the Control
+Plane and Nodes in Separate Phases] for more details which components are
+upgraded in each phase.
 +
-----
-# ansible-playbook [-i </path/to/inventory/file>] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
-----
-include::install_config/upgrading/automated_upgrades.adoc[tag=automated_upgrade_after_reboot]
-
-[[upgrading-to-ocp-3-3-asynchronous-releases]]
-=== Upgrading to {product-title} 3.3 Asynchronous Releases
-
-To apply
-xref:../../release_notes/ocp_3_3_release_notes.html#ocp-33-asynchronous-errata-updates[asynchronous errata updates] to an existing {product-title} 3.3 cluster:
-
-
-. Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-. Run the *_v3_3_* upgrade playbook (the same playbook that is used for
-xref:upgrading-to-ocp-3-3[upgrading from {product-title} 3.2 to 3.3]). If your
-inventory file is located somewhere other than the default
-*_/etc/ansible/hosts_*, add the `-i` flag to specify the location. If you
+If your inventory file is located somewhere other than the default
+*_/etc/ansible/hosts_*, add the `-i` flag to specify its location. If you
 previously used the `atomic-openshift-installer` command to run your
-installation, you can check *_~/.config/openshift/hosts_* (previously located at
-*_~/.config/openshift/.ansible/hosts_*) for the last inventory file that was
-used, if needed.
+installation, you can check *_~/.config/openshift/hosts_* for the last inventory
+file that was used, if needed.
++
+[NOTE]
+====
+You can add `--tags pre_upgrade` to the following `ansible-playbook` commands to
+run the pre-upgrade checks for the playbook. This is a dry-run option that
+preforms all pre-upgrade checks without actually upgrading any hosts, and
+reports any problems found.
+====
++
+*Option A) Upgrade control plane and nodes in a single phase.*
++
+Run the *_upgrade.yml_* playbook to upgrade the cluster in a single phase using
+one playbook; the control plane is still upgraded first, then nodes in-place:
 +
 ----
-# ansible-playbook [-i </path/to/inventory/file>] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
+# ansible-playbook -i </path/to/inventory/file> \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml \
+    [-e <customized_node_upgrade_variables>] <1>
 ----
+<1> See xref:customizing-node-upgrades[Customizing Node Upgrades] for any desired
+`<customized_node_upgrade_variables>`.
++
+*Option B) Upgrade the control plane and nodes in separate phases.*
+
+.. To upgrade only the control plane, run the *_upgrade_control_plane.yaml_*
+playbook:
++
+----
+# ansible-playbook -i </path/to/inventory/file> \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+----
+
+.. To upgrade only the nodes, run the *_upgrade_nodes.yaml_* playbook:
++
+----
+# ansible-playbook -i </path/to/inventory/file> \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml \
+    [-e <customized_node_upgrade_variables>] <1>
+----
+<1> See xref:customizing-node-upgrades[Customizing Node Upgrades] for any desired
+`<customized_node_upgrade_variables>`.
++
+If you are upgrading the nodes in groups as described in
+xref:customizing-node-upgrades[Customizing Node Upgrades], continue invoking the
+*_upgrade_nodes.yml_* playbook until all nodes have been successfully upgraded.
+
 include::install_config/upgrading/automated_upgrades.adoc[tag=automated_upgrade_after_reboot]
 endif::[]
 
@@ -327,7 +470,7 @@ endif::[]
 common issues:
 +
 ----
-# oadm diagnostics
+# oc adm diagnostics
 ...
 [Note] Summary of diagnostics execution:
 [Note] Completed with no errors or warnings seen.

--- a/install_config/upgrading/blue_green_deployments.adoc
+++ b/install_config/upgrading/blue_green_deployments.adoc
@@ -15,26 +15,32 @@ toc::[]
 
 [NOTE]
 ====
-This topic serves as an alternative node upgrade method to the approach in
-xref:../../install_config/upgrading/manual_upgrades.adoc#upgrading-nodes[Manual In-place Upgrades].
+This topic serves as an alternative approach for node upgrades to the in-place
+upgrade method.
 ====
 
-Blue-green deployments are a proven approach to reducing downtime caused while
-upgrading an environment. This is done by creating a parallel environment on
-which the new deployment can be installed. If a problem is detected, and after
-the new deployment is verified, traffic can be switched over with the option to
-rollback.
+The
+xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[blue-green deployment] upgrade method follows a similar flow to the in-place method:
+masters and etcd servers are still upgraded first, however a parallel
+environment is created for new nodes instead of upgrading them in-place.
 
-While blue-green is a valid strategy for deploying just about any software,
-there are always trade-offs. Not all environments have the same uptime
+This method allows administrators to switch traffic from the old set of nodes
+(e.g., the "blue" deployment) to the new set (e.g., the "green" deployment)
+after the new deployment has been verified. If a problem is detected, it is also
+then easy to rollback to the old deployment quickly.
+
+While blue-green is a proven and valid strategy for deploying just about any
+software, there are always trade-offs. Not all environments have the same uptime
 requirements or the resources to properly perform blue-green deployments. In an
 {product-title} environment, the most suitable candidate for blue-green
 deployments are the nodes. All user processes run on these systems and even
 critical pieces of {product-title} infrastructure are self-hosted there. Uptime
 is most important for these workloads and the additional complexity of
-blue-green deployments can be justified. The exact implementation of this
-approach varies based on your requirements. Often the main challenge is having the
-excess capacity to facilitate such an approach.
+blue-green deployments can be justified.
+
+The exact implementation of this approach varies based on your requirements.
+Often the main challenge is having the excess capacity to facilitate such an
+approach.
 
 ifdef::openshift-enterprise[]
 Another lesser challenge is that the administrator must temporarily share the

--- a/install_config/upgrading/index.adoc
+++ b/install_config/upgrading/index.adoc
@@ -42,7 +42,11 @@ blue-green deployment method.
 **In-place Upgrades**
 
 With in-place upgrades, the cluster upgrade is performed on all hosts in a
-single cluster. If you installed using the
+single, running cluster: first masters and then nodes. Pods are evacuated off of
+nodes and recreated on other running nodes before a node upgrade begins; this
+helps reduce downtime of user applications.
+
+If you installed using the
 ifdef::openshift-enterprise[]
 xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] or
 endif::[]
@@ -55,8 +59,12 @@ xref:../../install_config/upgrading/manual_upgrades.adoc#install-config-upgradin
 
 **Blue-green Deployments**
 
-With
-xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[blue-green deployments], you can reduce downtime caused while upgrading an environment by
-creating a parallel environment on which the new deployment can be installed. If
-a problem is detected, and after the new deployment is verified, traffic can be
-switched over with the option to rollback.
+The
+xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[blue-green deployment] upgrade method follows a similar flow to the in-place method:
+masters and etcd servers are still upgraded first, however a parallel
+environment is created for new nodes instead of upgrading them in-place.
+
+This method allows administrators to switch traffic from the old set of nodes
+(e.g., the "blue" deployment) to the new set (e.g., the "green" deployment)
+after the new deployment has been verified. If a problem is detected, it is also
+then easy to rollback to the old deployment quickly.

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -2,7 +2,7 @@
 = Performing Manual In-place Cluster Upgrades
 {product-author}
 {product-version}
-:latest-tag: v3.3.1.5
+:latest-tag: v3.4.0.37
 :data-uri:
 :icons:
 :experimental:
@@ -38,22 +38,22 @@ upgrade.
 
 [NOTE]
 ====
-Before upgrading your cluster to {product-title} 3.3, the cluster must be
+Before upgrading your cluster to {product-title} 3.4, the cluster must be
 already upgraded to the
-link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-32-asynchronous-errata-updates[latest asynchronous release of version 3.2]. Cluster upgrades cannot span more than one
-minor version at a time, so if your cluster is at version 3.0 or 3.1, you must
-first upgrade incrementally (e.g., 3.0 to 3.1, then 3.1 or 3.2).
+link:https://docs.openshift.com/container-platform/3.3/release_notes/ocp_3_3_release_notes.html#ocp-33-asynchronous-errata-updates[latest asynchronous release of version 3.3]. Cluster upgrades cannot span more than one
+minor version at a time, so if your cluster is at a version earlier than 3.3,
+you must first upgrade incrementally (e.g., 3.1 to 3.2, then 3.2 to 3.3).
 ====
 
 To prepare for a manual upgrade, follow these steps:
 
 ifdef::openshift-enterprise[]
-. If you are upgrading from version 3.2 to 3.3, manually disable the 3.2 channel
-and enable the 3.3 channel on each host:
+. If you are upgrading from {product-title} 3.3 to 3.4, manually disable the 3.3
+channel and enable the 3.4 channel on each host:
 +
 ----
-# subscription-manager repos --disable="rhel-7-server-ose-3.2-rpms" \
-    --enable="rhel-7-server-ose-3.3-rpms" \
+# subscription-manager repos --disable="rhel-7-server-ose-3.3-rpms" \
+    --enable="rhel-7-server-ose-3.4-rpms" \
     --enable="rhel-7-server-extras-rpms"
 ----
 +
@@ -72,18 +72,34 @@ that will be used in later sections:
 # yum install atomic-openshift-utils
 ----
 
-. Create an *etcd* backup on each master. The *etcd* package is required, even if
-using embedded etcd, for access to the `etcdctl` command to make the backup. The
-package is installed by default for RHEL Atomic Host 7 systems. If the master is
-a RHEL 7 system, ensure the package is installed:
+. Install or update to the following latest available **-excluder* packages on
+each RHEL 7 system, which helps ensure your systems stay on the correct versions
+of *atomic-openshift* and *docker* packages when you are not trying to upgrade,
+according to the {product-title} version:
 +
+----
+# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
+----
++
+These packages add entries to the `exclude` directive in the host's
+*_/etc/yum.conf_* file.
+
+. Create an *etcd* backup on each master. The *etcd* package is required, even if
+using embedded etcd, for access to the `etcdctl` command to make the backup.
++
+[NOTE]
+====
+The *etcd* package is installed by default for RHEL Atomic Host 7 systems. If
+the master is a RHEL 7 system and *etcd* is not already installed, install it
+now:
+
 ----
 # yum install etcd
 ----
-+
-Then, create the backup:
-+
 ====
++
+To create the backup, run:
++
 ----
 # ETCD_DATA_DIR=/var/lib/origin/openshift.local.etcd <1>
 # etcdctl backup \
@@ -95,7 +111,6 @@ For external etcd, use *_/var/lib/etcd_* instead.
 <2> Use the date of the backup, or some unique identifier, for `<date>`.
 The command will not make a backup if the `--backup-dir` location
 already exists.
-====
 
 . For any upgrade path, ensure that you are running the latest kernel on
 each RHEL 7 system:
@@ -106,9 +121,53 @@ each RHEL 7 system:
 
 [[upgrading-masters]]
 == Upgrading Master Components
-ifdef::openshift-origin[]
-Upgrade your masters first:
 
+Before upgrading any stand-alone nodes, upgrade the master components (which
+provide the _control plane_ for the cluster).
+
+. Run the following command on each master to remove the *atomic-openshift*
+packages from the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder unexclude
+----
+
+. Upgrade *etcd* on all master hosts and any external etcd hosts.
+
+.. For RHEL 7 systems using the RPM-based method:
+
+... Upgrade the *etcd* package:
++
+----
+# yum update etcd
+----
+
+... Restart the *etcd* service and review the logs to ensure it restarts
+successfully:
++
+----
+# systemctl restart etcd
+# journalctl -r -u etcd
+----
+
+.. For RHEL Atomic Host 7 systems and RHEL 7 systems using the containerized
+method:
+
+... Pull the latest *rhel7/etcd* image:
++
+----
+# docker pull registry.access.redhat.com/rhel7/etcd
+----
+
+... Restart the *etcd_container* service and review the logs to ensure it restarts
+successfully:
++
+----
+# systemctl restart etcd_container
+# journalctl -r -u etcd_container
+----
+
+ifdef::openshift-origin[]
 . On each master host, upgrade the *origin-master* package:
 +
 ----
@@ -183,11 +242,10 @@ configured as part of the OpenShift SDN, restart the *origin-node* and
 # journalctl -r -u openvswitch
 # journalctl -r -u origin-node
 ----
+
 endif::[]
 ifdef::openshift-enterprise[]
-Upgrade your master hosts first:
-
-. Upgrade the *atomic-openshift* packages or related images.
+. On each master host, upgrade the *atomic-openshift* packages or related images.
 
 .. For masters using the RPM-based method on a RHEL 7 system, upgrade all installed
 *atomic-openshift* packages:
@@ -200,11 +258,13 @@ Upgrade your master hosts first:
 system, set the `*IMAGE_VERSION*` parameter to the version you are upgrading to
 in the following files:
 +
+--
 - *_/etc/sysconfig/atomic-openshift-master_* (single master clusters only)
 - *_/etc/sysconfig/atomic-openshift-master-controllers_* (multi-master clusters only)
 - *_/etc/sysconfig/atomic-openshift-master-api_* (multi-master clusters only)
 - *_/etc/sysconfig/atomic-openshift-node_*
 - *_/etc/sysconfig/atomic-openshift-openvswitch_*
+--
 +
 For example:
 +
@@ -213,40 +273,6 @@ IMAGE_VERSION=<tag>
 ----
 +
 Replace `<tag>` with `{latest-tag}` for the latest version.
-
-. In {product-title} 3.3, protocol buffers are used by default for internal
-communications between node, masters, and controllers. To configure this, the
-following stanzas must be altered in the *_/etc/origin/master-config.yaml_*
-file on each master:
-+
-====
-----
-masterClients:
-  externalKubernetesClientConnectionOverrides:
-    acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
-    contentType: application/vnd.kubernetes.protobuf
-    burst: 400
-    qps: 200
-  externalKubernetesKubeConfig: ""
-  openshiftLoopbackClientConnectionOverrides:
-    acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
-    contentType: application/vnd.kubernetes.protobuf
-    burst: 600
-    qps: 300
-  openshiftLoopbackKubeConfig: openshift-master.kubeconfig
-----
-====
-+
-For more information on protocol buffers, see
-link:https://developers.google.com/protocol-buffers/docs/overview[https://developers.google.com/protocol-buffers/docs/overview].
-
-. In {product-title} 3.3, the
-`*kubernetesMasterConfig.admissionConfig.pluginConfig*` parameter in the
-*_/etc/origin/master-config.yaml_* file is being deprecated. If you are
-upgrading from version 3.2 to 3.3 and this parameter is in use, see
-xref:../../architecture/additional_concepts/admission_controllers.adoc#admission-controllers-general-admission-rules[General
-Admission Rules] for guidance on moving and merging into
-`*admissionConfig.pluginConfig*`.
 
 . Restart the master service(s) on each master and review logs to ensure they
 restart successfully.
@@ -279,27 +305,10 @@ configured as part of the OpenShift SDN, restart the *atomic-openshift-node* and
 ----
 
 endif::[]
-
-Upgrade any external etcd hosts using the RPM-based method on a RHEL 7 system:
-
-. Upgrade the *etcd* package:
+. If you are performing a cluster upgrade that requires updating Docker to version
+1.12, you must also perform the following steps if you are not already on Docker
+1.12:
 +
-----
-# yum update etcd
-----
-
-. Restart the *etcd* service and review the logs to ensure it restarts
-successfully:
-+
-----
-# systemctl restart etcd
-# journalctl -r -u etcd
-----
-
-ifdef::openshift-origin[]
-If you are performing a cluster upgrade that requires updating Docker to version
-1.10, you must also perform the following steps if you are not already on Docker 1.10:
-
 [IMPORTANT]
 ====
 The node component on masters is set by default to unschedulable status during
@@ -311,19 +320,9 @@ steps described in xref:upgrading-nodes[Upgrading Nodes] when you get to that
 section for those hosts as well.
 ====
 
-. Run the following script on each master and external etcd host to remove all
-containers and images, which is required to avoid a long upgrade process for
-older images after Docker is updated. Containers and images for pods backed by
-replication controllers will be recreated automatically:
-+
-----
-# chmod u+x /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
-# /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
-----
+.. Upgrade the *docker* package.
 
-. Upgrade Docker.
-
-.. For RHEL 7 systems:
+... For RHEL 7 systems:
 +
 ----
 # yum update docker
@@ -337,33 +336,44 @@ successfully:
 # journalctl -r -u docker
 ----
 
-.. For RHEL Atomic Host 7 systems, upgrade to the latest Atomic tree if one is
+... For RHEL Atomic Host 7 systems, upgrade to the latest Atomic tree if one is
 available:
 +
 [NOTE]
 ====
-If upgrading to RHEL Atomic Host 7.2.5, this upgrades Docker to version 1.10.
-See the
-link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-3-2-1-1-enhancements[OpenShift
-Enterprise 3.2.1.1 release notes] for details and known issues.
+If upgrading to RHEL Atomic Host 7.3.2, this upgrades Docker to version 1.12.
 ====
 +
 ----
 # atomic host upgrade
 ----
-+
-After the upgrade is completed and prepared for the next boot, reboot the host
+
+.. After the upgrade is completed and prepared for the next boot, reboot the host
 and ensure the *docker* service starts successfully:
 +
 ----
 # systemctl reboot
 # journalctl -r -u docker
 ----
-endif::[]
 
-During the upgrade, it can sometimes be useful to take a master out of rotation
-since some DNS client libraries will not properly to the other masters for
-cluster DNS. In addition to stopping the master and controller services, you
+.. Remove the following file, which is no longer required:
++
+----
+# rm /etc/systemd/system/docker.service.d/docker-sdn-ovs.conf
+----
+
+. Run the following command on each master to add the *atomic-openshift* packages
+back to the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder exclude
+----
+
+[NOTE]
+====
+During the cluster upgrade, it can sometimes be useful to take a master out of
+rotation since some DNS client libraries will not properly to the other masters
+for cluster DNS. In addition to stopping the master and controller services, you
 can remove the EndPoint from the Kubernetes service's `*subsets.addresses*`.
 
 ----
@@ -372,6 +382,7 @@ $ oc edit ep/kubernetes -n default
 
 When the master is restarted, the Kubernetes service will be automatically
 updated.
+====
 
 [[updating-policy-definitions]]
 == Updating Policy Definitions
@@ -396,7 +407,6 @@ any new or required permissions during upgrades.
 This command outputs a list of roles that are out of date and their new proposed
 values. For example:
 
-====
 ----
 # oadm policy reconcile-cluster-roles
 apiVersion: v1
@@ -412,7 +422,6 @@ items:
     - builds/custom
 ...
 ----
-====
 
 [NOTE]
 ====
@@ -468,14 +477,22 @@ scales based on the number of services in the entire cluster.
 
 [NOTE]
 ====
-xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[Blue-green
-deployments] are another proven approach to reducing downtime caused while
-updating an environment.
+You can alternatively use the
+xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[blue-green
+deployment] method at this point to create a parallel environment for new nodes
+instead of upgrading them in place.
 ====
 
 One at at time for each node that is not also a master, you must disable
 scheduling and evacuate its pods to other nodes, then upgrade packages and
 restart services.
+
+. Run the following command on each node to remove the *atomic-openshift*
+packages from the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder unexclude
+----
 
 . As a user with *cluster-admin* privileges, disable scheduling for the node:
 +
@@ -541,24 +558,6 @@ IMAGE_VERSION=<tag>
 +
 Replace `<tag>` with `{latest-tag}` for the latest version.
 
-. In {product-title} 3.3, protocol buffers are used by default for internal
-communications between node, masters, and controllers. To configure this, the
-following stanzas must be altered in the *_/etc/origin/node-config.yaml_*
-file on each node:
-+
-====
-----
-masterClientConnectionOverrides:
-  acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
-  contentType: application/vnd.kubernetes.protobuf
-  burst: 200
-  qps: 100
-----
-====
-+
-For more information on protocol buffers, see
-link:https://developers.google.com/protocol-buffers/docs/overview[https://developers.google.com/protocol-buffers/docs/overview].
-
 . Restart the *atomic-openshift-node* and *openvswitch* services and review the
 logs to ensure they restart successfully:
 +
@@ -570,21 +569,11 @@ logs to ensure they restart successfully:
 ----
 endif::[]
 
-ifdef::openshift-origin[]
 . If you are performing a cluster upgrade that requires updating Docker to version
-1.10, you must also perform the following steps if you are not already on Docker 1.10:
+1.12, you must also perform the following steps if you are not already on Docker
+1.12:
 
-.. Run the following script to remove all containers and images, which is required
-to avoid a long upgrade process for older images after Docker is updated.
-Containers and images for pods backed by replication controllers will be
-recreated automatically:
-+
-----
-# chmod u+x /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
-# /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
-----
-
-.. Upgrade Docker.
+.. Upgrade the *docker* package.
 
 ... For RHEL 7 systems:
 +
@@ -613,10 +602,7 @@ available:
 +
 [NOTE]
 ====
-If upgrading to RHEL Atomic Host 7.2.5, this upgrades Docker to version 1.10.
-See the
-link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-3-2-1-1-enhancements[OpenShift
-Enterprise 3.2.1.1 release notes] for details and known issues.
+If upgrading to RHEL Atomic Host 7.3.2, this upgrades Docker to version 1.10.
 ====
 +
 ----
@@ -630,7 +616,12 @@ and ensure the *docker* service starts successfully:
 # systemctl reboot
 # journalctl -r -u docker
 ----
-endif::[]
+
+.. Remove the following file, which is no longer required:
++
+----
+# rm /etc/systemd/system/docker.service.d/docker-sdn-ovs.conf
+----
 
 . Re-enable scheduling for the node:
 +
@@ -638,13 +629,19 @@ endif::[]
 # oadm manage-node <node> --schedulable
 ----
 
-. Repeat these steps on the next node, and continue repeating these steps until
-all nodes have been upgraded.
+. Run the following command on each node to add the *atomic-openshift* packages
+back to the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder exclude
+----
 
-After all nodes have been upgraded, as a user with *cluster-admin* privileges,
+. Repeat the previous steps on the next node, and continue repeating these steps
+until all nodes have been upgraded.
+
+. After all nodes have been upgraded, as a user with *cluster-admin* privileges,
 verify that all nodes are showing as *Ready*:
-
-====
++
 ----
 # oc get nodes
 NAME                        STATUS                     AGE
@@ -652,7 +649,6 @@ master.example.com          Ready,SchedulingDisabled   165d
 node1.example.com           Ready                      165d
 node2.example.com           Ready                      165d
 ----
-====
 
 [[upgrading-the-router]]
 == Upgrading the Router
@@ -664,15 +660,6 @@ the router image. To upgrade your router without disrupting services, you must
 have previously deployed a
 xref:../../admin_guide/high_availability.adoc#configuring-a-highly-available-routing-service[highly-available
 routing service].
-
-ifdef::openshift-enterprise[]
-[NOTE]
-====
-If you previously customized your HAProxy routing template, then, depending on
-the changes, additional steps may be required due to changes in the routing data
-structure starting in {product-title} 3.3. See xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-routing-data-structure-changes[Routing Data Structure Changes] in the {product-title} 3.3 Release Notes for details.
-====
-endif::[]
 
 ifdef::openshift-origin[]
 [IMPORTANT]
@@ -687,15 +674,12 @@ endif::[]
 Edit your router's deployment configuration. For example, if it has the default
 *router* name:
 
-====
 ----
 # oc edit dc/router
 ----
-====
 
 Apply the following changes:
 
-====
 ----
 ...
 spec:
@@ -713,7 +697,6 @@ endif::[]
         imagePullPolicy: IfNotPresent
         ...
 ----
-====
 <1> Adjust `<tag>` to match the version you are upgrading to (use `{latest-tag}`
 for the latest version).
 
@@ -762,6 +745,7 @@ upgrade will fail and should be restarted automatically. This will not disrupt
 pods that are already running.
 ====
 
+ifdef::openshift-origin[]
 [[updating-the-registry-configuration-file]]
 === Updating Custom Registry Configuration Files
 
@@ -771,19 +755,12 @@ You may safely skip this part if you do not use a custom registry configuration
 file.
 ====
 
-The internal Docker registry
-ifdef::openshift-enterprise[]
-version 3.3.0
-endif::[]
-ifdef::openshift-origin[]
-version 1.3.0
-endif::[]
-and higher requires following entries in the
-xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-middleware[middleware
-section] of the configuration file:
+The internal Docker registry version 1.4.0 and higher requires following entries
+in the
+xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-middleware[middleware section] of the configuration file:
 
-====
 [source,yaml]
+----
 middleware:
   registry:
     - name: openshift
@@ -791,7 +768,7 @@ middleware:
     - name: openshift
   storage:
     - name: openshift
-====
+----
 
 . Edit your custom configuration file, adding the missing entries.
 
@@ -828,6 +805,7 @@ by default. Existing deployments need to be modified using:
 ----
 # oc env dc/docker-registry REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA=true
 ----
+endif::[]
 
 [[updating-the-default-image-streams-and-templates]]
 == Updating the Default Image Streams and Templates
@@ -917,12 +895,12 @@ endif::[]
 +
 ====
 ----
-rpm -ql openshift-ansible-roles | grep examples | grep v1.3
+rpm -ql openshift-ansible-roles | grep examples | grep v1.4
 ----
 ====
 +
 In this example,
-*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/image-streams-rhel7.json_*
+*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/image-streams/image-streams-rhel7.json_*
 is the latest file that you want in the latest *openshift-ansible-roles* package.
 +
 *_/usr/share/openshift/examples/image-streams/image-streams-rhel7.json_* is not
@@ -932,14 +910,14 @@ running `oc`, which can run anywhere that has access to the master.
 
 . Install *atomic-openshift-utils* and its dependencies to install the new content
 into
-*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/_*.:
+*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/_*.:
 +
 ====
 ----
-$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/image-streams-rhel7.json
-$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/dotnet_imagestreams.json
-$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/image-streams-rhel7.json
-$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/dotnet_imagestreams.json
+$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/image-streams/image-streams-rhel7.json
+$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/image-streams/dotnet_imagestreams.json
+$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/image-streams/image-streams-rhel7.json
+$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/image-streams/dotnet_imagestreams.json
 ----
 ====
 
@@ -947,16 +925,16 @@ $ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshi
 +
 ====
 ----
-$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/
-$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/db-templates/
-$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/
-$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-templates/
-$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-streams/
-$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/
-$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/db-templates/
-$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/
-$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-templates/
-$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-streams/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/db-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/infrastructure-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/xpaas-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/xpaas-streams/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/db-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/infrastructure-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/xpaas-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/xpaas-streams/
 ----
 ====
 +
@@ -964,12 +942,12 @@ Errors are generated for items that already exist. This is expected behavior:
 +
 ====
 ----
-# oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/
-Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/cakephp-mysql.json": templates "cakephp-mysql-example" already exists
-Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/cakephp.json": templates "cakephp-example" already exists
-Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/dancer-mysql.json": templates "dancer-mysql-example" already exists
-Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/dancer.json": templates "dancer-example" already exists
-Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/django-postgresql.json": templates "django-psql-example" already exists
+# oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/cakephp-mysql.json": templates "cakephp-mysql-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/cakephp.json": templates "cakephp-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/dancer-mysql.json": templates "dancer-mysql-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/dancer.json": templates "dancer-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.4/quickstart-templates/django-postgresql.json": templates "django-psql-example" already exists
 ----
 ====
 
@@ -1304,7 +1282,7 @@ ifdef::openshift-origin[]
 1.3+.
 endif::[]
 ifdef::openshift-enterprise[]
-3.3+.
+3.4+.
 endif::[]
 ====
 
@@ -1353,6 +1331,20 @@ $ oadm policy add-cluster-role-to-user rolebinding-reader \
      system:serviceaccount:logging:aggregated-logging-elasticsearch
 ----
 
+. If you are upgrading from {product-title}
+ifdef::openshift-origin[]
+1.3 to 1.4,
+endif::[]
+ifdef::openshift-enterprise[]
+3.3 to 3.4,
+endif::[]
+add the *privileged* SCC to the *aggregated-logging-fluentd* service account:
++
+----
+$ oadm policy add-scc-to-user privileged \
+    system:serviceaccount:logging:aggregated-logging-fluentd
+----
+
 . In preparation for running the deployer, ensure that you have the configurations
 for your current deployment in the xref:../aggregate_logging.adoc#aggregate-logging-specifying-deployer-parameters[*logging-deployer* ConfigMap].
 +
@@ -1379,28 +1371,6 @@ of Fluentd pods, the deployer does delete the *logging-fluentd* Daemonset and re
 it from the *logging-fluentd-template* template.
 ====
 
-The latest EFK stack now uses Elasticsearch 2.3 with a common data model. This
-means Fluentd sends logs to Elasticsearch with a new indexing pattern for
-projects. The pattern is:
-+
-----
-project.{namespace_name}.{namespace_id}.YYYY.MM.DD
-----
-+
-For example:
-+
-----
-project.logging.5dad9bd0-a7a1-11e6-94a0-5254000db84b.2016.11.14
-----
-
-The pattern for the `operations` logs remains the same.
-
-[IMPORTANT]
-====
-Downgrading from Elasticsearch 2.3 to Elasticsearch 1.x is not possible due to
-migration to a new data structure.
-====
-
 [[manual-upgrading-cluster-metrics]]
 == Upgrading Cluster Metrics
 
@@ -1425,26 +1395,41 @@ and overwrites local changes to the metrics configurations.
 For example, the number of instances in a replica set is not saved.
 ====
 
-To update, follow the same steps as when the metrics components were
+To upgrade cluster metrics:
+
+. If you are upgrading from {product-title}
+ifdef::openshift-origin[]
+1.3 to 1.4,
+endif::[]
+ifdef::openshift-enterprise[]
+3.3 to 3.4,
+endif::[]
+first add the `view` permission to the *hawkular* service account:
++
+----
+$ oadm policy add-role-to-user view \
+        system:serviceaccount:openshift-infra:hawkular \
+        -n openshift-infra
+----
+
+. Then, follow the same steps as when the metrics components were
 xref:../../install_config/cluster_metrics.adoc#deploying-the-metrics-components[first deployed],
 using the
 xref:../../install_config/cluster_metrics.adoc#modifying-the-deployer-template[correct template],
 except this time, specify the `MODE=refresh` option:
-
-====
++
 ----
-$ oc new-app -f metrics-deployer.yaml \
+$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
+    -f metrics-deployer.yaml \
     -p HAWKULAR_METRICS_HOSTNAME=hm.example.com \
     -p MODE=refresh <1>
 ----
 <1> In the original deployment command, there was no `MODE=refresh`.
-====
 
 [NOTE]
 ====
-During the update, the metrics components do not run.
-Because of this, they cannot collect data
-and a gap normally appears in the graphs.
+During the update, the metrics components do not run. Because of this, they
+cannot collect data and a gap normally appears in the graphs.
 ====
 
 [[additional-instructions-per-release]]
@@ -1454,9 +1439,9 @@ Some {product-title} releases may have additional instructions specific to that
 release that must be performed to fully apply the updates across the cluster.
 ifdef::openshift-enterprise[]
 This section will be updated over time as new asynchronous updates are released
-for {product-title} 3.3.
+for {product-title} 3.4.
 
-See the xref:../../release_notes/ocp_3_3_release_notes.adoc#release-notes-ocp-3-3-release-notes[{product-title} 3.3 Release Notes] to review the latest release notes.
+See the xref:../../release_notes/ocp_3_3_release_notes.adoc#release-notes-ocp-3-4-release-notes[{product-title} 3.4 Release Notes] to review the latest release notes.
 endif::[]
 
 ifdef::openshift-origin[]
@@ -1537,15 +1522,12 @@ file.
 
 Edit your router's deployment configuration:
 
-====
 ----
 # oc edit dc/router
 ----
-====
 
 Apply the following changes:
 
-====
 ----
 ...
 spec:
@@ -1571,7 +1553,6 @@ spec:
       serviceAccountName: router <3>
 ...
 ----
-====
 <1> Add `updatePercent: -10` to allow down-then-up rolling upgrades.
 <2> Add `serviceAccount: router` to the template `*spec*`.
 <3> Add `serviceAccountName: router` to the template `*spec*`.

--- a/release_notes/ocp_3_4_release_notes.adoc
+++ b/release_notes/ocp_3_4_release_notes.adoc
@@ -1,0 +1,220 @@
+[[release-notes-ocp-3-4-release-notes]]
+= {product-title} 3.4 Release Notes
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+Red Hat {product-title} is a Platform as a Service (PaaS) that provides
+developers and IT organizations with a cloud application platform for deploying
+new applications on secure, scalable resources with minimal configuration and
+management overhead. {product-title} supports a wide selection of
+programming languages and frameworks, such as Java, Ruby, and PHP.
+
+Built on Red Hat Enterprise Linux and Google Kubernetes, {product-title}
+provides a secure and scalable multi-tenant operating system for today’s
+enterprise-class applications, while providing integrated application runtimes
+and libraries. {product-title} brings the OpenShift PaaS platform to customer
+data centers, enabling organizations to implement a private PaaS that meets
+security, privacy, compliance, and governance requirements.
+
+[[ocp-34-about-this-release]]
+== About This Release
+
+Red Hat {product-title} version 3.4 is now available. This release is based on
+link:https://github.com/openshift/origin/releases/tag/v1.4.0-rc1[OpenShift Origin 1.4]. New features, changes, bug fixes, and known issues that pertain to
+{product-title} 3.4 are included in this topic.
+
+For initial installations, see the
+xref:../install_config/install/planning.adoc#install-config-install-planning[Installing a Cluster] topics in the
+xref:../install_config/index.adoc#install-config-index[Installation and Configuration] documentation.
+
+To upgrade to this release from a previous version, see the xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[Upgrading a Cluster] topics in the xref:../install_config/index.adoc#install-config-index[Installation and Configuration] documentation.
+
+[[ocp-34-new-features-and-enhancements]]
+== New Features and Enhancements
+
+[[ocp-34-enterprise-container-registry]]
+=== Enterprise Container Registry
+
+This release adds the following improvements to the registry and its user
+experience.
+
+[[ocp-34-developer-experience]]
+=== Developer Experience
+
+This release adds the following improvements to the developer workflow when
+developing and testing applications on {product-title}.
+
+[[ocp-34-web-console]]
+=== Web Console
+
+This release adds the following improvements to the web console, including
+updates to existing features, usability overhauls, and a few brand new concepts.
+
+[[ocp-34-networking]]
+=== Networking
+
+This release adds the following improvements to networking components.
+
+[[ocp-34-security]]
+=== Security
+
+This release adds the following improvements to cluster security.
+
+[[ocp-34-cluster-longevity]]
+=== Cluster Longevity
+
+This release adds the following improvements to cluster longevity.
+
+[[ocp-34-framework-services]]
+=== Framework Services
+
+{product-title} provides resource usage metrics and log access to developers based on the Hawkular and Elasticsearch open source projects. This release adds the following improvements to these components.
+
+[[ocp-34-notable-technical-changes]]
+== Notable Technical Changes
+
+{product-title} 3.4 introduces the following notable technical changes.
+
+[[ocp-34-updated-infrastructure-components]]
+*Updated Infrastructure Components*
+
+- Kubernetes has been updated to v1.4.
+
+- {product-title} 3.4 requires Docker 1.12.
+
+- etcd has been updated to 3.1.0-rc.0.
++
+While etcd has been updated from etcd 2 to 3, {product-title} 3.4 continues to
+use the etcd v2 API for both new and upgraded clusters.
+
+- The latest EFK stack now uses Elasticsearch 2.4 with a common data model. This
+means Fluentd sends logs to Elasticsearch with a new indexing pattern for
+projects. The pattern is:
++
+----
+project.{namespace_name}.{namespace_id}.YYYY.MM.DD
+----
++
+For example:
++
+----
+project.logging.5dad9bd0-a7a1-11e6-94a0-5254000db84b.2016.11.14
+----
++
+The pattern for the `operations` logs remains the same.
++
+[IMPORTANT]
+====
+Downgrading from Elasticsearch 2.4 to Elasticsearch 1.x is not possible due to
+migration to a new data structure.
+====
+
+[[ocp-34-bug-fixes]]
+== Bug Fixes
+
+This release fixes bugs for the following components:
+
+*Authentication*
+
+*Builds*
+
+*Command Line Interface*
+
+*Image*
+
+*Image Registry*
+
+*Installer*
+
+*Kubernetes*
+
+*Logging*
+
+*Web Console*
+
+*Metrics*
+
+*Networking*
+
+*Quick Starts*
+
+*REST API*
+
+*Routing*
+
+*Storage*
+
+*Upgrade*
+
+[[ocp-34-technology-preview]]
+== Technology Preview Features
+
+Some features in this release are currently in Technology Preview. These
+experimental features are not intended for production use. Please note the
+following scope of support on the Red Hat Customer Portal for these features:
+
+https://access.redhat.com/support/offerings/techpreview[Technology Preview
+Features Support Scope]
+
+The following features are in Technology Preview:
+
+- xref:ocp-34-pipelines[OpenShift Pipelines]
+- xref:../dev_guide/builds.adoc#extended-builds[Extended Builds]
+- xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[Service Serving Certificate Secrets]
+- Introduced in OpenShift Enterprise 3.1.1,
+xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamic provisioning] of persistent storage volumes from Amazon EBS, Google Compute
+Disk, OpenStack Cinder storage providers remains in Technology Preview for
+{product-title} 3.4.
+
+[[ocp-34-known-issues]]
+== Known Issues
+
+* Setting the `*forks*` parameter in the *_/etc/ansible/ansible.cfg_* file to 11
+or higher is known to cause {product-title} installations to hang with Ansible
+2.2. The current default is 5. See
+link:http://docs.ansible.com/ansible/intro_configuration.html#forks[http://docs.ansible.com/ansible/intro_configuration.html#forks] for more on this parameter. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1367948[*BZ#1367948*])
+
+[[ocp-34-asynchronous-errata-updates]]
+== Asynchronous Errata Updates
+
+Security, bug fix, and enhancement updates for {product-title} 3.4 are released
+as asynchronous errata through the Red Hat Network. All {product-title} 3.4
+errata is https://access.redhat.com/downloads/content/290/[available on the Red
+Hat Customer Portal]. See the
+https://access.redhat.com/support/policy/updates/openshift[{product-title}
+Life Cycle] for more information about asynchronous errata.
+
+Red Hat Customer Portal users can enable errata notifications in the account
+settings for Red Hat Subscription Management (RHSM). When errata notifications
+are enabled, users are notified via email whenever new errata relevant to their
+registered systems are released.
+
+[NOTE]
+====
+Red Hat Customer Portal user accounts must have systems registered and consuming
+{product-title} entitlements for {product-title} errata notification
+emails to generate.
+====
+
+This section will continue to be updated over time to provide notes on
+enhancements and bug fixes for future asynchronous errata releases of
+{product-title} 3.4. Versioned asynchronous releases, for example with the form
+{product-title} 3.4.z, will be detailed in subsections. In addition, releases in
+which the errata text cannot fit in the space provided by the advisory will be
+detailed in subsections that follow.
+
+[IMPORTANT]
+====
+For any {product-title} release, always review the instructions on
+xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgrading your cluster] properly.
+====


### PR DESCRIPTION
Preview build:

http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/automated_upgrades.html

Includes:

- Updated "In-place or Blue-Green Upgrades" in the Overview topic with some more details
  - http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/index.html#install-config-upgrading-type
- New control plane vs node upgrade options
  - Description: http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/automated_upgrades.html#upgrading-control-plane-nodes-separate-phases
  - Steps inline: http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/automated_upgrades.html#upgrading-to-ocp-3-4
- Mentions `--tag pre_upgrade` option in a Note box.
- Customized node upgrades (serialization + label grouping)
  - http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/automated_upgrades.html#customizing-node-upgrades
- etcd3 upgrade
  - Inline for quick installer: http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/automated_upgrades.html#upgrading-using-the-installation-utility-to-upgrade
  - Inline for playbooks: http://file.rdu.redhat.com/~adellape/120216/upgrade34/install_config/upgrading/automated_upgrades.html#upgrading-to-ocp-3-4
- Removes the "Upgrading to `<version>` Asynchronous Releases" section and consolidates it into the re-titled "Upgrading to the Latest OpenShift Container Platform 3.4 Release", as the former was going to become really redundant w/ all the control plane stuff getting added.
- Starts a stub of the 3.4 release notes because I needed to link to it.

@dgoodwin @sdodson PTAL?