### PR TITLE
[enterprise-3.6] catalog: update documentation with new resource names

### DIFF
--- a/architecture/service_catalog/index.adoc
+++ b/architecture/service_catalog/index.adoc
@@ -47,9 +47,9 @@ Kubernetes. This allows users to connect any of their applications deployed in
 
 The service catalog allows cluster administrators to integrate multiple
 platforms using a single API specification. The {product-title} web console
-displays the service classes offered by brokers in the service catalog, allowing
-users to discover and instantiate those services for use with their
-applications.
+displays the cluster service classes offered by service brokers in the service
+catalog, allowing users to discover and instantiate those services for use with
+their applications.
 
 As a result, service users benefit from ease and consistency of use across
 different types of services from different providers, while service providers
@@ -67,17 +67,18 @@ New terms in the following are defined further in xref:service-catalog-concepts-
 ====
 
 image::svc-catalog-arch.png["Service Catalog Architecture"]
-<1> A cluster administrator registers one or more _service brokers_ with their {product-title}
-cluster. This can be done automatically during installation for some
-default-provided service brokers or manually.
-<2> Each service broker specifies a set of _service classes_ and variations of those
-services (_service plans_) to {product-title} that should be made available to
-users.
+<1> A cluster administrator registers one or more _cluster service brokers_ with
+their {product-title} cluster. This can be done automatically during installation
+for some default-provided service brokers or manually.
+<2> Each service broker specifies a set of _cluster service classes_ and
+variations of those services (_service plans_) to {product-title} that should be
+made available to users.
 <3> Using the {product-title} web console or CLI, users discover the services that
-are available. For example, a service class may be available that is a
+are available. For example, a cluster service class may be available that is a
 database-as-a-service called BestDataBase.
-<4> A user chooses a service class and requests a new _instance_ of their own. For
-example, a service instance may be a BestDataBase instance named `my_db`.
+<4> A user chooses a cluster service class and requests a new _instance_ of
+their own. For example, a service instance may be a BestDataBase instance named
+`my_db`.
 <5> A user links, or _binds_, their service instance to a set of pods (their
 application). For example, the `my_db` service instance may be bound to the
 user's application called `my_app`.
@@ -87,39 +88,59 @@ This infrastructure allows a loose coupling between applications running in
 those services to focus on its own business logic while leaving the management
 of these services to the provider.
 
+[[service-catalog-deleting-resources]]
+=== Deleting Resources
+
+When a user is done with a service (or perhaps no longer wishes to be billed),
+the service instance can be deleted. In order to delete the service instance,
+the service bindings must be removed first. Deleting the service bindings is
+known as _unbinding_. Part of the deletion process includes deleting the secret
+that references the service binding being deleted.
+
+Once all the service bindings are removed, the service instance may be deleted.
+Deleting the service instance is known as _deprovisioning_. 
+
 [[service-catalog-concepts-terminology]]
 == Concepts and Terminology
 
-Service Broker::
-A _service broker_ is a server that conforms to the OSB API specification and
-manages a set of one or more services. The software could be hosted within your
-own {product-title} cluster or elsewhere.
+Cluster Service Broker::
+A _cluster service broker_ is a server that conforms to the OSB API specification
+and manages a set of one or more services. The software could be hosted within|
+your own {product-title} cluster or elsewhere.
 +
-Cluster administrators can create `Broker` API resources representing service
-brokers and register them with their {product-title} cluster. This allows
-cluster administrators to make new types of managed services using that service
-broker available within their cluster.
+Cluster administrators can create `ClusterServiceBroker` API resources
+representing cluster service brokers and register them with their {product-title}
+cluster. This allows cluster administrators to make new types of managed services
+using that cluster service broker available within their cluster.
 +
-A `Broker` resource specifies connection details for a service broker and the
-set of services (and variations of those services) to {product-title} that
-should then be made available to users.
+A `ClusterServiceBroker` resource specifies connection details for a cluster
+service broker and the set of services (and variations of those services) to
+{product-title} that should then be made available to users. Of special note is
+the `authInfo` section, which contains the data used to authenticate with the
+cluster service broker.
 +
-.Example `Broker` Resource
+.Example `ClusterServiceBroker` Resource
 ----
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: Broker
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ClusterServiceBroker
 metadata:
   name: BestCompanySaaS
 spec:
   url: http://bestdatabase.example.com
