### PR TITLE
[enterprise-3.9] Use oc create secret instead of deprecated oc secret…

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -434,7 +434,7 @@ it to the builder service account, and then your `BuildConfig`.
 To create a secret from a *_.gitconfig_* file:
 
 ----
-$ oc secrets new mysecret .gitconfig=path/to/.gitconfig
+$ oc create secret generic <secret_name> --from-file=<path/to/.gitconfig>
 ----
 
 [NOTE]
@@ -458,16 +458,19 @@ Create the `secret` first before using the user name and password to access the
 private repository:
 
 ----
-$ oc secrets new-basicauth <secret_name> \
-    --username=<user_name> \
-    --password=<password>
+$ oc create secret generic <secret_name> \
+    --from-literal=username=<user_name> \
+    --from-literal=password=<password> \
+    --type=kubernetes.io/basic-auth
 ----
 
 To create a basic authentication secret with a token:
 
 ----
-$ oc secrets new-basicauth <secret_name> \
-    --password=<token>
+$ oc create secret generic <secret_name> \
+    --from-literal=password=<token> \
+    --type=kubernetes.io/basic-auth
+
 ----
 
 [[source-secrets-ssh-key-authentication]]
@@ -498,8 +501,9 @@ Before using the SSH key to access the private repository, create the secret
 first:
 
 ----
-$ oc secrets new-sshauth sshsecret \
-    --ssh-privatekey=$HOME/.ssh/id_rsa
+$ oc create secret generic <secret_name> \
+    --from-file=ssh-privatekey=<path/to/ssh/private/key> \
+    --type=kubernetes.io/ssh-auth
 ----
 
 [[source-secrets-trusted-certificate-authorities]]
@@ -519,7 +523,7 @@ significantly more secure than disabling Git's SSL verification, which accepts
 any TLS certificate that is presented.
 +
 ----
-$ oc secrets new mycert ca.crt=</path/to/file> <1>
+$ oc create secret generic mycert --from-file=ca.crt=</path/to/file> <1>
 ----
 <1> The key name *_ca.crt_* must be used.
 
@@ -540,45 +544,49 @@ creating source clone secrets for your specific needs.
 .. To create an SSH-based authentication secret with a *_.gitconfig_* file:
 +
 ----
-$ oc secrets new-sshauth sshsecret \
-    --ssh-privatekey=$HOME/.ssh/id_rsa \
-    --gitconfig=</path/to/file>
+$ oc create secret generic <secret_name> \
+    --from-file=ssh-privatekey=<path/to/ssh/private/key> \
+    --from-file=<path/to/.gitconfig> \
+    --type=kubernetes.io/ssh-auth
 ----
 
 .. To create a secret that combines a *_.gitconfig_* file and CA certificate:
 +
 ----
-$ oc secrets new mysecret \
-    ca.crt=path/to/certificate \
-    .gitconfig=path/to/.gitconfig
+$ oc create secret generic <secret_name> \
+    --from-file=ca.crt=<path/to/certificate> \
+    --from-file=<path/to/.gitconfig>
 ----
 
 .. To create a basic authentication secret with a CA certificate file:
 +
 ----
-$ oc secrets new-basicauth <secret_name> \
-    --username=<user_name> \
-    --password=<password> \
-    --ca-cert=</path/to/file>
+$ oc create secret generic <secret_name> \
+    --from-literal=username=<user_name> \
+    --from-literal=password=<password> \
+    --from-file=ca-cert=</path/to/file> \
+    --type=kubernetes.io/basic-auth
 ----
 
 .. To create a basic authentication secret with a *_.gitconfig_* file:
 +
 ----
-$ oc secrets new-basicauth <secret_name> \
-    --username=<user_name> \
-    --password=<password> \
-    --gitconfig=</path/to/file>
+$ oc create secret generic <secret_name> \
+    --from-literal=username=<user_name> \
+    --from-literal=password=<password> \
+    --from-file=</path/to/.gitconfig> \
+    --type=kubernetes.io/basic-auth
 ----
 
 .. To create a basic authentication secret with a *_.gitconfig_* file and CA certificate file:
 +
 ----
-$ oc secrets new-basicauth <secret_name> \
-    --username=<user_name> \
-    --password=<password> \
-    --gitconfig=</path/to/file> \
-    --ca-cert=</path/to/file>
+$ oc create secret generic <secret_name> \
+    --from-literal=username=<user_name> \
+    --from-literal=password=<password> \
+    --from-file=</path/to/.gitconfig> \
+    --from-file=ca-cert=</path/to/file> \
+    --type=kubernetes.io/basic-auth
 ----
 
 
@@ -681,7 +689,8 @@ To add an input secret to an existing `BuildConfig`:
 . Create the secret, if it does not exist:
 +
 ----
-$ oc secrets new secret-npmrc .npmrc=~/.npmrc
+$ oc create secret generic secret-npmrc \
+    --from-file=.npmrc=<path/to/.npmrc>
 ----
 +
 This creates a new secret named *_secret-npmrc_*, which contains the base64
