### PR TITLE
Add pages for new OpenShift on OpenStack provider

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -40,6 +40,19 @@ networking. Ensure that local firewall rules and other software making iptable
 changes do not alter the {product-title} and Docker service setup.
 ====
 
+ifdef::openshift-origin[]
+
+[[get-started-cloud-providers]]
+=== On-premises vs Cloud Providers
+
+{product-title} can be installed on-premises or hosted on public or private
+clouds. For more details,
+xref:../install_config/install/advanced_install.adoc#advanced-cloud-providers[see the advanced installation guide].
+
+Once you have your cluster nodes provisioned, choose the
+installation method that fits your case the best.
+endif::[]
+
 [[installation-methods]]
 == Installation Methods
 

--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -40,8 +40,6 @@ networking. Ensure that local firewall rules and other software making iptable
 changes do not alter the {product-title} and Docker service setup.
 ====
 
-ifdef::openshift-origin[]
-
 [[get-started-cloud-providers]]
 === On-premises vs Cloud Providers
 
@@ -51,7 +49,6 @@ xref:../install_config/install/advanced_install.adoc#advanced-cloud-providers[se
 
 Once you have your cluster nodes provisioned, choose the
 installation method that fits your case the best.
-endif::[]
 
 [[installation-methods]]
 == Installation Methods

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -80,10 +80,18 @@ xref:configuring-ansible[Configuring Ansible Inventory Files].
 [[advanced-cloud-providers]]
 === Choosing clouds over on-premises
 
-Provisioning of VMs in a cloud, defining your cloud infrastructure and applying
-the required post-provision configuration tasks may be assisted with Ansible
+Provisioning of VMs in a cloud, defining your cloud hosted infrastructure and
+applying post-provision configuration may be assisted with Ansible
 automation playbooks for the supported cloud providers. This advanced installation
 guide is happen to fulfill that purpose as well.
+
+ifdef::openshift-enterprise[]
+====
+A managed dedicated cloud hosted infrastructure may be alternatively
+operated as a service by Red Hat, see the
+link:https://www.openshift.com/dedicated/index.html[OpenShift Dedicated]
+product offering for more details.
+====
 
 ==== OpenStack provider
 
@@ -105,15 +113,17 @@ xref:../../install_config/configuring_openstack#install-config-configuring-opens
 and
 xref:configuring-ansible[Configuring Ansible Inventory Files].
 
+ifdef::openshift-enterprise[]
 ====
 [IMPORTANT]
 The reference architecture for automated installations based on
 link:https://docs.openstack.org/heat/latest[OpenStack Heat] templates for
-link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/deploying_red_hat_openshift_container_platform_3.4_on_red_hat_openstack_platform_10[{product-title} (OCP 3.4) on Red Hat OpenStack Platform 10]
+link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/deploying_red_hat_openshift_container_platform_3.4_on_red_hat_openstack_platform_10[{product-title} 3.4 on Red Hat OpenStack Platform 10]
 is deprecated. For OSP 13 time frame, it is being replaced with the
 link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible driven deployment solution].
 For automated installations, please follow that guide instead!
 ====
+endif::[]
 
 [[configuring-ansible]]
 == Configuring Ansible Inventory Files

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -71,9 +71,49 @@ see the
 xref:../../scaling_performance/install_practices.adoc#scaling-performance-install-best-practices[Scaling and Performance Guide].
 
 After following the instructions in the
-xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites] topic and
-deciding between the RPM and containerized methods, you can continue in this
-topic to xref:configuring-ansible[Configuring Ansible Inventory Files].
+xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[Prerequisites]
+topic, deciding between the RPM and containerized methods and
+xref:advanced-cloud-providers[choosing from the on-premises or cloud scenarios],
+you can continue in this topic to
+xref:configuring-ansible[Configuring Ansible Inventory Files].
+
+[[advanced-cloud-providers]]
+=== Choosing clouds over on-premises
+
+Provisioning of VMs in a cloud, defining your cloud infrastructure and applying
+the required post-provision configuration tasks may be assisted with Ansible
+automation playbooks for the supported cloud providers. This advanced installation
+guide is happen to fulfill that purpose as well.
+
+==== OpenStack provider
+
+In order to install {product-title} with manual steps using OpenStack CLI,
+see the
+link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/deploying_and_managing_red_hat_openshift_container_platform_3.6_on_red_hat_openstack_platform_10[reference architecture],
+which is actual for {product-title} 3.6 and Red Hat OpenStack Platform 10.
+
+As a prerequisite, you will have to provision VMs and configure the cloud
+infrastructure, like network, storage, firewall and security groups.
+Some of the basic configuration may be assisted by that reference architecture
+and the
+xref:../../install_config/install/prerequisites#prereq-cloud-provider-considerations[cloud provider considerations].
+For advanced configuration prerequisites, like DNS, load balancing and high
+availability, you may want to use the
+link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible automation playbooks]
+instead. For automated installations, see also
+xref:../../install_config/configuring_openstack#install-config-configuring-openstack[Configuring for OpenStack]
+and
+xref:configuring-ansible[Configuring Ansible Inventory Files].
+
+====
+[IMPORTANT]
+The reference architecture for automated installations based on
+link:https://docs.openstack.org/heat/latest[OpenStack Heat] templates for
+link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/deploying_red_hat_openshift_container_platform_3.4_on_red_hat_openstack_platform_10[{product-title} (OCP 3.4) on Red Hat OpenStack Platform 10]
+is deprecated. For OSP 13 time frame, it is being replaced with the
+link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible driven deployment solution].
+For automated installations, please follow that guide instead!
+====
 
 [[configuring-ansible]]
 == Configuring Ansible Inventory Files

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -102,13 +102,11 @@ which is actual for {product-title} 3.6 and Red Hat OpenStack Platform 10.
 
 As a prerequisite, you will have to provision VMs and configure the cloud
 infrastructure, like network, storage, firewall and security groups.
-Some of the basic configuration may be assisted by that reference architecture
-and the
-xref:../../install_config/install/prerequisites#prereq-cloud-provider-considerations[cloud provider considerations].
-For advanced configuration prerequisites, like DNS, load balancing and high
-availability, you may want to use the
-link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible automation playbooks]
-instead. For automated installations, see also
+These configuration tasks may be assisted by that reference architecture,
+the
+xref:../../install_config/install/prerequisites#prereq-cloud-provider-considerations[cloud provider considerations]
+and link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible playbooks]
+to automate it. See also
 xref:../../install_config/configuring_openstack#install-config-configuring-openstack[Configuring for OpenStack]
 and
 xref:configuring-ansible[Configuring Ansible Inventory Files].
@@ -119,7 +117,7 @@ ifdef::openshift-enterprise[]
 The reference architecture for automated installations based on
 link:https://docs.openstack.org/heat/latest[OpenStack Heat] templates for
 link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/deploying_red_hat_openshift_container_platform_3.4_on_red_hat_openstack_platform_10[{product-title} 3.4 on Red Hat OpenStack Platform 10]
-is deprecated. For OSP 13 time frame, it is being replaced with the
+is not supported anymore. For OSP 13 time frame, it is being replaced with the
 link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible driven deployment solution].
 For automated installations, please follow that guide instead!
 ====

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -105,7 +105,7 @@ infrastructure, like network, storage, firewall and security groups.
 These configuration tasks may be assisted by that reference architecture,
 the
 xref:../../install_config/install/prerequisites#prereq-cloud-provider-considerations[cloud provider considerations]
-and link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible playbooks]
+and link:https://github.com/openshift/openshift-ansible/tree/master/playbooks/openstack[Ansible playbooks]
 to automate it. See also
 xref:../../install_config/configuring_openstack#install-config-configuring-openstack[Configuring for OpenStack]
 and
