### PR TITLE
Scheduler configurable precidates section is not accurate

### DIFF
--- a/admin_guide/scheduling/scheduler.adoc
+++ b/admin_guide/scheduling/scheduler.adoc
@@ -419,11 +419,10 @@ same label values as that node.
 "predicates":[
       {
          "name":"<name>", <1>
-         "weight" : "1" <2>
          "argument":{
             "serviceAffinity":{
                "labels":[
-                  "<label>" <3>
+                  "<label>" <2>
                ]
             }
          }
@@ -431,8 +430,7 @@ same label values as that node.
    ],
 ----
 <1> Specify a name for the predicate.
-<2> Specify a weight from 1 (bad fit) to 10 (best fit).
-<3> Specify a label for matching.
+<2> Specify a label for matching.
 For example:
 
 [source,json]


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/issues/9598
"Predicates are boolean functions, they return true or false, so It does not make any sense to assign them a weigh, as it is stated in the configurable predicates section with ServiceAffinity and LabelsPresence predicates"