### PR TITLE
Removing excluder un/exclude steps per case 01801897

### DIFF
--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -134,18 +134,6 @@ To prepare for an automated upgrade:
 # yum update atomic-openshift-utils
 ----
 
-. Install or update to the following latest available **-excluder* packages on
-each RHEL 7 system, which helps ensure your systems stay on the correct versions
-of *atomic-openshift* and *docker* packages when you are not trying to upgrade,
-according to the {product-title} version:
-+
-----
-# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
-----
-+
-These packages add entries to the `exclude` directive in the host's
-*_/etc/yum.conf_* file.
-
 . You must be logged in as a cluster administrative user on the master host for
 the upgrade to succeed:
 +
@@ -185,13 +173,6 @@ To start an upgrade with the quick installer:
 
 . Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
 
-. Run the following command on each host to remove the *atomic-openshift* packages
-from the list of yum excludes on the host:
-+
-----
-# atomic-openshift-excluder unexclude
-----
-
 . Run the installer with the `upgrade` subcommand:
 +
 ----
@@ -200,15 +181,7 @@ from the list of yum excludes on the host:
 . Then, follow the on-screen instructions to upgrade to the latest release.
 // tag::automated_upgrade_after_reboot[]
 . After all master and node upgrades have completed, a recommendation will be
-printed to reboot all hosts. Before rebooting, run the following command on each
-master and node host to add the *atomic-openshift* packages back to the list of
-yum excludes on the host:
-+
-----
-# atomic-openshift-excluder exclude
-----
-+
-Then reboot all hosts.
+printed to reboot all hosts. 
 
 . After rebooting, if there are no additional features enabled, you can
 xref:verifying-the-upgrade[verify the upgrade]. Otherwise, the next step depends

--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -1,5 +1,5 @@
-[[install-config-upgrading-automated-upgrades]]
-= Performing Automated In-place Cluster Upgrades
+[[install-config-upgrading-manual-upgrades]]
+= Performing Manual In-place Cluster Upgrades
 {product-author}
 {product-version}
 :latest-tag: v3.3.1.25
@@ -14,26 +14,16 @@ toc::[]
 
 == Overview
 
-If you installed using the
-xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
-and the inventory file that was used is available, you can use the upgrade
-playbook to automate the OpenShift cluster upgrade process.
-ifdef::openshift-enterprise[]
-If you installed using the
-xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation] method
-and a *_~/.config/openshift/installer.cfg.yml_* file is available, you can use
-the installer to perform the automated upgrade.
-endif::[]
+As an alternative to performing an
+xref:../../install_config/upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[automated upgrade],
+you can manually upgrade your OpenShift cluster. To manually upgrade without
+disruption, it is important to upgrade each component as documented in this
+topic.
 
-The automated upgrade performs the following steps for you:
-
-* Applies the latest configuration.
-* Upgrades and restart master services.
-* Upgrades and restart node services.
-* Applies the latest cluster policies.
-* Updates the default router if one exists.
-* Updates the default registry if one exists.
-* Updates default image streams and InstantApp templates.
+Before you begin your upgrade, familiarize yourself now with the entire
+procedure. xref:additional-instructions-per-release[Specific releases may
+require additional steps] to be performed at key points before or during the
+standard upgrade process.
 
 [IMPORTANT]
 ====
@@ -43,71 +33,11 @@ before proceeding with an upgrade. Failure to do so can result in a failed
 upgrade.
 ====
 
-ifdef::openshift-origin[]
-[[running-upgrade-playbooks]]
-== Running Upgrade Playbooks
-
-Ensure that you have the latest *openshift-ansible* code checked out:
-
-----
-# cd ~/openshift-ansible
-# git pull https://github.com/openshift/openshift-ansible master
-----
-
-Then run one of the following upgrade playbooks utilizing the inventory file you
-used during the advanced installation. If your inventory file is located
-somewhere other than the default *_/etc/ansible/hosts_*, add the `-i` flag to
-specify the location.
-
-[[upgrading-to-openshift-origin-1-1]]
-=== Upgrading to OpenShift Origin 1.1
-
-To upgrade from OpenShift Origin 1.0 to 1.1, run the following playbook:
-
-----
-# ansible-playbook \
-    [-i </path/to/inventory/file>] \
-    playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
-----
-
-[NOTE]
-====
-The *_v3_0_to_v3_1_* in the above path is a reference to the related OpenShift
-Enterprise versions, however it is also the correct playbook to use when
-upgrading from OpenShift Origin 1.0 to 1.1.
-====
-
-When the upgrade finishes, a recommendation will be printed to reboot all hosts.
-After rebooting, continue to Updating Master and Node Certificates.
-
-[[upgrading-to-openshift-origin-1-1-z-releases]]
-=== Upgrading to OpenShift Origin 1.1.z Releases
-
-To upgrade an existing OpenShift Origin 1.1 cluster to the latest 1.1.z release,
-run the following playbook:
-
-----
-# ansible-playbook \
-    [-i </path/to/inventory/file>] \
-    playbooks/byo/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
-----
-
-[NOTE]
-====
-The *v3_1_minor* in the above path is a reference to the related OpenShift
-Enterprise versions, however it is also the correct playbook to use when
-upgrading from OpenShift Origin 1.1 to the latest 1.1.z release.
-====
-
-When the upgrade finishes, a recommendation will be printed to reboot all hosts.
-After rebooting, continue to xref:verifying-the-upgrade[Verifying the Upgrade].
-endif::[]
+[[preparing-for-a-manual-upgrade]]
+== Preparing for a Manual Upgrade
 
 ifdef::openshift-enterprise[]
-[[preparing-for-an-automated-upgrade]]
-== Preparing for an Automated Upgrade
-
-[IMPORTANT]
+[NOTE]
 ====
 Before upgrading your cluster to {product-title} 3.3, the cluster must be
 already upgraded to the
@@ -115,182 +45,660 @@ link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_not
 minor version at a time, so if your cluster is at version 3.0 or 3.1, you must
 first upgrade incrementally (e.g., 3.0 to 3.1, then 3.1 or 3.2).
 ====
+endif::[]
 
-To prepare for an automated upgrade:
+To prepare for a manual upgrade, follow these steps:
 
-. If you are upgrading from version 3.2 to 3.3, manually disable the 3.2 channel and enable the 3.3 channel on each master and node host:
+ifdef::openshift-enterprise[]
+. If you are upgrading from version 3.2 to 3.3, manually disable the 3.2 channel
+and enable the 3.3 channel on each host:
 +
 ----
 # subscription-manager repos --disable="rhel-7-server-ose-3.2-rpms" \
-    --enable="rhel-7-server-ose-3.3-rpms"\
+    --enable="rhel-7-server-ose-3.3-rpms" \
     --enable="rhel-7-server-extras-rpms"
+----
++
+On RHEL 7 systems, also clear the *yum* cache:
++
+----
 # yum clean all
 ----
-. For any upgrade path, always ensure that you have the latest version of the
-*atomic-openshift-utils* package, which should also update the
-*openshift-ansible-** packages:
+endif::[]
+
+. Install or update to the latest available version of the
+*atomic-openshift-utils* package on each RHEL 7 system, which provides files
+that will be used in later sections:
 +
 ----
-# yum update atomic-openshift-utils
+# yum install atomic-openshift-utils
 ----
 
-. You must be logged in as a cluster administrative user on the master host for
-the upgrade to succeed:
+. Install or update to the following latest available **-excluder* packages on
+each RHEL 7 system, which helps ensure your systems stay on the correct versions
+of *atomic-openshift* and *docker* packages when you are not trying to upgrade,
+according to the {product-title} version:
 +
 ----
-$ oc login
+# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
 ----
++
+These packages add entries to the `exclude` directive in the host's
+*_/etc/yum.conf_* file.
 
