### PR TITLE
Inital doc changes for supporting multiple cidr addresses

### DIFF
--- a/admin_solutions/master_node_config.adoc
+++ b/admin_solutions/master_node_config.adoc
@@ -416,16 +416,17 @@ a|Holds all the client connection information for controllers and other system c
 a|To be passed to the compiled-in-network plug-in. Many of the options here can be controlled in the Ansible inventory.
 
 - `*NetworkPluginName*` (string)
-- `*ClusterNetworkCIDR*` (string)
-- `*HostSubnetLength*` (unsigned integer)
+- `*cidr*` (string)
+- `*hostSubnetLength*` (unsigned integer)
 - `*ServiceNetworkCIDR*` (string)
 - `*ExternalIPNetworkCIDRs*` (string array): Controls which values are acceptable for the service external IP field. If empty, no external IP may be set. It can contain a list of CIDRs which are checked for access. If a CIDR is prefixed with `!`, then IPs in that CIDR are rejected. Rejections are applied first, then the IP is checked against one of the allowed CIDRs. For security purposes, you should ensure this range does not overlap with your nodes, pods, or service CIDRs.
 
 For Example:
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.3.0.0/16
-  hostSubnetLength: 8
+  clusterNetworks
+  - cidr: 10.3.0.0/16
+    hostSubnetLength: 8
   networkPluginName: example/openshift-ovs-subnet
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
   serviceNetworkCIDR: 179.29.0.0/16

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -89,27 +89,30 @@ xref:../install_config/master_node_configuration.adoc#install-config-master-node
 [source,yaml]
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.128.0.0/14 <1>
-  hostSubnetLength: 9 <2>
-  networkPluginName: "redhat/openshift-ovs-subnet" <3>
-  serviceNetworkCIDR: 172.30.0.0/16 <4>
+  clusterNetworks: <1>
+  - cidr: 10.128.0.0/14 <2>
+    hostSubnetLength: 9 <3>
+  networkPluginName: "redhat/openshift-ovs-subnet" <4>
+  serviceNetworkCIDR: 172.30.0.0/16 <5>
 ----
-<1> Cluster network for node IP allocation
-<2> Number of bits for pod IP allocation within a node
-<3> Set to *redhat/openshift-ovs-subnet* for the *ovs-subnet* plug-in,
+<1> List of Cluster networks for node IP allocation
+<2> First Cluster network for node IP allocation
+<3> Number of bits for pod IP allocation within a node for it's Cluster Network
+<4> Set to *redhat/openshift-ovs-subnet* for the *ovs-subnet* plug-in,
 *redhat/openshift-ovs-multitenant* for the *ovs-multitenant* plug-in, or
 *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
-<4> Service IP allocation for the cluster
+<5> Service IP allocation for the cluster
 ====
 
 [IMPORTANT]
 ====
-The `*serviceNetworkCIDR*` and `*hostSubnetLength*` values cannot be changed
-after the cluster is first created, and `*clusterNetworkCIDR*` can only be
-changed to be a larger network that still contains the original network. For
-example, given the default value of *10.128.0.0/14*, you could change
-`*clusterNetworkCIDR*` to *10.128.0.0/9* (i.e., the entire upper half of net
-10) but not to *10.64.0.0/16*, because that does not overlap the original value.
+The `*serviceNetwotkCIDR*` value cannot be changed after the cluster is first
+created.
+
+The entries in `*clusterNetworks*` can be changed but the cluster will fail to
+start if nodes are allocated in `*cidr*` ranges no longer allocated in the master
+configuration file. Once defined a `*hostsubnetlength*` cannot be modified.
+
 ====
 
 [[configuring-the-pod-network-on-nodes]]

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -388,9 +388,12 @@ cluster.
 
 | Parameter Name | Description
 
-|`*ClusterNetworkCIDR*`
-|The CIDR string to specify the global overlay network's L3 space. This is
-reserved for the internal use of the cluster networking.
+|`*cidr*`
+|An entry in `*clusterNetworks*` that defines a range of a ClusterNetworks
+address space.
+
+|`*clusterNetworks*`
+|A list of ClusterNetworks that defines the global overlay networks L3 space
 
 |`*ExternalIPNetworkCIDRs*`
 |Controls what values are acceptable for the service external IP field. If
@@ -400,10 +403,6 @@ rejected. Rejections will be applied first, then the IP checked against one of
 the allowed CIDRs. You must ensure this range does not overlap with your nodes,
 pods, or service CIDRs for security reasons.
 
-|`*HostSubnetLength*`
-|The number of bits to allocate to each host's subnet. For example, 8 would mean a
-/24 network on the host.
-
 |`*IngressIPNetworkCIDR*`
 |Controls the range to assign ingress IPs from for services of type
 *LoadBalancer* on bare metal. It may contain a single CIDR that it will be
@@ -411,9 +410,9 @@ allocated from. By default `172.46.0.0/16` is configured. For security reasons,
 you should ensure that this range does not overlap with the CIDRs reserved for
 external IPs, nodes, pods, or services.
 
-|`*HostSubnetLength*`
-|The number of bits to allocate to each host's subnet. For example, 8 would mean a
-/24 network on the host.
+|`*hostSubnetLength*`
+|The number of bits to allocate to each host's subnet in a corresponding `*cidr*` range.
+For example, 8 would mean a /24 network on the host.
 
 |`*NetworkConfig*`
 |Provides network options for the node.


### PR DESCRIPTION
PR14558 adds the ability to configure multiple cluster networks to allocate nodes from. This is to document that change 