### PR TITLE
search: replace search provider

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -1,0 +1,51 @@
+function hcSearchCategory(label, version) {
+// optional version filters search results for a single specific product version
+// currently can be used with OCP and Origin only
+
+  var modalSearch = document.getElementById("hc-search-modal");
+  var searchBtn = document.getElementById("hc-search-btn");
+  var closeModal = document.getElementById("hc-modal-close");
+  var searchResults = document.getElementById("hc-search-results");
+  var query = document.getElementById("hc-search-input");
+
+  // pressing enter in the input = search btn click
+  query.addEventListener("keyup", function(event) {
+    event.preventDefault();
+    if (event.keyCode == 13) {
+        searchBtn.click();
+    }
+  });
+
+  //prepare iframe (without source)
+  var iframe = document.createElement("iframe");
+  iframe.frameBorder=0;
+  iframe.width="100%";
+  iframe.height=0.7*window.innerHeight;
+  iframe.id="search-result-iframe";
+
+  // open the modal and finalize the iframe on click
+  searchBtn.onclick = function() {
+    if (query.value) {
+  	modalSearch.style.display = "block";
+    // limit search to a signle version, if specified
+    var urlFilter = (typeof version === "undefined" || version == "Branch Build") ? "" : (" url:*\\/" + version + "\\/*");
+    var iframeSrc = "https://help.openshift.com/customsearch.html?q=" +
+                    encodeURIComponent(query.value) +
+                    encodeURIComponent(urlFilter) +
+                    "&l=" + encodeURIComponent(label);
+  	iframe.setAttribute("src", iframeSrc);
+          searchResults.appendChild(iframe);
+    }
+  }
+
+  // hide search modal
+  closeModal.onclick = function() {
+    modalSearch.style.display = "none";
+  }
+
+  window.onclick = function(event) {
+    if (event.target == modalSearch) {
+      modalSearch.style.display = "none";
+    }
+  }
+}  // hcSearchCategory(label)

--- a/_stylesheets/search.css
+++ b/_stylesheets/search.css
@@ -1,0 +1,48 @@
+#hc-search-input {
+    font-size: 12px;
+    height: 25px;
+    width: 70%;
+}
+
+#hc-search-btn {
+    font-size: 12px;
+    height: 25px;
+    width: 25%;
+}
+
+#hc-search-modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    padding-top: 5%;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgb(0,0,0);
+    background-color: rgba(0,0,0,0.4);
+}
+
+#hc-modal-content {
+    background-color: #fefefe;
+    margin: auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    height: 80vh;
+}
+
+#hc-modal-close {
+    color: #aaaaaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+#hc-modal-close:hover,
+#hc-modal-close:focus {
+    color: #000;
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -11,6 +11,7 @@
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css">
   <link href="<%= File.join(css_path, 'docs.css') %>" rel="stylesheet" />
+  <link href="<%= File.join(css_path, 'search.css') %>" rel="stylesheet" />
   <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png">
   <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="text/css">
   <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->
@@ -30,6 +31,7 @@
   <script src="https://assets.openshift.net/content/subdomain.js" type="text/javascript"></script>
   <script src="<%= File.join(javascripts_path, "bootstrap-offcanvas.js") %>" type="text/javascript"></script>
   <script src="<%= File.join(javascripts_path, "reformat-html.js") %>" type="text/javascript"></script>
+  <script src="<%= File.join(javascripts_path, "hc-search.js") %>" type="text/javascript"></script>
   <%= render("_templates/_analytics.html.erb", :distro_key => distro_key) %>
 </head>
 <body>

--- a/_templates/_search_dedicated.html.erb
+++ b/_templates/_search_dedicated.html.erb
@@ -1,13 +1,15 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results"></div>
+  </div>
+</div>
+
 <script>
