### PR TITLE
Update Scheduler Docs

### DIFF
--- a/admin_guide/scheduling/scheduler.adoc
+++ b/admin_guide/scheduling/scheduler.adoc
@@ -412,11 +412,10 @@ same label values as that node.
 "predicates":[
       {
          "name":"<name>", <1>
-         "weight" : "1" <2>
          "argument":{
             "serviceAffinity":{
                "labels":[
-                  "<label>" <3>
+                  "<label>" <2>
                ]
             }
          }
@@ -424,14 +423,13 @@ same label values as that node.
    ],
 ----
 <1> Specify a name for the predicate.
-<2> Specify a weight from 1 (bad fit) to 10 (best fit).
-<3> Specify a label for matching.
+<2> Specify a label to match.
+
 For example:
 
 [source,json]
 ----
          "name":"ZoneAffinity",
-         "weight" : "1"
          "argument":{
             "serviceAffinity":{
                "labels":[
@@ -446,21 +444,19 @@ see xref:../../admin_guide/scheduling/pod_placement.adoc#controlling-pod-placeme
 Multiple-level labels are also supported. Users can also specify all pods for a service to
 be scheduled on nodes within the same region and within the same zone (under the region).
 
-**_LabelsPresence_** checks whether a particular node has a certain label
-defined or not, regardless of its value. Matching by label can be useful, for
-example, where nodes have their physical location or status defined by labels.
+The `labelsPresence` parameter checks whether a particular node has a specific label. The labels create node _groups_ that the
+`LabelPreference` priority uses. Matching by label can be useful, for example, where nodes have their physical location or status defined by labels.
 
 [source,json]
 ----
 "predicates":[
       {
          "name":"<name>", <1>
-         "weight" : "1" <2>
          "argument":{
             "labelsPresence":{
                "labels":[
-                  "<label>" <3>
-                presence: true/false <4>
+                  "<label>" <2>
+                presence: "true" <3>
                ]
             }
          }
@@ -468,22 +464,20 @@ example, where nodes have their physical location or status defined by labels.
    ],
 ----
 <1> Specify a name for the predicate.
-<2> Specify a weight from 1 (bad fit) to 10 (best fit).
-<3> Specify a label for matching.
-<4> Specify whether the labels are required.
+<2> Specify a label to match.
+<3> Specify whether the labels are required, either `true` or `false`.
 +
 * For `presence:false`, if any of the requested labels are present in the node labels,
 the pod cannot be scheduled. If the labels are not present, the pod can be scheduled.
 +
 * For `presence:true`, if all of the requested labels are present in the node labels,
-the pod can be scheduled. If all of the lables are not present, the pod is not scheduled.
+the pod can be scheduled. If all of the labels are not present, the pod is not scheduled.
 
 For example:
 
 [source,json]
 ----
          "name":"RackPreferred",
-         "weight" : "1"
          "argument":{
             "labelsPresence":{
                "labels":[
@@ -625,7 +619,7 @@ concentration of pods.
          "weight" : "1" <2>
          "argument":{
             "serviceAntiAffinity":{
-               "labels":[
+               "label":[
                   "<label>" <3>
                ]
             }
@@ -634,35 +628,44 @@ concentration of pods.
    ]
 ----
 <1> Specify a name for the priority.
-<2> Specify a weight from 1 (bad fit) to 10 (best fit).
-<3> Specify a label for matching.
+<2> Specify a weight. Enter a non-zero positive value.
+<3> Specify a label to match.
 
 For example:
 
 [source,json]
 ----
-         "name":"RackSpread",
-         "weight" : "1"
+         "name":"RackSpread", <1>
+         "weight" : "1"     <2>
          "argument":{
             "serviceAffinity":{
-               "labels":[
-                  "rack"
+               "label":[    <3>
+                  "rack"   
 ----
+<1> Specify a name for the priority.
+<2> Specify a weight. Enter a non-zero positive value.
+<3> Specify a label to match.
 
-**_LabelPreference_** prefers nodes that have a particular label defined,
-regardless of its value.
+[NOTE]
+====
+In some situations using `ServiceAntiAffinity` based on custom labels does not spread pod as expected. 
+See link:https://access.redhat.com/solutions/3432401[this Red Hat Solution]. 
+====
+
+*The `labelPreference` parameter gives priority based on the specified label. 
+If the label is present on a node, that node is given priority.
+If no label is specified, priority is given to nodes that do not have a label.
 
 [source,json]
 ----
-"predicates":[
+"priorities":[
       {
          "name":"<name>", <1>
-         "weight" : "1" <2>
-         "argument":{
-            "labelsPresence":{
-               "labels":[
-                  "<label>" <3>
-                presence: true/false <4>
+         "weight" : "1"  <2>
+          "argument":{
+            "labelPreference":{
+               "label":[
+                  "<label>"  <3>
                ]
             }
          }
@@ -670,28 +673,8 @@ regardless of its value.
    ],
 ----
 <1> Specify a name for the priority.
-<2> Specify a weight from 1 (bad fit) to 10 (best fit).
-<3> Specify a label for matching.
-<4> Specify whether the labels are required.
-+
-* For `presence:false`, if any of the requested labels are present in the node labels,
-the pod cannot be scheduled. If the labels are not present, the pod can be scheduled.
-+
-* For `presence:true`, if all of the requested labels are present in the node labels,
-the pod can be scheduled. If all of the lables are not present, the pod is not scheduled.
-
-For example:
-
-[source,json]
-----
-         "name":"RackPreferred",
-         "weight" : "1"
-         "argument":{
-            "labelsPresence":{
-               "labels":[
-                  "rack"
-----
-
+<2> Specify a weight. Enter a non-zero positive value.
+<3> Specify a label to match.
 
 [[use-cases]]
 == Use Cases
@@ -908,5 +891,4 @@ priorities:
         presence: true
   - name: "ServiceSpreadingPriority"
     weight: 1
-
 ----


### PR DESCRIPTION
From BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1596472
**1.** _Wrong statements or examples that I can tell:
Predicates [3] are boolean functions, they return true/false. The example is wrong, it does not make sense to have a weigh in a predicate.  Both ServiceAffinity and LabelsPresence Configurable Predicates examples are wrong.

Configurable priorities [4] examples are wrong.
They apply only to one label. So label must be in singular "label", not "labels"

Weight can be any positive value. It does not need to range between 0 and 10. Actually, in [5] you can see a default weight of 10000 in a function._

**2.** Do we want to add: 
_Service-Anti-Affinity based on custom labels is not recommended to achieve equal distribution of pods across multiple zones... it's highly recommended to use failure-domain.beta.kubernetes.io/region and failure-domain.beta.kubernetes.io/zone node label_ 
https://access.redhat.com/solutions/3432401

