### PR TITLE
Deploy metrics using ansible: https://trello.com/c/piaWOfvB/

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -105,7 +105,7 @@ to configure persistent storage for your metrics pods.
 The size requirement of the Cassandra storage is dependent on the number of
 pods. It is the administrator's responsibility to ensure that the size
 requirements are sufficient for their setup and to monitor usage to ensure that
-the disk does not become full.  The size of the persisted volume is specified with the `*openshift_metrics_cassandra_pv_size*`
+the disk does not become full.  The size of the persisted volume claim is specified with the `*openshift_metrics_cassandra_pvc_size*`
 xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[ansible variable] which is set to 10 GB by default.
 
 If you would like to use xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned persistent volumes]
@@ -324,12 +324,12 @@ be added to your inventory file if it is necessary to override them.
 | The frequency that metrics are gathered defined as a number and time identifier(s,m,h)
 (e.g. 15s for 15 seconds).
 
-|`*openshift_metrics_cassandra_pv_prefix*`
+|`*openshift_metrics_cassandra_pvc_prefix*`
 |The persistent volume claim prefix created for Cassandra. A serial number is appended to the prefix starting
   from 1.
 
-|`*openshift_metrics_cassandra_pv_size*`
-| The persistent volume size for each of the Cassandra  nodes.
+|`*openshift_metrics_cassandra_cpvc_size*`
+| The persistent volume claim size for each of the Cassandra  nodes.
 
 |`*openshift_metrics_cassandra_storage_type*`
 | Use `emptydir` for ephemeral storage (for  testing), `pv` to use persistent volumes
@@ -414,7 +414,7 @@ xref:../install_config/cluster_metrics.adoc#configuring-openshift-metrics[config
 If you are using
 xref:../install_config/cluster_metrics.adoc#metrics-persistent-storage[persistent
 storage] with Cassandra, it is the administrator's responsibility to set a
-sufficient disk size for the cluster using the `*openshift_metrics_cassandra_pv_size*` variable.
+sufficient disk size for the cluster using the `*openshift_metrics_cassandra_pvc_size*` variable.
 It is also the administrator's responsibility to monitor disk usage to make sure
 that it does not become full.
 

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -355,6 +355,9 @@ by the start script based on available memory of the node on which it is schedul
 |`*openshift_metrics_cassandra_request_cpu*`
 | The CPU request for the Cassandra pod
 
+|`*openshift_metrics_cassandra_storage_group*`
+| The supplemental storage group to use for Cassandra
+
 |`*openshift_metrics_hawkular_ca*`
 | An optional certificate file:0 used to sign the Hawkular certificate
 

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -66,78 +66,24 @@ address of the node, then Heapster will fail to retrieve any metrics.
 ====
 endif::[]
 
-The components for cluster metrics must be deployed to the *openshift-infra*
-project. This allows xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[horizontal pod
-autoscalers] to discover the Heapster service and use it to retrieve metrics
-that can be used for autoscaling.
+An Ansible playbook is available to deploy cluster metrics.  You should familiarize yourself with the
+xref:../install_config/install/advanced_install.adoc[advanced installation and configuration] section.
+This provides information for prepairing to use Ansible and includes information about configuration.
+Parameters are added to the Ansible inventory file to configure various areas of cluster metrics.
 
-All of the following commands in this topic must be executed under the
-*openshift-infra* project. To switch to the *openshift-infra* project:
+The following describe the various areas and the parameters that can be added to the Ansible
+inventory file in order to modify the defaults:
 
-----
-$ oc project openshift-infra
-----
-
-To enable cluster metrics, you must next configure the following:
-
-- xref:../install_config/cluster_metrics.adoc#metrics-service-accounts[Service Accounts]
+- xref:../install_config/cluster_metrics.adoc#metrics-namespace[Metrics Project]
 - xref:../install_config/cluster_metrics.adoc#metrics-data-storage[Metrics Data Storage]
-- xref:../install_config/cluster_metrics.adoc#metrics-deployer[Metrics Deployer]
 
-[[metrics-service-accounts]]
-== Service Accounts
+[[metrics-namespace]]
+== Metrics Project
 
