### PR TITLE
Revert advanced audit techpreview drop from 3.7

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -717,7 +717,7 @@ At present this is only implemented for emptyDir volumes, and if the underlying
 |===
 
 [[master-node-config-audit-config]]
-=== Basic Audit
+=== Audit Configuration
 
 Audit provides a security-relevant chronological set of records documenting the
 sequence of activities that have affected system by individual users,
@@ -802,6 +802,21 @@ openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/log/openp
 [[master-node-config-advanced-audit]]
 === Advanced Audit
 
+[IMPORTANT]
+====
+Advanced audit is a Technology Preview feature and it is subject to change in future releases.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
 The advanced audit feature provides several improvements over the
 xref:master-node-config-audit-config[basic audit functionality], including
 fine-grained events filtering and multiple output back ends. The following table
@@ -839,12 +854,9 @@ To enable the advanced audit feature, you must provide either `policyFile` or
 .Sample Audit Policy Configuration
 [source,yaml]
 ----
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1alpha1
 kind: Policy
 rules:
-
-  # A catch-all rule to log all other requests at the Metadata level.
-  - level: Metadata <1>
 
   # Do not log watch requests by the "system:kube-proxy" on endpoints or services
   - level: None <1>
@@ -881,6 +893,9 @@ rules:
     resources:
     - group: "" # core API group
     - group: "extensions" # Version of group should NOT be included.
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata <1>
 ----
 <1> There are four possible levels every event can be logged at:
 +


### PR DESCRIPTION
This needs to land for 3.7, since `audit/v1beta1` is not available there and audit is in tech preview. The tech preview is dropped from 3.8 only. 

@mburke5678 @openshift/team-documentation 