### PR TITLE
Added documentation on how to enable Ingres Object support

### DIFF
--- a/architecture/topics/haproxy_template_router.adoc
+++ b/architecture/topics/haproxy_template_router.adoc
@@ -126,3 +126,22 @@ The router controller scrapes the following items. These are only available with
 |ssh_tunnel_open_count|Counter of SSH tunnel total open attempts
 |ssh_tunnel_open_fail_count|Counter of SSH tunnel failed open attempts
 |===
+
+=== Ingress Objects
+
+It is possible to set the HAProxy router up as a
+link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress
+Controller] so that it will pay attention to both Route and Ingress
+objects.  If configured this way the same rules apply for claiming a
+domain for a namespace based on the creation time of the object.
+
+The advantage is that this is compatible with Kubernetes Ingress
+objects.  However, there are a few disadvantages:
+
+1. Ingress objects store the keys and certificates in Secrets.  So the Router will need permission to read all secrets in the system.
+2. Ingress objects only support edge termination for `https` routes.
+
+To configure an existing router to have Ingress support (assuming the default name of `router` for the Deployment Config and the ):
+
+1. `oc env dc router ROUTER_ENABLE_INGRESS=true`
+2. `oc adm policy add-role-to-user cluster-admin router`

--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -45,6 +45,7 @@ connections (and any time HAProxy is reloaded), the old HAProxy processes
 will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`ROUTER_DENIED_DOMAINS` | | A comma-separated list of domains that the host name in a route can not be part of. No subdomain in the domain can be used either. Overrides option `ROUTER_ALLOWED_DOMAINS`.
 |`ROUTER_ENABLE_COMPRESSION`| | If `true` or `TRUE`, compress responses when possible.
+|`ROUTER_ENABLE_INGRESS`| | If `true` or `TRUE`, look at both Ingress objects and Route objects.
 |`ROUTER_LISTEN_ADDR`| 0.0.0.0:1936 | Sets the listening address for xref:../../install_config/router/default_haproxy_router.adoc#exposing-the-router-metrics[router metrics].
 |`ROUTER_LOG_LEVEL` | warning | The log level to send to the syslog server.
 |`ROUTER_MAX_CONNECTIONS`| 20000 | Maximum number of concurrent connections.


### PR DESCRIPTION
This PR documents how to enable the experimental Ingress Object
support in the OpenShift haproxy-based router.

Please note that this support is experimental and should not be merged
into OSE yet.