### PR TITLE
Bug 1476997 Added info about f5 needing ramp node

### DIFF
--- a/architecture/additional_concepts/f5_big_ip.adoc
+++ b/architecture/additional_concepts/f5_big_ip.adoc
@@ -130,6 +130,12 @@ xref:../../install_config/router/f5_router.adoc#setting-up-f5-native-integration
 integration of F5 with {product-title}], you do not need to configure a ramp
 node for F5 to be able to reach the pods on the overlay network as created by
 OpenShift SDN.
+
+Also, only *F5 BIG-IP®* appliance version 12.x and above works with the native integration
+presented in this section. You also need `sdn-services` add-on license for the
+integration to work properly.
+For version 11.x, xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[set up a ramp
+node].
 endif::[]
 ifdef::openshift-dedicated[]
 With native integration of F5 with {product-title},

--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -212,10 +212,10 @@ Native Integration] section of the Routes topic.
 
 [NOTE]
 ====
-Only *F5 BIG-IP®* appliance version 12.x and above will work with the Native integration
+Only *F5 BIG-IP®* appliance version 12.x and above works with the native integration
 presented in this section. You also need sdn-services add-on license for the
 integration to work properly.
-For version 11.x, follow the instructions to set up the 
+For version 11.x, follow the instructions to set up a 
 xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[_ramp
 node_].
 ====


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=1476997

Essentially copied a note box to the architecture guide about the versions required for OCP versions.

cc: @rajatchopra 