### PR TITLE
[enterprise-3.7] Fixes typo in documentation

### DIFF
--- a/admin_guide/service_accounts.adoc
+++ b/admin_guide/service_accounts.adoc
@@ -229,7 +229,7 @@ build pods.
 |====
 
 To configure the project where those service accounts are created, set the
-`*openshiftInfrastructureNamespace*` field in in the
+`*openshiftInfrastructureNamespace*` field in the
 *_/etc/origin/master/master-config.yml_* file on the master:
 
 ====


### PR DESCRIPTION
(cherry picked from commit 7b7c565875179002ffa32b5f6ed9613617e54df4) xref:"https://github.com/openshift/openshift-docs/pull/5491"