### PR TITLE
Cleanup S2I image building docs

### DIFF
--- a/creating_images/s2i.adoc
+++ b/creating_images/s2i.adoc
@@ -35,7 +35,7 @@ During the build process, S2I must place sources and scripts inside the builder
 image. To do so, S2I creates a *_tar_* file that contains the sources and
 scripts, then streams that file into the builder image. Before executing the
 *_assemble_* script, S2I untars that file and places its contents into the
-location specified with the `--destination` flag or the `*io.openshift.s2i.destination*`
+location specified by the `*io.openshift.s2i.destination*`
 label from the builder image, with the default location being the
 *_/tmp_* directory.
 
@@ -45,14 +45,17 @@ interpreter (the `/bin/sh` command); this allows your image to use the fastest
 possible build path. If the `tar` or `/bin/sh` command is not available, the
 `s2i build` process is forced to automatically perform an additional container build
 to put both the sources and the scripts inside the image, and only then run the
-usual `s2i build` procedure.
+usual build.
 
 See the following diagram for the basic S2I build workflow:
 
 .Build Workflow
 image::s2i-flow.png[S2I workflow]
 
-* Run build's responsibility is to untar the sources, scripts and artifacts (if such exist) and invoke the `assemble` script. If this is the second run (after catching `tar` or `/bin/sh` not found error) it is responsible only for invoking `assemble` script, since both scripts and sources are already there.
+* Run build's responsibility is to untar the sources, scripts and artifacts 
+  (if such exist) and invoke the `assemble` script.  If this is the second run 
+  (after catching `tar` or `/bin/sh` not found error) it is responsible only 
+  for invoking `assemble` script, since both scripts and sources are already there.
 
 
 [[s2i-scripts]]
@@ -63,20 +66,17 @@ executable inside the builder image. S2I supports multiple options providing
 `assemble`/`run`/`save-artifacts` scripts. All of these locations are checked on
 each build in the following order:
 
-1. A script found at the `--scripts-url` URL
+
+1. A script xref:../dev_guide/builds/build_strategies.adoc#override-builder-image-scripts[specified in the BuildConfig]
 2. A script found in the application source `.s2i/bin` directory
 3. A script found at the default image URL (`io.openshift.s2i.scripts-url` label)
 
-Both the `io.openshift.s2i.scripts-url` label specified in the image and the `--scripts-url` flag
-can take one of the following form:
+Both the `io.openshift.s2i.scripts-url` label specified in the image and the 
+script specified in a BuildConfig can take one of the following forms:
 
 - `image:///path_to_scripts_dir` - absolute path inside the image to a directory where the S2I scripts are located
 - `$$file:///path_to_scripts_dir$$` - relative or absolute path to a directory on the host where the S2I scripts are located
 - `http(s)://path_to_scripts_dir` - URL to a directory where the S2I scripts are located
-
-NOTE: In case where the scripts are already placed inside the image (using `--scripts-url`
-or `io.openshift.s2i.scripts-url` with value `image:///path/in/image`) then setting `--destination`
-or `io.openshift.s2i.destination` label applies only to sources and artifacts.
 
 .S2I Scripts
 [cols="3a,8a",options="header"]


### PR DESCRIPTION
Removes references to flags on the s2i command.

Fixes https://github.com/openshift/openshift-docs/issues/5403