### PR TITLE
Allow specifying haproxy SSL Cipher list

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -125,6 +125,14 @@ WebSocket traffic uses the same route conventions and supports the same TLS
 termination types as other traffic.
 ====
 
+For a secure connection to be established a cipher common to the client and sever
+must be nogotiated. As time goes on new more secure
+link:https://wiki.mozilla.org/Security/Server_Side_TLS[ciphers] become available and
+are integrated into client software. As older clients become obsolete, the older less
+secure ciphers can be dropped.  The router by default, supports a broad range of commonly
+available clients. The router can be configured to use a selected set of xref:ciphers[ciphers]
+that support desired clients and don't include the less secure ciphers.
+
 [[routes-template-routers]]
 
 === Template Routers
@@ -287,13 +295,8 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`*ROUTER_ALLOW_WILDCARD_ROUTES*`|  |  When set to `true` or `TRUE`, any routes with a wildcard policy of `Subdomain` that pass the router admission checks will be serviced by the HAProxy router.
 |`*ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK*` |  | Set to `true` to relax the namespace ownership policy.
 |`*ROUTER_STRICT_SNI*` |  | xref:strict-sni[strict-sni]
+|`*ROUTER_CIPHERS*` | intermediate  | Specify the set of xref:ciphers[ciphers] supported by bind.
 |===
-
-[[time-units]]
-*TimeUnits* are represented by a number followed by the unit: `us`
-*(microseconds), `ms` (milliseconds, default), `s` (seconds), `m` (minutes), `h`
-*(hours), `d` (days). The regular expression is:
-[1-9][0-9]*(us\|ms\|s\|m\|h\|d)
 
 [NOTE]
 ====
@@ -302,6 +305,13 @@ ports that the router is listening on, `ROUTER_SERVICE_SNI_PORT` and
 `ROUTER_SERVICE_NO_SNI_PORT`. These ports can be anything you want as long as
 they are unique on the machine. These ports will not be exposed externally.
 ====
+
+[[time-units]]
+== Timeouts
+*TimeUnits* are represented by a number followed by the unit:
+`us` (microseconds), `ms` (milliseconds, default), `s` (seconds), `m` (minutes), `h`
+(hours), `d` (days).
+The regular expression is: [1-9][0-9]*(us\|ms\|s\|m\|h\|d)
 
 [[strict-sni]]
 == HAProxy Strict SNI
@@ -323,6 +333,33 @@ $ oc adm router --strict-sni
 ----
 
 This sets `ROUTER_STRICT_SNI=true`.
+
+[[ciphers]]
+== Router Cipher Suite
+
+Each client, e.g., Chrome 30, Java8, includes a suite of ciphers that it can use to securely connect with the router.
+The router must have at least one of the ciphers for the connection to complete.  The
+link:https://wiki.mozilla.org/Security/Server_Side_TLS[Security/Server Side TLS] reference guide provides
+three reference profiles that support various clients.
+
+.Router Cipher Profiles
+[cols="2,6", options="header"]
+|===
+|Profile | Oldest compatible client
+|modern| Firefox 27, Chrome 30, IE 11 on Windows 7, Edge, Opera 17, Safari 9, Android 5.0, Java 8
+|intermediate|Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
+|old|Windows XP IE6, Java 6
+|===
+
+The router defaults to the "intermediate" profile. A different profile may be selected when the router is created
+by using the --ciphers option, or after the router is created by changing the `ROUTER_CIPHERS` environment variable.
+The values are: modern, intermediate, or old. Alternatively, a set of ":" separated ciphers may be provided. The ciphers
+must be from the set displayed by:
+
+----
+openssl ciphers
+----
+
 
 [[route-hostnames]]
 
