### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -748,7 +748,7 @@ blobs are mirrored for faster access later.
 You can set the policy in a specification of image stream tag as
 `referencePolicy.type`.
 
-.Exmple of Insecure Tag with a Local Reference Policy
+.Example of Insecure Tag with a Local Reference Policy
 ====
 [source,yaml]
 ----


### PR DESCRIPTION
This PR fixes a minor typo in the documentation "Exmple" vs "Example"

https://docs.openshift.org/latest/dev_guide/managing_images.html