### PR TITLE
Cleanup kubernetes_infra, add HA master/etcd collocate notes

### DIFF
--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -10,7 +10,6 @@
 
 toc::[]
 
-ifdef::openshift-origin,openshift-online,openshift-dedicated,openshift-enterprise[]
 == Overview
 Within {product-title}, Kubernetes manages containerized applications across a
 set of containers or hosts and provides mechanisms for deployment, maintenance,
@@ -31,13 +30,12 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 endif::[]
 uses Kubernetes 1.9 and Docker 1.13.
 ====
-endif::[]
 
 [[master]]
 
 == Masters
 The master is the host or hosts that contain the master components, including
-the API server, controller manager server, and *etcd*. The master manages
+the API server, controller manager server, and etcd. The master manages
 xref:node[nodes] in its Kubernetes cluster and schedules
 xref:../core_concepts/pods_and_services.adoc#pods[pods] to run on nodes.
 
@@ -53,13 +51,13 @@ xref:../core_concepts/pods_and_services.adoc#pods[pods] to run on nodes.
 and replication controllers. It also assigns pods to nodes and synchronizes pod
 information with service configuration. Can be run as a standalone process.
 
-|*etcd*
-|*etcd* stores the persistent master state while other components watch *etcd*
-for changes to bring themselves into the desired state. *etcd* can be optionally
+|etcd
+|etcd stores the persistent master state while other components watch etcd
+for changes to bring themselves into the desired state. etcd can be optionally
 configured for high availability, typically deployed with 2n+1 peer services.
 
 |Controller Manager Server
-|The controller manager server watches *etcd* for changes to replication
+|The controller manager server watches etcd for changes to replication
 controller objects and then uses the API to enforce the desired state.
 Can be run as a standalone process. Several such processes create a cluster with
 one active leader at a time.
@@ -85,7 +83,7 @@ While in a single master configuration, the availability of running applications
 remains if the master or any of its services fail. However, failure of master
 services reduces the ability of the system to respond to application failures or
 creation of new applications.
-ifdef::openshift-origin,openshift-dedicated,openshift-enterprise[]
+ifdef::openshift-origin,openshift-enterprise[]
 You can optionally configure your masters for high
 availability (HA) to ensure that the cluster has no single point of failure.
 
@@ -99,22 +97,13 @@ that the runbook must be consulted. For example, a cold standby of the master
 host can adequately fulfill SLAs that require no more than minutes of downtime
 for creation of new applications or recovery of failed application components.
 
-2. Use a high availability solution to configure your masters and ensure that
-the cluster has no single point of failure.
-ifdef::openshift-enterprise,openshift-origin[]
-The xref:../../install_config/install/advanced_install.adoc#install-config-install-advanced-install[advanced
-installation method]
-endif::[]
-ifdef::openshift-dedicated[]
-{product-title}'s advanced installation method (see the
-https://docs.openshift.com/enterprise/3.1/install_config/install/advanced_install.html[OpenShift
-Enterprise Cluster Administration] documentation for details)
-endif::[]
-provides specific examples using the `native` HA method and configuring HAProxy.
-You can also take the concepts and apply them towards your existing HA solutions
-using the `native` method instead of HAProxy.
-endif::openshift-origin,openshift-dedicated,openshift-enterprise[]
-ifdef::openshift-enterprise,openshift-origin[]
+2. Use a high availability solution to configure your masters and ensure that the
+cluster has no single point of failure. The
+xref:../../install_config/install/advanced_install.adoc#multiple-masters[advanced
+installation method] provides specific examples using the `native` HA method and
+configuring HAProxy. You can also take the concepts and apply them towards your
+existing HA solutions using the `native` method instead of HAProxy.
+
 [NOTE]
 ====
 Moving from a single master cluster to multiple masters after installation is
@@ -128,26 +117,36 @@ following availability:
 [cols="1,1,3"]
 .Availability Matrix with HAProxy
 |===
-|Role |Style| Notes
+|Role |Style |Notes
 
-|*etcd*
+|etcd
 |Active-active
