### PR TITLE
[enterprise-3.6] Logging and metrics version example uses v3.6 in 3.7 doc

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -349,7 +349,7 @@ added to your inventory file if it is necessary to override them.
 |`openshift_metrics_image_prefix`
 |The prefix for the component images. With
 ifdef::openshift-origin[]
-`openshift/origin-metrics-cassandra:v3.6`, set prefix `openshift/origin-`.
+`openshift/origin-metrics-cassandra:v3.6.1`, set prefix `openshift/origin-`.
 endif::[]
 ifdef::openshift-enterprise[]
 The prefix for the component images. With `openshift3/ose-metrics-cassandra:v3.6.173.0.21`, set prefix `openshift/ose-`.
@@ -358,7 +358,7 @@ endif::[]
 |`openshift_metrics_image_version`
 |The version for the component images. For example, with
 ifdef::openshift-origin[]
-`openshift/origin-metrics-cassandra:v3.6`, set version  as `v3.6`.
+`openshift/origin-metrics-cassandra:v3.6.1`, set version  as `v3.6`.
 endif::[]
 ifdef::openshift-enterprise[]
 `openshift3/ose-metrics-cassandra:v3.6.173.0.21`, set version as `v3.6.173.0.21`, or to


### PR DESCRIPTION
Per BZ, added `.1` to image tag.
https://bugzilla.redhat.com/show_bug.cgi?id=1527274#c10