### PR TITLE
[enterprise-3.6] add reset Docker storage per BZ-1501504

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -487,6 +487,90 @@ default value for `max-pods` is `250`. This means that unless the node has 25
 cores or more, by default, `pods-per-core` will be the limiting factor.
 // end::admin_guide_manage_nodes[]
 
+[[managing-nodes-docker-reset]]
+== Resetting Docker Storage
+
+As you download Docker images and run and delete containers, Docker does not always free up mapped disk space. As a result, over time you can run out of space on a node,
+which might prevent {product-title} from being able to create new pods or cause pod creation to take several minutes.
+
+For example, the following shows pods that are still in the `ContainerCreating` state after six minutes and the events log shows a xref:../dev_guide/events.adoc#events-reference[FailedSync event].
+
+[source,bash]
+----
+$ oc get pod
+NAME                               READY     STATUS              RESTARTS   AGE
+cakephp-mysql-persistent-1-build   0/1       ContainerCreating   0          6m
+mysql-1-9767d                      0/1       ContainerCreating   0          2m
+mysql-1-deploy                     0/1       ContainerCreating   0          6m
+
+$ oc get events
+LASTSEEN   FIRSTSEEN   COUNT     NAME                               KIND                    SUBOBJECT                     TYPE      REASON                         SOURCE                                                 MESSAGE
+6m         6m          1         cakephp-mysql-persistent-1-build   Pod                                                   Normal    Scheduled                      default-scheduler                                      Successfully assigned cakephp-mysql-persistent-1-build to ip-172-31-71-195.us-east-2.compute.internal
+2m         5m          4         cakephp-mysql-persistent-1-build   Pod                                                   Warning   FailedSync                     kubelet, ip-172-31-71-195.us-east-2.compute.internal   Error syncing pod
+2m         4m          4         cakephp-mysql-persistent-1-build   Pod                                                   Normal    SandboxChanged                 kubelet, ip-172-31-71-195.us-east-2.compute.internal   Pod sandbox changed, it will be killed and re-created.
+----
+
+One solution to this problem is to reset Docker storage to remove artifacts not needed by Docker.
+
+On the node where you want to restart Docker storage:
+
+. Run the following command to mark the node as unschedulable:
++
+----
+$ oadm manage-node <node> --schedulable=false
+----
+
+. Run the following command to shut down Docker and the *atomic-openshift-node* service:
++
+----
+$ systemctl stop docker atomic-openshift-node
+----
+
+. Run the following command to remove the local volume directory:
++
+----
+$ rm -rf /var/lib/origin/openshift.local.volumes
+----
++
+This command clears the local image cache. As a result, images, including `ose-*` images, will need to be re-pulled.
+This might result in slower pod start times while the image store recovers.
+
+. Remove the *_/var/lib/docker_* directory:
++
+----
+$ rm -rf /var/lib/docker
+----
+
+. Run the following command to reset the Docker storage:
++
+----
+$ docker-storage-setup --reset
+----
+
+. Run the following command to recreate the Docker storage:
++
+----
+$ docker-storage-setup
+----
+
+. Recreate the *_/var/lib/docker_* directory:
++
+----
+$ mkdir /var/lib/docker
+----
+
+. Run the following command to restart Docker and the *atomic-openshift-node* service:
++
+----
+$ systemctl start docker atomic-openshift-node
+----
+
+. Run the following command to mark the node as schedulable:
++
+----
+$ oadm manage-node <node> --schedulable=true
+----
+
 [[manage-node-change-node-traffic-interface]]
 == Changing Node Traffic Interface
 


### PR DESCRIPTION
(cherry picked from commit 001e6beda60f7972243e2aaac312a1807dfff340) xref:https://github.com/openshift/openshift-docs/pull/6205