### PR TITLE
Hawkular hostname

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1471,7 +1471,6 @@ to enable cluster metrics when using the advanced installation method:
 [OSEv3:vars]
 
 openshift_metrics_install_metrics=true
-openshift_metrics_hawkular_hostname=hawkular-metrics.{{openshift_master_default_subdomain}}
 ----
 
 The metrics public URL can be set during cluster
@@ -1481,6 +1480,9 @@ which defaults to:
 `\https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics`
 
 If you alter this variable, ensure the host name is accessible via your router.
+
+`openshift_metrics_hawkular_hostname=hawkular-metrics.{{openshift_master_default_subdomain}}`
+
 
 [[advanced-install-cluster-metrics-storage]]
 ==== Configuring Metrics Storage

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1471,6 +1471,7 @@ to enable cluster metrics when using the advanced installation method:
 [OSEv3:vars]
 
 openshift_metrics_install_metrics=true
+openshift_metrics_hawkular_hostname=hawkular-metrics.{{openshift_master_default_subdomain}}
 ----
 
 The metrics public URL can be set during cluster


### PR DESCRIPTION
From #9214,
a example value for the ansible variable `openshift_metrics_hawkular_hostname`  is added.
