### PR TITLE
Correcting location of Quota and Limit Ranges details

### DIFF
--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -390,7 +390,7 @@ $ oc create -f <limit_range_file> -n <project>
 
 // tag::admin_limits_viewing[]
 You can view any limit ranges defined in a project by navigating in the web
-console to the project's *Settings* tab.
+console to the project's *Quota* page.
 
 You can also use the CLI to view limit range details:
 

--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -412,7 +412,7 @@ $ oc create -f resource-quota.json -n demoproject
 
 // tag::admin_quota_viewing[]
 You can view usage statistics related to any hard limits defined in a project's
-quota by navigating in the web console to the project's *Settings* tab.
+quota by navigating in the web console to the project's *Quota* page.
 
 You can also use the CLI to view quota details:
 


### PR DESCRIPTION
Quota and Limit Ranges are now listed on the Quota page, so I'm updating the references to them.

@ahardin-rh, PTAL