### PR TITLE
Update docs.css for <code>, <strong>, <screen>, and callout bgcolor

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -488,7 +488,7 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .sidebarblock h1.subheader, .sidebarblock h2.subheader, .sidebarblock h3.subheader, .sidebarblock .subheader#toctitle, .sidebarblock > .content > .subheader.title, .sidebarblock h4.subheader, .sidebarblock h5.subheader, .sidebarblock h6.subheader { line-height: 1.4; }
 .sidebarblock > .content > .title { color: #7a2518; margin-top: 0; line-height: 1.6; }
 .exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
-.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 0px; background-color: #F0F3F5; -webkit-border-radius: 5px; border-radius: 5px; padding: 1.5em 2.5em; word-wrap: break-word; }
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 0px; background-color: #333; -webkit-border-radius: 0px; border-radius: 0px; padding: 1.5em 2.5em; word-wrap: break-word; color: #FFFFFF; font-family: "Roboto Mono", monospace; }
 .literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
 .literalblock pre > code, .literalblock pre[class] > code, .listingblock pre > code, .listingblock pre[class] > code { display: block; }
 .listingblock > .content { position: relative; }
@@ -590,6 +590,9 @@ span.footnote a:active, span.footnoteref a:active { text-decoration: underline; 
 .gist .file-data > table { border: none; background: #fff; width: 100%; margin-bottom: 0; }
 .gist .file-data > table td.line-data { width: 99%; }
 div.unbreakable { page-break-inside: avoid; }
+code { color: #404040; background-color: #e7e7e7; font-weight: bold; font-family: "Roboto Mono", monospace;}
+strong { color: #404040; font-weight: bold; font-family: "Roboto Mono", monospace; }
+a strong { color: inherit; }
 .replaceable { font-style: italic; font-color: inherit; font-family: inherit; }
 .parameter { font-style: italic; font-family: monospace; }
 .userinput { font-weight: bold; font-family: monospace; }
@@ -641,7 +644,7 @@ span.icon > .fa { cursor: default; }
 .admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #ec7a08; }
 .admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #ec7a08; }
 .admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #c00; }
-.conum[data-value] { display: inline-block; color: white !important; background-color: #333333; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; line-height: 20px; font-family: "Open Sans", "Sans", sans-serif; font-style: normal; font-weight: bold; text-indent: -1px; }
+.conum[data-value] { display: inline-block; color: white !important; background-color: #c00; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; line-height: 20px; font-family: "Open Sans", "Sans", sans-serif; font-style: normal; font-weight: bold; text-indent: -1px; }
 .conum[data-value] * { color: white !important; }
 .conum[data-value] + b { display: none; }
 .conum[data-value]:after { content: attr(data-value); }


### PR DESCRIPTION
PTAL @openshift/team-documentation 

## New formatting:

![screenshot from 2017-02-09 17-07-22](https://cloud.githubusercontent.com/assets/3442316/22805154/3fb13770-eeea-11e6-85eb-5e9973d6a0e1.png)

## Old formatting:

![screenshot from 2017-02-09 17-08-57](https://cloud.githubusercontent.com/assets/3442316/22805197/776c753a-eeea-11e6-8721-2124ff9108aa.png)

## Equivalent Customer Portal formatting:

![screenshot from 2017-02-09 17-09-47](https://cloud.githubusercontent.com/assets/3442316/22805226/9427e150-eeea-11e6-9e8d-668b5f7fe737.png)

