### PR TITLE
Trello-695 Document Message Collection Guarantees

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -209,7 +209,7 @@ secret to be used for pulling component images from an authenticated registry.
 | The minute of the hour Curator will run.
 
 |`openshift_logging_curator_run_timezone`
-|The timezone Curator uses for figuring out its run time. Provide a the 
+|The timezone Curator uses for figuring out its run time. Provide the
 timezone as a string in the tzselect(8) or timedatectl(1) "Region/Locality"
 format, for example `America/New_York` or `UTC`.
 
@@ -901,6 +901,23 @@ xref:../install/configuring_inventory_file.adoc#configuring-node-host-labels[nod
 
 Fluentd uses `journald` as the system log source. These are log messages from
 the operating system, the container runtime, and OpenShift.
+
+The available container runtimes provide minimal information to identify the
+source of log messages. Log collection and normalization of logs can occur after
+a pod is deleted and additional metadata cannot be retrieved from the
+API server, such as labels or annotations.
+
+If a pod with a given name and namespace is deleted before the log collector
+finishes processing logs, there might not be a way to distinguish the log messages
+from a similarly named pod and namespace. This can cause logs to be indexed and
+annotated to an index that is not owned by the user who deployed the pod.
+
+[IMPORTANT]
+====
+The available container runtimes provide minimal information to identify the
+source of log messages and do not guarantee unique individual log
+messages or that these messages can be traced to their source.
+====
 
 Clean installations of {product-title} 3.9 use `json-file` as the default log
 driver, but environments upgraded from {product-title} 3.7 will maintain their


### PR DESCRIPTION
@jcantrill - This is my first pass for this card. From the doc, it wasn't clear [to me] if this applies to journald alone, json-file, both, or neither. 

Can you help provide guidance on the content and where is best fits in the documentation? 

We'll also need to address the statement in the following paragraph for 3.10: " Clean installations of {product-title} 3.9 use `json-file` as the default log driver..." Does this apply still for 3.10?

Thanks! :sun_with_face: 

https://trello.com/c/TXO785oo/896-document-document-message-collection-guarantees