### PR TITLE
Undo changes to daemonset RBAC docs

### DIFF
--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -712,6 +712,25 @@ Subjects:
 
 
 ifdef::openshift-enterprise,openshift-origin,atomic-registry[]
+[[admin-guide-granting-users-daemonset-permissions]]
+== Granting Users Daemonset Permissions
+
+By default, project developers do not have the permission to create
+xref:../dev_guide/daemonsets.adoc#dev-guide-daemonsets[daemonsets]. As a cluster
+administrator, you can grant them the abilities.
+
+. Create the cluster role:
++
+----
+$ oc create clusterrole daemonset-admin --verb=create,delete,get,list,update,watch --resource=daemonsets.extensions
+----
+
+. Create the local role binding:
++
+----
+$ oc adm policy add-role-to-user daemonset-admin <user>
+----
+
 [[creating-local-role]]
 == Creating a Local Role
 

--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -24,6 +24,13 @@ For more information on daemonsets, see the link:http://kubernetes.io/docs/admin
 [[dev-guide-creating-daemonsets]]
 == Creating Daemonsets
 
+[IMPORTANT]
+====
+Before creating daemonsets, ensure you have been
+xref:../admin_guide/manage_rbac.adoc#admin-guide-granting-users-daemonset-permissions[given
+the required role by your {product-title} administrator].
+====
+
 When creating daemonsets, the `*nodeSelector*` field is used to indicate the
 nodes on which the daemonset should deploy replicas.
 


### PR DESCRIPTION
Revert "Remove daemonset from RBAC docs"

This reverts commit 9912d863c3ff2c7333e4aaa42e4b6efe42abc3ec.

Revert "Removed link to Granting Users Daemonset Permissions as followup to PR#7981"

This reverts commit 015ed3852fd0344c6a49495db76277f0316ce832.

Bug 1536304
Bug 1501514

xref: https://github.com/openshift/origin/pull/18971

/assign @simo5 @ahardin-rh 

Need to undo these changes until we can safely enable daemonset permissions.