### PR TITLE
Bug 1592855 added step for labeling default project to managing networking

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1377,9 +1377,10 @@ Alternatively, you can create a policy allowing full access from the default nam
 +
 [IMPORTANT]
 ====
-You only need to do this once for the entire cluster. The cluster administrator role is required to add labels to namesapces.
+If you labeled the default project with the `default` label in a previous
+procedure, then skip this step. The cluster administrator role is required to
+add labels to namespaces.
 ====
-
 +
 [source,bash]
 ----
@@ -1390,7 +1391,7 @@ $ oc label namespace default name=default
 +
 [NOTE]
 ====
-Perform this step for each namespace you want to allow conntections into. Users with the Project Administrator role can create policies.
+Perform this step for each namespace you want to allow connections into. Users with the Project Administrator role can create policies.
 ====
 +
 [source,yaml]
@@ -1417,6 +1418,21 @@ new project is created. To do this:
 . Create a custom project template and configure the master to use it, as
 described in
 xref:../admin_guide/managing_projects.adoc#modifying-the-template-for-new-projects[Modifying the Template for New Projects].
+
+. Label the `default` project with the `default` label:
++
+[IMPORTANT]
+====
+If you labeled the default project with the `default` label in a previous
+procedure, then skip this step. The cluster administrator role is required to
+add labels to namespaces.
+====
++
+[source,bash]
+----
+$ oc label namespace default name=default
+----
+
 . Edit the template to include the desired `NetworkPolicy` objects:
 +
 [source, bash]


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=1592855

Straight-forward issue.

@openshift/team-documentation PTAL