### PR TITLE
STATS_PORT and ROUTER_METRICS_TYPE changes

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -46,6 +46,7 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`ROUTER_ENABLE_COMPRESSION`| | If `true` or `TRUE`, compress responses when possible.
 |`ROUTER_LOG_LEVEL` | warning | The log level to send to the syslog server.
 |`ROUTER_MAX_CONNECTIONS`| 20000 | Maximum number of concurrent connections.
+|`ROUTER_METRICS_TYPE`| haproxy | Type of router metrics collection. haproxy generates metrics in Prometheus format.
 |`ROUTER_OVERRIDE_HOSTNAME`|  | If set `true`, override the spec.host value for a route with the template in `ROUTER_SUBDOMAIN`.
 |`ROUTER_SERVICE_HTTPS_PORT` | 443 | Port to listen for HTTPS requests.
 |`ROUTER_SERVICE_HTTP_PORT` | 80 | Port to listen for HTTP requests.
@@ -64,7 +65,7 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 //|`*ROUTE_FIELDS*` |  | A field selector to apply to routes to watch, empty means all. (FUTURE: it does not have complete support we need in upstream/k8s.)
 |`ROUTE_LABELS` |  | A label selector to apply to the routes to watch, empty means all.
 |`STATS_PASSWORD` |  | The password needed to access router stats (if the router implementation supports it).
-|`STATS_PORT` |  | Port to expose statistics on (if the router implementation supports it).  If not set, stats are not exposed.
+|`STATS_PORT` |  | Port to expose statistics on (if the router implementation supports it).  Must be set when ROUTER_METRICS_TYPE=haproxy. Otherwise, if not set, stats are not exposed.
 |`STATS_USERNAME` |  | The user name needed to access router stats (if the router implementation supports it).
 |`TEMPLATE_FILE` | `/var/lib/haproxy/conf/custom/` `haproxy-config-custom.template` | The path to the HAProxy template file (in the container image).
 |`RELOAD_INTERVAL` | 5s | The minimum frequency the router is allowed to reload to accept new changes. xref:time-units[(TimeUnits)]


### PR DESCRIPTION
STATS_PORT=0 when ROUTER_METRICS_TYPE=haproxy is not supported.

Change STATS_PORT description, add ROUTER_METRICS_TYPE description.

Fixes bug 1466133
https://bugzilla.redhat.com/show_bug.cgi?id=1466133

origin PR 16621
https://github.com/openshift/origin/pull/16621