### PR TITLE
[enterprise-3.5] CP Removed Templates from Architecure TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -176,6 +176,7 @@ Topics:
         Distros: openshift-*
       - Name: Templates
         File: templates
+        Alias: dev_guide/templates
         Distros: openshift-*
   - Name: Additional Concepts
     Dir: additional_concepts


### PR DESCRIPTION
(cherry picked from commit 958ff460732f6ae1c0d2f87b0914b9b01878ae7e) xref:https://github.com/openshift/openshift-docs/pull/5787