### PR TITLE
Added description of the allowed/denied domain feature

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -201,12 +201,14 @@ variables on the *deployment config* for the router to alter its configuration.
 |`*NAMESPACE_LABELS*` |  | A label selector to apply to namespaces to watch, empty means all.
 |`*PROJECT_LABELS*` |  | A label selector to apply to projects to watch, emtpy means all.
 |`*RELOAD_SCRIPT*` |  | The path to the reload script to use to reload the router.
+|`*ROUTER_ALLOWED_DOMAINS*` | | A comma separated list of domains that the hostname in a route can only be part of.  Any subdomain in the domain can be used.  Option `ROUTER_DENIED_DOMAINS` overrides any values given in this option.  If set, everything outside of the allowed domains will be rejected.
 |`*ROUTER_BACKEND_CHECK_INTERVAL*` | 5000ms | Length of time between subsequent "liveness" checks on backends.
 |`*ROUTER_COMPRESSION_MIME*` | "text/html text/plain text/css" | A space separated list of mime types to compress.
 |`*ROUTER_DEFAULT_CLIENT_TIMEOUT*`| 30s | Length of time within which a client has to acknowledge or send data.
 |`*ROUTER_DEFAULT_CONNECT_TIMEOUT*`| 5s | The maximum connect time.
 |`*ROUTER_DEFAULT_SERVER_TIMEOUT*`| 30s | Length of time within which a server has to acknowledge or send data.
 |`*ROUTER_DEFAULT_TUNNEL_TIMEOUT*` | 1h | Length of time till which TCP or WebSocket connections will remain open.
+|`*ROUTER_DENIED_DOMAINS*` | | A comma separated list of domains that the hostname in a route can not be part of.  No subdomain in the domain can be used either.  Overrides option `ROUTER_ALLOWED_DOMAINS`.
 |`*ROUTER_ENABLE_COMPRESSION*`| false | If `true`, compress responses when possible.
 |`*ROUTER_LOG_LEVEL*` | warning | The log level to send to the syslog server.
 |`*ROUTER_OVERRIDE_HOSTNAME*`|  | If set, override the spec.host value for a route with the template in ROUTER_SUBDOMAIN.


### PR DESCRIPTION
We have added a feature when we supported wildcard routes to also
limit some domains that can be used.  This adds the documentation of
the environment variables that control it.

This is for 3.4.