### PR TITLE
Followup to 3460 about kubernetes/openshift api

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1458,10 +1458,13 @@ within {product-title}:
 So, for example, when:
 
 * <command> = `oc`
-* <version> = The client version. For example, `v3.3.0`. This can change depending on if the request is made against the Kubernetes API at `/api`, or the {product-title} API at `/oapi`
+* <version> = The client version. For example, `v3.3.0`. Requests made against the Kubernetes
+API at `/api` receive the Kubernetes version, while requests made against the
+{product-title} API at `/oapi` receive the {product-title} version (as specified
+by `oc version`)
 * <platform> = `linux`
 * <architecture> = `amd64`
-* <client> = `openshift`, or `kubernetes` depending on if the request is made against the Kubernetes API at `/api`, or the {product-title} API at `/oapi`.
+* <client> = `openshift`, or `kubernetes` depending on if the request is made against the Kubernetes API at `/api`, or the {product-title} API at `/oapi`
 * <git_commit> = The Git commit of the client version (for example, `f034127`)
 
 the user agent will be:


### PR DESCRIPTION
As per https://bugzilla.redhat.com/show_bug.cgi?id=1393218#c6

No rev history needed.