### PR TITLE
Update .NET Core supported version numbers

### DIFF
--- a/using_images/s2i_images/dot_net_core.adoc
+++ b/using_images/s2i_images/dot_net_core.adoc
@@ -33,6 +33,7 @@ and Python from within {product-title}.
 [[dot-net-core-supported-versions]]
 == Supported Versions
 
+* .NET Core version 1.0
 * .NET Core version 1.1
 ** Supported on Red Hat Enterprise Linux (RHEL) 7
 ifdef::openshift-enterprise[]
@@ -48,6 +49,7 @@ endif::openshift-enterprise[]
 The RHEL 7 images are available through Red Hat's subscription registry using:
 
 ----
+$ docker pull registry.access.redhat.com/dotnet/dotnetcore-10-rhel7
 $ docker pull registry.access.redhat.com/dotnet/dotnetcore-11-rhel7
 ----
 
@@ -82,6 +84,7 @@ An image can be used to build an application by running `oc new-app` against a
 sample repository:
 
 ----
+$ oc new-app registry.access.redhat.com/dotnet/dotnetcore-10-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.0 --context-dir=app
 $ oc new-app registry.access.redhat.com/dotnet/dotnetcore-11-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.1 --context-dir=app
 ----
 


### PR DESCRIPTION
Upstream (Microsoft) and Red Hat both intend to support .NET Core 1.0 and 1.1 for the same duration of time.

See:
- https://www.microsoft.com/net/core/support

1.0 is classified as a Long Term Release while 1.1 is classified as a Fast Track Release (sometimes called Current). The original expectation was that 1.1 would actually End of Life before 1.0. A
theoretical 1.2 will serve as 1.1's replacement. Now that 2.0 is being targetted for some time in 2017 and there's no 1.2 on the horizon, both 1.0 and 1.1 will EOL on the same date.

Update docs to reflect that both are supported and available for use.

This undoes part of https://github.com/openshift/openshift-docs/pull/3897

cc @ahardin-rh @jerboaa @aheslin @tmds