### PR TITLE
Modify aws.conf file path

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -21,7 +21,7 @@ properly, some additional configurations will need to be completed on the
 [[configuring-aws-variables]]
 == Configuring AWS Variables
 
-To set the required AWS variables, create a *_/etc/aws/aws.conf_* file with the
+To set the required AWS variables, create a *_/etc/origin/cloudprovider/aws.conf_* file with the
 following contents on all of your {product-title} hosts, both masters and nodes:
 
 
@@ -74,7 +74,7 @@ xref:../install_config/install/advanced_install.adoc#advanced-install-configurin
 ====
 When Ansible configures AWS, the following files are created for you:
 
-- *_/etc/aws/aws.conf_*
+- *_/etc/origin/cloudprovider/aws.conf_*
 - *_/etc/origin/master/master-config.yaml_*
 - *_/etc/origin/node/node-config.yaml_*
 - *_/etc/sysconfig/atomic-openshift-master_*
@@ -98,12 +98,12 @@ kubernetesMasterConfig:
     cloud-provider:
       - "aws"
     cloud-config:
-      - "/etc/aws/aws.conf"
+      - "/etc/origin/cloudprovider/aws.conf"
   controllerArguments:
     cloud-provider:
       - "aws"
     cloud-config:
-      - "/etc/aws/aws.conf"
+      - "/etc/origin/cloudprovider/aws.conf"
 ----
 
 Currently, the `nodeName` *must* match the instance name in AWS in order
@@ -132,7 +132,7 @@ kubeletArguments:
   cloud-provider:
     - "aws"
   cloud-config:
-    - "/etc/aws/aws.conf"
+    - "/etc/origin/cloudprovider/aws.conf"
 ----
 
 [IMPORTANT]


### PR DESCRIPTION
In order to be aligned with the configuration put in place by ansible during the installation using the playbooks from 'openshift-ansible' repository, the aws.conf file path must be updated to match that info.

Moving from : /etc/aws/aws.conf
To: /etc/origin/cloudprovider/aws.conf