### PR TITLE
[enterprise-3.9] add a sample dockerfile for consuming input secrets

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -784,9 +784,28 @@ into that directory, relative to your *_Dockerfile_* location. This makes the
 secret files available to the Docker build operation as part of the context
 directory used during the build.
 
+.Example of a Dockerfile referencing secret data
+====
+----
+FROM centos/ruby-22-centos7
+
+USER root
+ADD ./secret-dir /secrets
+COPY ./secret2 /
+
+# Create a shell script that will output secrets when the image is run
+RUN echo '#!/bin/sh' > /secret_report.sh
+RUN echo '(test -f /secrets/secret1 && echo -n "secret1=" && cat /secrets/secret1)' >> /secret_report.sh
+RUN echo '(test -f /secret2 && echo -n "relative-secret2=" && cat /secret2)' >> /secret_report.sh
+RUN chmod 755 /secret_report.sh
+
+CMD ["/bin/sh", "-c", "/secret_report.sh"]
+----
+====
+
 [NOTE]
 ====
-Users should always remove their input secrets from the final application image
+Users should normally remove their input secrets from the final application image
 so that the secrets are not present in the container running from that image.
 However, the secrets will still exist in the image itself in the layer where
 they were added. This removal should be part of the *_Dockerfile_* itself.


### PR DESCRIPTION
(cherry picked from commit 8f2ba27bc10195e7e9f1b1e2ef5d1801963825e4) xref:https://github.com/openshift/openshift-docs/pull/7214