### PR TITLE
Fix HPA docs to point to correct versions

### DIFF
--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -103,20 +103,18 @@ definition when using version one of the horizontal pod autoscaler:
 ====
 [source,yaml,options="nowrap"]
 ----
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: frontend <1>
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps.openshift.io/v1 <4>
     kind: DeploymentConfig <2>
     name: frontend <3>
-    apiVersion: v1 <4>
-    subresource: scale
   minReplicas: 1 <5>
   maxReplicas: 10 <6>
-  cpuUtilization:
-    targetPercentage: 80 <7>
+  targetCPUUtilizationPercentage: 80 <7>
 ----
 <1> The name of this horizontal pod autoscaler object
 <2> The kind of object to scale
@@ -133,13 +131,13 @@ autoscaler:
 
 [source,yaml,options="nowrap"]
 ----
-apiVersion: autoscaling/v2alpha1
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: hpa-resource-metrics-cpu <1>
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1 <2>
+    apiVersion: v1 <2>
     kind: ReplicationController <3>
     name: hello-hpa-cpu <4>
   minReplicas: 1 <5>
@@ -167,30 +165,20 @@ you can specify the minimum number of pods and the average memory utilization
 your pods should target as well, otherwise those are given default values from
 the {product-title} server.
 
-. Memory-based autoscaling is only available with the `v2alpha1` version of the
-autoscaling API. Enable memory-based autoscaling by adding the following to your
-cluster's `master-config.yaml` file:
-+
-[source,bash]
-----
-...
-apiServerArguments:
-  runtime-config:
-  - apis/autoscaling/v2alpha1=true
-...
-----
+. Memory-based autoscaling is only available with the `v2beta1` version of the
+autoscaling API.
 
 . Place the following in a file, such as `hpa.yaml`:
 +
 [source,yaml,options="nowrap"]
 ----
-apiVersion: autoscaling/v2alpha1
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: hpa-resource-metrics-memory <1>
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1 <2>
+    apiVersion: v1 <2>
     kind: ReplicationController <3>
     name: hello-hpa-memory <4>
   minReplicas: 1 <5>
@@ -262,7 +250,7 @@ Events:
 <2> The current CPU utilization across all pods controlled by the deployment configuration.
 <3> The minimum number of replicas to scale down to.
 <4> The maximum number of replicas to scale up to.
-<4> If the object used the `v2alpha1` API, xref:viewing-a-hpa-status[status conditions] are displayed.
+<4> If the object used the `v2beta1` API, xref:viewing-a-hpa-status[status conditions] are displayed.
 
 [[viewing-a-hpa-status]]
 === Viewing Horizontal Pod Autoscaler Status Conditions
@@ -285,30 +273,8 @@ is able to calculate desired scales.
 ** A `True` condition indicates that you need to raise or lower the minimum or maximum replica count in order to scale.
 ** A `False` condition indicates that the requested scaling is allowed.
 
-The horizontal pod autoscaler status conditions are only available with the `v2alpha1` version of the
-autoscaling API by adding the following to your cluster's `master-config.yaml` file:
-
-[source,yaml]
-----
-kubernetesMasterConfig:
-  ...
-  apiServerArguments:
-    runtime-config:
-    - apis/autoscaling/v2alpha1=true
-----
-
-Restart the {product-title} services:
-
-ifdef::openshift-enterprise[]
-----
-# systemctl restart atomic-openshift-master-api atomic-openshift-master-controllers
-----
-endif::[]
-ifdef::openshift-origin[]
-----
-# systemctl restart origin-master-api origin-master-controllers
-----
-endif::[]
+The horizontal pod autoscaler status conditions are only available with the `v2beta1` version of the
+autoscaling API.
 
 To see the conditions affecting a horizontal pod autoscaler, use `oc describe hpa`. Conditions appear in the `status.conditions` field:
 


### PR DESCRIPTION
The HPA docs had a number of incorrect API versions:

- They stil referenced extensions/v1beta1, which was removed in 3.7
- They had the legacy group-version for deployments, which is discouraged.
- They had the completely incorrect group-version for ReplicationControllers