### PR TITLE
Added notes about Quick Installer deprecation in 3.9

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -43,11 +43,6 @@ xref:running-the-advanced-installation-system-container[containerized version of
 Technology Preview feature.
 ====
 
-ifdef::openshift-enterprise[]
-Alternatively, you can use the xref:../../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation]
-method if you prefer an interactive installation experience.
-endif::[]
-
 [NOTE]
 ====
 To install {product-title} as a stand-alone registry, see
@@ -513,12 +508,12 @@ which may cause invalid configurations. Example usage:
 |`openshift_docker_options`
 a|This variable configures additional `docker` options within
 *_/etc/sysconfig/docker_*, such as options used in
-xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs]. 
-Use `json-file` or `journald`. The default is `journald`. 
-Example usage: 
+xref:../../install_config/install/host_preparation.adoc#managing-docker-container-logs[Managing Container Logs].
+Use `json-file` or `journald`. The default is `journald`.
+Example usage:
 ----
 "--log-driver json-file --log-opt max-size=1M --log-opt max-file=3"
-"--log-driver journald" 
+"--log-driver journald"
 ----
 Do not use when
 xref:advanced-install-docker-system-container[running `docker` as a system container].
@@ -812,7 +807,7 @@ openshift_docker_additional_registries=example.com
 
 If you are using a Cockpit registry console image other than the default or require a specific version of the console,
 specify the desired registry within the
-*_/etc/ansible/hosts_* file. 
+*_/etc/ansible/hosts_* file.
 
 ----
 openshift_cockpit_deployer_prefix=<registry-name>/<namespace>/
@@ -835,7 +830,7 @@ For example:
 If your image is at *_registry.example.com/openshift3/registry-console_* and you require
 version 1.4.1, enter:
 ----
-openshift_cockpit_deployer_prefix='registry.example.com/openshift3/' 
+openshift_cockpit_deployer_prefix='registry.example.com/openshift3/'
 openshift_cockpit_deployer_version='1.4.1'
 ----
 

--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -678,6 +678,14 @@ to prepare your hosts.
 When you are ready to proceed, you can install {product-title} using the
 xref:quick_install.adoc#install-config-install-quick-install[quick installation] or
 xref:advanced_install.adoc#install-config-install-advanced-install[advanced installation] method.
+
+[IMPORTANT]
+====
+As of {product-title} 3.9, the quick installation method is deprecated. In a
+future release, it will be removed completely.
+
+Using the quick installer to upgrade from version 3.7 to 3.9 is not supported.
+====
 endif::[]
 
 ifdef::openshift-origin[]

--- a/install_config/install/planning.adoc
+++ b/install_config/install/planning.adoc
@@ -49,6 +49,14 @@ endif::[]
 [[installation-methods]]
 == Installation Methods
 
+[IMPORTANT]
+====
+As of {product-title} 3.9, the quick installation method is deprecated. In a
+future release, it will be removed completely.
+
+Using the quick installer to upgrade from version 3.7 to 3.9 is not supported.
+====
+
 Both the quick and advanced installation methods are supported for development
 and production environments. If you want to quickly get {product-title} up and
 running to try out for the first time, use the quick installer and let the
@@ -102,9 +110,9 @@ not supported.
 [[single-master-single-box]]
 === Single Master and Node on One System
 
-{product-title} can be installed on a single system 
-for a xref:../../dev_guide/application_lifecycle/promoting_applications.adoc#dev-guide-promoting-application-de[development] environment only. 
-An _all-in-one environment_ is not considered a production environment. 
+{product-title} can be installed on a single system
+for a xref:../../dev_guide/application_lifecycle/promoting_applications.adoc#dev-guide-promoting-application-de[development] environment only.
+An _all-in-one environment_ is not considered a production environment.
 
 [[single-master-multi-node]]
 === Single Master and Multiple Nodes

--- a/install_config/install/quick_install.adoc
+++ b/install_config/install/quick_install.adoc
@@ -20,6 +20,14 @@ toc::[]
 
 == Overview
 
