### PR TITLE
Slight clarification to multitenant-to-networkpolicy migration doc

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -280,8 +280,9 @@ $ oc get netnamespace
 [[migrating-between-sdn-plugins-networkpolicy]]
 === Migrating from ovs-multitenant to ovs-networkpolicy
 
-Before migrating from the *ovs-multitenant* plug-in to the *ovs-networkpolicy*
-plug-in, ensure that every namespace has a unique `NetID`. This means that if you
+In addition to the generic plugin migration steps above, there is one additional step
+when migrating from the *ovs-multitenant* plug-in to the *ovs-networkpolicy* plug-in;
+you must ensure that every namespace has a unique `NetID`. This means that if you
 have previously
 xref:../admin_guide/managing_networking.adoc#joining-project-networks[joined projects
 together] or


### PR DESCRIPTION
If someone follows a link directly to "Migrating from ovs-multitenant to ovs-networkpolicy", they might not notice that it's a subsection of a larger "Migrating Between SDN Plug-ins" section that they also need to read the rest of. This just adds a quick reference to the previous section there. Feel free to rewrite.
