### PR TITLE
create new topic for image streams

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -167,11 +167,14 @@ Topics:
     Distros: openshift-*
   - Name: Projects and Users
     File: projects_and_users
-  - Name: Builds and Image Streams
-    File: builds_and_image_streams
+  - Name: Builds
+    File: builds
     Distros: openshift-*
   - Name: Image Streams
-    File: builds_and_image_streams
+    File: image_streams
+    Distros: openshift-*
+  - Name: Image Streams
+    File: image_streams
     Distros: atomic-*
   - Name: Deployments
     File: deployments

--- a/admin_guide/building_dependency_trees.adoc
+++ b/admin_guide/building_dependency_trees.adoc
@@ -13,19 +13,19 @@ toc::[]
 == Overview
 {product-title} uses xref:../dev_guide/builds/triggering_builds.adoc#image-change-triggers[image
 change triggers] in a `BuildConfig` to detect when an
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tag] has been updated. You can use the `oadm build-chain` command to
 build a dependency tree that identifies which
 xref:../architecture/core_concepts/containers_and_images.adoc#docker-images[images]
 would be affected by updating an image in a specified
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../architecture/core_concepts/image_streams.adoc#image-streams[image
 stream].
 
 The `build-chain` tool can determine which
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[builds]
+xref:../architecture/core_concepts/build.adoc#architecture-core-concepts-builds[builds]
 to trigger; it analyzes the output of those builds to determine if they will in
 turn update another
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tag]. If they do, the tool continues to follow the dependency tree.
 Lastly, it outputs a graph specifying the image stream tags
 that would be impacted by an update to the top-level tag. The default output

--- a/admin_guide/monitoring_images.adoc
+++ b/admin_guide/monitoring_images.adoc
@@ -14,7 +14,7 @@ toc::[]
 == Overview
 
 You can monitor
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[images]
+xref:../architecture/core_concepts/image_streams.adoc#image-streams[images]
 in your instance using the
 xref:../cli_reference/index.adoc#cli-reference-index[CLI].
 

--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -348,7 +348,7 @@ xref:image-prune-conditions[the conditions] that must apply for an image to be
 considered a candidate for pruning.
 
 Especially ensure that images you want removed occur at higher positions in each
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[tag
+xref:../architecture/core_concepts/image_streams.adoc#image-stream-tag[tag
 history] than your chosen tag revisions threshold. For example, consider an old
 and obsolete image named `sha:abz`. By running the following command in
 namespace `N`, where the image is tagged, you will see the image is tagged three
@@ -379,7 +379,7 @@ younger than the specified threshold.
 ====
 
 . Delete all the
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[_istags_]
+xref:../architecture/core_concepts/image_streams.adoc#image-stream-tag[_istags_]
 where the position is below the revision threshold, which means
 `myapp:v2.1` and `myapp:v2.1-may-2016`.
 

--- a/admin_guide/securing_builds.adoc
+++ b/admin_guide/securing_builds.adoc
@@ -12,17 +12,17 @@ toc::[]
 
 == Overview
 
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[Builds]
+xref:../architecture/core_concepts/build.adoc#architecture-core-concepts-builds[Builds]
 in {product-title} are run in
 xref:../install_config/install/prerequisites.adoc#security-warning[privileged containers] that
 have access to the Docker daemon socket. As a security measure, it is
 recommended to limit who can run builds and the strategy that is used for those
 builds.
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[Custom
+xref:../architecture/core_concepts/build.adoc#custom-build[Custom
 builds] are inherently less safe than
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source
+xref:../architecture/core_concepts/build.adoc#source-build[Source
 builds], given that they can execute any code in the build with potentially full
-access to the node's Docker socket, and as such are disabled by default.  xref:../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker
+access to the node's Docker socket, and as such are disabled by default.  xref:../architecture/core_concepts/build.adoc#docker-build[Docker
 build] permission should also be granted with caution as a vulnerability in the Docker build
 logic could result in a privileges being granted on the host node.
 

--- a/architecture/additional_concepts/scm.adoc
+++ b/architecture/additional_concepts/scm.adoc
@@ -15,7 +15,7 @@ example, on link:https://github.com/[GitHub], link:https://bitbucket.org/[Bitbuc
 etc.). Currently, {product-title} only supports link:https://git-scm.com/[Git] solutions.
 
 SCM integration is tightly coupled with
-xref:../core_concepts/builds_and_image_streams.adoc#architecture-core-concepts-builds-and-image-streams[builds],
+xref:../core_concepts/build.adoc#architecture-core-concepts-builds[builds],
 the two points being:
 
 - Creating a `BuildConfig` using a repository, which allows building your

--- a/architecture/core_concepts/build.adoc
+++ b/architecture/core_concepts/build.adoc
@@ -1,0 +1,166 @@
+[[architecture-core-concepts-builds]]
+= Builds
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
+[[builds]]
+A _build_ is the process of transforming input parameters into a resulting
+object. Most often, the process is used to transform input parameters or source
+code into a runnable image. A
+xref:../../dev_guide/builds/index.adoc#defining-a-buildconfig[`BuildConfig`]
+object is the definition of the entire build process.
+
+{product-title} leverages Kubernetes by creating Docker-formatted containers from build
+images and pushing them to a
+xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[container registry].
+
+Build objects share common characteristics: inputs for a build, the need to
+complete a build process, logging the build process, publishing resources from
+successful builds, and publishing the final status of the build. Builds take
+advantage of resource restrictions, specifying limitations on resources such as
+CPU usage, memory usage, and build or pod execution time.
+
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+The {product-title} build system provides extensible support for _build
+strategies_ that are based on selectable types specified in the build API. There
+are three primary build strategies available:
+
+- xref:docker-build[Docker build]
+- xref:source-build[Source-to-Image (S2I) build]
+- xref:custom-build[Custom build]
+
+By default, Docker builds and S2I builds are supported.
+
+endif::[]
+The resulting object of a build depends on the builder used to create it. For
+Docker and S2I builds, the resulting objects are runnable images. For Custom
+builds, the resulting objects are whatever the builder image author has
+specified.
+
+Additionally, the
+xref:pipeline-build[Pipeline build]
+strategy can be used to implement sophisticated workflows:
+
+- continuous integration
+- continuous deployment
+
+For a list of build commands, see the
+xref:../../dev_guide/builds/index.adoc#dev-guide-how-builds-work[Developer's Guide].
+
+For more information on how {product-title} leverages Docker for builds, see the
+link:https://github.com/openshift/origin/blob/master/docs/builds.md#how-it-works[upstream
+documentation].
+
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+[[docker-build]]
+== Docker Build
+
+The Docker build strategy invokes the https://docs.docker.com/engine/reference/commandline/build/[docker build] command, and it therefore expects a repository with a *_Dockerfile_* and all required
+artifacts in it to produce a runnable image.
+endif::[]
+
+[[source-build]]
+== Source-to-Image (S2I) Build
+
+xref:../../creating_images/s2i.adoc#creating-images-s2i[Source-to-Image (S2I)] is a tool for
+building reproducible, Docker-formatted container images. It produces ready-to-run images by
+injecting application source into a container image and assembling a new image. The new image incorporates the base image (the builder) and built source
+and is ready to use with the `docker run` command. S2I supports incremental
+builds, which re-use previously downloaded dependencies, previously built
+artifacts, etc.
+
+The advantages of S2I include the following:
+
+[horizontal]
+Image flexibility:: S2I scripts can be written to inject application code into
+almost any existing Docker-formatted container image, taking advantage of the existing ecosystem.
+Note that, currently, S2I relies on `tar` to inject application
+source, so the image needs to be able to process tarred content.
+
+Speed:: With S2I, the assemble process can perform a large number of complex
+operations without creating a new layer at each step, resulting in a fast
+process. In addition, S2I scripts can be written to re-use artifacts stored in a
+previous version of the application image, rather than having to download or
+build them each time the build is run.
+
+Patchability:: S2I allows you to rebuild the application consistently if an
+underlying image needs a patch due to a security issue.
+
+Operational efficiency:: By restricting build operations instead of allowing
+arbitrary actions, as a *_Dockerfile_* would allow, the PaaS operator can avoid
+accidental or intentional abuses of the build system.
+
+Operational security:: Building an arbitrary *_Dockerfile_* exposes the host
+system to root privilege escalation. This can be exploited by a malicious user
+because the entire Docker build process is run as a user with Docker privileges.
+S2I restricts the operations performed as a root user and can run the scripts
+as a non-root user.
+
+User efficiency:: S2I prevents developers from performing arbitrary `yum
+install` type operations, which could slow down development iteration, during
+their application build.
+
+Ecosystem:: S2I encourages a shared ecosystem of images where you can leverage
+best practices for your applications.
+
+Reproducibility:: Produced images can include all inputs including specific versions
+of build tools and dependencies. This ensures that the image can be reproduced
+precisely.
+
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+[[custom-build]]
+== Custom Build
+
+The Custom build strategy allows developers to define a specific builder image
+responsible for the entire build process. Using your own builder image allows
+you to customize your build process.
+
+A xref:../../creating_images/custom.adoc#creating-images-custom[Custom builder image] is a plain Docker-formatted container image embedded with build process logic, for example for building RPMs or base images. The `openshift/origin-custom-docker-builder` image is available
+on the
+https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder[Docker Hub] registry as an example implementation of a Custom builder image.
+endif::[]
+
+[[pipeline-build]]
+== Pipeline Build
+
+The Pipeline build strategy allows developers to define a _Jenkins pipeline_
+for execution by the Jenkins pipeline plugin.
+The build can be started, monitored, and managed by
+{product-title} in the same way as any other build type.
+
+Pipeline workflows are defined in a Jenkinsfile,
+either embedded directly in the build configuration,
+or supplied in a Git repository and referenced by the build configuration.
+
+The first time a project defines a build configuration using a Pipeline
+strategy, {product-title} instantiates a Jenkins server to execute the
+pipeline.  Subsequent Pipeline build configurations in the project share this
+Jenkins server.
+
+ifdef::openshift-origin,openshift-enterprise[]
+For more details on how the Jenkins server is deployed and how to configure or
+disable the autoprovisioning behavior, see
+xref:../../install_config/configuring_pipeline_execution.adoc#install-config-configuring-pipeline-execution[Configuring Pipeline Execution].
+endif::[]
+
+
+[NOTE]
+====
+The Jenkins server is not automatically removed,
+even if all Pipeline build configurations are deleted.
+It must be manually deleted by the user.
+====
+
+For more information about Jenkins Pipelines, please see the
+link:https://jenkins.io/doc/pipeline/[Jenkins documentation].
+
+endif::[]

