### PR TITLE
Various fixes to guidelines for creating images

### DIFF
--- a/creating_images/guidelines.adoc
+++ b/creating_images/guidelines.adoc
@@ -196,10 +196,13 @@ as what environment variable to set.
 
 *Avoid SSHD*
 
-It is best to avoid running *SSHD* in your image. For accessing running
-containers, You can use the `docker exec` command locally to access containers
-that are running. Alternatively, you can use the {product-title} tooling since
-it allows you to execute arbitrary commands in images that are running.
+It is best to avoid running *SSHD* in your image. You can use the `docker exec`
+command to access containers that are running on the local host. Alternatively,
+you can use the
+xref:../dev_guide/executing_remote_commands.adoc#dev-guide-executing-remote-commands[`oc
+exec`] command or the
+xref:../dev_guide/ssh_environment.adoc#dev-guide-ssh-environment[`oc rsh` ]
+command to access containers that are running on the {product-title} cluster.
 Installing and running *SSHD* in your image opens up additional vectors for
 attack and requirements for security patching.
 
@@ -268,7 +271,7 @@ xref:s2i.adoc#creating-images-s2i[S2I Requirements] topic.
 
 By default, {product-title} runs containers using an arbitrarily assigned user
 ID. This provides additional security against processes escaping the container
-due to a container engine vulnerability and thereby achieves escalated
+due to a container engine vulnerability and thereby achieving escalated
 permissions on the host node.
 
 For an image to support running as an arbitrary user, directories and files that


### PR DESCRIPTION
Deleting a spurious introductory phrase: "For accessing running containers,".

Improve the wording around `docker exec`.

Mention `oc exec` and `oc rsh` explicitly instead of vaguely referring to "tooling", and link to the relevant documentation for the two commands.

Fix parallelism: "security against processes escaping [...] and thereby achieving [...]".