### PR TITLE
Add redcircle imgs in callouts for release_notes/index

### DIFF
--- a/release_notes/index.adoc
+++ b/release_notes/index.adoc
@@ -58,6 +58,8 @@ capabilities that are not supported by a 3.1 server.
 |image:redcircle-1.png[]
 
 |===
-<1> Fully compatible.
-<2> `oc` client may not be able to access server features.
-<3> `oc` client may provide options and features that may not be compatible with the accessed server.
+image:redcircle-1.png[] Fully compatible.
+
+image:redcircle-2.png[] `oc` client may not be able to access server features.
+
+image:redcircle-3.png[] `oc` client may provide options and features that may not be compatible with the accessed server.


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/4711.

The Customer Portal builds don't seem to be able to render the callout circles automatically when they don't have an actual matching reference in a codeblock (which does work on docs.openshift).

![screenshot from 2017-07-07 16-52-25](https://user-images.githubusercontent.com/3442316/27976485-b38f164e-6334-11e7-8c15-7a160a16c46f.png)


Adding the red circle images manually to fake it.