### PR TITLE
Added pointer to Quotas and Limits topic

### DIFF
--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -247,7 +247,6 @@ triggers:
 ----
 ====
 
-
 [[image-change-trigger]]
 === ImageChange Trigger
 //tag::image-change-trig[]
@@ -308,8 +307,6 @@ For more information, see:
 $ oc set triggers --help
 ----
 
-
-
 [[deployment-resources]]
 == Setting Deployment Resources
 
@@ -356,6 +353,11 @@ items is required:
 <1> The `requests` object contains the list of resources that correspond to
 the list of resources in the quota.
 ====
+
+See
+xref:../../dev_guide/compute_resources.adoc#dev-guide-compute-resources[Quotas
+and Limit Ranges] to learn more about compute resources and the differences
+between requests and limits.
 
 ifdef::openshift-enterprise,openshift-dedicated,openshift-origin[]
 - A xref:../../admin_guide/limits.adoc#admin-guide-limits[limit range] defined in your project, where the


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-docs/issues/8901

@miminar Can you please help me review this content, or point me in the right direction? To address the issue above, I added a pointer to the section that discusses requests vs limits, but we may not fully answer these questions that came up:

- Does it make sense to use both at the same time?
- What's the impact/behavior? 
- What will determine the amount of memory a pod actually gets?

Let me know if we should expand the content in https://docs.openshift.com/container-platform/3.9/dev_guide/compute_resources.html#dev-requests-vs-limits