### PR TITLE
Router support for Strict-Transport-Security (hsts)

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -601,6 +601,7 @@ For all the items outlined in this section, you can set annotations on the
 |`*haproxy.router.openshift.io/timeout*` | Sets a server-side timeout for the route. xref:time-units[(TimeUnits)] | `ROUTER_DEFAULT_SERVER_TIMEOUT`
 |`*router.openshift.io/haproxy.health.check.interval*`| Sets the interval for the back-end health checks. xref:time-units[(TimeUnits)] | `ROUTER_BACKEND_CHECK_INTERVAL`
 |`*haproxy.router.openshift.io/ip_whitelist*` | Sets a xref:whitelist[whitelist] for the route. |
+|`*haproxy.router.openshift.io/hsts_header*` | Sets a xref:hsts[Strict-Transport-Security] header for the route. |
 |===
 
 .A Route Setting Custom Timeout
@@ -669,6 +670,54 @@ metadata:
   annotations:
     haproxy.router.openshift.io/ip_whitelist: 180.5.61.153 192.168.1.0/24 10.0.0.0/8
 ----
+
+[[hsts]]
+== Strict-Transport-Security (HSTS)
+
+Strict-Transport-Security (hsts) policy (as described in
+link:https://tools.ietf.org/html/rfc6797[RFC 6797]) is a way that the
+host can tell clients to always use https requests to the host. When this
+is not used, a http request to a host that requires https results in the host
+possibly generating a redirect to the https url or it may just drop the
+request. The redirect can expose information about the site.
+
+HSTS adds a Strict-Transport-Security header to https responses from the site.
+The client (often a browser) reads the header and from then on enforces the policy.
+All requests to the http URL are changed to https before the request is sent.
+This eliminates the need for a redirect.
+
+HSTS can be added to a route by adding the haproxy.router.openshift.io/hsts_header
+to the route. The value of the annotation is the set of parameters that are
+included in the header.
+
+The Strict-Transport-Security header max-age parameter is required. It indicates the
+length of time, in seconds, the hsts policy is in effect. The client updates max-age
+whenever a response with a Strict-Transport-Security header is received from the host.
+When the max-age reaches 0 the client discards the policy.  When you wish to stop using hsts
+on a route, set max-age=0. Don't just delete the annotation or route.
+
+The optional includeSubDomains parameter tells the client that all subdomains of the host
+are to be treated the same as the host.
+
+The optional preload parameter tells the client that it should load the policy,
+if max-age is still greater than 0, while initializing
+itself.
+
+.A Route Specifying a hsts annotation:
+====
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload <1><2><3>
+----
+<1> max-age=31536000 - number of sesconds the policy is valid. - required (31536000 is one year)
+<2> includeSubDomains - treat all subdomains the same as the host - optional
+<3> preload - preload the policy when the client initializes - optional
+====
+
 
 [[wildcard-subdomain-route-policy]]
 == Creating Routes Specifying a Wildcard Subdomain Policy


### PR DESCRIPTION
OSE 3.7

Strict-Transport-Security (hsts) policy (RFC 6797) is a way that the
host can tell clients to always use https requests to the host. It is
controlled by adding the haproxy.router.openshift.io/hsts_header annotation
to the route. When the Strict-Transport-Security response is received
by a client, it observes the policy until:
1) It is updated by another response from the host, or
2) the max-age decrements to 0

The max-age is only updated when the client receives a response
that contains the Strict-Transport-Security header. Otherwise
that the client just decrements max-age to 0.  When hsts policy is
no longer desired for a host set max-age=0 in the annotation rather
than deleting the annotation. When a client makes another request
the response will cause the policy to be discarded.

In the route add the annotation:
metadata:
  annotations:
    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains

Bug: 1430035
https://bugzilla.redhat.com/show_bug.cgi?id=1430035

Trello:
https://trello.com/c/H1FhCI1I/452-3-sccfsi-support-hsts-policy