### PR TITLE
Refactor search logic for future OCP releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Gemfile.lock
 *.swp
+.asciidoctor
 _package
 _preview
 architecture/core_concepts/images/docker-diagram.png

--- a/_templates/_search_enterprise.html.erb
+++ b/_templates/_search_enterprise.html.erb
@@ -9,8 +9,8 @@
     s.parentNode.insertBefore(gcse, s);
   })();
 </script>
-<% if version == '3.3' %>
-<gcse:search defaultToRefinement="Container Platform <%= version %>"></gcse:search>
-<% else %>
+<% if version == '3.0' or version == '3.1' or version == '3.2' %>
 <gcse:search defaultToRefinement="Enterprise <%= version %>"></gcse:search>
+<% else %>
+<gcse:search defaultToRefinement="Container Platform <%= version %>"></gcse:search>
 <% end %>


### PR DESCRIPTION
This change affects the search code behavior for enterprise releases such that future releases are automatically associated with "Container Platform X.Y" refinements in Google Custom Search, as opposed to the "Enterprise X.Y" refinements used for commercial releases 3.0 - 3.2.