### PR TITLE
BZ1489519 Formatting fix for Origin docs

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -731,11 +731,10 @@ Some deployments require that the user override the detected host names and IP
 addresses for the hosts. To see the default values, run the `*openshift_facts*`
 playbook:
 
-====
 ----
-# ansible-playbook playbooks/byo/openshift_facts.yml
+# ansible-playbook  [-i /path/to/inventory] \
+    ~/openshift-ansible/playbooks/byo/config.yml
 ----
-====
 
 Now, verify the detected common settings. If they are not what you expect them
 to be, you can override them.
@@ -843,7 +842,7 @@ To run a containerized GlusterFS-backed OpenShift Container Registry:
 
 - A minimum of 3 storage nodes is required.
 - Each storage node must have at least 1 raw block device with at least 10 GB of
-free storage. 
+free storage.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1489519

No need for labels and milestones. This is Origin only, since related changes were applied in https://github.com/openshift/openshift-docs/pull/5211 against 3.6.