### PR TITLE
Fix S2I Python documentation for Online

### DIFF
--- a/using_images/s2i_images/python.adoc
+++ b/using_images/s2i_images/python.adoc
@@ -14,9 +14,9 @@ toc::[]
 {product-title} provides
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
 enabled Python images for building and running Python applications.
-ifdef::openshift-origin[]
+ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-python[Python S2I builder image]
-endif::openshift-origin[]
+endif::openshift-enterprise[]
 ifdef::openshift-enterprise[]
 The Python S2I builder image
 endif::openshift-enterprise[]
@@ -33,32 +33,50 @@ https://github.com/openshift/sti-python/tree/master/3.5[3.5] of Python.
 
 == Images
 
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/rhscl/python-27-rhel7
+$ docker pull registry.access.redhat.com/openshift3/python-33-rhel7
+$ docker pull registry.access.redhat.com/rhscl/python-34-rhel7
+$ docker pull registry.access.redhat.com/rhscl/python-35-rhel7
+----
+
+You can use these images through the `python` image stream.
+endif::openshift-online[]
+
+ifndef::openshift-online[]
 These images come in two flavors, depending on your needs:
 
 * RHEL 7
 * CentOS 7
 
-*RHEL 7 Based Image*
+*RHEL 7 Based Images*
 
-The RHEL 7 images are available through Red Hat's subscription registry using:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
+$ docker pull registry.access.redhat.com/rhscl/python-27-rhel7
 $ docker pull registry.access.redhat.com/openshift3/python-33-rhel7
+$ docker pull registry.access.redhat.com/rhscl/python-34-rhel7
 $ docker pull registry.access.redhat.com/rhscl/python-35-rhel7
 ----
 
-*CentOS 7 Based Image*
+*CentOS 7 Based Images*
 
-These images are available on DockerHub. To download them:
+These images are available on Docker Hub:
 
 ----
+$ docker pull centos/python-27-centos7
 $ docker pull openshift/python-33-centos7
+$ docker pull centos/python-34-centos7
 $ docker pull centos/python-35-centos7
 ----
 
 To use these images, you can either access them directly from these
 xref:../../architecture/infrastructure_components/image_registry.adoc#architecture-infrastructure-components-image-registry[image
-registries], or push them into your
+registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
@@ -67,6 +85,7 @@ external location. Your {product-title} resources can then reference the
 ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example
 image stream definitions] for all the provided {product-title} images.
+endif::openshift-online[]
 
 == Configuration
 The Python image supports a number of environment variables which can be set to
@@ -167,3 +186,20 @@ $ oc rsh <pod_id>
 
 After you enter into the running container, your current directory is set to
 *_/opt/app-root/src_*, where the source code is located.
+
+ifdef::openshift-online[]
+[[python-templates]]
+== Python Templates
+
+{product-title} includes an example template to deploy a
+link:https://github.com/openshift/nodejs-ex[sample Django application].
+This template builds and deploys the sample application on Python 3.5 with a
+PostgreSQL database using a persistent volume for storage.
+
+The sample application can be built and deployed using the
+`rhscl/python-35-rhel7` image with the following command:
+
+----
+$ oc new-app --template=django-psql-persistent
+----
+endif::openshift-online[]


### PR DESCRIPTION
• For Online and Dedicated, fix a bad ifdef that decapitated a sentence in the introduction.

• For Online, only mention the rhel7 images, not the centos7 images.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Delete a spurious comma.

• For Online, tell the reader to use the "python" image stream.

• Add a section for Online about the django-psql-persistent template for the sample application.

---

FYI @ahardin-rh.