### PR TITLE
adding yum-utils to host prep

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -120,7 +120,7 @@ For RHEL 7 systems:
 . Install the following base packages:
 +
 ----
-# yum install wget git net-tools bind-utils iptables-services bridge-utils bash-completion kexec-tools sos psacct
+# yum install wget git net-tools bind-utils yum-utils iptables-services bridge-utils bash-completion kexec-tools sos psacct
 ----
 
 . Update the system to the latest packages:


### PR DESCRIPTION
@jianlinliu, we got a report on issue https://github.com/openshift/openshift-docs/issues/9106 that `yum-utils` was a required package for cluster hosts. Will you please confirm that this addition is correct and that it should apply back to version 3.3? 