### PR TITLE
install_config/install/advanced_install.adoc: raise minimal Ansible version to 2.2.0

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -47,7 +47,7 @@ xref:../../install_config/install/stand_alone_registry.adoc#install-config-insta
 Before installing {product-title}, you must first see the xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites] topic to
 prepare your hosts, which includes verifying system and environment requirements
 per component type and properly installing and configuring Docker. It also
-includes installing Ansible version 1.8.4 or later, as the advanced installation
+includes installing Ansible version 2.2.0 or later, as the advanced installation
 method is based on Ansible playbooks and as such requires directly invoking
 Ansible.
 


### PR DESCRIPTION
At this moment documentation says that [`It also includes installing Ansible version 1.8.4 or later`](https://docs.openshift.org/latest/install_config/install/advanced_install.html#advanced-before-you-begin) but it doesn't work because [minimal supported version now is 2.2.0](https://github.com/openshift/openshift-ansible#setup).

This PR fixes the outdated doc.

PTAL @openshift/team-documentation 