### PR TITLE
update example externalIP using rfc5737

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -296,7 +296,7 @@ restarted.
 ====
 ----
 networkConfig:
-  ExternalIPNetworkCIDR: 172.47.0.0/24
+  ExternalIPNetworkCIDR: 192.0.1.0.0/24
 ----
 ====
 
@@ -324,7 +324,7 @@ networkConfig:
             }
         ],
         "externalIPs" : [
-            "80.11.12.10"         <1>
+            "192.0.1.1"         <1>
         ]
     }
 }


### PR DESCRIPTION
the example network from `master-config.yaml` did not match the `externalIP` used by the service below it.
i propose the use of RFC5737 IP addresses since these are meant to simulate IPs external to the cluster.