### PR TITLE
Use fewer shell manipulations to get at data

### DIFF
--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -174,7 +174,7 @@ To do so, edit the *_/usr/lib/systemd/system/etcd.service_* file, and add
 +
 ----
 # sed -i '/ExecStart/s/"$/  --force-new-cluster"/' /usr/lib/systemd/system/etcd.service
-# cat /usr/lib/systemd/system/etcd.service  | grep ExecStart
+# systemctl show etcd.service --property ExecStart --no-pager
 
 ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd --force-new-cluster"
 ----
@@ -192,7 +192,7 @@ Then, restart the *etcd* service:
 +
 ----
 # sed -i '/ExecStart/s/ --force-new-cluster//' /usr/lib/systemd/system/etcd.service
-# cat /usr/lib/systemd/system/etcd.service  | grep ExecStart
+# systemctl show etcd.service --property ExecStart --no-pager
 
 ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd"
 ----
@@ -300,7 +300,7 @@ To do so, edit the *_/usr/lib/systemd/system/etcd.service_* file, and add
 +
 ----
 # sed -i '/ExecStart/s/"$/  --force-new-cluster"/' /usr/lib/systemd/system/etcd.service
-# cat /usr/lib/systemd/system/etcd.service  | grep ExecStart
+# systemctl show etcd.service --property ExecStart --no-pager
 
 ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd --force-new-cluster"
 ----
@@ -318,7 +318,7 @@ Then restart the *etcd* service:
 +
 ----
 # sed -i '/ExecStart/s/ --force-new-cluster//' /usr/lib/systemd/system/etcd.service
-# cat /usr/lib/systemd/system/etcd.service  | grep ExecStart
+# systemctl show etcd.service --property ExecStart --no-pager
 
 ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd"
 ----
@@ -817,16 +817,15 @@ what path to back up by looking at the `*mountPath*` for volumes in the
 . Get the application data `*mountPath*` from the `*deploymentconfig*`:
 +
 ----
-$ oc export dc/jenkins|grep mountPath
-        - mountPath: /var/lib/jenkins
+$ oc get dc/jenkins -o jsonpath='{ .spec.template.spec.containers[?(@.name=="jenkins")].volumeMounts[?(@.name=="jenkins-data")].mountPath }'
+/var/lib/jenkins
 ----
 
 . Get the name of the pod that is currently running:
 +
 ----
-$ oc get po --selector=deploymentconfig=jenkins
-NAME              READY     STATUS    RESTARTS   AGE
-jenkins-1-a3347   1/1       Running   0          18h
+$ oc get pod --selector=deploymentconfig=jenkins -o jsonpath='{ .metadata.name }'
+jenkins-1-37nux
 ----
 
 . Use the `oc rsync` command to copy application data:
@@ -876,7 +875,7 @@ Depending on the application, you may be required to restart the application.
 . Restart the application with new data (_optional_):
 +
 ----
-$ oc delete po jenkins-1-37nux
+$ oc delete pod jenkins-1-37nux
 ----
 +
 Alternatively, you can scale down the deployment to 0, and then up again:


### PR DESCRIPTION
When grabbing a property from a `systemd` unit file, it is preferrable
to use the built-in `systemctl get-property` instead of using `grep` as
the property may very well span multiple lines, thereby making it hard
to use `grep` to capture it's full value.

Similarly, when inspecting objects in OpenShift, it is preferrable to
use `oc get -o jsonpath='{}'` to index into the actual object rather
than using `grep` on the output of `oc export`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>