### PR TITLE
Document that custom builds are disabled by default

### DIFF
--- a/admin_guide/securing_builds.adoc
+++ b/admin_guide/securing_builds.adoc
@@ -22,12 +22,14 @@ xref:../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[Cu
 builds] are inherently less safe than
 xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source
 builds], given that they can execute any code in the build with potentially full
-access to the node's Docker socket.  xref:../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker
+access to the node's Docker socket, and as such are disabled by default.  xref:../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker
 build] permission should also be granted with caution as a vulnerability in the Docker build
 logic could result in a privileges being granted on the host node.
 
-By default, all users that can create builds are granted permission to use all
-build strategies (Docker, Source-to-Image, and Custom).
+By default, all users that can create builds are granted permission to use the
+Docker and Source-to-Image build strategies. Users with xref:../architecture/additional_concepts/authorization.adoc#roles[*cluster-admin*]
+privileges can enable the Custom build strategy, as referenced in the xref:restricting-build-strategies-to-a-user-globally[Restricting Build Strategies to a User Globally]
+section of this page.
 
 You can control who can build with what build strategy using an
 xref:../architecture/additional_concepts/authorization.adoc#architecture-additional-concepts-authorization[authorization


### PR DESCRIPTION
Update documentation to reflect that custom builds are disabled by default.

Closes https://github.com/openshift/openshift-docs/issues/4081