-You must configure xref:../admin_guide/service_accounts.adoc#admin-guide-service-accounts[service accounts]
-for:
-
-* xref:../install_config/cluster_metrics.adoc#metrics-deployer-service-account[Metrics Deployer]
-* xref:../install_config/cluster_metrics.adoc#heapster-service-account[Heapster]
-
-[[metrics-deployer-service-account]]
-=== Metrics Deployer Service Account
-
-The xref:metrics-deployer[Metrics Deployer] will be discussed in a later step,
-but you must first set up a service account for it:
-
-. Create a *metrics-deployer* service account:
-+
-----
-$ oc create -f - <<API
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: metrics-deployer
-secrets:
-- name: metrics-deployer
-API
-----
-
-. Before it can deploy components, the *metrics-deployer* service account must
-also be granted the `edit` permission for the *openshift-infra* project:
-+
-----
-$ oadm policy add-role-to-user \
-    edit system:serviceaccount:openshift-infra:metrics-deployer
-----
-
-[[heapster-service-account]]
-=== Heapster Service Account
-
-The Heapster component requires access to the master server to list all
-available nodes and access the `/stats` endpoint for each node. Before it can do
-this, the Heapster service account requires the `cluster-reader` permission:
-
-----
-$ oadm policy add-cluster-role-to-user \
-    cluster-reader system:serviceaccount:openshift-infra:heapster
-----
-
-[NOTE]
-====
-The Heapster service account is created automatically during the
-xref:../install_config/cluster_metrics.adoc#deploying-the-metrics-components[Deploying
-the Metrics Components] step.
-====
+The components for cluster metrics must be deployed to the *openshift-infra*
+project in order for autoscaling to work. xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[Horizontal pod
+autoscalers] specifically use this project to discover the Heapster service and use it to retrieve metrics.  The metrics
+project can be changed by adding `*openshift_metrics_project*` to the inventory file.
 
 [[metrics-data-storage]]
 == Metrics Data Storage
@@ -153,35 +99,24 @@ Running {product-title} cluster metrics with persistent storage means that
 your metrics will be stored to a
 xref:../architecture/additional_concepts/storage.adoc#persistent-volumes[persistent
 volume] and be able to survive a pod being restarted or recreated. This is
-ideal if you require your metrics data to be guarded from data loss.  For production environments it is highly recommended to configure persistent storage for your metrics pods.
-
-The size of the persisted volume can be specified with the `CASSANDRA_PV_SIZE`
-xref:../install_config/cluster_metrics.adoc#deployer-template-parameters[template
-parameter]. By default it is set to 10 GB, which may or may not be sufficient
-for the size of the cluster you are using. If you require more space, for
-instance 100 GB, you could specify it with something like this:
-
-----
-$ oc process -f metrics-deployer.yaml \
-    -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-    -v CASSANDRA_PV_SIZE=100Gi \
-    | oc create -f -
-----
+ideal if you require your metrics data to be guarded from data loss.  For production environments it is highly recommended
+to configure persistent storage for your metrics pods.
 
 The size requirement of the Cassandra storage is dependent on the number of
 pods. It is the administrator's responsibility to ensure that the size
 requirements are sufficient for their setup and to monitor usage to ensure that
-the disk does not become full.
+the disk does not become full.  The size of the persisted volume is specified with the `*openshift_metrics_cassandra_pv_size*`
+xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[ansible variable] which is set to 10 GB by default.
 
-If you would like to use xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned persistent volumes] 
-you must set the `*DYNAMICALLY_PROVISION_STORAGE*`
-xref:../install_config/cluster_metrics.adoc#modifying-the-deployer-template[template option] 
-to `true` for the Metrics Deployer.
+If you would like to use xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned persistent volumes]
+set the `*openshift_metrics_cassandra_storage_type*`
+xref:../install_config/cluster_metrics.adoc#metrics-ansible-variable[variable]
+to `*dynamic*` in the inventory file.
 
 [[capacity-planning-for-openshift-metrics]]
 === Capacity Planning for Cluster Metrics
 
-After the metrics deployer runs, the output of `oc get pods` should resemble the following:
+After running the `*openshift_metrics*` Ansible role, the output of `oc get pods` should resemble the following:
 
 ====
 ----
@@ -194,20 +129,23 @@ After the metrics deployer runs, the output of `oc get pods` should resemble the
 ====
 
 {product-title} metrics are stored using the Cassandra database, which is
-deployed with settings of `*MAX_HEAP_SIZE=512M*` and `*NEW_HEAP_SIZE=100M*`.
-These values should cover most  {product-title} metrics installations, but you
-can modify them in the
+deployed with settings of `*openshift_metrics_cassandra_limits_memory*: 2G`; this value could
+be adjusted further based upon the avialable memory as determined by the Cassandra start script.
+This value should cover most  {product-title} metrics installations, but you
+can modify, via environment variables, `*MAX_HEAP_SIZE*` along with heap new generation
+size (`*HEAP_NEWSIZE*`) in the
 ifdef::openshift-origin[]
-link:https://github.com/openshift/origin-metrics/blob/master/cassandra/Dockerfile[Cassandra Dockerfile] 
+link:https://github.com/openshift/origin-metrics/blob/master/cassandra/Dockerfile[Cassandra Dockerfile]
 endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 Cassandra Dockerfile
 endif::openshift-enterprise[]
 prior to deploying cluster metrics.
 
-By default, metrics data is stored for 7 days. You can configure this with the `*METRIC_DURATION*` parameter in the
+By default, metrics data is stored for 7 days. You can configure this by setting the `*openshift_metrics_duration*`
+variable in your hosts file which will update the upon deployment
 ifdef::openshift-origin[]
