### PR TITLE
The literal kind is "DeploymentConfig" not "DeploymentConfiguration"

### DIFF
--- a/architecture/core_concepts/deployments.adoc
+++ b/architecture/core_concepts/deployments.adoc
@@ -126,7 +126,7 @@ deployments also provide the ability to transition from an existing
 deployment of an image to a new one and also define hooks to be run
 before or after creating the replication controller.
 
-The {product-title} `*DeploymentConfiguration*` object defines the following
+The {product-title} `*DeploymentConfig*` object defines the following
 details of a deployment:
 
 1. The elements of a `*ReplicationController*` definition.
@@ -145,7 +145,7 @@ controller is retained to enable easy rollback if needed.
 For detailed instructions on how to create and interact with deployments,
 refer to xref:../../dev_guide/deployments/basic_deployment_operations.adoc#dev-guide-basic-deployment-operations[Deployments].
 
-Here is an example `*DeploymentConfiguration*` definition with some
+Here is an example `*DeploymentConfig*` definition with some
 omissions and callouts:
 
 [source,yaml]


### PR DESCRIPTION
Using two terms for same thing is somewhat confusing, perhaps even worth renaming the chapter "Deployments and Deployment Configs"?
Anyway what's OK in prose is not acceptable in literal font, that should math the actual `kind: DeploymentConfig`.