### PR TITLE
clarifying NTP prereq

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -173,7 +173,7 @@ can be assigned cluster-wide:
 
 [[cluster-variables-table]]
 .General Cluster Variables
-[options="header"]
+[cols=".^5,.^5a",options="header"]
 |===
 
 |Variable |Purpose
@@ -211,6 +211,15 @@ Containerized Hosts] for more details.
 ifdef::openshift-enterprise[]
 Containerized installations are supported starting in {product-title} 3.1.1.
 endif::[]
+
+|`openshift_clock_enabled`
+| Whether to enable Network Time Protocol (NTP) on cluster nodes. `true` by default.
+[IMPORTANT]
+====
+To prevent masters and nodes in the
+cluster from going out of sync, do not change the default value of this parameter.
+====
+
 
 |`openshift_master_admission_plugin_config`
 a|This variable sets the parameter and arbitrary JSON values as per the requirement in your inventory hosts file.

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -233,18 +233,6 @@ link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atom
 Graph Driver] section of the Atomic Host documentation for instructions on how
 to to enable the `overlay2` graph driver for the Docker service.
 
-[[prereq-NTP]]
-=== NTP
-
-You must enable Network Time Protocol (NTP) to prevent masters and nodes in the
-cluster from going out of sync. Set `openshift_clock_enabled` to `true` in the
-Ansible inventory file to enable NTP on masters and nodes in the cluster during
-Ansible installation.
-
-----
-# openshift_clock_enabled=true
-----
-
 [[security-warning]]
 === Security Warning
 


### PR DESCRIPTION
NTP is enabled by default in versions 3.7 and later. See https://github.com/openshift/openshift-docs/issues/9202#issuecomment-389026257

@jianlinliu and @openshift/team-documentation, PTAL 