### PR TITLE
Added Project Idling and Account Pruning sections

### DIFF
--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -146,6 +146,28 @@ include any application objects for access by multiple projects, such as
 templates and images. These objects should be those that do not require
 communication between the pods.
 
+ifdef::openshift-online[]
+[[projects-idling]]
+== Project Idling
+In {product-title} Starter, a project that is inactive for more than 24 hours
+is idled. When a project's network activity falls below a configured threshold,
+a project is deemed inactive. When a project is idled, the replica count is set
+to `0` and all pods are deleted. All persistent volumes (PVs) and persistent
+volume claims (PVCs) in the project are left untouched. Upon receiving network
+traffic, the replica count will be scaled back to whatever it was before being
+idled.
 
+In the web console, you will see your deployment as *Idled due to inactivity*
+and you can manually scale the deployment back up.
 
+If network traffic does not restore a project's replica counts, then you may
+have to manually scale up the deployment.
 
+[[account-pruning]]
+== Account Pruning
+If your {product-title} Starter account is inactive, meaning that you have had
+no running pods in your project for 3 days, you will receive a warning email
+that your account is to be deprovisioned. If you do not take corrective action
+and create pods within 5 days, your account is automatically deprovisioned. Once
+your account is deprovisioned, you can register again.
+endif::[]


### PR DESCRIPTION
This work separates Idling content from Hibernation content (xref: https://github.com/openshift/openshift-docs/pull/4470) and adds information about Pruning. 