### PR TITLE
Added link to WordPress blog

### DIFF
--- a/dev_guide/migrating_applications/web_framework_applications.adoc
+++ b/dev_guide/migrating_applications/web_framework_applications.adoc
@@ -13,9 +13,9 @@ toc::[]
 
 == Overview
 
-This topic reviews how to migrate Python, Ruby, PHP, Perl, Node.js, Ghost, JBoss
-EAP, JBoss WS (Tomcat), and Wildfly 10 (JBoss AS) web framework applications
-from OpenShift version 2 (v2) to OpenShift version 3 (v3).
+This topic reviews how to migrate Python, Ruby, PHP, Perl, Node.js, WordPress,
+Ghost, JBoss EAP, JBoss WS (Tomcat), and Wildfly 10 (JBoss AS) web framework
+applications from OpenShift version 2 (v2) to OpenShift version 3 (v3).
 
 [[dev-guide-migrating-web-framework-applications-python]]
 == Python
@@ -281,6 +281,13 @@ $ oc new-app https://github.com/<github-id>/<repo-name>.git
 |    |Nodejs-mongodb-example (quickstart)
 
 |===
+
+[[dev-guide-migrating-web-framework-applications-wordpress]]
+== WordPress
+
+For guidance on migrating WordPress applications to {product-title} v3, see the
+link:https://blog.openshift.com/migrating-wordpress-openshift-3/[OpenShift
+blog].
 
 [[dev-guide-migrating-web-framework-applications-ghost]]
 == Ghost


### PR DESCRIPTION
https://trello.com/c/3EVckFWA/539-update-the-migration-guide-for-migrating-v2-apps-to-v3

WP blog is now published