### PR TITLE
Initial documention for Trident from NetApp

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -63,25 +63,34 @@ the following lifecycle.
 
 === Provisioning
 
-A cluster administrator creates some number of PVs. They carry the details of
-the real storage that is available for use by cluster users. They exist in the
-API and are available for consumption.
+A cluster administrator configures one or more dynamic provisioners that
+provision storage and a matching PV in response to a requests from a developer
+defined in a PVC.
+
+Alternatively, a cluster administrator may create some number of PVs in
+advance that carry the details of the real storage that is available for
+use by cluster users. They exist in the API and are available for consumption.
 
 [[binding]]
 
 === Binding
 
 A user creates a `PersistentVolumeClaim` with a specific amount of storage
-requested and with certain access modes. A control loop in the master watches
-for new PVCs, finds a matching PV (if possible), and binds them together. The
-user will always get at least what they asked for, but the volume may be in
-excess of what was requested. To minimize the excess, {product-title} binds to
-the smallest PV that matches all other criteria.
+requested and with certain access modes and optionally a `StorageClass`. A
+control loop in the master watches for new PVCs, either finds a matching PV
+or waits for a provisioner for the `StorageClass` to create one, then binds them
+together.
 
-Claims remain unbound indefinitely if a matching volume does not exist. Claims
+The user will always get at least what they asked for, but the volume may be in
+excess of what was requested. This is especially true with manually provisioned
+PVs. To minimize the excess, {product-title} binds to the smallest PV that
+matches all other criteria.
+
+Claims remain unbound indefinitely if a matching volume does not exist or cannot
+be created with any available provisioner servicing a `StorageClass`. Claims
 are bound as matching volumes become available. For example, a cluster
-provisioned with many 50Gi volumes would not match a PVC requesting 100Gi. The
-PVC can be bound when a 100Gi PV is added to the cluster.
+with many manually provisioned 50Gi volumes would not match a PVC requesting
+100Gi. The PVC can be bound when a 100Gi PV is added to the cluster.
 
 [[using]]
 
@@ -380,6 +389,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: myclaim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: gold
 spec:
   accessModes:
     - ReadWriteOnce
@@ -389,6 +400,15 @@ spec:
 
 ----
 ====
+
+[[pvc-storage-class]]
+=== Storage Class
+
+Claims can optionally request a specific `StorageClass`. Dynamic provisioners
+are configured by the cluster administrator to service one or more storage
+classes and will create a PV on-demand that match the specifications in the
+PVC if they are able to. It is also possible for the cluster administrator to
+set a default `StorageClass` for all PVCs.
 
 [[pvc-access-modes]]
 === Access Modes

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -71,6 +71,11 @@ node with `*Key=KubernetesCluster,Value=clusterid*`.
 |xref:../../install_config/configuring_openstack.adoc#install-config-configuring-openstack[Configuring for OpenStack]
 |
 
+|Trident from NetApp
+|`netapp.io/trident`
+|xref:../../install_config/configuring_trident.adoc[Configuring for Trident]
+|Storage orchestrator for NetApp ONTAP, SolidFire and E-Series storage
+
 |===
 
 
@@ -305,6 +310,30 @@ parameters:
 <7> The name of Ceph Secret for `userId` to map Ceph RBD image. It must exist in the same namespace as PVCs. It is required.
 ====
 
+[[trident]]
+=== Trident Object Definition
+
+.trident.yaml
+====
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: gold
+provisioner: netapp.io/trident <1>
+parameters: <2>
+  media: "ssd"
+  provisioningType: "thin"
+  snapshots: "true"
+
+----
+Trident uses the parameters as selection criteria for the different pools of
+storage that are registered with it. Trident itself is configured separately.
+
+<1> For more information about installing Trident with OpenShift, see the link:https://github.com/NetApp/trident[Trident documentation]
+<2> For more information about supported parameters, see the link:https://github.com/NetApp/trident#storage-attributes[storage attributes] section of the Trident documentation
+====
 
 [[moreinfo]]
 == Additional Information and Examples


### PR DESCRIPTION
Per @munchee13, adding basic storage class documentation for NetApp's Trident project in the dynamic provisioning section, with pointers to the Trident documentation describing how to configure it for OpenShift.

Trident actually creates iSCSI and/or NFS PVs dynamically, so I didn't see any need to update any of the PV docs.

Also made a minor adjustment to the higher level persistent storage topic to suggest dynamic provisioning in general first. It's subtle, but most people I talk to want to go right there rather than manage them by hand at this point.