### PR TITLE
BZ-1463961 removed paragrah on BuildConfig.spec.output.imageLabels 

### DIFF
--- a/dev_guide/builds.adoc
+++ b/dev_guide/builds.adoc
@@ -2386,24 +2386,6 @@ Docker and Source builds set the following labels on output images:
 |Source URL for the build
 |===
 
-You can also use the `BuildConfig.spec.output.imageLabels` field to specify a
-list of custom labels that will be applied to each image built from the BuildConfig.
-
-.Custom labels to be applied to built images
-====
-[source,yaml]
-----
-output:
-  to:
-    kind: "ImageStreamTag"
-    name: "my-image:latest"
-  imageLabels:
-  - name: "vendor"
-    value: "MyCompany"
-  - name: "authoritative-source-url"
-    value: "registry.mycompany.com"
-----
-====
 
 [[using-external-artifacts]]
 == Using External Artifacts During a Build


### PR DESCRIPTION
@bparees 

I removed the paragraph that starts with: "You can also use the BuildConfig.spec.output.imageLabels field" and the "Custom labels to be applied to built images" example. 

These were added here: 
https://github.com/openshift/openshift-docs/commit/b04413ba9390a64ccb3a1b887cb701fad379953f

