### PR TITLE
Fixed an ifndef error

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -130,7 +130,7 @@ integrated registry, use `--reference-policy=local`. The registry uses the
 ifdef::openshift-origin,openshift-enterprise[]
 xref:../install_config/registry/extended_registry_configuration.adoc#middleware-repository-pullthrough[pull-through feature]
 endif::[]
-ifndef::openshift-origin+openshift-enterprise[]
+ifndef::openshift-origin,openshift-enterprise[]
 pull-through feature
 endif::[]
 to serve the image to the client. By default, the image blobs are


### PR DESCRIPTION
I was alerted to this error from a translation question (the _pull-through feature_ phrase was repeated in Origin). 
I made this change to the `ifndef` statement to match how similar `ifdef` statements are formatted. It works in an *asciibinder build* preview. 

@openshift/team-documentation PTAL to make sure this command is now correct.

ps. I noticed after-the-fact that the error was fixed in 3.9 and 3.10. https://github.com/openshift/openshift-docs/pull/8038