### PR TITLE
Updated docs for 3.9 web console

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -530,29 +530,25 @@ xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Master
 |===
 
 [[configuring-host-port]]
-=== Configuring Master API and Console Ports
+=== Configuring Master API Port
 
-To configure the default ports used by the master API and web console, configure
-the following variables in the *_/etc/ansible/hosts_* file:
+To configure the default ports used by the master API, configure the following
+variables in the *_/etc/ansible/hosts_* file:
 
 [[advanced-master-ports]]
-.Master API and Console Ports
+.Master API Port
 [options="header"]
 |===
 
 |Variable |Purpose
 |`openshift_master_api_port`
 |This variable sets the port number to access the {product-title} API.
-
-|`openshift_master_console_port`
-|This variable sets the console port number to access the {product-title} console with a web browser.
 |===
 
 For example:
 
 ----
 openshift_master_api_port=3443
-openshift_master_console_port=8756
 ----
 
 [[configuring-cluster-pre-install-checks]]
@@ -1704,8 +1700,7 @@ openshift_logging_storage_kind=dynamic
 Starting with {product-title} 3.7, the
 xref:../../architecture/service_catalog/index.adoc#architecture-additional-concepts-service-catalog[service
 catalog] is enabled by default during installation. Enabling the service broker
-allows service brokers to be registered with the catalog. The web console is
-also configured to enable an updated landing page for browsing the catalog.
+allows service brokers to be registered with the catalog.
 
 [NOTE]
 ====
@@ -1721,8 +1716,7 @@ endif::[]
 ----
 ====
 
-When the service catalog is enabled, the web console shows the updated landing
-page. The OpenShift Ansible broker and template service broker are both enabled
+When the service catalog is enabled, the OpenShift Ansible broker and template service broker are both enabled
 as well; see xref:configuring-openshift-ansible-broker[Configuring the OpenShift Ansible Broker] and xref:configuring-template-service-broker[Configuring the Template Service Broker] for more information.
 
 [[configuring-openshift-ansible-broker]]
@@ -1847,17 +1841,37 @@ xref:../../install_config/web_console_customization.adoc#install-config-web-cons
 
 |Variable |Purpose
 
+|`openshift_web_console_install`
+|Determines whether to install the web console. Can be set to `true` or `false`. Defaults to `true`.
+
+|`openshift_web_console_prefix`
+|The prefix for the component images. With
+ifdef::openshift-origin[]
+`openshift/origin-web-console:v3.9`, set prefix `openshift/origin-`.
+endif::[]
+ifdef::openshift-enterprise[]
+`openshift3/ose-web-console:v3.9`, set prefix `openshift/ose-`.
+endif::[]
+
+|`openshift_web_console_version`
+|The version for the component images. For example, with
+ifdef::openshift-origin[]
+`openshift/origin-web-console:v3.9`, set version as `v3.9`.
+endif::[]
+ifdef::openshift-enterprise[]
+`openshift3/ose-web-console:v3.9`, set prefix `openshift/ose-`.
+`openshift3/ose-web-console:v3.9.173.0.5`, set version as `v3.9.173.0.5`, or to
+always get the latest 3.9 image, set `v3.9`.
+endif::[]
+
 |`openshift_master_logout_url`
-|Sets `logoutURL` in the master configuration. See xref:../../install_config/web_console_customization.adoc#changing-the-logout-url[Changing the Logout URL] for details. Example value: `\http://example.com`
+|Sets `clusterInfo.logoutPublicURL` in the web console configuration. See xref:../../install_config/web_console_customization.adoc#changing-the-logout-url[Changing the Logout URL] for details. Example value: `\https://example.com/logout`
 
-|`openshift_master_extension_scripts`
-|Sets `extensionScripts` in the master configuration. See xref:../../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets] for details. Example value: `['/path/to/script1.js','/path/to/script2.js']`
+|`openshift_web_console_extension_script_urls`
+|Sets `extensions.scriptURLs` in the web console configuration. See xref:../../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets] for details. Example value: `['https://example.com/scripts/menu-customization.js','https://example.com/scripts/nav-customization.js']`
 
