### PR TITLE
Link to keycloak/rhsso as oidc auth provider

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1633,6 +1633,17 @@ Set *OpenIDIdentityProvider* in the `*identityProviders*` stanza to integrate
 with an OpenID Connect identity provider using an
 link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].
 
+ifdef::openshift-origin[]
+You can link:https://www.keycloak.org/docs/latest/server_admin/index.html#openshift[configure a Keycloak] server as an OpenID
+Connect identity provider for {product-title}.
+endif::[]
+
+ifdef::openshift-enterprise[]
+You can 
+link:https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_single_sign-on_for_openshift/tutorials[configure Red Hat Single Sign-On]
+as an OpenID Connect identity provider for {product-title}. 
+endif::[]
+
 [NOTE]
 ====
 *ID Token* and *UserInfo* decryptions are not supported.


### PR DESCRIPTION
Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>
edits to https://github.com/openshift/openshift-docs/pull/9088