### PR TITLE
Include the controller verification for 3.7

### DIFF
--- a/day_two_guide/environment_health_checks.adoc
+++ b/day_two_guide/environment_health_checks.adoc
@@ -48,15 +48,14 @@ include::day_two_guide/topics/docker_storage.adoc[]
 
 include::day_two_guide/topics/api_service_status.adoc[]
 
-////
+
 [[day-two-guide-controller-role-verification]]
 == Controller role verification
 
 include::day_two_guide/topics/controller_role_verification.adoc[]
-////
+
 
 [[day-two-guide-verifying_mtu]]
 == Verifying correct Maximum Transmission Unit (MTU) size
 
 include::day_two_guide/topics/verifying_mtu.adoc[]
-

--- a/day_two_guide/topics/controller_role_verification.adoc
+++ b/day_two_guide/topics/controller_role_verification.adoc
@@ -15,9 +15,7 @@ The {product-title} controllers execute a procedure to choose which host runs
 the service. The current running value is stored in an annotation in a special
 `configmap` stored in the `kube-system` project.
 
-Verification of the master host actively running the
-`atomic-openshift-master-controllers.service` service is performed by running
-the following command as `cluster-admin`:
+Verify the master host running the `atomic-openshift-master-controllers`  service as a `cluster-admin` user:
 
 ----
 $ oc get -n kube-system cm openshift-master-controllers -o yaml
@@ -42,9 +40,10 @@ The command outputs the current master controller in the
 master-<hostname>-<ip>-<8_random_characters>
 ----
 
-In order to properly filter the hostname, the following command can be used:
+Find the hostname of the master host by filtering the output using the
+following:
 
 ----
-$ oc get -n kube-system cm openshift-master-controllers -o json | jq -r .metadata.annotations[] | jq -r .holderIdentity | sed -e 's/^master-//g' -e 's/-[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}-.\{8\}$//g'
+$ oc get -n kube-system cm openshift-master-controllers -o json | jq -r '.metadata.annotations[] | fromjson.holderIdentity | match("^master-(.*)-[0-9.]*-[0-9a-z]{8}$") | .captures[0].string'
 ose-master-0.example.com
 ----

--- a/day_two_guide/topics/controller_role_verification.adoc
+++ b/day_two_guide/topics/controller_role_verification.adoc
@@ -12,31 +12,39 @@ hosts. The service runs in active/passive mode, meaning it should only be
 running on one master at any time.
 
 The {product-title} controllers execute a procedure to choose which host runs
-the service. The current running value is stored in the etcd cluster within the `/openshift.io/leases/controllers` key.
+the service. The current running value is stored in an annotation in a special
+`configmap` stored in the `kube-system` project.
 
 Verification of the master host actively running the
 `atomic-openshift-master-controllers.service` service is performed by running
-the following command on any of the master nodes:
+the following command as `cluster-admin`:
 
 ----
-# etcdctl2 get /openshift.io/leases/controllers
-master-0fz9x9k2
+$ oc get -n kube-system cm openshift-master-controllers -o yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"master-ose-master-0.example.com-10.19.115.212-dnwrtcl4","leaseDurationSeconds":15,"acquireTime":"2018-02-17T18:16:54Z","renewTime":"2018-02-19T13:50:33Z","leaderTransitions":16}'
+  creationTimestamp: 2018-02-02T10:30:04Z
+  name: openshift-master-controllers
+  namespace: kube-system
+  resourceVersion: "17349662"
+  selfLink: /api/v1/namespaces/kube-system/configmaps/openshift-master-controllers
+  uid: 08636843-0804-11e8-8580-fa163eb934f0
 ----
 
-The command outputs an identifier of the master host running the controller
-service, but currently this identifier is generated randomly when the service is
-executed. To get the ID of every master search the
-`atomic-openshift-master-controllers.service` logs for a master host ID:
+The command outputs the current master controller in the
+`control-plane.alpha.kubernetes.io/leader` annotation, within the
+`holderIdentity` property as:
 
 ----
-I1130 11:40:56.778373   30138 leaderelection.go:127] Attempting to acquire controller lease as master-8sn5gpzn, renewing every 30s
+master-<hostname>-<ip>-<8_random_characters>
 ----
 
-In order to find the identifiers of the master nodes, log in to each master node
-and run:
+In order to properly filter the hostname, the following command can be used:
 
 ----
-$ journalctl -b -u atomic-openshift-master-controllers.service --output cat | grep 'Attempting to acquire controller lease as' | tail -1 | sed 's/.*lease as \(.*\),.*/\1/'
-master-0fz9x9k2
+$ oc get -n kube-system cm openshift-master-controllers -o json | jq -r .metadata.annotations[] | jq -r .holderIdentity | sed -e 's/^master-//g' -e 's/-[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}-.\{8\}$//g'
+ose-master-0.example.com
 ----
-


### PR DESCRIPTION
As part of the missing items from day 2 ops, I've fixed this for 3.7
@bfallonf PTAL