### PR TITLE
[online-3.7] remove incorrect note about scheduled import

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -806,12 +806,6 @@ spec:
       scheduled: true
 ----
 
-[NOTE]
-====
-By default, `*importPolicy.scheduled*` is disabled and must be enabled in the
-master configuration file.
-====
-
 [[insecure-registries]]
 === Importing Images from Insecure Registries
 


### PR DESCRIPTION
(cherry picked from commit 2bc48ea8b7b58eb10810ee7c17d8144c3bfc3329) xref:https://github.com/openshift/openshift-docs/pull/6344