### PR TITLE
removing notes about master being unschedulable

### DIFF
--- a/day_two_guide/topics/proc_backing-up-master.adoc
+++ b/day_two_guide/topics/proc_backing-up-master.adoc
@@ -30,8 +30,7 @@ You can customize {product-title} services, such as increasing the log level or
 using proxies. The configuration files are stored in the `/etc/sysconfig`
 directory.
 
-Because the masters are also unschedulable nodes, back up the entire
-`/etc/origin` directory.
+Because the masters are also nodes, back up the entire `/etc/origin` directory.
 
 [discrete]
 == Procedure

--- a/day_two_guide/topics/proc_deprecating-master.adoc
+++ b/day_two_guide/topics/proc_deprecating-master.adoc
@@ -63,7 +63,7 @@ $ sudo systemctl disable --now atomic-openshift-master-api
 $ sudo systemctl disable --now atomic-openshift-master-controllers
 ----
 
-. Because the master host is a unschedulable {product-title} node, follow the
+. Because the master host is a schedulable {product-title} node, follow the
 steps in the
 xref:../day_two_guide/host_level_tasks.html#deprecating-node_deprecating-etcd[Deprecating
 a node host] section.


### PR DESCRIPTION
@bfallonf, you pointed out on the monster DR PR that in 3.9 and later, master nodes are not unschedulable. Do these changes sound reasonable to you?