### PR TITLE
Introduce embedded etcd migration doc

### DIFF
--- a/install_config/upgrading/migrating_embedded_etcd.adoc
+++ b/install_config/upgrading/migrating_embedded_etcd.adoc
@@ -1,0 +1,72 @@
+[[install-config-upgrading-etcd-data-migration]]
+= Migrating embedded etcd to external etcd
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+Until {product-title} 3.6 it was possible to deploy a cluster with an embedded etcd.
+Since {product-title} 3.7 it is no longer possible.
+Additionaly, the etcd API version since {product-title} 3.6 defaults to v3
+and since {product-title} 3.7 the v3 is the only version allowed.
+Thus, older deployments with embedded etcd with the etcd API version v2 need to migrate
+to the external etcd first
+xref:../../install_config/upgrading/migrating_etcd.adoc[followed by data migration]
+before they can be upgrade to {product-title} 3.7.
+
+This migration process performs the following steps:
+
+- Stop the master service
+- Perform an etcd backup of embedded etcd
+- Deploy external etcd (on the master or new host)
+- Perform backup of original etcd master certificates
+- Generate new etcd certificates for the master
+- Transfer embedded etcd backup to the external etcd host
+- Start external etcd from the transfered etcd backup
+- Re-configure master to use the external etcd
+- Start master
+
+[[etcd-embedded-migration-automated]]
+== Running the Automated Migration Playbook
+
+Either migration to external rpm etcd or external containerized etcd is currently supported.
+
+A migration playbook is provided to automate all aspects of the process; this is the preferred method for performing the migration.
+You must have access to your existing inventory file with both master and external etcd host defined in their separate groups. 
+
+. Ensure you have the latest version of the *openshift-ansible* packages
+installed:
++
+----
+# yum upgrade openshift-ansible\*
+----
+
+The inventory is expected to have exactly one host in [etcd] group.
+In most scenarios it's best just to use your existing master, there's no need for a separate host.
+
+. Run the *_embedded2external.yml_* playbook using your inventory file:
++
+----
+# ansible-playbook [-i /path/to/inventory] \
+ifdef::openshift-enterprise[]
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-etcd/embedded2external.yml
+endif::[]
+ifdef::openshift-origin[]
+    ~/openshift-ansible/playbooks/byo/openshift-etcd/embedded2external.yml
+endif::[]
+----
+
+[[etcd-embedded-migration-manual]]
+== Running the Manual Migration
+
+Currently, the manual migration is not recommended as it requires a deployment
+of new etcd cluster and re-deployment of etcd master certificates.
+


### PR DESCRIPTION
Describing only automatic migration via playbook as the manual migration requires additional steps that are hard to describe, e.g. etcd master certificates re-deployment. One needs to run corresponding ansible playbook for to re-deployment. So the manual migration will not be actually a manual migration. So, I would describe the manual steps only when a customer asks for it.

Trello: https://trello.com/c/9fnBfkT5/528-3-migrate-embedded-etcd-hosts-to-external-process?menu=filter&filter=label:committed-3.7