### PR TITLE
[enterprise-3.6] Bug 1454566, added guidance on userNameAttributes as…

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -1049,6 +1049,14 @@ The object specification for the configuration file is below.  Note that the dif
 objects have different fields.  For example, xref:sync-ldap-v1-activedirectoryconfig[v1.ActiveDirectoryConfig] has no `groupsQuery`
 field whereas xref:sync-ldap-v1-rfc2307config[v1.RFC2307Config] and xref:sync-ldap-v1-augmentedactivedirectoryconfig[v1.AugmentedActiveDirectoryConfig] both do.
 
+[IMPORTANT]
+====
+There is no support for binary attributes. All attribute data coming from the
+LDAP server must be in the format of a UTF-8 encoded string. For example, never
+use a binary attribute, such as `objectGUID`, as an ID attribute. You must use
+string attributes, such as `sAMAccountName` or `userPrincipalName`, instead.
+====
+
 [[sync-ldap-v1-ldapsyncconfig]]
 === v1.LDAPSyncConfig
 
@@ -1080,7 +1088,7 @@ group sync.
 
 |`insecure`
 |If `true`, indicates the connection should not use TLS. Cannot be set to true with a URL scheme of `ldaps://` If `false`, `ldaps://` URLs connect using TLS, and `ldap://` URLs are upgraded to a TLS connection using StartTLS as specified in link:https://tools.ietf.org/html/rfc2830[].
-|boolean.
+|boolean
 
 |`ca`
 |Optional trusted certificate authority bundle to use when making requests to the server. If empty, the default system roots are used.
@@ -1206,7 +1214,8 @@ group sync interacts with an LDAP server using the RFC2307 schema.
 |string
 
 |`userNameAttributes`
-|Defines which attributes on an LDAP user entry will be used, in order, as its {product-title} user name. The first attribute with a non-empty value is used. This should match your `PreferredUsername` setting for your `LDAPPasswordIdentityProvider`.
+|Defines which attributes on an LDAP user entry will be used, in order, as its {product-title} user name. The first attribute with a non-empty value is used. This should match your `PreferredUsername` setting for your `LDAPPasswordIdentityProvider`. The attribute to use as the name of the user in the {product-title} Group
+record. `mail` or `sAMAccountName` are preferred choices in most installations.
 |string array
 
 |`tolerateMemberNotFoundErrors`
@@ -1234,7 +1243,8 @@ schema.
 |xref:sync-ldap-v1-ldapquery[v1.LDAPQuery]
 
 |`userNameAttributes`
-|Defines which attributes on an LDAP user entry will be interpreted as its {product-title} user name.
+|Defines which attributes on an LDAP user entry will be interpreted as its {product-title} user name. The attribute to use as the name of the user in the {product-title} Group
+record. `mail` or `sAMAccountName` are preferred choices in most installations.
 |string array
 
 |`groupMembershipAttributes`
@@ -1258,7 +1268,8 @@ Active Directory schema.
 |xref:sync-ldap-v1-ldapquery[v1.LDAPQuery]
 
 |`userNameAttributes`
-|Defines which attributes on an LDAP user entry will be interpreted as its {product-title} user name.
+|Defines which attributes on an LDAP user entry will be interpreted as its {product-title} user name. The attribute to use as the name of the user in the {product-title} Group
+record. `mail` or `sAMAccountName` are preferred choices in most installations.
 |string array
 
 |`groupMembershipAttributes`


### PR DESCRIPTION
… strings

(cherry picked from commit 7b986eee8e59aedfb2029359b654eff27f666680) xref:https://github.com/openshift/openshift-docs/pull/5343