### PR TITLE
[OCP 3.4] Removed Templates from Architecure TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -174,6 +174,7 @@ Topics:
         Distros: openshift-*
       - Name: Templates
         File: templates
+        Alias: dev_guide/templates  
         Distros: openshift-*
   - Name: Additional Concepts
     Dir: additional_concepts


### PR DESCRIPTION
No rev history needed. Separate PR covered the removal of this file.