### PR TITLE
Add Membership whitelist customization docs to console customization page 

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -230,6 +230,33 @@ width and height. The ideal height is *20px*.
 Add the stylesheet as described in
 xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
 
+[[changing-the-membership-whitelist]]
+== Customizing the Membership Whitelist
+
+The default whitelist in the membership page shows a subset of cluster roles, such as 
+`admin`, `basic-user`, `edit`, and so on. It also shows custom roles defined within a project.
+
+For example, to add your own set of custom cluster roles to the whitelist:
+
+[source, javascript]
+----
+window.OPENSHIFT_CONSTANTS.MEMBERSHIP_WHITELIST = [
+  "admin",
+  "basic-user",
+  "edit",
+  "system:deployer",
+  "system:image-builder",
+  "system:image-puller",
+  "system:image-pusher",
+  "view",
+  "custom-role-1",
+  "custom-role-2"
+];
+----
+
+Add the script as described in
+xref:loading-custom-scripts-and-stylesheets[Loading Extension Scripts and Stylesheets].
+
 [[changing-links-to-documentation]]
 == Changing Links to Documentation
 


### PR DESCRIPTION
Per [this bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1577568)

Adds a short block that describes how the default list of roles listed on the membership page can be customized.  At present, the membership dropdown will list the following:

- `ClusterRole`s in this set: `  "admin",  "basic-user",  "edit",  "system:deployer",  "system:image-builder",  "system:image-puller",  "system:image-pusher",  "view",`
- any custom `Role` in a namespace/project 

This is a fairly sensible default as users will likely only need the specified `ClusterRole`s  above.  The additional `ClusterRole`s are overwhelming (but still visible via the "show all roles" checkbox). 

We also assume that any custom `Role` in a project is created for a reason, so ought to be displayed by default.

@ahardin-rh @adellape @spadgett 