### PR TITLE
admin_guide/encrypting_data: add note about required etcd version

### DIFF
--- a/admin_guide/encrypting_data.adoc
+++ b/admin_guide/encrypting_data.adoc
@@ -14,6 +14,16 @@ This topic reviews how to enable and configure encryption of secret data at the
 datastore layer. While the examples use the `secrets` resource, any resource can be
 encrypted, such as `configmaps`.
 
+[WARNING]
+====
+This is an alpha feature and may change in future.
+====
+
+[IMPORTANT]
+====
+etcd v3 or later is required in order to use this feature.
+====
+
 [[encrypting-data-configuration]]
 == Configuration and Determining Whether Encryption Is Already Enabled
 


### PR DESCRIPTION
To reduce confusion of the users who are still on etcd2 but would like to try data encryption, I added a note that this feature only works on etcd3.

The identical changes have been already made for Kubernetes: https://github.com/kubernetes/website/pull/5521

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1502767

PTAL @smarterclayton @openshift/team-documentation 
CC @simo5 