### PR TITLE
Adjust adv_install toc + edits

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 == Overview
 A reference configuration implemented using
-http://www.ansible.com[Ansible] playbooks is available as the _advanced
+link:http://docs.ansible.com/ansible/[Ansible] playbooks is available as the _advanced
 installation_ method for installing a {product-title} cluster. Familiarity with Ansible is
 assumed, however you can use this configuration as a reference to create your
 own implementation using the configuration management tool of your choosing.
@@ -56,126 +56,41 @@ Ansible.
 
 If you are interested in installing {product-title} using the containerized method
 (optional for RHEL but required for RHEL Atomic Host), see
-xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[Installing on
-Containerized Hosts] to ensure that you understand the differences between these
+xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[Installing on Containerized Hosts] to ensure that you understand the differences between these
 methods, then return to this topic to continue.
 
 For large-scale installs, including suggestions for optimizing install time,
 see the
-xref:../../scaling_performance/install_practices.adoc#scaling-performance-install-best-practices[Scaling
-and Performance Guide].
+xref:../../scaling_performance/install_practices.adoc#scaling-performance-install-best-practices[Scaling and Performance Guide].
 
 After following the instructions in the
 xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites] topic and
 deciding between the RPM and containerized methods, you can continue in this
-topic to xref:configuring-ansible[Configuring Ansible].
+topic to xref:configuring-ansible[Configuring Ansible Inventory Files].
 
 [[configuring-ansible]]
+== Configuring Ansible Inventory Files
 
-== Configuring Ansible
-
-The *_/etc/ansible/hosts_* file is Ansible's inventory file for the playbook to
-use during the installation. The inventory file describes the configuration for
-your {product-title} cluster. You must replace the default contents of the file
-with your desired configuration.
+The *_/etc/ansible/hosts_* file is Ansible's inventory file for the playbook
+used to install {product-title}. The inventory file describes the configuration
+for your {product-title} cluster. You must replace the default contents of the
+file with your desired configuration.
 
 The following sections describe commonly-used variables to set in your inventory
-file during an advanced installation, followed by example inventory files you
-can use as a starting point for your installation. The examples describe various
-environment topographies, including xref:multiple-masters[using multiple
-masters for high availability]. You can choose an example that matches your
-requirements, modify it to match your own environment, and use it as your
-inventory file when xref:running-the-advanced-installation[running the advanced
-installation].
+file during an advanced installation, followed by
+xref:adv-install-example-inventory-fiies[example inventory files] you can use as
+a starting point for your installation.
 
-[[configuring-host-variables]]
-=== Configuring Host Variables
+Many of the Ansible variables described are optional. Accepting the default
+values should suffice for development environments, but for production
+environments it is recommended you read through and become familiar with the
+various options available.
 
-To assign environment variables to hosts during the Ansible installation, indicate
-the desired variables in the *_/etc/ansible/hosts_* file after the host entry in
-the *[masters]* or *[nodes]* sections. For example:
-
-----
-[masters]
-ec2-52-6-179-239.compute-1.amazonaws.com openshift_public_hostname=ose3-master.public.example.com
-----
-
-The following table describes variables for use with the Ansible installer that
-can be assigned to individual host entries:
-
-[[advanced-host-variables]]
-.Host Variables
-[options="header"]
-|===
-
-|Variable |Purpose
-
-|`*openshift_hostname*`
-|This variable overrides the internal cluster host name for the system. Use this
-when the system's default IP address does not resolve to the system host name.
-
-|`*openshift_public_hostname*`
-|This variable overrides the system's public host name. Use this for cloud
-installations, or for hosts on networks using a network address translation
-(NAT).
-
-|`*openshift_ip*`
-|This variable overrides the cluster internal IP address for the system. Use
-this when using an interface that is not configured with the default route.
-
-|`*openshift_public_ip*`
-|This variable overrides the system's public IP address. Use this for cloud
-installations, or for hosts on networks using a network address translation
-(NAT).
-
-|`*containerized*`
-|If set to *true*, containerized {product-title} services are run on the target master and
-node hosts instead of installed using RPM packages. If set to *false* or unset,
-the default RPM method is used. RHEL Atomic Host requires the containerized
-method, and is automatically selected for you based on the detection of the
-*_/run/ostree-booted_* file. See
-xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[Installing on
-Containerized Hosts] for more details.
-ifdef::openshift-enterprise[]
-Containerized installations are supported starting in {product-title} 3.1.1.
-endif::[]
-
-|`*openshift_node_labels*`
-|This variable adds labels to nodes during installation. See
-xref:configuring-node-host-labels[Configuring Node Host Labels] for more
-details.
-
-|`*openshift_node_kubelet_args*`
-|This variable is used to configure `kubeletArguments` on nodes, such as
-arguments used in xref:../../admin_guide/garbage_collection.adoc#admin-guide-garbage-collection[container and
-image garbage collection], and to
-xref:../../admin_guide/manage_nodes.adoc#configuring-node-resources[specify
-resources per node]. `kubeletArguments` are key value pairs that are passed
-directly to the Kubelet that match the
-http://kubernetes.io/v1.1/docs/admin/kubelet.html[Kubelet's command line
-arguments]. `kubeletArguments` are not migrated or validated and may become
-invalid if used. These values override other settings in node configuration
-which may cause invalid configurations. Example usage:
-*{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
-
-|`*openshift_hosted_router_selector*`
-|Default node selector for automatically deploying router pods. See
-xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
-
-|`*openshift_registry_selector*`
-|Default node selector for automatically deploying registry pods. See
-xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
-
-|`*openshift_docker_options*`
-|This variable configures additional Docker options within *_/etc/sysconfig/docker_*, such as
-options used in xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs].
-Example usage: *"--log-driver json-file --log-opt max-size=1M --log-opt max-file=3"*.
-
-|`openshift_schedulable`
-|This variable configures whether the host is marked as a schedulable node,
-meaning that it is available for placement of new pods. See
-xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Masters].
-|===
+The example inventories describe various environment topographies, including
+xref:multiple-masters[using multiple masters for high availability]. You can
+choose an example that matches your requirements, modify it to match your own
+environment, and use it as your inventory file when
+xref:running-the-advanced-installation[running the advanced installation].
 
 [[configuring-cluster-variables]]
 === Configuring Cluster Variables
