### PR TITLE
Clarify that Ansible configures AWS API credentials

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -130,15 +130,16 @@ Zone = us-east-1c <1>
 resides; this information is obtained from the AWS Managment Console.
 
 
-[[aws-configuring-masters]]
-== Configuring {product-title} Masters for AWS
+[[aws-configuring-openshift]]
+== Configuring {product-title} for AWS
 
-You can set the AWS configuration on your {product-title} master hosts in two ways:
+You can set the AWS configuration on {product-title} in two ways:
 
-- xref:aws-configuring-masters-ansible[using Ansible]
-- xref:aws-configuring-masters-manually[manually, by modifying the *_master-config.yaml_* file]
+- xref:aws-configuring-openshift-ansible[using Ansible] or
+- xref:aws-configuring-masters-manually[manually, by modifying the
+*_master-config.yaml_*, *_node-config.yaml_*, and related *_/etc/sysconfig/_* files].
 
-[[aws-configuring-masters-ansible]]
+[[aws-configuring-openshift-ansible]]
 === Configuring {product-title} for AWS with Ansible
 
 During cluster installations,  AWS can be configured using the
@@ -172,7 +173,7 @@ xref:../install/configuring_inventory_file.adoc#configuring-ansible[inventory fi
 
 [NOTE]
 ====
-When Ansible configures AWS, the following files are created for you:
+When Ansible configures AWS, it automatically makes the necessary changes to the following files:
 
 - *_/etc/origin/cloudprovider/aws.conf_*
 - *_/etc/origin/master/master-config.yaml_*
@@ -219,7 +220,7 @@ container. Therefore, *_aws.conf_* should be in *_/etc/origin/_* instead of
 *_/etc/_*.
 ====
 
-[[aws-configuring-nodes]]
+[[aws-configuring-nodes-manually]]
 === Manually Configuring {product-title} Nodes for AWS
 
 Edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
@@ -243,7 +244,7 @@ container. Therefore, *_aws.conf_* should be in *_/etc/origin/_* instead of
 ====
 
 [[aws-setting-key-value-access-pairs]]
-== Setting Key Value Access Pairs
+=== Manually Setting Key-Value Access Pairs
 
 Make sure the following environment variables are set in the
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
The organization of the "Configuring {product-title} Masters for AWS" section is confusing.  It is not clear which steps must be performed manually and which steps the installer can perform.  This PR makes the following changes in order to reduce confusion:

* Delete "Masters" from the "Configuring {product-title} Masters for AWS" heading and anchors, and correct wording in the section that only referred to master configuration files; the subsections address nodes as well as masters.

* Amend the note under "Configuring {product-title} for AWS with Ansible" to state not that Ansible creates the various configuration files (it does that in any case) but rather that it can make the necessary changes to those files.

* ~~Delete reference to `/etc/sysconfig/atomic-openshift-master`, which the installer does not configure (and has not since 3.7).~~ [Edit: This was fixed in #9507.]

* Hyphenate "Key-Value".

* Add "Manually" to the heading "Setting Key-Value Access Pairs", and subordinate it under "Configuring {product-title} for AWS" alongside the other manual configuration steps in order to avoid falsely delineating automatic and manual configuration.