### PR TITLE
Fix command for downloading migration script

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -234,7 +234,7 @@ plugin, by using this helper script, while still running the *ovs-multitenant* p
 +
 [source, bash]
 ----
-$ curl https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
+$ curl -O https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
 $ chmod a+x migrate-network-policy.sh
 ----
 . Run the script (requires the cluster administrator role).


### PR DESCRIPTION
Oops, QE noticed this; the command as given will just dump the script to stdout. You need `-O` to make it save it to a file.

Needs to be copied to 3.6/3.7/etc.

@bfallonf 