### PR TITLE
bug 1555344 adding SkyDNS context

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -368,10 +368,11 @@ advanced installation of {product-title} (using Ansible), because this option
 overrides the default IP address set by xref:../../admin_solutions/master_node_config.adoc#node-config-options[`*dnsIP*`].
 
 Instead, allow the installer to configure each node to use *dnsmasq* and forward
-requests to SkyDNS or the external DNS provider. If you do set the
-`*openshift_dns_ip*` option, then it should be set either with a DNS IP that
-queries SkyDNS first, or to the SkyDNS service or endpoint IP (the Kubernetes
-service IP).
+requests to the external DNS provider or SkyDNS, the internal DNS service for
+cluster-wide DNS resolution of internal hostnames for services and pods. If you
+do set the `*openshift_dns_ip*` option, then it should be set either with a DNS
+IP that queries SkyDNS first, or to the SkyDNS service or endpoint IP (the
+Kubernetes service IP).
 ====
 
 To verify that hosts can be resolved by your DNS server:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1555344

@bfallonf, does this sound ok to you? I didn't see a good topic to link to. [This known issue](https://docs.openshift.com/container-platform/3.9/install_config/storage_examples/gluster_backed_registry.html#backing-docker-registry-with-glusterfs-storage-pod-cannot-resolve) has the most info about changing `dnsmasq`, but I'm not convinced that it's close enough to this scenario.