--- a/architecture/core_concepts/image_streams.adoc
+++ b/architecture/core_concepts/image_streams.adoc
@@ -1,5 +1,5 @@
-[[architecture-core-concepts-builds-and-image-streams]]
-= Builds and Image Streams
+[[architecture-core-concepts-image-streams]]
+= Image Streams
 {product-author}
 {product-version}
 :data-uri:
@@ -11,170 +11,7 @@
 
 toc::[]
 
-ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
-[[builds]]
-== Builds
-
-A _build_ is the process of transforming input parameters into a resulting
-object. Most often, the process is used to transform input parameters or source
-code into a runnable image. A
-xref:../../dev_guide/builds/index.adoc#defining-a-buildconfig[`BuildConfig`]
-object is the definition of the entire build process.
-
-{product-title} leverages Kubernetes by creating Docker-formatted containers from build
-images and pushing them to a
-xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[container registry].
-
-Build objects share common characteristics: inputs for a build, the need to
-complete a build process, logging the build process, publishing resources from
-successful builds, and publishing the final status of the build. Builds take
-advantage of resource restrictions, specifying limitations on resources such as
-CPU usage, memory usage, and build or pod execution time.
-
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
-The {product-title} build system provides extensible support for _build
-strategies_ that are based on selectable types specified in the build API. There
-are three primary build strategies available:
-
-- xref:docker-build[Docker build]
-- xref:source-build[Source-to-Image (S2I) build]
-- xref:custom-build[Custom build]
-
-By default, Docker builds and S2I builds are supported.
-
-endif::[]
-The resulting object of a build depends on the builder used to create it. For
-Docker and S2I builds, the resulting objects are runnable images. For Custom
-builds, the resulting objects are whatever the builder image author has
-specified.
-
-Additionally, the
-xref:pipeline-build[Pipeline build]
-strategy can be used to implement sophisticated workflows:
-
-- continuous integration
-- continuous deployment
-
-For a list of build commands, see the
-xref:../../dev_guide/builds/index.adoc#dev-guide-how-builds-work[Developer's Guide].
-
-For more information on how {product-title} leverages Docker for builds, see the
-link:https://github.com/openshift/origin/blob/master/docs/builds.md#how-it-works[upstream
-documentation].
-
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
-[[docker-build]]
-=== Docker Build
-
-The Docker build strategy invokes the https://docs.docker.com/engine/reference/commandline/build/[docker build] command, and it therefore expects a repository with a *_Dockerfile_* and all required
-artifacts in it to produce a runnable image.
-endif::[]
-
-[[source-build]]
-=== Source-to-Image (S2I) Build
-
-xref:../../creating_images/s2i.adoc#creating-images-s2i[Source-to-Image (S2I)] is a tool for
-building reproducible, Docker-formatted container images. It produces ready-to-run images by
-injecting application source into a container image and assembling a new image. The new image incorporates the base image (the builder) and built source
-and is ready to use with the `docker run` command. S2I supports incremental
-builds, which re-use previously downloaded dependencies, previously built
-artifacts, etc.
-
-The advantages of S2I include the following:
-
-[horizontal]
-Image flexibility:: S2I scripts can be written to inject application code into
-almost any existing Docker-formatted container image, taking advantage of the existing ecosystem.
-Note that, currently, S2I relies on `tar` to inject application
-source, so the image needs to be able to process tarred content.
-
-Speed:: With S2I, the assemble process can perform a large number of complex
-operations without creating a new layer at each step, resulting in a fast
-process. In addition, S2I scripts can be written to re-use artifacts stored in a
-previous version of the application image, rather than having to download or
-build them each time the build is run.
-
-Patchability:: S2I allows you to rebuild the application consistently if an
-underlying image needs a patch due to a security issue.
-
-Operational efficiency:: By restricting build operations instead of allowing
-arbitrary actions, as a *_Dockerfile_* would allow, the PaaS operator can avoid
-accidental or intentional abuses of the build system.
-
-Operational security:: Building an arbitrary *_Dockerfile_* exposes the host
-system to root privilege escalation. This can be exploited by a malicious user
-because the entire Docker build process is run as a user with Docker privileges.
-S2I restricts the operations performed as a root user and can run the scripts
-as a non-root user.
-
-User efficiency:: S2I prevents developers from performing arbitrary `yum
-install` type operations, which could slow down development iteration, during
-their application build.
-
-Ecosystem:: S2I encourages a shared ecosystem of images where you can leverage
-best practices for your applications.
-
-Reproducibility:: Produced images can include all inputs including specific versions
-of build tools and dependencies. This ensures that the image can be reproduced
-precisely.
-
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
-[[custom-build]]
-=== Custom Build
-
-The Custom build strategy allows developers to define a specific builder image
-responsible for the entire build process. Using your own builder image allows
-you to customize your build process.
-
-A xref:../../creating_images/custom.adoc#creating-images-custom[Custom builder image] is a plain Docker-formatted container image embedded with build process logic, for example for building RPMs or base images. The `openshift/origin-custom-docker-builder` image is available
-on the
-https://registry.hub.docker.com/u/openshift/origin-custom-docker-builder[Docker Hub] registry as an example implementation of a Custom builder image.
-endif::[]
-
-[[pipeline-build]]
-=== Pipeline Build
-
-The Pipeline build strategy allows developers to define a _Jenkins pipeline_
-for execution by the Jenkins pipeline plugin.
-The build can be started, monitored, and managed by
-{product-title} in the same way as any other build type.
-
-Pipeline workflows are defined in a Jenkinsfile,
-either embedded directly in the build configuration,
-or supplied in a Git repository and referenced by the build configuration.
-
-The first time a project defines a build configuration using a Pipeline
-strategy, {product-title} instantiates a Jenkins server to execute the
-pipeline.  Subsequent Pipeline build configurations in the project share this
-Jenkins server.
-
-ifdef::openshift-origin,openshift-enterprise[]
-For more details on how the Jenkins server is deployed and how to configure or
-disable the autoprovisioning behavior, see
-xref:../../install_config/configuring_pipeline_execution.adoc#install-config-configuring-pipeline-execution[Configuring Pipeline Execution].
-endif::[]
-ifdef::openshift-dedicated[]
-For more details on how the Jenkins server is deployed and how to configure or
-disable the autoprovisioning behavior, see
-xref:../../admin_guide/osd_configuring_pipeline_execution.adoc#admin-guide-osd-configuring-pipeline-execution[Configuring Pipeline Execution].
-endif::[]
-
-
-[NOTE]
-====
-The Jenkins server is not automatically removed,
-even if all Pipeline build configurations are deleted.
-It must be manually deleted by the user.
-====
-
-For more information about Jenkins Pipelines, please see the
-link:https://jenkins.io/doc/pipeline/[Jenkins documentation].
-
-endif::[]
-
 [[image-streams]]
