### PR TITLE
Bug 1570284: Add NFS support note for registry/metrics/logging

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -850,6 +850,16 @@ Set the following role variables to install and configure Prometheus.
 
 |===
 
+[IMPORTANT]
+====
+The use of NFS storage for registry, metrics, and logging components is only
+supported for proof of concept environments and not for production environments.
+To install or upgrade to {product-title} 3.9 using such a configuration, you
+must opt-in by setting the cluster variable
+`openshift_enable_unsupported_configurations` to `true`, otherwise the procedure
+will fail.
+====
+
 [[openshift-prometheus-deploy]]
 === Deploying Prometheus Using Ansible Installer
 

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -936,57 +936,8 @@ There are several options for enabling registry storage when using the advanced
 installer:
 
 [discrete]
-[[advanced-install-registry-storage-nfs-host-group]]
-===== Option A: NFS Host Group
-
-[NOTE]
-====
-The use of NFS for registry storage is experimental and not supported in {product-title}.
-====
-
-When the following variables are set, an NFS volume is created during an
-advanced install with the path *_<nfs_directory>/<volume_name>_* on the host
-within the `[nfs]` host group. For example, the volume path using these options
-would be *_/exports/registry_*:
-
-----
-[OSEv3:vars]
-
-openshift_hosted_registry_storage_kind=nfs
-openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
-openshift_hosted_registry_storage_nfs_directory=/exports
-openshift_hosted_registry_storage_nfs_options='*(rw,root_squash)'
-openshift_hosted_registry_storage_volume_name=registry
-openshift_hosted_registry_storage_volume_size=10Gi
-----
-
-[discrete]
-[[advanced-install-registry-storage-external-nfs]]
-===== Option B: External NFS Host
-
-[NOTE]
-====
-The use of NFS for registry storage is experimental and not supported in {product-title}.
-====
-
-To use an external NFS volume, one must already exist with a path of
-*_<nfs_directory>/<volume_name>_* on the storage host. The remote volume path
-using the following options would be *_nfs.example.com:/exports/registry_*.
-
-----
-[OSEv3:vars]
-
-openshift_hosted_registry_storage_kind=nfs
-openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
-openshift_hosted_registry_storage_host=nfs.example.com
-openshift_hosted_registry_storage_nfs_directory=/exports
-openshift_hosted_registry_storage_volume_name=registry
-openshift_hosted_registry_storage_volume_size=10Gi
-----
-
-[discrete]
 [[advanced-install-registry-storage-openstack]]
-===== Option C: OpenStack Platform
+===== Option A: OpenStack Platform
 
 An OpenStack storage configuration must already exist.
 
@@ -1002,7 +953,7 @@ openshift_hosted_registry_storage_volume_size=10Gi
 
 [discrete]
 [[advanced-install-registry-storage-aws]]
-===== Option D: AWS or Another S3 Storage Solution
+===== Option B: AWS or Another S3 Storage Solution
 
 The simple storage solution (S3) bucket must already exist.
 
@@ -1027,6 +978,61 @@ region endpoint parameter:
 
 ----
 openshift_hosted_registry_storage_s3_regionendpoint=https://myendpoint.example.com/
+----
+
+[discrete]
+[[advanced-install-registry-storage-nfs-host-group]]
+===== Option C: NFS Host Group
+
+// tag::nfs_storage_unsupported[]
+[IMPORTANT]
+====
+The use of NFS storage for registry, metrics, and logging components is only
+supported for proof of concept environments and not for production environments.
+To install or upgrade to {product-title} 3.9 using such a configuration, you
+must opt-in by setting the cluster variable
+`openshift_enable_unsupported_configurations` to `true`, otherwise the procedure
+will fail.
+====
+// end::nfs_storage_unsupported[]
+
+When the following variables are set, an NFS volume is created during an
+advanced install with the path *_<nfs_directory>/<volume_name>_* on the host
+within the `[nfs]` host group. For example, the volume path using these options
+would be *_/exports/registry_*:
+
+----
+[OSEv3:vars]
+
+openshift_enable_unsupported_configurations=true
+openshift_hosted_registry_storage_kind=nfs
+openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+openshift_hosted_registry_storage_nfs_directory=/exports
+openshift_hosted_registry_storage_nfs_options='*(rw,root_squash)'
+openshift_hosted_registry_storage_volume_name=registry
+openshift_hosted_registry_storage_volume_size=10Gi
+----
+
+[discrete]
+[[advanced-install-registry-storage-external-nfs]]
+===== Option D: External NFS Host
+
+include::install_config/install/advanced_install.adoc[tag=nfs_storage_unsupported]
+
+To use an external NFS volume, one must already exist with a path of
+*_<nfs_directory>/<volume_name>_* on the storage host. The remote volume path
+using the following options would be *_nfs.example.com:/exports/registry_*.
+
+----
+[OSEv3:vars]
+
+openshift_enable_unsupported_configurations=true
+openshift_hosted_registry_storage_kind=nfs
+openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+openshift_hosted_registry_storage_host=nfs.example.com
+openshift_hosted_registry_storage_nfs_directory=/exports
+openshift_hosted_registry_storage_volume_name=registry
+openshift_hosted_registry_storage_volume_size=10Gi
 ----
 
 [discrete]
