### PR TITLE
[enterprise-3.5] Add description for volume option `--configmap-name`

### DIFF
--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -134,6 +134,10 @@ character.
 |Name of the secret. Mandatory parameter for `--type=secret`.
 |
 
+|`--configmap-name`
+|Name of the configmap. Mandatory parameter for `--type=configmap`.
+|
+
 |`--claim-name`
 |Name of the persistent volume claim. Mandatory parameter for
 `--type=persistentVolumeClaim`.


### PR DESCRIPTION
Fixes #5980

(cherry picked from commit 0decb049476841643e14da75ef6c16bade5f5ab2) xref:https://github.com/openshift/openshift-docs/pull/5981