### PR TITLE
 Bug 1463721 - Adding Push Dates to Asynchronous Errata Updates

### DIFF
--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -1299,6 +1299,8 @@ xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgra
 [[ocp-3-3-0-34]]
 === RHBA-2016:1988 - {product-title} 3.3.0.34 Bug Fix Update
 
+*Post Date: 2016-10-04*
+
 {product-title} release 3.3.0.34 is now available. The list of packages and bug
 fixes included in the update are documented in the
 link:https://access.redhat.com/errata/RHBA-2016:1988[RHBA-2016:1988] advisory.
@@ -1314,6 +1316,8 @@ xref:../install_config/upgrading/automated_upgrades.adoc#running-the-upgrade-pla
 
 [[ocp-3-3-1-3]]
 === RHBA-2016:2084 - {product-title} 3.3.1.3 Bug Fix and Enhancement Update
+
+*Post Date: 2016-10-27*
 
 {product-title} release 3.3.1.3 is now available. The list of packages included
 in the update are documented in the
@@ -1492,6 +1496,8 @@ extended termination time, however, should make normal shutdown scenarios safer.
 
 [[ocp-33-relnotes-rhba-2016-2122]]
 === RHBA-2016:2122 - atomic-openshift-utils Bug Fix Update
+
+*Post Date: 2016-10-27*
 
 {product-title} bug fix advisory
 link:https://access.redhat.com/errata/RHBA-2016:2122[RHBA-2016:2122],
@@ -1692,6 +1698,8 @@ xref:..//install_config/install/host_preparation.html#installing-docker[Installi
 [[ocp-3-3-1-4]]
 === RHSA-2016:2696 - {product-title} 3.3.1.4 Security and Bug Fix Update
 
+*Post Date: 2016-11-15*
+
 {product-title} release 3.3.1.4 is now available. The list of packages and bug
 fixes included in the update are documented in the
 link:https://access.redhat.com/errata/RHSA-2016:2696[RHSA-2016:2696] advisory.
@@ -1708,6 +1716,8 @@ xref:../install_config/upgrading/automated_upgrades.adoc#running-the-upgrade-pla
 
 [[ocp-3-3-1-5]]
 === RHBA-2016:2801 - {product-title} 3.3.1.5 Bug Fix Update
+
+*Post Date: 2016-11-17*
 
 {product-title} release 3.3.1.5 is now available. The list of packages and bug
 fixes included in the update are documented in the

--- a/release_notes/ocp_3_4_release_notes.adoc
+++ b/release_notes/ocp_3_4_release_notes.adoc
@@ -919,6 +919,8 @@ xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgra
 [[ocp-3-4-0-40]]
 === RHBA-2017:0186 - {product-title} 3.4.0.40 Bug Fix Update
 
+*Post Date: 2017-01-24*
+
 {product-title} release 3.4.0.40 is now available. The list of packages and bug
 fixes included in the update are documented in the
 link:https://access.redhat.com/errata/RHBA-2017:0186[RHBA-2017:0186] advisory.
@@ -941,6 +943,8 @@ link:https://access.redhat.com/solutions/2887651[]
 
 [[ocp-3-4-1-2]]
 === RHBA-2017:0218 - {product-title} 3.4.1.2 Bug Fix Update
+
+*Post Date: 2017-01-31*
 
 {product-title} release 3.4.1.2 is now available. The list of packages and bug
 fixes included in the update are documented in the
@@ -1010,6 +1014,8 @@ This release fixes bugs for the following components:
 
 [[ocp-3-4-1-5]]
 === RHBA-2017:0268 - {product-title} 3.4.1.5 Bug Fix Update
+
+*Post Date: 2017-02-09*
 
 {product-title} release 3.4.1.5 is now available. The list of packages and bug
 fixes included in the update are documented in the

--- a/release_notes/ocp_3_5_release_notes.adoc
+++ b/release_notes/ocp_3_5_release_notes.adoc
@@ -1709,6 +1709,8 @@ xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgra
 [[ocp-3-5-rhba-2017-0903]]
 === RHBA-2017:0903 - atomic-openshift-utils Bug Fix and Enhancement Update
 
