### PR TITLE
Fixed typo

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1611,7 +1611,7 @@ To disable automatic deployment, set the following cluster variables in your
 inventory file:
 
 ----
-openshift_enable_service_catalog=true
+openshift_enable_service_catalog=false
 ifdef::openshift-origin[]
 openshift_service_catalog_image_prefix=openshift/origin-
 openshift_service_catalog_image_version=latest


### PR DESCRIPTION
I assume that `openshift_enable_service_catalog` should be set to `false` to disable the automatic deployment of the Service Catalog.  This PR fixes that.