### PR TITLE
The osm_cluster_network_cidr, openshift_portal_net, and osm_host_subnet_length no longer set by default.

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -157,7 +157,7 @@ for any changes to take effect.
 The `*serviceNetworkCIDR*` and `*hostSubnetLength*` values cannot be changed
 after the cluster is first created, and `*clusterNetworkCIDR*` can only be
 changed to be a larger network that still contains the original network. For
-example, given the default value of *10.128.0.0/14*, you could change
+example, given the typical value of *10.128.0.0/14*, you could change
 `*clusterNetworkCIDR*` to *10.128.0.0/9* (i.e., the entire upper half of net
 10) but not to *10.64.0.0/16*, because that does not overlap the original value.
 ====

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -386,7 +386,7 @@ use the multitenant SDN plug-in.
 |This variable overrides the SDN cluster network CIDR block. This is the network
 from which pod IPs are assigned. This network block should be a private block
 and must not conflict with existing network blocks in your infrastructure to
-which pods, nodes, or the master may require access. Defaults to `10.128.0.0/14`
+which pods, nodes, or the master may require access. Reasonable value is `10.128.0.0/14`
 and cannot be arbitrarily re-configured after deployment, although certain
 changes to it can be made in the
 xref:../../install_config/configuring_sdn.adoc#configuring-the-pod-network-on-masters[SDN
@@ -399,15 +399,15 @@ will be created within the
 xref:../../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[{product-title}
 SDN]. This network block should be private and must not conflict with any
 existing network blocks in your infrastructure to which pods, nodes, or the
-master may require access to, or the installation will fail. Defaults to
-`172.30.0.0/16`, and cannot be re-configured after deployment. If changing from the default, avoid `172.17.0.0/16`, which the *docker0* network bridge uses by default, or modify the *docker0* network.
+master may require access to, or the installation will fail. Reasonable value is
+`172.30.0.0/16`, and cannot be re-configured after deployment. Try to avoid `172.17.0.0/16`, which the *docker0* network bridge uses by default, or modify the *docker0* network.
 
 |`osm_host_subnet_length`
 |This variable specifies the size of the per host subnet allocated for pod IPs
 by
 xref:../../architecture/networking/sdn.adoc#sdn-design-on-masters[{product-title}
-SDN]. Defaults to `9` which means that a subnet of size /23 is allocated to each
-host; for example, given the default 10.128.0.0/14 cluster network, this will
+SDN]. Reasonable value is `9` which means that a subnet of size /23 is allocated to each
+host; for example, given the typical 10.128.0.0/14 cluster network, this will
 allocate 10.128.0.0/23, 10.128.2.0/23, 10.128.4.0/23, and so on. This cannot be
 re-configured after deployment.
 
@@ -2031,6 +2031,10 @@ endif::[]
 # uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
 #openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
+osm_cluster_network_cidr=10.128.0.0/14
+openshift_portal_net=172.30.0.0/16
+osm_host_subnet_length=9
+
 # host group for masters
 [masters]
 master.example.com
@@ -2122,6 +2126,10 @@ endif::[]
 
 # uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
 #openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
+
+osm_cluster_network_cidr=10.128.0.0/14
+openshift_portal_net=172.30.0.0/16
+osm_host_subnet_length=9
 
 # host group for masters
 [masters]
@@ -2302,6 +2310,10 @@ openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'imag
 # enable ntp on masters to ensure proper failover
 openshift_clock_enabled=true
 
+osm_cluster_network_cidr=10.128.0.0/14
+openshift_portal_net=172.30.0.0/16
+osm_host_subnet_length=9
+
 # host group for masters
 [masters]
 master1.example.com
@@ -2402,6 +2414,10 @@ openshift_deployment_type=openshift-enterprise
 openshift_master_cluster_method=native
 openshift_master_cluster_hostname=openshift-cluster.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
+
+osm_cluster_network_cidr=10.128.0.0/14
+openshift_portal_net=172.30.0.0/16
+osm_host_subnet_length=9
 
 # host group for masters
 [masters]

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -260,7 +260,7 @@ xref:../registry/securing_and_exposing_registry.adoc#securing-the-registry[requi
 
 [IMPORTANT]
 ====
-172.30.0.0/16 is the default value of the `*servicesSubnet*` variable in the
+172.30.0.0/16 is the typical value of the `*servicesSubnet*` variable in the
 *_master-config.yaml_* file. If this has changed, then the `--insecure-registry`
 value in the above step should be adjusted to match, as it is indicating the
 subnet for the registry to use. Note that the `*openshift_portal_net*`


### PR DESCRIPTION
This is related to changes from https://bugzilla.redhat.com/show_bug.cgi?id=1451023 and https://github.com/openshift/openshift-ansible/pull/5430.