### PR TITLE
Revert "daemonset editing actually updated pods"

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -893,7 +893,7 @@ Topics:
   File: downward_api
 - Name: Projected Volumes
   File: projected_volumes
-- Name: Using DaemonSets
+- Name: Using Daemonsets
   File: daemonsets
   Distros: openshift-enterprise,openshift-dedicated,openshift-origin
 - Name: Pod Autoscaling

--- a/admin_guide/image_policy.adoc
+++ b/admin_guide/image_policy.adoc
@@ -207,12 +207,12 @@ the default is *pods*.
 <5> List of annotations to match on the image object's metadata.
 <6> If you are not able to resolve the image, do not fail the pod.
 <7> Array of rules allowing use of image streams in Kubernetes resources. The
-default configuration allows pods, ReplicationControllers, ReplicaSets,
-StatefulSets, DaemonSets, deployments, and jobs to use same-project image stream
+default configuration allows pods, replicationcontrollers, replicasets,
+statefulsets, daemonsets, deployments, and jobs to use same-project image stream
 tag references in their image fields.
-<8> Identifies the group and resource to which this rule applies. If the resource is
-`*`, this rule applies to all resources in that group.
-<9> `LocalNames` allows single segment names (for example, `*ruby:2.4*`) to
+<8> Identifies the group and resource to which this rule applies. If resource is
+`*`, this rule will apply to all resources in that group.
+<9> `LocalNames` will allow single segment names (for example, `*ruby:2.4*`) to
 be interpreted as namespace-local image stream tags, but only if the resource or
 target image stream has
 xref:../dev_guide/managing_images.adoc#using-is-with-k8s[`local name resolution`] enabled.

--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -326,7 +326,7 @@ $ oc adm drain <node1> <node2> [--pod-selector=<pod_selector>]
 
 You can force deletion of bare pods by using the `--force` option. When set to
 `true`, deletion continues even if there are pods not managed by a replication
-controller, ReplicaSet, job, DaemonSet, or StatefulSet:
+controller, ReplicaSet, job, daemonset, or StatefulSet:
 
 ----
 $ oc adm drain <node1> <node2> --force=true

--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -313,7 +313,7 @@ To maintain the existing link:https://kubernetes.io/docs/admin/node/#node-contro
 
 
 [[admin-guide-taints-daemonsets]]
-== DaemonSets and Tolerations
+== Daemonsets and Tolerations
 
 link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.alpha.kubernetes.io/unreachable` and `node.alpha.kubernetes.io/notReady`
 with no `tolerationSeconds` to ensure that DaemonSet pods are never evicted due to these problems, even when the Default Toleration Seconds feature is disabled.

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -199,7 +199,7 @@ Once bound to a node, a pod will never be bound to another node. This means that
 | `Always`.
 
 |Pods that need to run one-per-machine
-|xref:../../dev_guide/daemonsets.adoc#dev-guide-daemonsets[DaemonSet]
+|xref:../../dev_guide/daemonsets.adoc#dev-guide-daemonsets[Daemonset]
 |Any
 |===
 

--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -1,5 +1,5 @@
 [[dev-guide-daemonsets]]
-= Using DaemonSets
+= Using Daemonsets
 {product-author}
 {product-version}
 :data-uri:
@@ -13,28 +13,28 @@ toc::[]
 
 == Overview
 
-You can use a DaemonSet to run replicas of a pod on specific or all nodes in an
+A daemonset can be used to run replicas of a pod on specific or all nodes in an
 {product-title} cluster.
 
-Use DaemonSets to create shared storage, run a logging pod on every node in
+Use daemonsets to create shared storage, run a logging pod on every node in
 your cluster, or deploy a monitoring agent on every node.
 
-For security reasons, only cluster administrators can create DaemonSets.
-(xref:../admin_guide/manage_rbac.adoc#admin-guide-granting-users-daemonset-permissions[Granting Users DaemonSet Permissions.])
+For security reasons, only cluster administrators can create daemonsets.
+(xref:../admin_guide/manage_rbac.adoc#admin-guide-granting-users-daemonset-permissions[Granting Users Daemonset Permissions.])
 
-For more information on DaemonSets, see the link:http://kubernetes.io/docs/admin/daemons/[Kubernetes documentation].
+For more information on daemonsets, see the link:http://kubernetes.io/docs/admin/daemons/[Kubernetes documentation].
 
 [IMPORTANT]
 ====
-DaemonSet scheduling is incompatible with project's default node selector.
-If you fail to disable it, the DaemonSet gets restricted by merging with the
+Daemonset scheduling is incompatible with project's default node selector.
+If you fail to disable it, the daemonset gets restricted by merging with the
 default node selector. This results in frequent pod recreates on the nodes that
 got unselected by the merged node selector, which in turn puts unwanted load on
 the cluster.
 
 Therefore,
 
-* Before you start using DaemonSets, disable the default project-wide
+* Before you start using daemonsets, disable the default project-wide
 xref:../admin_guide/managing_projects.adoc#using-node-selectors[node selector]
 in your namespace, by setting the namespace annotation `openshift.io/node-selector` to an empty string:
 
@@ -49,12 +49,12 @@ in your namespace, by setting the namespace annotation `openshift.io/node-select
 ====
 
 [[dev-guide-creating-daemonsets]]
