### PR TITLE
Fix incorrect example for downward API

### DIFF
--- a/dev_guide/downward_api.adoc
+++ b/dev_guide/downward_api.adoc
@@ -144,7 +144,7 @@ configure this volume. The plug-in supports the following fields:
 spec:
   volumes:
     - name: podinfo
-      metadata: <1>
+      downwardAPI:: <1>
         items: <2>
           -name: "labels" <3>
            fieldRef:


### PR DESCRIPTION
Looking at the upstream Kubernetes docs they use `downwardAPI:`instead of `metadata`.