### PR TITLE
Fix typo in tree graph

### DIFF
--- a/apb_devel/writing/getting_started.adoc
+++ b/apb_devel/writing/getting_started.adoc
@@ -566,7 +566,7 @@ my-test-apb/
 ├── apb.yml
 ├── Dockerfile
 ├── playbooks
-│   └── provision.yml <1>
+│   └── deprovision.yml <1>
 └── roles
     └── deprovision-my-test-apb
         └── tasks


### PR DESCRIPTION
Looks like a copy-pasta mistake from tree graph earlier in document.