### PR TITLE
Removed assetConfig.publicURL per Gaoyun comment in BZ

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -70,7 +70,7 @@ A default certificate must be configured in the `servingInfo.certFile` and
 [NOTE]
 ====
 The `namedCertificates` section should only be configured for the host name
-associated with the `masterPublicURL`, `assetConfig.publicURL`, and
+associated with the `masterPublicURL` and
 `oauthConfig.assetPublicURL` settings. Using a custom serving certificate for
 the host name associated with the `masterURL` will result in TLS errors as
 infrastructure components will attempt to contact the master API using the


### PR DESCRIPTION
Removed `assetConfig.publicURL` per Gaoyun comment in BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1557166