### PR TITLE
add "Configuring Cluster Preflight Checks" sub-section

### DIFF
--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -115,3 +115,55 @@ A client with *cluster-admin* access available (for any user, but only the
 current master) should be able to diagnose the status of infrastructure such as
 nodes, registry, and router. In each case, running `oc adm diagnostics` looks
 for the client configuration in its standard location and uses it if available.
+
+[[additional-cluster-health-checks]]
+== Additional Diagnostic Checks
+
+Some additional diagnostic checks are available through the https://hub.docker.com/r/openshift/openshift-ansible[openshift-ansible]
+Docker image. These checks are a set of diagnostic tasks meant to be run against a running OpenShift cluster.
+They are used to ensure Etcd cluster storage sanity, that correct package versions exist on the host machine, and to ensure a working logging stack deployment.
+
+
+An action plugin for the OpenShift Health Checks role automatically discovers all diagnostic checks, and executes only those selected in a play.
+Some checks have tags, which allow for groups of related checks to be run together as part of a play.
+
+The following table describes available health checks that can be run on a deployed OpenShift cluster.
+
+[[diagnostic-checks]]
+.Diagnostic Checks
+[options="header"]
+|===
+
+|Check Name |Purpose |Tags
+
+|`*ovs_version*`
+|This check ensures that a host has the correct version of Open vSwitch installed for the currently deployed version of OpenShift.
+|`health`
+
+|`*kibana*`, `*curator*`, `*elasticsearch*`, `*fluentd*`
+|This set of checks verifies that `Elasticsearch`, `Fluentd`, and `Curator` pods have been deployed and are in a `running` state, and that a connection can be established between the control host and the exposed `Kibana` URL.
+
+A check for each component can be run on its own, or the entire  set of checks for the logging stack can be run by using the `logging` tag.
+|`health`, `logging`
+
+|`*etcd_imagedata_size*`
+|This check measures the total size of OpenShift image data in an Etcd cluster. Fails if the calculated size exceeds a user-defined limit. If no limit is specified, this check will fail if the size of OpenShift image data amounts to `50%`
+or more of the currently used space in the Etcd cluster.
+
+A user-defined limit may be set by passing the variable `etcd_max_image_data_size_bytes=10000` to the `openshift_health_checker` role.
+|`etcd`
+
+|`*etcd_volume*`
+|This check ensures that the volume usage for an Etcd cluster is below a maximum user-specified threshold. If no maximum threshold value is specified, it is defaulted to `90%` of the total volume size.
+
+A user-defined limit may be set by passing the variable `etcd_device_usage_threshold_percent=90` to the `openshift_health_checker` role.
+|`health`, `etcd`
+
+|`*docker_storage*`
+|Only runs on checks that depend on Docker (nodes and containerized installations). Checks that total thinpool usage for the logical volume does not exceed a user defined limit.
+If no user-defined limit is set, the maximum thinpool usage threshold defaults to `90%` of the total size available.
+The threshold limit for total thinpool percent usage can be set with a variable in your inventory file: `max_thinpool_data_usage_percent: 90`
+|`health`, `preflight`
+|===
+
+A similar set of checks, meant to run as part of the installation process can be found in xref:../../install_config/install/advanced_install.adoc#configuring-cluster-preflight-checks[Configuring Cluster Preflight Checks].

--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -106,7 +106,7 @@ and/or may be running on a host where {product-title} master or node servers are
 operating. The diagnostics attempt to use as much access as the user has
 available.
 
