### PR TITLE
Add DNS example to Joining Project Networks

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -46,7 +46,10 @@ $ oadm pod-network join-projects --to=<project1> <project2> <project3>
 ----
 
 In the above example, all the pods and services in `<project2>` and `<project3>`
-can now access any pods and services in `<project1>` and vice versa.
+can now access any pods and services in `<project1>` and vice versa. Services
+can be accessed either by IP or fully-qualified DNS name 
+(`<service>.<pod_namespace>.svc.cluster.local`). For example, to access a
+service named `db` in a project `myproject`, use `db.myproject.svc.clsuter.local`.
 
 Alternatively, instead of specifying specific project names, you can use the
 `--selector=<project_selector>` option.


### PR DESCRIPTION
Add a reminder to use the fully-qualified DNS name when referencing services across projects.