### PR TITLE
[enterprise-3.3] Fix mysql links

### DIFF
--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -19,8 +19,8 @@ settings provided via configuration.
 == Versions
 Currently, {product-title} provides versions
 link:https://github.com/openshift/mysql/tree/master/5.5[5.5],
-link:https://github.com/openshift/mysql/tree/master/5.5[5.6], and
-link:https://github.com/openshift/mysql/tree/master/5.6[5.7] of MySQL.
+link:https://github.com/openshift/mysql/tree/master/5.6[5.6], and
+link:https://github.com/openshift/mysql/tree/master/5.7[5.7] of MySQL.
 
 == Images
 


### PR DESCRIPTION
(cherry picked from commit 968308c1bdcd7f2df20e06deb100915df5fb06f5) xref:https://github.com/openshift/openshift-docs/pull/6225