### PR TITLE
require nodeName to match instance name with cloud provider

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -106,6 +106,10 @@ kubernetesMasterConfig:
       - "/etc/aws/aws.conf"
 ----
 
+Currently, the `nodeName` *must* match the instance name in AWS in order
+for the cloud provider integration to work properly.  The name must also be
+RFC1123 compliant.
+
 [IMPORTANT]
 ====
 When triggering a containerized installation, only the directories of

--- a/install_config/configuring_gce.adoc
+++ b/install_config/configuring_gce.adoc
@@ -123,7 +123,11 @@ kubeletArguments:
 
 ----
 ====
-+
+
+Currently, the `nodeName` *must* match the instance name in GCE in order
+for the cloud provider integration to work properly.  The name must also be
+RFC1123 compliant.
+
 [IMPORTANT]
 ====
 When triggering a containerized installation, only the directories of

--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -150,6 +150,10 @@ kubeletArguments:
 <1> Name of the OpenStack instance where the node runs (i.e., name of the virtual machine)
 ====
 
+Currently, the `nodeName` *must* match the instance name in Openstack in order
+for the cloud provider integration to work properly.  The name must also be
+RFC1123 compliant.
+
 [IMPORTANT]
 ====
 When triggering a containerized installation, only the directories of


### PR DESCRIPTION
We had a number of bugs filed over the past year involving customers trying to set the `nodeName` to the hostname (or other things) on nodes with cloud provider integration enabled.  This leads to a myriad of issues involving failed storage mounting, nodes being deleted, etc.

This PR adds an explicit statement that the nodeName should match the instance name when using cloud provider integration.

@derekwaynecarr @sdodson 