### PR TITLE
Mark masters as schedulable when they're infra

### DIFF
--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -170,7 +170,7 @@ when adding a new node:
 ====
 ----
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 
@@ -235,7 +235,7 @@ adding new nodes:
 ====
 ----
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 node3.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -507,7 +507,7 @@ environment has the 'region=infra' label.
 ====
 
 [[marking-masters-as-unschedulable-nodes]]
-=== Marking Masters as Unschedulable Nodes
+=== Marking Masters as Schedulable Nodes
 
 Any hosts you designate as masters during the installation process should also
 be configured as nodes by adding them to the *[nodes]* section so that the
@@ -516,14 +516,16 @@ xref:../../architecture/additional_concepts/networking.adoc#openshift-sdn[{produ
 SDN].
 
 However, in order to ensure that your masters are not burdened with running
-pods, you can make them
+pods, they are by default marked unschedulable.
 xref:../../admin_guide/manage_nodes.adoc#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
-by adding the `*openshift_schedulable=false*` option any node that is also a
-master. For example:
+
+The examples in this document use masters as 'infra' nodes and have been marked
+schedulable ensuring the router and registry are deployed properly. In a production
+environment you should have dedicated infra nodes. For example:
 
 ----
 [nodes]
-master.example.com openshift_node_labels="{'region':'infra','zone':'default'}" openshift_schedulable=false
+master.example.com openshift_node_labels="{'region':'infra','zone':'default'}" openshift_schedulable=true
 ----
 
 [[advanced-install-session-options]]
@@ -847,7 +849,7 @@ master.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
@@ -929,7 +931,7 @@ etcd3.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
@@ -1112,7 +1114,7 @@ lb.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
@@ -1205,7 +1207,7 @@ lb.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----

--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -248,7 +248,7 @@ lb.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----


### PR DESCRIPTION
Somewhere along the way the installer started marking masters as
unschedulable by default but the documentation was not updated to
reflect that. Since all of our examples use the masters as infra nodes
this means that the router and registry won't deploy properly so mark
them as schedulable. We may want to simply move to listing dedicated
infra nodes to simplify this.