### PR TITLE
[enterprise-3.9] Documenting Cluster Loader's additional functionality.

### DIFF
--- a/scaling_performance/using_cluster_loader.adoc
+++ b/scaling_performance/using_cluster_loader.adoc
@@ -85,17 +85,21 @@ end of the test.
 |A sub-object with one or many definition(s). Under `projects`, each
 namespace to create is defined and `projects` has several mandatory subheadings.
 
-|`tuningSet`
+|`tuningset`
 |A sub-object with one definition per configuration. `TuningSet` allows the user
 to define a tuning set to add configurable timing to project or object creation
 (pods, templates, etc).
+
+|`sync`
+|An optional sub-object with one definition per configuration. Adds synchronization 
+possibilies during object creation.
 |===
 
 .Fields under `projects`
 |===
 |Field |Description
 
-|`number`
+|`num`
 |An integer. One definition of the count of how many projects to create.
 
 |`basename`
@@ -105,6 +109,14 @@ identical namespaces will be appended to `Basename` to prevent collisions.
 |`tuning`
 |A string. One definition of what tuning set you want to apply to the objects,
 which you deploy inside this namespace.
+
+|`configmaps`
+|A list of key-value pairs. Key is ConfigMap name, value is a path to a file to create
+the ConfigMap from.
+
+|`secrets`
+|A list of key-value pairs. Key is Secret name, value is a path to a file to create
+the Secret from.
 
 |`pods`
 |A sub-object with one or many definition(s) of pods to deploy.
@@ -120,7 +132,7 @@ which you deploy inside this namespace.
 |`total`
 |This field is not used.
 
-|`number`
+|`num`
 |An integer. The number of pods or templates to deploy.
 
 |`image`
@@ -181,8 +193,32 @@ defined in `stepsize`.
 not successful.
 
 |`delay`
-|An integer. How many milliseconds (ms) to wait between creation requests
+|An integer. How many milliseconds (ms) to wait between creation requests.
 |===
+
+.Fields under `sync`
+|===
+|Field |Description
+
+|`server`
+|A sub-object with `enabled` and `port` fields. Boolean `enabled` defines
+whether to start a HTTP server for pod synchronization.  Integer `port`
+defines HTTP server port to listen on (9090 by default).
+
+|`running`
+|A boolean. Wait for pods with labels matching `selectors` to go into Running state?
+
+|`succeeded`
+|A boolean. Wait for pods with labels matching `selectors` to go into Completed state?
+
+|`selectors`
+|A list of selectors to match pods in Running/Completed states.
+
+|`timeout`
+|A string. Synchronization timeout to wait for pods in Running/Completed states. For non 0 values use 
+units: [ns\|us\|ms\|s\|m\|h].
+|===
+
 
 [[configuring-cluster-loader-configuration-file-example]]
 === Example Cluster Loader Configuration File


### PR DESCRIPTION
Documenting synchronization primitives and the possibility
to create ConfigMaps and Secrets from files as implemented by
https://github.com/openshift/origin/pull/17894

(cherry picked from commit c85b8a91c40951f2f9e2b9fa91fd1191d2ea57e9) xref:https://github.com/openshift/openshift-docs/pull/7297