### PR TITLE
Fix typo Kuberbetes to Kubernetes

### DIFF
--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -21,7 +21,7 @@ detect and handle unhealthy containers.
 
 == Container Health Checks Using Probes
 
-A probe is a Kuberbetes action that periodically performs diagnostics on a
+A probe is a Kubernetes action that periodically performs diagnostics on a
 running container. Currently, two types of probes exist, each serving a
 different purpose:
 


### PR DESCRIPTION
Fixed a typo in Application Health page under
Container Health Checks Using Probes.

Fixes #4256 