### PR TITLE
Revert techpreview for cronjobs and cli plugins dropped in d81ad2ca

### DIFF
--- a/cli_reference/extend_cli.adoc
+++ b/cli_reference/extend_cli.adoc
@@ -23,6 +23,21 @@ and one or more binary, script, or assets files.
 
 CLI plug-ins are currently only available under the `oc plugin` subcommand.
 
+[IMPORTANT]
+====
+CLI plug-ins are currently a Technology Preview feature.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
+Technology Preview features support scope] for more information.
+endif::[]
+====
+
 [[cli-plugins-prerequisites]]
 == Prerequisites
 


### PR DESCRIPTION
@ahardin-rh @openshift/team-documentation this reverts the tech preview for cli plugins and cronjobs that I'm sure we did not drop it there. This NEEDS to get into 3.9.