### PR TITLE
[enterprise-3.6] CP Removed Templates from Architecure TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -182,6 +182,7 @@ Topics:
         Distros: openshift-*
       - Name: Templates
         File: templates
+        Alias: dev_guide/templates
         Distros: openshift-*
   - Name: Additional Concepts
     Dir: additional_concepts


### PR DESCRIPTION
(cherry picked from commit 4eed554de53c0f3f9664871196b904058e7ce400) xref:https://github.com/openshift/openshift-docs/pull/5776