### PR TITLE
Document how to expand the service CIDR range

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -154,12 +154,21 @@ for any changes to take effect.
 
 [IMPORTANT]
 ====
-The `*serviceNetworkCIDR*` and `*hostSubnetLength*` values cannot be changed
-after the cluster is first created, and `*clusterNetworkCIDR*` can only be
-changed to be a larger network that still contains the original network. For
-example, given the default value of *10.128.0.0/14*, you could change
-`*clusterNetworkCIDR*` to *10.128.0.0/9* (i.e., the entire upper half of net
-10) but not to *10.64.0.0/16*, because that does not overlap the original value.
+The `*hostSubnetLength*` value cannot be changed after the cluster is
+first created, `*clusterNetworkCIDR*` can only be changed to be a
+larger network that still contains the original network, and
+`*serviceNetworkCIDR*` can only be expanded. For example, given the
+default value of *10.128.0.0/14*, you could change
+`*clusterNetworkCIDR*` to *10.128.0.0/9* (i.e., the entire upper half
+of net 10) but not to *10.64.0.0/16*, because that does not overlap
+the original value.
+
+You could change `*serviceNetworkCIDR*` from *172.30.0.0/16* to
+*172.30.0.0/15*, but not to *172.28.0.0/14* because even though the
+original range is entirely inside the new range, the original range
+must be at the start of the CIDR.  See
+[growing-the-service-network](growing the service network) for
+details.
 ====
 
 [[configuring-the-pod-network-on-nodes]]
@@ -182,6 +191,27 @@ networkConfig:
 *redhat/openshift-ovs-multitenant* for the *ovs-multitenant* plug-in, or
 *redhat/openshift-ovs-networkpolicy* for the *ovs-networkpolicy* plug-in
 ====
+
+[[growing-the-service-network]]
+== Growing the Service Network
+
+If you are running low on addresses in your Service network and can expand the range so that it includes the current range at the beginning of the new range, then you can:
+
+. Change the `*serviceNetworkCIDR*` parameter on all
+xref:configuring-the-pod-network-on-masters[masters] in their configuration files.
+ifdef::openshift-origin[].  You can only change the number following the / to a smaller number.
+. Delete the `*clusterNetwork*` object in OpensShift:
+----
+$ oc delete clusternetwork default
+----
+. Restart the *origin-master-api* and *origin-master-controller*  services on masters .
+endif::[]
+ifdef::openshift-enterprise[]
+. Restart the *atomic-openshift-master-api* and *atomic-openshift-master-controllers*
+on masters.
+endif::[]
+. Update the inventory file to change the openshift_portal_net to the new CIDR and run the playbook `*config.yml*` to redeploy the cluster
+. Evacuate each node, one by one, restart it, and then re-enable it
 
 [[migrating-between-sdn-plugins]]
 == Migrating Between SDN Plug-ins


### PR DESCRIPTION
Change the documentation to document the procedure for how to change the service CIDR and under what circumstances it is allowed.

For 3.10 only.

Fixes bug 1571229 (https://bugzilla.redhat.com/show_bug.cgi?id=1571229)