### PR TITLE
Document the DROP_SYN_DURING_RESTART and FIN timeout env variables

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -21,15 +21,21 @@ $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 |`DEFAULT_CERTIFICATE` |  | The contents of a default certificate to use for routes that don't expose a TLS server cert; in PEM format.
 |`DEFAULT_CERTIFICATE_DIR` |  | A path to a directory that contains a file named *_tls.crt_*. If *_tls.crt_* is not a PEM file which also contains a private key, it is first combined with a file named tls.key in the same directory. The PEM-format contents are then used as the default certificate. Only used if `DEFAULT_CERTIFICATE` or `DEFAULT_CERTIFICATE_PATH` are not specified.
 |`DEFAULT_CERTIFICATE_PATH` |  | A path to default certificate to use for routes that don't expose a TLS server cert; in PEM format. Only used if `DEFAULT_CERTIFICATE` is not specified.
+|`DROP_SYN_DURING_RESTART` |  `false` | When set to `true`, enables an iptables rule to drop certain packets during a restart to provide a seamless restart.
+ifdef::openshift-origin,openshift-enterprise[]
+See xref:../../install_config/router/default_haproxy_router.adoc#preventing-connection-failures-during-restarts[the install guide] for details.
+endif::[]
 |`EXTENDED_VALIDATION` | `true` | If `true`, the router confirms that the certificate is structurally correct. It does not verify the certificate against any CA. Set `false` to turn off the tests.
 |`NAMESPACE_LABELS` |  | A label selector to apply to namespaces to watch, empty means all.
 |`PROJECT_LABELS` |  | A label selector to apply to projects to watch, emtpy means all.
 |`RELOAD_SCRIPT` |  | The path to the reload script to use to reload the router.
 |`ROUTER_ALLOWED_DOMAINS` | | A comma-separated list of domains that the host name in a route can only be part of. Any subdomain in the domain can be used. Option `ROUTER_DENIED_DOMAINS` overrides any values given in this option. If set, everything outside of the allowed domains will be rejected.
 |`ROUTER_BACKEND_CHECK_INTERVAL` | 5000ms | Length of time between subsequent "liveness" checks on backends. xref:time-units[(TimeUnits)]
+|`ROUTER_CLIENT_FIN_TIMEOUT` | 1s | Controls the TCP FIN timeout period for the client connecting to the route. If the FIN sent to close the connection is not answered within the given time, HAProxy will close the connection anyway.  This is harmless if set to a low value and uses fewer resources on the router.  xref:time-units[(TimeUnits)]
 |`ROUTER_COMPRESSION_MIME` | "text/html text/plain text/css" | A space separated list of mime types to compress.
 |`ROUTER_DEFAULT_CLIENT_TIMEOUT`| 30s | Length of time within which a client has to acknowledge or send data. xref:time-units[(TimeUnits)]
 |`ROUTER_DEFAULT_CONNECT_TIMEOUT`| 5s | The maximum connect time. xref:time-units[(TimeUnits)]
+|`ROUTER_DEFAULT_SERVER_FIN_TIMEOUT` | 1s | Controls the TCP FIN timeout from the router to the pod backing the route.  xref:time-units[(TimeUnits)]
 |`ROUTER_DEFAULT_SERVER_TIMEOUT`| 30s | Length of time within which a server has to acknowledge or send data. xref:time-units[(TimeUnits)]
 |`ROUTER_DEFAULT_TUNNEL_TIMEOUT` | 1h | Length of time till which TCP or WebSocket connections will remain open. If you have websockets/tcp
 connections (and any time HAProxy is reloaded), the old HAProxy processes


### PR DESCRIPTION
We never documented DROP_SYN_DURING_RESTART, this fixes that.

It also adds documentation of the new ROUTER_CLIENT_FIN_TIMEOUT and ROUTER_DEFAULT_SERVER_FIN_TIMEOUT environment variables.  They were added by PR https://github.com/openshift/origin/pull/14220

For 1.6.0 only at the moment.