### PR TITLE
[enterprise-3.9] Added note to double-escape special chars in inventory file

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -85,6 +85,8 @@ xref:../install_config/install/advanced_install.adoc#advanced-install-configurin
 - `*openshift_cloudprovider_openstack_region*`
 - `*openshift_cloudprovider_openstack_lb_subnet_id*`
 
+include::install_config/topics/escaping_special_characters.adoc[]
+
 .Example OpenStack Configuration with Ansible
 ====
 ----

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -169,6 +169,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth',
 openshift_master_default_subdomain=apps.test.example.com
 ----
 
+include::install_config/topics/escaping_special_characters.adoc[]
+
 The following tables describe variables for use with the Ansible installer that
 can be assigned cluster-wide:
 

--- a/install_config/topics/escaping_special_characters.adoc
+++ b/install_config/topics/escaping_special_characters.adoc
@@ -1,0 +1,18 @@
+////
+Escaping special characters in ansible variables file
+
+This module included in the following assemblies:
+* install_config/configuring_openstack.adoc
+* install_config/install/advanced_install.adoc
+////
+
+[IMPORTANT]
+====
+If a parameter value in the Ansible inventory file contains special characters,
+such as `pass:[#]`, `{` or `}`, you must double-escape the value (that is
+enclose the value in both single and double quotation marks). For example, to
+use `pass:[mypasswordwith###hashsigns]` as a value for the variable
+`openshift_cloudprovider_openstack_password`, declare it as
+`openshift_cloudprovider_openstack_password='"mypasswordwith###hashsigns"'` in
+the Ansible host inventory file.
+====


### PR DESCRIPTION
Cherrypickerd from https://github.com/openshift/openshift-docs/pull/9758/commits/7eb3a7f9d85a2988a7baccfdac368c78167561b8 PR #9758 