### PR TITLE
[enterprise-3.6] Added information about providing storage to an etcd…

### DIFF
--- a/scaling_performance/host_practices.adoc
+++ b/scaling_performance/host_practices.adoc
@@ -136,6 +136,68 @@ endif::[]
 etcd processes are typically memory intensive. Master / API server processes are CPU intensive. This makes them a reasonable co-location pair within a single machine or virtual machine (VM). Optimize communication between etcd and master hosts either by co-locating them on the same host, or providing a dedicated network.
 ====
 
+[[providing-storage-to-an-etcd-node-using-pci-passthrough-with-openstack]]
+=== Providing Storage to an etcd Node Using PCI Passthrough with OpenStack
+
+To provide fast storage to an etcd node so that etcd is stable at large scale,
+use PCI passthrough to pass a non-volatile memory express (NVMe) device directly
+to the etcd node. To set this up with Red Hat OpenStack 11 or later, complete
+the following on the OpenStack compute nodes where the PCI device exists.
+
+. Ensure Intel Vt-x is enabled in BIOS.
+
+. Enable the input–output memory management unit (IOMMU). In the
+*_/etc/sysconfig/grub_* file, add `intel_iommu=on iommu=pt` to the end of the
+`GRUB_CMDLINX_LINUX` line, within the quotation marks.
+
+.  Regenerate *_/etc/grub2.cfg_* by running:
++
+----
+$ grub2-mkconfig -o /etc/grub2.cfg
+----
+
+. Reboot the system.
+
+. On controllers in *_/etc/nova.conf_*:
++
+----
+[filter_scheduler]
+
+enabled_filters=RetryFilter,AvailabilityZoneFilter,RamFilter,DiskFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter
+
+available_filters=nova.scheduler.filters.all_filters
+
+[pci]
+
+alias = { "vendor_id":"144d", "product_id":"a820",
+"device_type":"type-PCI", "name":"nvme" }
+----
+
+. Restart `nova-api` and `nova-scheduler` on the controllers.
+
+. On compute nodes in *_/etc/nova/nova.conf_*:
++
+----
+[pci]
+
+passthrough_whitelist = { "address": "0000:06:00.0" }
+
+alias = { "vendor_id":"144d", "product_id":"a820",
+"device_type":"type-PCI", "name":"nvme" }
+----
++
+To retrieve the required `address`, `vendor_id`, and `product_id` values of the
+NVMe device you want to passthrough, run:
++
+----
+# lspci -nn | grep devicename
+----
+
+. Restart `nova-compute` on the compute nodes.
+
+. Configure the OpenStack version you are running to use the NVMe and launch the
+etcd node.
+
 [[scaling-performance-capacity-tuned-profile]]
 == Scaling Hosts Using the TuneD Profile
 


### PR DESCRIPTION
… node using PCI passthrough

(cherry picked from commit a29d88231e0ab2e83068416dc5e5ffbf01f24232) xref:https://github.com/openshift/openshift-docs/pull/5476