### PR TITLE
advanced_install: note need for host prep

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -44,9 +44,9 @@ xref:../../install_config/install/stand_alone_registry.adoc#install-config-insta
 [[advanced-before-you-begin]]
 == Before You Begin
 
-Before installing {product-title}, you must first see the xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites] topic to
+Before installing {product-title}, you must first see the xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites] and xref:../../install_config/install/host_preparation.adoc[Host Preparation] topics to
 prepare your hosts, which includes verifying system and environment requirements
-per component type and properly installing and configuring Docker. It also
+per component type and properly installing and configuring Docker. Preparation also
 includes installing Ansible version 1.8.4 or later, as the advanced installation
 method is based on Ansible playbooks and as such requires directly invoking
 Ansible.


### PR DESCRIPTION
I noticed in the advanced install there's a pointer to the "Prerequisites" but it shows using the playbooks in /usr/share/ansible/openshift-ansible/ without any indication of how that actually gets there. It's described in the "Host Prep" topic.