### PR TITLE
Bug 1418364 Replaced Version with <tag> under Deploying the EFK Stack

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -2,6 +2,12 @@
 = Aggregating Container Logs
 {product-author}
 {product-version}
+ifdef::openshift-enterprise[]
+:latest-tag: v3.4.1
+endif::[]
+ifdef::openshift-origin[]
+:latest-tag: v1.4.1
+endif::[]
 :data-uri:
 :icons:
 :experimental:
@@ -336,17 +342,21 @@ With parameters:
 ifdef::openshift-origin[]
 ----
 $ oc new-app logging-deployer-template \
-             --param IMAGE_VERSION=v1.2.0 \
+             --param IMAGE_VERSION=<tag> \
              --param MODE=install
 ----
 endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 ----
 $ oc new-app logging-deployer-template \
-             --param IMAGE_VERSION=3.3.0 \
+             --param IMAGE_VERSION=<tag> \
              --param MODE=install
 ----
+
 endif::openshift-enterprise[]
+
+Replace `<tag>` with `{latest-tag}` for the latest version.
+
 ====
 
 [cols="3,7",options="header"]

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -339,21 +339,11 @@ $ oc new-app logging-deployer-template
 
 With parameters:
 
-ifdef::openshift-origin[]
 ----
 $ oc new-app logging-deployer-template \
              --param IMAGE_VERSION=<tag> \
              --param MODE=install
 ----
-endif::openshift-origin[]
-ifdef::openshift-enterprise[]
-----
-$ oc new-app logging-deployer-template \
-             --param IMAGE_VERSION=<tag> \
-             --param MODE=install
-----
-
-endif::openshift-enterprise[]
 
 Replace `<tag>` with `{latest-tag}` for the latest version.
 


### PR DESCRIPTION
I replaced the hard-coded version number with the <tag> variable and added the variable value to the header, with separate variable/value sets for Origin and Enterprise.