### PR TITLE
Bug#1373366 - Restrict certain pvs only for a given tenant - Fixes

### DIFF
--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -228,7 +228,7 @@ explicit limit for those resources.
 // tag::admin_quota_object_counts_1[]
 
 .*_core-object-counts.yaml_*
-====
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -249,13 +249,13 @@ project.
 <3> The total number of replication controllers that can exist in the project.
 <4> The total number of secrets that can exist in the project.
 <5> The total number of services that can exist in the project.
-====
+
 // end::admin_quota_object_counts_1[]
 
 // tag::admin_quota_object_counts_2[]
 
 .*_openshift-object-counts.yaml_*
-====
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -267,14 +267,14 @@ spec:
     openshift.io/imagestreams: "10" <1>
 ----
 <1> The total number of image streams that can exist in the project.
-====
+
 
 // end::admin_quota_object_counts_2[]
 
 // tag::admin_quota_compute_resources[]
 
 .*_compute-resources.yaml_*
-====
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -299,12 +299,12 @@ exceed 1Gi.
 2 cores.
 <5> Across all pods in a non-terminal state, the sum of memory limits cannot
 exceed 2Gi.
-====
+
 
 // end::admin_quota_compute_resources[]
 
 .*_besteffort.yaml_*
-====
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -321,10 +321,10 @@ spec:
 of service that can exist in the project.
 <2> Restricts the quota to only matching pods that have *BestEffort* quality of
 service for either memory or CPU.
-====
+
 
 .*_compute-resources-long-running.yaml_*
-====
+[source, yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
@@ -343,10 +343,10 @@ spec:
 <3> Across all pods in a non-terminal state, the sum of memory limits cannot exceed this value.
 <4> Restricts the quota to only matching pods where `spec.activeDeadlineSeconds is nil`.  For example,
 this quota would not charge for build or deployer pods.
-====
+
 
 .*_compute-resources-time-bound.yaml_*
-====
+[source, yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
@@ -365,10 +365,11 @@ spec:
 <3> Across all pods in a non-terminal state, the sum of memory limits cannot exceed this value.
 <4> Restricts the quota to only matching pods where `spec.activeDeadlineSeconds >=0`.  For example,
 this quota would charge for build or deployer pods, but not long running pods like a web server or database.
-====
+
 
 .*storage-consumption.yaml*
-====
+
+[source, yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
@@ -379,14 +380,18 @@ spec:
     persistentvolumeclaims: "10" <1>
     requests.storage: "50Gi" <2>
     gold.storageclass.storage.k8s.io/requests.storage: "10Gi" <3>
-    bronze.storageclass.storage.k8s.io/requests.storage: "20Gi" <4>
+    silver.storageclass.storage.k8s.io/requests.storage: "20Gi" <4>
+    silver.storageclass.storage.k8s.io/persistentvolumeclaims: "5" <5>
+    bronze.storageclass.storage.k8s.io/requests.storage: "0" <6>
+    bronze.storageclass.storage.k8s.io/persistentvolumeclaims: "0" <7>
 ----
 <1> The total number of persistent volume claims in a project
 <2> Across all persistent volume claims in a project, the sum of storage requested cannot exceed this value.
 <3> Across all persistent volume claims in a project, the sum of storage requested in the gold storage class cannot exceed this value.
-<4> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value.
-====
-
+<4> Across all persistent volume claims in a project, the sum of storage requested in the silver storage class cannot exceed this value.
+<5> Across all persistent volume claims in a project, the total number of claims in the silver storage class cannot exceed this value.
+<6> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value. When this is set to `0`, it means bronze storage class cannot request storage.
+<7> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value. When this is set to `0`, it means bronze storage class cannot create claims.
 
 // end::admin_quota_sample_definitions[]
 
@@ -420,7 +425,7 @@ You can also use the CLI to view quota details:
 . First, get the list of quotas defined in the project. For example, for a project
 called *demoproject*:
 +
-====
+
 ----
 $ oc get quota -n demoproject
 NAME                AGE
@@ -428,12 +433,12 @@ besteffort          11m
 compute-resources   2m
 core-object-counts  29m
 ----
-====
+
 
 . Then, describe the quota you are interested in, for example the
 *core-object-counts* quota:
 +
-====
+
 ----
 $ oc describe quota core-object-counts -n demoproject
 Name:			core-object-counts
@@ -446,7 +451,7 @@ replicationcontrollers	3	20
 secrets			9	10
 services		2	10
 ----
-====
+
 // end::admin_quota_viewing[]
 
 [[configuring-quota-sync-period]]
@@ -461,7 +466,7 @@ reuse the resources. You can change the `*resource-quota-sync-period*` setting
 to have the set of resources regenerate at the desired amount of time (in
 seconds) and for the resources to be available again:
 
-====
+
 [source,yaml]
 ----
 kubernetesMasterConfig:
@@ -473,7 +478,7 @@ kubernetesMasterConfig:
     resource-quota-sync-period:
       - "10s"
 ----
-====
+
 
 After making any changes, restart the master service to apply them.
 
@@ -518,7 +523,7 @@ would not be able to create any storage of that type.
 In order to require explicit quota to consume a particular resource,
 the following stanza should be added to the master-config.yaml.
 
-====
+
 [source,yaml]
 ----
 admissionConfig:
@@ -534,7 +539,7 @@ admissionConfig:
 ----
 <1> The group/resource to whose consumption is limited by default.
 <2> The name of the resource tracked by quota associated with the group/resource to limit by default.
-====
+
 
 In the above example, the quota system will intercept every operation that
 creates or updates a `PersistentVolumeClaim`.  It checks what resources understood


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1373366

Updated the storage-consumption example in Setting Quotas topic. Added following values and description to the example:
```
    silver.storageclass.storage.k8s.io/requests.storage: "20Gi" <4>
    silver.storageclass.storage.k8s.io/persistentvolumeclaims: "5" <5>
    bronze.storageclass.storage.k8s.io/requests.storage: "0" <6>
    bronze.storageclass.storage.k8s.io/persistentvolumeclaims: "0" <7>
```
<4> Across all persistent volume claims in a project, the sum of storage requested in the silver storage class cannot exceed this value.
<5> Across all persistent volume claims in a project, the total number of claims in the silver storage class cannot exceed this value.
<6> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value. When this is set to `0`, it means bronze storage class cannot request storage.
<7> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value. When this is set to `0`, it means bronze storage class cannot create claims.