### PR TITLE
Fix the OpenShift SDN migration steps

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -251,12 +251,19 @@ If you are already using one SDN plug-in and want to switch to another:
 xref:configuring-the-pod-network-on-masters[masters] and
 xref:configuring-the-pod-network-on-nodes[nodes] in their configuration files.
 ifdef::openshift-origin[]
-. Restart the *origin-master-api* and *origin-master-controller*  services on masters and the *origin-node* service
-on nodes.
+. Restart the *origin-master-api* and *origin-master-controller* services on all masters.
+. Stop the *origin-node* service on all masters and nodes.
 endif::[]
 ifdef::openshift-enterprise[]
-. Restart the *atomic-openshift-master-api* and *atomic-openshift-master-controllers*
-on masters and the *atomic-openshift-node* service on nodes.
+. Restart the *atomic-openshift-master-api* and *atomic-openshift-master-controllers* services on all masters.
+. Stop the *atomic-origin-node* service on all masters and nodes.
+endif::[]
+. If you are switching between OpenShift SDN plug-ins, restart the *openvswitch* service on all masters and nodes.
+ifdef::openshift-origin[]
+. Restart the *origin-node* service on all masters and nodes.
+endif::[]
+ifdef::openshift-enterprise[]
+. Restart the *atomic-openshift-node* service on all masters and nodes.
 endif::[]
 . If you are switching from an OpenShift SDN plug-in to a
 third-party plug-in, then clean up OpenShift SDN-specific


### PR DESCRIPTION
We need to restart openvswitch to clean out the rules before we
restart the node processes.

Fixes bug 1569244 (https://bugzilla.redhat.com/show_bug.cgi?id=1569244)