### PR TITLE
Remove reference to PatternFly icons as a bug prevents them from working

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -378,8 +378,7 @@ endif::[]
 <6> An icon to be displayed with your template in the web console. Choose from
 our existing
 link:https://rawgit.com/openshift/openshift-logos-icon/master/demo.html[logo icons] when possible. You can also use icons from
-link:http://fontawesome.io/icons/[FontAwesome] and
-link:https://www.patternfly.org/styles/icons/[Patternfly].
+link:http://fontawesome.io/icons/[FontAwesome].
 ifdef::openshift-enterprise,openshift-origin[]
 Alternatively, provide icons through
 xref:../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[CSS


### PR DESCRIPTION
Corresponding bug https://github.com/openshift/origin/issues/17745

@ahardin-rh, please review.  This bug exists in 3.4-3.7 (but we'll backport the bug fix to 3.7).  Which other branches do I need to PR to?

cc: @jwforres 