### PR TITLE
Wrong yaml snippet of the master-config.yaml file (named certificates nesting)

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -87,19 +87,18 @@ servingInfo:
   logoutURL: ""
   masterPublicURL: https://openshift.example.com:8443
   publicURL: https://openshift.example.com:8443/console/
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: master.server.crt <1>
+  clientCA: ""
+  keyFile: master.server.key <1>
+  maxRequestsInFlight: 0
+  requestTimeoutSeconds: 0
   namedCertificates:
-    bindAddress: 0.0.0.0:8443
-    bindNetwork: tcp4
-    certFile: master.server.crt <1>
-    clientCA: ""
-    keyFile: master.server.key <1>
-    maxRequestsInFlight: 0
-    requestTimeoutSeconds: 0
-    namedCertificates:
-      - certFile: wildcard.example.com.crt <2>
-        keyFile: wildcard.example.com.key <2>
-        names:
-          - "openshift.example.com"
+    - certFile: wildcard.example.com.crt <2>
+      keyFile: wildcard.example.com.key <2>
+      names:
+        - "openshift.example.com"
   metricsPublicURL: "https://metrics.os.example.com/hawkular/metrics"
 
 ----
@@ -300,19 +299,18 @@ servingInfo:
   logoutURL: ""
   masterPublicURL: https://openshift.example.com:8443
   publicURL: https://openshift.example.com:8443/console/
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: master.server.crt
+  clientCA: ""
+  keyFile: master.server.key
+  maxRequestsInFlight: 0
+  requestTimeoutSeconds: 0
   namedCertificates:
-    bindAddress: 0.0.0.0:8443
-    bindNetwork: tcp4
-    certFile: master.server.crt
-    clientCA: ""
-    keyFile: master.server.key
-    maxRequestsInFlight: 0
-    requestTimeoutSeconds: 0
-    namedCertificates:
-      - certFile: wildcard.example.com.crt <1>
-        keyFile: wildcard.example.com.key <2>
-        names:
-          - "openshift.example.com"
+    - certFile: wildcard.example.com.crt <1>
+      keyFile: wildcard.example.com.key <2>
+      names:
+        - "openshift.example.com"
   metricsPublicURL: "https://metrics.os.example.com/hawkular/metrics"
 ----
 +


### PR DESCRIPTION
Fixing wrong `servingInfo` yaml block (Incorrect nesting of the element `namedCertificates`)