### PR TITLE
Set host-network to false in f5_router.adoc

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -109,6 +109,7 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
+    --host-network=false \
     --service-account=router
 ----
 ====
@@ -124,6 +125,7 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
+    --host-network=false \
     --service-account=router
 ----
 ====
@@ -253,6 +255,7 @@ $ oadm router \
     --external-host-private-key=/path/to/key \
     --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
     --service-account=router \
+    --host-network=false \
     --external-host-internal-ip=10.3.89.213 \
     --external-host-vxlan-gw=10.131.0.5/14
 ----


### PR DESCRIPTION
host-network is set to true by default. There is no reason to require this, therefore we should set it false.