### PR TITLE
Modify the cluster limits for ocp v3.10

### DIFF
--- a/scaling_performance/cluster_limits.adoc
+++ b/scaling_performance/cluster_limits.adoc
@@ -68,7 +68,7 @@ number of objects of a given type in a single namespace can make those loops
 expensive and slow down processing given state changes.]
 | 15,000
 | 15,000
-| 5,000
+| 3,000
 
 | Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
 | 10,000


### PR DESCRIPTION
This commit modifies the pods per namespace limit for ocp v3.10 to
stay in sync with the upstream cluster limits.