### PR TITLE
[dedicated-3.9] remove env var advice from Custom Builder documentation

### DIFF
--- a/creating_images/custom.adoc
+++ b/creating_images/custom.adoc
@@ -85,14 +85,6 @@ enabled in the build configuration (if `*exposeDockerSocket*` was set to
 
 |===
 
-It is recommended that you write your Custom builder image to only read the
-information provided by the `*BUILD*` environment variable, which conforms to an
-{product-title} API version. You can then parse the required information from the
-build definition JSON instead of relying on the other individual environment
-variables provided to the builder image. However, the individual environment
-variables are provided for convenience if you do not want to parse the build
-definition.
-
 [[custom-builder-workflow]]
 == Custom Builder Workflow
 


### PR DESCRIPTION
(cherry picked from commit f7073a18909f0c073ee53c0c2ba961ee689fc423) xref:https://github.com/openshift/openshift-docs/pull/5480