### PR TITLE
Advance Install updates

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -31,7 +31,6 @@ a supported version of Fedora, CentOS, or RHEL.
 endif::[]
 The host initiating the installation does not need to be intended for inclusion
 in the {product-title} cluster, but it can be.
-
 ====
 
 ifdef::openshift-enterprise[]
@@ -264,20 +263,17 @@ master may require access to, or the installation will fail. Defaults to
 |This variable overrides the default subdomain to use for exposed
 xref:../../architecture/core_concepts/routes.adoc#architecture-core-concepts-routes[routes].
 
-|`openshift_master_image_policy_config`
-|Sets `imagePolicyConfig` in the master configuration. See xref:../../install_config/master_node_configuration.adoc#master-config-image-config[Image Configuration] for details.
-
 |`openshift_node_proxy_mode`
 |This variable specifies the
 xref:../../architecture/core_concepts/pods_and_services.adoc#service-proxy-mode[service
 proxy mode] to use: either `iptables` for the default, pure-`iptables`
 implementation, or `userspace` for the user space proxy.
 
-|`openshift_router_selector`
+|`*openshift_hosted_router_selector*`
 |Default node selector for automatically deploying router pods. See
 xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 
-|`openshift_registry_selector`
+|`*openshift_registry_selector*`
 |Default node selector for automatically deploying registry pods. See
 xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 
@@ -332,6 +328,10 @@ If you alter this variable, ensure the host name is accessible via your router.
 See xref:advanced-install-cluster-metrics[Configuring Cluster Metrics] for
 details.
 
+|`openshift_clusterid`
+|This variable is a cluster identifier unique to the AWS Availability Zone. Using this avoids potential issues in Amazon Web Service
+(AWS) with multiple zones or multiple clusters. See xref:../../install_config/configuring_aws.adoc#aws-cluster-labeling[Labeling Clusters for AWS] for details.
+
 |`openshift_image_tag`
 |Use this variable to specify a container image tag to install or configure.
 
@@ -347,8 +347,8 @@ after the cluster is set up, then an upgrade can be triggered, resulting in
 downtime.
 
 * If `openshift_image_tag` is set, its value is used for all hosts in
-containerized environments, even those that have another version installed. If
-* `openshift_pkg_version` is set, its value is used for all hosts in RPM-based
+containerized environments, even those that have another version installed.
+* If `openshift_pkg_version` is set, its value is used for all hosts in RPM-based
 environments, even those that have another version installed.
 ====
 
@@ -401,25 +401,25 @@ can be assigned to individual host entries:
 
 |Variable |Purpose
 
-|`openshift_hostname`
+|`*openshift_hostname*`
 |This variable overrides the internal cluster host name for the system. Use this
 when the system's default IP address does not resolve to the system host name.
 
-|`openshift_public_hostname`
+|`*openshift_public_hostname*`
 |This variable overrides the system's public host name. Use this for cloud
 installations, or for hosts on networks using a network address translation
 (NAT).
 
-|`openshift_ip`
+|`*openshift_ip*`
 |This variable overrides the cluster internal IP address for the system. Use
 this when using an interface that is not configured with the default route.
 
-|`openshift_public_ip`
+|`*openshift_public_ip*`
 |This variable overrides the system's public IP address. Use this for cloud
 installations, or for hosts on networks using a network address translation
 (NAT).
 
-|`containerized`
+|`*containerized*`
 |If set to *true*, containerized {product-title} services are run on the target master and
 node hosts instead of installed using RPM packages. If set to *false* or unset,
 the default RPM method is used. RHEL Atomic Host requires the containerized
@@ -430,12 +430,12 @@ ifdef::openshift-enterprise[]
 Containerized installations are supported starting in {product-title} 3.1.1.
 endif::[]
 
-|`openshift_node_labels`
+|`*openshift_node_labels*`
 |This variable adds labels to nodes during installation. See
 xref:configuring-node-host-labels[Configuring Node Host Labels] for more
 details.
 
-|`openshift_node_kubelet_args`
+|`*openshift_node_kubelet_args*`
 |This variable is used to configure `kubeletArguments` on nodes, such as
 arguments used in xref:../../admin_guide/garbage_collection.adoc#admin-guide-garbage-collection[container and
 image garbage collection], and to
