### PR TITLE
Remove recommendation that the local etcd instance be listed first in master configuration

### DIFF
--- a/scaling_performance/host_practices.adoc
+++ b/scaling_performance/host_practices.adoc
@@ -25,9 +25,6 @@ Optimize this traffic path by:
 
 * Ensuring an uncongested, low latency LAN communication link between master hosts.
 
-* Ensuring the first etcd server listed in
- *_/etc/origin/master/master-config.yaml_* is the local etcd instance.
-
 [[scaling-performance-capacity-host-practices-node]]
 == Recommended Practices for {product-title} Node Hosts
 


### PR DESCRIPTION
Removing this recommendation that the local etcd instance should be listed first in master configuration based on discussion in https://github.com/openshift/openshift-ansible/pull/4312. Endpoints are chosen [randomly](https://github.com/coreos/etcd/blob/02f4a9a034f65f588599eaf6d756b98b55640c98/client/client.go#L59-L80) so sorting would offer no benefit.

/cc @bfallonf @adellape @sdodson 