### PR TITLE
[enterprise-3.7] Use an annotation to provide a route cookie

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -594,6 +594,9 @@ For all the items outlined in this section, you can set annotations on the
 |Variable | Description | Environment Variable Used as Default
 |`*haproxy.router.openshift.io/balance*`| Sets the xref:load-balancing[load-balancing algorithm]. Available options are `source`, `roundrobin`, and `leastconn`. | `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, use `ROUTER_LOAD_BALANCE_ALGORITHM`.
 |`*haproxy.router.openshift.io/disable_cookies*`| Disables the use of cookies to track related connections. If set to `true` or `TRUE`, the balance algorithm is used to choose which back-end serves connections for each incoming HTTP request. |
+|`*haproxy.router.openshift.io/cookie_name*`| Specifies an optional cookie to be used for
+this route. The name must consist of any combination of upper and lower case letters, digits, "_",
+and "-". The default is the hashed internal key name for the route. |
 |`*haproxy.router.openshift.io/rate-limit-connections*`| Setting `true` or `TRUE` to enables rate limiting functionality. |
 |`*haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp*`| Limits the number of concurrent TCP connections shared by an IP address. |
 |`*haproxy.router.openshift.io/rate-limit-connections.rate-http*`| Limits the rate at which an IP address can make HTTP requests. |

--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -32,6 +32,8 @@ endif::[]
 |`ROUTER_ALLOWED_DOMAINS` | | A comma-separated list of domains that the host name in a route can only be part of. Any subdomain in the domain can be used. Option `ROUTER_DENIED_DOMAINS` overrides any values given in this option. If set, everything outside of the allowed domains will be rejected.
 |`ROUTER_BACKEND_CHECK_INTERVAL` | 5000ms | Length of time between subsequent "liveness" checks on backends. xref:time-units[(TimeUnits)]
 |`ROUTER_CLIENT_FIN_TIMEOUT` | 1s | Controls the TCP FIN timeout period for the client connecting to the route. If the FIN sent to close the connection is not answered within the given time, HAProxy will close the connection anyway.  This is harmless if set to a low value and uses fewer resources on the router.  xref:time-units[(TimeUnits)]
+|`ROUTER_COOKIE_NAME` |  | Specifies cookie name to override the internally generated default name.  The name must consist of any combination of upper and lower case letters, digits, "_",
+and "-". The default is the hashed internal key name for the route.
 |`ROUTER_COMPRESSION_MIME` | "text/html text/plain text/css" | A space separated list of mime types to compress.
 |`ROUTER_DEFAULT_CLIENT_TIMEOUT`| 30s | Length of time within which a client has to acknowledge or send data. xref:time-units[(TimeUnits)]
 |`ROUTER_DEFAULT_CONNECT_TIMEOUT`| 5s | The maximum connect time. xref:time-units[(TimeUnits)]


### PR DESCRIPTION
Route annotation:
router.openshift.io/router.cookie.name
can be used to set a cookie name for the route.

Added ROUTER_COOKIE_NAME for setting cookie name for all routes.

The cookie must pass regex filter "[a-zA-Z0-9_-]+"

https://trello.com/c/dZpU26W9
(3) Allow routes to set the cookie names for session stickiness

origin PR 16454
https://github.com/openshift/origin/pull/16454

(cherry picked from commit 4971e9d86bc55bbacd1c99164a136ab274e19c35)

https://github.com/openshift/openshift-docs/pull/5309