### PR TITLE
Link to cluster limits page to clarify max-pods-per-nodes from core concepts

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -35,9 +35,11 @@ maintain state when recreated. Therefore pods should usually be managed by
 higher-level xref:../../architecture/core_concepts/deployments.adoc#replication-controllers[controllers],
 rather than directly by users.
 
-[IMPORTANT]
+[NOTE]
 ====
-The recommended maximum number of pods per {product-title} node host is 110.
+For the maximum number of pods per {project-title} node host, see the
+xref:../../scaling_performance/cluster_limits.adoc#scaling-performance-current-cluster-limits[Cluster
+Limits].
 ====
 
 [WARNING]


### PR DESCRIPTION
The recommended pods-per-node maximum number is not consistent with our cluster limits page and nowhere is the details why 110 pods-per-node maximum is recommended.

So fix this by creating a link to the official limits table in the scaling guide.

