### PR TITLE
Removed link to Granting Users Daemonset Permissions as followup to PR#7981

### DIFF
--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -24,13 +24,6 @@ For more information on daemonsets, see the link:http://kubernetes.io/docs/admin
 [[dev-guide-creating-daemonsets]]
 == Creating Daemonsets
 
-[IMPORTANT]
-====
-Before creating daemonsets, ensure you have been
-xref:../admin_guide/manage_rbac.adoc#admin-guide-granting-users-daemonset-permissions[given
-the required role by your {product-title} administrator].
-====
-
 When creating daemonsets, the `*nodeSelector*` field is used to indicate the
 nodes on which the daemonset should deploy replicas.
 


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/7981

Users are given rights to daemonset by default in 3.9 per @enj 