### PR TITLE
Fix PHP Laravel quickstart name

### DIFF
--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -277,6 +277,6 @@ The sample Laravel application can be built and deployed using the
 `rhscl/php-70-rhel7` image with the following command:
 
 ----
-$ oc new-app --template=laravel-mysql-example
+$ oc new-app --template=laravel-mysql-persistent
 ----
 endif::openshift-online[]


### PR DESCRIPTION
The template for Laravel was renamed from "laravel-mysql-example" to "laravel-mysql-persistent", so update the example that references the template by the old name.