### PR TITLE
Fixed cluster role procedure to be 3.6 consistent

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -104,7 +104,20 @@ route even after creation.  You can also create a role to allow specific users
 to do so:
 
 ----
-$ oc create clusterrole route-editor --verb=update --resource=routes.route.openshift.io/custom-host
+$ oc create -f - <<EOF
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: route-editor
+rules:
+- apiGroups:
+  - route.openshift.io
+  - ""
+  resources:
+  - routes/custom-host
+  verbs:
+  - update
+EOF
 ----
 
 You can then bind the new role to a user:


### PR DESCRIPTION
Current step is for 3.9. Changed this to be 3.6 correct.

cc @Miciah 