### PR TITLE
Added note to restart after modifying identity provider

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -60,6 +60,14 @@ xref:../architecture/additional_concepts/authorization.adoc#roles[Roles] need
 to be assigned to administer the setup with an external user.
 ====
 
+[NOTE]
+====
+After making changes to an identity provider you must restart the master service for the changes to take effect:
+----
+# systemctl restart atomic-openshift-master
+----
+====
+
 [[identity-providers-ansible]]
 == Configuring Identity Providers with Ansible
 


### PR DESCRIPTION
As a new user I modified the identity provider but had no idea how to make it take effect.  Luckily I found this in some training on the web but it should be in these instructions too.