-link:https://github.com/openshift/origin-metrics/blob/master/metrics.yaml[*_metrics.yaml_* configuration file]. 
+link:https://github.com/openshift/origin-metrics/blob/master/metrics.yaml[*_metrics.yaml_* configuration file].
 endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 *_metrics.yaml_* configuration file.
@@ -248,8 +186,8 @@ These two test cases are presented on the following graph:
 image::https://raw.githubusercontent.com/ekuric/openshift/master/metrics/1_10kpods.png[1000 pods vs 10000 pods monitored during 24 hours]
 endif::openshift-origin[]
 
-If the default value of 7 days for `*METRIC_DURATION*` and 10 seconds for
-`*METRIC_RESOLUTION*` are preserved, then weekly storage requirements for the Cassandra pod would be:
+If the default value of 7 days for `*openshift_metrics_duration*` and 10 seconds for
+`*openshift_metrics_resolution*` are preserved, then weekly storage requirements for the Cassandra pod would be:
 
 |===
 | |1000 pods | 10000 pods
@@ -269,12 +207,14 @@ will occur.
 ====
 
 For cluster metrics to work with persistent storage, ensure that the persistent
-volume has the *ReadWriteOnce* access mode. If this mode is not active, then the persistent volume claim cannot locate the persistent volume, and Cassandra fails to start.
+volume has the *ReadWriteOnce* access mode. If this mode is not active, then the persistent volume claim
+cannot locate the persistent volume, and Cassandra fails to start.
 
 To use persistent storage with the metric components, ensure that a
-xref:../architecture/additional_concepts/storage.adoc#persistent-volumes[persistent volume] of sufficient size is available. The creation of
-xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent volume claims] is handled by the
-xref:../install_config/cluster_metrics.adoc#metrics-deployer[Metrics Deployer].
+xref:../architecture/additional_concepts/storage.adoc#persistent-volumes[persistent volume] of
+sufficient size is available. The creation of
+xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent volume claims] is handled by
+the OpenShift Ansible `*openshift_metrics*` role.
 
 {product-title} metrics also supports
 ifdef::openshift-origin[]
@@ -283,8 +223,8 @@ endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 dynamically-provisioned persistent volumes.
 endif::openshift-enterprise[]
-To use this feature with {product-title} metrics, it is necessary to add an
-additional flag to the metrics-deployer: `DYNAMICALLY_PROVISION_STORAGE=true`.
+To use this feature with {product-title} metrics, it is necessary to set the value
+of `*openshift_metrics_cassandra_storage_type*` to `*dynamic*`.
 You can use EBS, GCE, and Cinder storage back-ends to
 xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provision persistent volumes].
 
@@ -298,9 +238,9 @@ non-persistent data does come with the risk of permanent data loss. However,
 metrics can still survive a container being restarted.
 
 In order to use non-persistent storage, you must set the
-`*USE_PERSISTENT_STORAGE*`
-xref:../install_config/cluster_metrics.adoc#modifying-the-deployer-template[template
-option] to `false` for the Metrics Deployer.
+`*openshift_metrics_cassandra_storage_type*`
+xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[variable] to `*emptydir*`
+in the inventory file.
 
 [NOTE]
 ====
@@ -310,19 +250,16 @@ pod is running. Ensure *_/var_* has enough free space to accommodate metrics
 storage.
 ====
 
-[[metrics-deployer]]
-== Metrics Deployer
+[[metrics-ansible-role]]
+== Metrics Ansible Role
 
-The Metrics Deployer deploys and configures all of the metrics components. You
-can configure it by passing in information from
-xref:../dev_guide/secrets.adoc#dev-guide-secrets[secrets] and by passing
-parameters to the Metrics Deployer's
-xref:../architecture/core_concepts/templates.adoc#architecture-core-concepts-templates[template].
+The OpenShift Ansible `*openshift_metrics*` role configures and deploys all of the
+metrics components using the variables from the xref:../install_config/install/advanced_install.adoc[inventory file].
 
-[[metrics-deployer-using-secrets]]
+[[metrics-using-secrets]]
 === Using Secrets
 
-The Metrics Deployer will auto-generate self-signed certificates for use between its
+The OpenShift Ansible `*openshift_metrics*` role will auto-generate self-signed certificates for use between its
 components and will generate a
 xref:../architecture/core_concepts/routes.adoc#secured-routes[re-encrypting route] to expose
 the Hawkular Metrics service. This route is what allows the web console to access the Hawkular Metrics
@@ -331,217 +268,153 @@ service.
 In order for the browser running the web console to trust the connection through this route,
 it must trust the route's certificate. This can be accomplished by
 xref:metrics-using-secrets-byo-certs[providing your own certificates] signed by a trusted
