### PR TITLE
added important note about image versions

### DIFF
--- a/using_images/index.adoc
+++ b/using_images/index.adoc
@@ -23,4 +23,10 @@ example, `registry.access.redhat.com/jboss-eap-6/eap64-openshift` for
 the JBoss EAP image.
 
 All Red Hat supported images covered in this book are described in the https://access.redhat.com/containers[Red Hat Container Catalog]. For every version of each image, you can find details on its contents and usage. Browse or search for the image that interests you.
+
+[IMPORTANT]
+====
+The newer versions of container images are not compatible with earlier versions of {product-title}. Verify and use the correct version of container images, based on your version of {product-title}.
+====
+
 endif::[]


### PR DESCRIPTION
we should add a note in the docs that images are not backward compatible and that you should use the image that is right for the version of OCP that you are currently using?