### PR TITLE
[enterprise-3.7] Remove references to NetworkPolicy being Tech Preview

### DIFF
--- a/architecture/topics/openshift_sdn_plugins.adoc
+++ b/architecture/topics/openshift_sdn_plugins.adoc
@@ -13,7 +13,7 @@ allowed to communicate with all other pods, and all other pods can communicate
 with them. In {product-title} clusters, the *default* project has VNID 0. This
 facilitates certain services, such as the load balancer, to communicate with
 all other pods in the cluster and vice versa.
-* The *ovs-networkpolicy* plug-in (currently in Tech Preview) allows project
+* The *ovs-networkpolicy* plug-in allows project
 administrators to configure their own isolation policies using
 xref:../../admin_guide/managing_networking.adoc#admin-guide-networking-networkpolicy[NetworkPolicy objects].
 


### PR DESCRIPTION
(cherry picked from commit f3bb6675675ffddc84ff82cf0e4b79977d30adba) xref:https://github.com/openshift/openshift-docs/pull/7081