### PR TITLE
Updating for `Configuring for Amazon Web Services`

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -58,10 +58,10 @@ Configuring AWS for {product-title} requires the following permissions:
 
 [IMPORTANT]
 ====
-* Every master, node, and subnet must have the `KubernetesCluster: value` tag.
+* Every master, node, and subnet must have the `kubernetes.io/cluster/<name>,Value=<clusterid>` tag.
 * One security group, preferably the one linked to the nodes, must have the
-`KubernetesCluster: value` tag.
- ** Do not tag all security groups with the `KubernetesCluster: value` tag or the
+`kubernetes.io/cluster/<name>,Value=<clusterid>` tag.
+ ** Do not tag all security groups with the `kubernetes.io/cluster/<name>,Value=<clusterid>` tag or the
 Elastic Load Balancing (ELB) will not be able to create a load balancer.
 
 ====
@@ -69,7 +69,7 @@ Elastic Load Balancing (ELB) will not be able to create a load balancer.
 [[configuring-aws-variables]]
 == Configuring AWS Variables
 
-To set the required AWS variables, create a *_/etc/aws/aws.conf_* file with the
+To set the required AWS variables, create a *_/etc/origin/cloudprovider/aws.conf_* file with the
 following contents on all of your {product-title} hosts, both masters and nodes:
 
 
@@ -124,7 +124,7 @@ xref:../install_config/install/advanced_install.adoc#advanced-install-configurin
 ====
 When Ansible configures AWS, the following files are created for you:
 
-- *_/etc/aws/aws.conf_*
+- *_/etc/origin/cloudprovider/aws.conf_*
 - *_/etc/origin/master/master-config.yaml_*
 - *_/etc/origin/node/node-config.yaml_*
 - *_/etc/sysconfig/atomic-openshift-master_*
@@ -150,12 +150,12 @@ kubernetesMasterConfig:
     cloud-provider:
       - "aws"
     cloud-config:
-      - "/etc/aws/aws.conf"
+      - "/etc/origin/cloudprovider/aws.conf"
   controllerArguments:
     cloud-provider:
       - "aws"
     cloud-config:
-      - "/etc/aws/aws.conf"
+      - "/etc/origin/cloudprovider/aws.conf"
 ----
 
 Currently, the `nodeName` *must* match the instance name in AWS in order
@@ -184,7 +184,7 @@ kubeletArguments:
   cloud-provider:
     - "aws"
   cloud-config:
-    - "/etc/aws/aws.conf"
+    - "/etc/origin/cloudprovider/aws.conf"
 ----
 
 [IMPORTANT]
@@ -201,12 +201,12 @@ container. Therefore, *_aws.conf_* should be in *_/etc/origin/_* instead of
 Make sure the following environment variables are set in the
 ifdef::openshift-enterprise[]
 *_/etc/sysconfig/atomic-openshift-master-api_* file and
-*_/etc/sysconfig/atomic-openshift-master-containers_* file on masters and the
+*_/etc/sysconfig/atomic-openshift-master-controllers_* file on masters and the
 *_/etc/sysconfig/atomic-openshift-node_* file on nodes:
 endif::[]
 ifdef::openshift-origin[]
 *_/etc/sysconfig/origin-master-api_* file and
-*_/etc/sysconfig/origin-master-containers_* file on masters and the
+*_/etc/sysconfig/origin-master-controllers_* file on masters and the
 *_/etc/sysconfig/origin-node_* file on nodes:
 endif::[]
 


### PR DESCRIPTION
- The correct tag of the resources should be `kubernetes.io/cluster/<name>,Value=<clusterid>`

- The generated file by installer should be `/etc/origin/cloudprovider/aws.conf`

- Correct `atomic-openshift-master-containers` to `atomic-openshift-master-controllers`