### PR TITLE
Update docs related to creating bindings to roles

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -170,15 +170,13 @@ ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 |*admin* |A project manager. If used in a
 xref:cluster-policy-and-local-policy[local binding], an *admin* user will have
 rights to view any resource in the project and modify any resource in the
-project except for role creation and quota. If the *cluster-admin* wants to
-allow an *admin* to modify roles, the *cluster-admin* must create a
-project-scoped `*Policy*` object using JSON.
+project except for quota.
 
 |*basic-user* |A user that can get basic information about projects and users.
 
 |*cluster-admin* |A super-user that can perform any action in any project. When
 granted to a user within a local policy, they have full control over quota and
-roles and every action on every resource in the project.
+every action on every resource in the project.
 
 |*cluster-status* |A user that can get basic cluster status information.
 
@@ -253,11 +251,6 @@ view local bindings.
 endif::[]
 However, if other default roles are added to users and groups within a local
 policy, they become listed in the CLI output, as well.
-
-If you find that these roles do not suit you, a *cluster-admin* user can create
-a `*policyBinding*` object named `_<projectname>_:default` with the CLI using a
-JSON file. This allows the project *admin* to bind users to roles that are
-defined only in the `_<projectname>_` local policy.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Users no longer need cluster admin privileges to create a role binding that references a role in their namespace.  In the past we required a cluster admin to create the policy binding object before a normal user could perform these bindings.  This change is part of the deprecation of policy and policy binding objects in 3.6.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: https://github.com/openshift/openshift-docs/issues/4021#issuecomment-308580736 https://github.com/openshift/origin/pull/14547

cc @adellape @liggitt 