### PR TITLE
Added paragraph about accepting ipv6 traffic

### DIFF
--- a/dev_guide/getting_traffic_into_cluster.adoc
+++ b/dev_guide/getting_traffic_into_cluster.adoc
@@ -94,6 +94,21 @@ When a set of routes is created in various projects, the overall set of routes
 is available to the set of routers. Each router admits (or selects) routes from
 the set of routes. By default, all routers admit all routes.
 
+ifdef::openshift-enterprise[]
+As of {product-title} 3.6, routers can accept IPV6 traffic of all route types
+(for example, edge terminated, passthrough, and re-encrypted routes) from
+outside the cluster by default. While the cluster accepts IPV6 traffic if it is
+configured, all communications inside the cluster are still performed using
+IPv4.
+
+[IMPORTANT]
+====
+HAProxy cannot terminate IPV6 traffic if the router pod is created using the
+`--host-network=false` option. This is because the internal network does not yet
+support IPv6 for pods.
+====
+endif::[]
+
 Routers that have permission to view all of the
 xref:../architecture/core_concepts/pods_and_services.adoc#labels[labels] in all
 namespaces can select routes to admit based on the labels. This is called


### PR DESCRIPTION
As per: https://trello.com/c/oyvq5IqN/450-document-2-support-ipv6-terminated-at-the-router-with-internal-ipv4-ipv6

cc @imcsk8 