### PR TITLE
Various fixes to router sharding documentation

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -238,6 +238,7 @@ Modify a xref:../dev_guide/volumes.adoc#dev-guide-volumes[volume]:
 $ oc volume <object_type>/<object_name> [--option]
 ----
 
+[[oc-label]]
 === label
 Update the labels on a object:
 ----
@@ -282,6 +283,7 @@ $ oc delete all -l <label>
 === set
 Modify a specific property of the specified object.
 
+[[oc-set-env]]
 ==== set env
 Sets an environment variable on a deployment configuration or a build configuration:
 ----

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -444,17 +444,18 @@ corresponding to the `router=first` label.
 [[using-router-shards]]
 == Using Router Shards
 
-xref:../../architecture/networking/routes.html#router-sharding[_Router sharding_] uses
+xref:../../architecture/networking/routes.adoc#router-sharding[_Router sharding_] uses
 xref:../../architecture/networking/routes.adoc#env-variables[`NAMESPACE_LABELS`]
 and
 xref:../../architecture/networking/routes.adoc#env-variables[`ROUTE_LABELS`],
 to filter router namespaces and routes.
-This enables you to partition routes amongst multiple router deployments
-effectively distributing the set of routes.
+This enables you to distribute subsets of routes over multiple router deployments.
+By using non-overlapping subsets, you can effectively partition the set of routes.
+Alternatively, you may define shards comprising overlapping subsets of routes.
 
 By default, a router selects all routes from all  xref:../../architecture/core_concepts/projects_and_users.adoc#projects[projects (namespaces)].
-Sharding adds labels to routes and
-each router shard selects routes with specific labels.
+Sharding involves adding labels to routes or namespaces and label selectors to routers.
+Each router shard comprises the routes that are selected by a specific set of label selectors or belong to the namespaces that are selected by a specific set of label selectors.
 
 [NOTE]
 ====
@@ -468,12 +469,12 @@ Because an external DNS server is needed to route requests to the desired shard,
 the administrator is responsible for making a separate DNS entry
 for each router in a project. A router will not forward unknown routes to another router.
 
-For example:
+Consider the following example:
 
-* If Router A lives on host 192.168.0.5 and has routes with `*.foo.com`.
-* And Router B lives on host 192.168.1.9 and has routes with `*.example.com.`
+* Router A lives on host 192.168.0.5 and has routes with `*.foo.com`.
+* Router B lives on host 192.168.1.9 and has routes with `*.example.com`.
 
-Separate DNS entries must resolve `\*.foo.com` to the node hosting Router A and `*.example.com` to the node hosting Router B:
+Separate DNS entries must resolve `*.foo.com` to the node hosting Router A and `*.example.com` to the node hosting Router B:
 
 * `*.foo.com A IN 192.168.0.5`
 * `*.example.com A IN 192.168.1.9`
@@ -481,82 +482,113 @@ Separate DNS entries must resolve `\*.foo.com` to the node hosting Router A and 
 
 *Router Sharding Examples*
 
-This section describes router sharding using xref:using-router-shards-namespace[project (namespace) labels]
-or xref:using-router-shards-names[project (namespace) names].
+This section describes router sharding using namespace and route labels.
 
 [[using-router-shards-namespace]]
 .Router Sharding Based on Namespace Labels
 image::router_sharding_namespace_labels.png[Router Sharding Based on Namespace Labels]
 
-Example: A router deployment `finops-router` is run with route selector
-`NAMESPACE_LABELS="name in (finance, ops)"` and a router deployment `dev-router`
-is run with route selector `NAMESPACE_LABELS="name=dev"`.
+You can configure a router with a namespace label selector using the following
+command:
 
-If all routes are in the three namespaces `finance`, `ops` or `dev`, then this
-could effectively distribute your routes across two router deployments.
+----
+$ oc set env dc/router NAMESPACE_LABELS="router=r1"
+----
 
-In the above scenario, sharding becomes a special case of partitioning
-with no overlapping sets. Routes are divided amongst multiple router shards.
+Because the router has a selector on the namespace, the router will handle
+routes only for matching namespaces.  In order to make this selector match
+a namespace, label the namespace accordingly:
 
-The criteria for route selection governs how the routes are distributed. It is
-possible to have routes that overlap across multiple router deployments.
+----
+$ oc label namespace default "router=r1"
+----
 
