### PR TITLE
Various fixes to quota documentation

### DIFF
--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -35,6 +35,11 @@ endif::[]
 The following describes the set of compute resources and object types that may be
 managed by a quota.
 
+[NOTE]
+====
+A pod is in a terminal state if `status.phase in (Failed, Succeeded)` is true.
+====
+
 .Compute Resources Managed by Quota
 [cols="3a,8a",options="header"]
 |===
@@ -42,40 +47,40 @@ managed by a quota.
 |Resource Name |Description
 
 |`*cpu*`
-|Across all pods in a non-terminal state, the sum of CPU requests cannot exceed
-this value. `*cpu*` and `*requests.cpu*`are the same value and can be used
+|The sum of CPU requests across all pods in a non-terminal state cannot exceed
+this value. `*cpu*` and `*requests.cpu*` are the same value and can be used
 interchangeably.
 
 |`*memory*`
-|Across all pods in a non-terminal state, the sum of memory requests cannot
+|The sum of memory requests across all pods in a non-terminal state cannot
 exceed this value. `*memory*` and `*requests.memory*` are the same value and can
 be used interchangeably.
 
 |`*requests.cpu*`
-|Across all pods in a non-terminal state, the sum of CPU requests cannot exceed
-this value. `*cpu*` and `*requests.cpu*`are the same value and can be used
+|The sum of CPU requests across all pods in a non-terminal state cannot exceed
+this value. `*cpu*` and `*requests.cpu*` are the same value and can be used
 interchangeably.
 
 |`*requests.memory*`
-|Across all pods in a non-terminal state, the sum of memory requests cannot
+|The sum of memory requests across all pods in a non-terminal state cannot
 exceed this value. `*memory*` and `*requests.memory*` are the same value and can
 be used interchangeably.
 
 |`*requests.storage*`
-|Across all persistent volume claim in any state, the sum of storage requests cannot
+|The sum of storage requests across all persistent volume claims cannot
 exceed this value. `*storage*` and `*requests.storage*` are the same value and can
 be used interchangeably.
 
 |`*limits.cpu*`
-|Across all pods in a non-terminal state, the sum of CPU limits cannot exceed
+|The sum of CPU limits across all pods in a non-terminal state cannot exceed
 this value.
 
 |`*limits.memory*`
-|Across all pods in a non-terminal state, the sum of memory limits cannot exceed
+|The sum of memory limits across all pods in a non-terminal state cannot exceed
 this value.
 
 |`*limits.storage*`
-|Across all persistent volume claims, the sum of storage limits cannot
+|The sum of storage limits across all persistent volume claims cannot
 exceed this value.
 |===
 
@@ -88,7 +93,6 @@ exceed this value.
 
 |`*pods*`
 |The total number of pods in a non-terminal state that can exist in the project.
-A pod is in a terminal state if `status.phase in (Failed, Succeeded)` is true.
 
 |`*replicationcontrollers*`
 |The total number of replication controllers that can exist in the project.
@@ -121,9 +125,9 @@ Each quota can have an associated set of _scopes_. A quota will only
 measure usage for a resource if it matches the intersection of enumerated
 scopes.
 
-When a scope is added to a quota, it limits the number of resources it supports
-to those that pertain to the scope. Resources specified on the quota outside of
-the allowed set results in a validation error.
+Adding a scope to a quota restricts the set of resources to which that quota can
+apply. Specifying a resource outside of the allowed set results in a validation
+error.
 
 [cols="3a,8a",options="header"]
 |===
@@ -131,10 +135,10 @@ the allowed set results in a validation error.
 |Scope |Description
 
 |*Terminating*
-|Match pods where `spec.activeDeadlineSeconds >= 0`
+|Match pods where `spec.activeDeadlineSeconds >= 0`.
 
 |*NotTerminating*
-|Match pods where `spec.activeDeadlineSeconds is nil`
+|Match pods where `spec.activeDeadlineSeconds` is `nil`.
 
 |*BestEffort*
 |Match pods that have best effort quality of service for either `*cpu*` or
@@ -145,11 +149,11 @@ the allowed set results in a validation error.
 `*memory*`.
 |===
 
-A *BestEffort* scope restricts a quota to limit the following resources:
+A *BestEffort* scope restricts a quota to limiting the following resources:
 
 - `*pods*`
 
-A *Terminating*, *NotTerminating*, and *NotBestEffort* scope restricts a quota
+A *Terminating*, *NotTerminating*, or *NotBestEffort* scope restricts a quota
 to tracking the following resources:
 
 - `*pods*`
@@ -192,13 +196,13 @@ the system.
 // tag::admin_quota_requests_vs_limits[]
 When allocating
 xref:../dev_guide/compute_resources.adoc#dev-compute-resources[compute
-resources], each container may specify a request and a limit value for either
-CPU or memory. The quota can be configured to quota either value.
+resources], each container may specify a request and a limit value each for
+CPU and memory. Quotas can restrict any of these values.
 
 If the quota has a value specified for `*requests.cpu*` or `*requests.memory*`,
-then it requires that every incoming container makes an explicit request for
+then it requires that every incoming container make an explicit request for
 those resources. If the quota has a value specified for `*limits.cpu*` or
-`*limits.memory*`, then it requires that every incoming container specifies an
+`*limits.memory*`, then it requires that every incoming container specify an
 explicit limit for those resources.
 // end::admin_quota_requests_vs_limits[]
 


### PR DESCRIPTION
Pull the definition of "terminal state" out of the "pods" entry of the "Object Counts Managed by Quota" table and place the definition prominently above the "Compute Resources Managed by Quota" table above because entries in both tables use the phrase.

Reword some cumbersome sentences in the table to be a little less cumbersome.

Rephrase the note about how a quota's scope limits the resources to which the quota can apply.

Add some missing periods

Use a gerund after "restricts to".

Correct an "and" to "or".

Rephrase the description of what quotas and limits a container may specify. A quota does not "quota"; rather, it "restricts".

Use the present subjunctive in subordinate clauses after "it requires" ("it requires that every X specify", not "specifies", and likewise for "make" versus "makes").