### PR TITLE
Updated downgrade steps for OCP 3.4

### DIFF
--- a/install_config/downgrade.adoc
+++ b/install_config/downgrade.adoc
@@ -15,23 +15,17 @@ toc::[]
 == Overview
 
 Following an {product-title}
-xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgrade], it may be desirable in
-extreme cases to downgrade your cluster to a previous version. The following
-sections outline the required steps for each system in a cluster to perform such
-a downgrade for the {product-title} 3.2 to 3.1 downgrade path.
+xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgrade],
+it may be desirable in extreme cases to downgrade your cluster to a previous
+version. The following sections outline the required steps for each system in a
+cluster to perform such a downgrade for the {product-title} 3.4 to 3.3 downgrade
+path.
 
 [WARNING]
 ====
 These steps are currently only supported for
 xref:../install_config/install/rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[RPM-based
 installations] of {product-title} and assumes downtime of the entire cluster.
-====
-
-[IMPORTANT]
-====
-For the {product-title} 3.1 to 3.0 downgrade path, see the
-link:https://docs.openshift.com/enterprise/3.1/install_config/downgrade.html[OpenShift
-Enterprise 3.1] documentation, which has modified steps.
 ====
 
 [[downgrade-verifying-backups]]
@@ -42,21 +36,17 @@ xref:../install_config/upgrading/index.adoc#install-config-upgrading-index[upgra
 a backup of the *_master-config.yaml_* file and the etcd data directory. Ensure
 these exist on your masters and etcd members:
 
-====
 ----
 /etc/origin/master/master-config.yaml.<timestamp>
 /var/lib/origin/etcd-backup-<timestamp>
 ----
-====
 
 Also, back up the *_node-config.yaml_* file on each node (including masters,
 which have the node component on them) with a timestamp:
 
-====
 ----
 /etc/origin/node/node-config.yaml.<timestamp>
 ----
-====
 
 If you are using an external etcd cluster (versus the single embedded etcd), the
 backup is likely created on all etcd members, though only one is required for
@@ -66,13 +56,12 @@ The RPM downgrade process in a later step should create *_.rpmsave_* backups of
 the following files, but it may be a good idea to keep a separate copy
 regardless:
 
-====
 ----
 /etc/sysconfig/atomic-openshift-master
 /etc/etcd/etcd.conf <1>
 ----
 <1> Only required if using external etcd.
-====
+
 
 [[downgrade-shutting-down-the-cluster]]
 == Shutting Down the Cluster
@@ -82,46 +71,45 @@ ensure the relevant services are stopped.
 
 On the master in a single master cluster:
 
-====
 ----
 # systemctl stop atomic-openshift-master
 ----
-====
 
 On each master in a multi-master cluster:
 
-====
 ----
 # systemctl stop atomic-openshift-master-api
 # systemctl stop atomic-openshift-master-controllers
 ----
-====
 
 
 On all master and node hosts:
 
-====
 ----
 # systemctl stop atomic-openshift-node
 ----
-====
 
 On any external etcd hosts:
 
-====
 ----
 # systemctl stop etcd
 ----
-====
-
 
 [[downgrade-removing-rpms]]
 == Removing RPMs
 
-On all masters, nodes, and etcd members (if using an external etcd cluster),
-remove the following packages:
+. The **-excluder* packages add entries to the exclude directive in the host’s
+*_/etc/yum.conf_* file when installed. Run the following command on each host to
+remove the `atomic-openshift-*` and `docker` packages from the exclude list:
++
+----
+# atomic-openshift-excluder unexclude
+# atomic-openshift-docker-excluder unexclude
+----
 
-====
+. On all masters, nodes, and etcd members (if using an external etcd cluster),
+remove the following packages:
++
 ----
 # yum remove atomic-openshift \
     atomic-openshift-clients \
@@ -129,29 +117,26 @@ remove the following packages:
     atomic-openshift-master \
     openvswitch \
     atomic-openshift-sdn-ovs \
-    tuned-profiles-atomic-openshift-node
+    tuned-profiles-atomic-openshift-node \
+    atomic-openshift-excluder \
+    atomic-openshift-docker-excluder
 ----
-====
 
-If you are using external etcd, also remove the *etcd* package:
-
-====
+. If you are using external etcd, also remove the *etcd* package:
++
 ----
 # yum remove etcd
 ----
-====
-
-For embedded etcd, you can leave the *etcd* package installed, as the package is
-only required so that the `etcdctl` command is available to issue operations in
-later steps.
++
+If using the embedded etcd, leave the *etcd* package installed. It is required
+for running the `etcdctl` command to issue operations in later steps.
 
 [[downgrade-docker]]
 == Downgrading Docker
 
-{product-title} 3.2 requires Docker 1.9.1 and also supports Docker 1.10.3,
-however {product-title} 3.1 requires Docker 1.8.2.
+{product-title} 3.3 requires Docker 1.10.3.
 
-Downgrade to Docker 1.8.2 on each host using the following steps:
+Downgrade to Docker 1.10.3. on each host using the following steps:
 
 . Remove all local containers and images on the host. Any pods backed by a
 replication controller will be recreated.
