### PR TITLE
hostsubnet requires a specific annotation for multi-tenancy to work

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -427,7 +427,8 @@ address. All nodes of the cluster must learn this automatically.
 . Since the overlay network is multi-tenant aware, F5 must use a VxLAN ID that is
 representative of an `admin` domain, ensuring that all tenants are reachable by
 the F5. Ensure that F5 encapsulates all packets with a `vnid` of `0` (the
-default `vnid` for the `admin` name space in {product-title}).
+default `vnid` for the `admin` name space in {product-title}). This is accomplished
+by putting an annotation on the manually created `hostsubnet` - `pod.network.openshift.io/fixed-vnid-host: 0`
 
 A ghost `hostsubnet` is manually created as part of the setup, which fulfills
 the third and forth listed requirements. When the F5 controller pod is launched,
@@ -444,7 +445,10 @@ the cluster. It is hijacked by an external appliance.
 The first requirement is fulfilled by the F5 controller pod once it is launched.
 The second requirement is also fulfilled by the F5 controller pod, but it is an
 ongoing process. For each new node that is added to the cluster, the controller
-pod creates an entry in the VxLAN device’s VTEP FDB.
+pod creates an entry in the VxLAN device’s VTEP FDB. The controller pod needs access
+to the 'nodes' resource in the cluster, which can be accomplished by giving the
+service account appropriate privileges. Use the following command for the purpose -
+`oadm policy add-cluster-role-to-user system:sdn-reader system:serviceaccount:default:router`
 
 *Data Flow from the F5 Host*
 

--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -194,7 +194,8 @@ $ cat > f5-hostsubnet.yaml << EOF
     "metadata": {
         "name": "openshift-f5-node",
         "annotations": {
-        "pod.network.openshift.io/assign-subnet": "true"
+        "pod.network.openshift.io/assign-subnet": "true",
+	"pod.network.openshift.io/fixed-vnid-host": "0"   # Make F5 global
         }
     },
     "host": "openshift-f5-node",
@@ -230,10 +231,14 @@ this example).
 (for example, `10.131.0.5`). Use the mask of the pod network (`14`). The
 gateway address becomes: `10.131.0.5/14`.
 
-. Launch the F5 controller pod, following xref:deploying-the-f5-router[these instructions]. However,
-use the two new additional options for VXLAN native integration:
+. Launch the F5 controller pod, following xref:deploying-the-f5-router[these instructions]. 
+Additionally, allow the access to 'node' cluster resource for the service account and 
+use the two new additional options for VXLAN native integration.
 +
 ----
+$ # add policy to allow router to access nodes using the sdn-reader role
+$ oadm policy add-cluster-role-to-user system:sdn-reader system:serviceaccount:default:router
+$ # Launch the router pod with vxlan-gw and f5's internal ip as extra args
 $ #--external-host-internal-ip=10.3.89.213
 $ #--external-host-vxlan-gw=10.131.0.5/14
 $ oadm router \
@@ -246,8 +251,8 @@ $ oadm router \
     --external-host-private-key=/path/to/key \
     --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
     --service-account=router \
-   --external-host-internal-ip=10.3.89.213 \
-   --external-host-vxlan-gw=10.131.0.5/14
+    --external-host-internal-ip=10.3.89.213 \
+    --external-host-vxlan-gw=10.131.0.5/14
 ----
 +
 The F5 set up is now ready, without the need to set up the ramp node.


### PR DESCRIPTION
Missed the annotation in the code blob. Without this fix, multi-tenancy will block F5 from operating across projects.

@lihongan Review please. Thanks.
/cc @ahardin-rh