### PR TITLE
Issue 9165, remove confusing reference to "free" account

### DIFF
--- a/dev_guide/projects.adoc
+++ b/dev_guide/projects.adoc
@@ -223,7 +223,7 @@ within the project.
 === Adding Collaborators
 {product-title} Pro subscribers can add collaborators by following these steps:
 
-. Each user you want to add as a collaborator must create a free account at
+. Each user you want to add as a collaborator must create an account at
  link:https://developers.redhat.com/[developers.redhat.com]. Once your
  collaborator has confirmed their Red Hat Developers account, you can add them
  to your subscription.


### PR DESCRIPTION
This addresses https://github.com/openshift/openshift-docs/issues/9165

The reference to "free" is confusing. The rest of the page makes it clear that this is for Pro (paid) only.

