### PR TITLE
add docs comparing oc and kubectl

### DIFF
--- a/cli_reference/differences_oc_kubectl.adoc
+++ b/cli_reference/differences_oc_kubectl.adoc
@@ -1,0 +1,38 @@
+[[cli-reference-differences-oc-kubectl]]
+= Why use oc over kubectl?
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+A copy of `kubectl` is included in {product-title} command line interface (CLI).
+Although there are several similarities between these two clients, this guide's aim
+is to clarify the main reasons and scenarios for using one over the other.
+
+== Using oc
+
+The `oc` binary offers the same capabilities as the `kubectl` binary, on top of that it is extencded
+to natively support {product-title} features, such as:
+
+- Full support for OpenShift resources (DeploymentConifgs, BuildConfigs, Routes, ImageStreams, ImageStreamTags, etc.).
+These are resources specific to {product-title}, and not available in Kubernetes.
+- Authentication: The `oc` binary offers a built-in `login` command which allows authentication.
+See xref:../dev_guide/authentication.adoc[developer authentication] and
+xref:../install_config/configuring_authentication.adoc[configuring authentication] for more information.
+- Additional commands, such as `new-app`, which make it easier to get new applications started using existing source code
+or prebuilt images.
+
+== Using kubectl
+
+The `kubectl` binary is provided as a means to support existing workflows and scripts for users coming from a DIY
+Kubernetes environment.
+
+Existing users of `kubectl` can continue to use this binary with no changes to the api, but should consider upgrading
+to `oc` in order to gain the added functionality mentioned in the previous section.
+
+Because `oc` is built on top of `kubectl`, converting a `kubectl` binary to `oc` is as simple as changing the binary's name
+from `kubectl` to `oc`.
+
+See xref:../cli_reference/get_started_cli.adoc#cli-reference-get-started-cli[Get Started with the CLI] for
+installation and setup instructions.


### PR DESCRIPTION
Adds documentation explaining the main differences between `oc` and `kubectl`.
Trello card: https://trello.com/c/BumbnGUY

cc @mfojtik @liggitt @derekwaynecarr 