### PR TITLE
TYPO: Fixes wrong Cluster Logging variable name.

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1567,7 +1567,7 @@ automatically by default during installation.
 To disable automatic deployment, set the following cluster variable:
 
 ----
-openshift_metrics_install_logging=false
+openshift_logging_install_logging=false
 ----
 ====
 


### PR DESCRIPTION
Changes openshift_metrics_install_logging to openshift_logging_install_logging.