### PR TITLE
Changed parameter names in Audit Configuration

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -711,10 +711,10 @@ AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" response="200"
 
 | Parameter Name | Description
 
-|`Enabled`
+|`enabled`
 |A boolean to enable or disable audit logs. Default is `false`.
 
-|`AuditFilePath`
+|`auditFilePath`
 |File path where the requests should be logged to. If not set, logs are printed
 to master logs.
 


### PR DESCRIPTION
related to this warning in the journal '...W0306 20:53:52.706793  106410 start_master.go:278] Warning: auditConfig.auditFilePath: Required value: audit can now be logged to a separate file, master start will continue.' I changed the first letter from capital to small. After this change it works well...
Audit log is activated and is logging into a defined file.