### PR TITLE
Fixed the default for the RELOAD_INTERVAL (12s -> 5s)

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -59,7 +59,7 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`STATS_PORT` |  | Port to expose statistics on (if the router implementation supports it).  If not set, stats are not exposed.
 |`STATS_USERNAME` |  | The user name needed to access router stats (if the router implementation supports it).
 |`TEMPLATE_FILE` | `/var/lib/haproxy/conf/custom/` `haproxy-config-custom.template` | The path to the HAProxy template file (in the container image).
-|`RELOAD_INTERVAL` | 12s | The minimum frequency the router is allowed to reload to accept new changes. xref:time-units[(TimeUnits)]
+|`RELOAD_INTERVAL` | 5s | The minimum frequency the router is allowed to reload to accept new changes. xref:time-units[(TimeUnits)]
 |`ROUTER_USE_PROXY_PROTOCOL`|  | When set to `true` or `TRUE`, HAProxy expects incoming connections to use the `PROXY` protocol on port 80 or port 443. The source IP address can pass through a load balancer if the load balancer supports the protocol, for example Amazon ELB.
 |`ROUTER_ALLOW_WILDCARD_ROUTES`|  |  When set to `true` or `TRUE`, any routes with a wildcard policy of `Subdomain` that pass the router admission checks will be serviced by the HAProxy router.
 |`ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK` |  | Set to `true` to relax the namespace ownership policy.


### PR DESCRIPTION
The docs had the wrong default listed.

This is wrong in version 3.1 and all subsequent versions (But I don't mind if it is only fixed in the current release... it's not a severe problem).