@@ -968,7 +1005,7 @@ For example, to deny the `[{asterisk}.]open.header.test`, `[{asterisk}.]openshif
 `[{asterisk}.]block.it` routes for the `myrouter` route:
 
 ----
-$ oadm router myrouter ...
+$ oc adm router myrouter ...
 $ oc set env dc/myrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it"
 ----
 
@@ -994,7 +1031,7 @@ $ oc expose service/<name> --hostname="api.openshift.org"
 Alternatively, to block any routes where the host name is _not_ set to `[{asterisk}.]stickshift.org` or `[{asterisk}.]kates.net`:
 
 ----
-$ oadm router myrouter ...
+$ oc adm router myrouter ...
 $ oc set env dc/myrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net"
 ----
 
@@ -1020,7 +1057,7 @@ $ oc expose service/<name> --hostname="www.deny.it"
 To implement both scenarios, run:
 
 ----
-$ oadm router adrouter ...
+$ oc adm router adrouter ...
 $ oc env dc/adrouter ROUTER_ALLOWED_DOMAINS="openshift.org, kates.net" \
     ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net"
 ----
@@ -1114,7 +1151,7 @@ This feature can be set during router creation or by setting an environment
 variable in the router's deployment configuration.
 
 ----
-$ oadm router ... --disable-namespace-ownership-check=true
+$ oc adm router ... --disable-namespace-ownership-check=true
 ----
 
 ----

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -13,10 +13,10 @@ toc::[]
 
 == Overview
 
-The `oadm router` command is provided with the administrator CLI to simplify the
+The `oc adm router` command is provided with the administrator CLI to simplify the
 tasks of setting up routers in a new installation. If you followed the
 xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation], then
-a default router was automatically created for you. The `oadm router` command
+a default router was automatically created for you. The `oc adm router` command
 creates the service and deployment configuration objects. Just about every form
 of communication between {product-title} components is secured by TLS and uses
 various certificates and authentication methods. Use the `--service-account` option
@@ -36,16 +36,16 @@ achieve this by dedicating infrastructure nodes to run services such as routers.
 ====
 It is recommended to use separate distinct *openshift-router* service account
 with your router. This can be provided using the `--service-account` flag to the
-`oadm router` command.
+`oc adm router` command.
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router --dry-run --service-account=router //<1>
+$ oc adm router --dry-run --service-account=router //<1>
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router --dry-run --service-account=router //<1>
+$ oc adm router --dry-run --service-account=router //<1>
 ----
 endif::[]
 <1> `--service-account` is the name of a xref:../../admin_guide/service_accounts.adoc#admin-guide-service-accounts[service account]
@@ -58,7 +58,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-Router pods created using `oadm router` have default resource requests
+Router pods created using `oc adm router` have default resource requests
 that a node must satisfy for the router pod to be deployed. In an
 effort to increase the reliability of infrastructure components, the default
 resource requests are used to increase the QoS tier of the router pods above
@@ -78,12 +78,12 @@ not exist, run the following to create a router:
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router <router_name> --replicas=<number> --service-account=router
+$ oc adm router <router_name> --replicas=<number> --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router <router_name> --replicas=<number> --service-account=router
+$ oc adm router <router_name> --replicas=<number> --service-account=router
 ----
 endif::[]
 
@@ -110,12 +110,12 @@ endif::[]
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router --dry-run --service-account=router
+$ oc adm router --dry-run --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router --dry-run --service-account=router
+$ oc adm router --dry-run --service-account=router
 ----
 endif::[]
 
@@ -126,12 +126,12 @@ To see what the default router would look like if created:
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router -o yaml --service-account=router
+$ oc adm router -o yaml --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router -o yaml --service-account=router
+$ oc adm router -o yaml --service-account=router
 ----
 endif::[]
 
@@ -143,25 +143,25 @@ xref:../../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[node label]:
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router <router_name> --replicas=<number> --selector=<label> \
+$ oc adm router <router_name> --replicas=<number> --selector=<label> \
     --service-account=router
 ----
 
 For example, if you want to create a router named `router` and have it placed on a node labeled with `region=infra`:
 ----
-$ oadm router router --replicas=1 --selector='region=infra' \
+$ oc adm router router --replicas=1 --selector='region=infra' \
   --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router <router_name> --replicas=<number> --selector=<label> \
+$ oc adm router <router_name> --replicas=<number> --selector=<label> \
     --service-account=router
 ----
 
 For example, if you want to create a router named `router` and have it placed on a node labeled with `region=infra`:
 ----
-$ oadm router router --replicas=1 --selector='region=infra' \
+$ oc adm router router --replicas=1 --selector='region=infra' \
   --service-account=router
 ----
 endif::[]
@@ -183,13 +183,13 @@ To use a different router image and view the router configuration that would be 
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router <router_name> -o <format> --images=<image> \
+$ oc adm router <router_name> -o <format> --images=<image> \
     --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router <router_name> -o <format> --images=<image> \
+$ oc adm router <router_name> -o <format> --images=<image> \
     --service-account=router
 ----
 endif::[]
@@ -198,13 +198,13 @@ For example:
 
 ifdef::openshift-enterprise[]
 ----
-$ oadm router region-west -o yaml --images=myrepo/somerouter:mytag \
+$ oc adm router region-west -o yaml --images=myrepo/somerouter:mytag \
     --service-account=router
 ----
 endif::[]
 ifdef::openshift-origin[]
 ----
-$ oadm router region-west -o yaml --images=myrepo/somerouter:mytag \
+$ oc adm router region-west -o yaml --images=myrepo/somerouter:mytag \
     --service-account=router
 ----
 endif::[]
@@ -251,7 +251,7 @@ When the router is created, the `--max-connections=` option sets the desired
 limit:
 
 ----
-$ oadm router --max-connections=10000   ....
+$ oc adm router --max-connections=10000   ....
 ----
 
 Edit the `ROUTER_MAX_CONNECTIONS` environment variable in the router's
@@ -272,6 +272,26 @@ deployment configuration. It can also be set when the router is created by using
 $ oc adm router --strict-sni
 ----
 
+[[bind-ciphers]]
+== TLS Cipher Suites
+
+The router
+xref:../../architecture/core_concepts/routes.adoc#ciphers[cipher suite] can be
+set when the router is created by using the --ciphers option.
+
+----
+$ oc adm router --ciphers=modern   ....
+----
+
+The values are: modern, intermediate, or old. The default is intermediate. Alternatively, a set
+of ":" separated ciphers may be provided. The ciphers must be from the set displayed by:
+
+----
+$ openssl ciphers
+----
+
+Alternatively, the ROUTER_CIPHERS environment variable can be used.
+
 [[highly-available-routers]]
 == Highly-Available Routers
 
@@ -291,7 +311,7 @@ appropriately (to `1` replica).
 
 ====
 ----
-$ oadm router --replicas=0 --ports='10080:10080,10443:10443' //<1>
+$ oc adm router --replicas=0 --ports='10080:10080,10443:10443' //<1>
 $ oc set env dc/router ROUTER_SERVICE_HTTP_PORT=10080  \
                    ROUTER_SERVICE_HTTPS_PORT=10443
 $ oc scale dc/router --replicas=1
@@ -510,7 +530,7 @@ Some routes may have other labels, entirely, or none at all.
 |===
 
 Here is a convenience script *_mkshard_*  that
-ilustrates how `oadm router`, `oc set env`, and `oc scale`
+ilustrates how `oc adm router`, `oc set env`, and `oc scale`
 work together to make a router shard.
 
 ====
@@ -521,7 +541,7 @@ work together to make a router shard.
 id=$1
 sel="$2"
 router=router-shard-$id           //<1>
-oadm router $router --replicas=0  //<2>
+oc adm router $router --replicas=0  //<2>
 dc=dc/router-shard-$id            //<3>
 oc set env   $dc ROUTE_LABELS="$sel"  //<4>
 oc scale $dc --replicas=3         //<5>
@@ -666,7 +686,7 @@ This permits the router to read the labels that are applied to the namespaces.
 Now create and label the router:
 
 ----
-$ oadm router ...  --service-account=router
+$ oc adm router ...  --service-account=router
 $ oc set env dc/router NAMESPACE_LABELS="router=r1"
 ----
 
@@ -723,7 +743,7 @@ The cluster administrator can use the `--router-canonical-hostname` option with
 the router's canonical host name when creating the router. For example:
 
 ----
-# oadm router myrouter --router-canonical-hostname="rtr.example.com"
+# oc adm router myrouter --router-canonical-hostname="rtr.example.com"
 ----
 
 This creates the `ROUTER_CANONCAL_HOSTNAME` environment variable in the router's
@@ -820,7 +840,7 @@ no-route-hostname-mynamespace.v3.openshift.test
 [[forcing-route-hostnames-to-a-custom-routing-subdomain]]
 == Forcing Route Host Names to a Custom Routing Subdomain
 If an administrator wants to restrict all routes to a specific routing
-subdomain, they can pass the `--force-subdomain` option to the `oadm
+subdomain, they can pass the `--force-subdomain` option to the `oc adm
 router` command. This forces the router to override any host names specified in
 a route and generate one based on the template provided to the
 `--force-subdomain` option.
