### PR TITLE
[enterprise-3.7] Clarify multi-cast setup

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1006,8 +1006,8 @@ If you have
 xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined
 networks together], you will need to enable Multicast in each projects'
 `netnamespace` in order for it to take effect in any of the projects. To enable
-Multicast in the `default` project, you must also enable it in all other
-projects that have been
+Multicast in the `default` project, you must also enable it in the `kube-service-catalog`
+project and all other projects that have been
 xref:../admin_guide/managing_networking.adoc#making-project-networks-global[made
 global].
 


### PR DESCRIPTION
The kube-service-catalog namespace is now also made global (by ansible
openshift/openshift-ansible#4756), so if you want multicast to work in
vnid 0, you have to set the
netnamespace.network.openshift.io/multicast-enabled=true
annotation on both namespaces (i.e. default and kube-service-catalog).

fixes: 1512477
https://bugzilla.redhat.com/show_bug.cgi?id=1512477
(cherry picked from commit 6952ae475d43f538037cae02f2d729384eb48e2e) xref:https://github.com/openshift/openshift-docs/pull/6346