### PR TITLE
Use newer label format for AWS cluster id

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -54,7 +54,8 @@ configured provider's API to create new storage resources:
 |`kubernetes.io/aws-ebs`
 |xref:../../install_config/configuring_aws.adoc#install-config-configuring-aws[Configuring for AWS]
 |For dynamic provisioning when using multiple clusters in different zones, tag each
-node with `*Key=KubernetesCluster,Value=clusterid*`.
+node with `*Key=kubernetes.io/cluster/xxxx,Value=clusterid*` where `xxxx` and `clusterid` are unique
+per cluster. In versions prior to 3.6, this was `*Key=KubernetesCluster,Value=clusterid*`.
 
 |GCE Persistent Disk (gcePD)
 |`kubernetes.io/gce-pd`


### PR DESCRIPTION
This applies to 3.6 and newer.