### PR TITLE
Fix S2I Perl documentation for Online

### DIFF
--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -14,9 +14,9 @@ toc::[]
 {product-title} provides
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
 enabled Perl images for building and running Perl applications.
-ifdef::openshift-origin[]
+ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-perl[Perl S2I builder image]
-endif::openshift-origin[]
+endif::openshift-enterprise[]
 ifdef::openshift-enterprise[]
 The Perl S2I builder image
 endif::openshift-enterprise[]
@@ -25,27 +25,44 @@ new image containing your Perl application. This resulting image can be run
 either by {product-title} or by Docker.
 
 == Versions
-Currently, {product-title} supports version
-https://github.com/openshift/sti-perl/tree/master/5.16[5.16] of Perl.
+Currently, {product-title} supports versions
+https://github.com/openshift/sti-perl/tree/master/5.16[5.16],
+https://github.com/openshift/sti-perl/tree/master/5.20[5.20], and
+https://github.com/openshift/sti-perl/tree/master/5.24[5.24] of Perl.
 
 == Images
 
-This image comes in two flavors, depending on your needs:
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/perl-516-rhel7
+$ docker pull registry.access.redhat.com/rhscl/perl-520-rhel7
+$ docker pull registry.access.redhat.com/rhscl/perl-524-rhel7
+----
+
+You can use these images through the `perl` image stream.
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+Images comes in two flavors, depending on your needs:
 
 * RHEL 7
 * CentOS 7
 
-*RHEL 7 Based Image*
+*RHEL 7 Based Images*
 
-The RHEL 7 image is available through Red Hat's subscription registry using:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/perl-516-rhel7
+$ docker pull registry.access.redhat.com/rhscl/perl-520-rhel7
+$ docker pull registry.access.redhat.com/rhscl/perl-524-rhel7
 ----
 
 *CentOS 7 Based Image*
 
-This image is available on DockerHub. To download it:
+A CentOS image for Perl 5.16 is available on Docker Hub:
 
 ----
 $ docker pull openshift/perl-516-centos7
@@ -53,7 +70,7 @@ $ docker pull openshift/perl-516-centos7
 
 To use these images, you can either access them directly from these
 xref:../../architecture/infrastructure_components/image_registry.adoc#architecture-infrastructure-components-image-registry[image
-registries], or push them into your
+registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
@@ -62,6 +79,7 @@ external location. Your {product-title}t resources can then reference the
 ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example
 image stream definitions] for all the provided {product-title} images.
+endif::openshift-online[]
 
 == Configuration
 The Perl image supports a number of environment variables which can be set to
@@ -150,3 +168,20 @@ $ oc rsh <pod_id>
 
 After you enter into the running container, your current directory is set to
 *_/opt/app-root/src_*, where the source code is located.
+
+ifdef::openshift-online[]
+[[perl-templates]]
+== Perl Templates
+
+{product-title} includes an example template to deploy a
+link:https://github.com/openshift/dancer-ex[sample Dancer application].
+This template builds and deploys the sample application on Perl 5.24 with a
+MySQL database using a persistent volume for storage.
+
+The sample application can be built and deployed using the
+`rhscl/perl-524-rhel7` image with the following command:
+
+----
+$ oc new-app --template=dancer-mysql-persistent
+----
+endif::openshift-online[]


### PR DESCRIPTION
• For Online and Dedicated, fix a bad ifdef that decapitated a sentence in the introduction.

• Update the list of supported Perl versions and available images.

• For Online, only mention the rhel7 images, not the centos7 image.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Delete a spurious comma.

• For Online, tell the reader to use the "perl" image stream.

• Add a section for Online about the perl-mysql-persistent template for the sample Dancer application.

---

FYI @ahardin-rh.