### PR TITLE
Contiv1

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -185,6 +185,9 @@ Topics:
       - Name: Flannel
         File: flannel
         Distros: openshift-*
+      - Name: Contiv
+        File: contiv
+        Distros: openshift-origin
       - Name: Authentication
         File: authentication
       - Name: Authorization

--- a/architecture/additional_concepts/contiv.adoc
+++ b/architecture/additional_concepts/contiv.adoc
@@ -1,0 +1,32 @@
+[[architecture-additional-concepts-contiv]]
+= Contiv
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+[[architecture-additional-concepts-contiv-overview]]
+== Overview
+
+*contiv* is a virtual networking layer designed specifically for containers. 
+{product-title} can use it for networking containers instead of the default
+software-defined networking (SDN) components.
+
+[[architecture-additional-concepts-contiv-architecture]]
+== Architecture
+
+Each host within the network runs an agent called *contiv*, which is
+responsibile for:
+
+- Managing a unique subnet on each host
+- Distributing IP addresses to each container on its host
+- Mapping routes from one container to another, even if on different hosts
+
+Each *contiv* agent provides this infomation to a centralized *etcd* store so
+other agents on hosts can create an overlay network and route packets to
+any container within the *contiv* network.

--- a/architecture/additional_concepts/contiv.adoc
+++ b/architecture/additional_concepts/contiv.adoc
@@ -13,20 +13,22 @@ toc::[]
 [[architecture-additional-concepts-contiv-overview]]
 == Overview
 
-*contiv* is a virtual networking layer designed specifically for containers. 
-{product-title} can use it for networking containers instead of the default
-software-defined networking (SDN) components.
+*Contiv* is an open-source networking plugin module for container infrastructure. 
+*Contiv* provides an infrastructure for application-oriented network policies and support for a range of multiple networking modes. These include a configurable set of overlay networking modes, physical networking modes and support for industry-leading hardware.  {product-title} can use it for networking containers instead of the default Openshift SDN. Full technical details on *contiv* are available at the 
+link:http://contiv.github.io[Contiv github pages] 
 
 [[architecture-additional-concepts-contiv-architecture]]
 == Architecture
 
-Each host within the network runs an agent called *contiv*, which is
-responsibile for:
+Each node within the cluster runs a *contiv* agent called *netplugin* while the master hosts run the *contiv* controller (referred to as *netmaster*) alongwith supporting control plane components (such as *etcd*). 
 
-- Managing a unique subnet on each host
-- Distributing IP addresses to each container on its host
-- Mapping routes from one container to another, even if on different hosts
+Together the components of *contiv (*netmaster* and *netplugin*) handle key networking functions for Openshift including 
 
-Each *contiv* agent provides this infomation to a centralized *etcd* store so
-other agents on hosts can create an overlay network and route packets to
-any container within the *contiv* network.
+- Assigning IP addresses to each container pod on each cluster node 
+- Creating and managing multiple separate container network instances for different groups of containers 
+- Configuring the network forwarding layer components for layer 2 or layer 3 forwarding
+- Configuring and enforcing a range of network policies that provide  
+- Providing management interfaces (including both CLI and GUI) to configure and manage contiv-specific features and configurations
+- Providing an infrastructure for role based controls that allow for multiple role based network operations workflows. 
+
+*Contiv* uses the Container Network Interface (link:https://kubernetes.io/docs/admin/network-plugins/#cni[CNI]) to interface with Openshift/ Kubernetes. A key value store based on *etcd* is used to store contiv-specific state information. This is in addition to and separate from the instance of *etcd* used by other components in the system including Openshift itself. 


### PR DESCRIPTION
Documentation commit for Contiv networking option for Openshift Origin. Contiv is a new container networking plugin (see contiv.github.io for more details) which has been verified to work with Openshift Origin. This commit adds a topic under the Architecture section of Openshift Origin documentation to introduce this feature.