-== Image Streams
-
 An image stream and its associated tags provide an abstraction for referencing 
 xref:../../architecture/core_concepts/containers_and_images.adoc#docker-images[Docker images] from within {product-title}.
 The image stream and its tags allow you to see what images are available 
@@ -182,9 +19,11 @@ and ensure that you are using the specific image you need even if the image in t
 
 Image streams do not contain actual image data, but present a single virtual view of related images, similar to an image repository. 
 
-You can  configure xref:../../dev_guide/builds/triggering_builds.adoc#image-change-triggers[Builds] and
+ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
+You can configure xref:../../dev_guide/builds/triggering_builds.adoc#image-change-triggers[Builds] and
 xref:../../dev_guide/deployments/basic_deployment_operations.adoc#image-change-trigger[Deployments] to watch an image stream
 for notifications when new images are added and react by performing a Build or Deployment, respectively.
+endif::[]
 
 For example, if a Deployment is using a certain image and a new version of that image is created, 
 a Deployment could be automatically performed to pick up the new version of the image.
@@ -250,7 +89,6 @@ If the source image has changed, that change is picked up and reflected in the i
 
 * Users that lack permission to read or list images on the cluster level can still retrieve the images tagged in a project using image streams.
 
-
 For a curated set of image streams, see the
 link:https://github.com/openshift/library[OpenShift Image Streams and Templates
 library].
@@ -261,7 +99,7 @@ When using image streams, it is important to understand what the image stream ta
 
 * If your image stream tag follows another image stream tag (it does not point directly to a docker image tag), it is possible that the image stream tag will be updated to follow a different image stream tag in the future. Again, this could result in picking up an incompatible version change.
 
-=== Important terms
+== Important terms
 
 Docker repository::
 A collection of related docker images and tags identifying them.
@@ -323,9 +161,8 @@ A trigger that causes a specific action when an image stream tag changes. For ex
 causes a trigger to fire when there are Deployments, Builds, or other resources listening for those. See xref:image-stream-triggers[Image Stream Triggers] below.
 
 [[image-stream-configure]]
-=== Configuring Image Streams
+== Configuring Image Streams
 
-ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
 An image stream object file contains the following elements. 
 
 ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
@@ -378,15 +215,17 @@ status:
 <4> The SHA identifier that this image stream tag previously referenced. Can be used to rollback to an older image.
 <5> The image stream tag name.
 
+ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
 For a sample build configuration that references an image stream, see xref:../../dev_guide/builds/index.adoc#defining-a-buildconfig[What Is a BuildConfig?]
 in the `Strategy` stanza of the configuration. 
 
 For a sample deployment configuration that references an image stream, 
 see xref:../../dev_guide/deployments/how_deployments_work.adoc#creating-a-deployment-configuration[Creating a Deployment Configuration] 
 in the `Strategy` stanza of the configuration.
+endif::[]
 
 [[image-stream-image]]
-=== Image Stream Images
+== Image Stream Images
 
 An _image stream image_ points from within an image stream
 to a particular image ID. 
@@ -412,7 +251,7 @@ origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b91
 ----
 
 [[image-stream-tag]]
-=== Image Stream Tags
+== Image Stream Tags
 
 An _image stream tag_ is a named pointer to an image in an _image stream_. It
 is often abbreviated as _istag_. An image stream tag is used to reference or retrieve
@@ -475,9 +314,8 @@ would be:
 origin-ruby-sample:latest
 ----
 
-
 [[image-stream-triggers]]
-=== Image Stream Change Triggers
+== Image Stream Change Triggers
 
 Image stream triggers allow your Builds and Deployments to be automatically invoked when a new version of an upstream image is available.
 
@@ -488,7 +326,7 @@ This is achieved by monitoring that particular image stream tag and notifying th
 include::dev_guide/deployments/basic_deployment_operations.adoc[tag=image-change-trig]
 
 [[image-stream-mappings]]
