### PR TITLE
Restore PatternFly link now that https://github.com/openshift/origin/…

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -378,7 +378,7 @@ endif::[]
 <6> An icon to be displayed with your template in the web console. Choose from
 our existing
 link:https://rawgit.com/openshift/openshift-logos-icon/master/demo.html[logo icons] when possible. You can also use icons from
-link:http://fontawesome.io/icons/[FontAwesome].
+link:http://fontawesome.io/icons/[FontAwesome] and link:https://www.patternfly.org/styles/icons/[PatternFly].
 ifdef::openshift-enterprise,openshift-origin[]
 Alternatively, provide icons through
 xref:../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[CSS


### PR DESCRIPTION
…issues/17745 is fixed

Now that PatternFly icons work, we can restore the link for the 3.9 documentation.

attn: @ahardin-rh 