### PR TITLE
OCP 3.7 Release: Various Link Fixes

### DIFF
--- a/admin_guide/garbage_collection.adoc
+++ b/admin_guide/garbage_collection.adoc
@@ -14,7 +14,7 @@ toc::[]
 
 The {product-title} node performs two types of garbage collection:
 
-* xref:container-garbage-collection[Container garbage collection]: Removes
+* xref:container-garbage-collection[Container garbage collection] Removes
 terminated containers. Typically run every minute.
 * xref:image-garbage-collection[Image garbage collection]: Removes images not
 referenced by any running pods. Typically run every five minutes.

--- a/admin_guide/image_signatures.adoc
+++ b/admin_guide/image_signatures.adoc
@@ -248,8 +248,6 @@ characters long. The `<cryptographic_signature>` must follow the specification
 documented in the
 link:https://github.com/containers/image/blob/master/docs/atomic-signature.md#the-cryptographic-signature[containers/image] library.
 
-=======
-
 [[importing-signatures-from-sigstore]]
 === Importing Image Signatures Automatically from Signature Stores
 

--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -381,8 +381,8 @@ Across all persistent volume claims in a project, the following must hold true:
 [[creating-a-limit-range]]
 == Creating a Limit Range
 
-To apply a limit range to a project, create a xref:limit-range-obj-def[limit range
-object definition] on your file system to your desired specifications, then run:
+To apply a limit range to a project, create a limit range
+object definition on your file system to your desired specifications, then run:
 
 ----
 $ oc create -f <limit_range_file> -n <project>

--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -146,7 +146,7 @@ You can also assign static IP addresses to projects, ensuring that all
 outgoing external connections from the specified project have recognizable
 origins. This is different from the default egress router, which is used to send
 traffic to specific destinations. See the
-xref:enabling-fixed-ips-for-external-project-traffic[Enabling Fixed IPs for
+xref:enabling-static-ips-for-external-project-traffic[Enabling Fixed IPs for
 External Project Traffic] section for more information.
 
 As an {product-title} cluster administrator, you can control egress traffic in three ways:

--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -131,7 +131,7 @@ an advanced installation], or
 xref:../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[added to a node
 after installation].
 ====
-endif::openshift-origin,openshift-enterprise[]
+endif::openshift-enterprise,openshift-origin[]
 
 === Setting the Cluster-wide Default Node Selector
 
@@ -299,8 +299,6 @@ labels for users and groups.
 
 Once your changes are made, restart {product-title} for the changes to take
 effect.
-
-endif::[]
 
 ifdef::openshift-origin[]
 ----

--- a/admin_guide/monitoring_images.adoc
+++ b/admin_guide/monitoring_images.adoc
@@ -80,5 +80,4 @@ xref:../install_config/registry/index.adoc#install-config-registry-overview[Red 
 [[monitoring-images-pruning]]
 == Pruning Images
 
-The information returned from the above commands is helpful when performing
-xref:pruning_resources.adoc#pruning-images[image pruning].
+The information returned from the above commands is helpful when performing image pruning.

--- a/admin_guide/out_of_resource_handling.adoc
+++ b/admin_guide/out_of_resource_handling.adoc
@@ -497,7 +497,7 @@ The node then kills the container with the highest score.
 
 Containers with the lowest quality of service that are consuming the largest amount of memory relative to the scheduling request are failed first.
 
-Unlike pod eviction, if a pod container is OOM failed, it can be restarted by the node based on the node xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[restart policy].
+Unlike pod eviction, if a pod container is OOM failed, it can be restarted by the node based on the node restart policy.
 
 
 [[out-of-resource-scheduler]]

--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -211,7 +211,7 @@ run outside of the cluster network, the route needs to be provided using
 .^|`--force-insecure`
 |*Use caution with this option.* Allow an insecure connection to the Docker
 registry that is hosted via HTTP or has an invalid HTTPS certificate. See
-xref:#pruning-images-secure-or-insecure[Using Secure or Insecure Connections]
+xref:pruning-images-secure-or-insecure[Using Secure or Insecure Connections]
 for more information.
 
 .^|`--keep-tag-revisions=<N>`
@@ -453,8 +453,7 @@ ifdef::openshift-origin,openshift-enterprise[]
 == Hard Pruning the Registry
 
 The OpenShift Container Registry can accumulate blobs that are not referenced by
-the {product-title} cluster's etcd. The basic xref:pruning-images[Pruning
-Images] procedure, therefore, is unable to operate on them. These are called
+the {product-title} cluster's etcd. The basic Pruning Images procedure, therefore, is unable to operate on them. These are called
 _orphaned blobs_.
 
 Orphaned blobs can occur from the following scenarios:
