### PR TITLE
fixed formatting for svcat in 3.10 release notes

### DIFF
--- a/release_notes/ocp_3_10_release_notes.adoc
+++ b/release_notes/ocp_3_10_release_notes.adoc
@@ -531,8 +531,8 @@ replaced as needed, without affecting the persistent data stored on the PV.
 [[ocp-310-service-catalog-CLI]]
 ==== Service Catalog command-line interface (CLI)
 
-The Service Catalog command-line interface (CLI) utility called svcat is
-available for easier interaction with Service Catalog resources. svcat
+The Service Catalog command-line interface (CLI) utility called `svcat` is
+available for easier interaction with Service Catalog resources. `svcat`
 communicates with the Service Catalog API by using the aggregated API endpoint
 on an OpenShift cluster.
 


### PR DESCRIPTION
Changed svcat to `svcat`