### PR TITLE
Add `rpm` command to reall verify Docker version

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -241,6 +241,7 @@ After the package installation is complete, verify that version 1.12 was
 installed:
 +
 ----
+# rpm -V docker-1.12.6
 # docker version
 ----
 
@@ -561,16 +562,16 @@ $ atomic trust add --type insecureAcceptAnything 172.30.1.1:5000
 $ atomic trust add --sigstoretype atomic \
   --pubkeys pub@example.com \
   172.30.1.1:5000/production
-  
+
 $ atomic trust add --sigstoretype atomic \
   --pubkeys /etc/pki/example.com.pub \
   172.30.1.1:5000/production
-  
+
 $ atomic trust add --sigstoretype web \
   --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
   --pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release \
   registry.access.redhat.com
-  
+
 $ sudo atomic trust show
 * (default)                         accept
 172.30.1.1:5000                     accept


### PR DESCRIPTION
If we want the user to be verifying that the correct version of the
Docker RPM was installed in the preceeding step, we should instruct them
to use `rpm -V` as well as visual confirmation for a more fool-proof
process.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>