### PR TITLE
Bug 1332711 Added more info to openID auth topic

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1657,18 +1657,25 @@ Claims are read from the JWT `id_token` returned from the OpenID identity
 provider and, if specified, from the JSON returned by the `*UserInfo*` URL.
 
 At least one claim must be configured to use as the user's identity. The
-link:http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims[standard identity claim] is `sub`.
+standard identity claim is `sub`.
 
 You can also indicate which claims to use as the user's preferred user name,
 display name, and email address. If multiple claims are specified, the first one
-with a non-empty value is used. The
-link:http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims[standard claims] are:
+with a non-empty value is used. The standard claims are:
 
 [horizontal]
-`sub`:: The user identity.
-`preferred_username`:: The preferred user name when provisioning a user.
+`sub`:: Short for "subject identifier." The remote identity for the user at the
+issuer.
+`preferred_username`:: The preferred user name when provisioning a user. A
+shorthand name that the user wants to be referred to as, such as `janedoe`. Typically
+a value that corresponding to the user's login or username in the authentication
+system, such as username or email.
 `email`:: Email address.
 `name`:: Display name.
+
+See the
+link:http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims[OpenID
+claims documentation] for more information.
 
 [NOTE]
 ====
@@ -1677,8 +1684,6 @@ Using an OpenID Connect identity provider requires users to get a token using
 ====
 
 .Standard Master Configuration Using *OpenIDIdentityProvider*
-====
-
 ----
 oauthConfig:
   ...
@@ -1693,8 +1698,8 @@ oauthConfig:
       clientID: ... <5>
       clientSecret: ... <6>
       claims:
-        id:
-        - sub <7>
+        id: <7>
+        - sub
         preferredUsername:
         - preferred_username
         name:
@@ -1720,13 +1725,13 @@ must be allowed to redirect to `<master>/oauth2callback/<identityProviderName>`.
 <6> The client secret. This value may also be provided in an
 xref:../install_config/master_node_configuration.adoc#master-node-configuration-passwords-and-other-data[environment
 variable, external file, or encrypted file].
-<7> Use the value of the `sub` claim in the returned `id_token` as the user's
-identity.
+<7> List of claims to use as the identity. First non-empty claim is used. At
+least one claim is required. If none of the listed claims have a value,
+authentication fails. For example, this uses the value of the `sub` claim in the returned `id_token` as the user's identity.
 <8> link:http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint[Authorization Endpoint]
 described in the OpenID spec. Must use `https`.
 <9> link:http://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint[Token Endpoint]
 described in the OpenID spec. Must use `https`.
-====
 
 A custom certificate bundle, extra scopes, extra authorization request
 parameters, and `*userInfo*` URL can also be specified:


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=1332711

I'm not sure if I'm off the mark here. @liggitt you were in the customer case. Could you please verify my changes here? There's a lot of talk about identity and identity provider objects in the case, and I don't want to mess them up.

Also, is the `claims` part of the example accurate? Should the `sub` (at minimum) parts have replaceables, or better examples? Let me know if I'm not being specific enough.