### PR TITLE
Fix S2I MySQL documentation for Online

### DIFF
--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -17,31 +17,48 @@ provide database services based on username, password, and database name
 settings provided via configuration.
 
 == Versions
-Currently, {product-title} provides version
-link:https://github.com/openshift/mysql/tree/master/5.5[5.5] and
-link:https://github.com/openshift/mysql/tree/master/5.6[5.6] of MySQL.
+Currently, {product-title} provides versions
+link:https://github.com/openshift/mysql/tree/master/5.5[5.5],
+link:https://github.com/openshift/mysql/tree/master/5.5[5.6], and
+link:https://github.com/openshift/mysql/tree/master/5.6[5.7] of MySQL.
 
 == Images
 
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/mysql-55-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mysql-56-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mysql-57-rhel7
+----
+
+You can use these images through the `mysql` image stream.
+endif::[]
+
+ifndef::openshift-online[]
 This image comes in two flavors, depending on your needs:
 
 * RHEL 7
 * CentOS 7
 
-*RHEL 7 Based Image*
+*RHEL 7 Based Images*
 
-The RHEL 7 image is available through Red Hat's subscription registry via:
+The RHEL 7 image is available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/mysql-55-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mysql-56-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mysql-57-rhel7
 ----
 
-*CentOS 7 Based Image*
+*CentOS 7 Based Images*
 
-This image is available on DockerHub. To download it:
+CentOS images for MySQL 5.5 and 5.6 are available on Docker Hub:
 
 ----
 $ docker pull openshift/mysql-55-centos7
+$ docker pull openshift/mysql-56-centos7
 ----
 
 To use these images, you can either access them directly from these
@@ -51,6 +68,7 @@ either in your Docker registry or at the external location. Your {product-title}
 resources can then reference the ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example]
 ImageStream definitions for all the provided {product-title} images.
+endif::[]
 
 == Configuration and Usage
 
@@ -72,11 +90,14 @@ $ oc new-app \
     -e MYSQL_USER=<username> \
     -e MYSQL_PASSWORD=<password> \
     -e MYSQL_DATABASE=<database_name> \
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
     registry.access.redhat.com/openshift3/mysql-55-rhel7
 endif::[]
 ifdef::openshift-origin[]
     openshift/mysql-55-centos7
+endif::[]
+ifdef::openshift-online[]
+    mysql:5.5
 endif::[]
 ----
 
@@ -196,7 +217,13 @@ MySQL settings can be configured with the following environment variables:
 
 |`*MYSQL_KEY_BUFFER_SIZE*`
 |The size of the buffer used for index blocks.
-|32M (or 10% of available memory)
+|
+ifdef::openshift-online[]
+10% of available memory
+endif::[]
+ifndef::openshift-online[]
+32M (or 10% of available memory)
+endif::[]
 
 |`*MYSQL_SORT_BUFFER_SIZE*`
 |The size of the buffer used for sorting.
@@ -204,25 +231,57 @@ MySQL settings can be configured with the following environment variables:
 
 |`*MYSQL_READ_BUFFER_SIZE*`
 |The size of the buffer used for a sequential scan.
-|8M (or 5% of available memory)
+|
+ifdef::openshift-online[]
+5% of available memory
+endif::[]
+ifndef::openshift-online[]
+8M (or 5% of available memory)
+endif::[]
 
 |`*MYSQL_INNODB_BUFFER_POOL_SIZE*`
 |The size of the buffer pool where InnoDB caches table and index data.
-|32M (or 50% of available memory)
+|
+ifdef::openshift-online[]
+50% of available memory
+endif::[]
+ifndef::openshift-online[]
+32M (or 50% of available memory)
+endif::[]
 
 |`*MYSQL_INNODB_LOG_FILE_SIZE*`
 |The size of each log file in a log group.
-|8M (or 15% of available memory)
+|
+ifdef::openshift-online[]
+15% of available memory
+endif::[]
+ifndef::openshift-online[]
+8M (or 15% of available memory)
+endif::[]
 
 |`*MYSQL_INNODB_LOG_BUFFER_SIZE*`
 |The size of the buffer that InnoDB uses to write to the log files on disk.
-|8M (or 15% of available memory)
+|
+ifdef::openshift-online[]
+15% of available memory
+endif::[]
+ifndef::openshift-online[]
+8M (or 15% of available memory)
+endif::[]
 |===
 
