### PR TITLE
Change tag link, OCP should baseed on origin 1.4, not rc version.

### DIFF
--- a/release_notes/ocp_3_4_release_notes.adoc
+++ b/release_notes/ocp_3_4_release_notes.adoc
@@ -32,7 +32,7 @@ security, privacy, compliance, and governance requirements.
 Red Hat {product-title} version 3.4
 (link:https://access.redhat.com/errata/RHBA-2017:0066[RHBA-2017:0066]) is now
 available. This release is based on
-link:https://github.com/openshift/origin/releases/tag/v1.4.0-rc1[OpenShift Origin 1.4]. New features, changes, bug fixes, and known issues that pertain to
+link:https://github.com/openshift/origin/releases/tag/v1.4.0[OpenShift Origin 1.4]. New features, changes, bug fixes, and known issues that pertain to
 {product-title} 3.4 are included in this topic.
 
 For initial installations, see the


### PR DESCRIPTION
the same typo in 'enterprise-3.4' branch.