### PR TITLE
Removed F5 Router Partition Paths content from 3.3

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -60,9 +60,6 @@ Required to upload and delete key and certificate files for routes.
 |`--external-host-insecure`
 |A Boolean flag that indicates that the F5 router should skip strict certificate
 verification with the *F5 BIG-IP®* host.
-
-|`--external-host-partition-path`
-|Specifies the *F5 BIG-IP®* xref:f5-router-partition-paths[partition path] (the default is */Common*).
 |===
 
 As with the HAProxy router, the `oadm router` command creates the service and
@@ -126,25 +123,3 @@ $ oadm router \
 ----
 ====
 endif::[]
-
-[[f5-router-partition-paths]]
-== F5 Router Partition Paths
-Partition paths allow you to store your {product-title} routing configuration in
-a custom *F5 BIG-IP®* administrative partition, instead of the default */Common*
-partition. You can use custom administrative partitions to secure *F5 BIG-IP®*
-environments. This means that an {product-title}-specific configuration stored
-in *F5 BIG-IP®* system objects reside within a logical container, allowing
-administrators to define access control policies on that specific administrative
-partition.
-
-See the
-link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_0_0/tmos_partitions.html[*F5 BIG-IP®* documentation] for more information about administrative partitions.
-
-Use the `--external-host-partition-path` flag when
-xref:deploying-the-f5-router[deploying the F5 router] to specify a partition
-path:
-====
-----
-$ oadm router --external-host-partition-path=/OpenShift/zone1 ...
-----
-====


### PR DESCRIPTION
Removes F5 Router Partition Paths content from enterprise-3.3 branch per @knobunc

@adellape PTAL