### PR TITLE
fixing single-master restore command

### DIFF
--- a/admin_guide/backup_restore.adoc
+++ b/admin_guide/backup_restore.adoc
@@ -759,9 +759,9 @@ backup and enable and restart all relevant services.
 On the master in a single master cluster:
 
 ----
-# cp /etc/sysconfig/atomic-openshift-master.rpmsave /etc/sysconfig/atomic-openshift-master
-# cp /etc/origin/master/master-config.yaml.<timestamp> /etc/origin/master/master-config.yaml
-# cp /etc/origin/node/node-config.yaml.<timestamp> /etc/origin/node/node-config.yaml
+# cp ${MYBACKUPDIR}/etc/sysconfig/atomic-openshift-master /etc/sysconfig/atomic-openshift-master
+# cp ${MYBACKUPDIR}/etc/origin/master/master-config.yaml.<timestamp> /etc/origin/master/master-config.yaml
+# cp ${MYBACKUPDIR}/etc/origin/node/node-config.yaml.<timestamp> /etc/origin/node/node-config.yaml
 # systemctl enable atomic-openshift-master
 # systemctl enable atomic-openshift-node
 # systemctl start atomic-openshift-master


### PR DESCRIPTION
@jiajliu, when I confirmed the build of the [original PR](https://github.com/openshift/openshift-docs/pull/10273) for https://bugzilla.redhat.com/show_bug.cgi?id=1567530, I noticed that this command was different for single master versions in 3.3-3.5.

Will you PTAL?