### PR TITLE
Doc ROUTER_BIND_PORTS_AFTER_SYNC and ROUTER_OVERRIDE_DOMAINS

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -32,6 +32,7 @@ endif::[]
 |`ROUTER_ALLOWED_DOMAINS` | | A comma-separated list of domains that the host name in a route can only be part of. Any subdomain in the domain can be used. Option `ROUTER_DENIED_DOMAINS` overrides any values given in this option. If set, everything outside of the allowed domains will be rejected.
 |`ROUTER_BACKEND_CHECK_INTERVAL` | 5000ms | Length of time between subsequent "liveness" checks on backends. xref:time-units[(TimeUnits)]
 |`ROUTER_BACKEND_PROCESS_ENDPOINTS` | | String to specify how the endpoints should be processed while using the template function processEndpointsForAlias. Valid values are ["shuffle", ""]. "shuffle" will randomize the elements upon every call. Default behavior returns in pre-determined order.
+|`ROUTER_BIND_PORTS_AFTER_SYNC` | `false` | If `true` or `TRUE`, then the router will not bind to any ports until it has completely synchronized state.  If this is not set, it will bind and start processing requests immediately, but there may be routes that are not loaded.
 |`ROUTER_CLIENT_FIN_TIMEOUT` | 1s | Controls the TCP FIN timeout period for the client connecting to the route. If the FIN sent to close the connection is not answered within the given time, HAProxy will close the connection anyway.  This is harmless if set to a low value and uses fewer resources on the router.  xref:time-units[(TimeUnits)]
 |`ROUTER_COOKIE_NAME` |  | Specifies cookie name to override the internally generated default name.  The name must consist of any combination of upper and lower case letters, digits, "_",
 and "-". The default is the hashed internal key name for the route.
@@ -50,6 +51,7 @@ will "linger" around for that period. xref:time-units[(TimeUnits)]
 |`ROUTER_LOG_LEVEL` | warning | The log level to send to the syslog server.
 |`ROUTER_MAX_CONNECTIONS`| 20000 | Maximum number of concurrent connections.
 |`ROUTER_METRICS_TYPE`| haproxy | Generate metrics for xref:../../install_config/router/default_haproxy_router.adoc#exposing-the-router-metrics[the HAProxy router]. (haproxy is the only supported value)
+|`ROUTER_OVERRIDE_DOMAINS`|  | A comma separated list of domain names.  If a route's domain name matches the host in a route, the hostname is ignored and the pattern defined in `ROUTER_SUBDOMAIN` is used.
 |`ROUTER_OVERRIDE_HOSTNAME`|  | If set `true`, override the spec.host value for a route with the template in `ROUTER_SUBDOMAIN`.
 |`ROUTER_SERVICE_HTTPS_PORT` | 443 | Port to listen for HTTPS requests.
 |`ROUTER_SERVICE_HTTP_PORT` | 80 | Port to listen for HTTP requests.


### PR DESCRIPTION
Add missing docs for some environment variables.