### PR TITLE
Bug 1446164 Deleted instances of oc deploy --cancel

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -444,13 +444,6 @@ Override the *Spec.Strategy.DockerStrategy.NoCache* option of a docker-strategy 
 $oc start-build --no-cache
 ----
 
-=== deploy
-View a deployment, or manually start, cancel, or retry a deployment:
-
-----
-$ oc deploy <deploymentconfig>
-----
-
 === rollback
 Perform a
 xref:../dev_guide/deployments/basic_deployment_operations.adoc#rolling-back-a-deployment[rollback]:

--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -165,13 +165,6 @@
 
   // View the history of the 'database' DeploymentConfig
   $ oc rollout history dc/database
-
-  // Retry the latest failed deployment based on the 'frontend' DeploymentConfig
-  // The deployer pod and any hook pods are deleted for the latest failed deployment
-  $ oc deploy dc/frontend --retry
-
-  // Cancel the in-progress deployment based on the 'frontend' DeploymentConfig
-  $ oc deploy dc/frontend --cancel
 ----
 ====
 

--- a/dev_guide/application_lifecycle/promoting_applications.adoc
+++ b/dev_guide/application_lifecycle/promoting_applications.adoc
@@ -413,7 +413,6 @@ the API object is updated by the promotion step (for example, `oc apply`).
 
 Otherwise, the `oc` commands that facilitate manual deployment include:
 
-* `oc deploy`: The original method to view, start, cancel, or retry deployments.
 * `oc rollout`: The new approach to manage deployments, including pause and resume semantics and richer features around managing history.
 * `oc rollback`: Allows for reversion to a previous deployment; in the promotion scenario, if testing of a new version encounters issues, confirming it still works with the previous version could be warranted.
 
@@ -773,8 +772,7 @@ application image that may be running.
 
 . link:https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/configuration/jobs/OpenShift%20Sample/config.xml#L23-L29[The second step] is the equivalent of an `oc start-build frontend` call.
 
-. link:https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/configuration/jobs/OpenShift%20Sample/config.xml#L31-L39[The third step] is the equivalent of an `oc deploy frontend --latest` or `oc rollout
-latest dc/frontend` call.
+. link:https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/configuration/jobs/OpenShift%20Sample/config.xml#L31-L39[The third step] is the equivalent of an `oc rollout latest dc/frontend` call.
 
 . link:https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/configuration/jobs/OpenShift%20Sample/config.xml#L41-47[The fourth step] is the "test" for this sample. It ensures that the associated
 service for this application is in fact accessible from a network perspective.

--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -59,25 +59,7 @@ xref:../../architecture/infrastructure_components/web_console.adoc#project-overv
 console] shows deployments in the *Browse* tab.
 ====
 
-[[canceling-a-deployment]]
-
-== Canceling a Deployment
-
-To cancel a running or stuck deployment process:
-
-----
-$ oc deploy --cancel dc/<name>
-----
-
-[WARNING]
-====
-The cancellation is a best-effort operation, and may take some time to complete.
-The replication controller may partially or totally complete its deployment
-before the cancellation is effective. When canceled, the deployment
-configuration will be automatically rolled back by scaling up the previous
-running replication controller.
-====
-
+////
 [[retrying-a-deployment]]
 
 == Retrying a Deployment
@@ -98,6 +80,7 @@ Retrying a deployment restarts the deployment process and does not create a new
 deployment revision. The restarted replication controller will have the same configuration
 it had when it failed.
 ====
+////
 
 [[rolling-back-a-deployment]]
 == Rolling Back a Deployment

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1025,7 +1025,7 @@ $ oc volume dc/router --add --mount-path=/etc/pki/tls/private --secret-name='rou
 . Deploy the router.
 +
 ----
-$ oc deploy router --latest
+$ oc rollout latest dc/router
 ----
 
 [[using-secured-routes]]


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=1446164

cc @coreydaley @bparees 

I believe this fulfills this BZ, but there might be a larger question of the role of "oc deploy" and which options are indeed still around. Also, some of the "--help" output still lists "oc deploy --cancel" as a viable option, so I'm not sure if that needs to be changed as well.