### PR TITLE
introduce embedded etcd migration doc

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -333,6 +333,8 @@ Topics:
     File: blue_green_deployments
   - Name: Operating System Updates and Upgrades
     File: os_upgrades
+  - Name: Migrating Embedded etcd to External etcd
+    File: migrating_embedded_etcd
   - Name: Migrating etcd Data
     File: migrating_etcd
   - Name: Known Issues

--- a/install_config/upgrading/migrating_embedded_etcd.adoc
+++ b/install_config/upgrading/migrating_embedded_etcd.adoc
@@ -1,0 +1,78 @@
+[[install-config-upgrading-etcd-data-migration]]
+= Migrating Embedded etcd to External etcd
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+
+Until {product-title} 3.6, it was possible to deploy a cluster with an embedded
+etcd. As of {product-title} 3.7, this is no longer possible. Additionally, the
+etcd API version since {product-title} 3.6 defaults to v3. Also, since
+{product-title} 3.7, the v3 is the only version allowed. Therefore, older
+deployments with embedded etcd with the etcd API version v2 need to migrate to
+the external etcd first,
+xref:../../install_config/upgrading/migrating_etcd.adoc#install-config-upgrading-etcd-data-migration[followed
+by data migration], before they can be upgraded to {product-title} 3.7.
+
+This migration process performs the following steps:
+
+. Stop the master service.
+. Perform an etcd backup of embedded etcd.
+. Deploy external etcd (on the master or new host).
+. Perform a backup of the original etcd master certificates.
+. Generate new etcd certificates for the master.
+. Transfer the embedded etcd backup to the external etcd host.
+. Start the external etcd from the transfered etcd backup.
+. Re-configure master to use the external etcd.
+. Start master.
+
+[[etcd-embedded-migration-automated]]
+== Running the Automated Migration Playbook
+
+Migration to external RPM etcd or external containerized etcd is currently
+supported.
+
+A migration playbook is provided to automate all aspects of the process; this is
+the preferred method for performing the migration. You must have access to your
+existing inventory file with both the master and external etcd host defined in
+their separate groups.
+
+In order to perform the migration on Red Hat Enterprise Linux Atomic Host, you
+must be running Atomic Host 7.4 or later.
+
+. Ensure you have the latest version of the *openshift-ansible* packages
+installed:
++
+----
+# yum upgrade openshift-ansible\*
+----
++
+The inventory is expected to have exactly one host in the `[etcd]` group. In
+most scenarios, it is best to use your existing master, as there is no need for
+a separate host.
+
+. Run the *_embedded2external.yml_* playbook using your inventory file:
++
+----
+# ansible-playbook [-i /path/to/inventory] \
+ifdef::openshift-enterprise[]
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-etcd/embedded2external.yml
+endif::[]
+ifdef::openshift-origin[]
+    ~/openshift-ansible/playbooks/byo/openshift-etcd/embedded2external.yml
+endif::[]
+----
+
+[[etcd-embedded-migration-manual]]
+== Running the Manual Migration
+
+Currently, manual migration is not recommended, as it requires a deployment of
+the new etcd cluster and re-deployment of etcd master certificates.

--- a/install_config/upgrading/migrating_etcd.adoc
+++ b/install_config/upgrading/migrating_etcd.adoc
@@ -14,14 +14,21 @@ toc::[]
 == Overview
 
 While etcd was updated from etcd v2 to v3 in a
-link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous release], {product-title} continued using an etcd v2 data model and API for both
+link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous
+release], {product-title} continued using an etcd v2 data model and API for both
 new and upgraded clusters. Starting with {product-title} 3.6, new installations
 began using the v3 data model as well, providing
-xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved performance and scalability].
+xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved
+performance and scalability].
 
 For existing clusters that upgraded to {product-title} 3.6, however, the etcd
 data must be migrated from v2 to v3 as a post-upgrade step. This must be
 performed using openshift-ansible version 3.6.173.0.21 or later.
+
+Until {product-title} 3.6, it was possible to deploy a cluster with an embedded
+etcd. As of {product-title} 3.7, this is no longer possible. See
+xref:../../install_config/upgrading/migrating_embedded_etcd.adoc#install-config-upgrading-etcd-data-migration[Migrating
+Embedded etcd to External etcd].
 
 The etcd v2 to v3 data migration is performed as an offline migration which
 means all etcd members and master services are stopped during the migration.
@@ -30,14 +37,14 @@ outage of the API, web console, and controllers.
 
 This migration process performs the following steps:
 
-- Stop the master API and controller services
-- Perform an etcd backup on all etcd members
-- Perform a migration on the first etcd host
-- Remove etcd data from any remaining etcd hosts
-- Perform an etcd scaleup operation adding additional etcd hosts one by one
-- Re-introduce TTL information on specific keys
-- Reconfigure the masters for etcd v3 storage
-- Start the master API and controller services
+. Stop the master API and controller services.
+. Perform an etcd backup on all etcd members.
+. Perform a migration on the first etcd host
+. Remove etcd data from any remaining etcd hosts.
+. Perform an etcd scaleup operation adding additional etcd hosts one by one.
+. Re-introduce TTL information on specific keys.
+. Reconfigure the masters for etcd v3 storage.
+. Start the master API and controller services.
 
 [[etcd-data-migration-before-you-begin]]
 == Before You Begin
@@ -49,11 +56,10 @@ DNS services to run on every node, rather than on the masters, which ensures
 that, even when master services are taken down, existing pods continue to
 function as expected.
 
-The migration process is currently only supported on clusters that have etcd
-hosts specifically defined in their inventory file. Therefore, the migration
-cannot be used for clusters which utilize the embedded etcd which runs as part
-of the master process. Support for migrating embedded etcd installations will be
-added in a future release.
+Older deployments with embedded etcd with the etcd API version v2 need to
+migrate to the external etcd before migrating data. See
+xref:../../install_config/upgrading/migrating_embedded_etcd.adoc#install-config-upgrading-etcd-data-migration[Migrating
+Embedded etcd to External etcd].
 
 [[etcd-data-migration-automated]]
 == Running the Automated Migration Playbook


### PR DESCRIPTION
Continues the work in https://github.com/openshift/openshift-docs/pull/5723

Preview Builds:
http://file.rdu.redhat.com/~ahardin/11032017/ingvagabund-fork/install_config/upgrading/migrating_embedded_etcd.html

http://file.rdu.redhat.com/~ahardin/11032017/ingvagabund-fork/install_config/upgrading/migrating_etcd.html

Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1509195
https://bugzilla.redhat.com/show_bug.cgi?id=1508698
https://trello.com/c/XmEEJ8Ut/707-document-migrate-embedded-etcd-hosts-to-external-process