### PR TITLE
Bug 1443742 Fix some typos in high availabilty guide

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -40,8 +40,8 @@ or in *FAULT*` state when the *check* script fails. The
 xref:check-notify[*notify* script] is called with the new state whenever the
 state changes.
 
-{product-title} supports creation of IP failover deployment configration, by
-running the `oadm ipfailover` command. The IP failover deployment configration
+{product-title} supports creation of IP failover deployment configuration, by
+running the `oadm ipfailover` command. The IP failover deployment configuration
 specifies the set of VIP addresses, and the set of nodes on which to service
 them. A cluster can have multiple IP failover deployment configurations, with
 each managing its own set of unique VIP addresses. Each node in the IP failover
@@ -214,7 +214,7 @@ link:http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-g
 the AWS console].
 ====
 
-As an administrator, you can configure ipfailover on an entire cluster, or on a subset of nodes, as defined by the label selector. You can also configure multiple IP failover deployment configrations in your cluster,  where each one is independent of the others. The `oadm ipfailover` command creates a ipfailover deployment configration which ensures that a failover pod runs on each of the nodes matching the constraints or the label used. This pod runs link:http://www.keepalived.org/[*Keepalived*] which uses VRRP (Virtual Router Redundancy Protocol) among all the *Keepalived* daemons to ensure that the service on the watched port is available, and if it is not, *Keepalived* will automatically float the VIPs.
+As an administrator, you can configure ipfailover on an entire cluster, or on a subset of nodes, as defined by the label selector. You can also configure multiple IP failover deployment configurations in your cluster,  where each one is independent of the others. The `oadm ipfailover` command creates a ipfailover deployment confiugration which ensures that a failover pod runs on each of the nodes matching the constraints or the label used. This pod runs link:http://www.keepalived.org/[*Keepalived*] which uses VRRP (Virtual Router Redundancy Protocol) among all the *Keepalived* daemons to ensure that the service on the watched port is available, and if it is not, *Keepalived* will automatically float the VIPs.
 
 For production use, make sure to use a `--selector=<label>` with at least two nodes to select
 the nodes. Also, set a `--replicas=<n>` value that matches the
@@ -506,14 +506,14 @@ See xref:../admin_guide/high_availability.adoc#ha-vrrp-id-offset[this discussion
 [[ha-vrrp-id-offset]]
 === VRRP ID Offset
 
-Each ipfailover pod managed by the ipfailover deployment configration (1 pod per node/replica) runs a *keepalived* daemon. As more ipfailover deployment configrations are configured, more pods are created and more daemons join into the common VRRP negotiation. This negotiation is done by all the *keepalived* daemons and it determines which nodes will service which VIPs.
+Each ipfailover pod managed by the ipfailover deployment configuration (1 pod per node/replica) runs a *keepalived* daemon. As more ipfailover deployment configurations are configured, more pods are created and more daemons join into the common VRRP negotiation. This negotiation is done by all the *keepalived* daemons and it determines which nodes will service which VIPs.
 
 Internally, *keepalived* assigns a unique vrrp-id to each VIP. The negotiation uses this set of vrrp-ids, when a decision is made, the VIP corresponding to the winning vrrp-id is serviced on the winning node.
 
-Therefore, for every VIP defined in the ipfailover deployment configration, the ipfailover pod must assign a corresponding vrrp-id. This is done by starting at `--vrrp-id-offset` and sequentially assigning the vrrp-ids to
+Therefore, for every VIP defined in the ipfailover deployment configuration, the ipfailover pod must assign a corresponding vrrp-id. This is done by starting at `--vrrp-id-offset` and sequentially assigning the vrrp-ids to
 the list of VIPs.  The vrrp-ids may have values in the range 1..255.
 
-When there are multiple ipfailover deployment configration care must be taken to specify `--vrrp-id-offset` so that there is room to increase the number of VIPS in the deployment configration and none of the vrrp-id ranges overlap.
+When there are multiple ipfailover deployment configuration care must be taken to specify `--vrrp-id-offset` so that there is room to increase the number of VIPS in the deployment configuration and none of the vrrp-id ranges overlap.
 
 [[configuring-a-highly-available-service]]
 === Configuring a Highly-available Service
@@ -599,7 +599,7 @@ $ oc create -n <namespace> -f ./examples/geo-cache.json
 +
 [IMPORTANT]
 ====
-The *router*, *geo-cache*, and ipfailover all create deployment configration and all must have different names.
+The *router*, *geo-cache*, and ipfailover all create deployment configuration and all must have different names.
 ====
 
 . Specify the VIPs and the port number that ipfailover should monitor on the desired instances.


### PR DESCRIPTION
As per: https://bugzilla.redhat.com/show_bug.cgi?id=1443742

I don't think a rev history or review is needed.