### PR TITLE
[enterprise-3.7] Update registry cert secret name to match installer

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -84,7 +84,7 @@ security reasons, it is recommended to not make it greater than this value.
 . Create the secret for the registry certificates:
 +
 ----
-$ oc secrets new registry-secret \
+$ oc secrets new registry-certificates \
     /etc/secrets/registry.crt \
     /etc/secrets/registry.key
 ----
@@ -93,8 +93,8 @@ $ oc secrets new registry-secret \
 service account):
 +
 ----
-$ oc secrets link registry registry-secret
-$ oc secrets link default  registry-secret
+$ oc secrets link registry registry-certificates
+$ oc secrets link default  registry-certificates
 ----
 +
 [NOTE]
@@ -115,7 +115,7 @@ $ oc rollout pause dc/docker-registry
 +
 ----
 $ oc volume dc/docker-registry --add --type=secret \
-    --secret-name=registry-secret -m /etc/secrets
+    --secret-name=registry-certificates -m /etc/secrets
 ----
 +
 . Enable TLS by adding the following environment variables to the registry


### PR DESCRIPTION
The installer uses registry-certificates as the secret's name when securing the
registry. Update the docs to match the behaviour if this is performed manually.

(cherry picked from commit eadd7c8ca728602fbf7a2de93118f375c2a21f63) xref:https://github.com/openshift/openshift-docs/pull/3691