### PR TITLE
Note node disruption kills bare pods

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -40,6 +40,12 @@ rather than directly by users.
 The recommended maximum number of pods per {product-title} node host is 110.
 ====
 
+[WARNING]
+====
+Bare pods that are not managed by a xref:../architecture/core_concepts/deployments.adoc#replication-controllers[replication
+controller] will be not rescheduled upon node disruption.
+====
+
 Below is an example definition of a pod that provides a long-running
 service, which is actually a part of the {product-title} infrastructure: the
 integrated container registry. It demonstrates many features of pods, most of


### PR DESCRIPTION
Clarification about what happens when a pod that is not backed up by a replication controllers is terminated on a node.