### PR TITLE
Minor fixes to the managing projects topic

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 == Overview
 
-In {product-title}, projects are used to isolate content from groups of developers. As an administrator, you can give developers access to certain projects, allow them to create their own, and give them administrator rights.
+In {product-title}, projects are used to group and isolate related objects. As an administrator, you can give developers access to certain projects, allow them to create their own, and give them administrative rights within individual projects.
 
 [[selfprovisioning-projects]]
 == Self-provisioning Projects
@@ -29,7 +29,7 @@ command use this endpoint when a developer xref:../dev_guide/projects.adoc#dev-g
 [[modifying-the-template-for-new-projects]]
 === Modifying the Template for New Projects
 The API server automatically provisions projects based on the template that is
-defined in the `projectRequestTemplate` parameter of the *_master-config.yaml_*
+identified by the `projectRequestTemplate` parameter of the *_master-config.yaml_*
 file. If the parameter is not defined, the API server creates a default template
 that creates a project with the requested name, and assigns the requesting user
 to the "admin" role for that project.
@@ -99,7 +99,7 @@ $ oadm policy remove-cluster-role-from-group self-provisioner system:authenticat
 ----
 
 When disabling self-provisioning, set the `projectRequestMessage` parameter in the
-*_master-config.yaml_* file instructing developers on how to request a new
+*_master-config.yaml_* file to instruct developers on how to request a new
 project. This parameter is a string that will be presented to the developer in
 the web console and command line when they attempt to self-provision a project.
 For example:
@@ -251,21 +251,7 @@ Projects], then the generated template does not include the annotation
 In order to specify limits for users, a configuration must be specified for the
 plug-in within the master configuration file
 (*_/etc/origin/master/master-config.yaml_*). The plug-in configuration takes a
-list of user label selectors and the associated maximum project requests:
-
-[source, yaml]
-----
-apiVersion: v1
-kind: ProjectRequestLimitConfig
-limits:
-- selector:
-    label1=value1
-    label2=value2
-  maxProjects: 10
-- selector:
-    label3=value3
-  maxProjects: 5
-----
+list of user label selectors and the associated maximum project requests.
 
 Selectors are evaluated in order. The first one matching the current user will
 be used to determine the maximum number of projects. If a selector is not
@@ -296,10 +282,10 @@ admissionConfig:
         - maxProjects: 2 <3>
 ----
 
-<1> For selector `level=admin` no `*maxProjects*` is specified. This means that users
-with this label will not have a maximum of project requests
+<1> For selector `level=admin`, no `*maxProjects*` is specified. This means that users
+with this label will not have a maximum of project requests.
 
-<2> For selector `level=advanced` a maximum number of 10 projects will be allowed.
+<2> For selector `level=advanced`, a maximum number of 10 projects will be allowed.
 
 <3> For the third entry, no selector is specified. This means that it will be applied
 to any user that doesn't satisfy the previous two rules. Because rules are evaluated


### PR DESCRIPTION
Reword a few sentences for clarity, delete a redundant example (which is followed by an almost identical example), and add some missing commas.