### PR TITLE
Adding --build-env to oc new-app documentation

### DIFF
--- a/dev_guide/application_lifecycle/new_app.adoc
+++ b/dev_guide/application_lifecycle/new_app.adoc
@@ -389,6 +389,35 @@ Any `BuildConfig` objects created as part of `new-app` processing will not be up
 environment variables passed via the `-e|--env` or `--env-file` argument.
 ====
 
+[[specifying-build-environment-variables]]
+
+==== Specifying Build Environment Variables
+
+When generating applications from a xref:specifying-a-template[template], xref:specifying-source-code[source], or an
+xref:specifying-an-image[image], you can use the `--build-env` argument to pass
+environment variables to the build container at run time:
+
+----
+$ oc new-app openshift/ruby-23-centos7 \
+    --build-env HTTP_PROXY=http://myproxy.net:1337/ \
+    --build-env GEM_HOME=~/.gem
+----
+
+The variables can also be read from a file using the `--build-env-file` argument:
+
+----
+$ cat ruby.env
+HTTP_PROXY=http://myproxy.net:1337/
+GEM_HOME=~/.gem
+$ oc new-app openshift/ruby-23-centos7 --build-env-file=ruby.env
+----
+
+Additionally, environment variables can be given on standard input by using
+`--build-env-file=-`:
+
+----
+$ cat ruby.env | oc new-app openshift/ruby-23-centos7 --build-env-file=-
+----
 
 [[specifying-labels]]
 


### PR DESCRIPTION
Adding description and example usage of the
oc new-app --build-env command