### PR TITLE
WIP: Adding advanced installation settings for glusterfs backed registry and persistent storage for new/greenfield installations

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -426,6 +426,304 @@ openshift_examples_modify_imagestreams=true
 |Set to `true` if pointing to a registry other than the default. Modifies the image stream location to the value of `*oreg_url*`.
 |===
 
+[[advanced-install-configuring-integrated-glusterfs-backed-registry]]
+=== Configuring an Integrated GlusterFS Backed Registry
+
+ifdef::openshift-enterprise[]
+An integrated GlusterFS Registry can be configured and deployed during the initial installation
+of the cluster to offer a more reliable image registry. link:https://access.redhat.com/documentation/en-us/red_hat_gluster_storage/3.1/html/container-native_storage_for_openshift_container_platform_3.4/[Red Hat Container Native Storage (CNS)] has been integrated into the {product-title} Advanced Installation procedure utilizing containerized GlusterFS storage pods to back the Docker registry.
+endif::[]
+
+ifdef::openshift-origin[]
+An integrated GlusterFS Registry can be configured and deployed during the initial installation
+of the cluster to offer a more reliable image registry. See link:https://github.com/gluster/gluster-kubernetes[Running Containerized GlusterFS in Kubernetes] for additional information on containerized storage using GlusterFS.
+endif::[]
+
+Some additional prerequisites and host preparation are required beyond the normal {product-title} xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites]. 
+
+.Additional Prerequisites and Host Preparation
+[options="header"]
+|===
+
+|Prerequisite |Description
+|`*Storage Nodes*`
+|A minimum of 3 storage nodes must be available to run GlusterFS integrated registry (3-way replication)
+ 
+ Each storage node must have at least 1 raw block device with at least 10GB of free storage
+ifdef::openshift-enterprise[]
+|`*Enable Storage Repo*`
+|rh-gluster-3-for-rhel-7-server-rpms will need to be enabled. 
+
+      `# subscription-manager repos --enable=rh-gluster-3-for-rhel-7-server-rpms`
+endif::[]
+ifdef::openshift-enterprise[]
+|`*Required Software Components*`
+|Install *glusterfs-client* on each storage node. 
+
+      `# yum install glusterfs-client -y`
+
+endif::[]
+ifdef::openshift-origin[]
+|`*Required Software Components*`
+|Install *glusterfs-client* or *glusterfs-fuse* packages (mount.glusterfs) on each storage node. 
+
+endif::[]
+|===
+
+
+In the inventory/hosts file the following will need to be configured
+
+.Integrated GlusterFS Registry Variables and Groups
+[options="header"]
+|===
+
+|Variable |Purpose
+|`*glusterfs_registry*`
+|Placed in the OSEv3:children section and enables the [glusterfs_registry] group
+
+|`*[glusterfs_registry]*`
+| The group of storage nodes that will host the GlusterFS Registry along with the `glusterfs_devices` list parameter
+
+  <hostname or ip> `glusterfs_devices`='[ "(path-to-device)", "(...)" ]'
+
+|`*openshift_hosted_registry_storage_kind=glusterfs*`
+|Placed in the OSEv3:vars section and enables GlusterFS Registry if `[glusterfs_registry]` group exists and `glusterfs_registry` group_name exists
+
+|`*Nodes labeled with region=Infra*`
+|{product-title} will install the integrated docker registry pods and the associated routers on nodes 
+ containing the *infra* label. If this label does not exist on at least one node, the registry deployment will fail.
+
+ `openshift_node_labels="{'region': 'infra'}"`
+
+|===
+
+
+Example:
+----
+[OSEv3:children]
+masters
+nodes
+glusterfs_registry <1>
+
+[OSEv3:vars]
+ansible_ssh_user=root
+openshift_master_default_subdomain=cloudapps.example.com
+ifdef::openshift-enterprise[]
+openshift_deployment_type=openshift-enterprise
+endif::[]
+ifdef::openshift-origin[]
+openshift_deployment_type=origin
+endif::[]
+openshift_hosted_registry_storage_kind=glusterfs <2>
+
+[nodes]
+192.168.10.11  openshift_schedulable=True node=True openshift_node_labels="{'region': 'infra'}" <3>
+...
+...
+
+[glusterfs_registry] <4>
+192.168.10.11 glusterfs_devices='[ "/dev/xvdc", "/dev/xvdd" ]'
+192.168.10.12 glusterfs_devices='[ "/dev/xvdc", "/dev/xvdd" ]'
+192.168.10.13 glusterfs_devices='[ "/dev/xvdc", "/dev/xvdd" ]'
+
+[masters]
+...
+...
+----
+<1> OSEv3:children group_name.
+<2> OSEv3:vars variable that enables GlusterFS Registry.
+<3> Infrastructure label for nodes that will host registry and other infrastructure pods such as default routers, etc... 
+<4> Group that lists the Registry storage nodes and the list of raw block devices.
+
+[NOTE]
+====
+If no registry options are used the default {product-title} registry is ephermal and all data will be lost if the pod no longer exists.
+{product-title} also supports a single node NFS integrated registry but will lack redundancy and reliability
+compared with an Integrated GlusterFS Registry.
+====
+
+[[advanced-install-configuring-containerized-glusterfs-backed-persistent-storage]]
+=== Configuring Containerized GlusterFS Backed Persistent Storage
+
+Along with the ability to install and back a GlusterFS Integrated Registry as explained in the previous section, GlusterFS can also be configured and installed in the {product-title} cluster for 
+xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[Peristent Storage] and xref:../storage_examples/gluster_dynamic_example.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[Dynamic Provisioning]. After successful installation all required components to start using and provisioning storage will exist, including Endpoints, Services and a StorageClass.
+
+[NOTE]
+====
+This storage should be separate from the Integrated Docker Registry GlusterFS backed storage (if installed), and will also require additional nodes.
+For example, if the Integrated Docker Registry Backed by GlusterFS is also configured, that would be a total of 6 storage nodes needed (3 for Registry and 3 for Persistent Storage).
+This limitation is based on Heketi's ability to only manage a single storage pool at this time.
+====
+
+Some additional prerequisites and host preparation are required beyond the normal {product-title} xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites]. 
+
+.Additional Prerequisites and Host Preparation
+[options="header"]
+|===
+
+|Prerequisite |Description
+|`*Storage Nodes*`
+|A minimum of 3 storage nodes must be available to run GlusterFS integrated registry (3-way replication)
+ 
+ Each storage node must have at least 1 raw block device with at least 10GB of free storage. However, it is
+ recommended to have at least 100GB available for usage with Persistent Storage and Dynamic Provisioning.
+ifdef::openshift-enterprise[]
+|`*Enable Storage Repo*`
+|rh-gluster-3-for-rhel-7-server-rpms will need to be enabled. 
+
+      `# subscription-manager repos --enable=rh-gluster-3-for-rhel-7-server-rpms`
+endif::[]
+ifdef::openshift-enterprise[]
+|`*Required Software Components*`
+|Verify/Install *glusterfs-client* on each storage node. 
+
+      `# yum install glusterfs-client -y`
+
+endif::[]
+ifdef::openshift-origin[]
+|`*Required Software Components*`
+|Verify/Install *glusterfs-client* or *glusterfs-fuse* packages (mount.glusterfs) on each storage node. 
+
+ Install link:https://github.com/heketi/heketi/releases[heketi-client] on same host that will run the openshift-ansible installer (typically one of the master nodes).
+
+endif::[]
+|===
+
+
+In the inventory/hosts file the following will need to be configured
+
+.Integrated GlusterFS Persistent Storage Variables and Groups
+[options="header"]
+|===
+
+|Variable |Purpose
+|`*glusterfs*`
+|Placed in the OSEv3:children section and enables the [glusterfs] group
+
+|`*[glusterfs]*`
+| The group of storage nodes that will host the GlusterFS storage along with the `glusterfs_devices` list parameter
+
+  <hostname or ip> `glusterfs_devices`='[ "(path-to-device)", "(...)" ]'
+
+|===
+
+
+.Additional GlusterFS Persistent Storage Variables and Groups (Optional).
+[options="header"]
+|===
+
+|Variable |Purpose
+|`*openshift_storage_glusterfs_namespace*`
+|Placed in the OSEv3:children section and allows users to specify a new namespace to host the storage pods otherwise they are installed
+ in `default` namespace.
+
+  `openshift_storage_glusterfs_namespace=mystorage`
+
+|`*openshift_storage_glusterfs_name*`
+| The base name used for the GlusterFS storage pods.
+
+  `openshift_storage_glusterfs_name=scratchspace`
+
+|===
+
+[NOTE]
+====
+If `openshift_storage_glusterfs_namespace` is not set, the GlusterFS storage pods will assume `default` namespace.
+====
+
+Example:
+----
+[OSEv3:children]
+masters
+nodes
+glusterfs <1>
+
+[OSEv3:vars]
+ansible_ssh_user=root
+openshift_master_default_subdomain=cloudapps.example.com
+ifdef::openshift-enterprise[]
+openshift_deployment_type=openshift-enterprise
+endif::[]
+ifdef::openshift-origin[]
+openshift_deployment_type=origin
+endif::[]
+
+[nodes]
+192.168.10.11  openshift_schedulable=True node=True openshift_node_labels="{'region': 'infra'}" <2>
+...
+...
+
+[glusterfs] <3>
+192.168.10.11 glusterfs_devices='[ "/dev/xvdc", "/dev/xvdd" ]'
+192.168.10.12 glusterfs_devices='[ "/dev/xvdc", "/dev/xvdd" ]'
+192.168.10.13 glusterfs_devices='[ "/dev/xvdc", "/dev/xvdd" ]'
+
+[masters]
+...
+...
+----
+<1> OSEv3:children group_name.
+<2> Infrastructure label for nodes that will host registry and other infrastructure pods such as default routers, etc...
+<3> Group that lists the Registry storage nodes and the list of raw block devices.
+
+[NOTE]
+====
+As stated, both GlusterFS backed Registry and GlusterFS Persistent Storage can be installed on the same cluster using
+Advanced Installation.
+====
+
+
+*Post Installation Configuration*
+
+- Update the `/etc/dnsmasq.conf` on all masters to enable proper DNS communication between the masters nodes and the `Heketi` server pods routes.
+  Add the following line replacing with appropriate values:
+  
+----
+address=/.<openshift_master_default_subdomain>/<Router_IP>
+
+eg.
+   address=/.cloudapps.example.com/172.18.23.24
+----   
+
+- Restart dnsmasq Service.
+
+----
+systemctl restart dnsmasq`
+----
+
+- From a master verify that the `route` is working
+
+----
+#oc get routes
+NAME                  HOST/PORT                                           PATH      SERVICES              PORT      TERMINATION   WILDCARD
+heketi-scratchspace   heketi-scratchspace-default.cloudapps.example.com             heketi-scratchspace   <all>                   None
+
+#curl http://heketi-scratchspace-default.cloudapps.example.com/hello
+Hello from Heketi.
+
+----
+
+- Verfiy that the GlusterFS StorageClass was created
+
+----
+#oc get storageclass
+NAME                  TYPE
+glusterfs-storage     kubernetes.io/glusterfs
+
+----
+
+[NOTE]
+====
+Default name for the *route* will be `heketi-TBD` unless this was overridden 
+using the `openshift_glusterfs_storage_name=MYNAME` variable in the ansible hosts file.
+====
+
+[NOTE]
+====
+After successful installation, xref:../storage_examples/gluster_dynamic_example.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[Dynamic Provisioning]
+of GlusterFS volumes can occur by xref:../storage_examples/gluster_dynamic_example.html#create-a-pvc-ro-request-storage-for-your-application[creating a PVC to request storage].
+ 
+====
 
 [[advanced-install-configuring-global-proxy]]
 === Configuring Global Proxy Options


### PR DESCRIPTION
This PR is my initial work in progress and focuses on the Advanced Installation instructions - adding 2 new sections for installing GlusterFS backed registry on initial install (greenfield) and/or installing GlusterFS for persistent storage.  For 3.6 this is our main focus...

There are many ways to skin the cat on this, but we should guide the user to a very well defined set of instructions with exact values they need.  Other features might be worth documenting as well, but need to think where we should put those (swapping registry, etc...) and if they are better suited for 3.7 release??

@erinboyd @jarrpa @adellape - take a look