### PR TITLE
Clarifies procedure for a git clone with a self-signed TLS certificate

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -207,7 +207,7 @@ on how to create a builder image supporting incremental builds.
 This feature is in technology preview. This means the API may change without
 notice or the feature may be removed entirely. For a supported mechanism to
 produce application images with runtime-only content, consider using the
-xref:builds.adoc#image-source[Image Source] feature and defining two builds, one
+xref:image-source[Image Source] feature and defining two builds, one
 which produces an image containing the runtime artifacts and a second build
 which consumes the runtime artifacts from that image and adds them to a
 runtime-only image.
@@ -733,7 +733,7 @@ source:
 
 [[source-code]]
 
-=== Git Repository Source Options
+=== Git Source
 
 When the `*BuildConfig.spec.source.type*` is `*Git*`, a Git repository is
 required, and an inline Dockerfile is optional.
@@ -781,9 +781,8 @@ branch refs.
 To perform a full Git clone of the `master` for the specified repository, set
 the `*ref*` to `master`.
 
-[[using-a-proxy-for-git-cloning]]
-
-==== Using a Proxy for Git Cloning
+[[using-a-proxy]]
+==== Using a Proxy
 
 // tag::using-a-proxy-for-git-cloning-1[]
 
@@ -818,49 +817,219 @@ endif::[]
 
 // end::using-a-proxy-for-git-cloning-1[]
 
-[[trusted-certificate-authorities]]
-==== Trusted Certificate Authorities
+[[source-secrets]]
+==== Source Secrets
 
-The set of TLS certificate authorities that are trusted during a `git clone`
-operation are built into the {product-title} infrastructure images.  If your Git
-server uses a self-signed certificate or one signed by an authority not trusted
-by the image, you can disable TLS  verification by setting the
-`*GIT_SSL_NO_VERIFY*` environment variable to *true* in the appropriate strategy
-section of your build configuration. You can use the
-xref:../dev_guide/environment_variables.adoc#overview[`oc set env`] command to
-manage `*BuildConfig*` environment variables.
+[[overview]]
+===== Overview
 
-[[using-private-repositories-for-builds]]
-==== Using Private Repositories for Builds
+Source secrets are used to provide the builder pod with access to git repositories
+that it would not normally have access to such as private repositories or
+repositories with self-signed/untrusted SSL certificates.
 
-Supply valid credentials to build an application from a private repository.
+The following source secret configurations are supported:
 
-Currently two types of authentication are supported: basic username-password
-and SSH key based authentication.
+- xref:gitconfig-file[Gitconfig File]
+- xref:basic-authentication[Basic Authentication]
+- xref:ssh-key-authentication[SSH Key Authentication]
+- xref:trusted-certificate-authorities[Trusted Certificate Authorities]
+
+[NOTE]
+====
+You can also use xref:combinations[combinations] of the these configurations
+to suite your specific situation.
+====
+
+All source secrets must be linked to the builder account and added to the build config
+using the following instructions:
+
+. Add the `*secret*` to the builder service account. Each build is run with
+the `builder` role, so you need to give it access to your secret with the
+following command:
++
+====
+----
+$ oc secrets link builder basicsecret
+----
+====
+
+. Add a `*sourceSecret*` field to the `*source*` section inside the
+`*BuildConfig*` and set it to the name of the `*secret*` that you created,
+which in this case is `*basicsecret*`.
++
+====
+[source,yaml]
+----
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  name: "sample-build"
+spec:
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "sample-image:latest"
+  source:
+    git:
+      uri: "https://github.com/user/app.git"
+    sourceSecret:
+      name: "basicsecret"
+    type: "Git"
+  strategy:
+    sourceStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "python-33-centos7:latest"
+    type: "Source"
+----
+====
+
+[NOTE]
+====
+You can also use the `*oc set build-secret*` command to set the secret on the
+existing build configuration:
+----
+$ oc set build-secret --source bc/sample-build basicsecret
+----
+====
+xref:using-secrets-in-the-buildconfig[Defining Secrets in the
+BuildConfig] provides more information on this topic.
+
+[[gitconfig-file]]
+===== Gitconfig File
+
+If the cloning of your application is dependent on a `.gitconfig` file
+you can create a secret that contains it, and then add
+it to the builder service account, and then your `BuildConfig`.
+
+
+To create a secret from a `.gitconfig` file:
+
+====
+----
+$ oc secrets new mysecret .gitconfig=path/to/.gitconfig
+----
+====
+
+[NOTE]
+====
+SSL verification can be turned off, if `sslVerify=false` is set for the `http`
+section in your `.gitconfig` file:
+----
+[http]
+        sslVerify=false
+----
+====
 
 [[basic-authentication]]
 ===== Basic Authentication
 
 Basic authentication requires either a combination of `username` and `password`,
-or a `token` to authenticate against the SCM server. A `CA certificate` file,
-or a `.gitconfig` file can be attached.
+or a `token` to authenticate against the SCM server.
 
