### PR TITLE
Add 'oc get sa' info

### DIFF
--- a/admin_guide/service_accounts.adoc
+++ b/admin_guide/service_accounts.adoc
@@ -30,7 +30,8 @@ endif::[]
 Service accounts provide a flexible way to control API access without sharing a
 regular user's credentials.
 
-[[sa-user-names-and-groups]]
+[[admin-sa-user-names-and-groups]]
+// tag::sa-user-names-and-groups[]
 == User Names and Groups
 
 Every service account has an associated user name that can be granted roles,
@@ -43,11 +44,9 @@ system:serviceaccount:<project>:<name>
 For example, to add the *view* role to the *robot* service account in the
 *top-secret* project:
 
-====
 ----
 $ oc policy add-role-to-user view system:serviceaccount:top-secret:robot
 ----
-====
 
 Every service account is also a member of two groups:
 
@@ -58,20 +57,89 @@ specified project.
 For example, to allow all service accounts in all projects to view resources in
 the *top-secret* project:
 
-====
 ----
 $ oc policy add-role-to-group view system:serviceaccounts -n top-secret
 ----
-====
 
 To allow all service accounts in the *managers* project to edit resources in the
 *top-secret* project:
 
-====
 ----
 $ oc policy add-role-to-group edit system:serviceaccounts:managers -n top-secret
 ----
-====
+// end::sa-user-names-and-groups[]
+
+
+[[admin-managing-service-accounts]]
+// tag::managing-service-accounts[]
+ifdef::openshift-online,openshift-origin,openshift-dedicated,openshift-enterprise[]
+== Managing Service Accounts
+
+Service accounts are API objects that exist within each project. To manage
+service accounts, you can use the `oc` command with the `sa` or `serviceaccount`
+object type or use the web console.
+
+To get a list of existing service accounts in the current project:
+
+----
+$ oc get sa
+NAME       SECRETS   AGE
+builder    2         2d
+default    2         2d
+deployer   2         2d
+----
+
+To create a new service account:
+
+----
+$ oc create sa robot
+serviceaccount "robot" created
+----
+endif::[]
+
+ifdef::atomic-registry[]
+[[managing-service-account-credentials]]
+== Managing Service Account Credentials
+endif::[]
+
+As soon as a service account is created, two secrets are automatically added to
+it:
+
+* an API token
+* credentials for the
+ifdef::openshift-enterprise,openshift-origin,openshift-online,openshift-dedicated[]
+OpenShift Container Registry
+endif::[]
+ifdef::atomic-registry[]
+internal registry
+endif::[]
+
+These can be seen by describing the service account:
+
+----
+$ oc describe sa robot
+Name:		robot
+Namespace:	project1
+Labels:		<none>
+Annotations:	<none>
+
+Image pull secrets:	robot-dockercfg-qzbhb
+
+Mountable secrets: 	robot-token-f4khf
+                   	robot-dockercfg-qzbhb
+
+Tokens:            	robot-token-f4khf
+                   	robot-token-z8h44
+
+----
+
+The system ensures that service accounts always have an API token and registry
+credentials.
+
+The generated API token and registry credentials do not expire, but they can be
+revoked by deleting the secret. When the secret is deleted, a new one is
+automatically generated to take its place.
+// tag::managing-service-accounts[]
 
 [[enabling-service-account-authentication]]
 == Enabling Service Account Authentication

--- a/dev_guide/service_accounts.adoc
+++ b/dev_guide/service_accounts.adoc
@@ -30,46 +30,7 @@ Service accounts provide a flexible way to control API access without sharing a
 regular user's credentials.
 
 [[dev-sa-user-names-and-groups]]
-== User Names and Groups
-
-Every service account has an associated user name that can be granted roles,
-just like a regular user. The user name is derived from its project and name:
-
-----
-system:serviceaccount:<project>:<name>
-----
-
-For example, to add the *view* role to the *robot* service account in the
-*top-secret* project:
-
-====
-----
-$ oc policy add-role-to-user view system:serviceaccount:top-secret:robot
-----
-====
-
-Every service account is also a member of two groups:
-
-system:serviceaccounts:: Includes all service accounts in the system.
-system:serviceaccounts:<project>:: Includes all service accounts in the specified project.
-
-For example, to allow all service accounts in all projects to view resources in
-the *top-secret* project:
-
-====
-----
-$ oc policy add-role-to-group view system:serviceaccounts -n top-secret
-----
-====
-
-To allow all service accounts in the *managers* project to edit resources in the
-*top-secret* project:
-
-====
-----
-$ oc policy add-role-to-group edit system:serviceaccounts:managers -n top-secret
-----
-====
+include::admin_guide/service_accounts.adoc[tag=sa-user-names-and-groups]
 
 [[default-service-accounts-and-roles]]
 == Default Service Accounts and Roles
@@ -97,53 +58,8 @@ All service accounts in a project are given the *system:image-puller* role,
 which allows pulling images from any image stream in the project using the
 internal Docker registry.
 
-ifdef::openshift-online,openshift-origin,openshift-dedicated,openshift-enterprise[]
-[[managing-service-accounts]]
-== Managing Service Accounts
-
-Service accounts are API objects that exist within each project. They can be
-created or deleted like any other API object.
-
-====
-----
-$ oc create serviceaccount robot
-serviceaccounts/robot
-----
-====
-endif::[]
-
-[[managing-service-account-credentials]]
-== Managing Service Account Credentials
-
-As soon as a service account is created, two secrets are automatically added to
-it:
-
-* an API token
-* credentials for the internal Docker registry
-
-These can be seen by describing the service account:
-
-====
-----
-$ oc describe serviceaccount robot
-Name:               robot
-Labels:             <none>
-Image pull secrets:	robot-dockercfg-624cx
-
-Mountable secrets: 	robot-token-uzkbh
-                   	robot-dockercfg-624cx
-
-Tokens:            	robot-token-8bhpp
-                   	robot-token-uzkbh
-----
-====
-
-The system ensures that service accounts always have an API token and internal
-Docker registry credentials.
-
-The generated API token and Docker registry credentials do not expire, but they
-can be revoked by deleting the secret. When the secret is deleted, a new one is
-automatically generated to take its place.
+[[dev-managing-service-accounts]]
+include::admin_guide/service_accounts.adoc[tag=managing-service-accounts]
 
 ifdef::openshift-online,openshift-origin,openshift-dedicated,openshift-enterprise[]
 [[managing-allowed-secrets]]


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/764

Adds more `sa` CLI usage to `admin_guide/service_accounts` and uses tags to `include` it into `dev_guide/service_accounts`. Also has to do some awkward ifdef'ing because of what is and isn't included in the `atomic-registry`, but it works.

Preview (internal):

http://file.rdu.redhat.com/~adellape/072417/sa_get/dev_guide/service_accounts.html#dev-managing-service-accounts