### PR TITLE
[online-3.7] Router - document published metrics 

### DIFF
--- a/architecture/topics/haproxy_template_router.adoc
+++ b/architecture/topics/haproxy_template_router.adoc
@@ -28,3 +28,101 @@ plug-in and finally into an HAProxy configuration:
 
 .HAProxy Router Data Flow
 image::router_model.png[HAProxy Router Data Flow]
+
+[[haproxy-metrics]]
+=== HAProxy Template Router Metrics
+
+The HAProxy router exposes or publishes metrics in
+link:https://Prometheus.io/docs/concepts/data_model/[Prometheus format]
+for consumption by external metrics collection and aggregation systems (e.g. Prometheus, statsd).
+The router can be
+xref:../../install_config/router/default_haproxy_router.adoc#exposing-the-router-metrics[confiugred]
+to provide
+link:https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#9[HAProxy CSV format] metrics, or
+provide no router metrics at all.
+
+The metrics are collected from both the router controller and from HAProxy every 5 seconds.
+The router metrics counters start at zero when the router is deployed and increase over time.
+The HAProxy metrics counters are reset to zero every time haproxy is reloaded.  The router
+collects HAProxy statistics for each frontend, backend and server.  To reduce resource usage
+when there are more than 500 servers, the backends are reported instead of the servers since
+a backend can have multiple servers.
+
+The statistics are a subset of the available HAProxy
+link:https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#9.1[Statistics].
+
+The following HAProxy metrics are collected on a preiodic basis and converted to Prometheus
+format.  For every frontend the "F" counters are collected. When the total number of servers
+is less than the Server Threshold (default 500), the "b" counters are collected for each
+backend and the "S" server counters are collected for each server. Otherwise, the "B"
+counters are collected for each backend and no server counters are collected.
+
+In the following table:
+
+Column 1 - Index from HAProxy CSV statistics
+
+Column 2
+|===
+|F|Frontend metrics
+|b|Backend metrics when not showing Server metrics due to the Server Threshold,
+|B|Backend metrics when showing Server metrics
+|S|Server metrics.
+|===
+
+Column 3 - The counter
+
+Column 4 - Counter description
+// defaultSelectedMetrics = []int{2, 4, 5, 7, 8, 9, 13, 14, 17, 21, 24, 33, 35, 40, 43, 60}
+// reducedBackendExports: map[int]struct{}{2: {}, 3: {}, 7: {}, 17: {}},
+|===
+|Index|Usage|Counter|Description
+|2|bBS|current_queue|Current number of queued requests not assigned to any server.
+//|3|bBS|max_queue|Maximum observed number of queued requests not assigned to any server.
+|4|FbS|current_sessions|Current number of active sessions.
+|5|FbS|max_sessions|Maximum observed number of active sessions.
+//|6|FbS|limit_sessions|Configured session limit.
+|7|FbBS|connections_total|Total number of connections.
+|8|FbS|bytes_in_total|Current total of incoming bytes.
+|9|FbS|bytes_out_total|Current total of outgoing bytes.
+//|10|F|requests_denied_total|Total of requests denied for security.
+//|12|F|request_errors_total|Total of request errors.
+|13|bS|connection_errors_total|Total of connection errors.
+|14|bS|response_errors_total|Total of response errors.
+//|15|bS|retry_warnings_total|Total of retry warnings.
+//|16|bS|redispatch_warnings_total|Total of redispatch warnings.
+|17|bBS|up|Current health status of the backend (1 = UP, 0 = DOWN).
+//|18|b.S|weight|Total weight of the servers in the backend.
+|21|S|check_failures_total|Total number of failed health checks.
+|24|S|downtime_seconds_total|Total downtime in seconds.", nil),
+|33|FbS|current_session_rate|Current number of sessions per second over last elapsed second.
+//|34|F|limit_session_rate|Configured limit on new sessions per second.
+|35|FbS|max_session_rate|Maximum observed number of sessions per second.
+//|38|S|check_duration_milliseconds|Previously run health check duration, in milliseconds.
+//|39|FbS|http_responses_total|Total of HTTP responses, code 1xx
+|40|FbS|http_responses_total|Total of HTTP responses, code 2xx
+//|41|FbS|http_responses_total|Total of HTTP responses, code 3xx
+//|42|FbS|http_responses_total|Total of HTTP responses, code 4xx
+|43|FbS|http_responses_total|Total of HTTP responses, code 5xx
+//|44|FbS|http_responses_total|Total of HTTP responses, code other
+//|48|F|http_requests_total|Total HTTP requests.
+|60|FbS|http_average_response_latency_milliseconds|of the last 1024 requests in milliseconds.
+|===
+
+
+The router controller scrapes the following items. These are only available with Prometheus format metrics.
+|===
+|Name|Description
+|template_router_reload_seconds|Measures the time spent reloading the router in seconds.
+|template_router_write_config_seconds|Measures the time spent writing out the router configuration to disk in seconds.
+|haproxy_exporter_up|Was the last scrape of haproxy successful.
+|haproxy_exporter_csv_parse_failures|Number of errors while parsing CSV.
+|haproxy_exporter_scrape_interval|The time in seconds before another scrape is allowed, proportional to size of data.
+|haproxy_exporter_server_threshold|Number of servers tracked and the current threshold value.
+|haproxy_exporter_total_scrapes|Current total HAProxy scrapes.
+|http_request_duration_microseconds|The HTTP request latencies in microseconds.
+|http_request_size_bytes|The HTTP request sizes in bytes.
+|http_response_size_bytes|The HTTP response sizes in bytes.
+|openshift_build_info|A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift was built.
+|ssh_tunnel_open_count|Counter of SSH tunnel total open attempts
+|ssh_tunnel_open_fail_count|Counter of SSH tunnel failed open attempts
+|===

