### PR TITLE
[enterprise-3.5] moved cloud specific sections to the individual cloud docs

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -66,6 +66,55 @@ Elastic Load Balancing (ELB) will not be able to create a load balancer.
 
 ====
 
+[[configuring-a-security-group-aws]]
+== Configuring a Security Group
+When installing {product-title} on AWS, ensure that you set up the appropriate
+security groups.
+include::install_config/topics/configuring_a_security_group.adoc[]
+
+[[overriding-detected-ip-addresses-host-names-aws]]
+==== Overriding Detected IP Addresses and Host Names
+In AWS, situations that require overriding the variables include:
+
+[cols="1,2"options="header"]
+|===
+|Variable |Usage
+
+|`*hostname*`
+a|The user is installing in a VPC that is not configured for both `*DNS hostnames*` and `*DNS resolution*`.
+
+|`*ip*`
+a|You have multiple network interfaces configured and want to
+use one other than the default. You must also set the
+`*openshift_set_node_ip*` parameter to `True`, or the SDN attempts to
+use the `*hostname*` setting or tries to resolve the host name for the IP address.
+
+|`*public_hostname*`
+a| - A master instance where the VPC subnet is not configured for `*Auto-assign
+Public IP*`. For external access to this master, you need to have an ELB or
+other load balancer configured that would provide the external access needed, or
+you need to connect over a VPN connection to the internal name of the host.
+- A master instance where metadata is disabled.
+- This value is not actually used by the nodes.
+
+|`*public_ip*`
+a| - A master instance where the VPC subnet is not configured for `*Auto-assign Public IP*`.
+- A master instance where metadata is disabled.
+- This value is not actually used by the nodes.
+
+|===
+
+[WARNING]
+====
+If `*openshift_hostname*` is set to a value other than the metadata-provided
+`*private-dns-name*` value, the native cloud integration for those providers
+will no longer work.
+====
+
+For EC2 hosts in particular, they must be deployed in a VPC that has both
+`*DNS host names*` and `*DNS resolution*` enabled, and `*openshift_hostname*`
+should not be overridden.
+
 [[configuring-aws-variables]]
 == Configuring AWS Variables
 

--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -28,6 +28,12 @@ on.) you need the member role for the tenant.
 
 |===
 
+[[configuring-a-security-group-openstack]]
+== Configuring a Security Group
+When installing {product-title} on OpenStack, ensure that you set up the
+appropriate security groups.
+include::install_config/topics/configuring_a_security_group.adoc[]
+
 [[configuring-openstack-variables]]
 == Configuring OpenStack Variables
 To set the required OpenStack variables, create a *_/etc/cloud.conf_* file with

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -684,52 +684,10 @@ xref:../../install_config/persistent_storage/persistent_storage_iscsi.adoc#insta
 There are certain aspects to take into consideration if installing {product-title}
 on a cloud provider.
 
-==== Configuring a Security Group
-
-When installing on AWS or OpenStack, ensure that you set up the appropriate
-security groups. These are some ports that you should have in your security
-groups, without which the installation will fail. You may need more depending on
-the cluster configuration you want to install. For more information and to
-adjust your security groups accordingly, see xref:required-ports[Required Ports]
-for more information.
-
-[cols="1,2"]
-|===
-|*All {product-title} Hosts*
-a|- tcp/22 from host running the installer/Ansible
-
-|*etcd Security Group*
-a|- tcp/2379 from masters
-- tcp/2380 from etcd hosts
-
-|*Master Security Group*
-a|- tcp/8443 from 0.0.0.0/0
-ifdef::openshift-origin[]
-- tcp/53 from all {product-title} hosts for environments installed prior to or upgraded to 1.2
-- udp/53 from all {product-title} hosts for environments installed prior to or upgraded to 1.2
-- tcp/8053 from all {product-title} hosts for new environments installed with 1.2
-- udp/8053 from all {product-title} hosts for new environments installed with 1.2
-endif::[]
-ifdef::openshift-enterprise[]
-- tcp/53 from all {product-title} hosts for environments installed prior to or upgraded to 3.2
-- udp/53 from all {product-title} hosts for environments installed prior to or upgraded to 3.2
-- tcp/8053 from all {product-title} hosts for new environments installed with 3.2
-- udp/8053 from all {product-title} hosts for new environments installed with 3.2
-endif::[]
-
-|*Node Security Group*
-a|- tcp/10250 from masters
-- udp/4789 from nodes
-
-|*Infrastructure Nodes*
-(ones that can host the {product-title} router)
-a|- tcp/443 from 0.0.0.0/0
-- tcp/80 from 0.0.0.0/0
-
-|===
-
-If configuring ELBs for load balancing the masters and/or routers, you also need
-to configure Ingress and Egress security groups for the ELBs appropriately.
+* For Amazon Web Services, see the xref:../../install_config/configuring_aws.adoc#configuring-aws-permissions[Permissions] and the
+xref:../../install_config/configuring_aws.adoc#configuring-a-security-group-aws[Configuring a Security Group] sections.
+* For OpenStack, see the  xref:../../install_config/configuring_openstack.adoc#configuring-openstack-permissions[Permissions] and the
+xref:../../install_config/configuring_openstack.adoc#configuring-a-security-group-openstack[Configuring a Security Group] sections.
 
 ==== Overriding Detected IP Addresses and Host Names
 
