### PR TITLE
Fix broken links in Install and Config docs

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -422,7 +422,7 @@ image garbage collection], and to
 xref:../../admin_guide/manage_nodes.adoc#configuring-node-resources[specify
 resources per node]. `kubeletArguments` are key value pairs that are passed
 directly to the Kubelet that match the
-http://kubernetes.io/v1.1/docs/admin/kubelet.html[Kubelet's command line
+https://kubernetes.io/docs/admin/kubelet/[Kubelet's command line
 arguments]. `kubeletArguments` are not migrated or validated and may become
 invalid if used. These values override other settings in node configuration
 which may cause invalid configurations. Example usage:

--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -390,7 +390,7 @@ each PV.
 
 They are many ways that you can use scripts to automate the above tasks. You can
 use an
-link:https://github.com/openshift/openshift-ansible/tree/master/roles/kube_nfs_volumes[example
+link:https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_node_certificates[example
 Ansible playbook] to help you get started.
 
 [[nfs-additional-config-and-troubleshooting]]

--- a/install_config/storage_examples/gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/gluster_dynamic_example.adoc
@@ -22,9 +22,7 @@ GlusterFS. All `oc` commands are executed on the {product-title} master host.
 
 This topic provides an end-to-end example of how to dynamically provision
 GlusterFS volumes. In this example, a simple NGINX HelloWorld application is
-deployed using the
-link:https://access.redhat.com/documentation/en/red-hat-gluster-storage/3.1/paged/container-native-storage-for-openshift-container-platform/chapter-2-red-hat-gluster-storage-container-native-with-openshift-container-platform[
-Red Hat Container Native Storage (CNS)] solution. CNS hyper-converges GlusterFS
+deployed using the link:https://access.redhat.com/documentation/en-us/red_hat_gluster_storage/3.3/html/container-native_storage_for_openshift_container_platform/[Red Hat Container Native Storage (CNS)] solution. CNS hyper-converges GlusterFS
 storage by containerizing it into the {product-title} cluster.
 
 The

--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -1068,11 +1068,11 @@ group sync.
 |Name |Description |Schema
 
 |`kind`
-|String value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: link:http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds[]
+|String value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: link:https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#types-kinds[]
 |string
 
 |`apiVersion`
-|Defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: link:http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources[]
+|Defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: link:https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#resources[]
 |string
 
 |`url`


### PR DESCRIPTION
This PR fixes #5519 .

Four of the five links have been replaced with working versions from the new documentation file trees. The only link that was not replaced was the link referenced in the example sigstore file below:

```
$ atomic trust add --sigstoretype web \
  --sigstore https://access.redhat.com/webassets/docker/content/sigstore \
  --pubkeys /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release \
  registry.access.redhat.com
```

I don't think that link is actually dead; I just think it can't be accessed without the public keys. Could a reviewer confirm? Thanks very much!