### PR TITLE
[online-3.9] clarify config map <-> pod template sync in jenkins

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -578,8 +578,23 @@ After startup, the
 link:https://github.com/openshift/jenkins-sync-plugin[OpenShift Sync plug-in]
 monitors the API server of {product-title} for updates to `ImageStreams`,
 `ImageStreamTags`, and `ConfigMaps` and adjusts the configuration of the
-Kubernetes plug-in based on the presence or absence of the noted labels and
-annotations.
+Kubernetes plug-in.
+
+In particular, the following rules will apply:
+
+- Removal of the label or annotation from the `ConfigMap`, `ImageStream`, or
+`ImageStreamTag` will result in the deletion of any existing `PodTemplate` from
+the configuration of the Kubernetes plug-in.
+- Similarly, if those objects are removed, the corresponding configuration
+is removed from the Kubernetes plug-in.
+- Conversely, either the creation of appropriately labeled or annotated `ConfigMap`,
+`ImageStream`, or `ImageStreamTag` objects, or the adding of labels after their
+initial creation, leads to the creation of a `PodTemplate` in the Kubernetes-plugin
+configuration.
+- In the case of the `PodTemplate` via `ConfigMap` form, changes to the `ConfigMap`
+data for the `PodTemplate`will be applied to the `PodTemplate` settings in the
+Kubernetes plug-in configuration, and will override any changes made to the
+`PodTemplate` via the Jenkins UI in the interim between changes to the `ConfigMap`.
 
 To use a container image as a Jenkins slave, the image must run the slave agent as
 an entrypoint. For more details about this, refer to the official


### PR DESCRIPTION
(cherry picked from commit 4d550147af4658e931a0585bc3f3cf0290dfd80b) xref:https://github.com/openshift/openshift-docs/pull/6756