### PR TITLE
Fix storage size typo

### DIFF
--- a/install_config/persistent_storage/persistent_storage_azure_file.adoc
+++ b/install_config/persistent_storage/persistent_storage_azure_file.adoc
@@ -101,7 +101,7 @@ metadata:
   name: "pv0001" <1>
 spec:
   capacity:
-    storage: "5120Gi" <2>
+    storage: "5Gi" <2>
   accessModes:
     - "ReadWriteMany"
   azureFile: <3>


### PR DESCRIPTION
The command of "oc get pv" on page https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_azure_file.html#creating-azure-storage-account-secret show that the size the 5Gi.

This should apply to OCP/enterprise-3.6 and above.