### PR TITLE
[3.6] Document NetworkPolicies for router traffic, ovs-networkpolicy migration script

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -988,6 +988,65 @@ to accept any connection allowed by each policy. That is,  connections on any
 port from pods in the *_same_* namespace, and connections on ports `80` and
 `443` from pods in *_any_* namespace.
 
+[[admin-guide-networking-networkpolicy-routers]]
+=== NetworkPolicy and Routers
+
+When using the *ovs-multitenant* plugin, traffic from
+xref:../architecture/topics/routers.adoc[routers] is automatically allowed into all
+namespaces (because the routers are normally in the "default" namespace, and all
+namespaces allow connections from pods in that namespace). With the *ovs-networkpolicy*
+plugin, this does not happen automatically, so if you have a policy that isolates a
+namespace by default, you will need to take additional steps to allow routers to access
+it.
+
+One option is to create a policy for each service, allowing access from all sources. eg:
+
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-to-database-service
+spec:
+  podSelector:
+    matchLabels:
+      role: database
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 5432
+----
+
+This will allow routers to access the service, but will allow pods in other users'
+namespaces to access it as well. (In general, this should not be a problem though, since
+those pods could normally just access the service via the public router anyway.)
+
+Alternatively, you can create a policy allowing full access from the default namespace, as
+in the *ovs-multitenant* plugin:
+
+. First, a cluster administrator must add a label to the default namespace so it can be
+matched:
++
+----
+$ oc label namespace default name=default
+----
+. Then project administrators can create policies allowing connections from that
+namespace:
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-from-default-namespace
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: default
+----
+
 [[admin-guide-networking-networkpolicy-setting-default]]
 === Setting a Default NetworkPolicy for New Projects
 Cluster administrators can modify the default project template to enable
@@ -1019,11 +1078,22 @@ objects:
 - apiVersion: extensions/v1beta1
   kind: NetworkPolicy
   metadata:
-    name: allow-same-namespace
+    name: allow-from-same-namespace
   spec:
     podSelector:
     ingress:
     - from:
       - podSelector: {}
+- apiVersion: extensions/v1beta1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-default-namespace
+  spec:
+    podSelector:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: default
 ...
 ----

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -211,6 +211,53 @@ Check VNIDs by running:
 $ oc get netnamespace
 ----
 
+[[migrating-between-sdn-plugins-networkpolicy]]
+=== Migrating from the ovs-multitenant Plugin to ovs-networkpolicy
+
+Before migrating from *ovs-multitenant* to *ovs-networkpolicy*, you must ensure that every
+namespace has a unique `NetID`; that means that if you have previously
+xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined projects
+together] or
+xref:../admin_guide/managing_networking.adoc#making-project-networks-global[made projects
+global], you will need to undo that before switching to the *ovs-networkpolicy* plugin, or
+NetworkPolicy objects may not function correctly.
+
+A helper script is available that fixes `NetID`s, creates NetworkPolicy objects to isolate
+previously-isolated namespaces, and enabled connections between previously-joined
+namespaces.
+
+. Download https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
++
+----
+$ curl https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
+$ chmod a+x migrate-network-policy.sh
+----
+. While still running the *ovs-multitenant* plugin (that is, before running any of the
+migration steps above), run that script as a user with cluster administrator rights on
+the OpenShift cluster
++
+----
+$ ./migrate-network-policy.sh
+----
+
+After running the script, every project will now be fully isolated from every other
+project, so connection attempts between pods in different projects will fail until you
+complete the migration to the *ovs-networkpolicy* plugin.
+
+If you want newly-created projects to also have the same policies by default, you can set
+xref:../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy-setting-default[default
+NetworkPolicy objects] to be created matching the `default-deny` and
+`allow-from-global-namespaces` policies created by the migration script.
+
+[NOTE]
+====
+In case of script failures or other errors, or if you later decide you want to revert back
+to the *ovs-multitenant* plugin, you can use the
+link:https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/unmigrate-network-policy.sh[un-migration
+script]. This script undoes the changes made by the migration script and re-joins
+previously-joined projects.
+====
+
 [[external-access-to-the-cluster-network]]
 == External Access to the Cluster Network
 


### PR DESCRIPTION
Backport of half of #6380 to 3.6; it includes the doc updates, but doesn't remove the mentions of "Tech Preview".

I was going to merge in @gaurav-nelson 's fixes from #6437, but that also included a bunch of fixes to other parts of the docs and I wasn't sure if you'd want to backport those to 3.6 or not. So I left that out.
