### PR TITLE
BZ: 1582813: Removed content not specific to 3.6

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -335,28 +335,6 @@ background per minute. The default value is 60.
 scheduled for background import are checked against the upstream repository. The
 default value is 15 minutes.
 
-|`*AllowedRegistriesForImport*`
-|Limits the docker registries that normal users may import
-images from. Set this list to the registries that you trust to contain valid Docker
-images and that you want applications to be able to import from. Users with
-permission to create Images or ImageStreamMappings via the API are not affected by
-this policy - typically only administrators or system integrations will have those
-permissions.
-
-|`*InternalRegistryHostname*`
-|Sets the hostname for the default internal image
-registry. The value must be in `*hostname[:port]*` format.
-For backward compatibility, users can still use `*OPENSHIFT_DEFAULT_REGISTRY*`
-environment variable but this setting overrides the environment variable.  When
-this is set, the internal registry must have its hostname set as well.
-
-|`*ExternalRegistryHostname*`
-|ExternalRegistryHostname sets the hostname for the default external image
-registry. The external hostname should be set only when the image registry
-is exposed externally. The value is used in `*publicDockerImageRepository*`
-field in ImageStreams. The value must be in `*hostname[:port]*` format.
-|===
-
 [[master-node-config-kubernetes-master-config]]
 === Kubernetes Master Configuration
 


### PR DESCRIPTION
introduced via: https://github.com/openshift/openshift-docs/blame/enterprise-3.6/install_config/master_node_configuration.adoc#L338

cc: @mburke5678 