### PR TITLE
manual node certificate signing draft

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -592,6 +592,9 @@ Topics:
 - Name: Pruning Objects
   File: pruning_resources
   Distros: openshift-origin,openshift-enterprise
+- Name: Managing node certificate requests and update
+  File: managing_node_certificates
+  Distros: openshift-origin,openshift-enterprise  
 - Name: Extending the Kubernetes API with Custom Resources
   File: custom_resource_definitions
   Distros: openshift-origin,openshift-enterprise

--- a/admin_guide/managing_node_certificates.adoc
+++ b/admin_guide/managing_node_certificates.adoc
@@ -1,0 +1,51 @@
+[[managing-node-certificates]]
+= Managing node certificate requests and updates
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+
+If you 
+xref:../install_config/install/advanced_install.adoc#advanced-install-node-certificates[configured 
+manual node certificate request approval] during 
+xref:../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced installation],
+you must manually approve node certificate requests. You must also manually 
+update the certificates.
+
+
+[[approving-node-certificate-requests]]
+== Approving node certificate requests
+
+You must perform the following steps as a cluster adminstrator.
+
+. List the outstanding node certificate signing requests:
++
+----
+$ oc adm csr
+
+SAMPLE COMMAND OUTPUT
+----
+
+. Follow your process to approve the certificate request and provide the node
+certificate. For example, you create a certificate with an external signing
+authority.
+
+. Upload the signed certificate to the node.
+
+----
+$ oc adm csr -flags <node_identifier>
+----
+
+[[updating-manual-node-certificates]]
+== Updating manually-approved node Certificates
+
+To update manually provided node certificates, take these steps:
+
+. TBD

--- a/cli_reference/admin_cli_operations.adoc
+++ b/cli_reference/admin_cli_operations.adoc
@@ -198,6 +198,13 @@ $ oc adm ca
 ----
 endif::[]
 
+=== csr
+Lists certificate approval requests:
+----
+$ oc adm csr
+----
+endif::[]
+
 [[other-cli-operations]]
 
 == Other CLI Operations

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -276,6 +276,10 @@ use it.
 validity for etcd CA, peer, server and client certificates. Defaults to `1825`
 (5 years).
 
+|`openshift_approve_node_certificate_requests`
+|Whether to automatically approve certificate signing requests from nodes. Defaults to `true`.
+See xref:advanced-install-node-certificates[Configuring Manual Node Certificate Approval].
+
 |`os_firewall_use_firewalld`
 |Set to `true` to use firewalld instead of the default iptables. Not available on RHEL Atomic Host. See the xref:advanced-install-configuring-firewalls[Configuring the Firewall] section for more information.
 
@@ -1460,6 +1464,33 @@ etcd_ca_default_days=1825
 
 These values are also used when
 xref:../../install_config/redeploying_certificates.adoc#install-config-redeploying-certificates[redeploying certificates] via Ansible post-installation.
+
+[[advanced-install-node-certificates]]
+=== Configuring Manual Node Certificate Approval
+
+When you create a new {product-title} node, the node generates a certificate
+signing request and sends it to the master node. By default, the {product-title}
+master node automatically approves this request and sends the following
+certificates to the node:
+
+* list
+* of
+* certs
+
+You might not want to automatically approve node certificate requests, such as if:
+
+* Regulations or internal processes require an external certificate authority.
+* You need to sign keys outside of the the {product-title} cluster.
+* You do not want to share your signing authority key with the {product-title}
+master.
+
+To configure manual node certificate approval, set the following parameter in
+the inventory file:
+----
+[OSEv3:vars]
+
+openshift_approve_node_certificate_requests=false
+----
 
 [[advanced-install-cluster-metrics]]
 === Configuring Cluster Metrics


### PR DESCRIPTION
@sdodson, here's a very rough skeleton of what the manual node signing request docs might look like.  Will you please provide this information or tell me who else would have it?

- the inventory parameter that you set to `false` to enable this manual cert signing
- the list of certs this impacts
- the command to list the cert requests
- the flag to provide the cert
- steps to manually provide updated certs, if any
- which distros this change is valid in (it sounds like an origin and enterprise change, but please confirm) 