### PR TITLE
Followup to PR3845

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -1073,135 +1073,110 @@ link:https://github.com/openshift/origin/blob/master/images/router/clear-route-s
 script].
 
 
-[[router-domain-policy]]
-== Allowing/Denying certain Domains in Routes
+[[architecture-core-concepts-routes-deny-allow]]
+== Denying or Allowing Certain Domains in Routes
 
-A router can be configured to allow only a specific subset of domains or
-deny specific domains from the host names in a route. This policy is set
-using the `ROUTER_DENIED_DOMAINS` and/or `ROUTER_ALLOWED_DOMAINS`
-environment variables.
-If these variables are specified, the domains listed in the
-`ROUTER_DENIED_DOMAINS` are not allowed in any routes. And the domains
-liste in `ROUTER_ALLOWED_DOMAINS` are the only ones allowed in any routes.
-Note that the domains in the list of denied domains take precedence over
-the list of allowed domains.
-The order of precedence is to first check the deny list (if any) and if
-the host name is not in the list of denied domains, only then check the
-list of allowed domains. The list of allowed domains on the other hand is
-more restrictive and ensures that the router only admits routes with hosts
-that belong to that list.
+A router can be configured to deny or allow a specific subset of domains from
+the host names in a route using the `ROUTER_DENIED_DOMAINS` and
+`ROUTER_ALLOWED_DOMAINS` environment variables.
 
-.Router run with just a list of denied domains
-====
+[cols="2"]
+|===
 
-----
-$ oadm router denrouter ...
-$ oc set env dc/denrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it" <1>
-----
+|`*ROUTER_DENIED_DOMAINS*` | Domains listed are not allowed in any indicated routes.
+|`*ROUTER_ALLOWED_DOMAINS*` | Only the domains listed are allowed in any indicated routes.
 
-----
-<1> Will block any routes where the host name is set to
-    `[*.]open.header.test`, `[*.]openshift.org` and `[*.]block.it`.
+|===
 
-The examples below indicate whether or not the `denrouter` will admit or
-deny a route based on the route's host name.
-----
-$ oc expose service/<name> --hostname="open.header.test"       # Denied.
+The domains in the list of denied domains take precedence over the list of
+allowed domains. Meaning {product-title} first checks the deny list (if
+applicable), and if the host name is not in the list of denied domains, it then
+checks the list of allowed domains. However, the list of allowed domains is more
+restrictive, and ensures that the router only admits routes with hosts that
+belong to that list.
 
-$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
-
-$ oc expose service/<name> --hostname="foo.header.test"        # Admitted.
-
-$ oc expose service/<name> --hostname="block.it"               # Denied.
-
-$ oc expose service/<name> --hostname="franco.baresi.block.it" # Denied.
-
-$ oc expose service/<name> --hostname="www.allow.it"           # Allowed.
-
-$ oc expose service/<name> --hostname="www.openshift.test"     # Allowed.
-
-$ oc expose service/<name> --hostname="openshift.org"          # Denied.
-
-$ oc expose service/<name> --hostname="api.openshift.org"      # Denied.
-----
-====
-
-
-.Router run with just a list of allowed domains
-====
+For example, to deny the `[*.]open.header.test`, `[*.]openshift.org` and
+`[*.]block.it` routes for the `myrouter` route:
 
 ----
-$ oadm router allrouter ...
-$ oc set env dc/allrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net" <1>
+$ oadm router myrouter ...
+$ oc set env dc/myrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it"
 ----
 
+This means that `myrouter` will admit the following based on the route's name:
+
 ----
-<1> Will block any routes where the host name is _not_ set to
-    `[*.]stickshift.org` or `[*.]kates.net`.
-
-The examples below indicate whether or not the `allrouter` will admit or
-deny a route based on the route's host name.
+$ oc expose service/<name> --hostname="foo.header.test" 
+$ oc expose service/<name> --hostname="www.allow.it"
+$ oc expose service/<name> --hostname="www.openshift.test"
 ----
-$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
 
-$ oc expose service/<name> --hostname="stickshift.org"         # Admitted.
+However, `myrouter` will deny the following:
 
-$ oc expose service/<name> --hostname="www.stickshift.org"     # Admitted.
-
-$ oc expose service/<name> --hostname="a.b.c.stickshift.org"   # Allowed.
-
-$ oc expose service/<name> --hostname="drive.ottomatic.org"    # Denied.
-
-$ oc expose service/<name> --hostname="www.wayless.com"        # Denied.
-
-$ oc expose service/<name> --hostname="www.deny.it"            # Denied.
-
-$ oc expose service/<name> --hostname="kates.net"              # Allowed.
-
-$ oc expose service/<name> --hostname="api.kates.net"          # Allowed.
-
-$ oc expose service/<name> --hostname="erno.r.kube.kates.net"  # Allowed.
 ----
