### PR TITLE
Bug 1561279 Removed openshift3/ose-federation from install

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -203,7 +203,6 @@ $ docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-egress-http-proxy:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-egress-router:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-f5-router:<tag>
-$ docker pull registry.access.redhat.com/openshift3/ose-federation:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-haproxy-router:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-keepalived-ipfailover:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
@@ -342,7 +341,6 @@ $ docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/ose-egress-http-proxy \
     registry.access.redhat.com/openshift3/ose-egress-router \
     registry.access.redhat.com/openshift3/ose-f5-router \
-    registry.access.redhat.com/openshift3/ose-federation \
     registry.access.redhat.com/openshift3/ose-haproxy-router \
     registry.access.redhat.com/openshift3/ose-keepalived-ipfailover \
     registry.access.redhat.com/openshift3/ose-pod \


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=1561279

@sferich888 This goes back to 3.6, so will cherrypick to those branches.