### PR TITLE
Automatic width for columns

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -15,7 +15,7 @@ $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 ----
 
 .Router Environment Variables
-[cols="2,2,6", options="header"]
+[cols="2,2,6", options="header,autowidth"]
 |===
 |Variable | Default | Description
 |`DEFAULT_CERTIFICATE` |  | The contents of a default certificate to use for routes that don't expose a TLS server cert; in PEM format.


### PR DESCRIPTION
due to the fact that the https://docs.openshift.org/latest/architecture/networking/routes.html#env-variables does not fits into the content width let's calculate the asciidoctor the width for the columns