### PR TITLE
[enterprise-3.6]Removed reference to openshift_use_dnsmasq=true

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -322,9 +322,6 @@ any other type of DNS application.
 *NetworkManager* is required on the nodes in order to populate *dnsmasq* with
 the DNS IP addresses. DNS does not work properly when the network interface for
 {product-title} has `NM_CONTROLLED=no`.
-
-DNSMSQ must be enabled (`openshift_use_dnsmasq=true`) or the installation will fail
-and critical features will not function.
 ====
 
 The following is an example set of DNS records for the xref:../../install_config/install/planning.adoc#single-master-multi-node[Single Master and Multiple Nodes] scenario:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1557411
xref:https://github.com/openshift/openshift-docs/pull/8434