### PR TITLE
Updating HAProxy performance numbers for 3.10.

### DIFF
--- a/scaling_performance/routing_optimization.adoc
+++ b/scaling_performance/routing_optimization.adoc
@@ -22,31 +22,54 @@ xref:../install_config/router/index.adoc#install-config-router-overview[router]
 is the ingress point for all external traffic destined for {product-title}
 services.
 
-On an public cloud instance of size 4 vCPU/16GB RAM, a single HAProxy router is able to handle
-between 7000-32000 HTTP keep-alive requests depending on encryption, page size,
-and the number of connections used. For example, when using TLS
-xref:../architecture/networking/routes.adoc#edge-termination[edge] or
-xref:../architecture/networking/routes.adoc#re-encryption-termination[re-encryption]
-terminations with large page sizes and a high numbers of connections, expect to
-see results in the lower range. With HTTP keep-alive, a single HAProxy router is
-capable of saturating 1 Gbit NIC at page sizes as small as 8 kB.
+When evaluating a single HAProxy router performance in terms of
+HTTP requests handled per second, the performance varies depending
+on many factors. In particular:
 
-The table below shows HTTP keep-alive performance on such a public cloud
-instance with a single HAProxy and 100 routes:
+* HTTP keep-alive/close mode,
 
-[cols="2,3,3",options="header"]
+* xref:../architecture/networking/routes.adoc#route-types[route type]
+
+* TLS session resumption client support
+
+* number of concurrent connections per target route
+
+* number of target routes 
+
+* backend server page size
+
+* underlying infrastructure (network/SDN solution, CPU, and so on)
+
+While performance in your specific environment will vary, our lab
+tests on a public cloud instance of size 4 vCPU/16GB RAM, a single
+HAProxy router handling 100 routes terminated by backends serving
+1kB static pages is able to handle the following.
+
+In HTTP keep-alive mode scenarios:
+
+[cols="2",options="header"]
 |===
-|*Encryption* |*Page size* |*HTTP(s) requests per second*
-|none |1kB |15435
-|none |4kB |11947
-|edge |1kB |7467
-|edge |4kB |7678
-|passthrough |1kB |25789
-|passthrough |4kB |17876
-|re-encrypt |1kB |7611
-|re-encrypt |4kB |7395
-
+|*Encryption* |*HTTP(s) requests per second*
+|none |22577
+|edge |11642
+|passthrough |33335
+|re-encrypt |11521
 |===
+
+In HTTP close (no keep-alive) scenarios:
+
+[cols="2",options="header"]
+|===
+|*Encryption* |*HTTP(s) requests per second*
+|none |5771
+|edge |1780
+|passthrough |3488
+|re-encrypt |1248
+|===
+
+TLS session resumption was used for encrypted routes. With HTTP
+keep-alive, a single HAProxy router is capable of saturating 1 Gbit
+NIC at page sizes as small as 8 kB.
 
 When running on bare metal with modern processors, you can expect roughly
 twice the performance of the public cloud instance above. This


### PR DESCRIPTION
This commit updates the HAProxy performance for 3.10 and adds HTTP close (non-keepalive) scenarios for the 4 route terminations.  Also updating the factors that affect router performance.