### PR TITLE
Revert "[enterprise-3.5] Logging and metrics version example uses v3.6 in 3.7 doc "

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -116,10 +116,10 @@ between nodes in a cluster.
 ifdef::openshift-origin[]
 |`openshift_logging_image_prefix`
 |The prefix for logging component images. For example, setting the prefix to
-*openshift/origin-* creates *openshift/origin-logging-fluentd:v3.5*.
+*openshift/origin-* creates *openshift/origin-logging-fluentd:v1.5*.
 |`openshift_logging_image_version`
 |The version for logging component images. For example, setting the version to
-*v1.5* creates *openshift/origin-logging-fluentd:v3.5*.
+*v1.5* creates *openshift/origin-logging-fluentd:v1.5*.
 endif::openshift-origin[]
 
 ifdef::openshift-enterprise[]

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -349,16 +349,18 @@ added to your inventory file if it is necessary to override them.
 |`openshift_metrics_image_prefix`
 |The prefix for the component images. With
 ifdef::openshift-origin[]
-`openshift/origin-metrics-cassandra:v3.5`, set prefix `openshift/origin-`.
+`openshift/origin-metrics-cassandra:v1.3`, set prefix `openshift/origin-`.
 endif::[]
 ifdef::openshift-enterprise[]
-The prefix for the component images. With openshift/origin-metrics-cassandra:v3.5.0, set prefix openshift/origin-.
+`openshift3/ose-metrics-cassandra:3.5.0`, set prefix `openshift/ose-`.
+For example, for `openshift3/ose-metrics-cassandra:3.5.0`, set `3.5.0`, or to
+always get the latest 3.5 image, set `v3.5`.
 endif::[]
 
 |`openshift_metrics_image_version`
 |The version for the component images. For example, with
 ifdef::openshift-origin[]
-`openshift/origin-metrics-cassandra:v3.5`, set version  as `v3.5`.
+`openshift/origin-metrics-cassandra:v1.3`, set version  as `v1.3`.
 endif::[]
 ifdef::openshift-enterprise[]
 `openshift3/ose-metrics-cassandra:3.5.0`, set version as `3.5.0`, or to


### PR DESCRIPTION
Reverts openshift/openshift-docs#10228

Reverting as there is no origin-logging-fluentd:v3.5