@@ -118,7 +118,7 @@ The reference architecture for automated installations based on
 link:https://docs.openstack.org/heat/latest[OpenStack Heat] templates for
 link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/deploying_red_hat_openshift_container_platform_3.4_on_red_hat_openstack_platform_10[{product-title} 3.4 on Red Hat OpenStack Platform 10]
 is not supported anymore. For OSP 13 time frame, it is being replaced with the
-link:https://github.com/openshift/openshift-ansible-contrib/tree/master/playbooks/provisioning/openstack[Ansible driven deployment solution].
+link:https://github.com/openshift/openshift-ansible/tree/master/playbooks/openstack[Ansible driven deployment solution].
 For automated installations, please follow that guide instead!
 ====
 endif::[]

--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -17,6 +17,9 @@ toc::[]
 For production environments, several factors influence installation. Consider
 the following questions as you read through the documentation:
 
+* _Do you install on-premises or in public/private clouds?_ The xref:planning-cloud-providers[Installation Methods]
+section provides more information about the cloud providers options available.
+
 * _Which installation method do you want to use?_ The xref:installation-methods[Installation Methods]
 section provides some information about the quick and advanced installation
 methods.
@@ -64,6 +67,14 @@ your cluster’s configuration and adjust the number of hosts in the cluster usi
 the same installer tool. If you wanted to later switch to using the advanced
 method, you can create an inventory file for your configuration and carry on
 that way.
+
+[[planning-cloud-providers]]
+=== On-premises vs Cloud Providers
+
+{product-title} can be installed on-premises or hosted on public or private
+clouds. The aforementioned Ansible playbooks will help you with automation of
+the provisioning and installation processes. For more details,
+xref:../../install_config/install/advanced_install.adoc#advanced-cloud-providers[see the advanced installation guide].
 
 [[sizing]]
 == Sizing Considerations

--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -20,6 +20,19 @@ the following questions as you read through the documentation:
 * _Do you install on-premises or in public/private clouds?_ The xref:planning-cloud-providers[Installation Methods]
 section provides more information about the cloud providers options available.
 
+ifdef::openshift-enterprise[]
+* _Do you need a dedicated cloud hosted infrastructure?_ There might be
+managed multi-tenant alternatives as well. For example, operated as a service
+by Red Hat cloud hosted infrastructure where your workloads run
+alongside other customers' containers. If that fits your case, see
+link:https://www.openshift.com/[OpenShift Online] for more details.
+
+* _Will you manage your dedicated cloud hosted infrastructure or prefer
+having it managed as a service?_ See the
+link:https://www.openshift.com/dedicated/index.html[OpenShift Dedicated]
+product offering that might fit the case better.
+endif::[]
+
 * _Which installation method do you want to use?_ The xref:installation-methods[Installation Methods]
 section provides some information about the quick and advanced installation
 methods.


### PR DESCRIPTION
The new shift-on-stack provider [0] complements and will replace some of
the existing documentation for OCP on OSP 10 reference architecture.
It is planned to be the supported solution in the OSP 13 time frame.

Note that the provider is being moved under the openshift-ansible
repo [1]. Its link must be updated after the documentation moved as
the part of that change request.
"Configuring OpenShift Origin for OpenStack with Ansible" will likely
need some updates as well.

[0] https://github.com/openshift/openshift-ansible-contrib
[1] https://github.com/openshift/openshift-ansible/pull/6039

Changes:

* Clarify on-premises and cloud providers cases in
  the Getting Started, Planning and Advanced Installation pages for
  the openshift-origin/enterprise distros.
* Link documentation pages for the shift-on-stack provider, which
  is currently hosted in-repo docs.
* Add a link and a deprecation note for OCP 2.6 on OSP 10 reference
  architecture based on Heat Templates.

Highlight other cloud offerings as well.
Describe alternative cloud solitions in the planning OpenShift
Enterprise installation pages. For some cases, OpenShift Dedicated
or Online might be a better fit. This makes things more clear for
users from the first docs pages read.

Additionally, highlight the Dedicated alternative, when describing
the cloud hosted infrustracture configuration prerequisites in the
Enterprise advanced installation guide.

Depends-on https://github.com/openshift/openshift-ansible/pull/6039

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>