### PR TITLE
Adding missing CLI Plug-ins entry to OCP 3.7 Release Notes

### DIFF
--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -1182,6 +1182,19 @@ running, failing, failure reasons, and so on).
 * Timing information on build objects themselves to show how long they spent in
 various steps (not exposed as Prometheus metrics).
 
+[[ocp-37-cli-plug-ins]]
+==== CLI Plug-ins (Technology Preview)
+
+CLI plug-ins are currently in xref:ocp-37-technology-preview[Technology Preview]
+and not for production workloads.
+
+Usually called _plug-ins_ or _binary extensions_, this feature allows you to
+extend the default set of `oc` commands available and, therefore, allows you to
+perform new tasks.
+
+See xref:../cli_reference/extend_cli.adoc#cli-reference-extend-cli[Extending the
+CLI] for information on how to install and write extensions for the CLI.
+
 [[ocp-37-web-console]]
 === Web Console
 
@@ -2805,6 +2818,7 @@ The following new features are now available in Technology Preview:
 - xref:ocp-37-local-persistent-volumes[Local Storage Persistent Volumes]
 - xref:ocp-37-crio[CRI-O]
 - xref:ocp-37-tenant-driven-storage-snapshotting[Tenant-driven Storage Snapshotting]
+- xref:ocp-37-cli-plug-ins[CLI Plug-ins]
 
 The following features that were formerly in Technology Preview from a previous
 {product-title} release are now fully supported:


### PR DESCRIPTION
@vikram-redhat @sspeiche This adds in the missing entry per discussion in https://bugzilla.redhat.com/show_bug.cgi?id=1259803