### PR TITLE
Edited out 7001 port

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -59,7 +59,7 @@ supported on Fedora, CentOS, and Red Hat Enterprise Linux (RHEL) hosts only.
 
 [CAUTION]
 ====
-{product-title} listens on ports 53, 7001, and 8443. If another service is
+{product-title} listens on ports 53 and 8443. If another service is
 already listening on those ports you must stop that service before launching
 the {product-title} container.
 ====


### PR DESCRIPTION
As per: https://github.com/openshift/openshift-docs/issues/3847

No review or rev history needed. And is Origin-specific, so I don't think labels or milestone is needed either. 