### PR TITLE
[enterprise-3.6] Haproxy fails to start

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1021,7 +1021,7 @@ $ oc env dc/router DEFAULT_CERTIFICATE_DIR=/etc/pki/tls/private
 . Export the certificate to PEM format:
 +
 ----
-$ cat custom-router.crt custom-ca.crt > custom-router.pem 
+$ cat custom-router.key custom-router.crt custom-ca.crt > custom-router.crt
 ----
 
 . Overwrite or create a router certificate secret: 


### PR DESCRIPTION
It the key is not also included in the crt file:

[ALERT] 066/154859 (49) : parsing [/var/lib/haproxy/conf/haproxy.config:120] : 'bind 127.0.0.1:10444' : unable to load SSL private key from PEM file '/etc/pki/tls/private/tls.crt'.
[ALERT] 066/154859 (49) : parsing [/var/lib/haproxy/conf/haproxy.config:161] : 'bind 127.0.0.1:10443' : unable to load SSL private key from PEM file '/etc/pki/tls/private/tls.crt'.