### PR TITLE
Correct the supported PostgreSQL versions and fix the broken links

### DIFF
--- a/using_images/db_images/postgresql.adoc
+++ b/using_images/db_images/postgresql.adoc
@@ -18,7 +18,7 @@ settings provided via configuration.
 
 == Versions
 Currently, {product-title} supports versions
-https://github.com/openshift/postgresql/tree/master/9.2[9.2], https://github.com/openshift/postgresql/tree/master/9.4[9.4], and https://github.com/openshift/postgresql/tree/master/9.5[9.5] of PostgreSQL.
+https://github.com/sclorg/rhscl-dockerfiles/tree/master/rhel7.rh-postgresql94[9.4], and https://github.com/sclorg/postgresql-container/tree/generated/9.5[9.5] of PostgreSQL.
 
 == Images
 
@@ -26,7 +26,6 @@ ifdef::openshift-online[]
 RHEL 7 images are available through the Red Hat Registry:
 
 ----
-$ docker pull registry.access.redhat.com/openshift3/postgresql-92-rhel7
 $ docker pull registry.access.redhat.com/rhscl/postgresql-94-rhel7
 $ docker pull registry.access.redhat.com/rhscl/postgresql-95-rhel7
 ----
@@ -45,7 +44,6 @@ These images come in two flavors, depending on your needs:
 The RHEL 7 images are available through the Red Hat Registry:
 
 ----
-$ docker pull registry.access.redhat.com/openshift3/postgresql-92-rhel7
 $ docker pull registry.access.redhat.com/rhscl/postgresql-94-rhel7
 $ docker pull registry.access.redhat.com/rhscl/postgresql-95-rhel7
 ----
@@ -55,15 +53,8 @@ $ docker pull registry.access.redhat.com/rhscl/postgresql-95-rhel7
 These images are available on Docker Hub:
 
 ----
-$ docker pull openshift/postgresql-92-centos7
 $ docker pull centos/postgresql-94-centos7
 $ docker pull centos/postgresql-95-centos7
-----
-
-or
-
-----
-$ docker pull centos/postgresql-94-centos7
 ----
 
 To use these images, you can either access them directly from these
@@ -96,13 +87,13 @@ $ oc new-app \
     -e POSTGRESQL_PASSWORD=<password> \
     -e POSTGRESQL_DATABASE=<database_name> \
 ifdef::openshift-enterprise,openshift-dedicated[]
-    registry.access.redhat.com/rhscl/postgresql-94-rhel7
+    registry.access.redhat.com/rhscl/postgresql-95-rhel7
 endif::[]
 ifdef::openshift-origin[]
-    centos/postgresql-94-centos7
+    centos/postgresql-95-centos7
 endif::[]
 ifdef::openshift-online[]
-    postgresql:9.4
+    postgresql:9.5
 endif::[]
 ----
 
@@ -135,7 +126,7 @@ authenticate as the database user:
 ====
 ----
 bash-4.2$ PGPASSWORD=$POSTGRESQL_PASSWORD psql -h postgresql $POSTGRESQL_DATABASE $POSTGRESQL_USER
-psql (9.2.8)
+psql (9.5.16)
 Type "help" for help.
 
 default=>


### PR DESCRIPTION
Correct the supported PostgreSQL versions based on a [0] article for OCP 3.9, and fix the broken links. 
In fact, PostgreSQL v9.2 has not supported from the OpenShift Container Platform v3.5 and v9.4 is also  deprecated now.

So I only remained v9.4 and v9.5 on the page including example commands, and fix the broken links to the related repositories. 

I also opened a BZ  here: https://bugzilla.redhat.com/show_bug.cgi?id=1597074

[0] OpenShift Container Platform Tested Integrations [https://access.redhat.com/articles/2176281]