### PR TITLE
Document prometheus authentication metrics

### DIFF
--- a/architecture/additional_concepts/authentication.adoc
+++ b/architecture/additional_concepts/authentication.adoc
@@ -674,3 +674,13 @@ responses from `/oauth/authorize`, and how they should be handled:
 |401    | `WWW-Authenticate` header missing                                                                                                                | No challenge authentication is possible. Fail and show response body (which might contain links or details on alternate methods to obtain an OAuth token)
 |Other  | Other                                                                                                                                            | Fail, optionally surfacing response body to the user
 |===
+
+[[authentication-prometheus-system-metrics]]
+=== Authentication Metrics for Prometheus
+
+{product-title} captures the following Prometheus system metrics duing authentication attempts:
+* `openshift_auth_basic_password_count` counts the number of `oc login` user name and password attempts.
+* `openshift_auth_basic_password_count_result` counts the number of `oc login` user name and password attempts by result (success or error).
+* `openshift_auth_form_password_count` counts the number of web console login attempts.
+* `openshift_auth_form_password_count_result` counts the number of web console login attempts by result (success or error).
+* `openshift_auth_password_total` counts the total number of `oc login` and web console login attempts.


### PR DESCRIPTION
Here's some text for the prometheus metrics that we capture relating to auth. I stuck this at the end of architecture/additional_concepts/authentication.adoc though I'm not sure if that's the right place (I figured there may be one place to document all of the system metrics).
@ahardin-rh