-=== Image Stream Mappings
+== Image Stream Mappings
 
 When the
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[integrated
@@ -633,13 +471,13 @@ image:
 ----
 
 [[image-stream-mappings-working]]
-=== Working with Image Streams
+== Working with Image Streams
 
 The following sections describe how to use image streams and image stream tags. For more information on working with
 image streams, see xref:../../dev_guide/managing_images.adoc#dev-guide-managing-images[Managing Images].
 
 [[image-stream-mappings-working-getting]]
-==== Getting Information about Image Streams
+=== Getting Information about Image Streams
 
 To get general information about the image stream and detailed information about all the tags it is pointing to,
 use the following command:
@@ -703,7 +541,7 @@ More information is output than shown.
 ====
 
 [[image-stream-mappings-working-adding]]
-==== Adding Additional Tags to an Image Stream
+=== Adding Additional Tags to an Image Stream
 
 To add a tag that points to one of the existing tags, you can use the `oc tag` command:
 
@@ -748,7 +586,7 @@ latest
 ----
 
 [[image-stream-mappings-working-adding-tags]]
-==== Adding Tags for an External Image
+=== Adding Tags for an External Image
 
 Use the `oc tag` command for all tag-related operations, such as adding tags pointing to internal or external images:
 
@@ -767,7 +605,7 @@ If the external image is secured, you will need to create a secret with credenti
 See xref:../../dev_guide/managing_images.adoc#private-registries[Importing Images from Private Registries] for more details.
 
 [[image-stream-mappings-working-updating]]
-==== Updating an Image Stream Tag
+=== Updating an Image Stream Tag
 
 To update a tag to reflect another tag in an image stream:
 
@@ -782,7 +620,7 @@ oc tag python:3.6 python:latest
 Tag python:latest set to python@sha256:438208801c4806548460b27bd1fbcb7bb188273d13871ab43f.
 ----
 
-==== Removing Image Stream Tags from an Image Stream
+=== Removing Image Stream Tags from an Image Stream
 
 To remove old tags from an image stream:
 
@@ -800,7 +638,7 @@ Deleted tag default/python:3.5.
 
 
 [[image-stream-mappings-working-periodic]]
-==== Configuring Periodic Importing of Tags
+=== Configuring Periodic Importing of Tags
 
 When working with an external Docker registry, to periodically re-import an image (such as, to get latest security updates), use the `--scheduled` flag:
 
@@ -816,8 +654,13 @@ oc tag docker.io/python:3.6.0 python:3.6 --scheduled
 Tag python:3.6 set to import docker.io/python:3.6.0 periodically.
 ----
 
+ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
 This command causes {product-title} to periodically update this particular image stream tag. This period is a
 xref:../../install_config/master_node_configuration.adoc#master-config-image-config[cluster-wide setting] set to 15 minutes by default.
+endif::[]
+ifdef::atomic-registry
+This command causes {product-title} to periodically update this particular image stream tag. This period is a cluster-wide setting set to 15 minutes by default.
+endif::[]
 
 To remove the periodic check, re-run above command but omit the `--scheduled` flag. This will reset its behavior to default.
 

--- a/architecture/core_concepts/index.adoc
+++ b/architecture/core_concepts/index.adoc
@@ -17,8 +17,9 @@ for deploying your applications.
 communicate with each other and proxy connections.
 - xref:projects_and_users.adoc#architecture-core-concepts-projects-and-users[Projects and users] provide the space and means
 for communities to organize and manage their content together.
-- xref:builds_and_image_streams.adoc#architecture-core-concepts-builds-and-image-streams[Builds and image streams] allow you to
-build working images and react to new images.
+- xref:builds.adoc#architecture-core-concepts-builds[Builds] allow you to
+build working images.
+- xref:image_streams.adoc#architecture-core-concepts-image-streams[Image Streams] allow your builds to react to new images.
 - xref:deployments.adoc#architecture-core-concepts-deployments[Deployments] add expanded support for the software
 development and deployment lifecycle.
 - xref:routes.adoc#architecture-core-concepts-routes[Routes] announce your service to the world.

--- a/architecture/core_concepts/templates.adoc
+++ b/architecture/core_concepts/templates.adoc
@@ -19,7 +19,7 @@ can be parameterized and processed to produce a list of objects
 for creation by {product-title}. The objects to create can include
 anything that users have permission to create within a project,
 for example xref:pods_and_services.adoc#services[services],
-xref:builds_and_image_streams.adoc#builds[build configurations], and
+xref:builds.adoc#architecture-core-concepts-builds[build configurations], and
 xref:deployments.adoc#deployments-and-deployment-configurations[deployment
 configurations]. A template may also define a set of
 xref:pods_and_services.adoc#labels[labels] to apply to every object

--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -33,7 +33,7 @@ enable teams to collaborate through xref:additional_concepts/authorization.adoc#
 authorization.
 * A xref:infrastructure_components/kubernetes_infrastructure.adoc#architecture-infrastructure-components-kubernetes-infrastructure[Kubernetes-based cluster]
 to manage services.
-* An image abstraction called xref:core_concepts/builds_and_image_streams.adoc#architecture-core-concepts-builds-and-image-streams[image streams] to enhance image management.
+* An image abstraction called xref:core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image streams] to enhance image management.
 
 endif::[]
 ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
@@ -50,7 +50,7 @@ xref:infrastructure_components/kubernetes_infrastructure.adoc#architecture-infra
 {product-title} adds:
 
 - Source code management,
-xref:core_concepts/builds_and_image_streams.adoc#builds[builds], and
+xref:core_concepts/builds.adoc#architecture-core-concepts-builds[builds], and
 xref:core_concepts/deployments.adoc#architecture-core-concepts-deployments[deployments] for developers
 - Managing and promoting
 xref:core_concepts/containers_and_images.adoc#docker-images[images] at scale
@@ -81,7 +81,7 @@ status or write back to the object.
 Users make calls to the REST API to change the state of the system. Controllers
 use the REST API to read the user's desired state, and then try to bring the
 other parts of the system into sync. For example, when a user requests a
-xref:core_concepts/builds_and_image_streams.adoc#builds[build] they create a
+xref:core_concepts/builds.adoc#architecture-core-concepts-builds[build] they create a
 "build" object. The build controller sees that a new build has been created, and
 runs a process on the cluster to perform that build. When the build completes,
 the controller updates the build object via the REST API and the user sees that
@@ -163,7 +163,7 @@ By default, a new internal PKI is created for each deployment of
 {product-title}. The internal PKI uses 2048 bit RSA keys and SHA-256 signatures.
 endif::[]
 ifdef::openshift-origin,openshift-enterprise[]
-xref:../install_config/certificate_customization.adoc#install-config-certificate-customization[Custom certificates] for public hosts are supported as well. 
+xref:../install_config/certificate_customization.adoc#install-config-certificate-customization[Custom certificates] for public hosts are supported as well.
 endif::[]
 
 {product-title} uses Golang’s standard library implementation of

--- a/architecture/infrastructure_components/image_registry.adoc
+++ b/architecture/infrastructure_components/image_registry.adoc
@@ -22,14 +22,14 @@ third parties, and the integrated {product-title} registry.
 
 {product-title} provides an integrated container registry called _OpenShift
 Container Registry_ (OCR) that adds the ability to automatically provision new image repositories on
-demand. This provides users with a built-in location for their application xref:../core_concepts/builds_and_image_streams.adoc#builds[builds] to push the
+demand. This provides users with a built-in location for their application xref:../core_concepts/build.adoc#architecture-core-concepts-builds[builds] to push the
 resulting images.
 
 Whenever a new image is pushed to OCR, the registry notifies {product-title}
 about the new image, passing along all the information about it, such as the
 namespace, name, and image metadata. Different pieces of {product-title} react
 to new images, creating new
-xref:../core_concepts/builds_and_image_streams.adoc#builds[builds] and
+xref:../core_concepts/build.adoc#architecture-core-concepts-builds[builds] and
 xref:../core_concepts/deployments.adoc#deployments-and-deployment-configurations[deployments].
 
 OCR can also be deployed as a stand-alone component that acts solely as a

--- a/creating_images/s2i.adoc
+++ b/creating_images/s2i.adoc
@@ -11,7 +11,7 @@
 toc::[]
 
 == Overview
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image
+xref:../architecture/core_concepts/build.adoc#source-build[Source-to-Image
 (S2I)] is a framework that makes it easy to write images that take application
 source code as an input and produce a new image that runs the assembled
 application as output.
@@ -52,9 +52,9 @@ See the following diagram for the basic S2I build workflow:
 .Build Workflow
 image::s2i-flow.png[S2I workflow]
 
-* Run build's responsibility is to untar the sources, scripts and artifacts 
-  (if such exist) and invoke the `assemble` script.  If this is the second run 
-  (after catching `tar` or `/bin/sh` not found error) it is responsible only 
+* Run build's responsibility is to untar the sources, scripts and artifacts
+  (if such exist) and invoke the `assemble` script.  If this is the second run
+  (after catching `tar` or `/bin/sh` not found error) it is responsible only
   for invoking `assemble` script, since both scripts and sources are already there.
 
 
@@ -71,7 +71,7 @@ each build in the following order:
 2. A script found in the application source `.s2i/bin` directory
 3. A script found at the default image URL (`io.openshift.s2i.scripts-url` label)
 
