### PR TITLE
Bug 1491127, clarified details about technology preview features

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -1007,8 +1007,6 @@ how to configure HAProxy routers to allow wildcard routes].
 Sometimes features are available in Technology Preview. By default, these
 features are disabled and hidden in the web console.
 
-Currently, there are no web console features in Technology Preview.
-
 To enable a Technology Preview feature:
 
 . Save this script to a file (for example, *_tech-preview.js_*):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1491127

@spadgett @jwforres According to the above BZ, is the other information on enabling features in Technology Preview still accurate? Statefulsets does not seem to be disabled by default in the web console, so should we update some of the language there?  I removed mention of what is currently in tech preview, as this would need to be maintained across each release. Thanks!