### PR TITLE
Fix S2I MongoDB documentation for Online

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -22,14 +22,8 @@ https://github.com/openshift/mongodb/tree/master/2.4[2.4], https://github.com/op
 
 == Images
 
-These images come in two flavors, depending on your needs:
-
-* RHEL 7
-* CentOS 7
-
-*RHEL 7 Based Image*
-
-The RHEL 7 images are available through Red Hat's subscription registry via:
+ifdef::openshift-online[]
+RHEL 7 images are available through the Red Hat Registry:
 
 ----
 $ docker pull registry.access.redhat.com/openshift3/mongodb-24-rhel7
@@ -37,9 +31,28 @@ $ docker pull registry.access.redhat.com/rhscl/mongodb-26-rhel7
 $ docker pull registry.access.redhat.com/rhscl/mongodb-32-rhel7
 ----
 
-*CentOS 7 Based Image*
+You can use these images through the `mongodb` image stream.
+endif::[]
 
-These images are available on DockerHub. To download them:
+ifndef::openshift-online[]
+These images come in two flavors, depending on your needs:
+
+* RHEL 7
+* CentOS 7
+
+*RHEL 7 Based Images*
+
+The RHEL 7 images are available through the Red Hat Registry:
+
+----
+$ docker pull registry.access.redhat.com/openshift3/mongodb-24-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mongodb-26-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mongodb-32-rhel7
+----
+
+*CentOS 7 Based Images*
+
+These images are available on Docker Hub:
 
 ----
 $ docker pull openshift/mongodb-24-centos7
@@ -54,19 +67,21 @@ either in your Docker registry or at the external location. Your {product-title}
 resources can then reference the ImageStream. You can find
 https://github.com/openshift/origin/tree/master/examples/image-streams[example]
 ImageStream definitions for all the provided {product-title} images.
+endif::[]
 
 == Configuration and Usage
 
 === Initializing the Database
 
-The first time you use the shared volume, the database is created along with the
+You can configure MongoDB with an ephemeral volume or a persistent volume.
+The first time you use the volume, the database is created along with the
 database administrator user. Afterwards, the MongoDB daemon starts up. If you
 are re-attaching the volume to another container, then the database, database
 user, and the administrator user are not created, and the MongoDB daemon starts.
 
 The following command creates a new database
 xref:../../architecture/core_concepts/pods_and_services.adoc#pods[pod] with
-MongoDB running in a container:
+MongoDB running in a container with an ephemeral volume:
 
 ----
 $ oc new-app \
@@ -74,11 +89,14 @@ $ oc new-app \
     -e MONGODB_PASSWORD=<password> \
     -e MONGODB_DATABASE=<database_name> \
     -e MONGODB_ADMIN_PASSWORD=<admin_password> \
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
     registry.access.redhat.com/rhscl/mongodb-26-rhel7
 endif::[]
 ifdef::openshift-origin[]
     centos/mongodb-26-centos7
+endif::[]
+ifdef::openshift-online[]
+    mongodb:2.6
 endif::[]
 ----
 
@@ -303,6 +321,10 @@ See xref:../../install_config/imagestreams_templates.adoc#install-config-imagest
 for more details, if required.
 endif::[]
 
+ifdef::openshift-online[]
+The following template is available:
+endif::[]
+ifndef::openshift-online[]
 There are two templates available:
 
 * `mongodb-ephemeral` is for development/testing purposes only because it uses
@@ -310,9 +332,13 @@ ephemeral storage for the database content. This means that if the database
 pod is restarted for any reason, such as the pod being moved to another node
 or the deployment configuration being updated and triggering a redeploy, all
 data will be lost.
+endif::[]
 * `mongodb-persistent` uses a persistent volume store for the database data
-which means the data will survive a pod restart. Using persistent volumes
-requires a persistent volume pool be defined in the {product-title} deployment.
+which means the data will survive a pod restart.
+ifndef::openshift-online[]
+Using persistent volumes requires a persistent volume pool be defined in the
+{product-title} deployment.
+endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 Cluster administrator instructions for setting up the pool are located
 xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[here].


### PR DESCRIPTION
• For Online, only mention the rhel7 images, and tell the user to use the "mongodb" image stream.

• Change "Red Hat's subscription registry" to "the Red Hat Registry".

• Change "DockerHub" to "Docker Hub".

• Reword the description of the image's initialization to mention volumes before referring to "the" volume, and change "shared volume" to just "volume".

• Fix the `oc new-app` command for Online and Dedicated.

• Conditionalize the description of the templates to show only the "mongodb-persistent" template, and hide the "mongodb-ephemeral" template, for Online.

• For Online, omit mention of initializing persistent volume pools.

---

FYI @ahardin-rh.