### PR TITLE
Fix indentation in example pod spec for ConfigMaps

### DIFF
--- a/dev_guide/configmaps.adoc
+++ b/dev_guide/configmaps.adoc
@@ -346,9 +346,9 @@ spec:
               name: special-config <2>
               key: special.type <3>
               optional: true <4>
-        envFrom:<5>
-          - configMapRef:
-              name: env-config <6>
+      envFrom: <5>
+        - configMapRef:
+            name: env-config <6>
   restartPolicy: Never
 ----
 


### PR DESCRIPTION
Just a small indentation fix (which I also confirmed to work).  Gave me a bit of a headache when I looked at this part of the docs and tried to make sense of the invalid yaml snippet there