### PR TITLE
Bug 1432110 added section on maven behind proxies

### DIFF
--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -279,6 +279,18 @@ MAVEN_ARGS_APPEND=" -s path/to/file"
 ====
 ////
 
+[[using-maven-behind-a-proxy]]
+== Using Maven Behind a Proxy
+
+Using Maven with proxies requires using the `HTTP_PROXY_NONPROXYHOSTS` variable.
+
+See the
+link:https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html-single/red_hat_jboss_enterprise_application_platform_for_openshift/#configuring_eap_for_openshift[Red
+Hat JBoss Enterprise Application Platform for OpenShift documentation] for
+information about configuring your {product-title} environment for Red Hat
+JBoss Enterprise Application Platform, including the step for setting up Maven
+behind a proxy.
+
 [[s2i-builds]]
 
 == Configuring S2I Builds for Proxies


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1432110

@ahardin-rh @adellape @bmcelvee @mburke5678 

Can I get an opinion on this? Originally, this was a section in the OpenShift docs, but there was a issue reported that it shouldn't be, then it was taken out, but then this BZ was reported to put it back in. Instead, I've just put a para telling the reader to check the EAP docs, where the info is now.

Would this be better as it was? The old info is just commented out in the OpenShift docs (just above this new para).