### PR TITLE
Remove features the integration doesn't have

### DIFF
--- a/architecture/additional_concepts/f5_big_ip.adoc
+++ b/architecture/additional_concepts/f5_big_ip.adoc
@@ -27,9 +27,7 @@ xref:../../architecture/core_concepts/routes.adoc#re-encryption-termination[re-e
 xref:../../architecture/core_concepts/routes.adoc#passthrough-termination[passthrough terminated] routes matching on HTTP
 vhost and request path.
 
-The F5 router has feature parity with the
-xref:../../architecture/core_concepts/routes.adoc#haproxy-template-router[HAProxy template router],
-and has additional features over the *F5 BIG-IP®* support in
+The F5 router has additional features over the *F5 BIG-IP®* support in
 ifdef::openshift-enterprise[]
 OpenShift Enterprise 2.
 endif::[]
@@ -40,7 +38,6 @@ Compared with the *routing-daemon* used in earlier
 versions, the F5 router additionally supports:
 
 - path-based routing (using policy rules),
-- re-encryption (implemented using client and server SSL profiles), and
 - passthrough of encrypted connections (implemented using an iRule that parses
 the SNI protocol and uses a data group that is maintained by the F5 router for
 the servername lookup).


### PR DESCRIPTION
F5 router plugin doesn't have feature parity with ha proxy routers.
Doesn't support re-encrypt, doesn't support, iddle pods, etc.