### PR TITLE
[enterprise-3.5] Logging and metrics version example uses v3.6 in 3.7 doc REDO

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -349,18 +349,16 @@ added to your inventory file if it is necessary to override them.
 |`openshift_metrics_image_prefix`
 |The prefix for the component images. With
 ifdef::openshift-origin[]
-`openshift/origin-metrics-cassandra:v1.3`, set prefix `openshift/origin-`.
+`openshift/origin-metrics-cassandra:v1.5.1`, set prefix `openshift/origin-`.
 endif::[]
 ifdef::openshift-enterprise[]
-`openshift3/ose-metrics-cassandra:3.5.0`, set prefix `openshift/ose-`.
-For example, for `openshift3/ose-metrics-cassandra:3.5.0`, set `3.5.0`, or to
-always get the latest 3.5 image, set `v3.5`.
+The prefix for the component images. With `openshift/origin-metrics-cassandra:v3.5.0`, set prefix `openshift/origin-`.
 endif::[]
 
 |`openshift_metrics_image_version`
 |The version for the component images. For example, with
 ifdef::openshift-origin[]
-`openshift/origin-metrics-cassandra:v1.3`, set version  as `v1.3`.
+`openshift/origin-metrics-cassandra:v1.5.1`, set version  as `v1.5.1`.
 endif::[]
 ifdef::openshift-enterprise[]
 `openshift3/ose-metrics-cassandra:3.5.0`, set version as `3.5.0`, or to


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1527274

Related to https://github.com/openshift/openshift-docs/pull/10196

Fixes needed changes reverted by https://github.com/openshift/openshift-docs/pull/10271 