### PR TITLE
Fix/add Online ifndefs re: Docker build source/strat

### DIFF
--- a/dev_guide/builds/basic_build_operations.adoc
+++ b/dev_guide/builds/basic_build_operations.adoc
@@ -40,7 +40,11 @@ Specify the `--env` flag to set any desired environment variable for the build:
 $ oc start-build <buildconfig_name> --env=<key>=<value>
 ----
 
-Rather than relying on a Git source pull or a Dockerfile for a build, you can
+Rather than relying on a Git source pull
+ifndef::openshift-online[]
+or a Dockerfile
+endif::[]
+for a build, you can
 can also start a build by directly pushing your source, which could be the
 contents of a Git or SVN working directory, a set of prebuilt binary artifacts
 you want to deploy, or a single file. This can be done by specifying one of the
@@ -139,7 +143,11 @@ This displays information such as:
 * Digest of the image in the destination registry
 * How the build was created
 
-If the build uses the `Docker` or `Source` strategy, the `oc describe` output also
+If the build uses the
+ifndef::openshift-online[]
+`Docker` or
+endif::[]
+`Source` strategy, the `oc describe` output also
 includes information about the source revision used for the build, including the
 commit ID, author, committer, and message.
 
@@ -169,7 +177,11 @@ $ oc logs --version=<number> bc/<buildconfig_name>
 *Log Verbosity*
 
 To enable more verbose output, pass the `BUILD_LOGLEVEL` environment variable
-as part of the `sourceStrategy` or `dockerStrategy` in a `BuildConfig`:
+as part of the `sourceStrategy`
+ifndef::openshift-online[]
+or `dockerStrategy`
+endif::[]
+in a `BuildConfig`:
 
 [source,yaml]
 ----

--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -17,16 +17,22 @@ toc::[]
 A _build input_ provides source content for builds to operate on. There are
 several ways to provide source in {product-title}. In order of precedence:
 
+ifndef::openshift-online[]
 * xref:dockerfile-source[Inline Dockerfile definitions]
+endif::[]
 * xref:image-source[Content extracted from existing images]
 * xref:source-code[Git repositories]
 * xref:binary-source[Binary inputs]
 * xref:using-secrets-during-build[Input secrets]
 * xref:using-external-artifacts[External artifacts]
 
-Different inputs can be combined into a single build. As the inline Dockerfile takes
+Different inputs can be combined into a single build.
+ifndef::openshift-online[]
+As the inline Dockerfile takes
 precedence, it can overwrite any other file named *_Dockerfile_* provided by
-another input. Binary input and Git repositories are mutually exclusive inputs.
+another input.
+endif::[]
+Binary input and Git repositories are mutually exclusive inputs.
 
 Input secrets are useful for when you do not want certain resources or
 credentials used during a build to be available in the final application image
@@ -44,12 +50,17 @@ working directory using the target path.
 . The build process changes directories into the `contextDir`, if one is
 defined.
 
+ifndef::openshift-online[]
 . The inline Dockerfile, if any, is written to the current directory.
+endif::[]
 
 . The content from the current directory is provided to the build process
-for reference by the Dockerfile, *_assemble_* script, or custom builder logic.
-This means any input content that resides outside the `contextDir` will be
-ignored by the build.
+for reference by the
+ifndef::openshift-online[]
+Dockerfile, custom builder logic, or
+endif::[]
+*_assemble_* script. This means any input content that resides outside the
+`contextDir` will be ignored by the build.
 
 The following example of a source definition includes multiple input types and
 an explanation of how they are combined. For more details on how each input type
@@ -69,13 +80,18 @@ source:
     - destinationDir: app/dir/injected/dir <2>
       sourcePath: /usr/lib/somefile.jar
   contextDir: "app/dir" <3>
+ifndef::openshift-online[]
   dockerfile: "FROM centos:7\nRUN yum install -y httpd" <4>
+endif::[]
 ----
 <1> The repository to be cloned into the working directory for the build.
 <2> *_/usr/lib/somefile.jar_* from `myinputimage` will be stored in *_<workingdir>/app/dir/injected/dir_*.
 <3> The working directory for the build will become *_<original_workingdir>/app/dir_*.
+ifndef::openshift-online[]
 <4> A Dockerfile with this content will be created in *_<original_workingdir>/app/dir_*, overwriting any existing file with that name.
+endif::[]
 
+ifndef::openshift-online[]
 [[dockerfile-source]]
 == Dockerfile Source
 
@@ -95,6 +111,7 @@ source:
   dockerfile: "FROM centos:7\nRUN yum install -y httpd" <1>
 ----
 <1> The `dockerfile` field contains an inline Dockerfile that will be built.
+endif::[]
 
 [[image-source]]
 == Image Source
