### PR TITLE
Bug 1388691: Manual router/registry cert redeploy

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -12,13 +12,25 @@ toc::[]
 
 == Overview
 
-This topic reviews how to check cluster certificate expiration dates, back up
-the certificates, and redeploy them using Ansible playbooks. This method fixes
-common certificate errors. Possible use cases include:
+{product-title} uses certificates to provide secure connections for the
+following components:
+
+- masters (API server and controllers)
+- etcd
+- nodes
+- registry
+- router
+
+You can use Ansible playbooks to automate checking cluster certificate
+expiration dates, backing up the certificates, and redeploying the master, node,
+and etcd certificates in your environment, which can fix common certificate
+errors. Certificates for the registry and router must be redeployed manually.
+
+Possible use cases for redeploying certificates include:
 
 - The installer detected the wrong host names and the issue was identified too late.
 - The certificates are expired and you need to update them.
-- You have a new CA and would like to create certificates using it instead
+- You have a new CA and would like to create certificates using it instead.
 
 [[install-config-cert-expiry]]
 == Checking Certificate Expirations
@@ -89,10 +101,9 @@ The {product-title} installer provides a set of example certificate expiration
 playbooks, using different sets of configuration for the
 `openshift_certificate_expiry` role.
 
-Just like the
-xref:install-config-running-the-certificate-redeploy-playbook[redeploying certificates playbook], these playbooks must be used with an inventory that is
-representative of the cluster. For best results, run `ansible-playbook` with the
-`-v` option.
+These playbooks must be used with an
+xref:../install_config/install/advanced_install.adoc#configuring-ansible[inventory file] that is representative of the cluster. For best results, run
+`ansible-playbook` with the `-v` option.
 
 Using the *_easy-mode.yaml_* example playbook, you can try the role out before
 tweaking it to your specifications as needed. This playbook:
@@ -219,55 +230,272 @@ $ jq '.summary.warning,.summary.expired' /tmp/cert-expiry-report.json
 0
 ----
 
-[[install-config-running-the-certificate-redeploy-playbook]]
-== Running the Certificate Redeploy Playbook
+[[redeploying-certificates-master-etcd-node]]
+== Master, etcd, and Node Certificates
 
-Running the certificate redeploy playbook will redeploy {product-title}
-certificates that exist on systems (master, node, etcd):
+Use the *_redeploy-certificates.yml_* playbook to redeploy master, etcd, and
+node certificates on all relevant hosts. Just like the certificate expiry
+playbooks, this playbook must be run with an
+xref:../install_config/install/advanced_install.adoc#configuring-ansible[inventory file] that is representative of the cluster.
+
+In particular, the inventory must specify or override all host names and IP
+addresses set via the following variables such that they match the current
+cluster configuration:
+
+- `openshift_hostname`
+- `openshift_public_hostname`
+- `openshift_ip`
+- `openshift_public_ip`
+- `openshift_master_cluster_hostname`
+- `openshift_master_cluster_public_hostname`
+
+[[redeploying-master-etcd-node-certificates-current-ca]]
+=== Redeploying Using the Current CA
+
+By default, the *_redeploy-certificates.yml_* playbook does _not_ regenerate the
+{product-title} CA. New certificates are created using the current
+{product-title} CA.
+
+To redeploy master, etcd, and node certificates using the current
+{product-title} CA, run the playbook, specifying your inventory file:
 
 ----
-$ ansible-playbook -i <inventory> playbooks/byo/openshift-cluster/redeploy-certificates.yml
+$ ansible-playbook -i <inventory_file> \
+    playbooks/byo/openshift-cluster/redeploy-certificates.yml
 ----
 
-[WARNING]
-====
-This playbook must be run with an inventory that is representative of the
-cluster. The inventory must specify or override all host names and IP addresses
-set via `*openshift_hostname*`, `*openshift_public_hostname*`, `*openshift_ip*`,
-`*openshift_public_ip*`, `*openshift_master_cluster_hostname*`, or
-`*openshift_master_cluster_public_hostname*` such that they match the current
-cluster configuration.
-====
+[[redeploying-master-etcd-node-certificates-new-custom-ca]]
+=== Redeploying Using a New or Custom CA
 