-A xref:../dev_guide/secrets.adoc#dev-guide-secrets[`*secret*`] is used to store your keys.
-
-. Create the `*secret*` first before using the username and password to access
+Create the `*secret*` first before using the username and password to access
 the private repository:
-+
+
 ====
 ----
 $ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD
 ----
 ====
 
-.. To create a Basic Authentication Secret with a token:
-+
+To create a Basic Authentication Secret with a token:
+
 ====
 ----
 $ oc secrets new-basicauth basicsecret --password=TOKEN
+----
+====
+
+[[ssh-key-authentication]]
+===== SSH Key Authentication
+
+SSH Key Based Authentication requires a private SSH key.
+
+The repository keys are usually located in the `$HOME/.ssh/` directory, and are named
+`id_dsa.pub`, `id_ecdsa.pub`, `id_ed25519.pub`, or `id_rsa.pub` by default.
+Generate SSH key credentials with the following command:
+
+====
+----
+$ ssh-keygen -t rsa -C "your_email@example.com"
+----
+====
+
+[NOTE]
+====
+Creating a passphrase for the SSH key prevents {product-title} from building.
+When prompted for a passphrase, leave it blank.
+====
+
+Two files are created: the public key and a corresponding private key (one of
+`id_dsa`, `id_ecdsa`, `id_ed25519`, or `id_rsa`). With both of these in place,
+consult your source control management (SCM) system's manual on how to upload
+the public key. The private key will be used to access your private repository.
+
+Create the `*secret*` first before using the SSH key to access the private
+repository:
+
+====
+----
+$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa
+----
+====
+
+[[trusted-certificate-authorities]]
+===== Trusted Certificate Authorities
+
+The set of TLS certificate authorities that are trusted during a `git clone`
+operation are built into the {product-title} infrastructure images.  If your Git
+server uses a self-signed certificate or one signed by an authority not trusted
+by the image, you have several options.
+
+. Create a secret with a CA certificate file (recommended)
++
+A secret containing a `CA certificate` in a key named
+`ca.crt` will automatically be used by `git` to trust your
+self-signed or otherwise un-trusted TLS certificate during
+the `git clone` operation. Utilizing this method is significantly
+more secure than disabling git's ssl verification which will accept
+any TLS certificate that is presented.
++
+====
+----
+# the key name ca.crt MUST be used
+$ oc secrets new mycert ca.crt=FILENAME
+----
+====
+
+. Disable git TLS verification
++
+You can disable git's TLS verification by setting the
+`*GIT_SSL_NO_VERIFY*` environment variable to *true* in the appropriate strategy
+section of your build configuration. You can use the
+xref:../dev_guide/environment_variables.adoc#overview[`oc set env`] command to
+manage `*BuildConfig*` environment variables.
+
+[[combinations]]
+===== Combinations
+
+Below are several examples of how you can combine the above methods for
+creating `Source Secrets` for your specific needs.
+
+.. To create an SSH Based Authentication Secret with a `.gitconfig` file:
++
+====
+----
+$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa --gitconfig=FILENAME
+----
+====
+
+.. To create a secret that combines a `.gitconfig` file and `CA certificate`:
++
+====
+----
+$ oc secrets new mysecret ca.crt=path/to/certificate .gitconfig=path/to/.gitconfig
 ----
 ====
 
@@ -880,232 +1049,13 @@ $ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD -
 ----
 ====
 
-. Add the `*secret*` to the builder service account. Each build is run with
-the `builder` role, so you need to give it access your secret with the
-following command:
+.. To create a Basic Authentication Secret with a `.gitconfig` file and CA certificate file:
 +
 ====
 ----
-$ oc secrets link builder basicsecret
+$ oc secrets new-basicauth basicsecret --username=USERNAME --password=PASSWORD --gitconfig=FILENAME --ca-cert=FILENAME
 ----
 ====
