### PR TITLE
[enterprise-3.5] fix typo for heketi sample topology file name

### DIFF
--- a/install_config/storage_examples/containerized_heketi_with_dedicated_gluster.adoc
+++ b/install_config/storage_examples/containerized_heketi_with_dedicated_gluster.adoc
@@ -112,12 +112,12 @@ a Gluster volume, it is skipped and ignored.
 ====
 
 . Create and load the topology file. There is a sample file located in
-*_/usr/share/heketi/toplogy-sample.json_* by default, or *_/etc/heketi_*
+*_/usr/share/heketi/topology-sample.json_* by default, or *_/etc/heketi_*
 depending on how it was installed.
 +
 [NOTE]
 ====
-Depending upon your method of installation this file may not exist. If it is missing, manually create the *_toplogy-sample.json_* file, as shown in the following example.
+Depending upon your method of installation this file may not exist. If it is missing, manually create the *_topology-sample.json_* file, as shown in the following example.
 ====
 +
 [source, json]
@@ -188,7 +188,7 @@ environment.
 +
 [source, bash]
 ----
-$ heketi-cli topology load --json=toplogy-sample.json
+$ heketi-cli topology load --json=topology-sample.json
 
     	Found node gluster23.rhs on cluster bdf9d8ca3fa269ff89854faf58f34b9a
    		Adding device /dev/sde ... OK

--- a/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
@@ -151,7 +151,7 @@ a Gluster volume, it will be skipped and ignored.
 ====
 
 . Create and load the topology file. There is a sample file located in
-*_/usr/share/heketi/toplogy-sample.json_* by default, or *_/etc/heketi_*
+*_/usr/share/heketi/topology-sample.json_* by default, or *_/etc/heketi_*
 depending on how it was installed.
 +
 [source,json]


### PR DESCRIPTION
(cherry picked from commit 5ad2b4462af06a7cbfb21e3322e4cfb7be83ba7c) xref:https://github.com/openshift/openshift-docs/pull/7020