+*Post Date: 2017-04-12*
+
 {product-title} and bug fix advisory
 link:https://access.redhat.com/errata/RHBA-2017:0903[RHBA-2017:0903], providing
 updated *atomic-openshift-utils*, *ansible*, and *openshift-ansible* packages

--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -793,6 +793,8 @@ cluster] properly.
 [[ose-32-relnotes-rhba-2016-1208]]
 === RHBA-2016:1208 - atomic-openshift-utils Bug Fix Update
 
+*Post Date: 2016-06-07*
+
 OpenShift Enterprise bug fix advisory
 https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1208[RHBA-2016:1208],
 providing updated *atomic-openshift-utils* and *openshift-ansible* packages that
@@ -944,6 +946,8 @@ these options correctly.
 
 [[ose-3-2-1-1]]
 === RHBA-2016:1343 - OpenShift Enterprise 3.2.1.1 bug fix and enhancement update
+
+*Post Date: 2016-06-27*
 
 {product-title} release 3.2.1.1
 (https://access.redhat.com/errata/product/290/ver=3.1/rhel---7/x86_64/RHBA-2016:1343[RHBA-2016:1343])
@@ -1164,6 +1168,8 @@ link:https://github.com/openshift/origin/issues/9491[*openshift/origin#9491*])
 [[ose-3-2-1-4]]
 === RHBA-2016:1383 - OpenShift Enterprise 3.2.1.4 bug fix and enhancement update
 
+*Post Date: 2016-07-05*
+
 {product-title} release 3.2.1.4
 (https://access.redhat.com/errata/product/290/ver=3.1/rhel---7/x86_64/RHBA-2016:1383[RHBA-2016:1383])
 is now available. The list of bug fixes included in the update are documented in
@@ -1190,6 +1196,8 @@ way to the latest asynchronous release at once.
 
 [[ose-3-2-1-9]]
 === RHBA-2016:1466 - OpenShift Enterprise 3.2.1.9 security and bug fix update
+
+*Post Date: 2016-07-20*
 
 {product-title} release 3.2.1.9
 (https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1466[RHBA-2016:1466])
@@ -1218,6 +1226,8 @@ way to the latest asynchronous release at once.
 
 [[ose-3-2-1-13]]
 === RHBA-2016:1608 - OpenShift Enterprise 3.2.1.13 bug fix and enhancement update
+
+*Post Date: 2016-08-11*
 
 {product-title} release 3.2.1.13
 (https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1608[RHBA-2016:1608])
@@ -1251,6 +1261,8 @@ way to the latest asynchronous release at once.
 
 [[ose-32-relnotes-rhba-2016-1639]]
 === RHBA-2016:1639 - atomic-openshift-utils Bug Fix and Enhancement Update
+
+*Post Date: 2016-08-18*
 
 OpenShift Enterprise bug fix advisory
 https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHBA-2016:1639[RHBA-2016:1639],
@@ -1370,6 +1382,8 @@ upgrades now complete successfully on RHEL Atomic Host systems.
 
 [[ose-3-2-1-15]]
 === RHSA-2016:1853 - OpenShift Enterprise 3.2.1.15 security and bug fix update
+
+*Post Date: 2016-09-12*
 
 {product-title} release 3.2.1.15
 (link:https://access.redhat.com/errata/product/290/ver=3.2/rhel---7/x86_64/RHSA-2016:1853[RHSA-2016:1853])


### PR DESCRIPTION
Quality of life update for Release Notes. Based on a OpenShift Container Platform [customer's request](https://bugzilla.redhat.com/show_bug.cgi?id=1463721). Added Errata Push dates from [the download pages](https://access.redhat.com/downloads/content/290/ver=3.5/rhel---7/3.5.5.26/x86_64/product-errata) for the following releases:

* 3.2
* 3.3
* 3.4
* 3.5

I haven't updated 3.1 because the Release Notes page follows a slightly different format to the other pages, and there's no appropriate place for the Push Date to sit in the page. In addition, the only listed update is 3.1.1.

Changes render as below:

<img width="701" alt="screen shot 2017-06-21 at 18 58 18" src="https://user-images.githubusercontent.com/4622553/27399133-b08133f2-56b3-11e7-970a-63d9c659b6e7.png">




