### PR TITLE
rm io.openshift.expose-services label

### DIFF
--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -581,7 +581,6 @@ image:
         io.openshift.build.source-location: https://github.com/openshift/ruby-hello-world.git
         io.openshift.builder-base-version: 8d95148
         io.openshift.builder-version: 8847438ba06307f86ac877465eadc835201241df
-        io.openshift.expose-services: 8080:http
         io.openshift.s2i.scripts-url: image:///usr/libexec/s2i
         io.openshift.tags: builder,ruby,ruby22
         io.s2i.scripts-url: image:///usr/libexec/s2i

--- a/creating_images/metadata.adoc
+++ b/creating_images/metadata.adoc
@@ -83,21 +83,6 @@ LABEL io.k8s.description The MySQL 5.5 Server with master-slave replication supp
 ----
 ====
 
-|`*io.openshift.expose-services*`
-|This label contains a list of service ports that match with the `EXPOSE`
-instructions in the _*Dockerfile*_ and provide more descriptive information about
-what actual service on the given port provides to consumers.
-
-The format is `PORT[/PROTO]:NAME` where the `[PROTO]` part is optional and it
-defaults to `tcp` if it is not specified.
-
-====
-
-----
-LABEL io.openshift.expose-services 2020/udp:ftp,8080:https
-----
-====
-
 |`*io.openshift.non-scalable*`
 |An image might use this variable to suggest that it does not support scaling.
 The UI will then communicate this to consumers of that image. Being not-scalable

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -329,7 +329,6 @@ image:
         io.k8s.display-name: Ruby 2.2
         io.openshift.builder-base-version: 8d95148
         io.openshift.builder-version: 8847438ba06307f86ac877465eadc835201241df
-        io.openshift.expose-services: 8080:http
         io.openshift.s2i.scripts-url: image:///usr/libexec/s2i
         io.openshift.tags: builder,ruby,ruby22
         io.s2i.scripts-url: image:///usr/libexec/s2i


### PR DESCRIPTION
Remove the io.openshift.expose-services label from docs.
This is not consumed in any meaningful way by OpenShift.

Bug [1583274](https://bugzilla.redhat.com/show_bug.cgi?id=1583274)