### PR TITLE
Add etcd migration note for 3.7

### DIFF
--- a/install_config/upgrading/migrating_etcd.adoc
+++ b/install_config/upgrading/migrating_etcd.adoc
@@ -13,17 +13,21 @@ toc::[]
 
 == Overview
 
-While etcd was updated from etcd v2 to v3 in a
-link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous
-release], {product-title} continued using an etcd v2 data model and API for both
-new and upgraded clusters. Starting with {product-title} 3.6, new installations
-began using the v3 data model as well, providing
-xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved
-performance and scalability].
+While etcd in {product-title} was updated from etcd v2 to v3 in a
+link:https://docs.openshift.com/container-platform/3.4/release_notes/ocp_3_4_release_notes.html#ocp-34-notable-technical-changes[previous release], {product-title} continued using an etcd v2 data model and API for both new and upgraded clusters.
 
-For existing clusters that upgraded to {product-title} 3.6, however, the etcd
-data must be migrated from v2 to v3 as a post-upgrade step. This must be
-performed using openshift-ansible version 3.6.173.0.21 or later.
+Starting with {product-title} 3.6, new installations began using the v3 data
+model as well, providing
+xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[improved performance and scalability]. For existing clusters that upgraded to
+{product-title} 3.6, however, the etcd data can be migrated from v2 to v3 using the post-upgrade steps below.
+
+[NOTE]
+====
+{product-title} 3.6 does not enforce or require the migration from etcd data
+model v2 to v3. However, the migration is required before upgrading to {product-title} 3.7.
+See
+xref:../../scaling_performance/host_practices.adoc#scaling-performance-capacity-host-practices-etcd[Recommended Practices for OpenShift Container Platform etcd Hosts] for more details.
+====
 
 Until {product-title} 3.6, it was possible to deploy a cluster with an embedded
 etcd. As of {product-title} 3.7, this is no longer possible. See
@@ -82,6 +86,14 @@ and enable the 3.7 channel on the host you are running the migration from:
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-fast-datapath-rpms"
 # yum clean all
+----
+
+. The migration can only be performed using *openshift-ansible* version
+3.6.173.0.21 or later. Ensure you have the latest version of the
+*openshift-ansible* packages installed:
++
+----
+# yum upgrade openshift-ansible\*
 ----
 
 . Run the *_migrate.yml_* playbook using your inventory file:


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1533656

Per QE's recommendation (https://bugzilla.redhat.com/show_bug.cgi?id=1523375#c4) that similar tweaks be made to the 3.7 version of the doc:

http://file.rdu.redhat.com/~adellape/011118/37_etcdnote/install_config/upgrading/migrating_etcd.html#overview

@sdodson @openshift/team-documentation PTAL again, this time for 3.7?