### PR TITLE
fix capitalization of clusterIP

### DIFF
--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -29,7 +29,7 @@ service prior to deleting it, and arrange to replace the newly assigned IP addre
 with the saved one in the new *docker-registry* service.
 
 // NB: Snarfed from <https://github.com/openshift/openshift-docs/issues/1494>.
-. Make a note of the `ClusterIP` for the service:
+. Make a note of the `clusterIP` for the service:
 +
 ----
 $ oc get svc/docker-registry -o yaml | grep clusterIP:
@@ -50,7 +50,7 @@ $ oadm registry <options> -o yaml > registry.yaml
 ----
 
 . Edit *_registry.yaml_*, find the `Service` there,
-and change its `ClusterIP` to the address noted in step 1.
+and change its `clusterIP` to the address noted in step 1.
 
 . Create the registry using the modified *_registry.yaml_*:
 +


### PR DESCRIPTION
The docs use "ClusterIP" when the field in yaml is "clusterIP"; using the capital C will cause the steps to not work but without error message or indication why