### PR TITLE
[enterprise-3.7] Fix command typo

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -593,7 +593,7 @@ openshift_examples_modify_imagestreams=true
 Depending on your registry, you may need to configure:
 ----
 openshift_docker_additional_registries=example.com
-oopenshift_docker_insecure_registries=example.com
+openshift_docker_insecure_registries=example.com
 ----
 
 .Registry Variables


### PR DESCRIPTION
(cherry picked from commit 1beb22c5770b76c3dfab80c7fbec189721163aaf) xref:https://github.com/openshift/openshift-docs/pull/7433