### PR TITLE
Adding the accessTokenMaxAgeSeconds parameter to Dedicated

### DIFF
--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -137,10 +137,19 @@ one of the specified `redirectURIs`.
 
 
 [[accessTokenMaxAgeSeconds]]
+ifdef::openshift-origin,openshift-enterprise[]
 The `accessTokenMaxAgeSeconds` value overrides the
 xref:../../install_config/configuring_authentication.adoc#token-options[default `accessTokenMaxAgeSeconds` value] in the master configuration file
 for individual OAuth clients. Setting this value for a client allows long-lived access tokens for that client
 without affecting the lifetime of other clients.
+endif::[]
+ifdef::openshift-dedicated[]
+The `accessTokenMaxAgeSeconds` value overrides the
+default `accessTokenMaxAgeSeconds` value in the master configuration file
+for individual OAuth clients. Setting this value for a client allows long-lived access tokens for that client
+without affecting the lifetime of other clients. If you want to use this feature, please open a support case 
+on the link:https://access.redhat.com/support/[Red Hat Customer Portal].
+endif::[]
 
 * If `null`, the default value in the master configuration file is used.
 * If set to `0`, the token will not expire.


### PR DESCRIPTION
Adding the `accessTokenMaxAgeSeconds` parameter with note to open support case to Dedicated per @stuartchuan
Original PR https://github.com/openshift/openshift-docs/pull/5338