### PR TITLE
[enterprise-3.7] Fix typo in prometheus auth section

### DIFF
--- a/architecture/additional_concepts/authentication.adoc
+++ b/architecture/additional_concepts/authentication.adoc
@@ -675,7 +675,8 @@ responses from `/oauth/authorize`, and how they should be handled:
 [[authentication-prometheus-system-metrics]]
 === Authentication Metrics for Prometheus
 
-{product-title} captures the following Prometheus system metrics duing authentication attempts:
+{product-title} captures the following Prometheus system metrics during authentication attempts:
+
 * `openshift_auth_basic_password_count` counts the number of `oc login` user name and password attempts.
 * `openshift_auth_basic_password_count_result` counts the number of `oc login` user name and password attempts by result (success or error).
 * `openshift_auth_form_password_count` counts the number of web console login attempts.


### PR DESCRIPTION
(cherry picked from commit 90b5054b8e707cb6ace7392d8a86517a94b6f64a) xref:https://github.com/openshift/openshift-docs/pull/5995