### PR TITLE
delete the deprecated command oc env

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -211,12 +211,6 @@ $ oc edit <object_type>/<object_name> \
     -o <object_type_format>
 ----
 
-=== env
-Update the desired object type with a new environment variable:
-----
-$ oc env <object_type>/<object_name> <var_name>=<value>
-----
-
 === volume
 Modify a xref:../dev_guide/volumes.adoc#dev-guide-volumes[volume]:
 ----


### PR DESCRIPTION
**_oc env_** command has been instead by **_oc set env_**, it is deprecated.