### PR TITLE
[enterprise-3.5] Emphasize the Docker build strategy is not accepted …

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -26,6 +26,14 @@ endif::[]
 * xref:using-secrets-during-build[Input secrets]
 * xref:using-external-artifacts[External artifacts]
 
+ifdef::openshift-online[]
+[IMPORTANT]
+====
+The Docker build strategy is not supported in {product-title}. Therefore, inline
+Dockerfile definitions are not accepted.
+====
+endif::[]
+
 Different inputs can be combined into a single build.
 ifndef::openshift-online[]
 As the inline Dockerfile takes

--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -11,6 +11,13 @@
 
 toc::[]
 
+
+ifdef::openshift-online[]
+[IMPORTANT]
+====
+The Docker build strategy is not supported in {product-title}.
+====
+endif::[]
 [[source-to-image-strategy-options]]
 == Source-to-Image Strategy Options
 


### PR DESCRIPTION
…in Online

(cherry picked from commit 6f8a4bc7a5cbbb6d0b210f74594f67d4fac2a0ca) xref:"https://github.com/openshift/openshift-docs/pull/5497"