### PR TITLE
Improvements to NetworkPolicy docs

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1029,35 +1029,47 @@ xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[confi
 to use the *ovs-networkpolicy* plug-in], network isolation is controlled
 entirely by
 link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network/network-policy.md[`NetworkPolicy`
-objects]. In particular, by default, all projects are able to access pods in all
-other projects. To isolate a project, opt in to isolation by configuring the
-Namespace object, then create a `NetworkPolicy` object to indicate the allowed
-incoming connections.
+objects]. In particular, by default, all pods in a project are accessible from all sources.
+To isolate one or more pods in a project, you can create `NetworkPolicy` objects in that project
+to indicate the allowed incoming connections. Project administrators can create and delete
+`NetworkPolicy` objects within their own project.
 
-. Configure the pod network in the master configuration file at *_/etc/origin/master/master-config.yaml_*:
-+
+Pods that have no `NetworkPolicy` objects pointing to them are fully accessible, while
+Pods that have one or more `NetworkPolicy` objects pointing to them are isolated, and only
+accept connections that are accepted by at least one of their `NetworkPolicy` objects.
+This means you can make a project "deny by default" by adding a `NetworkPolicy` that
+matches all pods but accepts no traffic:
+
 [source,yaml]
 ----
-networkConfig:
- ...
-  networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
- ...
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: deny-by-default
+spec:
+  podSelector:
+  ingress: []
 ----
-<1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
 
-. Configure the pod network policy on each node configuration file at *_/etc/origin/node/node-config.yaml_*:
-+
+Alternatively, you could make pods accept connections from other pods in the same project,
+but reject all other connections from other projects:
+
 [source,yaml]
 ----
-networkConfig:
-  ...
-  networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}
 ----
-<1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
 
-. Project administrators can create and delete `NetworkPolicy` objects within
-their own project. Create the `NetworkPolicy` objects:
-+
+An example of a more specific `NetworkPolicy` would be one allowing HTTP and HTTPS access
+to pods with the label `role=frontend`:
+
 [source,yaml]
 ----
 kind: NetworkPolicy
@@ -1066,6 +1078,8 @@ metadata:
   name: allow-http-and-https
 spec:
   podSelector:
+    matchLabels:
+      role: frontend
   ingress:
   - ports:
     - protocol: TCP
@@ -1074,3 +1088,45 @@ spec:
       port: 443
 ----
 
+Since `NetworkPolicy` objects are additive, if you created both the `allow-same-namespace`
+and `allow-http-and-https` policies in the same project, then pods with the label
+`role=frontend` would accept any connection allowed by either policy: connections on any
+port from pods in the *same* namespace, and connections on ports 80 and 443 from pods in
+*any* namespace.
+
+[[admin-guide-networking-default-networkpolicy]]
+=== Setting a Default NetworkPolicy for New Projects
+
+By modifying the default project template, it is possible for a cluster administrator to
+cause one or more `NetworkPolicy` objects to be automatically created in any newly-created
+projects.
+
+. Create a custom project template and configure the master to use it, as described in
+xref:../admin_guide/managing_projects.adoc#modifying-the-template-for-new-projects[Modifying the Template for New Projects].
+. Edit the template to include the desired `NetworkPolicy` objects:
++
+----
+$ oc edit template project-request -n default
+----
++
+Add each default policy as a new element in the `objects` array. Eg:
++
+====
+----
+objects:
+...
+- apiVersion: extensions/v1beta1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+  spec:
+    podSelector:
+    ingress:
+    - from:
+      - podSelector: {}
+...
+----
+====
++
+(Currently, this must be done with `oc edit`; it is not possible to use `oc patch` to
+modify a `Template` object.)


### PR DESCRIPTION
1. Remove lingering reference to the pre-3.6 NetworkPolicy semantics ("opt in to isolation by configuring the Namespace object")
2. Give a few more specific NetworkPolicy examples
3. Be clearer about the 3.6-and-later semantics where pods are isolated if and only if they are selected by some NetworkPolicy
4. Be clearer about combining NetworkPolicies
5. Talk about modifying the default project template to automatically create NetworkPolicies

Feel free to rewrite

@bfallonf 