### PR TITLE
Correct playbook path for Metrics deployment or Upgrade

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -502,7 +502,7 @@ The following command sets the Hawkular Metrics route to use
 You must have a persistent volume of sufficient size available.
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_metrics.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift-metrics.yml \
    -e openshift_metrics_install_metrics=True \
    -e openshift_metrics_hawkular_hostname=hawkular-metrics.example.com \
    -e openshift_metrics_cassandra_storage_type=pv
@@ -515,7 +515,7 @@ The following command sets the Hawkular Metrics route to use
 *hawkular-metrics.example.com* and deploy without persistent storage.
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_metrics.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift-metrics.yml \
    -e openshift_metrics_install_metrics=True \
    -e openshift_metrics_hawkular_hostname=hawkular-metrics.example.com
 ----
@@ -727,6 +727,6 @@ You can remove everything deployed by the OpenShift Ansible `openshift_metrics` 
 by performing the following steps:
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_metrics.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift-metrics.yml \
    -e openshift_metrics_install_metrics=False
 ----

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -542,7 +542,7 @@ logging deployment upgrade.
 
 // tag::automated-metrics-upgrade-steps[]
 To upgrade an existing cluster metrics deployment, you must use the provided
-*_/usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/openshift_metrics.yml_*
+*_/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml_*
 Ansible playbook. This is the playbook to use if you were deploying metrics for
 the first time on an existing cluster, but is also used to upgrade existing
 metrics deployments.


### PR DESCRIPTION
The playbook path for Metrics deployment or Upgrade should be /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml instead of /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/openshift_metrics.yml 