### PR TITLE
[online-3.9] Bug 1506654, updated to state that oc exec does not work…

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -667,7 +667,7 @@ $ oc proxy --port=<port> --www=<static_directory>
 [IMPORTANT]
 ====
 link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. Instead,
-administrators can SSH into a node host, then use the `docker exec` command on
-the desired container.
+`oc exec` command does not work when accessing privileged containers except when
+the command is executed by a `cluster-admin` user. Administrators can SSH into
+a node host, then use the `docker exec` command on the desired container.
 ====

--- a/dev_guide/executing_remote_commands.adoc
+++ b/dev_guide/executing_remote_commands.adoc
@@ -18,7 +18,8 @@ to run general Linux commands for routine operations in the container.
 [IMPORTANT]
 ====
 link:https://access.redhat.com/errata/RHSA-2015:1650[For security purposes], the
-`oc exec` command does not work when accessing privileged containers. See the
+`oc exec` command does not work when accessing privileged containers except when
+the command is executed by a `cluster-admin` user. See the
 xref:../cli_reference/basic_cli_operations.adoc#troubleshooting-and-debugging-cli-operations[CLI
 operations topic] for more information.
 ====


### PR DESCRIPTION
… when accessing privileged containers except when the command is executed by a cluster-admin user

(cherry picked from commit e65385a74139ce5a800190673dc4093ab7a40ef8) xref:https://github.com/openshift/openshift-docs/pull/7060