### PR TITLE
Redirect for HAProxy Router

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -166,9 +166,12 @@ AddType text/vtt                            vtt
 
     # Online/Dedicated/OCP redirects for 3.7
     RewriteRule ^dedicated/admin_guide/manage_authorization_policy\.html(.*)$ /dedicated/admin_guide/manage_rbac.html [L,R=301]
-    
+        
     # Online/Dedicated/OCP redirects for 3.7 + 3.9
     RewriteRule ^(online|dedicated|container-platform)/(3\.7|3\.9)/using_images/docker_images/index\.html(.*)$ /$1/$2/using_images/other_images/other_container_images.html$3 [NE,L,R=301]
+
+    # Online/Dedicated/OCP redirects for 3.9
+    RewriteRule ^(online|dedicated|container-platform)/architecture/networking/haproxy-router\.html(.*)$ /architecture/networking/assembly_available_router_plugins.html [L,R=301]
 
     # Developers console redirect
     RewriteRule ^online/getting_started/developers/developers_console\.html(.*)$ /online/getting_started/index.html$1 [NE,L,R=301]


### PR DESCRIPTION
For HAProxy Router which has been moved via: https://github.com/openshift/openshift-docs/pull/9632.

cc: @bfallonf 