### PR TITLE
Fix hyper link typo and wrong version tag in ocp_3_9_release_notes

### DIFF
--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -32,7 +32,7 @@ security, privacy, compliance, and governance requirements.
 Red Hat {product-title} version 3.9
 (link:https://access.redhat.com/errata/RHBA-2018:0489[RHBA-2018:0489]) is now
 available. This release is based on
-link:https://github.com/openshift/origin/releases/tag/v3.9.0-rc.0[OpenShift
+link:https://github.com/openshift/origin/releases/tag/v3.9.0[OpenShift
 Origin 3.9]. New features, changes, bug fixes, and known issues that pertain to
 {product-title} 3.9 are included in this topic.
 
@@ -879,7 +879,7 @@ Deployments Support]
 - xref:../architecture/additional_concepts/storage.adoc#pv-mount-options[Mount Options]
 - xref:../install_config/install/advanced_install.adoc#advanced-install-configuring-system-containers[Installation of etcd, Docker Daemon, and Ansible Installer as System Containers]
 - xref:../install_config/install/advanced_install.adoc#running-the-advanced-installation-system-container[Running OpenShift Installer as a System Container]
-- xref:../admin_guide/overcommit.adoc#configuring-reserve-resource[`experimental-qos-reserved`]
+- xref:../admin_guide/overcommit.adoc#configuring-reserve-resources[experimental-qos-reserved]
 - xref:../admin_guide/sysctls.adoc#admin-guide-sysctls[pod sysctls]
 - xref:../admin_guide/managing_networking.adoc#enabling-static-ips-for-external-project-traffic[Enabling Static IPs for External Project Traffic]
 - xref:../install_config/master_node_configuration.adoc#master-node-config-audit-config[Central Audit]


### PR DESCRIPTION
Fix: https://github.com/openshift/openshift-docs/issues/8355

1. The xref should be "xref:../admin_guide/overcommit.adoc#configuring-reserve-resources".
2. There is no v3.9.0-rc.0 tag, should be v3.9.0.