### PR TITLE
Bug 1591999 Note - disable Docker image check for disconnected installs

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -176,6 +176,14 @@ do
 done
 ----
 
+[NOTE]
+====
+If you are syncing images on each of the hosts, rather than storing them in a
+local repository to pull from, you must disable the Docker image check or
+Skopeo will attempt to pull images even though they are locally cached and
+available.
+====
+
 [[disconnected-syncing-images]]
 === Syncing Images
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1591999