-Certificate Authority. The Metric Deployer's secret allows you to pass your own certificates
+Certificate Authority. The `*openshift_metrics*` role allows you to specify your own certificates
 which it will then use when creating the route.
 
-If you do not wish to provide your own certificates, the router's default certificate will
-be used instead.
+The router's default certificate are used if you do not provide your own.
 
 [[metrics-using-secrets-byo-certs]]
 ==== Providing Your Own Certificates
 
 To provide your own certificate which will be used by the
 xref:../architecture/core_concepts/routes.adoc#secured-routes[re-encrypting route],
-you can pass these values as
-xref:../dev_guide/secrets.adoc#dev-guide-secrets[secrets] to the Metrics Deployer.
+you can set the 'cert, key, and ca' xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[variables]
+in your inventory file.
 
 The `hawkular-metrics.pem` value needs to contain the certificate in its *_.pem_*
 format. You may also need to provide the certificate for the Certificate Authority
 which signed this *_pem_* file via the `hawkular-metrics-ca.cert` secret.
 
-====
-----
-$ oc secrets new metrics-deployer \
-    hawkular-metrics.pem=/home/openshift/metrics/hm.pem \
-    hawkular-metrics-ca.cert=/home/openshift/metrics/hm-ca.cert
-----
-====
-
-When these secrets are provided, the deployer uses these values to specify the
-`key`, `certificate` and `caCertificate` values for the re-encrypting route it generated.
-
 For more information, please see the
 xref:../architecture/core_concepts/routes.adoc#secured-routes[re-encryption
 route documentation].
 
+[[metrics-ansible-variables]]
+==== Metrics Ansible Variables
 
-[[metrics-using-secrets-autogenerated]]
-==== Using the Router's Default Certificate
+The `openshift_metrics` role included with OpenShift Ansible defines the tasks to deploy
+cluster metrics.  Following is a list of role variables that can
+be added to your inventory file if it is necessary to override them.
 
-If the `hawkular-metrics.pem` value is not specified, the re-encrypting route will
-use the router's default certificate, which may not be trusted by browsers.
-
-A secret named *metrics-deployer* will still be required in this situation. This
-can be considered a "dummy" secret since the secret it specifies is not actually used
-by the component.
-
-To create a "dummy" secret that does not specify a certificate value:
-
-----
-$ oc secrets new metrics-deployer nothing=/dev/null
-----
-
-[[deployer-secret-options]]
-==== Deployer Secret Options
-
-The following table contains more advanced configuration options, detailing all
-the secrets which can be used by the deployer:
-
-[cols="2,4",options="header"]
-|===
-
-|Secret Name |Description
-
-|*_hawkular-metrics.pem_*
-|The *_pem_* file to use for the Hawkular Metrics certificate used for the
-re-encrypting route. This certificate *must* contain the host name used by the
-route (e.g., `*HAWKULAR_METRICS_HOSTNAME*`). The default router's certificate is
-used for the route if this option is unspecified.
-
-|*_hawkular-metrics-ca.cert_*
-|The certificate for the CA used to sign the *_hawkular-metrics.pem_*. This is optional if the *_hawkular-metrics.pem_*
-does not contain the CA certificate directly.
-
-|*_heapster.cert_*
-|The certificate for Heapster to use. This is auto-generated if unspecified.
-
-|*_heapster.key_*
-|The key to use with the Heapster certificate. This is ignored if
-*_heapster.cert_* is not specified
-
-|*_heapster_client_ca.cert_*
-|The certificate that generates *_heapster.cert_*. This is required if
-*_heapster.cert_* is specified.  Otherwise, the main CA for the {product-title}
-installation is used. In order for
-xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[horizontal pod autoscaling] to function
-properly, this should not be overridden.
-
-|*_heapster_allowed_users_*
-|A file containing a comma-separated list of CN to accept from certificates
-signed with the specified CA. By default, this is set to allow the
-{product-title} service proxy to connect.  If you override this, make sure to
-add `system:master-proxy` to the list in order to allow
-xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[horizontal pod autoscaling] to function
-properly.
-
-|===
-
-[[modifying-the-deployer-template]]
-=== Modifying the Deployer Template
-
-The {product-title}  installer uses a
-xref:../architecture/core_concepts/templates.adoc#architecture-core-concepts-templates[template] to deploy the
-metrics components. The default template can be found at the following path:
-
-ifdef::openshift-origin[]
-====
-----
-/usr/share/openshift/examples/infrastructure-templates/origin/metrics-deployer.yaml
-----
-====
-
-[NOTE]
-====
-Depending on your installation method, the template may not be present in your
-{product-title} installation. If so, the template can be found at the following GitHub
-location:
-
-https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_examples/files/examples/v1.2/infrastructure-templates/origin/metrics-deployer.yaml
-====
-
-endif::[]
-ifdef::openshift-enterprise[]
-====
-----
-/usr/share/openshift/examples/infrastructure-templates/enterprise/metrics-deployer.yaml
-----
-====
-endif::[]
-
-In case you need to make any changes to this file, copy it to another directory
-with the file name *_metrics-deployer.yaml_* and refer to the new location when
-using it in the following sections.
-
-[[deployer-template-parameters]]
-==== Deployer Template Parameters
-
-The deployer template parameter options and their defaults are listed in the
-default *_metrics-deployer.yaml_* file. If required, you can override these
-values when creating the Metrics Deployer.
-
-.Template Parameters
+.Ansible Variables
 [options="header"]
 |===
 
