### PR TITLE
Define Daemonsets as Technology Preview

### DIFF
--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -21,6 +21,22 @@ your cluster, or deploy a monitoring agent on every node.
 
 For more information on daemonsets, see the link:http://kubernetes.io/docs/admin/daemons/[Kubernetes documentation].
 
+[IMPORTANT]
+====
+Using daemonsets is a Technology Preview feature only.
+ifdef::openshift-enterprise[]
+Technology Preview features are not
+supported with Red Hat production service level agreements (SLAs), might not be
+functionally complete, and Red Hat does not recommend to use them for
+production. These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the
+development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
 [[dev-guide-creating-daemonsets]]
 == Creating Daemonsets
 


### PR DESCRIPTION
In OCP 3.2 Daemonsets were added and not defined as Technology Preview, however they are in later releases.