### PR TITLE
admission_controllers.html: don't show link in non-enterprise docs

### DIFF
--- a/architecture/additional_concepts/admission_controllers.adoc
+++ b/architecture/additional_concepts/admission_controllers.adoc
@@ -121,7 +121,9 @@ ifdef::openshift-dedicated[]
 - xref:../../admin_guide/osd_build_defaults_overrides.adoc#admin-guide-osd-build-defaults-overrides[Configuring Global Build Defaults and Overrides]
 endif::[]
 - xref:../../admin_guide/scheduling/scheduler.adoc#controlling-pod-placement[Controlling Pod Placement]
+ifdef::openshift-enterprise[]
 - xref:../../admin_solutions/user_role_mgmt.adoc#role-binding-restriction[Restricting Role Bindings]
+endif::[]
 
 [[admission-controllers-using-containers]]
 == Admission Controllers Using Containers


### PR DESCRIPTION
Fixes #5240

PTAL @openshift/team-documentation @pweil- 
CC @simo5 