-After satisfying these steps, there are two methods for running the automated
-upgrade:
-
-- xref:upgrading-using-the-installation-utility-to-upgrade[Using the installer]
-- xref:running-the-upgrade-playbook-directly[Running the upgrade playbook directly]
-
-Choose and follow one of these methods.
-
-[[upgrading-using-the-installation-utility-to-upgrade]]
-== Using the Installer to Upgrade
-
-If you installed {product-title} using the
-xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation] method,
-you should have an installation configuration file located at
-*_~/.config/openshift/installer.cfg.yml_*. The installer requires this file to
-start an upgrade.
-
-The installer supports upgrading between minor versions of {product-title}
-(one minor version at a time, e.g., 3.2 to 3.3) as well as between
-xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-asynchronous-errata-updates[asynchronous errata updates] within a minor version (e.g., 3.3.z).
-
-If you have an older format installation configuration file in
-*_~/.config/openshift/installer.cfg.yml_* from an installation of a previous
-cluster version, the installer will attempt to upgrade the file to the new supported
-format. If you do not have an installation configuration file of any format, you
-can
-xref:../../install_config/install/quick_install.adoc#defining-an-installation-configuration-file[create one manually].
-
-To start an upgrade with the quick installer:
-
-. Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-
-. Run the installer with the `upgrade` subcommand:
+. Create an *etcd* backup on each master. The *etcd* package is required, even if
+using embedded etcd, for access to the `etcdctl` command to make the backup. The
+package is installed by default for RHEL Atomic Host 7 systems. If the master is
+a RHEL 7 system, ensure the package is installed:
 +
 ----
-# atomic-openshift-installer upgrade
+# yum install etcd
 ----
-. Then, follow the on-screen instructions to upgrade to the latest release.
-// tag::automated_upgrade_after_reboot[]
-. After all master and node upgrades have completed, a recommendation will be
-printed to reboot all hosts. 
-
-. After rebooting, if there are no additional features enabled, you can
-xref:verifying-the-upgrade[verify the upgrade]. Otherwise, the next step depends
-on what additional features have you previously enabled.
 +
-[cols="1,4"]
-|===
-| Feature | Next Step
+Then, create the backup:
++
+====
+----
+# ETCD_DATA_DIR=/var/lib/origin/openshift.local.etcd <1>
+# etcdctl backup \
+    --data-dir $ETCD_DATA_DIR \
+    --backup-dir $ETCD_DATA_DIR.bak.<date> <2>
+----
+<1> This directory is for embedded etcd.
+For external etcd, use *_/var/lib/etcd_* instead.
+<2> Use the date of the backup, or some unique identifier, for `<date>`.
+The command will not make a backup if the `--backup-dir` location
+already exists.
+====
 
-| Aggregated Logging
-| xref:automated-upgrading-efk-logging-stack[Upgrade the EFK logging stack.]
-
-| Cluster Metrics
-| xref:automated-upgrading-cluster-metrics[Upgrade cluster metrics.]
-|===
-// end::automated_upgrade_after_reboot[]
-
-[[running-the-upgrade-playbook-directly]]
-== Running the Upgrade Playbook Directly
-
-You can run the automated upgrade playbook using Ansible directly, similar
-to the advanced installation method, if you have an inventory file.
-
-The same *_v3_3_* upgrade playbook can be used to upgrade either of the
-following to the latest 3.3 release:
-
-- xref:upgrading-to-ocp-3-3[Existing {product-title} 3.2 clusters]
-- xref:upgrading-to-ocp-3-3-asynchronous-releases[Existing {product-title} 3.3 clusters]
-
-[[upgrading-to-ocp-3-3]]
-=== Upgrading to {product-title} 3.3
-
-To run an upgrade from {product-title} 3.2 to 3.3:
-
-. Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-. Ensure the `*deployment_type*` parameter in your inventory file is set to
-`openshift-enterprise`.
-. If you have multiple masters configured and want to enable rolling, full system
-restarts of the hosts, you can set the `*openshift_rolling_restart_mode*`
-parameter in your inventory file to `system`. Otherwise, the default value
-`services` performs rolling service restarts on HA masters, but does not reboot
-the systems. See
-xref:../install/advanced_install.adoc#configuring-cluster-variables[Configuring
-Cluster Variables] for details.
-. Run the *_v3_3_* upgrade playbook. If your inventory file is located somewhere
-other than the default *_/etc/ansible/hosts_*, add the `-i` flag to specify the
-location. If you previously used the `atomic-openshift-installer` command to run
-your installation, you can check *_~/.config/openshift/hosts_* (previously
-located at *_~/.config/openshift/.ansible/hosts_*) for the last inventory file
-that was used, if needed.
+. For any upgrade path, ensure that you are running the latest kernel on
+each RHEL 7 system:
 +
 ----
-# ansible-playbook [-i </path/to/inventory/file>] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
+# yum update kernel
 ----
-include::install_config/upgrading/automated_upgrades.adoc[tag=automated_upgrade_after_reboot]
 
-[[upgrading-to-ocp-3-3-asynchronous-releases]]
-=== Upgrading to {product-title} 3.3 Asynchronous Releases
+[[upgrading-masters]]
+== Upgrading Master Components
+ifdef::openshift-origin[]
+Upgrade your masters first:
 
-To apply
-xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-asynchronous-errata-updates[asynchronous errata updates] to an existing {product-title} 3.3 cluster:
-
-. Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-. Run the *_v3_3_* upgrade playbook (the same playbook that is used for
-xref:upgrading-to-ocp-3-3[upgrading from {product-title} 3.2 to 3.3]). If your
-inventory file is located somewhere other than the default
-*_/etc/ansible/hosts_*, add the `-i` flag to specify the location. If you
-previously used the `atomic-openshift-installer` command to run your
-installation, you can check *_~/.config/openshift/hosts_* (previously located at
-*_~/.config/openshift/.ansible/hosts_*) for the last inventory file that was
-used, if needed.
+. On each master host, upgrade the *origin-master* package:
 +
 ----
-# ansible-playbook [-i </path/to/inventory/file>] \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
+# yum upgrade origin-master
 ----
