### PR TITLE
Bug#1523619 - Updated resource quota name to match examples

### DIFF
--- a/admin_solutions/user_role_mgmt.adoc
+++ b/admin_solutions/user_role_mgmt.adoc
@@ -35,11 +35,12 @@ can be created to a maximum of 10:
 
 . Create a *_resource-quota.yaml_* file with the following contents:
 +
+[source, yaml]
 ----
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: compute-resources
+  name: resource-quota
 spec:
   hard:
     pods: "10"
@@ -47,6 +48,7 @@ spec:
 +
 . Create the quota using the file you just wrote to apply it to the "awesomeproject":
 +
+[source, bash]
 ----
 $ oc create -f resource-quota.yaml -n awesomeproject
 ----
@@ -55,17 +57,17 @@ After the quota has been in effect for a little while, you can view the usage st
 +
 . If required, list the quotas defined in the project to see the names of all defined quotas:
 +
-====
+[source, bash]
 ----
 $ oc get quota -n awesomeproject
 NAME                AGE
 resource-quota      39m
 ----
-====
+
 +
 . Describe the resource quota for which you want statistics:
 +
-====
+[source, bash]
 ----
 $ oc describe quota resource-quota -n awesomeproject
 Name:			resource-quota
@@ -74,12 +76,13 @@ Resource		Used	Hard
 --------		----	----
 pods     		3	10
 ----
-====
+
 +
 . Optionally, you can
 xref:../admin_guide/quota.adoc#configuring-quota-sync-period[configure the quota synchronization period], which controls how long to wait before restoring quota usage after resources are deleted.
 . If you want to remove an active quota to no longer enforce the limits of a project:
 +
+[source, bash]
 ----
 $ oc delete quota <quota_name>
 ----
@@ -143,6 +146,7 @@ To define privilege levels for project requests:
 
 . Apply label selectors to users. For example, to apply the `level` label selector with a value of `bronze`:
 +
+[source, bash]
 ----
 $ oc label user <user_name> level=bronze
 ----
@@ -150,6 +154,7 @@ $ oc label user <user_name> level=bronze
 Repeat this step for all bronze users, and then for the other levels.
 . Optionally, verify the previous step by viewing the list of labeled users for each value:
 +
+[source, bash]
 ----
 $ oc get users -l level=bronze
 $ oc get users -l level=silver
@@ -159,6 +164,7 @@ $ oc get users -l level=platinum
 +
 If you need to remove a label from a user to make a correction:
 +
+[source, bash]
 ----
 $ oc label user <user_name> level-
 ----
@@ -189,6 +195,7 @@ admissionConfig:
 +
 . Restart the master host for the changes to take effect.
 +
+[source, bash]
 ----
 $ systemctl restart atomic-openshift-master
 ----
@@ -215,6 +222,7 @@ of the defined quota currently being used is stored on the ResourceQuota object
 itself. In that case, you could check the amount of used resources, such as CPU
 usage:
 
+[source, bash]
 ----
 $ oc get quota
 ----
@@ -222,6 +230,7 @@ $ oc get quota
 However, this would not tell you what is actually being consumed.
 To determine what is actually being consumed, use the `oc describe` command:
 
+[source, bash]
 ----
 $ oc describe quota <quota-name>
 ----
@@ -252,7 +261,7 @@ xref:../admin_solutions/user_role_mgmt.adoc#view-roles-users-cluster[the entire 
 
 There are special groups that are assigned to users. You can target users with these groups, but you cannot modify them. These special groups are as follows:
 
-[options="header"]
+[cols="1,2", options="header"]
 |===
 
 |Group |Description
@@ -285,7 +294,7 @@ $ oadm policy add-cluster-role-to-group <role> system:authenticated
 Currently, by default the `system:authenticated` and `sytem:authenticated:oauth`
 groups receive the following roles:
 
-[options="header"]
+[cols="1,2", options="header"]
 |===
 
 |Role |Description
@@ -313,7 +322,7 @@ groups receive the following roles:
 === Viewing Roles and Users for a Project
 To view a list of all users that are bound to the project and their roles:
 
-====
+[source, bash]
 ----
 $ oc get rolebindings
 NAME                    ROLE                    USERS     GROUPS                                 SERVICE ACCOUNTS   SUBJECTS
@@ -322,13 +331,12 @@ admin                   /admin                  jsmith
 system:deployers        /system:deployer                                                         deployer
 system:image-builders   /system:image-builder                                                    builder
 ----
-====
 
 [[view-roles-users-cluster]]
 === Viewing Roles and Users for the Cluster
 To view a list of users and what they have access to across the entire cluster:
 
-====
+[source, bash]
 ----
 $ oc get clusterrolebindings
 NAME                                            ROLE                                       USERS           GROUPS                                         SERVICE ACCOUNTS                                   SUBJECTS
@@ -366,7 +374,6 @@ system:deployment-controller                    /system:deployment-controller   
 system:masters                                  /system:master                                             system:masters
 system:service-load-balancer-controller         /system:service-load-balancer-controller                                                                  openshift-infra/service-load-balancer-controller
 ----
-====
 
 These commands can generate huge lists, so you may want to pipe the output into a text file that you can search through more easily.
 