@@ -495,7 +494,7 @@ images that are no longer needed. The hard prune does not remove images on its
 own. It only removes blobs stored in the registry storage. Therefore, you should
 run this just before the hard prune.
 +
-See xref:pruning-images[Pruning Images] for steps.
+See Pruning Images for steps.
 
 . +++<b>Switch the registry to read-only mode:</b>+++ If the registry is not
 running in read-only mode, any pushes happening at the same time as the prune

--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -159,7 +159,7 @@
 |Added list of storage resources that can be managed by quota to the xref:../admin_guide/quota.adoc#managed-by-quota[Resources Managed by Quota] section and added gold and bronze storage classes to `storage-consumption.yaml` example.
 
 |xref:../admin_guide/pruning_resources.adoc#admin-guide-pruning-resources[Pruning Objects]
-|Added note to xref:../admin_guide/pruning_resources.adoc#pruning-builds[Pruning Builds] linking to the xref:../dev_guide/builds/advanced_build_operations.adoc#build-pruning[Build Pruning] section.
+|Added note to Pruning Builds linking to the xref:../dev_guide/builds/advanced_build_operations.adoc#build-pruning[Build Pruning] section.
 
 .2+.^|xref:../admin_guide/overcommit.adoc#admin-guide-overcommit[Overcommitting]
 |Added the xref:../admin_guide/overcommit.adoc#tune-buffer-chunk-limit[Tune Buffer Chunk Limit] section.

--- a/admin_guide/scheduling/node_affinity.adoc
+++ b/admin_guide/scheduling/node_affinity.adoc
@@ -57,7 +57,7 @@ spec:
 <1> The stanza to configure node affinity.
 <2> Defines a required rule.
 <3> The key/value pair (label) that must be matched to apply the rule.
-<4> The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator] represents the relationship between the label on the node and the set of values in the `matchExpression` parameters in the pod specification. This value can be `In`, `NotIn`, `Exists`, or `DoesNotExist`, `Lt`, or `Gt`.
+<4> The operator represents the relationship between the label on the node and the set of values in the `matchExpression` parameters in the pod specification. This value can be `In`, `NotIn`, `Exists`, or `DoesNotExist`, `Lt`, or `Gt`.
 
 The following example is a node specification with a preferred rule that a node with a label whose key is `e2e-az-EastWest` and whose value is either `e2e-az-East` or `e2e-az-West` is preferred for the pod:
 
@@ -89,7 +89,7 @@ spec:
 <2> Defines a preferred rule.
 <3> Specifies a weight for a preferred rule. The node with highest weight is preferred.
 <4> The key/value pair (label) that must be matched to apply the rule.
-<4> The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator] represents the relationship between the label on the node and the set of values in the `matchExpression` parameters in the pod specification. This value can be `In`, `NotIn`, `Exists`, or `DoesNotExist`, `Lt`, or `Gt`.
+<4> The operator represents the relationship between the label on the node and the set of values in the `matchExpression` parameters in the pod specification. This value can be `In`, `NotIn`, `Exists`, or `DoesNotExist`, `Lt`, or `Gt`.
 
 There is no explicit _node anti-affinity_ concept, but using the `NotIn` or `DoesNotExist` operator replicates that behavior.
 
@@ -127,7 +127,7 @@ $ oc label node node1 e2e-az-name=e2e-az1
 +
 .. Specify the key and values that must be met. If you want the new pod to be scheduled on the node you edited, use the same `key` and `value` parameters as the label in the node.
 +
-.. Specify an `operator`. The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator can be `In`, `NotIn`, `Exists`, `DoesNotExist`, `Lt`, or `Gt`]. For example, use the operator `In` to require the label to be in the node:
+.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, `DoesNotExist`, `Lt`, or `Gt`. For example, use the operator `In` to require the label to be in the node:
 +
 ----
 spec:
@@ -179,7 +179,7 @@ $ oc label node node1 e2e-az-name=e2e-az3
             - e2e-az3
 ----
 
-. Specify an `operator`. The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator can be `In`, `NotIn`, `Exists`, `DoesNotExist`, `Lt`, or `Gt`]. For example, use the operator `In` to require the label to be in the node.
+. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, `DoesNotExist`, `Lt`, or `Gt`. For example, use the operator `In` to require the label to be in the node.
 
 . Create the pod.
 +

