### PR TITLE
[enterprise-3.7] clarify when env variables appear in builds

### DIFF
--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -118,15 +118,16 @@ documentation] for information on how S2I scripts are used.
 
 There are two ways to make environment variables available to the
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[source build]
-process and resulting \image: xref:environment-files[environment files] and
-xref:buildconfig-environment[*BuildConfig* environment] values.
+process and resulting image: xref:environment-files[environment files] and
+xref:buildconfig-environment[*BuildConfig* environment] values.  Variables provided will
+be present during the build process and in the output image.
 
 [[environment-files]]
 ==== Environment Files
 Source build enables you to set environment values (one per line) inside your
 application, by specifying them in a *_.s2i/environment_* file in the source
 repository. The environment variables specified in this file are present during
-the build process and in the final container image. The complete list of supported
+the build process and in the output image. The complete list of supported
 environment variables is available in the
 xref:../../using_images/index.adoc#using-images-index[documentation] for each image.
 


### PR DESCRIPTION
(cherry picked from commit 002e044aba0b36ed8ad99853ff7fe05a58f5f348) xref:"https://github.com/openshift/openshift-docs/pull/6191"