### PR TITLE
Brief note about timeouts in the haproxy router

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -83,6 +83,11 @@ endif::[]
 
 [NOTE]
 ====
+Some of the timeouts that we expose interact casuing the total timeout to be longer then specified.
+====
+
+[NOTE]
+====
 If you want to run multiple routers on the same machine, you must change the
 ports that the router is listening on, `ROUTER_SERVICE_SNI_PORT` and
 `ROUTER_SERVICE_NO_SNI_PORT`. These ports can be anything you want as long as

--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -84,6 +84,9 @@ endif::[]
 [NOTE]
 ====
 Some of the timeouts that we expose interact casuing the total timeout to be longer then specified.
+
+For example:
+ROUTER_SLOWLORIS_HTTP_KEEPALIVE adjusts "timeout http-keep-alive", but haproxy still waits on the "tcp-request inspect-delay" which we set to 5s. So the overall timeout will be ROUTER_SLOWLORIS_HTTP_KEEPALIVE + 5s.
 ====
 
 [NOTE]


### PR DESCRIPTION
Some of the timeouts that we allow cluster administrators to set
interact with others that we expose or in some cases don't expose.
Causing haproxy to actually timeout as the sum of those timeouts

Ex.

setting
ROUTER_SLOWLORIS_HTTP_KEEPALIVE to 10s

because we set "tcp-request inspect-delay" to 5s

ROUTER_SLOWLORIS_HTTP_KEEPALIVE triggers and then the inspect-delay
waits to timeout so the connection closes after 15s

bug 1562244
https://bugzilla.redhat.com/show_bug.cgi?id=1562244