+[IMPORTANT]
+====
+As of {product-title} 3.9, the quick installation method is deprecated. In a
+future release, it will be removed completely.
+
+Using the quick installer to upgrade from version 3.7 to 3.9 is not supported.
+====
+
 The _quick installation_ method allows you to use an interactive CLI utility,
 the `atomic-openshift-installer` command, to install {product-title} across a
 set of hosts. This installer can deploy {product-title} components on targeted

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -19,12 +19,14 @@ If you installed using the
 xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
 and the inventory file that was used is available, you can use the upgrade
 playbook to automate the OpenShift cluster upgrade process.
-ifdef::openshift-enterprise[]
-If you installed using the
-xref:../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation] method
-and a *_~/.config/openshift/installer.cfg.yml_* file is available, you can use
-the quick installer to perform the automated upgrade.
-endif::[]
+
+[IMPORTANT]
+====
+As of {product-title} 3.9, the quick installation method is deprecated. In a
+future release, it will be removed completely.
+
+Using the quick installer to upgrade from version 3.7 to 3.9 is not supported.
+====
 
 The automated upgrade performs the following steps for you:
 
@@ -195,46 +197,8 @@ $ oc login
 ----
 ////
 
-After satisfying these steps, there are two methods for running the automated
-upgrade:
-
-- xref:upgrading-using-the-installation-utility-to-upgrade[Using the quick installer]
-- xref:running-the-upgrade-playbook-directly[Running the upgrade playbook directly]
-
-Choose and follow one of these methods.
-
-[[upgrading-using-the-installation-utility-to-upgrade]]
-== Using the Quick Installer to Upgrade
-
-If you installed {product-title} using the
-xref:../install_config/install/quick_install.adoc#install-config-install-quick-install[quick installation] method,
-you should have an installation configuration file located at
-*_~/.config/openshift/installer.cfg.yml_*. The quick installer requires this file to
-start an upgrade.
-
-The quick installer supports upgrading between minor versions of {product-title}
-(one minor version at a time, e.g., 3.5 to 3.6) as well as between
-asynchronous errata updates within a minor version (e.g., 3.6.z).
-
-If you have an older format installation configuration file in
-*_~/.config/openshift/installer.cfg.yml_* from an installation of a previous
-cluster version, the quick installer will attempt to upgrade the file to the new supported
-format. If you do not have an installation configuration file of any format, you
-can
-xref:../install_config/install/quick_install.adoc#defining-an-installation-configuration-file[create one manually].
-
-To start an upgrade with the quick installer:
-
-. Satisfy the steps in xref:preparing-for-an-automated-upgrade[Preparing for an Automated Upgrade] to ensure you are using the latest upgrade playbooks.
-
-. Run the quick installer with the `upgrade` subcommand:
-+
-----
-# atomic-openshift-installer upgrade
-----
-. Then, follow the on-screen instructions to upgrade to the latest release.
-
-include::upgrading/automated_upgrades.adoc[tag=automated_upgrade_after_reboot]
+After satisfying these steps, xref:running-the-upgrade-playbook-directly[run the
+upgrade playbook directly].
 
 [[running-the-upgrade-playbook-directly]]
 == Running Upgrade Playbooks Directly

--- a/upgrading/manual_upgrades.adoc
+++ b/upgrading/manual_upgrades.adoc
@@ -261,21 +261,21 @@ kubernetesMasterConfig:
 # systemctl enable origin-master-controllers
 ----
 
-. Configure Dnsmasq. Because of changes made in {product-title} 3.6, you will need to 
-perform the following steps to configure dnsmasq as part of the upgrade. See DNS Changes 
+. Configure Dnsmasq. Because of changes made in {product-title} 3.6, you will need to
+perform the following steps to configure dnsmasq as part of the upgrade. See DNS Changes
 under xref:../../release_notes/ocp_3_6_release_notes.adoc#ocp-36-notable-technical-changes[Notable Technical Changes]
 in the {product-title} 3.6 Release Notes.
 +
 .. Create a *_/etc/origin/node/node-dnsmasq.conf_*  node configuration file.
 +
-----  
+----
 server=/in-addr.arpa/127.0.0.1
 server=/cluster.local/127.0.0.1
 ----
 
 .. Edit the *_/etc/dnsmasq.d/origin-dns.conf_* file as follows:
 +
-----  
+----
 no-resolv
 domain-needed
 no-negcache
