### PR TITLE
Static egress IPs are no longer tech preview

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1000,22 +1000,6 @@ resources can recognize the traffic.
 Unlike the egress router, this is subject to `EgressNetworkPolicy` firewall
 rules.
 
-[IMPORTANT]
-====
-Enabling static IPs for external project traffic is a Technology Preview feature
-only.
-ifdef::openshift-enterprise[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-For more information on Red Hat Technology Preview features support scope, see
-https://access.redhat.com/support/offerings/techpreview/.
-endif::[]
-====
-
 To enable static source IPs:
 
 . Update the `NetNamespace` with the desired IP:


### PR DESCRIPTION
The "static per-project egress IPs" feature is no longer tech preview as of 3.9. (This is already mentioned in the release notes.)

(This is against master but it will need to be backported to 3.9 too.)