### PR TITLE
minor elaborate around git pr refs

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -192,11 +192,14 @@ in repositories downloading faster, including the commit history.
 
 A shallow clone is also used when the `ref` field is specified and set to an
 existing remote branch name. However, if you specify the `ref` field to a
-specific commit, the system will fallback to a regular Git clone operation and
+specific commit, the system will fallback to a `git clone` operation and
 checkout the commit, because using the `--depth=1` option only works with named
 branch refs.
 
-To perform a full Git clone of the `master` for the specified repository, set
+If the `ref` field denotes a pull request, the system will use a `git fetch` operation
+and then checkout `FETCH_HEAD`.
+
+To perform a full `git clone` of the `master` for the specified repository, set
 the `ref` to `master`.
 
 [[using-a-proxy-for-git-cloning]]


### PR DESCRIPTION
@bparees ptal

I added this since the existing doc dives into the precise details of the git operations used based on what `ref` specifically points to.