### PR TITLE
Add Dynatrace Monitoring for OpenShift docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -528,6 +528,9 @@ Topics:
   File: docker_tasks
 - Name: Managing Certificates
   File: certificate_management
+- Name: Monitoring OpenShift with Dynatrace
+  File: dynatrace_oneagent_installation
+  Distros: openshift-origin
 ---
 Name: Cluster Administration
 Dir: admin_guide

--- a/day_two_guide/dynatrace_oneagent_installation.adoc
+++ b/day_two_guide/dynatrace_oneagent_installation.adoc
@@ -1,0 +1,43 @@
+[[day_two_dynatrace_oneagent_installation]]
+= Monitoring OpenShift with Dynatrace
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+This topic contains steps to roll out Dynatrace OneAgent to all of the {product-title}
+cluster nodes to allow for monitoring all applications running within the {product-title} cluster as well as the cluster nodes itselfes.
+
+The instructions provided in this guideline require access to the enterprise-ready link:https://access.redhat.com/containers/?tab=overview#/registry.connect.redhat.com/dynatrace/oneagent[dynatrace/oneagent] image from the Red Hat Container Catalog. 
+
+[[day-two-guide-locate-dynatrace-oneagent-installer-url]]
+== Locate Dynatrace OneAgent installer URL
+
+include::day_two_guide/topics_dynatrace/locate_installer_url.adoc[leveloffset=+2]
+
+[[day-two-guide-dynatrace-oneagent-installation]]
+== Installation
+
+include::day_two_guide/topics_dynatrace/installation.adoc[leveloffset=+2]
+
+[[day-two-guide-dynatrace-oneagent-uninstallation]]
+== Uninstallation
+
+include::day_two_guide/topics_dynatrace/uninstallation.adoc[leveloffset=+2]
+
+[[day-two-guide-dynatrace-oneagent-updating]]
+== Updating
+
+include::day_two_guide/topics_dynatrace/updating.adoc[leveloffset=+2]
+
+[[day-two-guide-dynatrace-troubleshooting]]
+== Troubleshooting
+
+include::day_two_guide/topics_dynatrace/troubleshooting.adoc[leveloffset=+2]
+

