### PR TITLE
Followup edits to PR 3757

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -16,8 +16,9 @@ toc::[]
 This topic describes the management of the overall xref:../architecture/additional_concepts/networking.adoc[cluster network],
 including project isolation and outbound traffic control.
 
-(Pod-level networking features, such as per-pod bandwidth limits, are
-discussed in xref:managing_pods.adoc[Managing Pods].)
+Pod-level networking features, such as per-pod bandwidth limits, are discussed
+in xref:../admin_guide/managing_pods.adoc#admin-guide-manage-pods[Managing
+Pods].
 
 [[admin-guide-pod-network]]
 == Managing Pod Networks
@@ -420,50 +421,80 @@ $ oc create -f <replication_controller>.json
 oc describe rc <replication_controller>
 ----
 
-[[multicast]]
+[[admin-guide-networking-multicast]]
 == Enabling Multicast
 
-Normally, multicast traffic between pods is disabled in {product-title}, but you
-can enable it on a per-project basis by setting an annotation on the project's
-corresponding NetNamespace object:
-
+[IMPORTANT]
 ====
+Enabling multicast networking is a Technology Preview only. Technology
+Preview features are not supported with Red Hat production service level
+agreements (SLAs), might not be functionally complete, and Red Hat does not
+recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+For more information on Red Hat Technology Preview features support scope, 
+see https://access.redhat.com/support/offerings/techpreview/. 
+====
+
+Multicast traffic between {product-title} pods is disabled by default. You can
+enable Multicast on a per-project basis by setting an annotation on the
+project's corresponding `netnamespace` object:
+
 ----
-# oc annotate netnamespace <namespace_name> \
+# oc annotate netnamespace <namespace> \
     netnamespace.network.openshift.io/multicast-enabled=true
 ----
-====
 
-This is a Tech Preview feature and the details may change in the future.
+Disable multicast by removing the annotation:
 
-You can later disable multicast again by removing the annotation:
-
-====
 ----
-# oc annotate netnamespace <namespace_name> \
+# oc annotate netnamespace <namespace> \
     netnamespace.network.openshift.io/multicast-enabled-
 ----
+
+If you have
+xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined
+networks together], you will need to enable Multicast in each projects'
+`netnamespace` in order for it to take effect in any of the projects. To enable
+Multicast in the `default` project, you must also enable it in all other
+projects that have been
+xref:../admin_guide/managing_networking.adoc#making-project-networks-global[made
+global]. 
+
+[NOTE]
+====
+Multicast global projects are not "global", but instead communicate with only
+other global projects via Multicast, not with all projects in the cluster, as is
+the case with unicast.
 ====
 
-If you have <<joining-project-networks,joined networks together>> with
-`oadm pod-network` you will need to enable multicast in each of the projects'
-NetNamespaces in order for it to take effect in any of the projects. You cannot
-enable multicast in the "default" project or in any other project that has been
-<<making-project-networks-global,made global>>, nor can you send multicast
-packets into or out of global projects.
+[[admin-guide-networking-networkpolicy]]
+== Enabling NetworkPolicy
 
-[[networkpolicy]]
-== NetworkPolicy
+[IMPORTANT]
+====
+Enabling the Kubernetes `NetworkPolicy` is a Technology Preview only. Technology
+Preview features are not supported with Red Hat production service level
+agreements (SLAs), might not be functionally complete, and Red Hat does not
+recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
 
-Kubernetes NetworkPolicy is not currently fully supported by {product-title},
-and the *ovs-subnet* and *ovs-multitenant* plugins ignore NetworkPolicy objects.
-However, a Tech Preview of NetworkPolicy support is available by using the
-*ovs-networkpolicy* plugin.
+For more information on Red Hat Technology Preview features support scope, 
+see https://access.redhat.com/support/offerings/techpreview/. 
+====
 
-In a cluster xref:../../install_config/configuring_sdn.adoc#install-config-configuring-sdn[configured to use the *ovs-networkpolicy* plugin],
-network isolation is controlled entirely by NetworkPolicy objects and the associated
-Namespace annotation, as described in the link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network-policy.md[NetworkPolicy documentation].
-In particular, by default, all projects are able to access pods in all other
-projects. A project that wants to be isolated must first opt in to isolation by
-setting the proper annotation on its Namespace object, and then create NetworkPolicy
-objects indicating what incoming connections should be allowed.
+Kubernetes `NetworkPolicy` is not currently fully supported by {product-title},
+and the *ovs-subnet* and *ovs-multitenant* plug-ins ignore `NetworkPolicy`
+objects. However, a Technology Preview of `NetworkPolicy` support is available by
+using the *ovs-networkpolicy* plug-in.
+
+In a cluster
+xref:../../install_config/configuring_sdn.adoc#install-config-configuring-sdn[configured
+to use the *ovs-networkpolicy* plug-in], network isolation is controlled
+entirely by `NetworkPolicy` objects and the link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network-policy.md[associated Namespace annotation]. In particular, by default, all projects are able to access pods
+in all other projects. The project to be isolated must first be configured to
+opt in to isolation by setting the proper annotation on its Namespace object,
+and then creating `NetworkPolicy` objects indicating the incoming connections to
+be allowed.

--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -34,7 +34,7 @@ facilitates certain services like the load balancer, etc. to communicate with
 all other pods in the cluster and vice versa.
 * The *ovs-networkpolicy* plug-in (currently in Tech Preview) allows project
 administrators to configure their own isolation policies using
-xref:../../admin_guide/managing_networking.adoc#networkpolicy[NetworkPolicy objects].
+xref:../../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy[NetworkPolicy objects].
 
 Following is a detailed discussion of the design and operation of
 OpenShift SDN, which may be useful for troubleshooting.


### PR DESCRIPTION
As per: #3575 

Moves the networking stuff from "Managing Pods" to a "Managing Networks" file. It was @danwinship 's idea, and I agree.

@ahardin-rh @adellape @bmcelvee @mburke5678 open for peer review. Let me know thoughts on the placement of things as well, if you have ideas.