### PR TITLE
[enterprise-3.7] clean up some imagestream doc

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -77,20 +77,24 @@ container images identified by tags, you can add tags to an image stream using t
 $ oc tag <source> <destination>
 ----
 
-For example, to configure the *ruby* image's *latest* tag to always refer to the
-current image for the tag *2.0*:
+For example, to configure the *ruby* imagestream's *static-2.0* tag to always refer to the
+current image for the *ruby* imagestream's *2.0* tag:
 
 ----
-$ oc tag ruby:latest ruby:2.0
+$ oc tag ruby:2.0 ruby:static-2.0
 ----
+
+This will create a new imagestream tag named *static-2.0* in the *ruby* imagestream.  The
+new tag will directly reference the image id that the *ruby:2.0* imagestream tag pointed
+to at the time `oc tag` was run, and the image it points to will never change.
 
 There are different types of tags available. The default behavior uses a
 _permanent_ tag, which points to a specific image in time; even when the source
-changes, it will not reflect in the destination tag.
+changes, the new (destination) tag will not change.
 
-A _tracking_ tag means the destination tag's metadata will be imported during
-the import. To ensure the destination tag is updated whenever the source tag
-changes, use the `--alias=true` flag:
+A _tracking_ tag means the destination tag's metadata will be updated during
+the import of the source tag. To ensure the destination tag is updated whenever the 
+source tag changes, use the `--alias=true` flag:
 
 ----
 $ oc tag --alias=true <source> <destination>
@@ -108,6 +112,9 @@ refreshed (i.e., re-imported) periodically. The period is configured globally at
 system level. See xref:importing-tag-and-image-metadata[Importing Tag and Image
 Metadata] for more details.
 
+The `--reference` flag will create an imagestream tag that is not imported.  The
+tag will simply point to the source location, permanently.
+
 If you want to instruct Docker to always fetch the tagged image from the
 integrated registry, use `--reference-policy=local`. The registry uses the
 ifdef::openshift-origin,openshift-enterprise[]
@@ -117,10 +124,10 @@ ifndef::openshift-origin+openshift-enterprise[]
 pull-through feature
 endif::[]
 to serve the image to the client. By default, the image blobs are
-mirrored locally by the registry. As a result, they are available for a  shorter
-time the next time they are needed. The flag also allows for pulling from
+mirrored locally by the registry. As a result, they can be pulled more quickly
+the next time they are needed. The flag also allows for pulling from
 insecure registries without a need to supply `--insecure-registry` to the Docker
-daemon if the image stream has an xref:insecure-registries[insecure annotation]
+daemon as long as the image stream has an xref:insecure-registries[insecure annotation]
 or the tag has an xref:insecure-tag-import-policy[insecure import policy].
 
 [[tag-naming]]
@@ -911,6 +918,20 @@ $ oc secrets new-dockercfg --help
 After the secret is configured, proceed with creating the new image stream or
 using the `oc import-image` command. During the import process, {product-title}
 will pick up the secrets and provide them to the remote party.
+
+[[trusting-registries]]
+=== Adding Trusted Certificates for External Registries
+
+If the registry you are importing from is using a certificate that is not signed
+by a standard certificate authority, you will need to explicitly configure the
+system to trust the registry's certificate or signing authority.  This can be 
+done by adding the CA certificate or registry certificate to the host system
+running the registry import controller (typically the master node).
+
+The certificate or CA certificate must be added to `/etc/pki/tls/certs` or `/etc/pki/ca-trust`,
+respectively, on the host system.  The `update-ca-trust` command will also need to be
+run on Red Hat distributions to pick up the certificate changes.
+
 
 [[importing-images-across-projects]]
 === Importing Images Across Projects


### PR DESCRIPTION
(cherry picked from commit 2ec80a66e6c88069852cbae5e8d3713436c81d5c) xref:https://github.com/openshift/openshift-docs/pull/5621