-|`openshift_master_extension_stylesheets`
-|Sets `extensionStylesheets` in the master configuration. See xref:../../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets] for details. Example value: `['/path/to/stylesheet1.css','/path/to/stylesheet2.css']`
-
-|`openshift_master_extensions`
-|Sets `extensions` in the master configuration. See xref:../../install_config/web_console_customization.adoc#serving-static-files[Serving Static Files] and xref:../../install_config/web_console_customization.adoc#customizing-the-about-page[Customizing the About Page] for details. Example value: `[{'name': 'images', 'sourceDirectory': '/path/to/my_images'}]`
+|`openshift_web_console_extension_stylesheet_urls`
+|Sets `extensions.stylesheetURLs` in the web console configuration. See xref:../../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets] for details. Example value: `['https://example.com/styles/logo.css','https://example.com/styles/custom-styles.css']`
 
 |`openshift_master_oauth_template`
 |Sets the OAuth template in the master configuration. See xref:../../install_config/web_console_customization.adoc#customizing-the-login-page[Customizing the Login Page] for details. Example value: `['/path/to/login-template.html']`
@@ -1867,6 +1881,12 @@ xref:../../install_config/web_console_customization.adoc#install-config-web-cons
 
 |`openshift_master_logging_public_url`
 |Sets `loggingPublicURL` in the master configuration. See xref:../../install_config/aggregate_logging.adoc#aggregate-logging-kibana[Kibana] for details. Example value: `\https://kibana.example.com`
+
+|`openshift_web_console_inactivity_timeout_minutes`
+|Configurate the web console to log the user out automatically after a period of inactivity. Must be a whole number greater than or equal to 5, or 0 to disable the feature. Defaults to 0 (disabled).
+
+|`openshift_web_console_cluster_resource_overrides_enabled`
+|Boolean value indicating if the cluster is configured for overcommit. When `true`, the web console will hide fields for CPU request, CPU limit, and memory request when editing resource limits since these values should be set by the cluster resource override configuration.
 
 |===
 
@@ -2092,8 +2112,8 @@ balancer or take other steps to provide a highly available load balancer.
 For an external load balancing solution, you must have:
 
 * A pre-created load balancer VIP configured for SSL passthrough.
-* A VIP listening on the port specified by the xref:advanced-master-ports[`openshift_master_api_port`] and xref:advanced-master-ports[`openshift_master_console_port`]
-values (8443 by default) and proxying back to all master hosts on that port.
+* A VIP listening on the port specified by the xref:advanced-master-ports[`openshift_master_api_port`]
+value (8443 by default) and proxying back to all master hosts on that port.
 * A domain name for VIP registered in DNS.
 ** The domain name will become the value of both
 `openshift_master_cluster_public_hostname` and
@@ -2645,11 +2665,6 @@ For example, for a master host with a host name of `master.openshift.com` and
 using the default port of `8443`, the web console would be found at `\https://master.openshift.com:8443/console`.
 
 // end::verifying-the-installation[]
-
-[NOTE]
-====
-The default port for the console is `8443`. If this was changed during the installation, the port can be found at *openshift_master_console_port* in the *_/etc/ansible/hosts_* file.
-====
 
 [discrete]
 [[verifying-multiple-etcd-hosts]]

--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -22,38 +22,73 @@ behavior of the web console and customize it for your needs.
 
 For example, extension scripts can be used to add your own
 company's branding or to add company-specific capabilities. A common use case
-for this is rebranding or white-labelling for different environments. You can
+for this is rebranding or white-labeling for different environments. You can
 use the same extension code, but provide settings that change the web console.
-You can change the look and feel of nearly any aspect of the user interface in
-this way.
+
+[CAUTION]
+====
+Take caution making extensive changes to the web console styles or behavior
+that are not documented below. While you add any scripts or stylesheets,
+significant customizations might need to be reworked on upgrades as the web
+console markup and behavior change in future versions.
+====
 
 [[loading-custom-scripts-and-stylesheets]]
 == Loading Extension Scripts and Stylesheets
 
