### PR TITLE
fixed typo error

### DIFF
--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -26,7 +26,7 @@ to the router.
 [[creating-routes]]
 == Creating Routes
 
-You can create unsecured and secured routes routes using the web console or the
+You can create unsecured and secured routes using the web console or the
 CLI.
 
 Using the web console, you can navigate to the *Routes* page, found under the


### PR DESCRIPTION
removed repeated word 'routes' from dev guide route doc

Fix #10460 