### PR TITLE
Fixed formatting around Note

### DIFF
--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -237,14 +237,14 @@ $ tar -xf <file>
 ----
 
 [NOTE]
-===
+====
 If you do not use RHEL or Fedora, ensure that *libc* is installed and on your library path.
 If *libc* is not available, you might see the following error when you run CLI commands:
 
----
+----
 oc: No such file or directory
----
-===
+----
+====
 
 // end::installcli[]
 


### PR DESCRIPTION
I noticed a formatting error in the Get Started with the CLI page right above [Basic Setup and Login](https://docs.openshift.com/container-platform/3.9/cli_reference/get_started_cli.html#basic-setup-and-login).
