### PR TITLE
Fix S2I Postgresql documentation for Online

### DIFF
--- a/using_images/db_images/postgresql.adoc
+++ b/using_images/db_images/postgresql.adoc
@@ -22,6 +22,19 @@ https://github.com/openshift/postgresql/tree/master/9.2[9.2], https://github.com
 
 == Images
 
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/postgresql-92-rhel7
+$ docker pull registry.access.redhat.com/rhscl/postgresql-94-rhel7
+$ docker pull registry.access.redhat.com/rhscl/postgresql-95-rhel7
+----
+
+You can use these images through the `postgresql` image stream.
+endif::[]
+
+ifndef::openshift-online[]
 These images come in two flavors, depending on your needs:
 
 * RHEL 7
@@ -29,7 +42,7 @@ These images come in two flavors, depending on your needs:
 
 *RHEL 7 Based Image*
 
-The RHEL 7 images are available through Red Hat's subscription registry via:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/postgresql-92-rhel7
@@ -39,7 +52,7 @@ $ docker pull registry.access.redhat.com/rhscl/postgresql-95-rhel7
 
 *CentOS 7 Based Image*
 
-These images are available on DockerHub. To download them:
+These images are available on Docker Hub:
 
 ----
 $ docker pull openshift/postgresql-92-centos7
@@ -60,6 +73,7 @@ either in your Docker registry or at the external location. Your {product-title}
 resources can then reference the ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example]
 ImageStream definitions for all the provided {product-title} images.
+endif::[]
 
 == Configuration and Usage
 
@@ -81,11 +95,14 @@ $ oc new-app \
     -e POSTGRESQL_USER=<username> \
     -e POSTGRESQL_PASSWORD=<password> \
     -e POSTGRESQL_DATABASE=<database_name> \
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
     registry.access.redhat.com/rhscl/postgresql-94-rhel7
 endif::[]
 ifdef::openshift-origin[]
     centos/postgresql-94-centos7
+endif::[]
+ifdef::openshift-online[]
+    postgresql:9.4
 endif::[]
 ----
 
@@ -303,23 +320,40 @@ xref:../../architecture/core_concepts/deployments.adoc#deployments-and-deploymen
 configuration] and a
 xref:../../architecture/core_concepts/pods_and_services.adoc#services[service].
 
-The PostgreSQL templates should have been registered in the default *openshift*
+The PostgreSQL
+ifdef::openshift-online[]
+template
+endif::[]
+ifndef::openshift-online[]
+templates
+endif::[]
+should have been registered in the default *openshift*
 project by your cluster administrator during the initial cluster setup.
 ifdef::openshift-enterprise,openshift-origin[]
 See xref:../../install_config/imagestreams_templates.adoc#install-config-imagestreams-templates[Loading the Default Image Streams and Templates]
 for more details, if required.
 endif::[]
 
+ifdef::openshift-online[]
+The following template is available:
+endif::[]
+ifndef::openshift-online[]
 There are two templates available:
+endif::[]
 
+ifndef::openshift-online[]
 * `PostgreSQL-ephemeral` is for development or testing purposes only because it
 uses ephemeral storage for the database content. This means that if the
 database pod is restarted for any reason, such as the pod being moved to
 another node or the deployment configuration being updated and triggering a
 redeploy, all data will be lost.
+endif::[]
 * `PostgreSQL-persistent` uses a persistent volume store for the database data
-which means the data will survive a pod restart. Using persistent volumes
-requires a persistent volume pool be defined in the {product-title} deployment.
+which means the data will survive a pod restart.
+ifndef::openshift-online[]
+Using persistent volumes requires a persistent volume pool be defined in the
+{product-title} deployment.
+endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 Cluster administrator instructions for setting up the pool are located
 xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[here].


### PR DESCRIPTION
• For Online, only mention the rhel7 images, not the centos7 images, and tell the reader to use the "postgresql" image stream.

• Fix a typo: "DockerHub" should be "Docker Hub".

• Fix the `oc new-app`command for Online and Dedicated.

• For Online, only mention the postgresql-persistent template (and not the postgresql-ephemeral template).

---

FYI @ahardin-rh.