### PR TITLE
[online-3.6] CP Removed Templates from Architecure TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -176,6 +176,7 @@ Topics:
         Distros: openshift-*
       - Name: Templates
         File: templates
+        Alias: dev_guide/templates
         Distros: openshift-*
   - Name: Additional Concepts
     Dir: additional_concepts


### PR DESCRIPTION
(cherry picked from commit 7efdc09b9d8cc9e5abc674dc3297d6cd6a2fd609) xref:https://github.com/openshift/openshift-docs/pull/5773