-|Fully redundant deployment with load balancing
+|Fully redundant deployment with load balancing.
+ifdef::openshift-origin,openshift-enterprise[]
+Can be installed on separate hosts or collocated on master hosts.
+endif::[]
 
 |API Server
 |Active-active
-|Managed by HAProxy
+|Managed by HAProxy.
 
 |Controller Manager Server
 |Active-passive
-|One instance is elected as a cluster leader at a time
+|One instance is elected as a cluster leader at a time.
 
 |HAProxy
 |Active-passive
-|Balances load between API master endpoints
+|Balances load between API master endpoints.
 |===
 
-ifdef::openshift-origin,openshift-online,openshift-dedicated,openshift-enterprise[]
+ifdef::openshift-origin,openshift-enterprise[]
+While clustered etcd requires an odd number of hosts for quorum, the master
+services have no quorum or requirement that they have an odd number of hosts.
+However, since you need at least two master services for HA, it is common to
+maintain a uniform odd number of hosts when collocating master services and
+etcd.
+endif::[]
+
 [[node]]
 
 == Nodes
@@ -191,7 +190,7 @@ A container manifest can be provided to a kubelet by:
 
 - A file path on the command line that is checked every 20 seconds.
 - An HTTP endpoint passed on the command line that is checked every 20 seconds.
-- The kubelet watching an *etcd* server, such as *_/registry/hosts/$(hostname -f)_*, and acting on any changes.
+- The kubelet watching an etcd server, such as *_/registry/hosts/$(hostname -f)_*, and acting on any changes.
 - The kubelet listening for HTTP and responding to a simple API to submit a new
  manifest.
 
@@ -208,8 +207,6 @@ forwarding across a set of back ends.
 === Node Object Definition
 
 The following is an example node object definition in Kubernetes:
-
-====
 
 [source,yaml]
 ----
@@ -233,17 +230,14 @@ status:
     osImage: ""
     systemUUID: ""
 ----
-
-<1> *`apiVersion`* defines the API version to use.
-<2> *`kind`* set to `Node` identifies this as a definition for a node
+<1> `apiVersion` defines the API version to use.
+<2> `kind` set to `Node` identifies this as a definition for a node
 object.
-<3> *`metadata.labels`* lists any
+<3> `metadata.labels` lists any
 xref:../core_concepts/pods_and_services.adoc#labels[labels] that have been added
 to the node.
-<4> *`metadata.name`* is a required value that defines the name of the node
+<4> `metadata.name` is a required value that defines the name of the node
 object. This value is shown in the `NAME` column when running the `oc get nodes`
 command.
-<5> *`spec.externalID`* defines the fully-qualified domain name where the node
-can be reached. Defaults to the *`metadata.name`* value when empty.
-====
-endif::[]
+<5> `spec.externalID` defines the fully-qualified domain name where the node
+can be reached. Defaults to the `metadata.name` value when empty.


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1292311, also some general formatting cleanup.

*[OCP preview]* http://file.rdu.redhat.com/~adellape/052318/arch_hamaster/architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters

While adding the HA master/etcd collocate notes here, noticed that a NOTE box had been broken due to some changes in https://github.com/openshift/openshift-docs/pull/9250, which was about making the topic more relevant for Online docs. While fixing that, also recalled that the `atomic-registry` distro had been recently deprecated via https://github.com/openshift/openshift-docs/pull/9136, so a lot of the large ifdefs in this topic were now extraneous. So I've cleaned that up, as well as made the Dedicated distro look more like the Online distro (there was a lot of complexity going on for the Dedicated distro in here that I don't think were actually needed).

@ahardin-rh PTAL to ensure your Online-related changes still look good to you (I've ifdef'd out my new notes so they shouldn't be showing up in Online):

*[Online preview]* http://file.rdu.redhat.com/~adellape/052318-online/arch_hamaster/architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters

@spurtell PTAL to ensure the content looks good for Dedicated. Basically I'm mirroring what has already been deemed relevant for Online wrt HA master discussion, but can revert if needed:

*[Dedicated preview]* http://file.rdu.redhat.com/~adellape/052318-dedicated/arch_hamaster/architecture/infrastructure_components/kubernetes_infrastructure.html#high-availability-masters