### PR TITLE
Correct incorrect route in oc new-app command

### DIFF
--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -347,7 +347,7 @@ the URL of the {product-title} OAuth provider, which is typically the master.
 ----
 $ oc new-app -n default --template=registry-console \
     -p OPENSHIFT_OAUTH_PROVIDER_URL="https://<openshift_oauth_url>:8443" \
-    -p REGISTRY_HOST=$(oc get route docker-registry -n default --template='{{ .spec.host }}') \
+    -p REGISTRY_HOST=$(oc get route registry-console -n default --template='{{ .spec.host }}') \
     -p COCKPIT_KUBE_URL=$(oc get route registry-console -n default --template='https://{{ .spec.host }}')
 ----
 


### PR DESCRIPTION
The docker-registry route does not exist, only the registry-console route. Changing the example command to use registry-console allows it to run successfully and the registry console UI to be accessed. I cannot confirm if this is correct behavior or that it simply "works".