### PR TITLE
[Bug 1413198] Added bullet for leaving port 9300 open

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -149,6 +149,9 @@ $ oadm policy add-cluster-role-to-user rolebinding-reader \
 this service account.
 ====
 
+. Ensure that port 9300 is open. By default the Elasticsearch service uses port 9300 for TCP communication between nodes in a cluster.  
+
+
 [[aggregate-logging-specifying-deployer-parameters]]
 == Specifying Deployer Parameters
 


### PR DESCRIPTION
Edited "Aggregating Container Logs" topic to add bullet to Pre-deployment Configuration to leave port 9300 open