### PR TITLE
Adding in Azure dynamic provisioning content for 3.5

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -74,6 +74,10 @@ the master node. To do this, set the
 |xref:../../install_config/configuring_openstack.adoc#install-config-configuring-openstack[Configuring for OpenStack]
 |
 
+|Azure Disk
+|`kubernetes.io/azure-dd`
+|xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[Configuring for Azure]
+
 |===
 
 
@@ -124,7 +128,7 @@ from plug-in to plug-in.
 [[storage-class-annotations]]
 === StorageClass Annotations
 
-To set a _StorageClass_ as the cluster-wide default: 
+To set a _StorageClass_ as the cluster-wide default:
 ----
    storageclass.beta.kubernetes.io/is-default-class: "true"
 ----
@@ -259,7 +263,7 @@ When the persistent volumes are dynamically provisioned, the Gluster plugin auto
 ====
 
 [[ceph-persistentdisk-cephRBD]]
-=== Ceph RBD Object Defintion
+=== Ceph RBD Object Definition
 
 .ceph-storageclass.yaml
 ====
@@ -287,6 +291,33 @@ parameters:
 <5> Ceph RBD pool. Default is "rbd".
 <6> Ceph client ID that is used to map the RBD image. Default is the same as `adminId`.
 <7> The name of Ceph Secret for `userId` to map RBD image. It must exist in the same namespace as PVCs. It is required.
+====
+
+[[azure-disk]]
+=== Azure Disk Object Definition
+
+.azure-disk-storageclass.yaml
+====
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS  <1>
+  location: eastus  <2>
+  storageAccount: azure_storage_account_name  <3>
+
+----
+
+<1> `skuName`: Azure storage account Sku tier. Default is empty.
+<2> `location`: Azure storage account location. Default is empty.
+<3> `storageAccount`: Azure storage account name. If storage account is not
+provided, all storage accounts associated with the resource group are searched
+to find one that matches `skuName` and `location`. If storage account is
+provided, `skuName` and `location` are ignored.
 ====
 
 [[moreinfo]]

--- a/install_config/persistent_storage/persistent_storage_azure.adoc
+++ b/install_config/persistent_storage/persistent_storage_azure.adoc
@@ -33,7 +33,9 @@ volume] framework allows administrators to provision a cluster with persistent
 storage and gives users a way to request those resources without having any
 knowledge of the underlying infrastructure.
 
-Persistent volumes are not bound to a single project or namespace;
+Azure Disk volumes can be
+xref:dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[provisioned
+dynamically].Persistent volumes are not bound to a single project or namespace;
 they can be shared across the {product-title} cluster.
 xref:../../architecture/additional_concepts/storage.adoc#persistent-volume-claims[Persistent
 volume claims], however, are specific to a project or namespace and can be


### PR DESCRIPTION
Previously mistakenly introduced content into 3.3 via https://github.com/openshift/openshift-docs/pull/3300 and was pulled down via https://github.com/openshift/openshift-docs/pull/3491 and https://github.com/openshift/openshift-docs/pull/3489.

Content specific to 3.4 was added back in via https://github.com/openshift/openshift-docs/pull/3492. This content is related to dynamic provisioning of Azure, which can't be added in until 3.5. 