### PR TITLE
Add openshift/hello-openshift dependency

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -183,6 +183,7 @@ endif::[]
 # docker pull registry.access.redhat.com/openshift3/ose-sti-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 # docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
+# docker pull docker.io/openshift/hello-openshift:latest
 # docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
 ----
 
@@ -270,6 +271,7 @@ and then transporting them:
     registry.access.redhat.com/openshift3/ose-sti-builder \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-pod \
+    docker.io/openshift/hello-openshift \
     registry.access.redhat.com/openshift3/ose-docker-registry
 ----
 


### PR DESCRIPTION
docker.io/openshift/hello-openshift is required to run successfully oc adm diagnostics.
Otherwise the user will not have network diagnostics



Squashed to satisfy: https://github.com/openshift/openshift-docs/pull/4008