### PR TITLE
Bug 1476914, Remove any reference to Docker Build Strategy from Online

### DIFF
--- a/dev_guide/application_lifecycle/new_app.adoc
+++ b/dev_guide/application_lifecycle/new_app.adoc
@@ -29,11 +29,9 @@ local or remote Git repository.
 
 To create an application using a Git repository in a local directory:
 
-====
 ----
 $ oc new-app /path/to/source/code
 ----
-====
 
 [NOTE]
 ====
@@ -46,21 +44,17 @@ xref:../builds/build_inputs.adoc#binary-source[binary build].
 You can use a subdirectory of your source code repository by specifying a
 `--context-dir` flag. To create an application using a remote Git repository and a context subdirectory:
 
-====
 ----
 $ oc new-app https://github.com/openshift/sti-ruby.git \
     --context-dir=2.0/test/puma-test-app
 ----
-====
 
 Also, when specifying a remote URL, you can specify a Git branch to use by
 appending `#<branch_name>` to the end of the URL:
 
-====
 ----
 $ oc new-app https://github.com/openshift/ruby-hello-world.git#beta4
 ----
-====
 
 The `new-app` command creates a xref:../../dev_guide/builds/index.adoc#defining-a-buildconfig[build configuration], which itself creates a new application
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image]
@@ -72,7 +66,7 @@ provide load-balanced access to the deployment running your image.
 
 {product-title} automatically xref:build-strategy-detection[detects] whether the
 ifndef::openshift-online[]
-`*Docker*`, 
+`*Docker*`,
 endif::[]
 `*Pipeline*` or `*Source*`
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#builds[build
@@ -86,12 +80,12 @@ xref:language-detection[detects an appropriate language builder image].
 If a *_Jenkinsfile_* exists in the root or specified context directory of the
 source repository when creating a new application, {product-title} generates a
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[`*Pipeline*`
-build strategy]. 
+build strategy].
 ifndef::openshift-online[]
 Otherwise, if a *_Dockerfile_* is found, {product-title}
 generates a
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[`*Docker*`
-build strategy]. 
+build strategy].
 endif::[]
 Otherwise, it generates a
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[`*Source*`
@@ -99,16 +93,20 @@ build strategy].
 
 You can override the build strategy by setting the `--strategy` flag to either
 ifndef::openshift-online[]
-`docker`, 
+`docker`,
 endif::[]
 `pipeline` or `source`.
 
-====
+ifndef::openshift-online[]
 ----
 $ oc new-app /home/user/code/myapp --strategy=docker
 ----
-====
-
+endif::[]
+ifdef::openshift-online[]
+----
+$ oc new-app /home/user/code/myapp --strategy=source
+----
+endif::[]
 [[language-detection]]
 
 **Language Detection**
@@ -167,19 +165,15 @@ xref:language-detection[language detection] are not carried out.
 For example, to use the *myproject/my-ruby* image stream with the source in a
 remote repository:
 
-====
 ----
 $ oc new-app myproject/my-ruby~https://github.com/openshift/ruby-hello-world.git
 ----
-====
 
 To use the *openshift/ruby-20-centos7:latest* container image stream with the source in a local repository:
 
-====
 ----
 $ oc new-app openshift/ruby-20-centos7:latest~/home/user/code/my-ruby-app
 ----
-====
 
 [[specifying-an-image]]
 
@@ -203,20 +197,16 @@ the same image is available to the {product-title} cluster nodes.
 
 For example, to create an application from the DockerHub MySQL image:
 
-====
 ----
 $ oc new-app mysql
 ----
-====
 
 To create an application using an image in a private registry, specify the full
 Docker image specification:
 
-====
 ----
 $ oc new-app myregistry:5000/example/myimage
 ----
-====
 
 [NOTE]
 ====
@@ -240,11 +230,9 @@ stream] and optional
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
 stream tag]:
 
-====
 ----
 $ oc new-app my-stream:v1
 ----
-====
 
 [[specifying-a-template]]
 
@@ -258,21 +246,17 @@ application template] and use it to create an application.
 
 To create an application from a stored template:
 
-====
 ----
 $ oc create -f examples/sample-app/application-template-stibuild.json
 $ oc new-app ruby-helloworld-sample
 ----
-====
 
 To directly use a template in your local file system, without first storing it
 in {product-title}, use the `-f|--file` argument:
 
