### PR TITLE
[enterprise-3.6] "Redeploying Master Certificates Only" recreates "Service Serving Certificates" CA Certificate 

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -395,6 +395,12 @@ $ ansible-playbook -i <inventory_file> \
     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/redeploy-master-certificates.yml
 ----
 
+====
+After running this playbook, regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs] 
+by deleting existing secrets that contain service serving certificates or removing and re-adding 
+annotations to appropriate services.
+====
+
 [[redeploying-etcd-certificates]]
 === Redeploying etcd Certificates Only
 


### PR DESCRIPTION
Adding note from https://github.com/openshift/openshift-docs/pull/8373 to 3.6