### PR TITLE
Fix typo: {product-tlte}

### DIFF
--- a/dev_guide/getting_traffic_into_cluster.adoc
+++ b/dev_guide/getting_traffic_into_cluster.adoc
@@ -176,7 +176,7 @@ INGRESS
 
 The external IP address is not managed by the underlying Kubernetes
 infrastructure and must be maintained and provided by a cluster administrator.
-While external IPs provide a solution for accessing services on the {product-tlte}
+While external IPs provide a solution for accessing services on the {product-title}
 cluster, there are several shortcomings:
 
 * The cluster administrator user must ensure the external IP is not in any range


### PR DESCRIPTION
Fix a typo of `{product-title}` as `{product-tlte}` in the "Getting Traffic into the Cluster" guide.  This typo caused the misspelled macro to appear literally in the rendered documentation.