### PR TITLE
Update h5 font color

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -592,6 +592,7 @@ span.footnote a:active, span.footnoteref a:active { text-decoration: underline; 
 .gist .file-data > table td.line-data { width: 99%; }
 div.unbreakable { page-break-inside: avoid; }
 code { color: #404040; background-color: #e7e7e7; font-weight: bold; font-family: "Roboto Mono", monospace;}
+h5 { color: #404040; }
 strong { color: #404040; font-weight: bold; font-family: "Roboto Mono", monospace; }
 a strong { color: inherit; }
 a code { color: inherit; }


### PR DESCRIPTION
It was previously inheriting as `#000000`, so this makes it match the other heading colors (`#404040`).