### PR TITLE
Add quotations mark to scheduled job example

### DIFF
--- a/dev_guide/scheduled_jobs.adoc
+++ b/dev_guide/scheduled_jobs.adoc
@@ -59,7 +59,7 @@ kind: ScheduledJob
 metadata:
   name: pi
 spec:
-  schedule: */1 * * * ?    <1>
+  schedule: "*/1 * * * *"  <1>
   jobTemplate:             <2>
     spec:
       template:


### PR DESCRIPTION
Current doc missed the quotations and it doesn't work as this error:

```
$ oc create -f a.yaml 
error: yaml: line 7: did not find expected alphabetic or numeric character
```

Also, this patch chnaged the `?` to `*`. According to the [k8s docs](https://kubernetes.io/docs/user-guide/cron-jobs/) `?` and `*` are same meaning, but it should be used consistently.