### PR TITLE
[3.4] routes: Delete features that are not in 3.4

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -260,7 +260,6 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`*ROUTER_DENIED_DOMAINS*` | | A comma-separated list of domains that the host name in a route can not be part of. No subdomain in the domain can be used either. Overrides option `ROUTER_ALLOWED_DOMAINS`.
 |`*ROUTER_ENABLE_COMPRESSION*`| | If `true` or `TRUE`, compress responses when possible.
 |`*ROUTER_LOG_LEVEL*` | warning | The log level to send to the syslog server.
-|`*ROUTER_MAX_CONNECTIONS*`| 20000 | Maximum number of concurrent connections.
 |`*ROUTER_OVERRIDE_HOSTNAME*`|  | If set `true`, override the spec.host value for a route with the template in `ROUTER_SUBDOMAIN`.
 |`*ROUTER_SERVICE_HTTPS_PORT*` | 443 | Port to listen for HTTPS requests.
 |`*ROUTER_SERVICE_HTTP_PORT*` | 80 | Port to listen for HTTP requests.
@@ -268,12 +267,10 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router will identify itself with in route statuses.  Required if `ROUTER_SERVICE_NAME` is used.
 |`*ROUTER_SERVICE_NO_SNI_PORT*` | 10443 | Internal port for some front-end to back-end communication (see note below).
 |`*ROUTER_SERVICE_SNI_PORT*` | 10444 | Internal port for some front-end to back-end communication (see note below).
-| `*ROUTER_SLOWLORIS_HTTP_KEEPALIVE*`| 300s | Set the maximum time to wait for a new HTTP request to appear. If this is set too low, it can confuse browsers and applications not expecting a small `keepalive` value. xref:time-units[(TimeUnits)]
 |`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s | Length of time the transmission of an HTTP request can take. xref:time-units[(TimeUnits)]
 |`*ROUTER_SUBDOMAIN*`|  | The template that should be used to generate the host name for a route without spec.host (e.g. ${name}-${namespace}.myapps.mycompany.com).
 |`*ROUTER_SYSLOG_ADDRESS*` |  | Address to send log messages. Disabled if empty.
 |`*ROUTER_TCP_BALANCE_SCHEME*` | source | Load-balancing strategy for multiple endpoints for pass-through routes. Available options are `source`, `roundrobin`, or `leastconn`.
-|`*ROUTER_LOAD_BALANCE_ALGORITHM*` | leastconn | Load-balancing strategy routes with multiple endpoints. Available options are `source`, `roundrobin`, and `leastconn`.
 //|`*ROUTE_FIELDS*` |  | A field selector to apply to routes to watch, empty means all.
 |`*ROUTE_LABELS*` |  | A label selector to apply to the routes to watch, empty means all.
 |`*STATS_PASSWORD*` |  | The password needed to access router stats (if the router implementation supports it).
@@ -283,7 +280,6 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`*RELOAD_INTERVAL*` | 12s | The minimum frequency the router is allowed to reload to accept new changes. xref:time-units[(TimeUnits)]
 |`*ROUTER_USE_PROXY_PROTOCOL*`|  | When set to `true` or `TRUE`, HAProxy expects incoming connections to use the `PROXY` protocol on port 80 or port 443. The source IP address can pass through a load balancer if the load balancer supports the protocol, for example Amazon ELB.
 |`*ROUTER_ALLOW_WILDCARD_ROUTES*`|  |  When set to `true` or `TRUE`, any routes with a wildcard policy of `Subdomain` that pass the router admission checks will be serviced by the HAProxy router.
-|`*ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK*` |  | Set to `true` to relax the namespace ownership policy.
 |===
 
 [[time-units]]
@@ -791,7 +787,7 @@ For all the items outlined in this section, you can set annotations on the
 [cols="3*", options="header"]
 |===
 |Variable | Description | Environment Variable Used as Default
-|`*haproxy.router.openshift.io/balance*`| Sets the load-balancing algorithm. Available options are `source`, `roundrobin`, and `leastconn`. | `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, use `ROUTER_LOAD_BALANCE_ALGORITHM`.
+|`*haproxy.router.openshift.io/balance*`| Sets the load-balancing algorithm. Available options are `source`, `roundrobin`, and `leastconn`. | `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, `leastconn`.
 |`*haproxy.router.openshift.io/disable_cookies*`| Disables the use of cookies to track related connections. If set to `true` or `TRUE`, the balance algorithm is used to choose which back-end serves connections for each incoming HTTP request. |
 |`*haproxy.router.openshift.io/rate-limit-connections*`| Setting `true` or `TRUE` to enables rate limiting functionality. |
 |`*haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp*`| Limits the number of concurrent TCP connections shared by an IP address. |


### PR DESCRIPTION
Delete some documentation that was erroneously added in commit 65579a513f6f21292b477955967e1660c3a5d601 for features that exist only in later versions of OpenShift Container Platform:

• Disabling the namespace ownership check, along with the `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK` variable, does not exist in 3.4.

• The `ROUTER_LOAD_BALANCE_ALGORITHM` variable does not exist in 3.4, and the default algorithm for routes that have no `haproxy.router.openshift.io/balance` annotation is "leastconn".

• The `ROUTER_MAX_CONNECTIONS` and `ROUTER_SLOWLORIS_HTTP_KEEPALIVE` variables and associated functionality do not exist in 3.4.

---

@pecameron, are these changes reasonable, or am I missing something?