### PR TITLE
Fix broken links in Architecture section

### DIFF
--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -22,8 +22,8 @@ By adding a limit range to your namespace, you can enforce the minimum and
 maximum amount of CPU and Memory consumed by an individual pod or container.
 
 See the
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/admission_control_limit_range.md[Kubernetes
-documentation] for more information.
+https://kubernetes.io/docs/admin/admission-controllers/#limitranger[Kurbenetes documentation]
+for more information.
 
 == ResourceQuota
 
@@ -36,12 +36,12 @@ cluster resources.
 
 ifdef::openshift-enterprise,openshift-origin[]
 See xref:../../admin_guide/quota.adoc#admin-guide-quota[Cluster Administration] and
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/admin/resource-quota.md[Kubernetes
+https://kubernetes.io/docs/admin/admission-controllers/#resourcequota[Kubernetes
 documentation] for more information on `*ResourceQuota*`.
 endif::[]
 
 ifdef::openshift-dedicated,openshift-online[]
-See https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/admin/resource-quota.md[Kubernetes
+See https://kubernetes.io/docs/admin/admission-controllers/#resourcequota[Kubernetes
 documentation] or contact your administrator for more information on `*ResourceQuota*`.
 endif::[]
 
@@ -69,7 +69,7 @@ administrator. Persistent volumes provide durable storage for stateful
 applications.
 
 See the
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/persistent-storage.md[Kubernetes
+https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistent-volumes[Kubernetes
 documentation] for more information.
 
 == PersistentVolumeClaim
@@ -81,7 +81,7 @@ binds them together. The claim is then used as a volume by a pod. Kubernetes
 makes sure the volume is available on the same node as the pod that requires it.
 
 See the
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/persistent-storage.md[Kubernetes
+https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[Kubernetes
 documentation] for more information.
 endif::[]
 

--- a/architecture/additional_concepts/overview.adoc
+++ b/architecture/additional_concepts/overview.adoc
@@ -8,5 +8,5 @@
 
 If you want to contribute to {product-title} documentation, see our
 https://github.com/openshift/openshift-docs[source repository] and
-https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.html[guidelines]
+https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc[guidelines]
 to get started.

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -242,9 +242,9 @@ endif::[]
 === Capacity
 
 Generally, a PV will have a specific storage capacity. This is set using the
-PV's `capacity` attribute. See the
-link:https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/resources.md[Kubernetes
-Resource Model] to understand the units expected by `capacity`.
+PV's `*capacity*` attribute. See the
+link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md[Kubernetes
+Resource Model] to understand the units expected by `*capacity*`.
 
 Currently, storage capacity is the only resource that can be set or requested.
 Future attributes may include IOPS, throughput, etc.
@@ -550,7 +550,7 @@ access modes.
 
 Claims, like pods, can request specific quantities of a resource. In this case,
 the request is for storage. The same
-link:https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/resources.md[resource
+https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#the-resource-model[resource
 model] applies to both volumes and claims.
 
 [[pvc-claims-as-volumes]]

--- a/architecture/core_concepts/deployments.adoc
+++ b/architecture/core_concepts/deployments.adoc
@@ -16,7 +16,7 @@ toc::[]
 == Replication Controllers
 
 A
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/replication-controller.md[replication
+https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/[replication
 controller] ensures that a specified number of replicas of a pod are running at
 all times. If pods exit or are deleted, the replication controller acts to
 instantiate more up to the defined number. Likewise, if there are more running

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -468,7 +468,7 @@ A service or replication controller that is defined to use pods with the
 *role=webserver* label treats both of these pods as part of the same group.
 
 The
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/labels.md[Kubernetes
+https://kubernetes.io/docs/concepts/overview/working-with-objects/labels[Kubernetes
 documentation] has more information on labels.
 
 [[endpoints]]

--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -77,7 +77,7 @@ Most objects in the system are scoped by namespace, but some are
 excepted and have no namespace, including nodes and users.
 
 The
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/admin/namespaces.md[Kubernetes
+https://kubernetes.io/docs/tasks/administer-cluster/namespaces/[Kubernetes
 documentation] has more information on namespaces.
 
 [[projects]]

--- a/creating_images/metadata.adoc
+++ b/creating_images/metadata.adoc
@@ -115,7 +115,7 @@ LABEL io.openshift.non-scalable     true
 |This label suggests how much resources the container image might need in order to
 work properly. The UI might warn the user that deploying this container image may
 exceed their user quota.  The values must be compatible with
-https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/resources.md#resource-quantities[Kubernetes
+https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities[Kubernetes
 quantity].
 
 ====


### PR DESCRIPTION
This pull-request is related to issue #5515 

I couldn't find a proper page about Resources in Kubernetes documentation, I just find a link in their repository that explains it.

If there is any problem, please let me know.
Thanks!
