### PR TITLE
Improve 3.3 EgressNetworkPolicy docs after bugfix

### DIFF
--- a/admin_guide/managing_pods.adoc
+++ b/admin_guide/managing_pods.adoc
@@ -236,13 +236,16 @@ To configure egress policy:
             {
                 "type": "Deny",
                 "to": {
-                    "cidrSelector": "0.0.0.0/32"
+                    "cidrSelector": "0.0.0.0/0"<1>
                 }
             }
         ]
     }
 }
 ----
+<1> In earlier versions of {product-name}, a bug required you to specify
+`"0.0.0.0/32"` rather than `"0.0.0.0/0"` for a "match all" rule. This is
+fixed as of 3.3.1.25.
 +
 When the example above is added in a project, it allows traffic to `1.2.3.0/24`,
 but denies access to all other external IP addresses. (Traffic to other pods is
@@ -251,7 +254,7 @@ not affected because the policy only applies to _external_ traffic.)
 The rules in an `EgressNetworkPolicy` are checked in order, and the
 first one that matches takes effect. If the two rules in the above example
 were swapped, then traffic would not be allowed to `1.2.3.0/24` because the
-`0.0.0.0/32` rule would be checked first, and it would match and deny all
+`0.0.0.0/0` rule would be checked first, and it would match and deny all
 traffic.
 
 . Use the JSON file to create an EgressNetworkPolicy object:


### PR DESCRIPTION
https://github.com/openshift/ose/pull/716 fixes a longstanding bug in 3.3's EgressNetworkPolicy implementation (relative to 3.4 and later). This updates the docs to match; with the next 3.3 release, using the "0.0.0.0/32" form will result in a warning being logged (though it will still work. But we should encourage people to use the correct form).

I don't know for sure that the version number I indicated there is accurate; https://bugzilla.redhat.com/show_bug.cgi?id=1440886 will track when the fix is going out, I guess. The docs fix can wait until after the OCP fix goes out, I just wanted to file the PR before I forgot about it...

Also, I don't know if you care about using "ifdefs" properly here since this is an OCP-specific branch anyway...