### PR TITLE
Optimize the commands to enable root group access in the Dockerfile

### DIFF
--- a/creating_images/guidelines.adoc
+++ b/creating_images/guidelines.adoc
@@ -281,9 +281,8 @@ to allow users in the root group to access them in the built image:
 
 ====
 ----
-RUN chgrp -R 0 /some/directory
-RUN chmod -R g+rw /some/directory
-RUN find /some/directory -type d -exec chmod g+x {} +
+RUN chgrp -R 0 /some/directory \
+  && chmod -R g+rwX /some/directory
 ----
 ====
 


### PR DESCRIPTION
Reduce the number of instructions to set the desired permissions (gid 0, g+rx for files, g+x for directories) in the Dockerfile:

- Use only one RUN statement
- Remove find command and replace it with a +X in the chmod command (X as +x for directories only)