### PR TITLE
Added hostnetwork to the ways to get traffic in

### DIFF
--- a/dev_guide/getting_traffic_into_cluster.adoc
+++ b/dev_guide/getting_traffic_into_cluster.adoc
@@ -397,6 +397,25 @@ down, the virtual IP address is automatically transferred to another host in the
 pool.
 
 
+[[host-network]]
+== Using Host Networking
+
+You can choose to let the pods use the networking of the host that
+they are on rather than containerizing the networking and using
+the SDN.  This is how the router works, and it can be a useful
+technique when you have to proxy a Layer 7 protocol that is not
+http/https/or TLS with SNI.  You can look at the way the router is
+configured to see how to set it up, but basically you need to set
+`hostNetwork: true` in the pod definition, and then run the router
+with a service account that has the `hostnetwork` permission.  You can
+grant the permission with `oc adm policy add-scc-to-user hostnetwork
+system:serviceaccount:default:someserviceaccountname`.
+
+Once configured, the pod can access all of the network interfaces on
+the node that it is running on, including the host's SDN interface.
+This allows you to make your own proxy, or allows you to run a program
+directly on the host interfaces directly.
+
 [[ingress-load-balancer]]
 == Non-Cloud Edge Router Load Balancer
 


### PR DESCRIPTION
We covered a bunch of ways to get traffic in to your pods, but I
realized we omitted hostnetwork.  This fixes that omission.

This can go into any version that has the file.  But I'm fine if it just goes into 3.6 and 3.7.