### PR TITLE
[enterprise-3.7] Added --dry-run option for oc adm drain for 3.7

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -267,6 +267,13 @@ Alternatively, instead of specifying specific node names (e.g., `<node1>
 <node2>`), you can use the `--selector=<node_selector>` option to evacuate pods
 on selected nodes.
 
+To list objects that will be migrated without actually performing the evacuation,
+use the `--dry-run` option and set it to `true`:
+
+----
+$ oc adm drain <node1> <node2>  --dry-run=true
+----
+
 [[rebooting-nodes]]
 == Rebooting Nodes
 

--- a/admin_guide/revhistory_admin_guide.adoc
+++ b/admin_guide/revhistory_admin_guide.adoc
@@ -7,6 +7,22 @@
 :experimental:
 
 // do-release: revhist-tables
+
+== Wed Feb 21 2018
+
+// tag::admin_guide_wed_feb_21_2018[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+//Wed Feb 21 2018
+|xref:../admin_guide/manage_nodes.adoc#admin-guide-manage-nodes[Managing Nodes]
+|Added information about the `--dry-run` option for `oc adm drain`.
+
+|===
+
+// end::admin_guide_wed_feb_21_2018[]
+
 == Fri Feb 16 2018
 
 // tag::admin_guide_fri_feb_16_2018[]

--- a/welcome/revhistory_full.adoc
+++ b/welcome/revhistory_full.adoc
@@ -10,6 +10,11 @@ The following sections aggregate the revision histories of each guide by publish
 date.
 
 // do-release: revhist-tables
+
+== Wed Feb 21 2018
+.Cluster Administration
+include::admin_guide/revhistory_admin_guide.adoc[tag=admin_guide_wed_feb_21_2018]
+
 == Fri Feb 16 2018
 .Using Images
 include::using_images/revhistory_using_images.adoc[tag=using_images_fri_feb_16_2018]


### PR DESCRIPTION
Continues the robot's cherry-pick work of https://github.com/openshift/openshift-docs/pull/7880 from https://github.com/openshift/openshift-docs/pull/7888 and adds revision history  :robot: 