### PR TITLE
Replace `oadm policy` by `oc adm policy` in some places

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -550,7 +550,7 @@ $ oc create serviceaccount ipfailover -n default
 +
 ====
 ----
-$ oadm policy add-scc-to-user privileged system:serviceaccount:default:ipfailover
+$ oc adm policy add-scc-to-user privileged system:serviceaccount:default:ipfailover
 ----
 ====
 

--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -209,9 +209,9 @@ Default SCCs will be created when the master is started if they are missing. To 
 to defaults, or update existing SCCs to new default definitions after an upgrade you may:
 
 . Delete any SCC you would like to be reset and let it be recreated by restarting the master
-. Use the `oadm policy reconcile-sccs` command
+. Use the `oc adm policy reconcile-sccs` command
 
-The `oadm policy reconcile-sccs` command will set all SCC policies to the default
+The `oc adm policy reconcile-sccs` command will set all SCC policies to the default
 values but retain any additional users, groups, labels, and annotations as well as priorities you
 may have already set. To view which SCCs will be changed you may run the command with no options or
 by specifying your preferred output with the `-o <format>` option.
@@ -248,14 +248,14 @@ administrator group access to create more _privileged pods_. To do so, you can:
 . Run:
 +
 ----
-$ oadm policy add-scc-to-user <scc_name> <user_name>
-$ oadm policy add-scc-to-group <scc_name> <group_name>
+$ oc adm policy add-scc-to-user <scc_name> <user_name>
+$ oc adm policy add-scc-to-group <scc_name> <group_name>
 ----
 
 For example, to allow the *e2e-user* access to the *privileged* SCC, run:
 
 ----
-$ oadm policy add-scc-to-user privileged e2e-user
+$ oc adm policy add-scc-to-user privileged e2e-user
 ----
 
 [WARNING]
@@ -281,7 +281,7 @@ $ oc create serviceaccount mysvcacct -n myproject
 Then, add the service account to the `privileged` SCC.
 
 ----
-$ oadm policy add-scc-to-user privileged system:serviceaccount:myproject:mysvcacct
+$ oc adm policy add-scc-to-user privileged system:serviceaccount:myproject:mysvcacct
 ----
 
 Then, ensure that the resource is being created on behalf of the service
@@ -299,7 +299,7 @@ pre-allocated UID, without granting everyone access to the *privileged* SCC:
 . Grant all authenticated users access to the *anyuid* SCC:
 +
 ----
-$ oadm policy add-scc-to-group anyuid system:authenticated
+$ oc adm policy add-scc-to-group anyuid system:authenticated
 ----
 
 [WARNING]
@@ -317,7 +317,7 @@ have certain expectations about how volumes are owned.  For these images, add
 the service account to the `anyuid` SCC.
 
 ----
-$ oadm policy add-scc-to-user anyuid system:serviceaccount:myproject:mysvcacct
+$ oc adm policy add-scc-to-user anyuid system:serviceaccount:myproject:mysvcacct
 ----
 
 [[use-mount-host-on-the-registry]]
@@ -438,26 +438,26 @@ Prioritization] section for more information on sorting.
 To add an SCC to a user:
 
 ----
-$ oadm policy add-scc-to-user <scc_name> <user_name>
+$ oc adm policy add-scc-to-user <scc_name> <user_name>
 ----
 
 To add an SCC to a service account:
 
 ----
-$ oadm policy add-scc-to-user <scc_name>  \
+$ oc adm policy add-scc-to-user <scc_name>  \
     system:serviceaccount:<serviceaccount_namespace>:<serviceaccount_name>
 ----
 
 To add an SCC to a group:
 
 ----
-$ oadm policy add-scc-to-group <scc_name> <group_name>
+$ oc adm policy add-scc-to-group <scc_name> <group_name>
 ----
 
 To add an SCC to all service accounts in a namespace:
 
 ----
-$ oadm policy add-scc-to-group <scc_name>  \
+$ oc adm policy add-scc-to-group <scc_name>  \
     system:serviceaccounts:<serviceaccount_namespace>
 ----
 endif::openshift-enterprise,openshift-origin[]

--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -286,7 +286,7 @@ Policy Definitions] for instructions on getting to the new recommendations
 using:
 
 ----
