### PR TITLE
Added OCP 3.5 Metrics Recommendations to the Enabling Cluster Metrics doc

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -252,6 +252,7 @@ If the `METRICS_DURATION` and `METRICS_RESOLUTION` values are kept at the
 default (`7` days and `15` seconds respectively), it is safe to plan Cassandra
 storage size requrements for week, as in the values above.
 
+
 [WARNING]
 ====
 Because {product-title} metrics uses the Cassandra database as a datastore for
@@ -263,10 +264,31 @@ link:http://docs.datastax.com/en/archived/cassandra/1.2/cassandra/architecture/a
 documentation].
 ====
 
-*Known Issues and Limitations*
+[discrete]
+[[metrics-recommendations-for-OCP-version-35]]
+==== Recommendations for {product-title} Version 3.5
+
+* Run metrics pods on dedicated {product-title}
+xref:../admin_guide/manage_nodes.adoc#infrastructure-nodes[infrastructure
+nodes].
+* Use persistent storage when configuring metrics. Set
+`USE_PERSISTENT_STORAGE=true`.
+* Keep the `METRICS_RESOLUTION=30` parameter in {product-title} metrics
+deployments. Using a value lower than the default value of `30` for
+`METRICS_RESOLUTION` is not recommended. When using the Ansible metrics
+installation procedure, this is the `openshift_metrics_resolution` parameter.
+* Closely monitor {product-title} nodes with host metrics pods to detect early
+capacity shortages (CPU and memory) on the host system. These capacity shortages
+can cause problems for metrics pods.
+* In {product-title} version 3.5 testing, test cases up to 25,000 pods were
+monitored in a {product-title} cluster.
+
+[discrete]
+[[cluster-metrics-known-issues-and-limitations]]
+==== Known Issues and Limitations
 
 Testing found that the `heapster` metrics component is capable of handling up to
-12000 pods. If the amount of pods exceed that number, Heapster begins to fall
+25,000 pods. If the amount of pods exceed that number, Heapster begins to fall
 behind in metrics processing, resulting in the possibility of metrics graphs no
 longer appearing. Work is ongoing to increase the number of pods that Heapster
 can gather metrics on, as well as upstream development of alternate


### PR DESCRIPTION
This continues the work from https://github.com/openshift/openshift-docs/pull/4019.

Related information was placed in the OCP 3.5 Release Notes via https://github.com/openshift/openshift-docs/pull/4046