### PR TITLE
Template examples do not have metadata:name field

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -503,6 +503,8 @@ Here is an example of a full template with parameter definitions and references:
 ----
 kind: Template
 apiVersion: v1
+metadata:
+  name: my-template
 objects:
   - kind: BuildConfig
     apiVersion: v1
@@ -579,6 +581,8 @@ earlier.
 ----
 kind: "Template"
 apiVersion: "v1"
+metadata:
+  name: my-template
 objects:
   - kind: "Service" <1>
     apiVersion: "v1"
@@ -661,27 +665,31 @@ Unless escaped with a backslash, Kubernetes' JSONPath implementation interprets
 characters such as `.`, `@`, and others as metacharacters, regardless of their
 position in the expression. Therefore, for example, to refer to a `ConfigMap`
 datum named `my.key`, the required JSONPath expression would be
-`{.data['my\.key']}`.
+`{.data['my\.key']}`. Depending on how the JSONPath expression is then written in YAML, 
+an additional backslash might be required, for example `"{.data['my\\.key']}"`.
 ====
 
 The following is an example of different objects' fields being exposed:
 
-====
 [source,yaml]
 ----
 kind: Template
 apiVersion: v1
+metadata:
+  name: my-template
 objects:
 - kind: ConfigMap
   apiVersion: v1
   metadata:
+    name: my-template-config
     annotations:
-      template.openshift.io/expose-username: "{.data['my\.username']}"
+      template.openshift.io/expose-username: "{.data['my\\.username']}"
   data:
     my.username: foo
 - kind: Secret
   apiVersion: v1
   metadata:
+    name: my-template-config-secret
     annotations:
       template.openshift.io/base64-expose-password: "{.data['password']}"
   stringData:
@@ -689,6 +697,7 @@ objects:
 - kind: Service
   apiVersion: v1
   metadata:
+    name: my-template-service
     annotations:
       template.openshift.io/expose-service_ip_port: "{.spec.clusterIP}:{.spec.ports[?(.name==\"web\")].port}"
   spec:
@@ -698,11 +707,12 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
+    name: my-template-route
     annotations:
       template.openshift.io/expose-uri: "http://{.spec.host}{.spec.path}"
   spec:
     path: mypath
-====
+----
 
 An example response to a `bind` operation given the above partial template
 follows:
@@ -802,6 +812,8 @@ annotation. Further examples can be found in the OpenShift quickstart templates.
 ----
 kind: Template
 apiVersion: v1
+metadata:
+  name: my-template
 objects:
 - kind: BuildConfig
   apiVersion: v1


### PR DESCRIPTION
@mfojtik @bparees If this is in your area, please advise if these changes are correct:

I was working with the templates topic in the Dev Guide and was getting an error for a few examples:
`The Template "" is invalid: metadata.name: Required value: name or generateName is required`

I added a metadata:name field and the template was created. 

Also, I got a YAML error on one example, and I needed to remove the \ in "{.data['my\.username']}"
```
metadata:
    annotations:
      template.openshift.io/expose-username: "{.data['my\.username']}"
```