### PR TITLE
Trello-590 Use `File` Buffer instead of `Memory` Buffer for Fluentd

### DIFF
--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -43,69 +43,44 @@ resource situations, containers that specify no resource requests are given the
 lowest quality of service.
 
 [[tune-buffer-chunk-limit]]
-=== Tune Buffer Chunk Limit
+=== Tuning Buffer Chunk Limit
 
-If Fluentd logger is unable to keep up with a high number of logs, you will need
-to increase the compute resource values.
+If the Fluentd logger is unable to keep up with a high number of logs, it will need
+to switch to file buffering to reduce memory usage and prevent data loss.
 
-The memory limit is used to calculate the Fluentd `buffer_queue_limit` as follows:
+The Fluentd `buffer_chunk_limit` is determined by the environment variable
+`BUFFER_SIZE_LIMIT`, which has the default value 16 MB. The file buffer size per
+output is determined by the environment variable `FILE_BUFFER_LIMIT`, which has
+the default value 2 GB. The permanent volume size has to be larger than
+`FILE_BUFFER_LIMIT` times number of output.
 
-----
-buffer_queue_limit = resource memory limit / (number of output * buffer_chunk_size)
-----
+On the Fluentd and Mux pods, permanent volume `/var/lib/fluentd` should be
+prepared by the PVC or hostmount, for example. That area is then used for the
+file buffers.
 
-By default, `buffer_chunk_size` is 1 MB.
-
-The following steps allow you to adjust the available resources.
-
-. Edit the daemonset of Fluentd:
-+
-----
-$ oc edit daemonset logging-fluentd
-
-resources:
-  limits:
-    cpu: 100m
-    memory: 512Mi
-----
-
-. Increase the values according to available resources. For example:
-+
-----
-resources:
-  limits:
-    cpu: 150m
-    memory: 1Gi
-----
-
-If the `mux` server is behind the incoming logs, the same configuration is
-avaialable. The memory limit is used to calculate the `mux` `buffer_queue_limit`
-as follows:
+The `buffer_type` and `buffer_path` are configured in the Fluentd config files as
+follows:
 
 ----
-buffer_queue_limit = resource memory limit / (number of output * buffer_chunk_size)
+$ egrep "buffer_type|buffer_path" *.conf
+output-es-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-output-es-config`
+output-es-ops-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-output-es-ops-config`
+es-copy-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-es-copy-config`
+es-ops-copy-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-es-ops-copy-config`
 ----
 
-By default, `buffer_chunk_size` is 1 MB.
+The Fluentd `buffer_queue_limit` is calculated as follows:
 
-. Edit the deploymentconfig of `mux`:
-+
 ----
-$ oc edit deploymentconfig logging-mux
-
-resources:
-  limits:
-    cpu: 500m
-    memory: 2Gi
-----
-
-. Increase the values according to available resources. For example:
-+
-----
-resources:
-  limits:
-    cpu: 600m
-    memory: 2.5Gi
+FILE_BUFFER_LIMIT / FILE_SIZE_LIMIT
 ----
 
 [[compute-resources]]


### PR DESCRIPTION
https://trello.com/c/XpreI533/509-5-use-file-buffer-instead-of-memory-buffer-for-fluentdloggingepic-ois-agl-perf

https://trello.com/c/IzxgZQcL/590-document-use-file-buffer-instead-of-memory-buffer-for-fluentdloggingepic-ois-agl-perf

