### PR TITLE
Add install for svc catalog, ansible/template svc broker

### DIFF
--- a/architecture/service_catalog/ansible_service_broker.adoc
+++ b/architecture/service_catalog/ansible_service_broker.adoc
@@ -14,12 +14,23 @@ toc::[]
 
 [NOTE]
 ====
-The service catalog is currently a Technology Preview feature.
-////
-ifdef::openshift-origin,openshift-enterprise[]
-To opt-in during installation or upgrade, see Installation & Configuration (TODO link).
+Enabling the Ansible service broker is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
 endif::[]
-////
+ifdef::openshift-origin,openshift-enterprise[]
+
+To opt-in during installation, see
+xref:../../install_config/install/advanced_install.adoc#enabling-ansible-service-catalog[Advanced Installation].
+endif::[]
 ====
 
 The Ansible service broker (ASB) is an implementation of the OSB API that

--- a/architecture/service_catalog/index.adoc
+++ b/architecture/service_catalog/index.adoc
@@ -15,12 +15,23 @@ toc::[]
 
 [NOTE]
 ====
-The service catalog is currently a Technology Preview feature.
-////
-ifdef::openshift-origin,openshift-enterprise[]
-To opt-in during installation or upgrade, see Installation & Configuration (TODO link).
+Enabling the service catalog is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
 endif::[]
-////
+
+ifdef::openshift-origin,openshift-enterprise[]
+To opt-in during installation, see
+xref:../../install_config/install/advanced_install.adoc#enabling-service-catalog[Advanced Installation].
+endif::[]
 ====
 
 When developing microservices-based applications to run on cloud native

--- a/architecture/service_catalog/template_service_broker.adoc
+++ b/architecture/service_catalog/template_service_broker.adoc
@@ -12,12 +12,24 @@ toc::[]
 {nbsp} +
 [NOTE]
 ====
-The service catalog is currently a Technology Preview feature.
-////
-ifdef::openshift-origin,openshift-enterprise[]
-To opt-in during installation or upgrade, see Installation & Configuration (TODO link).
+Enabling the template service broker is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
 endif::[]
-////
+
+ifdef::openshift-origin,openshift-enterprise[]
+To opt-in during installation, see
+xref:../../install_config/install/advanced_install.adoc#configuring-template-service-broker[Configuring
+the Template Service Broker].
+endif::[]
 ====
 
 The _template service broker_ (TSB) gives the service catalog visibility into

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1402,6 +1402,179 @@ xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#i
 openshift_hosted_logging_storage_kind=dynamic
 ----
 
+[[enabling-service-catalog]]
+=== Enabling the Service Catalog
+
+[NOTE]
+====
+Enabling the service catalog is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
+Enabling the
+xref:../../architecture/service_catalog/index.adoc#architecture-additional-concepts-service-catalog[service catalog] allows service brokers to be registered with the catalog. The web
+console is also configured to enable an updated landing page for browsing the
+catalog.
+
+To enable the service catalog, add the following in your inventory file's
+`[OSEv3:vars]` section:
+
+----
+openshift_enable_service_catalog=true
+ifdef::openshift-origin[]
+openshift_service_catalog_image_prefix=openshift/origin-
+openshift_service_catalog_image_version=latest
+endif::[]
+----
+
+When the service catalog is enabled, the web console shows the updated landing
+page but still uses the normal image stream and template behavior. The Ansible
+service broker is also enabled; see
+xref:configuring-ansible-service-broker[Configuring the Ansible Service Broker]
+for more details. To deploy and registry the template service broker (TSB), see
+xref:configuring-template-service-broker[Configuring the Template Service Broker].
+
+[[configuring-ansible-service-broker]]
+=== Configuring the Ansible Service Broker
+
+[NOTE]
+====
+Enabling the Ansible service broker is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
+If you have xref:enabling-service-catalog[enabled the service catalog], the
+xref:../../architecture/service_catalog/ansible_service_broker.adoc#arch-ansible-service-broker[Ansible service broker] (ASB) is also enabled.
+
+The ASB deploys its own etcd instance separate from the etcd used by the rest of
+the {product-title} cluster. The ASB's etcd instance requires separate storage
+using persistent volumes (PVs) to function. If no PV is available, etcd will
+wait until the PV can be satisfied. The ASB application will enter a `CrashLoop`
+state until its etcd instance is available.
+
+[NOTE]
+====
+The following example shows usage of an NFS host to provide the required PVs,
+but
+xref:../../install_config/persistent_storage/index.adoc#install-config-persistent-storage-index[other persistent storage providers] can be used instead.
+====
+
+Some Ansible playbook bundles (APBs) may also require a PV for their own usage.
+Two APBs are currently provided with {product-title} 3.6: MediaWiki and
+PostgreSQL. Both of these require their own PV to deploy.
+
+To configure the ASB:
+
+. In your inventory file, add `nfs` to the `[OSEv3:children]` section to enable
+the `[nfs]` group:
++
+----
+[OSEv3:children]
+masters
+nodes
+nfs
+----
+
+. Add a `[nfs]` group section and add the host name for the system that will
+be the NFS host:
++
+----
+[nfs]
+master1.example.com
+----
+
+. In addition to the settings from xref:enabling-service-catalog[Enabling the
+Service Catalog], add the following in the `[OSEv3:vars]`
+section:
++
+----
+openshift_hosted_etcd_storage_kind=nfs
+openshift_hosted_etcd_storage_nfs_options="*(rw,root_squash,sync,no_wdelay)"
+openshift_hosted_etcd_storage_nfs_directory=/opt/osev3-etcd <1>
+openshift_hosted_etcd_storage_volume_name=etcd-vol2 <1>
+openshift_hosted_etcd_storage_access_modes=["ReadWriteOnce"]
+openshift_hosted_etcd_storage_volume_size=1G
+openshift_hosted_etcd_storage_labels={'storage': 'etcd'}
+
+ifdef::openshift-origin[]
+ansible_service_broker_image_prefix=openshift/
+ansible_service_broker_registry_url="registry.access.redhat.com"
+ansible_service_broker_registry_user=<user_name> <2>
+ansible_service_broker_registry_password=<password> <2>
+ansible_service_broker_registry_organization=<organization> <2>
+endif::[]
+----
+<1> An NFS volume will be created with path `<nfs_directory>/<volume_name>` on the
+host within the `[nfs]` group. For example, the volume path using these options
+would be *_/opt/osev3-etcd/etcd-vol2_*.
+ifdef::openshift-origin[]
+<2> Only required if `ansible_service_broker_registry_url` is set to a registry that
+requires authentication for pulling APBs.
+endif::[]
++
+These settings create a persistent volume that is attached to the ASB's etcd
+instance during cluster installation.
+
+[[configuring-template-service-broker]]
+=== Configuring the Template Service Broker
+
+[NOTE]
+====
+Enabling the template service broker is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
+If you have xref:enabling-service-catalog[enabled the service catalog], you can
+also enable the
+xref:../../architecture/service_catalog/template_service_broker.adoc#arch-template-service-broke[template service broker] (TSB).
+
+To enable the TSB:
+
+. One or more projects must be defined as the broker's source
+namespace(s) for loading templates and image streams into the service catalog.
+Set the desired projects by modifying the following in your inventory file's
+`[OSEv3:vars]` section:
++
+----
+openshift_template_service_broker_namespaces=['openshift','myproject']
+----
+
+. The installer currently does not automate installation of the TSB, so additional
+steps must be run manually after the cluster installation has completed.
+Continue with the rest of the preparation of your inventory file, then see
+xref:running-the-advanced-installation[Running the Advanced Installation] for
+the additional steps to deploy the TSB.
+
 [[configuring-web-console-customization]]
 === Configuring Web Console Customization
 
