### PR TITLE
Update builddefaults documentation.

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -1212,35 +1212,39 @@ option.
 
 |`openshift_builddefaults_http_proxy`
 |This variable defines the `HTTP_PROXY` environment variable inserted into
-builds using the `BuildDefaults` admission controller. If
-`openshift_http_proxy` is set, this variable will inherit that value; you only
-need to set this if you want your builds to use a different value.
+builds using the `BuildDefaults` admission controller. If you do not define
+this parameter but define the `openshift_http_proxy` parameter, the
+`openshift_http_proxy` value is used. Set the
+`openshift_builddefaults_http_proxy` value to `False` to disable default
+http proxy for builds regardless of the `openshift_http_proxy` value.
 
 |`openshift_builddefaults_https_proxy`
-|This variable defines the `*HTTPS_PROXY*` environment variable inserted into
-builds using the `*BuildDefaults*` admission controller. If
-`*openshift_https_proxy*` is set, this variable will inherit that value; you
-only need to set this if you want your builds to use a different value.
+|This variable defines the `HTTPS_PROXY` environment variable inserted into
+builds using the `BuildDefaults` admission controller. If you do not define
+this parameter but define the `openshift_http_proxy` parameter, the
+`openshift_https_proxy` value is used. Set the
+`openshift_builddefaults_https_proxy` value to `False` to disable default
+https proxy for builds regardless of the `openshift_https_proxy` value.
 
 |`openshift_builddefaults_no_proxy`
 |This variable defines the `NO_PROXY` environment variable inserted into
-builds using the `BuildDefaults` admission controller. If
-`openshift_no_proxy` is set, this variable will inherit that value; you only
-need to set this if you want your builds to use a different value.
+builds using the `BuildDefaults` admission controller. Set the
+`openshift_builddefaults_no_proxy` value to `False` to disable default no proxy
+settings for builds regardless of the `openshift_no_proxy` value.
 
 |`openshift_builddefaults_git_http_proxy`
 |This variable defines the HTTP proxy used by `git clone` operations during a
-build, defined using the `BuildDefaults` admission controller. If
-`openshift_builddefaults_http_proxy` is set, this variable will inherit that
-value; you only need to set this if you want your `git clone` operations to use
-a different value.
+build, defined using the `BuildDefaults` admission controller. Set the
+`openshift_builddefaults_git_http_proxy` value to `False` to disable default
+http proxy for `git clone` operations during a build regardless of the
+`openshift_http_proxy` value.
 
 |`openshift_builddefaults_git_https_proxy`
 |This variable defines the HTTPS proxy used by `git clone` operations during a
-build, defined using the `BuildDefaults` admission controller. If
-`openshift_builddefaults_https_proxy` is set, this variable will inherit that
-value; you only need to set this if you want your `git clone` operations to use
-a different value.
+build, defined using the `BuildDefaults` admission controller. Set the
+`openshift_builddefaults_git_https_proxy` value to `False` to disable default
+https proxy for `git clone` operations during a build regardless of the
+`openshift_https_proxy` value.
 |===
 
 [[advanced-install-no-proxy-list]]


### PR DESCRIPTION
Update the documentation with the instructions how to keep the proxy settings, but disable it for the builds.