### PR TITLE
Bug 1379434, Removed references to the deprecated --api-version flag

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -107,7 +107,7 @@ registry options].
 . Update the scheme used for the registry's liveness probe from HTTP to HTTPS:
 +
 ----
-$ oc patch dc/docker-registry --api-version=v1 -p '{"spec": {"template": {"spec": {"containers":[{
+$ oc patch dc/docker-registry -p '{"spec": {"template": {"spec": {"containers":[{
     "name":"registry",
     "livenessProbe":  {"httpGet": {"scheme":"HTTPS"}}
   }]}}}}'
@@ -123,7 +123,7 @@ endif::[]
 or later, update the scheme used for the registry's readiness probe from HTTP to HTTPS:
 +
 ----
-$ oc patch dc/docker-registry --api-version=v1 -p '{"spec": {"template": {"spec": {"containers":[{
+$ oc patch dc/docker-registry -p '{"spec": {"template": {"spec": {"containers":[{
     "name":"registry",
     "readinessProbe":  {"httpGet": {"scheme":"HTTPS"}}
   }]}}}}'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1379434

Applies changes outlined in https://github.com/openshift/openshift-docs/pull/3446