### PR TITLE
Document the experimental registry signature endpoint

### DIFF
--- a/install_config/registry/accessing_registry.adoc
+++ b/install_config/registry/accessing_registry.adoc
@@ -272,3 +272,99 @@ cf2616975b4a: Image successfully pushed
 Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 ----
 ====
+
+[[access-reading-and-writing-image-signatures]]
+=== Reading and Writing Image Signatures
+The {product-title} integrated Docker Registry provides an "extensions" endpoint that
+allows you to write and read image signatures.
+The image signatures are stored in the {product-title} key-value store via Docker Registry API.
+
+[NOTE]
+====
+This endpoint is experimental and not supported by the upstream Docker Registry project.
+See link:https://docs.docker.com/registry/spec/api/[upstream API documentation] for
+general information about the Docker Registry API.
+====
+
+[[writing-image-signatures]]
+==== Writing Image Signatures
+In order to add a new signature to the Image, users can use the HTTP `PUT` method together
+with the JSON payload sent the extensions endpoint:
+
+====
+----
+PUT /extensions/v2/{namespace}/{name}/signatures/{digest}
+----
+====
+
+====
+----
+$ curl -X PUT --data @signature.json http://<user>:<token>@<registry-endpoint>:5000/extensions/v2/<namespace>/<name>/signatures/sha256:<digest>
+----
+====
+
+The JSON payload with the signature content should have the following structure:
+
+====
+----
+{
+  "version": 2,
+  "type":    "atomic",
+  "name":    "sha256:4028782c08eae4a8c9a28bf661c0a8d1c2fc8e19dbaae2b018b21011197e1484@cddeb7006d914716e2728000746a0b23",
+  "content": "<base64 encoded signature>",
+}
+----
+====
+
+The `name` field contains the name of the image signature, which has to be unique and in
+the following format: `<digest>@<name>`. The first part (`<digest>`) represents an image
+name and the second part (`<name>`) is the name of the signature.
+The signature name has to be 32 characters long.
+
+[NOTE]
+====
+In order to attach the signature to the Docker image the user must have the `system:image-signer` role.
+====
+
+[[reading-image-signatures]]
+==== Reading Image Signatures
+Assuming that you have already pushed the signed Docker image into the {product-title} integrated Docker
+Registry, you can read the signatures using the following command:
+
+====
+----
+GET /extensions/v2/{namespace}/{name}/signatures/{digest}
+----
+====
+
+====
+----
+$ curl http://<user>:<token>@<registry-endpoint>:5000/extensions/v2/<namespace>/<name>/signatures/sha256:<digest>
+----
+====
+
+Where the `namespace` represents the {product-title} project name or Docker Registry repository name and the `name`
+refers to the name of the repository. The `digest` represents the SHA256 checksum of the image.
+
+If the given Image contains the signature data, the output of the command above should
+produce following JSON response:
+
+====
+----
+{
+  "signatures": [
+  {
+    "version": 2,
+    "type":    "atomic",
+    "name":    "sha256:4028782c08eae4a8c9a28bf661c0a8d1c2fc8e19dbaae2b018b21011197e1484@cddeb7006d914716e2728000746a0b23",
+    "content": "<base64 encoded signature>",
+  }
+  ]
+}
+----
+====
+
+The `name` field contains the name of the image signature, which is unique and in the
+following format: `<digest>@<name>` where the `<digest>` represents the name of the image.
+The `name` has to be 32 character long.
+The `content` contains BASE64 encoded signature data (usually a GPG signed data).

--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -223,6 +223,14 @@ email argument values are ignored:
 $ docker login -p <token_value> -u unused -e unused <registry>[:<port>]
 ----
 
+[[image-signatures]]
+== Image Signatures
+
+The {product-title} integrated Docker registry allows the users to manipulate
+the image signatures using its own API.
+See xref:../install_config/registry/accessing_registry.adoc#access-reading-and-writing-image-signatures[reading and writing image signatures]
+for more information.
+
 [[rest-api-websockets]]
 == Websockets and Watching for Changes
 


### PR DESCRIPTION
This is WIP, I would like to add example of how you can sign the image using `atomic sign` or `atomic push` (@aweiteka to the rescue :-)

@openshift/team-documentation @miminar @legionus PTAL

Also i'm not sure what is the "right" section where this documentation should live (do we have something like "advanced registry" chapter?

The relevant Origin PR: https://github.com/openshift/origin/pull/12504

Also this documentation is for 3.4.1+ (do we have any label that says what is the target release? ;-)