### PR TITLE
Fix incorrect example for downward API

### DIFF
--- a/dev_guide/downward_api.adoc
+++ b/dev_guide/downward_api.adoc
@@ -144,7 +144,7 @@ configure this volume. The plug-in supports the following fields:
 spec:
   volumes:
     - name: podinfo
-      metadata: <1>
+      downwardAPI:: <1>
         items: <2>
           -name: "labels" <3>
            fieldRef:
@@ -179,16 +179,16 @@ spec:
   containers:
     - name: volume-test-container
       image: gcr.io/google_containers/busybox
-      command: ["sh", "-c", "cat /etc/labels /etc/annotations"]
+      command: ["sh", "-c", "cat /tmp/etc/pod_labels /tmp/etc/pod_annotations"]
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /tmp/etc
           readOnly: false
- volumes:
-   - downwardAPI:
-     name: podinfo
-       defaultMode: 420
-       items:
+  volumes:
+  - name: podinfo
+    downwardAPI:
+      defaultMode: 420
+      items:
       - fieldRef:
           fieldPath: metadata.name
         path: pod_name


### PR DESCRIPTION
Looking at the upstream Kubernetes docs they use `downwardAPI:`instead of `metadata`.

Updating yaml sample per https://github.com/openshift/openshift-docs/pull/7770

@wjiangjay, how far back is this change valid? I see this yaml file going back to 3.0.