### PR TITLE
[dedicated-3.6] CP Removed Templates from Architecure TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -173,6 +173,7 @@ Topics:
         Distros: openshift-*
       - Name: Templates
         File: templates
+        Alias: dev_guide/templates
         Distros: openshift-*
   - Name: Additional Concepts
     Dir: additional_concepts


### PR DESCRIPTION
(cherry picked from commit ff3fd53668b6a5cf83286ae065fd0242996c4f52) xref:https://github.com/openshift/openshift-docs/pull/5772