### PR TITLE
bug 1547396 fix disabling self-provisioning steps

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -90,37 +90,98 @@ to all authenticated developers by default.
 
 [[disabling-self-provisioning]]
 === Disabling Self-provisioning
-Removing the `self-provisioners`
-xref:../architecture/additional_concepts/authorization.adoc#roles[cluster role]
-from authenticated user groups will deny permissions for self-provisioning any new projects.
 
+You can prevent an authenticated user group from self-provisioning new projects.
+
+. Log in as a user with
+xref:../architecture/additional_concepts/authorization.adoc#roles[*cluster-admin*]
+privileges.
+. Review the `self-provisioners`
+xref:../admin_guide/manage_rbac.adoc#viewing-cluster-bindings[clusterrolebinding usage].
+Run the following command, then review the subjects in the `self-provisioners`
+section.
++
 ----
-$ oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated system:authenticated:oauth
+$ oc  describe clusterrolebinding.rbac self-provisioners
+
+Name:		self-provisioners
+Labels:		<none>
+Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Role:
+  Kind:	ClusterRole
+  Name:	self-provisioner
+Subjects:
+  Kind	Name				Namespace
+  ----	----				---------
+  Group	system:authenticated:oauth
 ----
 
-When disabling self-provisioning, set the `projectRequestMessage` parameter in the
-*_master-config.yaml_* file to instruct developers on how to request a new
-project. This parameter is a string that will be presented to the developer in
-the web console and command line when they attempt to self-provision a project.
-For example:
-
+. Remove the `self-provisioners`
+xref:../architecture/additional_concepts/authorization.adoc#roles[cluster role binding]
+from the group `system:authenticated:oauth`.
+** If the `self-provisioners` cluster role binding binds only the 
+`self-provisioners` role to the `system:authenticated:oauth` group, run the 
+following command:
++
 ----
-Contact your system administrator at projectname@example.com to request a project.
+$ oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
+----
++
+** If the `self-provisioners` clusterrolebinding binds the `self-provisioners` 
+role to more users, groups, or serviceaccounts than the
+`system:authenticated:oauth` group, run the following command:
++
+----
+$ oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth
 ----
 
-or:
-
-----
-To request a new project, fill out the project request form located at
+. Set the `projectRequestMessage` parameter value in the
+*_master-config.yaml_* file to instruct developers how to request a new
+project. This parameter value is a string that will be presented to a user in
+the web console and command line when the user attempts to self-provision a project.
+You might use one of the following messages:
++
+* To request a project, contact your system administrator at 
+projectname@example.com.
+* To request a new project, fill out the project request form located at
 https://internal.example.com/openshift-project-request.
-----
 
++
 .Example YAML file
+[source,yaml]
 ----
 ...
 projectConfig:
   ProjectRequestMessage: "message"
   ...
+----
+
+. Edit the `self-provisioners` cluster role binding to prevent 
+xref:../upgrading/manual_upgrades.adoc#updating-policy-definitions[automatic updates]
+to the role. Automatic updates reset the cluster roles to the default state.
+** To update the role binding from the command line:
+... Run the following command:
++
+----
+$ oc edit clusterrolebinding.rbac self-provisioners
+----
+... In the displayed role binding, set the `rbac.authorization.kubernetes.io/autoupdate` parameter
+ value to `false`, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "false"
+...
+----
+
+ ** To update the role binding by using a single command:
++
+----
+$ oc patch clusterrolebinding.rbac self-provisioners -p '{ "metadata": { "annotations": { "rbac.authorization.kubernetes.io/autoupdate": "false" } } }'
 ----
 
 [[using-node-selectors]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1547396

These commands are different in 3.7. The PR for 3.7 is here: https://github.com/openshift/openshift-docs/pull/9324

This bug also applies to branches before 3.6, but the commands are different. The PR for earlier branches is here: https://github.com/openshift/openshift-docs/pull/9276