### PR TITLE
Correct link to default inventory file for aggregated logging

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -97,7 +97,7 @@ be applied to their deployment configurations.
 Parameters for the EFK deployment may be specified to the
  xref:../install_config/install/advanced_install.adoc#configuring-ansible[inventory host file]
 to override the
- https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_metrics/defaults/main.yaml[defaults]. Read the
+ https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_logging/defaults/main.yml[defaults]. Read the
 xref:aggregated-elasticsearch[Elasticsearch]
 and the xref:aggregated-fluentd[Fluentd] sections
 before choosing parameters:


### PR DESCRIPTION
The existing link points to the metrics project.