### PR TITLE
Add cluster limits for ocp v3.10

### DIFF
--- a/scaling_performance/cluster_limits.adoc
+++ b/scaling_performance/cluster_limits.adoc
@@ -27,32 +27,38 @@ version or storage data format.
 [[scaling-performance-current-cluster-limits]]
 == {product-title}  Cluster Limits
 
-[options="header",cols="3*"]
+[options="header",cols="4*"]
 |===
-| Limit Type |3.7 Limit |3.9 Limit
+| Limit Type |3.7 Limit |3.9 Limit |3.10 Limit
 
 | Number of nodes footnoteref:[numberofnodes,Clusters with more than the stated limit are not supported. Consider splitting into multiple clusters.]
+| 2,000
 | 2,000
 | 2,000
 
 | Number of pods footnoteref:[numberofpods,The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.]
 | 120,000
 | 120,000
+| 120,000
 
 | Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per node]
+| 250
 | 250
 | 250
 
 | Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per core]
 | 10 is the default value. The maximum supported value is the number of pods per node.
 | 10 is the default value. The maximum supported value is the number of pods per node.
+| There is no default value. The maximum supported value is the number of pods per node.
 
 | Number of namespaces
+| 10,000
 | 10,000
 | 10,000
 
 | Number of builds: Pipeline Strategy
 | N/A
+| 10,000 (Default pod RAM 512Mi)
 | 10,000 (Default pod RAM 512Mi)
 
 | Number of pods per namespace footnoteref:[objectpernamespace,There are
@@ -62,16 +68,20 @@ number of objects of a given type in a single namespace can make those loops
 expensive and slow down processing given state changes.]
 | 15,000
 | 15,000
+| 15,000
 
 | Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| 10,000
 | 10,000
 | 10,000
 
 | Number of back-ends per service
 | 5,000
 | 5,000
+| 5,000
 
 | Number of deployments per namespace footnoteref:[objectpernamespace]
+| 20,000
 | 20,000
 | 20,000
 


### PR DESCRIPTION
This commit adds cluster limits for OpenShift v3.10 needed for
planning the environment.

https://trello.com/c/LjEXrDQZ/889-docs1-update-clusterlimits-page-for-310