-include::install_config/upgrading/automated_upgrades.adoc[tag=automated_upgrade_after_reboot]
+
+. If you are upgrading from OpenShift Origin 1.0 to 1.1:
+
+.. Create the following master proxy client certificates:
++
+----
+# cd /etc/origin/master/
+# oadm ca create-master-certs --cert-dir=/etc/origin/master/ \
+            --master=https://<internal-master-fqdn>:8443 \
+            --public-master=https://<external-master-fqdn>:8443 \
+            --hostnames=<external-master-fqdn>,<internal-master-fqdn>,localhost,127.0.0.1,<master-ip-address>,kubernetes.default.local \
+            --overwrite=false
+----
++
+This creates files at  *_/etc/origin/master/master.proxy-client.{crt,key}_*.
+Then, add the master proxy client certificates to the
+*_/etc/origin/master/master-config.yml_* file on each master:
++
+----
+kubernetesMasterConfig:
+  proxyClientInfo:
+    certFile: master.proxy-client.crt
+    keyFile: master.proxy-client.key
+----
+
+.. Enable the following renamed service(s) on master hosts.
++
+For single master clusters:
++
+----
+# systemctl enable origin-master
+----
++
+For multi-master clusters:
++
+----
+# systemctl enable origin-master-api
+# systemctl enable origin-master-controllers
+----
+
+. Restart the master service(s) on each master and review logs to ensure they
+restart successfully.
++
+For single master clusters:
++
+----
+# systemctl restart origin-master
+# journalctl -r -u origin-master
+----
++
+For multi-master clusters:
++
+----
+# systemctl restart origin-master-controllers
+# systemctl restart origin-master-api
+# journalctl -r -u origin-master-controllers
+# journalctl -r -u origin-master-api
+----
+
+. Because masters also have node components running on them in order to be
+configured as part of the OpenShift SDN, restart the *origin-node* and
+*openvswitch* services:
++
+----
+# systemctl restart origin-node
+# systemctl restart openvswitch
+# journalctl -r -u openvswitch
+# journalctl -r -u origin-node
+----
+endif::[]
+ifdef::openshift-enterprise[]
+Upgrade your master hosts first:
+
+. Run the following command on each master to remove the *atomic-openshift*
+packages from the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder unexclude
+----
+
+. Upgrade the *atomic-openshift* packages or related images.
+
+.. For masters using the RPM-based method on a RHEL 7 system, upgrade all installed
+*atomic-openshift* packages:
++
+----
+# yum upgrade atomic-openshift\*
+----
+
+.. For masters using the containerized method on a RHEL 7 or RHEL Atomic Host 7
+system, set the `*IMAGE_VERSION*` parameter to the version you are upgrading to
+in the following files:
++
+- *_/etc/sysconfig/atomic-openshift-master_* (single master clusters only)
+- *_/etc/sysconfig/atomic-openshift-master-controllers_* (multi-master clusters only)
+- *_/etc/sysconfig/atomic-openshift-master-api_* (multi-master clusters only)
+- *_/etc/sysconfig/atomic-openshift-node_*
+- *_/etc/sysconfig/atomic-openshift-openvswitch_*
++
+For example:
++
+----
+IMAGE_VERSION=<tag>
+----
++
+Replace `<tag>` with `{latest-tag}` for the latest version.
+
+. In {product-title} 3.3, protocol buffers are used by default for internal
+communications between node, masters, and controllers. To configure this, the
+following stanzas must be altered in the *_/etc/origin/master-config.yaml_*
+file on each master:
++
+====
+----
+masterClients:
+  externalKubernetesClientConnectionOverrides:
+    acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
+    contentType: application/vnd.kubernetes.protobuf
+    burst: 400
+    qps: 200
+  externalKubernetesKubeConfig: ""
+  openshiftLoopbackClientConnectionOverrides:
+    acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
+    contentType: application/vnd.kubernetes.protobuf
+    burst: 600
+    qps: 300
+  openshiftLoopbackKubeConfig: openshift-master.kubeconfig
+----
+====
++
+For more information on protocol buffers, see
+link:https://developers.google.com/protocol-buffers/docs/overview[https://developers.google.com/protocol-buffers/docs/overview].
+
+. In {product-title} 3.3, the
+`*kubernetesMasterConfig.admissionConfig.pluginConfig*` parameter in the
+*_/etc/origin/master-config.yaml_* file is being deprecated. If you are
+upgrading from version 3.2 to 3.3 and this parameter is in use, see
+xref:../../architecture/additional_concepts/admission_controllers.adoc#admission-controllers-general-admission-rules[General
+Admission Rules] for guidance on moving and merging into
+`*admissionConfig.pluginConfig*`.
+
+. Restart the master service(s) on each master and review logs to ensure they
+restart successfully.
++
+For single master clusters:
++
+----
+# systemctl restart atomic-openshift-master
+# journalctl -r -u atomic-openshift-master
+----
++
+For multi-master clusters:
++
+----
+# systemctl restart atomic-openshift-master-controllers
+# systemctl restart atomic-openshift-master-api
+# journalctl -r -u atomic-openshift-master-controllers
+# journalctl -r -u atomic-openshift-master-api
+----
+
+. Because masters also have node components running on them in order to be
+configured as part of the OpenShift SDN, restart the *atomic-openshift-node* and
+*openvswitch* services:
++
+----
+# systemctl restart atomic-openshift-node
+# systemctl restart openvswitch
+# journalctl -r -u openvswitch
+# journalctl -r -u atomic-openshift-node
+----
+
+. Run the following command on each master to add the *atomic-openshift* packages
+back to the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder exclude
+----
+
+endif::[]
+
+Upgrade any external etcd hosts using the RPM-based method on a RHEL 7 system:
+
+. Upgrade the *etcd* package:
++
+----
+# yum update etcd
+----
+
+. Restart the *etcd* service and review the logs to ensure it restarts
+successfully:
++
+----
+# systemctl restart etcd
+# journalctl -r -u etcd
+----
+
+ifdef::openshift-origin[]
+If you are performing a cluster upgrade that requires updating Docker to version
+1.10, you must also perform the following steps if you are not already on Docker 1.10:
+
+[IMPORTANT]
+====
+The node component on masters is set by default to unschedulable status during
+initial installation, so that pods are not deployed to them. However, it is
+possible to set them schedulable during the initial installation or manually
+thereafter. If any of your masters are also configured as a schedulable node,
+skip the following Docker upgrade steps for those masters and instead run all
+steps described in xref:upgrading-nodes[Upgrading Nodes] when you get to that
+section for those hosts as well.
+====
+
+. Run the following script on each master and external etcd host to remove all
+containers and images, which is required to avoid a long upgrade process for
+older images after Docker is updated. Containers and images for pods backed by
+replication controllers will be recreated automatically:
++
+----
+# chmod u+x /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
+# /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
+----
+
+. Upgrade Docker.
+
+.. For RHEL 7 systems:
++
+----
+# yum update docker
+----
++
+Then, restart the *docker* service and review the logs to ensure it restarts
+successfully:
++
+----
+# systemctl restart docker
+# journalctl -r -u docker
+----
+
+.. For RHEL Atomic Host 7 systems, upgrade to the latest Atomic tree if one is
+available:
++
+[NOTE]
+====
+If upgrading to RHEL Atomic Host 7.2.5, this upgrades Docker to version 1.10.
+See the
+ifdef::openshift-enterprise[]
+xref:../../release_notes/ose_3_2_release_notes.adoc#ose-3-2-1-1-enhancements[{product-title}
+3.2.1.1 release notes] for details and known issues.
+endif::[]
+ifdef::openshift-origin[]
+link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-3-2-1-1-enhancements[OpenShift
+Enterprise 3.2.1.1 release notes] for details and known issues.
+endif::[]
+====
++
+----
+# atomic host upgrade
+----
++
+After the upgrade is completed and prepared for the next boot, reboot the host
+and ensure the *docker* service starts successfully:
++
+----
+# systemctl reboot
+# journalctl -r -u docker
+----
+endif::[]
+
+[NOTE]
+====
+During the cluster upgrade, it can sometimes be useful to take a master out of
+rotation since some DNS client libraries will not properly to the other masters
+for cluster DNS. In addition to stopping the master and controller services, you
+can remove the EndPoint from the Kubernetes service's `*subsets.addresses*`.
+
+----
+$ oc edit ep/kubernetes -n default
+----
+
+When the master is restarted, the Kubernetes service will be automatically
+updated.
+====
+
+[[updating-policy-definitions]]
+== Updating Policy Definitions
+
+After a cluster upgrade, the recommended
+xref:../../architecture/additional_concepts/authorization.adoc#roles[default
+cluster roles] may be updated. To check if an update is recommended for
+your environment, you can run:
+
+----
+# oadm policy reconcile-cluster-roles
+----
+
+[WARNING]
+====
+If you have customized default cluster roles and want to ensure a role reconciliation
+does not modify those customized roles, annotate them with `openshift.io/reconcile-protect`
+set to `true`. Doing so means you are responsible for manually updating those roles with
+any new or required permissions during upgrades.
+====
+
+This command outputs a list of roles that are out of date and their new proposed
+values. For example:
+
+====
+----
+# oadm policy reconcile-cluster-roles
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: admin
+  rules:
+  - attributeRestrictions: null
+    resources:
+    - builds/custom
+...
+----
+====
+
+[NOTE]
+====
+Your output will vary based on the OpenShift version and any local
+customizations you have made. Review the proposed policy carefully.
+====
+
+You can either modify this output to re-apply any local policy changes you have
+made, or you can automatically apply the new policy using the following process:
+
+. Reconcile the cluster roles:
++
+----
+# oadm policy reconcile-cluster-roles \
+    --additive-only=true \
+    --confirm
+----
+
+. Reconcile the cluster role bindings:
++
+----
+# oadm policy reconcile-cluster-role-bindings \
+    --exclude-groups=system:authenticated \
+    --exclude-groups=system:authenticated:oauth \
+    --exclude-groups=system:unauthenticated \
+    --exclude-users=system:anonymous \
+    --additive-only=true \
+    --confirm
+----
+
+. Reconcile security context constraints:
++
+----
+# oadm policy reconcile-sccs \
+    --additive-only=true \
+    --confirm
+----
+
+[[upgrading-nodes]]
+== Upgrading Nodes
+
+After upgrading your masters, you can upgrade your nodes. When restarting the
+ifdef::openshift-origin[]
+*origin-node* service, there will be a brief disruption of outbound network
+endif::[]
+ifdef::openshift-enterprise[]
+*atomic-openshift-node* service, there will be a brief disruption of outbound network
+endif::[]
+connectivity from running pods to services while the
+xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#service-proxy[service
+proxy] is restarted. The length of this disruption should be very short and
+scales based on the number of services in the entire cluster.
+
+[NOTE]
+====
+xref:../../install_config/upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[Blue-green
+deployments] are another proven approach to reducing downtime caused while
+updating an environment.
+====
+
+One at at time for each node that is not also a master, you must disable
+scheduling and evacuate its pods to other nodes, then upgrade packages and
+restart services.
+
+
+. Run the following command on each node to remove the *atomic-openshift*
+packages from the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder unexclude
+----
+
+. As a user with *cluster-admin* privileges, disable scheduling for the node:
++
+----
+# oadm manage-node <node> --schedulable=false
+----
+
+. Evacuate pods on the node to other nodes:
++
+[IMPORTANT]
+====
+The `--force` option deletes any pods that are not backed by a replication
+controller.
+====
++
+----
+# oadm manage-node <node> --evacuate --force
+----
+
+ifdef::openshift-origin[]
+. On the node host, upgrade all *origin* packages:
++
+----
+# yum upgrade origin\*
+----
+
+. If you are upgrading from OpenShift Origin 1.0 to 1.1, enable the following
+renamed service on the node host:
++
+----
+# systemctl enable origin-node
+----
+
+. Restart the *origin-node* and *openvswitch* services and review the logs to
+ensure they restart successfully:
++
+----
+# systemctl restart origin-node
+# systemctl restart openvswitch
+# journalctl -r -u origin-node
+# journalctl -r -u openvswitch
+----
+
+endif::[]
+ifdef::openshift-enterprise[]
+. Upgrade the node component packages or related images.
+
+.. For nodes using the RPM-based method on a RHEL 7 system, upgrade all installed
+*atomic-openshift* packages:
++
+----
+# yum upgrade atomic-openshift\*
+----
+
+.. For nodes using the containerized method on a RHEL 7 or RHEL Atomic Host 7
+system, set the `*IMAGE_VERSION*` parameter in the
+*_/etc/sysconfig/atomic-openshift-node_* and *_/etc/sysconfig/openvswitch_*
+files to the version you are upgrading to. For example:
++
+----
+IMAGE_VERSION=<tag>
+----
++
+Replace `<tag>` with `{latest-tag}` for the latest version.
+
+. In {product-title} 3.3, protocol buffers are used by default for internal
+communications between node, masters, and controllers. To configure this, the
+following stanzas must be altered in the *_/etc/origin/node-config.yaml_*
+file on each node:
++
+----
+masterClientConnectionOverrides:
+  acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
+  contentType: application/vnd.kubernetes.protobuf
+  burst: 200
+  qps: 100
+----
++
+For more information on protocol buffers, see
+link:https://developers.google.com/protocol-buffers/docs/overview[https://developers.google.com/protocol-buffers/docs/overview].
+
+. Restart the *atomic-openshift-node* and *openvswitch* services and review the
+logs to ensure they restart successfully:
++
+----
+# systemctl restart atomic-openshift-node
+# systemctl restart openvswitch
+# journalctl -r -u atomic-openshift-node
+# journalctl -r -u openvswitch
+----
 endif::[]
 
 ifdef::openshift-origin[]