--- a/day_two_guide/topics_dynatrace/installation.adoc
+++ b/day_two_guide/topics_dynatrace/installation.adoc
@@ -1,0 +1,157 @@
+////
+Install Dynatrace OneAgent
+
+Module included in the following assemblies:
+
+* day_two_guide/dynatrace_oneagent_installation.adoc
+////
+
+The following template uses a Dynatrace OneAgent image with a DaemonSet to install Dynatrace OneAgent for full-stack monitoring on each node of an {product-title} cluster.
+
+[NOTE]
+====
+Please note that enforcing the below `dynatrace-oneagent.yml` template requires a service account named `dynatrace` that can create privileged pods. See below for detailed instructions.
+====
+
+[discrete]
+=== Procedure
+
+. Log into your {product-title} cluster as `system:admin`
++
+----
+$ oc login -u system:admin
+----
+
+. Select an {product-title} project to run the Dynatrace OneAgent image
++
+----
+$ oc project openshift-infra
+----
+
+. In this project, create a service account named `dynatrace`
++
+----
+$ oc create serviceaccount dynatrace
+----
+
+. Allow the `dynatrace` service account to pull images from the RHCC via `registry.connect.redhat.com`. Be sure to replace `[username]`, `[password]` and `[email]` with your Red Hat Customer Portal's account credentials
++
+----
+$ oc secrets new-dockercfg rhcc \
+    --docker-server=registry.connect.redhat.com \
+    --docker-username=[username] \
+    --docker-password=[password] \
+    --docker-email=[email]
+----
++
+----
+$ oc secrets link dynatrace rhcc --for=pull
+----
+
+. Grant the `dynatrace` service account permissions to run Dynatrace OneAgent as a privileged container
++
+----
+$ oc adm policy add-scc-to-user privileged -z dynatrace
+----
+
+. Deploy Dynatrace OneAgent using the `dynatrace-oneagent.yml` template. Replace `[oneagent-installer-script-url]` with your actual OneAgent xref:dynatrace_oneagent_installation.adoc#day-two-guide-locate-dynatrace-oneagent-installer-url[installer script url]. Be sure to enclose the URL with quotation marks. Otherwise the URL will break the commands
++
+The `dynatrace-oneagent.yml` template for {product-title}:
++
+----
+kind: Template
+apiVersion: v1
+name: dynatrace-oneagent
+labels:
+  template: dynatrace-oneagent
+metadata:
+  name: dynatrace-oneagent
+  annotations:
+    openshift.io/display-name: Dynatrace OneAgent
+    description: Installs Dynatrace OneAgent for all-in-one, full-stack monitoring of OpenShift with Dynatrace. Requires privileged access.
+objects:
+  - apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      name: dynatrace-oneagent
+    spec:
+      template:
+        metadata:
+          labels:
+            name: dynatrace-oneagent
+        spec:
+          containers:
+          - name: dynatrace-oneagent
+            image: registry.connect.redhat.com/dynatrace/oneagent
+            imagePullPolicy: Always
+            env:
+            - name: ONEAGENT_INSTALLER_SCRIPT_URL
+              value: "${ONEAGENT_INSTALLER_SCRIPT_URL}"
+            - name: ONEAGENT_INSTALLER_SKIP_CERT_CHECK
+              value: "${ONEAGENT_INSTALLER_SKIP_CERT_CHECK}"
+            args:
+            - "APP_LOG_CONTENT_ACCESS=1"
+            volumeMounts:
+            - name: host-root
+              mountPath: /mnt/root
+            securityContext:
+              privileged: true
+          volumes:
+          - name: host-root
+            hostPath:
+              path: /
+          hostIPC: true
+          hostNetwork: true
+          hostPID: true
+          serviceAccountName: dynatrace
+parameters:
+  - name: ONEAGENT_INSTALLER_SCRIPT_URL
+    description: "A URL that points to your cluster's OneAgent download location (Select \"Deploy Dynatrace\" from the Dynatrace navigation menu to access your URL). Example: https://EnvironmentID.live.dynatrace.com/installer/oneagent/unix/latest/AbCdEfGhIjKlMnOp."
+    required: true
+  - name: ONEAGENT_INSTALLER_SKIP_CERT_CHECK
+    description: "Must be true if the SSL certificate check upon OneAgent download will be omitted, otherwise false (default). If you're using a Dynatrace Managed cluster with a self-signed certificate, set this to true."
+    value: "false"
+    required: false
+----
++
+----
+$ oc process -f dynatrace-oneagent.yml ONEAGENT_INSTALLER_SCRIPT_URL="[oneagent-installer-script-url]" | oc create -f -
+----
+
+. Verify that the `dynatrace-oneagent` daemon set has been created successfully
++
+----
+$ oc status
+In project openshift-infra on server https://127.0.0.1:8443
+
+pod/dynatrace-oneagent-abcde runs dynatrace/oneagent
+----  
++
+Check if `dynatrace-oneagent` pods are running
++
+----
+$ oc get pods
+NAME                       READY     STATUS              RESTARTS   AGE
+dynatrace-oneagent-abcde   1/1       Running             0          1m
+----
++
+Check logs from `dynatrace-oneagent` pod
++
+----
+$ oc logs -f dynatrace-oneagent-abcde
+09:46:18 Deploying agent to /tmp/Dynatrace-OneAgent-Linux.sh via https://EnvironmentID.live.dynatrace.com/installer/oneagent/unix/latest/AbCdEfGhIjKlMnOp
+...
+09:46:24 Validating agent installer in /tmp/Dynatrace-OneAgent-Linux.sh
+Verification successful
+09:46:24 Started agent deployment as docker image, PID 1234.
+09:46:24 Container version: 1.x
+09:46:24 Checking root privileges...
+09:46:24 OK
+09:46:27 Installation started, version 1.x, build date: 01.01.2017, PID 1234.
+...
+----
+
+[NOTE]
+====
+For {product-title} versions 3.7 and higher, the Red Hat Container Catalog may not accept the auto-generated `dockercfg` secret type (because of link:https://bugzilla.redhat.com/show_bug.cgi?id=1476330[BZ#1476330]). Therefore, you must link:https://access.redhat.com/documentation/en-us/openshift_container_platform/3.7/html/developer_guide/dev-guide-managing-images#allowing-pods-to-reference-images-from-other-secured-registries[create a generic file-based secret using the generated file from a docker login command].
+====

--- a/day_two_guide/topics_dynatrace/locate_installer_url.adoc
+++ b/day_two_guide/topics_dynatrace/locate_installer_url.adoc
@@ -1,0 +1,18 @@
+////
+Locate Dynatrace OneAgent installer URL
+
+Module included in the following assemblies:
+
+* day_two_guide/dynatrace_oneagent_installation.adoc
+////
+
+The first step is to obtain the location for `ONEAGENT_INSTALLER_SCRIPT_URL`. This information is presented to you during Dynatrace OneAgent installation.
+
+[discrete]
+=== Procedure
+
+To get your `ONEAGENT_INSTALLER_SCRIPT_URL`
+
+. Select *Deploy Dynatrace* from the navigation menu.
+. Click *Start installation* and select *Linux*.
+. Copy the complete URL from the `wget` command. This is your `ONEAGENT_INSTALLER_SCRIPT_URL`. 

--- a/day_two_guide/topics_dynatrace/troubleshooting.adoc
+++ b/day_two_guide/topics_dynatrace/troubleshooting.adoc
@@ -1,0 +1,97 @@
+////
+Troubleshoot Dynatrace OneAgent installation
+
+Module included in the following assemblies:
+
+* day_two_guide/dynatrace_oneagent_installation.adoc
+////
+
+Find out how to solve problems that you may encounter when deploying OneAgent on an {product-title}.
+The first step is to obtain the location for `ONEAGENT_INSTALLER_SCRIPT_URL`. This information is presented to you during Dynatrace OneAgent xref:dynatrace_oneagent_installation.adoc#day-two-guide-dynatrace-oneagent-installation[installation].
+
+[discrete]
+=== Deployment seems successful, however the dynatrace/oneagent image can't be pulled 
+
+----
+$ oc get pods
+NAME                       READY   STATUS         RESTARTS   AGE
+dynatrace-oneagent-abcde   0/1     ErrImagePull   0          3s
+----
+
+----
+$ oc logs -f dynatrace-oneagent-abcde
+Error from server (BadRequest): container "dynatrace-oneagent" in pod "dynatrace-oneagent-abcde" is waiting to start: image can't be pulled
+----
+
+This is typically the case if the `dynatrace` service account hasn't been allowed to pull images from the RHCC (please see the xref:dynatrace_oneagent_installation.adoc#day-two-guide-dynatrace-oneagent-installation[installation] steps).
+
+[discrete]
+=== Deployment seems successful, but the dynatrace-oneagent container doesn't produce meaningful logs
+
+----
+$ oc get pods
+NAME                       READY   STATUS              RESTARTS   AGE
+dynatrace-oneagent-abcde   0/1     ContainerCreating   0          3s
+----
+
+----
+$ oc logs -f dynatrace-oneagent-abcde
+Error from server (BadRequest): container "dynatrace-oneagent" in pod "dynatrace-oneagent-abcde" is waiting to start: ContainerCreating
+----
+
+This is typically the case if the container hasn't yet fully started. Simply wait a few more seconds.
+
+[discrete]
+=== Deployment seems successful, but the dynatrace-oneagent container isn't running
+
+----
+$ oc process -f dynatrace-oneagent.yml ONEAGENT_INSTALLER_SCRIPT_URL="[oneagent-installer-script-url]" | oc create -f -
+daemonset "dynatrace-oneagent" created
+----
+
+Please note that quotes are needed to protect the special shell characters in the Dynatrace OneAgent installer URL.
+
+----
+$ oc get pods
+No resources found.
+----
+
+This is typically the case if the `dynatrace` service account hasn't been configured to run privileged pods (please see the xref:dynatrace_oneagent_installation.adoc#day-two-guide-dynatrace-oneagent-installation[installation] steps):
+
+----
+$ oc describe ds/dynatrace-oneagent
+Name:   dynatrace-oneagent
+Image(s): dynatrace/oneagent
+Selector: name=dynatrace-oneagent
+Node-Selector:  <none>
+Labels:   template=dynatrace-oneagent
+Desired Number of Nodes Scheduled: 0
+Current Number of Nodes Scheduled: 0
+Number of Nodes Misscheduled: 0
+Pods Status:  0 Running / 0 Waiting / 0 Succeeded / 0 Failed
+Events:
+  FirstSeen LastSeen  Count From    SubObjectPath Type    Reason    Message
+  --------- --------  ----- ----    ------------- --------  ------    -------
+  6m    3m    17  {daemon-set }     Warning   FailedCreate  Error creating: pods "dynatrace-oneagent-" is forbidden: unable to validate against any security context constraint: [spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used spec.securityContext.hostIPC: Invalid value: true: Host IPC is not allowed to be used spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.containers[0].securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used spec.containers[0].securityContext.hostIPC: Invalid value: true: Host IPC is not allowed to be used]
+----
+
+[discrete]
+=== Deployment was successful, but monitoring data isn't available in Dynatrace
+
+----
+$ oc get pods
+NAME                       READY     STATUS              RESTARTS   AGE
+dynatrace-oneagent-abcde   1/1       Running             0          1m
+----
+
+This is typically caused by a timing issue that occurs when application containers are started before Dynatrace OneAgent is fully installed on the system. As a consequence, some parts of your application may be uninstrumented. To be on the safe side, Dynatrace OneAgent should be fully installed and configured before you start your application containers. If your application is already running, restart its containers to achieve the same outcome.
+
+[NOTE]
+====
+If you plan to install Dynatrace OneAgent on more than 50 hosts, please consider serving the installer script via a dedicated server, such as Amazon S3. Otherwise, with more than 50 concurrent connections, Dynatrace Server may throttle requests.
+====
+
+[discrete]
+=== Limitations
+
+The same link:https://www.dynatrace.com/support/help/infrastructure/containers/how-do-i-deploy-dynatrace-oneagent-as-docker-container/#limitations[limitations] apply as when deploying OneAgent as a Docker container.

--- a/day_two_guide/topics_dynatrace/uninstallation.adoc
+++ b/day_two_guide/topics_dynatrace/uninstallation.adoc
@@ -1,0 +1,24 @@
+////
+Uninstall Dynatrace OneAgent
+
+Module included in the following assemblies:
+
+* day_two_guide/dynatrace_oneagent_installation.adoc
+////
+
+Uninstalling Dynatrace OneAgent from each node of an {product-title} cluster can be achieved as follows.
+
+[discrete]
+=== Procedure
+
+. Select the project that runs the `dynatrace-oneagent` daemon set
++
+----
+$ oc project openshift-infra
+----
+
+. Delete the `dynatrace-oneagent` daemon set:
++
+----
+$ oc delete ds/dynatrace-oneagent
+----

--- a/day_two_guide/topics_dynatrace/updating.adoc
+++ b/day_two_guide/topics_dynatrace/updating.adoc
@@ -1,0 +1,27 @@
+////
+Update Dynatrace OneAgent
+
+Module included in the following assemblies:
+
+* day_two_guide/dynatrace_oneagent_installation.adoc
+////
+
+Whenever a new version of Dynatrace OneAgent becomes available in Dynatrace, re-deploy Dynatrace OneAgent as explained in the steps below. The `dynatrace/oneagent` image will automatically fetch the latest version of Dynatrace OneAgent. If you've specified a default OneAgent install version for new hosts and applications in the link:https://www.dynatrace.com/support/help/installation/oneagent/how-do-i-update-dynatrace-agent/[OneAgent updates settings], the `dynatrace/oneagent` image will automatically fetch the defined default version of Dynatrace OneAgent.
+
+[discrete]
+=== Procedure
+
+. Delete the `dynatrace-oneagent` daemon set:
++
+----
+$ oc delete ds/dynatrace-oneagent
+----
+
+. Deploy Dynatrace OneAgent using the `dynatrace-oneagent.yml` template from the xref:dynatrace_oneagent_installation.adoc#day-two-guide-dynatrace-oneagent-installation[installation] section. Be sure to replace `[oneagent-installer-script-url]` with an appropriate download location
++
+----
+$ oc process -f dynatrace-oneagent.yml ONEAGENT_INSTALLER_SCRIPT_URL="[oneagent-installer-script-url]" | oc create -f -
+daemonset "dynatrace-oneagent" created
+----
++
+Please note that quotes are needed to protect special shell characters within the Dynatrace OneAgent installer URL.


### PR DESCRIPTION
This PR covers documentation for rolling out Dynatrace OneAgent to OpenShift cluster nodes. Documentation for our joint work on the Dynatrace Operator will follow soon. Integrating Dynatrace documentation for OpenShift with your docs was coordinated upfront with Chris Morgan and Jason Dobies. 