-====
 ----
 $ oc new-app -f examples/sample-app/application-template-stibuild.json
 ----
-====
 
 [[template-parameters]]
 
@@ -281,12 +265,10 @@ $ oc new-app -f examples/sample-app/application-template-stibuild.json
 When creating an application based on a xref:../templates.adoc#dev-guide-templates[template], use the
 `-p|--param` argument to set parameter values defined by the template:
 
-====
 ----
 $ oc new-app ruby-helloworld-sample \
     -p ADMIN_USERNAME=admin -p ADMIN_PASSWORD=mypassword
 ----
-====
 
 You can store your parameters in a file, then use that file with
 `--param-file` when instantiating a template. If you want to read the
@@ -327,11 +309,13 @@ command line. The `BuildConfig` specifies the strategy to use, the source
 location, and the build output location.
 
 a|`ImageStreams`
-a|For `BuildConfig`, two `ImageStreams` are usually created: one to
-represent the input image (the builder image in the case of `Source` builds or
-*FROM* image in case of `Docker` builds), and another one to represent the
-output image. If a container image was specified as input to `new-app`, then an
-image stream is created for that image as well.
+a|For `BuildConfig`, two `ImageStreams` are usually created. One
+represents the input image. With `Source` builds, this is the builder image.
+ifndef::openshift-online[]
+With `Docker` builds, this is the *FROM* image.
+endif::[]
+The second one represents the output image. If a container image was specified
+as input to `new-app`, then an image stream is created for that image as well.
 
 a|`DeploymentConfig`
 a|A `DeploymentConfig` is created either to deploy the output of a build, or a
@@ -429,11 +413,9 @@ can use the `-l|--label` argument to add labels to the created objects. Labels
 make it easy to collectively select, configure, and delete objects associated
 with the application.
 
-====
 ----
 $ oc new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
 ----
-====
 
 [[output-without-creation]]
 
@@ -446,14 +428,12 @@ objects.
 
 To output `new-app` artifacts to a file, edit them, then create them:
 
-====
 ----
 $ oc new-app https://github.com/openshift/ruby-hello-world \
     -o yaml > myapp.yaml
 $ vi myapp.yaml
 $ oc create -f myapp.yaml
 ----
-====
 
 // NB: The following sections are ordered by "tweak support";
 // first are those supported by command line options,
@@ -466,11 +446,9 @@ Objects created by `new-app` are normally named after the source repository, or
 the image used to generate them. You can set the name of the objects produced by
 adding a `--name` flag to the command:
 
-====
 ----
 $ oc new-app https://github.com/openshift/ruby-hello-world --name=myapp
 ----
-====
 
 [[object-project-or-namespace]]
 
@@ -479,12 +457,9 @@ $ oc new-app https://github.com/openshift/ruby-hello-world --name=myapp
 Normally, `new-app` creates objects in the current project. However, you can
 create objects in a different project by using the `-n|--namespace` argument:
 
-====
 ----
 $ oc new-app https://github.com/openshift/ruby-hello-world -n myproject
 ----
-====
-
 
 [[advanced-multiple-components-and-grouping]]
 
@@ -496,11 +471,10 @@ objects created by the single command. Environment variables apply to all
 components created from source or images.
 
 To create an application from a source repository and a Docker Hub image:
-====
+
 ----
 $ oc new-app https://github.com/openshift/ruby-hello-world mysql
 ----
-====
 
 [NOTE]
 ====
@@ -519,22 +493,18 @@ In order to specify which images to group together, use the `+` separator. The
 be grouped together. To group the image built from a source repository with
 other images, specify its builder image in the group:
 
-====
 ----
 $ oc new-app nginx+mysql
 ----
-====
 
 To deploy an image built from source and an external image together:
-====
+
 ----
 $ oc new-app \
     ruby~https://github.com/openshift/ruby-hello-world \
     mysql \
     --group=ruby+mysql
 ----
-====
-
 
 [[using-the-web-console-na]]
 


### PR DESCRIPTION
Preview build: http://file.rdu.redhat.com/~ahardin/08102017/docker-build-strategy-online/dev_guide/application_lifecycle/new_app.html

There were only a few minor references in the Online docs, following a more extensive content audit that took place several months ago. This PR removes those last references. 

This resolves https://bugzilla.redhat.com/show_bug.cgi?id=1476914