### PR TITLE
[enterprise-3.6]Added that RHEL Atomic Host 7.4+ is needed for migration on Atomic Host

### DIFF
--- a/install_config/upgrading/migrating_etcd.adoc
+++ b/install_config/upgrading/migrating_etcd.adoc
@@ -58,8 +58,13 @@ added in a future release.
 [[etcd-data-migration-automated]]
 == Running the Automated Migration Playbook
 
-A migration playbook is provided to automate all aspects of the process; this is the preferred method for performing the migration. You must have access
-to your existing inventory file with both masters and etcd hosts defined in their separate groups.
+A migration playbook is provided to automate all aspects of the process; this is
+the preferred method for performing the migration. You must have access to your
+existing inventory file with both masters and etcd hosts defined in their
+separate groups.
+
+In order to perform the migration on Red Hat Enterprise Linux Atomic Host, you
+must be running Atomic Host 7.4 or later.
 
 . Ensure you have the latest version of the *openshift-ansible* packages
 installed:


### PR DESCRIPTION
Companion PR of https://github.com/openshift/openshift-docs/pull/6126

Helps address:
https://bugzilla.redhat.com/show_bug.cgi?id=1509195
https://bugzilla.redhat.com/show_bug.cgi?id=1508698
https://trello.com/c/XmEEJ8Ut/707-document-migrate-embedded-etcd-hosts-to-external-process

@sdodson @ingvagabund @adellape PTAL