-To add scripts and stylesheets, edit the
-xref:../install_config/master_node_configuration.adoc#install-config-master-node-configuration[master configuration
-file]. The scripts and stylesheet files must exist on the Asset Server and are
-added with the following options:
+As of {product-title} 3.9, extension scripts and stylesheets can be hosted at
+any `https://` URL as long as the URL is accessible from the browser. The files
+might be hosted from a pod on the platform using a publicly accessible route,
+or on another server outside of {product-title}.
 
+To add scripts and stylesheets, edit the `webconsole-config` ConfigMap in the
+`openshift-web-console` namespace. The web console configuration is available
+in the `webconsole-config.yaml` key of the ConfigMap.
+
+----
+$ oc edit configmap/webconsole-config -n openshift-web-console
+----
+
+To add scripts, update the `extensions.scriptURLs` property. The value is an
+array of URLs.
+
+To add stylesheets, update the `extensions.stylesheetURLs` property. The value
+is an array of URLs.
+
+.Example `extensions.stylesheetURLs` Setting
 [source, yaml]
 ----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/script1.js
-    - /path/to/script2.js
-    - ...
-  extensionStylesheets:
-    - /path/to/stylesheet1.css
-    - /path/to/stylesheet2.css
-    - ...
+apiVersion: v1
+kind: ConfigMap
+data:
+  webconsole-config.yaml: |
+    apiVersion: webconsole.config.openshift.io/v1
+    extensions:
+      scriptURLs:
+        - https://example.com/scripts/menu-customization.js
+        - https://example.com/scripts/nav-customization.js
+      stylesheetURLs:
+        - https://example.com/styles/logo.css
+        - https://example.com/styles/custom-styles.css
+    [...]
 ----
+
+After saving the ConfigMap, the web console containers will be updated
+automatically for the new extension files within a few minutes.
 
 [NOTE]
 ====
-Wrap extension scripts in an Immediately Invoked Function Expression (IIFE).
-This ensures that you do not create global variables that conflict with the
-names used by the web console or by other extensions. For example:
+Scripts and stylesheets must be served with the correct content type or they
+will not be run by the browser. Scripts must be served with
+`Content-Type: application/javascript`
+and stylesheets with
+`Content-Type: text/css`.
+====
+
+It is a best practice to wrap extension scripts in an Immediately Invoked
+Function Expression (IIFE). This ensures that you do not create global
+variables that conflict with the names used by the web console or by other
+extensions. For example:
 
 [source, javascript]
 ----
@@ -61,27 +96,6 @@ names used by the web console or by other extensions. For example:
   // Put your extension code here...
 }());
 ----
-====
-
-
-Relative paths are resolved relative to the master configuration file. To pick
-up configuration changes, restart the server.
-
-Custom scripts and stylesheets are read once at server start time. To make
-developing extensions easier, you can reload scripts and stylesheets on every
-request by enabling development mode with the following setting:
-
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionDevelopment: true
-----
-
-When set, the web console reloads any changes to existing extension script or
-stylesheet files when you refresh the page in your browser. You still must
-restart the server when adding new extension stylesheets or scripts, however.
-This setting is only recommended for testing changes and not for production.
 
 The examples in the following sections show common ways you can customize the
 web console.
@@ -98,21 +112,32 @@ Origin] repository on GitHub.
 
 If you have a specific extension, but want to use different text in it for each
 of the environments, you can define the environment in the
-*_master-config.yaml_* file, and use the same extension script across
-environments. Pass settings from the *_master-config.yaml_* file to be used by
-the extension using the
-xref:../install_config/master_node_configuration.adoc#master-config-asset-config[`extensionProperties`
-mechanism]:
+web console configuration, and use the same extension script across environments.
+
+To add extension properties, edit the `webconsole-config` ConfigMap in the
+`openshift-web-console` namespace. The web console configuration is available
+in the `webconsole-config.yaml` key of the ConfigMap.
+
+----
+$ oc edit configmap/webconsole-config -n openshift-web-console
+----
+
+Update the `extensions.properties` value, which is a map of key-value pairs.
 
 [source,yaml]
 ----
-assetConfig:
-  extensionDevelopment: true
-  extensionProperties:
-    doc_url: https://docs.openshift.com
-    key1: value1
-    key2: value2
-  extensionScripts:
+apiVersion: v1
+kind: ConfigMap
+data:
+  webconsole-config.yaml: |
+    apiVersion: webconsole.config.openshift.io/v1
+    extensions:
+      [...]
+      properties:
+        doc_url: https://docs.openshift.com
+        key1: value1
+        key2: value2
+    [...]
 ----
 
 This results in a global variable that can be accessed by the extension, as if
