### PR TITLE
[enterprise-3.9] Removed duplicate time-units section

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -86,14 +86,6 @@ include::architecture/topics/sticky_sessions.adoc[]
 [[env-variables]]
 include::architecture/topics/router_environment_variables.adoc[]
 
-[[time-units]]
-== Timeouts
-`TimeUnits` are represented by a number followed by the unit: `us`
-*(microseconds), `ms` (milliseconds, default), `s` (seconds), `m` (minutes), `h`
-*(hours), `d` (days).
-
-The regular expression is: [1-9][0-9]*(us\|ms\|s\|m\|h\|d)
-
 [[load-balancing]]
 == Load-balancing Strategy
 
@@ -303,9 +295,9 @@ Path based routes specify a path component that can be compared against
 a URL (which requires that the traffic for the route be HTTP based) such
 that multiple routes can be served using the same host name, each with a
 different path. Routers should match routes based on the most specific
-path to the least; however, this depends on the router implementation. 
+path to the least; however, this depends on the router implementation.
 The host name and path are passed through to the backend server so it should be
-able to successfully answer requests for them. 
+able to successfully answer requests for them.
 For example: a request to http://example.com/foo/ that goes to the router will
 result in a pod seeing a request to http://example.com/foo/.
 


### PR DESCRIPTION
xref: https://github.com/openshift/openshift-docs/pull/9444