### PR TITLE
Add docs for containerized installer (system container)

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -31,6 +31,10 @@ a supported version of Fedora, CentOS, or RHEL.
 endif::[]
 The host initiating the installation does not need to be intended for inclusion
 in the {product-title} cluster, but it can be.
+
+Alternatively, a
+xref:running-the-advanced-installation-system-container[containerized version of the installer] is available as a system container, which is currently a
+Technology Preview feature.
 ====
 
 ifdef::openshift-enterprise[]
@@ -529,21 +533,14 @@ xref:../../install_config/redeploying_certificates.adoc#install-config-redeployi
 All system container components are
 ifdef::openshift-enterprise[]
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
-features in {product-title} 3.6.
 endif::[]
 ifdef::openshift-origin[]
-link:https://github.com/openshift/origin#support-for-kubernetes-alpha-features[Tech Preview] features in {product-title} 1.6.
+link:https://github.com/openshift/origin#support-for-kubernetes-alpha-features[Tech Preview] 
 endif::[]
-They must not be used in production and they are not supported for upgrades to
-{product-title} 
-ifdef::openshift-enterprise[]
-3.6.
-endif::[]
-ifdef::openshift-origin[]
-1.6.
-endif::[]
-During this phase, they are only meant for use with new cluster installations in
-non-production environments.
+features in {product-title} 3.6. They must not be used in production and they
+are not supported for upgrades to {product-title} 3.6. During this phase, they
+are only meant for use with new cluster installations in non-production
+environments.
 ====
 // end::syscontainers_techpreview[]
 
@@ -1678,21 +1675,112 @@ specifications, and save it as *_/etc/ansible/hosts_*.
 == Running the Advanced Installation
 
 After you have xref:configuring-ansible[configured Ansible] by defining an
-inventory file in *_/etc/ansible/hosts_*, you can run the advanced installation
-using the following playbook:
+inventory file in *_/etc/ansible/hosts_*, you run the advanced installation
+playbook via Ansible. {product-title} installations are currently supported
+using the RPM-based installer, while the containerized installer is currently a
+Technology Preview feature.
+
+[[running-the-advanced-installation-rpm]]
+=== Running the RPM-based Installer
+
+The RPM-based installer uses Ansible installed via RPM packages to run playbooks
+and configuration files available on the local host. To run the installer, use
+the following command, specifying `-i` if your inventory file located somewhere
+other than *_/etc/ansible/hosts_*:
 
 ----
 ifdef::openshift-enterprise[]
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+# ansible-playbook  [-i /path/to/inventory] \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 endif::[]
 ifdef::openshift-origin[]
-# ansible-playbook ~/openshift-ansible/playbooks/byo/config.yml
+# ansible-playbook [-i /path/to/inventory] \
+    ~/openshift-ansible/playbooks/byo/config.yml
 endif::[]
 ----
 
 If for any reason the installation fails, before re-running the installer, see
 xref:installer-known-issues[Known Issues] to check for any specific
 instructions or workarounds.
