### PR TITLE
Fix references to openshift_set_node_ip

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -445,17 +445,17 @@ where:
 - {product-title} is installed in a cloud provider where internal hostnames are not configured/resolvable by all hosts.
 - The node's IP from the master's perspective is not the same as the node's IP from its own perspective.
 
-Configuring the `*openshift_node_set_node_ip*` Ansible variable
+Configuring the `*openshift_set_node_ip*` Ansible variable
 forces node traffic through an interface other than the default network
 interface.
 
 To change the node traffic interface:
 
-. Set the `*openshift_node_set_node_ip*` Ansible variable to `true`.
+. Set the `*openshift_set_node_ip*` Ansible variable to `true`.
 . Set the `*openshift_ip*` to the IP address for the node you want to configure.
 [NOTE]
 ====
-Although  `*openshift_node_set_node_ip*` can be useful as a workaround for the
+Although  `*openshift_set_node_ip*` can be useful as a workaround for the
 cases stated in this section, it is generally not suited for production
 environments. This is because the node will no longer function properly if it
 receives a new IP address.

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -747,7 +747,7 @@ a|The user is installing in a VPC that is not configured for both `*DNS hostname
 |`*ip*`
 a|Possibly if they have multiple network interfaces configured and they want to
 use one other than the default. You must first set
-`*openshift_node_set_node_ip*` to `True`. Otherwise, the SDN would attempt to
+`*openshift_set_node_ip*` to `True`. Otherwise, the SDN would attempt to
 use the `*hostname*` setting or try to resolve the host name for the IP.
 
 |`*public_hostname*`


### PR DESCRIPTION
This renames openshift_node_set_node_ip to openshift_set_node_ip, since it is the correct openshift-ansible variable name: https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_node/tasks/main.yml#L29