### PR TITLE
Forbid creating aliases across different Image Streams docs

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -98,6 +98,13 @@ changes, use the `--alias=true` flag:
 $ oc tag --alias=true <source> <destination>
 ----
 
+[NOTE]
+====
+A _tracking_ tag is meant for creating permanent aliases (eg. `latest` or `stable`).
+As such it will work correctly _only_ within a single Image Stream. Trying to create
+a cross Image Stream alias will give you an error.
+====
+
 You can also add the `--scheduled=true` flag to have the destination tag be
 refreshed (i.e., re-imported) periodically. The period is configured globally at
 system level. See xref:importing-tag-and-image-metadata[Importing Tag and Image


### PR DESCRIPTION
Followup up to https://github.com/openshift/origin/pull/13632, fixing https://bugzilla.redhat.com/show_bug.cgi?id=1435588.

@mfojtik @smarterclayton fyi
@ahardin-rh ptal