-A client with ordinary access should be able to diagnose its connection
+A client with or`dinary access should be able to diagnose its connection
 to the master and run a diagnostic pod. If multiple users or masters are
 configured, connections will be tested for all, but the diagnostic pod
 only runs against the current user, server, or project.
@@ -117,15 +117,24 @@ nodes, registry, and router. In each case, running `oc adm diagnostics` looks
 for the client configuration in its standard location and uses it if available.
 
 [[additional-cluster-health-checks]]
-== Additional Diagnostic Checks
+== Additional Diagnostic Checks via Ansible
 
-Some additional diagnostic checks are available through the https://hub.docker.com/r/openshift/openshift-ansible[openshift-ansible]
-Docker image. These checks are a set of diagnostic tasks meant to be run against a running OpenShift cluster.
-They are used to ensure Etcd cluster storage sanity, that correct package versions exist on the host machine, and to ensure a working logging stack deployment.
+// TODO: add link to OSE image once it is available
+Some additional diagnostic checks are available through the openshift-ansible
+Docker image.
+Usage information for this image https://github.com/openshift/openshift-ansible/blob/master/README_CONTAINER_IMAGE.md[can be found here].
 
+A similar set of checks for checking certificate expiration can be found in ../../install_config/redeploying_certificates.adoc[Redeploying Certificates].
 
-An action plugin for the OpenShift Health Checks role automatically discovers all diagnostic checks, and executes only those selected in a play.
-Some checks have tags, which allow for groups of related checks to be run together as part of a play.
+The following checks belong to a diagnostic task meant to be run against the Ansible inventory file for a deployed OpenShift cluster.
+They can report common OpenShift-specific problems for the current OpenShift installation.
+
+To disable specific checks, include the variable `openshift_disable_check` with a
+comma-delimited list of check names in your inventory file. For example:
+
+----
+openshift_disable_check=ovs_version,etcd_volume
+----
 
 The following table describes available health checks that can be run on a deployed OpenShift cluster.
 
@@ -134,36 +143,32 @@ The following table describes available health checks that can be run on a deplo
 [options="header"]
 |===
 
-|Check Name |Purpose |Tags
+|Check Name |Purpose
 
 |`*ovs_version*`
 |This check ensures that a host has the correct version of Open vSwitch installed for the currently deployed version of OpenShift.
-|`health`
 
 |`*kibana*`, `*curator*`, `*elasticsearch*`, `*fluentd*`
 |This set of checks verifies that `Elasticsearch`, `Fluentd`, and `Curator` pods have been deployed and are in a `running` state, and that a connection can be established between the control host and the exposed `Kibana` URL.
-
-A check for each component can be run on its own, or the entire  set of checks for the logging stack can be run by using the `logging` tag.
-|`health`, `logging`
+These checks will only run if the `openshift_hosted_logging_deploy` inventory variable is set to `true`, to ensure that they are executed in a deployment where a logging stack has been deployed.
 
 |`*etcd_imagedata_size*`
-|This check measures the total size of OpenShift image data in an Etcd cluster. Fails if the calculated size exceeds a user-defined limit. If no limit is specified, this check will fail if the size of OpenShift image data amounts to `50%`
-or more of the currently used space in the Etcd cluster.
+|This check measures the total size of OpenShift image data in an etcd cluster. Fails if the calculated size exceeds a user-defined limit. If no limit is specified, this check will fail if the size of OpenShift image data amounts to `50%`
+or more of the currently used space in the etcd cluster.
 
-A user-defined limit may be set by passing the variable `etcd_max_image_data_size_bytes=10000` to the `openshift_health_checker` role.
-|`etcd`
+A failure from this check indicates that a significant amount of space in etcd is being taken up by OpenShift image data, which can eventually result in your etcd cluster crashing.
+
+A user-defined limit may be set by passing the variable `etcd_max_image_data_size_bytes=400000000` to the `openshift_health_checker` role.
 
 |`*etcd_volume*`
-|This check ensures that the volume usage for an Etcd cluster is below a maximum user-specified threshold. If no maximum threshold value is specified, it is defaulted to `90%` of the total volume size.
+|This check ensures that the volume usage for an etcd cluster is below a maximum user-specified threshold. If no maximum threshold value is specified, it is defaulted to `90%` of the total volume size.
 
 A user-defined limit may be set by passing the variable `etcd_device_usage_threshold_percent=90` to the `openshift_health_checker` role.
-|`health`, `etcd`
 
 |`*docker_storage*`
-|Only runs on checks that depend on Docker (nodes and containerized installations). Checks that total thinpool usage for the logical volume does not exceed a user defined limit.
-If no user-defined limit is set, the maximum thinpool usage threshold defaults to `90%` of the total size available.
-The threshold limit for total thinpool percent usage can be set with a variable in your inventory file: `max_thinpool_data_usage_percent: 90`
-|`health`, `preflight`
+|Only runs on hosts that depend on Docker (nodes and containerized installations). Checks that Docker's total usage does not exceed a user defined limit.
+If no user-defined limit is set, Docker's maximum usage threshold defaults to `90%` of the total size available.
+The threshold limit for total percent usage can be set with a variable in your inventory file: `max_thinpool_data_usage_percent: 90`
 |===
 
-A similar set of checks, meant to run as part of the installation process can be found in xref:../../install_config/install/advanced_install.adoc#configuring-cluster-preflight-checks[Configuring Cluster Preflight Checks].
+A similar set of checks, meant to run as part of the installation process can be found in ../../install_config/install/advanced_install.adoc#configuring-cluster-preinstall-checks[Configuring Cluster Pre-install Checks].

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -398,6 +398,77 @@ meaning that it is available for placement of new pods. See
 xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Masters].
 |===
 
+
+
+[[configuring-cluster-preflight-checks]]
+=== Configuring Cluster Preflight Checks
+
+Preflight checks are a set of diagnostic tasks that run as part of the `OpenShift Health Checks` Ansible role.
+They run prior to an Ansible installation of OpenShift, and ensure that required inventory values are set, and identify potential issues on a host
+that can prevent or interfere with a successful OpenShift installation.
+
+An action plugin for the Health Checks role automatically discovers all checks, and executes only those selected in a play.
+Some checks have tags, which allow for groups of related checks to be run together.
+
+To disable specific preflight checks, include the variable `openshift_disable_check` with a
+comma-delimited list of check names in your inventory file. For example:
+
+----
+openshift_disable_check=memory_availability,disk_availability
+----
+
+The following table describes available preflight checks that will run before every Ansible
+installaton:
+
+
+[[preflight-checks]]
+.Preflight Checks
+[options="header"]
+|===
+
+|Check Name |Purpose |Tags
+
+|`*memory_availability*`
+|This check ensures that a host has the recommended amount of memory for the specific deployment of OpenShift.
+Values are taken from the https://docs.openshift.org/latest/install_config/install/prerequisites.html#system-requirements[latest installation documentation].
+|`preflight`
+
+|`*disk_availability*`
+|This check only runs on etcd, master, and node hosts. It ensures that the mount path for an OpenShift installation has
+sufficient disk space remaining. Recommended disk values are taken from the https://docs.openshift.org/latest/install_config/install/prerequisites.html#system-requirements[latest installation documentation].
+|`preflight`
+
+|`*docker_storage*`
+|Only runs on checks that depend on Docker (nodes and containerized installations). Checks that total thinpool usage for the logical volume does not exceed a user defined limit.
+If no user-defined limit is set, the maximum thinpool usage threshold defaults to `90%` of the total size available.
+The threshold limit for total thinpool percent usage can be set with a variable in your inventory file: `max_thinpool_data_usage_percent: 90`
+|`health`, `preflight`
+
+|`*docker_storage_driver*`
+|Ensures that Docker is using a storage driver supported by OpenShift. If the https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver[devicemapper] storage driver is being used, the check
+additionally ensures that a loopback device is not being used.
+|`preflight`
+
+|`*docker_image_availability*`
+|Attempts to ensure that images required by an OpenShift installation are available either locally or in at least one of the configured Docker registries on the host machine.
+|`preflight`
+
+|`*package_version*`
+|Runs on `yum-based` systems determining if multiple releases of a required OpenShift package are available.
+Having multiple releases of a package available during an `enterprise` installation of OpenShift suggests that there are multiple `yum` repositories enabled for different releases, which may lead to installation problems.
+This check is skipped if the `openshift_release` variable is not defined in the inventory file.
+|`preflight`
+
+|`*package_availability*`
+|Runs prior to non-containerized installations of OpenShift. Ensures that RPM packages required for the current OpenShift installation are available.
+|`preflight`
+
+|`*package_update*`
+|Checks whether a `yum` update or package installation will succeed, without actually performing it or running `yum` on the host.
+|`preflight`
+|===
+
+
 [[advanced-install-configuring-registry-location]]
 === Configuring a Registry Location
 

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -400,72 +400,66 @@ xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Master
 
 
 
-[[configuring-cluster-preflight-checks]]
-=== Configuring Cluster Preflight Checks
+[[configuring-cluster-pre-install-checks]]
+=== Configuring Cluster Pre-install Checks
 
-Preflight checks are a set of diagnostic tasks that run as part of the `OpenShift Health Checks` Ansible role.
+Pre-install checks are a set of diagnostic tasks that run as part of the `OpenShift Health Checks` Ansible role.
 They run prior to an Ansible installation of OpenShift, and ensure that required inventory values are set, and identify potential issues on a host
 that can prevent or interfere with a successful OpenShift installation.
 
-An action plugin for the Health Checks role automatically discovers all checks, and executes only those selected in a play.
-Some checks have tags, which allow for groups of related checks to be run together.
+Checks may have one or more tags, which allow for groups of related checks to be run together.
 
-To disable specific preflight checks, include the variable `openshift_disable_check` with a
+To disable specific pre-install checks, include the variable `openshift_disable_check` with a
 comma-delimited list of check names in your inventory file. For example:
 
 ----
 openshift_disable_check=memory_availability,disk_availability
 ----
 
-The following table describes available preflight checks that will run before every Ansible
+The following table describes available pre-install checks that will run before every Ansible
 installaton:
 
 
-[[preflight-checks]]
-.Preflight Checks
+[[pre-install-checks]]
+.Pre-install Checks
 [options="header"]
 |===
 
-|Check Name |Purpose |Tags
+|Check Name |Purpose
 
 |`*memory_availability*`
 |This check ensures that a host has the recommended amount of memory for the specific deployment of OpenShift.
 Values are taken from the https://docs.openshift.org/latest/install_config/install/prerequisites.html#system-requirements[latest installation documentation].
-|`preflight`
+A user-defined value for minimum memory requirements may be set by passing the variable `openshift_check_min_host_memory_gb` to the `openshift_health_checker` role.
 
 |`*disk_availability*`
 |This check only runs on etcd, master, and node hosts. It ensures that the mount path for an OpenShift installation has
 sufficient disk space remaining. Recommended disk values are taken from the https://docs.openshift.org/latest/install_config/install/prerequisites.html#system-requirements[latest installation documentation].
-|`preflight`
+A user-defined value for minimum disk space requirements may be set by passing the variable `openshift_check_min_host_disk_gb` to the `openshift_health_checker` role.
 
 |`*docker_storage*`
-|Only runs on checks that depend on Docker (nodes and containerized installations). Checks that total thinpool usage for the logical volume does not exceed a user defined limit.
-If no user-defined limit is set, the maximum thinpool usage threshold defaults to `90%` of the total size available.
-The threshold limit for total thinpool percent usage can be set with a variable in your inventory file: `max_thinpool_data_usage_percent: 90`
-|`health`, `preflight`
+|Only runs on checks that depend on Docker (nodes and containerized installations). Checks that Docker's total usage does not exceed a user-defined limit.
+If no user-defined limit is set, Docker's maximum usage threshold defaults to `90%` of the total size available.
+The threshold limit for total percent usage can be set with a variable in your inventory file: `max_thinpool_data_usage_percent: 90`
+A user-defined limit for maximum thinpool usage may be set by passing the variable `max_thinpool_data_usage_percent=80%` to the `openshift_health_checker` role.
 
 |`*docker_storage_driver*`
 |Ensures that Docker is using a storage driver supported by OpenShift. If the https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver[devicemapper] storage driver is being used, the check
 additionally ensures that a loopback device is not being used.
-|`preflight`
 
 |`*docker_image_availability*`
 |Attempts to ensure that images required by an OpenShift installation are available either locally or in at least one of the configured Docker registries on the host machine.
-|`preflight`
 
 |`*package_version*`
 |Runs on `yum-based` systems determining if multiple releases of a required OpenShift package are available.
 Having multiple releases of a package available during an `enterprise` installation of OpenShift suggests that there are multiple `yum` repositories enabled for different releases, which may lead to installation problems.
 This check is skipped if the `openshift_release` variable is not defined in the inventory file.
-|`preflight`
 
 |`*package_availability*`
 |Runs prior to non-containerized installations of OpenShift. Ensures that RPM packages required for the current OpenShift installation are available.
-|`preflight`
 
 |`*package_update*`
 |Checks whether a `yum` update or package installation will succeed, without actually performing it or running `yum` on the host.
-|`preflight`
 |===
 
 


### PR DESCRIPTION
Related trello card: https://trello.com/c/dxXLsKYz

Documents the use of diagnostic tools. Adds subsections explaining preflight and non-preflight cluster health checks.

TODO
- [x] add section for `health` checks under [Diagnostic Tool](https://docs.openshift.com/container-platform/3.5/admin_guide/diagnostics_tool.html)

cc @adellape @brenton @sosiouxme 