### PR TITLE
Change default arp cache size on nodes

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1473,11 +1473,11 @@ accordingly.
 == ARP Cache Tuning for Large-scale Clusters
 
 In {product-title} clusters with large numbers of routes (greater than the
-value of `net.ipv4.neigh.default.gc_thresh3`, which is `1024` by default), you
-must increase the default values of sysctl variables to allow more entries in
-the ARP cache.
+value of `net.ipv4.neigh.default.gc_thresh3`, which is `65536` by default), you
+must increase the default values of sysctl variables on each node in the cluster
+running the router pod to allow more entries in the ARP cache.
 
-The kernel messages would be similar to the following:
+When the problem is occuring, the kernel messages would be similar to the following:
 
 ----
 [ 1738.811139] net_ratelimit: 1045 callbacks suppressed
@@ -1498,18 +1498,27 @@ To verify the actual amount of ARP entries for IPv4, run the following:
 ----
 
 If the number begins to approach the `net.ipv4.neigh.default.gc_thresh3`
-threshold, increase the values. Run the following on the nodes running the
-router pods. The following sysctl values are suggested for clusters with large
-numbers of routes:
+threshold, increase the values. Get the current value by running:
 
 ----
-net.ipv4.neigh.default.gc_thresh1 = 8192
-net.ipv4.neigh.default.gc_thresh2 = 32768
-net.ipv4.neigh.default.gc_thresh3 = 65536
+# sysctl net.ipv4.neigh.default.gc_thresh1
+net.ipv4.neigh.default.gc_thresh1 = 128
+# sysctl net.ipv4.neigh.default.gc_thresh2
+net.ipv4.neigh.default.gc_thresh2 = 512
+# sysctl net.ipv4.neigh.default.gc_thresh3
+net.ipv4.neigh.default.gc_thresh3 = 1024
 ----
 
-To make these settings permanent across reboots, create a
-link:https://access.redhat.com/solutions/1305833[custom tuned profile].
+The following sysctl sets the variables to the {product-title} current default values.
+
+----
+# sysctl net.ipv4.neigh.default.gc_thresh1=8192
+# sysctl net.ipv4.neigh.default.gc_thresh2=32768
+# sysctl net.ipv4.neigh.default.gc_thresh3=65536
+----
+
+To make these settings permanent, 
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html-single/Performance_Tuning_Guide/index.html#custom-profiles[see this document].
 
 [[deploy-router-protecting-against-ddos-attacks]]
 == Protecting Against DDoS Attacks


### PR DESCRIPTION
Code fix is in 3.6

In OCP clusters with large numbers of routes (greater than the value of
net.ipv4.neigh.default.gc_thresh3, which is 1024 by default) the ARP
cache is not large enough to accommodate for all the entries needed by
the nodes running the router pods.

This change increases the cache size.

bug 1425388
https://bugzilla.redhat.com/show_bug.cgi?id=1425388

Signed-off-by: Phil Cameron <pcameron@redhat.com>