### PR TITLE
Fixed formatting for other api object topic

### DIFF
--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -106,7 +106,6 @@ The following `*OAuthClient*` objects are automatically created:
 `openshift-challenging-client`:: Client used to request tokens with a user-agent that can handle WWW-Authenticate challenges
 
 .`*OAuthClient*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -125,7 +124,7 @@ redirectURIs:
 
 ----
 
-<1> The lifetime of access tokens in seconds (see xref:accessTokenMaxAgeSeconds[the description below]). 
+<1> The lifetime of access tokens in seconds (see xref:accessTokenMaxAgeSeconds[the description below]).
 <2> The `name` is used as the `client_id` parameter in OAuth requests.
 <3> When `respondWithChallenges` is set to `true`, unauthenticated requests to
 `/oauth/authorize` will result in `WWW-Authenticate` challenges, if supported by
@@ -135,16 +134,16 @@ in an authorization code flow.
 <5> One or more absolute URIs can be placed in the `redirectURIs` section. The
 `redirect_uri` parameter sent with authorization requests must be prefixed by
 one of the specified `redirectURIs`.
-====
+
 
 [[accessTokenMaxAgeSeconds]]
-The `accessTokenMaxAgeSeconds` value overrides the 
-xref:../../install_config/configuring_authentication.adoc#token-options[default `accessTokenMaxAgeSeconds` value] in the master configuration file 
-for individual OAuth clients. Setting this value for a client allows long-lived access tokens for that client 
-without affecting the lifetime of other clients. 
+The `accessTokenMaxAgeSeconds` value overrides the
+xref:../../install_config/configuring_authentication.adoc#token-options[default `accessTokenMaxAgeSeconds` value] in the master configuration file
+for individual OAuth clients. Setting this value for a client allows long-lived access tokens for that client
+without affecting the lifetime of other clients.
 
-* If `null`, the default value in the master configuration file is used. 
-* If set to `0`, the token will not expire. 
+* If `null`, the default value in the master configuration file is used.
+* If set to `0`, the token will not expire.
 * If set to a value greater than `0`, tokens issued for that client are given the specified expiration time. For example, `accessTokenMaxAgeSeconds: 172800` would cause the token to expire 48 hours after being issued.
 
 
@@ -157,10 +156,9 @@ Creation of `*OAuthClientAuthorization*` objects is done during an
 authorization request to the `*OAuth*` server.
 
 .`*OAuthClientAuthorization*` Object Definition
-====
 
 [source,yaml]
----
+----
 kind: "OAuthClientAuthorization"
 apiVersion: "v1"
 metadata:
@@ -171,9 +169,7 @@ clientName: "openshift-web-console"
 userName: "bob"
 userUID: "9311ac33-0fde-11e5-97a1-3c970e4b7ffe"
 scopes: []
----
-
-====
+----
 
 === OAuthAuthorizeToken
 An `*OAuthAuthorizeToken*` represents an `*OAuth*` authorization code, as
@@ -189,7 +185,6 @@ with a request to the */oauth/token* endpoint, as described in
 https://tools.ietf.org/html/rfc6749#section-4.1.3[RFC 6749, section 4.1.3].
 
 .`*OAuthAuthorizeToken*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -219,7 +214,6 @@ during the authorization flow that resulted in this token.
 OAuthAccessToken for.
 <6> `userUID` represents the UID of the User this token allows obtaining an
 OAuthAccessToken for.
-====
 
 === OAuthAccessToken
 An `*OAuthAccessToken*` represents an `*OAuth*` access token, as described in
@@ -232,7 +226,6 @@ section 4.1.3].
 Access tokens are used as bearer tokens to authenticate to the API.
 
 .`*OAuthAccessToken*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -262,7 +255,6 @@ authorization flow that resulted in this token.
 <6> `userUID` represents the User this token allows authentication as.
 <7> `authorizeToken` is the name of the OAuthAuthorizationToken used to obtain
 this token, if any.
-====
 
 == User Objects
 
@@ -284,10 +276,10 @@ ifdef::openshift-enterprise,openshift-origin[]
 [NOTE]
 ====
 If the identity provider is configured with the `lookup` mapping method, for example,
-if you are using an external LDAP system, this automatic mapping is not performed. 
-You must create the mapping manually. For more information, 
+if you are using an external LDAP system, this automatic mapping is not performed.
+You must create the mapping manually. For more information,
 see xref:../../install_config/configuring_authentication.adoc#LookupMappingMethod[Lookup Mapping Method].
-==== 
+====
 endif::[]
 
 - If the `*Identity*` already exists, but is not mapped to a `*User*`, login
@@ -299,7 +291,6 @@ given an `*OAuthAccessToken*` for the mapped `*User*`.
 `*OAuthAccessToken*` for the mapped `*User*`.
 
 .`*Identity*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -322,7 +313,6 @@ user:
 <3> `providerUserName` is the name that uniquely represents this identity in the scope of the identity provider.
 <4> The `name` in the `user` parameter is the name of the user this identity maps to.
 <5> The `uid` represents the UID of the user this identity maps to.
-====
 
 === User
 A `*User*` represents an actor in the system. Users are granted permissions by
@@ -338,7 +328,6 @@ User objects are created automatically on first login, or can be created via the
 API.
 
 .`*User*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -352,11 +341,11 @@ metadata:
 identities:
   - "anypassword:bob" <2>
 fullName: "Bob User" <3>
+----
 
 <1> `name` is the user name used when adding roles to a user.
 <2> The values in `identities` are Identity objects that map to this user. May be `null` or empty for users that cannot log in.
 <3> The `fullName` value is an optional display name of user.
-====
 
 === UserIdentityMapping
 A `*UserIdentityMapping*` maps an `*Identity*` to a `*User*`.
@@ -371,7 +360,6 @@ A `*User*` can have multiple identities mapped to it. This allows multiple login
 methods to identify the same `*User*`.
 
 .`*UserIdentityMapping*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -387,9 +375,9 @@ identity:
 user:
   name: "bob"
   uid: "9311ac33-0fde-11e5-97a1-3c970e4b7ffe"
+----
 
 <1> `*UserIdentityMapping*` name matches the mapped `*Identity*` name
-====
 
 [[group]]
 === Group
@@ -403,7 +391,6 @@ adding roles to users or to their groups.
 endif::[]
 
 .`*Group*` Object Definition
-====
 
 [source,yaml]
 ----
@@ -418,4 +405,3 @@ users:
 
 <1> `name` is the group name used when adding roles to a group.
 <2> The values in `users` are the names of User objects that are members of this group.
-====


### PR DESCRIPTION
Fixes following issues:

https://docs.openshift.com/container-platform/3.6/architecture/additional_concepts/other_api_objects.html#user

https://docs.openshift.com/container-platform/3.6/architecture/additional_concepts/other_api_objects.html#useridentitymapping

Both examples don't follow the same format as the other objects. 
The Explanatory bullet points (1,2,3, etc), are written in red, in what seems a text formatting problem.

Good example format:

https://docs.openshift.com/container-platform/3.6/architecture/additional_concepts/other_api_objects.html#oauthaccesstoken