### PR TITLE
Bug 1473664 document pods-per-core value 0

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -466,6 +466,11 @@ kubeletArguments:
 ----
 ====
 
+[NOTE]
+====
+Setting `pods-per-core` to 0, disables this limit.
+====
+
 `max-pods` sets the number of pods the node can run to a fixed value, regardless
 of the properties of the node.
 


### PR DESCRIPTION
As per https://bugzilla.redhat.com/1473664, setting `pods-per-core` to 0
disables this limit.

Documented at https://kubernetes.io/docs/admin/kubelet/