--- a/admin_guide/scheduling/pod_affinity.adoc
+++ b/admin_guide/scheduling/pod_affinity.adoc
@@ -62,7 +62,7 @@ spec:
 <1> Stanza to configure pod affinity.
 <2> Defines a required rule.
 <3> The key and value (label) that must be matched to apply the rule.
-<4> The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator] represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod.  Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
+<4> The operator represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod.  Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
 
 .Sample pod config file with pod anti-affinity
 [source,yaml]
@@ -94,7 +94,7 @@ spec:
 <2> Defines a preferred rule.
 <3> Specifies a weight for a preferred rule. The node that with highest weight is preferred.
 <4> The key and value (label) that must be matched to apply the rule.
-<4> The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator] represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod.  Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
+<4> The operator represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod.  Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
 
 
 [NOTE]
@@ -143,7 +143,7 @@ spec:
         topologyKey: failure-domain.beta.kubernetes.io/zone
 ----
 +
-.. Specify an `operator`. The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator] can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
+.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
 +
 .. Specify a `topologyKey`, which is a prepopulated link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[Kubernetes label] that the system uses to denote such a topology domain.
 
@@ -200,7 +200,7 @@ spec:
 +
 .. For a preferred rule, specify a weight, 1-100.
 +
-.. Specify an `operator`. The xref:../../rest_api/openshift_v1.adoc#unversioned-labelselectorrequirement[operator] can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
+.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
 
 . Specify a `topologyKey`, which is a prepopulated link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[Kubernetes label] that the system uses to denote such a topology domain.
 

--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -90,7 +90,7 @@ endif::[]
 A _custom resource_ is an extension of the Kubernetes API that extends the API or allows you to
 introduce your own API into a project or a cluster.
 
-See xref:../admin_guide/custom_resource_definitions.adoc#admin-guide-custom-resource[Extend the Kubernetes API with Custom Resources].
+  See xref:../../admin_guide/custom_resource_definitions.adoc#admin-guide-custom-resources[Extend the Kubernetes API with Custom Resources].
 
 == OAuth Objects
 

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -206,7 +206,7 @@ status of the volume.
 
 ifdef::openshift-enterprise,openshift-origin[]
 - xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[NFS]
-- xref:../../rest_api/kubernetes_v1.adoc#v1-hostpathvolumesource[HostPath]
+- HostPath
 - xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#install-config-persistent-storage-persistent-storage-glusterfs[GlusterFS]
 - xref:../../install_config/persistent_storage/persistent_storage_ceph_rbd.adoc#install-config-persistent-storage-persistent-storage-ceph-rbd[Ceph
 RBD]

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -149,10 +149,7 @@ a `*secret*` volume containing the service account credentials.
 This pod definition does not include attributes that
 are filled by {product-title} automatically after the pod is created and
 its lifecycle begins. The
-xref:../../rest_api/kubernetes_v1.adoc#rest-api-kubernetes-v1[Kubernetes API documentation]
-has complete details of the pod REST API object attributes, and the
-link:https://kubernetes.io/docs/concepts/workloads/pods/pod/[Kubernetes pod documentation]
-has details about the functionality and purpose of pods.
+link:https://kubernetes.io/docs/concepts/workloads/pods/pod/[Kubernetes pod documentation] has details about the functionality and purpose of pods.
 ====
 
 [[admin-manage-pod-preset]]
@@ -318,7 +315,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 [[service-externalip]]
 === Service externalIPs
 
-In addition to the cluster's internal IP addresses, the user can configure IP addresses that are xref:../../dev_guide/getting_traffic_into_cluster.adoc#getting-traffic-into-cluster[external to the cluster]. The administrator is responsible for ensuring that traffic arrives at a node with this IP.
+In addition to the cluster's internal IP addresses, the user can configure IP addresses that are external to the cluster. The administrator is responsible for ensuring that traffic arrives at a node with this IP.
 
 The externalIPs must be selected by the cluster adminitrators from the
 *ExternalIPNetworkCIDRs* range configured in

--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -252,6 +252,4 @@ command.
 can be reached. Defaults to the *`metadata.name`* value when empty.
 ====
 
-The xref:../../rest_api/kubernetes_v1.adoc#rest-api-kubernetes-v1[REST API Reference] has
-more details on these definitions.
 endif::[]

--- a/creating_images/custom.adoc
+++ b/creating_images/custom.adoc
@@ -46,8 +46,7 @@ variables with the information needed to proceed with the build:
 |Variable Name |Description
 
 |`*BUILD*`
