### PR TITLE
Multicast clarifications

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -984,9 +984,10 @@ At this time, multicast is best used for low bandwidth coordination or service
 discovery and not a high-bandwidth solution.
 ====
 
-Multicast traffic between {product-title} pods is disabled by default. You can
-enable Multicast on a per-project basis by setting an annotation on the
-project's corresponding `netnamespace` object:
+Multicast traffic between {product-title} pods is disabled by default. If you
+are using the *ovs-multitenant* or *ovs-networkpolicy* plugin, you can enable
+multicast on a per-project basis by setting an annotation on the project's
+corresponding `netnamespace` object:
 
 [source, bash]
 ----
@@ -1002,21 +1003,33 @@ $ oc annotate netnamespace <namespace> \
     netnamespace.network.openshift.io/multicast-enabled-
 ----
 
-If you have
-xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined
-networks together], you will need to enable Multicast in each projects'
-`netnamespace` in order for it to take effect in any of the projects. To enable
-Multicast in the `default` project, you must also enable it in the `kube-service-catalog`
-project and all other projects that have been
-xref:../admin_guide/managing_networking.adoc#making-project-networks-global[made
-global].
+When using the *ovs-multitenant* plugin:
 
-[NOTE]
-====
-Multicast global projects are not "global", but instead communicate with only
-other global projects via Multicast, not with all projects in the cluster, as is
-the case with unicast.
-====
+. In an isolated project, multicast packets sent by a pod will be delivered to
+all other pods in the project.
+. If you have
+xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined
+networks together], you will need to enable multicast in each project's
+`netnamespace` in order for it to take effect in any of the projects. Multicast
+packets sent by a pod in a joined network will be delivered to all pods in all
+of the joined-together networks.
+. To enable multicast in the `default` project, you must also enable it in the
+`kube-service-catalog` project and all other projects that have been
+xref:../admin_guide/managing_networking.adoc#making-project-networks-global[made
+global]. Global projects are not "global" for purposes of multicast; multicast
+packets sent by a pod in a global project will only be delivered to pods in
+other global projects, not to all pods in all projects. Likewise, pods in global
+projects will only receive multicast packets sent from pods in other global
+projects, not from all pods in all projects.
+
+When using the *ovs-networkpolicy* plugin:
+
+. Multicast packets sent by a pod will be delivered to all other pods in the
+project, regardless of `NetworkPolicy` objects. (Pods may be able to communicate
+over multicast even when they can't communicate over unicast.)
+. Multicast packets sent by a pod in one project will never be delivered to pods
+in any other project, even if there are `NetworkPolicy` objects allowing
+communication between the to projects.
 
 [[admin-guide-networking-networkpolicy]]
 == Enabling NetworkPolicy


### PR DESCRIPTION
Based on some questions from sales people about using multicast with the networkpolicy plugin.

I wasn't sure how to document the multitenant-specific vs networkpolicy-specific bits. Feel free to reorganize. Also, I wasn't sure if I should state explicitly that the subnet plugin doesn't support multicast at all, and/or that third-party network plugin may or may not support multicast but you'd have to consult the documentation for that plugin to find out.

Besides the multitenant-specific vs networkpolicy-specific changes, I also changed "multicast" to be written with a lowercase "m" when it's not at the start of a sentence, since it's not a proper noun.