-Both the `io.openshift.s2i.scripts-url` label specified in the image and the 
+Both the `io.openshift.s2i.scripts-url` label specified in the image and the
 script specified in a BuildConfig can take one of the following forms:
 
 - `image:///path_to_scripts_dir` - absolute path inside the image to a directory where the S2I scripts are located

--- a/creating_images/s2i_testing.adoc
+++ b/creating_images/s2i_testing.adoc
@@ -151,7 +151,7 @@ platform itself as a continuous integration system. The {product-title} platform
 is capable of building container images and is highly customizable.
 
 To set up an S2I image builder continuous integration system, define a
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[Custom
+xref:../architecture/core_concepts/build.adoc#custom-build[Custom
 build] and use the *openshift/sti-image-builder* image. This image executes all
 the steps mentioned in the xref:basic-testing-workflow[Basic Testing Workflow]
 section and creates a new S2I builder image.

--- a/dev_guide/application_lifecycle/new_app.adoc
+++ b/dev_guide/application_lifecycle/new_app.adoc
@@ -76,7 +76,7 @@ $ oc new-app https://github.com/openshift/ruby-hello-world.git#beta4
 ----
 
 The `new-app` command creates a xref:../../dev_guide/builds/index.adoc#defining-a-buildconfig[build configuration], which itself creates a new application
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image]
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image]
 from your source code. The `new-app` command typically also creates a
 xref:../../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[deployment
 configuration] to deploy the new image, and a
@@ -88,7 +88,7 @@ ifndef::openshift-online[]
 `*Docker*`,
 endif::[]
 `*Pipeline*` or `*Source*`
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#builds[build
+xref:../../architecture/core_concepts/build.adoc#architecture-core-concepts-builds[build
 strategy] should be used, and in the case of `*Source*` builds,
 xref:language-detection[detects an appropriate language builder image].
 
@@ -98,16 +98,16 @@ xref:language-detection[detects an appropriate language builder image].
 
 If a *_Jenkinsfile_* exists in the root or specified context directory of the
 source repository when creating a new application, {product-title} generates a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[`*Pipeline*`
+xref:../../architecture/core_concepts/build.adoc#pipeline-build[`*Pipeline*`
 build strategy].
 ifndef::openshift-online[]
 Otherwise, if a *_Dockerfile_* is found, {product-title}
 generates a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[`*Docker*`
+xref:../../architecture/core_concepts/build.adoc#docker-build[`*Docker*`
 build strategy].
 endif::[]
 Otherwise, it generates a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[`*Source*`
+xref:../../architecture/core_concepts/build.adoc#source-build[`*Source*`
 build strategy].
 
 You can override the build strategy by setting the `--strategy` flag to either
@@ -169,7 +169,7 @@ a|*_Godeps_*, *_main.go_*
 |===
 
 After a language is detected, `new-app` searches the {product-title} server for
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] tags that have a `*supports*` annotation matching the detected language,
 or an image stream that matches the name of the detected language. If a match is
 not found, `new-app` searches the https://registry.hub.docker.com[Docker Hub
@@ -244,9 +244,9 @@ the `--insecure-registry` flag.
 ====
 
 You can create an application from an existing
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] and optional
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tag]:
 
 ----
@@ -558,7 +558,7 @@ image::console_select_image_or_template.png["Select Builder Image"]
 [NOTE]
 ====
 Only
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream tags] that have the *builder* tag listed in their annotations
 appear in this list, as demonstrated here:
 ====

--- a/dev_guide/application_lifecycle/promoting_applications.adoc
+++ b/dev_guide/application_lifecycle/promoting_applications.adoc
@@ -125,7 +125,7 @@ of the system to facilitate testing of the different scenarios your application
 must support.
 ImageStreams, ImageStreamTags, and ImageStreamImage:: Detailed in the
 xref:dev-guide-promoting-application-images[Images] and
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[Image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[Image
 Streams] sections, these objects are central to the {product-title} additions
 around managing container images.
 ServiceAccounts and RoleBindings:: Management of permissions to other API
@@ -171,7 +171,7 @@ Rather than reference images directly, application definitions typically
 abstract the reference into an image stream. This means the image stream will be
 another API object that makes up the application components. For more details on
 image streams, see
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[Core
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[Core
 Concepts].
 
 [[dev-guide-promoting-application-components-summary]]
@@ -380,7 +380,7 @@ image stream to another, even across different projects in a cluster.
 . Second, the `oc import-image` serves as a bridge between external registries and
 image streams. It imports the metadata for a given image from the registry and
 stores it into the image stream as an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tag]. Various `BuildConfigs` and `DeploymentConfigs` in your project can
 reference those specific images.
 

--- a/dev_guide/builds/advanced_build_operations.adoc
+++ b/dev_guide/builds/advanced_build_operations.adoc
@@ -135,9 +135,9 @@ the compiled artifact, and a second build that places that artifact in a
 separate image that runs the artifact.
 ifndef::openshift-online[]
 In the following example, a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image]
+xref:../../architecture/core_concepts/build.adoc#source-build[Source-to-Image]
 build is combined with a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker]
+xref:../../architecture/core_concepts/build.adoc#docker-build[Docker]
 build to compile an artifact that is then placed in a separate runtime image.
 
 [NOTE]

--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -110,7 +110,7 @@ source repository contains a *_Dockerfile_* in the root directory,
 it will be overwritten with this content.
 
 The typical use for this field is to provide a `Dockerfile` to a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker
+xref:../../architecture/core_concepts/build.adoc#docker-build[Docker
 strategy] build.
 
 The source definition is part of the `spec` section in the `BuildConfig`:
@@ -129,7 +129,7 @@ endif::[]
 Additional files can be provided to the build process via images. Input images
 are referenced in the same way the `From` and `To` image targets are defined.
 This means both container images and
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tags] can be referenced. In conjunction with the image, you must provide
 one or more path pairs to indicate the path of the files or directories to copy
 the image and the destination to place them in the build context.
@@ -744,7 +744,7 @@ In both cases, the *_.npmrc_* file is added to the *_/etc_* directory of the
 build environment.
 ifndef::openshift-online[]
 Note that for a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker strategy] the destination directory must be a relative path.
+xref:../../architecture/core_concepts/build.adoc#docker-build[Docker strategy] the destination directory must be a relative path.
 endif::[]
 
 [[using-secrets-s2i-strategy]]

--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -22,7 +22,7 @@ endif::[]
 == Source-to-Image Strategy Options
 
 The following options are specific to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I
 build strategy].
 
 [[s2i-force-pull]]
@@ -117,7 +117,7 @@ documentation] for information on how S2I scripts are used.
 === Environment Variables
 
 There are two ways to make environment variables available to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[source build]
+xref:../../architecture/core_concepts/build.adoc#source-build[source build]
 process and resulting image. xref:environment-files[Environment files] and
 xref:buildconfig-environment[*BuildConfig* environment] values.  Variables provided will
 be present during the build process and in the output image.
@@ -182,7 +182,7 @@ repository:
 credentials for accessing a private source code repository.
 
 . Create a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image (S2I)
+xref:../../architecture/core_concepts/build.adoc#source-build[Source-to-Image (S2I)
 build configuration].
 
 . On the build configuration editor page or in the `create app from builder image` page of the
@@ -212,7 +212,7 @@ ifndef::openshift-online[]
 == Docker Strategy Options
 
 The following options are specific to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker
+xref:../../architecture/core_concepts/build.adoc#docker-build[Docker
 build strategy].
 
 
@@ -287,7 +287,7 @@ stored locally.
 === Environment Variables
 
 To make environment variables available to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Docker build]
+xref:../../architecture/core_concepts/build.adoc#docker-build[Docker build]
 process and resulting image, you can add environment variables to the
 `dockerStrategy` definition of the `BuildConfig`.
 
