### PR TITLE
Update access mode to supported ones

### DIFF
--- a/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
+++ b/install_config/storage_examples/storage_classes_dynamic_provisioning.adoc
@@ -121,7 +121,7 @@ metadata:
  name: pvc-engineering
 spec:
  accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
@@ -145,7 +145,7 @@ Check to see if your claim is bound:
 
 # oc get pvc
 NAME              STATUS    VOLUME                                     CAPACITY   ACCESSMODES   AGE
-pvc-engineering   Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           2m
+pvc-engineering   Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           2m
 
 ----
 ====
@@ -163,7 +163,7 @@ As a `cluster-admin` or `storage-admin` user, view the recent dynamically provis
 
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM                     REASON    AGE
-pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound     rh-eng/pvc-engineering              5m
+pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           Delete          Bound     rh-eng/pvc-engineering              5m
 
 ----
 ====
@@ -249,7 +249,7 @@ metadata:
  name: pvc-engineering2
 spec:
  accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
@@ -265,8 +265,8 @@ persistentvolumeclaim "pvc-engineering2" created
                                                                    3s
 # oc get pvc
 NAME               STATUS    VOLUME                                     CAPACITY   ACCESSMODES   AGE
-pvc-engineering    Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           41m
-pvc-engineering2   Bound     pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           7s  <1>
+pvc-engineering    Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           41m
+pvc-engineering2   Bound     pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWO           7s  <1>
 
 ----
 <1> `pvc-engineering2` is bound to a dynamically provisioned Volume by _default_.
@@ -279,9 +279,9 @@ far:
 ----
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM                     REASON    AGE
-pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete          Bound     rh-eng/pvc-engineering2             5m <1>
+pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound     rh-eng/pvc-engineering2             5m <1>
 pvc-ba4612ce-8b4d-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound     mytest/gce-dyn-claim1               21h
-pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound     rh-eng/pvc-engineering              46m <2>
+pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           Delete          Bound     rh-eng/pvc-engineering              46m <2>
 ----
 <1> This PV was bound to our _default_ dynamic volume from the _default_ _StorageClass_.
 <2> This PV was bound to our first PVC from <<example1>> with our _fast_ _StorageClass_.
@@ -303,7 +303,7 @@ spec:
  capacity:
    storage: 35Gi
  accessModes:
-   - ReadWriteMany
+   - ReadWriteOnce
  gcePersistentDisk:
    readOnly: false
    pdName: the-newly-created-gce-PD
@@ -325,10 +325,10 @@ Now view the PVs again. Notice that a `pv-manual-gce` volume is _Available_.
 ----
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM                     REASON    AGE
-pv-manual-gce                              35Gi       RWX           Retain          Available                                       4s
-pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete          Bound       rh-eng/pvc-engineering2             12m
+pv-manual-gce                              35Gi       RWO           Retain          Available                                       4s
+pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound       rh-eng/pvc-engineering2             12m
 pvc-ba4612ce-8b4d-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound       mytest/gce-dyn-claim1               21h
-pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound       rh-eng/pvc-engineering              53m
+pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           Delete          Bound       rh-eng/pvc-engineering              53m
 ----
 ====
 
@@ -345,7 +345,7 @@ metadata:
  name: pvc-engineering3
 spec:
  accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
  resources:
    requests:
      storage: 15Gi
@@ -361,9 +361,9 @@ dynamically provisioned Persistent Volume.
 
 # oc get pvc
 NAME               STATUS    VOLUME                                     CAPACITY   ACCESSMODES   AGE
-pvc-engineering    Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           1h
-pvc-engineering2   Bound     pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           19m
-pvc-engineering3   Bound     pvc-6fa8e73b-8c00-11e6-9962-42010af00004   15Gi       RWX           6s
+pvc-engineering    Bound     pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           1h
+pvc-engineering2   Bound     pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWO           19m
+pvc-engineering3   Bound     pvc-6fa8e73b-8c00-11e6-9962-42010af00004   15Gi       RWO           6s
 
 ----
 ====
@@ -390,7 +390,7 @@ spec:
  capacity:
    storage: 35Gi
  accessModes:
-   - ReadWriteMany
+   - ReadWriteOnce
  gcePersistentDisk:
    readOnly: false
    pdName: the-newly-created-gce-PD
@@ -415,11 +415,11 @@ List the PVs:
 
 # oc get pv
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM                     REASON    AGE
-pv-manual-gce                              35Gi       RWX           Retain          Available                                       4s <1>
-pv-manual-gce2                             35Gi       RWX           Retain          Bound       rh-eng/pvc-engineering3             4s <2>
-pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWX           Delete          Bound       rh-eng/pvc-engineering2             12m
+pv-manual-gce                              35Gi       RWO           Retain          Available                                       4s <1>
+pv-manual-gce2                             35Gi       RWO           Retain          Bound       rh-eng/pvc-engineering3             4s <2>
+pvc-a9f70544-8bfd-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound       rh-eng/pvc-engineering2             12m
 pvc-ba4612ce-8b4d-11e6-9962-42010af00004   5Gi        RWO           Delete          Bound       mytest/gce-dyn-claim1               21h
-pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWX           Delete          Bound       rh-eng/pvc-engineering              53m
+pvc-e9b4fef7-8bf7-11e6-9962-42010af00004   10Gi       RWO           Delete          Bound       rh-eng/pvc-engineering              53m
 
 ----
 <1> The original manual PV, still unbound and Available. This is because it was not created in the _default_ _StorageClass_.

--- a/install_config/storage_examples/storage_classes_legacy.adoc
+++ b/install_config/storage_examples/storage_classes_legacy.adoc
@@ -84,7 +84,7 @@ spec:
  capacity:
    storage: 35Gi
  accessModes:
-   - ReadWriteMany
+   - ReadWriteOnce
  gcePersistentDisk:
    readOnly: false
    pdName: the-existing-PD-volume-name-that-contains-the-valuable-data <2>
@@ -105,7 +105,7 @@ persistentvolume "pv-finance-history" created
 
 # oc get pv
 NAME                CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM                        REASON    AGE
-pv-finance-history   35Gi       RWX           Retain          Available                                          2d
+pv-finance-history   35Gi       RWO           Retain          Available                                          2d
 
 ----
 ====
@@ -125,7 +125,7 @@ metadata:
  name: pvc-finance-history
 spec:
  accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
  resources:
    requests:
      storage: 20Gi
@@ -144,12 +144,12 @@ persistentvolumeclaim "pvc-finance-history" created
 
 # oc get pvc
 NAME                  STATUS    VOLUME               CAPACITY   ACCESSMODES   AGE
-pvc-finance-history   Bound     pv-finance-history   35Gi       RWX           9m
+pvc-finance-history   Bound     pv-finance-history   35Gi       RWO           9m
 
 
 # oc get pv  (cluster/storage-admin)
 NAME                 CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM                         REASON    AGE
-pv-finance-history   35Gi       RWX           Retain          Bound       default/pvc-finance-history             5m
+pv-finance-history   35Gi       RWO           Retain          Bound       default/pvc-finance-history             5m
 
 ----
 ====


### PR DESCRIPTION
According to https://docs.openshift.com/container-platform/3.6/architecture/additional_concepts/storage.html#pv-access-modes , GCE persistent disks only supports access mode ReadWriteOnce.