### PR TITLE
DaemonSet editing actually updated pods 2

### DIFF
--- a/dev_guide/daemonsets.adoc
+++ b/dev_guide/daemonsets.adoc
@@ -121,12 +121,17 @@ Node:        openshift-node02.hostname.com/10.14.20.137
 
 [IMPORTANT]
 ====
-Currently, updating a daemonset's pod template does not affect existing pod
-replicas. Moreover, if you delete a daemonset and then create a new daemonset
-with a different template but the same label selector, it will recognize any
-existing pod replicas as having matching labels and thus will not update them or
+* If you update a DaemonSet's pod template, the existing pod
+replicas are not affected. 
+
+* If you delete a DaemonSet and then create a new DaemonSet
+with a different template but the same label selector, it recognizes any
+existing pod replicas as having matching labels and thus does not update them or
 create new replicas despite a mismatch in the pod template.
 
-To update a daemonset, force new pod replicas to be created by deleting the old
+* If you change node labels, the DaemonSet adds pods to nodes that match the new labels and deletes pods 
+from nodes that do not match the new labels.
+ 
+To update a DaemonSet, force new pod replicas to be created by deleting the old
 replicas or nodes.
 ====


### PR DESCRIPTION
In PR openshift/openshift-docs#9897, we tried to make the capitalization of DaemonSet consistent across all docs. But, the PR created too many merge errors, especially in the earlier branches (incl. files added that would need to be removed). I am reverting this PR. We can pursue the capitalization changes post-3.10.