### PR TITLE
Fixed typos in dedicated-3.6

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -89,7 +89,7 @@ did not have the ability to negotiate API versions against a server. So if you
 are using `oc` up to
 ifdef::openshift-origin[]
 1.0.4
-endif::openshift-origin[][]
+endif::openshift-origin[]
 ifdef::openshift-enterprise,openshift-online,openshift-dedicated[]
 3.0.1.0
 endif::openshift-enterprise,openshift-online,openshift-dedicated[]
@@ -272,7 +272,7 @@ $ oc delete all -l <label>
 ----
 
 === set
-Modify a specific property of the specified object. 
+Modify a specific property of the specified object.
 
 ==== set env
 Sets an environment variable on a deployment configuration or a build configuration:

--- a/dev_guide/dev_tutorials/maven_tutorial.adoc
+++ b/dev_guide/dev_tutorials/maven_tutorial.adoc
@@ -171,7 +171,7 @@ xref:../../architecture/networking/networking.adoc#architecture-additional-conce
 In your web browser, navigate to *_\http://<NexusIP>:8081/nexus/content/groups/public_* to confirm that it has stored your
 application's dependencies. You can also check the build logs to see if Maven is
 using the Nexus mirror. If successful, you should see output referencing the URL
-*_`http://nexus:8081_*.
+*_\http://nexus:8081_*.
 
 [[nexus-additional-resources]]
 == Additional Resources


### PR DESCRIPTION
Follow-up edits to https://github.com/openshift/openshift-docs/pull/6851 since 3.6 cherry-picks were messy