### PR TITLE
[DO NOT MERGE] Add .NET Core supported env vars and templates.

### DIFF
--- a/using_images/s2i_images/dot_net_core.adoc
+++ b/using_images/s2i_images/dot_net_core.adoc
@@ -66,8 +66,70 @@ link:https://github.com/redhat-developer/s2i-dotnetcore/blob/master/dotnet_image
 [[dot-net-core-configuration]]
 == Configuration
 
-The .NET Core image currently does not support any environment variables. No
-configuration is necessary.
+The .NET Core images support a number of environment variables which can be set to
+control the build behavior of your .NET Core app.
+
+[NOTE]
+====
+Environment variables that control build behavior must be set as part of the s2i build
+configuration or in the *_.s2i/environment_* file to make them available to the build
+steps.
+====
+
+.NET Core Environment Variables
+[cols="4a,6a,6a",options="header"]
+|===
+
+|Variable Name |Description |Default
+
+|`*DOTNET_STARTUP_PROJECT*`
+|Used to select the project to run. This must be the folder containing `project.json`.
+|Current working directory, a.k.a `.`
+
+|`*DOTNET_PUBLISH*`
+|Used to control whether the application should be built by executing
+ `dotnet build` or `dotnet publish`. To publish the application set the
+ value to `true`. It is recommended to publish your application.
+|For backwards compatibility, the default is `false`. In the next major release,
+ this variable will be removed and the builder will always publish the application.
+
+|`*DOTNET_ASSEMBLY_NAME*`
+|Used to select the assembly to run. This must NOT include the `.dll` extension.
+ Set this to the output assembly name specified in `project.json` (`name`, `buildOptions/outputName`).
+ For `project.json`, the assembly name defaults to the `project.json` parent folder.
+ When `project.json` is at the `context-dir`, the parent folder name will be `src`. So, by
+ default, this generates a `src.dll` assembly. Setting `DOTNET_ASSEMBLY_NAME` will cause:
+
+  - the assembly to be <DOTNET_ASSEMBLY_NAME>.dll
+  - the application sources to be in subfolder `DOTNET_ASSEMBLY_NAME` in the deployed container.
+
+|The name of the
+ parent folder of the folder with `project.json`.
+
+|`*DOTNET_RESTORE_SOURCES*`
+|Used to specify the space separated list of NuGet package sources used during the restore operation. This overrides
+ all of the sources specified in the NuGet.config file.
+|Unset.
+
+|`*DOTNET_NPM_TOOLS*`
+|Used to specify a list of npm packages to install before building the app.
+|Unset.
+
+|`*DOTNET_TEST_PROJECTS*`
+|Used to specify the space separated list of test projects to run. This must be folders containing
+ `project.json`. `dotnet test` is invoked for each folder.
+|Unset.
+
+|`*DOTNET_CONFIGURATION*`
+|Used to run the application in `Debug` or `Release` mode. This should be either
+ `Release` or `Debug`.
+|`Release`
+
+|`*ASPNETCORE_URLS*`
+|This variable is set to `http://*:8080` to configure ASP.NET Core to use the
+ port exposed by the image. It is **not** recommended to change this.
+|`http://*:8080`
+|===
 
 [[dot-net-quickly-deploy-applications]]
 == Quickly Deploying Applications from .NET Core Source
@@ -94,3 +156,39 @@ ifdef::openshift-enterprise[]
 The `oc new-app` command can detect .NET Core source starting in {product-title} 3.3.
 ====
 endif::openshift-enterprise[]
+
+[[dot-net-core-templates]]
+== .NET Core Templates
+
+[IMPORTANT]
+====
+
+The
+link:https://github.com/redhat-developer/s2i-dotnetcore/blob/master/templates[.NET
+image templates] and the .NET images streams must first be
+link:https://github.com/redhat-developer/s2i-dotnetcore#openshift-templates[installed].
+If you ran a standard installation, the templates and image streams will be
+present. This can be checked with `(oc get -n openshift templates; oc get -n openshift is) | grep dotnet`
+
+====
+
+The link:https://github.com/redhat-developer/s2i-dotnetcore-ex[.NET Core sample
+application] running on `dotnet/dotnetcore-10-rhel7` can be deployed with:
+
+----
+$ oc new-app --template dotnet-example
+----
+
+The link:https://github.com/redhat-developer/s2i-dotnetcore-ex[.NET Core sample
+application] running on `dotnet/dotnetcore-11-rhel7` can be deployed with:
+
+----
+$ oc new-app --template dotnet-example -p DOTNET_IMAGE_STREAM_TAG=dotnet:1.1 -p SOURCE_REPOSITORY_REF=dotnetcore-1.1
+----
+
+The link:https://github.com/aspnet/MusicStore[.NET Core MusicStore application]
+using PostgreSQL as database can be deployed with:
+
+----
+$ oc new-app --template=dotnet-pgsql-persistent
+----


### PR DESCRIPTION
- Add supported environment variables.
- Add examples of using the templates.

We should hold off on merging this until the templates are actually there. Perhaps we should split this into two PRs as the environment variables will work as soon as the images get released. The templates section will only work once a release with them being pre-loaded gets out. Ashley, would you be able to take this over?

Thoughts?

cc @omajid @ahardin-rh @tmds