### PR TITLE
Add jenkinsfile and openshift template

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,118 @@
+#!/usr/bin/env groovy
+
+// Pipeline variables
+def isPR=false                   // true if the branch being tested belongs to a PR
+def project=""                   // project where build and deploy will occur
+def projectCreated=false         // true if a project was created by this build and needs to be cleaned up
+def repoUrl=""                   // the URL of this project's repository
+def appName="openshift-docs"     // name of application to create
+def approved=false               // true if the preview was approved
+
+// uniqueName returns a name with a 16-character random character suffix
+def uniqueName = { String prefix ->
+  sh "cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 16 | head -n 1 > suffix"
+  suffix = readFile("suffix").trim()
+  return prefix + suffix
+}
+
+// setBuildStatus sets a status item on a GitHub commit
+def setBuildStatus = { String url, String context, String message, String state, String backref ->
+  step([
+    $class: "GitHubCommitStatusSetter",
+    reposSource: [$class: "ManuallyEnteredRepositorySource", url: url ],
+    contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context ],
+    errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+    statusBackrefSource: [ $class: "ManuallyEnteredBackrefSource", backref: backref ],
+    statusResultSource: [ $class: "ConditionalStatusResultSource", results: [
+        [$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}
+
+// getRepoURL retrieves the origin URL of the current source repository
+def getRepoURL = {
+  sh "git config --get remote.origin.url > originurl"
+  return readFile("originurl").trim()
+}
+
+// getRouteHostname retrieves the host name from the given route in an
+// OpenShift namespace
+def getRouteHostname = { String routeName, String projectName ->
+  sh "oc get route ${routeName} -n ${projectName} -o jsonpath='{ .spec.host }' > apphost"
+  return readFile("apphost").trim()
+}
+
+// setPreviewStatus sets a status item for each openshift-docs release
+def setPreviewStatus = { String url, String message, String state, String host, boolean includeLink ->
+   setBuildStatus(url, "ci/app-preview/origin", message, state, includeLink ? "http://${host}/openshift-origin/latest/welcome/index.html" : "")
+   setBuildStatus(url, "ci/app-preview/enterprise", message, state, includeLink ? "http://${host}/openshift-enterprise/master/welcome/index.html" : "")
+   setBuildStatus(url, "ci/app-preview/online", message, state, includeLink ? "http://${host}/openshift-online/master/welcome/index.html" : "")
+   setBuildStatus(url, "ci/app-preview/dedicated", message, state, includeLink ? "http://${host}/openshift-dedicated/master/welcome/index.html" : "")
+   setBuildStatus(url, "ci/app-preview/registry", message, state, includeLink ? "http://${host}/atomic-registry/latest/registry_quickstart/index.html" : "")
+}
+
+try { // Use a try block to perform cleanup in a finally block when the build fails
+
+  node {
+    // Initialize variables in default node context
+    isPR        = env.BRANCH_NAME ? env.BRANCH_NAME.startsWith("PR") : false
+    baseProject = env.PROJECT_NAME
+    project     = env.PROJECT_NAME
+
+    stage ('Checkout') {
+      checkout scm
+      repoUrl = getRepoURL()
+    }
+
+    // When testing a PR, create a new project to perform the build
+    // and deploy artifacts.
+    if (isPR) {
+      stage ('Create PR Project') {
+        setPreviewStatus(repoUrl, "Building application", "PENDING", "", false)
+        setBuildStatus(repoUrl, "ci/approve", "Aprove after testing", "PENDING", "")
+        project = uniqueName("${appName}-")
+        sh "oc new-project ${project}"
+        projectCreated=true
+        sh "oc policy add-role-to-group view system:authenticated -n ${project}"
+      }
+    }
+
+    stage ('Apply object configurations') {
+      sh "oc process -f _openshift/docs-template.yaml -n ${project} | oc apply -f - -n ${project}"
+    }
+
+    stage ('Build') {
+      sh "oc start-build ${appName} -n ${project} --from-repo=. --follow"
+    }
+
+
+    if (isPR) {
+      stage ('Verify Service') {
+        openshiftVerifyService serviceName: appName, namespace: project
+      }
+      def appHostName = getRouteHostname(appName, project)
+      setPreviewStatus(repoUrl, "The application is available", "SUCCESS", "${appHostName}", true)
+      setBuildStatus(repoUrl, "ci/approve", "Approve after testing", "PENDING", "${env.BUILD_URL}input/")
+      stage ('Manual Test') {
+        timeout(time:2, unit:'DAYS') {
+          input "Is everything OK?"
+        }
+      }
+      approved = true
+      setPreviewStatus(repoUrl, "Application previewed", "SUCCESS", "", false)
+      setBuildStatus(repoUrl, "ci/approve", "Manually approved", "SUCCESS", "")
+    }
+  }
+}
+finally {
+  if (projectCreated) {
+    node {
+      stage('Delete PR Project') {
+        if (!approved) {
+          setPreviewStatus(repoUrl, "Application previewed", "FAILURE", "", false)
+          setBuildStatus(repoUrl, "ci/approve", "Rejected", "FAILURE", "")
+        }
+        sh "oc delete project ${project}"
+      }
+    }
+  }
+}

--- a/_openshift/docs-template.yaml
+++ b/_openshift/docs-template.yaml
@@ -1,0 +1,151 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: openshift-docs
+parameters:
+- name: GIT_URI
+  displayName: Git Uri
+  value: https://github.com/openshift/openshift-docs.git
+- name: GIT_REF
+  displayName: Git Reference
+  value: master
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: openshift-docs
+    name: openshift-docs
+  spec: {}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      build: openshift-docs-s2i
+    name: openshift-docs-s2i
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/cewong/asciibinder-018-centos7:latest
+      name: latest
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+    labels:
+      app: openshift-docs
+    name: openshift-docs
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: openshift-docs:latest
+    runPolicy: Serial
+    source:
+      git:
+        uri: ${GIT_URI}
+        ref: ${GIT_REF}
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: openshift-docs-s2i:latest
+      type: Source
+    triggers: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: openshift-docs
+    name: openshift-docs
+  spec:
+    replicas: 1
+    selector:
+      app: openshift-docs
+      deploymentconfig: openshift-docs
+    strategy:
+      resources: {}
+      recreateParams: {}
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: openshift-docs
+          deploymentconfig: openshift-docs
+      spec:
+        containers:
+        - image: " "
+          imagePullPolicy: IfNotPresent
+          name: openshift-docs
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - openshift-docs
+        from:
+          kind: ImageStreamTag
+          name: openshift-docs:latest
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: openshift-docs
+    name: openshift-docs
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: openshift-docs
+      deploymentconfig: openshift-docs
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: openshift-docs
+    name: openshift-docs
+  spec:
+    port:
+      targetPort: 8080-tcp
+    to:
+      kind: Service
+      name: openshift-docs
+      weight: 100
+    wildcardPolicy: None


### PR DESCRIPTION
This PR creates a Jenkinsfile at the root of the docs repository. This enables the Jenkins GitHub Organization plugin to automatically instantiate a pipeline for this repository and run builds on PRs. 

It also adds an OpenShift template that can be used to build and run the doc repository for a given GIT_URI and GIT_REF.