@@ -355,8 +270,123 @@ configuration.
 |`*openshift_hosted_metrics_public_url*`
 |This variable sets the host name for integration with the metrics console. The
 default is
-`*https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics*`
+`\https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics`
 If you alter this variable, ensure the host name is accessible via your router.
+|===
+
+[[advanced-install-deployment-types]]
+=== Configuring Deployment Type
+
+Various defaults used throughout the playbooks and roles used by the installer
+are based on the deployment type configuration (usually defined in an Ansible
+inventory file).
+
+ifdef::openshift-enterprise[]
+Ensure the `deployment_type` parameter in your inventory file's `[OSEv3:vars]`
+section is set to `openshift-enterprise` to install the {product-title} variant:
+
+----
+[OSEv3:vars]
+openshift_deployment_type=openshift-enterprise
+----
+endif::[]
+ifdef::openshift-origin[]
+Ensure the `deployment_type` parameter in your inventory file's `[OSEv3:vars]`
+section is set to `origin` to install the {product-title} variant:
+
+----
+[OSEv3:vars]
+openshift_deployment_type=origin
+----
+endif::[]
+
+
+[[configuring-host-variables]]
+=== Configuring Host Variables
+
+To assign environment variables to hosts during the Ansible installation, indicate
+the desired variables in the *_/etc/ansible/hosts_* file after the host entry in
+the *[masters]* or *[nodes]* sections. For example:
+
+----
+[masters]
+ec2-52-6-179-239.compute-1.amazonaws.com openshift_public_hostname=ose3-master.public.example.com
+----
+
+The following table describes variables for use with the Ansible installer that
+can be assigned to individual host entries:
+
+[[advanced-host-variables]]
+.Host Variables
+[options="header"]
+|===
+
+|Variable |Purpose
+
+|`*openshift_hostname*`
+|This variable overrides the internal cluster host name for the system. Use this
+when the system's default IP address does not resolve to the system host name.
+
+|`*openshift_public_hostname*`
+|This variable overrides the system's public host name. Use this for cloud
+installations, or for hosts on networks using a network address translation
+(NAT).
+
+|`*openshift_ip*`
+|This variable overrides the cluster internal IP address for the system. Use
+this when using an interface that is not configured with the default route.
+
+|`*openshift_public_ip*`
+|This variable overrides the system's public IP address. Use this for cloud
+installations, or for hosts on networks using a network address translation
+(NAT).
+
+|`*containerized*`
+|If set to *true*, containerized {product-title} services are run on the target master and
+node hosts instead of installed using RPM packages. If set to *false* or unset,
+the default RPM method is used. RHEL Atomic Host requires the containerized
+method, and is automatically selected for you based on the detection of the
+*_/run/ostree-booted_* file. See
+xref:../../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[Installing on Containerized Hosts] for more details.
+ifdef::openshift-enterprise[]
+Containerized installations are supported starting in {product-title} 3.1.1.
+endif::[]
+
+|`*openshift_node_labels*`
+|This variable adds labels to nodes during installation. See
+xref:configuring-node-host-labels[Configuring Node Host Labels] for more
+details.
+
+|`*openshift_node_kubelet_args*`
+|This variable is used to configure `kubeletArguments` on nodes, such as
+arguments used in xref:../../admin_guide/garbage_collection.adoc#admin-guide-garbage-collection[container and
+image garbage collection], and to
+xref:../../admin_guide/manage_nodes.adoc#configuring-node-resources[specify
+resources per node]. `kubeletArguments` are key value pairs that are passed
+directly to the Kubelet that match the
+http://kubernetes.io/v1.1/docs/admin/kubelet.html[Kubelet's command line
+arguments]. `kubeletArguments` are not migrated or validated and may become
+invalid if used. These values override other settings in node configuration
+which may cause invalid configurations. Example usage:
+*{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
+
+|`*openshift_hosted_router_selector*`
+|Default node selector for automatically deploying router pods. See
+xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
+
+|`*openshift_registry_selector*`
+|Default node selector for automatically deploying registry pods. See
+xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
+
+|`*openshift_docker_options*`
+|This variable configures additional Docker options within *_/etc/sysconfig/docker_*, such as
+options used in xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs].
+Example usage: *"--log-driver json-file --log-opt max-size=1M --log-opt max-file=3"*.
+
+|`openshift_schedulable`
+|This variable configures whether the host is marked as a schedulable node,
+meaning that it is available for placement of new pods. See
+xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Masters].
 |===
 
 [[advanced-install-configuring-registry-location]]
