### PR TITLE
Bumped version # in Scaling and Performance guide

### DIFF
--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -78,7 +78,7 @@ The following table provides the maximum sizing limits for nodes and pods:
 |===
 |Type |Maximum
 
-|Maximum nodes per cluster |1000
+|Maximum nodes per cluster |2000
 
 |Maximum pods per cluster |120,000
 

--- a/scaling_performance/scaling_cluster_metrics.adoc
+++ b/scaling_performance/scaling_cluster_metrics.adoc
@@ -25,14 +25,14 @@ This topic provides information for scaling the metrics components.
 ifdef::openshift-enterprise[]
 [[cluster-metrics-horizontal-pod-autoscaling]]
 [NOTE]
-==== 
+====
 Autoscaling the metrics components, such as Hawkular and Heapster, is not supported by {product-title}.
 ====
 endif::[]
 
 
-[[metrics-recommendations-for-OCP-version-35]]
-== Recommendations for {product-title} Version 3.5
+[[metrics-recommendations-for-OCP-version-36]]
+== Recommendations for {product-title} Version 3.6
 
 * Run metrics pods on dedicated {product-title}
 xref:../admin_guide/manage_nodes.adoc#infrastructure-nodes[infrastructure
@@ -46,7 +46,7 @@ installation procedure, this is the `openshift_metrics_resolution` parameter.
 * Closely monitor {product-title} nodes with host metrics pods to detect early
 capacity shortages (CPU and memory) on the host system. These capacity shortages
 can cause problems for metrics pods.
-* In {product-title} version 3.5 testing, test cases up to 25,000 pods were
+* In {product-title} version 3.6 testing, test cases up to 25,000 pods were
 monitored in a {product-title} cluster.
 
 [[scaling-performance-capacity-planning]]
@@ -148,5 +148,3 @@ endif::openshift-enterprise[]
 If you add a new node to or remove an existing node from a Cassandra cluster,
 the data stored in the cluster rebalances across the cluster.
 ====
-
-


### PR DESCRIPTION
FYI @jeremyeder 
Are there any other updates needed to the guide before OCP 3.6 GA? Thanks!