-|Parameter |Description
+|Variable |Description
 
-|`*METRIC_DURATION*`
-|The number of days metrics should be stored.
+|`*openshift_metrics_install_metrics*`
+|Deploy metrics if `true`.  Otherwise undeploy
 
-|`*CASSANDRA_PV_SIZE*`
-|The persistent volume size for each of the Cassandra nodes.
+|`*openshift_metrics_start_cluster*`
+|Start the metrics cluster after deploying the components.
 
-|`*CASSANDRA_NODES*`
-|The number of initial Cassandra nodes to deploy.
+|`*openshift_metrics_image_prefix*`
+|The prefix for the component images. e.g for "openshift/origin-metrics-cassandra:v1.3", set prefix "openshift/origin-".
 
-|`*USE_PERSISTENT_STORAGE*`
-|Set to *true* for persistent storage; set to *false* to use non-persistent storage.
+|`*openshift_metrics_image_version*`
+|The version for the component images. e.g. for "openshift/origin-metrics-cassandra:v1.3", set version "v1.3"
 
-|`*DYNAMICALLY_PROVISION_STORAGE*`
-|Set to *true* to allow for xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned storage].
+|`*openshift_metrics_startup_timeout*`
+|The time in seconds to wait until Hawkular Metrics and Heapster starts up before attempting a restart.
 
-|`*REDEPLOY*`
-|If set to *true*, the deployer will try to delete all the existing components
-before trying to redeploy.
+|`*openshift_metrics_duration*`
+| The number of days to store metrics before they are purged
 
-|`*HAWKULAR_METRICS_HOSTNAME*`
-|External host name where clients can reach Hawkular Metrics.  This is the FQDN
-of the machine running the router pod.
+|`*openshift_metrics_resolution*`
+| The frequency that metrics are gathered defined as a number and time identifier(s,m,h)
+(e.g. 15s for 15 seconds).
 
-|`*MASTER_URL*`
-|Internal URL for the master, for authentication retrieval.
+|`*openshift_metrics_cassandra_pv_prefix*`
+|The persistent volume claim prefix created for Cassandra. A serial number is appended to the prefix starting
+  from 1.
 
-|`*IMAGE_VERSION*`
-|Specify version for metrics components. For example, for
-*openshift/origin-metrics-deployer:latest*, set version to *latest*.
+|`*openshift_metrics_cassandra_pv_size*`
+| The persistent volume size for each of the Cassandra  nodes.
 
-|`*IMAGE_PREFIX*`
-|Specify prefix for metrics components. For example, for
-*openshift/origin-metrics-deployer:latest*, set prefix to *openshift/origin-*.
+|`*openshift_metrics_cassandra_storage_type*`
+| Use `emptydir` for ephemeral storage (for  testing), `pv` to use persistent volumes
+(which need to be created before the installation) or `dynamic` for dynamic persistent volumes.
 
-|`*MODE*`
-a|Can be set to:
+|`*openshift_metrics_cassandra_replicas*`
+| The number of Cassandra nodes for the metrics stack.  There will be this many
+Cassandra replication controllers.
 
-- *preflight* to perform validation before a deployment.
-- *deploy* to perform an initial deployment.
-- *refresh* to delete and redeploy all components but to keep persisted data and routes.
-- *redeploy* to delete and redeploy everything (losing all data in the process).
-- *validate* to re-run validations after a deployment.
+|`*openshift_metrics_cassandra_limits_memory*`
+| The amount of memory to limit the Cassandra pod (e.g. 2G).  This value could be further adjusted
+by the start script based on available memory of the node on which it is scheduled.
 
-|`*IGNORE_PREFLIGHT*`
-|Can be set to *true* to disable the preflight checks. This allows the deployer
-to continue even if the preflight check has failed.
+|`*openshift_metrics_cassandra_limits_cpu*`
+| The CPU limit for the Cassandra pod.
 
