### PR TITLE
Document limited resources in quota

### DIFF
--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -497,3 +497,53 @@ If a quota has been defined for your project, see
 xref:../dev_guide/deployments/basic_deployment_operations.adoc#deployment-resources[Deployment Resources]
 for considerations on any deployment configurations.
 endif::[]
+
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+[[limited-resources-quota]]
+== Require Explicit Quota to Consume a Resource
+
+[NOTE]
+====
+This feature is tech preview and subject to change in future releases.
+====
+
+If a resource is not managed by quota, a user has no restriction
+on the amount of resource that can be consumed.  For example,
+if there is no quota on storage related to the gold storage class,
+the amount of gold storage a project can create is unbounded.
+
+For high-cost compute or storage resources, administrators may
+want to require an explicit quota be granted in order to consume
+a resource.  For example, if a project was not explicitly given quota
+for storage related to the gold storage class, users of that project
+would not be able to create any storage of that type.
+
+In order to require explicit quota to consume a particular resource,
+the following stanza should be added to the master-config.yaml.
+
+====
+[source,yaml]
+----
+admissionConfig:
+  pluginConfig:
+    ResourceQuota:
+      configuration:
+        apiVersion: resourcequota.admission.k8s.io/v1alpha1
+        kind: Configuration
+        limitedResources:
+        - resource: persistentvolumeclaims <1>
+          matchContains:
+        - gold.storageclass.storage.k8s.io/requests.storage <2>
+----
+<1> The group/resource to whose consumption is limited by default.
+<2> The name of the resource tracked by quota associated with the group/resource to limit by default.
+====
+
+In the above example, the quota system will intercept every operation that
+creates or updates a `PersistentVolumeClaim`.  It checks what resources understood
+by quota would be consumed, and if there is no covering quota for those resources
+in the project, the request is denied.  In this example, if a user creates a 
+`PersistentVolumeClaim` that uses storage associated with the gold storage class,
+and there is no matching quota in the project, the request is denied.
+
+endif::[]


### PR DESCRIPTION
this is a tech preview feature for OpenShift 3.6.

it lets an admin say a resource can only be used if there is a matching quota in the project.

/cc @mburke5678 @eparis 