### PR TITLE
update backward compatibility

### DIFF
--- a/release_notes/index.adoc
+++ b/release_notes/index.adoc
@@ -47,7 +47,7 @@ capabilities that are not supported by a 3.1 server.
 
 |
 |*X.Y* (`oc` Client)
-|*X.Y+N* footnoteref:[versionpolicyn,Where *N* is a number greater than 1.] (`oc` Client)
+|*X.Y+N* footnoteref:[versionpolicyn,Where *N* is a number greater than 0.] (`oc` Client)
 
 |*X.Y* (Server)
 |image:redcircle-1.png[]


### PR DESCRIPTION
This updates our oc skew to one release.  This is coming up now for the groupified APIs and when non-CRUD commands in `oc` can start using just the groupified versions them.

https://github.com/kubernetes/community/blob/master/contributors/design-proposals/versioning.md#supported-releases-and-component-skew indicates a one version compatibility guarantee.  While I wouldn't change capriciously, not all changes can be managed with a reasonable amount of debt.

