### PR TITLE
architecture/additional_concepts/authorization: rewording

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -606,21 +606,27 @@ These examples are in the context of a strategy using the preallocated values.
 *A FSGroup SCC Strategy of MustRunAs*
 
 If the pod defines a `*fsGroup*` ID, then that ID must equal the default
-`*FSGroup*` ID. Otherwise, the pod is not validated by that SCC and the next SCC
-is evaluated. If the `*FSGroup*` strategy is *RunAsAny* and the pod omits a
-`*fsGroup*` ID, then the pod matches the SCC based on `*FSGroup*` (though other
-strategies may not validate and thus cause the pod to fail).
+`*fsGroup*` ID. Otherwise, the pod is not validated by that SCC and the next SCC
+is evaluated.
+
+If the `*SecurityContextConstraints.fsGroup*` field has value *RunAsAny*
+and the pod specification omits the `*Pod.spec.securityContext.fsGroup*`,
+then this field is considered valid. Note that it is possible that during
+validation, other SCC settings will reject other pod fields and thus cause the
+pod to fail.
 
 *A SupplementalGroups SCC Strategy of MustRunAs*
 
-If the pod specification defines one or more `*SupplementalGroups*` IDs, then
+If the pod specification defines one or more `*supplementalGroups*` IDs, then
 the pod's IDs must equal one of the IDs in the namespace's
 *openshift.io/sa.scc.supplemental-groups* annotation. Otherwise, the pod is not
-validated by that SCC and the next SCC is evaluated. If the
-`*SupplementalGroups*` setting is *RunAsAny* and the pod specification omits a
-`*SupplementalGroups*` ID, then the pod matches the SCC based on
-`*SupplementalGroups*` (though other strategies may not validate and thus cause
-the pod to fail).
+validated by that SCC and the next SCC is evaluated.
+
+If the `*SecurityContextConstraints.supplementalGroups*` field has value *RunAsAny*
+and the pod specification omits the `*Pod.spec.securityContext.supplementalGroups*`,
+then this field is considered valid. Note that it is possible that during
+validation, other SCC settings will reject other pod fields and thus cause the
+pod to fail.
 
 [[scc-prioritization]]
 ==== SCC Prioritization


### PR DESCRIPTION
The sentence

> If the **SupplementalGroups** setting is *RunAsAny* and the pod specification omits a **SupplementalGroups** ID, then the pod matches the SCC based on **SupplementalGroups** (though other strategies may not validate and thus cause the pod to fail).

wasn't cleat to me so I tried to improve it. Now I can understand it from the first time although it more verbose.

PTAL @pweil- 
CC @mfojtik 