### PR TITLE
Add ovs-networkpolicy to the list of EgressNetworkPolicy plugins

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -290,7 +290,7 @@ access to `<project B>`. Or restrict application developers from updating from
 [CAUTION]
 ====
 You must have the
-xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[*ovs-multitenant* plugin] enabled in order to limit pod access via egress policy.
+xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[*ovs-multitenant* or *ovs-networkpolicy* plugin] enabled in order to limit pod access via egress policy.
 ====
 
 Project administrators can neither create `EgressNetworkPolicy` objects, nor


### PR DESCRIPTION
The docs needed to have ovs-networkpolicy added to the list of plugins that supportEgressNetworkPolicy.

This should be fixed in 3.9 and beyond.

Fixes https://github.com/openshift/openshift-docs/issues/7488