### PR TITLE
Bug 1454929 openshift_metrics_hawkular_hostname is no longer a required variable

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -439,6 +439,11 @@ pods are placed onto nodes with specific labels. For example,
 remove the HOSA from an installation. HOSA can be used to collect custom
 metrics from your pods. This component is currently in
 Technology Preview and is not installed by default.
+
+|`openshift_metrics_hawkular_hostname`
+|Set when executing the `openshift_metrics` Ansible role, since it uses the host
+name for the Hawkular Metrics xref:../architecture/networking/routes.adoc#architecture-core-concepts-routes[route].
+This value should correspond to a fully qualified domain name.
 |===
 
 [NOTE]
@@ -460,12 +465,6 @@ endif::[]
 
 See xref:../dev_guide/compute_resources.adoc#dev-compute-resources[Compute
 Resources] for further discussion on how to specify requests and limits.
-
-The only required variable is `openshift_metrics_hawkular_hostname`. This value is
-required when executing the `openshift_metrics` Ansible role because it uses the host name for the
-Hawkular Metrics xref:../architecture/networking/routes.adoc#architecture-core-concepts-routes[route]. This
-value should correspond to a fully qualified domain name. You must know
-the value of `openshift_metrics_hawkular_hostname` when configuring the console for metrics access.
 
 If you are using
 xref:../install_config/cluster_metrics.adoc#metrics-persistent-storage[persistent


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1454929