### PR TITLE
Bug 1481798: Add caveats that registry is secured/exposed by default

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -11,10 +11,21 @@
 
 toc::[]
 
-[[securing-the-registry]]
-== Securing the Registry
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+== Overview
 
-Optionally, you can secure the registry so that it serves traffic via TLS:
+By default, the OpenShift Container Registry is secured during cluster
+installation so that it serves traffic via TLS. A passthrough route is also
+created by default to expose the service externally.
+
+If for any reason your registry has not been secured or exposed, see the
+following sections for steps on how to manually do so.
+endif::[]
+
+[[securing-the-registry]]
+== Manually Securing the Registry
+
+To manually secure the registry to serve traffic via TLS:
 
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 . xref:../../install_config/registry/deploy_registry_existing_clusters.adoc#install-config-deploy-registry-existing-clusters[Deploy the registry].
@@ -221,40 +232,28 @@ Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
 ----
 
 [[exposing-the-registry]]
-== Exposing the Registry
+== Manually Exposing a Secure Registry
 
-To expose your internal registry externally, it is recommended that you run a
-xref:securing-the-registry[secure registry]. To expose the registry you must
-first have xref:../../install_config/router/index.adoc#install-config-router-overview[deployed a router].
+Instead of logging in to the OpenShift Container Registry from within the
+{product-title} cluster, you can gain external access to it by first securing
+the registry and then exposing it with a route. This allows you to log in to the
+registry from outside the cluster using the route address, and to tag and push
+images using the route host.
 
-. xref:../../install_config/registry/deploy_registry_existing_clusters.adoc#install-config-deploy-registry-existing-clusters[Deploy the registry].
-+
-. xref:securing-the-registry[Secure the registry].
-+
-. xref:../../install_config/router/index.adoc#install-config-router-overview[Deploy a router].
-+
-. Create a
-xref:../../architecture/networking/routes.adoc#secured-routes[passthrough]
-route via the `oc create route passthrough` command,
-specifying the registry as the route's service.
-By default, the name of the created route is the same as the service name.
-+
-For example:
-+
-----
-$ oc get svc
-NAME              CLUSTER_IP       EXTERNAL_IP   PORT(S)                 SELECTOR                  AGE
-docker-registry   172.30.69.167    <none>        5000/TCP                docker-registry=default   4h
-kubernetes        172.30.0.1       <none>        443/TCP,53/UDP,53/TCP   <none>                    4h
-router            172.30.172.132   <none>        80/TCP                  router=router             4h
+. Each of the following prerequisite steps are performed by default during a
+typical cluster installation. If they have not been, perform them manually:
 
-$ oc create route passthrough    \
-    --service=docker-registry    \//<1>
-    --hostname=<host>
-route "docker-registry" created     <2>
-----
-<1> Specify the registry as the route's service.
-<2> The route name is identical to the service name.
+.. xref:../../install_config/registry/deploy_registry_existing_clusters.adoc#install-config-deploy-registry-existing-clusters[Manually deploy the registry].
+
+.. xref:securing-the-registry[Manually secure the registry].
+
+.. xref:../../install_config/router/index.adoc#install-config-router-overview[Manually deploy a router].
+
+. A xref:../../architecture/core_concepts/routes.adoc#secured-routes[passthrough]
+route should have been created by default for the registry during the initial
+cluster installation:
+
+.. Verify whether the route exists:
 +
 ----
 $ oc get route/docker-registry -o yaml
@@ -270,30 +269,65 @@ spec:
   tls:
     termination: passthrough <3>
 ----
-<1> The host for your route.  You must be able to resolve this name externally via DNS to the router's IP address.
+<1> The host for your route. You must be able to resolve this name externally via
+DNS to the router's IP address.
 <2> The service name for your registry.
-<3> Specify this route as a passthrough route.
+<3> Specifies this route as a passthrough route.
 +
 [NOTE]
 ====
 Passthrough is currently the only type of route supported for exposing the
 secure registry.
 ====
+
+.. If it does not exist, create the route via the `oc create route passthrough`
+command, specifying the registry as the route’s service. By default, the name of
+the created route is the same as the service name:
+
+... Get the *docker-registry* service details:
 +
