### PR TITLE
install_config/registry/registry_known_issues: use oc patch

### DIFF
--- a/install_config/registry/registry_known_issues.adoc
+++ b/install_config/registry/registry_known_issues.adoc
@@ -47,9 +47,7 @@ This should return `ClientIP`, which is the default in recent {product-title}
 versions. If not, change it:
 +
 ----
-$ oc get -o yaml svc/docker-registry | \
-      sed 's/\(sessionAffinity:\s*\).*/\1ClientIP/' | \
-      oc replace -f -
+$ oc patch svc/docker-registry -p '{"spec":{"sessionAffinity": "ClientIP"}}'
 ----
 +
 . Ensure that the NFS export line of your registry volume on your NFS server has


### PR DESCRIPTION
This PR replaces usage of `oc get`/`sed`/`oc replace` by single `oc patch` command.

PTAL @openshift/team-documentation 