### PR TITLE
Duplicated variable 'openshift_metrics_cassandra_replicas'

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -343,9 +343,6 @@ start script based on available memory of the node on which it is scheduled.
 |The CPU limit for the Cassandra pod. For example, a value of `4000m` (4000
 millicores) would limit Cassandra to 4 CPUs.
 
-|`openshift_metrics_cassandra_replicas`
-|The number of replicas for Cassandra.
-
 |`openshift_metrics_cassandra_requests_memory`
 |The amount of memory to request for Cassandra pod. For example, a value of
 `2Gi` would request 2 GB of memory.


### PR DESCRIPTION
Hi,

The parameter is duplicated. "openshift_metrics_cassandra_replicas"

Thanks,
Jooho Lee.