### PR TITLE
Adding non-containerized glusterfs dynamic provisioning example

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -375,8 +375,10 @@ Topics:
         File: ceph_example
       - Name: Complete Example Using GlusterFS
         File: gluster_example
-      - Name: Dynamic Provisioning Example Using GlusterFS
+      - Name: Dynamic Provisioning Example Using Containerized GlusterFS
         File: gluster_dynamic_example
+      - Name: Dynamic Provisioning Example Using Non-Containerized GlusterFS
+        File: external_gluster_dynamic_example
       - Name: Mounting Volumes To Privileged Pods
         File: privileged_pod_storage
       - Name: Backing Docker Registry with GlusterFS Storage

--- a/install_config/storage_examples/external_gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/external_gluster_dynamic_example.adoc
@@ -1,0 +1,415 @@
+[[install-config-storage-examples-external-gluster-dynamic-example]]
+= Complete Example of Dynamic Provisioning Using Non-Containerized GlusterFS
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[NOTE]
+====
+This example assumes a working {product-title} installed and functioning along
+with Heketi and GlusterFS.
+
+All `oc` commands are executed on the {product-title} master host.
+====
+
+
+== Overview
+
+Container Native Storage (CNS) using Gluster and Heketi is a great way to perform dynamic provisioning 
+in a Kubernetes based cluster {product-title} for shared filesystems, but what if an existing Gluster cluster is available 
+and you want to provision storage from it rather than a containerized GlusterFS implementation?
+
+This example will show how simple it is to install and configure a Heketi Server to work with
+{product-title} to perform dynamic provisioning.
+
+This example assumes some familiarity with Kubernetes and the link:http://kubernetes.io/docs/user-guide/persistent-volumes/[Kubernetes Persistent Storage] model.
+
+This example also assumes you have access to an existing GlusterFS cluster that has raw devices available for consumption and management by Heketi Server.  If 
+you do not have this, you can create a 3 node cluster using your Virtual Machine solution of choice and make sure you create a few raw devices and give
+plenty of space (recommend at least 100GB).  See link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Installation_Guide/[installing Red Hat Gluster Install Guide].
+
+[[environment-and-prerequisites-for-this-example]]
+== Environment and prerequisites for this example
+
+GlusterFS Cluster running RHGS 3.1 (3 nodes, each with at least 2 X 100GB RAW devices)
+
+	   - gluster23.rhs (192.168.1.200)
+	   - gluster24.rhs (192.168.1.201)
+	   - gluster25.rhs (192.168.1.202)
+
+Heketi Server/Client Node running RHEL 7.x or RHGS 3.1 (Heketi can be installed on one of the Gluster Nodes)
+
+	   - glusterclient2.rhs (192.168.1.203)
+
+{product-title} Node
+
+	   - k8dev2.rhs (192.168.1.208)
+
+[NOTE]
+====
+This example uses a single node cluster (master + node)
+====
+
+[[installing-and-configuring-Heketi]]
+== Installing and configuring Heketi
+
+Heketi is used to manage our gluster cluster storage (adding volumes, removing volumes, etc…). As stated this can be RHEL or RHGS,
+and can be installed on one of the existing Gluster Storage Nodes.
+This example will use a stand-alone RHGS 3.1 Node running Heketi.
+
+The link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Administration_Guide/ch06s02.html[Red Hat Storage Administration Guide] can be used a reference
+during this process.
+
+
+. Install Heketi and the Heketi-Client.
++
+----
+	From the node designated to run Heketi and Client.
+
+	# yum install heketi heketi-client -y
+----
++
+[NOTE]
+====
+The Heketi Server can be any of the existing nodes, typically this will be the Master Node.
+For this example however, we used a separate Node not part of the GlusterFS or {product-title} cluster.
+====
+
+. Create and install Heketi private keys on each cluster node.
++
+----
+	From the Node that is running Heketi.
+
+ 	# ssh-keygen -f /etc/heketi/heketi_key -t rsa -N ''
+ 	# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster23.rhs
+	# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster24.rhs
+	# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster25.rhs
+ 	# chown heketi:heketi /etc/heketi/heketi_key*
+----
+
+
+. Edit the /usr/share/heketi/heketi.json file to setup the SSH executor.
++
+----
+	Below is an excerpt from the /usr/share/heketi/heketi.json file, the part to configure
+	is the executor and ssh section. 
+
+       ...
+	"executor": "ssh",  <1>
+
+	"_sshexec_comment": "SSH username and private key file information",
+	"sshexec": {
+  	  "keyfile": "/etc/heketi/heketi_key",  <2>
+  	  "user": "root",  <3>
+  	  "port": "22",  <4>
+  	  "fstab": "/etc/fstab"  <5>
+	},
+----
+<1> Change "executor": from mock to ssh
+<2> Add in the public key directory specified in previous step
+<3> Update SSH user (should have sudo/root type access)
+<4> Set the port to 22 - remove all other text
+<5> Set the fstab to default (etc/fstab) - remove all other text
+
+
+. Restart and enable.
++
+----
+	# systemctl restart heketi
+	# systemctl enable heketi
+----
+
+. Test connection to Heketi.
++
+----
+        # curl http://glusterclient2.rhs:8080/hello
+        Hello from Heketi
+----
+
+. Set an environment variable for the Heketi Server.
++
+----
+	# export HEKETI_CLI_SERVER=http://glusterclient2.rhs:8080
+----
+
+[[load-topology-and-using-heketi-with-gluster]]
+== Load topology and using Heketi with Gluster
+
+Topology is used to tell Heketi about the environment, what nodes and devices it will manage.
+
+[NOTE]
+====
+Heketi is currently limited to managing raw devices only, if a device is already a Gluster volume it
+will be skipped and ignored.
+====
+
+
+. Create and load the topology file
++
+----
+There is a sample file located in /usr/share/heketi/toplogy-sample.json (default) or /etc/heketi depending on how it was installed.
+
+
+{
+  "clusters": [
+    {
+      "nodes": [
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster23.rhs"
+              ],
+              "storage": [
+                "192.168.1.200"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster24.rhs"
+              ],
+              "storage": [
+                "192.168.1.201"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster25.rhs"
+              ],
+              "storage": [
+                "192.168.1.202"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+      ]
+    }
+  ]
+}
+----
+
+
+. Using heketi-cli, run the following command to load the topology of your environment.
++
+----
+	# heketi-cli topology load --json=topology.json
+
+    	Found node gluster23.rhs on cluster bdf9d8ca3fa269ff89854faf58f34b9a
+   		Adding device /dev/sde ... OK
+   	 	Adding device /dev/sdf ... OK
+    	Creating node gluster24.rhs ... ID: 8e677d8bebe13a3f6846e78a67f07f30
+   	 	Adding device /dev/sde ... OK
+   	 	Adding device /dev/sdf ... OK
+	...
+	...
+----
+
+
+
+. Create a Gluster volume to verify Heketi.
++
+----
+	# heketi-cli volume create --size=50
+----
+
+
+. View the volume information from one of the the Gluster nodes:
++
+----
+	# gluster volume info
+ 
+	Volume Name: vol_335d247ac57ecdf40ac616514cc6257f <1>
+	Type: Distributed-Replicate
+	Volume ID: 75be7940-9b09-4e7f-bfb0-a7eb24b411e3
+	Status: Started
+        ...
+	...
+
+----
+<1> Volume created by heketi-cli.
+
+
+[[dynamically-provision-a-volume]]
+== Dynamically Provision a Volume
+
+
+. Create a Storage Class.
++
+Below definition is based on the minimum requirements needed for this
+example to work with {product-title}.  To see xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[additional parameters and specification
+definitions].
++
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: gluster-dyn
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "http://glusterclient2.rhs:8080"  <1>
+  restauthenabled: "false"  <2>
+----
+<1> The Heketi Server from HEKETI_CLI_SERVER env variable.
+<2> Since we did not turn on authentication, setting this to false.
+
+
+. From the {product-title} master node, create the storage class.
++
+----
+	# oc create -f glusterfs-storageclass1.yaml
+	storageclass "gluster-dyn" created
+----
+
+. Now create a pvc, requesting the storage class, below is a sample definition.
++
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+ name: gluster-dyn-pvc
+ annotations:
+   volume.beta.kubernetes.io/storage-class: gluster-dyn
+spec:
+ accessModes:
+  - ReadWriteMany
+ resources:
+   requests:
+ 	storage: 30Gi
+----
+
+. From the {product-title} master node, create the pvc.
++
+----
+	# oc create -f glusterfs-pvc-storageclass.yaml
+	persistentvolumeclaim "gluster-dyn-pvc" created
+----
+
+. View the pvc to see that the volume was dynamically created and bound to the pvc.
++
+----
+	# oc get pvc
+	NAME          	STATUS	VOLUME                                 	CAPACITY   ACCESSMODES   STORAGECLASS   AGE
+	gluster-dyn-pvc   Bound 	pvc-78852230-d8e2-11e6-a3fa-0800279cf26f   30Gi   	RWX       	gluster-dyn	42s
+----
+
+. Verify and view the new volume on one of the Gluster Nodes.
++
+----
+	# gluster volume info
+ 
+	Volume Name: vol_335d247ac57ecdf40ac616514cc6257f <1>
+	Type: Distributed-Replicate
+	Volume ID: 75be7940-9b09-4e7f-bfb0-a7eb24b411e3
+	Status: Started
+        ...
+	Volume Name: vol_f1404b619e6be6ef673e2b29d58633be  <2>
+	Type: Distributed-Replicate
+	Volume ID: 7dc234d0-462f-4c6c-add3-fb9bc7e8da5e
+	Status: Started
+	Number of Bricks: 2 x 2 = 4
+	...
+
+----
+<1> Volume created by heketi-cli.
+<2> New dynamically created volume triggered by Kubernetes and the Storage Class.
+
+
+[[create-a-nginx-pod-that-uses-the-pvc]]
+== Create a NGINX pod that uses the PVC
+
+At this point we have a dynamically created GlusterFS volume, bound to a PersistentVolumeClaim, we can now utilize this claim
+in a pod.  We will create a simple NGINX pod.
+
+
+. Create the Pod YAML file.
++
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gluster-pod1
+  labels:
+    name: gluster-pod1
+spec:
+  containers:
+  - name: gluster-pod1
+    image: gcr.io/google_containers/nginx-slim:0.8
+    ports:
+    - name: web
+      containerPort: 80
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: gluster-vol1
+      mountPath: /usr/share/nginx/html
+  volumes:
+  - name: gluster-vol1
+    persistentVolumeClaim:
+      claimName: gluster-dyn-pvc <1>
+----
+<1> The name of the PVC created in the previous step.
+
+. Submit the pod yaml.
++
+----
+	# oc create -f nginx-pod.yaml
+	pod "gluster-pod1" created
+----
+
+. View the Pod (Give it a few minutes, it might need to download the image if it doesn't already exist).
++
+----
+	# oc get pods -o wide
+	NAME                               READY     STATUS    RESTARTS   AGE       IP               NODE
+	gluster-pod1                       1/1       Running   0          9m        10.38.0.0        node1
+
+----
+
+. Now we will exec into the container and create an index.html file.
++
+----
+	# oc exec -ti gluster-pod1 /bin/sh
+	$ cd /usr/share/nginx/html
+	$ echo 'Hello World from GlusterFS!!!' > index.html
+	$ ls
+	index.html
+	$ exit
+----
+
+. Now we can curl the URL of our pod.
++
+----
+	# curl http://10.38.0.0
+	Hello World from GlusterFS!!!
+----
+

--- a/install_config/storage_examples/gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/gluster_dynamic_example.adoc
@@ -1,5 +1,5 @@
 [[install-config-storage-examples-gluster-dynamic-example]]
-= Complete Example of Dynamic Provisioning Using GlusterFS
+= Complete Example of Dynamic Provisioning Using Containerized GlusterFS
 {product-author}
 {product-version}
 :data-uri:


### PR DESCRIPTION
This example is a variation from using the CNS (containerized approach) and instead uses an existing external Gluster cluster and how to easily configure that for use with dynamic provisioning.

This example should probably be targeted for 3.5 since that is the yaml examples I used

@adellape 