### PR TITLE
Remove Docker and Custom build strategies from the docs

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -146,11 +146,12 @@ source:
 <5> The location of the file to be copied out of the referenced image.
 <6> An optional secret provided if credentials are needed to access the input image.
 
+ifndef::openshift-online[]
 [NOTE]
 ====
 This feature is not supported for builds using the xref:using-secrets-custom-strategy[Custom Strategy].
 ====
-
+endif:[]
 
 [[source-code]]
 == Git Source
@@ -705,6 +706,7 @@ script. This means that the secret files will exist in the resulting image, but
 they will be empty for security reasons.
 ====
 
+ifndef::openshift-online[]
 [[using-secrets-docker-strategy]]
 === Docker Strategy
 
@@ -745,6 +747,7 @@ differently, based on your build use case.
 The inpout secrets are always mounted into the
 *_/var/run/secrets/openshift.io/build_* directory or your builder can parse the
 `$BUILD` environment variable, which includes the full build object.
+endif:[]
 
 [[using-external-artifacts]]
 == Using External Artifacts

--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -188,6 +188,7 @@ console], set the *Source Secret*.
 Enable pulling to a private registry by setting the `Pull Secret` in the build
 configuration and enable pushing by setting the `Push Secret`.
 
+ifndef::openshift-online[]
 [[docker-strategy-options]]
 == Docker Strategy Options
 
@@ -493,6 +494,7 @@ endif::[]
 
 You can also manage environment variables defined in the `BuildConfig` with the
 xref:../../dev_guide/environment_variables.adoc#dev-guide-environment-variables[`oc set env`] command.
+endif:[]
 
 [[pipeline-strategy-options]]
 == Pipeline Strategy Options

--- a/dev_guide/builds/index.adoc
+++ b/dev_guide/builds/index.adoc
@@ -24,20 +24,22 @@ A _build configuration_, or `BuildConfig`, is characterized by a _build strategy
 or more sources. The strategy determines the aforementioned process, while the
 sources provide its input.
 
-There are four build strategies:
+The build strategies are:
 
 - Source-to-Image (S2I)
 (xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[description],
 xref:build_strategies.adoc#source-to-image-strategy-options[options])
-- Docker
-(xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[description],
-xref:build_strategies.adoc#docker-strategy-options[options])
 - Pipeline
 (xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[description],
 xref:build_strategies.adoc#pipeline-strategy-options[options])
+ifndef::openshift-online[]
+- Docker
+(xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[description],
+xref:build_strategies.adoc#docker-strategy-options[options])
 - Custom
 (xref:../../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[description],
 xref:build_strategies.adoc#custom-strategy-options[options])
+endif:[]
 
 And there are six types of sources that can be given as
 xref:build_inputs.adoc#dev-guide-build-inputs[_build input_]:


### PR DESCRIPTION
OpenShift Online doesn't allow Docker and Custom build strategies
at the moment so the docs shouldn't reference to those information.

Signed-off-by: Vu Dinh <vdinh@redhat.com>