### PR TITLE
Update registry cert secret name to match installer

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -70,7 +70,7 @@ security reasons, it is recommended to not make it greater than this value.
 . Create the secret for the registry certificates:
 +
 ----
-$ oc secrets new registry-secret \
+$ oc secrets new registry-certificates \
     /etc/secrets/registry.crt \
     /etc/secrets/registry.key
 ----
@@ -79,8 +79,8 @@ $ oc secrets new registry-secret \
 service account):
 +
 ----
-$ oc secrets link registry registry-secret
-$ oc secrets link default  registry-secret
+$ oc secrets link registry registry-certificates
+$ oc secrets link default  registry-certificates
 ----
 +
 [NOTE]
@@ -95,7 +95,7 @@ secrets to a service is not required.
 +
 ----
 $ oc volume dc/docker-registry --add --type=secret \
-    --secret-name=registry-secret -m /etc/secrets
+    --secret-name=registry-certificates -m /etc/secrets
 ----
 +
 . Enable TLS by adding the following environment variables to the registry


### PR DESCRIPTION
The installer uses `registry-certificates` as the secret's name for the certs when securing the registry (see openshift/openshift-ansible#2409).

This updates the docs to use the same name name for the Secret for consistency when this is performed manually.
