### PR TITLE
Fix S2I PHP documentation for Online

### DIFF
--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -14,9 +14,9 @@ toc::[]
 {product-title} provides
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
 enabled PHP images for building and running PHP applications.
-ifdef::openshift-origin[]
+ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-php[PHP S2I builder image]
-endif::openshift-origin[]
+endif::openshift-enterprise[]
 ifdef::openshift-enterprise[]
 The PHP S2I builder image
 endif::openshift-enterprise[]
@@ -27,37 +27,54 @@ either by {product-title} or by Docker.
 [[php-versions]]
 == Versions
 
-Currently, {product-title} provides version
-link:https://github.com/openshift/sti-php/tree/master/5.5[5.5] and
-link:https://github.com/sclorg/s2i-php-container/tree/master/5.6[5.6] of PHP.
+Currently, {product-title} provides versions
+link:https://github.com/openshift/sti-php/tree/master/5.5[5.5],
+link:https://github.com/sclorg/s2i-php-container/tree/master/5.6[5.6], and
+link:https://github.com/sclorg/s2i-php-container/tree/master/7.0[7.0] of PHP.
 
 [[php-images]]
 == Images
 
-This image comes in two flavors, depending on your needs:
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/php-55-rhel7
+$ docker pull registry.access.redhat.com/rhscl/php-56-rhel7
+$ docker pull registry.access.redhat.com/rhscl/php-70-rhel7
+----
+
+You can use these images through the `php` image stream.
+endif::openshift-online[]
+
+ifndef::openshift-online[]
+These images come in two flavors, depending on your needs:
 
 * RHEL 7
 * CentOS 7
 
-*RHEL 7 Based Image*
+*RHEL 7 Based Images*
 
-The RHEL 7 image is available through Red Hat's subscription registry using:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/php-55-rhel7
+$ docker pull registry.access.redhat.com/rhscl/php-56-rhel7
+$ docker pull registry.access.redhat.com/rhscl/php-70-rhel7
 ----
 
-*CentOS 7 Based Image*
+*CentOS 7 Based Images*
 
-This image is available on DockerHub. To download it:
+CentOS images for PHP 5.5 and 5.6 are available on Docker Hub:
 
 ----
 $ docker pull openshift/php-55-centos7
+$ docker pull openshift/php-56-centos7
 ----
 
 To use these images, you can either access them directly from these
 xref:../../architecture/infrastructure_components/image_registry.adoc#architecture-infrastructure-components-image-registry[image
-registries], or push them into your
+registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
@@ -68,6 +85,7 @@ stream.
 You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example
 image stream definitions] for all the provided {product-title} images.
+endif::openshift-online[]
 
 [[php-configuration]]
 == Configuration
@@ -237,3 +255,28 @@ $ oc rsh <pod_id>
 
 After you enter into the running container, your current directory is set to
 *_/opt/app-root/src_*, where the source code is located.
+
+ifdef::openshift-online[]
+[[php-templates]]
+== PHP Templates
+
+{product-title} includes example templates to deploy a
+link:https://github.com/openshift/cakephp-ex[sample CakePHP application] or a
+link:https://github.com/luciddreamz/laravel-ex[sample Laravel application].
+Each template builds and deploys a sample application on PHP 7.0 with a
+MySQL database using a persistent volume for storage.
+
+The sample CakePHP application can be built and deployed using the
+`rhscl/php-70-rhel7` image with the following command:
+
+----
+$ oc new-app --template=cakephp-mysql-persistent
+----
+
+The sample Laravel application can be built and deployed using the
+`rhscl/php-70-rhel7` image with the following command:
+
+----
+$ oc new-app --template=laravel-mysql-example
+----
+endif::openshift-online[]


### PR DESCRIPTION
• For Online and Dedicated, fix a bad ifdef that decapitated a sentence in the introduction.

• Update the list of supported PHP versions and available images.

• For Online, only mention the rhel7 images, not the centos7 images.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Delete a spurious comma.

• For Online, tell the user to use the "php" image stream.

• Add a section for Online about the cakephp-mysql-persistent and laravel-mysql-example templates for the sample PHP applications.

---

FYI @ahardin-rh.