### PR TITLE
added warning for F5 router docs

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -21,6 +21,13 @@ The F5 router plug-in is available starting in {product-title} 3.0.2.
 ====
 endif::[]
 
+[WARNING]
+====
+The F5 router plug-in will be deprecated in {product_title} version 3.11. It
+will be replaced by the F5 BIG-IP Controller. For more information, see link:http://clouddocs.f5.com/containers/v2/openshift/[F5 Container Connector - OpenShift]. For information about migrating to the BIG-IP Controller, see
+link:http://clouddocs.f5.com/containers/v2/openshift/replace-f5-router.html[Replace the F5 Router in OpenShift].
+====
+
 The F5 router plug-in is provided as a container image and run as a pod, just
 like the
 xref:../../install_config/router/default_haproxy_router.adoc#install-config-router-default-haproxy[default


### PR DESCRIPTION
For https://trello.com/c/W8SALr79/809-document-spike-deprecate-f5router-in-favour-of-container-connectorrouter