### PR TITLE
Fix wrong resource type and name

### DIFF
--- a/install_config/storage_examples/binding_pv_by_label.adoc
+++ b/install_config/storage_examples/binding_pv_by_label.adoc
@@ -167,7 +167,7 @@ endpoints "glusterfs-cluster" created
 # oc create -f glusterfs-pv.yaml
 persistentvolume "gluster-volume" created
 # oc create -f glusterfs-pvc.yaml
-persistentvolume "gluster-volume" created
+persistentvolumeclaim "gluster-claim" created
 ----
 
 Lastly, confirm that the PV and PVC bound successfully.


### PR DESCRIPTION
We are creating pvc here, so the type should be persistentvolumeclaim, and the pvc name should be gluster-claim according to file glusterfs-pvc.yaml which is listed above.


This apply to branch/enterprise-3.3 and above.