### PR TITLE
Added enabling HSTS section

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1228,3 +1228,56 @@ objects:
             name: default
 ...
 ----
+
+[[admin-guide-enabling-hsts]]
+== Enabling HTTP Strict Transport Security
+
+HTTP Strict Transport Security (HSTS) policy is a security enhancement, which
+ensures that only HTTPS traffic is allowed on the host. Any HTTP requests are
+dropped by default. This is useful for ensuring secure interactions with
+websites, or to offer a secure application for the user's benefit.
+
+When HSTS is enabled, HSTS adds a Strict Transport Security header to HTTPS
+responses from the site. You can use the `insecureEdgeTerminationPolicy` value
+in a route to redirect to send HTTP to HTTPS. However, when HSTS is enabled, the
+client changes all requests from the HTTP URL to HTTPS before the request is
+sent, eliminating the need for a redirect. This is not required to be supported
+by the client, and can be disabled by setting `max-age=0`.
+
+[IMPORTANT]
+====
+HSTS works only with secure routes (either edge terminated or re-encrypt). The
+configuration is ineffective on HTTP or passthrough routes.
+====
+
+To enable HSTS to a route, add the `haproxy.router.openshift.io/hsts_header`
+value to the edge terminated or re-encrypt route:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload
+----
+
+[IMPORTANT]
+====
+Ensure there are no spaces and no other values in the parameters in the `haproxy.router.openshift.io/hsts_header` value. Only `max-age` is required.
+====
+
+The required `max-age` parameter indicates the length of time, in seconds, the
+HSTS policy is in effect for. The client updates `max-age` whenever a response
+with a HSTS header is received from the host. When `max-age` times out, the
+client discards the policy.
+
+The optional `includeSubDomains` parameter tells the client that all subdomains
+of the host are to be treated the same as the host.
+
+If `max-age` is greater than 0, the optional `preload` parameter allows external
+services to include this site in their HSTS preload lists. For example, sites
+such as Google can construct a list of sites that have `preload` set. Browsers
+can then use these lists to determine which sites to only talk to over HTTPS,
+even before they have interacted with the site. Without `preload` set, they need
+to have talked to the site over HTTPS to get the header.

--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -604,6 +604,8 @@ and "-". The default is the hashed internal key name for the route. |
 |`*haproxy.router.openshift.io/timeout*` | Sets a server-side timeout for the route. xref:time-units[(TimeUnits)] | `ROUTER_DEFAULT_SERVER_TIMEOUT`
 |`*router.openshift.io/haproxy.health.check.interval*`| Sets the interval for the back-end health checks. xref:time-units[(TimeUnits)] | `ROUTER_BACKEND_CHECK_INTERVAL`
 |`*haproxy.router.openshift.io/ip_whitelist*` | Sets a xref:whitelist[whitelist] for the route. |
+|`*haproxy.router.openshift.io/hsts_header*` | Sets a xref:hsts[Strict-Transport-Security] header for the edge terminated or re-encrypt route. |
+
 |===
 
 .A Route Setting Custom Timeout


### PR DESCRIPTION
From: #5365 

@pecameron I created this with info from your PR above, but added some context, moved the info, and gave it an edit.

As @zhaozhanqi asks in the other PR, is this available for all routes (insecure/edge/passthrough/reencrypt)? How can we verify that the route is accepting the feature? If you have any other thoughts, feel free to let me know as well.

cc @knobunc 