-
-. Add a `*sourceSecret*` field to the `*source*` section inside the
-`*BuildConfig*` and set it to the name of the `*secret*` that you created.
-In this case `*basicsecret*`:
-+
-====
-[source,yaml]
-----
-apiVersion: "v1"
-kind: "BuildConfig"
-metadata:
-  name: "sample-build"
-spec:
-  output:
-    to:
-      kind: "ImageStreamTag"
-      name: "sample-image:latest"
-  source:
-    git:
-      uri: "https://github.com/user/app.git" <1>
-    sourceSecret:
-      name: "basicsecret"
-    type: "Git"
-  strategy:
-    sourceStrategy:
-      from:
-        kind: "ImageStreamTag"
-        name: "python-33-centos7:latest"
-    type: "Source"
-----
-<1> The URL of private repository, accessed by basic authentication, is usually
-in the `http` or `https` form.
-====
-+
-You can also use the `*oc set build-secret*` command to set the secret on the
-existing build configuration:
-+
-====
-----
-$ oc set build-secret --source bc/sample-build basicsecret
-----
-====
-
-
-[[ssh-key-authentication]]
-===== SSH Key Based Authentication
-
-SSH Key Based Authentication requires a private SSH key. A `.gitconfig` file can
-also be attached.
-
-The repository keys are usually located in the `$HOME/.ssh/` directory, and are named
-`id_dsa.pub`, `id_ecdsa.pub`, `id_ed25519.pub`, or `id_rsa.pub` by default.
-Generate SSH key credentials with the following command:
-
-====
-
-----
-$ ssh-keygen -t rsa -C "your_email@example.com"
-----
-====
-
-[NOTE]
-====
-Creating a passphrase for the SSH key prevents {product-title} from building.
-When prompted for a passphrase, leave it blank.
-====
-
-Two files are created: the public key and a corresponding private key (one of
-`id_dsa`, `id_ecdsa`, `id_ed25519`, or `id_rsa`). With both of these in place,
-consult your source control management (SCM) system's manual on how to upload
-the public key. The private key will be used to access your private repository.
-
-A xref:../dev_guide/secrets.adoc#dev-guide-secrets[`*secret*`] is used to store your keys.
-
-. Create the `*secret*` first before using the SSH key to access the private
-repository:
-+
-====
-----
-$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa
-----
-====
-
-.. To create a SSH Based Authentication Secret with a `.gitconfig` file:
-+
-====
-----
-$ oc secrets new-sshauth sshsecret --ssh-privatekey=$HOME/.ssh/id_rsa --gitconfig=FILENAME
-----
-====
-
-. Add the `*secret*` to the builder service account. Each build is run with
-the `builder` role, so you need to give it access your secret with the
-following command:
-+
-====
-----
-$ oc secrets link builder sshsecret
-----
-====
-
-. Add a `*sourceSecret*` field into the `*source*` section inside the
-`*BuildConfig*` and set it to the name of the `*secret*` that you created.
-In this case `*sshsecret*`:
-+
-====
-[source,yaml]
-----
-apiVersion: "v1"
-kind: "BuildConfig"
-metadata:
-  name: "sample-build"
-spec:
-  output:
-    to:
-      kind: "ImageStreamTag"
-      name: "sample-image:latest"
-  source:
-    git:
-      uri: "git@repository.com:user/app.git" <1>
-    sourceSecret:
-      name: "sshsecret"
-    type: "Git"
-  strategy:
-    sourceStrategy:
-      from:
-        kind: "ImageStreamTag"
-        name: "python-33-centos7:latest"
-    type: "Source"
-----
-<1> The URL of private repository, accessed by a private SSH key, is usually
-in the form `git@example.com:<username>/<repository>.git`.
-====
-+
-You can also use the `*oc set build-secret*` command to set the secret on the
-existing build configuration:
-+
-====
-----
-$ oc set build-secret --source bc/sample-build sshsecret
-----
-====
-
-[[other-authentication]]
-===== Other
-
-If the cloning of your application is dependent on a CA certificate,
-`.gitconfig` file, or both, then you can create a secret that contains them, add
-it to the builder service account, and then your `BuildConfig`.
-
-. Create desired type of `*secret*`:
-
-.. To create a secret from a `.gitconfig`:
-+
-====
-----
-$ oc secrets new mysecret .gitconfig=path/to/.gitconfig
-----
-====
-.. To create a secret from a `CA certificate`:
-+
-====
-----
-$ oc secrets new mysecret ca.crt=path/to/certificate
-----
-====
-.. To create a secret from a `CA certificate` and `.gitconfig`:
-+
-====
-----
-$ oc secrets new mysecret ca.crt=path/to/certificate .gitconfig=path/to/.gitconfig
-----
-====
-+
-[NOTE]
-====
-SSL verification can be turned off, if `sslVerify=false` is set for the `http`
-section in your `.gitconfig` file:
-----
-[http]
-        sslVerify=false
-----
-====
-
-.  Add the `*secret*` to the builder service account. Each build is run with the
-the `builder` role, so you need to give it access your secret with the
-following command:
-+
-====
-----
-$ oc secrets link builder mysecret
-----
-====
-
-.  Add the `*secret*` to the `*BuildConfig*`:
-+
-====
-----
-source:
-  git:
-    uri: "https://github.com/openshift/nodejs-ex.git"
-  sourceSecret:
-    name: "mysecret"
-----
-====
-+
-You can also use the `*oc set build-secret*` command to set the secret on the
-existing build configuration:
-+
-====
-----
-$ oc set build-secret --source bc/sample-build mysecret
-----
-====
-
-xref:builds.adoc#using-secrets-in-the-buildconfig[Defining Secrets in the
-BuildConfig] provides more information on this topic.
 
 [[dockerfile-source]]
 


### PR DESCRIPTION
This update clarifies the procedure for adding a CA certificate to allow
doing a git clone over https using a self-signed or otherwise un-trusted
TLS certificate

Trello card: https://trello.com/c/Ajm1E1Qi/1038-1-make-it-easier-to-provide-a-trusted-ca-cert-for-cloning-builds-techdebt