### PR TITLE
routes: Fix conditionals for Online

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -23,7 +23,7 @@ Your administrator may have configured a
 ifdef::openshift-online,openshift-dedicated[]
 DNS wildcard entry
 endif::[]
-ifndef::openshift-online+openshift-dedicated[]
+ifndef::openshift-online,openshift-dedicated[]
 xref:../../install_config/install/prerequisites.adoc#prereq-dns[DNS wildcard entry]
 endif::[]
 that will resolve to the {product-title} node that is running the
@@ -75,6 +75,7 @@ to the number of addresses are _active_ and the rest are _passive_.
 A passive router is also known as a _hot-standby_ router.
 For example, with two VIP addresses and three routers,
 you have an "active-active-passive" configuration.
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 See
 ifdef::openshift-enterprise,openshift-origin[]
 xref:../../admin_guide/high_availability.adoc#configuring-a-highly-available-service[High Availability]
@@ -83,6 +84,7 @@ ifdef::openshift-dedicated[]
 the xref:../../admin_guide/high_availability.adoc#configuring-a-highly-available-service[{product-title} Cluster Administration documentation]
 endif::[]
 for more information on router VIP configuration.
+endif::[]
 
 Routes can be
 xref:router-sharding[sharded]
@@ -485,6 +487,7 @@ no-route-hostname-mynamespace.router.default.svc.cluster.local <1>
 *router.default.svc.cluster.local*.
 ====
 
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 A cluster administrator can also
 ifdef::openshift-enterprise,openshift-origin[]
 xref:../../install_config/router/default_haproxy_router.adoc#customizing-the-default-routing-subdomain[customize
@@ -494,6 +497,7 @@ ifdef::openshift-dedicated[]
 customize the suffix used as the default routing subdomain
 endif::[]
 for their environment.
+endif::[]
 
 [[route-types]]
 == Route Types
@@ -610,7 +614,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 xref:../../install_config/router/default_haproxy_router.adoc#using-wildcard-certificates[router's
 default certificate]
 endif::[]
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-online[]
 router's default certificate
 endif::[]
 will be used for TLS termination.


### PR DESCRIPTION
Fix an `ifndef` that is causing "DNS wildcard entry" to be rendered twice, once plain and once hyperlinked.

Conditionalize two sentences that had conditionalized parts for openshift-origin, openshift-enterprise, and openshift-dedicated but nothing for openshift-online, which is producing incomplete sentences in the Online documentation.

Fix conditionals in another sentence with conditionalized parts for openshift-origin, openshift-enterprise, and openshift-dedicated to use the openshift-dedicated text for openshift-online in order to avoid having an incomplete sentence in the Online documentation.

---

@adellape, the first change reverts a change you made in https://github.com/openshift/openshift-docs/pull/4388.  I'm confused why that change was made, but in any case, what we have now is not rendering correctly on https://docs.openshift.com/online/architecture/core_concepts/routes.html.