### PR TITLE
Remove referances to deprecated ClusterNetworkCIDR in docs

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -132,8 +132,9 @@ default):
 [source,yaml]
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.128.0.0/14 <1>
-  hostSubnetLength: 9 <2>
+  clusterNetworks:
+  - cidr: 10.128.0.0/14 <1>
+    hostSubnetLength: 9 <2>
   networkPluginName: "redhat/openshift-ovs-subnet" <3>
   serviceNetworkCIDR: 172.30.0.0/16 <4>
 ----
@@ -158,22 +159,20 @@ when the range is full, move to the next on the list.
 [source,yaml]
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.128.0.0/14 <1>
   clusterNetworks:
-  - cidr: 10.128.0.0/14 <2>
-    hostSubnetLength: 9 <3>
+  - cidr: 10.128.0.0/14 <1>
+    hostSubnetLength: 9 <2>
   - cidr: 10.132.0.0/14
     hostSubnetLength: 9
   externalIPNetworkCIDRs: null
   hostSubnetLength: 9
   ingressIPNetworkCIDR: 172.29.0.0/16
-  networkPluginName: redhat/openshift-ovs-multitenant <4>
+  networkPluginName: redhat/openshift-ovs-multitenant <3>
   serviceNetworkCIDR: 172.30.0.0/16
 ----
 <1> Cluster network for node IP allocation.
-<2> Ensure the first `cidr` entry matches the `clusterNetworkCIDR` entry.
-<3> Number of bits for pod IP allocation within a node. Must match with all other `hostSubnetLength` entries in the `NetworkConfig`.
-<4> Set to `redhat/openshift-ovs-subnet` for the *ovs-subnet* plug-in,
+<2> Number of bits for pod IP allocation within a node.
+<3> Set to `redhat/openshift-ovs-subnet` for the *ovs-subnet* plug-in,
 `redhat/openshift-ovs-multitenant` for the *ovs-multitenant* plug-in, or
 `redhat/openshift-ovs-networkpolicy` for the *ovs-networkpolicy* plug-in.
 
@@ -184,12 +183,19 @@ for any changes to take effect.
 
 [IMPORTANT]
 ====
-The `*serviceNetworkCIDR*` and `*hostSubnetLength*` values cannot be changed
-after the cluster is first created, and `*clusterNetworkCIDR*` can only be
-changed to be a larger network that still contains the original network. For
-example, given the default value of *10.128.0.0/14*, you could change
-`*clusterNetworkCIDR*` to *10.128.0.0/9* (i.e., the entire upper half of net
-10) but not to *10.64.0.0/16*, because that does not overlap the original value.
+The `*hostSubnetLength*` value cannot be changed after the cluster is
+first created, A `*cidr*` field can only be changed to be a
+larger network that still contains the original network if nodes are
+allocated within it's range , and
+`*serviceNetworkCIDR*` can only be expanded. For example, given the
+default value of *10.128.0.0/14*, you could change
+`*cidr*` to *10.128.0.0/9* (i.e., the entire upper half
+of net 10) but not to *10.64.0.0/16*, because that does not overlap
+the original value.
+
+You can change `*serviceNetworkCIDR*` from *172.30.0.0/16* to *172.30.0.0/15*,
+but not to *172.28.0.0/14*, because even though the original range is entirely
+inside the new range, the original range must be at the start of the CIDR.
 ====
 
 [[configuring-the-pod-network-on-nodes]]

--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -73,7 +73,9 @@ in the *_master-config.yaml_* file.
 .*_/etc/origin/master/master-config.yaml_*
 ----
 networkConfig:
-  clusterNetworkCIDR: 10.1.0.0/16
+  clusterNetworks:
+  - cidr: 10.1.0.0/16
+    hostSubnetLength: 9
   serviceNetworkCIDR: 172.30.0.0/16
 ----
 

--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -731,3 +731,4 @@ secrets:
   secret: db_creds
   apb_name: dh-rhscl-postgresql-apb
 ----
+


### PR DESCRIPTION
ClusterNetworkCIDR has been fully deprecated and the docs should
reflect that. Replace referances to ClusterNetworkCIDR to the proper
clusterNetworks object and respective fields