### PR TITLE
Documents node upgrade pre/mid/post hooks.

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -398,6 +398,10 @@ any ambiguity.
 openshift_master_upgrade_pre_hook=/usr/share/custom/pre_master.yml
 openshift_master_upgrade_hook=/usr/share/custom/master.yml
 openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
+
+openshift_node_upgrade_pre_hook=/usr/share/custom/pre_node.yml
+openshift_node_upgrade_hook=/usr/share/custom/node.yml
+openshift_node_upgrade_post_hook=/usr/share/custom/post_node.yml
 ----
 
 .Example *_pre_master.yml_* Task
@@ -419,6 +423,8 @@ openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
 [[upgrade-hooks-available-hooks]]
 ==== Available Upgrade Hooks
 
+[[upgrade-hooks-masters]]
+===== Master Upgrade Hooks
 `openshift_master_upgrade_pre_hook`::
 - Runs _before_ each master is upgraded.
 - This hook runs against _each master_ in serial.
@@ -428,7 +434,7 @@ or `local_action`].
 
 `openshift_master_upgrade_hook`::
 - Runs _after_ each master is upgraded, but _before_ its service or system restart.
-- This hook runs against **each master** in serial.
+- This hook runs against _each master_ in serial.
 - If a task must run against a different host, said task must use
 link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
 or `local_action`].
@@ -436,6 +442,29 @@ or `local_action`].
 `openshift_master_upgrade_post_hook`::
 - Runs _after_ each master is upgraded and has had its service or system restart.
 - This hook runs against _each master_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
+or `local_action`].
+
+[[upgrade-hooks-nodes]]
+===== Node Upgrade Hooks
+`openshift_node_upgrade_pre_hook`::
+- Runs _before_ each node is upgraded.
+- This hook runs against _each node_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
+or `local_action`].
+
+`openshift_node_upgrade_hook`::
+- Runs _after_ each node is upgraded, but _before_ it's marked schedulable again.
+- This hook runs against _each node_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
+or `local_action`].
+
+`openshift_node_upgrade_post_hook`::
+- Runs _after_ each node is upgraded; it's the _last_ node upgrade action.
+- This hook runs against _each node_ in serial.
 - If a task must run against a different host, said task must use
 link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
 or `local_action`].


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-docs/issues/8549.