### PR TITLE
Add an example to edit the scc non-interactively

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -437,6 +437,19 @@ $ oc edit scc restricted
 
 . Save the changes.
 
+=== Edit the SCCs non-interactively
+
+You can edit the different SCCs non-interactively with the
+xref:../cli_reference/basic_cli_operations.adoc#patch[oc patch] command.
+
+For example, to ensure `*allowHostDirVolumePlugin*` is `*true*` for the
+*restricted* scc:
++
+----
+oc patch scc restricted --type=json \
+  -p '[{"op": "replace", "path": "/allowHostDirVolumePlugin", "value":true}]'
+----
+
 === Ensure That Admission Attempts to Use a Specific SCC First
 
 You may control the sort ordering of SCCs in admission by setting the `Priority`


### PR DESCRIPTION
It's useful to be able to edit the scc non-interactively, for example
when wrapping the setup with configuration management.
Let's include an example that shows how to toggle
allowHostDirVolumePlugin to true for use with hostPath volumes.