### PR TITLE
Update StorageClass documentation to v1

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -419,14 +419,13 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: myclaim
-  annotations:
-    volume.beta.kubernetes.io/storage-class: gold
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 8Gi
+  storageClassName: gold
 
 ----
 

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -101,7 +101,7 @@ plug-in types.
 [source,yaml]
 ----
 kind: StorageClass <1>
-apiVersion: storage.k8s.io/v1beta1 <2>
+apiVersion: storage.k8s.io/v1 <2>
 metadata:
   name: foo <3>
   annotations: <4>
@@ -126,10 +126,16 @@ from plug-in to plug-in.
 
 To set a _StorageClass_ as the cluster-wide default:
 ----
-   storageclass.beta.kubernetes.io/is-default-class: "true"
+   storageclass.kubernetes.io/is-default-class: "true"
 ----
 This enables any Persistent Volume Claim (PVC) that does not specify a specific
 volume to automatically be provisioned through the _default_ StorageClass
+
+[NOTE]
+====
+Beta annotation `storageclass.beta.kubernetes.io/is-default-class` is still
+working. However it will be removed in a future release.
+====
 
 To set a _StorageClass_ description:
 ----
@@ -144,7 +150,7 @@ To set a _StorageClass_ description:
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: gold
 provisioner: kubernetes.io/cinder
@@ -163,7 +169,7 @@ parameters:
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs
@@ -190,7 +196,7 @@ parameters:
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd
@@ -210,7 +216,7 @@ parameters:
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: slow
 provisioner: kubernetes.io/glusterfs
@@ -277,7 +283,7 @@ type: kubernetes.io/glusterfs
 .ceph-storageclass.yaml
 [source,yaml]
 ----
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fast
@@ -306,7 +312,7 @@ parameters:
 .trident.yaml
 [source,yaml]
 ----
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gold

--- a/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
@@ -265,7 +265,7 @@ specification definitions.
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: gluster-dyn
 provisioner: kubernetes.io/glusterfs
@@ -292,14 +292,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
  name: gluster-dyn-pvc
- annotations:
-   volume.beta.kubernetes.io/storage-class: gluster-dyn
 spec:
  accessModes:
   - ReadWriteMany
  resources:
    requests:
         storage: 30Gi
+ storageClassName: gluster-dyn
 ----
 
 . From the {product-title} master host, create the PVC:

--- a/install_config/storage_examples/gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/gluster_dynamic_example.adoc
@@ -107,7 +107,7 @@ storage to be used with your _HelloWorld_ application.
 
 ====
 ----
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gluster-heketi  <1>
@@ -156,16 +156,15 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
  name: gluster1
- annotations:
-   volume.beta.kubernetes.io/storage-class: gluster-heketi  <1>
 spec:
  accessModes:
   - ReadWriteOnce
+ storageClassName: gluster-heketi  <1>
  resources:
    requests:
      storage: 5Gi <2>
 ----
-<1> The Kubernetes storage class annotation and the name of the storage class.
+<1> The name of the storage class.
 <2> The amount of storage requested.
 ====
 

--- a/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
+++ b/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
@@ -46,7 +46,7 @@ _StorageClass_.
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: slow <1>
 provisioner: kubernetes.io/gce-pd <2>
@@ -65,7 +65,7 @@ parameters:
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: fast
 provisioner: kubernetes.io/gce-pd
@@ -119,14 +119,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
  name: pvc-engineering
- annotations:
-   volume.beta.kubernetes.io/storage-class: fast
 spec:
  accessModes:
   - ReadWriteMany
  resources:
    requests:
      storage: 10Gi
+ storageClassName: fast
 ----
 ====
 
@@ -192,7 +191,7 @@ Pods can now reference the persistent volume claim and start using the volume.
 
 In this example, a `cluster-admin` or `storage-admin` enables a _default_
 storage class for all other users and projects that do not implicitly specify a
-_StorageClass_ annotation in their claim. This is useful for a `cluster-admin`
+_StorageClass_ in their claim. This is useful for a `cluster-admin`
 or `storage-admin` to provide easy management of a storage volume without having
 to set up or communicate specialized _StorageClasses_ across the cluster.
 
@@ -205,11 +204,11 @@ _StorageClass_.
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: generic <1>
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true" <2>
+    storageclass.kubernetes.io/is-default-class: "true" <2>
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
@@ -238,7 +237,7 @@ slow       kubernetes.io/gce-pd
 ====
 
 As a regular user, create a new claim definition without any _StorageClass_
