### PR TITLE
Add replica sets to objects capable of working with IS

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -360,7 +360,7 @@ xref:../dev_guide/deployments/basic_deployment_operations.adoc#dev-guide-basic-d
 Currently, it is also possible to make them work with native Kubernetes
 resources, such as xref:../dev_guide/jobs.adoc#dev-guide-jobs[jobs],
 xref:../architecture/core_concepts/deployments.adoc#replication-controllers[replication
-controllers], or
+controllers], replica sets or
 xref:../dev_guide/deployments/kubernetes_deployments.adoc#dev-guide-kubernetes-deployments-support[Kubernetes
 deployments].
 


### PR DESCRIPTION
@ahardin-rh a followup to your followup ;)
Originally I wanted to mention both replication controllers and replica sets, but I haven't fixed it after copy&paste. You've removed the duplication but we still need that info about replica set. This PR adds it.
Unfortunately, there's no reasonable link for RS, so just clean info must be sufficient.