### PR TITLE
[enterprise-3.6] Bumped Node.js version numbers

### DIFF
--- a/dev_guide/migrating_applications/web_framework_applications.adoc
+++ b/dev_guide/migrating_applications/web_framework_applications.adoc
@@ -281,6 +281,12 @@ $ oc new-app https://github.com/<github-id>/<repo-name>.git
 |    |Nodejs-mongodb-example. This quickstart template only supports Node.js version 6.
 
 |===
+ifdef::openshift-online[]
+[IMPORTANT]
+====
+In {product-title} v3, version 0.10 is deprecated and no longer available to use.
+====
+endif::openshift-online[]
 
 [[dev-guide-migrating-web-framework-applications-wordpress]]
 == WordPress

--- a/using_images/s2i_images/nodejs.adoc
+++ b/using_images/s2i_images/nodejs.adoc
@@ -24,11 +24,20 @@ assembles your application source with any required dependencies to create a
 new image containing your Node.js application. This resulting image can be run
 either by {product-title} or by Docker.
 
+[[nodejs-versions]]
 == Versions
 Currently, {product-title} provides versions
-https://github.com/openshift/sti-nodejs/tree/master/0.10[0.10] and
-https://github.com/openshift/sti-nodejs[4] of Node.js.
+link:https://github.com/openshift/sti-nodejs/tree/master/0.10[0.10],
+link:https://github.com/sclorg/s2i-nodejs-container/tree/master/4[4], and
+link:https://github.com/sclorg/s2i-nodejs-container/tree/master/6[6] of Node.js.
+ifdef::openshift-online[]
+[IMPORTANT]
+====
+In {product-title} v3, version 0.10 is deprecated and no longer available to use.
+====
+endif::openshift-online[]
 
+[[nodejs-images]]
 == Images
 
 ifdef::openshift-online[]


### PR DESCRIPTION
(cherry picked from commit e2ef8ec7b51b76f853fff7fea277f4d562c96a89) xref:"https://github.com/openshift/openshift-docs/pull/5486"