### PR TITLE
Add ose-recycler to the required images

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -181,7 +181,6 @@ endif::[]
 # docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
-
 ----
 
 . Pull all of the required {product-title} containerized components for the

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -176,7 +176,7 @@ endif::[]
 ----
 # docker pull registry.access.redhat.com/openshift3/ose-haproxy-router:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-deployer:<tag>
-# docker pull registry.access.redhat.com/openshift3/openshift3/ose-recycler:<tag>
+# docker pull registry.access.redhat.com/openshift3/ose-recycler:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-sti-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
@@ -263,7 +263,7 @@ and then transporting them:
 # docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/ose-haproxy-router \
     registry.access.redhat.com/openshift3/ose-deployer \
-    registry.access.redhat.com/openshift3/openshift3/ose-recycler \
+    registry.access.redhat.com/openshift3/ose-recycler \
     registry.access.redhat.com/openshift3/ose-sti-builder \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-pod \

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -176,10 +176,12 @@ endif::[]
 ----
 # docker pull registry.access.redhat.com/openshift3/ose-haproxy-router:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-deployer:<tag>
+# docker pull registry.access.redhat.com/openshift3/openshift3/ose-recycler:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-sti-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
+
 ----
 
 . Pull all of the required {product-title} containerized components for the
@@ -262,6 +264,7 @@ and then transporting them:
 # docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/ose-haproxy-router \
     registry.access.redhat.com/openshift3/ose-deployer \
+    registry.access.redhat.com/openshift3/openshift3/ose-recycler \
     registry.access.redhat.com/openshift3/ose-sti-builder \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-pod \


### PR DESCRIPTION
ose-recycler is needed to recycle released PV when
its reclaimpolicy is recycle. 
Fixes issue #4013