@@ -381,6 +388,7 @@ basic-user, self-provisioner, and cluster-reader.
 
 For a complete list of all available roles:
 
+[source, bash]
 ----
 $ oadm policy
 ----
@@ -394,6 +402,7 @@ xref:../admin_guide/manage_rbac.adoc#managing-role-bindings[Managing Role Bindin
 
 To bind a role to a user for the current project:
 
+[source, bash]
 ----
 $ oadm policy add-role-to-user <role> <user_name>
 ----
@@ -404,6 +413,7 @@ You can specify a project with the `-n` flag.
 
 To remove a role from a user for the current project:
 
+[source, bash]
 ----
 $ oadm policy remove-role-from-user <role> <user_name>
 ----
@@ -416,6 +426,7 @@ To bind a
 xref:../architecture/additional_concepts/authorization.adoc#cluster-policy-and-local-policy[cluster role]
 to a user for all projects:
 
+[source, bash]
 ----
 $ oadm policy add-cluster-role-to-user <role> <user_name>
 ----
@@ -426,6 +437,7 @@ To remove a
 xref:../architecture/additional_concepts/authorization.adoc#cluster-policy-and-local-policy[cluster role]
 from a user for all projects:
 
+[source, bash]
 ----
 $ oadm policy remove-cluster-role-from-user <role> <user_name>
 ----
@@ -434,6 +446,7 @@ $ oadm policy remove-cluster-role-from-user <role> <user_name>
 
 To bind a role to a specified group in the current project:
 
+[source, bash]
 ----
 $ oadm policy add-role-to-group <role> <groupname>
 ----
@@ -444,6 +457,7 @@ You can specify a project with the `-n` flag.
 
 To remove a role from a specified group in the current project:
 
+[source, bash]
 ----
 $ oadm policy remove-role-from-group <role> <groupname>
 ----
@@ -454,6 +468,7 @@ You can specify a project with the `-n` flag.
 
 To bind a role to a specified group for all projects in the cluster:
 
+[source, bash]
 ----
 $ oadm policy add-cluster-role-to-group <role> <groupname>
 ----
@@ -462,6 +477,7 @@ $ oadm policy add-cluster-role-to-group <role> <groupname>
 
 To remove a role from a specified group for all projects in the cluster:
 
+[source, bash]
 ----
 $ oadm policy remove-cluster-role-from-group <role> <groupname>
 ----
@@ -510,11 +526,13 @@ admissionConfig:
 
 Restart the {product-title} master for the change to take effect:
 ifdef::openshift-origin[]
+[source, bash]
 ----
 # systemctl restart origin-master
 ----
 endif::[]
 ifdef::openshift-enterprise[]
+[source, bash]
 ----
 # systemctl restart atomic-openshift-master
 ----
@@ -524,6 +542,7 @@ The following example creates a role binding restriction that permits role
 bindings that have matching users as subjects:
 
 .Example Role Binding Restriction Matching Users
+[source, bash]
 ----
 $ oc create -f - -n group1 <<EOF
 apiVersion: v1
@@ -556,6 +575,7 @@ allowed. The admission control plug-in will prohibit bindings with any subject
 that is not matched by some `RoleBindingRestriction` in the namespace:
 
 .Example of RoleBindingRestriction Enforcement
+[source, bash]
 ----
 $ oadm policy add-role-to-user view joe -n group1
 Error from server: rolebindings "view" is forbidden: rolebindings to User "joe" are not allowed in project "group1"
@@ -569,6 +589,7 @@ The following example creates a role binding restriction that permits role
 bindings with the group `group2` as the subject:
 
 .Example Role Binding Restriction Matching Groups
+[source, bash]
 ----
 $ oc create -f - -n group2 <<EOF
 apiVersion: v1
@@ -589,6 +610,7 @@ rolebindingrestriction "match-groups" created
 <3> Match any group that matches the specified label selector.
 
 .Example Role Binding Restriction Matching Service Accounts
+[source, bash]
 ----
 $ oc create -f - -n group2 <<EOF
 apiVersion: v1
@@ -635,6 +657,7 @@ By default, this role is granted to the `system:authenticated` group in the
 specified template from the `openshift` project and create the items in the
 current project:
 
+[source, bash]
 ----
 $ oc process openshift//<template-name> | oc create -f -
 ----
@@ -642,6 +665,7 @@ $ oc process openshift//<template-name> | oc create -f -
 You can also add the registry viewer role to a user, allowing them to view and
 pull images from a project:
 
+[source, bash]
 ----
 $ oc policy add-role-to-user registry-viewer <user-name>
 ----
@@ -661,6 +685,7 @@ affect (or destroy) the entire cluster.
 
 To create a basic administrator role within a project:
 
+[source, bash]
 ----
 $ oadm policy add-role-to-user admin <user_name> -n <project_name>
 ----
@@ -679,6 +704,7 @@ anything to any resource on the entire cluster, which can result in destruction
 if not used carefully.
 ====
 
+[source, bash]
 ----
 $ oadm policy add-cluster-role-to-user cluster-admin <user_name>
 ----


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1523619
- Updated resource quota name from `compute-resources` to `resource-quota`
- Removed old code formatting instances of `====` surrounding code blocks.
- Added `[source, bash]` and `[source,yaml]`tags to relevant code blocks.
- Fixed table column lengths