### PR TITLE
Removing Azure content that was prematurely published

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -327,9 +327,6 @@ Topics:
   - Name: Configuring for GCE
     File: configuring_gce
     Distros: openshift-origin,openshift-enterprise
-  - Name: Configuring for Azure
-    File: configuring_azure
-    Distros: openshift-origin,openshift-enterprise
   - Name: Configuring Persistent Storage
     Dir: persistent_storage
     Distros: openshift-origin,openshift-enterprise
@@ -354,8 +351,6 @@ Topics:
         File: persistent_storage_fibre_channel
       - Name: Dynamic Provisioning and Creating Storage Classes
         File: dynamically_provisioning_pvs
-      - Name: Using Azure Disk
-        File: persistent_storage_azure
       - Name: Volume Security
         File: pod_security_context
       - Name: Selector-Label Volume Binding


### PR DESCRIPTION
This removes Azure content from Origin that was introduced prematurely in https://github.com/openshift/openshift-docs/pull/3300.

Confirmed with Brad Childs of the storage team that dynamic provisioning support for Azure will be introduced in 3.5 (https://trello.com/c/WgqndKo6/288-21-implement-a-azure-block-provisioner-ops-rfe) and Azure storage features will be introduced in 3.4.