--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -44,8 +44,10 @@ connections (and any time HAProxy is reloaded), the old HAProxy processes
 will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`ROUTER_DENIED_DOMAINS` | | A comma-separated list of domains that the host name in a route can not be part of. No subdomain in the domain can be used either. Overrides option `ROUTER_ALLOWED_DOMAINS`.
 |`ROUTER_ENABLE_COMPRESSION`| | If `true` or `TRUE`, compress responses when possible.
+|`ROUTER_LISTEN_ADDR`| 0.0.0.0:1936 | Sets the listening address for xref:../../install_config/router/default_haproxy_router.adoc#exposing-the-router-metrics[router metrics].
 |`ROUTER_LOG_LEVEL` | warning | The log level to send to the syslog server.
 |`ROUTER_MAX_CONNECTIONS`| 20000 | Maximum number of concurrent connections.
+|`ROUTER_METRICS_TYPE`| haproxy | Generate metrics for xref:../../install_config/router/default_haproxy_router.adoc#exposing-the-router-metrics[the HAProxy router]. (haproxy is the only supported value)
 |`ROUTER_OVERRIDE_HOSTNAME`|  | If set `true`, override the spec.host value for a route with the template in `ROUTER_SUBDOMAIN`.
 |`ROUTER_SERVICE_HTTPS_PORT` | 443 | Port to listen for HTTPS requests.
 |`ROUTER_SERVICE_HTTP_PORT` | 80 | Port to listen for HTTP requests.

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1133,117 +1133,96 @@ add routes across the namespaces.
 [[exposing-the-router-metrics]]
 == Exposing Router Metrics
 
-Using the `--metrics-image` and `--expose-metrics` options, you can configure
-the {product-title} router to run a sidecar container that exposes or publishes
-router metrics for consumption by external metrics collection and aggregation
-systems (e.g. Prometheus, statsd).
+The
+xref:../../architecture/networking/haproxy-router.adoc#haproxy-metrics[HAProxy router metrics]
+are, by default, exposed or published in
+link:https://prometheus.io/docs/concepts/data_model/[Prometheus format]
+for consumption by external metrics collection and aggregation systems (e.g. Prometheus, statsd).
+Metrics are also available dirctly from the
+link:https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#9[HAProxy router] in its own CSV format.
 
-Depending on your router implementation, the image is appropriately set up and
-the metrics sidecar container is started when the router is deployed. For
-example, the HAProxy-based router implementation defaults to using the
-`prom/haproxy-exporter` image to run as a sidecar container, which can then be
-used as a metrics datasource by the Prometheus server.
+When you create a router, as below,
+====
+----
+$ oc adm router --service-account=router
+----
+====
+metrics are automatically available in Prometheus format on the stats-port, default 1936. To suppress metrics collection,
+====
+----
+
+To switch to the HAProxy CSV format metrics, edit the
+architecture/networking/routes.adoc
+xref:../../architecture/networking/routes.adoc#env-variables[environment variables]
+for the router dc and delete the following lines:
+
+====
+----
+          - name: ROUTER_LISTEN_ADDR
+            value: 0.0.0.0:1936
+          - name: ROUTER_METRICS_TYPE
+            value: haproxy
+----
+====
+Where 1936 is the STATS_PORT value.
 
 [NOTE]
 ====
-The `--metrics-image` option overrides the defaults for HAProxy-based router
-implementations and, in the case of custom implementations, enables the image to
-use for a custom metrics exporter or publisher.
+The `--expose-metrics` and `--metrics-image` options are deprecated. The haproxy-exporter
+side car is now integrated into the router controller so you can delete the sidecar container from existing
+router deployment configs. You can continue to use the side car in existing routers. New routers use the integrated metrics.
 ====
 
-ifdef::openshift-enterprise[]
-. Grab the HAProxy Prometheus exporter image from the Docker registry:
-+
-====
-----
-$ sudo docker pull prom/haproxy-exporter
-----
-====
 
-. Create the {product-title} router:
-+
+You can extract the raw statistics in Prometheus format by using the following.
+
+Information needed to access the metrics is found the router service annotations:
+
 ====
 ----
