### PR TITLE
3.7: remove references to NetworkPolicy being Tech Preview

### DIFF
--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -32,7 +32,7 @@ allowed to communicate with all other pods, and all other pods can communicate
 with them. In {product-title} clusters, the *default* project has VNID 0. This
 facilitates certain services like the load balancer, etc. to communicate with
 all other pods in the cluster and vice versa.
-* The *ovs-networkpolicy* plug-in (currently in Tech Preview) allows project
+* The *ovs-networkpolicy* plug-in allows project
 administrators to configure their own isolation policies using
 xref:../../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy[NetworkPolicy objects].
 

--- a/architecture/topics/openshift_sdn_plugins.adoc
+++ b/architecture/topics/openshift_sdn_plugins.adoc
@@ -13,7 +13,7 @@ allowed to communicate with all other pods, and all other pods can communicate
 with them. In {product-title} clusters, the *default* project has VNID 0. This
 facilitates certain services, such as the load balancer, to communicate with
 all other pods in the cluster and vice versa.
-* The *ovs-networkpolicy* plug-in (currently in Tech Preview) allows project
+* The *ovs-networkpolicy* plug-in allows project
 administrators to configure their own isolation policies using
 xref:../../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy[NetworkPolicy objects].
 

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -14,9 +14,9 @@ toc::[]
 
 The xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[OpenShift SDN] enables
 communication between pods across the {product-title} cluster, establishing a _pod
-network_. Two xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[SDN plug-ins]
-are currently available (*ovs-subnet* and *ovs-multitenant*), which provide
-different methods for configuring the pod network. A third (*ovs-networkpolicy*) is currently in Tech Preview.
+network_. Three xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[SDN plug-ins]
+are currently available (*ovs-subnet*, *ovs-multitenant*, and *ovs-networkpolicy*), which provide
+different methods for configuring the pod network.
 
 [[admin-guide-configuring-sdn-available-sdn-providers]]
 == Available SDN Providers
@@ -78,7 +78,7 @@ which is configurable in the Ansible inventory file.
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 
-# Configure the NetworkPolicy SDN plugin (Tech Preview)
+# Configure the NetworkPolicy SDN plugin
 # os_sdn_network_plugin_name='redhat/openshift-ovs-networkpolicy'
 
 # Disable the OpenShift SDN plugin


### PR DESCRIPTION
Parts of #6380 seem to have not been merged to enterprise-3.7. In particular, there are still references in the 3.7 docs to NetworkPolicy being Tech Preview. This fixes that.
