### PR TITLE
modules/create_crd_obj: point to CRD creation docs

### DIFF
--- a/modules/create_crd_obj.adoc
+++ b/modules/create_crd_obj.adoc
@@ -8,7 +8,7 @@ Module included in the following assemblies:
 ////
 
 [id='create-crd-obj-{context}']
-= Creating a custom objects from a CRD
+= Creating custom objects from a CRD
 
 ifeval::["{context}" == "admin-guide-custom-resources"]
 After you create the custom resource definition object, you can create
@@ -21,7 +21,7 @@ fields that contain arbitrary JSON code.
 . Create a YAML definition for the custom object. In the following example 
 definition, the `cronSpec` and `image` custom fields are set in a custom object 
 of kind `CronTab`. The kind `CronTab` comes from the `spec.kind` field of the
-custom resource definition object in the previous example.
+custom resource definition object in the link:create_crd.adoc[previous example].
 +
 .Example YAML file for a custom object
 

--- a/modules/manage_crd_obj.adoc
+++ b/modules/manage_crd_obj.adoc
@@ -37,7 +37,7 @@ oc get crontab
 oc get ct
 ----
 
-* You can also view the raw JSON data for a custom resource:
+* You can also view the raw YAML data for a custom resource:
 +
 ----
 oc get <kind> -o yaml


### PR DESCRIPTION
Fixes three nits:

- a grammatical error.
- points to docs related to creating a CRD, when talking about creating a CR (or else the context is lost, eg about `spec.kind`, `spec.shortnames`, etc).
- fixes `JSON` to `YAML` since the output is described in the YAML format below it.