@@ -173,49 +158,46 @@ Delete all images:
 # docker rmi $(docker images -q)
 ----
 
-. Use `yum swap` (instead of `yum downgrade`) to install Docker 1.8.2:
+. Use `yum swap` (instead of `yum downgrade`) to install Docker 1.10.3:
 +
 ----
-# yum swap docker-* docker-*1.8.2
+# yum swap docker-* docker-*1.10.3
 # sed -i 's/--storage-opt dm.use_deferred_deletion=true//' /etc/sysconfig/docker-storage
 # systemctl restart docker
 ----
 
-. You should now have Docker 1.8.2 installed and running on the host. Verify with
-the following:
+. You should now have Docker 1.10.3 installed and running on the host. Verify
+with the following:
 +
 ----
 # docker version
 Client:
- Version:      1.8.2-el7
+ Version:      1.10.3-el7
  API version:  1.20
- Package Version: docker-1.8.2-10.el7.x86_64
+ Package Version: docker-1.10.3.el7.x86_64
 [...]
 
 # systemctl status docker
 ● docker.service - Docker Application Container Engine
    Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; vendor preset: disabled)
-   Active: active (running) since Mon 2016-06-27 15:44:20 EDT; 33min ago
+   Active: active (running) since Wed 2017-06-21 15:44:20 EDT; 30min ago
 [...]
 ----
 
 [[downgrade-reinstalling-rpms]]
 == Reinstalling RPMs
 
-Disable the {product-title} 3.3 repositories, and re-enable the 3.2
+. Disable the {product-title} 3.4 repositories, and re-enable the 3.3
 repositories:
-
-====
++
 ----
 # subscription-manager repos \
-    --disable=rhel-7-server-ose-3.3-rpms \
-    --enable=rhel-7-server-ose-3.2-rpms
+    --disable=rhel-7-server-ose-3.4-rpms \
+    --enable=rhel-7-server-ose-3.3-rpms
 ----
-====
 
-On each master, install the following packages:
-
-====
+. On each master, install the following packages:
++
 ----
 # yum install atomic-openshift \
     atomic-openshift-clients \
@@ -223,30 +205,29 @@ On each master, install the following packages:
     atomic-openshift-master \
     openvswitch \
     atomic-openshift-sdn-ovs \
-    tuned-profiles-atomic-openshift-node
+    tuned-profiles-atomic-openshift-node \
+    atomic-openshift-excluder \
+    atomic-openshift-docker-excluder
 ----
-====
 
-On each node, install the following packages:
-
-====
+. On each node, install the following packages:
++
 ----
 # yum install atomic-openshift \
     atomic-openshift-node \
     openvswitch \
     atomic-openshift-sdn-ovs \
-    tuned-profiles-atomic-openshift-node
+    tuned-profiles-atomic-openshift-node \
+    atomic-openshift-excluder \
+    atomic-openshift-docker-excluder
 ----
-====
 
-If using an external etcd cluster, install the following package on each etcd
+. If using an external etcd cluster, install the following package on each etcd
 member:
-
-====
++
 ----
 # yum install etcd
 ----
-====
 
 [[downgrade-restore-etcd]]
 == Restoring etcd
@@ -264,9 +245,8 @@ and Restore].
 [[verifying-the-downgrade]]
 == Verifying the Downgrade
 
-To verify the downgrade, first check that all nodes are marked as *Ready*:
-
-====
+. To verify the downgrade, first check that all nodes are marked as *Ready*:
++
 ----
 # oc get nodes
 NAME                        STATUS                     AGE
@@ -274,30 +254,25 @@ master.example.com          Ready,SchedulingDisabled   165d
 node1.example.com           Ready                      165d
 node2.example.com           Ready                      165d
 ----
-====
 
-Then, verify that you are running the expected versions of the *docker-registry*
+. Then, verify that you are running the expected versions of the *docker-registry*
 and *router* images, if deployed:
-
-====
++
 ----
 ifdef::openshift-enterprise[]
 # oc get -n default dc/docker-registry -o json | grep \"image\"
-    "image": "openshift3/ose-docker-registry:v3.1.1.6",
+    "image": "openshift3/ose-docker-registry:v3.3.1.38-2",
 # oc get -n default dc/router -o json | grep \"image\"
-    "image": "openshift3/ose-haproxy-router:v3.1.1.6",
+    "image": "openshift3/ose-haproxy-router:v3.3.1.38-2",
 ----
-====
 
-You can use the diagnostics tool on the master to look for common issues and
-provide suggestions. In {product-title} 3.1, the `oc adm diagnostics` tool is
-available as `openshift ex diagnostics`:
-
-====
+. You can use the
+xref:../admin_guide/diagnostics_tool.adoc#admin-guide-diagnostics-tool[diagnostics
+tool] on the master to look for common issues and provide suggestions:
++
 ----
-# openshift ex diagnostics
+# oc adm diagnostics
 ...
 [Note] Summary of diagnostics execution:
 [Note] Completed with no errors or warnings seen.
 ----
-====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1457114

This addresses the downgrade process from OCP 3.4 to 3.3.

Preview Build: http://file.rdu.redhat.com/~ahardin/06212017/update-34-downgrade/install_config/downgrade.html