@@ -123,7 +148,7 @@ the following code was executed:
 window.OPENSHIFT_EXTENSION_PROPERTIES = {
   doc_url: "https://docs.openshift.com",
   key1: "value1",
-  key2: "value2",
+  key2: "value2"
 }
 ----
 
@@ -133,6 +158,7 @@ window.OPENSHIFT_EXTENSION_PROPERTIES = {
 As of {product-title} 3.6, there is an extension option to link to external
 logging solutions instead of using {product-title}'s EFK logging stack:
 
+[source, javascript]
 ----
 'use strict';
 angular.module("mylinkextensions", ['openshiftConsole'])
@@ -147,17 +173,10 @@ angular.module("mylinkextensions", ['openshiftConsole'])
 hawtioPluginLoader.addModule("mylinkextensions");
 ----
 
-The URL to the logging stack you are wanting to accessAD master configuration file. Then,
-restart the master host:
+The URL to the logging stack you are wanting to accessAD master configuration file.
 
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[customizing-and-disabling-the-guided-tour]]
 ==  Customizing and Disabling the Guided Tour
@@ -165,9 +184,13 @@ endif::[]
 A guided tour will pop up the first time a user logs in on a particular browser.
 You can enable the `auto_launch` for new users:
 
+[source, javascript]
 ----
 window.OPENSHIFT_CONSTANTS.GUIDED_TOURS.landing_page_tour.auto_launch = true;
 ----
+
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[customizing-documentation-links]]
 == Customizing Documentation Links
@@ -176,15 +199,18 @@ Documentation links on the landing page are customizable.
 `window.OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES` is an array of objects
 containing a title and an `href`. These will be turned into links. You can
 completely override the array, push or pop additional links, or modify the
-attributes of existing links.
+attributes of existing links. For example:
 
-.Example Link
+[source, javascript]
 ----
-{
+window.OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES.push({
   title: 'Blog',
   href: 'https://blog.openshift.com'
-}
+});
 ----
+
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[customizing-the-logo]]
 == Customizing the Logo
@@ -200,30 +226,11 @@ The following style changes the logo in the web console header:
 }
 ----
 
-. Replace the *example.com* URL with a URL to an actual image, and adjust the
+Replace the *example.com* URL with a URL to an actual image, and adjust the
 width and height. The ideal height is *20px*.
 
-. Save the style to a file (for example, *_logo.css_*) and add it to the master
-configuration file:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionStylesheets:
-    - /path/to/logo.css
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the stylesheet as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[changing-links-to-documentation]]
 == Changing Links to Documentation
@@ -248,27 +255,9 @@ window.OPENSHIFT_CONSTANTS.HELP_BASE_URL = "https://example.com/docs/"; <1>
 ----
 <1> The path must end in a `/`.
 
-Save this script to a file (for example, *_help-links.js_*) and add it to the
-master configuration file:
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/help-links.js
-----
-
-Restart the master host:
-
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
 
 [[adding-or-changing-links-to-download-the-cli]]
 == Adding or Changing Links to Download the CLI
@@ -302,27 +291,9 @@ window.OPENSHIFT_CONSTANTS.CLI = {
 };
 ----
 
-Save this script to a file (for example, *_cli-links.js_*) and add it to the
-master configuration file:
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/cli-links.js
-----
-
-Restart the master host:
-
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
 
 [[customizing-the-about-page]]
 === Customizing the About Page
