### PR TITLE
Bug 1475440 Corrected vxlan naming info

### DIFF
--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -360,9 +360,8 @@ on this bridge.
 cluster subnet gateway address, and is used for external network
 access. OpenShift SDN configures `netfilter` and routing rules to enable access
 from the cluster subnet to the external network via NAT.
-* `vxlan0`: The OVS VXLAN device (port 1 on `br0`), which provides access to
-containers on remote nodes.
-* `vethX` (in the main netns): A Linux virtual ethernet peer of `eth0` in the docker netns.  It will be attached to the OVS bridge on one of the other ports.
+* `vxlan_sys_4789`: The OVS VXLAN device (port 1 on `br0`), which provides access to containers on remote nodes. Referred to as `vxlan0` in the OVS rules.
+* `vethX` (in the main netns): A Linux virtual ethernet peer of `eth0` in the Docker netns. It will be attached to the OVS bridge on one of the other ports.
 
 
 === SDN Flows Inside a Node

--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -90,8 +90,7 @@ bridge.
 cluster subnet gateway address, and is used for external network
 access. OpenShift SDN configures *netfilter* and routing rules to enable access
 from the cluster subnet to the external network via NAT.
-* *vxlan0*, the OVS VXLAN device (port 1 on *br0*), which provides access to
-containers on remote nodes.
+* `vxlan_sys_4789`: The OVS VXLAN device (port 1 on `br0`), which provides access to containers on remote nodes. Referred to as `vxlan0` in the OVS rules.
 
 Each time a pod is started on the host, OpenShift SDN:
 


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=1475440

@sferich888 as discussed in the BZ. Please let me know if there's anything more needed for this BZ.