### PR TITLE
Bug#1397521 - Ingress Configuration now links to cloud providers example

### DIFF
--- a/admin_guide/tcp_ingress_external_ports.adoc
+++ b/admin_guide/tcp_ingress_external_ports.adoc
@@ -16,11 +16,11 @@ One approach to getting
 xref:../dev_guide/expose_service/index.adoc#getting-traffic-into-cluster-index[external
 traffic into the cluster] is by using ExternalIP or IngressIP addresses.
 
-[NOTE]
+[IMPORTANT]
 ====
-This feature is only supported in non-cloud deployments. For cloud (GCE, AWS, and OpenStack) deployments,
+This feature is only supported in non-cloud deployments. For cloud (GCE, AWS, and OpenStack) deployments, use the
 xref:../dev_guide/expose_service/expose_internal_ip_load_balancer.adoc#getting-traffic-into-cluster-load[load
-Balancer] services can be used to automatically deploy a cloud load balancer to target the service's endpoints.
+Balancer] services for automatic deployment of a cloud load balancer to target the service's endpoints.
 ====
 
 {product-title} supports two pools of IP addresses:
@@ -70,20 +70,13 @@ xref:../admin_guide/high_availability.adoc#configuring-ip-failover[`*oc adm ipfa
 For manually-configured external IPs, potential port clashes are handled on a first-come, first-served basis. If you request a port, it is only available if it has not yet been assigned for that IP address. For example:
 
 .Port clash example for manually-configured external IPs
-====
 Two services have been manually configured with the same external
 IP address of 172.7.7.7.
 
 `MongoDB service A` requests port 27017, and then
 `MongoDB service B` requests the same port; the first request gets the port.
-====
 
 However, port clashes are not an issue for external IPs assigned by the ingress controller, because the controller assigns each service a unique address.
-
-[NOTE]
-====
-Ingress IPs can only be assigned if the cluster is not running in the cloud. In cloud environments, LoadBalancer-type services configure cloud-specific load balancers.
-====
 
 [[unique-external-ips-ingress-traffic-configure-cluster]]
 == Configuring the Cluster to Use Unique External IPs
@@ -112,12 +105,12 @@ If you are using xref:../admin_guide/high_availability.adoc#admin-guide-high-ava
 endif::[]
 
 .Sample /etc/origin/master/master-config.yaml
-====
+
+[source,yaml]
 ----
 networkConfig:
   ingressIPNetworkCIDR: 172.29.0.0/16
 ----
-====
 
 [[unique-external-ips-ingress-traffic-configure-service]]
 === Configuring an Ingress IP for a Service
@@ -127,7 +120,7 @@ To assign an ingress IP:
 . Create a YAML file for a LoadBalancer service that requests a specific IP via the `*loadBalancerIP*` setting:
 +
 .Sample LoadBalancer Configuration
-====
+[source,yaml]
 ----
 apiVersion: v1
 kind: Service
@@ -142,14 +135,16 @@ spec:
   selector:
     name: my-db-selector
 ----
-====
+
 . Create a LoadBalancer service on your pod:
 +
+[source,bash]
 ----
 $ oc create -f loadbalancer.yaml
 ----
 . Check the service for an external IP. For example, for a service named `myservice`:
 +
+[source,bash]
 ----
 $ oc get svc myservice
 ----
@@ -157,6 +152,7 @@ $ oc get svc myservice
 When your LoadBalancer-type service has an external IP assigned, the output
 displays the IP:
 +
+[source,bash]
 ----
 NAME         CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
 myservice    172.30.74.106   172.29.0.1    3306/TCP    30s
@@ -195,15 +191,13 @@ The externalIPs must be selected by the administrator from the
 endif::[]
 
 .Sample externalIPNetworkCIDR /etc/origin/master/master-config.yaml
-====
+[source,yaml]
 ----
 networkConfig:
   externalIPNetworkCIDR: 172.47.0.0/24
 ----
-====
 
 .Service externalIPs Definition (JSON)
-====
 
 [source,json]
 ----
@@ -233,5 +227,3 @@ networkConfig:
 ----
 
 <1> List of External IP addresses on which the *port* is exposed. In addition to the internal IP addresses)
-
-====


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1397521

- Removed the older note with no information on Cloud providers
- Highlighted a note which points to info on how to handle the same using Load balancers
- Other minor formatting fixes