### PR TITLE
Fix getting openshift facts.

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -737,12 +737,14 @@ addresses for the hosts. To see the default values, run the `*openshift_facts*`
 playbook:
 
 ----
-# ansible-playbook  [-i /path/to/inventory] \
+# ansible all [-i /path/to/inventory] \
 ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py
+    -M /usr/share/ansible/openshift-ansible/roles/openshift_facts/library/ \
+    -m openshift_facts
 endif::[]
 ifdef::openshift-origin[]
-    ~/openshift-ansible/roles/openshift_facts/library/openshift_facts.py
+    -M ~/openshift-ansible/roles/openshift_facts/library/ \
+    -m openshift_facts
 endif::[]
 ----
 


### PR DESCRIPTION
**ansible-playbook /usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py** returns
```ERROR! Syntax Error while loading YAML.```
because openshift_facts.py is a python program.

This other way returns facts.