### PR TITLE
Rm externalIP/nodeport from OSO/OSD

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -224,22 +224,16 @@ to or removed from a service arbitrarily while the service remains consistently
 available, enabling anything that depends on the service to refer to it at a
 consistent address.  The default service clusterIP addresses are from the
 {product-title} internal network and they are used to permit pods to access each
-other. To permit external access to the service, additional externalIP and ingressIP addresses
-that are
-ifndef::openshift-online[]
-xref:../../dev_guide/getting_traffic_into_cluster.adoc#using-externalIP[external]
-endif::[]
-ifdef::openshift-online[]
-external
-endif::[]
-to cluster, can be assigned to the service. These externalIP addresses can also be virtual IP addresses that provide
+other.
+
 ifdef::openshift-enterprise,openshift-origin[]
-xref:../../admin_guide/high_availability.adoc#admin-guide-high-availability[highly available]
+To permit external access to the service, additional `externalIP` and
+`ingressIP` addresses that are
+xref:../../dev_guide/getting_traffic_into_cluster.adoc#using-externalIP[external]
+to the cluster can be assigned to the service. These `externalIP` addresses can
+also be virtual IP addresses that provide
+xref:../../admin_guide/high_availability.adoc#admin-guide-high-availability[highly available] access to the service.
 endif::[]
-ifdef::openshift-dedicated,openshift-online,atomic-registry[]
-highly available
-endif::[]
-access to the service.
 
 Services are assigned an IP address and port pair that, when accessed,
 proxy to an appropriate backing pod. A service uses a label selector to find
@@ -283,23 +277,20 @@ of internal IPs.
 The link:http://kubernetes.io/docs/user-guide/services/[Kubernetes
 documentation] has more information on services.
 
+ifdef::openshift-enterprise,openshift-origin[]
 [[service-externalip]]
 === Service externalIPs
 
-In addition to the cluster's internal IP addresses, the user can configure IP addresses that are external to the cluster. The administrator is responsible for ensuring that traffic arrives at a node with this IP.
+In addition to the cluster's internal IP addresses, the user can configure IP
+addresses that are external to the cluster. The administrator is responsible for
+ensuring that traffic arrives at a node with this IP.
 
-ifdef::openshift-origin,openshift-enterprise[]
-The externalIPs must be selected by the admin from the *ExternalIPNetworkCIDRs*
-range configured in
+The externalIPs must be selected by the cluster adminitrators from the
+*ExternalIPNetworkCIDRs* range configured in
 xref:../../admin_guide/tcp_ingress_external_ports.adoc#unique-external-ips-ingress-traffic-configure-cluster[*_master-config.yaml_*]
 file. When *_master-config.yaml_* is changed, the master service must be
 restarted.
-endif::[]
 
-ifdef::openshift-dedicated,openshift-online[]
-The externalIPs must be selected by the admin from the *ExternalIPNetworkCIDRs*
-range configured in master configuration file.
-endif::[]
 
 .Sample ExternalIPNetworkCIDR /etc/origin/master/master-config.yaml
 ====
@@ -342,6 +333,7 @@ networkConfig:
 <1> List of External IP addresses on which the *port* is exposed. In addition to the internal IP addresses)
 
 ====
+endif::[]
 
 ifdef::openshift-origin,openshift-enterprise[]
 [[service-ingressip]]
@@ -374,12 +366,12 @@ networkConfig:
 
 endif::[]
 
+ifdef::openshift-origin,openshift-enterprise[]
 [[service-nodeport]]
 === Service NodePort
 
 Setting the service `type=NodePort` will allocate a port from a flag-configured range (default: 30000-32767), and each node will proxy that port (the same port number on every node) into your service.
 
-ifdef::openshift-origin,openshift-enterprise[]
 The selected port will be reported in the service configuration, under  `spec.ports[*].nodePort`.
 
 To specify a custom port just place the port number in the nodePort field. The custom port number must be in the configured range for nodePorts. When '*master-config.yaml*' is changed the master service must be restarted.
@@ -399,7 +391,9 @@ and `spec.clusterIp:spec.ports[].port`
 ====
 Setting a nodePort is a privileged operation.
 ====
+endif::[]
 
+ifdef::openshift-origin,openshift-enterprise[]
 [[service-proxy-mode]]
 === Service Proxy Mode
 
@@ -419,6 +413,16 @@ checks] (or generally reliable nodes and pods), then the *iptables*-based
 service proxy is the best choice. Otherwise, you can enable the user space-based
 proxy when installing, or after deploying the cluster by editing the node
 configuration file.
+endif::[]
+
+ifdef::openshift-online,openshift-dedicated[]
+[[oso-osd-service-proxy]]
+=== Service Proxy
+
+{product-title} has an *iptables*-based implementation of the service-routing
+infrastructure. It uses probabilistic *iptables* rewriting rules to distribute
+incoming service connections between the endpoint pods. It also requires that
+all endpoints are always able to accept connections.
 endif::[]
 
 [[labels]]


### PR DESCRIPTION
Related to https://github.com/openshift/openshift-docs/pull/4734.

@vikram-redhat FYI because you did some similar Online fixes recently in here. This ifdefs out even more from both Dedicated and Online, per @spurtell.

- Hides "Service externalIPs"
- Hides "Service NodePort"
- Creates a special "Service Proxy Mode" just for Online/Dedicated and renames to just "Service Proxy" since there's only one mode option there