### PR TITLE
Removed F5 Router Partition Paths content from 3.1

### DIFF
--- a/install_config/install/deploy_router.adoc
+++ b/install_config/install/deploy_router.adoc
@@ -477,7 +477,7 @@ add routes across the namespaces.
 Using the `--metrics-image` and `--expose-metrics` options, you can configure
 the {product-title} router to run a sidecar container that exposes or publishes
 router metrics for consumption by external metrics collection and aggregation
-systems (e.g. Prometheus, statsd). 
+systems (e.g. Prometheus, statsd).
 
 Depending on your router implementation, the image is appropriately set up and
 the metrics sidecar container is started when the router is deployed. For
@@ -759,9 +759,6 @@ Required to upload and delete key and certificate files for routes.
 |`--external-host-insecure`
 |A Boolean flag that indicates that the F5 router should skip strict certificate
 verification with the *F5 BIG-IP®* host.
-
-|`--external-host-partition-path`
-|Specifies the *F5 BIG-IP®* xref:f5-router-partition-paths[partition path] (the default is */Common*).
 |===
 
 As with the HAProxy router, the `oadm router` command creates the service and
@@ -821,28 +818,6 @@ endif::[]
 xref:../../cli_reference/manage_cli_profiles.adoc#cli-reference-manage-cli-profiles[CLI configuration file]
 for the *openshift-router*. It is recommended using an *openshift-router*
 specific profile with appropriate permissions.
-
-[[f5-router-partition-paths]]
-=== F5 Router Partition Paths
-Partition paths allow you to store your OpenShift routing configuration in a
-custom *F5 BIG-IP®* administrative partition, instead of the default */Common*
-partition. You can use custom administrative partitions to secure *F5 BIG-IP®*
-environments. This means that an OpenShift-specific configuration stored in
-*F5 BIG-IP®* system objects reside within a logical container, allowing
-administrators to define access control policies on that specific administrative
-partition.
-
-See the
-link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_0_0/tmos_partitions.html[*F5 BIG-IP®* documentation] for more information about administrative partitions.
-
-Use the `--external-host-partition-path` flag when
-xref:deploying-the-f5-router[deploying the F5 router] to specify a partition
-path:
-====
-----
-$ oadm router --external-host-partition-path=/OpenShift/zone1 ...
-----
-====
 
 == What's Next?
 


### PR DESCRIPTION
Removes F5 Router Partition Paths content from enterprise-3.1 branch per @knobunc 

@adellape PTAL