### PR TITLE
add rslave propagation mode for volume mounts

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -72,7 +72,7 @@ the {product-title} container.
 $ sudo docker run -d --name "origin" \
         --privileged --pid=host --net=host \
         -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /var/lib/docker:/var/lib/docker:rw \
-        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes \
+        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave \
         openshift/origin start
 ----
 +


### PR DESCRIPTION
Reference: https://github.com/openshift/origin/issues/11601 and https://github.com/openshift/origin/pull/10571

Use rslave mode for volume mount when running origin in a container

@pmorie @derekwaynecarr 

@adellape 