### PR TITLE
[enterprise-3.9] Bug 1537672 clarify URL variable descriptions.

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -144,11 +144,13 @@ xref:../install_config/aggregate_logging.adoc#aggregate-logging-creating-the-cur
 
 |`openshift_logging_master_url`
 |The URL for the Kubernetes master, this does not need to be public facing but
-should be accessible from within the cluster.
+should be accessible from within the cluster. For example,
+https://<PRIVATE-MASTER-URL>:8443.
 
 |`openshift_logging_master_public_url`
 |The public facing URL for the Kubernetes master. This is used for Authentication
-redirection by the Kibana proxy.
+redirection by the Kibana proxy. For example,
+https://<CONSOLE-PUBLIC-URL-MASTER>:8443.
 
 |`openshift_logging_namespace`
 |The namespace where Aggregated Logging is deployed.


### PR DESCRIPTION
(cherry picked from commit 68851545d19e3bc05b965ae406aaceb0d1f1a989) xref:https://github.com/openshift/openshift-docs/pull/7341