### PR TITLE
Clarify NM_CONTROLLED requirement

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -303,7 +303,8 @@ any other type of DNS application.
 [NOTE]
 ====
 *NetworkManager* is required on the nodes in order to populate *dnsmasq* with
-the DNS IP addresses.
+the DNS IP addresses. DNS won't work properly when the network interface for
+OpenShift has `NM_CONTROLLED=no`.
 
 DNSMSQ must be enabled (`openshift_use_dnsmasq=true`) or the installation will fail
 and critical features will not function.
@@ -432,7 +433,8 @@ resolve on all nodes.
 ==== NetworkManager
 
 NetworkManager, a program for providing detection and configuration for systems
-to automatically connect to the network, is required.
+to automatically connect to the network, is required. DNS won't work properly
+when the network interface for OpenShift has `NM_CONTROLLED=no`.
 
 [[required-ports]]
 ==== Required Ports


### PR DESCRIPTION
Avoid misunderstanding that some users think NetworkManager is installed but has NM_CONTROLLED=no on network interface configs and DNS is not working.