### PR TITLE
Typo fix

### DIFF
--- a/upgrading/manual_upgrades.adoc
+++ b/upgrading/manual_upgrades.adoc
@@ -33,7 +33,7 @@ before proceeding with an upgrade. Failure to do so can result in a failed
 upgrade.
 
 If you are using GlusterFS, see
-xref:../upgrading/automated_upgrades#special-considerations-for-glusterfs[Special
+xref:../upgrading/automated_upgrades.adoc#special-considerations-for-glusterfs[Special
 Considerations When Using Containerized GlusterFS] before proceeding.
 ====
 


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/7991

Somehow the link in the preview build still worked even though I accidentally omitted the .adoc in the file path.

Fix already applied in the 3.7 branch, so just need to apply to 3.9 and master.