### PR TITLE
Added to reencrypt route example for default certs

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -786,17 +786,25 @@ spec:
 <1> The name of the object, which is limited to 63 characters.
 <2> The `*termination*` field is set to `reencrypt`. Other fields are as in edge
 termination.
-<3> The `*destinationCACertificate*` field specifies a CA certificate to
-validate the endpoint certificate, securing the connection from the router to
-the destination. This field is required, but only for re-encryption.
+<3> Required for re-encryption. `*destinationCACertificate*`
+specifies a CA certificate to validate the endpoint certificate, securing the
+connection from the router to the destination pods. If the service is using a service signing certificate, or the administrator has specified a default CA certificate for the router and the service has a certificate signed by that CA, this field can be omitted.
 ====
+
+If the `*destinationCACertificate*` field is left empty, the router
+automatically leverages the certificate authority that is generated for service
+serving certificates, and is injected into every pod as
+`/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`. This allows new
+routes that leverage end-to-end encryption without having to generate a
+certificate for the route. This is useful for custom routers or the F5 router,
+which might not allow the `destinationCACertificate` unless the administrator
+has allowed it.
 
 [NOTE]
 ====
 Re-encrypt routes can have an `insecureEdgeTerminationPolicy` with all of the
 same values as edge-terminated routes.
 ====
-
 
 [[router-sharding]]
 == Router Sharding


### PR DESCRIPTION
For: https://trello.com/c/MsyzMf0g/501-document-support-defaulting-the-destination-ca-certificate-to-the-service-serving-cert-address

cc: @smarterclayton 

Not sure if this is adequate. Will ask for ack over email.