### PR TITLE
replace portalIP with clusterIP

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -255,7 +255,7 @@ metadata:
 spec:
   selector:                  <2>
     docker-registry: default
-  portalIP: 172.30.136.123   <3>
+  clusterIP: 172.30.136.123   <3>
   ports:
   - nodePort: 0
     port: 5000               <4>


### PR DESCRIPTION
i believe `portalIP` was removed some time ago https://github.com/openshift/origin/pull/10777