### PR TITLE
Rm refs to auth_type:config and BZ#1526949 from 3.9+

### DIFF
--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -119,29 +119,27 @@ for APBs.
 |The name of the registry. Used by the broker to identify APBs from this registry.
 |Y
 
+|`user`
+|The user name for authenticating to the registry. Not used when `auth_type` is
+set to `secret` or `file`.
+|N
+
+|`pass`
+|The password for authenticating to the registry. Not used when `auth_type` is
+set to `secret` or `file`.
+|N
+
 |`auth_type`
-|How the broker should read the registry credentials. Can be `config` (uses
-`user` and `pass` as defined in the `registry` section), `secret` (uses a secret
-in the broker namespace), or `file` (uses a mounted file).
-|N footnoteref:[oabopenshiftregistrynote,`auth_type` is currently required for
-the `openshift` registry type, due to a bug that will be addressed in an
-upcoming release
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1526949[BZ#1526949]).
-`auth_name` is only required in this case if `auth_type` is set to `secret` or
-`file`. See xref:oab-config-isv[ISV Registry\].]
+|How the broker should read the registry credentials if they are not defined in
+the broker configuration via `user` and `pass`. Can be `secret` (uses a secret
+in the broker namespace) or `file` (uses a mounted file).
+|N
 
 |`auth_name`
 |Name of the secret or file storing the registry credentials that should be read.
 Used when `auth_type` is set to `secret`.
-|N footnoteref:[oabopenshiftregistrynote]
- 
-|`user`
-|The user name for authenticating to the registry when using `auth_type: config`.
-|N
+|N, only required when `auth_type` is set to `secret` or `file`.
 
-|`pass`
-|The password for authenticating to the registry when using `auth_type: config`.
-|N
 
 |`org`
 |The namespace or organization that the image is contained in.
@@ -218,28 +216,25 @@ broker:
 [[oab-config-registry-storing-creds]]
 === Storing Registry Credentials
 
-The `auth_type` field in the `registry` section of the broker configuration
-determines how the broker should read the registry credentials, either the
-`config`, `secret`, or `file` type.
+The broker configuration determines how the broker should read any registry
+credentials. They can be read from the `user` and `pass` values in the
+`registry` section, for example:
 
-With the `config` type, the registry credentials are read from the broker
-configuration's `user` and `pass` values in the `registry` section, for example:
-
+[source,yaml]
 ----
 registry:
   - name: isv
     type: openshift
     url: https://registry.connect.redhat.com
-    auth_type: config
     user: <user>
     pass: <password>
-...
 ----
 
-If you want to ensure these credentials are not publicly accessible, you can use
-the `secret` type to configure a registry to use a secret from the broker's
-namespace. Alternatively, you can use the `file` to configure a registry to use
-a secret mounted as a volume.
+If you want to ensure these credentials are not publicly accessible, the
+`auth_type` field in the `registry` section can be set to the `secret` or `file`
+type. The `secret` type configures a registry to use a secret from the broker's
+namespace, while the `file` type configures a registry to use a secret that has
+been mounted as a volume.
 
 To use the `secret` or `file` type:
 
@@ -269,9 +264,12 @@ $ oc create secret generic \
 . Choose whether you want to use the `secret` or `file` type:
 +
 --
-- To use the `secret` type, in the broker configuration, set `auth_type` to
+- To use the `secret` type:
+
+.. In the broker configuration, set `auth_type` to
 `secret` and `auth_name` to the name of the secret:
 +
+[source,yaml]
 ----
 registry:
   - name: isv
@@ -279,6 +277,14 @@ registry:
     url: https://registry.connect.redhat.com
     auth_type: secret
     auth_name: registry-credentials-secret
+----
+
+.. Set the namespace where the secret is located:
++
+[source,yaml]
+----
+openshift:
+  namespace: openshift-ansible-service-broker
 ----
 
 - To use the `file` type:
@@ -292,14 +298,16 @@ $ oc edit dc/asb -n openshift-ansible-service-broker
 +
 In the `containers.volumeMounts` section, add:
 +
+[source,yaml]
 ----
-      volumeMounts:
-        - name: reg-auth
-        mountPath: /tmp/registry-credentials  
+  volumeMounts:
+    - mountPath: /tmp/registry-credentials
+      name: reg-auth
 ----
 +
 In the `volumes` section, add:
 +
+[source,yaml]
 ----
     volumes:
       - name: reg-auth
@@ -311,6 +319,7 @@ In the `volumes` section, add:
 .. In the broker configuration, set `auth_type` to `file` and `auth_type` to the
 location of the file:
 +
+[source,yaml]
 ----
 registry:
   - name: isv
@@ -493,8 +502,7 @@ link:https://registry.connect.redhat.com[registry.connect.redhat.com].
 registry:
   - name: isv
     type: openshift
-    auth_type: config <1>
-    user: <user>
+    user: <user> <1>
     pass: <password>
     url: https://registry.connect.redhat.com
     images: <2>
@@ -503,12 +511,8 @@ registry:
     white_list:
       - ".*-apb$"
 ----
-<1> Using the `openshift` registry type currently requires that `auth_type` be
-declared in the configuration (to `config`, `secret`, or `file`) due to a bug
-that will be addressed in a future release
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1526949[BZ#1526949]). See
-xref:oab-config-registry-storing-creds[Storing Registry Credentials] for
-options.
+<1> See xref:oab-config-registry-storing-creds[Storing Registry Credentials] for
+other authentication options.
 <2> Because the `openshift` type currently cannot search the configured registry, it
 is required that you configure the broker with a list of images you would like
 to source from for when the broker bootstraps. The image names must be the fully
@@ -603,6 +607,11 @@ registry:
 
 |`image_pull_policy`
 |When to pull the image.
+|Y
+
+|`namespace`
+|The namespace that the broker has been deployed to. Important for things like
+passing parameter values via secret.
 |Y
 
 |`sandbox_role`


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/6755 to remove the 3.7 caveat for https://bugzilla.redhat.com/show_bug.cgi?id=1526949, which is fixed for 3.9.

Preview:

http://file.rdu.redhat.com/~adellape/021318/oab_openshift39/install_config/oab_broker_configuration.html