### PR TITLE
[RFE] Router sets its dns name in admitted routes

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -212,8 +212,9 @@ variables on the *deployment config* for the router to alter its configuration.
 |`*ROUTER_OVERRIDE_HOSTNAME*`|  | If set, override the spec.host value for a route with the template in ROUTER_SUBDOMAIN.
 |`*ROUTER_SERVICE_HTTPS_PORT*` | 443 | Port to listen for HTTPS requests.
 |`*ROUTER_SERVICE_HTTP_PORT*` | 80 | Port to listen for HTTP requests.
-|`*ROUTER_SERVICE_NAME*` | public | The name that the router will identify itself with in route statuses.
-|`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router will identify itself with in route statuses.  Required if `ROUTER_SERVICE_NAME` is used.
+|`*ROUTER_SERVICE_NAME*` | public | The name that the router will identify itself with in route status.
+|`*ROUTER_CANONICAL_HOSTNAME*` | | The (optional) hostname of the router that is shown in the in route status.
+|`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router will identify itself with in route status.  Required if `ROUTER_SERVICE_NAME` is used.
 |`*ROUTER_SERVICE_NO_SNI_PORT*` | 10443 | Internal port for some front-end to back-end communication (see note below).
 |`*ROUTER_SERVICE_SNI_PORT*` | 10444 | Internal port for some front-end to back-end communication (see note below).
 |`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s | Length of time the transmission of an HTTP request can take.

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -648,6 +648,88 @@ $ oc scale dc/router --replicas=0 && oc scale dc/router --replicas=1
 ----
 
 
+[[finding-router-hostname]]
+== Finding the Hostname of the Router
+
+When the user exposes a service, the hostname in the route is the DNS name that external
+users will use to access the application. The network admin for the external network must
+make sure the hostname resolves to the name of a router that has admitted the route.
+The user can set up their DNS with a CNAME that points to this hostname.
+
+The hostname of the router may not be known to the user. When it is not, the cluster administrator
+will provide it.  As a convenience, The cluster admin can provide the *--router-canonical-hostname=* 
+option with the router's canonical hostname when creating the router.
+
+For routers that already exist, the cluster admin can edit the router's deployment config and add
+the hostname in the *ROUTER_CANONICAL_HOSTNAME* environment variable.  The value in the current
+*ROUTER_CANONICAL_HOSTNAME* is displayed in the route status for all routers that have admitted the route.
+The route status is refreshed every time the router is reloaded.
+
+====
+----
+# oadm router myrouter --router-canonical-hostname="rtr.example.com"
+----
+====
+
+The above command ends up creating an environemnt variable *ROUTER_CANONCAL_HOSTNAME* in the
+Router's deployment config. *ROUTER_CANONCAL_HOSTNAME* contains the hostname of the router.
+
+====
+----
+$ oc get dc/myrouter -o yaml
+...
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+          - name: ROUTER_CANONCAL_HOSTNAME
+            value: rtr.example.com
+----
+====
+
+When the user creates a route all of the active routers evaluate the route and, if conditions
+are met, admit it.  When a router that defines the *ROUTER_CANONCAL_HOSTNAME* environment variable admits
+the route, the router places the value in the routerCanonicalHostname field in the route status.  The user
+can examine the route status to determine which, if any, routers have admitted the route.
+
+The user can run *oc get route -o yaml* to show the route status. The route status
+includes a list of routers that have admitted the route. The user selects a router from the
+list and finds the hostname of the router to pass along to the network admin.
+
+====
+----
+$ oc get route hello-route3 -o yaml
+...
+status:
+  ingress:
+
+    conditions:
+      lastTransitionTime: 2016-12-07T15:20:57Z
+      status: "True"
+      type: Admitted
+      host: hello.in.mycloud.com
+      routerCanonicalHostname: rtr.example.com
+      routerName: myrouter
+      wildcardPolicy: None
+----
+====
+
+*oc describe* inclues the hostname when available.
+
+====
+----
+$ oc describe route/hello-route3
+...
+Requested Host: hello.in.mycloud.com exposed on router myroute (host rtr.example.com) 12 minutes ago
+----
+====
+
+With the above information in hand, the user can ask the DNS admin to set up a CNAME from the route's
+host, *hello.in.mycloud.com*, to the router's canonical hostname, *rtr.example.com*. This will result
+in the traffic to *hello.in.mycloud.com* reaching the user's application.
+
+
 [[customizing-the-default-routing-subdomain]]
 == Customizing the Default Routing Subdomain
 You can customize the suffix used as the default routing subdomain for your
@@ -1401,7 +1483,7 @@ net.ipv4.neigh.default.gc_thresh2 = 32768
 net.ipv4.neigh.default.gc_thresh3 = 65536
 ----
 
-To make these settings permanent across reboots, create a 
+To make these settings permanent across reboots, create a
 link:https://access.redhat.com/solutions/1305833[custom tuned profile].
 
 [[deploy-router-protecting-against-ddos-attacks]]


### PR DESCRIPTION
Openshift 3.5 feature

The router is managed by the cluster admin and the admin knows the
external host name of the router. The user creates routes to route
desired host DNS names to the the application. The user doesn't have
access to the router (which is usually in a diffeent namespace). When
a router admits a route the user needs to work with the external
network admin to point the route's hostname to the router. Previously
the user had to contact the cluster admin to find the host name of the
router.

This change adds the --router-canonical-hostname= option to oadm router
which creates and populates the ROUTER_CANONICAL_HOSTNAME environment
variable in the router's dc. This is a string that contains the
canonical hostname of the router. Whenever the router reloads and
evaluates the routes the route's status is edited to include the router's
host name so the user can quickly access the information. If the
ROUTER_CANONICAL_HOSTNAME is updated or added to an existing router the
new information is updated in the admitted routes on the next reload.

The route (oc get route <routename> -o yaml) status reports the name
of the router(s) that have admitted the route. This change adds the
Router's host name to the status in the route.

The information is also reported in "oc describe route" as shown below.

Example:

oadm router myroutername --router-canonical-hostname=oh.my.heavens.org

oc get dc/myroutername -o yaml
...
spec:
  template:
    spec:
      containers:
      - env:
        - name: ROUTER_CANONICAL_HOSTNAME
          value: oh.my.heavens.org

oc get route hello-route3 -o yaml
...
status:
  ingress:
  - conditions:
    - lastTransitionTime: 2016-12-07T15:20:57Z
      status: "True"
      type: Admitted
    host: hello-openshift-v3.not.in3.mycloud.com
    routerCanonicalHostname: oh.my.heavens.org
    routerName: myroutername
    wildcardPolicy: None

oc describe route/hello-route3
...
Requested Host: hello-openshift-v3.not.in3.mycloud.com
          exposed on router myroutername (host oh.my.heavens.org) 12
minutes ago

bug 1393489
:walking_man: https://bugzilla.redhat.com/show_bug.cgi?id=1393489
Resolves origin-web-console issue 336
Trello:
https://trello.com/c/BLASUOQC/376-5-add-a-way-to-pass-a-preferred-dns-name-to-routers-to-populate-route-statuses-ingress-usability
https://github.com/openshift/origin/pull/12195

Signed-off-by: Phil Cameron <pcameron@redhat.com>