### PR TITLE
Added section to service catalog about outside routes

### DIFF
--- a/architecture/service_catalog/index.adoc
+++ b/architecture/service_catalog/index.adoc
@@ -101,6 +101,34 @@ references to the binding secret from the deployment. Otherwise, the next
 rollout will fail.
 ====
 
+ifdef::openshift-enterprise,openshift-origin[]
+[[service-catalog-route-planning]]
+== Service catalog compatibility with services outside of the cluster
+
+[NOTE]
+====
+This section is only relevant to clusters using the `NetworkPolicy` networking
+SDN plug-in.
+====
+
+The difference in networking policies can impact your service broker's
+accessibility. You must ensure that `NetworkPolicy` objects exist in your
+service broker, so that users can have appropriate access to these resources in
+their project or namespace. These `NetworkPolicy` objects are triggered by using
+the service catalog through provisioning or binding.
+
+For example, if the service broker creates a pod inside a user's project, then
+the service broker also needs to create a `NetworkPolicy` object with rules that
+allow access to the pods. Or, if the service catalog creates objects in a
+different namespace in the cluster, then the target project may need
+`NetworkPolicy` rules to allow the source project to talk to it.
+
+See the
+xref:../../admin_guide/managing_networking.adoc#admin-guide-manage-networking[Managing
+networking section of the cluster administrator guide] for more information on
+`NetworkPolicy` objects.
+endif::openshift-enterprise,openshift-origin[]
+
 [[service-catalog-concepts-terminology]]
 == Concepts and Terminology
 


### PR DESCRIPTION
For: https://trello.com/c/T2n6DiU2/51-3-document-network-isolation-integration-with-service-linking-related-to-service-catalog-sdndocs

tag @knobunc 

I feel like this is very much off the mark, and the last paragraph is a copy/paste of the sections that I think need to be a procedure, but let me know what you think. The information I had could be quite speculative for now and might be changing? Not sure.