### PR TITLE
Hide space after line continuation \ due to callout

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -66,7 +66,7 @@ $ sudo docker run -d --name "origin" \
         --privileged --pid=host --net=host \
         -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
         -v /var/lib/docker:/var/lib/docker:rw \
-        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave \ <1>
+        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave \# <1>
         openshift/origin start
 ----
 <1> `rslave` only works if the Docker version is 1.10 or later and a Red Hat distribution.


### PR DESCRIPTION
https://docs.openshift.org/latest/getting_started/administrators.html#running-in-a-docker-container
https://github.com/openshift/openshift-docs/blame/master/getting_started/administrators.adoc#L69
The source has:
```
$ sudo docker ... \
        -v ...:rslave \ <1>
        openshift/origin start
```
Copy-pasting this command into a shell doesn't work.
The callout marker — circled (1) — is not part of copy-pasted text, but the space preceding it is, so instead of \ working as line continuation, the shell taked it as escaped space, resulting in error:
```
/usr/bin/docker-current: Error parsing reference: " " is not a valid repository/tag: invalid reference format.
```
and the next line `openshift/origin start` got run as separate command.

=> Took me a while to find right syntax (I was googling "footnote" didn't realize it's different "callout" thing) and test it:
http://asciidoctor.org/docs/user-manual/#copy-and-paste-friendly-callouts

* CONTRIBUTING doesn't say how to build the docs.
  Worrying about syntax bugs me every time I try to contribute to Red Hat docs...
  OK, now I found `tools_and_setup.adoc` but TLDR :)
  * OK, `gem install ascii_binder`, `asciibinder build`, `asciibinder watch` are all I needed.  I recommend adding that in CONTRIBUTING or even README.
  * Hmm perhaps recommend https://asciidoclive.com/ or https://espadrine.github.io/AsciiDocBox/