### PR TITLE
Revert "Revert "Fix documentation for multizone pv configuration""

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -59,10 +59,7 @@ node with `*Key=KubernetesCluster,Value=clusterid*`.
 |GCE Persistent Disk (gcePD)
 |`kubernetes.io/gce-pd`
 |xref:../../install_config/configuring_gce.adoc#install-config-configuring-gce[Configuring for GCE]
-|In multi-zone configurations, persistent volumes (PVs) must be created in the same region/zone as
-the master node. To do this, set the
-`*failure-domain.beta.kubernetes.io/region*` and
-`*failure-domain.beta.kubernetes.io/zone*` PV labels to match the master node.
+|In multi-zone configurations, it is advisable to run one Openshift cluster per GCE project to avoid PVs from getting created in zones where no node from current cluster exists.
 
 |GlusterFS
 |`kubernetes.io/glusterfs`

--- a/install_config/persistent_storage/persistent_storage_gce.adoc
+++ b/install_config/persistent_storage/persistent_storage_gce.adoc
@@ -142,3 +142,36 @@ formatted with the given file system.
 
 This allows using unformatted GCE volumes as persistent volumes, because
 {product-title} formats them before the first use.
+
+[[gce-persistent-disk-multi-zone-configuration]]
+
+=== Multi-zone Configuration
+In multi-zone configurations, You must specify
+`*failure-domain.beta.kubernetes.io/region*` and
+`*failure-domain.beta.kubernetes.io/zone*` PV labels to match the zone where
+GCE volume exists.
+
+.Persistent Volume Object With Failure Domain
+====
+
+[source,yaml]
+----
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "pv0001"
+  labels:
+    failure-domain.beta.kubernetes.io/region: "us-central1" <1>
+    failure-domain.beta.kubernetes.io/zone: "us-central1-a" <2>
+spec:
+  capacity:
+    storage: "5Gi"
+  accessModes:
+    - "ReadWriteOnce"
+  gcePersistentDisk:
+    fsType: "ext4"
+    pdName: "pd-disk-1"
+----
+<1> The region in which the volume exists.
+<2> The zone in which the volume exists.
+====


### PR DESCRIPTION
This reverts commit e005a267daa9756249c1cd5fc4bfa653dd436b95.

Description of GCE Multizone PV configuration was mistakenly reverted.
So this PR is adding back information that were mistakenly deleted in [this commit](https://github.com/openshift/openshift-docs/pull/3316/commits/e005a267daa9756249c1cd5fc4bfa653dd436b95).

@gnufied @openshift/team-documentation PTAL

Target versions: 3.4 and 3.5