+
+[[running-the-advanced-installation-system-container]]
+=== Running the Containerized Installer
+
+include::install_config/install/advanced_install.adoc[tag=syscontainers_techpreview]
+
+The 
+ifdef::openshift-enterprise[]
+*openshift3/ose-ansible*
+endif::[]
+ifdef::openshift-origin[]
+*openshift/origin-ansible*
+endif::[]
+image is a containerized version of the {product-title} installer that runs as a
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/running_system_containers[system container]. System containers are stored and run outside of the traditional
+*docker* service. Functionally, using the containerized installer is the same as
+using the traditional RPM-based installer, except it is running in a
+containerized environment instead of directly on the host.
+
+. Use the Docker CLI to pull the image locally:
++
+----
+ifdef::openshift-enterprise[]
+$ docker pull registry.access.redhat.com/openshift3/ose-ansible:v3.6
+endif::[]
+ifdef::openshift-origin[]
+$ docker pull docker.io/openshift/origin-ansible:v3.6
+endif::[]
+----
+
+. The installer system container must be stored in
+link:https://access.redhat.com/documentation/en-us/red_hat_satellite/6.2/html/content_management_guide/managing_ostree_content[OSTree]
+instead of defaulting to *docker* daemon storage. Use the Atomic CLI to import
+the installer image from the local *docker* engine to OSTree storage:
++
+----
+$ atomic pull --storage ostree \
+ifdef::openshift-enterprise[]
+    docker:registry.access.redhat.com/openshift3/ose-ansible:v3.6
+endif::[]
+ifdef::openshift-origin[]
+    docker:docker.io/openshift/origin-ansible:v3.6
+endif::[]
+----
+
+. Install the system container so it is set up as a systemd service:
++
+----
+$ atomic install --system \
+    --storage=ostree \
+    --name=openshift-installer \//<1>
+    --set INVENTORY_FILE=/path/to/inventory \//<2>
+ifdef::openshift-enterprise[]
+    docker:registry.access.redhat.com/openshift3/ose-ansible:v3.6
+endif::[]
+ifdef::openshift-origin[]
+    docker:docker.io/openshift/origin-ansible:v3.6
+endif::[]
+----
+<1> Sets the name for the systemd service.
+<2> Specify the location for your inventory file on your local workstation.
+
+. Use the `systemctl` command to start the installer service as you would any
+other systemd service. This command initiates the cluster installation:
++
+----
+$ systemctl start openshift-installer
+----
++
+If for any reason the installation fails, before re-running the installer, see
+xref:installer-known-issues[Known Issues] to check for any specific instructions
+or workarounds.
+
+. After the installation completes, if you want to remove the system container,
+you can uninstall the image using the following command:
++
+----
+$ atomic uninstall openshift-installer
+----
 
 [[advanced-verifying-the-installation]]
 == Verifying the Installation

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1775,12 +1775,44 @@ If for any reason the installation fails, before re-running the installer, see
 xref:installer-known-issues[Known Issues] to check for any specific instructions
 or workarounds.
 
-. After the installation completes, if you want to remove the system container,
-you can uninstall the image using the following command:
+. After the installation completes, you can uninstall the system container if you want. However, if you need to run the installer again to run any other playbooks later, you would have to follow this procedure again.
++
+To uninstall the system container:
 +
 ----
 $ atomic uninstall openshift-installer
 ----
+
+[[running-the-advanced-installation-system-container-other-playbooks]]
+==== Running Other Playbooks
+
+After you have completed the cluster installation, if you want to later run any
+other playbooks using the containerized installer (for example, cluster upgrade
+playbooks), you can use the `PLAYBOOK_FILE` environment variable. The default
+value is `playbooks/byo/config.yml`, which is the main cluster installation
+playbook, but you can set it to the path of another playbook inside the
+container.
+
+For example:
+
+----
+$ atomic install --system \
+    --storage=ostree \
+    --name=openshift-installer \
+    --set INVENTORY_FILE=/etc/ansible/hosts \
+    --set PLAYBOOK_FILE=playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade.yml \//<1>
+ifdef::openshift-enterprise[]
+    docker:registry.access.redhat.com/openshift3/ose-ansible:v3.6
+endif::[]
+ifdef::openshift-origin[]
+    docker:docker.io/openshift/origin-ansible:v3.6
+endif::[]
+----
+<1> Set `PLAYBOOK_FILE` to the relative path of the playbook starting at the
+*_playbooks/_* directory. Playbooks mentioned elsewhere in {product-title}
+documentation assume use of the RPM-based installer, so use this relative path
+instead when using the containerized installer.
+
 
 [[advanced-verifying-the-installation]]
 == Verifying the Installation

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -120,11 +120,30 @@ For RHEL 7 systems:
 ----
 
 ifdef::openshift-enterprise[]
