### PR TITLE
Added a note about NetworkPolicy storage migration

### DIFF
--- a/upgrading/upgrading_known_issues.adoc
+++ b/upgrading/upgrading_known_issues.adoc
@@ -226,3 +226,20 @@ done
 ----
 $ bash oauthclientauthorization.sh
 ----
+
+[[upgrading-known-issue-BZ1570777]]
+== Missing NetworkPolicy Storage Migration Rules in 3.7.9-3.7.22
+
+`NetworkPolicy` objects have migration errors in releases 3.7.9-3.7.22 due to missing migration rules.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1570777[*BZ#1570777*])
+
+.Error Output
+----
+# oc adm --config=/etc/origin/master/admin.kubeconfig migrate storage --include=*  --confirm
+E0423 16:04:43.881409 error:     -n policy networkpolicies/allow-all: NetworkPolicy.networking.k8s.io "allow-all" is invalid: spec: Forbidden: updates to networkpolicy spec are forbidden.
+summary: total=1061 errors=1 ignored=0 unchanged=1010 migrated=49
+info: to rerun only failing resources, add --include=networkpolicies
+error: 1 resources failed to migrate
+----
+
+The solution is to upgrade the binaries to 3.7.23 or beyond and then migrate the storage.  If upgrading to 3.9 or beyond, upgrade to 3.7.23 first, migrate the storage and then do a normal upgrade.


### PR DESCRIPTION
This should go into release 3.7 and 3.9.

Fixes bug 1570777 (https://bugzilla.redhat.com/show_bug.cgi?id=1570777)