### PR TITLE
Fix file path to playbooks

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -544,7 +544,7 @@ The following command sets the Hawkular Metrics route to use
 You must have a persistent volume of sufficient size available.
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift-metrics.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/playbooks/byo/openshift-cluster/openshift-metrics.yml \
    -e openshift_metrics_install_metrics=True \
    -e openshift_metrics_hawkular_hostname=hawkular-metrics.example.com \
    -e openshift_metrics_cassandra_storage_type=pv
@@ -557,7 +557,7 @@ The following command sets the Hawkular Metrics route to use
 *hawkular-metrics.example.com* and deploy without persistent storage.
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift-metrics.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/playbooks/byo/openshift-cluster/openshift-metrics.yml \
    -e openshift_metrics_install_metrics=True \
    -e openshift_metrics_hawkular_hostname=hawkular-metrics.example.com
 ----
@@ -750,6 +750,6 @@ You can remove everything deployed by the OpenShift Ansible `openshift_metrics` 
 by performing the following steps:
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/byo/openshift-cluster/openshift-metrics.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/playbooks/byo/openshift-cluster/openshift-metrics.yml \
    -e openshift_metrics_install_metrics=False
 ----

--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -153,7 +153,7 @@ The following command sets the directory in the EFS volume to
 be mountable and writeable by the provisioner pod.
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_provisioners.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/playbooks/common/openshift-cluster/openshift_provisioners.yml \
    -e openshift_provisioners_install_provisioners=True \
    -e openshift_provisioners_efs=True \
    -e openshift_provisioners_efs_fsid=fs-47a2c22e \
@@ -207,6 +207,6 @@ You can remove everything deployed by the OpenShift Ansible `openshift_provision
 by running the following command:
 
 ----
-$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/common/openshift-cluster/openshift_provisioners.yml \
+$ ansible-playbook <OPENSHIFT_ANSIBLE_DIR>/playbooks/common/openshift-cluster/openshift_provisioners.yml \
    -e openshift_provisioners_install_provisioners=False
 ----


### PR DESCRIPTION
The correct path contains ```playbooks```
https://github.com/openshift/openshift-ansible/blob/master/playbooks/byo/openshift-cluster/openshift-metrics.yml
https://github.com/openshift/openshift-ansible/blob/master/playbooks/common/openshift-cluster/openshift_provisioners.yml