### PR TITLE
Need to enable ansible repo on control host for 3.9

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -95,7 +95,7 @@ that are necessary in order to install {product-title}. You may have already ena
 the first two repositories in this example.
 
 ----
-$ subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.7-rpms" --enable="rhel-7-fast-datapath-rpms"
+$ subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.7-rpms" --enable="rhel-7-fast-datapath-rpms" --enable="rhel-7-server-ansible-2.4-rpms"
 ----
 
 [NOTE]

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -130,6 +130,7 @@ $ subscription-manager attach --pool=<pool_id>
 $ subscription-manager repos --disable="*"
 $ subscription-manager repos \
     --enable="rhel-7-server-rpms" \
+    --enable="rhel-7-server-ansible-2.4-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ose-3.7-rpms"
@@ -165,6 +166,7 @@ modify the command for the appropriate path you created above:
 ----
 $ for repo in \
 rhel-7-server-rpms \
+rhel-7-server-ansible-2.4-rpms \
 rhel-7-server-extras-rpms \
 rhel-7-fast-datapath-rpms \
 rhel-7-server-ose-3.7-rpms
@@ -466,6 +468,11 @@ or host name of the Apache server hosting the software repositories:
 [rhel-7-server-rpms]
 name=rhel-7-server-rpms
 baseurl=http://<server_IP>/repos/rhel-7-server-rpms
+enabled=1
+gpgcheck=0
+[rhel-7-server-ansible-2.4-rpms]
+name=rhel-7-server-ansible-2.4-rpms
+baseurl=http://<server_IP>/repos/rhel-7-server-ansible-2.4-rpms
 enabled=1
 gpgcheck=0
 [rhel-7-server-extras-rpms]

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -87,6 +87,7 @@ Note that this could take a few minutes if you have a large number of available 
 ----
 # subscription-manager repos \
     --enable="rhel-7-server-rpms" \
+    --enable="rhel-7-server-ansible-2.4-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.7-rpms" \
     --enable="rhel-7-fast-datapath-rpms"

--- a/upgrading/manual_upgrades.adoc
+++ b/upgrading/manual_upgrades.adoc
@@ -69,6 +69,7 @@ channel and enable the 3.7 channel on each host:
 +
 ----
 # subscription-manager repos --disable="rhel-7-server-ose-3.6-rpms" \
+    --enable="rhel-7-server-ansible-2.4-rpms" \
     --enable="rhel-7-server-ose-3.7-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-fast-datapath-rpms"


### PR DESCRIPTION
In previous releases ansible was shipped in the OCP channels. In 3.9 we now require ansible from the ansible channels.