### PR TITLE
BZ#1595094 - added warning about overriding openshift_hostname variable

### DIFF
--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -147,6 +147,16 @@ After enabling the vSphere Cloud Provider, Node names are set to the VM names
 from the vCenter Inventory.
 ====
 
+[WARNING]
+====
+The `openshift_hostname` variable must match the virtual machine name and its
+host name. The `openshift_hostname` variable defines the `nodeName` value in the
+*_node-config.yaml_* file. This value is compared to the `nodeName` value
+determined by using the command `uname -n`. In case of a mismatch, the native
+cloud integration for those providers will not work.
+====
+
+
 [[vsphere-configuration-file]]
 == The VMware vSphere Configuration File
 Configuring {product-title} for VMware vSphere requires the


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1595094

Preview: http://bug1595094-fixes--gnelson-preview.netlify.com/openshift-enterprise/(head%20detached%20at%20fetch_head)/install_config/configuring_vsphere.html#vsphere-enabling