### PR TITLE
Bug 1547141: Update example of attaching GlusterFS PVC to docker registry

### DIFF
--- a/install_config/storage_examples/gluster_backed_registry.adoc
+++ b/install_config/storage_examples/gluster_backed_registry.adoc
@@ -98,7 +98,7 @@ instructions for troubleshooting before continuing.
 Then, attach the PVC:
 
 ----
-$ oc volume deploymentconfigs/docker-registry --add --name=v1 -t pvc \
+$ oc volume deploymentconfigs/docker-registry --add --name=registry-storage -t pvc \
      --claim-name=gluster-claim --overwrite
 ----
 


### PR DESCRIPTION
Improved example so that the oc volume command will work on a running docker registry deployment.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547141