### PR TITLE
add kexec sos psacct packages for support

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -109,7 +109,7 @@ For RHEL 7 systems:
 . Install the following base packages:
 +
 ----
-# yum install wget git net-tools bind-utils iptables-services bridge-utils bash-completion
+# yum install wget git net-tools bind-utils iptables-services bridge-utils bash-completion kexec sos psacct
 ----
 
 . Update the system to the latest packages:


### PR DESCRIPTION
The RHEL Support need the informations from kdump sa and sos report.
I would be wise to have this packages already installed on all machines