### PR TITLE
[enterprise-3.9] Removed note box per team discussion

### DIFF
--- a/dev_guide/projects.adoc
+++ b/dev_guide/projects.adoc
@@ -211,11 +211,6 @@ hosted with {product-title}. This allows multiple users to gain access to
 projects under a single subscription, without having to pay a monthly fee for
 every account.
 
-[NOTE]
-====
-Existing {product-title} Pro users do not need to be added as collaborators.
-====
-
 [[collaboration-restrictions]]
 === Collaboration Restrictions
 


### PR DESCRIPTION
(cherry picked from commit 0644a999f9ec2ae9ff44d70a5c1257838d657064) xref:https://github.com/openshift/openshift-docs/pull/6753