### PR TITLE
replace autocorrect word

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -80,7 +80,7 @@ Setting up a nodePort is a privileged operation.
 [IMPORTANT]
 ====
 Even though a service VIP is highly available, performance can still be affected. *keepalived* makes sure that each of the VIPs is serviced by some node in the configuration, and several VIPs may end up on the same node even when other nodes have none. Strategies that externally load balance across a set of VIPs
-may be thawed when ipfailover puts multiple VIPs on the same node.
+may be thwarted when ipfailover puts multiple VIPs on the same node.
 ====
 
 When you use ingressIP, you can set up ipfailover to have the same VIP range as the ingressIP range. You can also disable the


### PR DESCRIPTION
i believe the word 'thawed' was used by mistake when it should have been 'thwarted'