@@ -665,24 +695,8 @@ openshift_master_named_certificates=[{"certfile": "/root/STAR.openshift.com.crt"
 openshift_master_overwrite_named_certificates=true
 ----
 
-[[advanced-install-deployment-types]]
-=== Configuring Deployment Type
-
-Various defaults used throughout the playbooks and roles in this repository are
-set based on the deployment type configuration (usually defined in an Ansible
-hosts file).
-
-ifdef::openshift-enterprise[]
-Ensure the `deployment_type` parameter in your inventory file is set to
-`openshift-enterprise`.
-endif::[]
-ifdef::openshift-origin[]
-Ensure the `deployment_type` parameter in your inventory file is set to
-`origin`.
-endif::[]
-
 [[advanced-install-cluster-metrics]]
-== Configuring Cluster Metrics
+=== Configuring Cluster Metrics
 
 Cluster metrics are not set to automatically deploy by default. Set the
 following to enable cluster metrics when using the advanced install:
@@ -693,17 +707,21 @@ following to enable cluster metrics when using the advanced install:
 openshift_hosted_metrics_deploy=true
 ----
 
-=== Metrics Storage
+[[advanced-install-cluster-metrics-storage]]
+==== Configuring Metrics Storage
 
-The `*openshift_metrics_cassandra_storage_type*` variable must be set in order to
-use persistent storage. If `*openshift_metrics_cassandra_storage_type*` is not set,
-then cluster metrics data is stored in an `EmptyDir` volume, which will
-be deleted when the Cassandra pod terminates.
+The `openshift_metrics_cassandra_storage_type` variable must be set in order to
+use persistent storage for metrics. If
+`openshift_metrics_cassandra_storage_type` is not set, then cluster metrics data
+is stored in an `EmptyDir` volume, which will be deleted when the Cassandra pod
+terminates.
 
 There are three options for enabling cluster metrics storage when using the
 advanced install:
 
-*Option A - NFS Host Group*
+[discrete]
+[[advanced-install-cluster-metrics-storage-nfs-host-group]]
+===== Option A: NFS Host Group
 
 When the following variables are set, an NFS volume is created during an
 advanced install with path *_<nfs_directory>/<volume_name>_* on the host within
@@ -721,7 +739,9 @@ openshift_hosted_metrics_storage_volume_name=metrics
 openshift_hosted_metrics_storage_volume_size=10Gi
 ----
 
-*Option B - External NFS Host*
+[discrete]
+[[advanced-install-cluster-metrics-storage-external-nfs]]
+===== Option B: External NFS Host
 
 To use an external NFS volume, one must already exist with a path of
 *_<nfs_directory>/<volume_name>_* on the storage host.
@@ -740,19 +760,21 @@ openshift_hosted_metrics_storage_volume_size=10Gi
 The remote volume path using the following options would be
 *_nfs.example.com:/exports/metrics_*.
 
-*Option C - Dynamic*
+[discrete]
+[[advanced-install-cluster-metrics-storage-dynamic]]
+===== Option C: Dynamic
 
-Use the following variable if your {product-title} environment supports dynamic
-volume provisioning for your cloud platform:
+Use the following variable if your {product-title} environment supports
+xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamic volume provisioning] for your cloud provider:
 
 ----
 [OSEv3:vars]
 
-#openshift_metrics_cassandra_storage_type=dynamic
+openshift_metrics_cassandra_storage_type=dynamic
 ----
 
 [[advanced-install-cluster-logging]]
-== Configuring Cluster Logging
+=== Configuring Cluster Logging
 
 Cluster logging is not set to automatically deploy by default. Set the
 following to enable cluster logging when using the advanced installation method:
@@ -764,17 +786,19 @@ openshift_hosted_logging_deploy=true
 ----
 
 [[advanced-installation-logging-storage]]
-=== Logging Storage
+==== Configuring Logging Storage
 
-The `openshift_hosted_logging_storage_kind` variable must be set in order to
-use persistent storage. If `openshift_hosted_logging_storage_kind` is not set,
-then cluster logging data is stored in an `emptyDir` volume, which will
+The `openshift_hosted_logging_storage_kind` variable must be set in order to use
+persistent storage for logging. If `openshift_hosted_logging_storage_kind` is
+not set, then cluster logging data is stored in an `EmptyDir` volume, which will
 be deleted when the Elasticsearch pod terminates.
 
 There are three options for enabling cluster logging storage when using the
 advanced install:
 
-*Option A - NFS Host Group*
+[discrete]
+[[advanced-installation-logging-storage-nfs-host-group]]
+===== Option A: NFS Host Group
 
 When the following variables are set, an NFS volume is created during an
 advanced install with path *_<nfs_directory>/<volume_name>_* on the host within
@@ -792,7 +816,9 @@ openshift_hosted_logging_storage_volume_name=logging
 openshift_hosted_logging_storage_volume_size=10Gi
 ----
 
-*Option B - External NFS Host*
+[discrete]
+[[advanced-installation-logging-storage-external-nfs]]
+===== Option B: External NFS Host
 
 To use an external NFS volume, one must already exist with a path of
 *_<nfs_directory>/<volume_name>_* on the storage host.
@@ -811,19 +837,24 @@ openshift_hosted_logging_storage_volume_size=10Gi
 The remote volume path using the following options would be
 *_nfs.example.com:/exports/logging_*.
 
-*Option C - Dynamic*
+[discrete]
+[[advanced-installation-logging-storage-dynamic]]
+===== Option C: Dynamic
 
-Use the following variable if your {product-title} environment supports dynamic
-volume provisioning for your cloud platform:
+Use the following variable if your {product-title} environment supports
+xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamic volume provisioning] for your cloud provider:
 
 ----
 [OSEv3:vars]
 