@@ -830,7 +850,7 @@ a custom subdomain template `${name}-${namespace}.apps.example.com`.
 
 ====
 ----
-$ oadm router --force-subdomain='${name}-${namespace}.apps.example.com'
+$ oc adm router --force-subdomain='${name}-${namespace}.apps.example.com'
 ----
 ====
 
@@ -845,7 +865,7 @@ by a trusted certificate authority, but for convenience you can use the
 ====
 ----
 $ CA=/etc/origin/master
-$ oadm ca create-server-cert --signer-cert=$CA/ca.crt \
+$ oc adm ca create-server-cert --signer-cert=$CA/ca.crt \
       --signer-key=$CA/ca.key --signer-serial=$CA/ca.serial.txt \
       --hostnames='*.cloudapps.example.com' \
       --cert=cloudapps.crt --key=cloudapps.key
@@ -854,7 +874,7 @@ $ oadm ca create-server-cert --signer-cert=$CA/ca.crt \
 
 [NOTE]
 ====
-The `oadm ca create-server-cert` command generates a certificate that is valid
+The `oc adm ca create-server-cert` command generates a certificate that is valid
 for two years. This can be altered with the `--expire-days` option, but for
 security reasons, it is recommended to not make it greater than this value.
 ====
@@ -872,7 +892,7 @@ From there you can use the `--default-cert` flag:
 
 ====
 ----
