### PR TITLE
Sanitize openshift_master_cluster_hostname

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1428,7 +1428,7 @@ inventory file:
 
 ----
 openshift_master_cluster_method=native
-openshift_master_cluster_hostname=lb.openshift.com
+openshift_master_cluster_hostname=lb-internal.openshift.com
 openshift_master_cluster_public_hostname=custom.openshift.com
 ----
 
@@ -2200,7 +2200,7 @@ endif::[]
 # or to one or all of the masters defined in the inventory if no load
 # balancer is present.
 openshift_master_cluster_method=native
-openshift_master_cluster_hostname=openshift-cluster.example.com
+openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
 # apply updated node defaults
@@ -2312,7 +2312,7 @@ endif::[]
 # or to one or all of the masters defined in the inventory if no load
 # balancer is present.
 openshift_master_cluster_method=native
-openshift_master_cluster_hostname=openshift-cluster.example.com
+openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
 # host group for masters

--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -278,7 +278,7 @@ openshift_master_default_subdomain=apps.test.example.com
 # or to one or all of the masters defined in the inventory if no load
 # balancer is present.
 openshift_master_cluster_method=native
-openshift_master_cluster_hostname=openshift-cluster.example.com
+openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
 # apply updated node defaults


### PR DESCRIPTION
openshift_master_cluster_hostname should point to
the internal LB or internal master hostname.
Having the same values in this and in the public URL
leads to installation errors and missconfigurations.