-|The entire serialized JSON of the `*Build*`
-xref:../rest_api/openshift_v1.adoc#v1-build[object definition]. If you need to
+|The entire serialized JSON of the `*Build*` object definition. If you need to
 use a specific API version for serialization, you can set the
 `*buildAPIVersion*` parameter in the
 xref:../dev_guide/builds/build_strategies.adoc#custom-strategy-options[custom strategy
@@ -100,10 +99,6 @@ Although Custom builder image authors have great flexibility in defining the
 build process, your builder image must still adhere to the following required
 steps necessary for seamlessly running a build inside of {product-title}:
 
-. Read the `*Build*` xref:../rest_api/openshift_v1.adoc#v1-build[object
-definition], which contains all the necessary information about input parameters
-for the build.
+. The `*Build*` object definition contains all the necessary information about input parameters for the build.
 . Run the build process.
-. If your build produces an image, push it to the build's
-xref:../rest_api/openshift_v1.adoc#v1-buildoutput[output location] if it is
-defined. Other output locations can be passed with environment variables.
+. If your build produces an image, push it to the build's output location if it is defined. Other output locations can be passed with environment variables.

--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -118,7 +118,7 @@ documentation] for information on how S2I scripts are used.
 
 There are two ways to make environment variables available to the
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[source build]
-process and resulting image: xref:environment-files[environment files] and
+process and resulting image. xref:environment-files[Environment files] and
 xref:buildconfig-environment[*BuildConfig* environment] values.  Variables provided will
 be present during the build process and in the output image.
 

--- a/dev_guide/dev_tutorials/openshift_pipeline.adoc
+++ b/dev_guide/dev_tutorials/openshift_pipeline.adoc
@@ -50,10 +50,8 @@ If Jenkins auto-provisioning is enabled on your cluster, and you do not need to
 make any customizations to the Jenkins master, you can skip the previous step.
 
 ifdef::openshift-origin,openshift-enterprise[]
-For more information about
-Jenkins autoprovisioning, see
-xref:../../install_config/configuring_pipeline_execution.adoc[Configuring
-Pipeline Execution].
+For more information about Jenkins autoprovisioning, see
+xref:../../install_config/configuring_pipeline_execution.adoc#install-config-configuring-pipeline-execution[Configuring Pipeline Execution].
 endif::[]
 ====
 

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -369,6 +369,7 @@ Currently, it is also possible to make them work with native Kubernetes
 resources, such as xref:../dev_guide/jobs.adoc#dev-guide-jobs[jobs],
 xref:../architecture/core_concepts/deployments.adoc#replication-controllers[replication
 controllers], replica sets or
+ifdef::openshift-enterprise,openshift-origin[]
 xref:../dev_guide/deployments/kubernetes_deployments.adoc#dev-guide-kubernetes-deployments-support[Kubernetes
 deployments].
 

--- a/dev_guide/openshift_pipeline.adoc
+++ b/dev_guide/openshift_pipeline.adoc
@@ -124,7 +124,7 @@ desirable, or if you would like to use a Jenkins server external to OpenShift,
 you can disable it.
 
 ifdef::openshift-origin,openshift-enterprise[]
-See xref:../../install_config/configuring_pipeline_execution.adoc[Configuring
+See xref:../install_config/configuring_pipeline_execution.adoc#install-config-configuring-pipeline-execution[Configuring
 Pipeline Execution] for more information.
 endif::[]
 

--- a/dev_guide/pod_preset.adoc
+++ b/dev_guide/pod_preset.adoc
@@ -579,3 +579,4 @@ spec:
 ----
 +
 <1> The `ConfigMap` is added to the pod.
+////

--- a/dev_guide/revhistory_dev_guide.adoc
+++ b/dev_guide/revhistory_dev_guide.adoc
@@ -128,7 +128,7 @@ n|xref:../dev_guide/deployments/advanced_deployment_strategies.adoc#dev-guide-ad
 |Noted that the *tracking* tag works correctly only within a single image stream.
 |Added a new section on xref:../dev_guide/managing_images.adoc#using-is-with-k8s[Using Image Streams with Kubernetes Resources], a Technology Preview feature.
 
-|xref:../dev_guide/getting_traffic_into_cluster.adoc#getting-traffic-into-cluster[Getting Traffic into the Cluster]
+|Getting Traffic into the Cluster
 |Added information about the cluster accepting IPV6 traffic.
 
 |xref:../dev_guide/configmaps.adoc#dev-guide-configmaps[ConfigMaps]

