### PR TITLE
Document that you may need to install etcd package in order to run

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1523,6 +1523,13 @@ The default port for the console is `8443`. If this was changed during the insta
 
 If you installed multiple *etcd* hosts:
 
+. First verify that the *etcd* package is installed which provides the `etcdctl`
+command:
++
+----
+# yum install etcd
+----
+
 . On a master host, verify the *etcd* cluster health, substituting for the FQDNs
 of your *etcd* hosts in the following:
 +


### PR DESCRIPTION
etcdctl from the masters

If your master isn't also an etcd host then it won't be installed there. Otherwise everything is documented correctly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1372469