### PR TITLE
enable auto doc previews for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python 
+language: python
 
 cache: pip
 
@@ -8,13 +8,17 @@ before_install:
  - sudo gem install asciidoctor -v 1.5.4
  - sudo gem install asciidoctor-diagram -v 1.5.4
 
-install: 
+install:
  - pip install pyyaml
  - pip install aura.tar.gz
 
-script: 
+script:
  - python build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 3 --no-upstream-fetch
  - if [ "$TRAVIS_BRANCH" == "enterprise-3.9" ] || [ "$TRAVIS_BRANCH" == "enterprise-3.10" ]; then python build.py --distro openshift-online --product "OpenShift Container Platform" --version 3 --no-upstream-fetch; fi
  - if [ "$TRAVIS_BRANCH" == "enterprise-3.7" ] || [ "$TRAVIS_BRANCH" == "enterprise-3.9" ] || [ "$TRAVIS_BRANCH" == "enterprise-3.10" ]; then python build.py --distro openshift-dedicated --product "OpenShift Container Platform" --version 3 --no-upstream-fetch; fi
  - python makeBuild.py
 
+after_success:
+ - export USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
+ - echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\"}" > buildset.json
+ - "curl -H 'Content-Type: application/json' --request POST --data @buildset.json \"https://hooks.zapier.com/hooks/catch/3022285/wik1iz/\""


### PR DESCRIPTION
#### What this does?
It enables automatic docs previews. That is for every successful PR build, it creates a preview openshift-docs site and adds a comment to the PR with links to all the modified files.
#### How it works?

 1. After a successful build in Travis, Travis sends an API request along with PR details (`json` data) to [Zapier](https://zapier.com/).
 2. Zapier receives the API request and the data and checks:
	 a. If the PR if from one of the authorized users (member of openshift/team-documentation)
	 b. If the PR is against master branch
3. When these two conditions are met, Zapier sends an API request to the @openshift-docs-preview-bot Travis instance.
4. The @openshift-docs-preview-bot Travis instance then downloads the original PR branch and pushes that to the [openshift-docs-preview-bot's fork of the openshift-docs](https://github.com/openshift-docs-preview-bot/openshift-docs) repository.
5. If this is a new PR, Travis adds a comment to the PR with hyperlinks to:
	a. The modified files (only if number of modified files is five or less, and those files are not modules)
	b. Or the main site otherwise.
6. [Netlify](https://www.netlify.com/) is connected to the openshift-docs-preview-bot's fork repository and automatically builds for every pushed branch.

#### Caveats
1. Hyperlinks in comments does not work till the Netlify build finishes (it takes around two to three minutes).
2. Only 100 PRs per month will be processed. (Zapier free account limitation)

#### What else?
The checking and commenting script is available at [https://github.com/gaurav-nelson/scripts/blob/master/push_to_netlify.sh](https://github.com/gaurav-nelson/scripts/blob/master/push_to_netlify.sh). This allows us to easily modify comments logic and run other tests if required.