### PR TITLE
removing manageing templates section

### DIFF
--- a/getting_started/dedicated_administrators.adoc
+++ b/getting_started/dedicated_administrators.adoc
@@ -165,15 +165,6 @@ perform in any user-created project, and see
 xref:../admin_guide/service_accounts.adoc#admin-guide-service-accounts[Configuring Service Accounts] for more
 advanced, cluster-wide settings.
 
-[[gs-dedicated-admin-adding-or-removing-default-image-streams-and-templates]]
-== Adding or Removing Default Image Streams and Templates
-
-See xref:../admin_guide/osd_imagestreams_templates.adoc#admin-guide-osd-imagestreams-templates[Managing the Default
-Image Streams and Templates] for information on the core set of image streams
-and templates provided by default in the global *openshift* project. You can
-also modify, add, or remove these objects from the *openshift* project as a
-cluster administrator.
-
 [[gs-dedicated-admin-managing-quotas-and-limit-ranges]]
 == Managing Quotas and Limit Ranges
 


### PR DESCRIPTION
Just getting `master` caught up with this change made previously to the `dedicated` branch via https://github.com/openshift/openshift-docs/pull/4101.