### PR TITLE
Remove references to NetworkPolicy being Tech Preview

### DIFF
--- a/architecture/topics/openshift_sdn_plugins.adoc
+++ b/architecture/topics/openshift_sdn_plugins.adoc
@@ -14,7 +14,8 @@ with them. In {product-title} clusters, the *default* project has VNID 0. This
 facilitates certain services, such as the load balancer, to communicate with
 all other pods in the cluster and vice versa.
 * The *ovs-networkpolicy* plug-in allows project
-administrators to configure their own isolation policies using NetworkPolicy objects.
+administrators to configure their own isolation policies using
+xref:../../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy[NetworkPolicy objects].
 
 ifdef::openshift-enterprise,openshift-origin[]
 [NOTE]


### PR DESCRIPTION
For #7067 

- Some edits are already in the master but not in enterprise 3.7 branch.
- After merging this I will cherry-pick these changes to enterprise 3.7 branch.