+  authInfo:
+    basic:
+      secretRef:
+        namespace: test-ns
+        name: secret-name
 ----
 
-Service Class::
-Also synonymous with "service" in the context of the service catalog, a _service
-class_ is a type of managed service offered by a particular broker. Each time a
-new broker resource is added to the cluster, the service catalog controller
-connects to the corresponding service broker to obtain a list of service
-offerings. A new `ServiceClass` resource is automatically created for each.
+Cluster Service Class::
+Also synonymous with "service" in the context of the service catalog, a _cluster
+service class_ is a type of managed service offered by a particular cluster
+service broker. Each time a new cluser service broker resource is added to the
+cluster, the service catalog controller connects to the corresponding cluster
+service broker to obtain a list of service offerings. A new `ClusterServiceClass`
+resource is automatically created for each.
 +
 [NOTE]
 ====
@@ -130,10 +151,10 @@ These resources are not to be confused with how the term is used in the context
 of the service catalog and OSB API.
 ====
 +
-.Example `ServiceClass` Resource
+.Example `ClusterServiceClass` Resource
 ----
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: ServiceClass
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ClusterServiceClass
 metadata:
   name: smallDB
   brokerName: BestDataBase
@@ -141,27 +162,29 @@ metadata:
 ----
 
 Service Plan::
-A _service plan_ is represents tiers of a service class. For example, a service
-class may expose a set of plans that offer varying degrees of quality-of-service
-(QoS), each with a different cost associated with it.
+A _service plan_ is represents tiers of a cluster service class. For example, a
+cluster service class may expose a set of plans that offer varying degrees of
+quality-of-service (QoS), each with a different cost associated with it.
 
 Service Instance::
-A _service instance_ is a provisioned instance of a service class. When a user
-wants to use the capability provided by a service class, they can create a new
-instance.
+A _service instance_ is a provisioned instance of a cluster service class. When a
+user wants to use the capability provided by a service class, they can create a
+new service instance.
 +
-When a new `Instance` resource is created, the service catalog controller
-connects to the appropriate service broker and instructs it to provision the
-service instance.
+When a new `ServiceInstance` resource is created, the service catalog controller
+connects to the appropriate cluster service broker and instructs it to provision
+the service instance.
 +
-.Example `Instance` Resource
+.Example `ServiceInstance` Resource
 ----
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: Instance
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
 metadata:
   name: my_db
+  namespace: test-ns
 spec:
-  serviceClassName: smallDB
+  externalClusterServiceClassName: smallDB
+  externalClusterServicePlanName: default
 ----
 
 Application::
@@ -183,22 +206,51 @@ secrets can be mounted into pods as usual. There is also integration with
 `PodPresets`, which allow you to express how the secret should be consumed, and
 in which pods.
 +
-.Example `Binding` Resource
+.Example `ServiceBinding` Resource
 ----
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: Binding
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
 metadata:
   name: myBinding
+  namespace: test-ns
 spec:
+  instanceRef:
+    name: my_db
+  parameters:
+    securityLevel: confidential
   secretName: mySecret
-  <pod_selector_labels>
 ----
 
-[[service-catalog-provided-brokers]]
-== Provided Service Brokers
+Parameters::
+A _parameter_ is a special field available to pass additional data to the cluster
+service broker when using either service bindings or service instances. The only
+formatting requirement is for the parameters to be valid YAML (or JSON). In the
+above example, a security level parameter is passed to the cluster service broker
+in the service binding request. For parameters that need more security, place
+them in a secret and reference them using `parametersFrom`.
++
+.Example Service Binding Resource Referencing a Secret
+----
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: myBinding
+  namespace: test-ns
+spec:
+  instanceRef:
+    name: my_db
+  parametersFrom:
+    - secretKeyRef:
+        name: securityLevel
+        key: myKey
+  secretName: mySecret
 
-{product-title} provides the following service brokers for use with the service
-catalog.
+
+[[service-catalog-provided-cluster-brokers]]
+== Provided Cluster Service Brokers
+
+{product-title} provides the following cluster service brokers for use with the
+service catalog.
 
 [NOTE]
 ====


### PR DESCRIPTION
also add details for:
-deleting resources (deprovision/unbind)
-broker authentication info
-parameters available for bindings and instances

(cherry picked from commit 3e4f6a9a1c5bd4de4859cd716ba59130b3eb4c2f) xref:https://github.com/openshift/openshift-docs/pull/5667