-====
+$ oc expose service/<name> --hostname="open.header.test"
+$ oc expose service/<name> --hostname="www.open.header.test"
+$ oc expose service/<name> --hostname="block.it"
+$ oc expose service/<name> --hostname="franco.baresi.block.it"
+$ oc expose service/<name> --hostname="openshift.org"
+$ oc expose service/<name> --hostname="api.openshift.org"
+----
 
+Alternatively, to block any routes where the host name is _not_ set to `[*.]stickshift.org` or `[*.]kates.net`:
 
-.Router run with a both a list of allowed and denied domains
-====
+----
+$ oadm router myrouter ...
+$ oc set env dc/myrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net"
+----
+
+This means that the `myrouter` router will admit:
+
+----
+$ oc expose service/<name> --hostname="stickshift.org"
+$ oc expose service/<name> --hostname="www.stickshift.org" 
+$ oc expose service/<name> --hostname="kates.net" 
+$ oc expose service/<name> --hostname="api.kates.net"
+$ oc expose service/<name> --hostname="erno.r.kube.kates.net"
+----
+
+However, `myrouter` will deny the following:
+
+----
+$ oc expose service/<name> --hostname="www.open.header.test"
+$ oc expose service/<name> --hostname="drive.ottomatic.org"
+$ oc expose service/<name> --hostname="www.wayless.com"
+$ oc expose service/<name> --hostname="www.deny.it"
+----
+
+To implement both scenarios, run:
 
 ----
 $ oadm router adrouter ...
 $ oc env dc/adrouter ROUTER_ALLOWED_DOMAINS="openshift.org, kates.net" \
-    ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net" <1>
+    ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net"
 ----
 
+This will allow any routes where the host name is set to `[*.]openshift.org` or
+`[*.]kates.net`, and not allow any routes where the host name is set to
+`[*.]ops.openshift.org` or `[*.]metrics.kates.net`.
+
+Therefore, the following will be denied:
+
 ----
-<1> Will block any routes where the host name is set to `[*.]openshift.org`
-    or `[*.]kates.net`. And will not allow any routes where the host name
-    is set to `[*.]ops.openshift.org` or `[*.]metrics.kates.net`.
-
-The examples below indicate whether or not the `adrouter` will admit or
-deny a route based on the route's host name.
+$ oc expose service/<name> --hostname="www.open.header.test"
+$ oc expose service/<name> --hostname="ops.openshift.org"
+$ oc expose service/<name> --hostname="log.ops.openshift.org"
+$ oc expose service/<name> --hostname="www.block.it"
+$ oc expose service/<name> --hostname="metrics.kates.net"
+$ oc expose service/<name> --hostname="int.metrics.kates.net"
 ----
-$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
 
-$ oc expose service/<name> --hostname="openshift.org"          # Admitted.
+However, the following will be allowed:
 
-$ oc expose service/<name> --hostname="api.openshift.org"      # Admitted.
-
-$ oc expose service/<name> --hostname="m.api.openshift.org"    # Allowed.
-
-$ oc expose service/<name> --hostname="ops.openshift.org"      # Denied.
-
-$ oc expose service/<name> --hostname="log.ops.openshift.org"  # Denied.
-
-$ oc expose service/<name> --hostname="www.block.it"           # Denied.
-
-$ oc expose service/<name> --hostname="kates.net"              # Allowed.
-
-$ oc expose service/<name> --hostname="api.kates.net"          # Allowed.
-
-$ oc expose service/<name> --hostname="metrics.kates.net"      # Denied.
-
-$ oc expose service/<name> --hostname="int.metrics.kates.net"  # Denied.
 ----
-====
+$ oc expose service/<name> --hostname="openshift.org"
+$ oc expose service/<name> --hostname="api.openshift.org"
+$ oc expose service/<name> --hostname="m.api.openshift.org"
+$ oc expose service/<name> --hostname="kates.net"
+$ oc expose service/<name> --hostname="api.kates.net"
+----


### PR DESCRIPTION
As per #3845 

@ramr I ended up changing the layout a little. Can I get an ack I didn't confuse any of the information?

But also, I'm not sure if this is the right location for this info. After all, the `ROUTER_DENIED_DOMAINS` and `ROUTER_ALLOWED_DOMAINS` en vars are highlighted in the table earlier in the doc. I'm thinking it would be more at home here:

https://docs.openshift.com/container-platform/3.4/dev_guide/routes.html

But if it's an admin task, perhaps I can create a new file for the routes info? (Unless you think there's somewhere better for it in the Adming Guide). WDYT?