### PR TITLE
node_affinity: Delete unpaired callout

### DIFF
--- a/admin_guide/scheduling/node_affinity.adoc
+++ b/admin_guide/scheduling/node_affinity.adoc
@@ -169,7 +169,7 @@ $ oc label node node1 e2e-az-name=e2e-az3
 .. Specify the key and values that must be met. If you want the new pod to be scheduled on the node you edited, use the same `key` and `value` parameters as the label in the node:
 +
 ----
-      preferredDuringSchedulingIgnoredDuringExecution: <4>
+      preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:
           matchExpressions:


### PR DESCRIPTION
Delete an unpaired callout number in the "Preferred Node Affinity Rule" example.