### PR TITLE
Document critical pod annotations for openshift projects

### DIFF
--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -138,7 +138,7 @@ xref:../infrastructure_components/web_console.adoc#architecture-infrastructure-c
 [[architecture-projects-projects-at-install]]
 === Projects provided at installation
 
-{product-title} comes with a number of projects out of the box, and `openshift-*` are the most essential to users:
+{product-title} comes with a number of projects out of the box, and projects starting with `openshift-` are the most essential to users:
 
 *`openshift-*`*
 Starting from 3.10 and above, we have a number of projects starting with openshift- to host our master components running as pods and other infrastructure components. The pods created in these namespaces when having a xref:https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons[critical pod annotation], would be considered critical and they would have guaranteed admission by kubelet. Pods created for master components in these namespaces are already marked critical.

--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -138,13 +138,10 @@ xref:../infrastructure_components/web_console.adoc#architecture-infrastructure-c
 [[architecture-projects-projects-at-install]]
 === Projects provided at installation
 
-{product-title} comes with a number of projects out of the box, and `openshift` is the most essential to users:
+{product-title} comes with a number of projects out of the box, and `openshift-*` are the most essential to users:
 
-*`openshift`*
-A user-facing project, mainly for housing objects for day-to-day tasks. These
-include any application objects for access by multiple projects, such as
-templates and images. These objects should be those that do not require
-communication between the pods.
+*`openshift-*`*
+Starting from 3.10 and above, we have a number of projects starting with openshift- to host our master components running as pods and other infrastructure components. The pods created in these namespaces when having a xref:https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons[critical pod annotation], would be considered critical and they would have guaranteed admission by kubelet. Pods created for master components in these namespaces are already marked critical.
 
 ifdef::openshift-online[]
 [[projects-idling]]

--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -140,8 +140,7 @@ xref:../infrastructure_components/web_console.adoc#architecture-infrastructure-c
 
 {product-title} comes with a number of projects out of the box, and projects starting with `openshift-` are the most essential to users:
 
-*`openshift-*`*
-Starting from 3.10 and above, we have a number of projects starting with openshift- to host our master components running as pods and other infrastructure components. The pods created in these namespaces when having a xref:https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons[critical pod annotation], would be considered critical and they would have guaranteed admission by kubelet. Pods created for master components in these namespaces are already marked critical.
+Starting from 3.10 and above, we have a number of projects starting with `openshift-` to host our master components running as pods and other infrastructure components. The pods created in these namespaces when having a xref:https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons[critical pod annotation], would be considered critical and they would have guaranteed admission by kubelet. Pods created for master components in these namespaces are already marked critical.
 
 ifdef::openshift-online[]
 [[projects-idling]]

--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -140,7 +140,7 @@ xref:../infrastructure_components/web_console.adoc#architecture-infrastructure-c
 
 {product-title} comes with a number of projects out of the box, and projects starting with `openshift-` are the most essential to users:
 
-Starting from 3.10 and above, we have a number of projects starting with `openshift-` to host our master components running as pods and other infrastructure components. The pods created in these namespaces when having a xref:https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons[critical pod annotation], would be considered critical and they would have guaranteed admission by kubelet. Pods created for master components in these namespaces are already marked critical.
+Starting from 3.10 and above, we have a number of projects starting with `openshift-` to host our master components running as pods and other infrastructure components. The pods created in these namespaces when having a link:https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons[critical pod annotation], would be considered critical and they would have guaranteed admission by kubelet. Pods created for master components in these namespaces are already marked critical.
 
 ifdef::openshift-online[]
 [[projects-idling]]


### PR DESCRIPTION
This PR introduces doc changes for 3.10 critical static pod changes(xref: https://github.com/openshift/origin/pull/19104/files)  for guaranteed admission and ensuring critical static pods are not evicted in first place(https://trello.com/c/ebBOFnRQ/908-1-schedulerneed-documentation-that-experimentalcriticalpodannotation-is-being-enabled-by-default-and-scheduleralphakubernetesio) .

/cc @mburke5678 @sjenning @derekwaynecarr @aveshagarwal 

BTW,

- Is this appropriate place in documentation to create this PR?
- I see that https://github.com/openshift/openshift-docs/blob/master/architecture/infrastructure_components/kubernetes_infrastructure.adoc doesn't have any mention of static pods, is this being worked on or we don't need to put that information there?
