### PR TITLE
Added info and default for event-ttl

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -314,14 +314,15 @@ for the changes to take effect. See xref:master-node-config-restart-services[Res
 | Parameter Name | Description
 
 |`*AdmissionConfig*`
-Contains the xref:../architecture/additional_concepts/admission_controllers.adoc#architecture-additional-concepts-admission-controllers[admission control plug-in] configuration. {product-title} has a configurable list of admission controller plug-ins that are triggered whenever API objects are created or modified. This option allows you to override the default list of plug-ins; for example, disabling some plug-ins, adding others, changing the ordering, and specifying configuration. Both the list of plug-ins and their configuration can be controlled from Ansible.
+|Contains the xref:../architecture/additional_concepts/admission_controllers.adoc#architecture-additional-concepts-admission-controllers[admission control plug-in] configuration. {product-title} has a configurable list of admission controller plug-ins that are triggered whenever API objects are created or modified. This option allows you to override the default list of plug-ins; for example, disabling some plug-ins, adding others, changing the ordering, and specifying configuration. Both the list of plug-ins and their configuration can be controlled from Ansible.
 
 |`*APIServerArguments*`
 |Key-value pairs that will be passed directly to the Kube API server that match
 the API servers' command line arguments. These are not migrated, but if you
 reference a value that does not exist the server will not start. These values
 may override other settings in `*KubernetesMasterConfig*`, which may cause
-invalid configurations.
+invalid configurations. Use `APIServerArguments` with the `event-ttl` value to store events in etcd. The default is `2h`, but it can be set to less to prevent memory growth:
+
 ----
 apiServerArguments:
   event-ttl:


### PR DESCRIPTION
For: https://github.com/openshift/openshift-docs/issues/10488#event-1707618430

@openshift/team-documentation PTAL. Added `events-ttl` description and default, and fixed the broken table.