### PR TITLE
[enterprise-3.9] Trello 590 and 711 use file buffer

### DIFF
--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -45,68 +45,36 @@ lowest quality of service.
 [[tune-buffer-chunk-limit]]
 === Tune Buffer Chunk Limit
 
-If Fluentd logger is unable to keep up with a high number of logs, you will need
-to increase the compute resource values.
+If Fluentd logger is unable to keep up with a high number of logs, it will need
+to switch to file buffering to reduce memory usage and prevent data loss.
 
-The memory limit is used to calculate the Fluentd `buffer_queue_limit` as follows:
+The Fluentd `buffer_chunk_limit` is determined by the environment variable
+`BUFFER_SIZE_LIMIT`, which has the default value `8m`. The file buffer size per
+output is determined by the environment variable `FILE_BUFFER_LIMIT`, which has
+the default value `256Mi`. The permanent volume size must be larger than
+`FILE_BUFFER_LIMIT` multiplied by the output.
 
-----
-buffer_queue_limit = resource memory limit / (number of output * buffer_chunk_size)
-----
+On the Fluentd and Mux pods, permanent volume */var/lib/fluentd* should be
+prepared by the PVC or hostmount, for example. That area is then used for the
+file buffers.
 
-By default, `buffer_chunk_size` is 1 MB.
-
-The following steps allow you to adjust the available resources.
-
-. Edit the daemonset of Fluentd:
-+
-----
-$ oc edit daemonset logging-fluentd
-
-resources:
-  limits:
-    cpu: 100m
-    memory: 512Mi
-----
-
-. Increase the values according to available resources. For example:
-+
-----
-resources:
-  limits:
-    cpu: 150m
-    memory: 1Gi
-----
-
-If the `mux` server is behind the incoming logs, the same configuration is
-avaialable. The memory limit is used to calculate the `mux` `buffer_queue_limit`
-as follows:
+The `buffer_type` and `buffer_path` are configured in the Fluentd configuration files as
+follows:
 
 ----
-buffer_queue_limit = resource memory limit / (number of output * buffer_chunk_size)
+$ egrep "buffer_type|buffer_path" *.conf
+output-es-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-output-es-config`
+output-es-ops-config.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-output-es-ops-config`
+filter-pre-mux-client.conf:
+  buffer_type file
+  buffer_path `/var/lib/fluentd/buffer-mux-client`
 ----
 
-By default, `buffer_chunk_size` is 1 MB.
-
-. Edit the deploymentconfig of `mux`:
-+
-----
-$ oc edit deploymentconfig logging-mux
-
-resources:
-  limits:
-    cpu: 500m
-    memory: 2Gi
-----
-
-. Increase the values according to available resources. For example:
-+
-----
-resources:
-  limits:
-    cpu: 600m
-    memory: 2.5Gi
-----
+The Fluentd `buffer_queue_limit` is 32.
 
 [[compute-resources]]
 == Compute Resources


### PR DESCRIPTION
(cherry picked from commit 810828effd9d640488655380783616fe26738a62) xref:https://github.com/openshift/openshift-docs/pull/7305