### PR TITLE
Moved and reworded section on auto-scaling metric components 

### DIFF
--- a/scaling_performance/scaling_cluster_metrics.adoc
+++ b/scaling_performance/scaling_cluster_metrics.adoc
@@ -22,6 +22,15 @@ autoscalers] in order to determine when and how to scale.
 
 This topic provides information for scaling the metrics components.
 
+ifdef::openshift-enterprise[]
+[[cluster-metrics-horizontal-pod-autoscaling]]
+[NOTE]
+==== 
+Autoscaling the metrics components, such as Hawkular and Heapster, is not supported by {product-title}.
+====
+endif::[]
+
+
 [[metrics-recommendations-for-OCP-version-35]]
 == Recommendations for {product-title} Version 3.5
 
@@ -140,12 +149,4 @@ If you add a new node to or remove an existing node from a Cassandra cluster,
 the data stored in the cluster rebalances across the cluster.
 ====
 
-ifdef::openshift-enterprise[]
-[[cluster-metrics-horizontal-pod-autoscaling]]
-== Horizontal Pod Autoscaling
-
-{product-title} version 3.3 does not provide
-xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[Horizontal
-Pod Autoscaling (HPA)] support for metrics pods and scaling metrics pods.
-endif::[]
 


### PR DESCRIPTION
A section on HPA in the Scaling Cluster Metrics page appears to be a legacy section from 3.3. I removed:
Horizontal Pod Autoscaling
OpenShift Container Platform version 3.3 does not provide Horizontal Pod Autoscaling (HPA) support for metrics pods and scaling metrics pods.

For reference, see: https://docs.openshift.com/container-platform/3.5/scaling_performance/scaling_cluster_metrics.html#cluster-metrics-horizontal-pod-autoscaling