### PR TITLE
Adds ServerAliveInterval to ansible.cfg ssh options.

### DIFF
--- a/scaling_performance/install_practices.adoc
+++ b/scaling_performance/install_practices.adoc
@@ -73,7 +73,7 @@ callback_whitelist = profile_tasks
 become = False
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60
 control_path = %(directory)s/%%h-%%r
 pipelining = True <2>
 timeout = 10


### PR DESCRIPTION
[RHEL 7 CIS guide](http://www.itsecure.hu/library/image/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v2.1.1.pdf) point **5.2.13** recommends to set sshd ClientAliveInterval option to 300s,
so in clusters heavily loaded some ansible task may last more than 300s,
for exame the "oc adm migrate storage" which is run a few times
during OCP upgrades. As a result, ssh connection is closed by the server
causing the installer to fail.

ServerAliveInterval sets a timeout interval in seconds after which if no data has
been received from the server, ssh(1) will send a message through
the encrypted channel to request a response from the server.