### PR TITLE
updated networkpolicy examples to match master

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1049,12 +1049,14 @@ matches all pods but accepts no traffic.
 +
 [source,yaml]
 ----
-networkConfig:
- ...
-  networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
- ...
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: deny-by-default
+spec:
+  podSelector:
+  ingress: []
 ----
-<1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
 
 * *Only Accept connections from pods within project*
 +
@@ -1063,11 +1065,16 @@ but reject all other connections from pods in other projects:
 +
 [source,yaml]
 ----
-networkConfig:
-  ...
-  networkPluginName: "redhat/openshift-ovs-networkpolicy" <1>
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}
 ----
-<1> Set to *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
 
 * *Only allow HTTP and HTTPS traffic based on pod labels*
 +

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1469,7 +1469,7 @@ the same messages on port `5555`.
 Alternatively, you can configure your own custom *_fluent.conf_* in the
 `logging-fluentd` or `logging-mux` ConfigMaps.
 
-**Remote Environment Variables**
+**Fluentd Environment Variables**
 
 [cols="3,7",options="header"]
 |===
@@ -1511,7 +1511,7 @@ This implementation is insecure, and should only be used in environments
 where you can guarantee no snooping on the connection.
 ====
 
-**Fluentd Environment Variables**
+**Fluentd Logging Ansible Variables**
 
 [cols="3,7",options="header"]
 |===
@@ -1549,7 +1549,7 @@ set the tag on the syslog message.
 set the payload on the syslog message.
 |===
 
-**Mux Environment Variables**
+**Mux Logging Ansible Variables**
 
 [cols="3,7",options="header"]
 |===


### PR DESCRIPTION
Correcting network policy examples. From #6550 

cc @danwinship Can I get an ack? This doesn't entirely match up to what you asked for, but I think this is the correct one. The examples are this in master and 3.6, but not the stage branches. This (and the new 3.9 branch) is the only one that has to be updated.