### PR TITLE
Added example for making ceph-user-secret default

### DIFF
--- a/install_config/storage_examples/ceph_example.adoc
+++ b/install_config/storage_examples/ceph_example.adoc
@@ -273,3 +273,45 @@ spec:
 <1> `*securityContext*` must be defined at the pod level, not under a specific container.
 <2> All containers in the pod will have the same `*fsGroup*` ID.
 ====
+
+[[using-ceph-rbd-setting-default-secret]]
+== Setting ceph-user-secret as Default for Projects
+
+If you would like to make the persistent storage available to every project you have to modify the default project template.
+You can read more on modifying the default project template. Read more on xref:../admin_guide/managing_projects.adoc#selfprovisioning-projects[modifying the default project template].
+Adding this to your default project template allows every user who has access to create a project access to the Ceph cluster.
+
+.Default Project Example
+====
+[source,yaml]
+----
+...
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: project-request
+objects:
+- apiVersion: v1
+  kind: Project
+  metadata:
+    annotations:
+      openshift.io/description: ${PROJECT_DESCRIPTION}
+      openshift.io/display-name: ${PROJECT_DISPLAYNAME}
+      openshift.io/requester: ${PROJECT_REQUESTING_USER}
+    creationTimestamp: null
+    name: ${PROJECT_NAME}
+  spec: {}
+  status: {}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ceph-user-secret
+  data:
+    key: yoursupersecretbase64keygoeshere <1>
+  type:
+    kubernetes.io/rbd
+...
+----
+<1> Place your super secret Ceph user key here in base64 format. See xref:../install_config/storage_examples/ceph_example.adoc#using-ceph-rbd-creating-the-ceph-secret[Creating the Ceph Secret].
+====


### PR DESCRIPTION
This addition adds instructions on how to add the ceph-user-secret to every project created, thus eliminating the need for every user to add their own ceph key.