### PR TITLE
Bug 1466646 Remove reference to storage quota from docs

### DIFF
--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -66,11 +66,6 @@ interchangeably.
 exceed this value. `*memory*` and `*requests.memory*` are the same value and can
 be used interchangeably.
 
-|`*requests.storage*`
-|The sum of storage requests across all persistent volume claims cannot
-exceed this value. `*storage*` and `*requests.storage*` are the same value and can
-be used interchangeably.
-
 |`*limits.cpu*`
 |The sum of CPU limits across all pods in a non-terminal state cannot exceed
 this value.
@@ -78,10 +73,6 @@ this value.
 |`*limits.memory*`
 |The sum of memory limits across all pods in a non-terminal state cannot exceed
 this value.
-
-|`*limits.storage*`
-|The sum of storage limits across all persistent volume claims cannot
-exceed this value.
 |===
 
 


### PR DESCRIPTION
Remove both `requests.storage` and `limits.storage` from docs.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1466646