### PR TITLE
Headlless service and pod discovery

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -507,6 +507,120 @@ incoming service connections between the endpoint pods. It also requires that
 all endpoints are always able to accept connections.
 endif::[]
 
+[[headless-services]]
+=== Headless services
+If your application does not need load balancing or single-service IP addresses,
+you can create a headless service. When you create a headless service, no
+load-balancing or proxying is done and no cluster IP is allocated for this
+service. For such services, DNS is automatically configured depending on whether
+the service has selectors defined or not.
+
+*Services with selectors*: For headless services that define selectors, the
+endpoints controller creates `Endpoints` records in the API and modifies the
+DNS configuration to return `A` records (addresses) that point directly to the
+pods backing the service.
+
+*Services without selectors*: For headless services that do not define
+selectors, the endpoints controller does not create `Endpoints` records.
+However, the DNS system looks for and configures the following records:
+
+** For `ExternalName` type services, `CNAME` records.
+** For all other service types, `A` records for any endpoints that share a name
+with the service.
+
+[[headless-service-creation]]
+==== Creating a headless service
+Creating a headless service is similar to creating a standard service, but you
+do not declare the `ClusterIP` address. To create a headless service, add the
+`clusterIP: None` parameter value to the service YAML definition.
+
+For example, for a group of pods that you want to be a part of the same cluster or service.
+
+.List of pods
+[source, bash]
+----
+$ oc get pods -o wide
+NAME               READY  STATUS    RESTARTS   AGE    IP            NODE
+frontend-1-287hw   1/1    Running   0          7m     172.17.0.3    node_1
+frontend-1-68km5   1/1    Running   0          7m     172.17.0.6    node_1
+----
+
+You can define the headless service as:
+
+.Headless service definition
+[source, yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ruby-helloworld-sample
+    template: application-template-stibuild
+  name: frontend-headless <1>
+spec:
+  clusterIP: None <2>
+  ports:
+  - name: web
+    port: 5432
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: frontend <3>
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+----
+
+<1> Name of the headless service.
+<2> Setting `clusterIP` variable to `None` declares a headless service.
+<3> Selects all pods that have `frontend` label.
+
+Also, headless service does not have any IP address of its own.
+
+[source, bash]
+----
+$ oc get svc
+NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+frontend            ClusterIP   172.30.232.77    <none>        5432/TCP   12m
+frontend-headless   ClusterIP   None             <none>        5432/TCP   10m
+----
+
+[[headless-service-endpoint-discovery]]
+==== Endpoint discovery by using a headless service
+The benefit of using a headless service is that you can discover a pod's IP
+address directly. Standard services act as load balancer or proxy and give
+access to the workload object by using the service name. With headless services,
+the service name resolves to the set of IP addresses of the pods that are
+grouped by the service.
+
+When you look up the DNS `A` record for a standard service, you get the loadbalanced IP of the service.
+
+[source, bash]
+----
+$ dig frontend.test A +search +short
+172.30.232.77
+----
+
+But for a headless service, you get the list of IPs of individual pods.
+[source, bash]
+----
+$ dig frontend-headless.test A +search +short
+172.17.0.3
+172.17.0.6
+----
+
+[NOTE]
+====
+For using a headless service with a StatefulSet and related use cases where you
+need to resolve DNS for the pod during initialization and termination, set
+`publishNotReadyAddresses` to `true` (the default value is `false`). When
+`publishNotReadyAddresses` is set to `true`, it indicates that DNS
+implementations must publish the `notReadyAddresses` of subsets for the
+Endpoints associated with the Service.
+====
+
+
 [[labels]]
 
 == Labels


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1293988

We need to add information about how a "developer" from with in a pod can / should collect information from the Kubernetties or OpenShift API's (events) to be notified or see what "peers" (pods) it has.