### PR TITLE
Add documentation for 'build.openshift.io/source-secret-match-uri-' annotation

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -850,7 +850,8 @@ Source secrets are used to provide the builder pod with access to Git repositori
 that it would not normally have access to, such as private repositories or
 repositories with self-signed or untrusted SSL certificates.
 
-The following source secret configurations are supported:
+The following source secret configurations are supported.  Follow the link to
+learn how to create a source secret of the given configuration.
 
 - xref:gitconfig-file[Gitconfig File]
 - xref:basic-authentication[Basic Authentication]
@@ -863,23 +864,83 @@ You can also use xref:combinations[combinations] of the these configurations
 to meet your specific needs.
 ====
 
-All source secrets must be linked to the builder account and added to the build
-configuration using the following instructions:
+Builds are run with the *builder* service account, which must have access to any
+source secrets used.  Access is granted with the following command:
 
-. Add the secret to the builder service account. Each build is run with
-the *builder* role, so you must give it access to your secret with the
-following command:
-+
 ====
 ----
-$ oc secrets link builder basicsecret
+$ oc secrets link builder mysecret
 ----
 ====
 
-. Add a `sourceSecret` field to the `source` section inside the `BuildConfig` and
-set it to the name of the `secret` that you created (`basicsecret`, in this
+[[automatic-addition-of-a-source-secret-to-a-build-configuration]]
+===== Automatic addition of a source secret to a build configuration
+
+{product-title} can automatically add a source secret to relevant build
+configurations if the source secret includes one or more annotations prefixed
+with the text `build.openshift.io/source-secret-match-uri-`.  The value of
+each annotation indicates a URI pattern of a source repository against which the
+secret matches.  The URI pattern must consist of all of:
+
+- a valid scheme (`*://`, `git://`, `http://`, `https://` or `ssh://`)
+- a host (`\*` or a valid hostname or IP address optionally preceeded by `*.`)
+- a path (`/\*` or `/` followed by any characters optionally including `*` characters).
+
+In all of the above, a `*` character is interpreted as a wildcard.
+
+[NOTE]
+====
+{product-title} will not automatically add a source secret to a build
+configuration which already contains a source secret.
+====
+
+If multiple source secrets match the URI of a particular source repository,
+{product-title} will select a secret with a longest match.  This allows for
+basic overriding, as in the following example.
+
+The following fragment shows two partial source secrets, the first matching any
+server in the domain `mycorp.com` accessed by HTTPS; the second overriding
+access to servers mydev1.mycorp.com and mydev2.mycorp.com:
+
+====
+[source,yaml]
+----
+kind: Secret
+apiVersion: v1
+metadata:
+  name: matches-all-corporate-servers-https-only
+  annotations:
+    build.openshift.io/source-secret-match-uri-1: https://*.mycorp.com/*
+data:
+  ...
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: override-for-my-dev-servers-https-only
+  annotations:
+    build.openshift.io/source-secret-match-uri-1: https://mydev1.mycorp.com/*
+    build.openshift.io/source-secret-match-uri-2: https://mydev2.mycorp.com/*
+data:
+  ...
+----
+====
+
+A `build.openshift.io/source-secret-match-uri-` annotation may be added to a
+pre-existing secret as follows:
+
+----
+$ oc annotate secret mysecret 'build.openshift.io/source-secret-match-uri-1=https://*.mycorp.com/*'
+----
+
+[[manual-addition-of-a-source-secret-to-a-build-configuration]]
+===== Manual addition of a source secret to a build configuration
+
+Source secrets can be added manually to a build configuration by adding a
+`sourceSecret` field to the `source` section inside the `BuildConfig` and
+setting it to the name of the `secret` that you created (`basicsecret`, in this
 example).
-+
+
 ====
 [source,yaml]
 ----
@@ -909,12 +970,13 @@ spec:
 
 [NOTE]
 ====
-You can also use the `oc set build-secret` command to set the secret on the
-existing build configuration:
+You can also use the `oc set build-secret` command to set the source secret on
+an existing build configuration:
 ----
 $ oc set build-secret --source bc/sample-build basicsecret
 ----
 ====
+
 xref:using-secrets-in-the-buildconfig[Defining Secrets in the
 BuildConfig] provides more information on this topic.
 


### PR DESCRIPTION
Documentation for https://trello.com/c/NoVpS2OS/1059-5-use-build-source-secret-based-on-annotation-on-secret-builds.  1.5 / 3.5.