### PR TITLE
[enterprise-3.10] Typo in prerequisites regarding the firewall

### DIFF
--- a/install/prerequisites.adoc
+++ b/install/prerequisites.adoc
@@ -657,7 +657,7 @@ connections, and is only required if you have clustered etcd.
 * Port *1936* can still be inaccessible due to your iptables rules. Use the following to configure iptables to open port *1936*:
 +
 ----
-# iptables OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp \
+# iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp \
     --dport 1936 -j ACCEPT
 ----
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1572935 