### PR TITLE
Fix `oc describe limits` example

### DIFF
--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -65,7 +65,7 @@ spec:
       maxLimitRequestRatio:
         cpu: "10" <14>
 ----
-<1> The name of the limit range document.
+<1> The name of the limit range object.
 <2> The maximum amount of CPU that a pod can request on a node across all
 containers.
 <3> The maximum amount of memory that a pod can request on a node across all
@@ -367,7 +367,7 @@ Across all persistent volume claims in a project, the following must hold true:
   }
 }
 ----
-<1> The name of the limit range document.
+<1> The name of the limit range object.
 <2> The minimum amount of storage that can be requested in a persistent volume claim
 <3> The maximum amount of storage that can be requested in a persistent volume claim
 ====
@@ -410,18 +410,18 @@ resource-limits   6d
 +
 ====
 ----
-$ oc describe limits resource-limits
-Name:                     limits
-Namespace:                default
-Type                      Resource                 Min  Max Request Limit Limit/Request
-----                      --------                 ---  --- ------- ----- -------------
-Pod                       memory                   6Mi  1Gi -       -     -
-Pod                       cpu                      200m  2  -       -     -
-Container                 cpu                      100m  2  200m    300m  10
-Container                 memory                   4Mi  1Gi 100Mi   200Mi -
-openshift.io/Image        storage                  -    1Gi -       -     -
-openshift.io/ImageStream  openshift.io/image-tags  -    10  -       -     -
-openshift.io/ImageStream  openshift.io/images      -    12  -       -     -
+$ oc describe limits resource-limits -n demoproject
+Name:                           resource-limits
+Namespace:                      demoproject
+Type                            Resource                Min     Max     Default Request Default Limit   Max Limit/Request Ratio
+----                            --------                ---     ---     --------------- -------------   -----------------------
+Pod                             cpu                     200m    2       -               -               -
+Pod                             memory                  6Mi     1Gi     -               -               -
+Container                       cpu                     100m    2       200m            300m            10
+Container                       memory                  4Mi     1Gi     100Mi           200Mi           -
+openshift.io/Image              storage                 -       1Gi     -               -               -
+openshift.io/ImageStream        openshift.io/image      -       12      -               -               -
+openshift.io/ImageStream        openshift.io/image-tags -       10      -               -               -
 ----
 ====
 // end::admin_limits_viewing[]


### PR DESCRIPTION
Add the missing `-n demoproject` option to the `oc describe limits` example to be consistent with the other examples.

Update the example output to reflect the current output.

Refer to the LimitRange object as an "object" rather than as a "document".