### PR TITLE
Add node upgrade hooks, various updates for 3.10 upgrade

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -307,6 +307,26 @@ example:
 openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true',]}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.pods-per-core','value': ['20']}]}]
 ----
 
+.. In order to convert a {product-title} 3.9 cluster to using the new node group
+definitions and mappings, all hosts previously defined in the `[nodes]`
+inventory group must be assigned an `openshift_node_group_name`. This value is
+used to select the ConfigMap that configures each node.
++
+For example:
++
+----
+[nodes]
+master[1:3].example.com openshift_node_group_name='node-config-master'
+infra-node1.example.com openshift_node_group_name='node-config-infra'
+infra-node2.example.com openshift_node_group_name='node-config-infra'
+node1.example.com openshift_node_group_name='node-config-infra'
+node2.example.com openshift_node_group_name='node-config-infra'
+----
++
+In addition, remove the `openshift_node_labels` setting from any existing host
+entries `[nodes]` group if they are set. Node labels should now be defined in
+the ConfigMap associated with the host's `openshift_node_group_name` instead. 
+
 .. The upgrade process will be blocked until you have the newly required ConfigMaps
 for bootstrapping nodes in the *openshift-node* project. Run the following
 playbook to have the defaults created (or if you defined the
@@ -331,26 +351,6 @@ Then use `oc describe` to inspect them individually:
 ----
 $ oc describe configmaps -n openshift-node <configmap_name>
 ----
-
-.. In order to convert a {product-title} 3.9 cluster to using the new node group
-definitions and mappings, all hosts previously defined in the `[nodes]`
-inventory group must be assigned an `openshift_node_group_name`. This value is
-used to select the ConfigMap that configures each node.
-+
-For example:
-+
-----
-[nodes]
-master[1:3].example.com openshift_node_group_name='node-config-master'
-infra-node1.example.com openshift_node_group_name='node-config-infra'
-infra-node2.example.com openshift_node_group_name='node-config-infra'
-node1.example.com openshift_node_group_name='node-config-infra'
-node2.example.com openshift_node_group_name='node-config-infra'
-----
-+
-In addition, remove the `openshift_node_labels` setting from any existing host
-entries `[nodes]` group if they are set. Node labels should now be defined in
-the ConfigMap associated with the host's `openshift_node_group_name` instead. 
 
 . If you have applied manual configuration changes to your master or node
 configuration files since your last Ansible playbook run (whether that was
@@ -396,14 +396,14 @@ When upgrading in separate phases, the control plane phase includes upgrading:
 
 - master components
 - node services running on masters
-- Docker running on masters
-- Docker running on any stand-alone etcd hosts
+- Docker or CRI-O running on masters
+- Docker or CRI-O running on any stand-alone etcd hosts
 
 When upgrading only the nodes, the control plane must already be upgraded. The
 node phase includes upgrading:
 
 - node services running on stand-alone nodes
-- Docker running on stand-alone nodes
+- Docker or CRI-O running on stand-alone nodes
 
 [NOTE]
 ====
@@ -521,6 +521,10 @@ any ambiguity.
 openshift_master_upgrade_pre_hook=/usr/share/custom/pre_master.yml
 openshift_master_upgrade_hook=/usr/share/custom/master.yml
 openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
+
+openshift_node_upgrade_pre_hook=/usr/share/custom/pre_node.yml
+openshift_node_upgrade_hook=/usr/share/custom/node.yml
+openshift_node_upgrade_post_hook=/usr/share/custom/post_node.yml
 ----
 
 .Example *_pre_master.yml_* Task
@@ -542,26 +546,57 @@ openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
 [[upgrade-hooks-available-hooks]]
 ==== Available Upgrade Hooks
 
-`openshift_master_upgrade_pre_hook`::
-- Runs _before_ each master is upgraded.
+[[upgrade-hooks-masters]]
+.Master Upgrade Hooks
+[cols="1,1",options="header"]
+|===
+|Hook Name |Description
+
+|`openshift_master_upgrade_pre_hook`
+a|- Runs _before_ each master is upgraded.
+- This hook runs against _each master_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to` or `local_action`].
+
+|`openshift_master_upgrade_hook`
+a|- Runs _after_ each master is upgraded, but _before_ its service or system restart.
+- This hook runs against _each master_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to` or `local_action`].
+
+|`openshift_master_upgrade_post_hook`
+a|- Runs _after_ each master is upgraded and has had its service or system restart.
 - This hook runs against _each master_ in serial.
 - If a task must run against a different host, said task must use
 link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
 or `local_action`].
+|===
 
-`openshift_master_upgrade_hook`::
-- Runs _after_ each master is upgraded, but _before_ its service or system restart.
-- This hook runs against **each master** in serial.
-- If a task must run against a different host, said task must use
-link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
-or `local_action`].
+[[upgrade-hooks-nodes]]
+.Node Upgrade Hooks
+[cols="1,1",options="header"]
+|===
+|Hook Name |Description
 
-`openshift_master_upgrade_post_hook`::
-- Runs _after_ each master is upgraded and has had its service or system restart.
-- This hook runs against _each master_ in serial.
+|`openshift_node_upgrade_pre_hook`
+a|- Runs _before_ each node is upgraded.
+- This hook runs against _each node_ in serial.
 - If a task must run against a different host, said task must use
-link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to`
-or `local_action`].
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to` or `local_action`].
+
+|`openshift_node_upgrade_hook`
+a|- Runs _after_ each node is upgraded, but _before_ it's marked schedulable again.
+- This hook runs against _each node_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to` or `local_action`].
+
+|`openshift_node_upgrade_post_hook`
+a|- Runs _after_ each node is upgraded; it's the _last_ node upgrade action.
+- This hook runs against _each node_ in serial.
+- If a task must run against a different host, said task must use
+link:http://docs.ansible.com/ansible/playbooks_delegation.html#delegation[`delegate_to` or `local_action`].
+
+|===
 
 [[upgrading-to-ocp-3-10]]
 == Upgrading to the Latest {product-title} 3.10 Release


### PR DESCRIPTION
Pulls in https://github.com/openshift/openshift-docs/pull/8552 and makes other 3.10 upgrade edits based on feedback from https://github.com/openshift/openshift-docs/pull/10717.

Preview:

http://file.rdu.redhat.com/~adellape/071318/upgrade310_2/upgrading/automated_upgrades.html#preparing-for-an-automated-upgrade

http://file.rdu.redhat.com/~adellape/071318/upgrade310_2/upgrading/automated_upgrades.html#upgrade-hooks-available-hooks