### PR TITLE
Added information about BuildConfig spec.output.imageLabels

### DIFF
--- a/creating_images/metadata.adoc
+++ b/creating_images/metadata.adoc
@@ -125,3 +125,8 @@ LABEL io.openshift.min-cpu     4
 ----
 ====
 |===
+
+Build configurations support the ability to add arbitrary labels to the
+container image during a build. These are specified in
+`spec.output.imageLabels`. Currently, there is no way to use variables, so you
+must patch the `BuildConfig` on a per-build basis.


### PR DESCRIPTION
https://trello.com/c/HB9IwGj5/925-5-add-arbitrary-labels-to-docker-images
https://bugzilla.redhat.com/show_bug.cgi?id=1567252