### PR TITLE
Updated support matrix links

### DIFF
--- a/dev_guide/migrating_applications/web_framework_applications.adoc
+++ b/dev_guide/migrating_applications/web_framework_applications.adoc
@@ -53,7 +53,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 |===
 |v2 |v3
 
-|Python: 2.6, 2.7, 3.3   |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|Python: 2.6, 2.7, 3.3   |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |Django     |Django-psql-example (quickstart)
 
@@ -111,7 +111,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 |===
 |v2 |v3
 
-|Ruby: 1.8, 1.9, 2.0   |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|Ruby: 1.8, 1.9, 2.0   |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |Ruby on Rails: 3, 4     |Rails-postgresql-example (quickstart)
 
@@ -156,7 +156,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 |===
 |v2 |v3
 
-|PHP: 5.3, 5.4   |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|PHP: 5.3, 5.4   |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |PHP 5.4 with Zend Server 6.1    |
 
@@ -237,7 +237,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 |===
 |v2 |v3
 
-|Perl: 5.10  |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|Perl: 5.10  |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |    |Dancer-mysql-example (quickstart)
 
@@ -300,7 +300,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 |===
 |v2 |v3
 
-|Node.js 0.10  |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|Node.js 0.10  |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |    |Nodejs-mongodb-example. This quickstart template only supports Node.js version 6.
 
@@ -458,9 +458,9 @@ ifdef::openshift-enterprise,openshift-origin[]
 
 |JBoss App Server 7  |
 
-|Tomcat 6 (JBoss EWS 1.0)   |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|Tomcat 6 (JBoss EWS 1.0)   |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
-|Tomcat 7 (JBoss EWS 2.0)  |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|Tomcat 7 (JBoss EWS 2.0)  |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |Vert.x 2.1  |
 
@@ -472,15 +472,15 @@ ifdef::openshift-enterprise,openshift-origin[]
 
 |CapeDwarf  |
 
-|JBoss Data Virtualization 6  |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|JBoss Data Virtualization 6  |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
-|JBoss Enterprise App Platform (EAP) 6   |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|JBoss Enterprise App Platform (EAP) 6   |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |JBoss Unified Push Server 1.0.0.Beta1, Beta2  |
 
-|JBoss BPM Suite   |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|JBoss BPM Suite   |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
-|JBoss BRMS  |link:https://www.openshift.com/features/containers.html#enterprise36[Supported Container Images]
+|JBoss BRMS  |link:https://access.redhat.com/articles/2176281[Supported Container Images]
 
 |  |jboss-eap70-openshift: 1.3-Beta
 


### PR DESCRIPTION
Follow-up work to https://bugzilla.redhat.com/show_bug.cgi?id=1498912

cc @vikram-redhat @aheslin PTAL

Note that the Online and Dedicated support matrices links to https://www.openshift.com/features/containers.html are preserved, as https://access.redhat.com/articles/2176281 is only relevant to OCP.