### PR TITLE
[cherry-pick to 3.5 stage] delete misleading sentence about blob storage

### DIFF
--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -517,8 +517,8 @@ registry unless the blob exists locally. The remote candidates are calculated
 from **DockerImage** entries stored in status of the
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
 stream], a client pulls from. All the unique remote registry references in
-such entries will be tried in turn until the blob is found. The blob, served
-this way, will not be stored in the registry.
+such entries will be tried in turn until the blob is found.
+
 
 This feature is on by default. However, it can be disabled using a
 xref:docker-registry-configuration-reference-middleware[configuration option].


### PR DESCRIPTION
(cherry picked from commit d6b0d786be1aaac8d37e8169ff2bdd69a6dca73b)

https://github.com/openshift/openshift-docs/pull/5361