-:sect: automated
-include::install_config/upgrading/manual_upgrades.adoc[tag=30to31updatingcerts]
+. If you are performing a cluster upgrade that requires updating Docker to version
+1.10, you must also perform the following steps if you are not already on Docker 1.10:
+
+.. Run the following script to remove all containers and images, which is required
+to avoid a long upgrade process for older images after Docker is updated.
+Containers and images for pods backed by replication controllers will be
+recreated automatically:
++
+----
+# chmod u+x /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
+# /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/upgrades/files/nuke_images.sh
+----
+
+.. Upgrade Docker.
+
+... For RHEL 7 systems:
++
+----
+# yum update docker
+----
++
+Then, restart the *docker* service and review the logs to ensure it restarts
+successfully:
++
+----
+# systemctl restart docker
+# journalctl -r -u docker
+----
++
+After Docker is restarted, restart the *atomic-openshift-node* service again and
+review the logs to ensure it restarts successfully:
++
+----
+# systemctl restart atomic-openshift-node
+# journalctl -r -u atomic-openshift-node
+----
+
+... For RHEL Atomic Host 7 systems, upgrade to the latest Atomic tree if one is
+available:
++
+[NOTE]
+====
+If upgrading to RHEL Atomic Host 7.2.5, this upgrades Docker to version 1.10.
+See the
+ifdef::openshift-enterprise[]
+xref:../../release_notes/ose_3_2_release_notes.adoc#ose-3-2-1-1-enhancements[{product-title}
+3.2.1.1 release notes] for details and known issues.
+endif::[]
+ifdef::openshift-origin[]
+link:https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-3-2-1-1-enhancements[OpenShift
+Enterprise 3.2.1.1 release notes] for details and known issues.
+endif::[]
+====
++
+----
+# atomic host upgrade
+----
++
+After the upgrade is completed and prepared for the next boot, reboot the host
+and ensure the *docker* service starts successfully:
++
+----
+# systemctl reboot
+# journalctl -r -u docker
+----
 endif::[]
 
-[[automated-upgrading-efk-logging-stack]]
-== Upgrading the EFK Logging Stack
+. Re-enable scheduling for the node:
++
+----
+# oadm manage-node <node> --schedulable
+----
 
-If you have previously xref:../../install_config/aggregate_logging.adoc#install-config-aggregate-logging[deployed
-the EFK logging stack] and want to upgrade to the latest logging component
-images, the steps must be performed manually as shown in
-xref:../../install_config/upgrading/manual_upgrades.adoc#manual-upgrading-efk-logging-stack[Manual
-Upgrades].
+. Run the following command on the node to add the *atomic-openshift* packages
+back to the list of yum excludes on the host:
++
+----
+# atomic-openshift-excluder exclude
+----
 
-[[automated-upgrading-cluster-metrics]]
-== Upgrading Cluster Metrics
+. Repeat these steps on the next node, and continue repeating these steps until
+all nodes have been upgraded.
 
-If you have previously
-xref:../../install_config/cluster_metrics.adoc#install-config-cluster-metrics[deployed cluster metrics],
-you must manually
-xref:../../install_config/upgrading/manual_upgrades.adoc#manual-upgrading-cluster-metrics[update]
-to the latest metric components.
-
-[[verifying-the-upgrade]]
-== Verifying the Upgrade
-
-To verify the upgrade:
-
-. First check that all nodes are marked as *Ready*:
+. After all nodes have been upgraded, as a user with *cluster-admin* privileges,
+verify that all nodes are showing as *Ready*:
 +
 ----
 # oc get nodes
@@ -299,12 +707,1006 @@ master.example.com          Ready,SchedulingDisabled   165d
 node1.example.com           Ready                      165d
 node2.example.com           Ready                      165d
 ----
