### PR TITLE
admin_guide/manage_scc: improve the steps for using the privileged SCC

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -250,6 +250,15 @@ In some cases, an administrator might want to allow users or groups outside the
 administrator group access to create more _privileged pods_. To do so, you can:
 
 . Determine the user or group you would like to have access to the SCC.
++
+[WARNING]
+====
+Granting access to a user only works when the user directly creates a pod. For
+pods created on behalf of a user, **in most cases** by the system itself, **access
+should be given to a service account** under which related controller is operated
+upon. Examples of resources that create pods on behalf of a user are
+Deployments, StatefulSets, DaemonSets, etc.
+====
 
 . Run:
 +
@@ -257,21 +266,14 @@ administrator group access to create more _privileged pods_. To do so, you can:
 $ oc adm policy add-scc-to-user <scc_name> <user_name>
 $ oc adm policy add-scc-to-group <scc_name> <group_name>
 ----
-
++
 For example, to allow the *e2e-user* access to the *privileged* SCC, run:
-
++
 ----
 $ oc adm policy add-scc-to-user privileged e2e-user
 ----
 
-[WARNING]
-====
-Granting access to a user only works when the user directly creates a pod. For
-pods created on behalf of a user, in most cases by the system itself, access
-should be given to a service account under which related controller is operated
-upon. Examples of resources that create pods on behalf of a user are
-Deployments, StatefulSets, DaemonSets, etc.
-====
+. Modify `SecurityContext` of a container to request a privileged mode.
 
 [[grant-a-service-account-access-to-the-privileged-scc]]
 
@@ -294,6 +296,9 @@ Then, ensure that the resource is being created on behalf of the service
 account. To do so, set the `spec.serviceAccountName` field to a service account
 name. Leaving the service account name blank will result in the `default`
 service account being used.
+
+Then, ensure that at least one of the pod's containers is requesting a
+privileged mode in the security context.
 
 [[enable-images-to-run-with-user-in-the-dockerfile]]
 


### PR DESCRIPTION
This PR improves the documentation about getting use of the `privileged` SCC by mentioning that a pod have to request privileged mode explicitly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1492266

PTAL @pweil- 
CC @adelton @simo5 