### PR TITLE
[enterprise-3.7] Fix tiny typo in other_api_objects.adoc

### DIFF
--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -92,7 +92,7 @@ accessTokenMaxAgeSeconds: null <1>
 apiVersion: "v1"
 metadata:
   name: "openshift-web-console" <2>
-  selflink: "/osapi/v1/oAuthClients/openshift-web-console"
+  selflink: "/oapi/v1/oAuthClients/openshift-web-console"
   resourceVersion: "1"
   creationTimestamp: "2015-01-01T01:01:01Z"
 respondWithChallenges: false <3>


### PR DESCRIPTION
(cherry picked from commit e8f0ef62761b1b17ff844b103e991e288cc3f16f) xref:https://github.com/openshift/openshift-docs/pull/7009