### PR TITLE
removed links to rest_api

### DIFF
--- a/admin_guide/allocating_node_resources.adoc
+++ b/admin_guide/allocating_node_resources.adoc
@@ -162,7 +162,7 @@ $ curl <certificate details> https://<master>/api/v1/nodes/cluster.node22/proxy/
 }
 ----
 
-See xref:../rest_api/index.adoc#rest-api-index[REST API Overview] for more details about certificate details.
+See REST API Overview for more details about certificate details.
 
 [[node-enforcement-1]]
 == Node enforcement

--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -73,7 +73,7 @@ cluster], with data about the objects stored in
 xref:infrastructure_components/kubernetes_infrastructure.adoc#master[etcd], a
 reliable clustered key-value store. Those services are broken down by function:
 
-- xref:../rest_api/index.adoc#rest-api-index[REST APIs], which expose each of the
+- REST APIs, which expose each of the
 xref:core_concepts/index.adoc#architecture-core-concepts-index[core objects].
 - Controllers, which read those APIs, apply changes to other objects, and report
 status or write back to the object.
@@ -163,7 +163,7 @@ By default, a new internal PKI is created for each deployment of
 {product-title}. The internal PKI uses 2048 bit RSA keys and SHA-256 signatures.
 endif::[]
 ifdef::openshift-origin,openshift-enterprise[]
-xref:../install_config/certificate_customization.adoc#install-config-certificate-customization[Custom certificates] for public hosts are supported as well. 
+xref:../install_config/certificate_customization.adoc#install-config-certificate-customization[Custom certificates] for public hosts are supported as well.
 endif::[]
 
 {product-title} uses Golang’s standard library implementation of

--- a/install_config/install/docker_registry.adoc
+++ b/install_config/install/docker_registry.adoc
@@ -1192,8 +1192,7 @@ http:
 ==== Notifications
 
 link:https://docs.docker.com/registry/configuration/#notifications[Upstream
-options] are supported. The xref:../../rest_api/index.adoc#rest-api-index[REST API Reference]
-provides more comprehensive integration options.
+options] are supported. 
 
 Example:
 

--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -720,8 +720,7 @@ http:
 === Notifications
 
 link:https://docs.docker.com/registry/configuration/#notifications[Upstream
-options] are supported. The xref:../../rest_api/index.adoc#rest-api-index[REST API Reference]
-provides more comprehensive integration options.
+options] are supported. 
 
 Example:
 

--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -1168,9 +1168,6 @@ Cluster Metrics] for more information.
 
 Clients can now easily invoke a server API instead of relying on client logic.
 
-See xref:../rest_api/examples.adoc#template-instantiation[Template
-Instantiation] for more information.
-
 [[ocp-37-dev-experience-metrics]]
 ==== Metrics
 

--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -11,9 +11,7 @@
 toc::[]
 {nbsp} +
 The {product-title} distribution of Kubernetes includes the
-xref:../rest_api/kubernetes_v1.adoc#rest-api-kubernetes-v1[Kubernetes v1 REST
-API] and the xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[OpenShift
-v1 REST API]. These are RESTful APIs accessible via HTTP(s) on the
+Kubernetes v1 REST API and the OpenShift v1 REST API. These are RESTful APIs accessible via HTTP(s) on the
 {product-title} master servers.
 
 These REST APIs can be used to manage end-user applications, the cluster, and
@@ -94,7 +92,7 @@ in the Architecture documentation for a deeper discussion on roles.
 
 These examples provide a quick reference for making successful REST API calls.
 They use insecure methods. In these examples, a simple `GET` call is made to
-xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[list available resources].
+list available resources.
 
 [[rest-api-example-curl]]
 === cURL

--- a/rest_api/revhistory_rest_api.adoc
+++ b/rest_api/revhistory_rest_api.adoc
@@ -15,7 +15,7 @@
 
 |Affected Topic |Description of Change
 //Mon Sep 25 2017
