### PR TITLE
Document web console DISABLE_COPY_LOGIN_COMMAND flag

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -837,6 +837,45 @@ endif::[]
 
 endif::[]
 
+[[disabling-copy-login-command]]
+== Disabling the Copy Login Command
+
+The web console allows users to copy a login command, including the current
+access token, to the clipboard from the user menu and the Command Line Tools
+page. This function can be changed so that the user's access token is not
+included in the copied command.
+
+. Create the following configuration scripts within a file (for example,
+*_disable-copy-login.js_*):
++
+[source, javascript]
+----
+// Do not copy the user's access token in the copy login command.
+window.OPENSHIFT_CONSTANTS.DISABLE_COPY_LOGIN_COMMAND = true;
+----
+
+. Save the file and add it to the master configuration file at
+*_/etc/origin/master/master-config.yaml_*:
++
+[source, yaml]
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/disable-copy-login.js
+----
+
+. Restart the master host:
++
+----
+ifdef::openshift-origin[]
+# systemctl restart origin-master
+endif::[]
+ifdef::openshift-enterprise[]
+# systemctl restart atomic-openshift-master
+endif::[]
+----
+
 [[web-console-enable-wildcard-routes]]
 == Enabling Wildcard Routes
 


### PR DESCRIPTION
This is a new console flag in 3.7 for disabling the copy login feature.

@ahardin-rh @jwforres 