### PR TITLE
Sync 3.6 relnotes to master

### DIFF
--- a/release_notes/ocp_3_6_release_notes.adoc
+++ b/release_notes/ocp_3_6_release_notes.adoc
@@ -13,18 +13,17 @@ toc::[]
 
 == Overview
 
-Red Hat {product-title} is a Platform as a Service (PaaS) that provides
-developers and IT organizations with a cloud application platform for deploying
-new applications on secure, scalable resources with minimal configuration and
-management overhead. {product-title} supports a wide selection of
-programming languages and frameworks, such as Java, Ruby, and PHP.
+Red Hat {product-title} provides developers and IT organizations with a cloud
+application platform for deploying new applications on secure, scalable
+resources with minimal configuration and management overhead. {product-title}
+supports a wide selection of programming languages and frameworks, such as Java,
+Ruby, and PHP.
 
-Built on Red Hat Enterprise Linux and Google Kubernetes, {product-title}
-provides a secure and scalable multi-tenant operating system for today’s
-enterprise-class applications, while providing integrated application runtimes
-and libraries. {product-title} brings the OpenShift PaaS platform to customer
-data centers, enabling organizations to implement a private PaaS that meets
-security, privacy, compliance, and governance requirements.
+Built on Red Hat Enterprise Linux and Kubernetes, {product-title} provides a
+secure and scalable multi-tenant operating system for today’s enterprise-class
+applications, while providing integrated application runtimes and libraries.
+{product-title} enables organizations to meet security, privacy, compliance, and
+governance requirements.
 
 [[ocp-36-about-this-release]]
 == About This Release
@@ -38,6 +37,9 @@ Origin 3.6]. New features, changes, bug fixes, and known issues that pertain to
 
 {product-title} 3.6 is supported on RHEL 7.3 and newer with the latest packages
 from Extras, including Docker 1.12.
+
+TLSV1.2 is the only supported security version in {product-title} version 3.4
+and later. You must update if you are using TLSV1.0 or TLSV1.1.
 
 For initial installations, see the
 xref:../install_config/install/planning.adoc#install-config-install-planning[Installing
@@ -3440,3 +3442,196 @@ To upgrade an existing {product-title} 3.5 or 3.6 cluster to this latest
 release, use the automated upgrade playbook. See
 xref:../install_config/upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
 Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-6-173-0-112]]