@@ -151,17 +168,20 @@ ifndef::openshift-online[]
 ====
 This feature is not supported for builds using the xref:using-secrets-custom-strategy[Custom Strategy].
 ====
-endif:[]
+endif::[]
 
 [[source-code]]
 == Git Source
 
 When the `BuildConfig.spec.source.type` is `Git`, a Git repository is
-required, and an inline Dockerfile is optional.
+required.
+ifndef::openshift-online[]
+An inline Dockerfile is optional.
 
 The source code is fetched from the location specified and, if the
 `BuildConfig.spec.source.dockerfile` field is specified, the inline Dockerfile
 replaces the one in the `contextDir` of the Git repository.
+endif::[]
 
 The source definition is part of the `spec` section in the `BuildConfig`:
 
@@ -173,7 +193,9 @@ source:
     uri: "https://github.com/openshift/ruby-hello-world"
     ref: "master"
   contextDir: "app/dir" <2>
+ifndef::openshift-online[]
   dockerfile: "FROM openshift/ruby-22-centos7\nUSER example" <3>
+endif::[]
 ----
 <1> The `git` field contains the URI to the remote Git repository of the
 source code. Optionally, specify the `ref` field to check out a specific Git
@@ -182,9 +204,11 @@ reference. A valid `ref` can be a SHA1 tag or a branch name.
 the source code repository where the build looks for the application source
 code. If your application exists inside a sub-directory, you can override the
 default location (the root folder) using this field.
+ifndef::openshift-online[]
 <3> If the optional `dockerfile` field is provided, it should be a string
 containing a Dockerfile that overwrites any Dockerfile that may exist in the
 source repository.
+endif::[]
 
 When using the Git repository as a source without specifying the `ref`
 field, {product-title} performs a shallow clone (`--depth=1` clone). That means
@@ -591,6 +615,7 @@ valid way to run a build for this `BuildConfig` is to use `oc
 start-build` with one of the `--from` options to provide the requisite binary
 data.
 
+ifndef::openshift-online[]
 The `dockerfile` and `contextDir` xref:source-code[source options] have
 special meaning with binary builds.
 
@@ -599,6 +624,7 @@ used and the binary stream is an archive, its contents serve as a replacement
 Dockerfile to any Dockerfile in the archive. If `dockerfile` is used with the
 `--from-file` argument, and the file argument is named `dockerfile`, the value
 from `dockerfile` replaces the value from the binary stream.
+endif::[]
 
 In the case of the binary stream encapsulating extracted archive content, the
 value of the `contextDir` field is interpreted as a subdirectory within the
@@ -750,7 +776,7 @@ differently, based on your build use case.
 The inpout secrets are always mounted into the
 *_/var/run/secrets/openshift.io/build_* directory or your builder can parse the
 `$BUILD` environment variable, which includes the full build object.
-endif:[]
+endif::[]
 
 [[using-external-artifacts]]
 == Using External Artifacts
@@ -785,6 +811,7 @@ used by a Source build, see
 xref:build_strategies.adoc#override-builder-image-scripts[Overriding Builder Image Scripts].
 ====
 
+ifndef::openshift-online[]
 For a `Docker` build strategy, you must modify the *_Dockerfile_* and invoke
 shell commands with the
 link:https://docs.docker.com/engine/reference/builder/#run[`RUN` instruction]:
@@ -799,11 +826,15 @@ RUN wget http://repository.example.com/app/app-$APP_VERSION.jar -O app.jar
 EXPOSE 8080
 CMD [ "java", "-jar", "app.jar" ]
 ----
+endif::[]
 
 In practice, you may want to use an environment variable for the file location
 so that the specific file to be downloaded can be customized using an
 environment variable defined on the `BuildConfig`, rather than updating the
-*_assemble_* script or *_Dockerfile_*.
+ifndef::openshift-online[]
+*_Dockerfile_* or
+endif::[]
+*_assemble_* script.
 
 You can choose between different methods of defining environment variables:
 
@@ -912,8 +943,10 @@ the build configuration:
 $ oc set build-secret --pull bc/sample-build dockerhub
 ----
 
+ifndef::openshift-online[]
 [NOTE]
 ====
 This example uses `pullSecret` in a Source build, but it is also applicable
 in Docker and Custom builds.
 ====
+endif::[]

--- a/dev_guide/builds/build_output.adoc
+++ b/dev_guide/builds/build_output.adoc
@@ -14,7 +14,11 @@ toc::[]
 [[build-output]]
 == Build Output Overview
 
-Builds that use the `Docker` or `Source` strategy result in the creation of a
+Builds that use the
+ifndef::openshift-online[]
+`Docker` or
+endif::[]
+`Source` strategy result in the creation of a
 new container image. The image is then pushed to the container image registry
 specified in the `output` section of the `Build` specification.
 
@@ -49,7 +53,10 @@ spec:
 [[output-image-environment-variables]]
 == Output Image Environment Variables
 
