### PR TITLE
Added section on cookies and routes

### DIFF
--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -270,6 +270,47 @@ xref:../architecture/networking/routes.adoc#path-based-routes[path-based
 routing] are available in the
 xref:../architecture/networking/routes.adoc#architecture-core-concepts-routes[Architecture section].
 
+[[dev-guide-routes-allowing-endpoints-to-control-cookies]]
+== Allowing Route Endpoints to Control Cookie Names
+
+{product-title} provides sticky sessions, which enables stateful application
+traffic by ensuring all traffic hits the same endpoint. However, if the endpoint
+pod terminates, whether through restart, scaling, or a change in configuration,
+this statefulness can disappear.
+
+{product-title} can use cookies to configure session persistence. The router
+selects an endpoint to handle any user requests, and creates a cookie for the
+session. The cookie is passed back in the response to the request and the user
+sends the cookie back with the next request in the session. The cookie tells the
+router which endpoint is handling the session, ensuring that client requests use
+the cookie so that they are routed to the same pod.
+
+You can set a cookie name to overwrite the default, auto-generated one for the
+route. This allows the application receiving route traffic to know the cookie
+name. By deleting the cookie it can force the next request to re-choose an
+endpoint. So, if a server was overloaded it tries to shed the requests from the
+client and redistribute them.
+
+. Annotate the route with the desired cookie name:
++
+----
+$ oc annotate route <route_name> router.openshift.io/<cookie_name>= “-<cookie_annotation>”
+----
++
+For example, to annotate the cookie name of `my_cookie` to the `my_route` with
+the annotation of `my_cookie_anno`:
++
+----
+$ oc annotate route my_route router.openshift.io/my_cookie= “-my_cookie_anno”
+----
+
+. Save the cookie, and access the route:
++
+----
+$ curl $my_route -k -c /tmp/my_cookie
+----
+
+
 ifdef::openshift-online[]
 [[custom-route-and-hosts-and-certificates-restrictions]]
 == Restrictions


### PR DESCRIPTION
For [trello card](https://trello.com/c/aeJZjuVv/680-document-allow-routes-to-set-the-cookie-names-for-session-stickiness-ingress).

Will ask for review over email.

For 3.7 only.

cc @pecameron 