### PR TITLE
XFS quota for emptyDir volumes

### DIFF
--- a/day_two_guide/topics/node_maintenance.adoc
+++ b/day_two_guide/topics/node_maintenance.adoc
@@ -260,9 +260,10 @@ is lost. The location of the data in the *{rhocp}* node is located in
 be configured:
 
 NOTE: If the XFS filesystem hosting that folder is mounted with the
-`gquota` option in the `/etc/fstab`
-* the matching security context contraint’s `fsGroup` type set to `MustRunAs`
-* The `/etc/origin/node/node-config.yml` is configured as:
+`grpquota` option in the `/etc/fstab` file:
+
+* Set the matching security context contraint’s `fsGroup` type set to `MustRunAs`
+* xref:../install_config/master_node_configuration.adoc#node-config-volume-config[Configure the volume] using the node-config-compute configuration map in the openshift-node project.:
 
 [subs=+quotes]
 ----

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1081,13 +1081,10 @@ If -1, there is no limit on requests.
 |`*DynamicProvisioningEnabled*`
 |A boolean to enable or disable dynamic provisioning. Default is *true*.
 
-|FSGroup
-|Can be specified to enable a quota on local storage use per unique FSGroup ID.
+|*FSGroup*
+|Enables xref:node-config-volume-config[local storage quotas] on each node for each FSGroup.
 At present this is only implemented for emptyDir volumes, and if the underlying
 `*volumeDirectory*` is on an XFS filesystem.
-
-|`*LocalQuota*`
-|Contains options for controlling local volume quota on the node.
 
 |`*MasterVolumeConfig*`
 |Contains options for configuring volume plug-ins in the master node.
@@ -1346,9 +1343,6 @@ podManifestConfig: <2>
 proxyArguments:
   proxy-mode:
   - iptables <5>
-volumeConfig:
-  localQuota:
-   perFSGroup: null<6>
 servingInfo:
   bindAddress: 0.0.0.0:10250
   bindNetwork: tcp4
@@ -1370,11 +1364,6 @@ manifest files. This is used by the Kubelet to create pods on the node.
 data. The interval must be a positive value.
 <5> The xref:../architecture/core_concepts/pods_and_services.adoc#service-proxy-mode[service
 proxy implementation] to use.
-<6> Preliminary support for local emptyDir volume quotas, set this value to a resource
-quantity representing the desired quota per FSGroup, per node. (i.e. 1Gi, 512Mi, etc)
-Currently requires that the *_volumeDirectory_* be on an XFS filesystem mounted
-with the 'gquota' option, and the matching security context contraint's fsGroup
-type set to 'MustRunAs'.
 ====
 
 The node configuration file determines the resources of a node. See the
@@ -1433,6 +1422,37 @@ start on a machine that does not have docker started.
 |The handler to use for executing commands in Docker containers.
 
 |===
+
+[[node-config-volume-config]]
+=== Local Storage Configuration
+
+You can use the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-xfs[XFS quota subsystem] 
+to limit the size of `emptyDir` volumes and volumes based on an `emptyDir` volume, such as secrets and configuration maps, on each node.
+
+To limit the size of `emptyDir` volumes in an XFS filesystem, configure local volume quota for each unique 
+xref:../install_config/persistent_storage/pod_security_context.adoc#fsgroup[FSGroup] using the *_node-config-compute_* configuration map in the *openshift-node* project.
+
+----
+apiVersion: kubelet.config.openshift.io/v1
+kind: VolumeConfig
+  localQuota: <1>
+    perFSGroup: 1Gi <2>
+----
+
+<1> Contains options for controlling local volume quota on the node.
+<2> Set this value to a resource quantity representing the desired quota per 
+[FSGroup], per node, such as `1Gi`, `512Mi`, and so forth. 
+Requires the *volumeDirectory* to be on an XFS filesystem mounted with the `grpquota` option. The matching security context constraint *fsGroup* type must be 
+xref:../architecture/additional_concepts/authorization.adoc#authorization-FSGroup[set to `MustRunAs`].
+
+If no FSGroup is specified, indicating the request matched an SCC with `RunAsAny`, the quota
+application is skipped.
+
+[NOTE]
+====
+Do not edit the *_/etc/origin/node/volume-config.yaml_* file directly. The file is created from the *_node-config-compute_* configuration map. 
+Use the *_node-config-compute_* configuration map to create or edit the paramaters in the *_volume-config.yaml_* file.
+====
 
 [[master-node-configuration-parallel-image-pulls-with-docker]]
 === Parallel Image Pulls with Docker 1.9+


### PR DESCRIPTION
Seth:
As of 3.10, we no longer use the atomic-openshift-node binary.  All the functions it wrapped (ovn, ovs, kubelet) have all been broken out into separate services.  The kubelet is now the hyperkube binary built from openshift/kubernetes.

This means all the custom stuff we had wrapping the kubelet for our purposes is no long in effect.  The node-config.yaml file is not used directly by anything.  The "openshift start --write-flags" command is used to convert the node-config.yaml into a list of flags appropriate for the kubelet.  Among these patched-in features that don't translate in the new setup is XFS quota via the LocalQuota option in the node-config.yaml

https://docs.openshift.com/container-platform/3.9/install_config/master_node_configuration.html#master-node-config-volume-config

https://docs.openshift.com/container-platform/3.9/install_config/master_node_configuration.html#node-configuration-files

I converted that patch to a carry in our openshift/kubernetes in this PR
https://github.com/openshift/origin/pull/19533

However, because the kubelet does not understand the node-config.yaml and there is no flag by which the XFS quota configuration can be conveyed, the patch reads a new config file at a fixed location to configure the XFS quota.

The new config file path is
/var/lib/origin/openshift.local.volumes/volume-config.yaml

The file has the format:

apiVersion: kubelet.config.openshift.io/v1
kind: VolumeConfig
localQuota:
  perFSGroupInGiB: 1

This feature is very lightly documented.  The only two places I can find it mentioned are the links above.  The primary user, to our knowledge, is Online.

Michael, can you open a PR for 3.10 that updates the documentation to reflect this change?

Thanks and let me know if you have any questions.

FYI @sjenning 