### PR TITLE
Bug#1557152 - fixes wrong cloud providers appearing in docs

### DIFF
--- a/install_config/topics/applying_configuration_changes.adoc
+++ b/install_config/topics/applying_configuration_changes.adoc
@@ -28,9 +28,9 @@ endif::[]
 Switching from not using a cloud provider to using a cloud provider produces an
 error message. Adding the cloud provider tries to delete the node because the
 node switches from using the *hostname* as the `*externalID*` (which would have
-been the case when no cloud provider was being used) to using the AWS
-`*instance-id*` (which is what the AWS cloud provider specifies). To resolve
-this issue:
+been the case when no cloud provider was being used) to using the cloud
+provider's  `*instance-id*` (which is what the cloud provider specifies). To
+resolve this issue:
 
 .  Log in to the CLI as a cluster administrator.
 . Check and back up existing node labels:


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1557152

- removed AWS from the section which is common for all cloud providers.