@@ -448,17 +448,9 @@ invalid if used. These values override other settings in node configuration
 which may cause invalid configurations. Example usage:
 *{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
 
-|`openshift_hosted_router_selector`
-|Default node selector for automatically deploying router pods. See
-xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
-
-|`openshift_registry_selector`
-|Default node selector for automatically deploying registry pods. See
-xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
-
 |`*openshift_docker_options*`
-|This variable configures additional Docker options within *_/etc/sysconfig/docker_*, such as options used in xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs].
-
+|This variable configures additional Docker options within *_/etc/sysconfig/docker_*, such as
+options used in xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs].
 Example usage: *"--log-driver json-file --log-opt max-size=1M --log-opt max-file=3"*.
 
 |`openshift_schedulable`
@@ -577,7 +569,11 @@ inventory file. For example:
 openshift_disable_check=memory_availability,disk_availability
 ----
 
-A similar set of checks meant to run for diagnostic on existing clusters can be xref:../../admin_guide/diagnostics_tool.adoc#admin-guide-diagnostics-tool[Additional Diagnostic Checks via Ansible]. Another set of checks for checking certificate expiration can be found in  xref:../../install_config/redeploying_certificates.adoc#install-config-redeploying-certificates[Redeploying Certificates].
+A similar set of checks meant to run for diagnostic on existing clusters can be
+found in
+xref:../../admin_guide/diagnostics_tool.adoc#admin-guide-diagnostics-tool[Additional Diagnostic Checks via Ansible]. Another set of checks for checking certificate
+expiration can be found in
+xref:../../install_config/redeploying_certificates.adoc#install-config-redeploying-certificates[Redeploying Certificates].
 
 [[advanced-install-configuring-system-containers]]
 === Configuring System Containers
@@ -730,7 +726,6 @@ openshift_examples_modify_imagestreams=true
 
 |`*openshift_examples_modify_imagestreams*`
 |Set to `true` if pointing to a registry other than the default. Modifies the image stream location to the value of `*oreg_url*`.
-
 |===
 
 [[advanced-install-registry-storage]]
@@ -845,59 +840,60 @@ environment is defined for builds.
 
 |Variable |Purpose
 
-|`openshift_http_proxy`
-|This variable specifies the `HTTP_PROXY` environment variable for masters and
+|`*openshift_http_proxy*`
+|This variable specifies the `*HTTP_PROXY*` environment variable for masters and
 the Docker daemon.
 
-|`openshift_https_proxy`
-|This variable specifices the `HTTPS_PROXY` environment variable for masters
+|`*openshift_https_proxy*`
+|This variable specifices the `*HTTPS_PROXY*` environment variable for masters
 and the Docker daemon.
 
-|`openshift_no_proxy`
-|This variable is used to set the `NO_PROXY` environment variable for masters
+|`*openshift_no_proxy*`
+|This variable is used to set the `*NO_PROXY*` environment variable for masters
 and the Docker daemon. This value should be set to a comma separated list of
 host names or wildcard host names that should not use the defined proxy. This
 list will be augmented with the list of all defined {product-title} host names
 by default.
 
-|`openshift_generate_no_proxy_hosts`
+|`*openshift_generate_no_proxy_hosts*`
 |This boolean variable specifies whether or not the names of all defined
 OpenShift hosts and `pass:[*.cluster.local]` should be automatically appended to
-the `NO_PROXY` list. Defaults to `true`; set it to `false` to override this
+the `*NO_PROXY*` list. Defaults to *true*; set it to *false* to override this
 option.
 
-|`openshift_builddefaults_http_proxy`
-|This variable defines the `HTTP_PROXY` environment variable inserted into
-builds using the `BuildDefaults` admission controller. If
-`openshift_http_proxy` is set, this variable will inherit that value; you only
+|`*openshift_builddefaults_http_proxy*`
+|This variable defines the `*HTTP_PROXY*` environment variable inserted into
+builds using the `*BuildDefaults*` admission controller. If
+`*openshift_http_proxy*` is set, this variable will inherit that value; you only
 need to set this if you want your builds to use a different value.
 
-|`openshift_builddefaults_https_proxy`
+|`*openshift_builddefaults_https_proxy*`
 |This variable defines the `*HTTPS_PROXY*` environment variable inserted into
 builds using the `*BuildDefaults*` admission controller. If
 `*openshift_https_proxy*` is set, this variable will inherit that value; you
 only need to set this if you want your builds to use a different value.
 
-|`openshift_builddefaults_no_proxy`
-|This variable defines the `NO_PROXY` environment variable inserted into
-builds using the `BuildDefaults` admission controller. If
-`openshift_no_proxy` is set, this variable will inherit that value; you only
+|`*openshift_builddefaults_no_proxy*`
+|This variable defines the `*NO_PROXY*` environment variable inserted into
+builds using the `*BuildDefaults*` admission controller. If
+`*openshift_no_proxy*` is set, this variable will inherit that value; you only
 need to set this if you want your builds to use a different value.
 
