### PR TITLE
added more info to horizontal autoscaler docs

### DIFF
--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -124,36 +124,46 @@ spec:
 
 Use the `oc autoscale` command and specify the maximum number of pods to run at
 any given time. Optionally, you can specify the minimum number of pods and the
-average CPU utilization your pods should target as well, otherwise those are
+average memory utilization your pods should target as well, otherwise those are
 given default values from the {product-title} server.
 
-For example:
+. Enable the memory-based autoscaling by configuring the <file> file:
++
+----
+...
+apiServerArguments:
+  runtime-config:
+  - apis/autoscaling/v2alpha1=true
+...
+----
 
+. Specify the minimum number of pods and the average memory utilization your
+pods should target:
++
 ----
 $ oc autoscale dc/frontend --min 1 --max 10 /
-  --cpu-percent=80 deploymentconfig "hpa-resource-metrics-cpu" autoscaled
+  --cpu-percent=80 deploymentconfig "hpa-resource-metrics-memory" autoscaled
 ----
-
-The above example creates a horizontal pod autoscaler with the following
-definition:
-
++
+This command creates a horizontal pod autoscaler with the following definition:
++
 [source,yaml,options="nowrap"]
 ----
 apiVersion: autoscaling/v2alpha1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: hpa-resource-metrics-cpu <1>
+  name: hpa-resource-metrics-memory <1>
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1 <2>
     kind: ReplicationController <3>
-    name: hello-hpa-cpu <4>
+    name: hello-hpa-memory <4>
   minReplicas: 1 <5>
   maxReplicas: 10 <6>
   metrics:
   - type: Resource
     resource:
-      name: cpu
+      name: memory
       targetAverageValue: 50 <7>
 ----
 <1> The name of this horizontal pod autoscaler object

--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -127,7 +127,7 @@ any given time. Optionally, you can specify the minimum number of pods and the
 average memory utilization your pods should target as well, otherwise those are
 given default values from the {product-title} server.
 
-. Enable the memory-based autoscaling by configuring the <file> file:
+. Enable the memory-based autoscaling by configuring the `master-config.yaml` file:
 +
 ----
 ...

--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -127,7 +127,8 @@ any given time. Optionally, you can specify the minimum number of pods and the
 average memory utilization your pods should target as well, otherwise those are
 given default values from the {product-title} server.
 
-. Enable the memory-based autoscaling by configuring the `master-config.yaml` file:
+. Memory-base autoscaling is only available with the v2alpha1 version of the autoscaling API.
+  It must be enabled in your cluster's `master-config.yaml` file:
 +
 ----
 ...
@@ -137,15 +138,9 @@ apiServerArguments:
 ...
 ----
 
-. Specify the minimum number of pods and the average memory utilization your
-pods should target:
-+
-----
-$ oc autoscale dc/frontend --min 1 --max 10 /
-  --cpu-percent=80 deploymentconfig "hpa-resource-metrics-memory" autoscaled
-----
-+
-This command creates a horizontal pod autoscaler with the following definition:
+. Unlike CPU-based autoscaling, memory-based autoscaling requires specifying the autoscaler
+  using YAML instead of using the `oc autoscale` command.  Place the following in a file,
+  such as `hpa.yaml`:
 +
 [source,yaml,options="nowrap"]
 ----
@@ -164,7 +159,7 @@ spec:
   - type: Resource
     resource:
       name: memory
-      targetAverageValue: 50 <7>
+      targetAverageUtilization: 50 <7>
 ----
 <1> The name of this horizontal pod autoscaler object
 <2> The API version of the object to scale
@@ -172,8 +167,14 @@ spec:
 <4> The name of the object to scale
 <5> The minimum number of replicas to which to scale down
 <6> The maximum number of replicas to which to scale up
-<7> The average value of the requested CPU that each pod should be using
+<7> The average percentage of the requested memory that each pod should be using
 
+. Finally, create the autoscaler from the above file:
++
+----
+$ oc create -f hpa.yaml
+----
++
 
 
 [[viewing-a-hpa]]

--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -45,8 +45,11 @@ The following metrics are supported by horizontal pod autoscalers:
 
 |Metric |Description
 
-|CPU Utilization
+|CPU utilization
 |Percentage of the xref:../dev_guide/compute_resources.adoc#dev-cpu-requests[requested CPU]
+
+|Memory utilization
+|Percentage of the requested memory.
 |===
 
 [[hpa-autoscaling]]
@@ -71,7 +74,7 @@ directly to the replica count of the deployment configuration. Note that autosca
 applies only to the latest deployment in the `Complete` phase.
 
 [[creating-a-hpa]]
-== Creating a Horizontal Pod Autoscaler
+== Autoscaling for CPU Utilization
 
 Use the `oc autoscale` command and specify at least the maximum number of pods
 you want to run at any given time. You can optionally specify the minimum number
@@ -80,12 +83,10 @@ are given default values from the {product-title} server.
 
 For example:
 
-====
 ----
-$ oc autoscale dc/frontend --min 1 --max 10 --cpu-percent=80
-deploymentconfig "frontend" autoscaled
+$ oc autoscale dc/frontend --min 1 --max 10 /
+  --cpu-percent=80 deploymentconfig "frontend" autoscaled
 ----
-====
 
 The above example creates a horizontal pod autoscaler with the following
 definition:
@@ -117,6 +118,53 @@ spec:
 <6> The maximum number of replicas to which to scale up
 <7> The percentage of the requested CPU that each pod should ideally be using
 ====
+
+[[pod-autoscaling-memory]]
+== Autoscaling for Memory Utilization
+
+Use the `oc autoscale` command and specify the maximum number of pods to run at
+any given time. Optionally, you can specify the minimum number of pods and the
+average CPU utilization your pods should target as well, otherwise those are
+given default values from the {product-title} server.
+
+For example:
+
+----
+$ oc autoscale dc/frontend --min 1 --max 10 /
+  --cpu-percent=80 deploymentconfig "hpa-resource-metrics-cpu" autoscaled
+----
+
+The above example creates a horizontal pod autoscaler with the following
+definition:
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: autoscaling/v2alpha1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-resource-metrics-cpu <1>
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1 <2>
+    kind: ReplicationController <3>
+    name: hello-hpa-cpu <4>
+  minReplicas: 1 <5>
+  maxReplicas: 10 <6>
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageValue: 50 <7>
+----
+<1> The name of this horizontal pod autoscaler object
+<2> The API version of the object to scale
+<3> The kind of object to scale
+<4> The name of the object to scale
+<5> The minimum number of replicas to which to scale down
+<6> The maximum number of replicas to which to scale up
+<7> The average value of the requested CPU that each pod should be using
+
+
 
 [[viewing-a-hpa]]
 == Viewing a Horizontal Pod Autoscaler


### PR DESCRIPTION
As per: https://trello.com/c/7vxgSTxF/365-document-custom-metrics-extensible-metric-driven-hpa

@DirectXMan12 I'll tag you in trello, but I'm thinking that all that needs to be added to this card is objects into the table, then some rewriting to get away from the "only CPU utilization" phrase. Let me know if you disagree.