### PR TITLE
F5-router, "Idling applications" feature does not work

### DIFF
--- a/admin_guide/idling_applications.adoc
+++ b/admin_guide/idling_applications.adoc
@@ -67,5 +67,8 @@ Application services become active again when they receive network traffic and
 will be scaled back up their previous state. This includes both traffic to the
 services and traffic passing through routes.
 
-This works when using the default HAProxy router. You will need to configure
-other routers to detect idling to unidle these applications.
+[NOTE]
+====
+Automatic unidling by a router is currently only supported by the default HAProxy router.
+====
+


### PR DESCRIPTION
OSE   3.5, 3.4, and 3.3

Made a NOTE that this is HAProxy only
(moved last to lines of file into note)

bug 143165
https://bugzilla.redhat.com/show_bug.cgi?id=1431658