### PR TITLE
Remove daemonset from RBAC docs

### DIFF
--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -712,25 +712,6 @@ Subjects:
 
 
 ifdef::openshift-enterprise,openshift-origin,atomic-registry[]
-[[admin-guide-granting-users-daemonset-permissions]]
-== Granting Users Daemonset Permissions
-
-By default, project developers do not have the permission to create
-xref:../dev_guide/daemonsets.adoc#dev-guide-daemonsets[daemonsets]. As a cluster
-administrator, you can grant them the abilities.
-
-. Create the cluster role:
-+
-----
-$ oc create clusterrole daemonset-admin --verb=create,delete,get,list,update,watch --resource=daemonsets.extensions
-----
-
-. Create the local role binding:
-+
-----
-$ oc adm policy add-role-to-user daemonset-admin <user>
-----
-
 [[creating-local-role]]
 == Creating a Local Role
 


### PR DESCRIPTION
Users are given rights to daemonset by default in 3.9 so this section is not necessary.

/assign @ahardin-rh 