### PR TITLE
Sync 3.7 relnotes to master

### DIFF
--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -13,18 +13,17 @@ toc::[]
 
 == Overview
 
-Red Hat {product-title} is a Platform as a Service (PaaS) that provides
-developers and IT organizations with a cloud application platform for deploying
-new applications on secure, scalable resources with minimal configuration and
-management overhead. {product-title} supports a wide selection of
-programming languages and frameworks, such as Java, Ruby, and PHP.
+Red Hat {product-title} provides developers and IT organizations with a cloud
+application platform for deploying new applications on secure, scalable
+resources with minimal configuration and management overhead. {product-title}
+supports a wide selection of programming languages and frameworks, such as Java,
+Ruby, and PHP.
 
-Built on Red Hat Enterprise Linux and Google Kubernetes, {product-title}
-provides a secure and scalable multi-tenant operating system for today’s
-enterprise-class applications, while providing integrated application runtimes
-and libraries. {product-title} brings the OpenShift PaaS platform to customer
-data centers, enabling organizations to implement a private PaaS that meets
-security, privacy, compliance, and governance requirements.
+Built on Red Hat Enterprise Linux and Kubernetes, {product-title} provides a
+secure and scalable multi-tenant operating system for today’s enterprise-class
+applications, while providing integrated application runtimes and libraries.
+{product-title} enables organizations to meet security, privacy, compliance, and
+governance requirements.
 
 [[ocp-37-about-this-release]]
 == About This Release
@@ -38,6 +37,9 @@ Origin 3.7]. New features, changes, bug fixes, and known issues that pertain to
 
 {product-title} 3.7 is supported on RHEL 7.3, 7.4.2, and Atomic Host 7.4.2 and
 newer with the latest packages from Extras, including Docker 1.12.
+
+TLSV1.2 is the only supported security version in {product-title} version 3.4
+and later. You must update if you are using TLSV1.0 or TLSV1.1.
 
 For initial installations, see the
 xref:../install_config/install/planning.adoc#install-config-install-planning[Installing