-. Install the following package, which provides {product-title} utilities and pulls in
-other tools required by the
-xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] and
-xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
-methods, such as Ansible and related configuration files:
+. If you plan to use the
+xref:../../install_config/install/advanced_install.adoc#running-the-advanced-installation-rpm[RPM-based installer] to run an advanced installation, you can skip this step. However, if
+you plan to use the
+xref:../../install_config/install/advanced_install.adoc#running-the-advanced-installation-system-container[containerized installer] (currently a Technology Preview feature):
+
+.. Install the *atomic* package:
++
+----
+# yum install atomic
+----
+
+.. Install the *atomic-openshift-docker-excluder* package:
++
+----
+# yum install atomic-openshift-docker-excluder
+----
+
+.. Skip to xref:installing-docker[Installing Docker].
+
+. Install the following package, which provides RPM-based {product-title}
+installer utilities and pulls in other tools required by the
+xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick]
+and
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation] methods, such as Ansible and related configuration files:
 +
 ----
 # yum install atomic-openshift-utils
@@ -172,41 +191,52 @@ ifdef::openshift-origin[]
 == Preparing for Advanced Installations
 
 If you plan to use the
-xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
-method, you must install Ansible and clone the *openshift-ansible* repository from
-GitHub, which provides the required playbooks and configuration files.
+xref:../../install_config/install/advanced_install.adoc#running-the-advanced-installation-system-container[containerized installer] to run an advanced installation (currently a Technology Preview
+feature):
 
-For convenience, the following steps are provided if you want to use EPEL as a
+. Install the *atomic* package:
++
+----
+# yum install atomic
+----
+
+. Skip to xref:installing-docker[Installing Docker].
+
+If you plan to use the
+xref:../../install_config/install/advanced_install.adoc#running-the-advanced-installation-rpm[RPM-based installer] to run an advanced installation:
+
+. Install Ansible. For convenience, the following steps are provided if you want to use EPEL as a
 package source for Ansible:
 
-. Install the EPEL repository:
+.. Install the EPEL repository:
 +
 ----
 # yum -y install \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ----
 
-. Disable the EPEL repository globally so that it is not accidentally used during
+.. Disable the EPEL repository globally so that it is not accidentally used during
 later steps of the installation:
 +
 ----
 # sed -i -e "s/^enabled=1/enabled=0/" /etc/yum.repos.d/epel.repo
 ----
 
-. Install the packages for Ansible:
+.. Install the packages for Ansible:
 +
 ----
 # yum -y --enablerepo=epel install ansible pyOpenSSL
 ----
 
-To clone the *openshift-ansible* repository:
-
+. Clone the *openshift/openshift-ansible* repository from GitHub, which provides
+the required playbooks and configuration files:
++
 ----
 # cd ~
 # git clone https://github.com/openshift/openshift-ansible
 # cd openshift-ansible
 ----
-
++
 [NOTE]
 ====
 Be sure to stay on the *master* branch of the *openshift-ansible* repository


### PR DESCRIPTION
Split the "Running the Advanced Installation" section into two subsections, "Running the RPM-based Installer" (existing procedure) and "Running the Containerized Installer" (new procedure):

http://file.rdu.redhat.com/~adellape/080117/installer_syscontainer/install_config/install/advanced_install.html#running-the-advanced-installation

Also updated the "Host Preparation" topic to add alternative instructions for preparing for the containerized installer. For the OCP docs, the changes mostly happen in step 3 of the "Installing Base Packages" section:

http://file.rdu.redhat.com/~adellape/080117/installer_syscontainer/install_config/install/host_preparation.html#installing-base-packages

However for the Origin docs, the changes are mostly in this Origin-only "Preparing for an Advanced Installation" section:

http://file.rdu.redhat.com/~adellape/080117-origin/installer_syscontainer/install_config/install/host_preparation.html#preparing-for-advanced-installations-origin

@giuseppe @ashcrow PTAL for tech review.

@openshift/team-documentation PTAL for peer review.

Also requesting QE via https://trello.com/c/xmXRVjf4.