### PR TITLE
[online-3.9] Remove reference to PatternFly icons as a bug prevents t…

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -377,9 +377,8 @@ for the whole cluster.
 endif::[]
 <6> An icon to be displayed with your template in the web console. Choose from
 our existing
-link:https://rawgit.com/openshift/origin-web-console/master/app/styles/fonts/openshift-logos-icon/demo.html[logo icons] when possible. You can also use icons from
-link:http://fontawesome.io/icons/[FontAwesome] and
-link:https://www.patternfly.org/styles/icons/[Patternfly].
+link:https://rawgit.com/openshift/openshift-logos-icon/master/demo.html[logo icons] when possible. You can also use icons from
+link:http://fontawesome.io/icons/[FontAwesome].
 ifdef::openshift-enterprise,openshift-origin[]
 Alternatively, provide icons through
 xref:../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[CSS


### PR DESCRIPTION
…hem from working

Corresponding bug https://github.com/openshift/origin/issues/17745

(cherry picked from commit a819ea180d1e9fd56f95a12bde4cd033dcca0f1f) xref:https://github.com/openshift/openshift-docs/pull/6809