-Example: In addition to the `finops-router` and `dev-router` in the example
-above, you also have `devops-router`, which is run with a route selector
+Now if you create a route in the default namespace, the route is
+available in the default router:
+
+----
+$ oc create -f route1.yaml
+----
+
+Now create a new project (namespace) and create a route, `route2`.
+
+----
+$ oc new-project p1
+$ oc create -f route2.yaml
+----
+
+Notice the route is not available in your router.
+Now label namespace `p1` with `router=r1`
+
+----
+$ oc label namespace p1 "router=r1"
+----
+
+Adding this label makes the route available in the router.
+
+Example: A router deployment `finops-router` is configured with the label selector
+`NAMESPACE_LABELS="name in (finance, ops)"`, and a router deployment `dev-router`
+is configured with the label selector `NAMESPACE_LABELS="name=dev"`.
+
+If all routes are in namespaces labeled `name=finance`, `name=ops`, and
+`name=dev`, then this configuration effectively distributes your routes between
+the two router deployments.
+
+In the above scenario, sharding becomes a special case of partitioning,
+with no overlapping subsets. Routes are divided between router shards.
+
+The criteria for route selection govern how the routes are distributed. It is
+possible to have overlapping subsets of routes across router deployments.
+
+Example: In addition to `finops-router` and `dev-router` in the example
+above, you also have `devops-router`, which is configured with a label selector
 `NAMESPACE_LABELS="name in (dev, ops)"`.
 
-The routes in namespaces `dev` or `ops` now are serviced by two different router
-deployments. This becomes a case in which you have partitioned the routes with
-an overlapping set.
+The routes in namespaces labeled `name=dev` or `name=ops` now are serviced by
+two different router deployments. This becomes a case in which you have defined
+overlapping subsets of routes, as illustrated in <<using-router-shards-namespace>>.
 
 In addition, this enables you to create more complex routing rules, allowing the
-diversion of high priority traffic to the dedicated `finops-router`, but sending
-the lower priority ones to the `devops-router`.
+diversion of higher priority traffic to the dedicated `finops-router` while sending
+lower priority traffic to `devops-router`.
+
+[[using-router-shards-route]]
+.Router Sharding Based on Route Labels
 
 `NAMESPACE_LABELS` allows filtering of the projects to service and selecting
 all the routes from those projects, but you may want to partition routes based on
-other criteria in the routes themselves. The `ROUTE_LABELS` selector allows you
+other criteria associated with the routes themselves. The `ROUTE_LABELS` selector allows you
 to slice-and-dice the routes themselves.
 
-Example: A router deployment `prod-router` is run with route selector
-`ROUTE_LABELS="mydeployment=prod"` and a router deployment `devtest-router` is
-run with route selector `ROUTE_LABELS="mydeployment in (dev, test)"`.
+Example: A router deployment `prod-router` is configured with the label selector
+`ROUTE_LABELS="mydeployment=prod"`, and a router deployment `devtest-router` is
+configured with the label selector `ROUTE_LABELS="mydeployment in (dev, test)"`.
+
+This configuration partitions routes between the two router deployments
+according to the routes' labels, irrespective of their namespaces.
 
 The example assumes you have all the routes you want to be serviced tagged with
 a label `"mydeployment=<tag>"`.
 
-[[using-router-shards-names]]
-.Router Sharding Based on Namespace Names
-image::router_sharding_namespace_names.png[Router Sharding Based on Namespace Names]
-
 [[creating-router-shards]]
 === Creating Router Shards
 
-To implement router sharding, set
-xref:../../architecture/networking/routes.adoc#router-sharding[labels]
-on the routes in the pool
-and express the desired subset of those routes for the router to admit
-with a selection expression via the `oc set env` command.
-
-First, ensure that service account associated with the router has the
-xref:../../install_config/router/index.adoc#creating-the-router-service-account[`cluster reader`] permission.
-
-The rest of this section describes an extended example.
+This section describes an advanced example of router sharding.
 Suppose there are 26 routes, named `a` -- `z`,
-in the pool, with various labels:
+with various labels:
 
-.Possible labels on routes in the pool
+.Possible labels on routes
 ----
 sla=high       geo=east     hw=modest     dept=finance
 sla=medium     geo=west     hw=strong     dept=dev
 sla=low                                   dept=ops
 ----
 
-These labels express the concepts:
+These labels express the following concepts:
 service level agreement, geographical location,
 hardware requirements, and department.
-The routes in the pool can have at most one label from each column.
-Some routes may have other labels, entirely, or none at all.
+The routes can have at most one label from each column.
+Some routes may have other labels or no labels at all.
 
 [options="header",cols="1,1,1,1,1,3"]
 |===
@@ -607,8 +639,8 @@ Some routes may have other labels, entirely, or none at all.
 |===
 
 Here is a convenience script *_mkshard_*  that
-ilustrates how `oc adm router`, `oc set env`, and `oc scale`
-work together to make a router shard.
+illustrates how `oc adm router`, `oc set env`, and `oc scale`
+can be used together to make a router shard.
 
 ====
 [source,bash]
