### PR TITLE
Removed excluder un/exclude steps from 3.4 upgrade

### DIFF
--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -206,27 +206,14 @@ To start an upgrade with the quick installer:
 
 . Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
 
-. Run the following command on each host to remove the *atomic-openshift* packages
-from the list of yum excludes on the host:
-+
-----
-# atomic-openshift-excluder unexclude
-----
-
 . Run the installer with the `upgrade` subcommand:
 +
 ----
 # atomic-openshift-installer upgrade
 ----
 . Then, follow the on-screen instructions to upgrade to the latest release.
-// tag::automated_upgrade_after_reboot[]
-. Run the following command on each host to add the *atomic-openshift* packages
-back to the list of yum excludes on the host:
-+
-----
-# atomic-openshift-excluder exclude
-----
 
+// tag::automated_upgrade_after_reboot[]
 . After all master and node upgrades have completed, a recommendation will be
 printed to reboot all hosts. After rebooting, if there are no additional
 features enabled, you can xref:verifying-the-upgrade[verify the upgrade].
@@ -343,13 +330,6 @@ To upgrade an existing {product-title} 3.3 or 3.4 cluster to the latest 3.4
 release:
 
 . Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-
-. Run the following command on each host to remove the *atomic-openshift* packages
-from the list of yum excludes on the host:
-+
-----
-# atomic-openshift-excluder unexclude
-----
 
 . Ensure the `deployment_type` parameter in your inventory file is set to
 `openshift-enterprise`.


### PR DESCRIPTION
Removed .excluder exclude and unexclude from upgrade per https://access.redhat.com/support/cases/#/case/01801897.

"So I'd just need that the 3.3 and 3.4 documentation is updated to remove any "excluder" commands in the actual upgrade procedures, similar to how it currently is in 3.5:"