### PR TITLE
Bumped Kubernetes version number for 3.7

### DIFF
--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -38,7 +38,7 @@ optionally configure your masters for xref:high-availability-masters[high availa
 ifdef::openshift-enterprise,openshift-dedicated[]
 {product-version}
 endif::[]
-uses Kubernetes 1.6 and Docker 1.12.
+uses Kubernetes 1.7 and Docker 1.12.
 ====
 endif::[]
 


### PR DESCRIPTION
This content was okay in master, but still needed bumped in 3.7 docs.

cc @vikram-redhat 