### PR TITLE
[online-3.6] change cluster IP to service name in mongo-url env variable

### DIFF
--- a/getting_started/beyond_the_basics.adoc
+++ b/getting_started/beyond_the_basics.adoc
@@ -266,13 +266,7 @@ The `-p` flag sets the parameter values used by the *mongodb-persistent*
 database template.
 ====
 
-. Next, get the internal IP address and port of the newly-created MongoDB service:
-+
-----
-$ oc get services
-----
-+
-Note the `*CLUSTER_IP*` of the MongoDB service before heading to the next
+. Note the name of the MongoDB service before heading to the next
 section.
 
 [[btb-setting-environment-variables]]
@@ -286,8 +280,20 @@ so that it will utilize the MongoDB service, and enable the "Page view count"
 feature. Run:
 +
 ----
-$ oc set env dc/nodejs-mongodb-example \
-MONGO_URL='mongodb://admin:secret@<your_mongodb_service_ip>:27017/sampledb'
+$ oc set env dc/nodejs-mongodb-example
+MONGO_URL='mongodb://admin:secret@<MongoDB-service-name>:27017/sampledb'
+----
++
+[NOTE]
+====
+Services in the same project have automatically resolvable DNS names.
+====
++
+For example:
++
+----
+$ oc set env dc/nodejs-mongodb-example
+MONGO_URL='mongodb://admin:secret@mongodb-persistent:27017/sampledb'
 ----
 
 . Next, run `oc status` to confirm that an updated deployment has been kicked off.


### PR DESCRIPTION
(cherry picked from commit f8f2d2fe91a6d8571f0ccf5464606375485d2d71) xref:https://github.com/openshift/openshift-docs/pull/5598