### PR TITLE
Added API server load balancers HA requirement for production use

### DIFF
--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -149,12 +149,14 @@ following availability:
 
 [NOTE]
 ====
-The API Server load balancer HA must be ensured for production use. The unavailability of the 
-API Server load balancer would let the nodes unable to report their status. In such situation, 
-all pods will be marked dead and their endpoints will be removed from the service.
-The `native` HA method does not set up the API Server load balancer's HA. This can be achieved 
-by running multiple HAProxy load balancers and use keepalived to move a virtual IP between them 
-if one fails.
+In production {product-title} clusters, you must maintain high availability
+of the API Server load balancer. If the API Server load balancer is not
+available, nodes cannot report their status, all their pods are marked dead,
+and the pods' endpoints are removed from the service.
+
+You must separately configure HA for the API Server load balancer. To configure
+HA for it, you can run multiple HAProxy load balancers and use Keepalived to
+provide a floating virtual IP address for them.
 ====
 
 ifdef::openshift-origin,openshift-online,openshift-dedicated,openshift-enterprise[]

--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -147,6 +147,16 @@ following availability:
 |Balances load between API master endpoints
 |===
 
+[NOTE]
+====
+The API Server load balancer HA must be ensured for production use. The unavailability of the 
+API Server load balancer would let the nodes unable to report their status. In such situation, 
+all pods will be marked dead and their endpoints will be removed from the service.
+The `native` HA method does not set up the API Server load balancer's HA. This can be achieved 
+by running multiple HAProxy load balancers and use keepalived to move a virtual IP between them 
+if one fails.
+====
+
 ifdef::openshift-origin,openshift-online,openshift-dedicated,openshift-enterprise[]
 [[node]]
 


### PR DESCRIPTION
Based on BZ #1567868, need to have this in the official documentation. It applies to all OCP versions. @openshift/team-documentation