### PR TITLE
Added Storage Classes topic for Online for BZ#1411222

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -663,6 +663,9 @@ Topics:
     File: volumes
   - Name: Using Persistent Volumes
     File: persistent_volumes
+  - Name: Storage Classes
+    File: storage_classes
+    Distros: openshift-online
   - Name: Executing Remote Commands
     File: executing_remote_commands
   - Name: Copying Files

--- a/dev_guide/storage_classes.adoc
+++ b/dev_guide/storage_classes.adoc
@@ -1,0 +1,26 @@
+[[dev-guide-storage-classes]]
+= Storage Classes
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+The `StorageClass` resource object describes and classifies storage that can be
+requested, as well as provides a means for passing parameters for dynamically
+provisioned storage on demand. `StorageClass` objects can also serve as a
+management mechanism for controlling different levels of storage and access to
+the storage. Cluster administrators (users with `cluster-admin` privileges) or
+storage administrators (users with `storage-admin` privileges) define and create
+the `StorageClass` objects that users can request without needing any intimate
+knowledge about the underlying storage volume sources.
+
+In {product-title}, the storage class is configured and a single option is
+available to the user based on the underlying cloud provider.


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1411222

This topic is for Online only to prevent content duplication. Other Storage Classes content lives in the Installation and Configuration section of the docs, but Installation and Configuration does not appear in Online documentation.