### PR TITLE
Image signature configuration and deployment docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -524,6 +524,9 @@ Topics:
     File: manage_authorization_policy
   - Name: Image Policy
     File: image_policy
+  - Name: Image Signatures
+    File: image_signatures
+    Distros: openshift-origin,openshift-enterprise
   - Name: Scoped Tokens
     File: scoped_tokens
   - Name: Monitoring Images
@@ -780,9 +783,6 @@ Topics:
     File: service_accounts
   - Name: Managing Images
     File: managing_images
-  - Name: Image Signatures
-    File: image_signatures
-    Distros: openshift-origin,openshift-enterprise
   - Name: Quotas and Limit Ranges
     File: compute_resources
   - Name: Injecting Information into Pods Using Pod Presets

--- a/admin_guide/image_signatures.adoc
+++ b/admin_guide/image_signatures.adoc
@@ -25,22 +25,23 @@ on RHEL systems, see the
 link:https://access.redhat.com/articles/2750891#architecture[Container Image Signing Integration Guide].
 
 The OpenShift Container Registry allows the ability to store signatures via REST
-API. The `oc` CLI can be used to verify image signatures, with their validiated
+API. The `oc` CLI can be used to verify image signatures, with their validated
 displayed in the web console or CLI.
 
 ifdef::openshift-enterprise[]
 [NOTE]
 ====
 Initial support for storing image signatures was added in {product-title} 3.3.
+Initial support for verifying image signatures was added in {product-title} 3.6.
 ====
 endif::[]
 ifdef::openshift-origin[]
 [NOTE]
 ====
 Initial support for storing image signatures was added in {product-title} 1.3.
+Initial support for verifying image signatures was added in {product-title} 1.6.
 ====
 endif::[]
-
 
 [[signing-images-using-atomic-cli]]
 == Signing Images Using Atomic CLI
@@ -53,26 +54,112 @@ The `atomic` command line interface (CLI), version 1.12.5 or greater, provides
 commands for signing container images, which can be pushed to an OpenShift
 Container Registry. The `atomic` CLI is available on Red Hat-based
 distributions: RHEL, Centos, and Fedora.
+ifdef::openshift-enterprise[]
+The `atomic` CLI is pre-installed on RHEL Atomic Host systems. For information
+on installing the *atomic* package on a RHEL host, see
+xref:../../install_config/install/host_preparation.adoc#enabling-image-signature-support[Enabling Image Signature Support].
+endif::[]
 
-You can sign an image at push time:
+[IMPORTANT]
+====
+The `atomic` CLI uses the authenticated credentials from `oc login`. Be sure to
+use the same user on the same host for both `atomic` and `oc` commands. For example,
+if you execute `atomic` CLI as `sudo`, be sure to log in to {product-title}
+using `sudo oc login`.
+====
+
+In order to attach the signature to the image, the user must have the
+`image-signer` cluster role.
+ifdef::openshift-origin,openshift-enterprise[]
+Cluster administrators can add this using:
 
 ----
-$ atomic push [--sign-by ...] <image>
+$ oc adm policy add-cluster-role-to-user system:image-signer <user_name>
+----
+endif::[]
+
+Images may be signed at push time:
+
+----
+$ atomic push [--sign-by <gpg_key_id>] --type atomic <image>
 ----
 
-Or you can sign an image that has already been pushed to the registry:
-
-----
-$ atomic sign [--sign-by ...] <image>
-----
+Signatures are stored in {product-title} when the **atomic** transport type
+argument is specified. See xref:../security/deployment.adoc#security-deployment-signature-transports[signature transports]
+for more information.
 
 For full details on how to set up and perform image signing using the `atomic`
 CLI, see the
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/signing_container_images[RHEL Atomic Host Managing Containers: Signing Container Images] documentation.
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/signing_container_images[RHEL Atomic Host Managing Containers: Signing Container Images] documentation
+or the `atomic push --help` output for argument details.
 
 A specific example workflow of working with the `atomic` CLI and an OpenShift
 Container Registry is documented in the
 link:https://access.redhat.com/articles/2750891#working-with-openshift-and-atomic-registry[Container Image Signing Integration Guide].
