### PR TITLE
Added procedure to networkpolicy section

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -935,8 +935,48 @@ using the *ovs-networkpolicy* plug-in.
 In a cluster
 xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[configured
 to use the *ovs-networkpolicy* plug-in], network isolation is controlled
-entirely by `NetworkPolicy` objects and the link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network-policy.md[associated Namespace annotation]. In particular, by default, all projects are able to access pods
-in all other projects. The project to be isolated must first be configured to
-opt in to isolation by setting the proper annotation on its Namespace object,
-and then creating `NetworkPolicy` objects indicating the incoming connections to
-be allowed.
+entirely by
+link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network-policy.md[`NetworkPolicy`
+objects]. In particular, by default, all projects are able to access pods in all
+other projects. To isolate a project, opt in to isolation by configuring the
+Namespace object, then create a `NetworkPolicy` object to indicate the allowed
+incoming connections.
+
+. Create the `NetworkPolicy` objects:
++
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-http-and-https
+spec:
+  podSelector:
+  ingress:
+  - ports:
+    - protocol: TCP
+      - port: 80
+      - port: 443
+----
+
+. Configure the pod network in the master configuration file at *_/etc/origin/master/master-config.yaml_*:
++
+[source,yaml]
+----
+networkConfig:
+ ...
+  networkPluginName: "redhat/openshift-ovs-networkpolicy" <3>
+ ...
+----
+<1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
+
+. Configure the pod network policy on each node configuration file at *_/etc/origin/node/node-config.yaml_*:
++
+[source,yaml]
+----
+networkConfig:
+  ...
+  networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
+----
+<1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
+

--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -942,30 +942,13 @@ other projects. To isolate a project, opt in to isolation by configuring the
 Namespace object, then create a `NetworkPolicy` object to indicate the allowed
 incoming connections.
 
-. Create the `NetworkPolicy` objects:
-+
-[source,yaml]
-----
-kind: NetworkPolicy
-apiVersion: extensions/v1beta1
-metadata:
-  name: allow-http-and-https
-spec:
-  podSelector:
-  ingress:
-  - ports:
-    - protocol: TCP
-      - port: 80
-      - port: 443
-----
-
 . Configure the pod network in the master configuration file at *_/etc/origin/master/master-config.yaml_*:
 +
 [source,yaml]
 ----
 networkConfig:
  ...
-  networkPluginName: "redhat/openshift-ovs-networkpolicy" <3>
+  networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
  ...
 ----
 <1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
@@ -979,4 +962,22 @@ networkConfig:
   networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
 ----
 <1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
+
+. Create the `NetworkPolicy` objects:
++
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-http-and-https
+spec:
+  podSelector:
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+----
 


### PR DESCRIPTION
For: https://trello.com/c/jAKDNfuc/564-document-support-v1-semantics-for-networkpolicy-using-the-existing-object

cc: @danwinship 

Noticed for this card that there's no procedure for the NetworkPolicy section. Asking for ack over email.