### PR TITLE
Fixing an endif in the backup/restore topic

### DIFF
--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -30,7 +30,7 @@ storage],
 endif::openshift-enterprise,openshift-origin[]
 ifdef::openshift-dedicated[]
 persistent storage,
-endif::openshift-enterprise,openshift-origin[]
+endif::openshift-dedicated[]
 as those topics are left to the underlying storage provider. However,
 an example of how to perform a *generic* backup of
 xref:backup-application-data[application data] is provided.


### PR DESCRIPTION
This endif is right in 3.10-3.6, so I'm fixing master.