### PR TITLE
[OpenShift 3.7] Admins Can Configure Zones in Storage Class

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -170,17 +170,18 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   type: io1 <1>
   zone: us-east-1d <2>
-  iopsPerGB: "10" <3>
-  encrypted: true <4>
-  kmsKeyId: keyvalue <5>
+  zones: us-east-1d, us-east-1c <3>
+  iopsPerGB: "10" <4>
+  encrypted: true <5>
+  kmsKeyId: keyvalue <6>
 
 ----
-
 <1> Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
-<2> AWS zone. If not specified, volumes are generally round-robined across all active zones where the {product-title} cluster has a node.
-<3> Only for io1 volumes. I/O operations per second per GiB. The AWS volume plug-in multiplies this with the size of the requested volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which is the maximum supported by AWS. See AWS documentation for further details.
-<4> Denotes whether to encrypt the EBS volume. Valid values are `true` or `false`.
-<5> (optional) The full Amazon Resource Name (ARN) of the key to use when encrypting the volume. If none is supplied but encrypted is true, AWS generates a key. link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[See AWS docs for valid ARN value].
+<2> AWS zone. If neither zone nor zones is specified, volumes are generally round-robined across all active zones where the {product-title} cluster has a node. Zone and zones parameters must not be used at the same time.
+<3> A comma separated list of AWS zone(s). If neither zone nor zones is specified, volumes are generally round-robined across all active zones where the {product-title} cluster has a node. Zone and zones parameters must not be used at the same time.
+<4> Only for io1 volumes. I/O operations per second per GiB. The AWS volume plug-in multiplies this with the size of the requested volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which is the maximum supported by AWS. See AWS documentation for further details.
+<5> Denotes whether to encrypt the EBS volume. Valid values are `true` or `false`.
+<6> Optional. The full Amazon Resource Name (ARN) of the key to use when encrypting the volume. If none is supplied, but `encypted` is set to `true`, then AWS generates a key. See the link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] for a valid ARN value.
 
 [[gce-persistentdisk-gcePd]]
 === GCE PersistentDisk (gcePD) Object Defintion
@@ -196,10 +197,11 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard  <1>
   zone: us-central1-a  <2>
+  zones: us-central1-a, us-central1-b, us-east1-b  <3>
 ----
 <1> Select either `pd-standard` or `pd-ssd`. The default is `pd-ssd`.
-<2> GCE zone. If not specified, volumes are generally round-robined across all active zones where the {product-title} cluster has a node.
-
+<2> GCE zone. If neither zone nor zones is specified, volumes are generally round-robined across all active zones where the {product-title} cluster has a node. Zone and zones parameters must not be used at the same time.
+<3> A comma separated list of GCE zone(s). If neither zone nor zones is specified, volumes are generally round-robined across all active zones where the {product-title} cluster has a node. Zone and zones parameters must not be used at the same time.
 
 [[glusterfs]]
 === GlusterFS Object Defintion


### PR DESCRIPTION
The PR #38505 (https://github.com/kubernetes/kubernetes/pull/38505) added zones optional parameter to Storage Class for AWS and GCE provisioners.
There is Kubernetes documentation PR #3896 (https://github.com/kubernetes/kubernetes.github.io/pull/3896).

That's why OpenShift documentation needs to be updated accordingly.

Target OpenShift version: 3.7

@jsafrane @openshift/team-documentation PTAL