### PR TITLE
[enterprise-3.6] ipsec: small correction in clear policy explanation

### DIFF
--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -184,7 +184,7 @@ address space, your `private` policy file would contain `172.16.0.0/16`. Any
 number of additional subnets to encrypt may be added to this file, which results
 in all traffic to those subnets using IPsec as well.
 
-. Unencrypt the encryption between all hosts and the subnet gateway to ensure
+. Unencrypt the communication between all hosts and the subnet gateway to ensure
 that traffic can enter and exit the cluster. Add the gateway to the
 *_/etc/ipsec.d/policies/clear_* file:
 +


### PR DESCRIPTION
(cherry picked from commit 3cbe1e1e3f3a0eb8ef8e0a63cd3d8a4ab596d515) xref:https://github.com/openshift/openshift-docs/pull/5259