### PR TITLE
Noted that rslave mode only works with Docker v1.10 and later

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -72,9 +72,10 @@ the {product-title} container.
 $ sudo docker run -d --name "origin" \
         --privileged --pid=host --net=host \
         -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /var/lib/docker:/var/lib/docker:rw \
-        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave \
+        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave \ <1>
         openshift/origin start
 ----
+<1> `rslave` only works if the Docker version is 1.10 or later and a Red Hat distribution.
 +
 [NOTE]
 ====


### PR DESCRIPTION
follow-up to https://github.com/openshift/openshift-docs/pull/3356