### PR TITLE
Fix S2I MariaDB documentation for Online

### DIFF
--- a/using_images/db_images/mariadb.adoc
+++ b/using_images/db_images/mariadb.adoc
@@ -26,23 +26,35 @@ https://github.com/sclorg/mariadb-container/tree/master/10.1[10.1] of MariaDB.
 [[mariadb-images]]
 == Images
 
-These images come in two flavors, depending on your needs:
-
-* RHEL 7
-* CentOS 7
-
-*RHEL 7 Based Image*
-
-The RHEL 7 images are available through Red Hat's subscription registry:
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/rhscl/mariadb-100-rhel7
 $ docker pull registry.access.redhat.com/rhscl/mariadb-101-rhel7
 ----
 
-*CentOS 7 Based Image*
+You can use the MariaDB 10.1 image through the `mariadb` image stream.
+endif::[]
 
-These images are available on DockerHub. To download them:
+ifndef::openshift-online[]
+These images come in two flavors, depending on your needs:
+
+* RHEL 7
+* CentOS 7
+
+*RHEL 7 Based Images*
+
+The RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/rhscl/mariadb-100-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mariadb-101-rhel7
+----
+
+*CentOS 7 Based Images*
+
+These images are available on Docker Hub:
 
 ----
 $ docker pull openshift/mariadb-100-centos7
@@ -56,6 +68,7 @@ either in your Docker registry or at the external location. Your {product-title}
 resources can then reference the ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example]
 ImageStream definitions for all the provided {product-title} images.
+endif::[]
 
 [[mariadb-configuration-and-usage]]
 == Configuration and Usage
@@ -79,39 +92,15 @@ $ oc new-app \
     -e MYSQL_USER=<username> \
     -e MYSQL_PASSWORD=<password> \
     -e MYSQL_DATABASE=<database_name> \
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
     registry.access.redhat.com/rhscl/mariadb-101-rhel7
 endif::[]
 ifdef::openshift-origin[]
-    docker pull centos/mariadb-101-centos7
+    centos/mariadb-101-centos7
 endif::[]
-----
-
-If you want to set only the mandatory environment variables, and not store the
-database in a host directory, run:
-
-----
-ifdef::openshift-enterprise,openshift-online[]
-$ docker run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-100-rhel7
+ifdef::openshift-online[]
+    mariadb:10.1
 endif::[]
-ifdef::openshift-origin[]
-$ docker run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 mariadb-100-centos7
-endif::[]
-----
-
-This will create a container named `mariadb_database` running MySQL with
-database `db` and user with credentials `user:pass`. Port 3306 will be exposed
-and mapped to the host. If you want your database to be persistent across
-container executions, also add a `-v /host/db/path:/var/lib/mysql/data` argument.
-This will be the MySQL data directory.
-
-If the database directory is not initialized, the entrypoint script will first
-run `mysql_install_db` and set up the necessary database users and passwords. After the
-database is initialized, or if it was already present, `mysqld` is executed and
-will run as PID 1. To stop the detached container, run:
-
-----
-docker stop mariadb_database
 ----
 
 [[running-mariadb-commands-in-containers]]
@@ -263,12 +252,14 @@ for the database:
 * *_/var/lib/mysql/data_* - The MySQL data directory is where
 MariaDB stores database files.
 
+ifndef::openshift-online[]
 [NOTE]
 ====
 When mounting a directory from the host into the container, ensure that the
 mounted directory has the appropriate permissions. Also verify that the owner
 and group of the directory match the user name running inside the container.
 ====
+endif::[]
 
 [[mariadb-changing-passwords]]
 === Changing Passwords
@@ -378,13 +369,24 @@ xref:../../architecture/core_concepts/deployments.adoc#deployments-and-deploymen
 configuration] and a
 xref:../../architecture/core_concepts/pods_and_services.adoc#services[service].
 
-The MariaDB templates should have been registered in the default *openshift*
+The MariaDB
+ifdef::openshift-online[]
+template
+endif::[]
+ifndef::openshift-online[]
+templates
+endif::[]
+should have been registered in the default *openshift*
 project by your cluster administrator during the initial cluster setup.
 ifdef::openshift-enterprise,openshift-origin[]
 See xref:../../install_config/imagestreams_templates.adoc#install-config-imagestreams-templates[Loading the Default Image Streams and Templates]
 for more details, if required.
 endif::[]
 
+ifdef::openshift-online[]
+The following template is available:
+endif::[]
+ifndef::openshift-online[]
 There are two templates available:
 
 * `mariadb-ephemeral` is for development or testing purposes only because it uses
@@ -392,9 +394,13 @@ ephemeral storage for the database content. This means that if the database
 pod is restarted for any reason, such as the pod being moved to another node
 or the deployment configuration being updated and triggering a redeploy, all
 data will be lost.
+endif::openshift-online[]
 * `mariadb-persistent` uses a persistent volume store for the database data
-which means the data will survive a pod restart. Using persistent volumes
-requires a persistent volume pool be defined in the {product-title} deployment.
+which means the data will survive a pod restart.
+ifndef::openshift-online[]
+Using persistent volumes requires a persistent volume pool be defined in the
+{product-title} deployment.
+endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 Cluster administrator instructions for setting up the pool are located
 xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[here].
@@ -730,22 +736,22 @@ AIO (Asynchronous I/O) facilities due to resource limits.
 
 .Resolution
 
-1. Turn off AIO usage entirely,
-by setting environment variable `*MYSQL_AIO*` to have value `0`.
-On subsequent deployments, this arranges for the
-MySQL configuration variable `*innodb_use_native_aio*`
-to have value `0`.
+Turn off AIO usage entirely, by setting environment variable `*MYSQL_AIO*` to
+have value `0`.  On subsequent deployments, this arranges for the MySQL
+configuration variable `*innodb_use_native_aio*` to have value `0`.
 
-2. Increase the `aio-max-nr` kernel resource.
+ifndef::openshift-online[]
+Alternatively, increase the `aio-max-nr` kernel resource.
 The following example examines the current value of `aio-max-nr` and doubles it.
-+
+
 ----
 $ sysctl fs.aio-max-nr
 fs.aio-max-nr = 1048576
 # sysctl -w fs.aio-max-nr=2097152
 ----
-+
+
 This is a per-node resolution and lasts until the next node reboot.
+endif::[]
 
 // Add more subsections here.
 // TEMPLATE:


### PR DESCRIPTION
• For Online, only mention the rhel7 images, and tell the user to use the "mariadb" image stream.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Fix a bad ifdef that omitted part of a command for Online and Dedicated, and delete some spurious docker commands that somehow found their way in.

• For Online, hide notes about hostpath mounts, only mention the mariadb-persistent template (and not the mariadb-ephemeral template), and hide the troubleshooting information that requires Linux administrative privileges.

---

FYI @ahardin-rh.