@@ -742,6 +700,12 @@ playbook:
 # ansible-playbook playbooks/byo/openshift_facts.yml
 ----
 ====
+
+[IMPORTANT]
+====
+For Amazon Web Services, see the xref:../../install_config/configuring_aws.adoc#overriding-detected-ip-addresses-host-names-aws[Overriding Detected IP Addresses and Host Names] section.
+====
+
 
 Now, verify the detected common settings. If they are not what you expect them
 to be, you can override them.
@@ -782,44 +746,6 @@ If `*openshift_hostname*` is set to a value other than the metadata-provided
 `*private-dns-name*` value, the native cloud integration for those providers
 will no longer work.
 ====
-
-In AWS, situations that require overriding the variables include:
-
-[cols="1,2"options="header"]
-|===
-|Variable |Usage
-
-|`*hostname*`
-a|The user is installing in a VPC that is not configured for both `*DNS hostnames*` and `*DNS resolution*`.
-
-|`*ip*`
-a|You have multiple network interfaces configured and want to
-use one other than the default. You must also set the
-`*openshift_set_node_ip*` parameter to `True`, or the SDN attempts to
-use the `*hostname*` setting or tries to resolve the host name for the IP address.
-
-|`*public_hostname*`
-a| - A master instance where the VPC subnet is not configured for `*Auto-assign
-Public IP*`. For external access to this master, you need to have an ELB or
-other load balancer configured that would provide the external access needed, or
-you need to connect over a VPN connection to the internal name of the host.
-- A master instance where metadata is disabled.
-- This value is not actually used by the nodes.
-
-|`*public_ip*`
-a| - A master instance where the VPC subnet is not configured for `*Auto-assign Public IP*`.
-- A master instance where metadata is disabled.
-- This value is not actually used by the nodes.
-
-|===
-
-If setting `*openshift_hostname*` to something other than the metadata-provided
-`*private-dns-name*` value, the native cloud integration for those providers
-will no longer work.
-
-For EC2 hosts in particular, they must be deployed in a VPC that has both
-`*DNS host names*` and `*DNS resolution*` enabled, and `*openshift_hostname*`
-should not be overridden.
 
 ==== Post-Installation Configuration for Cloud Providers
 

--- a/install_config/topics/configuring_a_security_group.adoc
+++ b/install_config/topics/configuring_a_security_group.adoc
@@ -1,0 +1,52 @@
+////
+Configuring a Security Group
+
+This module included in the following assemblies:
+* install_config/configuring_aws.adoc
+* install_config/configuring_openstack.adoc
+////
+
+These are some ports that you must have in your security
+groups, without which the installation fails. You may need more depending on
+the cluster configuration you want to install. For more information and to
+adjust your security groups accordingly, see xref:../install_config/install/prerequisites.adoc#required-ports[Required Ports]
+for more information.
+
+[cols="h,2"]
+|===
+|All {product-title} Hosts
+a|- tcp/22 from host running the installer/Ansible
+
+|etcd Security Group
+a|- tcp/2379 from masters
+- tcp/2380 from etcd hosts
+
+|Master Security Group
+a|- tcp/8443 from 0.0.0.0/0
+ifdef::openshift-origin[]
+- tcp/53 from all {product-title} hosts for environments installed prior to or upgraded to 1.2
+- udp/53 from all {product-title} hosts for environments installed prior to or upgraded to 1.2
+- tcp/8053 from all {product-title} hosts for new environments installed with 1.2
+- udp/8053 from all {product-title} hosts for new environments installed with 1.2
+endif::[]
+ifdef::openshift-enterprise[]
+- tcp/53 from all {product-title} hosts for environments installed prior to or upgraded to 3.2
+- udp/53 from all {product-title} hosts for environments installed prior to or upgraded to 3.2
+- tcp/8053 from all {product-title} hosts for new environments installed with 3.2
+- udp/8053 from all {product-title} hosts for new environments installed with 3.2
+endif::[]
+
+|Node Security Group
+a|- tcp/10250 from masters
+- udp/4789 from nodes
+
+|Infrastructure Nodes
+(ones that can host the {product-title} router)
+a|- tcp/443 from 0.0.0.0/0
+- tcp/80 from 0.0.0.0/0
+
+|===
+
+If configuring external load-balancers (ELBs) for load balancing the masters
+and/or routers, you also need to configure Ingress and Egress security groups
+for the ELBs appropriately.


### PR DESCRIPTION
cherry-picked from https://github.com/openshift/openshift-docs/pull/8384/commits/5c7ad410ecf66220e9025a581acfc98fcc0c3e3d
pr #8384 