### PR TITLE
[enterprise-3.6]Fix incorrect example for downward API

### DIFF
--- a/dev_guide/downward_api.adoc
+++ b/dev_guide/downward_api.adoc
@@ -144,11 +144,11 @@ configure this volume. The plug-in supports the following fields:
 spec:
   volumes:
     - name: podinfo
-      metadata: <1>
-        items:  <2>
-          - name: "labels" <3>
-            fieldRef:
-              fieldPath: metadata.labels <4>
+      downwardAPI:: <1>
+        items: <2>
+          -name: "labels" <3>
+           fieldRef:
+              fieldPath: metadata.labels <4>  
 ----
 <1> The `*metadata*` field of the volume source configures the downward API
 volume.
@@ -179,21 +179,28 @@ spec:
   containers:
     - name: volume-test-container
       image: gcr.io/google_containers/busybox
-      command: ["sh", "-c", "cat /etc/labels /etc/annotations"]
+      command: ["sh", "-c", "cat /tmp/etc/pod_labels /tmp/etc/pod_annotations"]
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /tmp/etc
           readOnly: false
   volumes:
-    - name: podinfo
-      metadata:
-        items:
-          - name: "labels"
-            fieldRef:
-              fieldPath: metadata.labels
-          - name: "annotations"
-            fieldRef:
-              fieldPath: metadata.annotations
+  - name: podinfo
+    downwardAPI:
+      defaultMode: 420
+      items:
+      - fieldRef:
+          fieldPath: metadata.name
+        path: pod_name
+      - fieldRef:
+          fieldPath: metadata.namespace
+        path: pod_namespace
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: pod_labels
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: pod_annotations
   restartPolicy: Never
 ----
 ====


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/10130

@mdshuai, I can't find the relevant Kubernetes docs to confirm that the changes starting at line 190 are correct in version 3.6 and earlier. Will you PTAL? 