### PR TITLE
Bug 1499935 Create Logging Section in Cluster Administration Guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -636,6 +636,9 @@ Topics:
   File: idling_applications
 - Name: Analyzing Cluster Capacity
   File: cluster_capacity
+- Name: Logging
+  File: logging
+  Distros: openshift-origin,openshift-enterprise
 - Name: Revision History
   File: revhistory_admin_guide
   Distros: openshift-enterprise,openshift-dedicated

--- a/admin_guide/logging.adoc
+++ b/admin_guide/logging.adoc
@@ -1,0 +1,67 @@
+[[admin-guide-logging]]
+= Logging
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+As an {product-title} cluster administrator, you can deploy the EFK stack to
+aggregate logs for a range of {product-title} services. Application developers
+can view the logs of the projects for which they have view access. The EFK stack
+aggregates logs from hosts and applications, whether coming from multiple
+containers or even deleted pods.
+
+Once deployed in a cluster, the stack aggregates logs from all nodes and
+projects into Elasticsearch, and provides a Kibana UI to view any logs. Cluster
+administrators can view all logs, but application developers can only view logs
+for projects they have permission to view. The stack components communicate
+securely.
+
+[[tune-buffer-chunk-limit]]
+== Tuning Buffer Chunk Limit
+
+If the Fluentd logger is unable to keep up with a high number of logs, it will
+need to switch to file buffering to reduce memory usage and prevent data loss.
+
+The Fluentd `buffer_chunk_limit` is determined by the environment variable
+`BUFFER_SIZE_LIMIT`, which has the default value 16 MB. The file buffer size per
+output is determined by the environment variable `FILE_BUFFER_LIMIT`, which has
+the default value 2 GB. The permanent volume size has to be larger than
+`FILE_BUFFER_LIMIT` times number of output.
+
+On the Fluentd and Mux pods, permanent volume `/var/lib/fluentd` should be
+prepared by the PVC or hostmount, for example. That area is then used for the
+file buffers.
+
+The `buffer_type` and `buffer_path` are configured in the Fluentd config files as
+follows:
+
+----
+$ egrep "buffer_type|buffer_path" *.conf
+output-es-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-output-es-config`
+output-es-ops-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-output-es-ops-config`
+es-copy-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-es-copy-config`
+es-ops-copy-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-es-ops-copy-config`
+----
+
+The Fluentd `buffer_queue_limit` is calculated as follows:
+
+----
+FILE_BUFFER_LIMIT / FILE_SIZE_LIMIT
+----

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -27,7 +27,7 @@ containers or even deleted pods.
 
 The EFK stack is a modified version of the
 https://www.elastic.co/videos/introduction-to-the-elk-stack[ELK stack] and is
-comprised of:
+composed of:
 
 * https://www.elastic.co/products/elasticsearch[Elasticsearch (ES)]: An object store where all logs are stored.
 * http://www.fluentd.org/architecture[Fluentd]: Gathers logs from nodes and feeds them to Elasticsearch.
@@ -1472,7 +1472,7 @@ user access to a particular project.
 == Sending Logs to an External Syslog Server
 
 Use the `fluent-plugin-remote-syslog` plug-in on the host to send logs to an
-external syslog server. 
+external syslog server.
 
 Set environment variables in the `logging-fluentd` or `logging-mux` deployment
 configurations:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1499935

https://trello.com/c/IzxgZQcL/590-documevnt-use-file-buffer-instead-of-memory-buffer-for-fluentdloggingepic-ois-agl-perf
