### PR TITLE
Fix markup in 3.6 cluster var

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -298,7 +298,7 @@ default is
 `\https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics`
 If you alter this variable, ensure the host name is accessible via your router.
 
-|`*openshift_template_service_broker_namespaces*`
+|`openshift_template_service_broker_namespaces`
 |This variable enables the template service broker by specifying one of more
 namespaces whose templates will be served by the broker.
 |===


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/4225 added this 3.6 variable, and https://github.com/openshift/openshift-docs/pull/4504 adjusted the table for master/3.5 to use only backticks instead of asterisk+backticks. This PR updates just `openshift_template_service_broker_namespaces` and only for master/3.6.