### PR TITLE
Fixed syntax error and add required fields.

### DIFF
--- a/dev_guide/deployments/kubernetes_deployments.adoc
+++ b/dev_guide/deployments/kubernetes_deployments.adoc
@@ -32,12 +32,15 @@ bring up one *hello-openshift* pod:
 
 .Example Kubernetes Deployment Definition *_hello-openshift-deployment.yaml_*
 ----
-apiVersion: apiVersion: apps/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-openshift
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-openshift
   template:
     metadata:
       labels:


### PR DESCRIPTION
Since apps/v1, `spec.selector` is required. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/