### PR TITLE
Fix S2I .NET documentation for Online

### DIFF
--- a/using_images/s2i_images/dot_net_core.adoc
+++ b/using_images/s2i_images/dot_net_core.adoc
@@ -15,7 +15,7 @@ toc::[]
 
 link:http://developers.redhat.com/dotnet/[.NET Core] is a general purpose
 development platform featuring automatic memory management and modern
-programming languages. It allows users to build high quality applications
+programming languages. It allows users to build high-quality applications
 efficiently. .NET Core is available on Red Hat Enterprise Linux (RHEL 7) and
 {product-title} via certified containers. .NET Core offers:
 
@@ -38,30 +38,38 @@ and Python from within {product-title}.
 * Supported on Red Hat Enterprise Linux (RHEL) 7
 ifdef::openshift-enterprise[]
 and {product-title} versions 3.3 and later
+endif::openshift-enterprise[]
 
 [[dot-net-core-installing-images]]
 == Images
 
-Image stream definitions for the .NET Core on RHEL S2I image are now added
-during {product-title} installations.
-endif::openshift-enterprise[]
-
-The RHEL 7 images are available through Red Hat's subscription registry using:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/dotnet/dotnetcore-10-rhel7
 $ docker pull registry.access.redhat.com/dotnet/dotnetcore-11-rhel7
 ----
 
-To use these images, you can either access them directly from these
+ifdef::openshift-online[]
+You can use these images through the `dotnet` image stream.
+endif::openshift-online[]
+
+ifdef::openshift-enterprise[]
+Image stream definitions for the .NET Core on RHEL S2I image are
+now added during {product-title} installations.
+endif::openshift-enterprise[]
+
+ifdef::openshift-origin,openshift-dedicated[]
+To use these images, you can either access them directly from the
 xref:../../architecture/infrastructure_components/image_registry.adoc#architecture-infrastructure-components-image-registry[image
-registries], or push them into your
+registry] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 link:https://github.com/redhat-developer/s2i-dotnetcore/blob/master/dotnet_imagestreams.json[image stream definition].
+endif::openshift-origin,openshift-dedicated[]
 
 [[dot-net-core-configuration]]
 == Configuration
@@ -149,10 +157,19 @@ image stream will be present.
 An image can be used to build an application by running `oc new-app` against a
 sample repository:
 
+ifdef::openshift-online[]
+----
+$ oc new-app dotnet:1.0~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.0 --context-dir=app
+$ oc new-app dotnet:1.1~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.1 --context-dir=app
+----
+endif::openshift-online[]
+
+ifndef::openshift-online[]
 ----
 $ oc new-app registry.access.redhat.com/dotnet/dotnetcore-10-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.0 --context-dir=app
 $ oc new-app registry.access.redhat.com/dotnet/dotnetcore-11-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.1 --context-dir=app
 ----
+endif::openshift-online[]
 
 ifdef::openshift-enterprise[]
 [NOTE]
@@ -161,7 +178,7 @@ The `oc new-app` command can detect .NET Core source starting in {product-title}
 ====
 endif::openshift-enterprise[]
 
-
+ifndef::openshift-online[]
 [[dot-net-core-templates]]
 == .NET Core Templates
 ifdef::openshift-enterprise[]
@@ -202,3 +219,4 @@ using PostgreSQL as database can be deployed with:
 ----
 $ oc new-app --template=dotnet-pgsql-persistent
 ----
+endif::openshift-online[]


### PR DESCRIPTION
• Minor fixes ("high-quality applications", delete a stray comma, use singular "registry" where appropriate).

• Rework the documentation around image streams:

  • For Online, simply provide the name of the image stream.

  • For Enterprise, state that hte image stream is created on installation.

  • For Origin and Dedicated, state that the image streams need to be created.

• For Online, use the image stream in commands.

• For Online, ifdef out the entire section on templates since the templates are not provided in Online.

---

FYI @ahardin-rh.