### PR TITLE
Clarify GitHub Content type JSON in triggering_builds.adoc

### DIFF
--- a/dev_guide/builds/triggering_builds.adoc
+++ b/dev_guide/builds/triggering_builds.adoc
@@ -134,7 +134,7 @@ This generates a webhook GitHub URL that looks like:
 
 . Paste the URL output (similar to above) into the *Payload URL* field.
 
-. Set the *Content Type* to `application/json`.
+. Change the *Content Type* from GitHub's default `application/x-www-form-urlencoded` to `application/json`.
 
 . Click *Add webhook*.
 


### PR DESCRIPTION
I initially got this wrong, and realize it is explained between the lines further down in the `curl` examples, but one does not really read tht when just trying to set it directly up on GitHub, so why not clarify it there.