### PR TITLE
Bug 1418681 Arranged f5 router section

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -21,10 +21,41 @@ The F5 router plug-in is available starting in {product-title} 3.0.2.
 ====
 endif::[]
 
-The F5 router plug-in is provided as a container image and run as a pod, just like
-the xref:../../install_config/router/default_haproxy_router.adoc#install-config-router-default-haproxy[default HAProxy router]. Deploying the F5 router is
-done similarly as well, using the `oadm router` command but providing additional
-flags (or environment variables) to specify the following parameters for the *F5
+The F5 router plug-in is provided as a container image and run as a pod, just
+like the
+xref:../../install_config/router/default_haproxy_router.adoc#install-config-router-default-haproxy[default
+HAProxy router]. 
+
+[[install-router-f5-prerequisites]]
+== Prerequisites
+
+When deploying the F5 router plug-in, ensure you meet the following
+requirements:
+
+. An F5 host IP and credentials
+. The name of the virtual servers (for both HTTP and HTTPS)
+. The private key to the F5 instance
+. The host-internal IP and VXLAN gateway
+ifdef::openshift-origin[]
+. Ensure you have xref:../../install_config/router/index.adoc#creating-the-router-service-account[created the router service account].
+endif::[]
+
+[[deploying-the-f5-router]]
+== Deploying the F5 Router
+
+[IMPORTANT]
+====
+The F5 router must be run in privileged mode, because route certificates are
+copied using the `scp` command:
+
+----
+$ oadm policy remove-scc-from-user hostnetwork -z router
+$ oadm policy add-scc-to-user privileged -z router
+----
+====
+
+Deploy the F5 router with the `oadm router` command, but provide additional
+flags (or environment variables) specifying the following parameters for the *F5
 BIG-IP®* host:
 
 [[f5-router-flags]]
@@ -65,37 +96,8 @@ verification with the *F5 BIG-IP®* host.
 |Specifies the *F5 BIG-IP®* xref:f5-router-partition-paths[partition path] (the default is */Common*).
 |===
 
-As with the HAProxy router, the `oadm router` command creates the service and
-deployment configuration objects, and thus the replication controllers and
-pod(s) in which the F5 router itself runs. The replication controller restarts
-the F5 router in case of crashes. Because the F5 router is only watching routes
-and endpoints and configuring *F5 BIG-IP®* accordingly, running the F5 router in
-this way along with an appropriately configured *F5 BIG-IP®* deployment should
-satisfy high-availability requirements.
+For example:
 
-[[deploying-the-f5-router]]
-== Deploying the F5 Router
-
-The F5 router must be run in privileged mode because route certificates get
-copied using `scp`:
-
-----
-$ oadm policy remove-scc-from-user hostnetwork -z router
-$ oadm policy add-scc-to-user privileged -z router
-----
-
-To deploy the F5 router:
-
-. First,
-xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[establish
-a tunnel using a ramp node], which allows for the routing of traffic to pods
-through the xref:../../architecture/additional_concepts/sdn.adoc#architecture-additional-concepts-sdn[OpenShift SDN].
-ifdef::openshift-origin[]
-. Ensure you have xref:../../install_config/router/index.adoc#creating-the-router-service-account[created the router service account].
-endif::[]
-. Run the `oadm router` command with the xref:f5-router-flags[appropriate
-flags]. For example:
-+
 ifdef::openshift-enterprise[]
 ====
 ----
@@ -126,6 +128,14 @@ $ oadm router \
 ----
 ====
 endif::[]
+
+As with the HAProxy router, the `oadm router` command creates the service and
+deployment configuration objects, and thus the replication controllers and
+pod(s) in which the F5 router itself runs. The replication controller restarts
+the F5 router in case of crashes. Because the F5 router is watching routes,
+endpoints, and nodes and configuring *F5 BIG-IP®* accordingly, running the F5
+router in this way, along with an appropriately configured *F5 BIG-IP®*
+deployment, should satisfy high-availability requirements.
 
 [[f5-router-partition-paths]]
 == F5 Router Partition Paths
@@ -160,9 +170,16 @@ xref:../../architecture/core_concepts/routes.adoc#architecture-f5-native-integra
 Native Integration] section of the Routes topic.
 ====
 
+ifdef::openshift-enterprise[]
+As of {product-title} version 3.4, using native integration of F5 with
+{product-title} does not require configuring a ramp node for F5 to be able to
+reach the pods on the overlay network as created by OpenShift SDN.
+endif::[]
+ifdef::openshift-origin[]
 With native integration of F5 with {product-title}, you do not need to
 configure a ramp node for F5 to be able to reach the pods on the overlay network
 as created by OpenShift SDN.
+endif::[]
 
 The F5 controller pod needs to be launched with enough information so that it can
 successfully directly connect to pods.


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1418681

@ramr @knobunc PTAL. I arranged the section so that it has clearer prerequisites, so that the creation command and the environment variables were clearer. I also got rid of the references to needing a ramp node.

Thanks!