### PR TITLE
[3.3] routes: Delete features that are not in 3.3

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -216,33 +216,25 @@ $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 |`*NAMESPACE_LABELS*` |  | A label selector to apply to namespaces to watch, empty means all.
 |`*PROJECT_LABELS*` |  | A label selector to apply to projects to watch, emtpy means all.
 |`*RELOAD_SCRIPT*` |  | The path to the reload script to use to reload the router.
-|`*ROUTER_ALLOWED_DOMAINS*` | | A comma-separated list of domains that the host name in a route can only be part of. Any subdomain in the domain can be used. Option `ROUTER_DENIED_DOMAINS` overrides any values given in this option. If set, everything outside of the allowed domains will be rejected.
 |`*ROUTER_BACKEND_CHECK_INTERVAL*` | 5000ms | Length of time between subsequent "liveness" checks on backends. xref:time-units[(TimeUnits)]
-|`*ROUTER_COMPRESSION_MIME*` | "text/html text/plain text/css" | A space separated list of mime types to compress.
 |`*ROUTER_DEFAULT_CLIENT_TIMEOUT*`| 30s | Length of time within which a client has to acknowledge or send data. xref:time-units[(TimeUnits)]
 |`*ROUTER_DEFAULT_CONNECT_TIMEOUT*`| 5s | The maximum connect time. xref:time-units[(TimeUnits)]
 |`*ROUTER_DEFAULT_SERVER_TIMEOUT*`| 30s | Length of time within which a server has to acknowledge or send data. xref:time-units[(TimeUnits)]
 |`*ROUTER_DEFAULT_TUNNEL_TIMEOUT*` | 1h | Length of time till which TCP or WebSocket connections will remain open. If you have websockets/tcp
 connections (and any time HAProxy is reloaded), the old HAProxy processes
 will "linger" around for that period. xref:time-units[(TimeUnits)]
-|`*ROUTER_DENIED_DOMAINS*` | | A comma-separated list of domains that the host name in a route can not be part of. No subdomain in the domain can be used either. Overrides option `ROUTER_ALLOWED_DOMAINS`.
-|`*ROUTER_ENABLE_COMPRESSION*`| | If `true` or `TRUE`, compress responses when possible.
 |`*ROUTER_LOG_LEVEL*` | warning | The log level to send to the syslog server.
-|`*ROUTER_MAX_CONNECTIONS*`| 20000 | Maximum number of concurrent connections.
 |`*ROUTER_OVERRIDE_HOSTNAME*`|  | If set `true`, override the spec.host value for a route with the template in `ROUTER_SUBDOMAIN`.
 |`*ROUTER_SERVICE_HTTPS_PORT*` | 443 | Port to listen for HTTPS requests.
 |`*ROUTER_SERVICE_HTTP_PORT*` | 80 | Port to listen for HTTP requests.
 |`*ROUTER_SERVICE_NAME*` | public | The name that the router identifies itself in the in route status.
-|`*ROUTER_CANONICAL_HOSTNAME*` | | The (optional) host name of the router shown in the in route status.
 |`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router identifies itself in the in route status. Required if `ROUTER_SERVICE_NAME` is used.
 |`*ROUTER_SERVICE_NO_SNI_PORT*` | 10443 | Internal port for some front-end to back-end communication (see note below).
 |`*ROUTER_SERVICE_SNI_PORT*` | 10444 | Internal port for some front-end to back-end communication (see note below).
-| `*ROUTER_SLOWLORIS_HTTP_KEEPALIVE*`| 300s | Set the maximum time to wait for a new HTTP request to appear. If this is set too low, it can confuse browsers and applications not expecting a small `keepalive` value. xref:time-units[(TimeUnits)]
 |`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s | Length of time the transmission of an HTTP request can take. xref:time-units[(TimeUnits)]
 |`*ROUTER_SUBDOMAIN*`|  | The template that should be used to generate the host name for a route without spec.host (e.g. ${name}-${namespace}.myapps.mycompany.com).
 |`*ROUTER_SYSLOG_ADDRESS*` |  | Address to send log messages. Disabled if empty.
 |`*ROUTER_TCP_BALANCE_SCHEME*` | source | Load-balancing strategy for multiple endpoints for pass-through routes. Available options are `source`, `roundrobin`, or `leastconn`.
