### PR TITLE
Added footnote on macvlan to specify network when using multiples

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -460,10 +460,10 @@ endif::openshift-origin[]
   nodeSelector:
     site: springfield-1 <6>
 ----
-<1> The `pod.network.openshift.io/assign-macvlan annotation` creates a Macvlan
-network interface on the primary network interface, and then moves it into the
-pod's network name space before starting the *egress-router* container. Preserve
-the quotation marks around `"true"`. Omitting them results in errors.
+<1> Creates a Macvlan network interface on the primary network interface, and
+moves it into the pod's network project before starting the *egress-router*
+container. Preserve the quotation marks around `"true"`. Omitting them results
+in errors. To create the Macvlan interface on a network interface other than the primary one, set the annotation value to the name of that interface. For example, `eth1`.
 <2> IP address from the physical network that the node is on and is
 reserved by the cluster administrator for use by this pod.
 <3> Same value as the default gateway used by the node.
@@ -734,10 +734,10 @@ endif::openshift-origin[]
         !192.168.1.0/24
         *
 ----
-<1> The `pod.network.openshift.io/assign-macvlan annotation` creates a Macvlan
-network interface on the primary network interface, then moves it into the
-pod's network name space before starting the *egress-router* container. Preserve
-the quotation marks around `"true"`. Omitting them results in errors.
+<1> Creates a Macvlan network interface on the primary network interface, then
+moves it into the pod's network project before starting the *egress-router*
+container. Preserve the quotation marks around `"true"`. Omitting them results
+in errors.
 <2> An IP address from the physical network that the node itself is on and is
 reserved by the cluster administrator for use by this pod.
 <3> Same value as the default gateway used by the node itself.


### PR DESCRIPTION
For: https://trello.com/c/DDdu4qqM/723-document-support-selection-of-interface-when-using-macvlan

cc @danwinship PTAL

Or, should there be a new `pod.network.openshift.io/assign-macvlan: "eth1"` thrown in with the current one, instead of replacing it? Say, below it? That's the way it's worded in the dev trello card, but the test cases replace it.