### PR TITLE
[enterprise-3.9] Update local storage documentation

### DIFF
--- a/install_config/configuring_local.adoc
+++ b/install_config/configuring_local.adoc
@@ -71,12 +71,19 @@ a disk partition or an LVM), create suitable filesystems on these devices, and m
 [source]
 ----
 # device name   # mount point                  # FS    # options # extra
-/dev/sdb1       /mount/local-storage/ssd/disk1 ext4     defaults 1 2
-/dev/sdb2       /mount/local-storage/ssd/disk2 ext4     defaults 1 2
-/dev/sdb3       /mount/local-storage/ssd/disk3 ext4     defaults 1 2
-/dev/sdc1       /mount/local-storage/hdd/disk1 ext4     defaults 1 2
-/dev/sdc2       /mount/local-storage/hdd/disk2 ext4     defaults 1 2
+/dev/sdb1       /mnt/local-storage/ssd/disk1 ext4     defaults 1 2
+/dev/sdb2       /mnt/local-storage/ssd/disk2 ext4     defaults 1 2
+/dev/sdb3       /mnt/local-storage/ssd/disk3 ext4     defaults 1 2
+/dev/sdc1       /mnt/local-storage/hdd/disk1 ext4     defaults 1 2
+/dev/sdc2       /mnt/local-storage/hdd/disk2 ext4     defaults 1 2
 ----
+
+All volumes must be accessible to processes running within Docker containers. Change the labels of mounted filesystems to allow that:
+
+[source, bash]
+---
+$ chcon -R unconfined_u:object_r:svirt_sandbox_file_t:s0 /mnt/local-storage/
+---
 
 [[local-volume-configure-local-provisioner]]
 === Configure Local Provisioner
@@ -132,35 +139,46 @@ Before starting the provisioner, mount all local devices and create a ConfigMap
 with storage classes and their directories.
 ====
 
+
 Install the local provisioner from the link:https://raw.githubusercontent.com/jsafrane/origin/local-storage/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml[*_local-storage-provisioner-template.yaml_*] file.
 
-. Create a service account that allows running pods as a root user and use HostPath volumes:
+. Create a service account that allows running pods as a root user, use HostPath volumes and use any SELinux context to be able to monitor, manage, and clean local volumes:
 +
 [source, bash]
 ----
 $ oc create serviceaccount local-storage-admin
-$ oc adm policy add-scc-to-user hostmount-anyuid -z local-storage-admin
+$ oc adm policy add-scc-to-user privileged -z local-storage-admin
 ----
-Root privileges are required for the provisioner pod for allowing it to delete
-content on local volumes. HostPath is required to access the
-*_/mnt/local-storage_* path on the host.
+To allow the provisioner pod to delete content on local volumes created by any pod, root privileges and any SELinux context are required.
+ HostPath is required to access the *_/mnt/local-storage_* path on the host.
 
 . Install the template:
 +
 [source, bash]
 ----
-$ oc create -f https://raw.githubusercontent.com/jsafrane/origin/local-storage/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml
 ----
 
-. Instantiate the template by specifying values for `configmap` and `account` parameters:
+. Instantiate the template by specifying values for `configmap`, `account`, and `provisioner_image` parameters:
 +
 [source, bash]
 ----
 $ oc new-app -p CONFIGMAP=local-volume-config \
   -p SERVICE_ACCOUNT=local-storage-admin \
-  -p NAMESPACE=local-storage local-storage-provisioner
+  -p NAMESPACE=local-storage \
+ifdef::openshift-origin[]
+  -p PROVISIONER_IMAGE=quay.io/external_storage/local-volume-provisioner:v1.0.1 \
+endif::[]
+ifndef::openshift-origin[]
+  -p PROVISIONER_IMAGE=registry.access.redhat.com/openshift3/local-storage-provisioner:v3.9 \ <1>
+endif::[]
+  local-storage-provisioner
 ----
-See the link:https://raw.githubusercontent.com/jsafrane/origin/local-storage/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml[template] for other configurable options. This template creates a DaemonSet that runs a
+ifndef::openshift-origin[]
+<1> Replace `v3.9` with the right {product-title} version.
++
+endif::[]
+See the link:https://raw.githubusercontent.com/openshift/origin/master/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml[template] for other configurable options. This template creates a DaemonSet that runs a
 Pod on every node. The Pod watches directories specified in the `ConfigMap` and
 creates PVs for them automatically.
 +


### PR DESCRIPTION
- link to official origin repository instead of my fork
- add parameter with image name so enterprise customers may use Red Hat shipped and signed images
(cherry picked from commit 92cc919d13cafc9383235a6f2d2f293d3f1cc66d) xref:https://github.com/openshift/openshift-docs/pull/7633