### PR TITLE
IPSec documentation with libreswan 3.15

### DIFF
--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -38,10 +38,10 @@ with a host that does.
 
 [[admin-guide-ipsec-prerequisites]]
 === Step 1: Prerequisites
-Ensure that the *libreswan* package, version 3.19 or later, is installed
-on cluster hosts. Only version 3.19 and later includes the necessary
-opportunistic group functionality that allows hosts to be configured without
-knowledge of every other host in the cluster.
+Ensure that the *libreswan* package, version 3.15 or later, is installed
+on cluster hosts. If opportunistic group functionality is required then
+*libreswan* version 3.19 or later is required. At this time *libreswan*
+3.15 is the latest version supported on Red Hat Enterprise Linux 7.
 
 [[admin-guide-ipsec-certificates]]
 === Step 2: Certificates
@@ -97,6 +97,11 @@ file, as it is only temporary.
 Now that the necessary certificates are imported into the *libreswan*
 certificate database, create a policy that uses them to secure communication
 between hosts in your cluster.
+
+If using *libreswan* 3.19 or later then opportunistic group configuration is
+recommended. Otherwise explicit connections are required
+
+==== Opportunistic Group Configuration
 
 The following configuration creates two *libreswan* connections. The first
 encrypts traffic using the {product-title} certificates, while the second
@@ -159,11 +164,52 @@ that traffic can enter and exit the cluster. Add the gateway to the
 Additional hosts and subnets may be added to this file, which will result in
 all traffic to these hosts and subnets being unencrypted.
 
-. Restart the *libreswan* service to load the new configuration and policies,
+==== Explicit Connection Configuration
+
+In this configuration each node IPSec configuration must explicitly list
+configuration of every other node in the cluster. Use of a configuration
+management tool such as ansible to generate this file on each host is strongly
+recommended.
+
+. Place the following lines into the *_/etc/ipsec.d/openshift-cluster.conf_* file on each node for each other node:
++
+----
+conn <other_node_hostname>
+        left=<this_node_ip> <1>
+        leftid="CN=<this_node_cert_nickname>" <2>
+        leftrsasigkey=%cert
+        leftcert=<this_node_cert_nickname> <2>
+        right=<other_node_ip> <3>
+        rightid="CN=<other_node_cert_nickname>" <4>
+        rightrsasigkey=%cert
+        auto=start
+        keyingtries=%forever
+----
+<1> Replace <this_node_ip> with the cluster IP address of this node.
+<2> Replace <this_node_cert_nickname> with the node certificate nickname from step one.
+<3> Replace <other_node_ip> with the clusnter IP address of the other node.
+<4> Replace <other_node_cert_nickname> with the other node certificate nickname from step one.
+
+. Place the following content in *_/etc/ipsec.d/openshift-cluster.secrets_* file on each node:
++
+----
+: RSA "<this_node_cert_nickname>" <1>
+----
+<1> Replace <this_node_cert_nickname> with the node certificate nickname from step one.
+
+== Starting and Enabling IPSec
+
+. Start the *ipsec* service to load the new configuration and policies,
 and begin encrypting:
 +
 ----
-systemctl restart ipsec
+systemctl start ipsec
+----
+
+. Enable the *ipsec* service to start on boot:
++
+----
+systemctl enable ipsec
 ----
 
 [[admin-guide-ipsec-troubleshooting]]

--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -197,6 +197,23 @@ conn <other_node_hostname>
 ----
 <1> Replace <this_node_cert_nickname> with the node certificate nickname from step one.
 
+== IPSec Firewall Configuration
+
+All nodes within the cluster need to allow IPSec related network traffic. This
+includes IP protocol numbers 50 and 51 as well as UDP port 500.
+
+For example, if the cluster nodes communicate over interface eth0, rules of
+the following form may be used:
++
+---
+-A OS_FIREWALL_ALLOW -i eth0 -p 50 -j ACCEPT
+-A OS_FIREWALL_ALLOW -i eth0 -p 51 -j ACCEPT
+-A OS_FIREWALL_ALLOW -i eth0 -p udp --dport 500 -j ACCEPT
+---
+
+IPSec also uses UDP port 4500 for NAT traversal, though this should not apply
+to normal cluster deployments.
+
 == Starting and Enabling IPSec
 
 . Start the *ipsec* service to load the new configuration and policies,


### PR DESCRIPTION
The current documentation shows IPSec support with libreswan 3.19 with opportunistic groups. At present only up to version 3.15 of the libreswan package is supported on RHEL7. This is causing confusion and support issues around IPSec for OCP as the docs steer administrators to use unsupported software.

This pull request documents how to configure libreswan 3.15 without using opportunistic routing.

This configuration has been tested and automated with Ansible: https://github.com/jkupferer/ansible-role-openshift-ipsec