### PR TITLE
Bug 1557234: Add CFME 4.6 topics back in for OCP 3.9

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -323,6 +323,22 @@ Topics:
     File: proxy_protocol
   - Name: Using the F5 Router Plug-in
     File: f5_router
+- Name: Deploying Red Hat CloudForms
+  Dir: cfme
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Introduction
+    File: index
+  - Name: Requirements
+    File: requirements
+  - Name: Configuring Role Variables
+    File: role_variables
+  - Name: Running the Installer
+    File: installing
+  - Name: Enabling Container Provider Integration
+    File: container_provider
+  - Name: Uninstalling
+    File: uninstalling
 - Name: Master and Node Configuration
   File: master_node_configuration
 - Name: OpenShift Ansible Broker Configuration

--- a/install_config/cfme/container_provider.adoc
+++ b/install_config/cfme/container_provider.adoc
@@ -1,4 +1,4 @@
-[[install-config-cfme-cloud-provider]]
+[[install-config-cfme-container-provider]]
 = Enabling Container Provider Integration
 {product-author}
 {product-version}
@@ -91,7 +91,7 @@ ifdef::openshift-origin[]
 *_files/examples/container_providers.yml_*
 endif::[]
 ifdef::openshift-enterprise[]
-*_/usr/share/ansible/openshift-ansible/files/examples/container_providers.yml_*
+*_/usr/share/ansible/openshift-ansible/roles/openshift_management/files/examples/container_providers.yml_*
 endif::[]
 example somewhere, such as *_/tmp/cp.yml_*. You will be modifying this file.
 
@@ -199,5 +199,5 @@ ifdef::openshift-origin[]
 - link:http://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#_refreshing_multiple_management_systems[Refreshing Providers]
 endif::[]
 ifdef::openshift-enterprise[]
-- link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_providers/index#refreshing_cloud_providers[Managing Providers]
+- link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/managing_providers/index#refreshing_cloud_providers[Managing Providers]
 endif::[]

--- a/install_config/cfme/role_variables.adoc
+++ b/install_config/cfme/role_variables.adoc
@@ -35,15 +35,6 @@ installation when xref:installing.adoc#install-config-cfme-installing[running th
 |`false`
 |Boolean, set to `true` to install the application.
 
-ifdef::openshift-enterprise[]
-|`openshift_management_install_beta`
-|Yes
-|`false`
-|By setting this value to `true`, you acknowledge that the {mgmt-app} 4.6
-software is currently in beta, and support may be limited. This is required to
-begin the installation.
-endif::[]
-
 |`openshift_management_app_template`
 ifdef::openshift-enterprise[]
 |Yes
@@ -51,17 +42,21 @@ endif::[]
 ifdef::openshift-origin[]
 |No
 endif::[]
+
+ifdef::openshift-enterprise[]
+|`cfme-template`
+endif::[]
+ifdef::openshift-origin[]
 |`miq-template`
+endif::[]
 a|The deployment variant of {mgmt-app} to install.
 ifdef::openshift-origin[]
 Set `miq-template` for a containerized database or `miq-template-ext-db` for
 an external database.
 endif::[]
 ifdef::openshift-enterprise[]
-You must change it from the default `miq-template`, otherwise the upstream
-ManageIQ application will be installed instead of {mgmt-app}. Set
-`cfme-template` for a containerized database or `cfme-template-ext-db` for an
-external database.
+Set `cfme-template` for a containerized database or `cfme-template-ext-db` for
+an external database.
 endif::[]
 
 |`openshift_management_project`
@@ -77,12 +72,20 @@ endif::[]
 |`openshift_management_username`
 |No 
 |`admin` 
-|Default management user name. Changing this value does not change the username; only change this value if you have changed the name already and are running integration scripts (such as the script to xref:cloud_provider.adoc#install-config-cfme-cloud-provider[add cloud providers]).
+|Default management user name. Changing this value does not change the user name;
+only change this value if you have changed the name already and are running
+integration scripts (such as the script to
+xref:container_provider.adoc#install-config-cfme-container-provider[add
+container providers]).
 
 |`openshift_management_password`
 |No
 |`smartvm`
-|Default management password. Changing this value does not change the password; only change this value if you have changed the password already and are running integration scripts (such as the script to xref:cloud_provider.adoc#install-config-cfme-cloud-provider[add cloud providers]).
+|Default management password. Changing this value does not change the password;
+only change this value if you have changed the password already and are running
+integration scripts (such as the script to
+xref:container_provider.adoc#install-config-cfme-container-provider[add container
+providers]).
 |===
 
 [[cfme-customization-variables]]
@@ -178,8 +181,7 @@ openshift_management_template_parameters={'DATABASE_USER': 'root', 'DATABASE_PAS
 |No
 |`nfs` 
 |Storage type to use. Options are `nfs`, `nfs_external`, `preconfigured`, or
-`cloudprovider`. See
-xref:storage_class.adoc#install-config-cfme-storage-classes[Storage Class Options] for details on each.
+`cloudprovider`.
 |`openshift_management_storage_nfs_external_hostname`
 |No 
 |`false` 

--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -75,7 +75,14 @@ is run, administrators can choose to run hard prune (which is safe to run as
 long as the registry is put in read-only mode).
 
 [[ocp-39-cloudforms]]
-==== CloudForms 4.6 Container Management
+==== Red Hat CloudForms Management Engine 4.6 Container Management
+
+The installation playbooks in {product-title} 3.9 have been updated to support
+Red Hat CloudForms Management Engine (CFME) 4.6, which is now currently
+available. See the new
+xref:../install_config/cfme/index.adoc#install-config-cfme-intro[Deploying Red Hat CloudForms on OpenShift Container Platform] topics for further information.
+
+In addition, this release includes the following new features and updates:
 
 * {product-title} template provisioning
 * Offline OpenScapScans


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1557234

Updated CFME topics for current info:

http://file.rdu.redhat.com/~adellape/032718/add39cfme46/install_config/cfme/index.html#install-config-cfme-intro

Added mention in the OCP 3.9 Release Notes with a link to new topics:

http://file.rdu.redhat.com/~adellape/032718/add39cfme46/release_notes/ocp_3_9_release_notes.html#ocp-39-cloudforms