### PR TITLE
Remove references to Vagrant images

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -30,8 +30,7 @@ installing and configuring Docker. After ensuring your hosts are properly set
 up, you can continue by choosing one of the following installation methods.
 
 Docker and {product-title} must run on the Linux operating system. If you wish to
-run the server from a Windows or Mac OS X host, you should download and run the
-Origin Vagrant image as described in xref:building-from-source[Method 3].
+run the server from a Windows or Mac OS X host, you should start a Linux VM first.
 
 [CAUTION]
 ====
@@ -165,13 +164,6 @@ would generate their own keys and not have access to the system keys.
 
 Now that you have {product-title} successfully running in your environment,
 xref:try-it-out[try it out] by walking through a sample application lifecycle.
-
-=== Method 3: Building from Source [[building-from-source]]
-You can build {product-title} from source locally or using
-https://www.vagrantup.com/[Vagrant]. See the {product-title} repository on
-GitHub
-https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc#develop-on-virtual-machine-using-vagrant[for
-instructions].
 
 [[try-it-out]]
 == Try It Out

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -11,19 +11,6 @@
 
 toc::[]
 
-ifdef::openshift-origin[]
-[NOTE]
-====
-If you are using https://www.vagrantup.com[Vagrant] to run {product-title}, you
-do not need to go through the following sections. These changes are only
-necessary when you are setting up the host yourself. If you are using Vagrant,
-see the
-link:https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc#develop-on-virtual-machine-using-vagrant[Contributing
-Guide], then you can skip directly to trying out the
-xref:../../getting_started/administrators.adoc#try-it-out[sample applications].
-====
-endif::[]
-
 ifdef::openshift-enterprise[]
 
 [[software-prerequisites]]


### PR DESCRIPTION
OpenShift Origin developers do not support or upkeep the old set of
Vagrant images for development. We should not direct users to them or to
their documentation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/openshift-docs/issues/2457

/cc @mburke5678 