### PR TITLE
[enterprise-3.6] typo, which described in fact the opposite of what N…

### DIFF
--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -42,7 +42,7 @@ Taints and tolerations consist of a key, value, and effect. An operator allows y
 [cols="2a,3a"]
 !====
 !`NoSchedule`
-!* New pods that do not match the taint are scheduled onto that node.
+!* New pods that do not match the taint are not scheduled onto that node.
 * Existing pods on the node remain.
 !`PreferNoSchedule`
 !* New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to.


### PR DESCRIPTION
…oSchedule does

(cherry picked from commit 5d18c1da39a9509aa24f53dc5be93e6d1c599ef5) xref:https://github.com/openshift/openshift-docs/pull/6016