### PR TITLE
Do not serve certificate content for Non-SSL routes

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -286,6 +286,7 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`*ROUTER_USE_PROXY_PROTOCOL*`|  | When set to `true` or `TRUE`, HAProxy expects incoming connections to use the `PROXY` protocol on port 80 or port 443. The source IP address can pass through a load balancer if the load balancer supports the protocol, for example Amazon ELB.
 |`*ROUTER_ALLOW_WILDCARD_ROUTES*`|  |  When set to `true` or `TRUE`, any routes with a wildcard policy of `Subdomain` that pass the router admission checks will be serviced by the HAProxy router.
 |`*ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK*` |  | Set to `true` to relax the namespace ownership policy.
+|`*ROUTER_STRICT_SNI*` |  | xref:strict-sni[strict-sni]
 |===
 
 [[time-units]]
@@ -301,6 +302,27 @@ ports that the router is listening on, `ROUTER_SERVICE_SNI_PORT` and
 `ROUTER_SERVICE_NO_SNI_PORT`. These ports can be anything you want as long as
 they are unique on the machine. These ports will not be exposed externally.
 ====
+
+[[strict-sni]]
+== HAProxy Strict SNI
+
+By default, when a host does not resolve to a route in a HTTPS or TLS
+SNI request, the default certificate is returned to the caller as part of the
+503 response. This exposes the default certificate and can pose security
+concerns. HAProxy `strict-sni` option to bind suppresses use of the
+default certificate.
+
+The `ROUTER_STRICT_SNI` environment variable controls bind processing. When set to `true` or
+`TRUE`, `strict-sni` is added to the HAProxy bind. Default is `false`.
+
+The option can be set when the router is created or added later.
+
+----
+$ oc adm router --strict-sni
+----
+
+sets `ROUTER_STRICT_SNI=true`
+
 
 [[route-hostnames]]
 

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -259,6 +259,19 @@ deployment configuration to change the value. The router pods are restarted with
 the new value. If `ROUTER_MAX_CONNECTIONS` is not present, the default value of
 20000, is used.
 
+[[bind-strict-sni]]
+== HAProxy Strict SNI
+
+The
+xref:../../architecture/core_concepts/routes.adoc#strict-sni[HAProxy `strict-sni`] can be
+controlled through the `ROUTER_STRICT_SNI` environment variable in the router's
+deployment configuration. It can also be set when the router is created by using the
+`--strict-sni` command line option.
+
+----
+# oc adm router --strict-sni
+----
+
 [[highly-available-routers]]
 == Highly-Available Routers
 


### PR DESCRIPTION
Openshift 3.6

By default, when a host does not resolve to a route in a HTTPS or tls
sni request, the default cert is returned to the caller as part of the
503 response. This exposes the default cert and may pose security
concerns. Haproxy strict-sni option to bind suppresses use of the
default cert.

This adds a new environment variable to the router deployment
controller, ROUTER_STRICT_SNI, to control bind processing. When set
to "true" or "TRUE", "strict-sni" is added to the bind. Default
is "false".

oc adm router --strict-sni

sets ROUTER_STRICT_SNI="true"

origin PR 14621
https://github.com/openshift/origin/pull/14621

bug 1369865
https://bugzilla.redhat.com/show_bug.cgi?id=1369865