@@ -338,7 +309,7 @@ angular
   .config(function($routeProvider) {
     $routeProvider
       .when('/about', {
-        templateUrl: 'extensions/about/about.html',
+        templateUrl: 'https://example.com/extensions/about/about.html',
         controller: 'AboutController'
       });
     }
@@ -347,43 +318,27 @@ angular
 hawtioPluginLoader.addModule('aboutPageExtension');
 ----
 
-. Save the script to a file (for example, *_about/about.js_*).
-
 . Write a customized template.
-
-.. Start from the version of
++
+Start from the version of
 https://github.com/openshift/origin-web-console/blob/master/app/views/about.html[*_about.html_*]
 from the OpenShift Container Platform
 link:https://github.com/openshift/origin-web-console/branches[release] you are
 using. Within the template, there are two angular scope variables available:
 `version.master.openshift` and `version.master.kubernetes`.
 
-.. Save the custom template to a file (for example, *_about/about.html_*).
+. Host the template at a URL with the correct Cross-Origin Resource Sharing
+(CORS) response headers for the web console.
 
-.. Modify the master configuration file:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - about/about.js
-  ...
-  extensions:
-    - name: about
-      sourceDirectory: /path/to/about
-----
+.. Set `Access-Control-Allow-Origin` response to allow requests from the web console domain.
+.. Set `Access-Control-Allow-Methods` to include `GET`.
+.. Set `Access-Control-Allow-Headers` to include `Content-Type`.
+ 
+Alternatively, you can include the template directly in your JavaScript using AngularJS
+link:https://docs.angularjs.org/api/ng/service/$templateCache[*_$templateCache_*].
 
-.. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[configuring-navigation-menus]]
 == Configuring Navigation Menus
@@ -438,6 +393,9 @@ angular
 hawtioPluginLoader.addModule('<myExtensionModule>');
 ----
 
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
+
 [[web-console-application-launcher]]
 === Application Launcher
 
@@ -445,9 +403,6 @@ The top navigation bar also contains an optional application launcher for
 linking to other web applications. This dropdown menu is empty by default, but
 when links are added, appears to the left of the help menu in the masthead.
 
-. Create the configuration scripts within a file (for example,
-*_applicationLauncher.js_*):
-+
 [source, javascript]
 ----
 // Add items to the application launcher dropdown menu.
@@ -464,27 +419,8 @@ window.OPENSHIFT_CONSTANTS.APP_LAUNCHER_NAVIGATION = [{
 }];
 ----
 
-. Save the file and add it to the master configuration at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/applicationLauncher.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[system-status-badge]]
 === System Status Badge
@@ -494,9 +430,6 @@ to notify users of system-wide events such as maintenance windows. To make use
 of the existing styles using a yellow warning icon for the badge, follow the
 example below.
 
-. Create the configuration scripts within a file (for example,
-*_systemStatusBadge.js_*):
-+
 [source, javascript]
 ----
 'use strict';
@@ -527,27 +460,8 @@ angular
 hawtioPluginLoader.addModule('mysystemstatusbadgeextension');
 ----
 
-. Save the file and add it to the master configuration at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/systemStatusBadge.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[web-console-project-left-navigation]]
 === Project Left Navigation
@@ -563,9 +477,6 @@ experience and should be done with careful consideration. You may need to update
 this customization in future upgrades if you modify existing navigation items.
 ====
 
-. Create the configuration scripts within a file (for example,
-*_navigation.js_*):
-+
 [source, javascript]
 ----
 // Append a new primary nav item.  This is a simple direct navigation item
@@ -633,30 +544,8 @@ applicationsMenu.secondaryNavSections.push({ // Add a new secondary nav section 
 });
 ----
 
-. Save the file and add it to the master configuration at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/navigation.js
-----
-
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
-
-endif::[]
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[configuring-featured-applications]]
 == Configuring Featured Applications
@@ -667,9 +556,6 @@ icon, a title, a short description, and a link.
 
 image::featured_applications.png["Featured Applications"]
 
-. Create the following configuration scripts within a file (for example,
-*_featured-applications.js_*):
-+
 [source, javascript]
 ----
 // Add featured applications to the top of the catalog.
@@ -691,27 +577,8 @@ window.OPENSHIFT_CONSTANTS.SAAS_OFFERINGS = [{
 }];
 ----
 
-. Save the file and add it to the master configuration at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/featured-applications.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[configuring-catalog-categories]]
 == Configuring Catalog Categories
@@ -729,9 +596,6 @@ experience and should be done with careful consideration. You may need to update
 this customization in future upgrades if you modify existing category items.
 ====
 
