### PR TITLE
[enterprise-3.9] Updates code example to reflect text

### DIFF
--- a/install_config/configuring_pipeline_execution.adoc
+++ b/install_config/configuring_pipeline_execution.adoc
@@ -49,8 +49,8 @@ storage for Jenkins, add the following to your master configuration file:
 jenkinsPipelineConfig:
   autoProvisionEnabled: true <1>
   templateNamespace: openshift <2>
-  templateName: jenkins-pipeline <3>
-  serviceName: jenkins-pipeline-svc <4>
+  templateName: jenkins-persistent <3>
+  serviceName: jenkins-persistent-svc <4>
   parameters: <5>
     key1: value1
     key2: value2


### PR DESCRIPTION
The text describing the process to change the template
used for automatically creating a jenkins application
references "jenkins-persistent" but the code block uses
"jenkins-pipeline". This PR aligns that.
(cherry picked from commit 6d416301e645225d6256bf8fa3079112d1f20479) xref:https://github.com/openshift/openshift-docs/pull/6347