### PR TITLE
Updates Backup and Restore (Cluster Backup), adds Registry Certificate Backup topic.

### DIFF
--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -154,8 +154,8 @@ inside the container.
 +
 [NOTE]
 ====
-When working with one or more xref:../install_config/registry/securing_and_exposing_registry#exposing-the-registry[external secured registry], 
-*any host* required to pull or push images, hence to run pods, must trust registry certificates.
+When working with one or more xref:../install_config/registry/securing_and_exposing_registry.adoc#exposing-the-registry[external secured registry], 
+*_any host_* required to pull or push images, in order to run pods, must trust registry certificates.
 ====
 
 [[cluster-restore-single-member-etcd-clusters]]

--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -93,12 +93,18 @@ following sections), which depends on how *etcd* is deployed.
 [[cluster-backup]]
 == Cluster Backup
 
+[[master-backup]]
+=== Master Backup
+
 . Save all the certificates and keys, on each master:
 +
 ----
 # cd /etc/origin/master
 # tar cf /tmp/certs-and-keys-$(hostname).tar *.key *.crt
 ----
+
+[[etcd-backup]]
+=== Etcd Backup
 
 . If *etcd* is running on more than one host, stop it on each host:
 +
@@ -133,8 +139,24 @@ inside the container.
 . Copy the *_db_* file over to the backup you created:
 +
 ----
-$ cp "$ETCD_DATA_DIR"/member/snap/db "$HOTDIR"/member/snap/db'
+# cp "$ETCD_DATA_DIR"/member/snap/db "$HOTDIR"/member/snap/db'
 ----
+
+[[registry-certificates-backup]]
+=== Registry Certificates Backup
+
+. Save all the registry certificates, on every master and node host.
++
+----
+# cd /etc/docker/certs.d/
+# tar cf /tmp/docker-registry-certs-$(hostname).tar * 
+----
++
+[NOTE]
+====
+When working with one or more xref:../install_config/registry/securing_and_exposing_registry#exposing-the-registry[external secured registry], 
+*any host* required to pull or push images, hence to run pods, must trust registry certificates.
+====
 
 [[cluster-restore-single-member-etcd-clusters]]
 == Cluster Restore for Single-member etcd Clusters


### PR DESCRIPTION
Adress this BZ: [Docker certs are not mentioned on the backup/restore section](https://bugzilla.redhat.com/show_bug.cgi?id=1464494)