### PR TITLE
[enterprise-3.0] Fix status codes for success

### DIFF
--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -50,7 +50,7 @@ Both probes can be configured in three ways:
 *HTTP Checks*
 
 The kubelet uses a web hook to determine the healthiness of the container. The
-check is deemed successful if the hook returns with 200 or 399. The following is
+check is deemed successful if the HTTP response code is between 200 and 399. The following is
 an example of a readiness check using the HTTP checks method:
 
 .Readiness HTTP check
@@ -67,7 +67,7 @@ readinessProbe:
 ----
 ====
 
-A HTTP check is ideal for complex applications that can return with a 200 status
+A HTTP check is ideal for applications that return HTTP status codes
 when completely initialized.
 
 *Container Execution Checks*


### PR DESCRIPTION
Liveness and readiness probes succeed if the HTTP response code is 200-399, which is the range of HTTP success (2xx) and redirection (3xx).
fixes #9145