-#openshift_hosted_logging_storage_kind=dynamic
+openshift_hosted_logging_storage_kind=dynamic
 ----
 
+[[adv-install-example-inventory-files]]
+== Example Inventory Files
+
 [[single-master]]
-== Single Master Examples
+=== Single Master Examples
 
 You can configure an environment with a single master and multiple nodes, and
 either a single or multiple number of external *etcd* hosts.
@@ -834,8 +865,9 @@ Moving from a single master cluster to multiple masters after installation is
 not supported.
 ====
 
+[discrete]
 [[single-master-multi-node-ai]]
-*Single Master and Multiple Nodes*
+==== Single Master and Multiple Nodes
 
 The following table describes an example environment for a single
 xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master] (with *etcd* on the same host)
@@ -907,8 +939,9 @@ infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'defa
 To use this example, modify the file to match your environment and
 specifications, and save it as *_/etc/ansible/hosts_*.
 
+[discrete]
 [[single-master-multi-etcd-multi-node-ai]]
-*Single Master, Multiple etcd, and Multiple Nodes*
+==== Single Master, Multiple etcd, and Multiple Nodes
 
 The following table describes an example environment for a single
 xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master],
@@ -992,7 +1025,7 @@ To use this example, modify the file to match your environment and
 specifications, and save it as *_/etc/ansible/hosts_*.
 
 [[multiple-masters]]
-== Multiple Masters Examples
+=== Multiple Masters Examples
 
 You can configure an environment with multiple masters, multiple *etcd* hosts,
 and multiple nodes. Configuring
