### PR TITLE
Add guide for encrypting data at datastore layer

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -616,6 +616,9 @@ Topics:
   - Name: Sysctls
     File: sysctls
     Distros: openshift-origin,openshift-enterprise
+  - Name: Encrypting Data at Datastore Layer
+    File: encrypting_data
+    Distros: openshift-origin,openshift-enterprise
   - Name: Encrypting Hosts with IPsec
     File: ipsec
     Distros: openshift-origin,openshift-enterprise

--- a/admin_guide/encrypting_data.adoc
+++ b/admin_guide/encrypting_data.adoc
@@ -1,0 +1,290 @@
+[[admin-guide-encrypting-data-at-datastore]]
+= Encrypting Data at Datastore Layer
+:data-uri:
+:icons:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+[[encrypting-data-overview]]
+== Overview
+
+This topic shows how to enable and configure encryption of secret data at datastore layer. While
+examples use the `secrets` resource, any resource can be encrypted, such as *configmaps*.
+
+[[encrypting-data-configuration]]
+== Configuration and Determining Whether Encryption Is Already Enabled
+
+In order to activate experimental support for data encryption, an argument
+*--experimental-encryption-provider-config* should be passed to the Kubernetes API server:
+
+.Excerpt of *_master-config.yaml_*
+====
+
+[source,yaml]
+----
+kubernetesMasterConfig:
+  apiServerArguments:
+    experimental-encryption-provider-config:
+    - /path/to/encryption-config.yaml
+----
+====
+
+For more information about *_master-config.yaml_* and its format, see
+xref:install_config/master_node_configuration.html#master-configuration-files[Master Configuration
+Files] topic.
+
+[[encrypting-data-encryption-config]]
+== Understanding the Encryption Configuration
+
+.Encryption configuration file with all available providers
+====
+
+[source,yaml]
+----
+kind: EncryptionConfig
+apiVersion: v1
+resources: <1>
+  - resources: <2>
+    - secrets
+    providers: <3>
+    - aescbc: <4>
+        keys:
+        - name: key1 <5>
+          secret: c2VjcmV0IGlzIHNlY3VyZQ== <6>
+        - name: key2
+          secret: dGhpcyBpcyBwYXNzd29yZA==
+    - secretbox:
+        keys:
+        - name: key1
+          secret: YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=
+    - aesgcm:
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        - name: key2
+          secret: dGhpcyBpcyBwYXNzd29yZA==
+    - identity: {}
+----
+<1> Each `resources` array item is a separate config and contains a complete configuration.
+<2> The `resources.resources` field is an array of Kubernetes resource names (*resource* or
+*resource.group*) that should be encrypted.
+<3> The `providers` array is an ordered xref:encrypting-data-providers[list of
+the possible encryption providers]. Only one provider type may be specified per entry (*identity* or
+*aescbc* may be provided, but not both in the same item).
+<4> The first provider in the list is used to encrypt resources going into storage.
+<5> Arbitrary name of the secret.
+<6> Base64 encoded random key. Different providers have different key lengths. See instructions
+below xref:encrypting-data-process[how to generate key].
+====
+
+When reading resources from storage each provider that matches the stored data attempts to decrypt
+the data in order. If no provider can read the stored data due to a mismatch in format or secret
+key, an error is returned which prevents clients from accessing that resource.
+
+[IMPORTANT]
+====
+If any resource is not readable via the encryption config (because keys were changed),
+the only recourse is to delete that key from the underlying etcd directly. Calls attempting to
+read that resource will fail until it is deleted or a valid decryption key is provided.
+====
+
+[[encrypting-data-providers]]
+=== Available Providers
+
+[cols="1,1,1,1,1,3"]
+|===
+| Name | Encryption | Strength | Speed | Key Length | Other Considerations
+
+| *identity*
+| None
+| N/A
+| N/A
+| N/A
+| Resources written as-is without encryption. When set as the first provider, the resource will be
+decrypted as new values are written.
+
+| *aescbc*
+| AES-CBC with PKCS#7 padding
+| Strongest
+| Fast
+| 32-byte
+| The recommended choice for encryption but may be slightly slower than *secretbox*.
+
+| *secretbox*
+| XSalsa20 and Poly1305
+| Strong
+| Faster
+| 32-byte
+| A newer standard and may not be considered acceptable in environments that require high levels of
+review.
+
+| *aesgcm*
+| AES-GCM with a random initialization vector (IV)
+| Must be rotated every 200k writes
+| Fastest
+| 16, 24, or 32-byte
+| *Is not recommended* for use except when an automated key rotation scheme is implemented.
+
+|===
+
+Each provider supports multiple keys. The keys are tried in order for decryption, and if the
+provider is the first provider, the first key is used for encryption.
+
+[NOTE]
+====
+Kubernetes has no proper nonce generator and uses a random IV as nonce for AES-GCM. Since AES-GCM
+requires a proper nonce to be secure, AES-GCM is not recommended. The 200k write limit just limits
+the possibility of a fatal nonce misuse to a reasonable low margin.
+====
+
+[[encrypting-data-process]]
+== Encrypting Data
+
+Create a new encryption config file
+
+[source,yaml]
+----
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: <BASE 64 ENCODED SECRET>
+    - identity: {}
+----
+
+To create a new secret perform the following steps:
+
+. Generate a 32 byte random key and base64 encode it. For example, on Linux and
+macOS the following command can be used:
++
+----
+head -c 32 /dev/urandom | base64
+----
++
+[IMPORTANT]
+====
+The encryption key must be generated with an appropriate cryptographically secure random number
+generator like *_/dev/urandom_*. For example, `math/random` from Golang or `random.random()` from
+Python are not suitable.
+====
+
+. Place that value in the *secret* field
+
+. Restart API server
+
+[IMPORTANT]
+====
+The encryption provider config file contains keys that can decrypt content in etcd, so you must
+properly restrict permissions on masters so only the user who runs the master API server can read it.
+====
+
+
+[[encrypting-data-verification]]
+== Verifying that Data is Encrypted
+
+Data is encrypted when written to etcd. After restarting the API server any newly created or
+updated secrets should be encrypted when stored. To check, you can use the `etcdctl` command line
+program to retrieve the contents of your secret.
+
+. Create a new secret called `secret1` in the `default` namespace:
++
+----
+oc create secret generic secret1 -n default --from-literal=mykey=mydata
+----
+
+. Using the `etcdctl` commandline, read that secret out of etcd:
++
+----
+ETCDCTL_API=3 etcdctl get /kubernetes.io/secrets/default/secret1 -w fields [...] | grep Value
+----
++
+where *[...]* must be the additional arguments for connecting to the etcd server.
++
+The final command may look like this:
++
+----
+ETCDCTL_API=3 etcdctl get /kubernetes.io/secrets/default/secret1 -w fields \
+--cacert=/var/lib/origin/openshift.local.config/master/ca.crt \
+--key=/var/lib/origin/openshift.local.config/master/master.etcd-client.key \
+--cert=/var/lib/origin/openshift.local.config/master/master.etcd-client.crt \
+--endpoints 'https://127.0.0.1:4001' | grep Value
+----
+
+. Verify that the output of the command above is prefixed with *k8s:enc:aescbc:v1:* which
+indicates the *aescbc* provider has encrypted the resulting data.
+
+. Verify the secret is correctly decrypted when retrieved via the API:
++
+----
+oc get secret secret1 -n default -o yaml | grep mykey
+----
++
+should match *mykey: bXlkYXRh*
+
+[[encrypting-data-migration]]
+== Ensure All Secrets are Encrypted
+
+Since secrets are encrypted on write, performing an update on a secret will encrypt that content.
+
+----
+oc adm migrate storage --include=secrets --confirm
+----
+
+The command above reads all secrets and then updates them to apply server side encryption.
+If an error occurs due to a conflicting write, retry the command.
+For larger clusters, you may wish to subdivide the secrets by namespace or script an update.
+
+
+[[encrypting-data-rotation]]
+== Rotating a Decryption Key
+
+Changing the secret without incurring downtime requires a multi step operation, especially in
+the presence of a highly available deployment where multiple API servers are running.
+
+. Generate a new key and add it as the second key entry for the current provider on all servers
+
+. Restart all master processes to ensure each server can decrypt using the new key
+
+. Make the new key the first entry in the *keys* array so that it is used for encryption in the
+config
+
+. Restart all master processes to ensure each server now encrypts using the new key
+
+. Run `oc adm migrate storage --include=secrets --confirm` to encrypt all existing secrets with the
+new key
+
+. Remove the old decryption key from the config after you back up etcd with the new key in use and
+update all secrets
+
+With a single API server step 2 may be skipped
+
+
+[[encrypting-data-decryption]]
+== Decrypting Data
+
+To disable encryption at datastore layer place the *identity* provider as the first entry in the config:
+
+[source,yaml]
+----
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - identity: {}
+    - aescbc:
+        keys:
+        - name: key1
+          secret: <BASE 64 ENCODED SECRET>
+----
+
+and restart all master processes. Then run the command `oc adm migrate storage --include=secrets --confirm`
+to force all secrets to be decrypted.


### PR DESCRIPTION
This is a guide for enabling data encryption at datastore layer. It is based on the similar [Kubernetes guide](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) from @smarterclayton but it has been adapted for OpenShift.

PTAL @smarterclayton @openshift/team-documentation @openshift/sig-security

Trello: https://trello.com/c/yhuQZ3NP/84-5-security-sccfsi-encrypt-secrets-at-rest-in-etcd