### PR TITLE
Fixed playbook path.

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1259,7 +1259,7 @@ Remove everything generated during the deployment.
 
 ifdef::openshift-origin[]
 ----
-$ ansible-playbook playbooks/openshift-logging/config.yml \
+$ ansible-playbook playbooks/byo/openshift-cluster/openshift-logging.yml \
     -e openshift_logging_install_logging=False
 ----
 endif::openshift-origin[]
@@ -1267,7 +1267,7 @@ endif::openshift-origin[]
 ifdef::openshift-enterprise[]
 ----
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
     -e openshift_logging_install_logging=False
 ----
 endif::openshift-enterprise[]


### PR DESCRIPTION
In https://docs.openshift.com/container-platform/3.7/install_config/aggregate_logging.html#aggregate-logging-cleanup var "-e openshift_logging_install_logging=False" is missing but in repo is right.

Is master the right branch to do MR?