### PR TITLE
Bug 1548997: Add notes for unsupported APB async bind

### DIFF
--- a/apb_devel/cli_tooling.adoc
+++ b/apb_devel/cli_tooling.adoc
@@ -320,6 +320,12 @@ $ apb init [OPTIONS] NAME
 | `--skip-roles`           | Do not generate any roles
 |===
 
+[NOTE]
+====
+Async bind and unbind is an experimental feature and is not supported or enabled
+by default.
+====
+
 [discrete]
 ===== Examples
 
@@ -359,10 +365,10 @@ $ apb init my-new-apb --skip-deprovision
 ----
 
 Create directory *_my-new-apb_*, overwriting any old versions. The APB will be
-configured to be bindable and require async:
+configured to be bindable and set async to optional:
 
 ----
-$ apb init my-new-apb --force --bindable --async required
+$ apb init my-new-apb --force --bindable --async optional
 # my-new-apb/
 # ├── apb.yml
 # ├── Dockerfile

--- a/apb_devel/writing/reference.adoc
+++ b/apb_devel/writing/reference.adoc
@@ -59,7 +59,7 @@ application is declared. The following is an example APB spec:
   name: example-apb
   description: A short description of what this APB does
   bindable: True
-  async: optional
+  async: optional <1>
   metadata: 
     documentationUrl: <link_to_documentation>
     imageUrl: <link_to_url_of_image>
@@ -88,6 +88,8 @@ application is declared. The following is an example APB spec:
           title: Parameter Two
           type: boolean
 ----
+<1> Async bind and unbind is an experimental feature and is not supported or enabled
+by default.
 
 [[apb-devel-writing-ref-spec-top-level]]
 === Top-level Structure

--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -634,14 +634,6 @@ The `broker` section tells the broker what functionality should be enabled and
 disabled. It will also tell the broker where to find files on disk that will
 enable the full functionality.
 
-[NOTE]
-====
-With the absence of async bind, setting `launch_apb_on_bind` to `true` can cause
-the bind action to timeout and will span a retry. The broker will handle this
-with "409 Conflicts" because it is the same bind request with different
-parameters.
-====
-
 [options="header",cols="1,3,1,1"]
 |===
 
@@ -699,6 +691,15 @@ will attempt to create one.
 |`ansible-service-broker`
 |N
 |===
+
+[NOTE]
+====
+Async bind and unbind is an experimental feature and is not supported or enabled
+by default. With the absence of async bind, setting `launch_apb_on_bind` to
+`true` can cause the bind action to timeout and will span a retry. The broker
+will handle this with "409 Conflicts" because it is the same bind request with
+different parameters.
+====
 
 [[oab-config-secrets]]
 == Secrets Configuration

--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -304,7 +304,7 @@ Manager] for more information.
 ==== Huge Pages (Technology Preview)
 
 Huge pages is a feature currently in xref:ocp-39-technology-preview[Technology
-Preview] and not for production workloads..
+Preview] and not for production workloads.
 
 Memory is managed in blocks known as pages. On most systems, a page is 4Ki. 1Mi
 of memory is equal to 256 pages; 1Gi of memory is 256,000 pages, and so on. CPUs
@@ -832,7 +832,7 @@ now stable and supported.
 [[admin-solutions-guide-removed]]
 === Administrator Solutions Guide Removed
 
- In {product-title} 3.9, the Administrator Solutions guide is removed from the
+In {product-title} 3.9, the Administrator Solutions guide is removed from the
 {product-title} documentation. See the
 xref:../day_two_guide/index.adoc#day-two-guide-index[Day Two Operations Guide]
 instead.
@@ -945,7 +945,7 @@ updates the the etcd ca.crt in *_/etc/etcd/ca.crt_* as expected.
 pods deactivated. But, after upgrade, the HOSA pods are still being deployed. A
 new playbook, *uninstall_hosa.yaml*, has been created to remove HOSA from a
 {product-title} cluster when `openshift_metrics_install_hawkular_agent=false` in
-the Ansible inventory file..
+the Ansible inventory file.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1497408[*BZ#1497408*])
 
 * Because registry credentials for the broker were stored in a ConfigMap,
@@ -1255,6 +1255,11 @@ role has been changed to update TLS certificates.
 "databases" instead of "database". This is corrected with the tag "database"
 matching other services which is now properly shown in search results.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1510804[*BZ#1510804*])
+
+* Async bind and unbind is an experimental feature for the OpenShift Ansible
+broker (OAB) and is not supported or enabled by default. Red Hat's officially
+released APBs (PostgreSQL, MariaDB, MySQL, and Mediawiki) also do not support
+async bind and unbind. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1548997[*BZ#1548997*])
 
 * Previously, the etcd server was not accessible when using the `etcdctl` command.
 This was caused by the tcp being set to “0.0.0.0” instead of the expected


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1548997

@jwmatthews PTAL:

http://file.rdu.redhat.com/~adellape/040318/asyncbindnote/release_notes/ocp_3_9_release_notes.html#ocp-39-bug-fixes
http://file.rdu.redhat.com/~adellape/040318/asyncbindnote/install_config/oab_broker_configuration.html#oab-config-broker
http://file.rdu.redhat.com/~adellape/040318/asyncbindnote/apb_devel/cli_tooling.html#apb-devel-cli-init
http://file.rdu.redhat.com/~adellape/040318/asyncbindnote/apb_devel/writing/reference.html#apb-devel-writing-ref-spec