### PR TITLE
Use oc create secret instead of deprecated oc secrets subcommands

### DIFF
--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -726,13 +726,13 @@ endif::[]
 [options="nowrap"]
 ----
   // Create a new secret named my-secret with a key named ssh-privatekey
-  $ oc secrets new my-secret ~/.ssh/ssh-privatekey
+  $ oc create secret generic my-secret --from-file=ssh-privatekey=<path/to/ssh/private/key>
 
   // Create a new secret named my-secret with keys named ssh-privatekey and ssh-publickey instead of the names of the keys on disk
-  $ oc secrets new my-secret ssh-privatekey=~/.ssh/id_rsa ssh-publickey=~/.ssh/id_rsa.pub
+  $ oc create secret generic my-secret --from-file=ssh-privatekey=<path/to/ssh/private/key> --from-file=ssh-publickey=<path/to/ssh/public/key>
 
   // Create a new secret named my-secret with keys for each file in the folder "bar"
-  $ oc secrets new my-secret path/to/bar
+  $ oc create secret generic my-secret --from-file=<path/to/bar>
 ----
 ====
 

--- a/day_two_guide/topics/managing_docker_registries.adoc
+++ b/day_two_guide/topics/managing_docker_registries.adoc
@@ -299,19 +299,19 @@ to the `docker` registry:
 +
 ----
 $ oc project <my_project>
-$ oc secrets new-dockercfg <my_registry> --docker-server=<my.registry.example.com> --docker-username=<username> --docker-password=<my_password> --docker-email=<me@example.com>
+$ oc create secret docker-registry <my_registry> --docker-server=<my.registry.example.com> --docker-username=<username> --docker-password=<my_password> --docker-email=<me@example.com>
 ----
 
 . If a `.dockercfg` file exists, create the secret using the `oc` command:
 +
 ----
-$ oc secrets new <my_registry> .dockercfg=<.dockercfg>
+$ oc create secret generic <my_registry> --from-file=.dockercfg=<path/to/.dockercfg> --type=kubernetes.io/dockercfg
 ----
 
 . Populate the `$HOME/.docker/config.json` file:
 +
 ----
-$ oc secrets new <my_registry> .dockerconfigjson=<.docker/config.json>
+$ oc create secret generic <my_registry> --from-file=.dockerconfigjson=<path/to/.dockercfg> --type=kubernetes.io/dockerconfigjson
 ----
 
 . Use the `dockercfg` secret to pull images from the authenticated registry by
@@ -363,8 +363,8 @@ to the service accounts.
 +
 ----
 $ oc project <my_project>
-$ oc secrets new-dockercfg <my_registry> --docker-server=*<my_registry_example.com> --docker-username=<username> --docker-password=<my_password> --docker-email=<me@example.com>
-$ oc secrets new-dockercfg <my_docker_registry_ext_auth> --docker-server=<my.authsystem.example.com> --docker-username=<username> --docker-password=<my_password> --docker-email=<me@example.com>
+$ oc create secret docker-registry <my_registry> --docker-server=*<my_registry_example.com> --docker-username=<username> --docker-password=<my_password> --docker-email=<me@example.com>
+$ oc create secret docker-registry <my_docker_registry_ext_auth> --docker-server=<my.authsystem.example.com> --docker-username=<username> --docker-password=<my_password> --docker-email=<me@example.com>
 $ oc secrets link default <my_registry> --for=pull
 $ oc secrets link default <my_docker_registry_ext_auth> --for=pull
 $ oc secrets link builder <my_registry>
