### PR TITLE
remove . from vm name and remove the kubelet service restart

### DIFF
--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -40,7 +40,7 @@ VM Names can not:
 
 * begin with numbers.
 * have any capital letters.
-* have any special characters except `.` and `-`.
+* have any special characters except `-`.
 * be shorter than three characters and longer than 63 characters.
 ====
 
@@ -134,33 +134,6 @@ Datastore Storage Folder
 
 |===
 
-. Create the
-xref:vsphere-configuration-file[vSphere
-cloud configuration file `vsphere.conf`], and place it in the shared directory
-that is accessible from kubelet container, controller-manager pod, and the API
-server pod.
-
-.  Add the following flags to the kubelet that is running on every node and to
-the controller-manager and API server pods manifest files:
-+
-[source,bash]
-----
---cloud-provider=vsphere
---cloud-config=<Path of the vsphere.conf file>
-----
-
-. Restart the kubelet on all nodes by reloading the kubelet systemd unit file
-using:
-+
-----
-# systemctl daemon-reload
-----
-+
-Then restart the kubelet service for the changes to take effect:
-----
-# systemctl restart kubelet.service
-----
-+
 [NOTE]
 ====
 After enabling the vSphere Cloud Provider, Node names are set to the VM names
@@ -170,7 +143,7 @@ from the vCenter Inventory.
 [[vsphere-configuration-file]]
 == The VMWare vSphere Configuration File
 Configuring {product-title} for VMWare vSphere requires the
-*_/etc/vsphere/vsphere.conf_* file, on each node host.
+*_/etc/origin/cloudprovider/vsphere.conf_* file, on each node host.
 
 If the file does not exist, create it, and add the following:
 
@@ -217,12 +190,12 @@ kubernetesMasterConfig:
     cloud-provider:
     - "vsphere"
     cloud-config:
-    - "/etc/vsphere/vsphere.conf"
+    - "/etc/origin/cloudprovider/vsphere.conf"
   controllerArguments:
     cloud-provider:
     - "vsphere"
     cloud-config:
-    - "/etc/vsphere/vsphere.conf"
+    - "/etc/origin/cloudprovider/vsphere.conf"
 ----
 
 [IMPORTANT]
@@ -247,7 +220,7 @@ kubeletArguments:
   cloud-provider:
     - "vsphere"
   cloud-config:
-    - "/etc/vsphere/vsphere.conf"
+    - "/etc/origin/cloudprovider/vsphere.conf"
 
 ----
 +


### PR DESCRIPTION
I had a discussion with a customer implementation and the kubelet restart service confused them. 

I updated the documentation and removed those unnecessary steps. I also removed the section that said '.' are allowed in VM names. 

Resolves bz - https://bugzilla.redhat.com/show_bug.cgi?id=1532987
