### PR TITLE
Removing several pages from Online per content audit

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -747,6 +747,7 @@ Topics:
     File: configmaps
   - Name: Using Daemonsets
     File: daemonsets
+    Distros: openshift-enterprise,openshift-dedicated,openshift-origin
   - Name: Pod Autoscaling
     File: pod_autoscaling
   - Name: Managing Volumes
@@ -780,8 +781,10 @@ Topics:
     File: environment_variables
   - Name: Jobs
     File: jobs
+    Distros: openshift-enterprise,openshift-dedicated,openshift-origin
   - Name: Cron Jobs
     File: cron_jobs
+    Distros: openshift-enterprise,openshift-dedicated,openshift-origin
   - Name: Create from URL
     File: create_from_url
   - Name: Revision History
@@ -805,6 +808,7 @@ Topics:
     File: s2i_testing
   - Name: Custom Builder
     File: custom
+    Distros: openshift-enterprise,openshift-dedicated,openshift-origin
   - Name: Revision History
     File: revhistory_creating_images
     Distros: openshift-enterprise,openshift-dedicated


### PR DESCRIPTION
@tiwillia This removes the pages that are identified as not-applicable to Online in the content audit conducted by the Online team.

@aheslin FYI