### PR TITLE
[online-3.9] fix typo in image stream object definition

### DIFF
--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -353,7 +353,7 @@ status:
   dockerImageRepository: 172.30.56.218:5000/test/origin-ruby-sample <2>
   tags:
   - items:
-- created: 2017-09-02T10:15:09Z
+    - created: 2017-09-02T10:15:09Z
       dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d <3>
       generation: 2
       image: sha256:909de62d1f609a717ec433cc25ca5cf00941545c83a01fb31527771e1fab3fc5 <4>


### PR DESCRIPTION
(cherry picked from commit 2ef3963793c02dd756959263ee1b788126f68da9) xref:https://github.com/openshift/openshift-docs/pull/7166