### PR TITLE
Document the ovs-networkpolicy migration script and NetworkPolicy/Router interaction

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1004,25 +1004,9 @@ the case with unicast.
 [[admin-guide-networking-networkpolicy]]
 == Enabling NetworkPolicy
 
-[IMPORTANT]
-====
-Enabling the Kubernetes `NetworkPolicy` is a Technology Preview feature only.
-ifdef::openshift-enterprise[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-For more information on Red Hat Technology Preview features support scope, see
-https://access.redhat.com/support/offerings/techpreview/.
-endif::[]
-====
-
-Kubernetes `NetworkPolicy` is not currently fully supported by {product-title},
-and the *ovs-subnet* and *ovs-multitenant* plug-ins ignore `NetworkPolicy`
-objects. However, a Technology Preview of `NetworkPolicy` support is available
-by using the *ovs-networkpolicy* plug-in.
+The *ovs-subnet* and *ovs-multitenant* plug-ins have their own legacy models of network
+isolation, and don't support Kubernetes `NetworkPolicy`. However, `NetworkPolicy` support
+is available by using the *ovs-networkpolicy* plug-in.
 
 In a cluster
 xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[configured
@@ -1108,6 +1092,65 @@ to accept any connection allowed by each policy. That is,  connections on any
 port from pods in the *_same_* namespace, and connections on ports `80` and
 `443` from pods in *_any_* namespace.
 
+[[admin-guide-networking-networkpolicy-routers]]
+=== NetworkPolicy and Routers
+
+When using the *ovs-multitenant* plugin, traffic from
+xref:../architecture/topics/routers.adoc[routers] is automatically allowed into all
+namespaces (because the routers are normally in the "default" namespace, and all
+namespaces allow connections from pods in that namespace). With the *ovs-networkpolicy*
+plugin, this does not happen automatically, so if you have a policy that isolates a
+namespace by default, you will need to take additional steps to allow routers to access
+it.
+
+One option is to create a policy for each service, allowing access from all sources. eg:
+
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-to-database-service
+spec:
+  podSelector:
+    matchLabels:
+      role: database
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 5432
+----
+
+This will allow routers to access the service, but will allow pods in other users'
+namespaces to access it as well. (In general, this should not be a problem though, since
+those pods could normally just access the service via the public router anyway.)
+
+Alternatively, you can create a policy allowing full access from the default namespace, as
+in the *ovs-multitenant* plugin:
+
+. First, a cluster administrator must add a label to the default namespace so it can be
+matched:
++
+----
+$ oc label namespace default name=default
+----
+. Then project administrators can create policies allowing connections from that
+namespace:
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-from-default-namespace
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: default
+----
+
 [[admin-guide-networking-networkpolicy-setting-default]]
 === Setting a Default NetworkPolicy for New Projects
 Cluster administrators can modify the default project template to enable
@@ -1139,11 +1182,22 @@ objects:
 - apiVersion: extensions/v1beta1
   kind: NetworkPolicy
   metadata:
-    name: allow-same-namespace
+    name: allow-from-same-namespace
   spec:
     podSelector:
     ingress:
     - from:
       - podSelector: {}
+- apiVersion: extensions/v1beta1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-default-namespace
+  spec:
+    podSelector:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: default
 ...
 ----

--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -32,7 +32,7 @@ allowed to communicate with all other pods, and all other pods can communicate
 with them. In {product-title} clusters, the *default* project has VNID 0. This
 facilitates certain services like the load balancer, etc. to communicate with
 all other pods in the cluster and vice versa.
-* The *ovs-networkpolicy* plug-in (currently in Tech Preview) allows project
+* The *ovs-networkpolicy* plug-in allows project
 administrators to configure their own isolation policies using
 xref:../../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy[NetworkPolicy objects].
 

--- a/architecture/topics/openshift_sdn_plugins.adoc
+++ b/architecture/topics/openshift_sdn_plugins.adoc
@@ -13,7 +13,7 @@ allowed to communicate with all other pods, and all other pods can communicate
 with them. In {product-title} clusters, the *default* project has VNID 0. This
 facilitates certain services, such as the load balancer, to communicate with
 all other pods in the cluster and vice versa.
-* The *ovs-networkpolicy* plug-in (currently in Tech Preview) allows project
+* The *ovs-networkpolicy* plug-in allows project
 administrators to configure their own isolation policies using NetworkPolicy objects.
 
 ifdef::openshift-enterprise,openshift-origin[]

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -14,9 +14,9 @@ toc::[]
 
 The xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[OpenShift SDN] enables
 communication between pods across the {product-title} cluster, establishing a _pod
-network_. Two xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[SDN plug-ins]
-are currently available (*ovs-subnet* and *ovs-multitenant*), which provide
-different methods for configuring the pod network. A third (*ovs-networkpolicy*) is currently in Tech Preview.
+network_. Three xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[SDN plug-ins]
+are currently available (*ovs-subnet*, *ovs-multitenant*, and *ovs-networkpolicy*), which provide
+different methods for configuring the pod network.
 
 [[admin-guide-configuring-sdn-available-sdn-providers]]
 == Available SDN Providers
@@ -78,7 +78,7 @@ which is configurable in the Ansible inventory file.
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 
-# Configure the NetworkPolicy SDN plugin (Tech Preview)
+# Configure the NetworkPolicy SDN plugin
 # os_sdn_network_plugin_name='redhat/openshift-ovs-networkpolicy'
 
 # Disable the OpenShift SDN plugin
@@ -210,6 +210,53 @@ Check VNIDs by running:
 ----
 $ oc get netnamespace
 ----
+
+[[migrating-between-sdn-plugins-networkpolicy]]
+=== Migrating from the ovs-multitenant Plugin to ovs-networkpolicy
+
+Before migrating from *ovs-multitenant* to *ovs-networkpolicy*, you must ensure that every
+namespace has a unique `NetID`; that means that if you have previously
+xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined projects
+together] or
+xref:../admin_guide/managing_networking.adoc#making-project-networks-global[made projects
+global], you will need to undo that before switching to the *ovs-networkpolicy* plugin, or
+NetworkPolicy objects may not function correctly.
+
+A helper script is available that fixes `NetID`s, creates NetworkPolicy objects to isolate
+previously-isolated namespaces, and enabled connections between previously-joined
+namespaces.
+
+. Download https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
++
+----
+$ curl https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
+$ chmod a+x migrate-network-policy.sh
+----
+. While still running the *ovs-multitenant* plugin (that is, before running any of the
+migration steps above), run that script as a user with cluster administrator rights on
+the OpenShift cluster
++
+----
+$ ./migrate-network-policy.sh
+----
+
+After running the script, every project will now be fully isolated from every other
+project, so connection attempts between pods in different projects will fail until you
+complete the migration to the *ovs-networkpolicy* plugin.
+
+If you want newly-created projects to also have the same policies by default, you can set
+xref:../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy-setting-default[default
+NetworkPolicy objects] to be created matching the `default-deny` and
+`allow-from-global-namespaces` policies created by the migration script.
+
+[NOTE]
+====
+In case of script failures or other errors, or if you later decide you want to revert back
+to the *ovs-multitenant* plugin, you can use the
+link:https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/unmigrate-network-policy.sh[un-migration
+script]. This script undoes the changes made by the migration script and re-joins
+previously-joined projects.
+====
 
 [[external-access-to-the-cluster-network]]
 == External Access to the Cluster Network


### PR DESCRIPTION
Further "3.7 NetworkPolicy GA" work.

This includes a reference to a downloadable helper script; I wasn't sure how to do that. Are there other precedents for that in the docs? Should we maybe link to a support article instead for the enterprise case (but still link to github for the origin case)?

@bfallonf @vikram-redhat @gaurav-nelson 

As with #6127, this applies to 3.6 and later