### PR TITLE
Fix S2I Jenkins documentation for Online

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -21,35 +21,51 @@ This image also includes a sample Jenkins job, which triggers a new build of a `
 == Versions
 
 {product-title} follows the https://jenkins.io/changelog-stable/[LTS] releases of Jenkins.
+Currently, {product-title} provides versions 1.x and 2.x.
 
 [[jenkins-images]]
 == Images
 
-This image comes in two flavors, depending on your needs:
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/jenkins-1-rhel7
+$ docker pull registry.access.redhat.com/openshift3/jenkins-2-rhel7
+----
+
+You can use these images through the `jenkins` image stream.
+endif::[]
+
+ifndef::openshift-online[]
+These images come in two flavors, depending on your needs:
 
 * RHEL 7
 * CentOS 7
 
-*RHEL 7 Based Image*
+*RHEL 7 Based Images*
 
-The RHEL 7 image is available through Red Hat's subscription registry:
+The RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/jenkins-1-rhel7
+$ docker pull registry.access.redhat.com/openshift3/jenkins-2-rhel7
 ----
 
-*CentOS 7 Based Image*
+*CentOS 7 Based Images*
 
-This image is available on DockerHub. To download it:
+This image is available on Docker Hub:
 
 ----
 $ docker pull openshift/jenkins-1-centos7
+$ docker pull openshift/jenkins-2-centos7
 ----
 
 To use these images, you can either access them directly from these registries or push them into your {product-title} Docker registry.
 Additionally, you can create an ImageStream that points to the image, either in your Docker registry or at the external location.
 Your {product-title} resources can then reference the ImageStream.
 You can find https://github.com/openshift/origin/tree/master/examples/image-streams[example] ImageStream definitions for all the provided {product-title} images.
+endif::[]
 
 [[jenkins-configuration-and-usage]]
 == Configuration and Usage
@@ -74,16 +90,24 @@ environment variable on the Jenkins `*Deployment Config*` to anything other than
 configuration information from pod data or by interacting with the
 {product-title} API server.
 
-Valid credentials are controlled by your identity provider.
+Valid credentials are controlled by the {product-title} identity provider.
+ifndef::openshift-online[]
 For example, if `Allow All` is the default identity provider, you can provide
 any non-empty string for both the user name and password.
+endif::openshift-online[]
 
 For non-browser access, the OpenShift Login plug-in also supports using
 the HTTP bearer token authorization header to supply valid credentials for
 accessing Jenkins. Ensure to use the token associated with the
 serviceaccount for the project in which Jenkins is running, which, if you started
-Jenkins using the https://github.com/openshift/origin/blob/master/examples/jenkins/jenkins-ephemeral-template.json[jenkins-ephemeral]
-or https://github.com/openshift/origin/blob/master/examples/jenkins/jenkins-persistent-template.json[jenkins-persistent] templates, are found by using:
+Jenkins using the
+ifndef::openshift-online[]
+https://github.com/openshift/origin/blob/master/examples/jenkins/jenkins-ephemeral-template.json[jenkins-ephemeral]
+template or
+endif::[]
+https://github.com/openshift/origin/blob/master/examples/jenkins/jenkins-persistent-template.json[jenkins-persistent]
+template (see below),
+are found by using:
 
 ----
 $ oc describe serviceaccount jenkins
@@ -106,9 +130,15 @@ permissions mappings.
 ====
 The `admin` user that is pre-populated in the {product-title} Jenkins image with
 administrative privileges will not be given those privileges when
-{product-title} OAuth is used, unless the {product-title} cluster administrator
+{product-title} OAuth is
+ifdef::openshift-online[]
+used.
+endif::[]
+ifndef::openshift-online[]
+used, unless the {product-title} cluster administrator
 explicitly defines that user in the {product-title} identity provider and
 assigns the `admin` role to the user.
+endif::[]
 ====
 
 Jenkins' users permissions can be changed after the users are initially
@@ -122,42 +152,15 @@ You can control how often the polling occurs with the
 `OPENSHIFT_PERMISSIONS_POLL_INTERVAL` environment variable. The default polling
 interval is five minutes.
 
-.Creating a New Jenkins Pod
-
-. Ensure the
-ifdef::openshift-enterprise,openshift-origin[]
-xref:../../install_config/imagestreams_templates.adoc#install-config-imagestreams-templates[the default image streams and templates]
-endif::[]
-ifdef::openshift-dedicated,openshift-online[]
-default image streams and templates
-endif::[]
-are already installed.
-
-. Create a new Jenkins application using:
-.. Persistent volumes:
-----
-$ oc new-app jenkins-persistent
-----
-
-.. Or an `EmptyDir` type volume (where configuration does not persist across pod restarts):
-----
-$ oc new-app jenkins-ephemeral
-----
-
-[NOTE]
-====
-If you instantiate the template against releases prior to v3.4 of
-{product-title}, standard Jenkins authentication is used, and the default
-'admin' account will exist with password 'password'. See
-xref:../../using_images/other_images/jenkins.adoc#jenkins-jenkins-standard-authentication[Jenkins
-Standard Authentication] for details about changing this password.
-====
+The easiest way to create a new Jenkins service using OAuth authentication is to
+xref:jenkins-creating-jenkins-service-from-template[use a template] as described
+below.
 
 [[jenkins-jenkins-standard-authentication]]
 ==== Jenkins Standard Authentication
 
-Jenkins authentication is used by default if the image is run outside of
-{product-title}.
+Jenkins authentication is used by default if the image is run directly, without
+using a template.
 
 The first time Jenkins starts, the configuration is created along with the
 administrator user and password. The default user credentials are `*admin*` and
@@ -250,26 +253,85 @@ See xref:../../install_config/imagestreams_templates.adoc#install-config-imagest
 for more details, if required.
 endif::[]
 
-The two available templates both define a
-xref:../../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[deployment
+ifdef::openshift-online[]
+A template is provided that defines
+endif::[]
+ifndef::openshift-online[]
+The two available templates both define
+endif::[]
+a xref:../../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[deployment
 configuration] and a
-xref:../../architecture/core_concepts/pods_and_services.adoc#services[service],
-but differ in their storage strategy, which affects whether or not the Jenkins
-content persists across a pod restart.
+xref:../../architecture/core_concepts/pods_and_services.adoc#services[service].
+ifndef::openshift-online[]
+The templates differ in their storage strategy, which affects whether or not
+the Jenkins content persists across a pod restart.
+endif::[]
 
 [NOTE]
 ====
 A pod may be restarted when it is moved to another node, or when an update of the deployment configuration triggers a redeployment.
 ====
 
+ifndef::openshift-online[]
 * `jenkins-ephemeral` uses ephemeral storage. On pod restart, all data is lost.
 This template is useful for development or testing only.
+endif::[]
 
 * `jenkins-persistent` uses a persistent volume store. Data survives a pod
-restart. To use a persistent volume store, the cluster administrator must
+restart.
+ifndef::openshift-online[]
+To use a persistent volume store, the cluster administrator must
 define a persistent volume pool in the {product-title} deployment.
+endif::[]
 
-Once selected, you must xref:../../dev_guide/templates.adoc#dev-guide-templates[instantiate] the template to be able to use Jenkins.
+ifdef::openshift-online[]
+You
+endif:[]
+ifndef::openshift-online[]
+Once you have selected which template you want, you
+endif:[]
+must xref:../../dev_guide/templates.adoc#dev-guide-templates[instantiate] the
+template to be able to use Jenkins:
+
+.Creating a New Jenkins Service
+
+ifdef::openshift-online[]
+. Create a new Jenkins application using a persistent volume:
+----
+$ oc new-app jenkins-persistent
+----
+endif::[]
+
+ifndef::openshift-online[]
+. Ensure the
+ifdef::openshift-enterprise,openshift-origin[]
+xref:../../install_config/imagestreams_templates.adoc#install-config-imagestreams-templates[the default image streams and templates]
+endif::[]
+ifdef::openshift-dedicated[]
+default image streams and templates
+endif::[]
+are already installed.
+
+. Create a new Jenkins application using:
+.. A persistent volume:
+----
+$ oc new-app jenkins-persistent
+----
+
+.. Or an `EmptyDir` type volume (where configuration does not persist across pod restarts):
+----
+$ oc new-app jenkins-ephemeral
+----
+
+[NOTE]
+====
+If you instantiate the template against releases prior to v3.4 of
+{product-title}, standard Jenkins authentication is used, and the default
+`admin` account will exist with password `password`. See
+xref:../../using_images/other_images/jenkins.adoc#jenkins-jenkins-standard-authentication[Jenkins
+Standard Authentication] for details about changing this password.
+====
+endif::[]
 
 [[jenkins-as-s2i-builder]]
 == Using Jenkins as a Source-To-Image builder
@@ -349,27 +411,27 @@ plug-in] that allows Jenkins slaves to be dynamically provisioned on multiple
 container hosts using Kubernetes and {product-title}.
 
 To use the Kubernetes plug-in, {product-title} provides three images
-suitable for use as Jenkins slaves: the *_Base_*, *_Maven_*, and *_NodeJS_* images.
+suitable for use as Jenkins slaves: the *_Base_*, *_Maven_*, and *_Node.js_* images.
 
 The first is a https://github.com/openshift/jenkins/tree/master/slave-base[base image] for Jenkins slaves:
 
  - It pulls in both the required tools (headless Java, the Jenkins JNLP client) and the useful ones
-(including git, tar, zip, nss among others).
+(including git, tar, zip, and nss among others).
  - It establishes the JNLP slave agent as the entrypoint.
  - It includes the oc client tooling for invoking command line operations from within Jenkins jobs, and
- - It provides Dockerfiles for both Centos and RHEL images.
+ - It provides Dockerfiles for both CentOS and RHEL images.
 
-Two additional images, that extends the base image are also provided, namely:
+Two additional images that extend the base image are also provided:
 
 * https://github.com/openshift/jenkins/tree/master/slave-maven[Maven], and
-* https://github.com/openshift/jenkins/tree/master/slave-nodejs[NodeJS]
+* https://github.com/openshift/jenkins/tree/master/slave-nodejs[Node.js]
 
-Both the Maven and NodeJS slave images are configured as Kubernetes Pod Tempate images within the {product-title} Jenkins image's
+Both the Maven and Node.js slave images are configured as Kubernetes Pod Template images within the {product-title} Jenkins image's
 configuration for the Kubernetes plugin. That configuration includes labels for each of the images that can
 be applied to any of your Jenkins jobs under their "Restrict where this project can be run" setting. If the label is applied,
-execution of the given job will be done under an {product-title} Pod running the respective slave image.
+execution of the given job will be done under an {product-title} pod running the respective slave image.
 
-The Maven and NodeJS Jenkins slave images provide Dockerfiles for both Centos and RHEL that you can reference when building new slave images.
+The Maven and Node.js Jenkins slave images provide Dockerfiles for both CentOS and RHEL that you can reference when building new slave images.
 Also note the `contrib` and `contrib/bin` subdirectories. They allow for the insertion of configuration files and executable
 scripts for your image.
 
@@ -387,7 +449,7 @@ This scanning is only performed once, when the Jenkins master is starting.
 Please restart the Jenkins master if you label additional image streams(to pickup the added labels).
 ====
 
-To use a container image as an Jenkins slave, the image must run the slave agent as
+To use a container image as a Jenkins slave, the image must run the slave agent as
 an entrypoint. For more details about this, refer to the official
 https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Launchslaveagentheadlessly[Jenkins
 documentation].
@@ -408,7 +470,7 @@ the {product-title} server and the API artifacts hosted there.
 
 In addition to being accessible from the classic "freestyle" form of Jenkins
 job, the build steps as of version 1.0.14 of the {product-title} Pipeline
-Plug-in are also avaible to Jenkins Pipeline jobs via the DSL extension points
+Plug-in are also available to Jenkins Pipeline jobs via the DSL extension points
 provided by the Jenkins Pipeline Plug-in. The https://github.com/openshift/origin/blob/master/examples/jenkins/pipeline/samplepipeline.json[OpenShift Jenkins Pipeline build strategy sample]
 illustrates how to use the OpenShift Pipeline plugin DSL versions of its steps.
 
@@ -427,11 +489,11 @@ The experiences gained working with users of the OpenShift Pipeline plug-in, cou
 and OpenShift, have provided valuable insight into how to integrate {product-title} from Jenkins jobs.
 
 As such, the new experimental link:https://github.com/openshift/jenkins-client-plugin[OpenShift Client Plug-in for Jenkins]
-is now offered as a technical preview and is included in the OpenShift Jenkins images on Centos (*docker.io/openshift/jenkins-1-centos7:latest*
+is now offered as a technical preview and is included in the OpenShift Jenkins images on CentOS (*docker.io/openshift/jenkins-1-centos7:latest*
 and *docker.io/openshift/jenkins-2-centos7:latest*). The plug-in is also available from the Jenkins Update Center.  The OpenShift Client plug-in
 will eventually replace the OpenShift Pipeline plug-in as the tool for OpenShift integration from Jenkins jobs. The OpenShift Client Plug-in provides:
 
-- A Fluent-sytled syntax for use in Jenkins Pipelines
+- A Fluent-style syntax for use in Jenkins Pipelines
 - Use of and exposure to any option available with `oc`
 - Integration with Jenkins credentials and clusters
 - Continued support for classic Jenkins Freestyle jobs


### PR DESCRIPTION
• Move the commands to use templates from the "Configuration and Usage" section to the "Creating a Jenkins Service from a Template" section, and a reference from the former section to the later.  (This change is in a separate commit to ease reviewing.)

• Update the lists of versions and images to mention Jenkins 2.x.

• For Online, only mention the rhel7 images, and tell the user to use the
  "jenkins" image stream.

• Change "Red Hat's subscription registry" to "the Red Hat Registry".

• Change "DockerHub" to "Docker Hub".

• Change "your identity provider" to "the {product-title} identity provider", and conditionalize the examples involving the "Allow All" identity provider, which is not used for Online, or custom configuration to the identity provider.

• Conditionalize description of the templates to show only jenkins-persistent, and not jenkins-ephemeral, for Online.

• Note that standard authentication is used by default if the image is run without using a template (not only if run outside the cluster).

• Change "Persistent volumes" to "A persistent volume" (the template only claims one persistent volume).

• Change "Centos" to "CentOS".

• Change "NodeJS" to "Node.js".

• Other minor spelling, grammar, punctuation, and capitalization corrections.