### PR TITLE
Bug 1557349: Add APB tool user permission reqs for 3.7

### DIFF
--- a/apb_devel/cli_tooling.adoc
+++ b/apb_devel/cli_tooling.adoc
@@ -24,7 +24,32 @@ takes care of the details so they should be easy to deploy.
 [[apb-devel-cli-install-prereqs]]
 === Prerequisites
 
+[[apb-devel-cli-install-prereqs-docker]]
+==== Docker Daemon
+
 The `docker` daemon must be correctly installed and running on the system.
+
+[[apb-devel-cli-install-prereqs-access-permissions]]
+==== Access Permissions
+
+You must be logged in via `oc` as a user with *cluster-admin* permissions:
+
+----
+$ oc login -u <user> <openshift_server>
+----
+
+To add this role to another user, you can run the following as a user that
+already has such permissions (for example, the *system:admin* default system
+user):
+
+----
+$ oc adm policy \
+    add-cluster-role-to-user \
+    cluster-admin <user>
+----
+
+This permission requirement is so that the development lifecycle of the `apb`
+tool can function.
 
 ifdef::openshift-origin[]
 [[apb-devel-cli-install-containerized]]


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1557349

Preview:

http://file.rdu.redhat.com/~adellape/032018/apb_permissions/apb_devel/cli_tooling.html#apb-devel-cli-install-prereqs

@dymurray PTAL