### PR TITLE
Bug 1549690 Add note to update imagePullPolicy for EFK Automated Upgrade

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -533,10 +533,10 @@ on what additional features you have previously enabled.
 |Feature |Next Step
 
 |Aggregated Logging
-|xref:manual_upgrades.adoc#manual-upgrading-efk-logging-stack[Upgrade the EFK logging stack.]
+|xref:automated-upgrading-efk-logging-stack[Upgrade the EFK logging stack.]
 
 | Cluster Metrics
-|xref:manual_upgrades.adoc#manual-upgrading-cluster-metrics[Upgrade cluster metrics.]
+| xref:automated-upgrading-cluster-metrics[Upgrade cluster metrics.]
 |===
 // end::automated_upgrade_after_reboot[]
 
@@ -544,6 +544,99 @@ ifdef::openshift-origin[]
 :sect: automated
 include::upgrading/manual_upgrades.adoc[tag=30to31updatingcerts]
 endif::[]
+
+[[automated-upgrading-efk-logging-stack]]
+== Upgrading the EFK Logging Stack
+
+// tag::automated-logging-upgrade-steps[]
+To upgrade an existing EFK logging stack deployment, you must use the provided
+*_/usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml_*
+Ansible playbook. This is the playbook to use if you were deploying logging for
+the first time on an existing cluster, but is also used to upgrade existing
+logging deployments.
+
+. If you have not already done so, see
+xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Specifying Logging Ansible Variables] in the
+xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs] topic and update your Ansible inventory file to at least set the
+following required variable within the `[OSEv3:vars]` section:
++
+----
+[OSEv3:vars]
+
+openshift_logging_install_logging=true <1>
+openshift_logging_image_version=<tag> <2>
+----
+<1> Enables the ability to upgrade the logging stack.
+<2> Replace `<tag>` with `{latest-int-tag}` for the latest version.
+
+. Add any other `openshift_logging_*` variables that you want to specify to
+override the defaults, as described in
+xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Specifying Logging Ansible Variables].
+
+. When you have finished updating your inventory file, follow the instructions in
+xref:../install_config/aggregate_logging.adoc#deploying-the-efk-stack[Deploying
+the EFK Stack] to run the *_openshift-logging/config.yml_* playbook and complete
+the logging deployment upgrade.
+
+[NOTE]
+====
+If your Fluentd DeploymentConfig and DaemonSet for the EFK components are
+already set with:
+----
+        image: <image_name>:<vX.Y>
+        imagePullPolicy: IfNotPresent
+----
+
+The latest version <image_name> might not be pulled if there is already one with
+the same <image_name:vX.Y> stored locally on the node where the pod is being
+re-deployed. If so, manually change the DeploymentConfig and DaemonSet to
+`imagePullPolicy: Always` to make sure it is re-pulled.
+====
+
+// end::automated-logging-upgrade-steps[]
+
+[[automated-upgrading-cluster-metrics]]
+== Upgrading Cluster Metrics
+
+// tag::automated-metrics-upgrade-steps[]
+To upgrade an existing cluster metrics deployment, you must use the provided
+*_/usr/share/ansible/openshift-ansible/playbooks/openshift-metrics/config.yml_*
+Ansible playbook. This is the playbook to use if you were deploying metrics for
+the first time on an existing cluster, but is also used to upgrade existing
+metrics deployments.
+
+. If you have not already done so, see
+xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[Specifying
+Metrics Ansible Variables] in the
+xref:../install_config/cluster_metrics.adoc#install-config-cluster-metrics[Enabling
+Cluster Metrics] topic and update your Ansible inventory file to at least set
+the following required variables within the `[OSEv3:vars]` section:
++
+----
+[OSEv3:vars]
+
+openshift_metrics_install_metrics=true <1>
+openshift_metrics_image_version=<tag> <2>
+openshift_metrics_hawkular_hostname=<fqdn> <3>
+openshift_metrics_cassandra_storage_type=(emptydir|pv|dynamic) <4>
+----
+<1> Enables the ability to upgrade the metrics deployment.
+<2> Replace `<tag>` with `{latest-int-tag}` for the latest version.
+<3> Used for the Hawkular Metrics route. Should correspond to a fully qualified
+domain name.
+<4> Choose a type that is consistent with the previous deployment.
+
+. Add any other `openshift_metrics_*` variables that you want to specify to
+override the defaults, as described in
+xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[Specifying
+Metrics Ansible Variables].
+
+. When you have finished updating your inventory file, follow the instructions
+in
+xref:../install_config/cluster_metrics.adoc#deploying-the-metrics-components[Deploying
+the Metrics Deployment] to run the *_openshift-metrics/config.yml_* playbook and
+complete the metrics deployment upgrade.
+// end::automated-metrics-upgrade-steps[]
 
 [[special-considerations-for-mixed-environments]]
 == Special Considerations for Mixed Environments

