### PR TITLE
First create the volume for TEMPLATE_FILE then env

### DIFF
--- a/install_config/router/customized_haproxy_router.adoc
+++ b/install_config/router/customized_haproxy_router.adoc
@@ -512,12 +512,12 @@ Using `oc` commands::
 +
 [source,bash]
 ----
-$ oc set env dc/router \
-    TEMPLATE_FILE=/var/lib/haproxy/conf/custom/haproxy-config.template
 $ oc volume dc/router --add --overwrite \
     --name=config-volume \
     --mount-path=/var/lib/haproxy/conf/custom \
     --source='{"configMap": { "name": "customrouter"}}'
+$ oc set env dc/router \
+    TEMPLATE_FILE=/var/lib/haproxy/conf/custom/haproxy-config.template
 ----
 +
 Editing the Router Deployment Configuration::


### PR DESCRIPTION
Due to the fact that

```
oc set env dc/router ...
```

redeploys the router and will crash when the files is not there.

I suggest to first add the custom configmap and **then** set the variable for the TEMPLATE_FILE