-  (function() {
-    var cx = '013769182564158614814:ykypjfbua0a';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-        '//cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
+  hcSearchCategory("docs_dedicated");
 </script>
-<gcse:search></gcse:search>

--- a/_templates/_search_enterprise.html.erb
+++ b/_templates/_search_enterprise.html.erb
@@ -1,16 +1,15 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results"></div>
+  </div>
+</div>
+
 <script>
-  (function() {
-    var cx = '013769182564158614814:e-dp46b51vk';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
+  hcSearchCategory("docs_cp", "<%= version %>");
 </script>
-<% if version == '3.0' or version == '3.1' or version == '3.2' %>
-<gcse:search defaultToRefinement="Enterprise <%= version %>"></gcse:search>
-<% else %>
-<gcse:search defaultToRefinement="Container Platform <%= version %>"></gcse:search>
-<% end %>

--- a/_templates/_search_online.html
+++ b/_templates/_search_online.html
@@ -1,13 +1,15 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results"></div>
+  </div>
+</div>
+
 <script>
-  (function() {
-    var cx = '013769182564158614814:nh-uallhxiy';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-        '//cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
+  hcSearchCategory("docs_online");
 </script>
-<gcse:search></gcse:search>

--- a/_templates/_search_origin.html.erb
+++ b/_templates/_search_origin.html.erb
@@ -1,12 +1,15 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results"></div>
+  </div>
+</div>
+
 <script>
-  (function() {
-    var cx = '013769182564158614814:vdyz7waqya4';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
+  hcSearchCategory("docs_origin", "<%= version %>");
 </script>
-<gcse:search defaultToRefinement="<%= version %>"></gcse:search>

--- a/_templates/_search_other.html
+++ b/_templates/_search_other.html
@@ -1,12 +1,15 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results"></div>
+  </div>
+</div>
+
 <script>
-  (function() {
-    var cx = '013769182564158614814:e-dp46b51vk';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
+  hcSearchCategory("docs");
 </script>
-<gcse:search></gcse:search>

--- a/search-commercial.html
+++ b/search-commercial.html
@@ -352,12 +352,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             Contact Us
           </a>
         </li>
-        <li>
-          <form action="https://help.openshift.com/hc/en-us/search" method="get" id="cse-search-form">
-            <input name="query" id="cse-search-input" class="navbar-search-query form-control" type="text" placeholder="Search" tabindex="1" autocomplete="off" autofocus>
-            <button type="submit" class="btn btn-default fa fa-search" value="Search"></button>
-          </form>
-        </li>
       </ul>
     </div>
     <a class="navbar-brand" href="/"></a>
@@ -376,57 +370,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </div>
 
-<script src='https://www.google.com/jsapi' type='text/javascript'></script>
-<script type='text/javascript'>
-// google site search
-google.load('search', '1',{language: 'en', style: google.loader.themes.V2_DEFAULT});
-</script>
-<script type="text/javascript">
-// google site search
-google.setOnLoadCallback(function() {
-    var customSearchOptions = {};
-    var orderByOptions = {};
-    orderByOptions['keys'] = [{
-        label: 'Relevance',
-        key: ''
-    }, {
-        label: 'Date',
-        key: 'date'
-    }];
-    customSearchOptions['enableOrderBy'] = true;
-    customSearchOptions['orderByOptions'] = orderByOptions;
-    var googleAnalyticsOptions = {};
-    googleAnalyticsOptions['queryParameter'] = 'query';
-    googleAnalyticsOptions['categoryParameter'] = 'refinement';
-    customSearchOptions['googleAnalyticsOptions'] = googleAnalyticsOptions;
-    var customSearchControl = new google.search.CustomSearchControl('013769182564158614814:sa2exinkywe', customSearchOptions);
-    customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-    customSearchControl.setLinkTarget(google.search.Search.LINK_TARGET_PARENT);
-    var options = new google.search.DrawOptions();
-    options.enableSearchResultsOnly();
-    customSearchControl.draw('cse-search-results', options);
-    function parseParamsFromUrl() {
-        var params = {};
-        var parts = window.location.search.substr(1).split('&');
-        for (var i = 0; i < parts.length; i++) {
-            var keyValuePair = parts[i].split('=');
-            var key = decodeURIComponent(keyValuePair[0]);
-            params[key] = keyValuePair[1] ? decodeURIComponent(keyValuePair[1].replace(/\+/g, ' ')) : keyValuePair[1];
-        }
-        return params;
-    }
-    var urlParams = parseParamsFromUrl();
-    var queryParamName = 'query';
-    if (urlParams[queryParamName]) {
-        customSearchControl.execute(urlParams[queryParamName]);
-    }
-}, true);
-</script> 
-
 <section>
   <div class="container">
     <h1>Search Results</h1>
-    <div id="cse-search-results" class="search-results clearfix"></div>
+    <div id="hc-search-results" class="search-results clearfix"></div>
   </div>
 </section>
 
@@ -445,6 +392,32 @@ google.setOnLoadCallback(function() {
     </div>
 </footer>
 
+<script type="text/javascript">
+// custom help.openshift.com search
+function parseParamsFromUrl() {
+        var params = {};
+        var parts = window.location.search.substr(1).split('&');
+        for (var i = 0; i < parts.length; i++) {
+            var keyValuePair = parts[i].split('=');
+            var key = keyValuePair[0];
+            params[key] = keyValuePair[1];
+        }
+        return params;
+  }
+
+  var urlParams = parseParamsFromUrl();
+  var queryParamName = 'query';
+  var searchLabel = 'docs';
+
+  if (urlParams[queryParamName]) {
+        hciframe = document.createElement('iframe');
+        hciframe.width = '100%';
+        hciframe.height = 0.7 * window.innerHeight;
+        hciframe.frameBorder = '0';
+        hciframe.src = 'https://help.openshift.com/customsearch.html?q=' + urlParams[queryParamName] + '&l=' + searchLabel;
+        document.getElementById('hc-search-results').appendChild(hciframe);
+  }
+</script>
 <!-- Adobe DTM -->
 <script type="text/javascript">
 if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {


### PR DESCRIPTION
* replaces the current Google Site Search provider (expiring on 7/10)
  with a simple search used at help.openshift.com
* The Google Site Search is going to be downgraded to free Custom
   Search (displaying ads in search results), once expired

Note that Origin Docs are not yet indexed by the alternate search yet. Our crawler seems to have trouble with the incomplete certificate chain (#4732). This is not to be deployed before https://help.openshift.com/customsearch.html?q=pod&l=docs_origin provides some reasonable results.

Signed-off-by: Jiri Fiala <jfiala@redhat.com>