### PR TITLE
OCP 3.4: Updated minimum requirements for a master host

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -110,9 +110,9 @@ Master Hosts::
 In a highly available {product-title} cluster with external etcd, a master host
 should have 1 CPU core and 1.5 GB of memory, on top of the defaults in the table
 above, for each 1000 pods. Therefore, the recommended size of master host in an
-{product-title} cluster of 2000 pods would be 2 CPU cores and 5 GB of RAM, in
-addition to the minimum requirements for a master host of 2 CPU cores and 8 GB of
-RAM.
+{product-title} cluster of 2000 pods would be 2 CPU cores and 3 GB of RAM, in
+addition to the minimum requirements for a master host of 2 CPU cores and 16 GB
+of RAM.
 
 When planning an environment with multiple masters, a minimum of three etcd
 hosts as well as a load-balancer between the master hosts, is required.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1399414

At some point, these changes were overwritten. Originally introduced via https://github.com/openshift/openshift-docs/pull/2850