### PR TITLE
Remove the docs around dropping SYNs during reloads

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -21,10 +21,6 @@ $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 |`DEFAULT_CERTIFICATE` |  | The contents of a default certificate to use for routes that don't expose a TLS server cert; in PEM format.
 |`DEFAULT_CERTIFICATE_DIR` |  | A path to a directory that contains a file named *_tls.crt_*. If *_tls.crt_* is not a PEM file which also contains a private key, it is first combined with a file named tls.key in the same directory. The PEM-format contents are then used as the default certificate. Only used if `DEFAULT_CERTIFICATE` or `DEFAULT_CERTIFICATE_PATH` are not specified.
 |`DEFAULT_CERTIFICATE_PATH` |  | A path to default certificate to use for routes that don't expose a TLS server cert; in PEM format. Only used if `DEFAULT_CERTIFICATE` is not specified.
-|`DROP_SYN_DURING_RESTART` |  `false` | When set to `true`, enables an iptables rule to drop certain packets during a restart to provide a seamless restart.
-ifdef::openshift-origin,openshift-enterprise[]
-See xref:../../install_config/router/default_haproxy_router.adoc#preventing-connection-failures-during-restarts[the install guide] for details.
-endif::[]
 |`EXTENDED_VALIDATION` | `true` | If `true`, the router confirms that the certificate is structurally correct. It does not verify the certificate against any CA. Set `false` to turn off the tests.
 |`NAMESPACE_LABELS` |  | A label selector to apply to namespaces to watch, empty means all.
 |`PROJECT_LABELS` |  | A label selector to apply to projects to watch, emtpy means all.

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1600,52 +1600,10 @@ haproxy_server_bytes_in_total{namespace="default",pod="hello-rc-vkjqx",route="he
 [[preventing-connection-failures-during-restarts]]
 == Preventing Connection Failures During Restarts
 
-If you connect to the router while the proxy is reloading, there is a small
-chance that your connection will end up in the wrong network queue and be
-dropped. The issue is being addressed. In the meantime, it is possible to work
-around the problem by installing `iptables` rules to prevent connections during
-the reload window. However, doing so means that the router needs to run with
-elevated privilege so that it can manipulate `iptables` on the host. It also
-means that connections that happen during the reload are temporarily ignored and
-must retransmit their connection start, lengthening the time it takes to
-connect, but preventing connection failure.
+This is not needed if you are running OpenShift 3.9 or later.  Earlier
+releases used an *haproxy* version that could drop connections if they
+attempted to connect during the router reload.  Now, the reload is seamless.
 
-To prevent this, configure the router to use `iptables` by changing the service
-account, and setting an environment variable on the router.
-
-*Use a Privileged SCC*
-
-When creating the router, allow it to use the privileged SCC. This gives the
-router user the ability to create containers with root privileges on the nodes:
-
-----
-$ oc adm policy add-scc-to-user privileged -z router
-----
-
-*Patch the Router Deployment Configuration to Create a Privileged Container*
-
-You can now create privileged containers. Next, configure the router deployment
-configuration to use the privilege so that the router can set the iptables rules
-it needs. This patch changes the router deployment configuration so that the
-container that is created runs as privileged (and therefore gets correct
-capabilities) and run as root:
-
-----
-$ oc patch dc router -p '{"spec":{"template":{"spec":{"containers":[{"name":"router","securityContext":{"privileged":true}}],"securityContext":{"runAsUser": 0}}}}}'
-----
-
-*Configure the Router to Use iptables*
-
-Set the option on the router deployment configuration:
-
-====
-----
-$ oc set env dc/router -c router DROP_SYN_DURING_RESTART=1
-----
-====
-
-If you used a non-default name for the router, you must change *_dc/router_*
-accordingly.
 
 [[deploy-router-arp-cach-tuning-for-large-scale-clusters]]
 == ARP Cache Tuning for Large-scale Clusters


### PR DESCRIPTION
The 3.9 (and beyond) router is built on a version of haproxy that can
seamlessly reload without dropping connections.  The documentation for
how to do it the hacky way is no longer needed.  This patch removes
it.

Corresponding PR to remove the environment variable:
  https://github.com/openshift/origin/pull/19315

This is for 3.9 and 3.10.