### PR TITLE
Add explicit requirements to the F5 plugin doc

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -32,10 +32,21 @@ HAProxy router].
 When deploying the F5 router plug-in, ensure you meet the following
 requirements:
 
-. An F5 host IP and credentials
-. The name of the virtual servers (for both HTTP and HTTPS)
-. The private key to the F5 instance
-. The host-internal IP and VXLAN gateway
+. A F5 host IP with:
+** Credentials for API access
+** ssh acces via private key.
+. A virtual server for HTTP routes with:
+** _HTTP profile_ must be _http_.
+. A virtual server with HTTP profile routes with:
+** _HTTP profile_ must be _http_ 
+** _SSL Profile (client)_ must be _clientssl_ 
+** _SSL Profile (server)_ must be _serverssl_
+. For edge integration (not recommended):
+** A working ramp node
+** A working tunnel to the ramp node
+. For native integration:
+** A host-internal IP capable of communicating with all the nodes on the port 4789/UDP
+** The sdn-services addon license installed on the F5 host.
 ifdef::openshift-origin[]
 . Ensure you have xref:../../install_config/router/index.adoc#creating-the-router-service-account[created the router service account].
 endif::[]


### PR DESCRIPTION
The requirements for the F5 weren't epxlicit enough:
* Virtual servers have requirements that weren't mentioned
* Say explicitly API access is a requirement, webUI access does not
  guarantee API access.
* Mention SDN licensing needs for F5
* Mention required network connectivity