### PR TITLE
[online-3.9] Remove spurious '/' in route documentation

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -470,7 +470,7 @@ spec:
 ----
 <1> The name of the object, which is limited to 63 characters.
 <2> The `*termination*` field is `edge` for edge termination.
-<3> The insecure policy to redirect requests sent on an i/nsecure scheme `HTTP` to a secure scheme `HTTPS`.
+<3> The insecure policy to redirect requests sent on an insecure scheme `HTTP` to a secure scheme `HTTPS`.
 ====
 
 [[passthrough-termination]]


### PR DESCRIPTION
(cherry picked from commit fc7ed5ebfdaf9caedcbd370b42f0b7ecab7ab6f4) xref:https://github.com/openshift/openshift-docs/pull/6778