@@ -1847,16 +1849,6 @@ uppercase letter. This bug fix ensures that hostnames for node objects are
 created with lowercase letters.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1396350[*BZ#1396350*])
 
-* When upgrading between versions (specifically 3.3/1.3 or earlier to 3.4 or
-later) the default values for `clusterNetworkCIDR` and `hostSubnetLength`
-changed. If the inventory file did not specify corresponding inventory
-variables, the upgrade would fail. This caused the controller service to not
-start back up. This bug fix requires that the inventory variables be set before
-upgrading or installing. As a result, if the required inventory variables are
-not set, the upgrade or installation will stop and tell the administrator to set
-the variables.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1451023[*BZ#1451023*])
-
 * Previously, the node service was not restarted when Open vSwitch was restarted,
 which could result in a misconfigured networking environment. This bug fix
 updates the services to ensure that the node service is restarted whenever Open
@@ -3015,7 +3007,7 @@ regarding reuse of the PVC that was previously specified within a DC.
 separate OPS logging cluster and there is no `@OUTPUT` label in the
 *_fluent.conf_*, fluentd does not know how to route the operations logs. The
 operations logs are not logged. The user will see no new operations
-(`.operations.\*`) logs after the upgrade. Change the fluentd configuration to
+([x-]`.operations.*`) logs after the upgrade. Change the fluentd configuration to
 correctly handle the case both with and without the `@OUTPUT` label, and for the
 OPS and non-OPS cases. With this bug fix, operations logs flow uninterrupted
 after upgrade.
@@ -3325,6 +3317,547 @@ openshift3/snapshot-provisioner:v3.7.23-3
 ----
 
 [[ocp-3-7-23-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.6 or 3.7 cluster to this latest
+release, use the automated upgrade playbook. See
+xref:../upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
+Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-7-42-2]]
+=== RHBA-2018:0636 - {product-title} 3.7.42-2 Bug Fix and Enhancement Update
+
+Issued: 2018-04-05
+
+{product-title} release 3.7.42-2 is now available. The packages and bug fixes
+included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:0636[RHBA-2018:0636] advisory.
+The list of container images included in the update are documented in
+link:https://access.redhat.com/errata/RHBA-2018:0637[RHBA-2018:0637] advisory.
+
+Space precluded documenting all of the bug fixes for this release in
+the advisory. See the following sections for notes on upgrading and details on
+the bug fixes and enhancements included in this release.
+
+[[ocp-3-7-42-2-bug-fixes]]
+==== Bug Fixes
+
+* When a pod is admitted by "nonroot" SCC, the `securityContext.runAsUser`
+parameter is not set, and the user is able to provide an arbitrary image. This
+made it possible to escalate permissions within a container. This bug fixes the
+check in the kubelet, and now such a container will fail during its creation and
+will not run.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1518889[*BZ#1518889*])
+
+* Image validation used to validate old image objects, and the image signature
+import controller used to generate such an image. This could cause invalid
+images to be pushed to etcd. This bug fix changes the validation to validate new
+image objects and introduces logic to fix some invalid images. As a result, the
+controller no longer generates invalid images and it is no longer possible to
+upload an invalid image object.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1557607[*BZ#1557607*])
+
+* With the image registry, concurrent writes to the cache could cause a panic to
+occur. This bug fix protects writes to the cache with mutex. As a result, the
+cache is safe to use concurrently.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1549917[*BZ#1549917*])
+
+* Previously, when scaling up containerized masters, the registered
+`install_result` was not available when the install task was skipped for
+containerized hosts, causing scale up to fail. This bug fix defaults the value
+so that scale up can succeed.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1511357[*BZ#1511357*])
+
+* The `openshift-ansible docker_image_availability` check did not utilize the
+`osm_use_cockpit=false` variable. This check could fail because the
+*registry-console* (Cockpit) image was not available, even if it would never be
+used. The check now consults this variable. As a result, if
+`osm_use_cockpit=false` is set, then the *openshift-ansible*
+`docker_image_availability` check will not report a missing *registry-console*
+image. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1511616[*BZ#1511616*])
+
+* Amazon EC2 C5 instances use different identifiers for `bios_vendor`. Code which
+uses this information for identifying the host as an AWS instance was not being
+run. This bug fix adds logic to use the new `bios_vendor` identifier. As a
+result, AWS C5 instances are properly identified by *openshift-ansible* code.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538781[*BZ#1538781*])
+
+* The *_haproxy.cfg_* template in the *load-balancer* role was not updated to
+reflect changes in new versions of HAProxy, causing the service to fail to
+start. This bug fix updates the configuration file template to work for newer
+versions of HAProxy.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538789[*BZ#1538789*])
+
+* In order for the *_adhoc.yml_* playbook to list health checks, they are all
+loaded, and one failed to load in that environment. Listing health checks failed
+with an error. This bug fix adjusts the problematic health check, and as a
+result the listing works as expected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1509157[*BZ#1509157*])
+
+* Single host failures for installing packages were not resulting in a failed
+playbook run. This caused the playbook to continue and fail at a later point.
+This fix adds a play directive to cause the playbook to fail immediately if
+there are any host failures. As a result, if package installation fails for any
+host, the playbook will mpw fail immediately.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1512810[*BZ#1512810*])
+
+* The Jenkins image stream tags have been updated to allow for {product-title}
+version-specific image streams.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1525659[*BZ#1525659*])
+
+* An error message on etcd group validation has been updated to reflect the
+required configurations to better inform the user of the failure state.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538795[*BZ#1538795*])
+
+* A variable defined in an inventory file was being interpreted as a string, not a
+bool. This caused tasks to not be conditionally run as expected. This bug fix
+casts the string to a bool for a proper conditional check, and as a result tasks
+run as expected based on the inventory variable setting.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538816[*BZ#1538816*])
+
+* The `OPTIONS` value in the *_/etc/sysconfig/atomic-openshift-node_* file now
+works properly when multiple options are specified with containerized
+installations.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1539094[*BZ#1539094*])
+
+* When the [x-]`openshift_management_flavor*` variable was set in *_vars/main.yml_*,
+the variable was not dependent on the user inventory variable for overriding the
+deployment type. This bug fix updates the [x-]`openshift_management_flavor*` logic
+to be based on `openshift_management_app_template` from the inventory file. As a
+result, the requested management template can be successfully deployed.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1540246[*BZ#1540246*])
+
+* Alternative names in certificates were not being properly parsed. Alternatives
+with `email:` were being added as additional host names. This bug fix updates
+the logic to only add alternative names which begin with `DNS:`. As a result,
+`namedCertificates` are properly parsed and updated.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538896[*BZ#1538896*])
+
+* The *docker_image_availability* check did not take into account variables that
+specify a proxy to be used for pulling container images. The check could
+incorrectly report failure looking for images that are only available via proxy.
+This bug fix ensures the check now uses a proxy for looking up images if
+specified in the Ansible variables. The check should accurately report whether
+the necessary images are available. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1539146[*BZ#1539146*])
+
+* The *docker* daemon was incorrectly restarted when redeploying node
+certificates. This is only necessary when deploying a new CA and can safely be
+skipped, which ensures that running pods are not restarted when updating node
+certificates.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1542162[*BZ#1542162*])
+
+* A security fix to *openshift-elasticsearch-plugin* caused metrics requests to be
+rejected because the *oauth-proxy* does not pass the bearer token. This bug fix
+modifies the plug-in to accept a user name and password from the *oauth-proxy*
+and deploy with a randomly-generated password. As a result, data and metrics are
+correctly secured and able to be retrieved based on authorization.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1510320[*BZ#1510320*])
+
+* As part of an enhancement, configuration triggers are no longer used for
+Elasticsearch (ES), and it instead rolls out in a handler. The handler was
+watching the old ES pod to see if the ES cluster was green or yellow.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1533313[*BZ#1533313*])
+
+* Attempting to use an Ansible 2.4 feature in Ansible 2.3 caused the maximum
+recursion depth to be exceeded in cmp errors. This bug fix makes sure to use the
+right Ansible features with the correct version of Ansible. As a result, `mux`
+can be installed correctly with Ansible.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1540893[*BZ#1540893*])
+
+* A task assumed the `oc` binary was in the usable path of Ansible, causing the
+task to fail when the binary was not found. This bug fix modifies the task to
+allow the binary to be provided as an Ansible fact. As a result, the task
+completes successfully.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1541403[*BZ#1541403*])
+
+* Messages for which the unique namespace ID could not be determined could not be
+properly indexed. Messages could be lost and the error message appears in the
+logs. This bug fix modifies the cache algorithm to provide the necessary data or
+default the value to `orphaned`. As a result, the error message is resolved and
+messages are stored in an `orphaned` index when a unique namespace ID can not be
+determined.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1493022[*BZ#1493022*])
+
+* The multi-tenancy plug-in in Elasticsearch was inadvertently changed, while
+fixing another bug, not to look up projects for the user upon every login. This
+caused the list of projects to not be displayed properly. This bug fix changes
+the multi-tenancy plug-in in Elasticsearch back to look up projects for the user
+upon every login. As a result, the list of projects is displayed properly.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1511432[*BZ#1511432*])
+
+* Fluentd was adding the level field with a value of `3` or `6`, overwriting any
+existing level field. The level field set by the application was being removed,
+and the `3` or `6` value was not useful. With this bug fix, if there is already
+a `level` field in the record, then see if it is a "close" match to one of the
+canonical `level` field values. For example, if `level` is `CRITICAL`, convert
+to `crit`; if level is `WARN`, convert to `warning`. Otherwise, if it cannot be
+used directly or normalized, convert it to its string representation (ruby
+`to_s` method) and store the string value in the `level` field. As a result, if
+the record already has a level field, the value is normalized or preserved,
+otherwise, a value like `info` or `err` is used.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1515448[*BZ#1515448*])
+
+* A script that parsed user-supplied configuration produced an incorrect regular
+expression. This caused no impact on users; the non-escaped period in the
+regular expression matched the period in the project name as "any character".
+This bug fix properly escapes characters that should not be expanded as special
+characters in regular expressions. For example, regular expressions produced
+after applying this patch would look like [x-]`^\.operations\..*$` instead of
+`.operations.`
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1524644[*BZ#1524644*])
+
+* The load on the Elasticsearch cluster is great enough to cause a request from
+Kibana to timeout before it is able to get a response. This causes no results to
+be returned and Kibana to display an error. This bug fix modifies the Kibana
+image to allow configuration of the request timeout. As a result, Kibana is able
+to retrieve data from Elasticsearch.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538171[*BZ#1538171*])
+
+* When creating an Elasticsearch (ES) cluster of size 3+, the node quorum and
+recovery settings prevent the first ES node from ever reaching a ready and green
+state in time during a fresh install. This causes the playbook to time out
+waiting for the first ES node to be ready. With this bug fix, when new ES nodes
+are created, OpenShift no longer waits for them to be healthy since the recovery
+settings and quorum would have changed and will need all nodes to be running at
+the same time. As a result, the playbook no longer times out when creating large
+clusters of ES nodes.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1544243[*BZ#1544243*])
+
+* The Kibana container image was not built with the required header image. This
+bug fix replaces the OpenShift Origin header image with the OpenShift Container
+Platform header image. As a result, the Kibana page displays the desired header.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1547263[*BZ#1547263*])
+
+* The link generation code assumes all project logs are written to indices that
+have a common naming pattern. This can cause users to be linked to non-existent
+indices. With this bug fix, project logs that will be archived to different
+indices are annotated with the required information to properly build the link.
+As a result, users are routed using a link that will query the data store
+correctly and return data.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1547348[*BZ#1547348*])
+
+* Previously, the ClusterResourceOverride admission controller configuration was
+not passed through to the web console. This meant that the web console was
+showing fields for resource requests and limits in its forms that were
+calculated values and should have been hidden in the UI. The problem has been
+fixed, and the calculated request and limit fields are correctly hidden in the
+web console.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1501164[*BZ#1501164*])
+
+* On slow network connections, the Next button could sometimes take several
+secrets to enable when opening the create from builder image dialog on the
+OpenShift web console catalog landing page with the service catalog enabled.
+This problem has been fixed, and the Next button should now be enabled
+immediately when the dialog is displayed.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1512858[*BZ#1512858*])
+
+* Previously, the sample Git reference and context dir for building images sample
+repositories was not used when clicking the "Try Sample Repository" link in the
+web console add to project dialog. The sample reference and context dir are now
+properly set in the build config that is created when the sample is used.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1519096[*BZ#1519096*])
+
+* Previously, provisioned services that reference service classes or service plans
+that do not exist would not display correctly in the web console overview. This
+problem has been fixed. The web console now shows provisioned services even when
+its referenced service class doesn't exist.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1532182[*BZ#1532182*])
+
+* Previously, image stream tag aliases would not show up in the add to project
+dialog version dropdown when the alias was specified in "name:tag" format in the
+`from.name` property. The `oc tag --alias` uses this format. The web console now
+handles aliases in this format correctly, and they will show up as an alias in
+the version dropdown with the tag they reference.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1518497[*BZ#1518497*])
+
+* Previously, the web console would not correctly update a route host name in the
+route editor for users with authority to update custom hosts. This problem has
+been fixed, and the web console now correctly applies the changes when changing
+a route's host name.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1540783[*BZ#1540783*])
+
+* Use of javascript Array/String methods not supported by IE11 (Array.find,
+Array.findIndex, String.startsWith, String.endsWith) caused an error that
+prevents some A-MQ pages to show content when the user clicks on a tree node.
+This bug fix replaces the unsupported methods with the Lodash library equivalent
+methods. As a result, A-MQ pages show their content as expected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1543467[*BZ#1543467*])
+
+* Previously, when the service catalog was installed and then uninstalled using
+the Ansible playbooks, the web console still incorrectly showed the *Provisioned Services* menu item, which did not load any content when clicked. The bug is now
+fixed and the web console no longer shows the *Provisioned Services* menu after
+uninstalling the service catalog.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1549097[*BZ#1549097*])
+
+* The default *ui-select* selection field had a lower z-index value than the
+project bar. The *add to project* selection could be partially hidden at small
+browser viewport size because it was beneath the project bar. With this bug fix,
+the *ui-select* dropdown field a z-index was made 1 greater than the project
+bar. The *select* field will now appear over the project bar if needed.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1479114[*BZ#1479114*])
+
+* An {product-title} node was not waiting long enough for the VNID while master
+assigned VNID. It could take a while to propagate to the node, resulting in
+failed pod creation. With this bug fix, the timeout increased  from 1 to 5
+seconds for fetching VNID on the node and pod creation succeeds.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1540606[*BZ#1540606*])
+
+* When using the "static per-project egress IPs" feature, egress IPs may stop
+working in some circumstances if an egress IP is moved from one project to
+another, or from one node to another. Additionally, if the same egress IP is
+assigned to two different projects, or two different nodes, then it may not work
+correctly even after the duplicate assignment is removed. This bug fix addresses
+these issues and static per-project egress IPs now works more reliably.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1553297[*BZ#1553297*])
+
+* Certain initialization code was only run when doing a full SDN setup, and not
+when {product-title} was restarted and found the SDN was already up and running.
+If the *atomic-openshift-node* service was restarted, that node would be unable
+to create new per-project static egress IPs (`HostSubnet.EgressIPs`). The egress
+IP initialization code is now run in all circumstances. Per-project static
+egress IPs work correctly, even after a node restart.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1535658[*BZ#1535658*])
+
+* In some circumstances, iptables rules could become reordered in a way that would
+cause the "per-project static IP address" feature to stop working for some IP
+addresses. (For most users, egress IP addresses that ended with an even number
+would continue to work, but egress IP addresses ending with an odd number would
+fail.) External traffic from pods in a project that was supposed to use a
+per-project static IP address would end up using the normal node IP address
+instead. The iptables rules have been changed so that they now have the expected
+effect even when they get reordered. With this bug fix, the per-project static
+egress IP feature now works reliably.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1540611[*BZ#1540611*])
+
+* In some circumstances, nodes were apparently receiving a duplicate out-of-order
+HostSubnet "deleted" event from the master. When processing the duplicate event,
+the node could end up deleting OVS flows corresponding to an active node,
+causing pods on the two nodes to be unable to communicate with each other. This
+was most noticeable when it happened to a node hosting the registry. With this
+bug fix, the HostSubnet event-processing code will now notice that the event is
+a duplicate and ignore it. As a result, OVS flows are not deleted, and pods can
+communicate.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1546170[*BZ#1546170*])
+
+* Previously, a "transport endpoint is not connected" error occurred when deleting
+projects with pods using CNS backed PVs. This bug fix corrects the issue.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1546156[*BZ#1546156*])
+
+* When using the vSphere cloud provider, the `InternalIP` information was not
+populated for nodes. This would cause issues with Heapster since it uses the
+`InternalIP` for gathering metrics. With this bug fix, the `InternalIP`
+information is now populated and the issues are resolved.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1527315[*BZ#1527315*])
+
+* The installer has been modified to turn on API aggregation for upgrades to
+{product-title} 3.7, which is a required dependency for service catalog to work
+properly.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1523298[*BZ#1523298*])
+
+* Previously, the Ansible installer was not updating the  API service definition
+with newly generated certificate data. Also, the service catalog API  server was
+not being restarted to pick up the new certificates. Using mismatched CAs causes
+x509 errors in the API server logs and, with this bug fix, is now corrected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1523625[*BZ#1523625*])
+
+* {product-title} 3.7 upgrades were incorrectly using an old default etcd port
+value of `4001`. This bug fix modifies the value to the number, `2379`.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1535206[*BZ#1535206*])
+
+* Unbinding a template service instance throws an error if the template service
+instance was deleted. It becomes impossible to unbind a service instance if the
+template service instance was manually deleted, including if the project
+containing the TSI was deleted. The template service broker will return
+*success/gone* in cases where the unbind refers to a non-existent template
+service instance. With this bug fix, the unbind can proceed even if the TSI no
+longer exists.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1543044[*BZ#1543044*])
+
+* The broker overwrote the bind credentials on subsequent bind endpoint calls,
+causing bind credentials to be saved incorrectly. With this bug fix, bind
+credentials are now saved for every call.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1501512[*BZ#1501512*])
+
+* The update strategy in the controller manager template was incorrectly set.
+Previously, any parameters that were modified in the controller manager template
+would fail to cause the pod to redeploy with the updated changes. With this bug
+fix, the issue is corrected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1537227[*BZ#1537227*])
+
+* {product-title} checked mounted NFS volumes with `squash` (running as root).
+Permissions of {product-title} (running as root) were squashed to user `nobody`,
+which did not have permissions to access mounted NFS volumes. As a result,
+{product-title} checks failed and NFS volumes were not unmounted.
+{product-title} does not access mounted NFS volumes at all and checks for mounts
+by parsing the *_/proc_* filesystem. With this bug fix, NFS volumes with the
+root `squash` option are unmounted.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1536019[*BZ#1536019*])
+
+* Incorrect batch size calculations in Ansible 2.4.1 would cause playbooks to fail
+when using `max_fail_percentage`. The batch calculations were updated in
+Ansible 2.4.2 to correctly account for failures in each batch.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538807[*BZ#1538807*])
+
+* During the control plane upgrade, etcd is now upgraded to etcd 3.2.x.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1495486[*BZ#1495486*])
+
+[[ocp-3-7-42-2-enhancements]]
+==== Enhancements
+
+* To avoid the unplanned restart of Elasticsearch pods, which could cause loss of
+data, Elasticsearch deployment configurations are now created without
+configuration change triggers. When a configuration change is made to an
+Elasticsearch deployment configuration, it is no longer automatically rolled
+out, and can instead be done manually at a scheduled time. See
+xref:../install_config/aggregate_logging.adoc#manual-elasticsearch-rollouts[Manual Elasticsearch Rollouts] for steps on how to do so.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1498989[*BZ#1498989*])
+
+* Regular expressions are now allowed in Curator settings. A special tag can be
+used in Curator settings to specify custom regular expressions.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1541948[*BZ#1541948*])
+
+[[ocp-3-7-42-2-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.6 or 3.7 cluster to this latest
+release, use the automated upgrade playbook. See
+xref:../upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
+Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-7-44]]
+=== RHSA-2018:1231 - {product-title} 3.7.44 Security and Bug Fix Update
+
+Issued: 2018-04-29
+
+{product-title} release 3.7.44 is now available. The packages, security fixes,
+and bug fixes included in the update are documented in the
+link:https://access.redhat.com/errata/RHSA-2018:1231[RHSA-2018:1231] and
+link:https://access.redhat.com/errata/RHBA-2018:1261[RHBA-2018:1261] advisories.
+The list of container images included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1230[RHBA-2018:1230] and
+link:https://access.redhat.com/errata/RHBA-2018:1262[RHBA-2018:1262] advisories.
+
+[[ocp-3-7-44-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.6 or 3.7 cluster to this latest
+release, use the automated upgrade playbook. See
+xref:../upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
+Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-7-46]]
+=== RHBA-2018:1576 - {product-title} 3.7.46 Bug Fix and Enhancement Update
+
+Issued: 2018-05-18
+
+{product-title} release 3.7.46 is now available. The packages and bug fixes
+included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1576[RHBA-2018:1576] advisory.
+The list of container images included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1577[RRHBA-2018:1577] advisory.
+
+Space precluded documenting all of the bug fixes for this release in
+the advisory. See the following sections for notes on upgrading and details on
+the bug fixes and enhancements included in this release.
+
+[[ocp-3-7-46-bug-fixes]]
+==== Bug Fixes
+
+* Previously, the value of `openshift_master_extension_scripts` was not preserved
+during installations when the service catalog was enabled. This bug fix ensures
+that the scripts in `openshift_master_extension_scripts` are now correctly set
+during installation.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1541129[*BZ#1541129*])
+
+* When verifying various API endpoints, a timeout was not set. This meant that the
+verification would wait 120 seconds for the connection to fail and then wait the
+prescribed delay before retrying. This would have led to certain tasks waiting
+up to two hours rather than moving forward with the installation. With this bug
+fix, a connection timeout of two seconds has now been set.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1556679[*BZ#1556679*])
+
+* The EFS Provisioner image tag was incorrectly set to match the tag of all other
+OpenShift Container Platform images. This has been updated and now installations
+will pull from the `latest` image tag, which should be compatible with all
+versions of OpenShift Container Platform.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1566300[*BZ#1566300*])
+
+* The number of fluentd outputs is computed in the startup script run.sh. When the
+forward plug-in was configured, it was not correctly counted. This caused a
+number of output to be missed when the forward plug-in was configured. The
+number of output is used for calculating the file buffer size and the size grew
+larger than expected. This bug fix updates the logic of the calculation to
+include the forward plug-in case. As a result, the correct output number then
+the correct file buffer size is now derived when the forward plug-in is
+configured.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1569544[*BZ#1569544*])
+
+* The default write operation for fluentd to Elasticsearch is index. Writes can
+trigger unnecessary `delete` operations for Elasticsearch causing extra load
+that affects performance. This bug fix utilizes the `create` operation which
+will avoid 'delete' when duplicates are introduced.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1568415[*BZ#1568415*])
+
+* Due to incorrect management of OVS flows, if two nodes rebooted and swapped IP
+addresses when they came back up, then other nodes might become unable to send
+traffic to pods on one or both of those nodes. With this bug fix, the code that
+manages OVS flows is now more careful to make the correct changes in cases of
+node IP reassignment. As a result, pod-to-pod traffic should continue to work
+correctly even after nodes swap IP addresses.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1570396[*BZ#1570396*])
+
+* Updating egress policy required blocking outgoing traffic, patching OVS flows,
+and then re-enabling traffic. However, the OVS flow generation for DNS names was
+slow, resulting in a few seconds egress traffic downtime, which may not be
+acceptable. This bug fix changes update egress policy handling to pre-populate
+all new OVS flows before blocking the outgoing traffic. As a result, the
+downtime during egress policy updates is now reduced.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1571433[*BZ#1571433*])
+
+* When using per-namespace static egress IPs, all external traffic is routed
+through the egress IP. "External" means all traffic which is not directed to
+another pod, and so includes traffic from the pod to the pod's node. When pods
+are told to use the node's IP address for DNS, and the pod is using a static
+egress IP, then DNS traffic will be routed to the egress node first, and then
+back to the original node, which might be configured to not accept DNS requests
+from other hosts, causing the pod to be unable to resolve DNS. With this bug
+fix, pod-to-node DNS requests now bypass the egress IP and go directly to the
+node, and as a result DNS now works as expected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1570400[*BZ#1570400*])
+
+* This update fixes an issue where a node can stop reporting status if the
+connection to the Azure API is terminated uncleanly, resulting in a long timeout
+before the connection is re-established, blocking the status update loop.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1573122[*BZ#1573122*])
+
+* Resources consumed by pods whose node is unreachable or have past their
+termination grace period are no longer counted against quota.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1455743[*BZ#1455743*])
+
+[[ocp-3-7-46-enhancements]]
+==== Enhancements
+
+* You may now define a set of hooks to run arbitrary tasks during the node upgrade
+process. To implement these hooks, set `openshift_node_upgrade_pre_hook`,
+`openshift_node_upgrade_hook`, or `openshift_node_upgrade_post_hook` to the path
+of the task file you wish to execute. The `openshift_node_upgrade_pre_hook` hook
+is executed after draining the node and before it has been upgraded. The
+`openshift_node_upgrade_hook` hook is executed after the node has been drained
+and packages updated but before it is marked schedulable again. The
+`openshift_node_upgrade_post_hook` hook is executed after the node has been
+marked schedulable immediately before moving on to other nodes.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1572798[*BZ#1572798*])
+
+* Previously, OpenShift Container Platform defaulted the indexing request timeout
+for fluentd to 600 seconds, or about 10 minutes. In certain situations, this
+timeout was not long enough. If we make this essentially infinite, we'll avoid
+fluentd pods re-submitting requests unnecessarily. With this enhancement, the
+fluentd timeout is now 2147483648 and will wait for a very long time before
+resubmitting a request to Elasticsearch due to a timeout failure. As a result,
+this avoids fluentd pods being resubmitted unnecessarily.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1569548[*BZ#1569548*])
+
+[[ocp-3-7-46-upgrading]]
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.6 or 3.7 cluster to this latest


### PR DESCRIPTION
Catching up some 3.7 relnote changes that were mistakenly only made on enterprise-3.7. FYI @vikram-redhat @ahardin-rh 