### PR TITLE
Trello-681 Remove Depricated ES_copy Content

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -820,63 +820,6 @@ xref:fluentd-upgrade-source[Updating Fluentd's Log Source After a Docker Log
 Driver Update] for more information.
 ====
 
-[[fluentd-log-external-elasticsearch]]
-*Having Fluentd Send Logs to Another Elasticsearch*
-
-[NOTE]
-====
-The use of `ES_COPY` is being deprecated. To configure FluentD to send a copy of
-its logs to an external aggregator, use xref:fluentd-external-log-aggregator[Fluentd
-Secure Forward] instead.
-====
-
-You can configure Fluentd to send a copy of each log message to both the
-Elasticsearch instance included with {product-title} aggregated logging, _and_
-to an external Elasticsearch instance. For example, if you already have an
-Elasticsearch instance set up for auditing purposes, or data warehousing, you
-can send a copy of each log message to that Elasticsearch.
-
-This feature is controlled via environment variables on Fluentd, which can be
-modified as described below.
-
-If its environment variable `ES_COPY` is *true*, Fluentd sends a copy of the
-logs to another Elasticsearch. The names for the copy variables are just like
-the current `ES_HOST`, `OPS_HOST`, and other variables, except that they add
-`_COPY`: `ES_COPY_HOST`, `OPS_COPY_HOST`, and so on. There are some
-additional parameters added:
-
-* `ES_COPY_SCHEME`, `OPS_COPY_SCHEME` - can use either `http` or `https` - defaults
-  to `https`
-* `ES_COPY_USERNAME`, `OPS_COPY_USERNAME` - user name to use to authenticate to
-  Elasticsearch using username/password auth
-* `ES_COPY_PASSWORD`, `OPS_COPY_PASSWORD` - password to use to authenticate to
-  Elasticsearch using username/password auth
-
-[NOTE]
-====
-Sending logs directly to an AWS Elasticsearch instance is not supported. Use
-xref:fluentd-external-log-aggregator[Fluentd Secure Forward] to direct logs to
-an instance of Fluentd that you control and that is configured with the
-`fluent-plugin-aws-elasticsearch-service` plug-in.
-====
-
-To set the parameters:
-
-. Edit the DaemonSet for Fluentd:
-+
-----
-$ oc edit -n logging ds logging-fluentd
-----
-+
-Add or edit the environment variable `ES_COPY` to have the value `"true"` (with the quotes),
-and add or edit the COPY variables listed above.
-
-[NOTE]
-====
-These changes will not be persisted across multiple runs of the logging playbook. You
-will need to edit the DaemonSet each time to update environment variables.
-====
-
 [[fluentd-external-log-aggregator]]
 *Configuring Fluentd to Send Logs to an External Log Aggregator*
 
@@ -1472,7 +1415,7 @@ user access to a particular project.
 == Sending Logs to an External Syslog Server
 
 Use the `fluent-plugin-remote-syslog` plug-in on the host to send logs to an
-external syslog server. 
+external syslog server.
 
 Set environment variables in the `logging-fluentd` or `logging-mux` deployment
 configurations:


### PR DESCRIPTION
https://trello.com/c/mNs806SG/681-document-remove-deprecated-escopy-method-of-forwarding-logs-to-external-es

https://trello.com/c/hk39Z7q0/591-2-remove-deprecated-escopy-method-of-forwarding-logs-to-external-es