### PR TITLE
Add services per ns cluster limits for ocp v3.10

### DIFF
--- a/scaling_performance/cluster_limits.adoc
+++ b/scaling_performance/cluster_limits.adoc
@@ -75,6 +75,11 @@ expensive and slow down processing given state changes.]
 | 10,000
 | 10,000
 
+| Number of services per namespace
+| N/A
+| N/A
+| 5,000
+
 | Number of back-ends per service
 | 5,000
 | 5,000


### PR DESCRIPTION
The current services per ns limit is 5000 which is also the limit
in case of upstream kubernetes.