+ifdef::openshift-online[]
+Some of the memory-related parameters have percentages as default values.  These
+values are calculated dynamically during a container's startup based on
+xref:../../dev_guide/compute_resources.adoc#dev-memory-limits[memory limits].
+endif::[]
+
+ifndef::openshift-online[]
 Some of the memory-related parameters have two default values. The fixed value
 is used when a container does not have xref:../../dev_guide/compute_resources.adoc#dev-memory-limits[memory limits]
 assigned. The other value is calculated dynamically during a container's startup
 based on available memory.
+endif::[]
 
 === Volume Mount Points
 The MySQL image can be run with mounted volumes to enable persistent storage for
@@ -345,23 +404,40 @@ xref:../../architecture/core_concepts/deployments.adoc#deployments-and-deploymen
 configuration] and a
 xref:../../architecture/core_concepts/pods_and_services.adoc#services[service].
 
-The MySQL templates should have been registered in the default *openshift*
+The MySQL
+ifdef::openshift-online[]
+template
+endif::[]
+ifndef::openshift-online[]
+templates
+endif::[]
+should have been registered in the default *openshift*
 project by your cluster administrator during the initial cluster setup.
 ifdef::openshift-enterprise,openshift-origin[]
 See xref:../../install_config/imagestreams_templates.adoc#install-config-imagestreams-templates[Loading the Default Image Streams and Templates]
 for more details, if required.
 endif::[]
 
+ifdef::openshift-online[]
+The following template is available:
+endif::[]
+ifndef::openshift-online[]
 There are two templates available:
+endif::[]
 
+ifndef::openshift-online[]
 * `mysql-ephemeral` is for development or testing purposes only because it uses
 ephemeral storage for the database content. This means that if the database
 pod is restarted for any reason, such as the pod being moved to another node
 or the deployment configuration being updated and triggering a redeploy, all
 data will be lost.
+endif::[]
 * `mysql-persistent` uses a persistent volume store for the database data which
-means the data will survive a pod restart. Using persistent volumes requires a
-persistent volume pool be defined in the {product-title} deployment.
+means the data will survive a pod restart.
+ifndef::openshift-online[]
+Using persistent volumes requires a persistent volume pool be defined in the
+{product-title} deployment.
+endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 Cluster administrator instructions for setting up the pool are located
 xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[here].
@@ -509,16 +585,18 @@ spec:
 ----
 ====
 
+ifndef::openshift-online[]
 Since we claimed a persistent volume in this deployment configuration to have
 all data persisted for the MySQL master server, you must ask your cluster
 administrator to create a persistent volume that you can claim the storage from.
+endif::[]
 
 After the deployment configuration is created and the pod with MySQL master
 server is started, it will create the database defined by `*MYSQL_DATABASE*` and
 configure the server to replicate this database to slaves.
 
 The example provided defines only one replica of the MySQL master server. This
-causes {product-title}to start only one instance of the server. Multiple
+causes {product-title} to start only one instance of the server. Multiple
 instances (multi-master) is not supported and therefore you can not scale this
 replication controller.
 
@@ -693,22 +771,24 @@ AIO (Asynchronous I/O) facilities due to resource limits.
 
 .Resolution
 
-1. Turn off AIO usage entirely,
+Turn off AIO usage entirely
 by setting environment variable `*MYSQL_AIO*` to have value `0`.
 On subsequent deployments, this arranges for the
 MySQL configuration variable `*innodb_use_native_aio*`
 to have value `0`.
 
-2. Increase the `aio-max-nr` kernel resource.
+ifndef::openshift-online[]
+Alternatively, increase the `aio-max-nr` kernel resource.
 The following example examines the current value of `aio-max-nr` and doubles it.
-+
+
 ----
 $ sysctl fs.aio-max-nr
 fs.aio-max-nr = 1048576
 # sysctl -w fs.aio-max-nr=2097152
 ----
-+
+
 This is a per-node resolution and lasts until the next node reboot.
+endif::[]
 
 // Add more subsections here.
 // TEMPLATE:


### PR DESCRIPTION
• Update the list ofs supported PHP versions and available images.

• For Online, only mention the rhel7 images, not the centos7 images, and tell the reader to use the "mysql" image stream.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Fix the `oc new-app` command for Online and Dedicated.

• Conditionalize the memory-related parameters that have two default values, where one is used if there is a memory limit, since Online always has memory limits.

• Add a missing space in "{product-title} to".

• For Online, only mention the mysql-persistent template (and not the mysql-ephemeral template), and hide the troubleshooting information that requires Linux administrative privileges.

---

FYI @ahardin-rh.