### PR TITLE
Warn user to disable default node selector when using daemonsets

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -183,7 +183,7 @@ $ oc adm new-project myproject \
     --node-selector='type=user-node,region=east'
 ----
 
-Once this command is run, this becomes the adminstrator-set node selector for
+Once this command is run, this becomes the administrator-set node selector for
 all pods contained in the specified project.
 
 [NOTE]
@@ -215,7 +215,7 @@ You can also override the default value for an existing project namespace by usi
 ----
 
 If `openshift.io/node-selector` is set to an empty string (`oc adm new-project
---node-selector=""`), the project will not have an adminstrator-set node
+--node-selector=""`), the project will not have an administrator-set node
 selector, even if the cluster-wide default has been set. This means that, as a
 cluster administrator, you can set a default to restrict developer projects to a
 subset of nodes and still enable infrastructure or other projects to schedule

--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -19,7 +19,34 @@ A daemonset can be used to run replicas of a pod on specific or all nodes in an
 Use daemonsets to create shared storage, run a logging pod on every node in
 your cluster, or deploy a monitoring agent on every node.
 
+For security reasons, only cluster administrators can create daemonsets.
+(xref:../admin_guide/manage_rbac.adoc#admin-guide-granting-users-daemonset-permissions[Granting Users Daemonset Permissions.])
+
 For more information on daemonsets, see the link:http://kubernetes.io/docs/admin/daemons/[Kubernetes documentation].
+
+[IMPORTANT]
+====
+Daemonset scheduling is incompatible with project's default node selector.
+If you fail to disable it, the daemonset gets restricted by merging with the
+default node selector. This results in frequent pod recreates on the nodes that
+got unselected by the merged node selector, which in turn puts unwanted load on
+the cluster.
+
+Therefore,
+
+* Before you start using daemonsets, disable the default project-wide
+xref:../admin_guide/managing_projects.adoc#using-node-selectors[node selector]
+in your namespace, by setting the namespace annotation `openshift.io/node-selector` to an empty string:
+
+----
+# oc patch namespace myproject -p \
+    '{"metadata": {"annotations": {"openshift.io/node-selector": ""}}}'
+----
+
+* If you are creating a new project, overwrite the default node selector using
+`oc adm new-project --node-selector=""`.
+
+====
 
 [[dev-guide-creating-daemonsets]]
 == Creating Daemonsets


### PR DESCRIPTION
Stems from https://bugzilla.redhat.com/show_bug.cgi?id=1501514#c9

Permissions were disabled here: https://github.com/openshift/origin/pull/18971

This is a part of solving 3.9 blocker, so we need to backport it in time.

/cc @mfojtik 