### PR TITLE
changed link to configuring docker storage

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -75,8 +75,7 @@ endif::[]
 * Minimum 8 GB RAM.
 * Minimum 15 GB hard disk space for the file system containing *_/var/_*.
 * An additional minimum 15 GB unallocated space to be used for Docker's storage
-back end; see xref:configuring-docker-storage[Configuring Docker Storage]
-below.
+back end; see xref:host_preparation.adoc#configuring-docker-storage[Configuring Docker Storage].
 
 |External etcd Nodes
 |Minimum 20 GB hard disk space for etcd data.


### PR DESCRIPTION
"Configuring Docker Storage" seems to have been moved to a separate document instead of being explained "below"