### PR TITLE
dockerfilePath must be a path to a file

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -448,7 +448,7 @@ The `dockerfilePath` field allows the build to use a different path to
 locate your Dockerfile, relative to the `BuildConfig.spec.source.contextDir`
 field. It can be simply a different file name other than the default
 *_Dockerfile_* (for example, *_MyDockerfile_*), or a path to a Dockerfile in a
-subdirectory (for example, *_dockerfiles/app1/_*):
+subdirectory (for example, *_dockerfiles/app1/Dockerfile_*):
 
 ====
 [source,yaml]
@@ -456,7 +456,7 @@ subdirectory (for example, *_dockerfiles/app1/_*):
 strategy:
   type: Docker
   dockerStrategy:
-    dockerfilePath: dockerfiles/app1/
+    dockerfilePath: dockerfiles/app1/Dockerfile
 ----
 ====
 


### PR DESCRIPTION
dockerfilePath must be empty or be a path to a file.  It cannot be a path to a directory.
There is no logic to locate a file named "Dockerfile" within a directory. [imagebuilder.go](https://github.com/openshift/imagebuilder/blob/4f935b40669b54c135328bf2e0e94df3ec33f290/cmd/imagebuilder/imagebuilder.go#L44)