### PR TITLE
Various fixes to the volumes documentation

### DIFF
--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -30,7 +30,7 @@ to your pods.
 
 [NOTE]
 ====
-`*EmptyDir*` volume storage may be restricted by a quota based on the pods FSGroup, if enabled by your cluster administrator.
+`*EmptyDir*` volume storage may be restricted by a quota based on the pod's FSGroup, if enabled by your cluster administrator.
 ====
 
 You can use the CLI command `oc volume` to xref:adding-volumes[add],
@@ -53,7 +53,7 @@ $ oc volume <object_selection> <operation> <mandatory_parameters> <optional_para
 ----
 
 This topic uses the form `_<object_type>_/_<name>_` for `_<object_selection>_`
-in later examples, however you can choose one of the following options:
+in later examples. However, you can choose one of the following options:
 
 [[vol-object-selection]]
 .Object Selection


### PR DESCRIPTION
Add a missing apostrophe for the possessive: "based on the pod's FSGroup".

Fix a run-on sentence: "The topic uses the form [...] in later examples, however, you can choose [...]".