-. Create the following configuration scripts within a file (for example,
-*_catalog-categories.js_*):
-+
 [source, javascript]
 ----
 // Find the Languages category.
@@ -788,74 +652,46 @@ window.OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES.unshift({
 });
 ----
 
-. Save the file and add it to the master configuration at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/catalog-categories.js
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
-
-endif::[]
 [[configuring-quota-notification-messages]]
 == Configuring Quota Notification Messages
 
 Whenever a user reaches a quota, a quota notification is put into the notification drawer.
 A custom quota notification message, per
-xref:../dev_guide/compute_resources.adoc#dev-managed-by-quota[quota resource type], can be added to the notification.  For example:
-"Your project is over quota.  It is using 200% of 2 cores CPU (Limit). Upgrade to <a href='http://www.openshift.com'>
-OpenShift Pro</a> if you need additional resources.".  The "Upgrade to..." part of the notification is the custom
-message and may contain HTML such as links to additional resources.
+xref:../dev_guide/compute_resources.adoc#dev-managed-by-quota[quota resource type], can be added to the notification. For example:
 
-. Create the following configuration scripts within a file (for example,
-*_quota-messages.js_*):
-+
+[source, html]
+----
+Your project is over quota. It is using 200% of 2 cores CPU (Limit). Upgrade
+to <a href='https://www.openshift.com'>OpenShift Online Pro</a> if you need
+additional resources.
+----
+
+The "Upgrade to..." part of the notification is the custom message and may
+contain HTML such as links to additional resources.
+
+[NOTE]
+====
+Since the quota message is HTML markup, any special characters need to be
+properly escaped for HTML.
+====
+
+Set the `window.OPENSHIFT_CONSTANTS.QUOTA_NOTIFICATION_MESSAGE` property in an
+extension script to customize the message for each resource.
+
 [source, javascript]
 ----
 // Set custom notification messages per quota type/key
 window.OPENSHIFT_CONSTANTS.QUOTA_NOTIFICATION_MESSAGE = {
-    "pods": 'Upgrade to <a href="http://www.openshift.com">OpenShift Pro</a> if you need additional resources.',
-    "limits.memory": 'Upgrade to <a href="http://www.openshift.com">OpenShift Online Pro</a> if you need additional resources.'
-}
+  'pods': 'Upgrade to <a href="https://www.openshift.com">OpenShift Online Pro</a> if you need additional resources.',
+  'limits.memory': 'Upgrade to <a href="https://www.openshift.com">OpenShift Online Pro</a> if you need additional resources.'
+};
 ----
 
-. Save the file and add it to the master configuration at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/quota-messages.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
-
-endif::[]
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[configuring-the-create-from-url-namespace-whitelist]]
 == Configuring the Create From URL Namespace Whitelist
@@ -870,9 +706,6 @@ namespaces to the whitelist, follow these steps:
 `openshift` is included in the whitelist by default. Do not remove it.
 ====
 
-. Create the following configuration scripts within a file (for example,
-*_create-from-url-whitelist.js_*):
-+
 [source, javascript]
 ----
 // Add a namespace containing the image streams and/or templates
@@ -881,29 +714,8 @@ window.OPENSHIFT_CONSTANTS.CREATE_FROM_URL_WHITELIST.push(
 );
 ----
 
-. Save the file and add it to the master configuration file at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/create-from-url-whitelist.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
-
-endif::[]
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[disabling-copy-login-command]]
 == Disabling the Copy Login Command
@@ -913,36 +725,14 @@ access token, to the clipboard from the user menu and the Command Line Tools
 page. This function can be changed so that the user's access token is not
 included in the copied command.
 
-. Create the following configuration scripts within a file (for example,
-*_disable-copy-login.js_*):
-+
 [source, javascript]
 ----
 // Do not copy the user's access token in the copy login command.
 window.OPENSHIFT_CONSTANTS.DISABLE_COPY_LOGIN_COMMAND = true;
 ----
 
-. Save the file and add it to the master configuration file at
-*_/etc/origin/master/master-config.yaml_*:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/disable-copy-login.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 [[web-console-enable-wildcard-routes]]
 == Enabling Wildcard Routes
