### PR TITLE
Added information about the corsAllowedOrigins parameter behavior

### DIFF
--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -50,6 +50,22 @@ whitelist that host name by specifying the `--cors-allowed-origins` option
 on `openshift start` or from the related
 xref:../../install_config/master_node_configuration.adoc#master-configuration-files[master
 configuration file parameter `corsAllowedOrigins`].
+
+The `corsAllowedOrigins` parameter is controlled by the configuration field. No
+pinning or escaping is done to the value. The following is an example of how you
+can pin a host name and escape dots:
+
+----
+corsAllowedOrigins:
+- (?i)//my\.subdomain\.domain\.com(:|\z)
+----
+
+* The `(?i)` makes it case-insensitive.
+* The `//` pins to the beginning of the domain (and matches the double slash
+following `http:` or `https:`).
+* The `\.` escapes dots in the domain name.
+* The `(:|\z)` matches the end of the domain name `(\z)` or a port separator `(:)`.
+
 endif::openshift-enterprise,openshift-origin[]
 
 ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1482903

@liggitt PTAL. I notice we don't mention this parameter on this page: https://docs.openshift.com/container-platform/3.9/install_config/master_node_configuration.html, but it probably should be added. 
What is a good description for it, and where on the page should it be placed? I assume it should be part of https://docs.openshift.com/container-platform/3.9/install_config/master_node_configuration.html#master-config-controller-config. Is that correct? I will be doing a larger rework of that page soon, based on https://bugzilla.redhat.com/show_bug.cgi?id=1557178

Thanks!