### PR TITLE
add text in the pruning images section for --skip-registry option

### DIFF
--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -235,6 +235,16 @@ case it fails (the registry cannot be resolved or reached), an alternative
 route that works needs to be provided using this flag. The registry host name
 may be prefixed by `https://` or `http://` which will enforce particular
 connection protocol.
+
+.^|`--prune-registry`
+|In conjunction with the conditions stipulated by the other options, this option controls
+whether the data in the registry corresponding to the {product-title} Image API Objects
+is pruned. By default, image pruning processes both the
+Image API Objects and corresponding data in the registry.
+This options is useful when you are only concerned with removing etcd content, possibly
+to reduce the number of image objects, but are not concerned with cleaning up registry
+storage; or intend to do that separately by xref:#hard-pruning-registry[Hard Pruning the Registry],
+possibly during an appropriate maintenance window for the registry.
 |===
 
 [[image-prune-conditions]]
@@ -276,6 +286,26 @@ image streams that have a reference to the image in `*status.tags*`.
 `--prune-over-size-limit` cannot be combined with `--keep-tag-revisions` nor
 `--keep-younger-than` flags. Doing so will return an information that this
 operation is not allowed.
+====
+
+[NOTE]
+====
+Separating the removal of {product-title} Image API Objects and Image data
+from the Registry by using `--prune-registry=false` followed by
+xref:#hard-pruning-registry[Hard Pruning the Registry] narrows some timing windows,
+and is safer when compared to trying to prune both through one command. However,
+timing windows are not completely removed.
+
+For example, you can still create a Pod referencing an Image as pruning identifies that
+Image for pruning. You should still keep track of an API Object created during the pruning
+operations that might reference Images, so you can mitigate any references to deleted
+content.
+
+Also, keep in mind that re-doing the pruning without the `--prune-registry` option or with
+`--prune-registry=true` will not lead to pruning the associated storage in the image registry
+for images previously pruned by `--prune-registry=false`.
+Any images that were pruned with `--prune-registry=false` can only be deleted from
+registry storage by xref:#hard-pruning-registry[Hard Pruning the Registry].
 ====
 
 To see what a pruning operation would delete:


### PR DESCRIPTION
Doc for https://trello.com/c/V1anqimn/1418-5-image-soft-prune-imagestreams

@openshift/sig-developer-experience @bmcelvee ptal

disclaimer:  I sided on full transparency for this initial stab, trying to capture the warnings/concerns/recommendations that surfaced during the card planning and pr review activities.  Certainly during the 
review here, aside form massaging the wording to get it as good as possible, if the details are not appropriate for this context (perhaps better suited to the yet to be crafted, more comprehensive general image pruning recommendation/best-practices guide that @bparees cited), we can of course "prune" ;-) as needed.