-`Docker` and `Source` strategy builds set the following environment variables on output
+ifndef::openshift-online[]
+`Docker` and
+endif::[]
+`Source` strategy builds set the following environment variables on output
 images:
 
 [options="header"]
@@ -75,14 +82,20 @@ images:
 
 Additionally, any user-defined environment variable, for example those
 configured via
-xref:build_strategies.adoc#configuring-the-source-environment[`Source`] or
-xref:build_strategies.adoc#docker-strategy-environment[`Docker`] strategy
-options, will also be part of the output image environment variable list.
+xref:build_strategies.adoc#configuring-the-source-environment[`Source`]
+ifndef::openshift-online[]
+or xref:build_strategies.adoc#docker-strategy-environment[`Docker`]
+endif::[]
+strategy options, will also be part of the output image environment variable
+list.
 
 [[output-image-labels]]
 == Output Image Labels
 
-`Docker` and `Source` builds set the following labels on output images:
+ifndef::openshift-online[]
+`Docker` and
+endif::[]
+`Source` builds set the following labels on output images:
 
 [options="header"]
 |===
@@ -137,11 +150,13 @@ later be used to
 link:$$https://docs.docker.com/engine/reference/commandline/pull/#/pull-an-image-by-digest-immutable-identifier$$[pull the image by digest]
 regardless of its current tag.
 
-`Docker` and `Source` builds store the digest in
-`Build.status.output.to.imageDigest` after the image is pushed to a registry.
-The digest is computed by the registry. Therefore, it may not always be present,
-for example when the registry did not return a digest, or when the builder image
-did not understand its format.
+ifndef::openshift-online[]
+`Docker` and
+endif::[]
+`Source` builds store the digest in `Build.status.output.to.imageDigest` after
+the image is pushed to a registry. The digest is computed by the registry.
+Therefore, it may not always be present, for example when the registry did not
+return a digest, or when the builder image did not understand its format.
 
 .Built Image Digest After a Successful Push to the Registry
 [source,yaml]

--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -494,7 +494,7 @@ endif::[]
 
 You can also manage environment variables defined in the `BuildConfig` with the
 xref:../../dev_guide/environment_variables.adoc#dev-guide-environment-variables[`oc set env`] command.
-endif:[]
+endif::[]
 
 [[pipeline-strategy-options]]
 == Pipeline Strategy Options
@@ -556,7 +556,7 @@ process, you can add environment variables to the `jenkinsPipelineStrategy` defi
 of the `BuildConfig`.
 
 The environment variables defined there are set as parameters on the job in Jenkins associated with
-the `BuildConfig`. 
+the `BuildConfig`.
 
 For example:
 
@@ -573,9 +573,9 @@ jenkinsPipelineStrategy:
 Specifics on the mapping between `BuildConfig` environment variables and Jenkins job parameters:
 
 * When a Jenkins job is created or updated based on changes to a Pipeline strategy `BuildConfig`, any environment
-variables in the `BuildConfig` are mapped to Jenkins job parameters definitions, where the default values for the Jenkins job parameters 
+variables in the `BuildConfig` are mapped to Jenkins job parameters definitions, where the default values for the Jenkins job parameters
 definitions are the current values of the associated environment variables.
-* You can still add additional parameters (whose names differ from the names of the environment variables in the `BuildConfig`) 
+* You can still add additional parameters (whose names differ from the names of the environment variables in the `BuildConfig`)
 to the Jenkins job from the Jenkins console after the job's initial creation and they will be honored when builds are started for those Jenkins jobs.
 * How you start builds for the Jenkins job then dictates how the parameters are set.
 * If you start via `oc start-build`, the values of the environment variables in the `BuildConfig` are what the parameters are set
@@ -590,4 +590,3 @@ of starting a build for the job.
 
 You can also manage environment variables defined in the `BuildConfig` with the
 xref:../../dev_guide/environment_variables.adoc#dev-guide-environment-variables[`oc set env`] command.
-

--- a/dev_guide/builds/index.adoc
+++ b/dev_guide/builds/index.adoc
@@ -24,7 +24,11 @@ A _build configuration_, or `BuildConfig`, is characterized by a _build strategy
 or more sources. The strategy determines the aforementioned process, while the
 sources provide its input.
 
