### PR TITLE
Fixing link to heapster github repo 

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -16,7 +16,7 @@ toc::[]
 The
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#kubelet[kubelet]
 exposes metrics that can be collected and stored in back-ends by
-link:https://github.com/GoogleCloudPlatform/heapster[Heapster].
+link:https://github.com/kubernetes/heapster[Heapster].
 
 As an {product-title} administrator, you can view a cluster's metrics from all
 containers and components in one user interface. These metrics are also

--- a/scaling_performance/scaling_cluster_metrics.adoc
+++ b/scaling_performance/scaling_cluster_metrics.adoc
@@ -14,7 +14,7 @@ toc::[]
 == Overview
 
 {product-title} exposes metrics that can be collected and stored in back-ends by
-link:https://github.com/GoogleCloudPlatform/heapster[Heapster]. As an
+link:https://github.com/kubernetes/heapster[Heapster]. As an
 {product-title} administrator, you can view containers and components metrics in
 one user interface. These metrics are also used by
 xref:../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[horizontal pod


### PR DESCRIPTION
Hi,

pretty trivial fix/change, but the documentation is currently pointing the (old) GoogleCloudPlatform organization. 

fix: Simply pointing to the _real_ kubernetes org. repo ..