### PR TITLE
disconnected install updates

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -186,7 +186,20 @@ To sync the container images:
 $ systemctl start docker
 ----
 
-. Pull all of the required {product-title} containerized components.
+. If you are performing a xref:rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[containerized install],
+pull all of the required {product-title} host component images.
+ifdef::openshift-enterprise[]
+Replace `<tag>` with `{latest-tag}` for the latest version.
+endif::[]
++
+----
+# docker pull registry.access.redhat.com/rhel7/etcd
+# docker pull registry.access.redhat.com/openshift3/ose:<tag>
+# docker pull registry.access.redhat.com/openshift3/node:<tag>
+# docker pull registry.access.redhat.com/openshift3/openvswitch:<tag>
+----
+
+. Pull all of the required {product-title} infrastructure component images.
 ifdef::openshift-enterprise[]
 Replace `<tag>` with `{latest-tag}` for the latest version.
 endif::[]
@@ -214,7 +227,7 @@ $ docker pull registry.access.redhat.com/openshift3/node:<tag>
 $ docker pull registry.access.redhat.com/openshift3/openvswitch:<tag>
 ----
 
-. Pull all of the required {product-title} containerized components for the
+. Pull all of the required {product-title} component images for the
 additional centralized log aggregation and metrics aggregation components.
 ifdef::openshift-enterprise[]
 Replace `<tag>` with `{latest-int-tag}` for the latest version.
@@ -316,7 +329,18 @@ $ mkdir </path/to/repos/images>
 $ cd </path/to/repos/images>
 ----
 
-. Export the {product-title} containerized components:
+. If you are performing a xref:rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[containerized install],
+export the {product-title} host component images:
++
+----
+# docker save -o ose3-host-images.tar \
+    registry.access.redhat.com/rhel7/etcd \
+    registry.access.redhat.com/openshift3/ose \
+    registry.access.redhat.com/openshift3/node \
+    registry.access.redhat.com/openshift3/openvswitch
+----
+
+. Export the {product-title} infrastructure component images:
 +
 [source, bash]
 ----
@@ -342,7 +366,7 @@ $ docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/openvswitch
 ----
 
-. If you synchronized the metrics and log aggregation images, export:
+. If you synchronized the metrics and log aggregation images, export them:
 +
 [source, bash]
 ----
@@ -490,7 +514,7 @@ Skip the section titled *Host Registration* and start with *Installing Base Pack
 == Installing {product-title}
 
 [[disconnected-importing-containerized-components]]
-=== Importing {product-title} Containerized Components
+=== Importing {product-title} Component Images
 
 To import the relevant components, securely copy the images from the connected
 host to the individual {product-title} hosts:
@@ -499,20 +523,16 @@ host to the individual {product-title} hosts:
 ----
 $ scp /var/www/html/repos/images/ose3-images.tar root@<openshift_host_name>:
 $ ssh root@<openshift_host_name> "docker load -i ose3-images.tar"
-----
-
-If you prefer, you could use `wget` on each {product-title} host to fetch the
-tar file, and then perform the Docker import command locally. Perform the same
-steps for the metrics and logging images, if you synchronized them.
-
-On the host that will act as an {product-title} master, copy and import the
-builder images:
-
-[source, bash]
-----
 $ scp /var/www/html/images/ose3-builder-images.tar root@<openshift_master_host_name>:
 $ ssh root@<openshift_master_host_name> "docker load -i ose3-builder-images.tar"
 ----
+
+Perform the same steps for the host components if your install will be
+containerized. Perform the same steps for the metrics and logging images,
+if your cluster will use them.
+
+If you prefer, you could use `wget` on each {product-title} host to fetch the
+tar file, and then perform the Docker import command locally.
 
 [[disconnected-running-the-openshift-installer]]
 === Running the {product-title} Installer

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -198,6 +198,7 @@ $ docker pull registry.access.redhat.com/openshift3/ose-cluster-capacity:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-deployer:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
+$ docker pull registry.access.redhat.com/openshift3/registry-console:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-egress-http-proxy:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-egress-router:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-f5-router:<tag>
@@ -301,16 +302,6 @@ registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.1
 See the S2I table in the link:https://access.redhat.com/articles/2176281[OpenShift and Atomic Platform Tested Integrations page]
 for details about OpenShift image version compatibility.
 
-. If you are using a stand-alone registry or plan to enable the registry console
-with the integrated registry, you must pull the *registry-console* image.
-+
-Replace `<tag>` with `{latest-registry-console-tag}` for the latest version.
-+
-[source, bash]
-----
-$ docker pull registry.access.redhat.com/openshift3/registry-console:<tag>
-----
-
 [[disconnected-preparing-images-for-export]]
 === Preparing Images for Export
 
@@ -335,6 +326,7 @@ $ docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/ose-deployer \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-docker-registry \
+    registry.access.redhat.com/openshift3/registry-console
     registry.access.redhat.com/openshift3/ose-egress-http-proxy \
     registry.access.redhat.com/openshift3/ose-egress-router \
     registry.access.redhat.com/openshift3/ose-f5-router \


### PR DESCRIPTION
As I discovered while looking at bug https://bugzilla.redhat.com/show_bug.cgi?id=1480195#c12 this topic needed a few updates.

At this time there is no option to not install registry-console, and the install checks will look for its image to be there. So, just include it in the images needed for a disconnected install.

When doing a containerized install, the host components (master, node, ovs, etcd) need to be synchronized as well. This led to some confusing usage of the word "containerized" so that needed some clearing up too. I thought it best to only refer to those host components as "containerized", preferring to refer to the others as "components" or "images". We have host components, "on-cluster infrastructure components" (may be a bit too awkward), builder images, and logging/metrics images.

About builder images; for some reason, previous instructions indicated they were only needed on masters. AFAIK builders can run anywhere so I'm not sure why these were separated out, other than because they're all optional. So I fixed that too.

We could go into further nuances of where only a subset of the images are needed (e.g. infra nodes, master vs node components) but it seemed complicated enough already to me, and disk space is cheap. At least everything is covered; those who want to optimize can figure those things out.

All up for review of course. Questions?