### PR TITLE
removed --api-version flag which is deprecated

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -99,7 +99,7 @@ registry options].
 . Update the scheme used for the registry's liveness probe from HTTP to HTTPS:
 +
 ----
-$ oc patch dc/docker-registry --api-version=v1 -p '{"spec": {"template": {"spec": {"containers":[{
+$ oc patch dc/docker-registry -p '{"spec": {"template": {"spec": {"containers":[{
     "name":"registry",
     "livenessProbe":  {"httpGet": {"scheme":"HTTPS"}}
   }]}}}}'
@@ -115,7 +115,7 @@ endif::[]
 or later, update the scheme used for the registry's readiness probe from HTTP to HTTPS:
 +
 ----
-$ oc patch dc/docker-registry --api-version=v1 -p '{"spec": {"template": {"spec": {"containers":[{
+$ oc patch dc/docker-registry -p '{"spec": {"template": {"spec": {"containers":[{
     "name":"registry",
     "readinessProbe":  {"httpGet": {"scheme":"HTTPS"}}
   }]}}}}'


### PR DESCRIPTION
The docs specify to use the flag `--api-version=v1`. However, this is a deprecated flag and is not respected by the oc client, thus we should not need to keep it. This is to fix https://bugzilla.redhat.com/show_bug.cgi?id=1379434