-By default, the redeploy playbook does _not_ redeploy the {product-title} CA.
-New certificates are created using the original {product-title} CA.
+Setting `openshift_certificates_redeploy_ca=true` when running the
+*_redeploy-certificates.yml_* playbook causes the current {product-title} CA to
+also be regenerated and redeployed, and new certificates are created using the
+new CA.
 
-To redeploy all certificates including the {product-title} CA, specify
-`openshift_certificates_redeploy_ca=true`.
+Additionally, you can specify a
+xref:../install_config/certificate_customization.adoc#install-config-certificate-customization[custom CA certificate] when redeploying certificates instead of relying on a CA
+generated by {product-title}.
 
-For example:
+All pods using service accounts to communicate with the {product-title} API must
+be redeployed when the {product-title} CA is replaced, so the
+*_redeploy-certificates.yml_* playbook serially evacuates all nodes in the
+cluster when the `openshift_certificates_redeploy_ca=true` variable is set. When
+this evacuation happens, router and registry pods must have their certificates
+redeployed manually.
 
-----
-$ ansible-playbook -i <inventory> playbooks/byo/openshift-cluster/redeploy-certificates.yml \
---extra-vars "openshift_certificates_redeploy_ca=true"
-----
+To redeploy master, etcd, and node certificates _including_ a newly-generated or
+custom CA:
 
-This also adds a
-xref:../install_config/certificate_customization.adoc#install-config-certificate-customization[custom
-CA certificate]:
-
-====
+. If you want to use a custom CA, set the following variable in your inventory
+file:
++
 ----
 # Configure custom ca certificate
 # NOTE: CA certificate will not be replaced with existing clusters.
 # This option may only be specified when creating a new cluster or
 # when redeploying cluster certificates with the redeploy-certificates
 # playbook.
-#openshift_master_ca_certificate={'certfile': '/path/to/ca.crt', 'keyfile': '/path/to/ca.key'}
+openshift_master_ca_certificate={'certfile': '</path/to/ca.crt>', 'keyfile': '</path/to/ca.key>'}
 ----
-====
++
+If you do not set the above, then the current CA will be regenerated in the next
+step.
 