+=== RHBA-2018:1106 - {product-title} 3.6.173.0.112 Bug Fix Update
+
+Issued: 2018-04-12
+
+{product-title} release 3.6.173.0.112 is now available. The list of packages
+included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1106[RHBA-2018:1106] advisory.
+The list of container images included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1107[RHBA-2018:1107] advisory.
+
+Space precluded documenting all of the bug fixes for this release in the
+advisories. See the following sections for notes on upgrading and details on the
+bug fixes included in this release.
+
+[[ocp-3-6-173-0-112-bug-fixes]]
+==== Bug Fixes
+
+[discrete]
+===== Builds
+
+* The OpenShift Docker builder invokes the Docker build API without the
+`ForceRmTemp` flag. Containers from failed builds remain on the node where the
+build ran. These containers are not recognized by the kubelet for `gc` and are
+therefore accumulated until the node runs out of space. This bug fix modifies
+the Docker build API call from the OpenShift Docker builder to force the removal
+of temporary containers. As a result, failed containers no longer remain on the
+node where a Docker build ran.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1533181[*BZ#1533181*])
+
+* The login plug-in servlet filter was not getting re-registered in Jenkins after
+a restart until a login via the web console occurred. This made HTTP access to
+an OpenShift Jenkins pod with OAuth via bearer token impossible until the
+servlet filter was re-registered. This bug fix forces the re-register of the
+login plug-in servlet filter after pod restarts. As a result, HTTP access via
+bearer token is possible without having to login via the Jenkins console first.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1533938[*BZ#1533938*])
+
+[discrete]
+===== Installer
+
+* Amazon EC2 C5 instances use different identifiers for `bios_vendor`. Code which
+uses this information for identifying the host as an AWS instance was not being
+run. This bug fix adds logic to use the new `bios_vendor` identifier. As a
+result, AWS C5 instances are properly identified by *openshift-ansible* code.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538778[*BZ#1538778*])
+
+* {product-title} requires that host names conform to standards which preclude the
+use of uppercase letters. With this bug fix, the installer now ensures that the
+host names for node objects are created with lowercase letters.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1543749[*BZ#1543749*])
+
+* The `OPTIONS` value in *_/etc/sysconfig/atomic-openshift-node_* now works
+properly when multiple options are specified with containerized installations.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1539091[*BZ#1539091*])
+
+* HAProxy services files were not included in the uninstall playbook. This caused
+HAProxy service files to remain after running the uninstall playbook. This bug
+fix adds HAProxy service files to the uninstall playbook, and as a result they
+are remove after running the playbook.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1511294[*BZ#1511294*])
+
+* Alternative names in certificates were not being properly parsed. Alternatives
+with `email:` were being added as additional host names. This bug fix updates
+the logic to only add alternative names which begin with `DNS:`. As a result,
+`namedCertificates` are properly parsed and updated.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1538895[*BZ#1538895*])
+
+* The *docker_image_availability* check did not take into account variables that
+override specific container images used for containerized components. The check
+could incorrectly report failure looking for the default images when the
+overridden images to be used are actually available. This bug fix ensures the
+check now looks for override variables, and as a result the check should now
+accurately report whether the necessary images are available.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1539150[*BZ#1539150*])
+
+[discrete]
+===== Logging
+
+* The Fluentd input plug-ins treat the logs as ASCII-8BIT by default. Then, they
+are converted to UTF-8 to forward to ElasticSearch, where
+`UndefinedConversionError` is rarely observed. With this bug fix, if the
+environment variable `ENABLE_UTF8_FILTER` is set to `true`, the incoming logs
+are treated as UTF-8 and it eliminates the chance of the conversion error.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1505959[*BZ#1505959*])
+
+* Messages for which the unique namespace ID could not be determined could not be
+properly indexed. Messages could be lost and the error message appears in the
+logs. This bug fix modifies the cache algorithm to provide the necessary data or
+default the value to `orphaned`. As a result, the error message is resolved and
+messages are stored in an `orphaned` index when a unique namespace ID can not be
+determined.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1506286[*BZ#1506286*],
+link:https://bugzilla.redhat.com/show_bug.cgi?id=1525415[*BZ#1525415*])
+
+* The Kibana container image was not built with the required header image. This
+bug fix replaces the OpenShift Origin header image with the OpenShift Container
+Platform header image. As a result, the Kibana page displays the desired header.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1547347[*BZ#1547347*])
+
+* Fluentd inserts documents (logs) into Elasticsearch using the bulk insert API
+but relies upon Elasticsearch to generate UUIDs for each document. It does not
+remove successfully indexed documents from the bulk payload when the bulk
+operation fails. This causes the initial payload to be resubmitted and documents
+that were successfully indexed are submitted again which results in duplicate
+documents with different UUIDs. This bug fix ensures that document IDs are
+generated before submitting bulk insert requests. As a result, Elasticsearch
+will now disregard insert of documents that already exist in the data store and
+insert documents that do not.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1556897[*BZ#1556897*])
+
+* The link generation code assumes all project logs are written to indices that
+have a common naming pattern. This can cause users to be linked to non-existent
+indices. With this bug fix, project logs that will be archived to different
+indices are annotated with the required information to properly build the link.
+As a result, users are routed using a link that will query the data store
+correctly and return data.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1547688[*BZ#1547688*])
+
+[discrete]
+===== Web Console
+
+* Use of javascript Array/String methods not supported by IE11 (`Array.find`,
+`Array.findIndex`, `String.startsWith`, `String.endsWith`) caused an error that
+prevents some A-MQ pages to show content when the user clicks on a tree node.
+This bug fix replaces the unsupported methods with the Lodash library equivalent
+methods. As a result, A-MQ pages show their content as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1543435[*BZ#1543435*])
+
+* When multiple roles with long names are assigned to a user, the roles do not wrap below. This causes the page layout to break and pushes the "Add another role" form select input off the screen, preventing additional roles from being assigned to the user. This bug fix allows roles to vertically stack, and as a result the "Add another role" select input field now remains in place. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1545089[*BZ#1545089*])
+
+[discrete]
+===== Master
+
+* Rate limiting is causing some connections to masters from nodes to be dropped,
+causing node status to not be updated properly. This bug fix uses a separate
+(non-limited) client for node status. As a result, the node status should be
+properly saved in the master.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1527389[*BZ#1527389*])
+
+* This update fixes an issue in an event reported by the deployment configuration
+controller where the old replica count would be an unreasonably large and
+incorrect number.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1536189[*BZ#1536189*])
+
+[discrete]
+===== Pod
+
+* This update fixes an issue where when querying the Azure API for the existence
+of a instance and there was an error, the error was dropped and views as the
+instance not existing. This caused unintended side effects like the node to
+going into *NotReady* state or the pods being evicted from the node.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1550992[*BZ#1550992*])
+
+* This update fixes an issue where slow pod deletion on a node under eviction
+pressure could result in the eviction of all pods.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1509289[*BZ#1509289*])
+
+[discrete]
+===== Storage
+
+* Dynamic provisioning of Cinder volumes stops working after certain amount of
+time. Restarting {product-title} resolves this problem temporarily because it is
+unable to re-authenticate to OpenStack Keystone V3. This made it impossible to
+create new Cinder volumes using dynamic provisioning. This bug fixes
+{product-title} re-authentication to OpenStack Keystone V3, and as a result
+dynamic provisioning of new Cinder volumes works as expected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1527973[*BZ#1527973*])
+
+[[ocp-3-6-173-0-112-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.5 or 3.6 cluster to this latest release, use the
+automated upgrade playbook. See
+xref:../install_config/upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-6-173-0-117]]
+=== RHBA-2018:1579 - {product-title} 3.6.173.0.117 Bug Fix and Enhancement Update
+
+Issued: 2018-05-17
+
+{product-title} release 3.6.173.0.117 is now available. The packages, bug fixes,
+and enhancements included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1579[RHBA-2018:1579] advisory.
+The list of container images included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2018:1578[RHBA-2018:1578] advisory.
+
+[[ocp-3-6-173-0-117-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.5 or 3.6 cluster to this latest release, use the
+automated upgrade playbook. See
+xref:../install_config/upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing Automated In-place Cluster Upgrades] for instructions.


### PR DESCRIPTION
Catching up some 3.6 relnote changes that were mistakenly only made on enterprise-3.6. FYI @vikram-redhat @ahardin-rh