### PR TITLE
Add router http/2 enable environment variable description.

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -38,6 +38,7 @@ and "-". The default is the hashed internal key name for the route.
 |`ROUTER_DENIED_DOMAINS` | | A comma-separated list of domains that the host name in a route can not be part of. No subdomain in the domain can be used either. Overrides option `ROUTER_ALLOWED_DOMAINS`.
 |`ROUTER_ENABLE_COMPRESSION`| | If `true` or `TRUE`, compress responses when possible.
 |`ROUTER_ENABLE_INGRESS`| | If `true` or `TRUE`, look at both Ingress objects and Route objects.
+|`ROUTER_ENABLE_HTTP2`| | If `true` or `TRUE`, enables HTTP/2 protocol support for incoming connections to the router. The router automatically negotiates the connection down to HTTP/1.x if the client does not support the HTTP/2 protocol.
 |`ROUTER_LISTEN_ADDR`| 0.0.0.0:1936 | Sets the listening address for xref:../../install_config/router/default_haproxy_router.adoc#exposing-the-router-metrics[router metrics].
 |`ROUTER_LOG_LEVEL` | warning | The log level to send to the syslog server.
 |`ROUTER_MAX_CONNECTIONS`| 20000 | Maximum number of concurrent connections.


### PR DESCRIPTION
Docs for trello card: https://trello.com/c/qzvlzuyx/27-3-implement-router-http-2-support-terminating-at-the-router-router

Note: This is a 3.11 feature 

@knobunc @bfallonf  PTAL thx   [not sure who else to cc]