### PR TITLE
BZ1586368 Remove references to setting openshift_dns_ip

### DIFF
--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -299,16 +299,8 @@ the following process for name resolution:
 . By default, containers receive their DNS configuration
 file (*_/etc/resolv.conf_*) from their host.
 
-. {product-title} then inserts one DNS value into the pods
-(above the node's nameserver values). That value is defined in the
-*_/etc/origin/node/node-config.yaml_* file by the
-xref:../../install_config/master_node_configuration.adoc#node-configuration-files[`*dnsIP*`]
-parameter, which by default is set to the address of the host node because the host
-is using *dnsmasq*.
-
-. If the `*dnsIP*` parameter is omitted from the *_node-config.yaml_*
-file, then the value defaults to the kubernetes service IP, which is the first
-nameserver in the pod's *_/etc/resolv.conf_* file.
+. {product-title} then sets the pod's first namesever to the IP address of
+the node.
 
 As of {product-title}
 ifdef::openshift-enterprise[]
@@ -357,24 +349,7 @@ DHCP is enabled. If DHCP is:
 nameservers to NetworkManager.
 
 - Enabled, then the NetworkManager dispatch script automatically configures DNS
-based on the DHCP configuration. Optionally, you can add a value to xref:../../install_config/master_node_configuration.adoc#node-configuration-files[`*dnsIP*`]
-in the *_node-config.yaml_* file to prepend the pod's *_resolv.conf_* file. The
-second nameserver is then defined by the host's first nameserver. By default,
-this will be the IP address of the node host.
-+
-[NOTE]
-====
-For most configurations, do not set the `*openshift_dns_ip*` option during the
-advanced installation of {product-title} (using Ansible), because this option
-overrides the default IP address set by xref:../../install_config/master_node_configuration.adoc#node-configuration-files[`*dnsIP*`].
-
-Instead, allow the installer to configure each node to use *dnsmasq* and forward
-requests to the external DNS provider or SkyDNS, the internal DNS service for
-cluster-wide DNS resolution of internal hostnames for services and pods. If you
-do set the `*openshift_dns_ip*` option, then it should be set either with a DNS
-IP that queries SkyDNS first, or to the SkyDNS service or endpoint IP (the
-Kubernetes service IP).
-====
+based on the DHCP configuration.
 
 To verify that hosts can be resolved by your DNS server:
 

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1323,7 +1323,7 @@ authConfig:
   authorizationCacheSize: 1000
   authorizationCacheTTL: 5m
 dnsDomain: cluster.local
-dnsIP: 10.0.2.15 <1>
+dnsIP: 0.0.0.0 <1>
 dockerConfig:
   execHandlerName: native
 imageConfig:

--- a/upgrading/manual_upgrades.adoc
+++ b/upgrading/manual_upgrades.adoc
@@ -265,7 +265,6 @@ server=<dns_server2_ip_address>
 dnsBindAddress: 127.0.0.1:53
 dnsRecursiveResolvConf: /etc/origin/node/resolv.conf
 dnsDomain: cluster.local
-dnsIP: <node_ip_address> <1>
 ----
 +
 <1> This is the IP address of the node host.


### PR DESCRIPTION
The node config value dnsIP is no longer configurable in 3.10.

/cc @sjenning 