### PR TITLE
Advanced audit docs

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -774,8 +774,128 @@ The directory in `auditFilePath` will be created if it does not exist.
 openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/log/openpaas-oscp-audit/openpaas-oscp-audit.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5}
 ----
 
-[[node-configuration-files]]
+[[master-node-config-advanced-audit]]
+=== Advanced Audit
 
+[IMPORTANT]
+====
+Advanced audit is a Technology Preview feature and it is subject to change in future releases.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
+The advanced audit feature provides several improvements over the
+xref:master-node-config-audit-config[basic audit functionality], including
+fine-grained events filtering and multiple output back ends. The following table
+contains additional options you can use.
+
+.Advanced Audit Configuration Parameters
+
+[cols="3a,6a",options="header"]
+|===
+| Parameter Name | Description
+
+|`policyFile`
+|Path to the file that defines the audit policy configuration.
+
+|`policyConfiguration`
+|An embedded audit policy configuration.
+
+|`logFormat`
+|Specifies the format of the saved audit logs. Allowed values are `legacy` (the
+format used in basic audit), and `json`.
+
+|`webHookKubeConfig`
+|Path to a `.kubeconfig`-formatted file that defines the audit webhook
+configuration, where the events are sent to.
+
+|`webHookMode`
+|Specifies the strategy for sending audit events. Allowed values are `block`
+(blocks processing another event until the previous has fully processed) and
+`batch` (buffers events and delivers in batches).
+|===
+
+To enable the advanced audit feature, you must provide either `policyFile` or
+`policyConfiguration` describing the audit policy rules:
+
+.Sample Audit Policy Configuration
+[source,yaml]
+----
+apiVersion: audit.k8s.io/v1alpha1
+kind: Policy
+rules:
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata <1>
+
+  # Do not log watch requests by the "system:kube-proxy" on endpoints or services
+  - level: None <1>
+    users: ["system:kube-proxy"] <2>
+    verbs: ["watch"] <3>
+    resources: <4>
+    - group: ""
+      resources: ["endpoints", "services"]
+
+  # Do not log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated"] <5>
+    nonResourceURLs: <6>
+    - "/api*" # Wildcard matching.
+    - "/version"
+
+  # Log the request body of configmap changes in kube-system.
+  - level: Request
+    resources:
+    - group: "" # core API group
+      resources: ["configmaps"]
+    # This rule only applies to resources in the "kube-system" namespace.
+    # The empty string "" can be used to select non-namespaced resources.
+    namespaces: ["kube-system"] <7>
+
+  # Log configmap and secret changes in all other namespaces at the metadata level.
+  - level: Metadata
+    resources:
+    - group: "" # core API group
+      resources: ["secrets", "configmaps"]
+
+  # Log all other resources in core and extensions at the request level.
+  - level: Request
+    resources:
+    - group: "" # core API group
+    - group: "extensions" # Version of group should NOT be included.
+----
+<1> There are four possible levels every event can be logged at:
+`None` - Do not log events that match this rule.
+`Metadata` - Log request metadata (requesting user, time stamp, resource, verb, etc.), but
+not request or response body. This is the same level as the one used in basic
+audit.
+`Request` - Log event metadata and request body, but not response body.
+`RequestResponse` - Log event metadata, request, and response bodies.
+<2> A list of users the rule applies to. An empty list implies every user.
+<3> A list of verbs this rule applies to. An empty list implies every verb. This is
+ Kubernetes verb associated with API requests (including `get`, `list`, `watch`,
+ `create`, `update`, `patch`, `delete`, `deletecollection`, and `proxy`).
+<4> A list of resources the rule applies to. An empty list implies every resource.
+Each resource is specified as a group it is assigned to (for example, an empty for
+Kubernetes core API, batch, build.openshift.io, etc.), and a resource list from
+that group.
+<5> A list of groups the rule applies to. An empty list implies every group.
+<6> A list of non-resources URLs the rule applies to.
+<7> A list of namespaces the rule applies to. An empty list implies every namespace.
+
+For more information on advanced audit, see the
+link:https://kubernetes.io/docs/tasks/debug-application-cluster/audit[Kubernetes
+documentation]
+
+[[node-configuration-files]]
 == Node Configuration Files
 
 The following *_node-config.yaml_* file is a sample node configuration file that


### PR DESCRIPTION
This continues the work in https://github.com/openshift/openshift-docs/pull/5722 and addresses https://trello.com/c/RRulmyrf/617-document-sccfsi-audit-log-needs-to-capture-all-login-events-without-turning-on-debug-levels
and
https://trello.com/c/N0S7GGEB/618-document-sccfsi-audit-log-needs-to-capture-modifications-to-role-binds-and-scc-policies

PTAL @soltysh @adellape 