### PR TITLE
Trello: Promote Init Containers to GA

### DIFF
--- a/architecture/core_concepts/containers_and_images.adoc
+++ b/architecture/core_concepts/containers_and_images.adoc
@@ -50,10 +50,7 @@ containers allow you to reorganize setup scripts and binding code. An init
 container differs from a regular container in that it always runs to completion.
 Each init container must complete successfully before the next one is started.
 
-The link:http://kubernetes.io/docs/user-guide/pods/init-container/[Kubernetes
-documentation] has more information on init containers, including
-link:https://kubernetes.io/docs/user-guide/production-pods/#handling-initialization[usage
-examples].
+For more information, see xref:pods_and_services.adoc#pods-services-init-containers[Pods and Services].
 
 [[docker-images]]
 

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -53,6 +53,7 @@ service, which is actually a part of the {product-title} infrastructure: the
 integrated container registry. It demonstrates many features of pods, most of
 which are discussed in other topics and thus only briefly mentioned here:
 
+[[example-pod-definition]]
 .Pod Object Definition (YAML)
 ====
 
@@ -159,6 +160,58 @@ has complete details of the pod REST API object attributes, and the
 link:https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/pods.md[Kubernetes pod documentation]
 has details about the functionality and purpose of pods.
 ====
+
+[[pods-services-init-containers]]
+== Init Containers
+
+An link:https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[init container] is a container in a pod that is started before the pod app containers are started. Init containers can share volumes, perform network operations, and perform computations before the remaining containers start. Init containers can also block or delay the startup of application containers until some precondition is met. 
+
+When a pod starts, after the network and volumes are initialized, the init containers are started in order. Each init container must exit successfully before the next is invoked. If an init container fails to start (due to the runtime) or exits with failure, it is retried according to the pod 
+xref:../../dev_guide/configmaps.adoc#consuming-configmap-in-pods[`restartPolicy`]: 
+
+* `Always` - Tries restarting continuously, with an exponential back-off delay of (10s, 20s, 40s) until the pod is restarted. 
+* `Never` - Does not try to restart. Pods immediately fail and exit.  
+* `OnFailure` - Tries restarting with an exponential back-off delay of (10s, 20s, 40s) capped at five minutes.
+
+A pod cannot be ready until all init containers have succeeded. 
+
+See the Kubernetes documentation for some link:https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#examples[init container usage examples].
+
+The following example outlines a simple pod which has two init containers. The first init container waits for `myservice` and the second waits for `mydb`. Once both containers succeed, the Pod starts.
+
+.Sample Init Container Pod Object Definition (YAML)
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec:
+  containers:
+  - name: myapp-container 
+    image: busybox
+    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
+  initContainers:
+  - name: init-myservice <1>
+    image: busybox
+    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+  - name: init-mydb <2>
+    image: busybox
+    command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
+----
+
+====
+
+<1> Specifies the `myservice` container.
+<2> Specifies the `mydb` container.
+
+Each init container has all of the xref:example-pod-definition[fields of an app container] except for xref:../../dev_guide/application_health.adoc#container-health-checks-using-probes[`readinessProbe`]. Init containers must exit for pod startup to continue and cannot define readiness other than completion.
+
+Init containers can include xref:../../dev_guide/jobs.adoc#jobs-setting-maximum-duration[`activeDeadlineSeconds`] on the pod and xref:../../dev_guide/application_health.adoc#container-health-checks-using-probes[`livenessProbe`] on the container to prevent init containers from failing forever. The active deadline includes init containers.
 
 [[services]]
 


### PR DESCRIPTION
For Trello: https://trello.com/c/y5h5MhaB/387-document-node-promote-init-containers-to-ga

Per Derek email: it would be good if we can get a pod spec that uses init-containers demonstrated in this example: https://docs.openshift.org/latest/architecture/core_concepts/pods_and_services.html

there is a sample pod spec that uses an init-containers in the upstream doc here that could be inserted in the referenced example above.
https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

I took the end-user appearing information from
https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-init.md
and 
https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

Does this section cover the need?
Do I need more information? 
http://file.rdu.redhat.com/mburke/trello-init-containers/trello-init-containers/architecture/core_concepts/pods_and_services.html#init-containers