### PR TITLE
Fix typo in persistent_storage_iscsi/vsphere

### DIFF
--- a/install_config/persistent_storage/persistent_storage_iscsi.adoc
+++ b/install_config/persistent_storage/persistent_storage_iscsi.adoc
@@ -98,7 +98,7 @@ Each iSCSI LUN must be accessible by all nodes in the cluster.
 === iSCSI Multipathing
 For iSCSI-based storage, you can configure multiple paths by using the same IQN for more than one target portal IP address. Multipathing ensures access to the persistent volume when one or more of the components in a path fail.
 
-To specify multi-paths in pod specification use the `portal` field. For example:
+To specify multi-paths in pod specification use the `portals` field. For example:
 
 ====
 [source, yaml]
@@ -120,5 +120,5 @@ spec:
     fsType: ext4
     readOnly: false
 ----
-<1> Add additional target portals using the `portal` field.
+<1> Add additional target portals using the `portals` field.
 ====

--- a/install_config/persistent_storage/persistent_storage_vsphere.adoc
+++ b/install_config/persistent_storage/persistent_storage_vsphere.adoc
@@ -118,7 +118,7 @@ Changing the value of the `fsType` parameter after the volume is formatted and
 provisioned can result in data loss and pod failure.
 ====
 
-. Save your definition to a file, for example *vsphere-pv.yaml_*, and create the
+. Save your definition to a file, for example *_vsphere-pv.yaml_*, and create the
 persistent volume:
 +
 [source, bash]


### PR DESCRIPTION
Reference to https://docs.openshift.com/container-platform/3.6/install_config/persistent_storage/persistent_storage_iscsi.html#iscsi-multipath

Apply to branch/enterprise-3.6  and above.