### PR TITLE
Add some explanation of hostsubnets that span multiple octets

### DIFF
--- a/architecture/additional_concepts/sdn.adoc
+++ b/architecture/additional_concepts/sdn.adoc
@@ -65,6 +65,15 @@ given node is allocated 510 addresses that it can assign to the containers
 running on it. The size and address range of the cluster network are
 configurable, as is the host subnet size.
 
+[OpenShift SDN]
+====
+In order to make it easeier for humans to follow if a subnet extends into the next higher octet,
+we rotate the bits of the subnet number so subnets with all 0s in the shared octet are allocated
+first. So if the given network is "10.1.0.0/16" hostsubnetlength=6 then 10.1.0.0/26, 10.1.1.0/26,
+through 10.1.255.0/26 are allocated before the system fills in the gaps with 10.1.0.64/26,
+10.1.1.64/26, etc.
+====
+
 Note that OpenShift SDN on a master does not configure the local (master)
 host to have access to any cluster network. Consequently, a master host does not
 have access to pods via the cluster network, unless it is also running as a


### PR DESCRIPTION
Customer encountered undocumented behaviour regarding the allocation of hostsubnet addresses that span multiple octets. It is well documented in the code itself exposing that information should clear up issues in the future.


Bug [1554939](https://bugzilla.redhat.com/show_bug.cgi?id=1554939)