### PR TITLE
Adding/updating Jenkins Pipeline documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -749,6 +749,8 @@ Topics:
     File: ruby_on_rails
   - Name: Setting Up a Nexus Mirror
     File: maven_tutorial
+  - Name: OpenShift Pipeline
+    File: openshift_pipeline
 - Name: Builds
   Dir: builds
   Topics:
@@ -850,6 +852,8 @@ Topics:
 - Name: Jobs
   File: jobs
   Distros: openshift-enterprise,openshift-dedicated,openshift-origin,openshift-online
+- Name: OpenShift Pipeline
+  File: openshift_pipeline
 - Name: Cron Jobs
   File: cron_jobs
   Distros: openshift-enterprise,openshift-dedicated,openshift-origin,openshift-online

--- a/dev_guide/app_tutorials/openshift_pipeline.adoc
+++ b/dev_guide/app_tutorials/openshift_pipeline.adoc
@@ -1,0 +1,223 @@
+[[dev-guide-openshift-pipeline-builds]]
+= OpenShift Pipeline Builds
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[introduction]]
+
+== Introduction
+
+Whether you are creating a simple website or a complex web of microservices, it's quick
+and easy to use OpenShift Pipelines to build, test, deploy, and promote your applications on OpenShift.
+OpenShift Pipelines provide an OpenShift experience around Jenkins Pipelines.
+
+In addition to standard Jenkins Pipeline Syntax, the OpenShift Jenkins image provides the OpenShift DSL
+(_via the OpenShift Jenkins Client Plugin_), which aims to provide a readable, concise, comprehensive,
+and fluent syntax for rich interactions with an OpenShift API server, allowing for even more fine grained
+control over the build, deployment, and promotion of applications on your OpenShift cluster.
+
+For this example, we are going to create an OpenShift Pipeline that will build, deploy, and verify a Node.js/MongoDB
+application using the https://github.com/openshift/nodejs-ex/blob/master/openshift/templates/nodejs-mongodb.json[nodejs-mongodb.json] template.
+
+[[creating-the-jenkins-master]]
+
+== Creating the Jenkins Master
+
+Creating the Jenkins master via the command line:
+
+----
+  // select the project that you want to use
+  // or create a new project with oc new-project <project_name>
+  $ oc project <project_name>
+  // if you want to use persistent storage, use jenkins-persistent instead
+  $ oc new-app jenkins-ephemeral
+----
+
+[NOTE]
+====
+If Jenkins auto-provisioning is enabled on your cluster, and you don't need to make any customizations to the
+Jenkins master, you can skip the above step. For more information about Jenkins autoprovisioning see xref:../../install_config/configuring_pipeline_execution.html[Configuring Pipeline Execution].
+====
+
+[[the-pipeline-build-config]]
+
+== The Pipeline Build Config
+
+Now that the Jenkins master is up and running, we will create a build config that employs the Jenkins pipeline strategy
+to build, deploy, and scale our Node.js/MongoDB example application.
+
+Create a file named *nodejs-sample-pipeline.yaml* with the below content:
+
+[source,yaml]
+----
+kind: "BuildConfig"
+apiVersion: "v1"
+metadata:
+  name: "nodejs-sample-pipeline"
+spec:
+  strategy:
+    jenkinsPipelineStrategy:
+      jenkinsfile: <pipeline content from below>
+    type: JenkinsPipeline
+----
+
+For more information about configuring the Pipeline Build Strategy see xref:../../builds/build_strategies.html#pipeline-strategy-options[Pipeline Strategy Options].
+
+[[the-jenkinsfile]]
+
+== The Jenkinsfile
+
+Now that we have created the build config with a jenkinsPipelineStrategy, we need to tell the pipeline what to do.
+We will do this by using an inline Jenkinsfile, since we aren't going to be creating our own git repository for this application.
+
+Below is the Jenkinsfile content which is written in groovy using the OpenShift DSL.  For this example we will inline
+this content into the build config using the http://www.yaml.org/spec/1.2/spec.html#id2795688[YAML Literal Style], though
+including a Jenkinsfile in your source repository is the preferred Jenkins way of doing things.
+
+The completed build config can be viewed in the OpenShift Origin repository in the examples directory: https://github.com/openshift/origin/tree/master/examples/jenkins/pipeline/nodejs-sample-pipeline.yaml[nodejs-sample-pipeline.yaml].
+
+[source, groovy]
+----
+// path of the template to use
+def templatePath = 'https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json'
+// name of the template that will be created
+def templateName = 'nodejs-mongodb-example'
+openshift.withCluster() {
+  openshift.withProject() {
+    echo "Using project: ${openshift.project()}"
+    pipeline {
+      agent {
+        node {
+          // spin up a node.js slave pod to run this build on
+          label 'nodejs'
+        }
+      }
+      options {
+        // set a timeout of 20 minutes for this pipeline
+        timeout(time: 20, unit: 'MINUTES')
+      }
+      stages {
+        stage('cleanup') {
+          steps {
+            // delete everything with this template label
+            openshift.selector("all", [ template : templateName ]).delete()
+            // delete any secrets with this template label
+            if (openshift.selector("secrets", templateName).exists()) {
+              openshift.selector("secrets", templateName).delete()
+            }
+          }
+        }
+        stage('create') {
+          steps {
+            // create a new application from the templatePath
+            openshift.newApp(templatePath)
+          }
+        }
+        stage('build') {
+          steps {
+            def builds = openshift.selector("bc", templateName).related('builds')
+            // wait up to 5 minutes for the build to complete
+            timeout(5) {
+              builds.untilEach(1) {
+                return (it.object().status.phase == "Complete")
+              }
+            }
+          }
+        }
+        stage('deploy') {
+          steps {
+            def rm = openshift.selector("dc", templateName).rollout()
+            // wait up to 5 minutes for the deployment to complete
+            timeout(5) {
+              openshift.selector("dc", templateName).related('pods').untilEach(1) {
+                return (it.object().status.phase == "Running")
+              }
+            }
+          }
+        }
+        stage('tag') {
+          steps {
+            // if everything else succeeded, tag the ${templateName}:latest image as ${templateName}-staging:latest
+            // a pipeline build config for the staging environment can watch for the ${templateName}-staging:latest
+            // image to change and then deploy it to the staging environment
+            openshift.tag("${templateName}:latest", "${templateName}-staging:latest")
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+[NOTE]
+====
+The above example has been written using the *declarative pipeline* style, but the older *scripted pipeline* style is also supported.
+====
+
+
+[[creating-the-pipeline]]
+
+== Creating the Pipeline
+
+Now we can create the build config in our OpenShift cluster with the following command:
+
+[source]
+----
+$ oc create -f nodejs-sample-pipeline.yaml
+----
+
+If you don't want to create your own file, you can use the sample from the Origin repository with the following command:
+
+[source]
+----
+$ oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/pipeline/nodejs-sample-pipeline.yaml
+----
+
+For more information about the OpenShift DSL syntax used here see https://github.com/openshift/jenkins-client-plugin/blob/master/README.md[OpenShift Jenkins Client Plugin].
+
+[[starting-the-pipeline]]
+
+== Starting the Pipeline
+
+We can now start the pipeline with the following command:
+
+[source]
+----
+$ oc start-build nodejs-sample-pipeline
+----
+
+[NOTE]
+====
+Alternatively, you could also start your pipeline via the OpenShift Web Console by navigating to the Builds -> Pipeline
+section and clicking *Start Pipeline*, or by visiting the Jenkins Console, navigating to the Pipeline that you created,
+and clicking *Build Now*.
+====
+
+Once the pipeline has started you should see the following actions performed within your project:
+
+ * a job instance is created on the Jenkins server
+ * a slave pod is launched _(if your pipeline requires one)_
+ * the pipeline runs on the slave pod _(or the master if no slave is required)_
+ ** any previously created resources with the *template=nodejs-mongodb-example* label will be deleted
+ ** a new application (and all of it's associated resources) will be created from the *nodejs-mongodb-example* template
+ ** a build will be started using the *nodejs-mongodb-example* build config
+ *** the pipeline will wait until the build has completed to trigger the next stage
+ ** a deployment will be started using the *nodejs-mongodb-example* deployment config
+ *** the pipeline will wait until the deployment has completed to trigger the next stage
+ ** if the build and deploy are successful, the *nodejs-mongodb-example:latest* image will be tagged as *nodejs-mongodb-example:stage*
+ * the slave pod is deleted _(if one was required for the pipeline)_
+
+[NOTE]
+====
+The best way to visualize the pipeline execution is by viewing it in the OpenShift web console.  You can view your
+pipelines by logging into the web console and navigating to Builds -> Pipelines.
+====
+

--- a/dev_guide/openshift_pipeline.adoc
+++ b/dev_guide/openshift_pipeline.adoc
@@ -1,0 +1,115 @@
+[[dev-guide-openshift-pipeline]]
+= OpenShift Pipeline
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[overview]]
+
+== Overview
+
+OpenShift Pipelines give you fine-grained control over building, deploying, and promoting your applications on OpenShift.
+Using a combination of the Jenkins Pipeline Build Strategy, Jenkinsfiles, and the OpenShift DSL _(provided by the OpenShift
+Jenkins Client Plugin)_, you can create advanced build/test/deploy/promote Pipelines for any scenario.
+
+[[openshift-jenkins-Pipeline-plugin]]
+
+== OpenShift Jenkins Client Plugin
+
+The https://github.com/openshift/jenkins-client-plugin[OpenShift Jenkins Client Plugin] must be installed
+on your Jenkins master so that the OpenShift DSL will be available to use within the JenkinsFile for your
+application.  This plugin is installed and enabled by default when using the OpenShift Jenkins image.
+
+For more information about installing and configuring this plugin, see xref:../install_config/configuring_pipeline_execution.html#openshift-pipeline-dsl-plugin[Installation and Configuration - Configuring Pipeline Execution].
+
+[[the-openshift-dsl]]
+
+=== OpenShift DSL
+
+The OpenShift Jenkins Client Plugin provides a fluent-styled Domain Specific Language (DSL) for communicating with the OpenShift
+API from within the Jenkins slaves.  The OpenShift DSL is based on Groovy syntax and provides many convenience
+methods for controlling the lifecycle of your application such as Create, Build, Deploy, and Delete to name a few.
+
+The full details of the API are embedded within the plugin's online documentation within a running Jenkins instance. To find it:
+
+* Create a new Pipeline Item
+* Click "Pipeline Syntax" below the DSL text area
+* On the left navigation menu, click "Global Variables Reference"
+
+
+[[jenkins-pipeline-strategy]]
+
+== Jenkins Pipeline Strategy
+
+In order to take advantage of the OpenShift Pipelines within your project, you will need to utilize the
+xref:../../dev_guide/builds/build_strategies.html#pipeline-strategy-options[Jenkins Pipeline Build Strategy].
+This strategy defaults to using a *Jenkinsfile* at the root of your source repository, but also provides the
+following configuration options:
+
+* an inline jenkinsFile field within your BuildConfig
+* a jenkinsfilePath field within your BuildConfig that references the location of the JenkinsFile to use relative to the source contextDir.
+
+[NOTE]
+====
+The optional *jenkinsfilePath* field specifies the name of the file to use, relative to the source *contextDir*.
+If *contextDir* is omitted, it defaults to the root of the repository. If *jenkinsfilePath* is omitted, it defaults to *Jenkinsfile*.
+====
+
+For more detailed information about the Jenkins Pipeline Strategy see xref:../../dev_guide/builds/build_strategies.html#pipeline-strategy-options[Pipeline Strategy Options].
+
+[[the-jenkinsfile]]
+
+== Jenkinsfile
+
+The Jenkinsfile utilizes the standard groovy language syntax to allow fine grained control
+over the configuration, build, and deployment of your application.
+
+The Jenkinsfile can be supplied in one of the following ways:
+
+- a file located within your source code repository
+- embedded as part of your build configuration using the *jenkinsfile* field
+
+When using the first option, the Jenkinsfile must be included in your applications source code repository at one of the following locations:
+
+- A file named *Jenkinsfile* at the root of your repository
+- A file named *Jenkinsfile* at the root of the source *contextDir* of your repository
+- A file name specified via the *jenkinsfilePath* field of the *JenkinsPiplineStrategy* section of your build config, which is relative to the source *contextDir* if supplied, otherwise it defaults to the root of the repository
+
+The Jenkinsfile is executed on the Jenkins slave pod, which must have the OpenShift Client binaries available if you intend to use the OpenShift DSL.
+
+[[tutorial]]
+
+== Tutorial
+
+For a full walkthrough of building and deploying an application via a Jenkins Pipeline see xref:../app_tutorials/jenkins_pipeline.html#overview[Jenkins Pipeline Tutorial].
+
+[[advanced-topics]]
+
+== Advanced Topics
+
+[[disabling-jenkins-autoprovisioning]]
+
+=== Disabling Jenkins AutoProvisioning
+
+When a Pipeline build configuration is created, OpenShift checks to see if there is currently a Jenkins
+master pod provisioned in the current project.  If no Jenkins master is found, one is automatically created.
+If this behavior is not desirable (if you would like to use a Jenkins server external to OpenShift, for example),
+you can disable it.  See xref:../../install_config/configuring_pipeline_execution.html[Configuring Pipeline Execution] for more information.
+
+[[configuring-slave-pods]]
+
+=== Configuring Slave Pods
+
+The https://wiki.jenkins.io/display/JENKINS/Kubernetes+Plugin[Kubernetes Plugin] is also pre-installed in the official Jenkins image. This plugins allows
+the Jenkins master to create slave pods on OpenShift and delegate running jobs to them to achieve scalability as well as providing pods with specific
+runtimes for specific jobs.
+
+For more detailed information on configuring slave pods using the Kubernetes Plugin see https://github.com/jenkinsci/kubernetes-plugin/blob/master/README.md[Kubernetes Plugin README].
+

--- a/install_config/configuring_pipeline_execution.adoc
+++ b/install_config/configuring_pipeline_execution.adoc
@@ -83,4 +83,40 @@ xref:../dev_guide/integrating_external_services.adoc#dev-guide-integrating-exter
 The latter option could also be used to disable autoprovisioning in select
 projects only.
 
+== OpenShift Jenkins Client Plugin
+
+The OpenShift Jenkins Client Plugin is a Jenkins plugin which aims to provide a readable,
+concise, comprehensive, and fluent Jenkins Pipeline syntax for rich interactions with an
+OpenShift API Server. The plugin leverages the OpenShift command line tool (oc) which must
+be available on the nodes executing the script.
+
+For more information about installing and configuring the plugin, please use the links
+provided below which reference the official documentation.
+
+* https://github.com/openshift/jenkins-client-plugin/blob/master/README.md#installing[Installing]
+* https://github.com/openshift/jenkins-client-plugin/blob/master/README.md#configuring-an-openshift-cluster[Configuring an OpenShift Cluster]
+* https://github.com/openshift/jenkins-client-plugin/blob/master/README.md#setting-up-credentials[Setting up Credentials]
+* https://github.com/openshift/jenkins-client-plugin/blob/master/README.md#setting-up-jenkins-nodes[Setting up Jenkins Nodes]
+
+[NOTE]
+====
+Are you a developer looking for information about using this plugin?  If so, see xref:../dev_guide/builds/jenkins_pipeline_builds.adoc#jenkins-pipeline-overview[Jenkins Pipeline Builds].
+====
+
+== OpenShift Jenkins Sync Plugin
+
+This Jenkins plugin keeps OpenShift BuildConfig and Build objects in sync with Jenkins Jobs and Builds.
+
+The OpenShift jenkins Sync Plugin provides the following:
+
+ * dynamic job/run creation in Jenkins
+ * dynamic creation of slave pod templates from ImageStreams, ImageStreamTags, or ConfigMaps
+ * injecting of environment variables
+ * pipeline visualization in the OpenShift web console
+ * integration with the Jenkins git plugin, which passes commit information from OpenShift builds to the Jenkins git plugin
+
+For more information about this plugin, see:
+
+ * https://github.com/openshift/jenkins-sync-plugin/blob/master/README.md[OpenShift Jenkins Sync Plugin README]
+ * https://docs.openshift.org/latest/using_images/other_images/jenkins.html#sync-plug-in[Other Images - Jenkins - Sync Plugin]
 // end::installconfig_configuring_pipeline_execution[]

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -656,3 +656,15 @@ projects (when a `Build` is started).
 The Kubernetes plug-in is used to run Jenkins slaves as pods on your cluster.
 The auto-configuration of the Kubernetes plug-in is described
 in xref:../../using_images/other_images/jenkins.adoc#using-the-jenkins-kubernetes-plug-in-to-run-jobs[Using the Jenkins Kubernetes Plug-in to Run Jobs].
+
+[[memory-requirements]]
+== Memory Requirements
+
+The default memory allocation for the Jenkins container is 512Mi, regardless of whether you are using the Jenkins Ephemeral or Jenkins Persistent
+template. While Jenkins itself can easily operate within this limit, you will need to be mindful of any 'sh' invocations that you might be making
+from your pipelines, e.g. shell scripts, invoking the *oc* command via the OpenShift DSL, monitoring pids, etc., as these can quickly use up
+your memory allocation.
+
+You can easily increase the amount of memory available to Jenkins by overriding the *MEMORY_LIMIT* paramenter when instantiating the
+Jenkins Ephemeral or Jenkins Persistent template.  To learn more about overriding parameters in templates see the xref:../../templates.html[Templates]
+section of the Developer Guide.


### PR DESCRIPTION
Updating the Developers Guide section to include better documentation about
Jenkins Pipelines, how they work, how to create one, etc.

Trello: https://trello.com/c/rBojNLGj/1121-5-better-devguide-pipeline-docs-techdebt

Depends on: https://github.com/openshift/origin/pull/16880