### PR TITLE
Bug 1523375: Add etcd migration note for 3.6

### DIFF
--- a/install_config/upgrading/migrating_etcd.adoc
+++ b/install_config/upgrading/migrating_etcd.adoc
@@ -13,15 +13,21 @@ toc::[]
 
 == Overview
 
-While etcd was updated from etcd v2 to v3 in a
-link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous release], {product-title} continued using an etcd v2 data model and API for both
-new and upgraded clusters. Starting with {product-title} 3.6, new installations
-began using the v3 data model as well, providing
-xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved performance and scalability].
+While etcd in {product-title} was updated from etcd v2 to v3 in a
+link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous release], {product-title} continued using an etcd v2 data model and API for both new and upgraded clusters.
 
-For existing clusters that upgraded to {product-title} 3.6, however, the etcd
-data must be migrated from v2 to v3 as a post-upgrade step. This must be
-performed using openshift-ansible version 3.6.173.0.21 or later.
+Starting with {product-title} 3.6, new installations began using the v3 data
+model as well, providing
+xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved performance and scalability]. For existing clusters that upgraded to
+{product-title} 3.6, however, the etcd data can be migrated from v2 to v3 using the post-upgrade steps below.
+
+[NOTE]
+====
+{product-title} 3.6 does not enforce or require the migration from etcd data
+model v2 to v3. However, the migration is required before upgrading to {product-title} 3.7.
+See
+xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[Recommended Practices for OpenShift Container Platform etcd Hosts] for more details.
+====
 
 The etcd v2 to v3 data migration is performed as an offline migration which
 means all etcd members and master services are stopped during the migration.
@@ -66,8 +72,9 @@ separate groups.
 In order to perform the migration on Red Hat Enterprise Linux Atomic Host, you
 must be running Atomic Host 7.4 or later.
 
-. Ensure you have the latest version of the *openshift-ansible* packages
-installed:
+. The migration can only be performed using *openshift-ansible* version
+3.6.173.0.21 or later. Ensure you have the latest version of the
+*openshift-ansible* packages installed:
 +
 ----
 # yum upgrade openshift-ansible\*


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1523375

Clarifies that migrating from v2 to v3 etcd data is only required before upgrading to OCP 3.7.

PTAL @sdodson @openshift/team-documentation 

Preview: http://file.rdu.redhat.com/~adellape/010418/etcd_note/install_config/upgrading/migrating_etcd.html#overview