### PR TITLE
UPSTREAM: 3693: Cinder: Automatically Generate Zone if Availability in Storage Class is not Configured

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -154,7 +154,7 @@ parameters:
 
 ----
 <1> VolumeType created in Cinder. Default is empty.
-<2> Availability Zone. Default is empty.
+<2> Availability Zone. If not specified, volumes are generally round-robin-ed across all active zones where {product-title} cluster has a node.
 
 [[aws-elasticblockstore-ebs]]
 === AWS ElasticBlockStore (EBS) Object Defintion
@@ -177,7 +177,7 @@ parameters:
 ----
 
 <1> Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
-<2> AWS zone. If not specified, the zone is randomly selected from zones where {product-title} cluster has a node.
+<2> AWS zone. If not specified, volumes are generally round-robin-ed across all active zones where {product-title} cluster has a node.
 <3> Only for io1 volumes. I/O operations per second per GiB. The AWS volume plug-in multiplies this with the size of the requested volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which is the maximum supported by AWS. See AWS documentation for further details.
 <4> Denotes whether to encrypt the EBS volume. Valid values are `true` or `false`.
 <5> (optional) The full Amazon Resource Name (ARN) of the key to use when encrypting the volume. If none is supplied but encrypted is true, AWS generates a key. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
@@ -198,7 +198,7 @@ parameters:
   zone: us-central1-a  <2>
 ----
 <1> Select either `pd-standard` or `pd-ssd`. The default is `pd-ssd`.
-<2> GCE zone. If not specified, the zone is randomly chosen from zones in the same region as `controller-manager`.
+<2> GCE zone. If not specified, volumes are generally round-robin-ed across all active zones where {product-title} cluster has a node.
 
 
 [[glusterfs]]


### PR DESCRIPTION
Backport of Kubernetes PR https://github.com/kubernetes/kubernetes.github.io/pull/3693.

Corresponding source code OpenShift origin PR https://github.com/openshift/origin/pull/14159.

Documents the Cinder volume plugin behaviour in case the `availability` parameter in a Storage Class is not configured.

Improves description of aws-ebs and gce-pd volume plugins behavior in case `zone` parameter in a Storage Class is not configured.

Target OpenShift version: 3.6 and higher

@jsafrane @openshift/team-documentation PTAL
