### PR TITLE
[enterprise-3.6] updated description and added an example for service…

### DIFF
--- a/dev_guide/getting_traffic_into_cluster.adoc
+++ b/dev_guide/getting_traffic_into_cluster.adoc
@@ -76,8 +76,13 @@ configured to accept external requests and proxy them based on the configured
 xref:../architecture/networking/routes.adoc#architecture-core-concepts-routes[routes]. This is limited to HTTP/HTTPS(SNI)/TLS(SNI), which
 covers web applications.
 
+An administrator can create a
 ifdef::openshift-enterprise,openshift-origin[]
-An administrator can create a xref:../install_config/install/prerequisites.adoc#prereq-dns[wildcard DNS]
+xref:../install_config/install/prerequisites.adoc#prereq-dns[wildcard DNS]
+endif::[]
+ifdef::openshift-dedicated,openshift-online,atomic-registry[]
+wildcard DNS
+endif::[]
 entry, and then set up a router. Afterward, the users can self-service the edge
 router without having to contact the administrators. The router has controls to
 allow the administrator to specify whether the users can self-provision host
@@ -422,16 +427,85 @@ endif::[]
 [[using-nodeport]]
 == Using a Service NodePort
 
-Use xref:../architecture/core_concepts/pods_and_services.adoc#service-nodeport[NodePorts] to expose the service nodePort on all nodes in the cluster.
-NodePorts are in the 30-60k range by default, which means a NodePort is
-unlikely to match a service's intended port (for example, 8080 may be exposed
-as 31020). This use of ports is wasteful of scarce port resources.
-However, it is slightly easier to set up. Again, this requires more privileges.
+Use xref:../architecture/core_concepts/pods_and_services.adoc#service-nodeport[NodePorts] to expose the service nodePort on all nodes in the cluster. NodePorts allow load
+balancing across an entire cluster and are used by the LoadBalancer service type
+when running on a cloud provider. You can specify a specific nodePort (if not
+already in use) or allow the system to assign you one. When the nodePort is
+assigned, all nodes in the cluster will allow incoming traffic to that port, and
+then direct the traffic from that port to a local or remote endpoint under the
+service. By default, {product-title} allocates ports between `30000` and `32000`
+as NodePorts. For very high density environments, you may need to increase the
+range of ports. {product-title} automatically opens the nodePort range during
+installation for firewalls and cloud security groups for new clusters.
 
 The administrator must ensure the external IPs are routed to the nodes and local
 firewall rules on all nodes allow access to the open port.
 
 NodePorts and externalIP are independent and both can be used concurrently.
+
+[NOTE]
+====
+When enabled, a service NodePort listens on all nodes in the cluster. The service usually has multiple endpoints if there are more than one replicas (domain controller or replication controller) running. If traffic can get to any node in the cluster, the nodePort connects and traffic goes to one of the endpoints.
+====
+
+
+[[example-connecting-mysql-using-nodeport]]
+.Example Connecting to MySQL outside OpenShift using NodePort
+
+. Create a new database pod with MySQL:
++
+[source,bash]
+----
+$ oc new-app mysql --env=MYSQL_USER=user \
+--env=MYSQL_PASSWORD=pass --env=MYSQL_DATABASE=testdb -l db=mysql
+----
+. Edit the service object definition to include nodePort:
++
+[source, yaml]
+----
+kind: "Service"
+apiVersion: "v1"
+metadata:
+  name: "mysql"
+  labels:
+    name: "mysql"
+spec:
+  selector:
+    db: "mysql"
+    deploymentconfig: "mysql"
+  type: "NodePort"
+  sessionAffinity: "None"
+status:
+  ...
+----
+
+. Get the automatically assigned nodePort numder:
++
+[source,bash]
+----
+$ oc get svc mysql -o yaml |grep nodePort
+    nodePort: 30234
+----
+
+. Verify service access on all nodes:
++
+[source,bash]
+----
+$ mysql -u user -ppass testdb -h 192.168.133.3 --port=30234
+Welcome to the MariaDB monitor. Commands end with ; or \g.
+Your MySQL connection id is 1
+Server version: 5.5.45 MySQL Community Server (GPL)
+
+Copyright (c) 2000, 2015, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MySQL [testdb]> Bye
+
+$ mysql -u user -ppass testdb -h 192.168.133.4 --port=30234
+Welcome to the MariaDB monitor. Commands end with ; or \g.
+...
+----
 
 [[virtual-ip]]
 == Using Virtual IPs


### PR DESCRIPTION
… nodePort

(cherry picked from commit 2bbe9dc78dee583d383b37357d17b97e12bab632) https://github.com/openshift/openshift-docs/pull/5237