### PR TITLE
Add links to 3.3 and 3.6 release notes

### DIFF
--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -145,7 +145,7 @@ $ oc policy add-role-to-group registry-viewer system:unauthenticated
 {product-title} 3.3 adds a Google Cloud Storage (GCS) driver to enable its use
 as the storage back end for the registry's container images. Prior to GCS driver
 initialization, the {product-title} admin must set a
-link:https://github.com/docker/distribution/blob/master/docs/storage-drivers/gcs.md[bucket
+link:https://github.com/docker/docker.github.io/blob/master/registry/storage-drivers/gcs.md[bucket
 parameter] to define the name of the GCS bucket to store objects in.
 
 [[ocp-support-docker-distribution-2-4]]

--- a/release_notes/ocp_3_6_release_notes.adoc
+++ b/release_notes/ocp_3_6_release_notes.adoc
@@ -30,7 +30,7 @@ security, privacy, compliance, and governance requirements.
 == About This Release
 
 Red Hat {product-title} version 3.6
-(link:https://access.redhat.com/errata/RHBA-2017:1716[RHBA-2017:1716]) is now
+(link:https://access.redhat.com/errata/RHBA-2017:2847[RHBA-2017:2847]) is now
 available. This release is based on
 link:https://github.com/openshift/origin/releases/tag/v3.6.0-rc.0[OpenShift
 Origin 3.6]. New features, changes, bug fixes, and known issues that pertain to


### PR DESCRIPTION
This PR addresses #5520 .

Docker links have been updated to match their new page structure. However, the link to Red Hat's original 3.6.0 release seems to have been removed entirely. I relinked to 3.6's newest stable version (https://access.redhat.com/errata/RHBA-2017:2847), but please let me know if this is incorrect.