### PR TITLE
Don't list "m" as a valid suffix for memory

### DIFF
--- a/dev_guide/compute_resources.adoc
+++ b/dev_guide/compute_resources.adoc
@@ -121,7 +121,7 @@ node has 2 cores, the node's CPU capacity would be represented as 2000m. If you
 wanted to use 1/10 of a single core, it would be represented as 100m.
 
 Memory is measured in bytes. In addition, it may be used with SI suffices (E, P,
-T, G, M, K, m) or their power-of-two-equivalents (Ei, Pi, Ti, Gi, Mi, Ki).
+T, G, M, K) or their power-of-two-equivalents (Ei, Pi, Ti, Gi, Mi, Ki).
 
 ====
 [source,yaml]


### PR DESCRIPTION
In specifying a memory request or limit, the "m" suffix passes validation but is useless because we cannot manage memory at millibyte granularity, so do not list the suffix as allowed.