### PR TITLE
[enterprise-3.7] As part of origin PR 14008, the server list of an ha…

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -31,6 +31,7 @@ endif::[]
 |`RELOAD_SCRIPT` |  | The path to the reload script to use to reload the router.
 |`ROUTER_ALLOWED_DOMAINS` | | A comma-separated list of domains that the host name in a route can only be part of. Any subdomain in the domain can be used. Option `ROUTER_DENIED_DOMAINS` overrides any values given in this option. If set, everything outside of the allowed domains will be rejected.
 |`ROUTER_BACKEND_CHECK_INTERVAL` | 5000ms | Length of time between subsequent "liveness" checks on backends. xref:time-units[(TimeUnits)]
+|`ROUTER_BACKEND_PROCESS_ENDPOINTS` | | String to specify how the endpoints should be processed while using the template function processEndpointsForAlias. Valid values are ["shuffle", ""]. "shuffle" will randomize the elements upon every call. Default behavior returns in pre-determined order.
 |`ROUTER_CLIENT_FIN_TIMEOUT` | 1s | Controls the TCP FIN timeout period for the client connecting to the route. If the FIN sent to close the connection is not answered within the given time, HAProxy will close the connection anyway.  This is harmless if set to a low value and uses fewer resources on the router.  xref:time-units[(TimeUnits)]
 |`ROUTER_COOKIE_NAME` |  | Specifies cookie name to override the internally generated default name.  The name must consist of any combination of upper and lower case letters, digits, "_",
 and "-". The default is the hashed internal key name for the route.


### PR DESCRIPTION
…proxy template can now be shuffled on each reload. A new env var is introduced to select the processing choice (only one option 'shuffle' today).

(cherry picked from commit 4c5480f0244ee4943c0f46feda3c6d5c5a3d2b73) xref:https://github.com/openshift/openshift-docs/pull/4320