### PR TITLE
Fix typo in DNS example

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -49,7 +49,7 @@ In the above example, all the pods and services in `<project2>` and `<project3>`
 can now access any pods and services in `<project1>` and vice versa. Services
 can be accessed either by IP or fully-qualified DNS name 
 (`<service>.<pod_namespace>.svc.cluster.local`). For example, to access a
-service named `db` in a project `myproject`, use `db.myproject.svc.clsuter.local`.
+service named `db` in a project `myproject`, use `db.myproject.svc.cluster.local`.
 
 Alternatively, instead of specifying specific project names, you can use the
 `--selector=<project_selector>` option.


### PR DESCRIPTION
Fix typo in DNS example added in #4025 