### PR TITLE
[enterprise-3.5] fix(): List indent

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -66,6 +66,7 @@ endif::[]
 * 12.x
 
 However, the following features are not supported with *F5 BIG-IP®*:
+
 * xref:../../admin_guide/idling_applications.adoc#admin-guide-idling-applications[Idling applications]
 * Re-ecrypt routes
 * Unencrypted HTTP traffic in allow and redirect mode, with edge TLS termination


### PR DESCRIPTION
* Without a break line, list is not rendered properly, resulting in
continuous line including '*'

(cherry picked from commit da5593c8ab58f291e5b7819fcbba6aa712022736) xref:https://github.com/openshift/openshift-docs/pull/5918