@@ -330,7 +330,7 @@ repository"
 credentials for accessing a private source code repository.
 
 . Create a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[docker
+xref:../../architecture/core_concepts/build.adoc#docker-build[docker
 build configuration].
 
 . On the build configuration editor page or in the *fromimage* page of the
@@ -367,7 +367,7 @@ configuration and enable pushing by setting the `Push Secret`.
 == Custom Strategy Options
 
 The following options are specific to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[Custom
+xref:../../architecture/core_concepts/build.adoc#custom-build[Custom
 build strategy].
 
 [[custom-strategy-from]]
@@ -439,7 +439,7 @@ repository:
 credentials for accessing a private source code repository.
 
 . Create a
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[custom
+xref:../../architecture/core_concepts/build.adoc#custom-build[custom
 build configuration].
 
 . On the build configuration editor page or in the *fromimage* page of the
@@ -478,7 +478,7 @@ stored locally.
 === Environment Variables
 
 To make environment variables available to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[Custom build]
+xref:../../architecture/core_concepts/build.adoc#custom-build[Custom build]
 process, you can add environment variables to the `customStrategy` definition
 of the `BuildConfig`.
 
@@ -511,7 +511,7 @@ endif::[]
 == Pipeline Strategy Options
 
 The following options are specific to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline build strategy].
+xref:../../architecture/core_concepts/build.adoc#pipeline-build[Pipeline build strategy].
 
 [[jenkinsfile]]
 === Providing the Jenkinsfile
@@ -559,7 +559,7 @@ spec:
 === Environment Variables
 
 To make environment variables available to the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline build]
+xref:../../architecture/core_concepts/build.adoc#pipeline-build[Pipeline build]
 process, you can add environment variables to the `jenkinsPipelineStrategy` definition
 of the `BuildConfig`.
 

--- a/dev_guide/builds/index.adoc
+++ b/dev_guide/builds/index.adoc
@@ -15,7 +15,7 @@ toc::[]
 == What Is a Build?
 
 A
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#builds[_build_]
+xref:../../architecture/core_concepts/build.adoc#builds[_build_]
 in {product-title} is the process of transforming input parameters into a
 resulting object. Most often, builds are used to transform source code into a
 runnable container image.
@@ -31,17 +31,17 @@ endif::[]
 build strategies are:
 
 - Source-to-Image (S2I)
-(xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[description],
+(xref:../../architecture/core_concepts/build.adoc#source-build[description],
 xref:build_strategies.adoc#source-to-image-strategy-options[options])
 - Pipeline
-(xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[description],
+(xref:../../architecture/core_concepts/build.adoc#pipeline-build[description],
 xref:build_strategies.adoc#pipeline-strategy-options[options])
 ifndef::openshift-online[]
 - Docker
-(xref:../../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[description],
+(xref:../../architecture/core_concepts/build.adoc#docker-build[description],
 xref:build_strategies.adoc#docker-strategy-options[options])
 - Custom
-(xref:../../architecture/core_concepts/builds_and_image_streams.adoc#custom-build[description],
+(xref:../../architecture/core_concepts/build.adoc#custom-build[description],
 xref:build_strategies.adoc#custom-strategy-options[options])
 endif::[]
 

--- a/dev_guide/builds/triggering_builds.adoc
+++ b/dev_guide/builds/triggering_builds.adoc
@@ -398,7 +398,7 @@ are performed using consistent image tags for ease of reproduction.
 Image streams that point to container images in
 link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[v1
 Docker registries] only trigger a build once when the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tag] becomes available and not on subsequent image updates. This is due
 to the lack of uniquely identifiable images in v1 Docker registries.
 ====

--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -253,7 +253,7 @@ triggers:
 //tag::image-change-trig[]
 The `ImageChange` trigger results in a new replication controller whenever the
 content of an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[image
+xref:../../architecture/core_concepts/image_streams.adoc#image-stream-tag[image
 stream tag] changes (when a new version of the image is pushed).
 
 .An ImageChange Trigger

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -14,7 +14,7 @@ toc::[]
 == Overview
 
 An
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] comprises any number of
 xref:../architecture/core_concepts/containers_and_images.adoc#docker-images[container
 images] identified by tags. It presents a single virtual view of related images,
@@ -149,7 +149,7 @@ endif::[]
 
 Instead, if the tag is named `v2.0`, more image revisions are more likely. This
 results in longer
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[tag history] and, therefore, the image pruner will more likely remove old and unused images.
+xref:../architecture/core_concepts/image_streams.adoc#image-stream-tag[tag history] and, therefore, the image pruner will more likely remove old and unused images.
 ifdef::openshift-origin,openshift-enterprise[]
 Refer to xref:../admin_guide/pruning_resources.adoc#pruning-images[Pruning Images] for more information.
 endif::[]
@@ -884,7 +884,7 @@ endif::[]
 ===== Insecure Tag Import Policy
 The above annotation applies to all images and tags of a particular
 `ImageStream`. For a finer-grained control, policies may be set on
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[`istags`].
+xref:../architecture/core_concepts/image_streams.adoc#image-stream-tag[`istags`].
 Set `importPolicy.insecure` in the tag's definition to `true` to allow a
 fall-back to insecure transport just for images under this tag.
 

--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -19,7 +19,7 @@ that can be parameterized and processed to produce a list of objects
 for creation by {product-title}. A template can be processed to create
 anything you have permission to create within a project, for example
 xref:../architecture/core_concepts/pods_and_services.adoc#services[services],
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[build
+xref:../architecture/core_concepts/build.adoc#builds[build
 configurations], and
 xref:../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[deployment
 configurations]. A template may also define a set of

--- a/getting_started/beyond_the_basics.adoc
+++ b/getting_started/beyond_the_basics.adoc
@@ -186,10 +186,10 @@ resources created by the `oc new-app` command, for easy management later.
 +
 The tool will inspect the source code, locate an appropriate image that can
 build the source code, create an
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] for the new application image that will be built, then create the
 correct
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[build
+xref:../architecture/core_concepts/build.adoc#builds[build
 configuration],
 xref:../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[deployment
 configuration] and

--- a/install_config/configuring_pipeline_execution.adoc
+++ b/install_config/configuring_pipeline_execution.adoc
@@ -17,7 +17,7 @@ toc::[]
 // tag::installconfig_configuring_pipeline_execution[]
 
 The first time a user creates a build configuration using the
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline]
+xref:../architecture/core_concepts/build.adoc#pipeline-build[Pipeline]
 build strategy, {product-title} looks for a template named
 `*jenkins-ephemeral*` in the `*openshift*` namespace and instantiates it within
 the user's project. The `*jenkins-ephemeral*` template that ships with

--- a/install_config/imagestreams_templates.adoc
+++ b/install_config/imagestreams_templates.adoc
@@ -15,7 +15,7 @@ toc::[]
 
 ifdef::openshift-enterprise[]
 Your {product-title} installation includes useful sets of Red Hat-provided
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image streams]
+xref:../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image streams]
 and xref:../dev_guide/templates.adoc#dev-guide-templates[templates] to
 make it easy for developers to create new applications. By default, the
 xref:../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] and
@@ -27,7 +27,7 @@ endif::[]
 ifdef::openshift-origin[]
 You can populate your {product-title} installation with useful sets of
 Red Hat-provided
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image streams]
+xref:../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image streams]
 and
 xref:../dev_guide/templates.adoc#dev-guide-templates[templates] to
 make it easy for developers to create new applications. By default, the
@@ -297,7 +297,7 @@ endif::[]
 The Instant App and Quickstart templates define a full set of objects for a running application.
 These include:
 
-- xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[Build configurations]
+- xref:../architecture/core_concepts/build.adoc#builds[Build configurations]
 to build the application from source located in a GitHub public repository
 - xref:../architecture/core_concepts/deployments.adoc#deployments-and-deployment-configurations[Deployment configurations]
 to deploy the application image after it is built.

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -249,7 +249,7 @@ endif::[]
 ----
 
 . Pull the Red Hat-certified
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image
+xref:../../architecture/core_concepts/build.adoc#source-build[Source-to-Image
 (S2I)] builder images that you intend to use in your OpenShift environment. You
 can pull the following images:
 +

--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -44,7 +44,7 @@ OCR provides the following capabilities:
 xref:../../architecture/core_concepts/projects_and_users.adoc#architecture-core-concepts-projects-and-users[project namespace] model to enable teams to collaborate through
 xref:../../architecture/additional_concepts/authorization.adoc#architecture-additional-concepts-authorization[role-based access control (RBAC)] authorization.
 - A xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#architecture-infrastructure-components-kubernetes-infrastructure[Kubernetes-based cluster] to manage services.
-- An image abstraction called xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image streams] to enhance image management.
+- An image abstraction called xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image streams] to enhance image management.
 
 Administrators may want to deploy a stand-alone OCR to manage a registry
 separately that supports multiple {product-title} clusters. A stand-alone OCR

--- a/install_config/registry/accessing_registry.adoc
+++ b/install_config/registry/accessing_registry.adoc
@@ -236,7 +236,7 @@ $ docker pull docker.io/busybox
 
 . Tag the new image with the form `<registry_ip>:<port>/<project>/<image>`.
 The project name *must* appear in this
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[pull specification]
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[pull specification]
 for {product-title} to
 correctly place and later access the image in the registry.
 +

--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -61,7 +61,7 @@ $ oc create -f registry.yaml
 [[rebooting-the-masters]]
 Rebooting the Masters::
 
-If you are unable to re-use the IP address, any operation that uses a xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[pull specification]
+If you are unable to re-use the IP address, any operation that uses a xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[pull specification]
 that includes the old IP address will fail.
 To minimize cluster disruption, you must reboot the masters:
 +
@@ -548,7 +548,7 @@ The format of the value is the same as in `projectcachettl` case.
 If enabled, the registry will attempt to fetch requested blob from a remote
 registry unless the blob exists locally. The remote candidates are calculated
 from **DockerImage** entries stored in status of the
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream], a client pulls from. All the unique remote registry references in
 such entries will be tried in turn until the blob is found.
 

--- a/release_notes/ocp_3_3_release_notes.adoc
+++ b/release_notes/ocp_3_3_release_notes.adoc
@@ -246,7 +246,7 @@ already exist when you first declare a new pipeline build configuration.
 
 See the following for more on pipelines:
 
-- xref:../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline Concept]
+- xref:../architecture/core_concepts/build.adoc#pipeline-build[Pipeline Concept]
 - xref:../install_config/configuring_pipeline_execution.adoc#install-config-configuring-pipeline-execution[Configuring Pipeline Execution]
 - xref:../dev_guide/builds.adoc#pipeline-strategy-options[Pipeline Strategy Option]
 

--- a/release_notes/ocp_3_4_release_notes.adoc
+++ b/release_notes/ocp_3_4_release_notes.adoc
@@ -276,7 +276,7 @@ flexibility of the Jenkins ecosystem while managing your workflow from within
 
 See the following for more on pipelines:
 
-- xref:../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline Concept]
+- xref:../architecture/core_concepts/build.adoc#pipeline-build[Pipeline Concept]
 - xref:../install_config/configuring_pipeline_execution.adoc#install-config-configuring-pipeline-execution[Configuring Pipeline Execution]
 - xref:../dev_guide/builds/build_strategies.adoc#pipeline-strategy-options[Pipeline Strategy Option]
 

--- a/release_notes/v2_vs_v3.adoc
+++ b/release_notes/v2_vs_v3.adoc
@@ -114,7 +114,7 @@ From a packaging perspective, an image performs more tasks than a cartridge, and
 provides better encapsulation and flexibility. However, cartridges also included
 logic for building, deploying, and routing, which do not exist in images. In
 OpenShift v3, these additional needs are met by
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image
+xref:../architecture/core_concepts/build.adoc#source-build[Source-to-Image
 (S2I)] and xref:../dev_guide/templates.adoc#dev-guide-templates[configuring the
 template].
 
@@ -152,7 +152,7 @@ distinct operations with source being optional.
 
 In OpenShift v2, builds occurred in application gears. This meant downtime for
 non-scaled applications due to resource constraints. In v3,
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[builds]
+xref:../architecture/core_concepts/build.adoc#builds[builds]
 happen in separate containers. Also, OpenShift v2 build results used rsync to
 synchronize gears. In v3, build results are first committed as an immutable
 image and published to an internal registry. That image is then available to

--- a/security/build_process.adoc
+++ b/security/build_process.adoc
@@ -60,7 +60,7 @@ any API-compliant image registry.
 - _{product-title} Developer Guide_
 ** xref:../dev_guide/builds/index.adoc#dev-guide-how-builds-work[How Builds Work]
 ** xref:../dev_guide/builds/triggering_builds.adoc#dev-guide-triggering-builds[Triggering Builds]
-- _{product-title} Architecture_: xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image (S2I) Build]
+- _{product-title} Architecture_: xref:../architecture/core_concepts/build.adoc#source-build[Source-to-Image (S2I) Build]
 - _{product-title} Using Images_: xref:../using_images/other_images/jenkins.adoc#using-images-other-images-jenkins[Other Images -> Jenkins]
 
 [[security-build-securing-inputs-during-builds]]

--- a/security/container_content.adoc
+++ b/security/container_content.adoc
@@ -231,7 +231,7 @@ with an external URL for additional details:
 === Annotating Image Objects
 
 While
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream objects] are what an end-user of {product-title} operates against,
 xref:../rest_api/openshift_v1.adoc#v1-image[image objects] are annotated with
 security metadata. Image objects are cluster-scoped, pointing to a single image

--- a/security/registries.adoc
+++ b/security/registries.adoc
@@ -45,7 +45,7 @@ Red Hat certified container images, and direct you to the updated image.
 ==== Further Reading
 
 - More on immutable containers in {product-title}:
-** _{product-title} Architecture_: xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[Image Streams]
+** _{product-title} Architecture_: xref:../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[Image Streams]
 ** _{product-title} Developer Guide_: xref:../dev_guide/managing_images.adoc#referencing-images-in-image-streams[Referencing Images in Image Streams]
 
 ifdef::openshift-enterprise[]

--- a/using_images/index.adoc
+++ b/using_images/index.adoc
@@ -7,7 +7,7 @@
 :experimental:
 
 Use these topics to discover the different
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
+xref:../architecture/core_concepts/build.adoc#source-build[S2I
 (Source-to-Image)], database, and other container images that are available for
 {product-title} users.
 

--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -363,7 +363,7 @@ To customize the official {product-title} Jenkins image, you have two options:
 * Use Docker layering.
 * Use the image as a Source-To-Image builder, described here.
 
-You can use xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+You can use xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 to copy your custom Jenkins Jobs definitions, additional
 plug-ins or replace the provided *_config.xml_* file with your own, custom, configuration.
 

--- a/using_images/s2i_images/dot_net_core.adoc
+++ b/using_images/s2i_images/dot_net_core.adoc
@@ -81,7 +81,7 @@ xref:../../architecture/infrastructure_components/image_registry.adoc#architectu
 registry] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 link:https://github.com/redhat-developer/s2i-dotnetcore/blob/master/dotnet_imagestreams.json[image stream definition].

