### PR TITLE
[enterprise-3.9] added information on optional 1936 port

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -608,9 +608,10 @@ Only required to be internally open on master hosts.
 
 | *1936*
 |TCP
-| For router statistics use. Required to be open when running the template
-router to access statistics, and can be open externally or internally to
-connections depending on if you want the statistics to be expressed publicly.
+| (*Optional*) Required to be open when running the template router to access
+statistics. Can be open externally or internally to connections depending on if
+you want the statistics to be expressed publicly. Can require extra
+configuration to open. See the Notes section below for more information.
 
 | *4001*
 |TCP
@@ -642,6 +643,12 @@ connections, and is only required if you have clustered etcd.
 * When deployments are using the SDN, the pod network is accessed via a service proxy, unless it is accessing the registry from the same node the registry is deployed on.
 * {product-title} internal DNS cannot be received over SDN. Depending on the detected values of `*openshift_facts*`, or if the `*openshift_ip*` and `*openshift_public_ip*` values are overridden, it will be the computed value of `*openshift_ip*`. For non-cloud deployments, this will default to the IP address associated with the default route on the master host. For cloud deployments, it will default to the IP address associated with the first internal interface as defined by the cloud metadata.
 * The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed values of `*openshift_hostname*` and `*openshift_public_hostname*`.
+* Port *1936* can still be inaccessible due to your iptables rules. Use the following to configure iptables to open port *1936*:
++
+----
+# iptables OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp \
+    --dport 1936 -j ACCEPT
+----
 
 .Aggregated Logging
 [cols='2,1,8']


### PR DESCRIPTION
(cherry picked from commit 6ed36519fae61100da2452af19caa5b160f73643) xref:https://github.com/openshift/openshift-docs/pull/6881