### PR TITLE
Trello: removed svirt_sandbox_file_t per trello

### DIFF
--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -742,7 +742,8 @@ label.
 This means two things for unprivileged containers:
 
 - The volume will be given a `type` which is accessible by unprivileged
-containers. This `type` is usually *svirt_sandbox_file_t*.
+containers. This type is usually `container_file_t`, which treats volumes as container content. Previously, the label specified was `svirt_sandbox_file_t`. This label
+is xref:../../release_notes/ocp_3_5_release_notes.adoc#ocp-35-kubelet-directory-should-not-share-selinux-labels-with-its-containers[no longer used due to security concerns].
 - If a `level` is specified, the volume will be labeled with the given MCS
 label.
 


### PR DESCRIPTION
@vikram-redhat "Update the SELinux section of the Volume Security (Pod Security) topic [1] in the install config guide and remove the reference to svirt_sandbox_file_t. Also provide an explanation of the changes made due to this card, which have led to svirt_sandbox_file_t being removed."
https://trello.com/c/BGFPBpeF/519-13-make-selinux-more-secure