### PR TITLE
[dedicated-3.7] Updates link to mongodb docs

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -196,7 +196,7 @@ MongoDB settings can be configured with the following environment variables:
 |`*true*`
 
 |`*MONGODB_TEXT_SEARCH_ENABLED*`
-|(MongoDB version 2.4 only) Enables the https://docs.mongodb.org/v2.6/core/index-text/#text-search-text-command[text search] feature.
+|(MongoDB version 2.4 only) Enables the https://docs.mongodb.org/v2.4/core/index-text/#text-search-text-command[text search] feature.
 
 [NOTE]
 ====


### PR DESCRIPTION
The environment variable for `MONGODB_TEXT_SEARCH_ENABLED` is only available in
MongoDB version 2.4.  The link to the text search feature uses mongodb's docs
from 2.6 - where the specified section doesn't exist.  Updated the link to refer
to the mongodb 2.4 documentation.

(cherry picked from commit 3c397df95117ebf78dc4ef9f3cf024ea3fc323e0) xref:https://github.com/openshift/openshift-docs/pull/6785