### PR TITLE
[enterprise-3.6] Pod Anti Affinity Docs are inconsistent

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -382,34 +382,34 @@ anti-affinity can be set to either required or preferred.
 
 Using the `*docker-registry*` pod as an example, the first step in enabling
 this feature is to set the `*scheduler.alpha.kubernetes.io/affinity*` on the
-pod. Since this pod uses a deployment configuration, the most appropriate
-place to add the annotation is to the pod template's metadata.
+pod. 
 
-====
+[source,yaml]
 ----
-$ oc edit dc/docker-registry -o yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: with-pod-antiaffinity
+spec:
+  affinity:
+    podAntiAffinity: <1>
+      preferredDuringSchedulingIgnoredDuringExecution: <2>
+      - weight: 100 <3>
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: docker-registry <4>
+              operator: In <5>
+              values: 
+              - default
+          topologyKey: kubernetes.io/hostname
+----
 
-...
-  template:
-    metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/affinity: |
-          {
-            "podAntiAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": [{
-                "labelSelector": {
-                  "matchExpressions": [{
-                    "key": "docker-registry",
-                    "operator": "In",
-                    "values":["default"]
-                  }]
-                },
-                "topologyKey": "kubernetes.io/hostname"
-              }]
-            }
-          }
-----
-====
+<1> Stanza to configure pod anti-affinity.
+<2> Defines a preferred rule.
+<3> Specifies a weight for a preferred rule. The node with the highest weight is preferred.
+<4> Description of the pod label that determines when the anti-affinity rule applies. Specify a key and value for the label.
+<5> The operator represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod. Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
 
 [IMPORTANT]
 ====

--- a/admin_guide/scheduling/pod_affinity.adoc
+++ b/admin_guide/scheduling/pod_affinity.adoc
@@ -74,27 +74,26 @@ metadata:
 spec:
   affinity:
     podAntiAffinity: <1>
-      preferredDuringSchedulingIgnoredDuringExecution: <2>
-      - weight: 100 <3>
+      preferredDuringSchedulingIgnoredDuringExecution: <2> 
+      - weight: 100  <3>
         podAffinityTerm:
           labelSelector:
             matchExpressions:
-            - key: security <4>
+            - key: security <4> 
               operator: In <5>
               values:
-              - S2 <4>
+              - S2
           topologyKey: kubernetes.io/hostname
   containers:
   - name: with-pod-affinity
     image: docker.io/ocpqe/hello-pod
-
 ----
 
 <1> Stanza to configure pod anti-affinity.
 <2> Defines a preferred rule.
-<3> Specifies a weight for a preferred rule. The node that with highest weight is preferred.
-<4> The key and value (label) that must be matched to apply the rule.
-<5> The operator represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod.  Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
+<3> Specifies a weight for a preferred rule. The node with the highest weight is preferred.
+<4> Description of the pod label that determines when the anti-affinity rule applies. Specify a key and value for the label.
+<5> The operator represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod. Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
 
 
 [NOTE]


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/10914

Note, entered the commit message incorrectly with {enterprise-3.10]. This is a typo only.