### PR TITLE
Fix wrong name and size of dynamic provisioned pvc

### DIFF
--- a/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
+++ b/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
@@ -164,7 +164,7 @@ As a `cluster-admin` or `storage-admin` user, view the recent dynamically provis
 
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM                     REASON    AGE
-pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete          Bound     rh-eng/pvc-engineering2             5m
+pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound     rh-eng/pvc-engineering              5m
 
 ----
 ====


### PR DESCRIPTION
When get pvc, 
pvc name is "pvc-engineering", 
pv name is "pvc-e9b4fef7-8bf7-11e6-9962-42010af00004", 
and size is "10Gi"
```
# oc get pvc
NAME              STATUS    VOLUME                                     CAPACITY   ACCESSMODES   AGE
pvc-engineering   Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           2m
```

But the pvc name, pv name and size changed when get pv.

This PR fix above issue.