### PR TITLE
Added step to downgrade Ansible to 2.3 per BZ

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -127,6 +127,13 @@ methods, such as Ansible and related configuration files:
 # yum install atomic-openshift-utils
 ----
 
+. Downgrade the Ansible version 2.3.2. The 2.4 verson installed by the `atomic-openshift-utils` package 
+will cause the installer to fail. For example:
++
+----
+# yum downgrade ansible-2.3.2.0-2.el7.noarch
+---- 
+
 . Install the following **-excluder* packages on each RHEL 7 system, which helps
 ensure your systems stay on the correct versions of *atomic-openshift* and
 *docker* packages when you are not trying to upgrade, according to the


### PR DESCRIPTION
need to doc that could not install OCP by ansible 2.4, should use ansible 2.3
this is from a won't fix bug.
https://bugzilla.redhat.com/show_bug.cgi?id=1540103