### PR TITLE
BZ#1597945 - Rewrite: Azure disk object definition section

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -1,5 +1,5 @@
 [[install-config-persistent-storage-dynamically-provisioning-pvs]]
-= Dynamic Provisioning and Creating Storage Classes
+= Dynamic provisioning and creating storage classes
 {product-author}
 {product-version}
 :data-uri:
@@ -49,7 +49,7 @@ openshift_master_dynamic_provisioning_enabled=True
 
 
 [[available-dynamically-provisioned-plug-ins]]
-== Available Dynamically Provisioned Plug-ins
+== Available dynamically provisioned plug-ins
 
 {product-title} provides the following _provisioner plug-ins_, which have
 generic implementations for dynamic provisioning that use the cluster's
@@ -130,9 +130,9 @@ definition for a _StorageClass_ and specific examples for each of the supported
 plug-in types.
 
 [[basic-spec-definition]]
-=== Basic StorageClass Object Definition
+=== Basic StorageClass object definition
 
-.StorageClass Basic Object Definition
+.StorageClass Basic object definition
 [source,yaml]
 ----
 kind: StorageClass <1>
@@ -157,7 +157,7 @@ parameters: <6>
 from plug-in to plug-in.
 
 [[storage-class-annotations]]
-=== StorageClass Annotations
+=== StorageClass annotations
 
 To set a _StorageClass_ as the cluster-wide default:
 ----
@@ -179,7 +179,7 @@ To set a _StorageClass_ description:
 
 
 [[openstack-cinder-spec]]
-=== OpenStack Cinder Object Definition
+=== OpenStack Cinder object definition
 
 .cinder-storageclass.yaml
 [source,yaml]
@@ -202,7 +202,7 @@ the file system is created when the volume is mounted for the first time. The
 default value is `ext4`.
 
 [[aws-elasticblockstore-ebs]]
-=== AWS ElasticBlockStore (EBS) Object Definition
+=== AWS ElasticBlockStore (EBS) object definition
 
 .aws-ebs-storageclass.yaml
 [source,yaml]
@@ -243,7 +243,7 @@ the file system is created when the volume is mounted for the first time. The
 default value is `ext4`.
 
 [[gce-persistentdisk-gcePd]]
-=== GCE PersistentDisk (gcePD) Object Definition
+=== GCE PersistentDisk (gcePD) object definition
 
 .gce-pd-storageclass.yaml
 [source,yaml]
@@ -273,12 +273,12 @@ the file system is created when the volume is mounted for the first time. The
 default value is `ext4`.
 
 [[glusterfs]]
-=== GlusterFS Object Definition
+=== GlusterFS object definition
 
 include::install_config/persistent_storage/topics/glusterfs_storageclass.adoc[]
 
 [[ceph-persistentdisk-cephRBD]]
-=== Ceph RBD Object Definition
+=== Ceph RBD object definition
 
 .ceph-storageclass.yaml
 [source,yaml]
@@ -312,7 +312,7 @@ parameters:
  default value is `ext4`.
 
 [[trident]]
-=== Trident Object Definition
+=== Trident object definition
 
 .trident.yaml
 [source,yaml]
@@ -335,7 +335,7 @@ storage that are registered with it. Trident itself is configured separately.
 <2> For more information about supported parameters, see the link:https://github.com/NetApp/trident#storage-attributes[storage attributes] section of the Trident documentation.
 
 [[vsphere]]
-=== VMware vSphere Object Definition
+=== VMware vSphere object definition
 
 .vsphere-storageclass.yaml
 [source,yaml]
@@ -353,19 +353,19 @@ parameters:
 <2>  `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick`. See vSphere docs for details. Default: `thin`
 
 [[azure-file-secret-permission]]
-=== Azure File Object Definition
+=== Azure File object definition
 
 To configure Azure file dynamic provisioning:
 
 . Create the role in the user's project:
 +
 ----
-$ cat azf-role.yaml 
+$ cat azf-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: system:controller:persistent-volume-binder
-  namespace: <user's project name> 
+  namespace: <user's project name>
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -380,7 +380,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: system:controller:persistent-volume-binder
-  namespace: <user's project> 
+  namespace: <user's project>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -413,28 +413,8 @@ mountOptions:
 
 The user can now create a PVC that uses this storage class.
 
