### PR TITLE
dont send webhooks for merges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,4 @@ script:
  - python makeBuild.py
 
 after_success:
- - export USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
- - echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\"}" > buildset.json
- - "curl -H 'Content-Type: application/json' --request POST --data @buildset.json \"https://hooks.zapier.com/hooks/catch/3022285/wik1iz/\""
+ - bash autopreview.sh

--- a/autopreview.sh
+++ b/autopreview.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -ev
+
+ALLOWED_USERS=("gaurav-nelson" "tmorriso-rh" "mburke5678" "vikram-redhat" "ahardin-rh" "kalexand-rh" "adellape" "bfallonf" "bmcelvee" "ousleyp")
+USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
+COMMIT_HASH="$(git rev-parse @~)"
+mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PRs and not all merges
+    if [[ " ${ALLOWED_USERS[*]} " =~ " ${USERNAME} " ]]; then # to make sure it only runs on PRs from @openshift/team-documentation
+        if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "master" ] ; then # to make sure it does not run for direct master changes
+            if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]]; then # to make sure this doesn't run for genreal modifications
+                echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\"}" > buildset.json
+                curl -H 'Content-Type: application/json' --request POST --data @buildset.json "https://hooks.zapier.com/hooks/catch/3022285/wik1iz/"
+                echo -e "\\n\\033[0;32m[✓] Sent request for building a preview.\\033[0m"
+            else
+                echo -e "\\n\\033[1;33m[!] No .adoc files modified, not building a preview.\\033[0m"
+            fi
+        else
+            echo -e "\\n\\033[1;33m[!] Direct PR for master branch, not building a preview.\\033[0m"
+        fi
+    else
+        echo -e "\\n\\033[1;33m[!] ${USERNAME} is not a team member of @openshift/team-documentation, not building a preview.\\033[0m"
+    fi
+else
+    echo -e "\\n\\033[1;33m[!] Not a PR, not building a preview.\\033[0m"
+fi


### PR DESCRIPTION
Includes following updates:
- Separate script for sending preview generation request.
- Extra checks in place before sending preview generation request.
- Info messages including why a preview generation request is sent or not sent.

#### What is problematic with the current preview generation process?
Current process works as follows:
1. For every Github PR or master merge send webhook for preview generation.
2. Preview generator then checks for allowed user and builds a preview.

This is resulting in error messages on preview generator which I am subscribed to. The proposed updates will solve all these known errors.

#### What is the suggested flow in this update?
This makes sure that the webhook request is only sent if:
- Travis build is running for a PR (this saves sending request on merges)
- AND PR is from a member of openshift-team-docs (avoid building PRs for every pull request)
- AND Changed files includes at least one .adoc file (avoid build previews for configuration changes)