+
+[[verifying-image-signatures-using-openshift-cli]]
+== Verifying Image Signatures Using OpenShift CLI
+
+You can verify the signatures of an image imported to an OpenShift Container
+Registry using the `oc adm verify-image-signature` command. This command
+verifies if the image identity contained in the image signature can be trusted
+by using the public GPG key to verify the signature itself then match the
+provided expected identity with the identity (the pull spec) of the given image.
+
+By default, this command uses the public GPG keyring located in
+*_$GNUPGHOME/pubring.gpg_*, typically in path *_~/.gnupg_*. By default, this
+command does not save the result of the verification back to the image object.
+To do so, you must specify the `--save` flag, as shown below.
+
+[NOTE]
+====
+In order to verify the signature of an image, the user must have the
+`image-auditor` cluster role.
+ifdef::openshift-origin,openshift-enterprise[]
+Cluster administrators can add this using:
+
+----
+$ oc adm policy add-cluster-role-to-user system:image-auditor <user_name>
+----
+endif::[]
+====
+
+Using the `--save` flag on already verified image together with invalid GPG key
+or invalid expected identity causes the saved verification status to be removed,
+and the image will become unverified.
+
+To verify an image signature use the following format:
+
+----
+$ oc adm verify-image-signature <image> --expected-identity=<pull_spec> [--save] [options]
+----
+
+The `<pull_spec`> can be found by describing the image stream.
+The `<image>` may be found by describing the image stream tag.
+See the following example command output.
+
+.Example Image Signature Verification
+----
+$ oc describe is nodejs -n openshift
+Name:             nodejs
+Namespace:        openshift
+Created:          2 weeks ago
+Labels:           <none>
+Annotations:      openshift.io/display-name=Node.js
+                  openshift.io/image.dockerRepositoryCheck=2017-07-05T18:24:01Z
+Docker Pull Spec: 172.30.1.1:5000/openshift/nodejs
+...
+
+$ oc describe istag nodejs:latest -n openshift
+Image Name:	sha256:2bba968aedb7dd2aafe5fa8c7453f5ac36a0b9639f1bf5b03f95de325238b288
+...
+
+$ oc adm verify-image-signature \
+    sha256:2bba968aedb7dd2aafe5fa8c7453f5ac36a0b9639f1bf5b03f95de325238b288 \
+    --expected-identity 172.30.1.1:5000/openshift/nodejs:latest \
+    --public-key /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release \
+    --save
+----
 
 [[accessing-image-signatures-using-registry-api]]
 == Accessing Image Signatures Using Registry API
@@ -89,7 +176,7 @@ documentation] for general information about the Docker Registry API.
 ====
 
 [[writing-image-signatures-using-registry-api]]
-=== Writing Image Signatures
+=== Writing Image Signatures via API
 
 In order to add a new signature to the image, you can use the HTTP `PUT` method
 to send a JSON payload to the `extensions` endpoint:
@@ -120,21 +207,8 @@ characters long. The `<cryptographic_signature>` must follow the specification
 documented in the
 link:https://github.com/containers/image/blob/master/docs/atomic-signature.md#the-cryptographic-signature[containers/image] library.
 
-[NOTE]
-====
-In order to attach the signature to the image, the user must have the
-`system:image-signer` cluster role.
-ifdef::openshift-origin,openshift-enterprise[]
-Cluster administrators can add this using:
-
-----
-$ oc adm policy add-cluster-role-to-user system:image-signer <user_name>
-----
-endif::[]
-====
-
 [[reading-image-signatures-via-registry-api]]
-=== Reading Image Signatures
+=== Reading Image Signatures via API
 
 Assuming a signed image has already been pushed into the OpenShift Container
 Registry, you can read the signatures using the following command:
