### PR TITLE
BZ:1600199:Corrected the spelling error from clusteradmin to cluster-…

### DIFF
--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -798,13 +798,13 @@ Local roles should only created if a cluster role does not provide the set
 of permissions needed for a particular situation.
 
 Some cluster role names are initially confusing. The cluster role
-`clusteradmin` can be bound to a user using a local role binding, making it appear
+`cluster-admin` can be bound to a user using a local role binding, making it appear
 that this user has the privileges of a cluster administrator. This is not the case.
-The `clusteradmin` cluster role bound to a certain project is more like a super
+The `cluster-admin` cluster role bound to a certain project is more like a super
 administrator for that project, granting the permissions of the cluster role
 `admin`, plus a few additional permissions like the ability to edit rate limits.
 This can appear especially confusing via the web console UI, which does not list
 cluster role bindings (which are bound to true cluster administrators). However, it
-does list local role bindings (which could be used to locally bind `clusteradmin`).
+does list local role bindings (which could be used to locally bind `cluster-admin`).
 
 endif::[]


### PR DESCRIPTION
@openshift/team-documentation - BZ:1600199:Corrected the spelling error from clusteradmin to cluster-admin