### PR TITLE
Better explanation of region=infra + mark infra masters schedulable

### DIFF
--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -74,7 +74,6 @@ unattended mode:
 
 . The installer detects your current environment and allows you to add additional nodes:
 +
-====
 ----
 *** Installation Summary ***
 
@@ -98,7 +97,6 @@ nodes to your cluster.
 
 Are you ready to continue? [y/N]:
 ----
-====
 +
 Choose (y) and follow the on-screen instructions to complete your desired task.
 
@@ -152,14 +150,12 @@ package:
 +
 For example, to add a new node host, add *new_nodes*:
 +
-====
 ----
 [OSEv3:children]
 masters
 nodes
 new_nodes
 ----
-====
 +
 To add new master hosts, add *new_masters*.
 
@@ -167,28 +163,26 @@ To add new master hosts, add *new_masters*.
 specifying host information for any new hosts you want to add. For example,
 when adding a new node:
 +
-====
 ----
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 
 [new_nodes]
 node3.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----
-====
 +
 See
 xref:../install_config/install/advanced_install.adoc#advanced-host-variables[Configuring
 Host Variables] for more options.
 +
 When adding new masters, hosts added to the *[new_masters]* section must also be
-added to the *[new_nodes]* section with the `*openshift_schedulable=false*`
-variable. This ensures the new master host is part of the OpenShift SDN and that
-pods are not scheduled for placement on them. For example:
+added to the *[new_nodes]* section. This ensures the new master host is part of
+the OpenShift SDN.
 +
-====
 ----
 [masters]
 master[1:2].example.com
@@ -197,12 +191,25 @@ master[1:2].example.com
 master3.example.com
 
 [nodes]
-node[1:3].example.com openshift_node_labels="{'region': 'infra'}"
-master[1:2].example.com openshift_schedulable=false
+master[1:2].example.com
+node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
+node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 
 [new_nodes]
-master3.example.com openshift_schedulable=false
+master3.example.com
 ----
++
+Masters are also automatically marked as unschedulable for pod placement by the
+installer.
++
+[IMPORTANT]
+====
+If you label a master host with the `region=infra` label and have no other
+dedicated infrastructure nodes, you must also explicitly mark the host as
+schedulable by adding `openshift_schedulable=true` to the entry. Otherwise, the
+registry and router pods cannot be placed anywhere.
 ====
 
 . Run the *_scaleup.yml_* playbook. If your inventory file is located somewhere
@@ -232,14 +239,14 @@ definition itself in place) so that subsequent runs using this inventory file
 are aware of the nodes but do not handle them as new nodes. For example, when
 adding new nodes:
 +
-====
 ----
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 node3.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 
 [new_nodes]
 ----
-====

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -171,6 +171,10 @@ xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 options used in xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs].
 Example usage: *"--log-driver json-file --log-opt max-size=1M --log-opt max-file=3"*.
 
+|`openshift_schedulable`
+|This variable configures whether the host is marked as a schedulable node,
+meaning that it is available for placement of new pods. See
+xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Masters].
 |===
 
 [[configuring-cluster-variables]]
@@ -460,6 +464,36 @@ value; you only need to set this if you want your `git clone` operations to use
 a different value.
 |===
 
+
+[[marking-masters-as-unschedulable-nodes]]
+=== Configuring Schedulability on Masters
+
+Any hosts you designate as masters during the installation process should also
+be configured as nodes so that the masters are configured as part of the
+xref:../../architecture/additional_concepts/networking.adoc#openshift-sdn[OpenShift SDN]. You must do so by adding entries for these hosts to the `[nodes]` section:
+
+----
+[nodes]
+master.example.com
+----
+
+In order to ensure that your masters are not burdened with running pods, they
+are automatically marked unschedulable by default by the installer, meaning that
+new pods cannot be placed on the hosts. This is the same as setting the
+`openshift_schedulable=false` host variable.
+
+You can manually set a master host to schedulable during installation using the
+`openshift_schedulable=true` host variable, though this is not recommended in
+production environments:
+
+----
+[nodes]
+master.example.com openshift_schedulable=true
+----
+
+If you want to change the schedulability of a host post-installation, see
+xref:../../admin_guide/manage_nodes.adoc#marking-nodes-as-unschedulable-or-schedulable[Marking Nodes as Unschedulable or Schedulable].
+
 [[configuring-node-host-labels]]
 === Configuring Node Host Labels
 
@@ -468,22 +502,26 @@ xref:../../architecture/core_concepts/pods_and_services.adoc#labels[labels] to
 node hosts during the Ansible install by configuring the *_/etc/ansible/hosts_*
 file. Labels are useful for determining the placement of pods onto nodes using
 the xref:../../admin_guide/scheduler.adoc#configurable-predicates[scheduler].
-Other than *region=infra* (discussed below), the actual label names and values
-are arbitrary and can be assigned however you see fit per your cluster's
-requirements.
+Other than `region=infra` (discussed in
+xref:configuring-dedicated-infrastructure-nodes[Configuring Dedicated Infrastructure Nodes]), the actual label names and values are arbitrary and can
+be assigned however you see fit per your cluster's requirements.
 
 To assign labels to a node host during an Ansible install, use the