-. Then, verify that you are running the expected versions of the *docker-registry*
+
+[[upgrading-the-router]]
+== Upgrading the Router
+
+If you have previously
+xref:../../install_config/router/index.adoc#install-config-router-overview[deployed a router], the
+router deployment configuration must be upgraded to apply updates contained in
+the router image. To upgrade your router without disrupting services, you must
+have previously deployed a
+xref:../../admin_guide/high_availability.adoc#configuring-a-highly-available-routing-service[highly-available
+routing service].
+
+ifdef::openshift-enterprise[]
+[NOTE]
+====
+If you previously customized your HAProxy routing template, then, depending on
+the changes, additional steps may be required due to changes in the routing data
+structure starting in {product-title} 3.3. See xref:../../release_notes/ocp_3_3_release_notes.adoc#ocp-33-routing-data-structure-changes[Routing Data Structure Changes] in the {product-title} 3.3 Release Notes for details.
+====
+endif::[]
+
+ifdef::openshift-origin[]
+[IMPORTANT]
+====
+If you are upgrading to OpenShift Origin 1.0.4 or 1.0.5, first see the
+xref:additional-instructions-per-release[Additional Manual Instructions per
+Release] section for important steps specific to your upgrade, then continue
+with the router upgrade as described in this section.
+====
+endif::[]
+
+Edit your router's deployment configuration. For example, if it has the default
+*router* name:
+
+====
+----
+# oc edit dc/router
+----
+====
+
+Apply the following changes:
+
+====
+----
+...
+spec:
+ template:
+    spec:
+      containers:
+      - env:
+        ...
+ifdef::openshift-enterprise[]
+        image: registry.access.redhat.com/openshift3/ose-haproxy-router:<tag> <1>
+endif::[]
+ifdef::openshift-origin[]
+        image: openshift/origin-haproxy-router:v1.0.6 <1>
+endif::[]
+        imagePullPolicy: IfNotPresent
+        ...
+----
+====
+<1> Adjust `<tag>` to match the version you are upgrading to (use `{latest-tag}`
+for the latest version).
+
+You should see one router pod updated and then the next.
+
+[[upgrading-the-registry]]
+== Upgrading the Registry
+
+The registry must also be upgraded for changes to take effect in the registry
+image. If you have used a `*PersistentVolumeClaim*` or a host mount point, you
+may restart the registry without losing the contents of your registry.
+xref:../../install_config/registry/deploy_registry_existing_clusters.adoc#storage-for-the-registry[Storage for the Registry] details how to configure persistent storage for the registry.
+
+Edit your registry's deployment configuration:
+
+----
+# oc edit dc/docker-registry
+----
+
+Apply the following changes:
+
+----
+...
+spec:
+ template:
+    spec:
+      containers:
+      - env:
+        ...
+ifdef::openshift-enterprise[]
+        image: registry.access.redhat.com/openshift3/ose-docker-registry:<tag> <1>
+endif::[]
+ifdef::openshift-origin[]
+        image: openshift/origin-docker-registry:v1.0.4 <1>
+endif::[]
+        imagePullPolicy: IfNotPresent
+        ...
+----
+<1> Adjust `<tag>` to match the version you are upgrading to (use `{latest-tag}`
+for the latest version).
+
+[IMPORTANT]
+====
+Images that are being pushed or pulled from the internal registry at the time of
+upgrade will fail and should be restarted automatically. This will not disrupt
+pods that are already running.
+====
+
+[[updating-the-registry-configuration-file]]
+=== Updating Custom Registry Configuration Files
+
+[NOTE]
+====
+You may safely skip this part if you do not use a custom registry configuration
+file.
+====
+
+The internal Docker registry
+ifdef::openshift-enterprise[]
+version 3.3.0
+endif::[]
+ifdef::openshift-origin[]
+version 1.3.0
+endif::[]
+and higher requires following entries in the
+xref:../registry/extended_registry_configuration.adoc#docker-registry-configuration-reference-middleware[middleware
+section] of the configuration file:
+
+====
+[source,yaml]
+middleware:
+  registry:
+    - name: openshift
+  repository:
+    - name: openshift
+  storage:
+    - name: openshift
+====
+
+. Edit your custom configuration file, adding the missing entries.
+
+. xref:../registry/extended_registry_configuration.adoc#advanced-overriding-the-registry-configuration[Deploy
+your updated configuration].
+
+. Append the `--overwrite` flag to `oc volume
+dc/docker-registry --add` to replace a volume mount of your previous secret.
+
+. You can safely remove the old secret.
+
+[[enforcing-quota-in-the-registry]]
+=== Enforcing Quota in the Registry
+
+Quota must be enforced to prevent layer blobs that exceed the size limit from
+being written to the registry's storage. This can be achieved via a
+xref:../registry/extended_registry_configuration.adoc#registry-configuration-reference[configuration file]:
+====
+----
+...
+middleware:
+  repository:
+    - name: openshift
+      options:
+        enforcequota: true
+...
+----
+====
+
+Alternatively, use the `*REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA*`
+environment variable, which is set to `*true*` for the new registry deployments
+by default. Existing deployments need to be modified using:
+
+----
+# oc set env dc/docker-registry REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA=true
+----
+
+[[updating-the-default-image-streams-and-templates]]
+== Updating the Default Image Streams and Templates
+
+ifdef::openshift-origin[]
+By default, the xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced
+installation] method automatically creates default image streams, InstantApp
+templates, and database service templates in the *openshift* project, which is a
+default project to which all users have view access. These objects were created
+during installation from the JSON files located under
+*_/usr/share/openshift/examples_*.
+
+To update these objects:
+
+. Ensure that you have the latest *openshift-ansible* code checked out, which
+provides the example JSON files:
++
+----
+# cd ~/openshift-ansible
+# git pull https://github.com/openshift/openshift-ansible master
+----
+endif::[]
+ifdef::openshift-enterprise[]
+By default, the xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] and
+xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
+methods automatically create default image streams, InstantApp templates, and
+database service templates in the *openshift* project, which is a default
+project to which all users have view access. These objects were created during
+installation from the JSON files located under the
+*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/_*
+directory.
+
+[NOTE]
+====
+Because RHEL Atomic Host 7 cannot use *yum* to update packages, the following
+steps must take place on a RHEL 7 system.
+====
+
+. Update the packages that provide the example JSON files. On a subscribed Red
+Hat Enterprise Linux 7 system where you can run the CLI as a user with
+*cluster-admin* permissions, install or update to the latest version of the
+*atomic-openshift-utils* package, which should also update the
+*openshift-ansible-* packages:
++
+----
+# yum update atomic-openshift-utils
+----
++
+The *openshift-ansible-roles* package provides the latest example JSON files.
+endif::[]
+
+. After a manual upgrade, get the latest templates from
+*openshift-ansible-roles*:
++
+====
+----
+rpm -ql openshift-ansible-roles | grep examples | grep v1.3
+----
+====
++
+In this example,
+*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/image-streams-rhel7.json_*
+is the latest file that you want in the latest *openshift-ansible-roles* package.
++
+*_/usr/share/openshift/examples/image-streams/image-streams-rhel7.json_* is not
+owned by a package, but is updated by Ansible. If you are upgrading outside of
+Ansible. you need to get the latest .json files on the system where you are
+running `oc`, which can run anywhere that has access to the master.
+
+. Install *atomic-openshift-utils* and its dependencies to install the new content
+into
+*_/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/_*.:
++
+====
+----
+$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/image-streams-rhel7.json
+$ oc create -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/dotnet_imagestreams.json
+$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/image-streams-rhel7.json
+$ oc replace -n openshift -f  /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/image-streams/dotnet_imagestreams.json
+----
+====
+
+. Update the templates:
++
+====
+----
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/db-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-templates/
+$ oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-streams/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/db-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-templates/
+$ oc replace -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/xpaas-streams/
+----
+====
++
+Errors are generated for items that already exist. This is expected behavior:
++
+====
+----
+# oc create -n openshift -f /usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/cakephp-mysql.json": templates "cakephp-mysql-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/cakephp.json": templates "cakephp-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/dancer-mysql.json": templates "dancer-mysql-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/dancer.json": templates "dancer-example" already exists
+Error from server: error when creating "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.3/quickstart-templates/django-postgresql.json": templates "django-psql-example" already exists
+----
+====
+
+Now, content can be updated. Without running the automated upgrade playbooks,
+the content is not updated in *_/usr/share/openshift/_*.
+
+[[importing-the-latest-images]]
+== Importing the Latest Images
+
+After xref:updating-the-default-image-streams-and-templates[updating the
+default image streams], you may also want to ensure that the images within those
+streams are updated. For each image stream in the default *openshift* project,
+you can run:
+
+----
+# oc import-image -n openshift <imagestream>
+----
+
+For example, get the list of all image streams in the default *openshift*
+project:
+
+====
+----
+# oc get is -n openshift
+NAME     DOCKER REPO                                                      TAGS                   UPDATED
+mongodb  registry.access.redhat.com/openshift3/mongodb-24-rhel7           2.4,latest,v3.1.1.6    16 hours ago
+mysql    registry.access.redhat.com/openshift3/mysql-55-rhel7             5.5,latest,v3.1.1.6    16 hours ago
+nodejs   registry.access.redhat.com/openshift3/nodejs-010-rhel7           0.10,latest,v3.1.1.6   16 hours ago
+...
+----
+====
+
+Update each image stream one at a time:
+
+====
+----
+# oc import-image -n openshift nodejs
+The import completed successfully.
+
+Name:			nodejs
+Created:		10 seconds ago
+Labels:			<none>
+Annotations:		openshift.io/image.dockerRepositoryCheck=2016-07-05T19:20:30Z
+Docker Pull Spec:	172.30.204.22:5000/openshift/nodejs
+
+Tag	Spec								Created		PullSpec						Image
+latest	4								9 seconds ago	registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest	570ad8ed927fd5c2c9554ef4d9534cef808dfa05df31ec491c0969c3bd372b05
+4	registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest		9 seconds ago	<same>							570ad8ed927fd5c2c9554ef4d9534cef808dfa05df31ec491c0969c3bd372b05
+0.10	registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest	9 seconds ago	<same>							a1ef33be788a28ec2bdd48a9a5d174ebcfbe11c8e986d2996b77f5bccaaa4774
+----
+====
+
+[IMPORTANT]
+====
+In order to update your S2I-based applications, you must manually trigger a new
+build of those applications after importing the new images using `oc start-build
+<app-name>`.
+====
+
+ifdef::openshift-origin[]
+:sect: manual
+// tag::30to31updatingcerts[]
+[id='{sect}-updating-master-and-node-certificates']
+== Updating Master and Node Certificates
+
+The following steps may be required for any OpenShift cluster that was
+originally installed prior to the
+https://github.com/openshift/origin/releases[OpenShift Origin 1.0.8 release].
+This may include any and all updates from that version.
+
+[id='{sect}-updating-node-certificates']
+=== Node Certificates
+
+With the 1.0.8 release, certificates for each of the kubelet nodes were updated
+to include the IP address of the node. Any node certificates generated before
+the 1.0.8 release may not contain the IP address of the node.
+
+If a node is missing the IP address as part of its certificate, clients may
+refuse to connect to the kubelet endpoint. Usually this will result in errors
+regarding the certificate not containing an `IP SAN`.
+
+In order to remedy this situation, you may need to manually update the
+certificates for your node.
+
+[id='{sect}-checking-the-nodes-certificate']
+==== Checking the Node's Certificate
+
+The following command can be used to determine which Subject Alternative Names
+(SANs) are present in the node's serving certificate. In this example, the
+Subject Alternative Names are *mynode*, *mynode.mydomain.com*, and *1.2.3.4*:
+
+====
+----
+# openssl x509 -in /etc/origin/node/server.crt -text -noout | grep -A 1 "Subject Alternative Name"
+X509v3 Subject Alternative Name:
+DNS:mynode, DNS:mynode.mydomain.com, IP: 1.2.3.4
+----
+====
+
+Ensure that the `*nodeIP*` value set in the
+*_/etc/origin/node/node-config.yaml_* file is present in the IP values from the
+Subject Alternative Names listed in the node's serving certificate. If the
+`*nodeIP*` is not present, then it will need to be added to the node's
+certificate.
+
+If the `*nodeIP*` value is already contained within the Subject Alternative
+Names, then no further steps are required.
+
+You will need to know the Subject Alternative Names and `*nodeIP*` value for the
+following steps.
+
+[id='{sect}-generating-a-new-node-certificate']
+==== Generating a New Node Certificate
+
+If your current node certificate does not contain the proper IP address, then
+you must regenerate a new certificate for your node.
+
+[IMPORTANT]
+====
+Node certificates will be regenerated on the master (or first master) and are
+then copied into place on node systems.
+====
+
+. Create a temporary directory in which to perform the following steps:
++
+----
+# mkdir /tmp/node_certificate_update
+# cd /tmp/node_certificate_update
+----
+
+. Export the signing options:
++
+----
+# export signing_opts="--signer-cert=/etc/origin/master/ca.crt \
+    --signer-key=/etc/origin/master/ca.key \
+    --signer-serial=/etc/origin/master/ca.serial.txt"
+----
+
+. Generate the new certificate:
++
+----
+# oadm ca create-server-cert --cert=server.crt \
+  --key=server.key $signing_opts \
+  --hostnames=<existing_SANs>,<nodeIP>
+----
++
+For example, if the Subject Alternative Names from before were *mynode*,
+*mynode.mydomain.com*, and *1.2.3.4*, and the `*nodeIP*` was 10.10.10.1, then
+you would need to run the following command:
++
+----
+# oadm ca create-server-cert --cert=server.crt \
+  --key=server.key $signing_opts \
+  --hostnames=mynode,mynode.mydomain.com,1.2.3.4,10.10.10.1
+----
+
+[id='{sect}-replace-node-serving-certificates']
+==== Replace Node Serving Certificates
+
+Back up the existing *_/etc/origin/node/server.crt_* and
+*_/etc/origin/node/server.key_* files for your node:
+
+----
+# mv /etc/origin/node/server.crt /etc/origin/node/server.crt.bak
+# mv /etc/origin/node/server.key /etc/origin/node/server.key.bak
+----
+
+You must now copy the new *_server.crt_* and *_server.key_* created in the
+temporary directory during the previous step:
+
+----
+# mv /tmp/node_certificate_update/server.crt /etc/origin/node/server.crt
+# mv /tmp/node_certificate_update/server.key /etc/origin/node/server.key
+----
+
+After you have replaced the node's certificate, restart the node service:
+
+----
+# systemctl restart origin-node
+----
+
+[id='{sect}-updating-master-certificates']
+=== Master Certificates
+
+With the 1.0.8 release, certificates for each of the masters were updated to
+include all names that pods may use to communicate with masters. Any master
+certificates generated before the 1.0.8 release may not contain these additional
+service names.
+
+[id='{sect}-checking-the-masters-certificate']
+==== Checking the Master's Certificate
+
+The following command can be used to determine which Subject Alternative Names
+(SANs) are present in the master's serving certificate. In this example, the
+Subject Alternative Names are *mymaster*, *mymaster.mydomain.com*, and
+*1.2.3.4*:
+
+----
+# openssl x509 -in /etc/origin/master/master.server.crt -text -noout | grep -A 1 "Subject Alternative Name"
+X509v3 Subject Alternative Name:
+DNS:mymaster, DNS:mymaster.mydomain.com, IP: 1.2.3.4
+----
+
+Ensure that the following entries are present in the Subject Alternative Names
+for the master's serving certificate:
+
+[options="header"]
+|===
+|Entry |Example
+
+|Kubernetes service IP address
+|172.30.0.1
+
+|All master host names
+|*master1.example.com*
+
+|All master IP addresses
+|192.168.122.1
+
+|Public master host name in clustered environments
+|*public-master.example.com*
+
+|*kubernetes*
+|
+
+|*kubernetes.default*
+|
+
+|*kubernetes.default.svc*
+|
+
+|*kubernetes.default.svc.cluster.local*
+|
+
+|*openshift*
+|
+
+|*openshift.default*
+|
+
+|*openshift.default.svc*
+|
+
+|*openshift.default.svc.cluster.local*
+|
+|===
+
+If these names are already contained within the Subject Alternative Names, then
+no further steps are required.
+
+[id='{sect}-generating-a-new-master-certificate']
+==== Generating a New Master Certificate
+
+If your current master certificate does not contain all names from the list
+above, then you must generate a new certificate for your master:
+
+. Back up the existing *_/etc/origin/master/master.server.crt_* and
+*_/etc/origin/master/master.server.key_* files for your master:
++
+----
+# mv /etc/origin/master/master.server.crt /etc/origin/master/master.server.crt.bak
+# mv /etc/origin/master/master.server.key /etc/origin/master/master.server.key.bak
+----
+
+. Export the service names. These names will be used when generating the new
+certificate:
++
+----
+# export service_names="kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local,openshift,openshift.default,openshift.default.svc,openshift.default.svc.cluster.local"
+----
+
+. You will need the first IP in the services
+subnet (the *kubernetes* service IP) as well as the values of `*masterIP*`,
+`*masterURL*` and `*publicMasterURL*` contained in the
+*_/etc/origin/master/master-config.yaml_* file for the following steps.
++
+The *kubernetes* service IP can be obtained with:
++
+----
+# oc get svc/kubernetes --template='{{.spec.clusterIP}}'
+----
+
+. Generate the new certificate:
++
+====
+----
+# oadm ca create-master-certs \
+      --hostnames=<master_hostnames>,<master_IP_addresses>,<kubernetes_service_IP>,$service_names \ <1> <2> <3>
+      --master=<internal_master_address> \ <4>
+      --public-master=<public_master_address> \ <5>
+      --cert-dir=/etc/origin/master/ \
+      --overwrite=false
+----
+<1> Adjust `<master_hostnames>` to match your master host name. In a clustered
+environment, add all master host names.
+<2> Adjust `<master_IP_addresses>` to match the value of `*masterIP*`. In a
+clustered environment, add all master IP addresses.
+<3> Adjust `<kubernetes_service_IP>` to the first IP in the *kubernetes*
+services subnet.
+<4> Adjust `<internal_master_address>` to match the value of `*masterURL*`.
+<5> Adjust `<public_master_address>` to match the value of `*masterPublicURL*`.
+====
+
+. Restart master services. For single master deployments:
++
+----
+# systemctl restart origin-master
+----
++
+For native HA multiple master deployments:
++
+----
+# systemctl restart origin-master-api
+# systemctl restart origin-master-controllers
+----
++
+After the service restarts, the certificate update is complete.
+// end::30to31updatingcerts[]
+endif::[]
+
+[[manual-upgrading-efk-logging-stack]]
+== Upgrading the EFK Logging Stack
+
+Use the following to upgrade an
+xref:../../install_config/aggregate_logging.adoc#install-config-aggregate-logging[already-deployed EFK logging
+stack].
+
+[NOTE]
+====
+The following steps apply when upgrading to {product-title}
+ifdef::openshift-origin[]
+1.3+.
+endif::[]
+ifdef::openshift-enterprise[]
+3.3+.
+endif::[]
+====
+
+. Ensure you are working in the project where the EFK stack was previously
+deployed. For example, if the project is named *logging*:
++
+----
+$ oc project logging
+----
+
+. Recreate the deployer templates for service accounts and running the deployer:
++
+ifdef::openshift-enterprise[]
+----
+$ oc apply -n openshift -f \
+    /usr/share/openshift/examples/infrastructure-templates/enterprise/logging-deployer.yaml
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+$ oc apply -n openshift -f \
+    https://raw.githubusercontent.com/openshift/origin-aggregated-logging/master/deployer/deployer.yaml
+----
+endif::[]
+
+. Generate any missing service accounts and roles:
++
+----
+$ oc process logging-deployer-account-template | oc apply -f -
+----
+
+. Ensure that the cluster role `oauth-editor` is assigned to the *logging-deployer*
+service account:
++
+----
+$ oadm policy add-cluster-role-to-user oauth-editor \
+       system:serviceaccount:logging:logging-deployer
+----
+
+. In preparation for running the deployer, ensure that you have the configurations
+for your current deployment in the xref:../aggregate_logging.adoc#aggregate-logging-specifying-deployer-parameters[*logging-deployer* ConfigMap].
++
+[IMPORTANT]
+====
+Ensure that your image version is the latest version, not the currently installed
+version.
+====
+
+. Run the deployer with the parameter in `upgrade` mode:
++
+----
+$ oc new-app logging-deployer-template -p MODE=upgrade
+----
++
+Running the deployer in this mode handles scaling down the components to
+minimize loss of logs, patching configurations, generating missing secrets and
+keys, and scaling the components back up to their previous replica count.
++
+[IMPORTANT]
+====
+Due to the privileges needed to label and unlabel a node for controlling the deployment
+of Fluentd pods, the deployer does delete the *logging-fluentd* Daemonset and recreates
+it from the *logging-fluentd-template* template.
+====
+
+[[manual-upgrading-cluster-metrics]]
+== Upgrading Cluster Metrics
+
+After upgrading an
+xref:../../install_config/cluster_metrics.adoc#install-config-cluster-metrics[already-deployed Cluster Metrics install],
+you must update to a newer version of the metrics components.
+
+- The update process stops all the metrics containers,
+updates the metrics configuration files,
+and redeploys the newer components.
+
+- It does not change the metrics route.
+
+- It does not delete the metrics persistent volume claim.
+Metrics stored to persistent volumes before the update
+are available after the update completes.
+
+[IMPORTANT]
+====
+The update deletes all non-persisted metric values
+and overwrites local changes to the metrics configurations.
+For example, the number of instances in a replica set is not saved.
+====
+
+To update, follow the same steps as when the metrics components were
+xref:../../install_config/cluster_metrics.adoc#deploying-the-metrics-components[first deployed],
+using the
+xref:../../install_config/cluster_metrics.adoc#modifying-the-deployer-template[correct template],
+except this time, specify the `MODE=refresh` option:
+
+====
+----
+$ oc new-app -f metrics-deployer.yaml \
+    -p HAWKULAR_METRICS_HOSTNAME=hm.example.com,MODE=refresh <1>
+----
+<1> In the original deployment command, there was no `MODE=refresh`.
+====
+
+[NOTE]
+====
+During the update, the metrics components do not run.
+Because of this, they cannot collect data
+and a gap normally appears in the graphs.
+====
+
+[[additional-instructions-per-release]]
+== Additional Manual Steps Per Release
+
+Some {product-title} releases may have additional instructions specific to that
+release that must be performed to fully apply the updates across the cluster.
+ifdef::openshift-enterprise[]
+This section will be updated over time as new asynchronous updates are released
+for {product-title} 3.3.
+
+As of the latest 3.3 release ({latest-tag}), there are no 3.3 asynchronous
+releases that require additional instructions during upgrade. See the
+xref:../../release_notes/ocp_3_3_release_notes.adoc#release-notes-ocp-3-3-release-notes[{product-title} 3.3 Release Notes] to review the latest release notes.
+endif::[]
+
+ifdef::openshift-origin[]
+Read through the following sections carefully depending on your upgrade path, as
+you may be required to perform certain steps at key points during the standard
+upgrade process described earlier in this topic.
+
+[[openshift-origin-1-1-0]]
+=== OpenShift Origin 1.1.0
+
+There are no additional manual steps for this release that are not already
+mentioned inline during the xref:preparing-for-a-manual-upgrade[standard manual upgrade
+process].
+
+[[openshift-origin-1-0-4]]
+=== OpenShift Origin 1.0.4
+
+The following steps are required for the
+https://github.com/openshift/origin/releases/tag/v1.0.4[OpenShift Origin 1.0.4
+release].
+
+*Creating a Service Account for the Router*
+
+The default HAProxy router was updated to utilize host ports and requires that a
+service account be created and made a member of the privileged
+xref:../../admin_guide/manage_scc.adoc#admin-guide-manage-scc[security context constraint] (SCC).
+Additionally, "down-then-up" rolling upgrades have been added and is now the
+preferred strategy for upgrading routers.
+
+After upgrading your master and nodes but before updating to the newer router,
+you must create a service account for the router. As a cluster administrator,
+ensure you are operating on the *default* project:
+
+====
+----
+# oc project default
+----
+====
+
+Delete any existing *router* service account and create a new one:
+
+====
+----
+# oc delete serviceaccount/router
+serviceaccounts/router
+
+# echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' | oc create -f -
+serviceaccounts/router
+----
+====
+
+Edit the *privileged* SCC:
+
+====
+----
+# oc edit scc privileged
+----
+====
+
+Apply the following changes:
+
+====
+----
+allowHostDirVolumePlugin: true
+allowHostNetwork: true <1>
+allowHostPorts: true <2>
+allowPrivilegedContainer: true
+...
+users:
+- system:serviceaccount:openshift-infra:build-controller
+- system:serviceaccount:default:router <3>
+----
+<1> Add or update `allowHostNetwork: true`.
+<2> Add or update `allowHostPorts: true`.
+<3> Add the service account you created to the `*users*` list at the end of the
+file.
+====
+
+Edit your router's deployment configuration:
+
+====
+----
+# oc edit dc/router
+----
+====
+
+Apply the following changes:
+
+====
+----
+...
+spec:
+  replicas: 2
+  selector:
+    router: router
+  strategy:
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      timeoutSeconds: 120
+      updatePeriodSeconds: 1
+      updatePercent: -10 <1>
+    type: Rolling
+    ...
+  template:
+    ...
+    spec:
+      ...
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: router <2>
+      serviceAccountName: router <3>
+...
+----
+====
+<1> Add `updatePercent: -10` to allow down-then-up rolling upgrades.
+<2> Add `serviceAccount: router` to the template `*spec*`.
+<3> Add `serviceAccountName: router` to the template `*spec*`.
+
+Now upgrade your router per the xref:upgrading-the-router[standard router
+upgrade steps].
+
+[[openshift-origin-1-0-5]]
+=== OpenShift Origin 1.0.5
+
+The following steps are required for the
+https://github.com/openshift/origin/releases[OpenShift Origin 1.0.5
+release].
+
+*Switching the Router to Use the Host Network Stack*
+
+The default HAProxy router was updated to use the host networking stack by
+default instead of the former behavior of
+xref:../../install_config/router/default_haproxy_router.adoc#using-the-container-network-stack[using
+the container network stack], which proxied traffic to the router, which in turn
+proxied the traffic to the target service and container. This new default
+behavior benefits performance because network traffic from remote clients no
+longer needs to take multiple hops through user space in order to reach the
+target service and container.
+
+Additionally, the new default behavior enables the router to get the actual
+source IP address of the remote connection. This is useful for defining
+ingress rules based on the originating IP, supporting sticky sessions, and
+monitoring traffic, among other uses.
+
+Existing router deployments will continue to use the container network stack
+unless modified to switch to using the host network stack.
+
+To switch the router to use the host network stack, edit your router's
+deployment configuration:
+
+====
+----
+# oc edit dc/router
+----
+====
+
+Apply the following changes:
+
+====
+----
+...
+spec:
+  replicas: 2
+  selector:
+    router: router
+    ...
+  template:
+    ...
+    spec:
+      ...
+      ports:
+        - containerPort: 80 <1>
+          hostPort: 80
+          protocol: TCP
+        - containerPort: 443 <1>
+          hostPort: 443
+          protocol: TCP
+        - containerPort: 1936 <1>
+          hostPort: 1936
+          name: stats
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+      dnsPolicy: ClusterFirst
+      hostNetwork: true <2>
+      restartPolicy: Always
+...
+----
+====
+<1> For host networking, ensure that the `*containerPort*` value matches the
+`*hostPort*` values for each of the ports.
+<2> Add `*hostNetwork: true*` to the template `*spec*`.
+
+Now upgrade your router per the xref:upgrading-the-router[standard router
+upgrade steps].
+
+*Configuring serviceNetworkCIDR for the SDN*
+
+Add the `*serviceNetworkCIDR*` parameter to the `*networkConfig*` section in
+*_/etc/origin/master/master-config.yaml_*. This value should match the
+`*servicesSubnet*` value in the `*kubernetesMasterConfig*` section:
+
+====
+----
+kubernetesMasterConfig:
+  servicesSubnet: 172.30.0.0/16
+...
+networkConfig:
+  serviceNetworkCIDR: 172.30.0.0/16
+----
+====
+
+*Adding the Scheduler Configuration API Version*
+
+The scheduler configuration file incorrectly lacked `*kind*` and `*apiVersion*`
+fields when deployed using the quick or advanced installation methods. This will
+affect future upgrades, so it is important to add those values if they do not
+exist.
+
+Modify the *_/etc/origin/master/scheduler.json_* file to add the `*kind*` and
+`*apiVersion*` fields:
+
+====
+----
+{
+  "kind": "Policy", <1>
+  "apiVersion": "v1", <2>
+  "predicates": [
+  ...
+}
+----
+====
+<1> Add `*"kind": "Policy",*`
+<2> Add `*"apiVersion": "v1",*`
+endif::[]
+
+[[manual-upgrades-verifying-the-upgrade]]
+== Verifying the Upgrade
+
+To verify the upgrade, first check that all nodes are marked as *Ready*:
+
+====
+----
+# oc get nodes
+NAME                        STATUS                     AGE
+master.example.com          Ready,SchedulingDisabled   165d
+node1.example.com           Ready                      165d
+node2.example.com           Ready                      165d
+
+----
+====
+
+Then, verify that you are running the expected versions of the *docker-registry*
 and *router* images, if deployed.
 ifdef::openshift-enterprise[]
 Replace `<tag>` with `{latest-tag}` for the latest version.
 endif::[]
-+
+
 ----
 ifdef::openshift-enterprise[]
 # oc get -n default dc/docker-registry -o json | grep \"image\"
@@ -319,18 +1721,24 @@ ifdef::openshift-origin[]
     "image": "openshift/origin-haproxy-router:v1.0.6",
 endif::[]
 ----
+
+
 ifdef::openshift-origin[]
-. If you upgraded from Origin 1.0 to Origin 1.1, verify in your old
+If you upgraded from Origin 1.0 to Origin 1.1, verify in your old
 *_/etc/sysconfig/openshift-master_* and *_/etc/sysconfig/openshift-node_* files
 that any custom configuration is added to your new
 *_/etc/sysconfig/origin-master_* and *_/etc/sysconfig/origin-node_* files.
 endif::[]
-. After upgrading, you can use the diagnostics tool on the master to look for
+
+After upgrading, you can use the diagnostics tool on the master to look for
 common issues:
-+
+
+====
 ----
 # oadm diagnostics
 ...
 [Note] Summary of diagnostics execution:
 [Note] Completed with no errors or warnings seen.
 ----
+====
+

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -514,7 +514,6 @@ One at at time for each node that is not also a master, you must disable
 scheduling and evacuate its pods to other nodes, then upgrade packages and
 restart services.
 
-
 . Run the following command on each node to remove the *atomic-openshift*
 packages from the list of yum excludes on the host:
 +


### PR DESCRIPTION
Removed .excluder exclude and unexclude from upgrade per [case 01801897](https://access.redhat.com/support/cases/#/case/01801897):
"So I'd just need that the 3.3 and 3.4 documentation is updated to remove any "excluder" commands in the actual upgrade procedures, similar to how it currently is in 3.5:"