-|xref:../rest_api/examples.adoc#rest-api-examples[REST API Examples]
+|REST API Examples
 |Added a new REST API Examples topic.
 
 
@@ -33,7 +33,7 @@
 
 |Affected Topic |Description of Change
 //Wed Aug 09 2017
-|xref:../rest_api/openshift_v1.adoc#rest-api-openshift-v1[{product-title} v1 REST API]
+|{product-title} v1 REST API
 |Added information about allowing domain names in `EgressNetworkPolicy`.
 
 |===

--- a/security/container_content.adoc
+++ b/security/container_content.adoc
@@ -279,9 +279,7 @@ annotations:
 In most cases, external tools such as vulnerability scanners will develop a
 script or plug-in that watches for image updates, performs scanning and annotate
 the associated image object with the results. Typically this automation calls
-the {product-title} REST API to write the annotation. See
-xref:../rest_api/index.adoc#rest-api-index[REST API Reference] for general
-information on the REST API and `PATCH` call to update images.
+the {product-title} REST API to write the annotation. 
 
 [[security-integration-reference-example-api-call]]
 ==== Example REST API Call

--- a/security/monitoring.adoc
+++ b/security/monitoring.adoc
@@ -178,7 +178,7 @@ $ tail -5000 /var/log/openshift-audit.log \
 
 More advanced queries generally require the use of additional log analysis tools. Auditors will need a detailed familiarity
 with the OpenShift v1 API and Kubernetes v1 API to aggregate request summaries from the audit log according
-to which kind of resource is involved (the `uri` field). See xref:../rest_api/index.adoc#rest-api-index[REST API Reference] for details.
+to which kind of resource is involved (the `uri` field). 
 
 xref:../install_config/master_node_configuration.adoc#master-node-config-advanced-audit[More advanced audit logging capabilities]
 are introduced with {product-title} 3.7 as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature.

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -127,7 +127,7 @@ a|[none]
 .^|[big]#Advanced Resources#
 a|[none]
 
-* xref:../rest_api/index.adoc#rest-api-index[REST API reference]
+* REST API reference
 |===
 
 '''

--- a/whats_new/index.adoc
+++ b/whats_new/index.adoc
@@ -35,7 +35,7 @@ running where.
 
 The third important change is in the core system design: OpenShift and
 Kubernetes are built as sets of microservices working together through common
-xref:../rest_api/index.adoc#rest-api-index[REST APIs] to change the system. Those same APIs
+REST APIs to change the system. Those same APIs
 are available to system integrators, and those same core components can be
 disabled to allow alternative implementations. A great example of this are the
 *watch* APIs: clients can connect and receive a stream of changes to pods (or

--- a/whats_new/ose_3_0_release_notes.adoc
+++ b/whats_new/ose_3_0_release_notes.adoc
@@ -81,14 +81,7 @@ Console].
 - Using xref:../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[persistent volume] plug-ins
 other than the supported
 xref:../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[NFS]
-plug-in, such as
-xref:../rest_api/kubernetes_v1.adoc#v1-awselasticblockstorevolumesource[AWS
-Elastic Block Stores (EBS)],
-xref:../rest_api/kubernetes_v1.adoc#v1-gcepersistentdiskvolumesource[GCE
-Persistent Disks],
-xref:../rest_api/kubernetes_v1.adoc#v1-glusterfsvolumesource[GlusterFS],
-xref:../rest_api/kubernetes_v1.adoc#v1-iscsivolumesource[iSCSI], and
-xref:../rest_api/kubernetes_v1.adoc#v1-rbdvolumesource[RADOS (Ceph)].
+plug-in, such as AWS Elastic Block Stores (EBS), GCE Persistent Disks, GlusterFS, iSCSI, and RADOS (Ceph).
 
 == Known Issues
 


### PR DESCRIPTION
The API guides did not publish to the Customer Portal for 3.7. Consulting with @vikram-redhat, we decided to remove links to the API guide for 3.7 to avoid 404 errors.

https://bugzilla.redhat.com/show_bug.cgi?id=1525377