### PR TITLE
Product name does not render in code blocks

### DIFF
--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -394,7 +394,7 @@ default via 192.168.122.1 dev ens3
 10.128.0.0/14 dev tun0  proto kernel  scope link                        # This sends all pod traffic into OVS
 10.128.2.0/23 dev tun0  proto kernel  scope link  src 10.128.2.1        # This is traffic going to local pods, overriding the above
 169.254.0.0/16 dev ens3  scope link  metric 1002                        # This is for Zeroconf (may not be present)
-172.17.0.0/16 dev docker0  proto kernel  scope link  src 172.17.42.1    # Docker's private IPs... used only by things directly configured by docker; not {product-title}
+172.17.0.0/16 dev docker0  proto kernel  scope link  src 172.17.42.1    # Docker's private IPs... used only by things directly configured by docker; not OpenShift
 192.168.122.0/24 dev ens3  proto kernel  scope link  src 192.168.122.46 # The physical interface on the local subnet
 ....
 


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-docs/issues/4210

Used OpenShift as the product name, as this code block appears in both Origin and OCP docs.