### PR TITLE
[enterprise-3.7] Link to cluster limits page to clarify max-pods-per-nodes from core concepts

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -35,9 +35,11 @@ maintain state when recreated. Therefore pods should usually be managed by
 higher-level xref:../../architecture/core_concepts/deployments.adoc#replication-controllers[controllers],
 rather than directly by users.
 
-[IMPORTANT]
+[NOTE]
 ====
-The recommended maximum number of pods per {product-title} node host is 110.
+See the
+xref:../../scaling_performance/cluster_limits.adoc#scaling-performance-current-cluster-limits[Cluster
+Limits] page for the maximum number of pods per node supported limits of {product-title}.
 ====
 
 [WARNING]

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -39,7 +39,8 @@ rather than directly by users.
 ====
 See the
 xref:../../scaling_performance/cluster_limits.adoc#scaling-performance-current-cluster-limits[Cluster
-Limits] page for the maximum number of pods per node supported limits of {product-title}.
+Limits] page for the maximum number of pods per node supported limits of 
+{product-title}.
 ====
 
 [WARNING]


### PR DESCRIPTION
The backport of the following PR for v3.7

Link to cluster limits page to clarify max-pods-per-nodes from core concepts #10418