### PR TITLE
Bug 1585964 - Update web console architecture topic for 3.9+

### DIFF
--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -24,28 +24,28 @@ link:http://caniuse.com/#feat=websockets[WebSockets].
 ====
 
 ifdef::openshift-enterprise,openshift-origin[]
-The web console is started as part of the
-xref:kubernetes_infrastructure.adoc#master[master]. All static assets required
-to run the web console are served from the `openshift` binary. Administrators
-can also xref:../../install_config/web_console_customization.adoc#install-config-web-console-customization[customize the
-web console] using extensions, which let you run scripts and load custom
-stylesheets when the web console loads. You can change the look and feel of
-nearly any aspect of the user interface in this way.
+The web console runs as a pod on the xref:kubernetes_infrastructure.adoc#master[master].
+The static assets required to run the web console are served by the pod.
+Administrators can also
+xref:../../install_config/web_console_customization.adoc#install-config-web-console-customization[customize the web console]
+using extensions, which let you run scripts and load custom stylesheets when
+the web console loads.
 
 When you access the web console from a browser, it first loads all required
-static assets. It then makes requests to the {product-title} APIs using
-the values defined from the `openshift start` option
-`--public-master`, or from the related
-xref:../../install_config/master_node_configuration.adoc#master-configuration-files[master configuration file] parameter `masterPublicURL`.
-The web console uses WebSockets to maintain a persistent connection with the API
-server and receive updated information as soon as it is available.
+static assets. It then makes requests to the {product-title} APIs using the
+values defined from the `openshift start` option `--public-master`, or from the
+related parameter `masterPublicURL` in the `webconsole-config` config map
+defined in the `openshift-web-console` namespace. The web console uses
+WebSockets to maintain a persistent connection with the API server and receive
+updated information as soon as it is available.
 
 .Web Console Request Architecture
 image::web_console_request_arch.png["Web Console Request Architecture"]
 
 [[corsAllowedOrigins]]
 The configured host names and IP addresses for the web console are whitelisted to access the
-API server safely even when the browser would consider the requests to be link:http://www.w3.org/TR/cors/[cross-origin]. To access the API server from a web application using a different host name, you must
+API server safely even when the browser would consider the requests to be link:http://www.w3.org/TR/cors/[cross-origin].
+To access the API server from a web application using a different host name, you must
 whitelist that host name by specifying the `--cors-allowed-origins` option
 on `openshift start` or from the related
 xref:../../install_config/master_node_configuration.adoc#master-configuration-files[master


### PR DESCRIPTION
The web console now runs as a pod. Update the architecture topic to
reflect the change.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1585964

/assign @ahardin-rh 