-|`openshift_builddefaults_git_http_proxy`
+|`*openshift_builddefaults_git_http_proxy*`
 |This variable defines the HTTP proxy used by `git clone` operations during a
-build, defined using the `BuildDefaults` admission controller. If
-`openshift_builddefaults_http_proxy` is set, this variable will inherit that
+build, defined using the `*BuildDefaults*` admission controller. If
+`*openshift_builddefaults_http_proxy*` is set, this variable will inherit that
 value; you only need to set this if you want your `git clone` operations to use
 a different value.
 
-|`openshift_builddefaults_git_https_proxy`
+|`*openshift_builddefaults_git_https_proxy*`
 |This variable defines the HTTPS proxy used by `git clone` operations during a
-build, defined using the `BuildDefaults` admission controller. If
-`openshift_builddefaults_https_proxy` is set, this variable will inherit that
+build, defined using the `*BuildDefaults*` admission controller. If
+`*openshift_builddefaults_https_proxy*` is set, this variable will inherit that
 value; you only need to set this if you want your `git clone` operations to use
 a different value.
 |===
+
 
 ifdef::openshift-enterprise,openshift-origin[]
 [[advanced-install-configuring-firewalls]]
@@ -997,8 +993,9 @@ pods. They are set to `region=infra` by default:
 # openshift_registry_selector='region=infra'
 ----
 
-The registry and router are only able to run on node hosts with the `region=infra` label.
-Ensure that at least one node host in your {product-title} environment has the `region=infra` label. For example:
+The default router and registry will be automatically deployed during
+installation if nodes exist in the `[nodes]` section that match the selector
+settings. For example:
 
 ----
 [nodes]
@@ -1007,8 +1004,9 @@ infra-node1.example.com openshift_node_labels="{'region': 'infra','zone': 'defau
 
 [IMPORTANT]
 ====
-If there is not a node in the [nodes] section that matches the selector settings,
-the default router and registry will be deployed as failed with `Pending` status.
+The registry and router are only able to run on node hosts with the
+`region=infra` label. Ensure that at least one node host in your {product-title}
+environment has the `region=infra` label.
 ====
 
 It is recommended for production environments that you maintain dedicated
@@ -1345,7 +1343,7 @@ openshift_hosted_logging_storage_kind=dynamic
 === Single Master Examples
 
 You can configure an environment with a single master and multiple nodes, and
-either a single  embedded *etcd* or multiple external *etcd* hosts.
+either a single embedded *etcd* or multiple external *etcd* hosts.
 
 [NOTE]
 ====
@@ -1808,29 +1806,42 @@ specifications, and save it as *_/etc/ansible/hosts_*.
 
 [[running-the-advanced-installation]]
 == Running the Advanced Installation
-After you have finished xref:configuring-ansible[configuring Ansible] by
-defining your own inventory file in *_/etc/ansible/hosts_* or modifying one of
-the xref:adv-install-example-inventory-files[example inventories], follow these
-steps to run the advanced installation:
 
-// tag::BZ1466783-workaround-install[]
-. If you are using a proxy, you must add the IP address of the etcd endpoints to
-the `openshift_no_proxy` cluster variable in your inventory file.
-+
-[NOTE]
-====
-If you are not using a proxy, you can skip this step.
-====
-+
-In {product-title}
+After you have xref:configuring-ansible[configured Ansible] by defining an
+inventory file in *_/etc/ansible/hosts_*, you run the advanced installation
+playbook via Ansible. {product-title} installations are currently supported
+using the RPM-based installer, while the containerized installer is currently a
+Technology Preview feature.
+
+[[running-the-advanced-installation-rpm]]
+=== Running the RPM-based Installer
+
+The RPM-based installer uses Ansible installed via RPM packages to run playbooks
+and configuration files available on the local host. To run the installer, use
+the following command, specifying `-i` if your inventory file located somewhere
+other than *_/etc/ansible/hosts_*:
+
+----
 ifdef::openshift-enterprise[]
-3.4,
+# ansible-playbook  [-i /path/to/inventory] \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 endif::[]
 ifdef::openshift-origin[]
-1.4,
+# ansible-playbook [-i /path/to/inventory] \
+    ~/openshift-ansible/playbooks/byo/config.yml
 endif::[]
-the master connected to the etcd cluster using the host name of the etcd
-endpoints. In {product-title}
+----
+
+If for any reason the installation fails, before re-running the installer, see
+xref:installer-known-issues[Known Issues] to check for any specific
+instructions or workarounds.
+
+[[running-the-advanced-installation-system-container]]
+=== Running the Containerized Installer
+
+include::install_config/install/advanced_install.adoc[tag=syscontainers_techpreview]
+
+The
 ifdef::openshift-enterprise[]
 3.5,
 endif::[]