-== Creating DaemonSets
+== Creating Daemonsets
 
-When creating DaemonSets, the `*nodeSelector*` field is used to indicate the
-nodes on which the DaemonSet should deploy replicas.
+When creating daemonsets, the `*nodeSelector*` field is used to indicate the
+nodes on which the daemonset should deploy replicas.
 
-. Define the DaemonSet yaml file:
+. Define the daemonset yaml file:
 +
 ====
 ----
@@ -85,12 +85,12 @@ spec:
       serviceAccount: default
       terminationGracePeriodSeconds: 10
 ----
-<1> The label selector that determines which pods belong to the DaemonSet.
+<1> The label selector that determines which pods belong to the daemonset.
 <2> The pod template's label selector. Must match the label selector above.
 <3> The node selector that determines on which nodes pod replicas should be deployed.
 ====
 
-. Create the DaemonSet object:
+. Create the daemonset object:
 +
 ----
 oc create -f daemonset.yaml
@@ -98,7 +98,7 @@ oc create -f daemonset.yaml
 
 . To verify that the pods were created, and that each node has a pod replica:
 +
-.. Find the DaemonSet pods:
+.. Find the daemonset pods:
 +
 ====
 ----
@@ -121,17 +121,12 @@ Node:        openshift-node02.hostname.com/10.14.20.137
 
 [IMPORTANT]
 ====
-* If you update a DaemonSet's pod template, the existing pod
-replicas are not affected. 
-
-* If you delete a DaemonSet and then create a new DaemonSet
-with a different template but the same label selector, it recognizes any
-existing pod replicas as having matching labels and thus does not update them or
+Currently, updating a daemonset's pod template does not affect existing pod
+replicas. Moreover, if you delete a daemonset and then create a new daemonset
+with a different template but the same label selector, it will recognize any
+existing pod replicas as having matching labels and thus will not update them or
 create new replicas despite a mismatch in the pod template.
 
-* If you change node labels, the DaemonSet adds pods to nodes that match the new labels and deletes pods 
-from nodes that do not match the new labels.
- 
-To update a DaemonSet, force new pod replicas to be created by deleting the old
+To update a daemonset, force new pod replicas to be created by deleting the old
 replicas or nodes.
 ====

--- a/dev_guide/device_plugins.adoc
+++ b/dev_guide/device_plugins.adoc
@@ -25,7 +25,7 @@ Manager] code:
 [[plugin-deployment]]
 == Methods for Deploying a Device Plug-in
 
-* xref:../dev_guide/daemonsets.adoc#dev-guide-daemonsets[DaemonSets]
+* xref:../dev_guide/daemonsets.adoc#dev-guide-daemonsets[Daemonsets]
 are the recommended approach for device plug-in deployments.
 * Upon start, the device plug-in will try to create a UNIX domain socket at
 *_/var/lib/kubelet/device-plugin/_* on the node to serve RPCs from

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1040,7 +1040,7 @@ endif::[]
 | `openshift_logging_use_mux`
 |The default is set to `False`. If set to `True`,
 a service called `mux` is deployed. This service acts as a Fluentd
