### PR TITLE
Revert source-secret-match-uri commits for OCP 3.3

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -850,8 +850,7 @@ Source secrets are used to provide the builder pod with access to Git repositori
 that it would not normally have access to, such as private repositories or
 repositories with self-signed or untrusted SSL certificates.
 
-The following source secret configurations are supported.  Follow the link to
-learn how to create a source secret of the given configuration.
+The following source secret configurations are supported:
 
 - xref:gitconfig-file[Gitconfig File]
 - xref:basic-authentication[Basic Authentication]
@@ -864,14 +863,8 @@ You can also use xref:combinations[combinations] of the these configurations
 to meet your specific needs.
 ====
 
-Builds are run with the *builder* service account, which must have access to any
-source secrets used.  Access is granted with the following command:
-
-====
-----
-$ oc secrets link builder mysecret
-----
-====
+All source secrets must be linked to the builder account and added to the build
+configuration using the following instructions:
 
 [NOTE]
 ====
@@ -880,35 +873,6 @@ default. This means that if `serviceAccountConfig.limitSecretReferences` is set
 to `false` (the default setting) in the master configuration file, linking
 secrets to a service is not required.
 ====
-
-[[automatic-addition-of-a-source-secret-to-a-build-configuration]]
-===== Automatic addition of a source secret to a build configuration
-
-{product-title} can automatically add a source secret to relevant build
-configurations if the source secret includes one or more annotations prefixed
-with the text `build.openshift.io/source-secret-match-uri-`.  The value of
-each annotation indicates a URI pattern of a source repository against which the
-secret matches.  The URI pattern must consist of all of:
-
-- a valid scheme (`*://`, `git://`, `http://`, `https://` or `ssh://`)
-- a host (`\*` or a valid hostname or IP address optionally preceeded by `*.`)
-- a path (`/\*` or `/` followed by any characters optionally including `*` characters).
-
-In all of the above, a `*` character is interpreted as a wildcard.
-
-[NOTE]
-====
-{product-title} will not automatically add a source secret to a build
-configuration which already contains a source secret.
-====
-
-If multiple source secrets match the URI of a particular source repository,
-{product-title} will select a secret with a longest match.  This allows for
-basic overriding, as in the following example.
-
-The following fragment shows two partial source secrets, the first matching any
-server in the domain `mycorp.com` accessed by HTTPS; the second overriding
-access to servers mydev1.mycorp.com and mydev2.mycorp.com:
 
 . Add the secret to the builder service account. Each build is run with
 the *builder* role, so you must give it access to your secret with the
@@ -920,19 +884,8 @@ $ oc secrets link builder basicsecret
 ----
 ====
 
