### PR TITLE
Fix xref typo in advanced_install

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -78,7 +78,7 @@ file with your desired configuration.
 
 The following sections describe commonly-used variables to set in your inventory
 file during an advanced installation, followed by
-xref:adv-install-example-inventory-fiies[example inventory files] you can use as
+xref:adv-install-example-inventory-files[example inventory files] you can use as
 a starting point for your installation.
 
 Many of the Ansible variables described are optional. Accepting the default


### PR DESCRIPTION
Typo from https://github.com/openshift/openshift-docs/pull/4321.