### PR TITLE
Fix S2I Node.js documentation for Online

### DIFF
--- a/using_images/s2i_images/nodejs.adoc
+++ b/using_images/s2i_images/nodejs.adoc
@@ -14,9 +14,9 @@ toc::[]
 {product-title} provides
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
 enabled Node.js images for building and running Node.js applications.
-ifdef::openshift-origin[]
+ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-nodejs[Node.js S2I builder image]
-endif::openshift-origin[]
+endif::openshift-enterprise[]
 ifdef::openshift-enterprise[]
 The Node.js S2I builder image
 endif::openshift-enterprise[]
@@ -31,14 +31,26 @@ https://github.com/openshift/sti-nodejs[4] of Node.js.
 
 == Images
 
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/nodejs-010-rhel7
+$ docker pull registry.access.redhat.com/rhscl/nodejs-4-rhel7
+----
+
+You can use these images through the `nodejs` image stream.
+endif::openshift-online[]
+
+ifndef::openshift-online[]
 These images come in two flavors, depending on your needs:
 
 * RHEL 7
 * CentOS 7
 
-*RHEL 7 Based Image*
+*RHEL 7 Based Images*
 
-The RHEL 7 images are available through Red Hat's subscription registry using:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/nodejs-010-rhel7
@@ -47,7 +59,7 @@ $ docker pull registry.access.redhat.com/rhscl/nodejs-4-rhel7
 
 *CentOS 7 Based Image*
 
-This image is available on DockerHub. To download it:
+This image is available on Docker Hub:
 
 ----
 $ docker pull openshift/nodejs-010-centos7
@@ -64,6 +76,7 @@ external location. Your {product-title} resources can then reference the
 ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example
 image stream definitions] for all the provided {product-title} images.
+endif::openshift-online[]
 
 [[nodejs-configuration]]
 == Configuration
@@ -136,3 +149,20 @@ $ oc rsh <pod_id>
 
 Entering into a running container changes your current directory to
 *_/opt/app-root/src_*, where the source code is located.
+
+ifdef::openshift-online[]
+[[nodejs-templates]]
+== Node.js Templates
+
+{product-title} includes an example template to deploy a
+link:https://github.com/openshift/nodejs-ex[sample Node.js application].
+This template builds and deploys the sample application on Node.js with a
+MongoDB database using a persistent volume for storage.
+
+The sample application can be built and deployed using the
+`rhscl/nodejs-4-rhel7` image with the following command:
+
+----
+$ oc new-app --template=nodejs-mongo-persistent
+----
+endif::openshift-online[]


### PR DESCRIPTION
• For Online and Dedicated, fix a bad ifdef that decapitated a sentence in the introduction.

• For Online, only mention the nodejs-010-rhel7 and nodejs-4-rhel7 images, not the nodejs-010-centos7 image.

• For Online, tell the reader to use the "nodejs" image stream.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Add a section for Online about the nodejs-mongo-persistent template for the sample Node.js application.

---

FYI @ahardin-rh.