### PR TITLE
Bug 1426570: Temp workaround for docker-excluder bug in 3.4

### DIFF
--- a/install_config/revhistory_install_config.adoc
+++ b/install_config/revhistory_install_config.adoc
@@ -8,6 +8,25 @@
 
 // do-release: revhist-tables
 
+== Wed Mar 22 2017
+
+// tag::install_config_wed_mar_22_2017[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+//Mon Mar 20 2017
+
+|xref:../install_config/upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[Upgrading a Cluster -> Automated In-place Upgrades]
+.3+.^|Added a workaround for *atomic-openshift-docker-excluder* package upgrades. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1430929[*BZ#1430929*])
+
+|xref:../install_config/upgrading/manual_upgrades.adoc#install-config-upgrading-manual-upgrades[Upgrading a Cluster -> Manual In-place Upgrades]
+|xref:../install_config/upgrading/os_upgrades.adoc#install-config-upgrading-os-upgrades[Upgrading a Cluster -> Operating System Updates and Upgrades]
+
+|===
+
+// end::install_config_wed_mar_22_2017[]
+
 == Mon Mar 20 2017
 
 // tag::install_config_mon_mar_20_2017[]

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -146,17 +146,31 @@ channel and enable the 3.4 channel on each master and node host:
 # yum update atomic-openshift-utils
 ----
 
-. Install or update to the following latest available **-excluder* packages on
-each RHEL 7 system, which helps ensure your systems stay on the correct versions
-of *atomic-openshift* and *docker* packages when you are not trying to upgrade,
-according to the {product-title} version:
+. Install or update to the following latest available *atomic-openshift-excluder*
+package on each RHEL 7 system, which helps ensure your systems stay on the
+correct versions of *atomic-openshift* packages when you are not trying to
+upgrade, according to the {product-title} version:
 +
 ----
-# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
+# yum install atomic-openshift-excluder
 ----
 +
 These packages add entries to the `exclude` directive in the host's
 *_/etc/yum.conf_* file.
+
+. Due to a bug
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1430929[*BZ#1430929*]), if you
+previously installed the *atomic-openshift-docker-excluder* package as
+instructed in {product-title} 3.3, upgrading this package to the 3.4 version
+does not remove *docker*1.12** from the `exclude` directive as intended.
++
+As a workaround until the bug is fixed, remove the installed version of
+*atomic-openshift-docker-excluder* package, then install the 3.4 version:
++
+----
+# yum remove atomic-openshift-docker-excluder
+# yum install atomic-openshift-docker-excluder
+----
 
 . You must be logged in as a cluster administrative user on the master host for
 the upgrade to succeed:

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -84,17 +84,31 @@ that will be used in later sections:
 # yum install atomic-openshift-utils
 ----
 
-. Install or update to the following latest available **-excluder* packages on
-each RHEL 7 system, which helps ensure your systems stay on the correct versions
-of *atomic-openshift* and *docker* packages when you are not trying to upgrade,
-according to the {product-title} version:
+. Install or update to the following latest available *atomic-openshift-excluder*
+package on each RHEL 7 system, which helps ensure your systems stay on the
+correct versions of *atomic-openshift* packages when you are not trying to
+upgrade, according to the {product-title} version:
 +
 ----
-# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
+# yum install atomic-openshift-excluder
 ----
 +
 These packages add entries to the `exclude` directive in the host's
 *_/etc/yum.conf_* file.
+
+. Due to a bug
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1430929[*BZ#1430929*]), if you
+previously installed the *atomic-openshift-docker-excluder* package as
+instructed in {product-title} 3.3, upgrading this package to the 3.4 version
+does not remove *docker*1.12** from the `exclude` directive as intended.
++
+As a workaround until the bug is fixed, remove the installed version of
+*atomic-openshift-docker-excluder* package, then install the 3.4 version:
++
+----
+# yum remove atomic-openshift-docker-excluder
+# yum install atomic-openshift-docker-excluder
+----
 
 . Create an *etcd* backup on each master. The *etcd* package is required, even if
 using embedded etcd, for access to the `etcdctl` command to make the backup.

--- a/install_config/upgrading/os_upgrades.adoc
+++ b/install_config/upgrading/os_upgrades.adoc
@@ -28,17 +28,31 @@ $ oadm manage-node <node_name> --schedulable=false
 $ oadm drain <node_name> --force --delete-local-data --ignore-daemonsets
 ----
 
-. Install or update the **-excluder* packages on each host with the following.
-This ensures the hosts stay on the correct versions of {product-title}, as per
-the *atomic-openshift* and *docker* packages, instead of the most current
-versions:
+. Install or update to the following latest available *atomic-openshift-excluder*
+package on each RHEL 7 system, which helps ensure your systems stay on the
+correct versions of *atomic-openshift* packages when you are not trying to
+upgrade, according to the {product-title} version:
 +
 ----
-# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
+# yum install atomic-openshift-excluder
 ----
 +
-This adds entries to the `exclude` directive in the host's *_/etc/yum.conf_*
-file.
+These packages add entries to the `exclude` directive in the host's
+*_/etc/yum.conf_* file.
+
+. Due to a bug
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1430929[*BZ#1430929*]), if you
+previously installed the *atomic-openshift-docker-excluder* package as
+instructed in {product-title} 3.3, upgrading this package to the 3.4 version
+does not remove *docker*1.12** from the `exclude` directive as intended.
++
+As a workaround until the bug is fixed, remove the installed version of
+*atomic-openshift-docker-excluder* package, then install the 3.4 version:
++
+----
+# yum remove atomic-openshift-docker-excluder
+# yum install atomic-openshift-docker-excluder
+----
 
 . Update or upgrade the host packages, and reboot the host. A reboot ensures
 that the host is running the newest versions, and means that the `docker` and
@@ -56,5 +70,3 @@ the {product-title} node software will fix the flow rules.
 ----
 $ oadm manage-node <node_name> --schedulable=true
 ----
-
-

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -11,7 +11,13 @@ date.
 
 // do-release: revhist-tables
 
+== Wed Mar 22 2017
+
+.Installation and Configuration
+include::install_config/revhistory_install_config.adoc[tag=install_config_wed_mar_22_2017]
+
 == Mon Mar 20 2017
+
 .Architecture
 include::architecture/revhistory_architecture.adoc[tag=architecture_mon_mar_20_2017]
 


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1426570

Same change was made in the 3 related topics. For example, steps 3 and 4:

http://file.rdu.redhat.com/~adellape/032217/container-platform/3.4/install_config/upgrading/automated_upgrades.html#preparing-for-an-automated-upgrade

Making this change just on the 3.4 branch, and will revert commit https://github.com/openshift/openshift-docs/pull/4009/commits/ef6d1ea683f30c4feb7e774ceeab80c90576b889 after the fix is shipped.