### PR TITLE
Added information on upgrading to Pro

### DIFF
--- a/getting_started/choose_a_plan.adoc
+++ b/getting_started/choose_a_plan.adoc
@@ -47,8 +47,10 @@ image::online_pro_manage_plan.png[manage your plan]
 [[getting-started-upgrading-plan]]
 == Upgrading Your Plan
 
-If you are upgrading from {product-title} Starter to {product-title} Pro, see
-xref:../dev_guide/templates.adoc#export-as-template[Creating a Template from
+To upgrade your plan from {product-title} Starter to {product-title} Pro, visit
+link:https://manage.openshift.com[`manage.openshift.com`].
+
+See xref:../dev_guide/templates.adoc#export-as-template[Creating a Template from
 Existing Objects] for guidance on exporting all of your existing objects.
 
 [[getting-started-next-up-basic-walkthrough]]


### PR DESCRIPTION
This should land after October 17.

@tiwillia What page should users go to once they go to manage.openshift.com?