### PR TITLE
Added context variables to reuse module

### DIFF
--- a/day_two_guide/environment_backup.adoc
+++ b/day_two_guide/environment_backup.adoc
@@ -31,6 +31,7 @@ include::day_two_guide/topics/node_backup.adoc[]
 [[day-two-environment-etcd-backup]]
 === etcd backup
 
+:context: environment-backup
 include::day_two_guide/topics/etcd_backup.adoc[]
 
 [[day-two-environment-project-backup]]

--- a/day_two_guide/host_level_tasks.adoc
+++ b/day_two_guide/host_level_tasks.adoc
@@ -72,6 +72,7 @@ include::day_two_guide/topics/node_maintenance.adoc[]
 
 === etcd backup
 
+:context: host-level-tasks
 include::day_two_guide/topics/etcd_backup.adoc[]
 
 [[day-two-guide-etcd-restore]]
@@ -88,4 +89,3 @@ include::day_two_guide/topics/scaling_etcd.adoc[]
 === Removing an etcd host
 
 include::day_two_guide/topics/removing_etcd_host.adoc[]
-

--- a/day_two_guide/topics/etcd_backup.adoc
+++ b/day_two_guide/topics/etcd_backup.adoc
@@ -55,7 +55,7 @@ configuration file (`/etc/etcd/etcd.conf`) and the required certificates for
 cluster communication. All those files are generated at installation time by the
 Ansible installer.
 
-To back up the etcd configuration: 
+To back up the etcd configuration:
 
 ----
 $ ssh master-0
@@ -69,7 +69,7 @@ The backup is to be performed on every etcd member of the cluster
 as the certificates and configuration files are unique.
 ====
 
-[[etcd-data-backup]]
+[id='etcd-data-backup_{context}']
 ==== etcd data backup
 
 [discrete]


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/9093. This updates these files to use the context variable for reusing modules (this served as a good test).

@openshift/team-documentation 