### PR TITLE
[enterprise-3.7] Fix command for downloading migration script

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -234,7 +234,7 @@ plugin, by using this helper script, while still running the *ovs-multitenant* p
 +
 [source, bash]
 ----
-$ curl https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
+$ curl -O https://raw.githubusercontent.com/openshift/origin/master/contrib/migration/migrate-network-policy.sh
 $ chmod a+x migrate-network-policy.sh
 ----
 . Run the script (requires the cluster administrator role).


### PR DESCRIPTION
(cherry picked from commit 3371a0345a006635b3a31c79f69adde25283a51e) xref:https://github.com/openshift/openshift-docs/pull/6581