### PR TITLE
remove feature gate docs for huge pages

### DIFF
--- a/scaling_performance/managing_hugepages.adoc
+++ b/scaling_performance/managing_hugepages.adoc
@@ -45,40 +45,6 @@ huge pages. This topic describes how.
 . Nodes must pre-allocate huge pages in order for the node to report its huge
  page capacity. A node can only pre-allocate huge pages for a single size.
 
-. `HugePages` must be set to `true` across the system:
-+
-----
-# oc edit configmap <name>
-----
-+
-For example:
-+
-----
-# oc edit configmap node-config-compute -n openshift-node
-...
-kubeletArguments:
-...
-  feature-gates:
-  - HugePages=true
-
-# systemctl restart atomic-openshift-node
-----
-
-. The master API must be enabled for `feature-gates` with `HugePages=true`:
-+
-----
-# cat /etc/origin/master/master-config.yaml
-...
-kubernetesMasterConfig:
-  apiServerArguments:
-  ...
-  feature-gates:
-  - HugePages=true
-
-# master-restart api
-# master-restart controllers
-----
-
 [[consuming-huge-pages]]
 == Consuming Huge Pages
 


### PR DESCRIPTION
hugepages are no longer behind a feature gate.  they are enabled by default as of 3.10.  so we can remove the feature gate instructions.