### PR TITLE
Add a tool for generating master and node configuration description file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 all:
 	./_update_rest_api.py
-
 .PHONY: all
+
+master-node-api:
+	# this invocation assumes you have origin's code available in GOPATH
+	go run main.go github.com/openshift/origin/pkg/cmd/server/apis/config/v1>install_config/master_node_configuration_api.adoc
+.PHONY: master-node-api

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -341,6 +341,8 @@ Topics:
     File: uninstalling
 - Name: Master and Node Configuration
   File: master_node_configuration
+- Name: Master and Node Configuration API
+  File: master_node_configuration_api
 - Name: OpenShift Ansible Broker Configuration
   File: oab_broker_configuration
   Distros: openshift-origin,openshift-enterprise

--- a/install_config/master_node_configuration_api.adoc
+++ b/install_config/master_node_configuration_api.adoc
@@ -1,0 +1,999 @@
+[[master-node-config-api]]
+= Master and Node Configuration API
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+
+[[ActiveDirectoryConfig]]
+== ActiveDirectoryConfig
+ActiveDirectoryConfig holds the necessary configuration options to define how an LDAP group sync interacts with an LDAP
+server using the Active Directory schema
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AllUsersQuery|xref:LDAPQuery[LDAPQuery] |AllUsersQuery holds the template for an LDAP query that returns user entries.
+|UserNameAttributes|[]string |UserNameAttributes defines which attributes on an LDAP user entry will be interpreted as its OpenShift user name.
+|GroupMembershipAttributes|[]string |GroupMembershipAttributes defines which attributes on an LDAP user entry will be interpretedas the groups it is a member of
+|===
+
+[[AdmissionConfig]]
+== AdmissionConfig
+AdmissionConfig holds the necessary configuration options for admission
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|PluginConfig|map[string]xref:AdmissionPluginConfig[AdmissionPluginConfig] |PluginConfig allows specifying a configuration file per admission control plugin
+|PluginOrderOverride|[]string |PluginOrderOverride is a list of admission control plugin names that will be installedon the master. Order is significant. If empty, a default list of plugins is used.
+|===
+
+[[AdmissionPluginConfig]]
+== AdmissionPluginConfig
+AdmissionPluginConfig holds the necessary configuration options for admission plugins
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Location|string |Location is the path to a configuration file that contains the plugin'sconfiguration
+|Configuration|runtime.RawExtension |Configuration is an embedded configuration object to be used as the plugin'sconfiguration. If present, it will be used instead of the path to the configuration file.
+|===
+
+[[AggregatorConfig]]
+== AggregatorConfig
+AggregatorConfig holds information required to make the aggregator function.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ProxyClientInfo|xref:CertInfo[CertInfo] |ProxyClientInfo specifies the client cert/key to use when proxying to aggregated API servers
+|===
+
+[[AllowAllPasswordIdentityProvider]]
+== AllowAllPasswordIdentityProvider
+AllowAllPasswordIdentityProvider provides identities for users authenticating using non-empty passwords
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|===
+
+[[AllowedRegistries]]
+== AllowedRegistries
+AllowedRegistries represents a list of registries allowed for the image import.
+
+
+[[AuditConfig]]
+== AuditConfig
+AuditConfig holds configuration for the audit capabilities
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Enabled|bool |If this flag is set, audit log will be printed in the logs.The logs contains, method, user and a requested URL.
+|AuditFilePath|string |All requests coming to the apiserver will be logged to this file.
+|MaximumFileRetentionDays|int |Maximum number of days to retain old log files based on the timestamp encoded in their filename.
+|MaximumRetainedFiles|int |Maximum number of old log files to retain.
+|MaximumFileSizeMegabytes|int |Maximum size in megabytes of the log file before it gets rotated. Defaults to 100MB.
+|PolicyFile|string |PolicyFile is a path to the file that defines the audit policy configuration.
+|PolicyConfiguration|runtime.RawExtension |PolicyConfiguration is an embedded policy configuration object to be usedas the audit policy configuration. If present, it will be used instead ofthe path to the policy file.
+|LogFormat|xref:LogFormatType[LogFormatType] |Format of saved audits (legacy or json).
+|WebHookKubeConfig|string |Path to a .kubeconfig formatted file that defines the audit webhook configuration.
+|WebHookMode|xref:WebHookModeType[WebHookModeType] |Strategy for sending audit events (block or batch).
+|===
+
+[[AugmentedActiveDirectoryConfig]]
+== AugmentedActiveDirectoryConfig
+AugmentedActiveDirectoryConfig holds the necessary configuration options to define how an LDAP group sync interacts with an LDAP
+server using the augmented Active Directory schema
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AllUsersQuery|xref:LDAPQuery[LDAPQuery] |AllUsersQuery holds the template for an LDAP query that returns user entries.
+|UserNameAttributes|[]string |UserNameAttributes defines which attributes on an LDAP user entry will be interpreted as its OpenShift user name.
+|GroupMembershipAttributes|[]string |GroupMembershipAttributes defines which attributes on an LDAP user entry will be interpretedas the groups it is a member of
+|AllGroupsQuery|xref:LDAPQuery[LDAPQuery] |AllGroupsQuery holds the template for an LDAP query that returns group entries.
+|GroupUIDAttribute|string |GroupUIDAttributes defines which attribute on an LDAP group entry will be interpreted as its unique identifier.(ldapGroupUID)
+|GroupNameAttributes|[]string |GroupNameAttributes defines which attributes on an LDAP group entry will be interpreted as its name to use foran OpenShift group
+|===
+
+[[BasicAuthPasswordIdentityProvider]]
+== BasicAuthPasswordIdentityProvider
+BasicAuthPasswordIdentityProvider provides identities for users authenticating using HTTP basic auth credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+||xref:RemoteConnectionInfo[RemoteConnectionInfo] |RemoteConnectionInfo contains information about how to connect to the external basic auth server
+|===
+
+[[CertInfo]]
+== CertInfo
+CertInfo relates a certificate with a private key
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|CertFile|string |CertFile is a file containing a PEM-encoded certificate
+|KeyFile|string |KeyFile is a file containing a PEM-encoded private key for the certificate specified by CertFile
+|===
+
+[[ClientConnectionOverrides]]
+== ClientConnectionOverrides
+ClientConnectionOverrides are a set of overrides to the default client connection settings.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AcceptContentTypes|string |AcceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding thedefault value of 'application/json'. This field will control all connections to the server used by a particularclient.
+|ContentType|string |ContentType is the content type used when sending data to the server from this client.
+|QPS|float32 |QPS controls the number of queries per second allowed for this connection.
+|Burst|int32 |Burst allows extra queries to accumulate when a client is exceeding its rate.
+|===
+
+[[ClusterNetworkEntry]]
+== ClusterNetworkEntry
+ClusterNetworkEntry defines an individual cluster network. The CIDRs cannot overlap with other cluster network CIDRs, CIDRs reserved for external ips, CIDRs reserved for service networks, and CIDRs reserved for ingress ips.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|CIDR|string |CIDR defines the total range of a cluster networks address space.
+|HostSubnetLength|uint32 |HostSubnetLength is the number of bits of the accompanying CIDR address to allocate to each node. eg, 8 would mean that each node would have a /24 slice of the overlay network for its pod.
+|===
+
+[[ControllerConfig]]
+== ControllerConfig
+ControllerConfig holds configuration values for controllers
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Controllers|[]string |Controllers is a list of controllers to enable.  '*' enables all on-by-default controllers, 'foo' enables the controller "+named 'foo', '-foo' disables the controller named 'foo'.Defaults to "*".
+|Election|xref:ControllerElectionConfig[ControllerElectionConfig] |Election defines the configuration for electing a controller instance to make changes tothe cluster. If unspecified, the ControllerTTL value is checked to determine whether thelegacy direct etcd election code will be used.
+|ServiceServingCert|xref:ServiceServingCert[ServiceServingCert] |ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs forpods fulfilling a service to serve with.
+|===
+
+[[ControllerElectionConfig]]
+== ControllerElectionConfig
+ControllerElectionConfig contains configuration values for deciding how a controller
+will be elected to act as leader.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|LockName|string |LockName is the resource name used to act as the lock for determining which controllerinstance should lead.
+|LockNamespace|string |LockNamespace is the resource namespace used to act as the lock for determining whichcontroller instance should lead. It defaults to "kube-system"
+|LockResource|xref:GroupResource[GroupResource] |LockResource is the group and resource name to use to coordinate for the controller lock.If unset, defaults to "configmaps".
+|===
+
+[[DNSConfig]]
+== DNSConfig
+DNSConfig holds the necessary configuration options for DNS
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|BindAddress|string |BindAddress is the ip:port to serve DNS on
+|BindNetwork|string |BindNetwork is the type of network to bind to - defaults to "tcp4", accepts "tcp","tcp4", and "tcp6"
+|AllowRecursiveQueries|bool |AllowRecursiveQueries allows the DNS server on the master to answer queries recursively. Note that openresolvers can be used for DNS amplification attacks and the master DNS should not be made accessibleto public networks.
+|===
+
+[[DefaultAdmissionConfig]]
+== DefaultAdmissionConfig
+DefaultAdmissionConfig can be used to enable or disable various admission plugins.
+When this type is present as the `configuration` object under `pluginConfig` and *if* the admission plugin supports it,
+this will cause an "off by default" admission plugin to be enabled
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|Disable|bool |Disable turns off an admission plugin that is enabled by default.
+|===
+
+[[DenyAllPasswordIdentityProvider]]
+== DenyAllPasswordIdentityProvider
+DenyAllPasswordIdentityProvider provides no identities for users
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|===
+
+[[DockerConfig]]
+== DockerConfig
+DockerConfig holds Docker related configuration options.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ExecHandlerName|xref:DockerExecHandlerType[DockerExecHandlerType] |ExecHandlerName is the name of the handler to use for executingcommands in Docker containers.
+|DockerShimSocket|string |DockerShimSocket is the location of the dockershim socket the kubelet uses.Currently unix socket is supported on Linux, and tcp is supported on windows.Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'
+|DockershimRootDirectory|string |DockershimRootDirectory is the dockershim root directory.
+|===
+
+[[DockerExecHandlerType]]
+== DockerExecHandlerType
+
+
+[[EtcdConfig]]
+== EtcdConfig
+EtcdConfig holds the necessary configuration options for connecting with an etcd database
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ServingInfo|xref:ServingInfo[ServingInfo] |ServingInfo describes how to start serving the etcd master
+|Address|string |Address is the advertised host:port for client connections to etcd
+|PeerServingInfo|xref:ServingInfo[ServingInfo] |PeerServingInfo describes how to start serving the etcd peer
+|PeerAddress|string |PeerAddress is the advertised host:port for peer connections to etcd
+|StorageDir|string |StorageDir is the path to the etcd storage directory
+|===
+
+[[EtcdConnectionInfo]]
+== EtcdConnectionInfo
+EtcdConnectionInfo holds information necessary for connecting to an etcd server
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|URLs|[]string |URLs are the URLs for etcd
+|CA|string |CA is a file containing trusted roots for the etcd server certificates
+||xref:CertInfo[CertInfo] |CertInfo is the TLS client cert information for securing communication to etcdthis is anonymous so that we can inline it for serialization
+|===
+
+[[EtcdStorageConfig]]
+== EtcdStorageConfig
+EtcdStorageConfig holds the necessary configuration options for the etcd storage underlying OpenShift and Kubernetes
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|KubernetesStorageVersion|string |KubernetesStorageVersion is the API version that Kube resources in etcd should beserialized to. This value should *not* be advanced until all clients in thecluster that read from etcd have code that allows them to read the new version.
+|KubernetesStoragePrefix|string |KubernetesStoragePrefix is the path within etcd that the Kubernetes resources willbe rooted under. This value, if changed, will mean existing objects in etcd willno longer be located. The default value is 'kubernetes.io'.
+|OpenShiftStorageVersion|string |OpenShiftStorageVersion is the API version that OS resources in etcd should beserialized to. This value should *not* be advanced until all clients in thecluster that read from etcd have code that allows them to read the new version.
+|OpenShiftStoragePrefix|string |OpenShiftStoragePrefix is the path within etcd that the OpenShift resources willbe rooted under. This value, if changed, will mean existing objects in etcd willno longer be located. The default value is 'openshift.io'.
+|===
+
+[[ExtendedArguments]]
+== ExtendedArguments
+
+
+[[FeatureList]]
+== FeatureList
+FeatureList contains a set of features
+
+
+[[GitHubIdentityProvider]]
+== GitHubIdentityProvider
+GitHubIdentityProvider provides identities for users authenticating using GitHub credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|ClientID|string |ClientID is the oauth client ID
+|ClientSecret|xref:StringSource[StringSource] |ClientSecret is the oauth client secret
+|Organizations|[]string |Organizations optionally restricts which organizations are allowed to log in
+|Teams|[]string |Teams optionally restricts which teams are allowed to log in. Format is <org>/<team>.
+|===
+
+[[GitLabIdentityProvider]]
+== GitLabIdentityProvider
+GitLabIdentityProvider provides identities for users authenticating using GitLab credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|CA|string |CA is the optional trusted certificate authority bundle to use when making requests to the serverIf empty, the default system roots are used
+|URL|string |URL is the oauth server base URL
+|ClientID|string |ClientID is the oauth client ID
+|ClientSecret|xref:StringSource[StringSource] |ClientSecret is the oauth client secret
+|===
+
+[[GoogleIdentityProvider]]
+== GoogleIdentityProvider
+GoogleIdentityProvider provides identities for users authenticating using Google credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|ClientID|string |ClientID is the oauth client ID
+|ClientSecret|xref:StringSource[StringSource] |ClientSecret is the oauth client secret
+|HostedDomain|string |HostedDomain is the optional Google App domain (e.g. "mycompany.com") to restrict logins to
+|===
+
+[[GrantConfig]]
+== GrantConfig
+GrantConfig holds the necessary configuration options for grant handlers
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Method|xref:GrantHandlerType[GrantHandlerType] |Method determines the default strategy to use when an OAuth client requests a grant.This method will be used only if the specific OAuth client doesn't provide a strategyof their own. Valid grant handling methods are:- auto:   always approves grant requests, useful for trusted clients- prompt: prompts the end user for approval of grant requests, useful for third-party clients- deny:   always denies grant requests, useful for black-listed clients
+|ServiceAccountMethod|xref:GrantHandlerType[GrantHandlerType] |ServiceAccountMethod is used for determining client authorization for service account oauth client.It must be either: deny, prompt
+|===
+
+[[GrantHandlerType]]
+== GrantHandlerType
+
+
+[[GroupResource]]
+== GroupResource
+GroupResource points to a resource by its name and API group.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Group|string |Group is the name of an API group
+|Resource|string |Resource is the name of a resource.
+|===
+
+[[HTPasswdPasswordIdentityProvider]]
+== HTPasswdPasswordIdentityProvider
+HTPasswdPasswordIdentityProvider provides identities for users authenticating using htpasswd credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|File|string |File is a reference to your htpasswd file
+|===
+
+[[HTTPServingInfo]]
+== HTTPServingInfo
+HTTPServingInfo holds configuration for serving HTTP
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||xref:ServingInfo[ServingInfo] |ServingInfo is the HTTP serving information
+|MaxRequestsInFlight|int |MaxRequestsInFlight is the number of concurrent requests allowed to the server. If zero, no limit.
+|RequestTimeoutSeconds|int |RequestTimeoutSeconds is the number of seconds before requests are timed out. The default is 60 minutes, if-1 there is no limit on requests.
+|===
+
+[[IdentityProvider]]
+== IdentityProvider
+IdentityProvider provides identities for users authenticating using credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Name|string |Name is used to qualify the identities returned by this provider
+|UseAsChallenger|bool |UseAsChallenger indicates whether to issue WWW-Authenticate challenges for this provider
+|UseAsLogin|bool |UseAsLogin indicates whether to use this identity provider for unauthenticated browsers to login against
+|MappingMethod|string |MappingMethod determines how identities from this provider are mapped to users
+|Provider|runtime.RawExtension |Provider contains the information about how to set up a specific identity provider
+|===
+
+[[ImageConfig]]
+== ImageConfig
+ImageConfig holds the necessary configuration options for building image names for system components
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Format|string |Format is the format of the name to be built for the system component
+|Latest|bool |Latest determines if the latest tag will be pulled from the registry
+|===
+
+[[ImagePolicyConfig]]
+== ImagePolicyConfig
+ImagePolicyConfig holds the necessary configuration options for limits and behavior for importing images
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|MaxImagesBulkImportedPerRepository|int |MaxImagesBulkImportedPerRepository controls the number of images that are imported when a userdoes a bulk import of a Docker repository. This number defaults to 5 to prevent users fromimporting large numbers of images accidentally. Set -1 for no limit.
+|DisableScheduledImport|bool |DisableScheduledImport allows scheduled background import of images to be disabled.
+|ScheduledImageImportMinimumIntervalSeconds|int |ScheduledImageImportMinimumIntervalSeconds is the minimum number of seconds that can elapse between when image streamsscheduled for background import are checked against the upstream repository. The default value is 15 minutes.
+|MaxScheduledImageImportsPerMinute|int |MaxScheduledImageImportsPerMinute is the maximum number of scheduled image streams that will be imported in thebackground per minute. The default value is 60. Set to -1 for unlimited.
+|AllowedRegistriesForImport|xref:AllowedRegistries[AllowedRegistries] |AllowedRegistriesForImport limits the docker registries that normal users may importimages from. Set this list to the registries that you trust to contain valid Dockerimages and that you want applications to be able to import from. Users withpermission to create Images or ImageStreamMappings via the API are not affected bythis policy - typically only administrators or system integrations will have thosepermissions.
+|InternalRegistryHostname|string |InternalRegistryHostname sets the hostname for the default internal imageregistry. The value must be in "hostname[:port]" format.For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRYenvironment variable but this setting overrides the environment variable.
+|ExternalRegistryHostname|string |ExternalRegistryHostname sets the hostname for the default external imageregistry. The external hostname should be set only when the image registryis exposed externally. The value is used in 'publicDockerImageRepository'field in ImageStreams. The value must be in "hostname[:port]" format.
+|===
+
+[[JenkinsPipelineConfig]]
+== JenkinsPipelineConfig
+JenkinsPipelineConfig holds configuration for the Jenkins pipeline strategy
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AutoProvisionEnabled|bool |AutoProvisionEnabled determines whether a Jenkins server will be spawned from the providedtemplate when the first build config in the project with type JenkinsPipelineis created. When not specified this option defaults to true.
+|TemplateNamespace|string |TemplateNamespace contains the namespace name where the Jenkins template is stored
+|TemplateName|string |TemplateName is the name of the default Jenkins template
+|ServiceName|string |ServiceName is the name of the Jenkins service OpenShift uses to detectwhether a Jenkins pipeline handler has already been installed in a project.This value *must* match a service name in the provided template.
+|Parameters|map[string]string |Parameters specifies a set of optional parameters to the Jenkins template.
+|===
+
+[[KeystonePasswordIdentityProvider]]
+== KeystonePasswordIdentityProvider
+KeystonePasswordIdentityProvider provides identities for users authenticating using keystone password credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+||xref:RemoteConnectionInfo[RemoteConnectionInfo] |RemoteConnectionInfo contains information about how to connect to the keystone server
+|DomainName|string |Domain Name is required for keystone v3
+|===
+
+[[KubeletConnectionInfo]]
+== KubeletConnectionInfo
+KubeletConnectionInfo holds information necessary for connecting to a kubelet
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Port|uint |Port is the port to connect to kubelets on
+|CA|string |CA is the CA for verifying TLS connections to kubelets
+||xref:CertInfo[CertInfo] |CertInfo is the TLS client cert information for securing communication to kubeletsthis is anonymous so that we can inline it for serialization
+|===
+
+[[KubernetesMasterConfig]]
+== KubernetesMasterConfig
+KubernetesMasterConfig holds the necessary configuration options for the Kubernetes master
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|APILevels|[]string |APILevels is a list of API levels that should be enabled on startup: v1 as examples
+|DisabledAPIGroupVersions|map[string][]string |DisabledAPIGroupVersions is a map of groups to the versions (or *) that should be disabled.
+|MasterIP|string |MasterIP is the public IP address of kubernetes stuff.  If empty, the first result from net.InterfaceAddrs will be used.
+|MasterEndpointReconcileTTL|int |MasterEndpointReconcileTTL sets the time to live in seconds of an endpoint record recorded by each master. The endpoints are checkedat an interval that is 2/3 of this value and this value defaults to 15s if unset. In very large clusters, this value may be increased toreduce the possibility that the master endpoint record expires (due to other load on the etcd server) and causes masters to drop in andout of the kubernetes service record. It is not recommended to set this value below 15s.
+|ServicesSubnet|string |ServicesSubnet is the subnet to use for assigning service IPs
+|ServicesNodePortRange|string |ServicesNodePortRange is the range to use for assigning service public ports on a host.
+|SchedulerConfigFile|string |SchedulerConfigFile points to a file that describes how to set up the scheduler. If empty, you get the default scheduling rules.
+|PodEvictionTimeout|string |PodEvictionTimeout controls grace period for deleting pods on failed nodes.It takes valid time duration string. If empty, you get the default pod eviction timeout.
+|ProxyClientInfo|xref:CertInfo[CertInfo] |ProxyClientInfo specifies the client cert/key to use when proxying to pods
+|APIServerArguments|xref:ExtendedArguments[ExtendedArguments] |APIServerArguments are key value pairs that will be passed directly to the Kube apiserver that match the apiservers'scommand line arguments.  These are not migrated, but if you reference a value that does not exist the server will notstart. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.
+|ControllerArguments|xref:ExtendedArguments[ExtendedArguments] |ControllerArguments are key value pairs that will be passed directly to the Kube controller manager that match thecontroller manager's command line arguments.  These are not migrated, but if you reference a value that does not existthe server will not start. These values may override other settings in KubernetesMasterConfig which may cause invalidconfigurations.
+|SchedulerArguments|xref:ExtendedArguments[ExtendedArguments] |SchedulerArguments are key value pairs that will be passed directly to the Kube scheduler that match the scheduler'scommand line arguments.  These are not migrated, but if you reference a value that does not exist the server will notstart. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.
+|===
+
+[[LDAPAttributeMapping]]
+== LDAPAttributeMapping
+LDAPAttributeMapping maps LDAP attributes to OpenShift identity fields
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ID|[]string |ID is the list of attributes whose values should be used as the user ID. Required.LDAP standard identity attribute is "dn"
+|PreferredUsername|[]string |PreferredUsername is the list of attributes whose values should be used as the preferred username.LDAP standard login attribute is "uid"
+|Name|[]string |Name is the list of attributes whose values should be used as the display name. Optional.If unspecified, no display name is set for the identityLDAP standard display name attribute is "cn"
+|Email|[]string |Email is the list of attributes whose values should be used as the email address. Optional.If unspecified, no email is set for the identity
+|===
+
+[[LDAPPasswordIdentityProvider]]
+== LDAPPasswordIdentityProvider
+LDAPPasswordIdentityProvider provides identities for users authenticating using LDAP credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|URL|string |URL is an RFC 2255 URL which specifies the LDAP search parameters to use. The syntax of the URL isldap://host:port/basedn?attribute?scope?filter
+|BindDN|string |BindDN is an optional DN to bind with during the search phase.
+|BindPassword|xref:StringSource[StringSource] |BindPassword is an optional password to bind with during the search phase.
+|Insecure|bool |Insecure, if true, indicates the connection should not use TLS.Cannot be set to true with a URL scheme of "ldaps://"If false, "ldaps://" URLs connect using TLS, and "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830
+|CA|string |CA is the optional trusted certificate authority bundle to use when making requests to the serverIf empty, the default system roots are used
+|Attributes|xref:LDAPAttributeMapping[LDAPAttributeMapping] |Attributes maps LDAP attributes to identities
+|===
+
+[[LDAPQuery]]
+== LDAPQuery
+LDAPQuery holds the options necessary to build an LDAP query
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|BaseDN|string |The DN of the branch of the directory where all searches should start from
+|Scope|string |The (optional) scope of the search. Can be:base: only the base object,one:  all object on the base level,sub:  the entire subtreeDefaults to the entire subtree if not set
+|DerefAliases|string |The (optional) behavior of the search with regards to alisases. Can be:never:  never dereference aliases,search: only dereference in searching,base:   only dereference in finding the base object,always: always dereferenceDefaults to always dereferencing if not set
+|TimeLimit|int |TimeLimit holds the limit of time in seconds that any request to the server can remain outstandingbefore the wait for a response is given up. If this is 0, no client-side limit is imposed
+|Filter|string |Filter is a valid LDAP search filter that retrieves all relevant entries from the LDAP server with the base DN
+|PageSize|int |PageSize is the maximum preferred page size, measured in LDAP entries. A page size of 0 means no paging will be done.
+|===
+
+[[LDAPSyncConfig]]
+== LDAPSyncConfig
+LDAPSyncConfig holds the necessary configuration options to define an LDAP group sync
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|URL|string |Host is the scheme, host and port of the LDAP server to connect to:scheme://host:port
+|BindDN|string |BindDN is an optional DN to bind to the LDAP server with
+|BindPassword|xref:StringSource[StringSource] |BindPassword is an optional password to bind with during the search phase.
+|Insecure|bool |Insecure, if true, indicates the connection should not use TLS.Cannot be set to true with a URL scheme of "ldaps://"If false, "ldaps://" URLs connect using TLS, and "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830
+|CA|string |CA is the optional trusted certificate authority bundle to use when making requests to the serverIf empty, the default system roots are used
+|LDAPGroupUIDToOpenShiftGroupNameMapping|map[string]string |LDAPGroupUIDToOpenShiftGroupNameMapping is an optional direct mapping of LDAP group UIDs toOpenShift Group names
+|RFC2307Config|xref:RFC2307Config[RFC2307Config] |RFC2307Config holds the configuration for extracting data from an LDAP server set up in a fashionsimilar to RFC2307: first-class group and user entries, with group membership determined by amulti-valued attribute on the group entry listing its members
+|ActiveDirectoryConfig|xref:ActiveDirectoryConfig[ActiveDirectoryConfig] |ActiveDirectoryConfig holds the configuration for extracting data from an LDAP server set up in afashion similar to that used in Active Directory: first-class user entries, with group membershipdetermined by a multi-valued attribute on members listing groups they are a member of
+|AugmentedActiveDirectoryConfig|xref:AugmentedActiveDirectoryConfig[AugmentedActiveDirectoryConfig] |AugmentedActiveDirectoryConfig holds the configuration for extracting data from an LDAP serverset up in a fashion similar to that used in Active Directory as described above, with one addition:first-class group entries exist and are used to hold metadata but not group membership
+|===
+
+[[LocalQuota]]
+== LocalQuota
+LocalQuota contains options for controlling local volume quota on the node.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|PerFSGroup|resource.Quantity |FSGroup can be specified to enable a quota on local storage use per unique FSGroup ID.At present this is only implemented for emptyDir volumes, and if the underlyingvolumeDirectory is on an XFS filesystem.
+|===
+
+[[LogFormatType]]
+== LogFormatType
+
+
+[[MasterAuthConfig]]
+== MasterAuthConfig
+MasterAuthConfig configures authentication options in addition to the standard
+oauth token and client certificate authenticators
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|RequestHeader|xref:RequestHeaderAuthenticationOptions[RequestHeaderAuthenticationOptions] |RequestHeader holds options for setting up a front proxy against the the API.  It is optional.
+|WebhookTokenAuthenticators|[]xref:WebhookTokenAuthenticator[WebhookTokenAuthenticator] |WebhookTokenAuthnConfig, if present configures remote token reviewers
+|OAuthMetadataFile|string |OAuthMetadataFile is a path to a file containing the discovery endpoint for OAuth 2.0 AuthorizationServer Metadata for an external OAuth server.See IETF Draft: // https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2This option is mutually exclusive with OAuthConfig
+|===
+
+[[MasterClients]]
+== MasterClients
+MasterClients holds references to `.kubeconfig` files that qualify master clients for OpenShift and Kubernetes
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|OpenShiftLoopbackKubeConfig|string |OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master
+|OpenShiftLoopbackClientConnectionOverrides|xref:ClientConnectionOverrides[ClientConnectionOverrides] |OpenShiftLoopbackClientConnectionOverrides specifies client overrides for system components to loop back to this master.
+|===
+
+[[MasterConfig]]
+== MasterConfig
+MasterConfig holds the necessary configuration options for the OpenShift master
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|ServingInfo|xref:HTTPServingInfo[HTTPServingInfo] |ServingInfo describes how to start serving
+|AuthConfig|xref:MasterAuthConfig[MasterAuthConfig] |AuthConfig configures authentication options in addition to the standardoauth token and client certificate authenticators
+|AggregatorConfig|xref:AggregatorConfig[AggregatorConfig] |AggregatorConfig has options for configuring the aggregator component of the API server.
+|CORSAllowedOrigins|[]string |CORSAllowedOrigins
+|APILevels|[]string |APILevels is a list of API levels that should be enabled on startup: v1 as examples
+|MasterPublicURL|string |MasterPublicURL is how clients can access the OpenShift API server
+|Controllers|string |Controllers is a list of the controllers that should be started. If set to "none", no controllerswill start automatically. The default value is "*" which will start all controllers. Whenusing "*", you may exclude controllers by prepending a "-" in front of their name. No othervalues are recognized at this time.
+|AdmissionConfig|xref:AdmissionConfig[AdmissionConfig] |AdmissionConfig contains admission control plugin configuration.
+|ControllerConfig|xref:ControllerConfig[ControllerConfig] |ControllerConfig holds configuration values for controllers
+|EtcdStorageConfig|xref:EtcdStorageConfig[EtcdStorageConfig] |EtcdStorageConfig contains information about how API resources arestored in Etcd. These values are only relevant when etcd is thebacking store for the cluster.
+|EtcdClientInfo|xref:EtcdConnectionInfo[EtcdConnectionInfo] |EtcdClientInfo contains information about how to connect to etcd
+|KubeletClientInfo|xref:KubeletConnectionInfo[KubeletConnectionInfo] |KubeletClientInfo contains information about how to connect to kubelets
+|KubernetesMasterConfig|xref:KubernetesMasterConfig[KubernetesMasterConfig] |KubernetesMasterConfig, if present start the kubernetes master in this process
+|EtcdConfig|xref:EtcdConfig[EtcdConfig] |EtcdConfig, if present start etcd in this process
+|OAuthConfig|xref:OAuthConfig[OAuthConfig] |OAuthConfig, if present start the /oauth endpoint in this process
+|DNSConfig|xref:DNSConfig[DNSConfig] |DNSConfig, if present start the DNS server in this process
+|ServiceAccountConfig|xref:ServiceAccountConfig[ServiceAccountConfig] |ServiceAccountConfig holds options related to service accounts
+|MasterClients|xref:MasterClients[MasterClients] |MasterClients holds all the client connection information for controllers and other system components
+|ImageConfig|xref:ImageConfig[ImageConfig] |ImageConfig holds options that describe how to build image names for system components
+|ImagePolicyConfig|xref:ImagePolicyConfig[ImagePolicyConfig] |ImagePolicyConfig controls limits and behavior for importing images
+|PolicyConfig|xref:PolicyConfig[PolicyConfig] |PolicyConfig holds information about where to locate critical pieces of bootstrapping policy
+|ProjectConfig|xref:ProjectConfig[ProjectConfig] |ProjectConfig holds information about project creation and defaults
+|RoutingConfig|xref:RoutingConfig[RoutingConfig] |RoutingConfig holds information about routing and route generation
+|NetworkConfig|xref:MasterNetworkConfig[MasterNetworkConfig] |NetworkConfig to be passed to the compiled in network plugin
+|VolumeConfig|xref:MasterVolumeConfig[MasterVolumeConfig] |MasterVolumeConfig contains options for configuring volume plugins in the master node.
+|JenkinsPipelineConfig|xref:JenkinsPipelineConfig[JenkinsPipelineConfig] |JenkinsPipelineConfig holds information about the default Jenkins templateused for JenkinsPipeline build strategy.
+|AuditConfig|xref:AuditConfig[AuditConfig] |AuditConfig holds information related to auditing capabilities.
+|DisableOpenAPI|bool |DisableOpenAPI avoids starting the openapi endpoint because it is very expensive.This option will be removed at a later time.  It is never serialized.
+|===
+
+[[MasterNetworkConfig]]
+== MasterNetworkConfig
+MasterNetworkConfig to be passed to the compiled in network plugin
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|NetworkPluginName|string |NetworkPluginName is the name of the network plugin to use
+|DeprecatedClusterNetworkCIDR|string |ClusterNetworkCIDR is the CIDR string to specify the global overlay network's L3 space.  Deprecated, but maintained for backwards compatibility, use ClusterNetworks instead.
+|ClusterNetworks|[]xref:ClusterNetworkEntry[ClusterNetworkEntry] |ClusterNetworks is a list of ClusterNetwork objects that defines the global overlay network's L3 space by specifying a set of CIDR and netmasks that the SDN can allocate addressed from.  If this is specified, then ClusterNetworkCIDR and HostSubnetLength may not be set.
+|DeprecatedHostSubnetLength|uint32 |HostSubnetLength is the number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host.  Deprecated, but maintained for backwards compatibility, use ClusterNetworks instead.
+|ServiceNetworkCIDR|string |ServiceNetwork is the CIDR string to specify the service networks
+|ExternalIPNetworkCIDRs|[]string |ExternalIPNetworkCIDRs controls what values are acceptable for the service external IP field. If empty, no externalIPmay be set. It may contain a list of CIDRs which are checked for access. If a CIDR is prefixed with !, IPs in thatCIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. Youshould ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.
+|IngressIPNetworkCIDR|string |IngressIPNetworkCIDR controls the range to assign ingress ips from for services of type LoadBalancer on baremetal. If empty, ingress ips will not be assigned. It may contain a single CIDR that will be allocated from.For security reasons, you should ensure that this range does not overlap with the CIDRs reserved for external ips,nodes, pods, or services.
+|===
+
+[[MasterVolumeConfig]]
+== MasterVolumeConfig
+MasterVolumeConfig contains options for configuring volume plugins in the master node.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|DynamicProvisioningEnabled|bool |DynamicProvisioningEnabled is a boolean that toggles dynamic provisioning off when false, defaults to true
+|===
+
+[[NamedCertificate]]
+== NamedCertificate
+NamedCertificate specifies a certificate/key, and the names it should be served for
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Names|[]string |Names is a list of DNS names this certificate should be used to secureA name can be a normal DNS name, or can contain leading wildcard segments.
+||xref:CertInfo[CertInfo] |CertInfo is the TLS cert info for serving secure traffic
+|===
+
+[[NodeAuthConfig]]
+== NodeAuthConfig
+NodeAuthConfig holds authn/authz configuration options
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AuthenticationCacheTTL|string |AuthenticationCacheTTL indicates how long an authentication result should be cached.It takes a valid time duration string (e.g. "5m"). If empty, you get the default timeout. If zero (e.g. "0m"), caching is disabled
+|AuthenticationCacheSize|int |AuthenticationCacheSize indicates how many authentication results should be cached. If 0, the default cache size is used.
+|AuthorizationCacheTTL|string |AuthorizationCacheTTL indicates how long an authorization result should be cached.It takes a valid time duration string (e.g. "5m"). If empty, you get the default timeout. If zero (e.g. "0m"), caching is disabled
+|AuthorizationCacheSize|int |AuthorizationCacheSize indicates how many authorization results should be cached. If 0, the default cache size is used.
+|===
+
+[[NodeConfig]]
+== NodeConfig
+NodeConfig is the fully specified config starting an OpenShift node
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|NodeName|string |NodeName is the value used to identify this particular node in the cluster.  If possible, this should be your fully qualified hostname.If you're describing a set of static nodes to the master, this value must match one of the values in the list
+|NodeIP|string |Node may have multiple IPs, specify the IP to use for pod traffic routingIf not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
+|ServingInfo|xref:ServingInfo[ServingInfo] |ServingInfo describes how to start serving
+|MasterKubeConfig|string |MasterKubeConfig is a filename for the .kubeconfig file that describes how to connect this node to the master
+|MasterClientConnectionOverrides|xref:ClientConnectionOverrides[ClientConnectionOverrides] |MasterClientConnectionOverrides provides overrides to the client connection used to connect to the master.
+|DNSDomain|string |DNSDomain holds the domain suffix that will be used for the DNS search path inside each container. Defaults to'cluster.local'.
+|DNSIP|string |DNSIP is the IP address that pods will use to access cluster DNS. Defaults to the service IP of the Kubernetesmaster. This IP must be listening on port 53 for compatibility with libc resolvers (which cannot be configuredto resolve names from any other port). When running more complex local DNS configurations, this is often setto the local address of a DNS proxy like dnsmasq, which then will consult either the local DNS (seednsBindAddress) or the master DNS.
+|DNSBindAddress|string |DNSBindAddress is the ip:port to serve DNS on. If this is not set, the DNS server will not be started.Because most DNS resolvers will only listen on port 53, if you select an alternative port you will needa DNS proxy like dnsmasq to answer queries for containers. A common configuration is dnsmasq configuredon a node IP listening on 53 and delegating queries for dnsDomain to this process, while sending otherqueries to the host environments nameservers.
+|DNSNameservers|[]string |DNSNameservers is a list of ip:port values of recursive nameservers to forward queries to when runninga local DNS server if dnsBindAddress is set. If this value is empty, the DNS server will default tothe nameservers listed in /etc/resolv.conf. If you have configured dnsmasq or another DNS proxy on thesystem, this value should be set to the upstream nameservers dnsmasq resolves with.
+|DNSRecursiveResolvConf|string |DNSRecursiveResolvConf is a path to a resolv.conf file that contains settings for an upstream server.Only the nameservers and port fields are used. The file must exist and parse correctly. It adds extranameservers to DNSNameservers if set.
+|DeprecatedNetworkPluginName|string |Deprecated and maintained for backward compatibility, use NetworkConfig.NetworkPluginName instead
+|NetworkConfig|xref:NodeNetworkConfig[NodeNetworkConfig] |NetworkConfig provides network options for the node
+|VolumeDirectory|string |VolumeDirectory is the directory that volumes will be stored under
+|ImageConfig|xref:ImageConfig[ImageConfig] |ImageConfig holds options that describe how to build image names for system components
+|AllowDisabledDocker|bool |AllowDisabledDocker if true, the Kubelet will ignore errors from Docker.  This means that a node can start on a machine that doesn't have docker started.
+|PodManifestConfig|xref:PodManifestConfig[PodManifestConfig] |PodManifestConfig holds the configuration for enabling the Kubelet tocreate pods based from a manifest file(s) placed locally on the node
+|AuthConfig|xref:NodeAuthConfig[NodeAuthConfig] |AuthConfig holds authn/authz configuration options
+|DockerConfig|xref:DockerConfig[DockerConfig] |DockerConfig holds Docker related configuration options.
+|KubeletArguments|xref:ExtendedArguments[ExtendedArguments] |KubeletArguments are key value pairs that will be passed directly to the Kubelet that match the Kubelet'scommand line arguments.  These are not migrated or validated, so if you use them they may become invalid.These values override other settings in NodeConfig which may cause invalid configurations.
+|ProxyArguments|xref:ExtendedArguments[ExtendedArguments] |ProxyArguments are key value pairs that will be passed directly to the Proxy that match the Proxy'scommand line arguments.  These are not migrated or validated, so if you use them they may become invalid.These values override other settings in NodeConfig which may cause invalid configurations.
+|IPTablesSyncPeriod|string |IPTablesSyncPeriod is how often iptable rules are refreshed
+|EnableUnidling|bool |EnableUnidling controls whether or not the hybrid unidling proxy will be set up
+|VolumeConfig|xref:NodeVolumeConfig[NodeVolumeConfig] |VolumeConfig contains options for configuring volumes on the node.
+|===
+
+[[NodeNetworkConfig]]
+== NodeNetworkConfig
+NodeNetworkConfig provides network options for the node
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|NetworkPluginName|string |NetworkPluginName is a string specifying the networking plugin
+|MTU|uint32 |Maximum transmission unit for the network packets
+|===
+
+[[NodeVolumeConfig]]
+== NodeVolumeConfig
+NodeVolumeConfig contains options for configuring volumes on the node.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|LocalQuota|xref:LocalQuota[LocalQuota] |LocalQuota contains options for controlling local volume quota on the node.
+|===
+
+[[OAuthConfig]]
+== OAuthConfig
+OAuthConfig holds the necessary configuration options for OAuth authentication
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|MasterCA|string |MasterCA is the CA for verifying the TLS connection back to the MasterURL.
+|MasterURL|string |MasterURL is used for making server-to-server calls to exchange authorization codes for access tokens
+|MasterPublicURL|string |MasterPublicURL is used for building valid client redirect URLs for internal and external access
+|AssetPublicURL|string |AssetPublicURL is used for building valid client redirect URLs for external access
+|AlwaysShowProviderSelection|bool |AlwaysShowProviderSelection will force the provider selection page to render even when there is only a single provider.
+|IdentityProviders|[]xref:IdentityProvider[IdentityProvider] |IdentityProviders is an ordered list of ways for a user to identify themselves
+|GrantConfig|xref:GrantConfig[GrantConfig] |GrantConfig describes how to handle grants
+|SessionConfig|xref:SessionConfig[SessionConfig] |SessionConfig hold information about configuring sessions.
+|TokenConfig|xref:TokenConfig[TokenConfig] |TokenConfig contains options for authorization and access tokens
+|Templates|xref:OAuthTemplates[OAuthTemplates] |Templates allow you to customize pages like the login page.
+|===
+
+[[OAuthTemplates]]
+== OAuthTemplates
+OAuthTemplates allow for customization of pages like the login page
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Login|string |Login is a path to a file containing a go template used to render the login page.If unspecified, the default login page is used.
+|ProviderSelection|string |ProviderSelection is a path to a file containing a go template used to render the provider selection page.If unspecified, the default provider selection page is used.
+|Error|string |Error is a path to a file containing a go template used to render error pages during the authentication or grant flowIf unspecified, the default error page is used.
+|===
+
+[[OpenIDClaims]]
+== OpenIDClaims
+OpenIDClaims contains a list of OpenID claims to use when authenticating with an OpenID identity provider
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ID|[]string |ID is the list of claims whose values should be used as the user ID. Required.OpenID standard identity claim is "sub"
+|PreferredUsername|[]string |PreferredUsername is the list of claims whose values should be used as the preferred username.If unspecified, the preferred username is determined from the value of the id claim
+|Name|[]string |Name is the list of claims whose values should be used as the display name. Optional.If unspecified, no display name is set for the identity
+|Email|[]string |Email is the list of claims whose values should be used as the email address. Optional.If unspecified, no email is set for the identity
+|===
+
+[[OpenIDIdentityProvider]]
+== OpenIDIdentityProvider
+OpenIDIdentityProvider provides identities for users authenticating using OpenID credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|CA|string |CA is the optional trusted certificate authority bundle to use when making requests to the serverIf empty, the default system roots are used
+|ClientID|string |ClientID is the oauth client ID
+|ClientSecret|xref:StringSource[StringSource] |ClientSecret is the oauth client secret
+|ExtraScopes|[]string |ExtraScopes are any scopes to request in addition to the standard "openid" scope.
+|ExtraAuthorizeParameters|map[string]string |ExtraAuthorizeParameters are any custom parameters to add to the authorize request.
+|URLs|xref:OpenIDURLs[OpenIDURLs] |URLs to use to authenticate
+|Claims|xref:OpenIDClaims[OpenIDClaims] |Claims mappings
+|===
+
+[[OpenIDURLs]]
+== OpenIDURLs
+OpenIDURLs are URLs to use when authenticating with an OpenID identity provider
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Authorize|string |Authorize is the oauth authorization URL
+|Token|string |Token is the oauth token granting URL
+|UserInfo|string |UserInfo is the optional userinfo URL.If present, a granted access_token is used to request claimsIf empty, a granted id_token is parsed for claims
+|===
+
+[[PodManifestConfig]]
+== PodManifestConfig
+PodManifestConfig holds the necessary configuration options for using pod manifests
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Path|string |Path specifies the path for the pod manifest file or directoryIf its a directory, its expected to contain on or more manifest filesThis is used by the Kubelet to create pods on the node
+|FileCheckIntervalSeconds|int64 |FileCheckIntervalSeconds is the interval in seconds for checking the manifest file(s) for new dataThe interval needs to be a positive value
+|===
+
+[[PolicyConfig]]
+== PolicyConfig
+ holds the necessary configuration options for
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|UserAgentMatchingConfig|xref:UserAgentMatchingConfig[UserAgentMatchingConfig] |UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+|===
+
+[[ProjectConfig]]
+== ProjectConfig
+ holds the necessary configuration options for
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|DefaultNodeSelector|string |DefaultNodeSelector holds default project node label selector
+|ProjectRequestMessage|string |ProjectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint
+|ProjectRequestTemplate|string |ProjectRequestTemplate is the template to use for creating projects in response to projectrequest.It is in the format namespace/template and it is optional.If it is not specified, a default template is used.
+|SecurityAllocator|xref:SecurityAllocator[SecurityAllocator] |SecurityAllocator controls the automatic allocation of UIDs and MCS labels to a project. If nil, allocation is disabled.
+|===
+
+[[RFC2307Config]]
+== RFC2307Config
+RFC2307Config holds the necessary configuration options to define how an LDAP group sync interacts with an LDAP
+server using the RFC2307 schema
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AllGroupsQuery|xref:LDAPQuery[LDAPQuery] |AllGroupsQuery holds the template for an LDAP query that returns group entries.
+|GroupUIDAttribute|string |GroupUIDAttributes defines which attribute on an LDAP group entry will be interpreted as its unique identifier.(ldapGroupUID)
+|GroupNameAttributes|[]string |GroupNameAttributes defines which attributes on an LDAP group entry will be interpreted as its name to use foran OpenShift group
+|GroupMembershipAttributes|[]string |GroupMembershipAttributes defines which attributes on an LDAP group entry will be interpreted  as its members.The values contained in those attributes must be queryable by your UserUIDAttribute
+|AllUsersQuery|xref:LDAPQuery[LDAPQuery] |AllUsersQuery holds the template for an LDAP query that returns user entries.
+|UserUIDAttribute|string |UserUIDAttribute defines which attribute on an LDAP user entry will be interpreted as its unique identifier.It must correspond to values that will be found from the GroupMembershipAttributes
+|UserNameAttributes|[]string |UserNameAttributes defines which attributes on an LDAP user entry will be used, in order, as its OpenShift user name.The first attribute with a non-empty value is used. This should match your PreferredUsername setting for your LDAPPasswordIdentityProvider
+|TolerateMemberNotFoundErrors|bool |TolerateMemberNotFoundErrors determines the behavior of the LDAP sync job when missing user entries areencountered. If 'true', an LDAP query for users that doesn't find any will be tolerated and an onlyand error will be logged. If 'false', the LDAP sync job will fail if a query for users doesn't findany. The default value is 'false'. Misconfigured LDAP sync jobs with this flag set to 'true' can causegroup membership to be removed, so it is recommended to use this flag with caution.
+|TolerateMemberOutOfScopeErrors|bool |TolerateMemberOutOfScopeErrors determines the behavior of the LDAP sync job when out-of-scope user entriesare encountered. If 'true', an LDAP query for a user that falls outside of the base DN given for the alluser query will be tolerated and only an error will be logged. If 'false', the LDAP sync job will failif a user query would search outside of the base DN specified by the all user query. Misconfigured LDAPsync jobs with this flag set to 'true' can result in groups missing users, so it is recommended to usethis flag with caution.
+|===
+
+[[RegistryLocation]]
+== RegistryLocation
+RegistryLocation contains a location of the registry specified by the registry domain
+name. The domain name might include wildcards, like '*' or '??'.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|DomainName|string |DomainName specifies a domain name for the registryIn case the registry use non-standard (80 or 443) port, the port should be includedin the domain name as well.
+|Insecure|bool |Insecure indicates whether the registry is secure (https) or insecure (http)By default (if not specified) the registry is assumed as secure.
+|===
+
+[[RemoteConnectionInfo]]
+== RemoteConnectionInfo
+RemoteConnectionInfo holds information necessary for establishing a remote connection
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|URL|string |URL is the remote URL to connect to
+|CA|string |CA is the CA for verifying TLS connections
+||xref:CertInfo[CertInfo] |CertInfo is the TLS client cert information to presentthis is anonymous so that we can inline it for serialization
+|===
+
+[[RequestHeaderAuthenticationOptions]]
+== RequestHeaderAuthenticationOptions
+RequestHeaderAuthenticationOptions provides options for setting up a front proxy against the entire
+API instead of against the /oauth endpoint.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ClientCA|string |ClientCA is a file with the trusted signer certs.  It is required.
+|ClientCommonNames|[]string |ClientCommonNames is a required list of common names to require a match from.
+|UsernameHeaders|[]string |UsernameHeaders is the list of headers to check for user information.  First hit wins.
+|GroupHeaders|[]string |GroupNameHeader is the set of headers to check for group information.  All are unioned.
+|ExtraHeaderPrefixes|[]string |ExtraHeaderPrefixes is the set of request header prefixes to inspect for user extra. X-Remote-Extra- is suggested.
+|===
+
+[[RequestHeaderIdentityProvider]]
+== RequestHeaderIdentityProvider
+RequestHeaderIdentityProvider provides identities for users authenticating using request header credentials
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|LoginURL|string |LoginURL is a URL to redirect unauthenticated /authorize requests toUnauthenticated requests from OAuth clients which expect interactive logins will be redirected here${url} is replaced with the current URL, escaped to be safe in a query parameterhttps://www.example.com/sso-login?then=${url}${query} is replaced with the current query stringhttps://www.example.com/auth-proxy/oauth/authorize?${query}
+|ChallengeURL|string |ChallengeURL is a URL to redirect unauthenticated /authorize requests toUnauthenticated requests from OAuth clients which expect WWW-Authenticate challenges will be redirected here${url} is replaced with the current URL, escaped to be safe in a query parameterhttps://www.example.com/sso-login?then=${url}${query} is replaced with the current query stringhttps://www.example.com/auth-proxy/oauth/authorize?${query}
+|ClientCA|string |ClientCA is a file with the trusted signer certs.  If empty, no request verification is done, and any direct request to the OAuth server can impersonate any identity from this provider, merely by setting a request header.
+|ClientCommonNames|[]string |ClientCommonNames is an optional list of common names to require a match from. If empty, any client certificate validated against the clientCA bundle is considered authoritative.
+|Headers|[]string |Headers is the set of headers to check for identity information
+|PreferredUsernameHeaders|[]string |PreferredUsernameHeaders is the set of headers to check for the preferred username
+|NameHeaders|[]string |NameHeaders is the set of headers to check for the display name
+|EmailHeaders|[]string |EmailHeaders is the set of headers to check for the email address
+|===
+
+[[RoutingConfig]]
+== RoutingConfig
+RoutingConfig holds the necessary configuration options for routing to subdomains
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Subdomain|string |Subdomain is the suffix appended to $service.$namespace. to form the default route hostnameDEPRECATED: This field is being replaced by routers setting their own defaults. This is the"default" route.
+|===
+
+[[SecurityAllocator]]
+== SecurityAllocator
+SecurityAllocator controls the automatic allocation of UIDs and MCS labels to a project. If nil, allocation is disabled.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|UIDAllocatorRange|string |UIDAllocatorRange defines the total set of Unix user IDs (UIDs) that will be allocated to projects automatically, and the size of theblock each namespace gets. For example, 1000-1999/10 will allocate ten UIDs per namespace, and will be able to allocate up to 100 blocksbefore running out of space. The default is to allocate from 1 billion to 2 billion in 10k blocks (which is the expected size of theranges Docker images will use once user namespaces are started).
+|MCSAllocatorRange|string |MCSAllocatorRange defines the range of MCS categories that will be assigned to namespaces. The format is"<prefix>/<numberOfLabels>[,<maxCategory>]". The default is "s0/2" and will allocate from c0 -> c1023, which means a total of 535k labelsare available (1024 choose 2 ~ 535k). If this value is changed after startup, new projects may receive labels that are already allocatedto other projects. Prefix may be any valid SELinux set of terms (including user, role, and type), although leaving them as the defaultwill allow the server to set them automatically.Examples:* s0:/2     - Allocate labels from s0:c0,c0 to s0:c511,c511* s0:/2,512 - Allocate labels from s0:c0,c0,c0 to s0:c511,c511,511
+|MCSLabelsPerProject|int |MCSLabelsPerProject defines the number of labels that should be reserved per project. The default is 5 to match the default UID and MCSranges (100k namespaces, 535k/5 labels).
+|===
+
+[[ServiceAccountConfig]]
+== ServiceAccountConfig
+ServiceAccountConfig holds the necessary configuration options for a service account
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ManagedNames|[]string |ManagedNames is a list of service account names that will be auto-created in every namespace.If no names are specified, the ServiceAccountsController will not be started.
+|LimitSecretReferences|bool |LimitSecretReferences controls whether or not to allow a service account to reference any secret in a namespacewithout explicitly referencing them
+|PrivateKeyFile|string |PrivateKeyFile is a file containing a PEM-encoded private RSA key, used to sign service account tokens.If no private key is specified, the service account TokensController will not be started.
+|PublicKeyFiles|[]string |PublicKeyFiles is a list of files, each containing a PEM-encoded public RSA key.(If any file contains a private key, the public portion of the key is used)The list of public keys is used to verify presented service account tokens.Each key is tried in order until the list is exhausted or verification succeeds.If no keys are specified, no service account authentication will be available.
+|MasterCA|string |MasterCA is the CA for verifying the TLS connection back to the master.  The service account controller will automaticallyinject the contents of this file into pods so they can verify connections to the master.
+|===
+
+[[ServiceServingCert]]
+== ServiceServingCert
+ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for
+pods fulfilling a service to serve with.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Signer|xref:CertInfo[CertInfo] |Signer holds the signing information used to automatically sign serving certificates.If this value is nil, then certs are not signed automatically.
+|===
+
+[[ServingInfo]]
+== ServingInfo
+ServingInfo holds information about serving web pages
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|BindAddress|string |BindAddress is the ip:port to serve on
+|BindNetwork|string |BindNetwork is the type of network to bind to - defaults to "tcp4", accepts "tcp","tcp4", and "tcp6"
+||xref:CertInfo[CertInfo] |CertInfo is the TLS cert info for serving secure traffic.this is anonymous so that we can inline it for serialization
+|ClientCA|string |ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
+|NamedCertificates|[]xref:NamedCertificate[NamedCertificate] |NamedCertificates is a list of certificates to use to secure requests to specific hostnames
+|MinTLSVersion|string |MinTLSVersion is the minimum TLS version supported.Values must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
+|CipherSuites|[]string |CipherSuites contains an overridden list of ciphers for the server to support.Values must match cipher suite IDs from https://golang.org/pkg/crypto/tls/#pkg-constants
+|===
+
+[[SessionConfig]]
+== SessionConfig
+SessionConfig specifies options for cookie-based sessions. Used by AuthRequestHandlerSession
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|SessionSecretsFile|string |SessionSecretsFile is a reference to a file containing a serialized SessionSecrets objectIf no file is specified, a random signing and encryption key are generated at each server start
+|SessionMaxAgeSeconds|int32 |SessionMaxAgeSeconds specifies how long created sessions last. Used by AuthRequestHandlerSession
+|SessionName|string |SessionName is the cookie name used to store the session
+|===
+
+[[SessionSecret]]
+== SessionSecret
+SessionSecret is a secret used to authenticate/decrypt cookie-based sessions
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Authentication|string |Authentication is used to authenticate sessions using HMAC. Recommended to use a secret with 32 or 64 bytes.
+|Encryption|string |Encryption is used to encrypt sessions. Must be 16, 24, or 32 characters long, to select AES-128, AES-
+|===
+
+[[SessionSecrets]]
+== SessionSecrets
+SessionSecrets list the secrets to use to sign/encrypt and authenticate/decrypt created sessions.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||metav1.TypeMeta |
+|Secrets|[]xref:SessionSecret[SessionSecret] |Secrets is a list of secretsNew sessions are signed and encrypted using the first secret.Existing sessions are decrypted/authenticated by each secret until one succeeds. This allows rotating secrets.
+|===
+
+[[StringSource]]
+== StringSource
+StringSource allows specifying a string inline, or externally via env var or file.
+When it contains only a string value, it marshals to a simple JSON string.
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||xref:StringSourceSpec[StringSourceSpec] |StringSourceSpec specifies the string value, or external location
+|===
+
+[[StringSourceSpec]]
+== StringSourceSpec
+StringSourceSpec specifies a string value, or external location
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Value|string |Value specifies the cleartext value, or an encrypted value if keyFile is specified.
+|Env|string |Env specifies an envvar containing the cleartext value, or an encrypted value if the keyFile is specified.
+|File|string |File references a file containing the cleartext value, or an encrypted value if a keyFile is specified.
+|KeyFile|string |KeyFile references a file containing the key to use to decrypt the value.
+|===
+
+[[TokenConfig]]
+== TokenConfig
+TokenConfig holds the necessary configuration options for authorization and access tokens
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|AuthorizeTokenMaxAgeSeconds|int32 |AuthorizeTokenMaxAgeSeconds defines the maximum age of authorize tokens
+|AccessTokenMaxAgeSeconds|int32 |AccessTokenMaxAgeSeconds defines the maximum age of access tokens
+|AccessTokenInactivityTimeoutSeconds|int32 |AccessTokenInactivityTimeoutSeconds defined the default tokeninactivity timeout for tokens granted by any client.Setting it to nil means the feature is completely disabled (default)The default setting can be overriden on OAuthClient basis.The value represents the maximum amount of time that can occur betweenconsecutive uses of the token. Tokens become invalid if they are notused within this temporal window. The user will need to acquire a newtoken to regain access once a token times out.Valid values are:- 0: Tokens never time out- X: Tokens time out if there is no activity for X secondsThe current minimum allowed value for X is 300 (5 minutes)
+|===
+
+[[UserAgentDenyRule]]
+== UserAgentDenyRule
+UserAgentDenyRule adds a rejection message that can be used to help a user figure out how to get an approved client
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+||xref:UserAgentMatchRule[UserAgentMatchRule] |
+|RejectionMessage|string |RejectionMessage is the message shown when rejecting a client.  If it is not a set, the default message is used.
+|===
+
+[[UserAgentMatchRule]]
+== UserAgentMatchRule
+UserAgentMatchRule describes how to match a given request based on User-Agent and HTTPVerb
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|Regex|string |UserAgentRegex is a regex that is checked against the User-Agent.Known variants of oc clients1. oc accessing kube resources: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d2. oc accessing openshift resources: oc/v1.1.3 (linux/amd64) openshift/b348c2f3. openshift kubectl accessing kube resources:  openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d4. openshift kubectl accessing openshift resources: openshift/v1.1.3 (linux/amd64) openshift/b348c2f5. oadm accessing kube resources: oadm/v1.2.0 (linux/amd64) kubernetes/bc4550d6. oadm accessing openshift resources: oadm/v1.1.3 (linux/amd64) openshift/b348c2f7. openshift cli accessing kube resources: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d8. openshift cli accessing openshift resources: openshift/v1.1.3 (linux/amd64) openshift/b348c2f
+|HTTPVerbs|[]string |HTTPVerbs specifies which HTTP verbs should be matched.  An empty list means "match all verbs".
+|===
+
+[[UserAgentMatchingConfig]]
+== UserAgentMatchingConfig
+UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|RequiredClients|[]xref:UserAgentMatchRule[UserAgentMatchRule] |If this list is non-empty, then a User-Agent must match one of the UserAgentRegexes to be allowed
+|DeniedClients|[]xref:UserAgentDenyRule[UserAgentDenyRule] |If this list is non-empty, then a User-Agent must not match any of the UserAgentRegexes
+|DefaultRejectionMessage|string |DefaultRejectionMessage is the message shown when rejecting a client.  If it is not a set, a generic message is given.
+|===
+
+[[WebHookModeType]]
+== WebHookModeType
+
+
+[[WebhookTokenAuthenticator]]
+== WebhookTokenAuthenticator
+WebhookTokenAuthenticators holds the necessary configuation options for
+external token authenticators
+[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+|ConfigFile|string |ConfigFile is a path to a Kubeconfig file with the webhook configuration
+|CacheTTL|string |CacheTTL indicates how long an authentication result should be cached.It takes a valid time duration string (e.g. "5m").If empty, you get a default timeout of 2 minutes.If zero (e.g. "0m"), caching is disabled
+|===
+

--- a/main.go
+++ b/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"golang.org/x/tools/godoc"
+	"golang.org/x/tools/godoc/vfs"
+)
+
+var (
+	pkgTemplate = `{{with .PDoc}}[[master-node-config-api]]
+= Master and Node Configuration API
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+toc::[]
+{{range .Types}}{{$tname := .Name}}{{$tname_html := html .Name}}
+[[{{$tname_html}}]]
+== {{$tname_html}}
+{{.Doc}}{{.Decl | genDecl}}
+{{end}}{{end}}
+`
+	pres *godoc.Presentation
+	fs   = vfs.NameSpace{}
+
+	funcs = map[string]interface{}{
+		"base":    path.Base,
+		"genDecl": handleDeclaration,
+	}
+)
+
+// handleDeclaration parses ast.GenDecl object retrieving only type declarations
+// and their structures.
+func handleDeclaration(a *ast.GenDecl) string {
+	var buf bytes.Buffer
+	for _, s := range a.Specs {
+		if ts, ok := s.(*ast.TypeSpec); ok {
+			if st, ok := ts.Type.(*ast.StructType); ok {
+				fmt.Fprintf(&buf, `[cols="2a,2a,6a",options="header"]
+|===
+|Field |Type| Description
+`)
+				for _, l := range st.Fields.List {
+					fmt.Fprint(&buf, "|")
+					for _, i := range l.Names {
+						fmt.Fprintf(&buf, "%s", i.Name)
+					}
+					fmt.Fprintf(&buf, "|%s |", printType(l.Type))
+					if l.Doc != nil {
+						for _, c := range l.Doc.List {
+							fmt.Fprintf(&buf, "%s", strings.TrimLeft(c.Text, "// "))
+						}
+					}
+					fmt.Fprintf(&buf, "\n")
+				}
+				fmt.Fprintf(&buf, "|===")
+			}
+		}
+	}
+	return buf.String()
+}
+
+// printType is reponsible for parsing the type and returning human readable
+// information about type, if necessary linking to other parts of this document.
+func printType(typ ast.Expr) string {
+	switch t := typ.(type) {
+	case *ast.Ident:
+		if isBuiltin(t.Name) {
+			return t.Name
+		}
+		return fmt.Sprintf("xref:%s[%s]", t.Name, t.Name)
+	case *ast.StarExpr:
+		return printType(t.X)
+	case *ast.ArrayType:
+		return fmt.Sprintf("[]%s", printType(t.Elt))
+	case *ast.MapType:
+		return fmt.Sprintf("map[%s]%s", printType(t.Key), printType(t.Value))
+	case *ast.SelectorExpr:
+		return fmt.Sprintf("%s.%s", t.X, t.Sel)
+	}
+	return ""
+}
+
+// isBuiltin verifies if the given name is a builtin type for which we should
+// not generate link.
+func isBuiltin(name string) bool {
+	return name == "bool" || name == "string" || strings.HasPrefix(name, "int") ||
+		strings.HasPrefix(name, "uint") || strings.HasPrefix(name, "float")
+}
+
+func main() {
+	flag.Parse()
+
+	// use file system of underlying OS
+	fs.Bind("/", vfs.OS(runtime.GOROOT()), "/", vfs.BindReplace)
+
+	// Bind $GOPATH trees into Go root.
+	for _, p := range filepath.SplitList(build.Default.GOPATH) {
+		fs.Bind("/src/pkg", vfs.OS(p), "/src", vfs.BindAfter)
+	}
+
+	corpus := godoc.NewCorpus(fs)
+	corpus.Verbose = true
+
+	pres = godoc.NewPresentation(corpus)
+	pres.TabWidth = 4
+	pres.ShowTimestamps = false
+	pres.ShowPlayground = false
+	pres.ShowExamples = false
+	pres.DeclLinks = true
+	pres.SrcMode = false
+	pres.HTMLMode = false
+
+	var err error
+	pres.PackageText, err = template.New("package.txt").Funcs(pres.FuncMap()).Funcs(funcs).Parse(pkgTemplate)
+	if err != nil {
+		log.Fatal("readTemplate: ", err)
+	}
+
+	if err = godoc.CommandLine(os.Stdout, fs, pres, flag.Args()); err != nil {
+		log.Print(err)
+	}
+}


### PR DESCRIPTION
@openshift/team-documentation this tool will allow generating a reasonable tabular documentation for master and node config. Lemme know what you think. 

@derekwaynecarr @mfojtik we've talked about it some time ago, sorry it took me this long :blush: 
Derek, do we want to generate appropriate docs for 3.9 as well?