--- a/dev_guide/volumes.adoc
+++ b/dev_guide/volumes.adoc
@@ -144,8 +144,7 @@ character.
 
 |`--source`
 |Details of volume source as a JSON string. Recommended if the desired volume
-source is not supported by `--type`. See
-xref:../rest_api/kubernetes_v1.adoc#rest-api-kubernetes-v1[available volume sources]
+source is not supported by `--type`.
 |
 
 |`-o, --output`

--- a/install_config/cfme/role_variables.adoc
+++ b/install_config/cfme/role_variables.adoc
@@ -178,8 +178,7 @@ openshift_management_template_parameters={'DATABASE_USER': 'root', 'DATABASE_PAS
 |No
 |`nfs` 
 |Storage type to use. Options are `nfs`, `nfs_external`, `preconfigured`, or
-`cloudprovider`. See
-xref:storage_class.adoc#install-config-cfme-storage-classes[Storage Class Options] for details on each.
+`cloudprovider`.
 |`openshift_management_storage_nfs_external_hostname`
 |No 
 |`false` 

--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -249,7 +249,7 @@ typical cluster installation. If they have not been, perform them manually:
 
 .. xref:../../install_config/router/index.adoc#install-config-router-overview[Manually deploy a router].
 
-. A xref:../../architecture/core_concepts/routes.adoc#secured-routes[passthrough]
+. A xref:../../architecture/networking/routes.adoc#secured-routes[passthrough]
 route should have been created by default for the registry during the initial
 cluster installation:
 

--- a/install_config/upgrading/migrating_embedded_etcd.adoc
+++ b/install_config/upgrading/migrating_embedded_etcd.adoc
@@ -1,4 +1,4 @@
-[[install-config-upgrading-etcd-data-migration]]
+[[install-config-upgrading-ee-etcd-data-migration]]
 = Migrating Embedded etcd to External etcd
 {product-author}
 {product-version}

--- a/rest_api/oapi/v1.Build.adoc
+++ b/rest_api/oapi/v1.Build.adoc
@@ -1,3 +1,4 @@
+[[rest-api-v1-build]]
 = v1.Build
 {product-author}
 {product-version}

--- a/scaling_performance/cluster_limits.adoc
+++ b/scaling_performance/cluster_limits.adoc
@@ -71,7 +71,7 @@ expensive and slow down processing given state changes.]
 ====
 Oversubscribing the physical resources on a node affects resource guarantees the
 Kubernetes scheduler makes during pod placement. Learn what measures you can
-take to xref:../../admin_guide/overcommit.adoc#disabling-swap-memory[avoid memory swapping].
+take to xref:../admin_guide/overcommit.adoc#disabling-swap-memory[avoid memory swapping].
 ====
 
 While

--- a/scaling_performance/revhistory_scaling_performance.adoc
+++ b/scaling_performance/revhistory_scaling_performance.adoc
@@ -15,7 +15,7 @@
 |Affected Topic |Description of Change
 //Mon Aug 14 2017
 
-|xref:../scaling_performance/network_optimization.adoc#scaling-performance-routing-network-optimization[Routing and Network Optimization]
+|xref:../scaling_performance/network_optimization.adoc#scaling-performance-network-optimization[Routing and Network Optimization]
 |Added the xref:../scaling_performance/network_optimization.adoc#scaling-performance-optimizing-mtu[Optimizing the MTU for Your Network] section.
 
 |===
@@ -52,7 +52,7 @@ n|xref:../scaling_performance/optimizing_compute_resources.adoc#scaling-performa
 |xref:../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices[Recommended Host Practices]
 |Updated etcd performance guidance.
 
-|xref:../scaling_performance/network_optimization.adoc#scaling-performance-routing-network-optimization[Routing and Network Optimization]
+|xref:../scaling_performance/network_optimization.adoc#scaling-performance-network-optimization[Routing and Network Optimization]
 |Added a new section on xref:../scaling_performance/network_optimization.adoc#scaling-performance-optimizing-router-haproxy[performance optimizations for the HAProxy router].
 
 |===

--- a/security/container_content.adoc
+++ b/security/container_content.adoc
@@ -233,7 +233,7 @@ with an external URL for additional details:
 While
 xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
 stream objects] are what an end-user of {product-title} operates against,
-xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[image objects] are annotated with
+image objects are annotated with
 security metadata. Image objects are cluster-scoped, pointing to a single image
 that may be referenced by many image streams and tags.
 


### PR DESCRIPTION
Contains various link fixes for OCP 3.7 release and contains up to date content merged into the 3.7 branch. Still has some last minute link issues from in the Install Config which should get resolved when the release notes are ready to go.