### PR TITLE
[enterprise-3.6] Fix wrong link to ceph installation

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -69,7 +69,7 @@ per cluster. In versions prior to 3.6, this was `*Key=KubernetesCluster,Value=cl
 
 |Ceph RBD
 |`kubernetes.io/rbd`
-|xref:../../install_config/configuring_openstack.adoc#install-config-configuring-openstack[Configuring for OpenStack]
+|xref:../../install_config/persistent_storage_ceph_rbd.adoc#install-config-persistent-storage-persistent-storage-ceph-rbd[Configuring Ceph RBD]
 |
 
 |Trident from NetApp


### PR DESCRIPTION
(cherry picked from commit 6b2eee24ad4f37ab9a40415b01eaf4e853021d5c) xref:https://github.com/openshift/openshift-docs/pull/5700