--- a/upgrading/manual_upgrades.adoc
+++ b/upgrading/manual_upgrades.adoc
@@ -1448,34 +1448,7 @@ ifdef::openshift-origin[]
 endif::[]
 ====
 
-To upgrade an existing EFK logging stack deployment, you must use the provided
-*_/usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml_*
-Ansible playbook. This is the playbook to use if you were deploying logging for
-the first time on an existing cluster, but is also used to upgrade existing
-logging deployments.
-
-. If you have not already done so, see
-xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Specifying Logging Ansible Variables] in the
-xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs] topic and update your Ansible inventory file to at least set the
-following required variable within the `[OSEv3:vars]` section:
-+
-----
-[OSEv3:vars]
-
-openshift_logging_install_logging=true <1>
-openshift_logging_image_version=<tag> <2>
-----
-<1> Enables the ability to upgrade the logging stack.
-<2> Replace `<tag>` with `{latest-int-tag}` for the latest version.
-
-. Add any other `openshift_logging_*` variables that you want to specify to
-override the defaults, as described in
-xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Specifying Logging Ansible Variables].
-
-. When you have finished updating your inventory file, follow the instructions in
-xref:../install_config/aggregate_logging.adoc#deploying-the-efk-stack[Deploying
-the EFK Stack] to run the *_openshift-logging/config.yml_* playbook and complete
-the logging deployment upgrade.
+include::upgrading/automated_upgrades.adoc[tag=automated-logging-upgrade-steps]
 
 [[manual-upgrading-cluster-metrics]]
 == Upgrading Cluster Metrics
@@ -1492,44 +1465,7 @@ ifdef::openshift-origin[]
 endif::[]
 ====
 
-To upgrade an existing cluster metrics deployment, you must use the provided
-*_/usr/share/ansible/openshift-ansible/playbooks/openshift-metrics/config.yml_*
-Ansible playbook. This is the playbook to use if you were deploying metrics for
-the first time on an existing cluster, but is also used to upgrade existing
-metrics deployments.
-
-. If you have not already done so, see
-xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[Specifying
-Metrics Ansible Variables] in the
-xref:../install_config/cluster_metrics.adoc#install-config-cluster-metrics[Enabling
-Cluster Metrics] topic and update your Ansible inventory file to at least set
-the following required variables within the `[OSEv3:vars]` section:
-+
-----
-[OSEv3:vars]
-
-openshift_metrics_install_metrics=true <1>
-openshift_metrics_image_version=<tag> <2>
-openshift_metrics_hawkular_hostname=<fqdn> <3>
-openshift_metrics_cassandra_storage_type=(emptydir|pv|dynamic) <4>
-----
-<1> Enables the ability to upgrade the metrics deployment.
-<2> Replace `<tag>` with `{latest-int-tag}` for the latest version.
-<3> Used for the Hawkular Metrics route. Should correspond to a fully qualified
-domain name.
-<4> Choose a type that is consistent with the previous deployment.
-
-. Add any other `openshift_metrics_*` variables that you want to specify to
-override the defaults, as described in
-xref:../install_config/cluster_metrics.adoc#metrics-ansible-variables[Specifying
-Metrics Ansible Variables].
-
-. When you have finished updating your inventory file, follow the instructions
-in
-xref:../install_config/cluster_metrics.adoc#deploying-the-metrics-components[Deploying
-the Metrics Deployment] to run the *_openshift-metrics/config.yml_* playbook and
-complete the metrics deployment upgrade.
-
+include::upgrading/automated_upgrades.adoc[tag=automated-metrics-upgrade-steps]
 
 [[additional-instructions-per-release]]
 == Additional Manual Steps Per Release


### PR DESCRIPTION
Replaces https://github.com/openshift/openshift-docs/pull/9817 for reverting changes to the Upgrading the EFK Logging Stack and Upgrading Cluster Metrics sections. 

Note added per https://bugzilla.redhat.com/show_bug.cgi?id=1549690.