### PR TITLE
Fix anchor that was changed to oc adm should be oadm

### DIFF
--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -24,7 +24,7 @@ it is also an all-in-one command that can perform all the same actions as the
 endif::[]
 
 ifdef::openshift-dedicated[]
-The `oc adm` command (formerly the `oc adm` command) is used for administrator CLI
+The `oc adm` command (formerly the `oadm` command) is used for administrator CLI
 operations.
 endif::[]
 The administrator CLI differs from the normal set of commands under the
@@ -39,7 +39,7 @@ depending on your account type.
 ====
 endif::[]
 
-[[oc adm-common-operations]]
+[[oadm-common-operations]]
 
 == Common Operations
 The administrator CLI allows interaction with the various objects that are


### PR DESCRIPTION
Changes two references to oadm to oc adm that should remain oadm via
https://github.com/openshift/openshift-docs/pull/7132