### PR TITLE
Bug 1558327, added link to Local Storage Persistent Volumes content

### DIFF
--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -1359,7 +1359,7 @@ features marked *GA* indicate _General Availability_.
 |TP
 |TP
 
-|Local Storage Persistent Volumes
+|xref:../install_config/persistent_storage/persistent_storage_local.adoc#install-config-persistent-storage-persistent-storage-local[Local Storage Persistent Volumes]
 | -
 |TP
 |TP


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1558327
This is a change to the 3.9 release notes only. The change does not persist into 3.10.