### PR TITLE
Bug 1403639 Updated image versions and clarified PVC info

### DIFF
--- a/getting_started/devpreview_faq.adoc
+++ b/getting_started/devpreview_faq.adoc
@@ -34,7 +34,7 @@ plan for the current (v2) offering and provide you with adequate time to migrate
 applications to the new platform.
 
 WHAT ARE THE RESOURCE LIMITS DURING THE DEVELOPER PREVIEW?::
-Each user can create 1 project with up to 2 GiB memory, 4 CPU cores, and 2 x 1
+Each user can create a single project with up to 2 GiB memory, 4 CPU cores, and 2 x 1
 GiB persistent volumes. For more detailed limits, see the *Settings* tab on your
 project's Overview page in the web console.
 
@@ -53,27 +53,10 @@ If you are interested in trying the {product-title} (Next Gen) Developer Preview
 just complete the registration form after your account expires and we will
 provision a fresh set of resources for you as soon as they become available.
 
-WHAT LANGUAGES ARE SUPPORTED?::
-The {product-title} (Next Gen) Developer Preview currently supports:
+WHAT LANGUAGES AND DATABASE SERVICES ARE SUPPORTED?::
+The {product-title} (Next Gen) Developer Preview currently supports a number of developer languages and database services, including JBoss Middleware services.
 
-- Node.js (0.10)
-- PHP (5.5, 5.6)
-- Python (2.7, 3.3, 3.4)
-- Ruby (2.0, 2.2)
-- Perl (5.16, 5.20)
-- Java (6, 7, 8, EE) is available via optional JBoss Middleware Services (JBoss
-EAP and JBoss Web Server)
-
-WHAT DATABASE SERVICES ARE SUPPORTED?::
-The {product-title} (Next Gen) Developer Preview currently supports:
-
-- MongoDB (2.4, 2.6)
-- MySQL (5.5, 5.6)
-- PostgreSQL (9.2, 9.4)
-
-WHAT JBOSS MIDDLEWARE SERVICES ARE AVAILABLE IN THE DEVELOPER PREVIEW?::
-JBoss EAP and JBoss Web Server are available to try during the {product-title}
-(Next Gen) Developer Preview.
+See the link:https://www.openshift.com/features/cartridges.html#online3[OpenShift features page] for the list of available languages and services.
 
 CAN USERS RUN IMAGES FROM DOCKER HUB OR PUSH THEIR OWN IMAGES TO THE REGISTRY?::
 Yes, but with a few caveats. For
@@ -153,14 +136,14 @@ to any images you choose to import into your project. These conditions are
 enforced via the {product-title} xref:../dev_guide/compute_resources.adoc#dev-guide-compute-resources[quotas,
 limit ranges, and compute resources] systems.
 
-* A memory limit of 2GiB is in place. The 2 GiB is spread out across the project's
+* A memory limit of 2 GiB is in place. The 2 GiB is spread out across the project's
 pods and containers.
 * Maximum counts are in place for pods, replication controllers, services, and
 secrets (though some amount of these secrets will be needed by the system's
 build and deployer service accounts).
 * Any Dockerfile `VOLUME` instruction must be mounted with either a persistent
 volume claim (PVC) or an EmptyDir at this time.
-* The project associated with a user can allocate up to two PVCs.
+* The project associated with a user can allocate up to two PVCs of up to 1 GiB each.
 * No images that run as *root* are allowed.
 * Only the Source-to-Image (S2I) build strategy is allowed for any build
 configurations imported into your project.


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1403639

But also: #3315  and #3314 

Fixed some info in the dev preview FAQ

@adellape @aheslin Can I get an ack on the image version numbers? I got that info from here: https://www.openshift.com/devpreview/

Thanks.