### PR TITLE
Replace link to 'common' playbook with link to 'byo' and fix image prefix + nodeselector

### DIFF
--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -120,7 +120,7 @@ creates. It must exist and be mountable by the EFS provisioner. Defaults to
 *_StorageClasses_* specify. Defaults to `openshift.org/aws-efs`.
 
 |`openshift_provisioners_efs_nodeselector` | A map of labels to select the nodes
-where the pod will land. For example: `{"node":"infra","region":"west"}`.
+where the pod will land. For example: `'{"node":"infra","region":"west"}'`.
 
 |`openshift_provisioners_efs_supplementalgroup` | The supplemental group to give
 the pod, in case it is needed for permission to write to the EFS file system.
@@ -151,6 +151,7 @@ $ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift_provi
    -e openshift_provisioners_efs_aws_access_key_id=AKIAIOSFODNN7EXAMPLE \
    -e openshift_provisioners_efs_aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
    -e openshift_provisioners_efs_path=/data/persistentvolumes
+   -e openshift_provisioners_efs_nodeselector='{"node":"infra","region":"west"}' \
 ----
 
 [[nfs-selinux]]

--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -22,7 +22,7 @@ independently of {product-title}.
 
 [[provisioners-before-you-begin]]
 == Before You Begin
-An link:https://github.com/openshift/openshift-ansible/blob/master/playbooks/common/openshift-cluster/openshift_provisioners.yml[Ansible Playbook] is also available to deploy and upgrade external provisioners.
+An link:https://github.com/openshift/openshift-ansible/blob/master/playbooks/byo/openshift-cluster/openshift_provisioners.yml[Ansible Playbook] is also available to deploy and upgrade external provisioners.
 
 [NOTE]
 ====
@@ -153,7 +153,7 @@ The following command sets the directory in the EFS volume to
 be mountable and writeable by the provisioner pod.
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_provisioners.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift_provisioners.yml \
    -e openshift_provisioners_install_provisioners=True \
    -e openshift_provisioners_efs=True \
    -e openshift_provisioners_efs_fsid=fs-47a2c22e \
@@ -207,6 +207,6 @@ You can remove everything deployed by the OpenShift Ansible `openshift_provision
 by running the following command:
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_provisioners.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift_provisioners.yml \
    -e openshift_provisioners_install_provisioners=False
 ----

--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -56,21 +56,11 @@ which the `install` variable is `true`.
 
 |`openshift_provisioners_image_prefix`
 |The prefix for the component images. For example, with
-ifdef::openshift-origin[]
-`openshift/origin-efs-provisioner:v1.0.0`, set prefix `openshift/origin-`.
-endif::[]
-ifdef::openshift-enterprise[]
 `openshift3/efs-provisioner:v3.6`, set prefix `openshift3/`.
-endif::[]
 
 |`openshift_provisioners_image_version`
 |The version for the component images. For example, with
-ifdef::openshift-origin[]
-`openshift/origin-efs-provisioner:v1.0.0`, set version  as `v1.0.0`.
-endif::[]
-ifdef::openshift-enterprise[]
 `openshift3/efs-provisioner:v3.6`, set version as `v3.6`.
-endif::[]
 
 |`openshift_provisioners_project`
 |The project to deploy provisioners in. Defaults to `openshift-infra`.


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1486841 , we have to use the new byo playbook  added by https://github.com/openshift/openshift-ansible/pull/5179, else vars aren't initialized and the install fails