### PR TITLE
adding a brief note about DNS and egress network policy

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -274,6 +274,17 @@ different, and the egress network policy may not be enforced as expected. In the
 above example, suppose `www.foo.com` resolved to `10.11.12.13` and has a DNS TTL
 of one minute, but was later changed to `20.21.22.23`. {product-title} will then
 take up to one minute to adapt to these changes.
++
+[NOTE]
+====
+The egress firewall always allows pods access to the external interface of the
+node the pod is on for DNS resolution. If your DNS resolution is not handled by
+something on the local node, then you will need to add egress firewall rules
+allowing access to the DNS server's IP addresses if you are using domain names
+in your pods. The xref:../install_config/install/quick_install.adoc#install-config-install-quick-install[default installer]
+sets up a local dnsmasq, so if you are using that setup you will not need to add extra rules.
+====
+
 
 . Use the JSON file to create an EgressNetworkPolicy object:
 +


### PR DESCRIPTION
The solution to [BZ1458849](https://bugzilla.redhat.com/show_bug.cgi?id=1458849) works when using the default ansible install. Adding a note to the section about managing egressnetworkpolicy that the administrator may need to explicitly allow DNS traffic