### PR TITLE
Update NetworkPolicy objects to use v1 API

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1050,7 +1050,7 @@ matches all pods but accepts no traffic.
 [source,yaml]
 ----
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: deny-by-default
 spec:
@@ -1066,7 +1066,7 @@ but reject all other connections from pods in other projects:
 [source,yaml]
 ----
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-same-namespace
 spec:
@@ -1084,7 +1084,7 @@ To enable only HTTP and HTTPS access to the pods with a specific label
 [source,yaml]
 ----
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-http-and-https
 spec:
@@ -1123,7 +1123,7 @@ One option is to create a policy for each service, allowing access from all sour
 [source,yaml]
 ----
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-to-database-service
 spec:
@@ -1165,7 +1165,7 @@ Perform this step for each namespace you want to allow conntections into. Users 
 [source,yaml]
 ----
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-from-default-namespace
 spec:
@@ -1206,7 +1206,7 @@ command. Currently, it is not possible to use `oc patch` to add objects to a
 ----
 objects:
 ...
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
     name: allow-from-same-namespace
@@ -1215,7 +1215,7 @@ objects:
     ingress:
     - from:
       - podSelector: {}
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
     name: allow-from-default-namespace


### PR DESCRIPTION
In OCP 3.9 we will have kube 1.9, with NetworkPolicy v1, so we should update the examples to use the new API version.

(This change is correct for 3.8 as well if we are doing 3.8 docs. We don't want it for 3.7 or earlier.)