### PR TITLE
[enterprise-3.5] Removed Router Cipher Suite section

### DIFF
--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -369,35 +369,10 @@ $ oc adm router --strict-sni
 
 This sets `ROUTER_STRICT_SNI=true`.
 
-[[ciphers]]
-== Router Cipher Suite
-
-Each client (for example, Chrome 30, or Java8) includes a suite of ciphers used
-to securely connect with the router. The router must have at least one of the
-ciphers for the connection to be complete:
-
-.Router Cipher Profiles
-[cols="2,6", options="header"]
-|===
-|Profile | Oldest compatible client
-|modern| Firefox 27, Chrome 30, IE 11 on Windows 7, Edge, Opera 17, Safari 9, Android 5.0, Java 8
-|intermediate|Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
-|old|Windows XP IE6, Java 6
-|===
-
-See the link:https://wiki.mozilla.org/Security/Server_Side_TLS[Security/Server
-Side TLS] reference guide for more information.
-
-The router defaults to the `intermediate` profile. You can select a different
-profile using the `--ciphers` option when creating a route, or by changing
-the `ROUTER_CIPHERS` environment variable with the values `modern`,
-`intermediate`, or `old` for an existing router. Alternatively, a set of ":"
-separated ciphers can be provided. The ciphers must be from the set displayed
-by:
-
-----
-openssl ciphers
-----
+[NOTE]
+====
+See xref:../../install_config/router/customized_haproxy_router.adoc#install-config-router-customized-haproxy[Deploying a Customized HAProxy Router] to implement new features within the application back-ends, or modify the current operation.
+====
 
 [[route-hostnames]]
 


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1524486

Cherry-picked from https://github.com/openshift/openshift-docs/pull/6880/commits/cea433f40f4da215a5f671a72c28bbc5c434344c PR #6880 