### PR TITLE
Bug 1546254- Add required path for openshift-ansible installer to succeed.

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -11,6 +11,18 @@
 
 toc::[]
 
+[[setting-path]]
+== Setting PATH
+
+The PATH for the root user on each host must contain the following directories:
+
+- /bin
+- /sbin
+- /usr/bin
+- /usr/sbin
+
+These should all be included by default in a fresh RHEL 7.x installation. 
+
 ifdef::openshift-enterprise[]
 
 [[software-prerequisites]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1546254