### PR TITLE
Added Tech Preview notes for Kuryr SDN topics for 3.10

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -377,7 +377,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Configuring Kuryr SDN
   File: configuring_kuryrsdn
-  Distros: openshift-origin
+  Distros: openshift-origin,openshift-enterprise
 - Name: Configuring for AWS
   File: configuring_aws
   Distros: openshift-origin,openshift-enterprise
@@ -673,7 +673,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Kuryr SDN Administration
   File: kuryr
-  Distros: openshift-origin
+  Distros: openshift-origin,openshift-enterprise
 - Name: Revision History
   File: revhistory_admin_guide
   Distros: openshift-enterprise,openshift-dedicated

--- a/admin_guide/kuryr.adoc
+++ b/admin_guide/kuryr.adoc
@@ -12,6 +12,22 @@
 toc::[]
 
 == Overview
+
+[IMPORTANT]
+====
+Kuryr SDN Administration is a Technology Preview feature.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
 xref:../../install_config/configuring_kuryrsdn.adoc#install-config-configuring-kuryr-sdn[Kuryr]
 (or Kuryr-Kubernetes) is one of the SDN choices for {product-title}. Kuryr uses
 an OpenStack networking service, Neutron, to connect pods to the network. With
@@ -30,4 +46,4 @@ Kuryr's use.
 
 To get rid of them you can either look them up by ids that were specified in
 `kuryr.conf` or if you've created a separate OpenStack user for Kuryr
-resources, by querying OpenStack APIs with that username.
+resources, by querying OpenStack APIs with that user name.

--- a/architecture/networking/network_plugins.adoc
+++ b/architecture/networking/network_plugins.adoc
@@ -30,9 +30,9 @@ ifndef::openshift-online[]
 endif::[]
 
 ifdef::openshift-origin[]
-- xref:../../architecture/networking/network_plugins.adoc#contiv-adn[Contiv SDN] 
+- xref:../../architecture/networking/network_plugins.adoc#contiv-adn[Contiv SDN]
 endif::[]
- 
+
 ifdef::openshift-enterprise,openshift-origin[]
 - xref:../../architecture/networking/network_plugins.adoc#nuage-sdn[Nuage Networks SDN]
 endif::[]
@@ -68,7 +68,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 include::architecture/topics/nuage.adoc[]
 endif::[]
 
-ifdef::openshift-origin[]
+ifdef::openshift-enterprise,openshift-origin[]
 [[kuryr-sdn]]
 == Kuryr SDN for {product-title}
 include::architecture/topics/kuryr.adoc[]

--- a/install_config/configuring_kuryrsdn.adoc
+++ b/install_config/configuring_kuryrsdn.adoc
@@ -13,6 +13,21 @@ toc::[]
 [[kuryr-sdn-and-openshift]]
 == Kuryr SDN and {product-title}
 
+[IMPORTANT]
+====
+The ability to configure Kuryr SDN is a Technology Preview feature.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+endif::[]
+====
+
 link:https://docs.openstack.org/kuryr-kubernetes/latest/[Kuryr] (or more
 specifically Kuryr-Kubernetes) is an SDN solution built using
 link:https://github.com/containernetworking/cni[CNI] and
@@ -103,4 +118,4 @@ pods are deployed successfully:
 ----
 
 kuryr-cni pods should run on every {product-title} node. Single
-kuryr-controller instance should run on any of the nodes.
+kuryr-controller instances should run on any of the nodes.


### PR DESCRIPTION
This is follow-up work to https://github.com/openshift/openshift-docs/pull/5845

Once QE reviews, that content needs to be cherry-picked. The content that was originally only in the Origin docs, but also needs applied to the OCP 3.10 docs. This PR adds in the Technology Preview notes and provides some other follow-up edits.

@bmeng Can you please give all of the Kuryr SDN content a QE review now that it is to appear in OCP docs? Thank you!

cc @vikram-redhat @aheslin @bfallonf 
