### PR TITLE
bug 1548385 using .gitignore with a secured git repo before 3.9

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -458,6 +458,53 @@ section in your *_.gitconfig_* file:
 ----
 ====
 
+[[source-secrets-gitconfig-file-secured]]
+==== .gitconfig File for Secured Git
+
+If your Git server is secured with 2-way SSL and user name with password
+you must add the certificate files to your source build and add references to
+the certificate files in the *_.gitconfig_* file:
+
+. Add the *_client.crt_*, *_cacert.crt_*, and *_client.key_* files to the 
+*_/var/run/secrets/openshift.io/source/_* folder in the
+xref:../../dev_guide/application_lifecycle/new_app.adoc#specifying-source-code[application
+source code].
+
+. In the *_.gitconfig_* file for the server, add the `[http]` section
+shown in the following example:
++
+----
+# cat .gitconfig
+[user]
+        name = <name>
+        email = <email>
+[http]
+        sslVerify = false
+        sslCert = /var/run/secrets/openshift.io/source/client.crt
+        sslKey = /var/run/secrets/openshift.io/source/client.key
+        sslCaInfo = /var/run/secrets/openshift.io/source/cacert.crt
+----
+
+. Create the secret        
+----
+$ oc secrets new <secret_name> \
+--from-literal=username=<user_name> \ <1>
+--from-literal=password=<password> \ <2>
+--from-file=.gitconfig=.gitconfig \
+--from-file=client.crt=/var/run/secrets/openshift.io/source/client.crt \
+--from-file=cacert.crt=/var/run/secrets/openshift.io/source/cacert.crt \
+--from-file=client.key=/var/run/secrets/openshift.io/source/client.key
+----
+<1> The user's Git user name.
+<2> The password for this user.
+
+[IMPORTANT]
+====
+To avoid having to enter your password again, be sure to specify the S2I image in 
+your builds. However, if you cannot clone the repository, you still need to 
+specify your user name and password to promote the build.
+====
+
 [[source-secrets-basic-authentication]]
 ==== Basic Authentication
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1548385

https://github.com/openshift/openshift-docs/pull/9547 works for 3.9 and later. Earlier versions use `oc secrets new` instead of `oc create secret`.