### PR TITLE
Remove `service.alpha.openshift.io/dependencies` recommendation

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -846,30 +846,6 @@ objects:
 [[other-recommendations]]
 === Other Recommendations
 
-* Group related services together in the management console by adding the
-`service.alpha.openshift.io/dependencies` annotation to the Service object in
-your template.
-+
-.Group the Frontend and Database Services Together on the Management Console Overview
-====
-[source,yaml]
-----
-kind: "Template"
-apiVersion: "v1"
-objects:
-  - kind: "Service"
-    apiVersion: "v1"
-    metadata:
-      name: "frontend"
-      annotations:
-        "service.alpha.openshift.io/dependencies": "[{\"name\": \"database\", \"kind\": \"Service\"}]"
-...
-  - kind: "Service"
-    apiVersion: "v1"
-    metadata:
-      name: "database"
-----
-====
 * Set xref:compute_resources.adoc#dev-compute-resources[memory, CPU], and
 xref:../architecture/additional_concepts/storage.adoc#pvc-resources[storage]
 default sizes to make sure your application is given enough resources to run


### PR DESCRIPTION
Since the service.alpha.openshift.io/dependencies is no longer used by the web console overview we need to remove it from docs.

Closes https://github.com/openshift/origin-web-console/issues/2319