### PR TITLE
Adjust openshift_hosted_metrics_public_url info / formatting

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -293,10 +293,11 @@ to the *docker* configuration.
 configuration.
 
 |`openshift_hosted_metrics_public_url`
-|This variable sets the host name for integration with the metrics console. The
-default is
-`\https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics`
+|This variable sets the host name for integration with the metrics console by
+overriding `metricsPublicURL` in the master configuration for cluster metrics.
 If you alter this variable, ensure the host name is accessible via your router.
+See xref:advanced-install-cluster-metrics[Configuring Cluster Metrics] for
+details.
 
 |`openshift_template_service_broker_namespaces`
 |This variable enables the template service broker by specifying one of more
@@ -756,6 +757,15 @@ following to enable cluster metrics when using the advanced install:
 
 openshift_hosted_metrics_deploy=true
 ----
+
+The {product-title} web console uses the data coming from the Hawkular Metrics
+service to display its graphs. The metrics public URL can be set during cluster
+installation using the `openshift_hosted_metrics_public_url` Ansible variable,
+which defaults to:
+
+`\https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics`
+
+If you alter this variable, ensure the host name is accessible via your router.
 
 [[advanced-install-cluster-metrics-storage]]
 ==== Configuring Metrics Storage


### PR DESCRIPTION
This was making the Cluster Variables table really wide. Moving the long example URL to the related subsection so there's more room.

Preview:

http://file.rdu.redhat.com/~adellape/060117/long_url/install_config/install/advanced_install.html

@openshift/team-documentation PTAL