-All pods using service accounts to communicate with the {product-title} API must
-be redeployed when the {product-title} CA is replaced so the certificate
-redeploy playbook will serially evacuate all nodes in the cluster when this
-variable is set.
+. Run the *_redeploy-certificates.yml_* playbook with the
+`openshift_certificates_redeploy_ca=true` variable, specifying your inventory
+file:
++
+----
+$ ansible-playbook -i <inventory_file> \
+    playbooks/byo/openshift-cluster/redeploy-certificates.yml \
+    --extra-vars "openshift_certificates_redeploy_ca=true"
+----
+
+. As discussed previously, the playbook now serially evacuates all nodes in the
+cluster, requiring manual redeployment of registry and router certificates. See
+xref:redeploying-registry-and-router-certificates[Redeploying Registry and
+Router Certificates] to complete this procedure.
+
+[[redeploying-registry-and-router-certificates]]
+== Registry and Router Certificates
+
+When nodes are evacuated due to a redeployed CA, registry and router pods are
+restarted. This can cause outages because they cannot reach the masters using
+their old certificates.
+
+To address this issue, or to redeploy these certificates for any reason, you can
+manually redeploy registry and router certificates.
+
+[[redeploying-registry-certificates-manually]]
+=== Redeploying Registry Certificates Manually
+
+To redeploy registry certificates manually, you must add new registry
+certificates to a secret named `registry-certificates`, then redeploy the
+registry:
+
+. Switch to the `default` project for the remainder of these steps:
++
+----
+$ oc project default
+----
+
+. If your registry was initially created on {product-title} 3.1 or earlier, it may
+still be using environment variables to store certificates (which has been
+deprecated in favor of using secrets).
+
+.. Run the following and look for the
+`OPENSHIFT_CA_DATA`, `OPENSHIFT_CERT_DATA`, `OPENSHIFT_KEY_DATA` environment
+variables:
++
+----
+$ oc env dc/docker-registry --list
+----
+
+.. If they do not exist, skip this step. If they do, create the following `ClusterRoleBinding`:
++
+----
+$ cat <<EOF |
+apiVersion: v1
+groupNames: null
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: registry-registry-role
+roleRef:
+  kind: ClusterRole
+  name: system:registry
+subjects:
+- kind: ServiceAccount
+  name: registry
+  namespace: default
+userNames:
+- system:serviceaccount:default:registry
+EOF
+oc create -f -
+----
++
+Then, run the following to remove the environment variables:
++
+----
+$ oc env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+----
+
+. Set the following environment variables locally to make later commands less
+complex:
++
+----
+$ REGISTRY_IP=`oc get service docker-registry -o jsonpath='{.spec.clusterIP}'`
+$ REGISTRY_HOSTNAME=`oc get route/docker-registry -o jsonpath='{.spec.host}'`
+----
+
+. Create new registry certificates:
++
+----
+$ oc adm ca create-server-cert \
+    --signer-cert=/etc/origin/master/ca.crt \
+    --signer-key=/etc/origin/master/ca.key \
+    --hostnames=$REGISTRY_IP,docker-registry.default.svc.cluster.local,$REGISTRY_HOSTNAME \
+    --cert=/etc/origin/master/registry.crt \
+    --key=/etc/origin/master/registry.key \
+    --signer-serial=/etc/origin/master/ca.serial.txt
+----
+
+. Update the `registry-certificates` secret with the new registry certificates:
++
+----
+$ oc secret new registry-certificates \
+    /etc/origin/master/registry.crt \
+    /etc/origin/master/registry.key \
+    -o json | oc replace -f -
+----
+
+. Redeploy the registry:
++
+----
+$ oc deploy dc/docker-registry --latest
+----
+
+[[redeploying-router-certificates-manually]]
+=== Redeploying Router Certificates Manually
+
+When routers are initially deployed, an annotation is added to the router's
+service that automatically creates a
+xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service serving certificate secret].
+
+To redeploy router certificates manually, that service serving certificate can
+be triggered to be recreated by deleting the secret, removing and re-adding
+annotations to the `router` service, then redeploying the router:
+
+. Switch to the `default` project for the remainder of these steps:
++
+----
+$ oc project default
+----
+
+. If your router was initially created on {product-title} 3.1 or earlier, it may
+still be using environment variables to store certificates (which has been
+deprecated in favor of using service serving certificate secret).
+
+.. Run the following and look for the
+`OPENSHIFT_CA_DATA`, `OPENSHIFT_CERT_DATA`, `OPENSHIFT_KEY_DATA` environment
+variables:
++
+----
+$ oc env dc/router --list
+----
+
+.. If they do not exist, skip this step. If they do, create the following `ClusterRoleBinding`:
++
+----
+$ cat <<EOF |
+apiVersion: v1
+groupNames: null
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: router-router-role
+roleRef:
+  kind: ClusterRole
+  name: system:router
+subjects:
+- kind: ServiceAccount
+  name: router
+  namespace: default
+userNames:
+- system:serviceaccount:default:router
+EOF
+oc create -f -
+----
++
+Then, run the following to remove the environment variables:
++
+----
+$ oc env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+----
+
+. Delete the `router-certs` secret:
++
+----
+$ oc delete secret router-certs
+----
+
+. Remove the following annotations from the `router` service:
++
+----
+$ oc annotate service router \
+    service.alpha.openshift.io/serving-cert-secret-name- \
+    service.alpha.openshift.io/serving-cert-signed-by-
+----
+
+. Re-add the annotations:
++
+----
+$ oc annotate service router \
+    service.alpha.openshift.io/serving-cert-secret-name=router-certs
+----
+
+. Redeploy the router:
++
+----
+$ oc deploy dc/router --latest
+----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1388691

Builds on https://github.com/openshift/openshift-docs/pull/3712, preparing way for 1.5/3.5 cert redeploy doc changes, while getting the manual registry/router steps in for <= 3.4 until the changes are backported later.

@ahardin-rh @abutcher PTAL. Preview:

http://file.rdu.redhat.com/~adellape/022817/router-registry-manual/install_config/redeploying_certificates.html