@@ -1510,11 +1516,7 @@ openshift_metrics_cassandra_storage_type=dynamic
 [[advanced-install-cluster-metrics-storage-nfs-host-group]]
 ===== Option B: NFS Host Group
 
-[IMPORTANT]
-====
-The use of NFS for metrics storage is experimental and not supported in
-{product-title}.
-====
+include::install_config/install/advanced_install.adoc[tag=nfs_storage_unsupported]
 
 When the following variables are set, an NFS volume is created during an
 advanced install with path *_<nfs_directory>/<volume_name>_* on the host within
@@ -1524,6 +1526,7 @@ be *_/exports/metrics_*:
 ----
 [OSEv3:vars]
 
+openshift_enable_unsupported_configurations=true
 openshift_metrics_storage_kind=nfs
 openshift_metrics_storage_access_modes=['ReadWriteOnce']
 openshift_metrics_storage_nfs_directory=/exports
@@ -1536,11 +1539,7 @@ openshift_metrics_storage_volume_size=10Gi
 [[advanced-install-cluster-metrics-storage-external-nfs]]
 ===== Option C: External NFS Host
 
-[IMPORTANT]
-====
-The use of NFS for metrics storage is experimental and not supported in
-{product-title}.
-====
+include::install_config/install/advanced_install.adoc[tag=nfs_storage_unsupported]
 
 To use an external NFS volume, one must already exist with a path of
 *_<nfs_directory>/<volume_name>_* on the storage host.
@@ -1548,6 +1547,7 @@ To use an external NFS volume, one must already exist with a path of
 ----
 [OSEv3:vars]
 
+openshift_enable_unsupported_configurations=true
 openshift_metrics_storage_kind=nfs
 openshift_metrics_storage_access_modes=['ReadWriteOnce']
 openshift_metrics_storage_host=nfs.example.com
@@ -1600,11 +1600,7 @@ openshift_logging_es_pvc_dynamic=true
 [[advanced-installation-logging-storage-nfs-host-group]]
 ===== Option B: NFS Host Group
 
-[IMPORTANT]
-====
-The use of NFS for logging storage is experimental and not supported in
-{product-title}.
-====
+include::install_config/install/advanced_install.adoc[tag=nfs_storage_unsupported]
 
 When the following variables are set, an NFS volume is created during an
 advanced install with path *_<nfs_directory>/<volume_name>_* on the host within
@@ -1614,6 +1610,7 @@ the `[nfs]` host group. For example, the volume path using these options would b
 ----
 [OSEv3:vars]
 
+openshift_enable_unsupported_configurations=true
 openshift_logging_storage_kind=nfs
 openshift_logging_storage_access_modes=['ReadWriteOnce']
 openshift_logging_storage_nfs_directory=/exports
@@ -1626,11 +1623,7 @@ openshift_logging_storage_volume_size=10Gi
 [[advanced-installation-logging-storage-external-nfs]]
 ===== Option C: External NFS Host
 
-[IMPORTANT]
-====
-The use of NFS for logging storage is experimental and not supported in
-{product-title}.
-====
+include::install_config/install/advanced_install.adoc[tag=nfs_storage_unsupported]
 
 To use an external NFS volume, one must already exist with a path of
 *_<nfs_directory>/<volume_name>_* on the storage host.
@@ -1638,6 +1631,7 @@ To use an external NFS volume, one must already exist with a path of
 ----
 [OSEv3:vars]
 
+openshift_enable_unsupported_configurations=true
 openshift_logging_storage_kind=nfs
 openshift_logging_storage_access_modes=['ReadWriteOnce']
 openshift_logging_storage_host=nfs.example.com

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -203,6 +203,13 @@ manually per host, see
 xref:../admin_guide/overcommit.adoc#disabling-swap-memory[Disabling Swap Memory]
 in the Cluster Administration guide to disable it on each host.
 
+.. The use of NFS storage for registry, metrics, and logging components is only
+supported for proof of concept environments and not for production environments.
+To install or upgrade to {product-title} 3.9 using such a configuration, you
+must opt-in by setting the cluster variable
+`openshift_enable_unsupported_configurations` to `true`, otherwise the procedure
+will fail.
+
 . For any upgrade path, always ensure that you have the latest version of the
 *atomic-openshift-utils* package on each RHEL 7 system, which also updates the
 *openshift-ansible-** packages:


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1570284

Also re-ordered the registry storage options so that the unsupported NFS options were not the first ones listed.

@michaelgugino @sdodson PTAL, e.g.:

http://file.rdu.redhat.com/~adellape/042418/nfs_unsupport/install_config/install/advanced_install.html#advanced-install-registry
http://file.rdu.redhat.com/~adellape/042418/nfs_unsupport/upgrading/automated_upgrades.html#preparing-for-an-automated-upgrade