### PR TITLE
Correct wording around etcd v3 playbook versions

### DIFF
--- a/install_config/upgrading/migrating_etcd.adoc
+++ b/install_config/upgrading/migrating_etcd.adoc
@@ -21,8 +21,7 @@ xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-
 
 For existing clusters that upgraded to {product-title} 3.6, however, the etcd
 data must be migrated from v2 to v3 as a post-upgrade step. This must be
-performed before upgrading to the future release of {product-title} 3.7, but it
-can be done at any time starting with release {product-title} 3.6.1.
+performed using openshift-ansible version 3.6.173.0.21 or later.
 
 The etcd v2 to v3 data migration is performed as an offline migration which
 means all etcd members and master services are stopped during the migration.
@@ -60,7 +59,7 @@ added in a future release.
 == Running the Automated Migration Playbook
 
 A migration playbook is provided to automate all aspects of the process; this is the preferred method for performing the migration. You must have access
-to your existing inventory file with both masters and etcd hosts defined in their separate groups. 
+to your existing inventory file with both masters and etcd hosts defined in their separate groups.
 
 . Ensure you have the latest version of the *openshift-ansible* packages
 installed:


### PR DESCRIPTION
People were looking for a literal "3.6.1" version and getting confused.