### PR TITLE
[enterprise-3.5] Don't advice to modify default SCCs.

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -425,56 +425,59 @@ To provide additional capabilities:
 === Modify Cluster Default Behavior
 
 To modify your cluster so that it does not pre-allocate UIDs, allows containers
-to run as any user, and prevents privileged containers:
+to run as any user, but prevents privileged containers, grant access to the
+*anyuid* SCC for everyone:
 
-[NOTE]
-====
-In order to preserve customized SCCs during upgrades, do not edit settings on
-the default SCCs other than priority, users, groups, labels, and annotations.
-====
-
-. Edit the *restricted* SCC:
-+
 ----
- $ oc edit scc restricted
+ $ oc adm policy add-scc-to-group anyuid system:authenticated
 ----
-
-. Change `*runAsUser.Type*` to *RunAsAny*.
-
-. Ensure `*allowPrivilegedContainer*` is set to false.
-
-. Save the changes.
 
 To modify your cluster so that it does not pre-allocate UIDs and does not allow
-containers to run as root:
+containers to run as root, grant access to the *nonroot* SCC for everyone:
 
-. Edit the *restricted* SCC:
-+
 ----
- $ oc edit scc restricted
+ $ oc adm policy add-scc-to-group nonroot system:authenticated
 ----
 
-. Change `*runAsUser.Type*` to *MustRunAsNonRoot*.
+[WARNING]
+====
+Be very careful with any modifications that have a cluster-wide impact. When
+you grant an SCC to all authenticated users, as in the previous example, or
+modify an SCC that applies to all users, such as the *restricted* SCC, it also
+affects Kubernetes and {product-title} components, including the web console
+and integrated docker registry. Changes made with these SCCs can cause these
+components to stop functioning.
 
-. Save the changes.
+Always prefer creating a custom SCC and target it to only specific users or
+groups. This way potential issues are confined to the affected users or groups
+and do not impact critical cluster components.
+====
 
 [[use-the-hostpath-volume-plugin]]
 
 === Use the hostPath Volume Plug-in
 
 To relax the security in your cluster so that pods are allowed to use the
-`hostPath` volume plug-in without granting everyone access to the *privileged*
-SCC:
+`hostPath` volume plug-in without granting everyone access to more privileged
+SCCs such as *privileged*, *hostaccess*, or *hostmount-anyuid*, take the
+following actions:
 
-. Edit the *restricted* SCC:
+. xref:creating-new-security-context-constraints[Create a new SCC] named `hostpath`
+
+. Set the `*allowHostDirVolumePlugin*` parameter to `true` for the new SCC:
 +
 ----
-$ oc edit scc restricted
+$ oc patch scc hostpath -p '{"allowHostDirVolumePlugin": true}'
 ----
 
-. Add `*allowHostDirVolumePlugin: true*`.
+. Grant access to this SCC to all users:
++
+----
+$ oc adm policy add-scc-to-group hostpath system:authenticated
+----
 
-. Save the changes.
+Now, all the pods that request `hostPath` volumes are admitted by the
+`hostpath` SCC.
 
 === Ensure That Admission Attempts to Use a Specific SCC First
 

--- a/admin_guide/seccomp.adoc
+++ b/admin_guide/seccomp.adoc
@@ -102,7 +102,7 @@ The allowable formats of the *seccompProfiles* field include:
 * *unconfined*: unconfined profile, and disables seccomp
 * *localhost/<profile-name>*: the profile installed to the node's local seccomp profile root
 +
-For example, if you are using the default *docker/default* profile, configure the *restricted* SCC with:
+For example, if you are using the default *docker/default* profile, configure your SCC with:
 +
 ----
 seccompProfiles:
@@ -112,7 +112,7 @@ seccompProfiles:
 [[seccomp-configuring-openshift-with-custom-seccomp]]
 ==  Configuring {product-title} for a Custom Seccomp Profile
 
-To ensure pods in your cluster run with a custom profile in the *restricted* SCC:
+To ensure pods in your cluster run with a custom profile:
 
 . Create the seccomp profile in *seccomp-profile-root*.
 
@@ -137,7 +137,7 @@ ifdef::openshift-origin[]
 ----
 endif::[]
 
-. Configure the *restricted* SCC:
+. Configure your SCC:
 +
 ----
 seccompProfiles:


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/9927

- seccomp.adoc: don't suggect to modify "restricted" SCC.
- manage_scc.adoc: advise to use anyuid and nonroot instead of modifying restricted SCC.
- manage_scc.adoc: advise to create a custom SCC instead of modifying restricted SCC.