### PR TITLE
Make haproxy maxconn configurable

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -221,6 +221,7 @@ $ oc set env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LO
 |`*ROUTER_DENIED_DOMAINS*` | | A comma-separated list of domains that the host name in a route can not be part of. No subdomain in the domain can be used either. Overrides option `ROUTER_ALLOWED_DOMAINS`.
 |`*ROUTER_ENABLE_COMPRESSION*`| false | If `true`, compress responses when possible.
 |`*ROUTER_LOG_LEVEL*` | warning | The log level to send to the syslog server.
+|`*ROUTER_MAX_CONNECTIONS*`| 2000 | Maximum number of concurrent connections.
 |`*ROUTER_OVERRIDE_HOSTNAME*`|  | If set, override the spec.host value for a route with the template in ROUTER_SUBDOMAIN.
 |`*ROUTER_SERVICE_HTTPS_PORT*` | 443 | Port to listen for HTTPS requests.
 |`*ROUTER_SERVICE_HTTP_PORT*` | 80 | Port to listen for HTTP requests.

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -241,6 +241,30 @@ oc label route <route=name> key=value
 $ oc describe dc/<route_name>
 ----
 
+
+[[concurrent-connections]]
+Setting the Maximum Number of Concurrent Connections::
+
+The default maximum number of connections that can be handled by the router is 20000. 
+You can change that limit depending on your needs.  Too few connections will prevent the
+health check from working which causes unneeded restarts. The system needs to be configured
+to support the maximum number of connections.  The limits shown in 'sysctl fs.nr_open' and
+'sysctl fs.file-max' must be large enough or haproxy will not start.
+
+
+When the router is created the --max-connections= option sets the desired limit, 
+
+====
+----
+$ oadm router --max-connections=10000   ....
+----
+====
+
+The *ROUTER_MAX_CONNECTIONS* environment variable in the router's deployment config can
+be edited to change the value. The router pods are restarted with the new value.
+If *ROUTER_MAX_CONNECTIONS* is not present the default, 20000, is used.
+
+
 [[highly-available-routers]]
 == Highly-Available Routers
 


### PR DESCRIPTION
bug fix in 3.5 

The haproxy maxconn (maximum connections) is by default 2000. This
change make that configurable with a defaul tof 20000 through the
oadm router --max-connections= option when creating a router and through
changing the ROUTER_MAX_CONNECTIONS environment variable in an existing
router.

origin PR 12716

bug 1405440
https://bugzilla.redhat.com/show_bug.cgi?id=1405440