### PR TITLE
Adds note about scheduled imports

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -756,6 +756,12 @@ spec:
 ----
 ====
 
+[NOTE]
+
+====
+The scheduled import is by default disabled and must be enabled in the master configuration.
+====
+
 [[insecure-registries]]
 === Importing Images from Insecure Registries
 


### PR DESCRIPTION
By default the scheduled imports is disabled.
It is currently not written in the documentation
that it must be specifically enabled.


EDIT: I can recreate the PR for the correct branch if master is incorrect.