### PR TITLE
[online-3.6] clarify image-pusher role

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -1027,9 +1027,17 @@ Before performing this procedure, the following must be satisfied:
 
 - The destination project you push to must already exist.
 - The user must be authorized to `{get, update} "imagestream/layers"` in that
-project. The *system:image-pusher* role can be added to a user to provide these
-permissions. If you are a project administrator, then you would also have these
-permissions.
+project. In addition, since the image stream does not already exist, the user 
+must be authorized to `{create} "imagestream"` in that project.  If you are a project 
+administrator, then you would have these permissions.
+
+[NOTE]
+====
+The *system:image-pusher* role does not grant permission to create new image streams,
+only to push images to existing image streams, so it cannot be used to push images
+to image streams that do not yet exist unless additional permissions are also granted to 
+the user.
+====
 
 To create an image stream by manually pushing an image:
 


### PR DESCRIPTION
(cherry picked from commit 514dd4f941f6b156e57010fcb5d808d54e73ea55) xref:https://github.com/openshift/openshift-docs/pull/6621