### PR TITLE
Update disconnected installation

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -236,6 +236,7 @@ $ docker pull registry.access.redhat.com/openshift3/metrics-cassandra:<tag>
 $ docker pull registry.access.redhat.com/openshift3/metrics-hawkular-metrics:<tag>
 $ docker pull registry.access.redhat.com/openshift3/metrics-hawkular-openshift-agent:<tag>
 $ docker pull registry.access.redhat.com/openshift3/metrics-heapster:<tag>
+$ docker pull registry.access.redhat.com/openshift3/oauth-proxy:<tag>
 ----
 
 . For the service catalog, OpenShift Ansible broker, and template service broker
@@ -250,6 +251,7 @@ endif::[]
 ----
 $ docker pull registry.access.redhat.com/openshift3/ose-service-catalog:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-ansible-service-broker:<tag>
+$ docker pull registry.access.redhat.com/openshift3/ose-template-service-broker:<tag>
 ----
 +
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
Containerized component oauth-proxy is required for enterprise logging.