### PR TITLE
add documentation for openshift_template_service_broker_namespaces configurable

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -348,6 +348,10 @@ configuration.
 default is
 `*https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics*`
 If you alter this variable, ensure the host name is accessible via your router.
+
+|`*openshift_template_service_broker_namespaces*`
+|This variable enables the template service broker by specifying one of more
+namespaces whose templates will be served by the broker.
 |===
 
 [[advanced-install-configuring-registry-location]]


### PR DESCRIPTION
@bparees 

Should be merged *after* https://github.com/openshift/openshift-ansible/pull/3982.

3.6 only.