### PR TITLE
sudo with systemctl in registry quickstart

### DIFF
--- a/registry_quickstart/administrators/index.adoc
+++ b/registry_quickstart/administrators/index.adoc
@@ -95,7 +95,7 @@ three container services managed by systemd. Enabling this service ensures it is
 started after a host reboot.
 +
 ----
-$ systemctl enable --now atomic-registry-master.service
+$ sudo systemctl enable --now atomic-registry-master.service
 ----
 +
 . **Setup**. When all three services have been verified to be running, run the


### PR DESCRIPTION
The other commands in this section use `sudo` - add it here as well, since this step requires root access.