### PR TITLE
Documented the route annotation limiting concurrent connections

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -604,6 +604,7 @@ For all the items outlined in this section, you can set annotations on the
 |`*haproxy.router.openshift.io/cookie_name*`| Specifies an optional cookie to be used for
 this route. The name must consist of any combination of upper and lower case letters, digits, "_",
 and "-". The default is the hashed internal key name for the route. |
+|`*haproxy.router.openshift.io/pod-concurrent-connections*`| Sets the maximum number of connections that are allowed to a backing pod from a router.  Note: if there are multiple pods, each can have this many connections.  But if you have multiple routers, there is no coordination among them, each may connect this many times. If not set, there is no limit. |
 |`*haproxy.router.openshift.io/rate-limit-connections*`| Setting `true` or `TRUE` to enables rate limiting functionality. |
 |`*haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp*`| Limits the number of concurrent TCP connections shared by an IP address. |
 |`*haproxy.router.openshift.io/rate-limit-connections.rate-http*`| Limits the rate at which an IP address can make HTTP requests. |
@@ -612,7 +613,6 @@ and "-". The default is the hashed internal key name for the route. |
 |`*router.openshift.io/haproxy.health.check.interval*`| Sets the interval for the back-end health checks. xref:time-units[(TimeUnits)] | `ROUTER_BACKEND_CHECK_INTERVAL`
 |`*haproxy.router.openshift.io/ip_whitelist*` | Sets a xref:whitelist[whitelist] for the route. |
 |`*haproxy.router.openshift.io/hsts_header*` | Sets a Strict-Transport-Security header for the edge terminated or re-encrypt route. |
-
 |===
 
 .A Route Setting Custom Timeout

--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -604,7 +604,7 @@ For all the items outlined in this section, you can set annotations on the
 |`*haproxy.router.openshift.io/cookie_name*`| Specifies an optional cookie to be used for
 this route. The name must consist of any combination of upper and lower case letters, digits, "_",
 and "-". The default is the hashed internal key name for the route. |
-|`*haproxy.router.openshift.io/pod-concurrent-connections*`| Sets the maximum number of connections that are allowed to a backing pod from a router.  Note: if there are multiple pods, each can have this many connections.  But if you have multiple routers, there is no coordination among them, each may connect this many times. If not set, there is no limit. |
+|`*haproxy.router.openshift.io/pod-concurrent-connections*`| Sets the maximum number of connections that are allowed to a backing pod from a router.  Note: if there are multiple pods, each can have this many connections.  But if you have multiple routers, there is no coordination among them, each may connect this many times. If not set, or set to 0, there is no limit. |
 |`*haproxy.router.openshift.io/rate-limit-connections*`| Setting `true` or `TRUE` to enables rate limiting functionality. |
 |`*haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp*`| Limits the number of concurrent TCP connections shared by an IP address. |
 |`*haproxy.router.openshift.io/rate-limit-connections.rate-http*`| Limits the rate at which an IP address can make HTTP requests. |


### PR DESCRIPTION
This adds documentation for haproxy.router.openshift.io/pod-concurrent-connections

Added to OpenShift by https://github.com/openshift/origin/pull/15559