### PR TITLE
Fixed typo or copy/paste obvious error.

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -733,7 +733,7 @@ playbook:
 
 ----
 # ansible-playbook  [-i /path/to/inventory] \
-    ~/openshift-ansible/playbooks/byo/config.yml
+    ~/openshift-ansible/playbooks/byo/openshift_facts.yml
 ----
 
 Now, verify the detected common settings. If they are not what you expect them


### PR DESCRIPTION
openshift_facts was called config like in the install