@@ -289,23 +289,23 @@ listen-address=<node_ip_address> <1>
 
 .. Edit the *_/etc/dnsmasq.d/origin-upstream-dns.conf_* file as follows:
 +
----- 
+----
 server=<dns_server1_ip_address>
 server=<dns_server2_ip_address>
 ----
 
-.. Edit the *_/etc/origin/node/node-config.yaml_* as follows: 
+.. Edit the *_/etc/origin/node/node-config.yaml_* as follows:
 +
 ----
-dnsBindAddress: 127.0.0.1:53 
-dnsRecursiveResolvConf: /etc/origin/node/resolv.conf 
-dnsDomain: cluster.local 
+dnsBindAddress: 127.0.0.1:53
+dnsRecursiveResolvConf: /etc/origin/node/resolv.conf
+dnsDomain: cluster.local
 dnsIP: <node_ip_address> <1>
 ----
 +
 <1> This is the IP address of the node host.
 
-.. Update the *_/etc/systemd/system/atomic-openshift-node.service_* node systemd unit file: 
+.. Update the *_/etc/systemd/system/atomic-openshift-node.service_* node systemd unit file:
 +
 ----
 [Unit]
@@ -341,10 +341,10 @@ OOMScoreAdjust=-999
 WantedBy=multi-user.target
 ----
 +
-.. Reload systemd and restart node service. 
+.. Reload systemd and restart node service.
 +
 ----
-# systemctl daemon-reload 
+# systemctl daemon-reload
 # systemctl restart atomic-openshift-node dnsmaq
 ----
 
@@ -398,19 +398,19 @@ IMAGE_VERSION=<tag>
 +
 Replace `<tag>` with `{latest-tag}` for the latest version.
 
-. Configure Dnsmasq. Because of changes made in {product-title} 3.6, you will need to 
-perform the following steps to configure dnsmasq as part of the upgrade. See DNS Changes 
+. Configure Dnsmasq. Because of changes made in {product-title} 3.6, you will need to
+perform the following steps to configure dnsmasq as part of the upgrade. See DNS Changes
 under xref:../../release_notes/ocp_3_6_release_notes.adoc#ocp-36-notable-technical-changes[Notable Technical Changes]
 in the {product-title} 3.6 Release Notes.
 +
 .. Download the following script:
 +
 ----
-# wget https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.6/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh -O /etc/NetworkManager/dispatcher.d/99-origin-dns.sh 
-# chmod 755 /etc/NetworkManager/dispatcher.d/99-origin-dns.sh 
+# wget https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.6/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh -O /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
+# chmod 755 /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
 ----
 +
-This command downloads the *99-origin-dns.sh* script and copies the script to the *_/etc/NetworkManager/dispatcher.d/_* directory. 
+This command downloads the *99-origin-dns.sh* script and copies the script to the *_/etc/NetworkManager/dispatcher.d/_* directory.
 This script configure pods to use the node IP address as resolver. Using 127.0.0.1 inside a pod would fail.
 
 .. Edit the master DNS configuration file to listen on port 8053. This avoids conflicts on port 53 and opens port 8053 in the firewall.
@@ -1001,9 +1001,9 @@ provides the example JSON files:
 ----
 endif::[]
 ifdef::openshift-enterprise[]
-By default, the xref:../install_config/install/quick_install.adoc#install-config-install-quick-install[quick] and
+By default, the
 xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation]
-methods automatically create default image streams, InstantApp templates, and
+method automatically creates default image streams, InstantApp templates, and
 database service templates in the *openshift* project, which is a default
 project to which all users have view access. These objects were created during
 installation from the JSON files located under the


### PR DESCRIPTION
https://trello.com/c/SnucbUnb/772-document-depreciate-announce-quick-installer-will-be-removed-from-ocp-310

Preview Builds:
http://file.rdu.redhat.com/~ahardin/03072018/deprecate-quick-install/install_config/install/quick_install.html#overview

http://file.rdu.redhat.com/~ahardin/03072018/deprecate-quick-install/install_config/install/planning.html#installation-methods

http://file.rdu.redhat.com/~ahardin/03072018/deprecate-quick-install/install_config/install/host_preparation.html#what-s-next

http://file.rdu.redhat.com/~ahardin/03072018/deprecate-quick-install/upgrading/automated_upgrades.html#overview