-. Next, you must trust the certificates being used for the registry on your host system.
-The certificates referenced were created when you secured your registry.
+----
+$ oc get svc
+NAME              CLUSTER_IP       EXTERNAL_IP   PORT(S)                 SELECTOR                  AGE
+docker-registry   172.30.69.167    <none>        5000/TCP                docker-registry=default   4h
+kubernetes        172.30.0.1       <none>        443/TCP,53/UDP,53/TCP   <none>                    4h
+router            172.30.172.132   <none>        80/TCP                  router=router             4h
+----
+
+... Create the route:
++
+----
+$ oc create route passthrough    \
+    --service=docker-registry    \//<1>
+    --hostname=<host>
+route "docker-registry" created     <2>
+----
+<1> Specifies the registry as the route's service.
+<2> The route name is identical to the service name.
+
+. Next, you must trust the certificates being used for the registry on your host
+system. The certificates referenced were created when you secured your registry.
 +
 ----
 $ sudo mkdir -p /etc/docker/certs.d/<host>
-$ sudo cp <ca certificate file> /etc/docker/certs.d/<host>
+$ sudo cp <ca_certificate_file> /etc/docker/certs.d/<host>
 $ sudo systemctl restart docker
 ----
-+
 
-. xref:../../install_config/registry/accessing_registry.adoc#access[Log in to the registry] using the information from securing the
-registry. However, this time point to the host name used in the route rather
-than your service IP. You should now be able to tag and push images using the
-route host.
+. xref:../../install_config/registry/accessing_registry.adoc#access[Log in to the registry] using the information from securing the registry. However, this time
+point to the host name used in the route rather than your service IP. When
+logging in to a secured and exposed registry, make sure you specify the registry
+in the `docker login` command:
++
+----
+# docker login -e user@company.com \
+    -u f83j5h6 \
+    -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 \
+    <host>
+----
+
+. You can now tag and push images using the route host. For example, to tag and
+push a `busybox` image in a project called `test`:
 +
 ----
 $ oc get imagestreams -n test
@@ -326,33 +360,9 @@ busybox   172.30.11.215:5000/test/busybox   latest    2 seconds ago
 Your image streams will have the IP address and port of the registry service,
 not the route name and port. See `oc get imagestreams` for details.
 ====
-+
-[NOTE]
-====
-In the `<host>/test/busybox` example above, `test` refers to the project name.
-====
-
-
-[[access-secure-registry-by-exposing-route]]
-=== Exposing a Secure Registry
-
-Instead of logging in to the registry from within the {product-title} cluster,
-you can gain external access to it by first
-xref:securing-the-registry[securing the registry] and then
-xref:exposing-the-registry[exposing the registry].
-This allows you to log in to the registry from outside the cluster using the
-route address, and to tag and push images using the route host.
-
-When
-xref:../../install_config/registry/accessing_registry.adoc#access-logging-in-to-the-registry[logging in] to the secured and exposed
-registry, make sure you specify the registry in the login command. For example:
-
-----
-docker login -e user@company.com -u f83j5h6 -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 registry.example.com:80
-----
 
 [[access-insecure-registry-by-exposing-route]]
-=== Exposing a Non-Secure Registry
+== Manually Exposing a Non-Secure Registry
 
 Instead of securing the registry in order to expose the registry, you can simply
 expose a non-secure registry for non-production {product-title} environments.
@@ -421,10 +431,12 @@ Also, ensure that Docker is running on the client.
 ====
 
 When
-xref:../../install_config/registry/accessing_registry.adoc#access-logging-in-to-the-registry[logging in] to the non-secured and
-exposed registry, make sure you specify the registry in the login command. For
-example:
+xref:../../install_config/registry/accessing_registry.adoc#access-logging-in-to-the-registry[logging in] to the non-secured and exposed registry, make sure you specify the registry
+in the `docker login` command. For example:
 
 ----
-docker login -e user@company.com -u f83j5h6 -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 registry.example.com:80
+# docker login -e user@company.com \
+    -u f83j5h6 \
+    -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 \
+    <host>
 ----


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1481798

The docs still acted like these this was not done by default already. Updated the doc to say what is likely already done by default, and frame the existing steps as _manual_ procedures you can do if for some reason the registry is no longer secured/exposed.

@abutcher @openshift/team-documentation PTAL:

http://file.rdu.redhat.com/~adellape/081617/regroute/install_config/registry/securing_and_exposing_registry.html