### PR TITLE
[enterprise-3.4] CP Removed Templates from Architecure TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -174,6 +174,7 @@ Topics:
         Distros: openshift-*
       - Name: Templates
         File: templates
+        Alias: dev_guide/templates  
         Distros: openshift-*
   - Name: Additional Concepts
     Dir: additional_concepts


### PR DESCRIPTION
(cherry picked from commit 9d1029b8c03bca83607f8d74e44a8d2ac0a83aba) xref:https://github.com/openshift/openshift-docs/pull/5775