-`secure_forward` aggregator for the node agent Fluentd DaemonSets running in the
+`secure_forward` aggregator for the node agent Fluentd daemonsets running in the
 cluster. Use `openshift_logging_use_mux` to reduce the number of connections to
 the OpenShift API server, and configure each node in Fluentd to send raw logs to
 `mux` and turn off the Kubernetes metadata plug-in. This requires the use of
@@ -1145,7 +1145,7 @@ To scale Elasicsearch to zero:
 $ oc scale --replicas=0 dc/<ELASTICSEARCH_DC>
 ----
 
-Change nodeSelector in the DaemonSet configuration to match zero:
+Change nodeSelector in the daemonset configuration to match zero:
 
 .Get the fluentd node selector:
 ----
@@ -1154,7 +1154,7 @@ $ oc get ds logging-fluentd -o yaml |grep -A 1 Selector
        logging-infra-fluentd: "true"
 ----
 
-.Use the `oc patch` command to modify the DaemonSet nodeSelector:
+.Use the `oc patch` command to modify the daemonset nodeSelector:
 ----
 $ oc patch ds logging-fluentd -p '{"spec":{"template":{"spec":{"nodeSelector":{"nonexistlabel":"true"}}}}}'
 ----
@@ -1171,10 +1171,10 @@ Scale Elastcsearch back up from zero:
 $ oc scale --replicas=# dc/<ELASTICSEARCH_DC>
 ----
 
-Change nodeSelector in the DaemonSet configuration back to
+Change nodeSelector in the daemonset configuration back to
 logging-infra-fluentd: "true".
 
-Use the `oc patch` command to modify the DaemonSet nodeSelector:
+Use the `oc patch` command to modify the daemonset nodeSelector:
 ----
 oc patch ds logging-fluentd -p '{"spec":{"template":{"spec":{"nodeSelector":{"logging-infra-fluentd":"true"}}}}}'
 ----

--- a/install_config/persistent_storage/persistent_storage_csi.adoc
+++ b/install_config/persistent_storage/persistent_storage_csi.adoc
@@ -85,7 +85,7 @@ The CSI driver deployed on the node should have as few credentials to the storag
 
 Since {product-title} does not ship with any CSI driver installed, this example shows how to deploy a community driver for OpenStack Cinder in {product-title}.
 
-. Create a new project where the CSI components will run and a new service account that will run the components. Explicit node selector is used to run the DaemonSet with the CSI driver also on master nodes.
+. Create a new project where the CSI components will run and a new service account that will run the components. Explicit node selector is used to run the Daemonset with the CSI driver also on master nodes.
 +
 [source,shell]
 ----

--- a/install_config/persistent_storage/persistent_storage_local.adoc
+++ b/install_config/persistent_storage/persistent_storage_local.adoc
@@ -59,7 +59,7 @@ spec:
 
 * Creating a PV by specifying a directory with node affinity.
 * A Pod using the PVC that is bound to the previously mentioned PV always get scheduled to that node.
-* External static provisioner DaemonSet that discovers local directories, creates, cleans up and deletes PVs.
+* External static provisioner daemonset that discovers local directories, creates, cleans up and deletes PVs.
 
 *What does not work:*
 
@@ -71,5 +71,5 @@ spec:
 *** Run a workaround controller that unbinds PVCs for pods that are stuck pending.
 * If mounts are added after the external provisioner is started, then external provisioner cannot detect the correct capcity of mounts.
 ** Workarounds:
-*** Before adding any new mount points, first stop the DaemonSet, add the new mount points, and then start the DaemonSet.
+*** Before adding any new mount points, first stop the daemonset, add the new mount points, and then start the daemonset.
 * `fsgroup` conflict occurs if multiple pods using the same PVC specify different `fsgroup` 's.

--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -82,11 +82,11 @@ endif::[]
 Use the `oc adm registry` command to deploy the registry as a `DaemonSet` with the
 `--daemonset` option.
 