-$ oadm router \
-    --credentials='/etc/origin/master/openshift-router.kubeconfig' \
-    --service-account=router --expose-metrics
-----
-====
-+
-Or, optionally, use the `--metrics-image` option to override the HAProxy
-defaults:
-+
-====
-----
-$ oadm router \
-    --credentials='/etc/origin/master/openshift-router.kubeconfig' \
-    --service-account=router --expose-metrics  \
-    --metrics-image=prom/haproxy-exporter
-----
-====
-endif::[]
-ifdef::openshift-origin[]
-. Grab the HAProxy Prometheus exporter image from the Docker registry:
-+
-====
-----
-$ sudo docker pull prom/haproxy-exporter
+metadata:
+  annotations:
+    prometheus.io/port: "1936"
+    prometheus.io/scrape: "true"
+    prometheus.openshift.io/password: IImoDqON02
+    prometheus.openshift.io/username: admin
 ----
 ====
 
-. Create the {product-title} router:
-+
-====
-----
-$ oadm router \
-    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
-    --service-account=router --expose-metrics
-----
-====
-+
-Or, optionally, use the `--metrics-image` option to override the HAProxy
-defaults:
-+
-====
-----
-$ oadm router \
-    --credentials=${ROUTER_KUBECONFIG:-"$KUBECONFIG"} \
-    --service-account=router --expose-metrics  \
-    --metrics-image=prom/haproxy-exporter
-----
-====
-endif::[]
+The metrics port is set from the STATS_PORT, default 1936. You may need to confiugre your firewall to permit access.
+Use the above username and password to access the metrics. The path is "/metrics".
 
-. Once the haproxy-exporter containers (and your HAProxy router) have started,
-point Prometheus to the sidecar container on port 9101 on the node where the
-haproxy-exporter container is running:
-+
-====
 ----
-$ haproxy_exporter_ip="<enter-ip-address-or-hostname>"
-$ cat > haproxy-scraper.yml  <<CFGEOF
----
-global:
-  scrape_interval: "60s"
-  scrape_timeout:  "10s"
-  # external_labels:
-    # source: openshift-router
-
-scrape_configs:
-  - job_name:  "haproxy"
-    target_groups:
-      - targets:
-        - "${haproxy_exporter_ip}:9101"
-CFGEOF
-
-$ #  And start prometheus as you would normally using the above config file.
-$ echo "  - Example:  prometheus -config.file=haproxy-scraper.yml "
-$ echo "              or you can start it as a container on {product-title}!!
-
-$ echo "  - Once the prometheus server is up, view the {product-title} HAProxy "
-$ echo "    router metrics at: http://<ip>:9090/consoles/haproxy.html "
+$ curl <user>:<password>@<router_IP>:<STATS_PORT>/metrics
+for example:
+$ curl admin:sLzdR6SgDJ@10.254.254.35:1936/metrics
+...
+# HELP haproxy_backend_connections_total Total number of connections.
+# TYPE haproxy_backend_connections_total gauge
+haproxy_backend_connections_total{backend="http",namespace="default",route="hello-route"} 0
+haproxy_backend_connections_total{backend="http",namespace="default",route="hello-route-alt"} 0
+haproxy_backend_connections_total{backend="http",namespace="default",route="hello-route01"} 0
+...
+# HELP haproxy_exporter_server_threshold Number of servers tracked and the current threshold value.
+# TYPE haproxy_exporter_server_threshold gauge
+haproxy_exporter_server_threshold{type="current"} 11
+haproxy_exporter_server_threshold{type="limit"} 500
+...
+# HELP haproxy_frontend_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_frontend_bytes_in_total gauge
+haproxy_frontend_bytes_in_total{frontend="fe_no_sni"} 0
+haproxy_frontend_bytes_in_total{frontend="fe_sni"} 0
+haproxy_frontend_bytes_in_total{frontend="public"} 119070
+...
+# HELP haproxy_server_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_server_bytes_in_total gauge
+haproxy_server_bytes_in_total{namespace="",pod="",route="",server="fe_no_sni",service=""} 0
+haproxy_server_bytes_in_total{namespace="",pod="",route="",server="fe_sni",service=""} 0
+haproxy_server_bytes_in_total{namespace="default",pod="docker-registry-5-nk5fz",route="docker-registry",server="10.130.0.89:5000",service="docker-registry"} 0
+haproxy_server_bytes_in_total{namespace="default",pod="hello-rc-vkjqx",route="hello-route",server="10.130.0.90:8080",service="hello-svc-1"} 0
+...
 ----
-====
+
 
 [[preventing-connection-failures-during-restarts]]
 == Preventing Connection Failures During Restarts


### PR DESCRIPTION
Documents metrics that are published by the router
Document installation and configuration
Document related environment variables

Trello:
https://trello.com/c/EHq8dqNj/529-document-the-metrics-the-router-exposes
(cherry picked from commit 2c23c51) xref:#5699