### PR TITLE
Updated GSG section on installation process

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -142,30 +142,24 @@ $ for host in master.openshift.example.com \
     done
 ----
 
-[[run-the-installer]]
-=== Run the Installer
+[[run-the-installation-playbooks]]
+=== Run the Installation Playbooks
 
-Run the installer on the master.
+. Reference an example host file in *_/usr/share/doc/openshift-ansible-docs-3.9.31/docs/example-inventories_*.
 
+. Select an example, then edit it with your host names.
+
+. Run:
++
 ----
-$ atomic-openshift-installer install
+$ ansible-playbook -i <your_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 ----
 
-This is an interactive install process that guides you through the various
-steps. In most cases, you want the default options. When it starts, select the
-option for {product-title}.
-You are installing one master and one node and the domain name is the FQDN
-as mentioned at the start of this section, `master.openshift.example.com` and
-`node.openshift.example.com`.
-
-IMPORTANT: At the step where the installer asks you for the FQDN for the routes,
-you *must* use `apps.openshift.example.com`, or
-`cloudapps.openshift.example.com` as discussed earlier, and NOT
-`openshift.example.com`. If you make an error, you can edit the
-*_/etc/origin/master/master-config.yaml_* at the end of the install process and
-make this change yourself by looking for the `subdomain` entry.
-
-This install process takes approximately 5-10 minutes.
+. Run:
++
+----
+$ ansible-playbook -i <your_file>  /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+----
 
 [[start-openshift]]
 === Start {product-title}


### PR DESCRIPTION
Now that Quick Installation is deprecated in 3.10, this is an update of the Getting Started topic. We may eventually remove this Getting Started topic, but we need to make these updates now. 

@sdodson Please review. Thanks!

@vikram-redhat FYI