### PR TITLE
architecture/additional_concepts/authorization: improvements to the list of allowed volume types

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -521,44 +521,50 @@ The usage of specific volume types can be controlled by setting the `volumes`
 field of the SCC. The allowable values of this field correspond to the volume
 sources that are defined when creating a volume:
 
-* *azureFile*
-* *azureDisk*
-* *flocker*
-* *flexVolume*
-* *hostPath*
-* *emptyDir*
-* *gcePersistentDisk*
-* *awsElasticBlockStore*
-* *gitRepo*
-* *secret*
-* *nfs*
-* *iscsi*
-* *glusterfs*
-* *persistentVolumeClaim*
-* *rbd*
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#azurefilevolume[*azureFile*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#azurediskvolume[*azureDisk*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#flocker[*flocker*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#flexvolume[*flexVolume*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#hostpath[*hostPath*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[*emptyDir*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk[*gcePersistentDisk*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore[*awsElasticBlockStore*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#gitrepo[*gitRepo*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#secret[*secret*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#nfs[*nfs*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#iscsi[*iscsi*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#glusterfs[*glusterfs*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim[*persistentVolumeClaim*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#rbd[*rbd*]
 * *cinder*
-* *cephFS*
-* *downwardAPI*
-* *fc*
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#cephfs[*cephFS*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#downwardapi[*downwardAPI*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#fc-fibre-channel[*fc*]
 * *configMap*
-* *vsphere*
-* *quobyte*
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#vspherevolume[*vsphereVolume*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#quobyte[*quobyte*]
 * *photonPersistentDisk*
-*  ***
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#projected[*projected*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#portworxvolume[*portworxVolume*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#scaleio[*scaleIO*]
+* link:https://kubernetes.io/docs/concepts/storage/volumes/#storageos[*storageos*]
+* *** (a special value to allow the use of all volume types)
+* *none* (a special value to disallow the use of all volumes types. Exist only for backwards compatibility)
 
 The recommended minimum set of allowed volumes for new SCCs are *configMap*,
-*downwardAPI*, *emptyDir*, *persistentVolumeClaim*, and *secret*.
+*downwardAPI*, *emptyDir*, *persistentVolumeClaim*, *secret*, and *projected*.
 
 [NOTE]
 ====
-`***` is a special value to allow the use of all volume types.
+The list of allowable volume types is not exhaustive because new types are
+added with each release of {product-title}.
 ====
 
 [NOTE]
 ====
 For backwards compatibility, the usage of `allowHostDirVolumePlugin` overrides
 settings in the `volumes` field.  For example, if `allowHostDirVolumePlugin`
-is set to false but allowed in the `volumes*` field, then the `hostPath`
+is set to false but allowed in the `volumes` field, then the `hostPath`
 value will be removed from `volumes`.
 ====
 


### PR DESCRIPTION
- add missing volume types
- mention "none" volume type
- add links to the Kubernetes documentation for the volume types
- fix field name
- add note that the list can be outdated
- add "projected" to the list of recommended minimum of allowed volumes

@pweil- @liggitt PTAL  and let me know if we don't want to document "none" value.

CC @simo5 