### PR TITLE
HOSA Steps include invalid wget

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -565,8 +565,8 @@ all your pods even if the `ovs_multitenant` plug-in is enabled.
 To deploy the agent, you will need to gather two configuration files:
 ifdef::openshift-origin[]
 ----
-$ wget https://github.com/openshift/origin-metrics/blob/master/hawkular-agent/hawkular-openshift-agent-configmap.yaml
-$ wget https://github.com/openshift/origin-metrics/blob/master/hawkular-agent/hawkular-openshift-agent.yaml
+$ wget https://raw.githubusercontent.com/openshift/origin-metrics/enterprise/hawkular-openshift-agent/hawkular-openshift-agent-configmap.yaml
+$ wget https://raw.githubusercontent.com/openshift/origin-metrics/enterprise/hawkular-openshift-agent/hawkular-openshift-agent.yaml
 ----
 endif::[]
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
The steps for the [Hawkular OpenShift Agent](https://docs.openshift.com/container-platform/3.5/install_config/cluster_metrics.html#deploying-hawkular-openshift-agent)  (HOSA) Tech Preview Feature requires the user to `wget` two files from github but the URLs were not valid and would produce two unusable files. I have determined the URLs that should work and corrected them in this.