### PR TITLE
Rewrite S2I Java documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -820,7 +820,7 @@ Topics:
         File: index
       - Name: Java
         File: java
-        Distros: openshift-origin,openshift-online
+        Distros: openshift-online
       - Name: .NET Core
         File: dot_net_core
         Distros: openshift-online,openshift-enterprise,openshift-dedicated

--- a/using_images/s2i_images/java.adoc
+++ b/using_images/s2i_images/java.adoc
@@ -10,93 +10,191 @@
 
 toc::[]
 
+[[s2i-images-java-overview]]
 == Overview
-{product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
-enabled Java images for building and running Java applications.
-ifdef::openshift-origin[]
-The https://github.com/fabric8io/java-main/tree/master/[Java S2I builder image]
-endif::openshift-origin[]
-ifdef::openshift-enterprise[]
-The Java S2I builder image
-endif::openshift-enterprise[]
-assembles your application source with any required dependencies to create a new
-image containing your Java application. This resulting image can be run either
-by {product-title} or by Docker. This image is intended for use with
-https://maven.apache.org[Maven]-based Java standalone projects (that are run via
-main class).
 
+{product-title} provides an
+xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
+builder image] for building Java applications.  This builder image takes your
+application source or binary artifacts, builds the source using Maven (if source
+was provided), and assembles the artifacts with any required dependencies to
+create a new, ready-to-run image containing your Java application. This
+resulting image can be run on {product-title} or run directly with Docker.
+
+The builder image is intended for use with
+link:https://maven.apache.org[Maven]-based Java standalone projects that are run
+via main class.
+
+
+[[s2i-images-java-versions]]
 == Versions
-The current version supports JDK 1.7 and Maven 3.2.x projects.
 
+The current version of the Java S2I builder image supports OpenJDK 1.8, Jolokia
+1.3.5, and Maven 3.3.9-2.8.
+
+
+[[s2i-images-java-images]]
 == Images
 
-To use this image, you can either access it directly from those
-xref:../../architecture/infrastructure_components/image_registry.adoc#architecture-infrastructure-components-image-registry[image
-registries], or push it into your
-xref:../../install_config/registry/index.adoc#install-config-registry-overview[{product-title} Docker registry].
-Additionally, you can create an
+The RHEL 7 image is available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+----
+
+ifdef::openshift-online[]
+You can use the image through the `redhat-openjdk18-openshift` image stream.
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+To use this image on {product-title}, you can either access it directly from
+the Red Hat Registry or push it into your
+xref:../../install_config/registry/index.adoc#install-config-registry-overview[{product-title}
+Docker registry].  Additionally, you can create an
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
 stream] that points to the image, either in your Docker registry or at the
-external location. Your {product-title} resources can then reference the ImageStream.
-You can find
-https://github.com/openshift/origin/tree/master/examples/image-streams[example]
-ImageStream definitions for all the provided {product-title} images.
+external location. Your {product-title} resources can then reference the
+link:https://github.com/jboss-openshift/application-templates/blob/master/jboss-image-streams.json[image
+stream definition].
+endif::openshift-online[]
 
+
+[[s2i-images-java-configuration]]
 == Configuration
 
 By default, the Java S2I builder image uses Maven to build the project with the
 following goals and options:
 
 ----
-$ mvn package dependency:copy-dependencies -Popenshift -DskipTests -e
+mvn -Dmaven.repo.local=/tmp/artifacts/m2 -s /tmp/artifacts/configuration/settings.xml -e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true package -Djava.net.preferIPv4Stack=true
 ----
 
-Based on these defaults, the image compiles the project and copies all the
-transitive dependencies into the output directory without running tests.
+Based on these defaults, the builder image compiles the project and copies all
+the transitive dependencies into the output directory without running tests.
 Additionally, if the project has a profile named `*openshift*`, then it is
 activated for the build.
 
 You can override these default goals and options by specifying the following environment variables:
 
 .Java Environment Variables
-[cols="4a,6a,6a",options="header"]
+[options="header"]
 |===
 
-|Variable name |Description |Example
+|Variable name |Description
+
+|`*ARTIFACT_DIR*`
+|The relative path to the target where JAR files are created for multi-module builds.
+
+|`*JAVA_MAIN_CLASS*`
+|The main class to use as the argument to Java. This can also be specified in the *_.s2i/environment_* file as a Maven property inside the project (*docker.env.Main*).
 
 |`*MAVEN_ARGS*`
 |The arguments that are passed to the mvn command.
-|To package and also run tests:
-----
-s2i build -e "MAVEN_ARGS=clean test package" <git_repo_URL> fabric8/java-main <target_image_name>
-----
-
-|`*JAVA_MAIN*`
-|Specifies the main class of the project. This can also be accomplished from within the *_.s2i/environment_* file as a Maven property inside the project (*docker.env.Main*).
-|
 
 |===
 
