### PR TITLE
Fixes incorrect statement about IPSec regarding throughput.

### DIFF
--- a/scaling_performance/network_optimization.adoc
+++ b/scaling_performance/network_optimization.adoc
@@ -242,7 +242,7 @@ enabled, regardless of the IP security system being used.
 
 IPSec encrypts traffic at the IP level, before it hits the NIC, protecting
 fields that would otherwise be used for NIC offloading. This means that some NIC
-acceleration features may not be usable when IPSec is enabled and will lead to increased throughput and CPU usage.
+acceleration features may not be usable when IPSec is enabled and will lead to decreased throughput and increased CPU usage.
 
 
 


### PR DESCRIPTION
Documentation falsely claims that the lack of hardware NIC acceleration will lead to increased network throughput when using IPSec.