### PR TITLE
Bug#1489497 Persistent Storage Using Fibre Channel Documentation should elaborate on the specification of the targetWWNs

### DIFF
--- a/install_config/persistent_storage/persistent_storage_fibre_channel.adoc
+++ b/install_config/persistent_storage/persistent_storage_fibre_channel.adoc
@@ -14,7 +14,7 @@ toc::[]
 == Overview
 You can provision your {product-title} cluster with
 xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent storage] using
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch25.html[Fibre Channel].
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-fibrechanel.html[Fibre Channel].
 Some familiarity with Kubernetes and Fibre Channel is assumed.
 
 The Kubernetes xref:../../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[persistent volume]
@@ -32,9 +32,10 @@ storage provider.
 
 == Provisioning
 Storage must exist in the underlying infrastructure before it can be mounted as
-a volume in {product-title}. All that is required for Fibre Channel persistent storage is the targetWWNs (array of Fibre Channel target's World Wide Names),
-a valid LUN number, and filesystem type, and the `*PersistentVolume*` API. Note, the number of LUNs must correspond to the number of Persistent Volumes that
-are created. In the example below, we have LUN as 2, therefore we have created two Persistent Volume definitions.
+a volume in {product-title}. All that is required for Fibre Channel persistent
+storage is the *targetWWNs* (array of Fibre Channel target's World Wide
+Names), a valid *LUN* number, filesystem type, and the `*PersistentVolume*`
+API. Persistent volume and a LUN have one-to-one mapping between them.
 
 [NOTE]
 ====
@@ -42,7 +43,6 @@ Fibre Channel does not support the 'Recycle' reclaim policy.
 ====
 
 .Persistent Volumes Object Definition
-====
 
 [source,yaml]
 ----
@@ -56,29 +56,11 @@ spec:
   accessModes:
     - ReadWriteOnce
   fc:
-    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5']
+    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <1>
     lun: 2
     fsType: ext4
 ----
-
-[source,yaml]
-----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: pv0002
-spec:
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadOnlyMany
-  fc:
-    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5']
-    lun: 2
-    fsType: ext4
-----
-
-====
+<1> Fibre Channel WWNs are identified as `/dev/disk/by-path/pci-<IDENTIFIER>-fc-0x<WWN>-lun-<LUN#>`, but you do not need to provide any part of the path leading up to the `WWN`, including the `0x`, and anything after, including the `-` (hyphen).
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1489497

Also includes fixes for 
- https://bugzilla.redhat.com/show_bug.cgi?id=1474839
- https://bugzilla.redhat.com/show_bug.cgi?id=1489483

- Added information about fibre channel path
- fixed a broken link
- Removed incorrect example text