--- a/using_images/s2i_images/index.adoc
+++ b/using_images/s2i_images/index.adoc
@@ -5,5 +5,5 @@
 :data-uri:
 
 This topic group includes information on the different
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I
 (Source-to-Image)] supported images available for {product-title} users.

--- a/using_images/s2i_images/java.adoc
+++ b/using_images/s2i_images/java.adoc
@@ -14,7 +14,7 @@ toc::[]
 == Overview
 
 {product-title} provides an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I
 builder image] for building Java applications.  This builder image takes your
 application source or binary artifacts, builds the source using Maven (if source
 was provided), and assembles the artifacts with any required dependencies to
@@ -51,7 +51,7 @@ To use this image on {product-title}, you can either access it directly from
 the Red Hat Registry or push it into your
 xref:../../install_config/registry/index.adoc#install-config-registry-overview[{product-title}
 Docker registry].  Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 link:https://github.com/jboss-openshift/application-templates/blob/master/jboss-image-streams.json[image

--- a/using_images/s2i_images/nodejs.adoc
+++ b/using_images/s2i_images/nodejs.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 {product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 enabled Node.js images for building and running Node.js applications.
 ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-nodejs[Node.js S2I builder image]
@@ -79,7 +79,7 @@ xref:../../architecture/infrastructure_components/image_registry.adoc#architectu
 registries], or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 ImageStream. You can find

--- a/using_images/s2i_images/perl.adoc
+++ b/using_images/s2i_images/perl.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 {product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 enabled Perl images for building and running Perl applications.
 ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-perl[Perl S2I builder image]
@@ -73,7 +73,7 @@ xref:../../architecture/infrastructure_components/image_registry.adoc#architectu
 registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title}t resources can then reference the
 ImageStream. You can find

--- a/using_images/s2i_images/php.adoc
+++ b/using_images/s2i_images/php.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 {product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 enabled PHP images for building and running PHP applications.
 ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-php[PHP S2I builder image]
@@ -77,7 +77,7 @@ xref:../../architecture/infrastructure_components/image_registry.adoc#architectu
 registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the image
 stream.

--- a/using_images/s2i_images/python.adoc
+++ b/using_images/s2i_images/python.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 {product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 enabled Python images for building and running Python applications.
 ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-python[Python S2I builder image]
@@ -79,7 +79,7 @@ xref:../../architecture/infrastructure_components/image_registry.adoc#architectu
 registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 ImageStream. You can find

--- a/using_images/s2i_images/ruby.adoc
+++ b/using_images/s2i_images/ruby.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 {product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 enabled Ruby images for building and running Ruby applications.
 ifndef::openshift-enterprise[]
 The https://github.com/openshift/sti-ruby[Ruby S2I builder image]
@@ -76,7 +76,7 @@ xref:../../architecture/infrastructure_components/image_registry.adoc#architectu
 registries] or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 ImageStream. You can find

--- a/using_images/s2i_images/wildfly.adoc
+++ b/using_images/s2i_images/wildfly.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 {product-title} provides
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I]
+xref:../../architecture/core_concepts/build.adoc#source-build[S2I]
 enabled Wildfly images for building and running Java applications.
 ifdef::openshift-origin[]
 The https://github.com/openshift-s2i/s2i-wildfly[Wildfly S2I builder image]
@@ -41,7 +41,7 @@ $ docker pull openshift/wildfly-100-centos7
 To use these images, you can either access them directly from DockerHub or push them into your
 xref:../../architecture/infrastructure_components/image_registry.adoc#integrated-openshift-registry[{product-title}
 Docker registry]. Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
+xref:../../architecture/core_concepts/image_streams.adoc#architecture-core-concepts-image-streams[image
 stream] that points to the image, either in your Docker registry or at the
 external location. Your {product-title} resources can then reference the
 ImageStream. You can find
@@ -81,29 +81,29 @@ steps.
 |Overrides the default arguments passed to Maven during the build process.
 
 |`*MAVEN_ARGS_APPEND*`
-|This value will be appended to either the default Maven arguments, or the value of `MAVEN_ARGS` if 
+|This value will be appended to either the default Maven arguments, or the value of `MAVEN_ARGS` if
 `MAVEN_ARGS` is set.
 
 |`*MAVEN_OPTS*`
-|Contains JVM parameters to Maven.  Will be appended to JVM arguments that are calculated by the image 
+|Contains JVM parameters to Maven.  Will be appended to JVM arguments that are calculated by the image
 itself (e.g. heap size), so values provided here will take precedence.
 
 |`*JAVA_GC_OPTS*`
-|When set to a non-null value, this value will be passed to the JVM instead of the default garbage collection tuning 
+|When set to a non-null value, this value will be passed to the JVM instead of the default garbage collection tuning
 values defined by the image.
 
 |`*CONTAINER_CORE_LIMIT*`
 |When set to a non-null value, the number of parallel garbage collection threads will be set to this value.
 
 |`*USE_JAVA_DIAGNOSTICS*`
-|When set to a non-null value, various JVM related diagnostics will be turned on such as verbose garbage 
+|When set to a non-null value, various JVM related diagnostics will be turned on such as verbose garbage
 collection tracing.
 
 |`*CONTAINER_CORE_LIMIT*`
 |When set to a non-null value, the number of parallel garbage collection threads will be set to this value.
 
 |`*AUTO_DEPLOY_EXPLODED*`
-|When set to `true`, Wildfly will automatically deploy exploded war content.  When unset or set to `false`, 
+|When set to `true`, Wildfly will automatically deploy exploded war content.  When unset or set to `false`,
 a `.dodeploy` file must be touched to trigger deployment of exploded war content.
 
 |`*MYSQL_DATABASE*`
@@ -130,7 +130,7 @@ rsh`] command to access the container.
 Hot deployment allows you to quickly make and deploy changes to your application
 without having to generate a new S2I build. Hot deployment for war files is already
 enabled, but to enable hot deployment of exploded war content, you must set the
-`*AUTO_DEPLOY_EXPLODED*` environment variable to `true`.  For example, see the 
+`*AUTO_DEPLOY_EXPLODED*` environment variable to `true`.  For example, see the
 xref:../../dev_guide/application_lifecycle/new_app.adoc#specifying-environment-variables[`oc new-app`]
 command. You can use the xref:../../dev_guide/environment_variables.adoc#set-environment-variables[`oc set env`]
 command to update environment variables of existing objects.

--- a/whats_new/carts_vs_images.adoc
+++ b/whats_new/carts_vs_images.adoc
@@ -55,7 +55,7 @@ distinct operations with source being optional.
 In OpenShift v2, builds happened in place as part of your application gears.
 This meant downtime for non scaled applications due to resource constraints. In
 v3,
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#builds[builds]
+xref:../architecture/core_concepts/build.adoc#builds[builds]
 happen in separate containers.
 
 Another change for builds is how those builds are transmitted between

--- a/whats_new/terminology.adoc
+++ b/whats_new/terminology.adoc
@@ -31,7 +31,7 @@ An image does more than a cartridge from a packaging perspective, providing
 better encapsulation and flexibility. But the cartridge concept also included
 logic for building, deploying, and routing which do not exist in images. In
 OpenShift v3, these additional needs are met by
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#source-build[Source-to-Image
+xref:../architecture/core_concepts/build.adoc#source-build[Source-to-Image
 (S2I)] and xref:../dev_guide/templates.adoc#dev-guide-templates[templated
 configuration].
 


### PR DESCRIPTION
Split the `Builds and Image Streams` topic into separate topics for `Builds` and for `Image Streams.` Changes from https://github.com/openshift/openshift-docs/pull/5322 made the `Image stream` section significantly longer than `Builds`.