-$ oadm router --default-cert=cloudapps.router.pem --service-account=router
+$ oc adm router --default-cert=cloudapps.router.pem --service-account=router
 ----
 ====
 
@@ -902,7 +922,7 @@ and key information. The TLS certificate is served by the router front end.
 First, start up a router instance:
 
 ----
-# oadm router --replicas=1 --service-account=router
+# oc adm router --replicas=1 --service-account=router
 ----
 
 Next, create a private key, csr and certificate for our edge secured route.
@@ -975,7 +995,7 @@ be serviced by the HAProxy router. Then, the HAProxy router exposes the
 associated service (for the route) per the route's wildcard policy.
 
 ----
-$ oadm router --replicas=0 ...
+$ oc adm router --replicas=0 ...
 $ oc set env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
 $ oc scale dc/router --replicas=1
 ----
@@ -994,7 +1014,7 @@ that match the subdomain (`*.example.org`).
 . Start up a router instance:
 +
 ----
-$ oadm router --replicas=0 --service-account=router
+$ oc adm router --replicas=0 --service-account=router
 $ oc set env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
 $ oc scale dc/router --replicas=1
 ----
@@ -1088,7 +1108,7 @@ non-overlapping claims for hosts in the subdomain `example.test` as long as a
 wildcard route has not claimed a subdomain.
 
 ----