-|`*USER_WRITE_ACCESS*`
-|Sets whether user accounts should be able to write metrics. Defaults to `false`
-so that only Heapster can write metrics and not individual users. It is
-recommended to disable user write access; if enabled, any user will be able to
-write metrics to the system which can affect performance and can cause Cassandra
-disk usage to unpredictably increase.
+|`*openshift_metrics_cassandra_replicas*`
+|The number of replicas for Cassandra
+
+|`*openshift_metrics_cassandra_request_memory*`
+| The amount of memory to request for Cassandra pod (e.g. 1.5G).
+
+|`*openshift_metrics_cassandra_request_cpu*`
+| The CPU request for the Cassandra pod
+
+|`*openshift_metrics_hawkular_ca*`
+| An optional certificate file:0 used to sign the Hawkular certificate
+
+|`*openshift_metrics_hawkular_cert*`
+|The certificate file used for re-encrypting the route to Hawkular metrics.  The certificate must contain
+the hostname used by the route. The default router certificate is used if unspecified.
+
+|`*openshift_metrics_hawkular_key*`
+| The key file used with the Hawkular certificate
+
+|`*openshift_metrics_hawkular_limits_memory*`
+| The amount of memory to limit the Hawkular pod (e.g. 2G).  This value could be further adjusted
+by the start script based on available memory of the node on which it is scheduled.
+
+|`*openshift_metrics_hawkular_limits_cpu*`
+| The CPU limit for the Hawkular pod.
+
+|`*openshift_metrics_hawkular_replicas*`
+| The number of replicas for Hawkular metrics
+
+|`*openshift_metrics_hawkular_request_memory*`
+| The amount of memory to request for Hawkular pod (e.g. 1.5G).
+
+|`*openshift_metrics_hawkular_request_cpu*`
+| The CPU request for the Hawkular pod
+
+|`*openshift_metrics_heapster_allowed_users*`
+| A comma-separated list of CN to accept.  By  default, this is set to allow the
+OpenShift service proxy to connect.  *Note:* Add `system:master-proxy` to the list
+when overriding in order to allow xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[horizontal pod autoscaling]
+to function properly.
+
+|`*openshift_metrics_heapster_limits_memory*`
+| The amount of memory to limit the Heapster pod (e.g. 2G).
+
+|`*openshift_metrics_heapster_limits_cpu*`
+| The CPU limit for the Heapster pod.
+
+|`*openshift_metrics_heapster_request_memory*`
+| The amount of memory to request for Heapster pod (e.g. 1.5G).
+
+|`*openshift_metrics_heapster_request_cpu*`
+| The CPU request for the Heapster pod
+
+|`*openshift_metrics_heapster_standalone*`
+|Deploy only heapster, without the Hawkular Metrics and Cassandra components.
 
 |===
 
-The only required parameter is `*HAWKULAR_METRICS_HOSTNAME*`. This value is
-required when creating the deployer because it specifies the host name for the
+The only required variable is `*openshift_metrics_hawkular_hostname*`. This value is
+required when executing the `*openshift_metrics*` Ansible role because it uses the host name for the
 Hawkular Metrics xref:../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[route]. This
 value should correspond to a fully qualified domain name. You must know
-the value of `*HAWKULAR_METRICS_HOSTNAME*` when
+the value of `*openshift_metrics_hawkular_hostname*` when
 xref:../install_config/cluster_metrics.adoc#configuring-openshift-metrics[configuring the console] for metrics access.
 
 If you are using
 xref:../install_config/cluster_metrics.adoc#metrics-persistent-storage[persistent
 storage] with Cassandra, it is the administrator's responsibility to set a
-sufficient disk size for the cluster using the `*CASSANDRA_PV_SIZE*` parameter.
+sufficient disk size for the cluster using the `*openshift_metrics_cassandra_pv_size*` variable.
 It is also the administrator's responsibility to monitor disk usage to make sure
 that it does not become full.
 
@@ -550,15 +423,15 @@ that it does not become full.
 Data loss will result if the Cassandra persisted volume runs out of sufficient space.
 ====
 
-All of the other parameters are optional and allow for greater customization.
+All of the other variables are optional and allow for greater customization.
 For instance, if you have a custom install in which the Kubernetes master is not
 available under *_https://kubernetes.default.svc:443_* you can specify the value
-to use instead with the `*MASTER_URL*` parameter. To deploy a specific version
-of the metrics components, use the `*IMAGE_VERSION*` parameter.
+to use instead with the `*openshift_metrics_master_url*` parameter. To deploy a specific version
+of the metrics components, modify the `*openshift_metrics_image_version*` variable.
 
 [WARNING]
 ====
-It is highly recommended to not use *latest* for the *IMAGE_VERSION*. The *latest*
+It is highly recommended to not use *latest* for the *openshift_metrics_image_version*. The *latest*
 version corresponds to the very latest version available and can cause issues if it brings in a
 newer version not meant to function on the version of {product-title} you are currently running.
 ====
@@ -566,14 +439,11 @@ newer version not meant to function on the version of {product-title} you are cu
 [[deploying-the-metrics-components]]
 == Deploying the Metric Components
 
-Because deploying and configuring all the metric components is handled by the
-Metrics Deployer, you can simply deploy everything in one step.
+Because deploying and configuring all the metric components is handled with OpenShift Ansible,
+you can deploy everything in one step.
 
 The following examples show you how to deploy metrics with and without
