### PR TITLE
clarify secret injector behaviour with alternate git URI style

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -306,29 +306,45 @@ secrets to a service is not required.
 ====
 
 [[automatic-addition-of-a-source-secret-to-a-build-configuration]]
-==== Automatically Adding Source Clone Secrets
+==== Automatically Adding a Source Clone Secret to a Build Configuration
 
-{product-title} can automatically add a source clone secret to relevant build
-configurations if the source clone secret includes one or more annotations
-prefixed with `build.openshift.io/source-secret-match-uri-`. The value of each
-annotation indicates a URI pattern of a source repository against which the
-secret matches. The URI pattern must consist of:
+When a `BuildConfig` is created, {product-title} can automatically populate its
+source clone secret reference.  This behaviour allows the resulting `Build`s to
+automatically use the credentials stored in the referenced `Secret` to
+authenticate to a remote Git repository, without requiring further
+configuration.
+
+To use this functionality, a `Secret` containing the Git repository credentials
+must exist in the namespace in which the `BuildConfig` will later be created.
+This `Secret` must additionally include one or more annotations prefixed with
+`build.openshift.io/source-secret-match-uri-`.  The value of each of these
+annotations is a URI pattern (defined below).  When a `BuildConfig` is created
+without a source clone secret reference and its Git source URI matches a URI
+pattern in a `Secret` annotation, {product-title} will automatically insert a
+reference to that `Secret` in the `BuildConfig`.
+
+A URI pattern must consist of:
 
 - a valid scheme (`*://`, `git://`, `http://`, `https://` or `ssh://`).
 - a host (`\*` or a valid hostname or IP address optionally preceded by `*.`).
-- a path (`/\*` or `/` followed by any characters optionally including `*` characters).
+- a path (`/\*` or `/` followed by any characters optionally including `*`
+  characters).
 
 In all of the above, a `*` character is interpreted as a wildcard.
 
 [NOTE]
 ====
-{product-title} will not automatically add a source clone secret to a build
-configuration that already contains a source clone secret.
+URI patterns only match Git source URIs which are conformant to RFC3986, e.g.
+https://github.com/openshift/origin.git.  They do not match the alternate SSH
+style that Git also uses, e.g. git@github.com:openshift/origin.git.
+
+It is not valid to attempt to express a URI pattern in the alternate style, or
+to include a username/password component in a URI pattern.
 ====
 
-If multiple source clone secrets match the URI of a particular source
-repository, {product-title} will select the secret with the longest match. This
-allows for basic overriding, as in the following example.
+If multiple `Secret`s match the Git URI of a particular `BuildConfig`,
+{product-title} will select the secret with the longest match. This allows for
+basic overriding, as in the following example.
 
 The following fragment shows two partial source clone secrets, the first
 matching any server in the domain `mycorp.com` accessed by HTTPS, and the second


### PR DESCRIPTION
Hopefully this change is a clarification.  It should go into all branches which have this doc section.