-$ oadm router ...
+$ oc adm router ...
 $ oc set env dc/router
 $ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
 
@@ -1111,7 +1131,7 @@ claim for `owner.example.test` or `aname.example.test` to succeed since the
 owning namespace is `ns1`.
 
 ----
-$ oadm router ...
+$ oc adm router ...
 $ oc set env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
 
 $ oc project ns1
@@ -1142,7 +1162,7 @@ for ``\*.example.test` to succeed since the owning namespace is `ns1` and the
 wildcard route belongs to that same namespace.
 
 ----
-$ oadm router ...
+$ oc adm router ...
 $ oc set env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
 
 $ oc project ns1
@@ -1161,7 +1181,7 @@ the claim for ``\*.example.test` to succeed since the owning namespace is `ns1`
 and the wildcard route belongs to another namespace `cyclone`.
 
 ----
-$ oadm router ...
+$ oc adm router ...
 $ oc set env dc/router
 $ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
 
@@ -1187,7 +1207,7 @@ claims subdomain `example.test`, only routes in the namespace `ns1` are allowed
 to claim any hosts in that same subdomain.
 
 ----
-$ oadm router ...
+$ oc adm router ...
 $ oc set env dc/router
 $ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
 
@@ -1241,7 +1261,7 @@ oldest route `junior.example.test` becomes the oldest route and block the
 wildcard route claimant.
 
 ----
-$ oadm router ...
+$ oc adm router ...
 $ oc set env dc/router
 $ oc project ns1 ROUTER_ALLOW_WILDCARD_ROUTES=true
 
@@ -1304,14 +1324,14 @@ example:
 ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm router --service-account=router --host-network=false
+$ oc adm router --service-account=router --host-network=false
 ----
 ====
 endif::[]
 ifdef::openshift-origin[]
 ====
 ----
-$ oadm router --service-account=router --host-network=false
+$ oc adm router --service-account=router --host-network=false
 ----
 ====
 endif::[]
@@ -1373,7 +1393,7 @@ $ sudo docker pull prom/haproxy-exporter
 +
 ====
 ----
-$ oadm router --service-account=router --expose-metrics
+$ oc adm router --service-account=router --expose-metrics
 ----
 ====
 +
@@ -1382,7 +1402,7 @@ defaults:
 +
 ====
 ----
-$ oadm router --service-account=router --expose-metrics \
+$ oc adm router --service-account=router --expose-metrics \
     --metrics-image=prom/haproxy-exporter
 ----
 ====
@@ -1400,7 +1420,7 @@ $ sudo docker pull prom/haproxy-exporter
 +
 ====
 ----
-$ oadm router --service-account=router --expose-metrics
+$ oc adm router --service-account=router --expose-metrics
 ----
 ====
 +
@@ -1409,7 +1429,7 @@ defaults:
 +
 ====
 ----
-$ oadm router --service-account=router --expose-metrics \
+$ oc adm router --service-account=router --expose-metrics \
     --metrics-image=prom/haproxy-exporter
 ----
 ====


### PR DESCRIPTION
Openshift 3.6

The user can select from among 3 predefined cipher lists: modern,
intermediate, or old. Alternatively the use may provide a custom
cipher list see "openssl ciphers". The list is used to negotiate a
cipher between a user and haproxyi during bind.

The predefined lists are from:
https://wiki.mozilla.org/Security/Server_Side_TLS

A new option to "oc adm router", --ciphers, is added to specify
the cipher list. The values are modern|intermediate|old, or a
":" separated list of ciphers from "man 1 ciphers"

Option --ciphers creates an environment variable, ROUTER_CIPHERS,
which is passed to the router pod.

----------------------
General cleanup: "oadm router" changed to "oc adm router"

Code changes are in:
Openshift/origin PR 14505
https://github.com/openshift/origin/pull/14505

Trello oeP7vrTZ
https://trello.com/c/oeP7vrTZ/285-3-allow-modification-of-haproxys-ssl-cipher-preference-ingress