### PR TITLE
ipfailover - Permission denied for check and notify scripts

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -345,7 +345,8 @@ $ oc create configmap mycustomcheck --from-file=mycheckscript.sh
 ----
 
 . There are two approaches to adding the script to the pod: use `oc` commands or
-edit the deployment configuration.
+edit the deployment configuration. In both cases the defaultMode for the mounted
+configMap files must allow execution.  A value of 0755 (493 decimal) is typical.
 
 .. Using `oc` commands:
 +
@@ -356,7 +357,7 @@ $ oc set env dc/ipf-ha-router \
 $ oc volume dc/ipf-ha-router --add --overwrite \
     --name=config-volume \
     --mount-path=/etc/keepalive \
-    --source='{"configMap": { "name": "mycustomcheck"}}'
+    --source='{"configMap": { "name": "mycustomcheck", "defaultMode": 493}}'
 ----
 +
 .. Editing the *ipf-ha-router* deployment configuration:
@@ -380,6 +381,7 @@ with a text editor.
 ...
       volumes: <3>
       - configMap:
+          defaultMode: 0755 <4>
           name: customrouter
         name: config-volume
 ...
@@ -388,6 +390,8 @@ with a text editor.
 environment variable to point to the mounted script file.
 <2> Add the `spec.container.volumeMounts` field to create the mount point.
 <3> Add a new `spec.volumes` field to mention the ConfigMap.
+<4> This sets execute permission on the files. When read back it will be
+displayed in decimal, 493.
 +
 ... Save the changes and exit the editor. This restarts *ipf-ha-router*.
 


### PR DESCRIPTION
Openshift 3.5

Document setting execute permission in configMap in the RC
volumes:configMap:defaultMode: 493

bug 1408172
https://bugzilla.redhat.com/show_bug.cgi?id=1408172