### PR TITLE
add steps to get docker-registry-ip

### DIFF
--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -184,7 +184,8 @@ strategy] processes.
 registries. If you have a registry that does not need a proxy for nodes to
 access, include the `NO_PROXY` parameter with the registry's host name, the
 registry service's IP address, and service name. This blacklists that registry,
-leaving the external HTTP proxy as the only option.
+leaving the external HTTP proxy as the only option. Retrieve the docker_registy_ip 
+by running: oc describe svc/docker-registry.
 
 . Edit the *_/etc/sysconfig/docker_* file and add the variables in shell format:
 +
@@ -192,7 +193,7 @@ leaving the external HTTP proxy as the only option.
 ----
 HTTP_PROXY=http://USERNAME:PASSWORD@10.0.1.1:8080/
 HTTPS_PROXY=https://USERNAME:PASSWORD@10.0.0.1:8080/
-NO_PROXY=master.hostname.example.com,172.30.123.45,docker-registry.default.svc.cluster.local
+NO_PROXY=master.hostname.example.com,<docker_registry_ip>,docker-registry.default.svc.cluster.local
 ----
 ====
 


### PR DESCRIPTION
**Motivation**
Clarify Docker Proxy Pull Configuration (NO_PROXY)

**Changes**
Include steps on how to retrieve the ip address for the docker-registry for the specific openshift installation.
Add a placeholder instead of using 172.30.123.45 as I understand this reflects that the ip should follow the format 172.30.<instance specific>.<instance specific>.