@@ -951,134 +741,16 @@ If you enabled wildcard routes for a router, you can also enable wildcard
 routes in the web console. This lets users enter hostnames starting with an
 asterisk like `*.example.com` when creating a route. To enable wildcard routes:
 
-. Save this script to a file (for example, *_enable-wildcard-routes.js_*):
-+
 [source, jsvascript]
 ----
 window.OPENSHIFT_CONSTANTS.DISABLE_WILDCARD_ROUTES = false;
 ----
 
-. Add it to the master configuration file:
-+
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/enable-wildcard-routes.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
 xref:../install_config/router/default_haproxy_router.adoc#using-wildcard-routes[Learn
 how to configure HAProxy routers to allow wildcard routes].
-
-[[web-console-enable-tech-preview-feature]]
-== Enabling Features in Technology Preview
-
-Sometimes features are available in Technology Preview. By default, these
-features are disabled and hidden in the web console.
-
-Currently, there are no web console features in Technology Preview.
-
-To enable a Technology Preview feature:
-
-. Save this script to a file (for example, *_tech-preview.js_*):
-+
-[source, javascript]
-----
-window.OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.<feature_name> = true;
-----
-
-. Add it to the master configuration file:
-+
-[source, javascript]
-----
-assetConfig:
-  ...
-  extensionScripts:
-    - /path/to/tech-preview.js
-----
-
-. Restart the master host:
-+
-----
-ifdef::openshift-origin[]
-# systemctl restart origin-master-api origin-master-controllers
-endif::[]
-ifdef::openshift-enterprise[]
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-endif::[]
-----
-
-[[serving-static-files]]
-== Serving Static Files
-
-You can serve other files from the Asset Server as well. For example, you might
-want to make the CLI executable available for download from the web console or
-add images to use in a custom stylesheet.
-
-Add the directory with the files you want using the following configuration
-option:
-
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensions:
-    - name: images
-      sourceDirectory: /path/to/my_images
-----
-
-The files under the *_/path/to/my_images_* directory will be available under the
-URL _/<context>/extensions/images_ in the web console.
-
-To reference these files from a stylesheet, you should generally use a relative
-path. For example:
-
-[source, css]
-----
-#header-logo {
-  background-image: url("../extensions/images/my-logo.png");
-}
-----
-
-[[enabling-html5-mode]]
-=== Enabling HTML5 Mode
-
-The web console has a special mode for supporting certain static web
-applications that use the HTML5 history API:
-
-[source, yaml]
-----
-assetConfig:
-  ...
-  extensions:
-    - name: my_extension
-      sourceDirectory: /path/to/myExtension
-      html5Mode: true
-----
-
-Setting `html5Mode` to *true* enables two behaviors:
-
-. Any request for a non-existent file under
-*_/<context>/extensions/my_extension/_* instead serves
-*_/path/to/myExtension/index.html_* rather than a "404 Not Found" page.
-. The element `<base href="/">` will be rewritten in
-*_/path/to/myExtension/index.html_* to use the actual base depending on the
-asset configuration; only this exact string is rewritten.
-
-This is needed for JavaScript frameworks such as AngularJS that require `base`
-to be set in *_index.html_*.
 
 [[customizing-the-login-page]]
 == Customizing the Login Page
@@ -1156,15 +828,26 @@ Relative paths are resolved relative to the master configuration file.
 == Changing the Logout URL
 
 You can change the location a console user is sent to when logging out of
-the console by modifying the `logoutURL` parameter in the
-*_/etc/origin/master/master-config.yaml_* file:
+the console by modifying the `clusterInfo.logoutPublicURL` parameter in the
+`webconsole-config` ConfigMap.
+
+----
+$ oc edit configmap/webconsole-config -n openshift-web-console
+----
+
+Here is an example that changes the logout URL to `https://www.example.com/logout`:
 
 [source, yaml]
 ----
-...
-assetConfig:
-  logoutURL: "http://www.example.com"
-...
+apiVersion: v1
+kind: ConfigMap
+data:
+  webconsole-config.yaml: |
+    apiVersion: webconsole.config.openshift.io/v1
+    clusterInfo:
+      [...]
+      logoutPublicURL: "https://www.example.com/logout"
+    [...]
 ----
 
 This can be useful when authenticating with
