### PR TITLE
Bug 1404347: Enhancements to Tag Naming section

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -33,7 +33,7 @@ deployments to behave. The following sections cover a range of these topics.
 == Tagging Images
 
 Before working with {product-title} image streams and their tags, it will help
-to first understand image tags in the context of Docker generally.
+to first understand image tags in the context of container images generally.
 
 Container images can have names added to them that make it more intuitive to determine
 what they contain, called a _tag_. Using a tag to specify the version of what is contained
@@ -53,7 +53,7 @@ The `<user_name>` part in the above could also refer to a
 xref:../architecture/core_concepts/projects_and_users.adoc#projects[project] or
 xref:../architecture/core_concepts/projects_and_users.adoc#namespaces[namespace]
 if the image is being stored in an {product-title} environment with an internal
-registry.
+registry (the OpenShift Container Registry).
 
 {product-title} provides the `oc tag` command, which is similar to the `docker
 tag` command, but operates on image streams instead of directly on images.
@@ -124,34 +124,54 @@ daemon if the image stream has an xref:insecure-registries[insecure annotation]
 or the tag has an xref:insecure-tag-import-policy[insecure import policy].
 
 [[tag-naming]]
-=== Tag Naming
+=== Recommended Tagging Conventions
 
-Images evolve over time and the tag reflects this. It always points to the
-latest image built. If there is too much information embedded in a tag name (for
-example, `v2.0.1-may-2016`), the tag will point to just one revision of an image
-and will never be updated. Using default image pruning options, such an image
-will never be removed. Instead, if the tag is named `v2.0`, more image revisions
-are more likely. This results in longer
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[tag
-history] and, therefore, the image pruner will more likely remove old and unused
-images.
+Images evolve over time and their tags reflect this. An image tag always points
+to the latest image built.
 
+If there is too much information embedded in a tag name (for example,
+`v2.0.1-may-2016`), the tag will point to just one revision of an image and will
+never be updated. Using default image pruning options, such an image will never
+be removed.
 ifdef::openshift-origin,openshift-enterprise[]
-Refer to xref:../admin_guide/pruning_resources.adoc#pruning-images[pruning images] for more information.
+In very large clusters, the schema of creating new tags for every revised image
+could eventually fill up the etcd datastore with excess tag metadata for images
+that are long outdated.
 endif::[]
 
-Although tag naming convention is up to you, here are a few examples:
+Instead, if the tag is named `v2.0`, more image revisions are more likely. This
+results in longer
+xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[tag history] and, therefore, the image pruner will more likely remove old and unused images.
+ifdef::openshift-origin,openshift-enterprise[]
+Refer to xref:../admin_guide/pruning_resources.adoc#pruning-images[Pruning Images] for more information.
+endif::[]
 
-[width="40%",frame="topbot",options="header"]
-|======================
+Although tag naming convention is up to you, here are a few examples in the
+format `<image_name>:<image_tag>`:
+
+.Image Tag Naming Conventions
+[width="50%",frame="topbot",options="header"]
+|===
 |Description |Example
-|Revision    |`v2.0.1`
-|Architecture|`v2.0-x86_64`
-|Base image  |`v1.2-centos7`
-|======================
+
+|Revision
+|`myimage:v2.0.1`
+
+|Architecture
+|`myimage:v2.0-x86_64`
+
+|Base image
+|`myimage:v1.2-centos7`
+
+|Latest (potentially unstable)
+|`myimage:latest`
+
+|Latest stable
+|`myimage:stable`
+|===
 
 If you require dates in tag names, periodically inspect old and unsupported
-images and _istags_ and remove them. Otherwise, you might experience increasing
+images and `istags` and remove them. Otherwise, you might experience increasing
 resource usage caused by old images.
 
 [[tag-removal]]


### PR DESCRIPTION
- Renames section from "Tag Naming" to "Recommended Tagging Conventions"
- Adds `latest` and `stable` example tags to the table
- Adds a comment (just for OCP/Origin docs) about etcd potentially filling up

Preview build:

http://file.rdu.redhat.com/~adellape/060617/tagging-stable/dev_guide/managing_images.html#tag-naming