### PR TITLE
Conditionalized the egress router image for origin/OSE

### DIFF
--- a/admin_guide/managing_pods.adoc
+++ b/admin_guide/managing_pods.adoc
@@ -188,7 +188,12 @@ metadata:
 spec:
   containers:
   - name: egress-router
+ifdef::openshift-enterprise[]
+    image: openshift3/ose-egress-router
+endif::openshift-enterprise[]
+ifdef::openshift-origin[]
     image: openshift/origin-egress-router
+endif::openshift-origin[]
     securityContext:
       privileged: true
     env:
@@ -219,7 +224,13 @@ Preserve the the quotation marks around `"true"`. Omitting them will result in
 errors.
 ====
 
-The pod contains a single container, using the *openshift/origin-egress-router*
+The pod contains a single container, using the
+ifdef::openshift-enterprise[]
+*openshift3/ose-egress-router*
+endif::openshift-enterprise[]
+ifdef::openshift-origin[]
+*openshift/origin-egress-router*
+endif::openshift-origin[]
 image, and that container is run privileged so that it can configure the Macvlan
 interface and set up `iptables` rules.
 


### PR DESCRIPTION
The image is different between Origin / OSE so we need to
conditionalize it in the docs.  This takes care of it.