### PR TITLE
Fix efs-provisioner image name/tag

### DIFF
--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -60,7 +60,7 @@ ifdef::openshift-origin[]
 `openshift/origin-efs-provisioner:v1.0.0`, set prefix `openshift/origin-`.
 endif::[]
 ifdef::openshift-enterprise[]
-`openshift3/openshift-efs-provisioner:3.6.0`, set prefix `openshift/openshift-`.
+`openshift3/efs-provisioner:v3.6`, set prefix `openshift3/`.
 endif::[]
 
 |`openshift_provisioners_image_version`
@@ -69,7 +69,7 @@ ifdef::openshift-origin[]
 `openshift/origin-efs-provisioner:v1.0.0`, set version  as `v1.0.0`.
 endif::[]
 ifdef::openshift-enterprise[]
-`openshift3/openshift-efs-provisioner:3.6.0`, set version as `3.6.0`.
+`openshift3/efs-provisioner:v3.6`, set version as `v3.6`.
 endif::[]
 
 |`openshift_provisioners_project`


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/4188 after trying to verify the image name and tag for OCP 3.6.

PTAL @wongma7 @gaurav-nelson 