-|`*ROUTER_LOAD_BALANCE_ALGORITHM*` | leastconn | Load-balancing strategy routes with multiple endpoints. Available options are `source`, `roundrobin`, and `leastconn`.
 //|`*ROUTE_FIELDS*` |  | A field selector to apply to routes to watch, empty means all.
 |`*ROUTE_LABELS*` |  | A label selector to apply to the routes to watch, empty means all.
 |`*STATS_PASSWORD*` |  | The password needed to access router stats (if the router implementation supports it).
@@ -251,8 +243,6 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`*TEMPLATE_FILE*` | `/var/lib/haproxy/conf/custom/` `haproxy-config-custom.template` | The path to the HAProxy template file (in the container image).
 |`*RELOAD_INTERVAL*` | 12s | The minimum frequency the router is allowed to reload to accept new changes. xref:time-units[(TimeUnits)]
 |`*ROUTER_USE_PROXY_PROTOCOL*`|  | When set to `true` or `TRUE`, HAProxy expects incoming connections to use the `PROXY` protocol on port 80 or port 443. The source IP address can pass through a load balancer if the load balancer supports the protocol, for example Amazon ELB.
-|`*ROUTER_ALLOW_WILDCARD_ROUTES*`|  |  When set to `true` or `TRUE`, any routes with a wildcard policy of `Subdomain` that pass the router admission checks will be serviced by the HAProxy router.
-|`*ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK*` |  | Set to `true` to relax the namespace ownership policy.
 |===
 
 [[time-units]]
@@ -860,7 +850,7 @@ For all the items outlined in this section, you can set annotations on the
 [cols="3*", options="header"]
 |===
 |Variable | Description | Environment Variable Used as Default
-|`*haproxy.router.openshift.io/balance*`| Sets the load-balancing algorithm. Available options are `source`, `roundrobin`, and `leastconn`. | `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, use `ROUTER_LOAD_BALANCE_ALGORITHM`.
+|`*haproxy.router.openshift.io/balance*`| Sets the load-balancing algorithm. Available options are `source`, `roundrobin`, and `leastconn`. | `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, `leastconn`.
 |`*haproxy.router.openshift.io/disable_cookies*`| Disables the use of cookies to track related connections. If set to `true` or `TRUE`, the balance algorithm is used to choose which back-end serves connections for each incoming HTTP request. |
 |`*haproxy.router.openshift.io/rate-limit-connections*`| Setting `true` or `TRUE` to enables rate limiting functionality. |
 |`*haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp*`| Limits the number of concurrent TCP connections shared by an IP address. |
@@ -892,39 +882,6 @@ Setting a server-side timeout value for passthrough routes too low can cause
 WebSocket connections to timeout frequently on that route.
 ====
 
-
-[[wildcard-subdomain-route-policy]]
-== Creating Routes Specifying a Wildcard Subdomain Policy
-
-A wildcard policy allows a user to define a route that covers all hosts within a
-domain (when the router is configured to allow it). A route can specify a
-wildcard policy as part of its configuration using the `wildcardPolicy` field.
-Any routers run with a policy allowing wildcard routes will expose the route
-appropriately based on the wildcard policy.
-
-ifdef::openshift-enterprise,openshift-origin[]
-xref:../../install_config/router/default_haproxy_router.adoc#install-config-router-default-haproxy[Learn how to configure HAProxy routers to allow wildcard routes].
-endif::[]
-
-.A Route Specifying a Subdomain WildcardPolicy
-====
-[source,yaml]
-----
-apiVersion: v1
-kind: Route
-spec:
-  host: wildcard.example.com  <1>
-  wildcardPolicy: Subdomain   <2>
-  to:
-    kind: Service
-    name: service-name
-----
-<1> Specifies the externally reachable host name used to expose a service.
-<2> Specifies that the externally reachable host name should allow all hosts
-    in the subdomain `example.com`. `*.example.com` is the subdomain for host
-    name `wildcard.example.com` to reach the exposed service.
-====
-
 [[route-status-field]]
 == Route Status
 
@@ -934,179 +891,3 @@ The routers do not clear the `route status` field. To remove the stale entries
 in the route status, use the
 link:https://github.com/openshift/origin/blob/master/images/router/clear-route-status.sh[clear-route-status
 script].