@@ -1922,6 +2095,87 @@ ifdef::openshift-origin[]
     ~/openshift-ansible/playbooks/byo/config.yml
 endif::[]
 ----
+
+[discrete]
+[[running-the-advanced-installation-tsb]]
+==== Optional: Deploying the Template Service Broker
+
+If you have xref:enabling-service-catalog[enabled the service catalog] and want
+to deploy the xref:configuring-template-service-broker[template service broker],
+run the following manual steps after the cluster installation completes
+successfully:
+
+[WARNING]
+====
+The template service broker (TSB) is currently a Technology Preview feature and
+should not be used in production clusters. Enabling the TSB currently requires
+opening unauthenticated access to the cluster; this security issue will be
+resolved before exiting the Technology Preview phase.
+====
+
+. Ensure that one or more source projects for the TSB were defined via
+`openshift_template_service_broker_namespaces` as described in
+xref:../../install_config/install/advanced_install.html#configuring-template-service-broker[Configuring the Template Service Broker].
+
+. Run the following command to enable unauthenticated access for the TSB:
++
+----
+$ oc adm policy add-cluster-role-to-group \
+    system:openshift:templateservicebroker-client \
+    system:unauthenticated system:authenticated
+----
+
+. Create a *_template-broker.yml_* file with the following contents:
++
+[source,yaml]
+----
+apiVersion: servicecatalog.k8s.io/v1alpha1
+kind: Broker
+metadata:
+  name: template-broker
+spec:
+  url: https://kubernetes.default.svc:443/brokers/template.openshift.io
+----
+
+. Use the file to register the broker:
++
+----
+$ oc create -f template-broker.yml
+----
+
+. Enable the Technology Preview feature in the web console to use the TSB instead
+of the standard `openshift` global library behavior.
+
+.. Save the following script to a file (for example, *_tech-preview.js_*):
++
+[source, javascript]
+----
+window.OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.template_service_broker = true;
+----
+
+.. Add the file to the master configuration file in
+*_/etc/origin/master/master-config.yml_*:
++
+[source, yaml]
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/tech-preview.js
+----
+
+.. Restart the master service:
++
+ifdef::openshift-origin[]
+----
+# systemctl restart origin-master
+----
+endif::[]
+ifdef::openshift-enterprise[]
+----
+# systemctl restart atomic-openshift-master
+----
+endif::[]
 
 If for any reason the installation fails, before re-running the installer, see
 xref:installer-known-issues[Known Issues] to check for any specific


### PR DESCRIPTION
FYI @ewolinetz @jwmatthews @bparees @pmorie - Still figuring some pieces out but here's a start if you have additions/corrections to throw in.

Preview build (internal):

Enabling the Service Catalog
http://file.rdu.redhat.com/~adellape/072617/svc_catalog_install/install_config/install/advanced_install.html#enabling-service-catalog

Configuring the Ansible Service Broker
http://file.rdu.redhat.com/~adellape/072617/svc_catalog_install/install_config/install/advanced_install.html#configuring-ansible-service-broker

Configuring the Template Service Broker
http://file.rdu.redhat.com/~adellape/072617/svc_catalog_install/install_config/install/advanced_install.html#configuring-template-service-broker

Running the Advanced Installation -> Optional: Deploying the Template Service Broker
http://file.rdu.redhat.com/~adellape/072617/svc_catalog_install/install_config/install/advanced_install.html#running-the-advanced-installation

~~TODO:~~

~~- [ ] Add req'd images to Disconnected Installation topic.~~ Will verify and get this into a follow-up PR.