### PR TITLE
Remove referances to deprecated ClusterNetworkCIDR in docs

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -102,8 +102,9 @@ default):
 [source,yaml]
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.128.0.0/14 <1>
-  hostSubnetLength: 9 <2>
+  clusterNetworks:
+  - cidr: 10.128.0.0/14 <1>
+    hostSubnetLength: 9 <2>
   networkPluginName: "redhat/openshift-ovs-subnet" <3>
   serviceNetworkCIDR: 172.30.0.0/16 <4>
 ----
@@ -128,22 +129,20 @@ when the range is full, move to the next on the list.
 [source,yaml]
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.128.0.0/14 <1>
   clusterNetworks:
-  - cidr: 10.128.0.0/14 <2>
-    hostSubnetLength: 9 <3>
+  - cidr: 10.128.0.0/14 <1>
+    hostSubnetLength: 9 <2>
   - cidr: 10.132.0.0/14
     hostSubnetLength: 9
   externalIPNetworkCIDRs: null
   hostSubnetLength: 9
   ingressIPNetworkCIDR: 172.29.0.0/16
-  networkPluginName: redhat/openshift-ovs-multitenant <4>
+  networkPluginName: redhat/openshift-ovs-multitenant <3>
   serviceNetworkCIDR: 172.30.0.0/16
 ----
 <1> Cluster network for node IP allocation.
-<2> Ensure the first `cidr` entry matches the `clusterNetworkCIDR` entry.
-<3> Number of bits for pod IP allocation within a node. Must match with all other `hostSubnetLength` entries in the `NetworkConfig`.
-<4> Set to `redhat/openshift-ovs-subnet` for the *ovs-subnet* plug-in,
+<2> Number of bits for pod IP allocation within a node.
+<3> Set to `redhat/openshift-ovs-subnet` for the *ovs-subnet* plug-in,
 `redhat/openshift-ovs-multitenant` for the *ovs-multitenant* plug-in, or
 `redhat/openshift-ovs-networkpolicy` for the *ovs-networkpolicy* plug-in.
 
@@ -155,11 +154,12 @@ for any changes to take effect.
 [IMPORTANT]
 ====
 The `*hostSubnetLength*` value cannot be changed after the cluster is
-first created, `*clusterNetworkCIDR*` can only be changed to be a
-larger network that still contains the original network, and
+first created, A `*cidr*` field can only be changed to be a
+larger network that still contains the original network if nodes are
+allocated within it's range , and
 `*serviceNetworkCIDR*` can only be expanded. For example, given the
 default value of *10.128.0.0/14*, you could change
-`*clusterNetworkCIDR*` to *10.128.0.0/9* (i.e., the entire upper half
+`*cidr*` to *10.128.0.0/9* (i.e., the entire upper half
 of net 10) but not to *10.64.0.0/16*, because that does not overlap
 the original value.
 

--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -73,7 +73,9 @@ in the *_master-config.yaml_* file.
 .*_/etc/origin/master/master-config.yaml_*
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.1.0.0/16
+  clusterNetworks:
+  - cidr: 10.1.0.0/16
+    hostSubnetLength: 9
   serviceNetworkCIDR: 172.30.0.0/16
 ----
 

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -778,8 +778,9 @@ external IPs, nodes, pods, or services.
 For Example:
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.3.0.0/16
-  hostSubnetLength: 8
+  clusterNetworks
+  - cidr: 10.3.0.0/16
+    hostSubnetLength: 8
   networkPluginName: example/openshift-ovs-subnet
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
   serviceNetworkCIDR: 179.29.0.0/16

--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -782,7 +782,7 @@ behind a proxy (see
 xref:../install_config/install/advanced_install.adoc#advanced-install-configuring-global-proxy[Configuring Global Proxy Options]), when the OAB is deployed it will:
 
 - inherit those cluster-wide proxy settings automatically and 
-- generate the required `NO_PROXY` list, including the `clusterNetworkCIDR` and `serviceNetworkCIDR`,
+- generate the required `NO_PROXY` list, including the `cidr` fields  and `serviceNetworkCIDR`,
 
 and no further configuration is needed.
 


### PR DESCRIPTION
ClusterNetworkCIDR has been fully deprecated and the docs should
reflect that. Replace referances to ClusterNetworkCIDR to the proper
clusterNetworks object and respective fields