### PR TITLE
Modify cluster limits for ocp v3.10

### DIFF
--- a/scaling_performance/cluster_limits.adoc
+++ b/scaling_performance/cluster_limits.adoc
@@ -39,7 +39,7 @@ version or storage data format.
 | Number of pods footnoteref:[numberofpods,The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.]
 | 120,000
 | 120,000
-| 120,000
+| 150,000
 
 | Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per node]
 | 250
@@ -68,7 +68,7 @@ number of objects of a given type in a single namespace can make those loops
 expensive and slow down processing given state changes.]
 | 15,000
 | 15,000
-| 15,000
+| 5,000
 
 | Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
 | 10,000
@@ -83,7 +83,7 @@ expensive and slow down processing given state changes.]
 | Number of deployments per namespace footnoteref:[objectpernamespace]
 | 20,000
 | 20,000
-| 20,000
+| 2,000
 
 |===
 


### PR DESCRIPTION
This commit modifies the limits for ocp v3.10 including number of pods,
number of pods per namespaces and deployments per namespace.