### PR TITLE
Revert "Removed section for 3.3 and 3.4 guides"

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -923,3 +923,73 @@ In order for a route to be created, an ingress object must have a host,
 service, and path.
 ====
 endif::[]
+
+[[disable-namespace-ownership-check]]
+== Disabling the Namespace Ownership Check
+
+Hosts and subdomains are owned by the namespace of the route that first
+makes the claim. Other routes created in the namespace can make claims on
+the subdomain. All other namespaces are prevented from making claims on
+the claimed hosts and subdomains. The namespace that owns the host also
+owns all paths associated with the host, for example `*_www.abc.xyz/path1_*`.
+
+For example, if the host `*_www.abc.xyz_*` is not claimed by any route.
+Creating route `r1` with host `*_www.abc.xyz_*` in namespace `ns1` makes
+namespace `ns1` the owner of host `*_www.abc.xyz_*` and subdomain `abc.xyz`
+for wildcard routes. If another namespace, `ns2`, tries to create a route
+with say a different path `*_www.abc.xyz/path1/path2_*`, it would fail
+because a route in another namespace (`ns1` in this case) owns that host.
+
+ifdef::openshift-enterprise,openshift-origin[]
+With
+xref:../../install_config/router/default_haproxy_router.adoc#using-wildcard-routes[wildcard routes]
+the namespace that owns the subdomain owns all hosts in the subdomain.
+If a namespace owns subdomain `*abc.xyz*` as in the above example,
+another namespace cannot claim `z.abc.xyz`.
+endif::[]
+
+By disabling the namespace ownership rules, you can disable these restrictions
+and allow hosts (and subdomains) to be claimed across namespaces.
+
+[WARNING]
+====
+If you decide to disable the namespace ownership checks in your router,
+be aware that this allows end users to claim ownership of hosts
+across namespaces. While this change can be desirable in certain
+development environments, use this feature with caution in production
+environments, and ensure that your cluster policy has locked down untrusted end
+users from creating routes.
+====
+
+For example, with `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true`, if
+namespace `ns1` creates the oldest route `r1`  `*_www.abc.xyz_*`,  it owns only
+the hostname (+ path).  Another namespace can create a wildcard route
+even though it does not have the oldest route in that subdomain (`abc.xyz`)
+and we could potentially have other namespaces claiming other
+non-wildcard overlapping hosts (for example, `foo.abc.xyz`, `bar.abc.xyz`,
+`baz.abc.xyz`) and their claims would be granted.
+
+Any other namespace (for example, `ns2`) can now create
+a route `r2`  `*_www.abc.xyz/p1/p2_*`,  and it would be admitted.  Similarly
+another namespace (`ns3`) can also create a route  `wildthing.abc.xyz`
+with a subdomain wildcard policy and it can own the wildcard.
+
+As this example demonstrates, the policy `ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true` is more
+lax and allows claims across namespaces.  The only time the router would
+reject a route with the namespace ownership disabled is if the host+path
+is already claimed.
+
+For example, if a new route `rx` tries to claim `*_www.abc.xyz/p1/p2_*`, it
+would be rejected as route `r2` owns that host+path combination.  This is true whether route `rx`
+is in the same namespace or other namespace since the exact host+path is already claimed.
+
+This feature can be set during router creation or by setting an environment
+variable in the router's deployment configuration.
+
+----
+$ oc adm router ... --disable-namespace-ownership-check=true
+----
+
+----
+$ oc env dc/router ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true
+----


### PR DESCRIPTION
This reverts commit 3770fafc5682e6d7558d1824d600f7e317a4a23d.

This content was removed from master, when it should have been removed only from the 3.3 and 3.4 branches.

cc: @bfallonf 