### PR TITLE
SCC: document AllowedFlexVolumes field

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -568,6 +568,24 @@ is set to false but allowed in the `volumes` field, then the `hostPath`
 value will be removed from `volumes`.
 ====
 
+[[authorization-allowed-flex-volumes]]
+=== Restricting an Access to Flexvolumes
+
+{product-title} provides additional control of Flexvolumes based on their
+driver. When SCC allows the usage of Flexvolumes, pods may request any Flexvolumes.
+But when cluster admin specifies driver names in the `AllowedFlexVolumes`
+field, pods may use only Flexvolumes with these drivers.
+
+.Example of limiting access to only two Flexvolumes
+[source,yaml]
+----
+volumes:
+- flexVolume
+allowedFlexVolumes:
+- driver: example/lvm
+- driver: example/cifs
+----
+
 [[authorization-seccomp]]
 === Seccomp
 


### PR DESCRIPTION
This PR documents new `AllowedFlexVolumes` field that will be added in 3.7

PR with implementation: https://github.com/openshift/origin/pull/15558
Trello card: https://trello.com/c/YT6sNEay/61-5-sccfsi-scc-flex-volume-support

PTAL @openshift/sig-security 