### PR TITLE
[enterprise-3.6] clarify binary input used for local content

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -22,7 +22,7 @@ ifndef::openshift-online[]
 endif::[]
 * xref:image-source[Content extracted from existing images]
 * xref:source-code[Git repositories]
-* xref:binary-source[Binary inputs]
+* xref:binary-source[Binary (Local) inputs]
 * xref:using-secrets-during-build[Input secrets]
 * xref:using-external-artifacts[External artifacts]
 
@@ -40,7 +40,7 @@ As the inline Dockerfile takes
 precedence, it can overwrite any other file named *_Dockerfile_* provided by
 another input.
 endif::[]
-Binary input and Git repositories are mutually exclusive inputs.
+Binary (local) input and Git repositories are mutually exclusive inputs.
 
 Input secrets are useful for when you do not want certain resources or
 credentials used during a build to be available in the final application image
@@ -650,9 +650,9 @@ $ oc secrets new-basicauth <secret_name> \
 
 
 [[binary-source]]
-== Binary Source
+== Binary (Local) Source
 
-Streaming content in binary format from a local file system to the builder is
+Streaming content from a local file system to the builder is
 called a `Binary` type build. The corresponding value of
 `BuildConfig.spec.source.type` is `Binary` for such builds.
 


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/10655