### PR TITLE
[enterprise-3.9] Ability to specify default tolerations via the build…

### DIFF
--- a/install_config/build_defaults_overrides.adoc
+++ b/install_config/build_defaults_overrides.adoc
@@ -211,6 +211,7 @@ endif::[]
 - `openshift_buildoverrides_image_labels`
 - `openshift_buildoverrides_nodeselectors`
 - `openshift_buildoverrides_annotations`
+- `openshift_buildoverrides_tolerations`
 
 .Example Build Overrides Configuration with Ansible
 ====
@@ -221,9 +222,10 @@ openshift_buildoverrides_force_pull=true
 openshift_buildoverrides_image_labels=[{'name':'imagelabelname1','value':'imagelabelvalue1'}]
 openshift_buildoverrides_nodeselectors={'nodelabel1':'nodelabelvalue1'}
 openshift_buildoverrides_annotations={'annotationkey1':'annotationvalue1'}
+openshift_buildoverrides_tolerations=[{'key':'mykey1','value':'myvalue1','effect':'NoSchedule','operator':'Equal'}]
 
 # Or you may optionally define your own build overrides configuration serialized as json
-#openshift_buildoverrides_json='{"BuildOverrides":{"configuration":{"apiVersion":"v1","kind":"BuildDefaultsConfig","forcePull":"true"}}}'
+#openshift_buildoverrides_json='{"BuildOverrides":{"configuration":{"apiVersion":"v1","kind":"BuildDefaultsConfig","forcePull":"true","tolerations":[{'key':'mykey1','value':'myvalue1','effect':'NoSchedule','operator':'Equal'}]}}}'
 ----
 ====
 
@@ -254,15 +256,26 @@ admissionConfig:
         annotations: <4>
           key1: value1
           key2: value2
+        tolerations: <5>
+        - key: mykey1
+          value: myvalue1
+          effect: NoSchedule
+          operator: Equal
+        - key: mykey2
+          value: myvalue2
+          effect: NoExecute
+          operator: Equal
 ----
 <1> Force all builds to pull their builder image and any source images before
 starting the build.
 <2> Additional labels to be applied to every image built. Labels
 defined here take precedence over labels defined in `BuildConfig`.
-<8> Build pods will only run on nodes with the `key1=value2` and `key2=value2` labels.
+<3> Build pods will only run on nodes with the `key1=value2` and `key2=value2` labels.
     Users can define additional key/value labels to further constrain the set of nodes
     a build runs on, but the *node* must have at least these labels.
-<9> Build pods will have these annotations added to them.
+<4> Build pods will have these annotations added to them.
+<5> Build pods will have any existing tolerations overridden by those listed here.
+
 ====
 
 . Restart the master service for the changes to take effect:


### PR DESCRIPTION
…config defaulter

Trello: https://trello.com/c/LNxlMjjU/1435-5-ability-to-specify-default-tolerations-via-the-buildconfig-defaulter-builds
(cherry picked from commit 2117f8a625076021c3026859516b563aaf01bca5) xref:https://github.com/openshift/openshift-docs/pull/6974