### PR TITLE
Prometheus registry metrics follow-up

### DIFF
--- a/install_config/registry/accessing_registry.adoc
+++ b/install_config/registry/accessing_registry.adoc
@@ -273,24 +273,24 @@ Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 ----
 ====
 
-[[accessing-metrics]]
-== Accessing Metrics
+[[accessing-registry-metrics]]
+== Accessing Registry Metrics
 
-The registry provides an endpoint for
+The OpenShift Container Registry provides an endpoint for
 link:https://prometheus.io/docs/introduction/overview/[Prometheus metrics].
-Prometheus is a standalone open-source systems monitoring and alerting toolkit.
+Prometheus is a stand-alone, open source systems monitoring and alerting
+toolkit.
 
-The metrics are exposed at `_/extensions/v2/metrics_` path of the registry endpoint.
-However, this route needs to be
-xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-openshift[enabled]
-first.
+The metrics are exposed at the *_/extensions/v2/metrics_* path of the registry
+endpoint. However, this route must first be enabled; see
+xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-openshift[Extended Registry Configuration] for instructions.
 
-The following is a very simple example of metrics query:
+The following is a simple example of a metrics query:
 
-====
 ----
-$ curl -s -u user:SECRET \ <1>
+$ curl -s -u <user>:<secret> \ <1>
     http://172.30.30.30:5000/extensions/v2/metrics | grep openshift | head -n 10
+    
 # HELP openshift_build_info A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift was built.
 # TYPE openshift_build_info gauge
 openshift_build_info{gitCommit="67275e1",gitVersion="v3.6.0-alpha.1+67275e1-803",major="3",minor="6+"} 1
@@ -302,12 +302,7 @@ openshift_registry_request_duration_seconds{name="test/origin-pod",operation="bl
 openshift_registry_request_duration_seconds_sum{name="test/origin-pod",operation="blobstore.create"} 0
 openshift_registry_request_duration_seconds_count{name="test/origin-pod",operation="blobstore.create"} 5
 ----
-<1> Note that the `*user*` can be arbitrary. What really matters is the `*SECRET*`
-which must match the value specified in
-xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-openshift[registry
-configuration].
-====
+<1> `<user>` can be arbitrary, but `<secret>` must match the value specified in the
+xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-openshift[registry configuration].
 
-Refer to
-link:https://prometheus.io/docs/querying/basics/[upstream documentation] for
-more advanced queries and recommended visualizers.
+See the link:https://prometheus.io/docs/querying/basics/[upstream Prometheus documentation] for more advanced queries and recommended visualizers.

--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -183,7 +183,7 @@ openshift:
   version: 1.0
   metrics:
     enabled: false
-    secret: PUT_YOUR_SECRET_HERE
+    secret: <secret>
 ----
 
 . Create a new secret called *registry-config* from your custom registry
@@ -589,32 +589,30 @@ configuration reference] above for particular option.
 [[docker-registry-configuration-reference-openshift]]
 === OpenShift
 
-This section reviews the configuration of global settings related to
-{product-title} specific features. In the future, `openshift`-related settings
-in the xref:docker-registry-configuration-reference-middleware[middleware
-section] will be obsolete. Currently, this section allows you to configure only
-for metrics collection.
+This section reviews the configuration of global settings for features specific
+to {product-title}. In a future release, `openshift`-related settings in the
+xref:docker-registry-configuration-reference-middleware[Middleware] section will
+be obsoleted.
 
-====
+Currently, this section allows you to configure registry metrics collection:
+
 ----
 openshift:
   version: 1.0 <1>
   metrics:
     enabled: false <2>
-    secret: PUT_YOUR_SECRET_HERE <3>
+    secret: <secret> <3>
 ----
-<1> A mandatory entry specifying configuration version of this section. The
-only supported value is `1.0`.
-<2> Can be set to `true` to enable metrics collection. The same can be
-achieved using the boolean environment variable
+<1> A mandatory entry specifying configuration version of this section. The only
+supported value is `1.0`.
+<2> Can be set to `true` to enable metrics collection. The same can be achieved
+using the boolean environment variable
 `REGISTRY_OPENSHIFT_METRICS_ENABLED=true`.
-<3> A secret used to authorize client requests. Metrics clients must use it as
-a bearer token in `Authorization` header. It can be overridden by the
-environment variable `REGISTRY_OPENSHIFT_METRICS_SECRET`.
-====
+<3> A secret used to authorize client requests. Metrics clients must use it as a
+bearer token in `Authorization` header. It can be overridden by the environment
+variable `REGISTRY_OPENSHIFT_METRICS_SECRET`.
 
-Refer to xref:accessing_registry.adoc#accessing-metrics[accessing metrics] for
-usage information.
+See xref:accessing_registry.adoc#accessing-registry-metrics[Accessing Registry Metrics] for usage information.
 
 [[docker-registry-configuration-reference-reporting]]
 === Reporting


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/4496.

@miminar @openshift/team-documentation PTAL:

http://file.rdu.redhat.com/~adellape/071917/prometheus_followup/install_config/registry/accessing_registry.html#accessing-registry-metrics

http://file.rdu.redhat.com/~adellape/071917/prometheus_followup/install_config/registry/extended_registry_configuration.html#docker-registry-configuration-reference-openshift