### PR TITLE
Bug 1282822 Arranged section creating routes and the post-creation options

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -185,10 +185,20 @@ addresses; because of the NAT configuration, the originating IP address
 ====
 
 [[env-variables]]
-*Configuration Parameters*
+== Configuration Parameters
 
 For all the items outlined in this section, you can set environment
-variables on the *deployment config* for the router to alter its configuration.
+variables on the *deployment config* for the router to alter its configuration, or use the `oc set env` command:
+
+----
+$ oc set env <object_type>/<object_name> KEY1=VALUE1 KEY2=VALUE2
+----
+
+For example:
+
+----
+$ oc set env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LOG_LEVEL=debug
+----
 
 .Router Configuration Parameters
 [cols="3*", options="header"]
@@ -230,12 +240,6 @@ variables on the *deployment config* for the router to alter its configuration.
 |`*TEMPLATE_FILE*` | `/var/lib/haproxy/conf/custom/haproxy-config-custom.template` | The path to the haproxy template file (in the image).
 |`*RELOAD_INTERVAL*` | 12s | The minimum frequency the router is allowed to reload to accept new changes.
 |===
-
-As an example, you can apply the parameters listed using the example:
-
-----
-$ oc set env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LOG_LEVEL=debug
-----
 
 [NOTE]
 ====

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -68,8 +68,32 @@ routers deployment configuration and you may want to increase them based on the
 load of the router.
 ====
 
+[[deploy-router-create-router]]
+== Creating a Router
+
+The
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick
+installation] process automatically creates a default router. If the router does
+not exist, run the following to create a router:
+
+ifdef::openshift-enterprise[]
+----
+$ oadm router <router_name> --replicas=<number> --service-account=router
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+$ oadm router <router_name> --replicas=<number> --service-account=router
+----
+endif::[]
+
+You can also xref:creating-router-shards[use router shards] to ensure that the
+router is filtered to specific namespaces or routes, or
+xref:../../architecture/core_concepts/routes.adoc#env-variables[set any
+environment variables] after router creation.
+
 [[basic-router-commands]]
-== Basic Router Commands
+== Other Basic Router Commands
 
 [[deploy-router-check-default]]
 Checking the Default Router::
@@ -108,24 +132,6 @@ endif::[]
 ifdef::openshift-origin[]
 ----
 $ oadm router -o yaml --service-account=router
-----
-endif::[]
-
-[[deploy-router-create-router]]
-Creating a Router::
-
-The
-xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation]
-process automatically creates a default router. To create a router if it does not exist:
-
-ifdef::openshift-enterprise[]
-----
-$ oadm router <router_name> --replicas=<number> --service-account=router
-----
-endif::[]
-ifdef::openshift-origin[]
-----
-$ oadm router <router_name> --replicas=<number> --service-account=router
 ----
 endif::[]
 


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1282822

A tough BZ as it's about dated docs, but I've tried to rearrange the necessary information after a conversation with @knobunc . I moved up the "creating a route" section, and included a bit on router shards and creating environment variables in a paragraph after. I also moved around the command for setting environment variables in the architecture section, thinking it's best to have that before instead of after the list on envars.

I'll ask for a ack from the BZ reporter in the BZ, but @knobunc let me know if you have any thoughts. I know you were asking specifically about the ROUTE_FIELDS and ROUTE_LABELS envars...