@@ -438,7 +438,7 @@ openshift_master_admission_plugin_config={"openshift.io/ImagePolicy":{"configura
 There is a current issue to be fixed in {product-title} 3.6.1 where
 `ImagePolicy` pods can not be deployed using default templates, and give the
 following error message `Failed create | Error creating: Pod "" is invalid:
-spec.containers[0].\image: Forbidden: this image is prohibited by policy`. 
+spec.containers[0].\image: Forbidden: this image is prohibited by policy`.
 
 See the
 https://access.redhat.com/solutions/3165041[Image Policy is not working as
@@ -629,7 +629,7 @@ $ TOKEN=$(oc sa get-token <my_serviceaccount> -n <registry_project>)
 . Use the token as the password to create a `dockercfg` secret:
 +
 ----
-$ oc secrets new-dockercfg <my_registry>
+$ oc create secret docker-registry <my_registry> \
   --docker-server=<myregistry.example.com> --docker-username=<notused> --docker-password=${TOKEN} --docker-email=<me@example.com>
 ----
 

--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -416,7 +416,7 @@ If no certificate is found, a self-signed certificate is created using the
 . Create the secret:
 +
 ----
-$ oc secrets new console-secret \
+$ oc create secret generic console-secret \
     /path/to/console.cert
 ----
 +

--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -78,7 +78,7 @@ security reasons, it is recommended to not make it greater than this value.
 . Create the secret for the registry certificates:
 +
 ----
-$ oc secrets new registry-certificates \
+$ oc create secret generic registry-certificates \
     /etc/secrets/registry.crt \
     /etc/secrets/registry.key
 ----

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -305,7 +305,7 @@ the new value. If `ROUTER_MAX_CONNECTIONS` is not present, the default value of
 ====
 A connection includes the frontend and internal backend. This counts as two
 connections. Be sure to set `ROUTER_MAX_CONNECTIONS` to double than the number
-of connections you intend to create. 
+of connections you intend to create.
 ====
 
 [[bind-strict-sni]]
@@ -1038,13 +1038,13 @@ If the certificate secret was added to the router, overwrite the secret. If not,
 To overwrite the secret, run the following command:
 +
 ----
-$ oc secrets new router-certs tls.crt=custom-router.crt tls.key=custom-router.key -o json --type='kubernetes.io/tls' --confirm | oc replace -f -
+$ oc create secret generic router-certs --from-file=tls.crt=custom-router.crt --from-file=tls.key=custom-router.key --type=kubernetes.io/tls -o json | oc replace -f -
 ----
 +
 To create a new secret, run the following commands:
 +
 ----
-$ oc secrets new router-certs tls.crt=custom-router.crt tls.key=custom-router.key --type='kubernetes.io/tls' --confirm
+$ oc create secret generic router-certs --from-file=tls.crt=custom-router.crt --from-file=tls.key=custom-router.key --type=kubernetes.io/tls
 
 $ oc volume dc/router --add --mount-path=/etc/pki/tls/private --secret-name='router-certs' --name router-certs
 ----

--- a/install_config/storage_examples/azure_blob_docker_registry_example.adoc
+++ b/install_config/storage_examples/azure_blob_docker_registry_example.adoc
@@ -69,7 +69,7 @@ middleware:
 +
 [source,bash]
 ----
-$ oc secrets new registry-config config.yaml=registryconfig.yaml
+$ oc create secret generic registry-config --from-file=config.yaml=registryconfig.yaml
 ----
 
 . Add the secret:
@@ -100,7 +100,7 @@ $ oc delete secret registry-config
 +
 [source,bash]
 ----
-$ oc secrets new registry-config config.yaml=registryconfig.yaml
+$ oc create secret generic registry-config --from-file=config.yaml=registryconfig.yaml
 ----
 
 .. Update the configuration by starting a new rollout:

--- a/security/build_process.adoc
+++ b/security/build_process.adoc
@@ -82,7 +82,7 @@ Using this example scenario, you can add an input secret to a new `BuildConfig`:
 . Create the secret, if it does not exist:
 +
 ----
-$ oc secrets new secret-npmrc .npmrc=~/.npmrc
+$ oc create secret generic secret-npmrc --from-file=.npmrc=~/.npmrc
 ----
 +
 This creates a new secret named *_secret-npmrc_*, which contains the base64


### PR DESCRIPTION
A followup to https://github.com/openshift/openshift-docs/pull/7262 sweeping the remaining `oc secrets` commands.

@openshift/team-documentation ptal