### PR TITLE
[enterprise-3.7] Update docs on reconcile commands and how/when to us…

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -273,14 +273,32 @@ ifdef::openshift-enterprise,openshift-origin[]
 === Updating Cluster Roles
 
 After any xref:../../install_config/upgrading/index.adoc#install-config-upgrading-index[{product-title} cluster
-upgrade], the recommended default roles may have been updated. See
+upgrade], the default roles are updated and automatically reconciled when the
+server is started. Additionally, see
 xref:../../install_config/upgrading/manual_upgrades.adoc#updating-policy-definitions[Updating
-Policy Definitions] for instructions on getting to the new recommendations
+Policy Definitions] for instructions on getting other recommendations
 using:
 
 ----
 $ oc adm policy reconcile-cluster-roles
 ----
+
+[[applying-custom-roles-and-permissions]]
+
+=== Applying Custom Roles and Permissions
+
+To add or update custom roles and permissions, it is strongly recommended to use
+the following command:
+
+----
+# oc auth reconcile -f FILE
+----
+
+This command ensures that new permissions are applied properly in a way that
+will not break other clients. This is done internally by computing logical
+covers operations between rule sets, which is something you cannot do via a
+JSON merge on policy files.
+
 endif::[]
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -425,10 +425,10 @@ updated.
 [[updating-policy-definitions]]
 == Updating Policy Definitions
 
-After a cluster upgrade, the recommended
+After a cluster upgrade, the default roles
 xref:../../architecture/additional_concepts/authorization.adoc#roles[default
-cluster roles] may be updated. To check if an update is recommended for
-your environment, you can run:
+cluster roles] are automatically updated. To check if all defaults are set as
+recommended for your environment, run:
 
 ----
 # oadm policy reconcile-cluster-roles
@@ -438,8 +438,10 @@ your environment, you can run:
 ====
 If you have customized default cluster roles and want to ensure a role reconciliation
 does not modify those customized roles, annotate them with `openshift.io/reconcile-protect`
-set to `true`. Doing so means you are responsible for manually updating those roles with
-any new or required permissions during upgrades.
+set to `true` when using the old Openshift policy format. When using the new RBAC
+roles, use `rbac.authorization.kubernetes.io/autoupdate` set to `false` instead.
+In doing so, you are responsible for manually updating those roles with any new
+or required permissions during upgrades.
 ====
 
 This command outputs a list of roles that are out of date and their new proposed


### PR DESCRIPTION
…e them

Mention the RBAC way of protecting roles from reconciliation.

Signed-off-by: Simo Sorce <simo@redhat.com>
(cherry picked from commit 6f2eb04cd45c2b94692c4e991d5e914921669eb9) xref:https://github.com/openshift/openshift-docs/pull/5725