-
-
-[[architecture-core-concepts-routes-deny-allow]]
-== Denying or Allowing Certain Domains in Routes
-
-A router can be configured to deny or allow a specific subset of domains from
-the host names in a route using the `ROUTER_DENIED_DOMAINS` and
-`ROUTER_ALLOWED_DOMAINS` environment variables.
-
-[cols="2"]
-|===
-
-|`*ROUTER_DENIED_DOMAINS*` | Domains listed are not allowed in any indicated routes.
-|`*ROUTER_ALLOWED_DOMAINS*` | Only the domains listed are allowed in any indicated routes.
-
-|===
-
-The domains in the list of denied domains take precedence over the list of
-allowed domains. Meaning {product-title} first checks the deny list (if
-applicable), and if the host name is not in the list of denied domains, it then
-checks the list of allowed domains. However, the list of allowed domains is more
-restrictive, and ensures that the router only admits routes with hosts that
-belong to that list.
-
-For example, to deny the `[{asterisk}.]open.header.test`, `[{asterisk}.]openshift.org` and
-`[{asterisk}.]block.it` routes for the `myrouter` route:
-
-----
-$ oadm router myrouter ...
-$ oc set env dc/myrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it"
-----
-
-This means that `myrouter` will admit the following based on the route's name:
-
-----
-$ oc expose service/<name> --hostname="foo.header.test"
-$ oc expose service/<name> --hostname="www.allow.it"
-$ oc expose service/<name> --hostname="www.openshift.test"
-----
-
-However, `myrouter` will deny the following:
-
-----
-$ oc expose service/<name> --hostname="open.header.test"
-$ oc expose service/<name> --hostname="www.open.header.test"
-$ oc expose service/<name> --hostname="block.it"
-$ oc expose service/<name> --hostname="franco.baresi.block.it"
-$ oc expose service/<name> --hostname="openshift.org"
-$ oc expose service/<name> --hostname="api.openshift.org"
-----
-
-Alternatively, to block any routes where the host name is _not_ set to `[{asterisk}.]stickshift.org` or `[{asterisk}.]kates.net`:
-
-----
-$ oadm router myrouter ...
-$ oc set env dc/myrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net"
-----
-
-This means that the `myrouter` router will admit:
-
-----
-$ oc expose service/<name> --hostname="stickshift.org"
-$ oc expose service/<name> --hostname="www.stickshift.org"
-$ oc expose service/<name> --hostname="kates.net"
-$ oc expose service/<name> --hostname="api.kates.net"
-$ oc expose service/<name> --hostname="erno.r.kube.kates.net"
-----
-
-However, `myrouter` will deny the following:
-
-----
-$ oc expose service/<name> --hostname="www.open.header.test"
-$ oc expose service/<name> --hostname="drive.ottomatic.org"
-$ oc expose service/<name> --hostname="www.wayless.com"
-$ oc expose service/<name> --hostname="www.deny.it"
-----
-
-To implement both scenarios, run:
-
-----
-$ oadm router adrouter ...
-$ oc env dc/adrouter ROUTER_ALLOWED_DOMAINS="openshift.org, kates.net" \
-    ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net"
-----
-
-This will allow any routes where the host name is set to `[{asterisk}.]openshift.org` or
-`[{asterisk}.]kates.net`, and not allow any routes where the host name is set to
-`[{asterisk}.]ops.openshift.org` or `[{asterisk}.]metrics.kates.net`.
-
-Therefore, the following will be denied:
-
-----
-$ oc expose service/<name> --hostname="www.open.header.test"
-$ oc expose service/<name> --hostname="ops.openshift.org"
-$ oc expose service/<name> --hostname="log.ops.openshift.org"
-$ oc expose service/<name> --hostname="www.block.it"
-$ oc expose service/<name> --hostname="metrics.kates.net"
-$ oc expose service/<name> --hostname="int.metrics.kates.net"
-----
-
-However, the following will be allowed:
-
-----
-$ oc expose service/<name> --hostname="openshift.org"
-$ oc expose service/<name> --hostname="api.openshift.org"
-$ oc expose service/<name> --hostname="m.api.openshift.org"
-$ oc expose service/<name> --hostname="kates.net"
-$ oc expose service/<name> --hostname="api.kates.net"
-----
-
-
-[[disable-namespace-ownership-check]]
-== Disabling the Namespace Ownership Check
-
-Hosts and subdomains are owned by the namespace of the route that first
-makes the claim. Other routes created in the namespace can make claims on
-the subdomain. All other namespaces are prevented from making claims on
-the claimed hosts and subdomains. The namespace that owns the host also
-owns all paths associated with the host, for example `*_www.abc.xyz/path1*`.
-
-For example, if the host `*_www.abc.xyz_*` is not claimed by any route.
-Creating route `r1` with host `*_www.abc.xyz_*` in namespace `ns1` makes
-namespace `ns1` the owner of host `*_www.abc.xyz_*` and subdomain `abc.xyz`
-for wildcard routes. If another namespace, `ns2`, tries to create a route
-with say a different path `*_www.abc.xyz/path1/path2_*`, it would fail
-because a route in another namespace (`ns1` in this case) owns that host.
-
-With wildcard routes the namespace that owns the subdomain owns all hosts in the subdomain.
-If a namespace owns subdomain `*abc.xyz*` as in the above example,
-another namespace cannot claim `z.abc.xyz`.
-
-By disabling the namespace ownership rules, you can disable these restrictions
-and allow hosts (and subdomains) to be claimed across namespaces.
-
-[WARNING]
-====
-If you decide to disable the namespace ownership checks in your router,
-be aware that this allows end users to claim ownership of hosts
-across namespaces. While this change can be desirable in certain
-development environments, use this feature with caution in production
-environments, and ensure that your cluster policy has locked down untrusted end
-users from creating routes.
-====
-
-For example, with `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true`, if
-namespace `ns1` creates the oldest route `r1`  `*_www.abc.xyz_*`,  it owns only
-the hostname (+ path).  Another namespace can create a wildcard route
-even though it does not have the oldest route in that subdomain (`abc.xyz`)
-and we could potentially have other namespaces claiming other
-non-wildcard overlapping hosts (for example, `foo.abc.xyz`, `bar.abc.xyz`,
-`baz.abc.xyz`) and their claims would be granted.
-
-Any other namespace (for example, `ns2`) can now create
-a route `r2`  `*_www.abc.xyz/p1/p2_*`,  and it would be admitted.  Similarly
-another namespace (`ns3`) can also create a route  `wildthing.abc.xyz`
-with a subdomain wildcard policy and it can own the wildcard.
-
-As this example demonstrates, the policy `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true` is more
-lax and allows claims across namespaces.  The only time the router would
-reject a route with the namespace ownership disabled is if the host+path
-is already claimed.
-
-For example, if a new route `rx` tries to claim `*_www.abc.xyz/p1/p2_*`, it
-would be rejected as route `r2` owns that host+path combination.  This is true whether route `rx`
-is in the same namespace or other namespace since the exact host+path is already claimed.
-
-This feature can be set during router creation or by setting an environment
-variable in the router's deployment configuration.
-
-----
-$ oadm router ... --disable-namespace-ownership-check=true
-----
-
-----
-$ oc env dc/router ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true
-----


