### PR TITLE
[enterprise-3.9] document spaces in JENKINS_JAVA_OVERRIDES, JNLP_JAVA…

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -230,7 +230,9 @@ override this.
 +
 Specifies additional options for the Jenkins JVM. These options are appended to
 all other options, including the Java options above, and may be used to override
-any of them if necessary.
+any of them if necessary.  Separate each additional option with a space; if any
+option contains space characters, escape them with a backslash.  Example
+settings: `-Dfoo -Dbar`; `-Dfoo=first\ value -Dbar=second\ value`.
 
 * `JENKINS_OPTS`
 +

--- a/using_images/other_images/jenkins_slaves.adoc
+++ b/using_images/other_images/jenkins_slaves.adoc
@@ -146,7 +146,9 @@ recommended to override this.
 +
 Specifies additional options for the Jenkins slave agent JVM. These options are
 appended to all other options, including the Java options above, and may be used
-to override any of them if necessary.
+to override any of them if necessary.  Separate each additional option with a
+space; if any option contains space characters, escape them with a backslash.
+Example settings: `-Dfoo -Dbar`; `-Dfoo=first\ value -Dbar=second\ value`.
 
 [[usage]]
 == Usage


### PR DESCRIPTION
…_OVERRIDES

(cherry picked from commit 1335dcd90d53721ad0e888950d6191eb70bcb7d1) xref:https://github.com/openshift/openshift-docs/pull/7213