-[[azure-unmanaged-disk]]
-=== Azure Unmanaged Disk Object Definition
-
-.azure-unmanaged-disk-storageclass.yaml
-[source,yaml]
-----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: slow
-provisioner: kubernetes.io/azure-disk
-parameters:
-  skuName: Standard_LRS  <1>
-  location: eastus  <2>
-  storageAccount: azure_storage_account_name  <3>
-----
-<1> Azure storage account SKU tier. Default is empty.
-<2> Azure storage account location. Default is empty.
-<3> Azure storage account name. This must reside in the same resource group as the cluster. If a storage account is specified, the `location` is ignored. If a storage account is not specified, a new storage account gets created in the same resource group as the cluster.
-
 [[azure-advanced-disk]]
-=== Advanced Azure Disk Object Definition
+=== Azure Disk object definition
 
 .azure-advanced-disk-storageclass.yaml
 [source,yaml]
@@ -445,11 +425,32 @@ metadata:
   name: slow
 provisioner: kubernetes.io/azure-disk
 parameters:
-  storageaccounttype: Standard_LRS  <1>
-  kind: Shared  <2>
+  storageAccount: azure_storage_account_name  <1>
+  storageaccounttype: Standard_LRS  <2>
+  kind: Dedicated  <3>
 ----
-<1> Azure storage account SKU tier. Default is empty. *Note:* Premium VM can attach both _Standard_LRS_ and _Premium_LRS_ disks, Standard VM can only attach _Standard_LRS_ disks, Managed VM can only attach managed disks, and unmanaged VM can only attach unmanaged disks.
-<2> possible values are `shared` (default), `dedicated`, and `managed`. When `kind` is `shared`, all unmanaged disks are created in a few shared storage accounts in the same resource group as the cluster. When `kind` is `dedicated`, a new dedicated storage account gets created for the new unmanaged disk in the same resource group as the cluster. When `kind` is `managed`, a new managed disk gets created.
+<1> Azure storage account name. This must reside in the same resource group as the
+cluster. If a storage account is specified, the `location` is ignored. If a
+storage account is not specified, a new storage account gets created in the same
+resource group as the cluster. If you are specifying a `storageAccount`, the
+value for `kind` must be `Dedicated`.
+<2> Azure storage account SKU tier. Default is empty. *Note:* Premium VM can attach
+both _Standard_LRS_ and _Premium_LRS_ disks, Standard VM can only attach
+_Standard_LRS_ disks, Managed VM can only attach managed disks, and unmanaged VM
+can only attach unmanaged disks.
+<3> Possible values are `Shared` (default), `Dedicated`, and `Managed`.
++
+.. If `kind` is set to `Shared`, Azure creates all unmanaged disks in a few shared
+storage accounts in the same resource group as the cluster.
+.. If `kind` is set to `Managed`, Azure creates new managed disks.
+.. If `kind` is set to `Dedicated` and a `storageAccount` is specified, Azure uses
+the specified storage account for the new unmanaged disk in the same resource
+group as the cluster. For this to work:
+ * The specified storage account must be in the same region.
+ * Azure Cloud Provider must have a write access to the storage account.
+ .. If `kind` is set to `Dedicated` and a `storageAccount` is not specified, Azure
+creates a new dedicated storage account for the new unmanaged disk in the same
+resource group as the cluster.
 
 [IMPORTANT]
 ====
@@ -464,7 +465,7 @@ this creates new storage accounts for future use.
 
 
 [[change-default-storage-class]]
-== Changing the Default StorageClass
+== Changing the default StorageClass
 If you are using GCE and AWS, use the following process to change the default StorageClass:
 
 . List the StorageClass:
@@ -507,7 +508,7 @@ standard (default)   kubernetes.io/gce-pd
 ----
 
 [[moreinfo]]
-== Additional Information and Examples
+== Additional information and examples
 
 - xref:../../install_config/storage_examples/storage_classes_dynamic_provisioning.adoc#install-config-storage-examples-storage-classes-dynamic-provisioning[Examples and uses of StorageClasses for Dynamic Provisioning]
 


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1597945

Changes:
- Removed "Azure Unmanaged Disk Object Definition" section.
- Added `storageAccount` field to sample yaml in "Advanced Azure Disk Object Definition" section
- Renamed "Advance Azure Disk Object Definition" section to "Azure Disk Object Definition"
- Updated explanation for the `kind` variable values

Preview: http://bug1597945-fixes--gnelson-preview.netlify.com/openshift-enterprise/(head%20detached%20at%20fetch_head)/install_config/persistent_storage/dynamically_provisioning_pvs.html#azure-advanced-disk