### PR TITLE
Fixed egress http proxy image references in examples on Managing Networking page 

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -415,7 +415,7 @@ Specifically, ensure that the following are enabled:
 
 The egress router can run in two different modes:
 xref:admin-guide-deploying-an-egress-router-pod[redirect mode] and
-xref:admin-guide-deploying-an-egress-router-http-proxy-pod[HTTP proxy mode].
+xref:admin-guide-deploying-an-egress-http-proxy-pod[HTTP proxy mode].
 Redirect mode works for all services except for HTTP and HTTPS. For HTTP and
 HTTPS services, use HTTP proxy mode.
 
@@ -693,7 +693,7 @@ The egress router does not automatically update when the ConfigMap changes.
 Restart the pod to get updates.
 ====
 
-[[admin-guide-deploying-an-egress-router-http-proxy-pod]]
+[[admin-guide-deploying-an-egress-http-proxy-pod]]
 ==== Deploying an Egress Router HTTP Proxy Pod
 
 In _HTTP proxy mode_, the egress router runs as an HTTP proxy on port `8080`.
@@ -734,10 +734,10 @@ endif::openshift-origin[]
   containers:
   - name: egress-router-proxy
 ifdef::openshift-enterprise[]
-    image: registry.access.redhat.com/openshift3/ose-egress-router-http-proxy
+    image: registry.access.redhat.com/openshift3/ose-egress-http-proxy
 endif::openshift-enterprise[]
 ifdef::openshift-origin[]
-    image: openshift/origin-egress-router-http-proxy
+    image: openshift/origin-egress-http-proxy
 endif::openshift-origin[]
     env:
     - name: EGRESS_HTTP_PROXY_DESTINATION <5>


### PR DESCRIPTION
Changed registry.access.redhat.com/openshift3/ose-egress-router-http-proxy to registry.access.redhat.com/openshift3/ose-egress-http-proxy
Changed openshift/origin-egress-router-http-proxy to image: openshift/origin-egress-http-proxy
Updated references to egress-router-http-proxy to egress-http-proxy

Applies to Origin and Enterprise. 