### PR TITLE
container_file_t context type within the container-selinux package is not shipped by rhel-7-server-extras-rpms yet

### DIFF
--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -741,10 +741,12 @@ label.
 
 This means two things for unprivileged containers:
 
-- The volume will be given a `type` which is accessible by unprivileged
-containers. This type is usually `container_file_t`, which treats volumes as container content. Previously, the label specified was `svirt_sandbox_file_t`. This label
-is no longer used due to security concerns.
-- If a `level` is specified, the volume will be labeled with the given MCS
+- The volume is given a type that is accessible by unprivileged containers.
+This type is usually `container_file_t` in Red Hat Enterprise Linux (RHEL) version 7.5 and later. This type treats volumes as
+container content. In previous RHEL versions, RHEL 7.4, 7.3, and so forth, the volume is given
+the `svirt_sandbox_file_t` type.
+
+- If a `level` is specified, the volume is labeled with the given MCS
 label.
 
 For a volume to be accessible by a pod, the pod must have both categories of the volume.


### PR DESCRIPTION
Per @niconosenzo in BZ [2018-07-10 04:07:27 EDT](https://bugzilla.redhat.com/show_bug.cgi?id=1544353#c2)
_(This issue) was just to add information about container type in 7.3|7.4 (svirt_sandbox_file_t) and 7.5 (container_file_t)._
@nicola