### PR TITLE
Use oc rollout latest instead of oc deploy --latest

### DIFF
--- a/dev_guide/deployments/advanced_deployment_strategies.adoc
+++ b/dev_guide/deployments/advanced_deployment_strategies.adoc
@@ -164,7 +164,7 @@ In the editor, add the line `ab-example: "true"` underneath `spec.selector` and
 . Trigger a re-deployment of the first shard to pick up the new labels:
 +
 ----
-$ oc deploy ab-example-a --latest
+$ oc rollout latest dc/ab-example-a
 ----
 
 . Create a service that uses the common label:
@@ -204,7 +204,7 @@ In the editor, add the line `ab-example: "true"` underneath `spec.selector` and
 . Trigger a re-deployment of the second shard to pick up the new labels:
 +
 ----
-$ oc deploy ab-example-b --latest
+$ oc rollout latest dc/ab-example-b
 ----
 
 . At this point, both sets of pods are being served under the route. However,

--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -17,7 +17,7 @@ You can start a new deployment process manually using the web console, or from
 the CLI:
 
 ----
-$ oc deploy --latest dc/<name>
+$ oc rollout latest dc/<name>
 ----
 
 [NOTE]

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -595,5 +595,5 @@ $ oc annotate service router \
 . Redeploy the router:
 +
 ----
-$ oc deploy dc/router --latest
+$ oc rollout latest dc/router
 ----


### PR DESCRIPTION
Because `oc deploy --latest` is deprecated

```console
$ oc deploy dc/ruby-ex --latest
Flag --latest has been deprecated, use 'oc rollout latest' instead
Started deployment #2
Use 'oc logs -f dc/ruby-ex' to track its progress.
```

I've updated docs to use `oc rollout latest` instead.

PTAL @openshift/team-documentation @tnozicka @kargakis 
CC @simo5 