### PR TITLE
cli ref extend cli: correct plugin name

### DIFF
--- a/cli_reference/extend_cli.adoc
+++ b/cli_reference/extend_cli.adoc
@@ -127,22 +127,26 @@ section.
 The descriptor file supports the following attributes:
 
 ----
-name: "name1"                 # REQUIRED: the plug-in command name, to be invoked under 'kubectl'
-shortDesc: "name1 plug-in"    # REQUIRED: the command short description, for help
+name: "great-plugin"              # REQUIRED: the plug-in command name, to be invoked under 'kubectl'
+shortDesc: "great-plugin plug-in" # REQUIRED: the command short description, for help
 longDesc: ""                      # the command long description, for help
 example: ""                       # command example(s), for help
 command: "./example"              # REQUIRED: the command, binary, or script to invoke when running the plug-in
 flags:                            # flags supported by the plug-in
-  - name: "flag-name"                  # REQUIRED for each flag: flag name
+  - name: "flag-name"             # REQUIRED for each flag: flag name
     shorthand: "f"                # short version of the flag name
-    desc: "example flag"             # REQUIRED for each flag: flag description
+    desc: "example flag"          # REQUIRED for each flag: flag description
     defValue: "extreme"           # default value of the flag
 tree:                             # allows the declaration of subcommands
   - ...                           # subcommands support the same set of attributes
 ----
 
 The preceding descriptor declares the `great-plugin` plug-in, which has
-one flag named `-f | --flag-name`.
+one flag named `-f | --flag-name`. It could be invoked as:
+
+----
+$ oc plugin great-plugin -f value
+----
 
 When the plug-in is invoked, it calls the `example` binary or script, which is
 located in the same directory as the descriptor file, passing a number of


### PR DESCRIPTION
The example yaml actually defined a plugin named `name1`. The fact that it's located in a directory called `great-plugin` is irrelevant. I also though an example usage would help.