@@ -173,34 +247,3 @@ the `<name>` is the name of the signature. The signature name must be 32
 characters long. The `<cryptographic_signature>` must follow the specification
 documented in the
 link:https://github.com/containers/image/blob/master/docs/atomic-signature.md#the-cryptographic-signature[containers/image] library.
-
-[[verifying-image-signatures-using-openshift-cli]]
-== Verifying Image Signatures Using OpenShift CLI
-
-You can verify the signatures of an image imported to an OpenShift Container
-Registry using the `oc adm verify-image-signature` command. This command
-verifies if the image identity contained in the image signature can be trusted
-by using the public GPG key to verify the signature itself then match the
-provided expected identity with the identity (the pull spec) of the given image.
-
-By default, this command uses the public GPG keyring located in
-*_$GNUPGHOME/pubring.gpg_*, typically in path *_~/.gnupg_*. By default, this
-command does not save the result of the verification back to the image object.
-To do so, you must specify the `--save` flag.
-
-[NOTE]
-====
-To modify the image signature verification status, your account must have to
-have permissions to edit image objects, for example using the `image-auditor`
-role.
-====
-
-Using the `--save` flag on already verified image together with invalid GPG key
-or invalid expected identity causes the saved verification status to be removed,
-and the image will become unverified.
-
-To verify an image signature:
-
-----
-$ oc adm verify-image-signature <image> --expected-identity=<pull_spec> [--save] [options]
-----

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -309,7 +309,7 @@ xref:../registry/securing_and_exposing_registry.adoc#securing-the-registry[requi
 172.30.0.0/16 is the default value of the `*servicesSubnet*` variable in the
 *_master-config.yaml_* file. If this has changed, then the `--insecure-registry`
 value in the above step should be adjusted to match, as it is indicating the
-subnet for the registry to use. Note that the `*openshift_portal_net*`
+subnet for the registry to use. Note that the `*openshift_master_portal_net*`
 variable can be set in the Ansible inventory file and used during the
 xref:advanced_install.adoc#configuring-ansible[advanced installation]
 method to modify the `*servicesSubnet*` variable.
@@ -546,6 +546,95 @@ according to the instructions above.
 See
 link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Logical_Volume_Manager_Administration/index.html[Logical
 Volume Manager Administration] for more detailed information on LVM management.
