### PR TITLE
bug 1547396 fix disabling self-provisioning steps in 3.6

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -92,29 +92,69 @@ to all authenticated developers by default.
 
 [[disabling-self-provisioning]]
 === Disabling Self-provisioning
-Removing the `self-provisioners`
-xref:../architecture/additional_concepts/authorization.adoc#roles[cluster role]
-from authenticated user groups will deny permissions for self-provisioning any new projects.
 
+You can prevent an authenticated user group from self-provisioning new projects.
+
+. Log in as a user with
+xref:../architecture/additional_concepts/authorization.adoc#roles[*cluster-admin*]
+privileges.
+. Remove the `self-provisioners`
+xref:../architecture/additional_concepts/authorization.adoc#roles[cluster role]
+from the group.
++
 ----
 $ oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated system:authenticated:oauth
 ----
 
-When disabling self-provisioning, set the `projectRequestMessage` parameter in the
-*_master-config.yaml_* file to instruct developers on how to request a new
-project. This parameter is a string that will be presented to the developer in
-the web console and command line when they attempt to self-provision a project.
-For example:
-
-----
-Contact your system administrator at projectname@example.com to request a project.
-----
-
-or:
-
-----
-To request a new project, fill out the project request form located at
+. Set the `projectRequestMessage` parameter value in the
+*_master-config.yaml_* file to instruct developers how to request a new
+project. This parameter value is a string that will be presented to a user in
+the web console and command line when the user attempts to self-provision a project.
+You might use one of the following messages:
++
+* To request a project, contact your system administrator at 
+projectname@example.com.
+* To request a new project, fill out the project request form located at
 https://internal.example.com/openshift-project-request.
+
++
+.Example YAML file
+[source,yaml]
+----
+...
+projectConfig:
+  ProjectRequestMessage: "message"
+  ...
+----
+
+. Edit the `self-provisioners` cluster role to prevent 
+xref:../upgrading/manual_upgrades.adoc#updating-policy-definitions[automatic updates]
+to the role. Automatic updates reset the cluster roles to the default state.
+** To update the role from the command line:
+... Run the following command:
++
+----
+$ oc edit clusterrole self-provisioner
+----
+... In the displayed role, set the `openshift.io/reconcile-protect` parameter
+ value to `true`, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    authorization.openshift.io/system-only: "true"
+    openshift.io/description: A user that can request project.
+    openshift.io/reconcile-protect: "true"
+...
+----
+
+ ** To update the role by using automation, use the following command:
++
+----
+$ oc patch clusterrole self-provisioner -p '{ "metadata": { "annotations": { "openshift.io/reconcile-protect": "true" } } }'
 ----
 
 [[using-node-selectors]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1547396

The commands are different in 3.6 and earlier, but the text is the same. I'll apply peer review comments from https://github.com/openshift/openshift-docs/pull/9275 to this PR.

@xltian, this section is present in the docs going back to 3.1. Will you PTAL and confirm that I should apply this change in versions 3.1-3.6? 