### PR TITLE
[enterprise-3.5] Router: Fix typo: ROUTER_CANONCAL_HOSTNAME

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -791,7 +791,7 @@ the router's canonical host name when creating the router. For example:
 # oadm router myrouter --router-canonical-hostname="rtr.example.com"
 ----
 
-This creates the `ROUTER_CANONCAL_HOSTNAME` environment variable in the router's
+This creates the `ROUTER_CANONICAL_HOSTNAME` environment variable in the router's
 deployment configuration containing the host name of the router.
 
 For routers that already exist, the cluster administrator can edit the router's
@@ -804,7 +804,7 @@ spec:
     spec:
       containers:
         - env:
-          - name: ROUTER_CANONCAL_HOSTNAME
+          - name: ROUTER_CANONICAL_HOSTNAME
             value: rtr.example.com
 ----
 
@@ -814,7 +814,7 @@ the router is reloaded.
 
 When a user creates a route, all of the active routers evaluate the route and,
 if conditions are met, admit it. When a router that defines the
-`ROUTER_CANONCAL_HOSTNAME` environment variable admits the route, the router
+`ROUTER_CANONICAL_HOSTNAME` environment variable admits the route, the router
 places the value in the `routerCanonicalHostname` field in the route status. The
 user can examine the route status to determine which, if any, routers have
 admitted the route, select a router from the list, and find the


### PR DESCRIPTION
(cherry picked from commit 4fe13d3141351960ccedfc567dde44b5382d7237) xref:https://github.com/openshift/openshift-docs/pull/5865