### PR TITLE
Bug 1418850 Commented out ipsec file

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -515,9 +515,9 @@ Topics:
   - Name: Sysctls
     File: sysctls
     Distros: openshift-origin,openshift-enterprise
-  - Name: Encrypting Hosts with IPsec
-    File: ipsec
-    Distros: openshift-origin,openshift-enterprise
+#  - Name: Encrypting Hosts with IPsec
+#    File: ipsec
+#    Distros: openshift-origin,openshift-enterprise
   - Name: Building Dependency Trees
     File: building_dependency_trees
     Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1418850

Commented out Ipsec file. Didn't delete the file, as it'll be supported in a later release.