### PR TITLE
[enterprise-3.7] registry config doc cleanup

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -298,20 +298,25 @@ provide a strategy of their own. Valid grant handling methods are:
 
 | Parameter Name | Description
 
-|`*DisableScheduledImport*`
-|Allows scheduled background import of images to be disabled.
-
 |`*Format*`
 |The format of the name to be built for the system component.
 
-|`*ImageConfig*`
-|Holds options that describe how to build image names for system components.
-
-|`*ImagePolicyConfig*`
-|Controls limits and behavior for importing images.
-
 |`*Latest*`
 |Determines if the latest tag will be pulled from the registry.
+
+|===
+
+[[master-config-image-policy-config]]
+=== Image Policy Configuration
+
+.Image Policy Configuration Parameters
+[cols="3a,6a",options="header"]
+|===
+
+| Parameter Name | Description
+
+|`*DisableScheduledImport*`
+|Allows scheduled background import of images to be disabled.
 
 |`*MaxImagesBulkImportedPerRepository*`
 |Controls the number of images that are imported when a user does a bulk import
@@ -326,6 +331,26 @@ background per minute. The default value is 60.
 |The minimum number of seconds that can elapse between when image streams
 scheduled for background import are checked against the upstream repository. The
 default value is 15 minutes.
+
+|`*AllowedRegistriesForImport*`
+|Limits the docker registries that normal users may import
+images from. Set this list to the registries that you trust to contain valid Docker
+images and that you want applications to be able to import from. Users with
+permission to create Images or ImageStreamMappings via the API are not affected by
+this policy - typically only administrators or system integrations will have those
+permissions.
+
+|`*InternalRegistryHostname*`
+|Sets the hostname for the default internal image
+registry. The value must be in `*hostname[:port]*` format.
+For backward compatibility, users can still use `*OPENSHIFT_DEFAULT_REGISTRY*`
+environment variable but this setting overrides the environment variable.
+
+|`*ExternalRegistryHostname*`
+|ExternalRegistryHostname sets the hostname for the default external image
+registry. The external hostname should be set only when the image registry
+is exposed externally. The value is used in `*publicDockerImageRepository*`
+field in ImageStreams. The value must be in `*hostname[:port]*` format.
 
 |===
 

--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -121,6 +121,33 @@ Once the whitelist is configured, if a user tries to pull from a docker registry
 that is not on the whitelist, they will receive an error message stating that
 this registry is not allowed.
 
+[[setting-the-registry-hostname]]
+== Setting the Registry Hostname
+
+You can configure the hostname and port the registry is known by for both internal and external references.
+By doing this, image streams will provide hostname based push and pull specifications for images, 
+allowing consumers of the images to be isolated from changes to the registry service ip and potentially 
+allowing image streams and their references to be portable between clusters.
+
+To set the hostname used to reference the registry from within the cluster, set the `internalRegistryHostname`
+in the `imagePolicyConfig` section of the master configuration file.  The external hostname is controlled by setting the `externalRegistryHostname` value in the same location.
+
+.Image Policy Configuration
+[source,yaml]
+----
+imagePolicyConfig:
+  internalRegistryHostname: docker-registry.default.svc.cluster.local:5000
+  externalRegistryHostname: docker-registry.mycompany.com
+----
+
+[NOTE]
+====
+If you have enabled TLS for your registry the server certificate must
+include the hostnames by which you expect the registry to be referenced.
+See xref:securing_and_exposing_registry.adoc#securing-the-registry[securing
+the registry] for instructions on adding hostnames to the server certificate.
+====
+
 [[advanced-overriding-the-registry-configuration]]
 == Overriding the Registry Configuration
 
@@ -609,6 +636,16 @@ openshift:
   metrics:
     enabled: false <2>
     secret: <secret> <3>
+  requests:
+    read:
+      maxrunning: 10 <4>
+      maxinqueue: 10 <5>
+      maxwaitinqueue 2m <6>
+    write:
+      maxrunning: 10 <7>
+      maxinqueue: 10 <8>
+      maxwaitinqueue 2m <9>
+
 ----
 <1> A mandatory entry specifying configuration version of this section. The only
 supported value is `1.0`.
@@ -618,6 +655,20 @@ using the boolean environment variable
 <3> A secret used to authorize client requests. Metrics clients must use it as a
 bearer token in `Authorization` header. It can be overridden by the environment
 variable `REGISTRY_OPENSHIFT_METRICS_SECRET`.
+<4> Maximum number of simultaneous pull requests.  It can be overridden by the
+environment variable `REGISTRY_OPENSHIFT_REQUESTS_READ_MAXRUNNING`.  Zero indicates no limit.
+<5> Maximum number of queued pull requests.  It can be overridden by the
+environment variable `REGISTRY_OPENSHIFT_REQUESTS_READ_MAXINQUEUE`.  Zero indicates no limit.
+<6> Maximum time a pull request can wait in the queue before being rejected.
+It can be overridden by the environment variable `REGISTRY_OPENSHIFT_REQUESTS_READ_MAXWAITINQUEUE`.
+Zero indicates no limit.
+<7> Maximum number of simultaneous push requests.  It can be overridden by the
+environment variable `REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXRUNNING`.  Zero indicates no limit.
+<8> Maximum number of queued push requests.  It can be overridden by the
+environment variable `REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXINQUEUE`.  Zero indicates no limit.
+<9> Maximum time a push request can wait in the queue before being rejected.  It can be overridden by the
+environment variable `REGISTRY_OPENSHIFT_REQUESTS_WRITE_MAXWAITINQUEUE`.
+Zero indicates no limit.
 
 See xref:accessing_registry.adoc#accessing-registry-metrics[Accessing Registry Metrics] for usage information.
 


### PR DESCRIPTION
(cherry picked from commit 3ecc8847398a35533c044389036e72dd38c91b83) xref:"https://github.com/openshift/openshift-docs/pull/6128"