### PR TITLE
[enterprise-3.9] added metadata:name to templates

### DIFF
--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -503,6 +503,8 @@ Here is an example of a full template with parameter definitions and references:
 ----
 kind: Template
 apiVersion: v1
+metadata:
+  name: my-template
 objects:
   - kind: BuildConfig
     apiVersion: v1
@@ -579,6 +581,8 @@ earlier.
 ----
 kind: "Template"
 apiVersion: "v1"
+metadata:
+  name: my-template
 objects:
   - kind: "Service" <1>
     apiVersion: "v1"
@@ -660,27 +664,31 @@ Unless escaped with a backslash, Kubernetes' JSONPath implementation interprets
 characters such as `.`, `@`, and others as metacharacters, regardless of their
 position in the expression. Therefore, for example, to refer to a `ConfigMap`
 datum named `my.key`, the required JSONPath expression would be
-`{.data['my\.key']}`.
+`{.data['my\.key']}`. Depending on how the JSONPath expression is then written in YAML, 
+an additional backslash might be required, for example `"{.data['my\\.key']}"`.
 ====
 
 The following is an example of different objects' fields being exposed:
 
-====
 [source,yaml]
 ----
 kind: Template
 apiVersion: v1
+metadata:
+  name: my-template
 objects:
 - kind: ConfigMap
   apiVersion: v1
   metadata:
+    name: my-template-config
     annotations:
-      template.openshift.io/expose-username: "{.data['my\.username']}"
+      template.openshift.io/expose-username: "{.data['my\\.username']}"
   data:
     my.username: foo
 - kind: Secret
   apiVersion: v1
   metadata:
+    name: my-template-config-secret
     annotations:
       template.openshift.io/base64-expose-password: "{.data['password']}"
   stringData:
@@ -688,6 +696,7 @@ objects:
 - kind: Service
   apiVersion: v1
   metadata:
+    name: my-template-service
     annotations:
       template.openshift.io/expose-service_ip_port: "{.spec.clusterIP}:{.spec.ports[?(.name==\"web\")].port}"
   spec:
@@ -697,11 +706,12 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
+    name: my-template-route
     annotations:
       template.openshift.io/expose-uri: "http://{.spec.host}{.spec.path}"
   spec:
     path: mypath
-====
+----
 
 An example response to a `bind` operation given the above partial template
 follows:
@@ -801,6 +811,8 @@ annotation. Further examples can be found in the OpenShift quickstart templates.
 ----
 kind: Template
 apiVersion: v1
+metadata:
+  name: my-template
 objects:
 - kind: BuildConfig
   apiVersion: v1


### PR DESCRIPTION
(cherry picked from commit b904e40531e1bd811f4a8c203c77085be2e4bf6f) xref:https://github.com/openshift/openshift-docs/pull/7071