-$ oadm policy reconcile-cluster-roles
+$ oc adm policy reconcile-cluster-roles
 ----
 endif::[]
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -631,7 +631,7 @@ local volume:
 +
 ====
 ----
-$ oadm policy add-scc-to-user privileged  \
+$ oc adm policy add-scc-to-user privileged  \
        system:serviceaccount:logging:aggregated-logging-elasticsearch <1>
 ----
 <1> Use the project you created earlier (for example, *logging*) when running the

--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -264,7 +264,7 @@ $ oc create serviceaccount registry -n default
 to the list of users allowed to run privileged containers:
 +
 ----
-$ oadm policy add-scc-to-user privileged system:serviceaccount:default:registry
+$ oc adm policy add-scc-to-user privileged system:serviceaccount:default:registry
 ----
 
 . Create the registry and specify that it use the new *registry* service

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1455,7 +1455,7 @@ When creating the router, allow it to use the privileged SCC. This gives the
 router user the ability to create containers with root privileges on the nodes:
 
 ----
-$ oadm policy add-scc-to-user privileged -z router
+$ oc adm policy add-scc-to-user privileged -z router
 ----
 
 *Patch the Router Deployment Configuration to Create a Privileged Container*

--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -73,8 +73,8 @@ The F5 router must be run in privileged mode, because route certificates are
 copied using the `scp` command:
 
 ----
-$ oadm policy remove-scc-from-user hostnetwork -z router
-$ oadm policy add-scc-to-user privileged -z router
+$ oc adm policy remove-scc-from-user hostnetwork -z router
+$ oc adm policy add-scc-to-user privileged -z router
 ----
 ====
 

--- a/install_config/router/index.adoc
+++ b/install_config/router/index.adoc
@@ -69,7 +69,7 @@ context constraint] (SCC) that allows it to specify host ports.
 To add a 'hostnetwork' SCC to the *router* service account in the *default* namespace:
 
 ----
-$ oadm policy add-scc-to-user hostnetwork system:serviceaccount:default:router
+$ oc adm policy add-scc-to-user hostnetwork system:serviceaccount:default:router
 ----
 
 [NOTE]

--- a/install_config/routing_from_edge_lb.adoc
+++ b/install_config/routing_from_edge_lb.adoc
@@ -256,7 +256,7 @@ To add the *f5ipfailover* in the *default* namespace to the *privileged* SCC, ru
 
 ====
 ----
-$ oadm policy add-scc-to-user privileged system:serviceaccount:default:f5ipfailover
+$ oc adm policy add-scc-to-user privileged system:serviceaccount:default:f5ipfailover
 ----
 ====
 

--- a/install_config/storage_examples/gluster_example.adoc
+++ b/install_config/storage_examples/gluster_example.adoc
@@ -316,7 +316,7 @@ The NGINX image may require to run in privileged mode to create the mount and
 run properly. An easy way to accomplish this is to simply add your user to the
 *privileged* Security Context Constraint (SCC):
 ----
-$ oadm policy add-scc-to-user privileged myuser
+$ oc adm policy add-scc-to-user privileged myuser
 ----
 
 Then, add the *privileged: true* to the containers `*securityContext:*` section

--- a/install_config/storage_examples/privileged_pod_storage.adoc
+++ b/install_config/storage_examples/privileged_pod_storage.adoc
@@ -78,18 +78,19 @@ user] to the *privileged* SCC (or to a group given access to the
 SCC) allows them to run *privileged* pods:
 
 . As the admin, add a user to the SCC:
++
 ----
-$ oadm policy add-scc-to-user privileged <username>
+$ oc adm policy add-scc-to-user privileged <username>
 ----
 
 . Log in as the regular user:
-
++
 ----
 $ oc login -u <username> -p <password>
 ----
 
 . Then, create a new project:
-
++
 ----
 $ oc new-project <project_name>
 ----


### PR DESCRIPTION
Because `oadm policy` doesn't work in some cases ([see example](https://github.com/openshift/origin/issues/11153#issuecomment-305416569)) while `oc adm` works always, [it's recommended to use the latter command and update the documentation](https://github.com/minishift/minishift/issues/587#issuecomment-302055435).

This PR do this by replacing some occurrences of `oadm policy add-scc-to-user` in the documentation.

PTAL @mfojtik @pweil- @openshift/team-documentation 

