### PR TITLE
Adding back in Azure content for 3.4

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -327,6 +327,9 @@ Topics:
   - Name: Configuring for GCE
     File: configuring_gce
     Distros: openshift-origin,openshift-enterprise
+  - Name: Configuring for Azure
+    File: configuring_azure
+    Distros: openshift-origin,openshift-enterprise
   - Name: Configuring Persistent Storage
     Dir: persistent_storage
     Distros: openshift-origin,openshift-enterprise
@@ -349,8 +352,10 @@ Topics:
         File: persistent_storage_iscsi
       - Name: Using Fibre Channel
         File: persistent_storage_fibre_channel
+      - Name: Using Azure Disk
+        File: persistent_storage_azure
       - Name: Dynamic Provisioning and Creating Storage Classes
-        File: dynamically_provisioning_pvs
+        File: dynamically_provisioning_pvs                
       - Name: Volume Security
         File: pod_security_context
       - Name: Selector-Label Volume Binding

--- a/install_config/persistent_storage/persistent_storage_azure.adoc
+++ b/install_config/persistent_storage/persistent_storage_azure.adoc
@@ -33,9 +33,7 @@ volume] framework allows administrators to provision a cluster with persistent
 storage and gives users a way to request those resources without having any
 knowledge of the underlying infrastructure.
 
-Azure Disk volumes can be
-xref:dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[provisioned
-dynamically]. Persistent volumes are not bound to a single project or namespace;
+Persistent volumes are not bound to a single project or namespace;
 they can be shared across the {product-title} cluster.
 xref:../../architecture/additional_concepts/storage.adoc#persistent-volume-claims[Persistent
 volume claims], however, are specific to a project or namespace and can be


### PR DESCRIPTION
Previously mistakenly introduced content into 3.3  via https://github.com/openshift/openshift-docs/pull/3300 and was pulled down via https://github.com/openshift/openshift-docs/pull/3491 and https://github.com/openshift/openshift-docs/pull/3489.

This is adding back topics to 3.4. Some other content in https://github.com/openshift/openshift-docs/pull/3300 related to dynamic provisioning of Azure can't be added in until 3.5. That will be reintroduced in a separate PR.