-persistent storage using the default template parameters. Optionally, you can
-specify any of the
-xref:../install_config/cluster_metrics.adoc#deployer-template-parameters[template
-parameters] when calling these commands.
+persistent storage using the default parameters.
 
 .Deploying with Persistent Storage
 ====
@@ -583,9 +453,10 @@ The following command sets the Hawkular Metrics route to use
 You must have a persistent volume of sufficient size available.
 
 ----
-$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
-    -f metrics-deployer.yaml \
-    -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_metrics.yml \
+   -e openshift_metrics_install_metrics=True \
+   -e openshift_metrics_hawkular_hostname=hawkular-metrics.example.com \
+   -e openshift_metrics_cassandra_storage_type=pv
 ----
 ====
 
@@ -595,10 +466,9 @@ The following command sets the Hawkular Metrics route to use
 *hawkular-metrics.example.com* and deploy without persistent storage.
 
 ----
-$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
-    -f metrics-deployer.yaml \
-    -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-    -p USE_PERSISTENT_STORAGE=false
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_metrics.yml \
+   -e openshift_metrics_install_metrics=True \
+   -e openshift_metrics_hawkular_hostname=hawkular-metrics.example.com
 ----
 ====
 
@@ -608,35 +478,11 @@ Because this is being deployed without persistent storage, metric data loss
 can occur.
 ====
 
-[[metrics-deployer-validations]]
-=== Metrics Deployer Validations
+[[metrics-diagnostics]]
+=== Metrics Diagnostics
 
-The metrics deployer does some validation both before and after deployment. If
-the pre-flight validation fails, the environment for deployment is considered
-unsuitable and the deployment is aborted. However, you can add
-`*IGNORE_PREFLIGHT=true*` to the deployer parameters if you believe the
-validation has erred.
-
-If post-deployment validation fails, the deployer finishes in an *Error* state,
-which indicates that you should check the deployer logs for issues that may
-require addressing.  For example, the validation may detect that the external
-*hawkular-metrics* route is not actually in use, because the route was already
-created somewhere else. The validation output at the end of a deployment should
-explain as clearly as possible any issues it finds and what you can do to
-address them.
-
-Once you have addressed deployment validation issues, you can re-run just the
-validation by running the deployer again with the `*MODE=validate*` parameter
-added, for example:
-
-----
-$ oc new-app --as=system:serviceaccount:openshift-infra:metrics-deployer \
-    -f metrics-deployer.yaml \
-    -p HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-    -p MODE=validate
-----
-
-There is also a diagnostic for metrics:
+The are some diagnostics for metrics to assist in evaluating the state of the
+metrics stack.  To execute diagnostics for metrics:
 
 ----
 $ oadm diagnostics MetricsApiProxy
@@ -650,18 +496,18 @@ service to display its graphs. The URL for accessing the Hawkular Metrics
 service must be configured via the `*metricsPublicURL*` option in the
 xref:../install_config/master_node_configuration.adoc#master-configuration-files[master
 configuration file] (*_/etc/origin/master/master-config.yaml_*). This URL
-corresponds to the route created with the `*HAWKULAR_METRICS_HOSTNAME*` template
-parameter during the
+corresponds to the route created with the `*openshift_metrics_hawkular_hostname*`
+inventory variable used during the
 xref:../install_config/cluster_metrics.adoc#deploying-the-metrics-components[deployment]
 of the metrics components.
 
 [NOTE]
 ====
-You must be able to resolve the `*HAWKULAR_METRICS_HOSTNAME*` from the browser
+You must be able to resolve the `*openshift_metrics_hawkular_hostname*` from the browser
 accessing the console.
 ====
 
-For example, if your `*HAWKULAR_METRICS_HOSTNAME*` corresponds to
+For example, if your `*openshift_metrics_hawkular_hostname*` corresponds to
 `hawkular-metrics.example.com`, then you must make the following change in the
 *_master-config.yaml_* file:
 
@@ -701,8 +547,8 @@ To access and manage metrics more directly, use the Hawkular Metrics API.
 When accessing Hawkular Metrics via the API, you will only be able to perform
 reads. Writing metrics has been disabled by default. If you want for individual
 users to also be able to write metrics, you must set the
-`*USER_WRITE_ACCESS*`
-xref:../install_config/cluster_metrics.adoc#deployer-template-parameters[deployer template parameter]
+`*openshift_metrics_hawkular_user_write_access*`
+xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[variable]
 to *true*.
 
 However, it is recommended to use the default configuration and only have
@@ -711,7 +557,7 @@ will be able to write metrics to the system, which can affect performance and
 cause Cassandra disk usage to unpredictably increase.
 ====
 
-The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation] 
+The link:http://www.hawkular.org/docs/rest/rest-metrics.html[Hawkular Metrics documentation]
 covers how to use the API, but there are a few differences when dealing with the
 version of Hawkular Metrics configured for use on {product-title}:
 
