### PR TITLE
Revert "BZ 1440961 Wrong image tag/version used when grabbing router configuration template"

### DIFF
--- a/install_config/router/customized_haproxy_router.adoc
+++ b/install_config/router/customized_haproxy_router.adoc
@@ -67,21 +67,16 @@ router-2-40fc3             1/1       Running   0          11d
 
 Alternatively, you can log onto the node that is running the router:
 
-ifdef::openshift-enterprise[]
 ----
+ifdef::openshift-enterprise[]
 # docker run --rm --interactive=true --tty --entrypoint=cat \
     registry.access.redhat.com/openshift3/ose-haproxy-router:$version haproxy-config.template
-----
-
-Replace `$version` with `v{product-version}` for the latest version.
 endif::[]
-
 ifdef::openshift-origin[]
-----
 # docker run --rm --interactive=true --tty --entrypoint=cat \
     openshift/origin-haproxy-router haproxy-config.template
-----
 endif::[]
+----
 
 The image name is from *docker images*.
 

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -2,9 +2,6 @@
 = Using the Default HAProxy Router
 {product-author}
 {product-version}
-:latest-tag: 
-:latest-int-tag: 
-:latest-registry-console-tag: 
 :data-uri:
 :icons:
 :experimental:


### PR DESCRIPTION
Reverts openshift/openshift-docs#5337. Didn't squash commits.