### PR TITLE
Make gluster endpoints and service the same name

### DIFF
--- a/install_config/storage_examples/gluster_example.adoc
+++ b/install_config/storage_examples/gluster_example.adoc
@@ -58,7 +58,7 @@ The named endpoints define each node in the Gluster-trusted storage pool:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: gluster-endpoints <1>
+  name: gluster-cluster <1>
 subsets:
 - addresses:              <2>
   - ip: 192.168.122.21
@@ -85,7 +85,7 @@ then create the endpoints object:
 ====
 ----
 # oc create -f gluster-endpoints.yaml
-endpoints "gluster-endpoints" created
+endpoints "gluster-cluster" created
 ----
 ====
 
@@ -93,9 +93,9 @@ Verify that the endpoints were created:
 
 ====
 ----
-# oc get endpoints gluster-endpoints
+# oc get endpoints gluster-cluster
 NAME                ENDPOINTS                           AGE
-gluster-endpoints   192.168.122.21:1,192.168.122.22:1   1m
+gluster-cluster     192.168.122.21:1,192.168.122.22:1   1m
 ----
 ====
 
@@ -111,7 +111,7 @@ To persist the Gluster endpoints, you also need to create a service.
 apiVersion: v1
 kind: Service
 metadata:
-  name: gluster-service <1>
+  name: gluster-cluster <1>
 spec:
   ports:
   - port: 1 <2>
@@ -127,7 +127,7 @@ then create the endpoints object:
 ====
 ----
 # oc create -f gluster-service.yaml
-endpoints "gluster-service" created
+endpoints "gluster-cluster" created
 ----
 ====
 
@@ -135,9 +135,9 @@ Verify that the service was created:
 
 ====
 ----
-# oc get service gluster-service
+# oc get service gluster-cluster
 NAME                CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
-gluster-service   10.0.0.130   <none>        1/TCP     9s
+gluster-cluster     10.0.0.130   <none>        1/TCP     9s
 
 ----
 ====
@@ -162,7 +162,7 @@ spec:
   accessModes:
   - ReadWriteMany    <3>
   glusterfs:         <4>
-    endpoints: gluster-endpoints        <5>
+    endpoints: gluster-cluster <5>
     path: /HadoopVol <6>
     readOnly: false
   persistentVolumeReclaimPolicy: Retain <7>


### PR DESCRIPTION
This prevents the endpoints from being automatically deleted