### PR TITLE
 removing the quotes from the initial blurbs

### DIFF
--- a/install_config/imagestreams_templates.adoc
+++ b/install_config/imagestreams_templates.adoc
@@ -169,9 +169,9 @@ endif::[]
 +
 ifdef::openshift-origin[]
 ----
-$ IMAGESTREAMDIR="~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams"; \
-    DBTEMPLATES="~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates"; \
-    QSTEMPLATES="~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates"
+$ IMAGESTREAMDIR=~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams; \
+    DBTEMPLATES=~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates; \
+    QSTEMPLATES=~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates
 ----
 endif::[]
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
Problem Solved after Removal of Quotes.

Explaination: 
After Executing : ```oc create -f $IMAGESTREAMDIR/image-streams-rhel7.json -n openshift```  I get ```error: the path "~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams/image-streams-centos7.json" does not exist```