### PR TITLE
Adding HPE Nimble Kube Storage Controller to list of dynamic provisioners

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -104,6 +104,11 @@ per cluster. In versions prior to 3.6, this was `*Key=KubernetesCluster,Value=cl
 |xref:../../install_config/configuring_azure.adoc#install-config-configuring-azure[Configuring for Azure]
 |
 
+|HPE Nimble Storage
+|`hpe.com/nimble`
+|link:https://infosight.hpe.com/InfoSight/media/cms/active/public/tmg_HPE_Nimble_Storage_Integration_Guide_for_Red_Hat_OpenShift_and_OpenShift_Origin_doc_version_family.whz/index.html[Configuring HPE Nimble Kube Storage Controller]
+|Dynamic Provisioning of HPE Nimble Storage resources using the HPE Nimble Kube Storage Controller.
+
 |===
 
 
@@ -461,7 +466,31 @@ Azure StorageClass is revised in {product-title} version 3.7. If you upgraded fr
 this creates new storage accounts for future use.
 ====
 
+[[nimble]]
+=== HPE Nimble Storage Object Definition
 
+.nimble.yaml
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: transactionaldb
+provisioner: hpe.com/nimble <1>
+parameters: <2>
+  description: "Persistent Volume provisioned from the transactionaldb StorageClass"
+  pool: "allflash"
+  folder: "Production"
+  protectionTemplate: "Local48h-Cloud90d"
+  perfPolicy: "SQL Server"
+  limitIOPS: "10000"
+  dedupe: "true"
+  fsMode: "0770"
+----
+The HPE Nimble Kube Storage Controller relies on a xref:../../install_config/persistent_storage/persistent_storage_flex_volume.html#flex-volume-drivers[FlexVolume driver] that is included in the HPE Nimble Storage Linux Toolkit (NLT), which can be obtained through link:https://infosight.hpe.com[HPE InfoSight] for HPE Nimble Storage customers and partners. For a brief overview, see the link:https://hub.openshift.com/primed/133-hpe-nimble-storage[OpenShift Primed] entry.
+
+<1> Installing and configuring the HPE Nimble Kube Storage Controller for {product-title}: link:https://infosight.hpe.com/InfoSight/media/cms/active/public/tmg_HPE_Nimble_Storage_Integration_Guide_for_Red_Hat_OpenShift_and_OpenShift_Origin_doc_version_family.whz/index.html[HPE Nimble Storage Integration Guide for Red Hat OpenShift and OpenShift Origin].
+<2> For a complete list of parameters the dynamic provisioner and the FlexVolume driver supports, see the link:https://infosight.hpe.com/InfoSight/media/cms/active/public/tmg_HPE_Nimble_Storage_Integration_Guide_for_Red_Hat_OpenShift_and_OpenShift_Origin_doc_version_family.whz/cnj1529443914400.html[supported StorageClass parameters].
 
 [[change-default-storage-class]]
 == Changing the Default StorageClass


### PR DESCRIPTION
PR relevant for OpenShift Origin and OpenShift Enterprise (all versions from 3.5 and up). @openshift/team-documentation