### PR TITLE
[enterprise-3.9] Rename openshift_hosted_router_selector

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -428,7 +428,7 @@ invalid if used. These values override other settings in node configuration
 which may cause invalid configurations. Example usage:
 *{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
 
-|`openshift_hosted_router_selector`
+|`openshift_router_selector`
 |Default node selector for automatically deploying router pods. See
 xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 


### PR DESCRIPTION
The variable openshift_hosted_router_selector is now openshift_router_selector. In this same
document openshift_router_selector is already used.

Reference:
https://github.com/openshift/openshift-ansible/commit/4b0f5219f4ec3eeb5433fc9f985b1e067b581276
(cherry picked from commit e4cd20c1d7415721b3a2c238b69d22f47e0c95a4) xref:https://github.com/openshift/openshift-docs/pull/6609