### PR TITLE
link to cluster limits page from admin guide to clarify max-pods

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -451,6 +451,12 @@ openshift_node_kubelet_args={'max-pods': ['40'], 'resolv-conf': ['/etc/resolv.co
 The following section is included in the Scaling and Performance Guide.
 ////
 // tag::admin_guide_manage_nodes[]
+
+[NOTE]
+====
+Please see the xref:../scaling_performance/cluster_limits.adoc#scaling-performance-current-cluster-limits[Cluster Limits] page for the maximum supported limits for each version of {product-title}.
+====
+
 In the *_/etc/origin/node/node-config.yaml_* file, two parameters control the
 maximum number of pods that can be scheduled to a node: `pods-per-core` and
 `max-pods`. When both options are in use, the lower of the two limits the number
@@ -487,7 +493,7 @@ Setting `pods-per-core` to 0 disables this limit.
 ====
 
 `max-pods` sets the number of pods the node can run to a fixed value, regardless
-of the properties of the node.
+of the properties of the node.  The xref:../scaling_performance/cluster_limits.adoc#scaling-performance-current-cluster-limits[Cluster Limits] page documents maximum supported values for `max-pods`.
 
 ----
 kubeletArguments:


### PR DESCRIPTION
A read of the admin_guide pods-per-node page the way it is currently written leads to possible ambiguity for our maximum supported limits of pods-per-node.

Fix this by creating a callout and pointing to the official limits table in the scaling guide.