### PR TITLE
Fixes to image annotation spec

### DIFF
--- a/security/container_content.adoc
+++ b/security/container_content.adoc
@@ -91,11 +91,12 @@ quality.images.openshift.io/<qualityType>.<providerId>: {}
 |Metadata type
 |`vulnerability` +
 `license` +
-`operations`
+`operations` +
+`policy`
 
 |`providerId`
 |Provider ID string
-|`redhatcloudforms` +
+|`openscap` +
 `redhatcatalog` +
 `redhatinsights` +
 `blackduck` +
@@ -109,7 +110,7 @@ quality.images.openshift.io/<qualityType>.<providerId>: {}
 quality.images.openshift.io/vulnerability.blackduck: {}
 quality.images.openshift.io/vulnerability.jfrog: {}
 quality.images.openshift.io/license.blackduck: {}
-quality.images.openshift.io/vulnerability.redhatcloudforms: {}
+quality.images.openshift.io/vulnerability.openscap: {}
 ----
 
 The value of the image quality annotation is structured data that must adhere to
@@ -128,7 +129,7 @@ the following format:
 |`timestamp`
 |Yes
 |Scan timestamp
-|Integer
+|String
 
 |`description`
 |No
@@ -136,8 +137,13 @@ the following format:
 |String
 
 |`reference`
+|Yes
+|URL of information source and/or more details. Required so user may validate the data.
+|String
+
+|`scannerVersion`
 |No
-|URL for detailed information
+|Scanner version
 |String
 
 |`compliant`
@@ -147,7 +153,7 @@ the following format:
 
 |`summary`
 |No
-|Summary of vulnerabilities found
+|Summary of issues found
 |List (see table below)
 |===
 
@@ -159,58 +165,64 @@ The `summary` field must adhere to the following format:
 |Field |Description |Type
 
 |`label`
-|Display label for component (e.g., critical, important, moderate, low, or freshness)
+|Display label for component (e.g., "critical", "important", "moderate", "low" or "health")
 |String
 
-|`score`
-|Score for this component (e.g., count of vulnerabilities found)
-|Integer
+|`data`
+|Data for this component (e.g., count of vulnerabilities found or score)
+|String
 
 |`severityIndex`
-|Component score index allowing for ordering and assigning graphical
-representation. The value is a range where `0` = low or none.
+|Component index allowing for ordering and assigning graphical
+representation. The value is range `0..3` where `0` = low.
 |Integer
+
+|`reference`
+|URL of information source and/or more details. Optional.
+|String
 |===
 
 [[security-example-annotation-values]]
 ==== Example Annotation Values
 
-This example shows a Red Hat CloudForms annotation for an image with
+This example shows an OpenSCAP annotation for an image with
 vulnerability summary data and a compliance boolean:
 
-.Red Hat CloudForms Annotation
+.OpenSCAP Annotation
 [source,json]
 ----
 {
-  “name”: “CloudForms”,
-  “description”: “vulnerability score”,
-  “timestamp”: 2147483647,
-  “reference”: null,
-  “compliant”: true,
-  “summary”: [
-    { “label”: “critical”, “score”: 4, “severityIndex”: 3 },
-    { “label”: “important”, “score”: 12, “severityIndex”: 2 },
-    { “label”: “moderate”, “score”: 8, “severityIndex”: 1 },
-    { “label”: “low”, “score”: 26, “severityIndex”: 0 }
+  "name": "OpenSCAP",
+  "description": "OpenSCAP vulnerability score",
+  "timestamp": "2016-09-08T05:04:46Z",
+  "reference": "https://www.open-scap.org/930492",
+  "compliant": true,
+  "scannerVersion": "1.2",
+  "summary": [
+    { "label": "critical", "data": "4", "severityIndex": 3, "reference": null },
+    { "label": "important", "data": "12", "severityIndex": 2, "reference": null },
+    { "label": "moderate", "data": "8", "severityIndex": 1, "reference": null },
+    { "label": "low", "data": "26", "severityIndex": 0, "reference": null }
   ]
 }
 ----
 
 This example shows a
-xref:../security/registries.adoc#security-registries-red-hat-registry-and-container-catalog[Red Hat Container Catalog] annotation for an image with vulnerability summary data
+xref:../security/registries.adoc#security-registries-red-hat-registry-and-container-catalog[Red Hat Container Catalog] annotation for an image with health index data
 with an external URL for additional details:
 
 .Red Hat Container Catalog Annotation
 [source,json]
 ----
 {
-  “name”: “Red Hat Container Catalog”,
-  “description”: “Container freshness score”,
-  “timestamp”: 2147483647,
-  “reference”: “https://access.redhat.com/errata/RHBA-2016:1566”,
-  “compliant”: null,
-  “summary”: [
-    { “label”: “Freshness”, “score”: 4, “severityIndex”: 4 }
+  "name": "Red Hat Container Catalog",
+  "description": "Container health index",
+  "timestamp": "2016-09-08T05:04:46Z",
+  "reference": "https://access.redhat.com/errata/RHBA-2016:1566",
+  "compliant": null,
+  "scannerVersion": "1.2",
+  "summary": [
+    { "label": "Health index", "data": "B", "severityIndex": 1, "reference": null }
   ]
 }
 ----
@@ -235,12 +247,13 @@ Replace `<image>` with an image digest, for example
 $ oc annotate image <image> \
     quality.images.openshift.io/vulnerability.redhatcatalog='{ \
     "name": "Red Hat Container Catalog", \
-    “description”: “Container freshness score”, \
-    “timestamp”: 2147483647, \
-    “compliant”: null, \
-    "reference": “https://access.redhat.com/errata/RHBA-2016:1566”, \
-    "summary": “[ \
-      { “label”: “Freshness”, “score”: 4, “severityIndex”: 4 } ]" }'
+    "description": "Container health index", \
+    "timestamp": "2016-09-08T05:04:46Z", \
+    "compliant": null, \
+    "scannerVersion": "1.2", \
+    "reference": "https://access.redhat.com/errata/RHBA-2016:1566", \
+    "summary": "[ \
+      { "label": "Health index", "data": 'B', "severityIndex": 1, "reference": null } ]" }'
 ----
 
 [[controlling-pod-execution]]
@@ -294,7 +307,7 @@ Below is example `PATCH` payload data.
 "metadata": {
   "annotations": {
     "quality.images.openshift.io/vulnerability.redhatcatalog":
-       "{ 'name': 'Red Hat Container Catalog', 'description': 'Container freshness score', 'timestamp': 2147483647, 'compliant': null, 'reference': 'https://access.redhat.com/errata/RHBA-2016:1566', 'summary': [{'label': 'Freshness', 'score': 4, 'severityIndex': 4}] }"
+       "{ 'name': 'Red Hat Container Catalog', 'description': 'Container health index', 'timestamp': '2016-09-08T05:04:46Z', 'compliant': null, 'reference': 'https://access.redhat.com/errata/RHBA-2016:1566', 'summary': [{'label': 'Health index', 'data': '4', 'severityIndex': 1, 'reference': null}] }"
     }
   }
 }


### PR DESCRIPTION
Updated based on feedback from #4206 

- added "policy" type
- reference URL is required for external data validation
- added optional reference URL per component
- score -> data string (allows for non-int data)
- CloudForms -> OpenSCAP
- fixed quote formatting

@goern could you review?

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>