### PR TITLE
Added document for labeling AWS resources on existing clusters

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -657,6 +657,9 @@ Topics:
   File: idling_applications
 - Name: Analyzing Cluster Capacity
   File: cluster_capacity
+- Name: Labeling Clusters for Amazon Web Services
+  File: aws_cluster_labeling
+  Distros: openshift-origin,openshift-enterprise
 - Name: Revision History
   File: revhistory_admin_guide
   Distros: openshift-enterprise,openshift-dedicated

--- a/admin_guide/aws_cluster_labeling.adoc
+++ b/admin_guide/aws_cluster_labeling.adoc
@@ -1,0 +1,63 @@
+[[admin-guide-aws-cluster-labeling]]
+= Labeling Clusters for Amazon Web Services (AWS)
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Overview
+
+This topic describes how to label an existing {product-title} cluster running on
+Amazon Web Services (AWS).
+
+To correctly identify which resources are associated with a cluster, tag
+resources with the key `kubernetes.io/cluster/<name>`, where `<name>` is a unique
+name for the cluster. Tagging all resources with the
+`kubernetes.io/cluster/<name>` tag avoids potential issues with multiple zones
+or multiple clusters.
+
+See
+xref:../install_config/configuring_aws.adoc#install-config-configuring-aws[Configuring
+AWS] for guidance on configuring AWS variables and {product-title} masters for
+AWS.
+
+See xref:../architecture/core_concepts/pods_and_services.adoc#labels[Pods and
+Services] to learn more about labeling and tagging in {product-title}.
+
+[[resources-that-need-tags]]
+== Resources That Need Tags
+There are four types of resources that need to be tagged:
+
+* Instances
+* Security Groups
+* Load Balancers
+* EBS Volumes
+
+[[tagging-an-existing-cluster]]
+== Tagging an Existing Cluster
+
+A cluster will use the value of the `kubernetes.io/cluster/<name>` tag to determine which
+resources belong to the cluster. Therefore, you must tag all resources with the
+key `kubernetes.io/cluster/<name>` and have the same value for that key.
+
+. Tag all instances with `kubernetes.io/cluster/<name>` and a value to be used as the cluster ID.
+. Tag any security groups with `kubernetes.io/cluster/<name>` and the same value used for the instances.
+. Tag any load balancers with `kubernetes.io/cluster/<name>` and the same value used for the instances.
+. Tag all EBS volumes with `kubernetes.io/cluster/<name>` and the same value used for the instances. The EBS Volumes that need to be tagged can found with:
++
+[source,bash]
+----
+$ oc get pv -o json|jq '.items[].spec.awsElasticBlockStore.volumeID'
+----
+
+. Restart `atomic-openshift-master` and `atomic-openshift-node` on all nodes:
++
+[source,bash]
+----
+# systemctl restart atomic-openshift-master-api atomic-openshift-master-controller atomic-openshift-node
+----


### PR DESCRIPTION
Continues the work in https://github.com/openshift/openshift-docs/pull/5732

Preview Build: http://file.rdu.redhat.com/~ahardin/11082017/rrati-fork/admin_guide/aws_cluster_labeling.html