### PR TITLE
Bug 1461935 Added updatePeriodSeconds and intervalSeconds

### DIFF
--- a/dev_guide/deployments/deployment_strategies.adoc
+++ b/dev_guide/deployments/deployment_strategies.adoc
@@ -67,23 +67,27 @@ application to handle it.
 
 The following is an example of the Rolling strategy:
 
-====
 [source,yaml]
 ----
 strategy:
   type: Rolling
   rollingParams:
-    timeoutSeconds: 120 <1>
-    maxSurge: "20%" <2>
-    maxUnavailable: "10%" <3>
-    pre: {} <4>
+    updatePeriodSeconds: 1 <1>
+    intervalSeconds: 1 <2>
+    timeoutSeconds: 120 <3>
+    maxSurge: "20%" <4>
+    maxUnavailable: "10%" <5>
+    pre: {} <6>
     post: {}
 ----
-<1> How long to wait for a scaling event before giving up. Optional; the default is 120.
-<2> `maxSurge` is optional and defaults to `25%` if not specified; see below.
-<3> `maxUnavailable` is optional and defaults to `25%` if not specified; see below.
-<4> `*pre*` and `*post*` are both xref:lifecycle-hooks[lifecycle hooks].
-====
+<1> The time to wait between individual pod updates. If unspecified, this value defaults to `1`.
+<2> The time to wait between polling the deployment status after update. If unspecified, this value defaults to `1`.
+<3> The time to wait for a scaling event before giving up. Optional; the default is `600`. Here, _giving up_ means 
+automatically rolling back to the previous complete deployment.
+<4> `maxSurge` is optional and defaults to `25%` if not specified. See the information below the following procedure.
+<5> `maxUnavailable` is optional and defaults to `25%` if not specified. See the information below the following procedure.
+<6> `*pre*` and `*post*` are both xref:lifecycle-hooks[lifecycle hooks].
+
 
 The Rolling strategy will:
 
@@ -183,8 +187,6 @@ process.
 
 The following is an example of the Recreate strategy:
 
-====
-
 [source,yaml]
 ----
 strategy:
@@ -197,7 +199,6 @@ strategy:
 
 <1> `recreateParams` are optional.
 <2> `pre`, `mid`, and `post` are xref:lifecycle-hooks[lifecycle hooks].
-====
 
 The Recreate strategy will:
 
@@ -233,8 +234,6 @@ The Custom strategy allows you to provide your own deployment behavior.
 
 The following is an example of the Custom strategy:
 
-====
-
 [source,yaml]
 ----
 strategy:
@@ -246,7 +245,6 @@ strategy:
       - name: ENV_1
         value: VALUE_1
 ----
-====
 
 In the above example, the `organization/strategy` container image provides the
 deployment behavior. The optional `command` array overrides any `CMD` directive
@@ -280,7 +278,6 @@ existing deployment strategies. Provide a custom shell script logic and call the
 container image, but the default {product-title} deployer image will be used
 instead:
 
-====
 [source,yaml]
 ----
 strategy:
@@ -296,11 +293,9 @@ strategy:
       openshift-deploy
       echo Complete
 ----
-====
 
 This will result in following deployment:
 
-====
 [source]
 ----
 Started deployment #2
@@ -315,7 +310,6 @@ Halfway there
 --> Success
 Complete
 ----
-====
 
 If the custom deployment strategy process requires access to the {product-title} API or the
 Kubernetes API the container that executes the strategy can use the service account token
@@ -331,8 +325,6 @@ the deployment process at predefined points within the strategy:
 
 The following is an example of a `pre` lifecycle hook:
 
-====
-
 [source,yaml]
 ----
 pre:
@@ -341,7 +333,6 @@ pre:
 ----
 
 <1> `execNewPod` is xref:pod-based-lifecycle-hook[a pod-based lifecycle hook].
-====
 
 Every hook has a `failurePolicy`, which defines the action the strategy should
 take when a hook failure is encountered:
@@ -372,8 +363,6 @@ template in a deployment configuration.
 The following simplified example deployment configuration uses the
 xref:rolling-strategy[Rolling strategy]. Triggers and some other minor details
 are omitted for brevity:
-
-====
 
 [source,yaml]
 ----
@@ -411,7 +400,6 @@ spec:
 <2> This `command` overrides any `ENTRYPOINT` defined by the `openshift/origin-ruby-sample` image.
 <3> `env` is an optional set of environment variables for the hook container.
 <4> `volumes` is an optional set of volume references for the hook container.
-====
 
 In this example, the `pre` hook will be executed in a new pod using the
 *openshift/origin-ruby-sample* image from the *helloworld* container. The hook

--- a/dev_guide/integrating_external_services.adoc
+++ b/dev_guide/integrating_external_services.adoc
@@ -22,11 +22,14 @@ they would any other internal service.
 One of the most common types of external services is an external database. To
 support an external database, an application needs:
 
-1. An endpoint to communicate with.
-2. A set of credentials and coordinates, including:
-   a.  A user name
-   b.  A passphrase
-   c.  A database name
+. An endpoint to communicate with.
+. A set of credentials and coordinates, including:
++
+* A user name
++
+* A passphrase
++
+* A database name
 
 The solution for integrating with an external database includes:
 
@@ -64,8 +67,6 @@ Instead, leave the `Selector` field unset. This represents the external service,
 making the `EndpointsController` ignore the service and allows you to specify
 endpoints manually:
 +
-====
-
 ----
   kind: "Service"
   apiVersion: "v1"
@@ -84,13 +85,9 @@ endpoints manually:
 
 <1> The `selector` field to leave blank.
 
