### PR TITLE
Bug 1520176 Correct logging variable and install default status

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1563,15 +1563,14 @@ openshift_metrics_cassandra_storage_type=dynamic
 [[advanced-install-cluster-logging]]
 === Configuring Cluster Logging
 
-Starting with {product-title} 3.7, cluster logging is set to deploy
-automatically by default during installation.
+Cluster logging is not set to automatically deploy by default. Set the
+following to enable cluster logging when using the advanced installation method:
 
-[NOTE]
 ====
-To disable automatic deployment, set the following cluster variable:
-
 ----
-openshift_logging_install_logging=false
+[OSEv3:vars]
+
+openshift_logging_install_logging=true
 ----
 ====
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1520176

@ewolinetz @jcantrill I changed this content according to the feedback from IRC yesterday. Is the `openshift_hosted_logging_deploy=true` variable still correct?

Thanks!