### PR TITLE
Fixed missing type flag and changed oadm to oc adm

### DIFF
--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -24,6 +24,16 @@ to view the statistics page, and enter the administrator password when prompted.
 This password and port are configured during the router installation, but they
 can be found by viewing the *_haproxy.config_* file on the container.
 
+To enable statistics view for the HAProxy router:
+
+----
+$ oc adm router hap --type=haproxy-router --service-account=router
+----
+
+The default statistics port is 1936. The `stats-port` cannot be `0` when using the HAProxy router.
+When using the HAProxy router, the metrics are in Prometheus format. When `type` is anything else the HAProxy CSV format is provided.
+
+
 == Disabling Statistics View
 By default the HAProxy statistics are exposed on port *1936* (with a
 password protected account). To disable exposing the HAProxy statistics,
@@ -32,20 +42,20 @@ specify *0* as the stats port number.
 ifdef::openshift-enterprise[]
 ====
 ----
-$ oadm router hap --service-account=router --stats-port=0
+$ oc adm router hap --type="" --service-account=router --stats-port=0
 ----
 ====
 endif::[]
 ifdef::openshift-origin[]
 ====
 ----
-$ oadm router hap --service-account=router --stats-port=0
+$ oc adm router hap --type="" --service-account=router --stats-port=0
 ----
 ====
 endif::[]
 
 
-Note: HAProxy will still collect and store statistics, it would just _not_
+Note: The `type` parameter must be empty. HAProxy will still collect and store statistics, it would just _not_
       expose them via a web listener. You can still get access to the
       statistics by sending a request to the HAProxy AF_UNIX socket inside
       the HAProxy Router container.


### PR DESCRIPTION
Per conversation with @pecameron. Need to add `-type=" "` to the `oadm router hap --service-account=router --stats-port=0` command. Also changed `oadm router` to `oc adm router`.