### PR TITLE
Clarified how haproxy counts the connections

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -295,7 +295,10 @@ $ oc adm router --max-connections=10000   ....
 Edit the xref:../../architecture/networking/routes.adoc#env-variables[`ROUTER_MAX_CONNECTIONS`] environment variable in the router's
 deployment configuration to change the value. The router pods are restarted with
 the new value. If `ROUTER_MAX_CONNECTIONS` is not present, the default value of
-20000, is used.
+20000, is used.    Be aware that each actual connection counts as two connections
+because of the way that HAProxy works.  There is a frontend and internally it
+dispatches to a backend.  So you should set this to double the number of connections
+that you want to accept externally.
 
 [[bind-strict-sni]]
 == HAProxy Strict SNI

--- a/scaling_performance/routing_optimization.adoc
+++ b/scaling_performance/routing_optimization.adoc
@@ -81,7 +81,10 @@ One of the most important tunable parameters for HAProxy scalability is the
 connections to a given number. Adjust this parameter by editing the
 xref:../install_config/router/default_haproxy_router.adoc#concurrent-connections[`ROUTER_MAX_CONNECTIONS`]
 environment variable in the {product-title} HAProxy router's deployment
-configuration file.
+configuration file.  Be aware that each actual connection counts as two connections
+because of the way that HAProxy works.  There is a frontend and internally it
+dispatches to a backend.  So you should set this to double the number of connections
+that you want to accept externally.
 
 [[scaling-performance-optimizing-router-haproxy-cpu-affinity]]
 ==== CPU and Interrupt Affinity


### PR DESCRIPTION
Since each connection to the router also uses an internal connection
from the frontend to the backend, each connection that the user thinks
about really counts for two.  So the user should set the maximum
connections to double the number of external connections that they
want to plan for.

This applies to all versions where ROUTER_MAX_CONNECTIONS has been documented.

@openshift/networking PTAL