### PR TITLE
Cherry-pick: Sync topic_map title, fix stray block + typo

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -393,7 +393,7 @@ Topics:
   - Name: Configuring Global Build Defaults and Overrides
     File: build_defaults_overrides
     Distros: openshift-origin,openshift-enterprise
-  - Name: Configuring Build Pipeline Execution
+  - Name: Configuring Pipeline Execution
     File: configuring_pipeline_execution
     Distros: openshift-origin,openshift-enterprise
   - Name: Configuring Routing
@@ -484,7 +484,7 @@ Topics:
   - Name: Configuring Global Build Defaults and Overrides
     File: osd_build_defaults_overrides
     Distros: openshift-dedicated
-  - Name: Configuring Build Pipeline Execution
+  - Name: Configuring Pipeline Execution
     File: osd_configuring_pipeline_execution
     Distros: openshift-dedicated
   - Name: Allocating Node Resources

--- a/install_config/configuring_pipeline_execution.adoc
+++ b/install_config/configuring_pipeline_execution.adoc
@@ -18,12 +18,10 @@ toc::[]
 
 The first time a user creates a build configuration using the
 xref:../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline]
-build strategy,
-{product-title} looks for the a template named 
-`*jenkins-ephemeral*` in the `*openshift*` namespace
-and instantiates it within the user's project.
-The `*jenkins-ephemeral*` template that ships with {product-title} creates,
-upon instantiation:
+build strategy, {product-title} looks for a template named
+`*jenkins-ephemeral*` in the `*openshift*` namespace and instantiates it within
+the user's project. The `*jenkins-ephemeral*` template that ships with
+{product-title} creates, upon instantiation:
 
 * a deployment configuration for Jenkins
   using the official {product-title} Jenkins image
@@ -84,6 +82,5 @@ xref:../dev_guide/integrating_external_services.adoc#dev-guide-integrating-exter
 
 The latter option could also be used to disable autoprovisioning in select
 projects only.
-====
 
 // end::installconfig_configuring_pipeline_execution[]


### PR DESCRIPTION
The stray `====` was breaking the Install&Config guide on the Customer Portal something fierce (left-nav stopped at this topic + all subsequent headings in single-html were borked).