-=== Working with Multi-module Projects
+[[s2i-images-java-deploy-applications]]
+== Building and Deploying Java Applications
+
+ifdef::openshift-enterprise[]
+[IMPORTANT]
+====
+The
+link:https://github.com/jboss-openshift/application-templates/blob/master/jboss-image-streams.json[OpenJDK
+image stream] must first be installed. If you ran a standard installation, the
+image stream will be present.
+====
+endif::openshift-enterprise[]
+
+The same S2I builder image can be used to build a Java application from source
+or from binary artifacts.
+
+[[s2i-images-java-deploy-applications-from-source]]
+== Building and Deploying from Source
+
+The Java S2I builder image can be used to build an application from source by running `oc
+new-app` against a source repository:
+
+ifdef::openshift-online[]
+----
+$ oc new-app redhat-openjdk18-openshift~https://github.com/jboss-openshift/openshift-quickstarts --context-dir=undertow-servlet
+----
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+----
+$ oc new-app registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift~https://github.com/jboss-openshift/openshift-quickstarts --context-dir=undertow-servlet
+----
+endif::openshift-online[]
+
+By default, tests are not run.  To build an application and run tests as part of
+the build, override the default `MAVEN_ARGS`, as in the following command:
+
+ifdef::openshift-online[]
+----
+$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='MAVEN_ARGS=-e -Popenshift -Dcom.redhat.xpaas.repo.redhatga package'
+----
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+----
+$ oc new-app registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='MAVEN_ARGS=-e -Popenshift -Dcom.redhat.xpaas.repo.redhatga package'
+----
+endif::openshift-online[]
 
 If a Java project consists of multiple Maven modules, it can be useful to
-explicitly specify the output directory, or which modules to build.
+explicitly specify the artifact output directory.  Specifying the directory
+where the Maven project outputs the artifacts enables the S2I build to pick
+them up.
 
-To specify which modules to build in a multi-module project, along with all
-their module dependencies:
+To specify the modules to build and the artifact output directory, use the
+following command:
+
+ifdef::openshift-online[]
+----
+$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='ARTIFACT_DIR=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
+----
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+----
+$ oc new-app registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='ARTIFACT_DIR=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
+----
+endif::openshift-online[]
+
+[[s2i-images-java-deploy-applications-from-source]]
+== Building and Deploying from Binary Artifacts
+
+The Java S2I builder image can be used to build an application using binary
+artifacts that you provide.  To do so, first create a new binary build using the
+`oc new-build` command:
+
+ifdef::openshift-online[]
+----
+$ oc new-build --name=<application-name> redhat-openjdk18-openshift --binary=true
+----
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+----
+$ oc new-build --name=<application-name> registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift --binary=true
+----
+endif::openshift-online[]
+
+Next, start a build using the `oc start-build` command, specifying the path to
+the binary artifacts on your local machine:
 
 ----
-s2i build -e "MAVEN_ARGS=install -pl <my.groupId>:<my.artifactId> -am" <git_repo_URL> fabric8/java-main <target_image_name>
+$ oc start-build <application-name> --from-dir=/path/to/artifacts --follow
 ----
 
-Specifying the directory where the Maven project outputs the artifacts helps the
-S2I build to pick them up. If unspecified, the default is the
-*_sources/target/_* directory.
-
-To specify the output directory and which modules to build in a multi-module
-project:
+Finally, use the `oc new-app` command to create an application:
 
 ----
-s2i build -e "OUTPUT_DIR=<path/to/myartifact/target>" -e "MAVEN_ARGS=install -pl <my.groupId>:<my.artifactId> -am" <git_repo_URL> fabric8/java-main <target_image_name>
+$ oc new-app <application-name>
 ----
+
+[[moreinfo]]
+== Additional Information and Examples
+
+- Find additional information and examples in the link:https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html-single/red_hat_java_s2i_for_openshift/[Red Hat JBoss Middleware] documentation.


### PR DESCRIPTION
Many fixes constituting nearly a full rewrite of the documentation for the S2I builder image for Java:

• Update the topic map to include the S2I Java documentation only for Online.  We will enable Enterprise and Dedicated once the default image streams for them are updated, and Origin once we have a suitable community image.

• Consistently use the phrase "S2I builder image" for clarity.

• For Online, fix a bad ifdef that decapitated a sentence in introduction.

• Mention that the builder image can take source or binary artifacts.

• Update the list of supported versions/components.

• For Online, tell the reader to use the "redhat-openjdk18-openshift" image stream.  Otherwise, as before, mention that an image stream can be created, but reference the image in commands rather than assuming an image stream exists.

• Provide the name of the image that is referred to throughout the documentation.

• Update an outdated reference to example image-stream definitions.

• Replace `OUTPUT_DIR` with `ARTIFACT_DIR`.

• Describe `ARTIFACT_DIR` in the list of variables in the configuration section.

• Replace `JAVA_CLASS` with `JAVA_CLASS_MAIN`.

• Rephrase the description of `JAVA_CLASS_MAIN`.

• Sort the list of variables alphabetically.

• Delete the example from the table since the table is squeezed and it is clearer to put the example outside the table.

• Replace `s2i` commands with `oc` commands.

• Describe both source and binary builds.

• Add an "additional information" section with a link to the Red Hat Java S2I for OpenShift section of the Red Hat JBoss Middleware for OpenShift documentation.

---

FYI @ahardin-rh.