### PR TITLE
Add etcd data migration v2 to v3

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -333,6 +333,8 @@ Topics:
     File: blue_green_deployments
   - Name: Operating System Updates and Upgrades
     File: os_upgrades
+  - Name: Migrating etcd Data
+    File: migrating_etcd
   - Name: Known Issues
     File: upgrading_known_issues
 - Name: Downgrading

--- a/install_config/upgrading/migrating_etcd.adoc
+++ b/install_config/upgrading/migrating_etcd.adoc
@@ -1,0 +1,311 @@
+[[install-config-upgrading-etcd-data-migration]]
+= Migrating etcd Data: v2 to v3
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+While etcd was updated from etcd v2 to v3 in a
+link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous release], {product-title} continued using an etcd v2 data model and API for both
+new and upgraded clusters. Starting with {product-title} 3.6, new installations
+began using the v3 data model as well, providing
+xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved performance and scalability].
+
+For existing clusters that upgraded to {product-title} 3.6, however, the etcd
+data must be migrated from v2 to v3 as a post-upgrade step. This must be
+performed before upgrading to the future release of {product-title} 3.7, but it
+can be done at any time starting with release {product-title} 3.6.1.
+
+The etcd v2 to v3 data migration is performed as an offline migration which
+means all etcd members and master services are stopped during the migration.
+Large clusters with up to 600MiB of etcd data can expect a 10 to 15 minute
+outage of the API, web console, and controllers.
+
+This migration process performs the following steps:
+
+- Stop the master API and controller services
+- Perform an etcd backup on all etcd members
+- Perform a migration on the first etcd host
+- Remove etcd data from any remaining etcd hosts
+- Perform an etcd scaleup operation adding additional etcd hosts one by one
+- Re-introduce TTL information on specific keys
+- Reconfigure the masters for etcd v3 storage
+- Start the master API and controller services
+
+[[etcd-data-migration-before-you-begin]]
+== Before You Begin
+
+You can only begin the etcd data migration process after upgrading to
+{product-title} 3.6, as previous versions are not compatible with etcd v3
+storage. Additionally, the upgrade to {product-title} 3.6 reconfigures cluster
+DNS services to run on every node, rather than on the masters, which ensures
+that, even when master services are taken down, existing pods continue to
+function as expected.
+
+The migration process is currently only supported on clusters that have etcd
+hosts specifically defined in their inventory file. Therefore, the migration
+cannot be used for clusters which utilize the embedded etcd which runs as part
+of the master process. Support for migrating embedded etcd installations will be
+added in a future release.
+
+[[etcd-data-migration-automated]]
+== Running the Automated Migration Playbook
+
+A migration playbook is provided to automate all aspects of the process; this is the preferred method for performing the migration. You must have access
+to your existing inventory file with both masters and etcd hosts defined in their separate groups. 
+
+. Ensure you have the latest version of the *openshift-ansible* packages
+installed:
++
+----
+# yum upgrade openshift-ansible\*
+----
+
+. Run the *_migrate.yml_* playbook using your inventory file:
++
+----
+# ansible-playbook [-i /path/to/inventory] \
+ifdef::openshift-enterprise[]
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-etcd/migrate.yml
+endif::[]
+ifdef::openshift-origin[]
+    ~/openshift-ansible/playbooks/byo/openshift-etcd/migrate.yml
+endif::[]
+----
+
+[[etcd-data-migration-manual]]
+== Running the Migration Manually
+
+The following procedure describes the steps required to successfully migrate the
+cluster (implemented as part of the Ansible etcd migration playbook).
+
+. +++<b>Create an etcd backup.</b>+++ See
+xref:../../admin_guide/backup_restore.adoc#cluster-backup[Backup and Restore]
+for steps.
+
+. +++<b>Stop masters and wait for etcd convergence:</b>+++
+
+.. Stop all master services:
++
+----
+# systemctl stop atomic-openshift-master \
+    atomic-openshift-master-api \
+    atomic-openshift-master-controllers
+----
+
+.. Before the migration can proceed, the etcd cluster must be healthy
+and raft indices of all etcd members must differ by one unit at most.
+At the same time, all etcd members and master daemons must be stopped.
++
+To check the etcd cluster is healthy you can run:
++
+----
+# etcdctl <certificate_details> <endpoint> cluster-health <1>
+member 2a3d833935d9d076 is healthy: got healthy result from https://etcd-test-1:2379
+member a83a3258059fee18 is healthy: got healthy result from https://etcd-test-2:2379
+member 22a9f2ddf18fee5f is healthy: got healthy result from https://etcd-test-3:2379
+cluster is healthy
+----
+<1> For `<certificate_details>`, see
+xref:../../admin_guide/backup_restore.adoc#adding-addtl-etcd-members[Backup and Restore] for an example of how to set certificate flags.
++
+To check a difference of raft indices you can run:
++
+----
+# ETCDCTL_API=3 etcdctl <certificate_details> <endpoint> -w table endpoint status
++------------------+------------------+---------+---------+-----------+-----------+------------+
+|     ENDPOINT     |        ID        | VERSION | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX |
++------------------+------------------+---------+---------+-----------+-----------+------------+
+| etcd-test-1:2379 | 2a3d833935d9d076 | 3.1.9   | 25 kB   | false     |       415 |        995 |
+| etcd-test-2:2379 | a83a3258059fee18 | 3.1.9   | 25 kB   | true      |       415 |        995 |
+| etcd-test-3:2379 | 22a9f2ddf18fee5f | 3.1.9   | 25 kB   | false     |       415 |        995 |
++------------------+------------------+---------+---------+-----------+-----------+------------+
+----
++
+If the minimum and maximum of raft indexes over all etcd members differ by more
+than one unit, wait a minute and try the command again.
+
+. +++<b>Migrate and scale up etcd:</b>+++
++
+[WARNING]
+====
+The migration should not be run repeatedly, as new v2 data can overwrite v3 data
+that has already migrated.
+====
+
+.. Stop etcd on all etcd hosts:
++
+----
+# systemctl stop etcd
+----
+
+.. Run the following command (with the *etcd* daemon stopped) on your first etcd
+host to perform the migration:
++
+----
+# ETCDCTL_API=3 etcdctl migrate --data-dir=/var/lib/etcd
+----
++
+The `--data-dir` target can in a different location depending on the deployment.
+For example, embedded etcd operates over the
+*_/var/lib/origin/openshift.local.etcd_* directory, and etcd run as a system
+container operates over the *_/var/lib/etcd/etcd.etcd_* directory.
++
+When complete, the migration responds with the following message if successful:
++
+----
+finished transforming keys
+----
++
+If there is no v2 data, it responds with:
++
+----
+no v2 keys to migrate
+----
+
+.. On each remaining etcd host, move the existing member directory to a backup
+location:
++
+----
+$ mv /var/lib/etcd/member /var/lib/etc/member.old
+----
+
+.. Create a new cluster on the first host:
++
+----
+# echo "ETCD_FORCE_NEW_CLUSTER=true" >> /etc/etcd/etcd.conf
+# systemctl start etcd
+# sed -i '/ETCD_FORCE_NEW_CLUSTER=true/d' /etc/etcd/etcd.conf
+# systemctl restart etcd
+----
+
+.. Scale up additional etcd hosts by following the
+xref:/backup_restore.adoc#adding-addtl-etcd-members[Adding Additional etcd
+Members] documentation.
+
+.. When the `etcdctl migrate` command is run without the `--no-ttl` option, TTL
+keys are migrated as well. Given that the TTL keys in v2 data are replaced with
+leases in v3 data, you must attach leases to all migrated TTL keys (with the
+*etcd* daemon running).
++
+After your etcd cluster is back online with all members, re-introduce the TTL
+information by running the following on the first master:
++
+----
+$ oadm migrate etcd-ttl --etcd-address=https://<ip_address>:2379 \
+    --cacert=/etc/origin/master/master.etcd-ca.crt \
+    --cert=/etc/origin/master/master.etcd-client.crt \
+    --key=/etc/origin/master/master.etcd-client.key \
+    --ttl-keys-prefix '/kubernetes.io/events' \
+    --lease-duration 1h
+$ oadm migrate etcd-ttl --etcd-address=https://<ip_address>:2379 \
+    --cacert=/etc/origin/master/master.etcd-ca.crt \
+    --cert=/etc/origin/master/master.etcd-client.crt \
+    --key=/etc/origin/master/master.etcd-client.key \
+    --ttl-keys-prefix '/kubernetes.io/masterleases' \
+    --lease-duration 10s
+$ oadm migrate etcd-ttl --etcd-address=https://<ip_address>:2379 \
+    --cacert=/etc/origin/master/master.etcd-ca.crt \
+    --cert=/etc/origin/master/master.etcd-client.crt \
+    --key=/etc/origin/master/master.etcd-client.key \
+    --ttl-keys-prefix '/openshift.io/oauth/accesstokens' \
+    --lease-duration 86400s
+$ oadm migrate etcd-ttl --etcd-address=https://<ip_address>:2379 \
+    --cacert=/etc/origin/master/master.etcd-ca.crt \
+    --cert=/etc/origin/master/master.etcd-client.crt \
+    --key=/etc/origin/master/master.etcd-client.key \
+    --ttl-keys-prefix '/openshift.io/oauth/authorizetokens' \
+    --lease-duration 500s
+$ oadm migrate etcd-ttl --etcd-address=https://<ip_address>:2379 \
+    --cacert=/etc/origin/master/master.etcd-ca.crt \
+    --cert=/etc/origin/master/master.etcd-client.crt \
+    --key=/etc/origin/master/master.etcd-client.key \
+    --ttl-keys-prefix '/openshift.io/leases/controllers' \
+    --lease-duration 10s
+----
+
+. +++<b>Reconfigure the master:</b>+++
+
+.. After the migration is complete, the
+xref:../install_config/master_node_configuration.adoc#master-configuration-files[master
+configuration file] (the *_/etc/origin/master/master-config.yaml_* file by
+default) must be updated so the master daemons can use the new storage back end:
++
+[source,yaml]
+----
+kubernetesMasterConfig:
+  apiServerArguments:
+    storage-backend:
+    - etcd3
+    storage-media-type:
+    - application/vnd.kubernetes.protobuf
+----
+
+.. Restart your services; for single master clusters, run:
++
+----
+# systemctl start atomic-openshift-master
+----
++
+For multiple master clusters, run the following on all masters:
++
+----
+# systemctl start atomic-openshift-master-api \
+    atomic-openshift-master-controllers
+----
+
+[[etcd-data-migration-recovering]]
+== Recovering from Migration Issues
+
+If you discover problems after the migration has completed, you may wish to restore
+from a backup:
+
+. Stop the master services:
++
+----
+# systemctl stop atomic-openshift-master \
+    atomic-openshift-master-api \
+    atomic-openshift-master-controllers
+----
+
+. Remove the `storage-backend` and `storage-media-type` keys from from
+`kubernetesMasterConfig.apiServerArguments` section in the master configuration
+file on each master:
++
+[source,yaml]
+----
+kubernetesMasterConfig:
+  apiServerArguments:
+   ...
+----
+
+. Restore from backups that were taken prior to the migration, located in
+a timestamped directory under *_/var/lib/etcd_*, such as:
++
+----
+/var/lib/etcd/openshift-backup-pre-migration20170825135732
+----
++
+Use procedure described in xref:backup_restore.adoc#cluster-restore-multiple-member-etcd-clusters[Cluster Restore for Multiple-member etcd Clusters]
+or xref:backup_restore.adoc#cluster-restore-single-member-etcd-clusters[Cluster Restore for Single-member etcd Clusters].
+
+. Restart master services; for single master clusters, run:
++
+----
+# systemctl start atomic-openshift-master
+----
++
+For multiple master clusters, run the following on all masters:
++
+----
+# systemctl start atomic-openshift-master-api \
+    atomic-openshift-master-controllers
+----


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/4652.

@sdodson @ingvagabund @openshift/team-documentation PTAL:

http://file.rdu.redhat.com/~adellape/083017/361etcd-migrate/361etcd-migrate/install_config/upgrading/migrating_etcd.html