### PR TITLE
Remove no_wdelay from NFS doc

### DIFF
--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -320,11 +320,9 @@ exported volume on the NFS server should conform to the following conditions:
 - Each export must be:
 +
 ----
-/<example_fs> *(rw,root_squash,no_wdelay)
+/<example_fs> *(rw,root_squash)
 ----
 +
-The `no_wdelay` option prevents the server from delaying writes, which greatly
-improves read-after-write consistency.
 
 - The firewall must be configured to allow traffic to the mount point. For NFSv4,
 the default port is 2049 (*nfs*). For NFSv3, there are three ports to configure:

--- a/install_config/registry/registry_known_issues.adoc
+++ b/install_config/registry/registry_known_issues.adoc
@@ -53,11 +53,9 @@ $ oc get -o yaml svc/docker-registry | \
 ----
 +
 . Ensure that the NFS export line of your registry volume on your NFS server has
-the `no_wdelay` options listed. See
-xref:../persistent_storage/persistent_storage_nfs.adoc#nfs-export-settings[Export
-Settings] in the
-xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[Persistent
-Storage Using NFS] topic for details.
+the `no_wdelay` options listed. The `no_wdelay` option prevents the server from
+delaying writes, which greatly improves read-after-write consistency, a
+requirement of the registry.
 
 == Pull of Internally Managed Image Fails with "not found" Error
 


### PR DESCRIPTION
@eparis as requested by email.

no_wdelay is there because the registry requires read-after-write consistency https://github.com/docker/distribution/issues/1176 and we ran into bugs. But this is the generic NFS page, we should not recommend it also for non-registry uses: let's confine the recommendation for no_wdelay to the registry 'known issues' page