### PR TITLE
added cockpit basename parameter for 3.7+

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -110,8 +110,8 @@ and
 xref:configuring-ansible[Configuring Ansible Inventory Files].
 
 ifdef::openshift-enterprise[]
-[IMPORTANT]
 ====
+[IMPORTANT]
 The reference architecture for automated installations based on
 link:https://docs.openstack.org/heat/latest[OpenStack Heat] templates for
 link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/deploying_red_hat_openshift_container_platform_3.4_on_red_hat_openstack_platform_10[{product-title} 3.4 on Red Hat OpenStack Platform 10]
@@ -363,7 +363,7 @@ re-configured after deployment.
 |`openshift_use_flannel`
 |This variable enables *flannel* as an alternative networking layer instead of
 the default SDN. If enabling *flannel*, disable the default SDN with the
-`openshift_use_openshift_sdn` variable. For more information, see xref:../../install_config/configuring_sdn.adoc#using-flannel[Using Flannel].
+`openshift_use_openshift_sdn` variable. For more information, see xref:../install_config/configuring_sdn.adoc#using-flannel[Using Flannel].
 
 |`openshift_docker_additional_registries`
 |{product-title} adds the specified additional registry or registries to the
@@ -390,26 +390,7 @@ details.
 |`openshift_clusterid`
 |This variable is a cluster identifier unique to the AWS Availability Zone. Using this avoids potential issues in Amazon Web Service
 (AWS) with multiple zones or multiple clusters. See xref:../../install_config/configuring_aws.adoc#aws-cluster-labeling[Labeling Clusters for AWS] for details.
-
-|`openshift_image_tag`
-|Use this variable to specify a container image tag to install or configure.
-
-|`openshift_pkg_version`
-|Use this variable to specify an RPM version to install or configure.
-
 |===
-
-[WARNING]
-====
-If you modify the `openshift_image_tag` or the `openshift_pkg_version` variables
-after the cluster is set up, then an upgrade can be triggered, resulting in
-downtime.
-
-* If `openshift_image_tag` is set, its value is used for all hosts in
-containerized environments, even those that have another version installed. If
-* `openshift_pkg_version` is set, its value is used for all hosts in RPM-based
-environments, even those that have another version installed.
-====
 
 [[advanced-install-deployment-types]]
 === Configuring Deployment Type
@@ -778,7 +759,6 @@ If you are using an image registry other than the default at
 ----
 oreg_url={registry}/openshift3/ose-${component}:${version}
 openshift_examples_modify_imagestreams=true
-openshift_docker_additional_registries={registry}
 ----
 
 .Registry Variables
@@ -801,6 +781,44 @@ For example:
 oreg_url=example.com/openshift3/ose-${component}:${version}
 openshift_examples_modify_imagestreams=true
 openshift_docker_additional_registries=example.com
+----
+
+[[advanced-install-configuring-registry-location]]
+=== Configuring the Registry Console
+
+If you are using a registry console image other than the default or require a specific version of the console,
+specify the desired registry within the
+*_/etc/ansible/hosts_* file. 
+
+----
+openshift_cockpit_deployer_prefix=<registry-name>/<namespace>/
+openshift_cockpit_deployer_basename=<my-console>
+openshift_cockpit_deployer_version=<cockpit-image-tag>
+----
+
+.Registry Variables
+[options="header"]
+|===
+
+|Variable |Purpose
+|`*openshift_cockpit_deployer_prefix*`
+|Specify the URL and path to the directory where the image is located.
+
+|`*openshift_cockpit_deployer_basename*`
+|Specify the name of the image.
+
+
+|`*openshift_cockpit_deployer_version*`
+|Specify the Cockpit image verion
+|===
+
+For example:
+If your image is at *_registry.example.com/openshift3/registry-console_* and you require
+version 1.4.1, enter:
+----
+openshift_cockpit_deployer_prefix='registry.example.com/openshift3/' 
+openshift_cockpit_deployer_basename=`registry-console`
+openshift_cockpit_deployer_version='1.4.1'
 ----
 
 [[advanced-install-registry-storage]]

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -817,7 +817,7 @@ If your image is at *_registry.example.com/openshift3/registry-console_* and you
 version 1.4.1, enter:
 ----
 openshift_cockpit_deployer_prefix='registry.example.com/openshift3/' 
-openshift_cockpit_deployer_basename=`registry-console`
+openshift_cockpit_deployer_basename=`cockpit-console-image`
 openshift_cockpit_deployer_version='1.4.1'
 ----
 


### PR DESCRIPTION
PR, if needed, to replace the `openshift_cockpit_deployer_basename` parameter that might not be in 3.6 and back.
https://github.com/openshift/openshift-docs/pull/7331