### PR TITLE
Various fixes to the jobs documentation

### DIFF
--- a/dev_guide/jobs.adoc
+++ b/dev_guide/jobs.adoc
@@ -16,10 +16,11 @@ A job, in contrast to
 xref:../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[a
 deployment] (or
 xref:../architecture/core_concepts/deployments.adoc#replication-controllers[a
-replication controller]), runs any number of pods to completion. A job tracks the
-overall progress of a task and updates its status with information about active,
-succeeded, and failed pods. Deleting a job will clean up any pods it created.
-Jobs are part of the Kubernetes API, which can be managed with `oc` commands like other
+replication controller], runs a pod with any number of replicas to completion. A
+job tracks the overall progress of a task and updates its status with information
+about active, succeeded, and failed pods. Deleting a job will clean up any pod
+replicas it created. Jobs are part of the Kubernetes API, which can be managed
+with `oc` commands like other
 xref:../cli_reference/basic_cli_operations.adoc#object-types[object types].
 
 See the http://kubernetes.io/docs/user-guide/jobs/[Kubernetes documentation] for
@@ -31,7 +32,7 @@ more information about jobs.
 A job configuration consists of the following key parts:
 
 - A pod template, which describes the application the pod will create.
-- An optional `*parallelism*` parameter, which specifies how many pods running in parallel should execute a job. If not specified, this defaults to
+- An optional `*parallelism*` parameter, which specifies how many pod replicas running in parallel should execute a job. If not specified, this defaults to
  the value in the `*completions*` parameter.
 - An optional `*completions*` parameter, specifying how many successful pod completions are needed to finish a job. If not specified, this value defaults to one.
 
@@ -58,18 +59,18 @@ spec:
       restartPolicy: Never
 ----
 
-1. Optional value for how many pods a job should run in parallel, defaults to `*completions*`.
-2. Optional value for how many successful pod completions is needed to mark a job completed, defaults to one.
+1. Optional value for how many pod replicas a job should run in parallel; defaults to `*completions*`.
+2. Optional value for how many successful pod completions are needed to mark a job completed; defaults to one.
 3. Template for the pod the controller creates.
 ====
 
 [[scaling-a-job]]
 == Scaling a Job
 
-A job can be scaled up or down by using the `oc scale` command with `--replicas`
-option, which, in the case of jobs, modifies the `*spec.parallelism*` parameter.
-This will result in modifying the number of pods running in parallel, executing
-a job.
+A job can be scaled up or down by using the `oc scale` command with the
+`--replicas` option, which, in the case of jobs, modifies the
+`*spec.parallelism*` parameter. This will result in modifying the number of pod
+replicas running in parallel, executing a job.
 
 The following command uses the example job above, and scales it to three:
 
@@ -93,7 +94,7 @@ set by default. When not set, there is no maximum duration enforced.
 
 The maximum duration is counted from the time when a first pod gets scheduled in
 the system, and defines how long a job can be active. It tracks overall time of
-an execution and is irrelevant to the number of completions (number of pods
+an execution and is irrelevant to the number of completions (number of pod replicas
 needed to execute a task). After reaching the specified timeout, the job is
 terminated by {product-title}.
 


### PR DESCRIPTION
Use the phrase "pod replicas" where appropriate for clarity.

Use a semicolon instead of a comma to separate independent clauses.

Change "completions is needed" to "completions are needed".

Add a missing article: "the `--replicas` option".