### PR TITLE
Bug 1384763 further scalability testing on cluster metrics

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -195,7 +195,7 @@ After the metrics deployer runs, the output of `oc get pods` should resemble the
 
 {product-title} metrics are stored using the Cassandra database, which is
 deployed with settings of `*MAX_HEAP_SIZE=512M*` and `*NEW_HEAP_SIZE=100M*`.
-These values should cover most  {product-title} metrics installations, but you
+These values should cover most {product-title} metrics installations, but you
 can modify them in the
 ifdef::openshift-origin[]
 link:https://github.com/openshift/origin-metrics/blob/master/cassandra/Dockerfile[Cassandra Dockerfile] 
@@ -212,55 +212,9 @@ endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 *_metrics.yaml_* configuration file.
 endif::openshift-enterprise[]
-After 7 days, Cassandra begins to purge the oldest metrics data.
+After seven days, Cassandra begins to purge the oldest metrics data.
 Metrics data for deleted pods and projects is not automatically
-purged; it is only removed once the data is 7 days old.
-
-.Data Accumulated by 10 Nodes and 1000 Pods
-====
-In a test scenario including 10 nodes and 1000 pods, a 24 hour period
-accumulated 2.5GB of metrics data. Therefore, the capacity planning formula for
-metrics data in this scenario is:
-
-(((2.5 × 10^9^) ÷ 1000) ÷ 24) ÷ 10^6^ = ~0.125 MB/hour per pod.
-====
-
-.Data Accumulated by 120 Nodes and 10000 Pods
-====
-In a test scenario including 120 nodes and 10000 pods, a 24 hour period
-accumulated 25GB of metrics data. Therefore, the capacity planning formula for
-metrics data in this scenario is:
-
-(((11.410 × 10^9^) ÷ 1000) ÷ 24) ÷ 10^6^ = 0.475 MB/hour
-====
-
-|===
-| |1000 pods| 10000 pods
-
-|Cassandra storage data accumulated over 24 hours (default metrics parameters)
-|2.5GB
-|11.4GB
-|===
-
-ifdef::openshift-origin[]
-These two test cases are presented on the following graph:
-
-image::https://raw.githubusercontent.com/ekuric/openshift/master/metrics/1_10kpods.png[1000 pods vs 10000 pods monitored during 24 hours]
-endif::openshift-origin[]
-
-If the default value of 7 days for `*METRIC_DURATION*` and 10 seconds for
-`*METRIC_RESOLUTION*` are preserved, then weekly storage requirements for the Cassandra pod would be:
-
-|===
-| |1000 pods | 10000 pods
-
-|Cassandra storage data accumulated over 7 days (default metrics parameters)
-|20GB
-|90GB
-|===
-
-In the previous table, an additional 10% was added to the expected storage space
-as a buffer for unexpected monitored pod usage.
+purged; it is only removed once the data is over seven days old.
 
 [WARNING]
 ====
@@ -287,6 +241,55 @@ To use this feature with {product-title} metrics, it is necessary to add an
 additional flag to the metrics-deployer: `DYNAMICALLY_PROVISION_STORAGE=true`.
 You can use EBS, GCE, and Cinder storage back-ends to
 xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provision persistent volumes].
+
+In tests performed with with 210 and 990 {product-title} nodes, where 10500 pods
+and 11000 pods were monitored respectively, the Cassandra database grew at the
+speed shown in the table below:
+
+.Cassandra Database storage requirements based on number of nodes/pods in the cluster
+[options="header"]
+|===
+|Number of Nodes |Number of Pods |Cassandra Storage growth speed |Cassandra storage growth per day |Cassandra storage growth per week
+
+|210
+|10500
+|500 MB per hour
+|15 GB
+|75 GB
+
+|990
+|11000
+|1 GB per hour
+|30 GB
+|210 GB
+|===
+
+In the above calculation, approximately 20% of the expected size was added as
+overhead to ensure that the storage requirements do not exceed calculated value.
+
+If the `METRICS_DURATION` and `METRICS_RESOLUTION` values are kept at the
+default (`7` days and `15` seconds respectively), it is safe to plan Cassandra
+storage size requrements for week, as in the values above.
+
+[WARNING]
+====
+Because {product-title} metrics uses the Cassandra database as a datastore for
+metrics data, if `USE_PERSISTANT_STORAGE=true` is set during the metrics set up
+process, `PV` will be on top in the network storage, with NFS as the default.
+However, using network storage in combination with Cassandra is not recommended,
+as per the
+link:http://docs.datastax.com/en/archived/cassandra/1.2/cassandra/architecture/architecturePlanningAntiPatterns_c.html[Cassandra
+documentation].
+====
+
+*Known Issues and Limitations*
+
+Testing found that the `heapster` metrics component is capable of handling up to
+12000 pods. If the amount of pods exceed that number, Heapster begins to fall
+behind in metrics processing, resulting in the possibility of metrics graphs no
+longer appearing. Work is ongoing to increase the number of pods that Heapster
+can gather metrics on, as well as upstream development of alternate
+metrics-gathering solutions.
 
 [[metrics-non-persistent-storage]]
 === Non-Persistent Storage


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1384763

@ekuric @jeremyeder This is the info from #3450 I've copied over. I was going to merge that PR, but a lot of the information was repeating what was already there, so I've really just added the information on the tests. Let me know if there's anything that I've not put in.

Also, would this make the other tests currently in the section irrelevant? That's here: https://docs.openshift.com/container-platform/3.3/install_config/cluster_metrics.html#capacity-planning-for-openshift-metrics (The two examples). Not sure how the testing works and if the new tests make the old ones out of date.

Also, please let me know if I've made any mistakes in my rewording of the PR.

Thanks