### PR TITLE
Stated that OCP 3.9 is supported with RHEL 7.5, now that it's released

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -28,7 +28,7 @@ ifdef::openshift-enterprise[]
 [[software-prerequisites]]
 == Operating System Requirements
 
-A base installation of RHEL 7.3 or 7.4 (with the latest packages from the Extras
+A base installation of 7.3, 7.4, or 7.5 (with the latest packages from the Extras
 channel) or RHEL Atomic Host 7.4.2 or later is required for master and node
 hosts. See the following documentation for the respective installation
 instructions, if required:
@@ -319,28 +319,28 @@ devices, which is not supported for production use and only appropriate for
 proof of concept environments. For production environments, you must create a
 thin pool logical volume and re-configure Docker to use that volume.
 
-Docker stores images and containers in a graph driver, which is a pluggable storage technology, such as *DeviceMapper*, 
-*OverlayFS*, and *Btrfs*. Each has advantages and disadvantages. For example, OverlayFS is faster than DeviceMapper 
-at starting and stopping containers, but is not Portable Operating System Interface for Unix (POSIX) compliant 
+Docker stores images and containers in a graph driver, which is a pluggable storage technology, such as *DeviceMapper*,
+*OverlayFS*, and *Btrfs*. Each has advantages and disadvantages. For example, OverlayFS is faster than DeviceMapper
+at starting and stopping containers, but is not Portable Operating System Interface for Unix (POSIX) compliant
 because of the architectural limitations of a union file system and is not supported prior to Red Hat Enterprise
-Linux 7.2. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/?version=7[Red Hat Enterprise Linux] release notes 
+Linux 7.2. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/?version=7[Red Hat Enterprise Linux] release notes
 for information on using OverlayFS with your version of RHEL.
 
-For more information on the benefits and limitations of DeviceMapper and OverlayFS, 
+For more information on the benefits and limitations of DeviceMapper and OverlayFS,
 see xref:../../scaling_performance/optimizing_storage.adoc#choosing-a-graph-driver[Choosing a Graph Driver].
 
 
 [[configuring-docker-overlayfs]]
 === Configuring OverlayFS
 
-OverlayFS is a type of union file system. It allows you to overlay one file system on top of another. 
-Changes are recorded in the upper file system, while the lower file system remains unmodified. 
+OverlayFS is a type of union file system. It allows you to overlay one file system on top of another.
+Changes are recorded in the upper file system, while the lower file system remains unmodified.
 
 xref:../../scaling_performance/optimizing_storage.adoc#comparing-overlay-graph-drivers[Comparing the Overlay vs. Overlay2 Graph Drivers]
 has more information about the *overlay* and *overlay2* drivers.
 
-For information on enabling the OverlayFS storage driver for the Docker service, see the 
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/managing_containers/#using_the_overlay_graph_driver[Red Hat 
+For information on enabling the OverlayFS storage driver for the Docker service, see the
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/managing_containers/#using_the_overlay_graph_driver[Red Hat
 Enterprise Linux Atomic Host documentation].
 
 

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -54,7 +54,7 @@ a|- Physical or virtual system, or an instance running on a public or private Ia
 ifdef::openshift-origin[]
 - Base OS: Fedora 21, CentOS 7.3,
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL
-7.3 or RHEL 7.4] with the "Minimal" installation option and the latest packages
+7.3, 7.4, or 7.5] with the "Minimal" installation option and the latest packages
 from the Extras channel, or
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/installation_and_configuration_guide/[RHEL
 Atomic Host] 7.4.5 or later.
@@ -62,7 +62,7 @@ endif::[]
 ifdef::openshift-enterprise[]
 - Base OS:
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL
-7.3 or 7.4] with the "Minimal" installation option and the latest packages from
+7.3, 7.4, or 7.5] with the "Minimal" installation option and the latest packages from
 the Extras channel, or
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/installation_and_configuration_guide/[RHEL
 Atomic Host] 7.4.5 or later.
@@ -80,14 +80,14 @@ a| * Physical or virtual system, or an instance running on a public or private I
 ifdef::openshift-origin[]
 * Base OS: Fedora 21, CentOS 7.3 or 7.4,
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL
-7.3 or 7.4] with "Minimal" installation option, or
+7.3, 7.4, or 7.5] with "Minimal" installation option, or
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/installation_and_configuration_guide/[RHEL
 Atomic Host] 7.4.5 or later.
 endif::[]
 ifdef::openshift-enterprise[]
 * Base OS:
 link:link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL
-7.3 or 7.4] with "Minimal" installation option, or
+7.3, 7.4, or 7.5] with "Minimal" installation option, or
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/installation_and_configuration_guide/[RHEL
 Atomic Host] 7.4.5 or later.
 endif::[]

--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -53,7 +53,7 @@ Installing a stand-alone OCR has the following hardware requirements:
 ifdef::openshift-origin[]
 Fedora 21, CentOS 7.4, or
 endif::[]
-RHEL 7.3 or 7.4 with the "Minimal" installation option and the latest packages from the
+RHEL 7.3, 7.4, or 7.5 with the "Minimal" installation option and the latest packages from the
 RHEL 7 Extras channel, or RHEL Atomic Host 7.4.5 or later.
 - NetworkManager 1.0 or later
 - 2 vCPU.
@@ -314,7 +314,7 @@ not a full {product-title} environment.
 
 After you have configured Ansible by defining an inventory file in *_/etc/ansible/hosts_*:
 
-. Run the *_prequisites.yml_* playbook to configure base packages and Docker. 
+. Run the *_prequisites.yml_* playbook to configure base packages and Docker.
 This must be run only once before deploying a new cluster. Use the following command, specifying `-i` if your
 inventory file located somewhere other than *_/etc/ansible/hosts_*:
 +

--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -42,7 +42,7 @@ not publicly release {product-title} 3.8 and, instead, is releasing
 xref:ocp-39-installation[Installation] for information on how this impacts
 installation and upgrade processes.
 
-{product-title} 3.9 is supported on RHEL 7.3 and 7.4 with the latest packages
+{product-title} 3.9 is supported on RHEL 7.3, 7.4, and 7.5 with the latest packages
 from Extras, including Docker 1.13. It is also supported on Atomic Host 7.4.5
 and newer. The *docker-latest* package is now deprecated.
 
@@ -177,7 +177,7 @@ glusterFS volumes.
 This can be done online from {product-title}. Previously, this was only
 available from the Heketi CLI. You edit the PVC with the new size, triggering a
 PV resize. This is fully qualified for glusterFs backed PVs. Gluster-block PV
-resize will be added with RHEL 7.5.
+resize was added with RHEL 7.5.
 
 . Add `allowVolumeExpansion=true` to the storage class.
 . Run:


### PR DESCRIPTION
https://trello.com/c/UjhMpcVP/882-ocp-39-release-notes-rhel-75