### PR TITLE
Fix typo in OCP3.7 release note.

### DIFF
--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -1020,7 +1020,7 @@ openshift_checks_output_dir=/tmp/checks
 === Metrics and Logging
 
 [[ocp-37-journald-system-logs]]
-==== Jourald for System Logs and JSON File for Container Logs
+==== Journald for System Logs and JSON File for Container Logs
 
 Docker log driver is set to `json-file` as the default for all nodes. Docker
 `log-driver` can be set to `journal`, but there is no log rate throttling with


### PR DESCRIPTION
Fix typo in OCP3.7 release note.