### PR TITLE
Add allow command "osd blacklist" to client.kube in ceph

### DIFF
--- a/install_config/storage_examples/ceph_rbd_dynamic_example.adoc
+++ b/install_config/storage_examples/ceph_rbd_dynamic_example.adoc
@@ -50,7 +50,7 @@ The `ceph-common` library must be installed on `all schedulable` {product-title}
 [source,bash]
 ----
 $ ceph osd pool create kube 1024
-$ ceph auth get-or-create client.kube mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=kube' -o ceph.client.kube.keyring
+$ ceph auth get-or-create client.kube mon 'allow r, allow command "osd blacklist"' osd 'allow class-read object_prefix rbd_children, allow rwx pool=kube' -o ceph.client.kube.keyring
 ----
 +
 [NOTE]


### PR DESCRIPTION
"osd blacklist" is required for rbd_util.go to remove lock.
You can get more info from[0]

[0] https://github.com/ceph/ceph-container/issues/642#issuecomment-341703844