### PR TITLE
Added openshift_set_node_ip reference .

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -310,6 +310,10 @@ options] in the OAuth configuration. See xref:advanced-install-session-options[C
 
 |`openshift_master_session_encryption_secrets`
 
+|`openshift_set_node_ip`
+|Configure `nodeIP` in the node config. This is needed in cases where node traffic is desired to go over an interface other than the default network interface.
+The host variable `openshift_ip` be also configured on each node.
+
 |`openshift_portal_net`
 |This variable configures the subnet in which
 xref:../../architecture/core_concepts/pods_and_services.adoc#services[services]


### PR DESCRIPTION
Is necessary to set the variable openshift_set_node_ip  to deploy openshift 3.7 in reference architecture described in https://blog.openshift.com/openshift-container-platform-reference-architecture-implementation-guides/ .

Setting openshift_ip on each node is also necessary.