### PR TITLE
Remove references to --credentials option

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -246,7 +246,6 @@ The list of command options described here are a subset that are relevant to thi
 
             <options> = One or more of:
                 --create
-                --credentials=<credentials>
                 -l,--selector=<selector>
                 --virtual-ips=<ip-range>
                 -i|--interface=<interface>
@@ -561,7 +560,6 @@ ifdef::openshift-enterprise[]
 $ oadm router ha-router-us-west --replicas=5 \
     --selector="ha-svc-nodes=geo-us-west" \
     --labels="ha-svc-nodes=geo-us-west" \
-    --credentials=/etc/origin/master/openshift-router.kubeconfig \
     --service-account=ipfailover
 ----
 ====
@@ -573,7 +571,6 @@ ifdef::openshift-origin[]
 $ oadm router ha-router-us-west --replicas=5 \
     --selector="ha-svc-nodes=geo-us-west" \
     --labels="ha-svc-nodes=geo-us-west" \
-    --credentials="$KUBECONFIG" \
     --service-account=ipfailover
 ----
 ====
@@ -611,7 +608,6 @@ $ oadm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
     --selector="ha-svc-nodes=geo-us-west" \
     --virtual-ips="10.245.2.101-105" \
-    --credentials=/etc/origin/master/openshift-router.kubeconfig \
     --iptables-chain="INPUT" \
     --service-account=ipfailover --create
 ----
@@ -624,7 +620,6 @@ $ oadm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
     --selector="ha-svc-nodes=geo-us-west" \
     --virtual-ips="10.245.2.101-105" \
-    --credentials="$KUBECONFIG" \
     --iptables-chain="INPUT" \
     --service-account=ipfailover --create
 ----
@@ -642,7 +637,6 @@ $ oadm ipfailover ipf-ha-geo-cache \
     --replicas=5 --watch-port=9736 \
     --selector="ha-svc-nodes=geo-us-west" \
     --virtual-ips=10.245.3.101-105 \
-    --credentials=/etc/origin/master/openshift-router.kubeconfig \
     --vrrp-id-offset=10 \
     --service-account=ipfailover --create
 ----
@@ -655,7 +649,6 @@ $ oadm ipfailover ipf-ha-geo-cache \
     --replicas=5 --watch-port=9736 \
     --selector="ha-svc-nodes=geo-us-west" \
     --virtual-ips=10.245.3.101-105 \
-    --credentials="$KUBECONFIG" \
     --vrrp-id-offset=10 \
     --service-account=ipfailover --create
 ----
@@ -689,7 +682,6 @@ $ oadm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
     --selector="ha-svc-nodes=geo-us-west" \
     --virtual-ips="10.245.2.101-105" \
-    --credentials=/etc/origin/master/openshift-router.kubeconfig \
     --service-account=ipfailover --create
 ----
 ====
@@ -701,7 +693,6 @@ $ oadm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
     --selector="ha-svc-nodes=geo-us-west" \
     --virtual-ips="10.245.2.101-105" \
-    --credentials="$KUBECONFIG" \
     --service-account=ipfailover --create
 ----
 ====

--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -32,16 +32,14 @@ specify *0* as the stats port number.
 ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm router hap --service-account=router --stats-port=0  \
-    --credentials='/etc/origin/master/openshift-router.kubeconfig'
+$ oadm router hap --service-account=router --stats-port=0
 ----
 ====
 endif::[]
 ifdef::openshift-origin[]
 ====
 ----
-$ oadm router hap --service-account=router --stats-port=0  \
-    --credentials="$KUBECONFIG"
+$ oadm router hap --service-account=router --stats-port=0
 ----
 ====
 endif::[]

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -54,7 +54,7 @@ This specifies:
 
 - An `<action>` to perform, such as `new-project` or `router`.
 - An available `<option>` to perform the action on as well as a value for the
-option. Options include `--output` or `--credentials`.
+option. Options include `--output`.
 
 [[basic-admin-cli-operations]]
 

--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -271,7 +271,7 @@ $ oc project default
 . Set up an integrated Docker registry for the {product-title} cluster:
 +
 ----
-$ oadm registry --credentials=./openshift.local.config/master/openshift-registry.kubeconfig
+$ oadm registry
 ----
 +
 It will take a few minutes for the registry image to download and start - use

--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -107,7 +107,6 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
-    --credentials='/etc/origin/master/openshift-router.kubeconfig' \//<1>
     --service-account=router
 ----
 ====
@@ -123,15 +122,10 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
-    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \//<1>
     --service-account=router
 ----
 ====
 endif::[]
-<1> `--credentials` is the path to the
-xref:../../cli_reference/manage_cli_profiles.adoc#cli-reference-manage-cli-profiles[CLI configuration file]
-for the *openshift-router*. It is recommended using an *openshift-router*
-specific profile with appropriate permissions.
 
 [[f5-router-partition-paths]]
 == F5 Router Partition Paths

--- a/using_images/xpaas_images/eap.adoc
+++ b/using_images/xpaas_images/eap.adoc
@@ -61,7 +61,7 @@ The following is a list of prerequisites for using the xPaaS JBoss EAP images:
 . *Install and Deploy Docker Registry* - Install the Docker Registry and then ensure that the Docker Registry is deployed to locally manage images as follows:
 +
 ----
-$ oadm registry --config=/etc/origin/master/admin.kubeconfig --credentials=/etc/origin/master/openshift-registry.kubeconfig
+$ oadm registry --config=/etc/origin/master/admin.kubeconfig
 ----
 +
 For further information, see xref:../../install_config/registry/index.adoc#install-config-registry-overview[Deploying a Docker Registry]

--- a/using_images/xpaas_images/sso.adoc
+++ b/using_images/xpaas_images/sso.adoc
@@ -51,8 +51,7 @@ The following is a list of prerequisites for using the SSO xPaaS image:
 . *Install and Deploy Docker Registry*: Install the Docker Registry and then ensure that the Docker Registry is deployed to locally manage images:
 +
 ----
-$ oadm registry --config=/etc/origin/master/admin.kubeconfig \
-    --credentials=/etc/origin/master/openshift-registry.kubeconfig
+$ oadm registry --config=/etc/origin/master/admin.kubeconfig
 ----
 +
 For more information, see xref:../../install_config/registry/index.adoc#install-config-registry-overview[Deploying a Docker Registry]


### PR DESCRIPTION
`--credentials` has been deprecated for several releases and should not be used. Removing doc references.