### PR TITLE
Removed openshift_template_service_broker_namespaces per BZ

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -480,10 +480,6 @@ xref:advanced-install-docker-system-container[running `docker` as a system conta
 meaning that it is available for placement of new pods. See
 xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Masters].
 
-|`*openshift_template_service_broker_namespaces*`
-|This variable enables the template service broker by specifying one of more
-namespaces whose templates will be served by the broker.
-openshift_template_service_broker_namespaces configurable
 |===
 
 [[configuring-host-port]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1557929

Making this change directly to 3.9 because the change in this PR was made to master and 3.7 via:
https://github.com/openshift/openshift-docs/pull/7554