### PR TITLE
Adds comment regarding not supporting password protected key files

### DIFF
--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -114,6 +114,14 @@ spec:
 ----
 ====
 
+Currently, password protected key files are not supported. HAProxy prompts for
+a password upon starting and does not have a way to automate this process. To
+remove a passphrase from a keyfile, you can run:
+
+----
+# openssl rsa -in <passwordProtectedKey.key> -out <new.key>
+----
+
 You can create a secured route without specifying a key and certificate,
 in which case the
 ifdef::openshift-enterprise,openshift-origin[]


### PR DESCRIPTION
Content was taken from :https://docs.openshift.com/container-platform/3.4/install_config/router/default_haproxy_router.html#using-secured-routes

Since these documents are filtered out of the OpenShift Dedicated docs, it's important to keep this information in a place where Dedicated customers can see it.