### PR TITLE
add timing comment to registry quickstart

### DIFF
--- a/registry_quickstart/administrators/index.adoc
+++ b/registry_quickstart/administrators/index.adoc
@@ -98,6 +98,12 @@ started after a host reboot.
 $ systemctl enable --now atomic-registry-master.service
 ----
 +
+The very first time you start this service, it may take a few seconds to pull
+down the `atomic-registry-master`, `atomic-registry-console` and
+`atomic-registry` container images from Docker Hub, and you will not see the
+images in `docker ps` yet until that is complete. Use `systemctl status
+atomic-registry\*` to watch the progress.
++
 . **Setup**. When all three services have been verified to be running, run the
 setup script. This creates the oauth client so the web console can connect. It
 also configures the registry service account so it can connect to the API master.


### PR DESCRIPTION
Users cannot jump immediately from starting the -master service in systemd to seeing running containers with "docker ps", because it takes a couple seconds for a host to pull down the images from Docker Hub.

Add a note to the docs that describes what is going on and how to troubleshoot.