### PR TITLE
[enterprise-3.9] correct documented 'git clone' behaviour

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -216,22 +216,15 @@ containing a Dockerfile that overwrites any Dockerfile that may exist in the
 source repository.
 endif::[]
 
-When using the Git repository as a source without specifying the `ref`
-field, {product-title} performs a shallow clone (`--depth=1` clone). That means
-only the `HEAD` (usually the `master` branch) is downloaded. This results
-in repositories downloading faster, including the commit history.
-
-A shallow clone is also used when the `ref` field is specified and set to an
-existing remote branch name. However, if you specify the `ref` field to a
-specific commit, the system will fallback to a `git clone` operation and
-checkout the commit, because using the `--depth=1` option only works with named
-branch refs.
-
 If the `ref` field denotes a pull request, the system will use a `git fetch` operation
 and then checkout `FETCH_HEAD`.
 
-To perform a full `git clone` of the `master` for the specified repository, set
-the `ref` to `master`.
+When no `ref` value is provided, {product-title} performs a shallow clone
+(`--depth=1`).  In this case, only the files associated with the most recent
+commit on the default branch (typically `master`) are downloaded.  This results
+in repositories downloading faster, but without the full commit history.  To
+perform a full `git clone` of the default branch of a specified repository, set
+`ref` to the name of the default branch (for example `master`).
 
 [[using-a-proxy-for-git-cloning]]
 === Using a Proxy


### PR DESCRIPTION
(cherry picked from commit caece2f6126381e4ae6317da5cc04091165b1e3a) xref:https://github.com/openshift/openshift-docs/pull/7108