### PR TITLE
Various fixes to daemonsets documentation

### DIFF
--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -13,8 +13,8 @@ toc::[]
 
 == Overview
 
-Daemonsets are used to run a copy of a pod on specific or all nodes in an
-{product-title} environment upon node creation.
+A daemonset can be used to run replicas of a pod on specific or all nodes in an
+{product-title} cluster.
 
 Use daemonsets to create shared storage, run a logging pod on every node in
 your cluster, or deploy a monitoring agent on every node.
@@ -31,8 +31,8 @@ xref:../admin_guide/manage_authorization_policy.adoc#admin-guide-granting-users-
 the required role by your {product-title} administrator].
 ====
 
-When creating Daemonsets, the `*nodeSelector*` field is used to indicate the
-nodes on which the Daemonset should deploy onto.
+When creating daemonsets, the `*nodeSelector*` field is used to indicate the
+nodes on which the daemonset should deploy replicas.
 
 . Define the daemonset yaml file:
 +
@@ -51,6 +51,8 @@ spec:
       labels:
         name: hello-daemonset <2>
     spec:
+      nodeSelector: <3>
+        type: infra
       containers:
       - image: openshift/hello-openshift
         imagePullPolicy: Always
@@ -63,8 +65,9 @@ spec:
       serviceAccount: default
       terminationGracePeriodSeconds: 10
 ----
-<1> The pod template.
-<2> The node selector indicating the appropriate labels. Must match the pod template above.
+<1> The label selector that determines which pods belong to the daemonset.
+<2> The pod template's label selector. Must match the label selector above.
+<3> The node selector that determines on which nodes pod replicas should be deployed.
 ====
 
 . Create the daemonset object:
@@ -73,8 +76,7 @@ spec:
 oc create -f daemonset.yaml
 ----
 
-. To verify that the pods were created, and that each node has a copy of the
-pod:
+. To verify that the pods were created, and that each node has a pod replica:
 +
 .. Find the daemonset pods:
 +
@@ -99,10 +101,12 @@ Node:        openshift-node02.hostname.com/10.14.20.137
 
 [IMPORTANT]
 ====
-Currently, you cannot update a daemonset. You can delete a daemonset, but
-creating and using a new daemonset with a different template will recognize the
-existing pod as having matching labels dispite a mismatch in the pod template.
+Currently, updating a daemonset's pod template does not affect existing pod
+replicas. Moreover, if you delete a daemonset and then create a new daemonset
+with a different template but the same label selector, it will recognize any
+existing pod replicas as having matching labels and thus will not update them or
+create new replicas despite a mismatch in the pod template.
 
-To update a daemonset, force a new pod to be created by deleting the pod or
-node.
+To update a daemonset, force new pod replicas to be created by deleting the old
+replicas or nodes.
 ====


### PR DESCRIPTION
Use consistent capitalization for daemonsets.

Use the phrase "pod replicas" where appropriate for clarity.

Instead of the term "environment", use the more command and precise term "cluster".

Correct the daemonset example to specify a nodeSelector and to identify the label selectors correctly.

Rephrase the note about updating the pod template in the daemonset for clarity.

Correct a typo in the note: "dispite" should be "despite".