### PR TITLE
Add openshift/hello-openshift dependency

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -282,8 +282,7 @@ and then transporting them:
     registry.access.redhat.com/openshift3/metrics-deployer \
     registry.access.redhat.com/openshift3/metrics-hawkular-metrics \
     registry.access.redhat.com/openshift3/metrics-cassandra \
-    registry.access.redhat.com/openshift3/metrics-heapster \
-    docker.io/openshift/hello-openshift
+    registry.access.redhat.com/openshift3/metrics-heapster
 ----
 
 . Export the S2I builder images that you synced in the previous section. For

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -180,6 +180,7 @@ endif::[]
 # docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
+# docker pull docker.io/openshift/hello-openshift:latest
 ----
 
 . Pull all of the required {product-title} containerized components for the
@@ -265,7 +266,8 @@ and then transporting them:
     registry.access.redhat.com/openshift3/ose-sti-builder \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-pod \
-    registry.access.redhat.com/openshift3/ose-docker-registry
+    registry.access.redhat.com/openshift3/ose-docker-registry \
+    docker.io/openshift/hello-openshift
 ----
 
 . If you synchronized the metrics and log aggregation images, export:
@@ -280,7 +282,8 @@ and then transporting them:
     registry.access.redhat.com/openshift3/metrics-deployer \
     registry.access.redhat.com/openshift3/metrics-hawkular-metrics \
     registry.access.redhat.com/openshift3/metrics-cassandra \
-    registry.access.redhat.com/openshift3/metrics-heapster
+    registry.access.redhat.com/openshift3/metrics-heapster \
+    docker.io/openshift/hello-openshift
 ----
 
 . Export the S2I builder images that you synced in the previous section. For


### PR DESCRIPTION
docker.io/openshift/hello-openshift is required to run successfully oc adm diagnostics.
Otherwise the user will not have network diagnostics