-`*openshift_node_labels*` variable with the desired labels added to the desired
-node host entry in the *[nodes]* section. In the following example, labels are
-set for a region called *primary* and a zone called *east*:
+`openshift_node_labels` variable with the desired labels added to the desired
+node host entry in the `[nodes]` section. In the following example, labels are
+set for a region called `primary` and a zone called `east`:
 
 ----
 [nodes]
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 ----
 
-The `*openshift_router_selector*` and `*openshift_registry_selector*` Ansible
-settings are set to *region=infra* by default:
+[[configuring-dedicated-infrastructure-nodes]]
+==== Configuring Dedicated Infrastructure Nodes
+
+The `openshift_router_selector` and `openshift_registry_selector` Ansible
+settings determine the label selectors used when placing registry and router
+pods. They are set to `region=infra` by default:
 
 ----
 # default selectors for router and registry services
@@ -491,39 +529,35 @@ settings are set to *region=infra* by default:
 # openshift_registry_selector='region=infra'
 ----
 
-The default router and registry will be automatically deployed if nodes exist
-that match the selector settings above. For example:
+The default router and registry will be automatically deployed during
+installation if nodes exist in the `[nodes]` section that match the selector
+settings. For example:
 
 ----
 [nodes]
-node1.example.com openshift_node_labels="{'region':'infra','zone':'default'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra','zone': 'default'}"
 ----
 
 [IMPORTANT]
 ====
 The registry and router are only able to run on node hosts with the
-'region=infra' label. Ensure that at least one node host in your {product-title}
-environment has the 'region=infra' label.
+`region=infra` label. Ensure that at least one node host in your {product-title}
+environment has the `region=infra` label.
 ====
 
-[[marking-masters-as-unschedulable-nodes]]
-=== Marking Masters as Unschedulable Nodes
+It is recommended for production environments that you maintain dedicated
+infrastructure nodes where the registry and router pods can run separately from
+pods used for user applications.
 
-Any hosts you designate as masters during the installation process should also
-be configured as nodes by adding them to the *[nodes]* section so that the
-masters are configured as part of the
-xref:../../architecture/additional_concepts/networking.adoc#openshift-sdn[{product-title}
-SDN].
-
-However, in order to ensure that your masters are not burdened with running
-pods, you can make them
-xref:../../admin_guide/manage_nodes.adoc#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
-by adding the `*openshift_schedulable=false*` option any node that is also a
-master. For example:
+As described in xref:marking-masters-as-unschedulable-nodes[Configuring
+Schedulability on Masters], master hosts are marked unschedulable by default. If
+you label a master host with `region=infra` and have no other dedicated
+infrastructure nodes, you must also explicitly mark these master hosts as
+schedulable. Otherwise, the registry and router pods cannot be placed anywhere:
 
 ----
 [nodes]
-master.example.com openshift_node_labels="{'region':'infra','zone':'default'}" openshift_schedulable=false
+master.example.com openshift_node_labels="{'region': 'infra','zone': 'default'}" openshift_schedulable=true
 ----
 
 [[advanced-install-session-options]]
@@ -847,9 +881,11 @@ master.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master.example.com
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 ----
 
 To use this example, modify the file to match your environment and
@@ -929,9 +965,11 @@ etcd3.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master.example.com
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 ----
 
 To use this example, modify the file to match your environment and
@@ -1112,9 +1150,11 @@ lb.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 ----
 ====
 
@@ -1205,9 +1245,11 @@ lb.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
+infra-node1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 ----
 ====
 

--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -179,7 +179,7 @@ registry.example.com
 
 # host group for nodes, includes region info
 [nodes]
-registry.example.com openshift_schedulable=true openshift_node_labels="{'region': 'infra', 'zone': 'default'}" <2>
+registry.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true <2>
 ----
 <1> Set `*deployment_subtype=registry*` to ensure installation of the stand-alone
 registry.
@@ -248,7 +248,7 @@ lb.example.com
 
 # host group for nodes, includes region info
 [nodes]
-master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+master[1:3].example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
 node1.example.com openshift_node_labels="{'region': 'primary', 'zone': 'east'}"
 node2.example.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 ----


### PR DESCRIPTION
@sdodson @gabemontero PTAL. This builds on https://github.com/openshift/openshift-docs/pull/4292 and adds more explicit recommendations about using dedicated infra nodes instead of letting masters be infra. It removes `region=infra` from any of the master entries throughout the docs, and instead adds 2 infra node entries in their place.

Preview of updated sections:

- [Configuring Schedulability on Masters](http://file.rdu.redhat.com/~adellape/050217/masters-are-unschedulable-by-default/install_config/install/advanced_install.html#marking-masters-as-unschedulable-nodes)
- [Configuring Node Host Labels
](http://file.rdu.redhat.com/~adellape/050217/masters-are-unschedulable-by-default/install_config/install/advanced_install.html#configuring-node-host-labels)

@openshift/team-documentation PTAL for peer review.