@@ -781,8 +627,8 @@ nodes. Scaling {product-title} metrics heapster pods is not recommended.
 [[cluster-metrics-scaling-pods-prereqs]]
 === Prerequisites
 
-If persistent storage was used to deploy {product-title} metrics, then you must 
-xref:../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[create a persistent volume (PV)] 
+If persistent storage was used to deploy {product-title} metrics, then you must
+xref:../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[create a persistent volume (PV)]
 for the new Cassandra pod to use before you can scale out the number of
 {product-title} metrics Cassandra pods. However, if Cassandra was deployed with
 dynamically provisioned PVs, then this step is not necessary.
@@ -792,19 +638,13 @@ dynamically provisioned PVs, then this step is not necessary.
 
 The Cassandra nodes use persistent storage, therefore scaling up or down is not possible with replication controllers.
 
-Scaling a Cassandra cluster requires you to use the `hawkular-cassandra-node` template. By default, the Cassandra cluster is a single-node cluster. 
+Scaling a Cassandra cluster requires you to modify the `*openshift_metrics_cassandra_replicas*` variable and
+re-running the xref:../install_config/cluster_metrics.adoc#deploying-the-metrics-components[deployment].
+By default, the Cassandra cluster is a single-node cluster.
 ifdef::openshift-origin[]
-To add a second node with 10Gi of storage:
 
-----
-# oc process hawkular-cassandra-node-pv \
-    -v IMAGE_PREFIX=openshift/origin- \
-    -v IMAGE_VERSION=devel \
-    -v PV_SIZE=10Gi \
-    -v NODE=2
-----
-
-To deploy more nodes, simply increase the `NODE` value.
+To deploy more nodes, provision storage if `*openshift_metrics_cassandra_replicas*` equals `pv` and
+increase the `*openshift_metrics_cassandra_replicas*` value.
 endif::openshift-origin[]
 
 ifdef::openshift-enterprise[]
@@ -814,6 +654,9 @@ replicas, run:
 ----
 # oc scale -n openshift-infra --replicas=2 rc hawkular-metrics
 ----
+
+or update your inventory file and re-run the xref:../install_config/cluster_metrics.adoc#deploying-the-metrics-components[deployment].
+
 endif::openshift-enterprise[]
 
 [NOTE]
@@ -835,15 +678,10 @@ endif::[]
 [[metrics-cleanup]]
 == Cleanup
 
-You can remove everything deloyed by the metrics deployer by performing the
-following steps:
+You can remove everything deployed by the OpenShift Ansible `*openshift_metrics*` role
+by performing the following steps:
 
 ----
-$ oc delete all,sa,templates,secrets,pvc --selector="metrics-infra"
-----
-
-To remove the deployer components, perform the following steps:
-
-----
-$ oc delete sa,secret metrics-deployer
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_metrics.yml \
+   -e openshift_metrics_install_metrics=False
 ----

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -318,7 +318,7 @@ re-configured after deployment.
 
 |`*openshift_use_flannel*`
 |This variable enables *flannel* as an alternative networking layer instead of
-the default SDN. If enabling *flannel*, disable the default SDN with the 
+the default SDN. If enabling *flannel*, disable the default SDN with the
 *openshift_use_openshift_sdn* variable. For more information, see xref:../configuring_sdn.adoc#using-flannel[Using Flannel].
 
 |`*openshift_docker_additional_registries*`
@@ -626,14 +626,14 @@ following to enable cluster metrics when using the advanced install:
 ----
 [OSEv3:vars]
 
-openshift_hosted_metrics_deploy=true
+openshift_metrics_install_metrics=true
 ----
 ====
 
 === Metrics Storage
 
-The `*openshift_hosted_metrics_storage_kind*` variable must be set in order to
-use persistent storage. If `*openshift_hosted_metrics_storage_kind*` is not set,
+The `*openshift_metrics_cassandra_storage_type*` variable must be set in order to
+use persistent storage. If `*openshift_metrics_cassandra_storage_type*` is not set,
 then cluster metrics data is stored in an `EmptyDir` volume, which will
 be deleted when the Cassandra pod terminates.
 
@@ -690,7 +690,7 @@ volume provisioning for your cloud platform:
 ----
 [OSEv3:vars]
 
-#openshift_hosted_metrics_storage_kind=dynamic
+#openshift_metrics_cassandra_storage_type=dynamic
 ----
 ====
 


### PR DESCRIPTION
This PR is a first attempt to document:

* deploying metrics using the ansible role 'openshift_metrics'

cc @sdodson @mwringe @bbguimaraes @bmcelvee 

I think there are additional changes that will be necessary in 'install/advanced_install.adoc' regarding nfs configuration for storage, but I do not think we have moved the 'hosted_metrics' vars to have an equivalent in the new role.  Not really certain we need to.
