### PR TITLE
Add back tech preview for dedicated and mysql

### DIFF
--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -462,7 +462,7 @@ be used in production.
 ====
 endif::[]
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated,openshift-online[]
 [NOTE]
 ====
 Enabling clustering for database images is currently in Technology Preview and


### PR DESCRIPTION
The tech preview label is missing from dedicated docs for mysql replication