### PR TITLE
Tuned profile hierarchy change.

### DIFF
--- a/scaling_performance/host_practices.adoc
+++ b/scaling_performance/host_practices.adoc
@@ -137,32 +137,39 @@ etcd processes are typically memory intensive. Master / API server processes are
 ====
 
 [[scaling-performance-capacity-tuned-profile]]
-== Scaling Hosts Using the TuneD Profile
+== Scaling Hosts Using the Tuned Profile
 
-TuneD is a tuning profile delivery mechanism enabled by default in Red Hat
-Enterprise Linux and other Red Hat products. TuneD customizes Linux settings,
+**Tuned** is a tuning profile delivery mechanism enabled by default in Red Hat
+Enterprise Linux and other Red Hat products. **Tuned** customizes Linux settings,
 such as sysctls, power management, and kernel command line options, to optimize
 the operating system for different workload performance and scalability
 requirements.
 
-{product-title} leverages the `tuned` daemon and includes TuneD profiles called
-`atomic-openshift-host` and `atomic-openshift-guest`. These profiles safely
+{product-title} leverages the `tuned` daemon and includes **Tuned** profiles called
+`openshift`, `openshift-node` and `openshift-control-plane`. These profiles safely
 increase some of the commonly encountered vertical scaling limits present in the
 kernel, and are automatically applied to your system during installation.
 
-The TuneD profiles support inheritance between profiles. On an {product-title}
-system, the findings delivered by TuneD will be the union of
-`throughput-performance` (the default for RHEL) and `atomic-openshift-guest`.
-TuneD will determine if you are running {product-title} on a virtual machine,
-and, if so, automatically apply `virtual-guest` tuning as well.
+The **Tuned** profiles support inheritance between profiles.  They also support
+an auto-parent functionality which selects a parent profile based on whether the
+profile is used in a virtual environment.  The `openshift` profile uses both of these
+features and is a parent of `openshift-node` and `openshift-control-plane` profiles.
+It contains tuning relevant to both {product-title} application nodes and control plane
+nodes respectively. The `openshift-node` and `openshift-control-plane` profiles
+are set on application and control plane nodes respectively.
 
-To see which TuneD profile is enabled on your system, run:
+The profile hierarchy with the `openshift` profile as a parent ensures the
+tuning delivered to the {product-title} system is a union of
+`throughput-performance` (the default for RHEL) for bare metal hosts
+and `virtual-guest` for RHEL and `atomic-guest` for RHEL Atomic Host nodes.
+
+To see which **Tuned** profile is enabled on your system, run:
 
 ----
 # tuned-adm active
-Current active profile: atomic-openshift-node-guest
+Current active profile: openshift-node
 ----
 
 See the
 link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html-single/Performance_Tuning_Guide/index.html#chap-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Tuned[Red
-Hat Enterprise Linux Performance Tuning Guide] for more information about TuneD.
+Hat Enterprise Linux Performance Tuning Guide] for more information about **Tuned**.


### PR DESCRIPTION
Documentation based on https://github.com/openshift/openshift-ansible/pull/5054 and https://github.com/openshift/openshift-ansible/pull/5089. See the former for a diagram.  Also changed TuneD --> **Tuned** based on RHEL documentation.

https://trello.com/c/Bw3Sk0Jt/624-document-scale-37-ocp-spike-update-tuned-profile-hierarchy-for-37