### PR TITLE
Remove reference to openshift_use_dnsmasq

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -310,9 +310,6 @@ any other type of DNS application.
 *NetworkManager* is required on the nodes in order to populate *dnsmasq* with
 the DNS IP addresses. DNS does not work properly when the network interface for
 {product-title} has `NM_CONTROLLED=no`.
-
-DNSMSQ must be enabled (`openshift_use_dnsmasq=true`) or the installation will fail
-and critical features will not function.
 ====
 
 The following is an example set of DNS records for the xref:../../install_config/install/planning.adoc#single-master-multi-node[Single Master and Multiple Nodes] scenario:


### PR DESCRIPTION
 Remove reference to openshift_use_dnsmasq on the prerequisites page since it is now deprecated.