-====
-
 . Next, create the required endpoints for the service. This gives the service
 proxy and router the location to send traffic directed to the service:
 +
-====
-
 ----
   kind: "Endpoints"
   apiVersion: "v1"
@@ -118,13 +115,9 @@ be] loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast
 <4> The `*port*` and `*name*` definition must match the `*port*` and `*name*`
 value in the service defined in the previous step.
 
-====
-
 [[mysql-define-service-using-fqdn]]
 ==== Using FQDN
 Use an `ExternalName` service without defining any ports or endpoints.
-
-====
 
 ----
   kind: "Service"
@@ -139,14 +132,11 @@ Use an `ExternalName` service without defining any ports or endpoints.
 
 <1> The `selector` field to leave blank.
 
-====
-
 === Step 2: Consume a Service
-. Now that the service and endpoints are defined, give the appropriate pods
+
+Now that the service and endpoints are defined, give the appropriate pods
 access to the credentials to use the service by setting environment variables in
 the appropriate containers:
-+
-====
 
 ----
   kind: "DeploymentConfig"
@@ -157,8 +147,8 @@ the appropriate containers:
     strategy:
       type: "Rolling"
       rollingParams:
-        updatePeriodSeconds: 1
-        intervalSeconds: 1
+        updatePeriodSeconds: 1 <2>
+        intervalSeconds: 1 <3>
         timeoutSeconds: 120
     replicas: 2
     selector:
@@ -179,21 +169,21 @@ the appropriate containers:
             env:
               -
                 name: "MYSQL_USER"
-                value: "${MYSQL_USER}" <2>
+                value: "${MYSQL_USER}" <4>
               -
                 name: "MYSQL_PASSWORD"
-                value: "${MYSQL_PASSWORD}" <3>
+                value: "${MYSQL_PASSWORD}" <5>
               -
                 name: "MYSQL_DATABASE"
-                value: "${MYSQL_DATABASE}" <4>
+                value: "${MYSQL_DATABASE}" <6>
 ----
 
 <1> Other fields on the `DeploymentConfig` are omitted
-<2> The user name to use with the service.
-<3> The passphrase to use with the service.
-<4> The database name.
-
-====
+<2> The time to wait between individual pod updates.
+<3> The time to wait between polling the deployment status after update.
+<4> The user name to use with the service.
+<5> The passphrase to use with the service.
+<6> The database name.
 
 *External Database Environment Variables*
 
@@ -239,10 +229,7 @@ provider:
 [[saas-define-service-using-ip-address]]
 ==== Using an IP address and Endpoints
 
-. Create an
-xref:../architecture/core_concepts/pods_and_services.adoc#services[{product-title}
-service] to represent the external service. This is similar to creating an
-internal service; however the difference is in the service's `Selector` field.
+. Create an xref:../architecture/core_concepts/pods_and_services.adoc#services[{product-title} service] to represent the external service. This is similar to creating an internal service; however the difference is in the service's `Selector` field.
 +
 Internal {product-title} services use the `Selector` field to associate pods with
 services using
@@ -259,8 +246,6 @@ associated with it. Instead, leave the `Selector` field unset. This makes the
 `EndpointsController` ignore the service and allows you to specify endpoints
 manually:
 +
-====
-
 ----
   kind: "Service"
   apiVersion: "v1"
@@ -279,13 +264,9 @@ manually:
 
 <1> The `selector` field to leave blank.
 
-====
-
 . Next, create endpoints for the service containing the information about where
 to send traffic directed to the service proxy and the router:
 +
-====
-
 ----
 kind: "Endpoints"
 apiVersion: "v1"
@@ -299,16 +280,12 @@ subsets: <2>
     port: 3306
 ----
 
-====
-
 <1> The name of the `Service` instance.
 <2> Traffic to the service is load-balanced between the `subsets` supplied here.
 
 . Now that the service and endpoints are defined, give pods the credentials to
 use the service by setting environment variables in the appropriate containers:
 +
-====
-
 ----
 ---
   kind: "DeploymentConfig"
@@ -319,8 +296,6 @@ use the service by setting environment variables in the appropriate containers:
     strategy:
       type: "Rolling"
       rollingParams:
-        updatePeriodSeconds: 1
-        intervalSeconds: 1
         timeoutSeconds: 120
     replicas: 1
     selector:
@@ -356,13 +331,9 @@ use the service by setting environment variables in the appropriate containers:
 <3> `SAAS_USERNAME`: The user name to use with the service.
 <4> `SAAS_PASSPHRASE`: The passphrase to use with the service.
 
-====
-
 [[saas-define-service-using-fqdn]]
 ==== Using FQDN
 Use an `ExternalName` service without defining any ports or endpoints.
-
-====
 
 ----
   kind: "Service"
@@ -376,8 +347,6 @@ Use an `ExternalName` service without defining any ports or endpoints.
 ----
 
 <1> The `selector` field to leave blank.
-
-====
 
 *External SaaS Provider Environment Variables*
 


### PR DESCRIPTION
Made changes per [Bug 1461935](https://bugzilla.redhat.com/show_bug.cgi?id=1461935):

* deployment_strategies.adoc: Added `updatePeriodSeconds` and `intervalSeconds` to Rolling Deployment example with definition from API Reference.

* integrating_external_services: Added `updatePeriodSeconds` and `intervalSeconds` definition from API Reference to _Step 2: Consume a Service_ example.

* *Note:* In error I added `updatePeriodSeconds` and `intervalSeconds`to the _Using an IP address and Endpoints_ and subsequently removed. This change appears in the PR. 