### PR TITLE
Added oadm deprecation note to OCP 3.9 release notes

### DIFF
--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -764,10 +764,16 @@ The `autoscaling/v2alpha1` API group has been removed
 
 [discrete]
 [[start-node-requires-swap-to-be-disabled]]
-== Start Node Requires Swap to be Disabled
+=== Start Node Requires Swap to be Disabled
 
 The {product-title} start node requires swap to be disabled. This is already
 done as part of the Ansible node installation.
+
+[discrete]
+[[oadm-deprecated]]
+=== oadm Command Is Deprecated
+
+The `oadm` command is now deprecated. Use `oc adm` instead.
 
 [discrete]
 [[hawkular-is-deprecated]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1555223