### PR TITLE
[enterprise-3.7] remove extraneous space

### DIFF
--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -335,7 +335,7 @@ scripts is to use a
 xref:../dev_guide/configmaps.adoc#dev-guide-configmaps[ConfigMap].
 
 The full path names of the *check* and *notify* scripts are added to the
-*keepalived* configuration file, *_ /etc/keepalived/keepalived.conf_*, which is
+*keepalived* configuration file, *_/etc/keepalived/keepalived.conf_*, which is
 loaded every time *keepalived* starts. The scripts can be added to the pod with
 a ConfigMap as follows.
 


### PR DESCRIPTION
a space was causing `_` to render literally rather than italicize the adjacent string
(cherry picked from commit de6dd4f752c60e8561bbfa0d2ab923e54b654ab2) xref:https://github.com/openshift/openshift-docs/pull/5831