-The build strategies are:
+The
+ifdef::openshift-online[]
+supported
+endif::[]
+build strategies are:
 
 - Source-to-Image (S2I)
 (xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[description],
@@ -39,13 +43,15 @@ xref:build_strategies.adoc#docker-strategy-options[options])
 - Custom
 (xref:../../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[description],
 xref:build_strategies.adoc#custom-strategy-options[options])
-endif:[]
+endif::[]
 
 And there are six types of sources that can be given as
 xref:build_inputs.adoc#dev-guide-build-inputs[_build input_]:
 
 - xref:build_inputs.adoc#source-code[Git]
+ifndef::openshift-online[]
 - xref:build_inputs.adoc#dockerfile-source[Dockerfile]
+endif::[]
 - xref:build_inputs.adoc#binary-source[Binary]
 - xref:build_inputs.adoc#image-source[Image]
 - xref:build_inputs.adoc#using-secrets-during-build[Input secrets]
@@ -53,8 +59,15 @@ xref:build_inputs.adoc#dev-guide-build-inputs[_build input_]:
 
 It is up to each build strategy to consider or ignore a certain type of source,
 as well as to determine how it is to be used. Binary and Git are mutually
-exclusive source types. Dockerfile and Image can be used by themselves, with
-each other, or together with either Git or Binary. The Binary source type is
+exclusive source types.
+ifdef::openshift-online[]
+Image can be used by itself or together with either Git or Binary.
+endif::[]
+ifdef::openshift-origin,openshift-dedicated,openshift-enterprise[]
+Dockerfile and Image can be used by themselves, with each other, or together
+with either Git or Binary.
+endif::[]
+The Binary source type is
 unique from the other options in xref:build_inputs.adoc#binary-source[how it is
 specified to the system].
 
@@ -98,7 +111,9 @@ spec:
     type: "Git"
     git:
       uri: "https://github.com/openshift/ruby-hello-world"
+ifndef::openshift-online[]
     dockerfile: "FROM openshift/ruby-22-centos7\nUSER example"
+endif::[]
   strategy: <5>
     type: "Source"
     sourceStrategy:
@@ -121,13 +136,19 @@ will run sequentially, not simultaneously.
 which cause a new build to be created.
 <4> The `source` section defines the source of the build. The source type
 determines the primary source of input, and can be either `Git`, to point to
-a code repository location, `Dockerfile`, to build from an inline Dockerfile,
+a code repository location,
+ifndef::openshift-online[]
+`Dockerfile`, to build from an inline Dockerfile,
+endif::[]
 or `Binary`, to accept binary payloads. It is possible to have multiple
 sources at once, refer to the documentation for each source type for details.
 <5> The `strategy` section describes the build strategy used to execute the
-build. You can specify `Source`, `Docker` and `Custom` strategies here.
-This above example uses the `ruby-20-centos7` container image that
-Source-To-Image will use for the application build.
+build. You can specify a `Source`
+ifndef::openshift-online[]
+, `Docker`, or `Custom`
+endif::[]
+strategy here. This above example uses the `ruby-20-centos7` container image
+that Source-To-Image will use for the application build.
 <6> After the container image is successfully built, it will be pushed into the
 repository described in the `output` section.
 <7> The `postCommit` section defines an optional xref:build_hooks.adoc#build-hooks[build hook].

--- a/dev_guide/builds/triggering_builds.adoc
+++ b/dev_guide/builds/triggering_builds.adoc
@@ -378,19 +378,21 @@ strategy:
   sourceStrategy:
     from:
       kind: "DockerImage"
-      name: "172.30.17.3:5001/mynamespace/ruby-20-centos7:immutableid"
+      name: "172.30.17.3:5001/mynamespace/ruby-20-centos7:<immutableid>"
 ----
 
 This ensures that the triggered build uses the new image that was just pushed to
 the repository, and the build can be re-run any time with the same inputs.
 
+ifndef::openshift-online[]
 In addition to setting the image field for all `Strategy` types, for custom
 builds, the `OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE` environment variable is checked.
 If it does not exist, then it is created with the immutable image reference. If
 it does exist then it is updated with the immutable image reference.
+endif::[]
 
 If a build is triggered due to a webhook trigger or manual request,
-the build that is created uses the `immutableid` resolved from the
+the build that is created uses the `<immutableid>` resolved from the
 `ImageStream` referenced by the `Strategy`. This ensures that builds
 are performed using consistent image tags for ease of reproduction.
 
@@ -454,4 +456,3 @@ webhook secret.
 
 For more information, consult the help documentation with `oc set triggers
 --help`
-

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -286,10 +286,10 @@ endif::[]
 
 ifdef::openshift-online[]
 You
-endif:[]
+endif::[]
 ifndef::openshift-online[]
 Once you have selected which template you want, you
-endif:[]
+endif::[]
 must xref:../../dev_guide/templates.adoc#dev-guide-templates[instantiate] the
 template to be able to use Jenkins:
 


### PR DESCRIPTION
Some bad endifs got in via https://github.com/openshift/openshift-docs/pull/4278 (`endif:[]` instead of `endif::[]`). Also found more references to the Dockerfile source type, which is for the Docker/Custom build strategy, and should therefore be omitted in Online docs.

Preview:

http://file.rdu.redhat.com/~adellape/050417/builds_online/dev_guide/builds/