### PR TITLE
Bug 1408293, clarified that if using a service the endpoints name must match the service name

### DIFF
--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -175,7 +175,8 @@ spec:
   ports:
   - port: 1
 ----
-<1> This name must be defined in the endpoints definition to match the endpoints to this service
+<1> This name must be defined in the endpoints definition. If using a service, then
+the endpoints name must match the service name.
 ====
 
 . Save the service definition to a file, for example *_gluster-service.yaml_*,
@@ -289,6 +290,11 @@ created in xref:creating-gluster-endpoints[Creating Gluster Endpoints].
 <6> The Gluster volume that will be accessed, as shown in the `gluster volume status`
 command.
 <7> The Recycle policy is currently not supported with glusterfs
+====
+
+[NOTE]
+====
+Endpoints are name-spaced. Each project accessing the Gluster volume needs its own endpoints.
 ====
 
 . Save the definition to a file, for example *_gluster-pv.yaml_*, and create

--- a/install_config/storage_examples/gluster_example.adoc
+++ b/install_config/storage_examples/gluster_example.adoc
@@ -72,7 +72,8 @@ subsets:
     protocol: TCP
 
 ----
-<1> The name of the endpoints is used in the PV definition below.
+<1> The endpoints name. If using a service, then the endpoints name must match the
+service name.
 <2> An array of IP addresses for each node in the Gluster pool. Currently, host
 names are not supported.
 <3> The port numbers are ignored, but must be legal port numbers. The value *1*
@@ -104,6 +105,11 @@ gluster-cluster     192.168.122.21:1,192.168.122.22:1   1m
 To persist the Gluster endpoints, you also need to create a service.
 ====
 
+[NOTE]
+====
+Endpoints are name-spaced. Each project accessing the Gluster volume needs its own endpoints.
+====
+
 .GlusterFS Service Definition
 ====
 [source,yaml]
@@ -117,7 +123,8 @@ spec:
   - port: 1 <2>
 
 ----
-<1> The name of the service.
+<1> The name of the service. If using a service, then the endpoints name must match
+the service name.
 <2> The port should match the same port used in the endpoints.
 ====
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1408293

This PR is follow-up work to:
https://github.com/openshift/openshift-docs/pull/3545
https://github.com/openshift/openshift-docs/pull/3546
https://github.com/openshift/openshift-docs/pull/3547