### PR TITLE
[dedicated-3.5] admin_guide/manage_scc: to make use of privileged SCC…

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -238,6 +238,15 @@ In some cases, an administrator might want to allow users or groups outside the
 administrator group access to create more _privileged pods_. To do so, you can:
 
 . Determine the user or group you would like to have access to the SCC.
++
+[WARNING]
+====
+Granting access to a user only works when the user directly creates a pod. For
+pods created on behalf of a user, **in most cases** by the system itself, **access
+should be given to a service account** under which related controller is operated
+upon. Examples of resources that create pods on behalf of a user are
+Deployments, StatefulSets, DaemonSets, etc.
+====
 
 . Run:
 +
@@ -245,21 +254,14 @@ administrator group access to create more _privileged pods_. To do so, you can:
 $ oadm policy add-scc-to-user <scc_name> <user_name>
 $ oadm policy add-scc-to-group <scc_name> <group_name>
 ----
-
++
 For example, to allow the *e2e-user* access to the *privileged* SCC, run:
-
++
 ----
 $ oadm policy add-scc-to-user privileged e2e-user
 ----
 
-[WARNING]
-====
-Granting access to a user only works when the user directly creates a pod. For
-pods created on behalf of a user, in most cases by the system itself, access
-should be given to a service account under which related controller is operated
-upon. Examples of resources that create pods on behalf of a user are
-Deployments, StatefulSets, DaemonSets, etc.
-====
+. Modify `SecurityContext` of a container to request a privileged mode.
 
 [[grant-a-service-account-access-to-the-privileged-scc]]
 
@@ -282,6 +284,9 @@ Then, ensure that the resource is being created on behalf of the service
 account. To do so, set the `spec.serviceAccountName` field to a service account
 name. Leaving the service account name blank will result in the `default`
 service account being used.
+
+Then, ensure that at least one of the pod's containers is requesting a
+privileged mode in the security context.
 
 [[enable-images-to-run-with-user-in-the-dockerfile]]
 


### PR DESCRIPTION
…, a pod have to request privileged mode.

Addressed to https://bugzilla.redhat.com/show_bug.cgi?id=1492266

(cherry picked from commit d7d4db179b50636c4164b4d89a4d26427454f8be) xref:https://github.com/openshift/openshift-docs/pull/5289