### PR TITLE
Add rhel-7-fast-datapath-rpms to the list of repos to be enabled

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -96,7 +96,8 @@ Note that this could take a few minutes if you have a large number of available 
 # subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-ose-3.4-rpms"
+    --enable="rhel-7-server-ose-3.4-rpms" \
+    --enable="rhel-7-fast-datapath-rpms"
 ----
 endif::[]
 

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -125,7 +125,8 @@ channel and enable the 3.4 channel on each master and node host:
 ----
 # subscription-manager repos --disable="rhel-7-server-ose-3.3-rpms" \
     --enable="rhel-7-server-ose-3.4-rpms"\
-    --enable="rhel-7-server-extras-rpms"
+    --enable="rhel-7-server-extras-rpms" \
+    --enable="rhel-7-fast-datapath-rpms"
 # yum clean all
 ----
 

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -54,7 +54,9 @@ channel and enable the 3.4 channel on each host:
 ----
 # subscription-manager repos --disable="rhel-7-server-ose-3.3-rpms" \
     --enable="rhel-7-server-ose-3.4-rpms" \
-    --enable="rhel-7-server-extras-rpms"
+    --enable="rhel-7-server-extras-rpms" \
+    --enable="rhel-7-fast-datapath-rpms"
+
 ----
 +
 On RHEL 7 systems, also clear the *yum* cache:


### PR DESCRIPTION
This repo is required for OCP 3.5 and later.

I didn't bump the 3.4 and 3.5 in the repos but we should do that for 3.5 release.