### PR TITLE
Update table CSS font-size: small

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -404,7 +404,7 @@ blockquote, blockquote p { line-height: 1.6; color: #6e6e6e; }
   #toctitle, .sidebarblock > .content > .title { line-height: 1.4; }
   #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
 }
-table { background: white; margin-bottom: 1.25em; border: solid 1px #dddddd; }
+table { background: white; margin-bottom: 1.25em; border: solid 1px #dddddd; font-size: small; }
 table thead, table tfoot { background: whitesmoke; font-weight: bold; }
 table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: #333333; text-align: left; }
 table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #333333; }


### PR DESCRIPTION
FYI @openshift/team-documentation. Also affects font size in admonitions (NOTE, IMPORTANT, etc).

New sizing:

![screenshot from 2017-11-03 11-57-27](https://user-images.githubusercontent.com/3442316/32383370-32399120-c08e-11e7-94e6-56e0f4ed9dc3.png)

Old sizing:

![screenshot from 2017-11-03 11-34-54](https://user-images.githubusercontent.com/3442316/32382255-1fa38ec4-c08b-11e7-8889-dfefece975eb.png)
