### PR TITLE
ipfailover - user check script overrides default

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -282,19 +282,19 @@ Each VIP in the set may end up being served by a different node.
 [[check-notify]]
 === Check and Notify Scripts
 
-The *keepalived* port monitoring feature supports one or two scripts that are
-run on a configured interval to verify that the application is available. The
-default script uses a simple
-xref:../install_config/install/prerequisites.adoc#required-ports[TCP
-connection] to verify that the application is running. This test is suppressed
-when the monitoring port is set to `0`. The administrator can supply an
-additional script that does the needed verification. For example, the script can
-test a web server by issuing a request and verifying the response. The script
-must exit with `0` for *PASS* and `1` for *FAIL*.
+*Keepalived* monitors the health of the application by periodically running 
+an optional user supplied check script.  For example, the script can test a
+web server by issuing a request and verifying the response.
 
-The administrator provides the additional script, via the
-`--check-script=<script>` option. By default, the check is done every two
-seconds, but can be changed using the `--check-interval=<seconds>` option.
+The script is provided through the `--check-script=<script>` option to the
+`oadm ipfailover` command. The script must exit with `0` for *PASS* or `1` for *FAIL*.
+
+By default, the check is done every two seconds, but can be changed using the
+`--check-interval=<seconds>` option.
+
+When a check script is not provided a simple default script is run that tests the
+xref:../install_config/install/prerequisites.adoc#required-ports[TCP connection].
+This default test is suppressed when the monitor port is 0.
 
 For each VIP, *keepalived* keeps the state of the node. The VIP on the node may
 be in *MASTER*, *BACKUP*, or *FAULT* state. All VIPs on the node that are not in


### PR DESCRIPTION
When the user supplies a check script, that check script replaces the
default check script. This change clearifies the wording in the doc.

bug bz1410721
https://bugzilla.redhat.com/show_bug.cgi?id=1410721

Signed-off-by: Phil Cameron <pcameron@redhat.com>