### PR TITLE
async operations/eventual consistency

### DIFF
--- a/architecture/service_catalog/index.adoc
+++ b/architecture/service_catalog/index.adoc
@@ -62,6 +62,12 @@ their own. For example, a service instance may be a BestDataBase instance named
 application). For example, the `my_db` service instance may be bound to the
 user's application called `my_app`.
 
+When a user makes a request to provision or deprovision a resource, the request
+is made to the service catalog which then sends a request to the appropriate
+cluster service broker.  With some services, some operations such as provision,
+deprovision and update are expected to take some time to fulfil.  If the cluster 
+service broker is unavailable, service catalog will continue to retry the operation.
+
 This infrastructure allows a loose coupling between applications running in
 {product-title} and the services they use. This allows the application that uses
 those services to focus on its own business logic while leaving the management
@@ -78,6 +84,14 @@ that references the service binding being deleted.
 
 Once all the service bindings are removed, the service instance may be deleted.
 Deleting the service instance is known as _deprovisioning_.
+
+If a project or namespace containing service bindings and service instances is
+deleted, the service catalog must first request the cluster service broker to
+delete the associated instances and bindings.  This is expected to delay the
+actual deletion of the project or namespace since service catalog must
+communicate with cluster service brokers and wait for them to perform their
+deprovisioning work. In normal circumstances this may take several minutes or
+longer depending on the service.
 
 [[service-catalog-concepts-terminology]]
 == Concepts and Terminology


### PR DESCRIPTION
We need to document the async fashion when dealing with cluster service brokers - - when a user deletes an instance, it may take some time for the deletion to actually occur.  If a namespace is deleted, the catalog objects must first be completely deleted first.