### PR TITLE
admin-guide:image-policy: allowed registries for import

### DIFF
--- a/admin_guide/image_policy.adoc
+++ b/admin_guide/image_policy.adoc
@@ -12,13 +12,100 @@ toc::[]
 
 == Overview
 
-You can control which images are allowed to run on your cluster using the ImagePolicy
-admission plug-in (currently considered beta). It allows you to control:
+You can control which images can be imported, tagged and/or run in a cluster.
+There are two facilities for this purpose.
+
+xref:#image-policy-configuring-the-image-policy-admission-plug-in[*Allowed
+Registries for import*] - Is an image policy configuration that allows to
+restrict image origins to particular set of external registries. This set of
+rules is applied to any image being imported or tagged into any image stream.
+Therefor any image referencing registry not matched by the rule set will be
+rejected.
+
+xref:#image-policy-testing-image-policy-admission-plug-in[*ImagePolicy
+admission plug-in*] - Lets you specify which images are allowed to be run on
+your cluster using. This is a beta feature. It allows you to control:
 
 - *The source of images*: which registries can be used to pull images
-- *Image resolution*: force pods to run with immutable digests to ensure the image does not change due to a re-tag
-- *Container image label restrictions*: force an image to have or not have particular labels
-- *Image annotation restrictions*: force an image in the integrated container registry to have or not have particular annotations
+- *Image resolution*: force pods to run with immutable digests to ensure the
+  image does not change due to a re-tag
+- *Container image label restrictions*: force an image to have or not have
+  particular labels
+- *Image annotation restrictions*: force an image in the integrated container
+  registry to have or not have particular annotations
+
+== Configuring Registries Allowed for Import
+
+Can be achieved in `*_master-config.yaml_*` under
+`imagePolicyConfig:allowedRegistriesForImport` section as demonstrated in the
+following example. If the setting is not present, all images are allowed.
+
+[[example-configuration-of-registries-allowed-for-import]]
+.Example Configuration of Registries Allowed for Import
+====
+[source,yaml]
+----
+imagePolicyConfig:
+  allowedRegistriesForImport:
+  -
+    domainName: registry.access.redhat.com <1>
+  - 
+    domainName: *.mydomain.com
+    insecure: true <2>
+  - 
+    domainName: local.registry.corp:5000 <3>
+----
+<1> Allow any image from the specified secure registry.
+<2> Allow any image from any insecure registry hosted on any sub-domain of
+`mydomain.com`. The `mydomain.com` is not whitelisted.
+<3> Allow any image from the given registry with port specified.
+====
+
+Each rule is composed of the following attributes:
+
+- `*domainName*`: is a hostname optionally terminated by `:<port>` suffix
+where special wildcard characters (`?`, `*`) are recognized. The former
+matches a sequence of characters of any length while the later matches
+exactly one character. The wildcard characters can be present both before and
+after `:` separator. The wildcards apply only to the part before or after the
+separator regardless of separator's presence.
+- `*insecure*`: is a boolean used to decide which ports will be matched if the
+`:<port>` part is missing from `*domainName*`. If true, the `*domainName*`
+will match registries with `:80` suffix or unspecified port as long as the
+insecure flag is used during import. If false, registries with `:443` suffix
+or unspecified port will be matched.
+
+[NOTE]
+====
+. If a rule should match both secure and insecure ports of the same domain, the
+rule needs to be listed twice (once with `insecure=true` and once with
+`insecure=false`.
+
+. Unqualified images references will be qualified to `docker.io` before any
+rule evaluation. To whitelist them, use `domainName: docker.io`.
+
+. `*domainName: \**` rule will match any registry hostname, but port will still
+be restricted to `443`. To match arbitrary registry serving on arbitrary port,
+use `*domainName: *:**`.
+====
+
+So for example:
+
+- `oc tag --insecure reg.mydomain.com/app:v1 app:v1` will be whitelisted by the
+second rule
+xref:#example-configuration-of-registries-allowed-for-import[above].
+- `oc import-image --from reg1.mydomain.com:80/foo foo:latest` will be also
+  whitelisted. But
+- `oc tag local.registry.corp/bar bar:latest` will be rejected because the port
+  does not match `5000` in the third rule.
+
+Rejected image imports will generate error messages similar to the one below:
+
+----
+The ImageStream "bar" is invalid:
+* spec.tags[latest].from.name: Forbidden: registry "local.registry.corp" not allowed by whitelist: "local.registry.corp:5000", "*.mydomain.com:80", "registry.access.redhat.com:443"
+* status.tags[latest].items[0].dockerImageReference: Forbidden: registry "local.registry.corp" not allowed by whitelist: "local.registry.corp:5000", "*.mydomain.com:80", "registry.access.redhat.com:443"
+----
 
 
 [[image-policy-configuring-the-image-policy-admission-plug-in]]


### PR DESCRIPTION
Documents feature/bugfix implemented/merged in openshift/origin#17783

Resolves #7123