### PR TITLE
Document recovery from resize failure

### DIFF
--- a/dev_guide/expanding_persistent_volumes.adoc
+++ b/dev_guide/expanding_persistent_volumes.adoc
@@ -116,3 +116,22 @@ object reflects the newly requested size in `PersistentVolume.Spec.Capacity`. At
 this point, you can create or re-create a new pod from the PVC to finish the
 file system resizing. Once the pod is running, the newly requested size is
 available and `FileSystemResizePending` condition is removed from the PVC.
+
+[[recover_from_resize_failure]]
+== Recovering from Failure when Expanding Volumes
+
+If expanding underlying storage fails either on master or node,
+{product-title} admin can manually recover the PVC state and cancel the resize requests that are
+continuously retried by the controller without administrator intervention.
+
+Currently, this can be done manually by completing the following steps:
+
+1. Mark the PV that is bound to the claim (PVC) with the `Retain` reclaim policy.
+   This can be done by editing the PV and changing persistentVolumeReclaimPolicy to `Retain`.
+2. Delete the PVC, so as we can re-create it later.
+3. To ensure that newly created PVC can bind to PV marked `Retain`, we will have to manually edit the PV
+   and delete `claimRef` entry from PV specs. This will mark the PV as `Available`. For more information
+   about prebinding PVCs please see xref:./persistent_volumes.adoc#persistent-volumes-volumes-and-claim-prebinding[Volume and claim prebinding].
+4. Re-create the PVC in a smaller size or a size that can be allocated by the underlying storage provider.
+   Also set `volumeName` field of PVC to name of PV, so as PVC can only bind to already provisioned PV.
+5. Restore the reclaim policy on the PV.


### PR DESCRIPTION
Document recovery steps from resize failure. Fixes - https://bugzilla.redhat.com/show_bug.cgi?id=1557097