### PR DESCRIPTION
Delete some documentation that was erroneously added in commit 0d723de2a3e67144b687f0305eee59c1eeeac29d for features that exist only in later versions of OpenShift Container Platform:

• The feature of denying or allowing certain domains in routes, along with the `ROUTER_ALLOWED_DOMAINS` and `ROUTER_DENIED_DOMAINS` variables, does not exist in 3.3.

• Disabling the namespace ownership check, along with the `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK` variable, does not exist in 3.3.

• The wildcard subdomain policy, along with the `ROUTER_ALLOW_WILDCARD_ROUTES` variable, does not exist in 3.3.

• The `ROUTER_LOAD_BALANCE_ALGORITHM` variable does not exist in 3.3, and the default algorithm for routes that have no `haproxy.router.openshift.io/balance` annotation is "leastconn".

• The following variables and associated functionality do not exist in 3.3: `ROUTER_COMPRESSION_MIME`, `ROUTER_ENABLE_COMPRESSION`, `ROUTER_MAX_CONNECTIONS`, `ROUTER_CANONICAL_HOSTNAME`, and `ROUTER_SLOWLORIS_HTTP_KEEPALIVE`.

---

@pecameron, are these changes appropriate? I couldn't find these variables or features when I grepped the 3.3 template and router code.  Is there some intention to backport them to 3.3, or should we delete them from the documentation?