### PR TITLE
enables travis cache feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.3.1
 gemfile: Gemfile


### PR DESCRIPTION
From https://docs.travis-ci.com/user/caching/#Bundler

`On Ruby and Objective-C projects, installing dependencies via Bundler can make up a large portion of the build duration. Caching the bundle between builds drastically reduces the time a build takes to run.`