@@ -1880,9 +1891,9 @@ xref:advanced-verifying-the-installation[Verifying the Installation].
 [[advanced-verifying-the-installation]]
 == Verifying the Installation
 
-// tag::verifying-the-installation[]
 After the installation completes:
 
+// tag::verifying-the-installation[]
 . Verify that the master is started and nodes
 are registered and reporting in *Ready* status. _On the master host_, run the
 following as root:
@@ -1902,11 +1913,13 @@ and the web console port number to access the web console with a web browser.
 For example, for a master host with a host name of `master.openshift.com` and
 using the default port of `8443`, the web console would be found at `\https://master.openshift.com:8443/console`.
 
-. Now that the install has been verified, run the following command on each master and node host to add the *atomic-openshift* packages back to the list of yum excludes on the host:
- +
- ----
- # atomic-openshift-excluder exclude
- ----
+. Now that the install has been verified, run the following command on each master
+and node host to add the *atomic-openshift* packages back to the list of yum
+excludes on the host:
++
+----
+# atomic-openshift-excluder exclude
+----
 
 // end::verifying-the-installation[]
 


### PR DESCRIPTION
# Recreation from History
Content leaked from the `master` branch into the `enterprise-3.5` branch because of the commit in PR https://github.com/openshift/openshift-docs/pull/6105 

 - For enterprise-3.5 branch only.

## How I modified this file?
1.	Created a new branch tracking the current ‘enterprise-3.5’ branch. `git checkout -b fix-3.5-adv-install --track upstream/enterprise-3.5`
2.	Hard reset to commit before the commit from PR#6150. `git reset --hard 5efd709`
3.	Manually checked and updated changes form following commits after PR#6150.
It includes changes from the following commits: 
### One
[enterprise-3.5] changed all instances of emptydir and EmptyDir to em…
Required changes https://github.com/openshift/openshift-docs/pull/6084/files#diff-fe94157edddadf88425cf07b556a00a3 
Changed `EmptyDir` to `emptyDir`
### Two 
[enterprise-3.5] link fixes weekly release (https://github.com/openshift/openshift-docs/commit/c421a44aece908c54934ce2ed63bd1c60a8816a7#diff-fe94157edddadf88425cf07b556a00a3)
Needed no changes (changes are already there)
### Three
[enterprise-3.5] Replace dead links in install and config docs(by Ver… (https://github.com/openshift/openshift-docs/commit/5a12b8353b8aafd864525ddf2dcaa87d5d62a747#diff-fe94157edddadf88425cf07b556a00a3)
Needed no changes (changes are already there)
### Four
[enterprise-3.5] Fixed environment variables (https://github.com/openshift/openshift-docs/commit/d18e3109fb440ee2ea57457eb5ce238f012f34d8#diff-fe94157edddadf88425cf07b556a00a3)
Moved `openshift_hosted_router_selector` and `openshift_registry_selector` to Configuring Cluster Variables section
### Five
[enterprise-3.5] Fixed typo in openshift_template_service_broker_name… (https://github.com/openshift/openshift-docs/commit/886f1be8df2ace635540fdf7c7c91e0420e81b67#diff-fe94157edddadf88425cf07b556a00a3)
No changes
### Six
[enterprise-3.5] added descriptions for openshift_image_tag and opens… (https://github.com/openshift/openshift-docs/commit/d7487fba541ad54a599ca776e105338e9852965a#diff-fe94157edddadf88425cf07b556a00a3)
Added `openshift_clusterid`, `openshift_image_tag`, `openshift_pkg_version` variables.
### Seven
[enterprise-3.5] fixes a bad link and a formatting issue (https://github.com/openshift/openshift-docs/commit/273f7fec8c67bd5483c657a496b0ebd81dbaac72#diff-fe94157edddadf88425cf07b556a00a3)
From https://github.com/openshift/openshift-docs/pull/7421/files 
Fixed the inter link to using flannel section.
### Eight
[enterprise-3.5] Weekly Release: 02/06/18 (https://github.com/openshift/openshift-docs/commit/8bf8da3c7de9e068de8e985ad2d180ac75e80e33#diff-fe94157edddadf88425cf07b556a00a3)
Removes `openshift_clusterid` variable which is not needed because of [enterprise-3.5] added descriptions for openshift_image_tag and opens…
No changes.

### Others
Other were weekly release fixes which were not applicable on the restored content.
