### PR TITLE
Add alt parameter for image according to W3C standards.

### DIFF
--- a/index-community.html
+++ b/index-community.html
@@ -41,7 +41,7 @@
 
          <div class="masthead clearfix">
            <div class="inner">
-             <a href="http://www.openshift.org"><image class="masthead-brand" src="_images/origin_logo.png" /></a>
+             <a href="http://www.openshift.org"><img class="masthead-brand" src="_images/origin_logo.png" alt="OpenShift Logo" /></a>
              <nav>
                 <ul class="nav masthead-nav">
                   <li><a href="http://www.openshift.org">Origin Home</a></li>


### PR DESCRIPTION
The OpenShift Origin logo image is missing out on the 'alt' value.
Please review the same. thanks.