### PR TITLE
Edit suggested in file admin_guide/scheduling/pod_placement.adoc

### DIFF
--- a/admin_guide/scheduling/pod_placement.adoc
+++ b/admin_guide/scheduling/pod_placement.adoc
@@ -50,10 +50,7 @@ spec:
   nodeName: <value>
 ----
 
-. Modify the master configuration file
-(*_/etc/origin/master/master-config.yaml_*) in two places:
-+
-.. Add `PodNodeConstraints` to the `admissionConfig` section:
+. Modify the master configuration file, *_/etc/origin/master/master-config.yaml_*, to add `PodNodeConstraints` to the `admissionConfig` section:
 +
 ----
 ...
@@ -63,20 +60,6 @@ admissionConfig:
       configuration:
         apiversion: v1
         kind: PodNodeConstraintsConfig
-...
-----
-
-.. Then, add the same to the `kubernetesMasterConfig` section:
-+
-----
-...
-kubernetesMasterConfig:
-  admissionConfig:
-    pluginConfig:
-      PodNodeConstraints:
-        configuration:
-          apiVersion: v1
-          kind: PodNodeConstraintsConfig
 ...
 ----
 
@@ -112,8 +95,8 @@ control over the labels that certain roles can specify in a pod configuration's
 label that appears in `nodeSelectorLabelBlacklist`.
 
 For example, an {product-title} cluster might consist of five data
-centers spread across two regions. In the U.S., "us-east", "us-central", and
-"us-west"; and in the Asia-Pacific region (APAC), "apac-east" and "apac-west".
+centers spread across two regions. In the U.S., *us-east*, *us-central*, and
+*us-west*; and in the Asia-Pacific region (APAC), *apac-east* and *apac-west*.
 Each node in each geographical region is labeled accordingly. For example,
 `region: us-east`.
 
@@ -170,10 +153,7 @@ spec:
 ...
 ----
 
-. Modify the master configuration file
-(*_/etc/origin/master/master-config.yaml_*) in two places:
-+
-.. Add `nodeSelectorLabelBlacklist` to the `admissionConfig` section with
+. Modify the master configuration file, *_/etc/origin/master/master-config.yaml_*, to add `nodeSelectorLabelBlacklist` to the `admissionConfig` section with
 the labels that are assigned to the node hosts you want to deny pod placement:
 +
 ----
@@ -187,23 +167,6 @@ admissionConfig:
         nodeSelectorLabelBlacklist:
           - kubernetes.io/hostname
           - <label>
-...
-----
-
-.. Then, add the same to the `kubernetesMasterConfig` section to restrict direct pod creation:
-+
-----
-...
-kubernetesMasterConfig:
-  admissionConfig:
-    pluginConfig:
-      PodNodeConstraints:
-        configuration:
-          apiVersion: v1
-          kind: PodNodeConstraintsConfig
-          nodeSelectorLabelBlacklist:
-            - kubernetes.io/hostname
-            - <label_1>
 ...
 ----
 
@@ -238,7 +201,7 @@ To activate the *Pod Node Selector* admission controller:
 
 . Configure the *Pod Node Selector* admission controller and whitelist, using one of the following methods: 
 
-** Add the following to the master configuration file (*_/etc/origin/master/master-config.yaml_*):
+** Add the following to the master configuration file, *_/etc/origin/master/master-config.yaml_*:
 +
 ----
 admissionConfig:


### PR DESCRIPTION
See https://github.com/openshift/openshift-docs/issues/9867
"In the Constraining Pod Placement Using Node Name section, PodNodeConstraints should not be placed in two places at master-config.yaml but only in the admissionConfig.pluginConfig field." 

Removed the steps to modify the `kubernetesMasterConfig` parameters. 