-annotation and save it to a file (`generic-pvc.yaml`). 
+requirement and save it to a file (`generic-pvc.yaml`).
 
 ._default_ Storage Claim Object Definition
 ====
@@ -334,7 +333,7 @@ pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete      
 ====
 
 Now create another claim identical to the `generic-pvc.yaml` PVC definition but
-change the name and do not set an annotation.
+change the name and do not set a storage class name.
 
 .Claim Object Definition
 ====
@@ -376,10 +375,10 @@ volume bound to the claim.
 
 To fix this, the `cluster-admin` or `storage-admin` user simply needs to create
 another GCE disk or delete the first manual PV and use a PV object definition 
-that assigns a _StorageClass_ annotation (`pv-manual-gce2.yaml`)
+that assigns a _StorageClass_ name (`pv-manual-gce2.yaml`)
 if necessary:
 
-.Manual PV Spec with _default_ StorageClass annotation
+.Manual PV Spec with _default_ StorageClass name
 ====
 [source,yaml]
 ----
@@ -387,8 +386,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
  name: pv-manual-gce2
- annotations:
-   volume.beta.kubernetes.io/storage-class: generic <1>
 spec:
  capacity:
    storage: 35Gi
@@ -398,8 +395,9 @@ spec:
    readOnly: false
    pdName: the-newly-created-gce-PD
    fsType: ext4
+ storageClassName: generic <1>
 ----
-<1> The annotation for previously created _generic_ _StorageClass_.
+<1> The name for previously created _generic_ _StorageClass_.
 ====
 
 Execute the object definition file:

--- a/install_config/storage_examples/storage_classes_legacy.adoc
+++ b/install_config/storage_examples/storage_classes_legacy.adoc
@@ -19,7 +19,7 @@ In this example, a legacy data volume exists and a `cluster-admin` or
 `storage-admin` needs to make it available for consumption in a particular
 project. Using _StorageClasses_ decreases the likelihood of other users and
 projects gaining access to this volume from a claim because the claim would have
-to have an exact matching value for the _StorageClass_ annotation. This example
+to have an exact matching value for the _StorageClass_ name. This example
 also disables dynamic provisioning. This example assumes:
 
 - Some familiarity with {product-title}, GCE, and Persistent Disks
@@ -35,7 +35,7 @@ As a `cluster-admin` or `storage-admin`, define and create the _StorageClass_ fo
 [source,yaml]
 ----
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: finance-history <1>
 provisioner: no-provisioning <2>
@@ -80,8 +80,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
  name: pv-finance-history
- annotations:
-   volume.beta.kubernetes.io/storage-class: finance-history <1>
 spec:
  capacity:
    storage: 35Gi
@@ -91,8 +89,9 @@ spec:
    readOnly: false
    pdName: the-existing-PD-volume-name-that-contains-the-valuable-data <2>
    fsType: ext4
+ storageClassName: finance-history <1>
 ----
-<1>  The _StorageClass_ annotation, that must match exactly.
+<1>  The _StorageClass_ name, that must match exactly.
 <2>  The name of the GCE disk that already exists and contains the legacy data.
 ====
 
@@ -114,7 +113,7 @@ pv-finance-history   35Gi       RWX           Retain          Available         
 Notice you have a `pv-finance-history` Available and ready for consumption.
 
 As a user, create a Persistent Volume Claim (PVC) as a YAML file and specify the
-correct _StorageClass_ annotation:
+correct _StorageClass_ name:
 
 .Claim for finance-history Object Definition
 ====
@@ -124,16 +123,15 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
  name: pvc-finance-history
- annotations:
-   volume.beta.kubernetes.io/storage-class: finance-history <1>
 spec:
  accessModes:
   - ReadWriteMany
  resources:
    requests:
      storage: 20Gi
+ storageClassName: finance-history <1>
 ----
-<1>  The _StorageClass_ annotation, that must match exactly or the claim will go unbound until it is deleted or another _StorageClass_ is created that matches the annotation.
+<1>  The _StorageClass_ name, that must match exactly or the claim will go unbound until it is deleted or another _StorageClass_ is created that matches the name.
 ====
 
 Create and view the PVC and PV to see if it is bound.


### PR DESCRIPTION
In 3.6, StorageClass reached GA. That means:

- annotation `volume.beta.kubernetes.io/storage-class` is obsolete, we have `pv.spec.storageClassName` and `pvc.spec.storageClassName` fields. The annotation still works to keep backward compatibility.
- StorageClass objects live in `storage.k8s.io/v1` API, not `storage.k8s.io/v1beta1`. `v1beta1` still works  to keep backward compatibility.