-A `build.openshift.io/source-secret-match-uri-` annotation may be added to a
-pre-existing secret as follows:
-
-----
-$ oc annotate secret mysecret 'build.openshift.io/source-secret-match-uri-1=https://*.mycorp.com/*'
-----
-
-[[manual-addition-of-a-source-secret-to-a-build-configuration]]
-===== Manual addition of a source secret to a build configuration
-
-Source secrets can be added manually to a build configuration by adding a
-`sourceSecret` field to the `source` section inside the `BuildConfig` and
-setting it to the name of the `secret` that you created (`basicsecret`, in this
+. Add a `sourceSecret` field to the `source` section inside the `BuildConfig` and
+set it to the name of the `secret` that you created (`basicsecret`, in this
 example).
 +
 ====
@@ -970,6 +923,7 @@ existing build configuration:
 $ oc set build-secret --source bc/sample-build basicsecret
 ----
 ====
+
 xref:using-secrets-in-the-buildconfig[Defining Secrets in the
 BuildConfig] provides more information on this topic.
 

--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -850,7 +850,8 @@ Source secrets are used to provide the builder pod with access to Git repositori
 that it would not normally have access to, such as private repositories or
 repositories with self-signed or untrusted SSL certificates.
 
-The following source secret configurations are supported:
+The following source secret configurations are supported.  Follow the link to
+learn how to create a source secret of the given configuration.
 
 - xref:gitconfig-file[Gitconfig File]
 - xref:basic-authentication[Basic Authentication]
@@ -864,11 +865,13 @@ to meet your specific needs.
 ====
 
 Builds are run with the *builder* service account, which must have access to any
-source secrets used. Access is granted with the following command:
+source secrets used.  Access is granted with the following command:
 
+====
 ----
 $ oc secrets link builder mysecret
 ----
+====
 
 [NOTE]
 ====
@@ -879,16 +882,16 @@ secrets to a service is not required.
 ====
 
 [[automatic-addition-of-a-source-secret-to-a-build-configuration]]
-===== Automatic Addition of a Source Secret to a Build Configuration
+===== Automatic addition of a source secret to a build configuration
 
 {product-title} can automatically add a source secret to relevant build
 configurations if the source secret includes one or more annotations prefixed
-with `build.openshift.io/source-secret-match-uri-`. The value of each annotation
-indicates a URI pattern of a source repository against which the secret matches.
-The URI pattern must consist of:
+with the text `build.openshift.io/source-secret-match-uri-`.  The value of
+each annotation indicates a URI pattern of a source repository against which the
+secret matches.  The URI pattern must consist of all of:
 
-- a valid scheme (`*://`, `git://`, `http://`, `https://` or `ssh://`).
-- a host (`\*` or a valid hostname or IP address optionally preceded by `*.`).
+- a valid scheme (`*://`, `git://`, `http://`, `https://` or `ssh://`)
+- a host (`\*` or a valid hostname or IP address optionally preceeded by `*.`)
 - a path (`/\*` or `/` followed by any characters optionally including `*` characters).
 
 In all of the above, a `*` character is interpreted as a wildcard.
@@ -896,15 +899,15 @@ In all of the above, a `*` character is interpreted as a wildcard.
 [NOTE]
 ====
 {product-title} will not automatically add a source secret to a build
-configuration that already contains a source secret.
+configuration which already contains a source secret.
 ====
 
 If multiple source secrets match the URI of a particular source repository,
-{product-title} will select the secret with the longest match. This allows for
+{product-title} will select a secret with a longest match.  This allows for
 basic overriding, as in the following example.
 
 The following fragment shows two partial source secrets, the first matching any
-server in the domain `mycorp.com` accessed by HTTPS, and the second overriding
+server in the domain `mycorp.com` accessed by HTTPS; the second overriding
 access to servers mydev1.mycorp.com and mydev2.mycorp.com:
 
 . Add the secret to the builder service account. Each build is run with
@@ -917,8 +920,19 @@ $ oc secrets link builder basicsecret
 ----
 ====
 
-. Add a `sourceSecret` field to the `source` section inside the `BuildConfig` and
-set it to the name of the `secret` that you created (`basicsecret`, in this
+A `build.openshift.io/source-secret-match-uri-` annotation may be added to a
+pre-existing secret as follows:
+
+----
+$ oc annotate secret mysecret 'build.openshift.io/source-secret-match-uri-1=https://*.mycorp.com/*'
+----
+
+[[manual-addition-of-a-source-secret-to-a-build-configuration]]
+===== Manual addition of a source secret to a build configuration
+
+Source secrets can be added manually to a build configuration by adding a
+`sourceSecret` field to the `source` section inside the `BuildConfig` and
+setting it to the name of the `secret` that you created (`basicsecret`, in this
 example).
 +
 ====


### PR DESCRIPTION
xrefs:

https://github.com/openshift/openshift-docs/pull/3465
https://github.com/openshift/openshift-docs/pull/3475
https://bugzilla.redhat.com/show_bug.cgi?id=1324213

FYI @bparees @jim-minter, here's the 3.3 version of https://github.com/openshift/openshift-docs/pull/3649.