### PR TITLE
Add reference to ipf-debug.sh script.

### DIFF
--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -612,6 +612,10 @@ replaced with an `iptables`-only solution.
 https://raw.githubusercontent.com/openshift/openshift-sdn/master/hack/debug.sh
 on the master (or from another machine with access to the master) to
 generate useful debugging information.
+. When debugging ipfailover problems run the script at
+https://raw.githubusercontent.com/openshift/openshift-sdn/master/hack/ipf-debug.sh
+on the master (or from another machine with access to the master) to
+generate useful debugging information.
 . Ask for help on Freenode IRC #openshift-dev (but be prepared to
 provide the output from the debugging script)
 


### PR DESCRIPTION
Openshift 3.5 feature

The ipf-debug.sh script looks at the ipfailover configuration and
reports intersting information to help the user understand what is
happening.

Trello card:
https://trello.com/c/yFco7WvY/268-5-ip-failover-diagnostic-script-demo-supportability-p3-5

openshift/openshift-sdn#324

Signed-off-by: Phil Cameron <pcameron@redhat.com>