### PR TITLE
Add more objects to the backup procedure

### DIFF
--- a/day_two_guide/topics/project_backup.adoc
+++ b/day_two_guide/topics/project_backup.adoc
@@ -77,7 +77,7 @@ however, does not export all objects, such as `role bindings`, `secrets`,
 `service accounts`, or `persistent volume claims`. To export these, run:
 +
 ----
-$ for object in secret serviceaccount rolebindings pvc
+$ for object in rolebindings serviceaccounts secrets imagestreamtags podpreset cms egressnetworkpolicies rolebindingrestrictions limitranges resourcequotas pvcs templates cronjobs statefulsets hpas deployments replicasets poddisruptionbudget endpoints
 do
   oc export $object -o yaml > $object.yaml
 done
@@ -130,24 +130,34 @@ For example:
 +
 ----
 $ ./project_export.sh myproject
-Exporting namespace to myproject/ns.json
-Exporting rolebindings to myproject/rolebindings.json
-Exporting serviceaccounts to myproject/serviceaccounts.json
-Exporting secrets to myproject/secrets.json
-Exporting deploymentconfigs to myproject/dc_*.json
+Exporting namespace to project-demo/ns.json
+Exporting rolebindings to project-demo/rolebindings.json
+Exporting serviceaccounts to project-demo/serviceaccounts.json
+Exporting secrets to project-demo/secrets.json
+Exporting deploymentconfigs to project-demo/dc_*.json
 Patching DC...
-Patching DC...
-Patching DC...
-Exporting buildconfigs to myproject/bcs.json
-Exporting builds to myproject/builds.json
-Exporting imagestreams to myproject/iss.json
-Exporting replicationcontrollers to myproject/rcs.json
-Exporting services to myproject/svcs.json
-Exporting pods to myproject/pods.json
-Exporting configmaps to myproject/cms.json
-Exporting pvcs to myproject/pvcs.json
-Exporting routes to myproject/routes.json
-Exporting templates to myproject/templates.json
+Exporting buildconfigs to project-demo/bcs.json
+Exporting builds to project-demo/builds.json
+Exporting imagestreams to project-demo/iss.json
+Exporting imagestreamtags to project-demo/imagestreamtags.json
+Exporting replicationcontrollers to project-demo/rcs.json
+Exporting services to project-demo/svc_*.json
+Exporting pods to project-demo/pods.json
+Exporting podpreset to project-demo/podpreset.json
+Exporting configmaps to project-demo/cms.json
+Exporting egressnetworkpolicies to project-demo/egressnetworkpolicies.json
+Exporting rolebindingrestrictions to project-demo/rolebindingrestrictions.json
+Exporting limitranges to project-demo/limitranges.json
+Exporting resourcequotas to project-demo/resourcequotas.json
+Exporting pvcs to project-demo/pvcs.json
+Exporting routes to project-demo/routes.json
+Exporting templates to project-demo/templates.json
+Exporting cronjobs to project-demo/cronjobs.json
+Exporting statefulsets to project-demo/statefulsets.json
+Exporting hpas to project-demo/hpas.json
+Exporting deployments to project-demo/deployments.json
+Exporting replicasets to project-demo/replicasets.json
+Exporting poddisruptionbudget to project-demo/poddisruptionbudget.json
 ----
 
 . Once executed, review the files to verify that the content has been properly
@@ -159,22 +169,32 @@ $ ls -1
 bcs.json
 builds.json
 cms.json
-dc_guestbook.json
-dc_guestbook_patched.json
-dc_hello-openshift.json
-dc_hello-openshift_patched.json
+cronjobs.json
 dc_ruby-ex.json
 dc_ruby-ex_patched.json
+deployments.json
+egressnetworkpolicies.json
+endpoint_external-mysql-service.json
+hpas.json
+imagestreamtags.json
 iss.json
+limitranges.json
 ns.json
+poddisruptionbudget.json
+podpreset.json
 pods.json
 pvcs.json
 rcs.json
+replicasets.json
+resourcequotas.json
+rolebindingrestrictions.json
 rolebindings.json
 routes.json
 secrets.json
 serviceaccounts.json
-svcs.json
+statefulsets.json
+svc_external-mysql-service.json
+svc_ruby-ex.json
 templates.json
 $ less bcs.json
 ...


### PR DESCRIPTION
As part of the feedback received on the day 2 ops guide by @jorgemoralespou he missed some objects in the backup procedure. I've added all the objects that I've found in the script [here](https://github.com/openshift/openshift-ansible-contrib/pull/943) and added those to the docs in this PR.
@bfallonf do you mind to take a look at this?
Thanks!!!