### PR TITLE
[enterprise-3.4]Update certificate_customization.adoc

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -80,15 +80,22 @@ internal `masterURL` host.
 .Custom Certificates Configuration
 ----
 servingInfo:
-  ...
+  logoutURL: ""
+  masterPublicURL: https://openshift.example.com:8443
+  publicURL: https://openshift.example.com:8443/console/
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: master.server.crt <1>
+  clientCA: ""
+  keyFile: master.server.key <1>
+  maxRequestsInFlight: 0
+  requestTimeoutSeconds: 0
   namedCertificates:
-  - certFile: custom.crt
-    keyFile: custom.key
-    names:
-    - "customhost.com"
-    - "api.customhost.com"
-    - "console.customhost.com"
-  ...
+    - certFile: wildcard.example.com.crt <2>
+      keyFile: wildcard.example.com.key <2>
+      names:
+        - "openshift.example.com"
+  metricsPublicURL: "https://metrics.os.example.com/hawkular/metrics"
 ----
 
 Relative paths are resolved relative to the master configuration file. Restart
@@ -99,8 +106,8 @@ For the master API or web console, wildcard names are accepted.
 [[configuring-custom-certificates-lb]]
 == Configuring a Custom Certificate for a Load Balancer
 
-If your {product-title} cluster uses the default load balancer or an enterprise-level load balancer, 
-you can use custom certificates to make the web console and API available externally using a publicly-signed custom certificate. leaving the existing internal certificates for 
+If your {product-title} cluster uses the default load balancer or an enterprise-level load balancer,
+you can use custom certificates to make the web console and API available externally using a publicly-signed custom certificate. leaving the existing internal certificates for
 the internal endpoints.
 
 To configure {product-title} to use custom certificates in this way:
@@ -112,19 +119,18 @@ servingInfo:
   logoutURL: ""
   masterPublicURL: https://openshift.example.com:8443
   publicURL: https://openshift.example.com:8443/console/
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: master.server.crt
+  clientCA: ""
+  keyFile: master.server.key
+  maxRequestsInFlight: 0
+  requestTimeoutSeconds: 0
   namedCertificates:
-    bindAddress: 0.0.0.0:8443
-    bindNetwork: tcp4
-    certFile: master.server.crt
-    clientCA: ""
-    keyFile: master.server.key
-    maxRequestsInFlight: 0
-    requestTimeoutSeconds: 0
-    namedCertificates:
-      - certFile: wildcard.example.com.crt <1>
-        keyFile: wildcard.example.com.key <2>
-        names:
-          - "openshift.example.com"
+    - certFile: wildcard.example.com.crt <1>
+      keyFile: wildcard.example.com.key <2>
+      names:
+        - "openshift.example.com"
   metricsPublicURL: "https://metrics.os.example.com/hawkular/metrics"
 ----
 +
@@ -134,12 +140,12 @@ servingInfo:
 +
 [NOTE]
 ====
-Configure the  `namedCertificates` section for only the host name associated with the `masterPublicURL` and `oauthConfig.assetPublicURL` settings.  
-Using a custom serving certificate for the host name associated with the `masterURL` causes in TLS errors as infrastructure components 
+Configure the  `namedCertificates` section for only the host name associated with the `masterPublicURL` and `oauthConfig.assetPublicURL` settings.
+Using a custom serving certificate for the host name associated with the `masterURL` causes in TLS errors as infrastructure components
 attempt to contact the master API using the internal masterURL host.
 ====
 
-. Specify the `openshift_master_cluster_public_hostname` and `openshift_master_cluster_hostname` paramaters in the Ansible inventory file, by default *_/etc/ansible/hosts_*. 
+. Specify the `openshift_master_cluster_public_hostname` and `openshift_master_cluster_hostname` paramaters in the Ansible inventory file, by default *_/etc/ansible/hosts_*.
 These values must be different. If they are the same, the named certificates will fail.
 +
 ----
@@ -153,4 +159,3 @@ openshift_master_cluster_public_hostname=public.paas.example.com <2>
 <2> The FQDN for external the load balancer with custom (public) certificate.
 
 For information specific to your load balancer environment, refer to link:https://access.redhat.com/documentation/en-us/reference_architectures/?category=openshift%2520container%2520platform&version=current%2520release[the {product-title} Reference Architecture for your provider] and link:http://v1.uncontained.io/playbooks/installation/load_balancing.html#custom-certificate-ssl-termination-production[Custom Certificate SSL Termination (Production)].
-


### PR DESCRIPTION
Fixing wrong `servingInfo` yaml block (Incorrect nesting of the element `namedCertificates`)

xref:https://github.com/openshift/openshift-docs/pull/9724