### PR TITLE
[online-3.9] Removed references to Tech Preview features from Online …

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -791,7 +791,7 @@ Topics:
   File: openshift_pipeline
 - Name: Cron Jobs
   File: cron_jobs
-  Distros: openshift-enterprise,openshift-dedicated,openshift-origin,openshift-online
+  Distros: openshift-enterprise,openshift-origin
 - Name: Create from URL
   File: create_from_url
 - Name: Application memory sizing

--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -829,22 +829,13 @@ is complicated, because nodes have both "external" IP addresses and
 pass through this chain, but other pod-to-node/master traffic may
 bypass it.
 
-[[admin-guide-networking-multicast]]
+ifdef::openshift-origin,openshift-enterprise[]
 == Enabling Multicast
 
 [IMPORTANT]
 ====
-Enabling multicast networking is a Technology Preview feature only.
-ifdef::openshift-enterprise[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-For more information on Red Hat Technology Preview features support scope, see
-https://access.redhat.com/support/offerings/techpreview/.
-endif::[]
+At this time, multicast is best used for low bandwidth coordination or service
+discovery and not a high-bandwidth solution.
 ====
 
 Multicast traffic between {product-title} pods is disabled by default. You can

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -423,8 +423,8 @@ cluster.
 
 The CLI shows the name of the PVC bound to the PV.
 
+ifdef::openshift-enterprise,openshift-origin[]
 [[pv-mount-options]]
-
 === Mount Options
 [IMPORTANT]
 ====
@@ -487,7 +487,7 @@ The following persistent volume types support mount options:
 ====
 Fibre Channel and HostPath persistent volumes do not support mount options.
 ====
-
+endif::openshift-enterprise,openshift-origin[]
 [[persistent-volume-claims]]
 
 == Persistent Volume Claims
@@ -569,8 +569,8 @@ spec:
 
 ----
 
+ifdef::openshift-enterprise,openshift-origin[]
 [[block-volume-support]]
-
 == Block Volume Support
 [IMPORTANT]
 ====
@@ -740,3 +740,4 @@ Unspecified values result in the default value of *Filesystem*.
 |GlusterFS
 |InProgress Kube 1.10
 |===
+endif::openshift-enterprise,openshift-origin[]

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -112,7 +112,9 @@ syntax:
 |`build` |
 |`buildConfig` | `bc`
 |`deploymentConfig` | `dc`
+ifdef::openshift-enterprise,openshift-origin[]
 |`deployments` (Technology Preview)| `deploy`
+endif::openshift-enterprise,openshift-origin[]
 |`event` |`ev`
 |`imageStream` | `is`
 |`imageStreamTag` | `istag`
@@ -123,7 +125,9 @@ syntax:
 |`pod` |`po`
 |`ResourceQuota` | `quota`
 |`replicationController` |`rc`
+ifdef::openshift-enterprise,openshift-origin[]
 |`replicaSet` (Technology Preview)|`rs`
+endif::openshift-enterprise,openshift-origin[]
 |`secrets` |
 |`service` |`svc`
 |`ServiceAccount` | `sa`

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -337,7 +337,7 @@ metadata:
   selflink: /oapi/v1/namespaces/openshift/imagestreamimages/ruby@3a335d7
 ----
 ====
-
+ifdef::openshift-enterprise,openshift-origin[]
 [[using-is-with-k8s]]
 == Using Image Streams with Kubernetes Resources (Technology Preview)
 
@@ -446,7 +446,7 @@ To disable image lookup, pass `*--enabled=false*`:
 ----
 $ oc set image-lookup deploy/mysql --enabled=false
 ----
-
+endif::openshift-enterprise,openshift-origin[]
 ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]
 [[image-pull-policy]]
 == Image Pull Policy
@@ -1124,10 +1124,10 @@ Value: array of triggers, where each item has the schema:
 ====
 
 
-When {product-title} sees one of the core Kubernetes resources that contains both a pod template (i.e, only CronJobs, Deployments, StatefulSets, DaemonSets, Jobs, ReplicaSets, ReplicationControllers, and Pods) and this annotation, it will attempt to update the object using the image currently associated with the ImageStreamTag referenced by trigger.  The update is performed against the `fieldPath` specified.  
+When {product-title} sees one of the core Kubernetes resources that contains both a pod template (i.e, only CronJobs, Deployments, StatefulSets, DaemonSets, Jobs, ReplicaSets, ReplicationControllers, and Pods) and this annotation, it will attempt to update the object using the image currently associated with the ImageStreamTag referenced by trigger.  The update is performed against the `fieldPath` specified.
 
 In the following example the trigger will fire when the `example:latest` imagestream tag is updated.  Upon firing, the object's pod template image reference for the `web` container will be updated with a new image value.  If the pod template is part of a Deployment definition, the change
-to the pod template will automatically trigger a deployment, effectively rolling out the new image. 
+to the pod template will automatically trigger a deployment, effectively rolling out the new image.
 
 ====
 ----

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -450,7 +450,7 @@ Once you have instantiated the service, you can copy the user name, password,
 and database name environment variables into a deployment configuration for
 another component that intends to access the database. That component can then
 access the database via the service that was defined.
-
+ifdef::openshift-origin,openshift-enterprise[]
 [[using-mysql-replication]]
 == Using MySQL Replication
 
@@ -460,15 +460,15 @@ ifdef::openshift-origin[]
 Replication support provided by the MySQL image is experimental and should not
 be used in production.
 ====
-endif::[]
+endif::openshift-origin[]
 
-ifdef::openshift-enterprise,openshift-dedicated,openshift-online[]
+ifdef::openshift-enterprise[]
 [NOTE]
 ====
 Enabling clustering for database images is currently in Technology Preview and
 not intended for production use.
 ====
-endif::[]
+endif::openshift-enterprise[[]
 
 Red Hat provides a proof-of-concept
 xref:../../dev_guide/templates.adoc#dev-guide-templates[template] for MySQL
@@ -489,7 +489,7 @@ The following sections detail the objects defined in the example template and
 describe how they work together to start a cluster of MySQL servers implementing
 master-slave replication. This is the recommended replication strategy for
 MySQL.
-
+endif::openshift-origin,openshift-enterprise[]
 [[creating-the-deployment-configuration-for-mysql-master]]
 === Creating the Deployment Configuration for the MySQL Master
 


### PR DESCRIPTION
…and Dedicated docs

(cherry picked from commit 0c6f83806955ed28a6417e7adcfdc2a017270734) xref:https://github.com/openshift/openshift-docs/pull/7466