### PR TITLE
admin-guide/ipsec: correct instructions for explicit configuration 'rightid' line

### DIFF
--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -52,6 +52,16 @@ IPSec requires 62 bytes. If the cluster is operating on an ethernet network with
 an MTU of 1500 then the SDN MTU should be 1388, to allow for the overhead of
 IPSec and the SDN encapsulation.
 
+After modifying the MTU in the {product-title} configuration, the SDN must be
+made aware of the change by removing the SDN interface and restarting the
+{product-title} node process.
++
+----
+# systemctl stop atomic-openshift-node
+# ovs-vsctl del-br br0
+# systemctl start atomic-openshift-node
+----
+
 [[admin-guide-ipsec-certificates]]
 === Step 2: Certificates
 By default, {product-title} secures cluster management communication with
@@ -184,6 +194,17 @@ configuration of every other node in the cluster. Using a configuration
 management tool such as Ansible to generate this file on each host is
 recommended.
 
+. This configuration also requires the full certificate subject of each node to
+be placed into the configuration for every other node. To read this subject from
+the node's certificate, use *openssl*:
++
+----
+# openssl x509 \
+  -in /path/to/client-certificate -text | \
+  grep "Subject:" | \
+  sed 's/[[:blank:]]*Subject: //'
+----
+
 . Place the following lines into the *_/etc/ipsec.d/openshift-cluster.conf_* file on each node for every other node in the cluster:
 +
 ====
@@ -194,7 +215,7 @@ conn <other_node_hostname>
         leftrsasigkey=%cert
         leftcert=<this_node_cert_nickname> <2>
         right=<other_node_ip> <3>
-        rightid="CN=<other_node_cert_nickname>" <4>
+        rightid="<other_node_cert_full_subject>" <4>
         rightrsasigkey=%cert
         auto=start
         keyingtries=%forever
@@ -202,7 +223,7 @@ conn <other_node_hostname>
 <1> Replace <this_node_ip> with the cluster IP address of this node.
 <2> Replace <this_node_cert_nickname> with the node certificate nickname from step one.
 <3> Replace <other_node_ip> with the cluster IP address of the other node.
-<4> Replace <other_node_cert_nickname> with the other node certificate nickname from step one.
+<4> Replace <other_node_cert_full_subject> with the other node's certificate subject from just above. For example: "O=system:nodes,CN=openshift-node-45.example.com".
 ====
 
 . Place the following in the *_/etc/ipsec.d/openshift-cluster.secrets_* file on each node:


### PR DESCRIPTION
Appears to require the full certificate subject rather than just the Common Name.

@openshift/networking 