### PR TITLE
[dedicated-3.7] Azure Disk Dynamic Provisioning

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -327,7 +327,6 @@ The table below lists the access modes supported by different persistent volumes
 [NOTE]
 ====
  * If pods rely on AWS EBS, GCE Persistent Disks, or Openstack Cinder PVs, use a xref:../../dev_guide/deployments/deployment_strategies.adoc#recreate-strategy[recreate deployment strategy]
-  * Azure Disk does not support dynamic provisioning.
 ====
 
 ifdef::openshift-dedicated,openshift-online[]

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -70,6 +70,17 @@ the master node. Do this by setting the
 |link:https://github.com/NetApp/trident[Configuring for Trident]
 |Storage orchestrator for NetApp ONTAP, SolidFire, and E-Series storage.
 
+
+|link:https://www.vmware.com/support/vsphere.html[VMWare vSphere]
+|`kubernetes.io/vsphere-volume`
+|link:http://kubernetes.io/docs/getting-started-guides/vsphere/[Getting Started with vSphere and Kubernetes]
+|
+
+|Azure Disk
+|`kubernetes.io/azure-disk`
+|xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[Configuring for Azure]
+|
+
 |===
 
 [IMPORTANT]
@@ -303,11 +314,82 @@ storage that are registered with it. Trident itself is configured separately.
 <1> For more information about installing Trident with {product-title}, see the link:https://github.com/NetApp/trident[Trident documentation].
 <2> For more information about supported parameters, see the link:https://github.com/NetApp/trident#storage-attributes[storage attributes] section of the Trident documentation.
 
-- OpenShift terminates unexpectedly and the dynamically provisioned
-AWS EBS
-contains useful data that must be recovered.
-The OpenShift users provide the storage administrators with a list of
-affected projects and their PVCs:
+[[vsphere]]
+=== VMWare vSphere Object Definition
+
+.vsphere-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/vsphere-volume <1>
+parameters:
+  diskformat: thin <2>
+
+----
+<1> For more information about using VMWare vSphere with {product-title}, see the link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[VMWare vSphere documentation].
+<2>  `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick`. See vSphere docs for details. Default: `thin`
+
+[[azure-unmanaged-disk]]
+=== Azure Unmanaged Disk Object Definition
+
+.azure-unmanaged-disk-storageclass.yaml
+[source,yaml]
+----
+  kind: StorageClass
+  apiVersion: storage.k8s.io/v1
+  metadata:
+    name: slow
+  provisioner: kubernetes.io/azure-disk
+  parameters:
+    skuName: Standard_LRS  <1>
+    location: eastus  <2>
+    storageAccount: azure_storage_account_name  <3>
+----
+<1> Azure storage account SKU tier. Default is empty.
+<2> Azure storage account location. Default is empty.
+<3> Azure storage account name. This must reside in the same resource group as the cluster. If a storage account is specified, the `location` is ignored. If a storage account is not specified, a new storage account gets created in the same resource group as the cluster.
+
+[[azure-advanced-disk]]
+=== Advanced Azure Disk Object Definition
+
+.azure-advanced-disk-storageclass.yaml
+[source,yaml]
+----
+  kind: StorageClass
+  apiVersion: storage.k8s.io/v1
+  metadata:
+    name: slow
+  provisioner: kubernetes.io/azure-disk
+  parameters:
+    storageaccounttype: Standard_LRS  <1>
+    kind: Shared  <2>
+----
+<1> Azure storage account SKU tier. Default is empty. *Note:* Premium VM can attach both _Standard_LRS_ and _Premium_LRS_ disks, Standard VM can only attach _Standard_LRS_ disks, Managed VM can only attach managed disks, and unmanaged VM can only attach unmanaged disks.
+<2> possible values are `shared` (default), `dedicated`, and `managed`. When `kind` is `shared`, all unmanaged disks are created in a few shared storage accounts in the same resource group as the cluster. When `kind` is `dedicated`, a new dedicated storage account gets created for the new unmanaged disk in the same resource group as the cluster. When `kind` is `managed`, a new managed disk gets created.
+
+
+[[change-default-storage-class]]
+== Changing the Default StorageClass
+If you are using GCE and AWS, use the following process to change the default StorageClass:
+
+. List the StorageClass:
++
+
+====
+----
+$ oc get storageclass
+
+NAME                 TYPE
+gp2 (default)        kubernetes.io/aws-ebs <1>
+standard             kubernetes.io/gce-pd
+----
+<1> `(default)` denotes the default StorageClass.
+====
+
+. Change the value of the annotation `storageclass.kubernetes.io/is-default-class` to `false` for the default StorageClass:
 +
 [cols="1,1"]
 |====


### PR DESCRIPTION
OpenShift 3.6 did not support Azure Disk dynamic provisioning.

Kubernetes from 1.7.2 supports two different types of Storage Classes for Azure Disk dynamic provisioning.

That's why the Azure Disk dynamic provisioning description is added to OpenShift 3.7 documentation.

(cherry picked from commit 0a3dc13286105cce54ccfb8be551cfc0f7f4b0c1) https://github.com/openshift/openshift-docs/pull/5768