### PR TITLE
bug 1579304 clarifying etcd backup location

### DIFF
--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -159,7 +159,7 @@ inside the container.
 . Copy the *_db_* file over to the backup you created:
 +
 ----
-# cp "$ETCD_DATA_DIR"/member/snap/db "$HOTDIR"/member/snap/db'
+# cp "$ETCD_DATA_DIR"/member/snap/db "$ETCD_DATA_DIR.bak"/member/snap/db
 ----
 
 [[registry-certificates-backup]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1579304

There's a [KB](https://access.redhat.com/solutions/3154561) that clarifies this command. I think the version of this command in 3.7 and later makes the KB irrelevant.