### PR TITLE
Add the attribute [autofocus] on [Search Documentation] input text

### DIFF
--- a/index-commercial.html
+++ b/index-commercial.html
@@ -354,7 +354,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </li>
         <li>
           <form action="https://help.openshift.com/hc/en-us/search" method="get" id="cse-search-form">
-            <input name="query" id="cse-search-input" class="navbar-search-query form-control" type="text" placeholder="Search" tabindex="1" autocomplete="off" autofocus>
+            <input name="query" id="cse-search-input" class="navbar-search-query form-control" type="text" placeholder="Search" tabindex="1" autocomplete="off" autofocus="autofocus">
             <button type="submit" class="btn btn-default fa fa-search" value="Search"></button>
           </form>
         </li>
@@ -385,7 +385,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <form action="https://docs.openshift.com/search.html" class="search has-button" id="cse-search-form-body" method="get" role="form">
               <div class="form-group">
                 <div class="search-pf-input-group">
-                  <input autocomplete="off" class="form-control" dir="ltr" id="cse-search-input-body" name="query" placeholder="Search Documentation" spellcheck="false" type="search">
+                  <input autocomplete="off" class="form-control" dir="ltr" id="cse-search-input-body" name="query" placeholder="Search Documentation" spellcheck="false" type="search" autofocus="autofocus">
                 </div>
               </div>
               <div class="form-group">


### PR DESCRIPTION
1. When opening https://docs.openshift.com/, the focus should be on the input text. fixed the #3857 .
2. The attribute [autofocus] must have a value.