### PR TITLE
Add documentation for RBAC to SCCs

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -880,6 +880,44 @@ in their SCC set.  This allows cluster administrators to run pods as any
 user by without specifying a `RunAsUser` on the pod's `SecurityContext`.  The
 administrator may still specify a `RunAsUser` if they wish.
 
+[[rbac-to-scc]]
+==== Role-Based Access to SCCs ====
+Starting with {product-title} 3.11, you can specify SCCs as a resource that
+is handled by RBAC. This allows you to scope access to your SCCs to a certain
+project or to the entire cluster. Assigning users, groups or service accounts
+directly to an SCC retains cluster-wide scope.
+
+To include access to SCCs for your role, you specify the following rule in
+the definition of the role:
+.Role-Based Access to SCCs
+[source,yaml]
+----
+rules:
+  apiGroups:
+  - security.openshift.io <1>
+  resources:
+  - securitycontextconstraints <2>
+  verbs:
+  - use
+  resourceNames:
+  - myPermittingSCC <3>
+----
+<1> The API group that includes the `securitycontextconstraints` resource
+<2> Name of the resource group that allows users to specify SCC names in the
+`resourceNames` field
+<3> An example name for an SCC you want to give access to
+
+A local or cluster role with such a rule allows the subjects that are bound to it with a
+rolebinding or a clusterrolebinding to use the user-defined SCC called
+*myPermittingSCC*.
+
+[NOTE]
+====
+Because RBAC is deisgned to prevent escalation, even project administrators will be
+unable to grant access to an SCC because they are not allowed, by default,
+to use the verb *use* on SCC resources, including the *restricted* SCC.
+====
+
 [[understanding-pre-allocated-values-and-security-context-constraints]]
 ==== Understanding Pre-allocated Values and Security Context Constraints
 


### PR DESCRIPTION
This PR adds documentation on role-based access control to security context constraints.

cc @simo5 