### PR TITLE
changes to arbitrary uid guidance

### DIFF
--- a/creating_images/guidelines.adoc
+++ b/creating_images/guidelines.adoc
@@ -284,8 +284,8 @@ to allow users in the root group to access them in the built image:
 
 ====
 ----
-RUN chgrp -R 0 /some/directory \
-  && chmod -R g+rwX /some/directory
+RUN chgrp -R 0 /some/directory && \
+    chmod -R g=u /some/directory
 ----
 ====
 
@@ -299,45 +299,33 @@ privileged user.
 Because the user ID of the container is generated dynamically, it will not have
 an associated entry in *_/etc/passwd_*. This can cause problems for applications
 that expect to be able to look up their user ID. One way to address this problem
-is to use link:https://cwrap.org/nss_wrapper.html[nss wrapper] and dynamically
-create a *_passwd_* file with the container's user ID as part of the image's
-start script:
+is to dynamically create a *_passwd_* file entry with the container's user ID as part
+of the image's start script. This is what a Dockerfile might include:
 
 ----
-export USER_ID=$(id -u)
-export GROUP_ID=$(id -g)
-envsubst < ${HOME}/passwd.template > /tmp/passwd
-export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-export NSS_WRAPPER_PASSWD=/tmp/passwd
-export NSS_WRAPPER_GROUP=/etc/group
+RUN chmod g=u /etc/passwd
+ENTRYPOINT [ "uid_entrypoint" ]
+USER 1001
 ----
 
-Where *_passwd.template_* contains:
+Where *_uid_entrypoint_* contains:
 
 ----
-root:x:0:0:root:/root:/bin/bash
-bin:x:1:1:bin:/bin:/sbin/nologin
-daemon:x:2:2:daemon:/sbin:/sbin/nologin
-adm:x:3:4:adm:/var/adm:/sbin/nologin
-lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
-sync:x:5:0:sync:/sbin:/bin/sync
-shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
-halt:x:7:0:halt:/sbin:/sbin/halt
-mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
-operator:x:11:0:operator:/root:/sbin/nologin
-games:x:12:100:games:/usr/games:/sbin/nologin
-ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
-nobody:x:99:99:Nobody:/:/sbin/nologin
-postgres:x:${USER_ID}:${GROUP_ID}:PostgreSQL Server:${HOME}:/bin/bash
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
 ----
 
-Additionally, you must install the *nss_wrapper* and *gettext* packages in your
-image for this to work. The latter provides the `envsubst` command. For
-example you can add this line to your *_Dockerfile_* for yum-based  images:
-
-----
-RUN yum -y install nss_wrapper gettext
-----
+For a complete example of this, see 
+ifdef::openshift-origin[]
+link:https://github.com/RHsyseng/container-rhel-examples/blob/master/starter-arbitrary-uid/Dockerfile.centos7[this Dockerfile]
+endif::[]
+ifdef::openshift-enterprise[]
+link:https://github.com/RHsyseng/container-rhel-examples/blob/master/starter-arbitrary-uid/Dockerfile[this Dockerfile]
+endif::[]
+.
 
 Lastly, the final *USER* declaration in the `Dockerfile` should specify the user
 ID (numeric value) and not the user name. This allows {product-title} to


### PR DESCRIPTION
Here are a few reasons for using this method over nss_wrapper:

- Faster image build time
  - Nothing extra has to be installed to the base image
- Smaller image (by 50mb+)
  - nss_wrapper & gettext install w/ dependencies
- Permanent user name recognition in an arbitrary uid container (e.g. openshift)
  - container-wide change vs singular process / expiring
    - nss_wrapper only identifies the user properly for a single command/execution
  - Things like systemd, ansible-playbook, & dbus daemon all work as expected with this arbitrary uid solution. Whereas nss_wrapper wasn’t a sufficient method for these commands to function, as they require addtl user lookups/checks.