@@ -659,8 +691,8 @@ Running *_mkshard_* several times creates several routers:
 Because a router shard is a construct
 xref:../../architecture/networking/routes.adoc#router-sharding[based on labels],
 you can modify either the labels (via
-xref:../../cli_reference/basic_cli_operations.adoc#application-modification-cli-operations[`oc label`])
-or the selection expression.
+xref:../../cli_reference/basic_cli_operations.adoc#oc-label[`oc label`])
+or the selection expression (via xref:../../cli_reference/basic_cli_operations.adoc#oc-set-env[`oc set env`]).
 
 This section extends the example started in the
 xref:creating-router-shards[Creating Router Shards] section,
@@ -717,19 +749,19 @@ and specifies a department to leave out of the shard,
 thus achieving the same result as the preceding example:
 
 ----
-$ modshard 3 ROUTE_LABELS='dept != finanace'
+$ modshard 3 ROUTE_LABELS='dept != finance'
 ----
 
-This example specifies shows three comma-separated qualities,
+This example specifies three comma-separated qualities,
 and results in only route `b` being selected:
 
 ----
 $ modshard 3 ROUTE_LABELS='hw=strong,type=dynamic,geo=west'
 ----
 
-Similarly to `ROUTE_LABELS`, which involve a route's labels,
-you can select routes based on the labels of the route's namespace labels,
-with the `NAMESPACE_LABELS` environment variable.
+Similarly to `ROUTE_LABELS`, which involves a route's labels,
+you can select routes based on the labels of the route's namespace
+using the `NAMESPACE_LABELS` environment variable.
 This example modifies `router-shard-3` to serve
 routes whose namespace has the label `frequency=weekly`:
 
@@ -746,65 +778,6 @@ $ modshard 3 \
     NAMESPACE_LABELS='frequency=weekly' \
     ROUTE_LABELS='sla=low'
 ----
-
-[[using-namespace-router-shards]]
-=== Using Namespace Router Shards
-
-The routes for a project can be handled by a selected router by using
-`NAMESPACE_LABELS`.
-The router is given a selector for a `NAMESPACE_LABELS`
-label and the project that wants to use the router applies the `NAMESPACE_LABELS`
-label to its namespace.
-
-First, ensure that service account associated with the router has the
-xref:../../install_config/router/index.adoc#creating-the-router-service-account[`cluster reader`] permission.
-This permits the router to read the labels that are applied to the namespaces.
-
-Now create and label the router:
-
-----
-$ oc adm router ...  --service-account=router
-$ oc set env dc/router NAMESPACE_LABELS="router=r1"
-----
-
-Because the router has a selector for a namespace, the router will handle
-routes for that namespace.  So, for example:
-
-----
-$ oc label namespace default "router=r1"
-----
-
-Now create routes in the default namespace, and the route is
-available in the default router:
-
-----
-$ oc create -f route1.yaml
-----
-
-Now create a new project (namespace) and create a route, route2.
-
-----
-$ oc new-project p1
-$ oc create -f route2.yaml
-----
-
-And notice the route is not available in your router.
-Now label namespace p1 with "router=r1"
-
-----
-$ oc label namespace p1 "router=r1"
-----
-
-Which makes the route available to the router.
-
-Note that removing the label from the namespace won't have immediate effect
-(as we don't see the updates in the router), so if you redeploy/start a new
-router pod, you should see the unlabelled effects.
-
-----
-$ oc scale dc/router --replicas=0 && oc scale dc/router --replicas=1
-----
-
 
 [[finding-router-hostname]]
 == Finding the Host Name of the Router


### PR DESCRIPTION
• Fix the link to the architecture documentation on router sharding.

• Fix use of "partitions" (which by definition are non-overlapping), and use set terminology more consistently.

• Be more explicit about how labels and label selectors are used to define router shards and more consistent in terminology for labels and label selectors.

• Avoid sentence fragments.

• Delete spurious backslash.

• Fix the introduction to the "Router Sharding Examples" section: All of the examples use label selectors, selecting either routes or namespaces by label.  Delete spurious cross-references.

• Delete the redundant "Using Namespace Router Shards" section and copy the relevant commands into the "Router Sharding Examples" section.

• Delete the note that states that removing the label from a namespace does not take effect immediately (my testing indicated that it does).

• Use consistent markup for namespace names, route names, and labels.

• Replace "amongst" with "between" when there are two things.

• Use correct verb number with "criteria" (plural).

• Explicitly reference the diagram illustrating router sharding based on namespace labels.

• Fix comparatives for two priorities of traffic: "higher" and "lower".

• Delete the `router_sharding_namespace_names.png` figure, which does not match any of the examples.

• Delete repetitious statements about labels and the `cluster-reader` permission in the "Creating Router Shards" section.

• Delete mention of "pools", which is unnecessary and fraught terminology.

• Delete spurious "entirely".

• Fix typo: "ilustrates" → "illustrates".

• Improve accuracy of the `oc label` cross-reference, and add a cross-reference for `oc set env`.

• Fix typo: "finanace" → "finance".

• Delete spurious "shows" in "This example specifies shows".

• Use correct verb number with `ROUTE_LABELS` (singular).

• Delete extra "labels" in "the labels of the route's namespace labels".