@@ -1054,8 +1087,9 @@ variable.
 
 To configure multiple masters, refer to the following section.
 
+[discrete]
 [[multi-masters-using-native-ha-ai]]
-*Multiple Masters with Multiple etcd, and Using Native HA*
+==== Multiple Masters with Multiple etcd
 
 The following describes an example environment for three
 xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[masters],
@@ -1177,8 +1211,9 @@ infra-node2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'defa
 To use this example, modify the file to match your environment and
 specifications, and save it as *_/etc/ansible/hosts_*.
 
-[[multi-masters-singel-etcd-using-native-ha]]
-*Multiple Masters with Master and etcd on the Same Host, and Using Native HA*
+[discrete]
+[[multi-masters-single-etcd-using-native-ha]]
+==== Multiple Masters with Master and etcd on the Same Host
 
 The following describes an example environment for three
 xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[masters] with xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[*etcd*] on each host,
@@ -1299,9 +1334,9 @@ instructions or workarounds.
 After the installation completes:
 
 . Verify that the master is started and nodes
-are registered and reporting in *Ready* status. *On the master host*, run the
+are registered and reporting in *Ready* status. _On the master host_, run the
 following as root:
-
++
 ----
 # oc get nodes
 
@@ -1311,18 +1346,16 @@ node1.example.com           Ready                      165d
 node2.example.com           Ready                      165d
 ----
 
-To verify that the web console is installed correctly, use the master host name and the console port number to access the console with a web browser.
+. To verify that the web console is installed correctly, use the master host name
+and the web console port number to access the web console with a web browser.
++
+For example, for a master host with a host name of `master.openshift.com` and
+using the default port of `8443`, the web console would be found at `\https://master.openshift.com:8443/console`.
 
-For example, for a master host with a hostname of `master.openshift.com` and using the default port of `8443`, the web console would be found at:
-
-----
-https://master.openshift.com:8443/console
-----
-
-Now that the install has been verified, run the following command on each master
+. Now that the install has been verified, run the following command on each master
 and node host to add the *atomic-openshift* packages back to the list of yum
 excludes on the host:
-
++
 ----
 # atomic-openshift-excluder exclude
 ----
@@ -1334,7 +1367,9 @@ excludes on the host:
 The default port for the console is `8443`. If this was changed during the installation, the port can be found at *openshift_master_console_port* in the *_/etc/ansible/hosts_* file.
 ====
 
-*Multiple etcd Hosts*
+[discrete]
+[[verifying-multiple-etcd-hosts]]
+==== Verifying Multiple etcd Hosts
 
 If you installed multiple *etcd* hosts:
 
@@ -1359,7 +1394,9 @@ of your *etcd* hosts in the following:
     --key-file=/etc/origin/master/master.etcd-client.key member list
 ----
 
-*Multiple Masters Using HAProxy*
+[discrete]
+[[verifying-multiple-masters-haproxy]]
+==== Verifying Multiple Masters Using HAProxy
 
 If you installed multiple masters using HAProxy as a load balancer, browse to
 the following URL according to your *[lb]* section definition and check

--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -282,7 +282,7 @@ xref:quick-verifying-the-installation[verify the installation].
 
 include::install_config/install/advanced_install.adoc[tag=verifying-the-installation]
 
-Then, see xref:quick-install-whats-next[What's Next] for the next steps on
+. Then, see xref:quick-install-whats-next[What's Next] for the next steps on
 configuring your {product-title} cluster.
 
 ////


### PR DESCRIPTION
- Renames "Configuring Ansible" to "Configuring Ansible Inventory Files".
- ~~Increases the `:toclevels:` to 3 (for `advanced_install.adoc` only) so that the "Configuring Dedicated Infrastructure Nodes" and "Configuring Metrics/Logging Storage" subsections are visible from the top TOC.~~
- Aligns "Configuring Cluster Metrics" and "Configuring Cluster Logging" up under the "Configuring Ansible Inventory Files" parent section.
- Adds a parent heading "Example Inventory Files" and sets "Single Master Examples" and "Multiple Masters Examples" under it.
- Minor reorders of some of the "Configuring Ansible..." subsections.
- Fixes the numbered ordering in the shared "Verifying the Installation" section.
- Other minor edits in various sections.

Preview build:

http://file.rdu.redhat.com/~adellape/050317/adv_install_toc/install_config/install/advanced_install.html

Before and after TOC at a glance:

![screenshot from 2017-05-04 11-51-05](https://cloud.githubusercontent.com/assets/3442316/25712685/4e2eb3b4-30c0-11e7-91b2-00cbd55e300a.png)