@@ -1183,41 +866,36 @@ many modifications to the web console can be configured using
 xref:../install_config/install/advanced_install.adoc#advanced-install-configuring-global-proxy[the following parameters], which are configurable in the inventory file:
 
 - xref:changing-the-logout-url[`openshift_master_logout_url`]
-- xref:loading-custom-scripts-and-stylesheets[`openshift_master_extension_scripts`]
-- xref:loading-custom-scripts-and-stylesheets[`openshift_master_extension_stylesheets`]
-- xref:serving-static-files[`openshift_master_extensions`]
-- xref:serving-static-files[`openshift_master_oauth_template`]
+- xref:loading-custom-scripts-and-stylesheets[`openshift_web_console_extension_script_urls`]
+- xref:loading-custom-scripts-and-stylesheets[`openshift_web_console_extension_stylesheet_urls`]
+- xref:customizing-the-login-page[`openshift_master_oauth_template`]
 - xref:../install_config/cluster_metrics.adoc#install-config-cluster-metrics[`openshift_master_metrics_public_url`]
 - xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[`openshift_master_logging_public_url`]
 
 .Example Web Console Customization with Ansible
 [source, bash]
 ----
-# Configure logoutURL in the master config for console customization
+# Configure `clusterInfo.logoutPublicURL` in the web console configuration
 # See: https://docs.openshift.com/enterprise/latest/install_config/web_console_customization.html#changing-the-logout-url
-#openshift_master_logout_url=http://example.com
+#openshift_master_logout_url=https://example.com/logout
 
-# Configure extensionScripts in the master config for console customization
+# Configure extension scripts for web console customization
 # See: https://docs.openshift.com/enterprise/latest/install_config/web_console_customization.html#loading-custom-scripts-and-stylesheets
-#openshift_master_extension_scripts=['/path/on/host/to/script1.js','/path/on/host/to/script2.js']
+#openshift_web_console_extension_script_urls=['https://example.com/scripts/menu-customization.js','https://example.com/scripts/nav-customization.js']
 
-# Configure extensionStylesheets in the master config for console customization
+# Configure extension stylesheets for web console customization
 # See: https://docs.openshift.com/enterprise/latest/install_config/web_console_customization.html#loading-custom-scripts-and-stylesheets
-#openshift_master_extension_stylesheets=['/path/on/host/to/stylesheet1.css','/path/on/host/to/stylesheet2.css']
+#openshift_web_console_extension_stylesheet_urls=['https://example.com/styles/logo.css','https://example.com/styles/custom-styles.css']
 
-# Configure extensions in the master config for console customization
-# See: https://docs.openshift.com/enterprise/latest/install_config/web_console_customization.html#serving-static-files
-#openshift_master_extensions=[{'name': 'images', 'sourceDirectory': '/path/to/my_images'}]
-
-# Configure extensions in the master config for console customization
-# See: https://docs.openshift.com/enterprise/latest/install_config/web_console_customization.html#serving-static-files
+# Configure a custom login template in the master config
+# See: https://docs.openshift.com/enterprise/latest/install_config/web_console_customization.html#customizing-the-login-page
 #openshift_master_oauth_template=/path/on/host/to/login-template.html
 
-# Configure metricsPublicURL in the master config for cluster metrics. Ansible is also able to configure metrics for you.
+# Configure `clusterInfo.metricsPublicURL` in the web console configuration for cluster metrics. Ansible is also able to configure metrics for you.
 # See: https://docs.openshift.com/enterprise/latest/install_config/cluster_metrics.html
 #openshift_master_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
 
-# Configure loggingPublicURL in the master config for aggregate logging. Ansible is also able to install logging for you.
+# Configure `clusterInfo.loggingPublicURL` in the web console configuration for aggregate logging. Ansible is also able to install logging for you.
 # See: https://docs.openshift.com/enterprise/latest/install_config/aggregate_logging.html
 #openshift_master_logging_public_url=https://kibana.example.com
 ----


### PR DESCRIPTION
The console has been split out into its own deployment running on the
platform in 3.9. Extensions are no longer loaded as files on the master,
but using URLs. Update the docs for the install and customization
changes.

/cc @ahardin-rh @jwforres 