+
+[[enabling-image-signature-support]]
+=== Enabling Image Signature Support
+
+{product-title} is capable of cryptographically verifying images are from
+trusted sources. The
+xref:../../security/deployment.adoc#security-deployment-from-where-images-deployed[Container Security Guide] provides a high-level description of how image signing works.
+
+You can configure image signature verification using the `atomic` command line
+interface (CLI), version 1.12.5 or greater.
+ifdef::openshift-enterprise[]
+The `atomic` CLI is pre-installed on RHEL Atomic Host systems.
+
+[NOTE]
+====
+For more on the `atomic` CLI, see the
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/cli_reference/prerequisites[Atomic CLI documentation].
+====
+endif::[]
+
+Install the *atomic* package if it is not installed on the host system:
+
+----
+$ yum install atomic
+----
+
+The **atomic trust** sub-command manages trust configuration. The default
+configuration is to whitelist all registries. This means no signature
+verification is configured.
+
+----
+$ atomic trust show
+* (default)                         accept
+----
+
+A reasonable configuration might be to whitelist a particular registry or
+namespace, blacklist (reject) untrusted registries, and require signature
+verification on a vendor registry. The following set of commands performs this
+example configuration:
+
+.Example Atomic Trust Configuration
+----
+$ atomic trust add --type insecureAcceptAnything 172.30.1.1:5000
+
+$ atomic trust add --sigstoretype atomic \
+  --pubkeys pub@example.com \
+  172.30.1.1:5000/production
+  
+$ atomic trust add --sigstoretype atomic \
+  --pubkeys /etc/pki/example.com.pub \
+  172.30.1.1:5000/production
+  
+$ atomic trust add --sigstoretype web \
+  --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
+  --pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release \
+  registry.access.redhat.com
+  
+$ sudo atomic trust show
+* (default)                         accept
+172.30.1.1:5000                     accept
+172.30.1.1:5000/production          signed security@example.com
+registry.access.redhat.com          signed security@redhat.com,security@redhat.com
+----
+
+When all the signed sources are verified, nodes may be further hardened with a
+global `reject` default:
+
+----
+$ atomic trust default reject
+
+$ atomic trust show
+* (default)                         reject
+172.30.1.1:5000                     accept
+172.30.1.1:5000/production          signed security@example.com
+registry.access.redhat.com          signed security@redhat.com,security@redhat.com
+----
+
+Use the `atomic` man page `man atomic-trust` for additional examples.
+
+The following files and directories comprise the trust configuration of a host:
+
+- *_/etc/containers/registries.d/*_*
+- *_/etc/containers/policy.json_*
+
+The trust configuration may be managed directly on each node or the generated
+files managed on a separate host and distributed to the appropriate nodes using
+Ansible, for example. See this
+link:https://access.redhat.com/articles/2750891#automating-cluster-configuration[Red Hat Knowledgebase Article] for an example of automating file distribution with
+Ansible.
 
 [[managing-docker-container-logs]]
 === Managing Container Logs

--- a/security/deployment.adoc
+++ b/security/deployment.adoc
@@ -48,6 +48,136 @@ $ oc set triggers dc/frontend \
 ** xref:../dev_guide/deployments/basic_deployment_operations.adoc#triggers[Setting Deployment Triggers]
 ** xref:../dev_guide/application_lifecycle/promoting_applications.adoc#dev-guide-promoting-applications[Application Life Cycle Management -> Promoting Applications Across Environments]
 
+[[security-deployment-from-where-images-deployed]]
+== Controlling What Image Sources Can Be Deployed
+
+It is important that the intended images are actually being deployed, that they
+are from trusted sources, and they have not been altered. Cryptographic signing
+provides this assurance. {product-title} enables cluster administrators to apply
+security policy that is broad or narrow, reflecting deployment environment and
+security requirements. Two parameters define this policy:
+
+- one or more registries (with optional project namespace)
+- trust type (accept, reject, or require public key(s))
+
+With these policy parameters, registries or parts of registries, even individual
+images, may be whitelisted (accept), blacklisted (reject), or define a trust
+relationship using trusted public key(s) to ensure the source is
+cryptographically verified. The policy rules apply to nodes. Policy may be
+applied uniformly across all nodes or targeted for different node workloads (for
+example, build, zone, or environment).
+
+.Example Image Signature Policy File
+----
+{
+    "default": [{"type": "reject"}],
+    "transports": {
+        "docker": {
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ]
+        },
+        "atomic": {
+            "172.30.1.1:5000/openshift": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+            "172.30.1.1:5000/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/example.com/pubkey"
+                }
+            ],
+            "172.30.1.1:5000": [{"type": "insecureAcceptAnything"}]
+        }
+    }
+}
+----
+
+The policy can be saved onto a node as *_/etc/containers/policy.json_*. This
+example enforces the following rules:
+
+. Require images from the Red Hat Registry (`registry.access.redhat.com`) to be
+signed by the Red Hat public key.
+. Require images from the OpenShift Container Registry in the *openshift*
+namespace to be signed by the Red Hat public key.
+. Require images from the OpenShift Container Registry in the *production*
+namespace to be signed by the public key for `example.com`.
+. Reject all other registries not specified by the global `default` definition.
+
+For specific instructions on configuring a host, see
+xref:../install_config/install/host_preparation.adoc#enabling-image-signature-support[Enabling Image Signature Support].
+See the section below for details on xref:security-deployment-signature-transports[Signature Transports].
+For more details on image signature policy, see the
+link:https://github.com/containers/image/blob/master/docs/policy.json.md[Signature verification policy file format] source code documentation.
+
+[[security-deployment-signature-transports]]
+=== Signature Transports
+
+A signature transport is a way to store and retrieve the binary signature blob.
+There are two types of signature transports.
+
+- `atomic`: Managed by the {product-title} API.
+- `docker`: Served as a local file or by a web server.
+
+Signatures using the `atomic` transport type are managed by the {product-title}
+API. Images must be stored by the OpenShift Container Registry. No additional
+configuration is required due to the *docker/distribution*
+xref:../admin_guide/image_signatures.adoc#reading-image-signatures-via-registry-api[`extensions` API] to auto-discover the image signature endpoint.
+
+Signatures using the `docker` transport type are served by local file or web
+server. They have the benefit of the most flexibility: any container registry
+can be used to serve images with an independent server to deliver binary
+signatures.
+
+However, the `docker` transport type requires additional configuration. Each
+node must be configured with the URI of the signature server using
+arbitrarily-named YAML files placed into a directory on the host system,
+*_/etc/containers/registries.d_* by default. The configuration files contain a
+registry URI and a signature server URI, or _sigstore_:
+
+.Example Registries.d File
+----
+docker:
+    registry.access.redhat.com:
+        sigstore: http://registry.access.redhat.com/content/sigstore/
+----
+
+This example file may be placed on each node as
+*_/etc/containers/registries.d/redhat.com.yaml_*. It defines a signature server
+(the `sigstore` parameter) to serve signatures for the `docker` transport type
+for the Red Hat Registry (`access.registry.redhat.com`). Placing these files
+onto a cluster of nodes may be automated using Ansible, for example. No service
+restart is required since policy and *_registries.d_* files are dynamically
+loaded by the container runtime.
+
+For more details, see the
+link:https://github.com/containers/image/blob/master/docs/registries.d.md[Registries Configuration Directory] or
+link:https://github.com/containers/image/blob/master/docs/signature-protocols.md[Signature access protocols] source code documentation.
+
+[discrete]
+[[security-deployment-further-reading-2]]
+==== Further Reading
+
+- _{product-title} Clutster Administration Guide_
+** xref:../admin_guide/scheduler.adoc[Scheduler]
+
+- _Red Hat Knowledge Base_
+** link:https://access.redhat.com/articles/2750891[Container Image Signing Integration Guide]
+
+- _Source Code Reference_
+** link:https://github.com/containers/image/blob/master/docs/policy.json.md[Image signing policy]
+** link:https://github.com/containers/image/blob/master/docs/signature-protocols.md[Signature transports]
+** link:https://github.com/containers/image/blob/master/docs/atomic-signature.md[Signature format]
+
 [[security-deployment-secrets-configmaps]]
 == Secrets and ConfigMaps
 
@@ -75,7 +205,7 @@ key-value pairs of configuration data that can be consumed in pods or used to
 store configuration data for system components such as controllers.
 
 [discrete]
-[[security-deployment-further-reading-2]]
+[[security-deployment-further-reading-3]]
 ==== Further Reading
 
 - _{product-title} Developer Guide_
@@ -101,7 +231,7 @@ If you have the required permissions, you can adjust the default SCC policies to
 be more permissive.
 
 [discrete]
-[[security-deployment-further-reading-3]]
+[[security-deployment-further-reading-4]]
 ==== Further Reading
 
 - _{product-title} Architecture_: xref:../architecture/additional_concepts/authorization.adoc#security-context-constraints[Security Context Constraints]


### PR DESCRIPTION
Picks up https://github.com/openshift/openshift-docs/pull/4784 and adds edits.

@aweiteka PTAL

http://file.rdu.redhat.com/~adellape/080417/image-signing/admin_guide/image_signatures.html
http://file.rdu.redhat.com/~adellape/080417/image-signing/install_config/install/host_preparation.html#enabling-image-signature-support
http://file.rdu.redhat.com/~adellape/080417/image-signing/security/deployment.html#security-deployment-from-where-images-deployed