### PR TITLE
Changed default Docker driver in Release Notes per BZ

### DIFF
--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -1029,6 +1029,23 @@ openshift_checks_output_dir=/tmp/checks
 [[ocp-37-metrics-and-logging]]
 === Metrics and Logging
 
+[[ocp-37-journald-system-logs]]
+==== Journald for System Logs and JSON File for Container Logs
+
+Docker log driver is set to `journald` as the default for all nodes. Docker
+`log-driver` can be set to `json-file`. Note that there is no log rate-throttling with
+the `journald` driver. So, there is always a risk for denial-of-service attacks
+from rogue containers.
+
+Fluentd will automatically determine which log driver (`journald` or
+`json-file`) the container runtime is using. Fluentd will now always read logs
+from journald and also *_/var/log/containers_* (if `log-driver` is set to
+`json-file`). Fluentd will no longer read from *_/var/log/messages_*.
+
+See
+xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating
+Container Logs] for more information.
+
 [[ocp-37-docker-events-and-api-calls-aggregated-to-efk-as-logs]]
 ==== Docker Events and API Calls Aggregated to EFK as Logs
 


### PR DESCRIPTION
Fixed release notes that was missed when working on https://github.com/openshift/openshift-docs/pull/7191/

See: https://bugzilla.redhat.com/show_bug.cgi?id=1526262#c16