### PR TITLE
Discourage reliance on openshift_docker_additional_registries

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -244,10 +244,13 @@ For example:
 openshift_docker_additional_registries=example.com:443
 ----
 
+Note: If you need to configure your cluster to use an alternate registry
+set `oreg_url` rather than rely on `openshift_docker_additional_registries`.
+
 |`openshift_docker_insecure_registries`
 |{product-title} adds the specified additional insecure registry or registries to
 the *docker* configuration. For any of these registries, secure sockets layer
-(SSL) is not verified. Also, add these registries to `openshift_docker_additional_registries`.
+(SSL) is not verified.
 
 |`openshift_docker_blocked_registries`
 |{product-title} adds the specified blocked registry or registries to the
@@ -657,17 +660,12 @@ openshift_examples_modify_imagestreams=true
 
 |`*openshift_examples_modify_imagestreams*`
 |Set to `true` if pointing to a registry other than the default. Modifies the image stream location to the value of `*oreg_url*`.
-
-|`*openshift_docker_additional_registries*`
-|Specify the additional registry or registries.
-If the registry required to access the registry is other than `80` include the port number required.
 |===
 
 For example:
 ----
 oreg_url=example.com/openshift3/ose-${component}:${version}
 openshift_examples_modify_imagestreams=true
-openshift_docker_additional_registries=example.com:443
 ----
 
 [[advanced-install-configuring-docker-route]]

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -657,7 +657,6 @@ openshift_examples_modify_imagestreams=true
 
 Depending on your registry, you may need to configure:
 ----
-openshift_docker_additional_registries=example.com
 openshift_docker_insecure_registries=example.com
 ----
 
@@ -682,6 +681,9 @@ your own registry to be used for Docker search and Docker pull. Use the
 `--add-registry` flag. The first registry added will be the first registry
 searched. For example, `add_registry=--add-registry registry.access.redhat.com
 --add-registry example.com`.
+
+Note: If you need to configure your cluster to use an alternate registry
+set `oreg_url` rather than rely on `openshift_docker_additional_registries`.
 
 |`openshift_docker_insecure_registries`
 |Set `openshift_docker_insecure_registries` to add its value in the

--- a/install/index.adoc
+++ b/install/index.adoc
@@ -297,7 +297,12 @@ installation, you can specify the registry information ahead of time. Set the
 following Ansible variables in your inventory file, as required:
 
 ----
-openshift_docker_additional_registries=<registry_hostname>
+ifdef::openshift-origin[]
+oreg_url='<registry_hostname>/openshift/origin-${component}:${version}'
+endif::[]
+ifdef::openshift-enterprise[]
+oreg_url='<registry_hostname>/openshift3/ose-${component}:${version}'
+endif::[]
 openshift_docker_insecure_registries=<registry_hostname>
 openshift_docker_blocked_registries=<registry_hostname>
 ----


### PR DESCRIPTION
openshift_docker_additional_registries should not be relied on in order to configure a cluster to use an alternative registry. So remove a few areas where we advise people to configure their cluster in that manner.

https://github.com/openshift/openshift-ansible/pull/8955 is related