### PR TITLE
Add note about pruning images with --namespace flag

### DIFF
--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -175,6 +175,13 @@ xref:../install_config/registry/extended_registry_configuration.adoc#docker-regi
 ====
 endif::[]
 
+[NOTE]
+====
+Pruning images with `--namespace` flag does not remove Images, only Image Streams.
+Images are non-namespaced resources and thus limiting pruning to a particular namespace
+makes it impossible to calculate their current usage.
+====
+
 .Prune Images CLI Configuration Options
 [cols="4,8",options="header"]
 |===


### PR DESCRIPTION
Specifying `--namespace` flag when pruning images causes some misunderstandings. Although we've mentioned that in our 3.4 release notes, I'll explicitly mention this here for other readers.

@openshift/team-documentation ptal