-DaemonSets ensure that when nodes are created, they contain copies of a
+Daemonsets ensure that when nodes are created, they contain copies of a
 specified pod. When the nodes are removed, the pods are garbage collected.
 
 For more information on `DaemonSets`, see
-xref:../../dev_guide/daemonsets.adoc#dev-guide-daemonsets[Using DaemonSets].
+xref:../../dev_guide/daemonsets.adoc#dev-guide-daemonsets[Using Daemonsets].
 
 ifdef::openshift-enterprise,openshift-origin[]
 [[registry-compute-resource]]

--- a/release_notes/ocp_3_5_release_notes.adoc
+++ b/release_notes/ocp_3_5_release_notes.adoc
@@ -147,7 +147,7 @@ These controllers now contain the logic:
 
 * replication controller
 * replica set
-* DaemonSet
+* daemonset
 * certificates
 * deployments
 * endpoints
@@ -1227,10 +1227,10 @@ reports `NotReady` faster when the docker daemon is down.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1418461[*BZ#1418461*])
 
 * The `oc adm drain --force` command was ignoring any pods that indicated they
-were managed by a DaemonSet even if the managing DaemonSet was missing. This bug
-fix updates the command to detect when a DaemonSet pod is orphaned and warn
-about the missing DaemonSet rather than generating an error. As a result, the
-command removes orphaned DaemonSet pods.
+were managed by a daemonset even if the managing daemonset was missing. This bug
+fix updates the command to detect when a daemonset pod is orphaned and warn
+about the missing daemonset rather than generating an error. As a result, the
+command removes orphaned daemonset pods.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1424678[*BZ#1424678*])
 
 * When attempting to connect to etcd to acquire a leader lease, the master

--- a/release_notes/ocp_3_6_release_notes.adoc
+++ b/release_notes/ocp_3_6_release_notes.adoc
@@ -2507,10 +2507,10 @@ To reduce the frequency of this problem, you can increase the Fluentd buffer
 chunk size. However, testing does not give consistent results.  You will need to
 stop, configure, and restart Fluentd running on all of your nodes.
 
-. Edit the DaemonSet:
+. Edit the daemonset:
 +
 ----
-# oc edit -n logging DaemonSet logging-fluentd
+# oc edit -n logging daemonset logging-fluentd
 ----
 
 . In the `env:` section, look for `BUFFER_SIZE_LIMIT`. If the value is less than
@@ -2519,7 +2519,7 @@ or `32Mi`. This will roughly increase the size of each bulk index request, which
 should decrease the number of such requests made to Elasticsearch, thereby
 allowing Elasticsearch to process them more efficiently.
 
-. Once the edit is saved, the Fluentd DaemonSet trigger should cause a restart of
+. Once the edit is saved, the Fluentd daemonset trigger should cause a restart of
 all of the Fluentd pods running in the cluster.
 +
 You can monitor the Elasticsearch bulk index thread pool to see how many bulk
@@ -3265,10 +3265,10 @@ include all needed resources and `oc get all` and the other problematic calls
 were fixed.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1515878[*BZ#1515878*])
 
-* Node selectors were incorrectly set on template service broker DaemonSet object.
+* Node selectors were incorrectly set on template service broker daemonset object.
 Consequently, the looping failed the deployment of template service broker pods
 and there was excessive CPU usage on master and nodes. The node selectors are
-now set correctly on the template service broker DaemonSet object and the
+now set correctly on the template service broker daemonset object and the
 template service broker pods now deploy correctly.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1524219[*BZ#1524219*])
 

--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -118,7 +118,7 @@ detected.
 When CRI-O use is enabled, it is installed alongside `docker`, which currently
 is required to perform build and push operations to the registry. Over time,
 temporary `docker` builds can accumulate on nodes. You can optionally set the
-following to enable garbage collection, which adds a DaemonSet to clean out the
+following to enable garbage collection, which adds a daemonset to clean out the
 builds:
 
 ----
@@ -126,7 +126,7 @@ openshift_crio_enable_docker_gc=true
 ----
 
 When enabled, it will run garbage collection on all nodes by default. You can
-also limit the running of the DaemonSet on specific nodes by setting the
+also limit the running of the daemonset on specific nodes by setting the
 following:
 
 ----
@@ -3124,10 +3124,10 @@ include all needed resources and `oc get all` and the other problematic calls
 were fixed.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1515878[*BZ#1515878*])
 
-* Node selectors were incorrectly set on template service broker DaemonSet object.
+* Node selectors were incorrectly set on template service broker daemonset object.
 Consequently, the looping failed the deployment of template service broker pods
 and there was excessive CPU usage on master and nodes. The node selectors are
-now set correctly on the template service broker DaemonSet object and the
+now set correctly on the template service broker daemonset object and the
 template service broker pods now deploy correctly.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1524219[*BZ#1524219*])
 

--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -133,7 +133,7 @@ detected.
 When CRI-O use is enabled, it is installed alongside `docker`, which currently
 is required to perform build and push operations to the registry. Over time,
 temporary `docker` builds can accumulate on nodes. You can optionally set the
-following to enable garbage collection, which adds a DaemonSet to clean out the
+following to enable garbage collection, which adds a daemonset to clean out the
 builds:
 
 ----
@@ -141,7 +141,7 @@ openshift_crio_enable_docker_gc=true
 ----
 
 When enabled, it will run garbage collection on all nodes by default. You can
-also limit the running of the DaemonSet on specific nodes by setting the
+also limit the running of the daemonset on specific nodes by setting the
 following:
 
 ----
@@ -428,7 +428,7 @@ do things, like HTTP/2, in the future.
 [[ocp-39-statefulsets-daemonsets-deployments]]
 ====  StatefulSets, DaemonSets, and Deployments Now Supported
 
-In {product-title}, statefulsets, DaemonSets, and deployments are now stable,
+In {product-title}, statefulsets, daemonsets, and deployments are now stable,
 supported, and out of Technology Preview.
 
 [[ocp-39-central-audit-capability]]
@@ -919,7 +919,7 @@ The core workloads API, which is composed of the `DaemonSet`, `Deployment`,
 `ReplicaSet`, and `StatefulSet kinds`, has been promoted to GA stability in the
 `apps/v1` group version. As such, the `apps/v1beta2` group version is
 deprecated, and all new code should use the kinds in the apps/v1 group version.
-For {product-title} this means the statefulsets, DaemonSets, and deployments are
+For {product-title} this means the statefulsets, daemonsets, and deployments are
 now stable and supported.
 
 [discrete]

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -784,7 +784,7 @@ GlusterFS pods are running.
 
 Special consideration must be taken when upgrading these nodes, as `drain` and
 `unschedule` will not terminate and evacuate the GlusterFS pods because they are
-running as part of a DaemonSet.
+running as part of a daemonset.
 
 There is also the potential for someone to run an upgrade on multiple nodes at
 the same time, which would lead to data availability issues if more than one was
@@ -821,7 +821,7 @@ other nodes in their class (`app` versus `infra`), one at a time.
 .. Run `oc get daemonset` to verify the label found under `NODE-SELECTOR`. The
 default value is `storagenode=glusterfs`.
 
-.. Remove the DaemonSet label from the node:
+.. Remove the daemonset label from the node:
 +
 ----
 $ oc label node <node_name> <daemonset_label>-
@@ -834,7 +834,7 @@ This will cause the GlusterFS pod to terminate on that node.
 .. To run the upgrade playbook on the single node where you terminated GlusterFS,
 use `-e openshift_upgrade_nodes_label="type=upgrade"`.
 
-.. When the upgrade completes, relabel the node with the DaemonSet selector:
+.. When the upgrade completes, relabel the node with the daemonset selector:
 +
 ----
 $ oc label node <node_name> <daemonset_label>


### PR DESCRIPTION
Reverts openshift/openshift-docs#9897

In PR openshift/openshift-docs#9897, we tried to make the capitalization of DaemonSet consistent across all docs. But, the PR created too many merge errors, especially in the earlier branches (incl. files added that would need to be removed). We can pursue this change post-3.10.  
