### PR TITLE
Fixed mistake in quota.adoc

### DIFF
--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -74,8 +74,8 @@ this value.
 |Across all pods in a non-terminal state, the sum of memory limits cannot exceed
 this value.
 
-|`*requests.storage*`
-|Across all persistent volume claims, the sum of storage requests cannot
+|`*limits.storage*`
+|Across all persistent volume claims, the sum of storage limits cannot
 exceed this value.
 |===
 


### PR DESCRIPTION
requests.storage was entered twice. I assume the intent was to show it as limits.storage instead.