### PR TITLE
Fix command to create new service account.

### DIFF
--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -71,7 +71,7 @@ serviceaccount "robot" created
 account in the *test* project the *admin* role:
 +
 ----
-$ oc policy add-role-to-user admin system:serviceaccounts:test:robot
+$ oc policy add-role-to-user admin system:serviceaccount:test:robot
 ----
 
 . Describe the service account to discover the secret token name:


### PR DESCRIPTION
There was a "s" too much that caused the command to create
a normal user instead of a service account.