### PR TITLE
Adding Flannel documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -185,6 +185,9 @@ Topics:
       - Name: Nuage SDN
         File: nuagesdn
         Distros: openshift-enterprise,openshift-origin
+      - Name: Flannel
+        File: flannel
+        Distros: openshift-*
       - Name: Authentication
         File: authentication
       - Name: Authorization

--- a/architecture/additional_concepts/flannel.adoc
+++ b/architecture/additional_concepts/flannel.adoc
@@ -1,0 +1,32 @@
+[[architecture-additional-concepts-flannel]]
+= Flannel
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+[[architecture-additional-concepts-flannel-overview]]
+== Overview
+
+*flannel* is a virtual networking layer designed specifically for containers. 
+{product-title} can use it for networking containers instead of the default
+software-defined networking (SDN) components.
+
+[[architecture-additional-concepts-flannel-architecture]]
+== Architecture
+
+Each host within the network runs an agent called *flanneld*, which is
+responsibile for:
+
+- Managing a unique subnet on each host
+- Distributing IP addresses to each container on its host
+- Mapping routes from one container to another, even if on different hosts
+
+Each *flanneld* agent provides this infomation to a centralized *etcd* store so
+other agents on hosts can create an overlay network and route packets to
+any container within the *flannel* network.

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -178,3 +178,22 @@ so that the master does not schedule containers on it.
 Both options are presented as part of a practical use-case in the documentation
 for configuring xref:../install_config/routing_from_edge_lb.adoc#install-config-routing-from-edge-lb[routing from an
 edge load-balancer to containers within {product-title} SDN].
+
+[[using-flannel]]
+== Using Flannel
+As an alternative to the default SDN, {product-title} also provides Ansible
+playbooks for installing *flannel*-based networking. This is useful if running
+{product-title} within a cloud provider platform, such as OpenStack, and you
+want to avoid using dual Open vSwtich SDN on both platforms.
+
+To enable *flannel* within your {product-title} cluster, set the following
+variables in your Ansible inventory file before running the installation.
+
+----
+openshift_use_openshift_sdn=false
+openshift_use_flannel=true
+----
+
+Setting the `*openshift_use_openshift_sdn*` variable to false disables the
+default SDN and setting the `*openshift_use_flannel*` variable to true enables
+*flannel* in place.

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -316,6 +316,11 @@ host; for example, given the default 10.128.0.0/14 cluster network, this will
 allocate 10.128.0.0/23, 10.128.2.0/23, 10.128.4.0/23, and so on. This *cannot* be
 re-configured after deployment.
 
+|`*openshift_use_flannel*`
+|This variable enables *flannel* as an alternative networking layer instead of
+the default SDN. If enabling *flannel*, disable the default SDN with the 
+*openshift_use_openshift_sdn* variable. For more information, see xref:../configuring_sdn.adoc#using-flannel[Using Flannel].
+
 |`*openshift_docker_additional_registries*`
 |{product-title} adds the specified additional registry or registries to the
 Docker configuration.


### PR DESCRIPTION
This is some initial documentation for flannel within OpenShift. This includes:

- Adding the openshift_use_flannel variable to the cluster variables table in the Advanced Installation section
- Adding some more detailed info in the SDN section of the Installation and Configuration guide
- Adding a new section in the Arch Guide about flannel