@@ -929,7 +938,9 @@ be used to store configuration and passwords.
 . Create the secret from your local *_.docker/config.json_* file:
 +
 ----
-$ oc secrets new dockerhub ~/.docker/config.json
+$ oc create secret generic dockerhub \
+    --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
+    --type=kubernetes.io/dockerconfigjson
 ----
 +
 This generates a JSON specification of the secret named `dockerhub` and

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -605,22 +605,28 @@ If you already have a *_.dockercfg_* file for
 the secured registry, you can create a secret from that file by running:
 
 ----
-$ oc secrets new <pull_secret_name> .dockercfg=<path/to/.dockercfg>
+$ oc create secret generic <pull_secret_name> \
+    --from-file=.dockercfg=<path/to/.dockercfg> \
+    --type=kubernetes.io/dockercfg
 ----
 
 Or if you have a *_$HOME/.docker/config.json_* file:
 
 ----
-$ oc secrets new <pull_secret_name> .dockerconfigjson=<path/to/.docker/config.json>
+$ oc create secret generic <pull_secret_name> \
+    --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
+    --type=kubernetes.io/dockerconfigjson
 ----
 
 If you do not already have a Docker credentials file for the secured registry,
 you can create a secret by running:
 
 ----
-$ oc secrets new-dockercfg <pull_secret_name> \
-    --docker-server=<registry_server> --docker-username=<user_name> \
-    --docker-password=<password> --docker-email=<email>
+$ oc create secret docker-registry <pull_secret_name> \
+    --docker-server=<registry_server> \
+    --docker-username=<user_name> \
+    --docker-password=<password> \
+    --docker-email=<email>
 ----
 
 To use a secret for pulling images for pods, you must add the secret to your
@@ -658,7 +664,7 @@ applies.
 . Create a secret for the delegated authentication server:
 +
 ----
-$ oc secret new-dockercfg \
+$ oc create secret docker-registry \
     --docker-server=sso.redhat.com \
     --docker-username=developer@example.com \
     --docker-password=******** \
@@ -671,7 +677,7 @@ secret/redhat-connect-sso
 . Create a secret for the private registry:
 +
 ----
-$ oc secret new-dockercfg \
+$ oc create secret docker-registry \
     --docker-server=privateregistry.example.com \
     --docker-username=developer@example.com \
     --docker-password=******** \
@@ -695,7 +701,7 @@ $ docker login registry.connect.redhat.com --username developer@example.com
 Password: *************
 Login Succeeded
 
-$ oc secret new redhat-connect .dockerconfigjson=/root/.docker/config.json
+$ oc create secret generic redhat-connect --from-file=.dockerconfigjson=.docker/config.json
 
 $ oc secrets link default redhat-connect --for=pull
 ----
@@ -969,7 +975,7 @@ which is used to store your credentials.
 Create the secret first, before importing the image from the private repository:
 
 ----
-$ oc secrets new-dockercfg <secret_name> \
+$ oc create secret docker-registry <secret_name> \
     --docker-server=<docker_registry_server> \
     --docker-username=<docker_user> \
     --docker-password=<docker_password> \
@@ -979,7 +985,7 @@ $ oc secrets new-dockercfg <secret_name> \
 For more options, see:
 
 ----
-$ oc secrets new-dockercfg --help
+$ oc create secret docker-registry --help
 ----
 
 After the secret is configured, proceed with creating the new image stream or
@@ -1053,15 +1059,15 @@ Before performing this procedure, the following must be satisfied:
 
 - The destination project you push to must already exist.
 - The user must be authorized to `{get, update} "imagestream/layers"` in that
-project. In addition, since the image stream does not already exist, the user 
-must be authorized to `{create} "imagestream"` in that project.  If you are a project 
+project. In addition, since the image stream does not already exist, the user
+must be authorized to `{create} "imagestream"` in that project.  If you are a project
 administrator, then you would have these permissions.
 
 [NOTE]
 ====
 The *system:image-pusher* role does not grant permission to create new image streams,
 only to push images to existing image streams, so it cannot be used to push images
-to image streams that do not yet exist unless additional permissions are also granted to 
+to image streams that do not yet exist unless additional permissions are also granted to
 the user.
 ====
 

--- a/dev_guide/service_accounts.adoc
+++ b/dev_guide/service_accounts.adoc
@@ -101,10 +101,12 @@ This example creates and adds secrets to a service account:
 
 ====
 ----
-$ oc secrets new secret-plans plan1.txt plan2.txt
+$ oc create secret generic secret-plans \
+    --from-file=plan1.txt \
+    --from-file=plan2.txt
 secret/secret-plans
 
-$ oc secrets new-dockercfg my-pull-secret \
+$ oc create secret docker-registry my-pull-secret \
     --docker-username=mastermind \
     --docker-password=12345 \
     --docker-email=mastermind@example.com


### PR DESCRIPTION
…s subcommands

(cherry picked from commit dd90773f3100b0a58f110e8075b07e118b079ca7) xref:https://github.com/openshift/openshift-docs/pull/7262