### PR TITLE
router-depricate --expose-metrics --metrics-image

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1535,14 +1535,6 @@ for the router dc and delete the following lines:
 ====
 Where 1936 is the STATS_PORT value.
 
-[NOTE]
-====
-The `--expose-metrics` and `--metrics-image` options are deprecated. The haproxy-exporter
-side car is now integrated into the router controller so you can delete the sidecar container from existing
-router deployment configs. You can continue to use the side car in existing routers. New routers use the integrated metrics.
-====
-
-
 You can extract the raw statistics in Prometheus format by using the following.
 
 Information needed to access the metrics is found the router service annotations:


### PR DESCRIPTION
OCP 3.11
This was announced in OCP 3.7

Signed-off-by: Phil Cameron <pcameron@redhat.com>