### PR TITLE
Fix unreasonable reserved resource example values

### DIFF
--- a/admin_guide/allocating_node_resources.adoc
+++ b/admin_guide/allocating_node_resources.adoc
@@ -42,7 +42,7 @@ You can set these in the `*kubeletArguments*` section of the
 xref:../install_config/master_node_configuration.adoc#node-configuration-files[node
 configuration file] (the *_/etc/origin/node/node-config.yaml_* file by default)
 using a set of `<resource_type>=<resource_quantity>` pairs (e.g.,
-*cpu=200m,memory=30G*). Add the section if it does not already exist:
+*cpu=200m,memory=512Mi*). Add the section if it does not already exist:
 
 .Node Allocatable Resources Settings
 ====
@@ -50,15 +50,15 @@ using a set of `<resource_type>=<resource_quantity>` pairs (e.g.,
 ----
 kubeletArguments:
   kube-reserved:
-    - "cpu=200m,memory=30G"
+    - "cpu=200m,memory=512Mi"
   system-reserved:
-    - "cpu=200m,memory=30G"
+    - "cpu=200m,memory=512Mi"
 ----
 ====
 
 Currently, the `*cpu*` and `*memory*` resource types are supported. For `*cpu*`,
-the resource quantity is specified in units of cores (e.g., 200m, 100Ki, 50M).
-For `*memory*`, it is specified in units of bytes (e.g., 200Ki, 100M, 50Gi).
+the resource quantity is specified in units of cores (e.g., 200m, 0.5, 1).
+For `*memory*`, it is specified in units of bytes (e.g., 200Ki, 50Mi, 5Gi).
 
 See xref:../dev_guide/compute_resources.adoc#dev-guide-compute-resources[Compute Resources] for more
 details.


### PR DESCRIPTION
The kube-reserved system-reserved exmple specifies extremely high memory 30G and it's inappropriate as an example. Make it reasonable.