### PR TITLE
Adding non-containerized glusterfs dynamic provisioning example

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -375,8 +375,10 @@ Topics:
         File: ceph_example
       - Name: Complete Example Using GlusterFS
         File: gluster_example
-      - Name: Dynamic Provisioning Example Using GlusterFS
+      - Name: Dynamic Provisioning Example Using Containerized GlusterFS
         File: gluster_dynamic_example
+      - Name: Dynamic Provisioning Example Using Dedicated GlusterFS
+        File: dedicated_gluster_dynamic_example
       - Name: Mounting Volumes To Privileged Pods
         File: privileged_pod_storage
       - Name: Backing Docker Registry with GlusterFS Storage

--- a/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
@@ -1,0 +1,408 @@
+[[install-config-storage-examples-dedicated-gluster-dynamic-example]]
+= Complete Example of Dynamic Provisioning Using Dedicated GlusterFS
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[dedicated-glusterfs-dynamic-example-overview]]
+== Overview
+
+[NOTE]
+====
+This example assumes a functioning {product-title} cluster along with Heketi and
+GlusterFS. All `oc` commands are executed on the {product-title} master host.
+====
+
+xref:gluster_dynamic_example.adoc#install-config-storage-examples-gluster-dynamic-example[Container Native Storage (CNS) using GlusterFS and Heketi] is a great way to perform dynamic
+provisioning for shared filesystems in a Kubernetes-based cluster like
+{product-title}. However, if an existing,
+xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#gfs-dedicated-storage-cluster[dedicated Gluster cluster] is available external to the {product-title} cluster, you can
+also provision storage from it rather than a containerized GlusterFS
+implementation.
+
+This example:
+
+- Shows how simple it is to install and configure a Heketi server to
+work with {product-title} to perform dynamic provisioning.
+
+- Assumes some familiarity with Kubernetes and the
+link:http://kubernetes.io/docs/user-guide/persistent-volumes/[Kubernetes Persistent Storage] model.
+
+- Assumes you have access to an existing, dedicated GlusterFS cluster that has raw
+devices available for consumption and management by a Heketi server. If you do
+not have this, you can create a three node cluster using your virtual machine
+solution of choice. Ensure sure you create a few raw devices and give plenty of
+space (at least 100GB recommended). See
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Installation_Guide/[Red Hat Gluster Storage Installation Guide].
+
+[[dedicated-glusterfs-dynamic-example-enviornment]]
+== Environment and Prerequisites
+
+This example uses the following environment and prerequisites:
+
+* GlusterFS cluster running Red Hat Gluster Storage (RHGS) 3.1. Three nodes, each with at least two 100GB RAW devices:
+** *gluster23.rhs* (192.168.1.200)
+** *gluster24.rhs* (192.168.1.201)
+** *gluster25.rhs* (192.168.1.202)
+
+* Heketi service/client node running Red Hat Enterprise Linux (RHEL) 7.x or RHGS 3.1. Heketi can be installed on one of the Gluster nodes:
+** *glusterclient2.rhs* (192.168.1.203)
+
+* {product-title} node. This example uses an all-in-one {product-title} cluster
+(master and node on a single host), though it can work using a standard,
+multi-node cluster as well.
+** *k8dev2.rhs* (192.168.1.208)
+
+[[dedicated-glusterfs-dynamic-example-install-heketi]]
+== Installing and Configuring Heketi
+
+Heketi is used to manage the Gluster cluster storage (adding volumes, removing
+volumes, etc.). As stated, this can be RHEL or RHGS, and can be installed on one
+of the existing Gluster storage nodes. This example uses a stand-alone RHGS 3.1
+node running Heketi.
+
+The
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Administration_Guide/ch06s02.html[Red Hat Gluster Storage Administration Guide] can be used a reference during this process.
+
+. Install Heketi and the Heketi client. From the host designated to run Heketi and
+the Heketi client, run:
++
+----
+# yum install heketi heketi-client -y
+----
++
+[NOTE]
+====
+The Heketi server can be any of the existing hosts, though typically this will
+be the {product-title} master host. This example, however, uses a separate host
+not part of the GlusterFS or {product-title} cluster.
+====
+
+. Create and install Heketi private keys on each GlusterFS cluster node. From the
+host that is running Heketi:
++
+----
+# ssh-keygen -f /etc/heketi/heketi_key -t rsa -N ''
+# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster23.rhs
+# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster24.rhs
+# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster25.rhs
+# chown heketi:heketi /etc/heketi/heketi_key*
+----
+
+. Edit the *_/usr/share/heketi/heketi.json_* file to setup the SSH executor. Below
+is an excerpt from the *_/usr/share/heketi/heketi.json file_*; the parts to
+configure are the `executor` and SSH sections:
++
+[source,json]
+----
+	"executor": "ssh", <1>
+
+	"_sshexec_comment": "SSH username and private key file information",
+	"sshexec": {
+  	  "keyfile": "/etc/heketi/heketi_key", <2>
+  	  "user": "root", <3>
+  	  "port": "22", <4>
+  	  "fstab": "/etc/fstab" <5>
+	},
+----
+<1> Change `executor` from `mock` to `ssh`.
+<2> Add in the public key directory specified in previous step.
+<3> Update `user` to a user that has `sudo` or root access.
+<4> Set `port` to `22` and remove all other text.
+<5> Set `fstab` to the default, `/etc/fstab` and remove all other text.
+
+. Restart and enable service:
++
+----
+# systemctl restart heketi
+# systemctl enable heketi
+----
+
+. Test the connection to Heketi:
++
+----
+# curl http://glusterclient2.rhs:8080/hello
+Hello from Heketi
+----
+
+. Set an environment variable for the Heketi server:
++
+----
+# export HEKETI_CLI_SERVER=http://glusterclient2.rhs:8080
+----
+
+[[dedicated-glusterfs-dynamic-example-loading-topology]]
+== Loading Topology
+
+Topology is used to tell Heketi about the environment and what nodes and devices
+it will manage.
+
+[NOTE]
+====
+Heketi is currently limited to managing raw devices only. If a device is already
+a Gluster volume, it will be skipped and ignored.
+====
+
+. Create and load the topology file. There is a sample file located in
+*_/usr/share/heketi/toplogy-sample.json_* by default, or *_/etc/heketi_*
+depending on how it was installed.
++
+[source,json]
+----
+{
+  "clusters": [
+    {
+      "nodes": [
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster23.rhs"
+              ],
+              "storage": [
+                "192.168.1.200"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster24.rhs"
+              ],
+              "storage": [
+                "192.168.1.201"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster25.rhs"
+              ],
+              "storage": [
+                "192.168.1.202"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+      ]
+    }
+  ]
+}
+----
+
+. Using `heketi-cli`, run the following command to load the topology of your
+environment.
++
+----
+# heketi-cli topology load --json=topology.json
+
+    	Found node gluster23.rhs on cluster bdf9d8ca3fa269ff89854faf58f34b9a
+   		Adding device /dev/sde ... OK
+   	 	Adding device /dev/sdf ... OK
+    	Creating node gluster24.rhs ... ID: 8e677d8bebe13a3f6846e78a67f07f30
+   	 	Adding device /dev/sde ... OK
+   	 	Adding device /dev/sdf ... OK
+...
+...
+----
+
+. Create a Gluster volume to verify Heketi:
++
+----
+# heketi-cli volume create --size=50
+----
+
+. View the volume information from one of the the Gluster nodes:
++
+----
+# gluster volume info
+
+	Volume Name: vol_335d247ac57ecdf40ac616514cc6257f <1>
+	Type: Distributed-Replicate
+	Volume ID: 75be7940-9b09-4e7f-bfb0-a7eb24b411e3
+	Status: Started
+...
+...
+----
+<1> Volume created by `heketi-cli`.
+
+[[dedicated-glusterfs-dynamic-example-provision-volume]]
+== Dynamically Provision a Volume
+
+. Create a `StorageClass` object definition. The definition below is based on the
+minimum requirements needed for this example to work with {product-title}. See
+xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[Dynamic
+Provisioning and Creating Storage Classes] for additional parameters and
+specification definitions.
++
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: gluster-dyn
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "http://glusterclient2.rhs:8080" <1>
+  restauthenabled: "false" <2>
+----
+<1> The Heketi server from the `HEKETI_CLI_SERVER` environment variable.
+<2> Since authentication is not turned on in this example, set to `false`.
+
+. From the {product-title} master host, create the storage class:
++
+----
+# oc create -f glusterfs-storageclass1.yaml
+storageclass "gluster-dyn" created
+----
+
+. Create a persistent volume claim (PVC), requesting the newly-created storage
+class. For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+ name: gluster-dyn-pvc
+ annotations:
+   volume.beta.kubernetes.io/storage-class: gluster-dyn
+spec:
+ accessModes:
+  - ReadWriteMany
+ resources:
+   requests:
+        storage: 30Gi
+----
+
+. From the {product-title} master host, create the PVC:
++
+----
+# oc create -f glusterfs-pvc-storageclass.yaml
+persistentvolumeclaim "gluster-dyn-pvc" created
+----
+
+. View the PVC to see that the volume was dynamically created and bound to the PVC:
++
+----
+# oc get pvc
+NAME          	STATUS	VOLUME                                 		CAPACITY   	ACCESSMODES   	STORAGECLASS   	AGE
+gluster-dyn-pvc Bound	pvc-78852230-d8e2-11e6-a3fa-0800279cf26f   	30Gi   		RWX       	gluster-dyn	42s
+----
+
+. Verify and view the new volume on one of the Gluster nodes:
++
+----
+# gluster volume info
+
+	Volume Name: vol_335d247ac57ecdf40ac616514cc6257f <1>
+	Type: Distributed-Replicate
+	Volume ID: 75be7940-9b09-4e7f-bfb0-a7eb24b411e3
+	Status: Started
+        ...
+	Volume Name: vol_f1404b619e6be6ef673e2b29d58633be <2>
+	Type: Distributed-Replicate
+	Volume ID: 7dc234d0-462f-4c6c-add3-fb9bc7e8da5e
+	Status: Started
+	Number of Bricks: 2 x 2 = 4
+	...
+----
+<1> Volume created by `heketi-cli`.
+<2> New dynamically created volume triggered by Kubernetes and the storage class.
+
+[[dedicated-glusterfs-dynamic-example-nginx]]
+== Creating a NGINX Pod That Uses the PVC
+
+At this point, you have a dynamically created GlusterFS volume bound to a PVC.
+You can now now utilize this PVC in a pod. In this example, create a simple
+NGINX pod.
+
+. Create the pod object definition:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gluster-pod1
+  labels:
+    name: gluster-pod1
+spec:
+  containers:
+  - name: gluster-pod1
+    image: gcr.io/google_containers/nginx-slim:0.8
+    ports:
+    - name: web
+      containerPort: 80
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: gluster-vol1
+      mountPath: /usr/share/nginx/html
+  volumes:
+  - name: gluster-vol1
+    persistentVolumeClaim:
+      claimName: gluster-dyn-pvc <1>
+----
+<1> The name of the PVC created in the previous step.
+
+. From the {product-title} master host, create the pod:
++
+----
+# oc create -f nginx-pod.yaml
+pod "gluster-pod1" created
+----
+
+. View the pod. Give it a few minutes, as it might need to download the image if
+it does not already exist:
++
+----
+# oc get pods -o wide
+NAME                               READY     STATUS    RESTARTS   AGE       IP               NODE
+gluster-pod1                       1/1       Running   0          9m        10.38.0.0        node1
+----
+
+. Now remote into the container with `oc exec` and create an *_index.html_* file:
++
+----
+# oc exec -ti gluster-pod1 /bin/sh
+$ cd /usr/share/nginx/html
+$ echo 'Hello World from GlusterFS!!!' > index.html
+$ ls
+index.html
+$ exit
+----
+
+. Now `curl` the URL of the pod:
++
+----
+# curl http://10.38.0.0
+Hello World from GlusterFS!!!
+----

--- a/install_config/storage_examples/gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/gluster_dynamic_example.adoc
@@ -1,5 +1,5 @@
 [[install-config-storage-examples-gluster-dynamic-example]]
-= Complete Example of Dynamic Provisioning Using GlusterFS
+= Complete Example of Dynamic Provisioning Using Containerized GlusterFS
 {product-author}
 {product-version}
 :data-uri:
@@ -11,16 +11,14 @@
 
 toc::[]
 
+[[cns-glusterfs-dynamic-example-overview]]
+== Overview
 
 [NOTE]
 ====
-This example assumes a working {product-title} installed and functioning along
-with Heketi and GlusterFS.
-
-All `oc` commands are executed on the {product-title} master host.
+This example assumes a functioning {product-title} cluster along with Heketi and
+GlusterFS. All `oc` commands are executed on the {product-title} master host.
 ====
-
-== Overview
 
 This topic provides an end-to-end example of how to dynamically provision
 GlusterFS volumes. In this example, a simple NGINX HelloWorld application is


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/3630 and includes further edits.

@screeley44 PTAL. Preview build:

http://file.rdu.redhat.com/~adellape/031017/screeley44-external_glusterfs_heketi/install_config/storage_examples/dedicated_gluster_dynamic_example.html