### PR TITLE
Update GSG for 3.10

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -97,7 +97,7 @@ the first two repositories in this example.
 ----
 $ subscription-manager repos --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-ose-3.9-rpms" \
+    --enable="rhel-7-server-ose-3.10-rpms" \
     --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.4-rpms"
 ----
@@ -110,13 +110,13 @@ This command tells your RHEL system that the tools required to install
 === Install the {product-title} Package
 
 The installer for {product-title} is provided by the
-`atomic-openshift-utils` package. Install it using `yum` on both the master and
+*openshift-ansible* package. Install it using `yum` on both the master and
 the node, after running `yum update`.
 
 ----
 $ yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion kexec-tools sos psacct
 $ yum -y update
-$ yum -y install atomic-openshift-utils
+$ yum -y install openshift-ansible
 $ yum -y install docker
 ----
 
@@ -145,33 +145,38 @@ $ for host in master.openshift.example.com \
 [[run-the-installation-playbooks]]
 === Run the Installation Playbooks
 
-. Reference an example host file in *_/usr/share/doc/openshift-ansible-docs-3.9.31/docs/example-inventories_*.
+. See
+xref:../install/example_inventories.adoc#install-config-example-inventories[Example
+Inventory Files] and select an example that closest matches your desired cluster
+configuration.
++
+[NOTE]
+====
+Further example host files are available as references in the
+*_/usr/share/doc/openshift-ansible-docs-3.10.<version>/docs/example-inventories/_*
+directory (replacing `<version>` with your latest installed version of the
+*openshift-ansible-docs* package, which will update over time as the
+*openshift-ansible* parent package is upgraded). See
+xref:../install/configuring_inventory_file.adoc#install-config-configuring-inventory-file[Configuring Your Inventory File]
+for full documentation on available inventory variables.
+====
 
-. Select an example, then edit it with your host names.
+. Edit the example inventory to use your host names, then save it to a file
+(default location is *_/etc/ansible/hosts_*).
 
-. Run:
+. Run the *_prerequisites.yml_* playbook using your inventory file:
 +
 ----
-$ ansible-playbook -i <your_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+$ ansible-playbook -i <inventory_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 ----
 
-. Run:
+. Run the *_deploy_cluster.yml_* playbook using your inventory file:
 +
 ----
-$ ansible-playbook -i <your_file>  /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ ansible-playbook -i <inventory_file> /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
 ----
 
-[[start-openshift]]
-=== Start {product-title}
-
-After a successful install, use the following command to start {product-title}.
-
-----
-# master-restart api
-# master-restart controllers
-----
-
-Once installed and started, before you add a new project, you need to set up
+After a successful install, but before you add a new project, you must set up
 basic authentication, user access, and routes.
 
 [[interact-with-openshift]]

--- a/install/example_inventories.adoc
+++ b/install/example_inventories.adoc
@@ -56,26 +56,26 @@ not supported.
 
 The following table describes an example environment for a single
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master]
-(with a single *etcd* on the same host), two
+(with a single etcd on the same host), two
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
-for hosting user applications, and two nodes with the `region=infra` label for hosting
+for hosting user applications, and two nodes with the `node-role.kubernetes.io/infra=true` label for hosting
 xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 
 [options="header"]
 |===
 
-|Host Name |Infrastructure Component to Install
+|Host Name |Component/Role(s) to Install
 
 |*master.example.com*
 |Master, etcd, and node
 
 |*node1.example.com*
-.2+.^|Node
+.2+.^|Compute node
 
 |*node2.example.com*
 
 |*infra-node1.example.com*
-.2+.^|Node (with `region=infra` label)
+.2+.^|Infrastructure node
 
 |*infra-node2.example.com*
 |===
@@ -154,13 +154,13 @@ three
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[etcd]
 hosts, two
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
-for hosting user applications, and two nodes with the `region=infra` label for hosting
+for hosting user applications, and two nodes with the `node-role.kubernetes.io/infra=true` label for hosting
 xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 
 [options="header"]
 |===
 
-|Host Name |Infrastructure Component to Install
+|Host Name |Component/Role(s) to Install
 
 |*master.example.com*
 |Master and node
@@ -173,12 +173,12 @@ xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 |*etcd3.example.com*
 
 |*node1.example.com*
-.2+.^|Node
+.2+.^|Compute node
 
 |*node2.example.com*
 
 |*infra-node1.example.com*
-.2+.^|Node (with `region=infra` label)
+.2+.^|Dedicated infrastructure node
 
 |*infra-node2.example.com*
 |===
@@ -303,16 +303,16 @@ xref:multi-masters-using-native-ha-ai[Multiple Masters with Multiple etcd]
 The following describes an example environment for three
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[masters]
 using the `native` HA method:, one HAProxy load balancer, three
-xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[*etcd*]
+xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[etcd]
 hosts, two
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
-for hosting user applications, and two nodes with the `region=infra` label for hosting
+for hosting user applications, and two nodes with the `node-role.kubernetes.io/infra=true` label for hosting
 xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 
 [options="header"]
 |===
 
-|Host Name |Infrastructure Component to Install
+|Host Name |Component/Role(s) to Install
 
 |*master1.example.com*
 .3+.^|Master (clustered using native HA) and node
@@ -325,19 +325,19 @@ xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 |HAProxy to load balance API master endpoints
 
 |*etcd1.example.com*
-.3+.^|*etcd*
+.3+.^|etcd
 
 |*etcd2.example.com*
 
 |*etcd3.example.com*
 
 |*node1.example.com*
-.2+.^|Node
+.2+.^|Compute node
 
 |*node2.example.com*
 
 |*infra-node1.example.com*
-.2+.^|Node (with `region=infra` label)
+.2+.^|Dedicated infrastructure node
 
 |*infra-node2.example.com*
 |===
@@ -428,16 +428,16 @@ specifications, and save it as *_/etc/ansible/hosts_*.
 The following describes an example environment for three
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[masters]
 using the `native` HA method (with
-xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[*etcd*]
+xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[etcd]
 on each host), one HAProxy load balancer, two
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
-for hosting user applications, and two nodes with the `region=infra` label for hosting
+for hosting user applications, and two nodes with the `node-role.kubernetes.io/infra=true` label for hosting
 xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 
 [options="header"]
 |===
 
-|Host Name |Infrastructure Component to Install
+|Host Name |Component/Role(s) to Install
 
 |*master1.example.com*
 .3+.^|Master (clustered using native HA) and node with etcd on each host
@@ -450,12 +450,12 @@ xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 |HAProxy to load balance API master endpoints
 
 |*node1.example.com*
-.2+.^|Node
+.2+.^|Compute node
 
 |*node2.example.com*
 
 |*infra-node1.example.com*
-.2+.^|Node (with `region=infra` label)
+.2+.^|Dedicated infrastructure node
 
 |*infra-node2.example.com*
 |===


### PR DESCRIPTION
Follows-up on https://github.com/openshift/openshift-docs/pull/10697.

- Use 3.10 repos and file paths
- Use *openshift-ansible* package
- Point to our Example Inventory Files topic instead of on-disk examples, because they're more straight-forward
- Clean up some region / role language

Preview:

http://file.rdu.redhat.com/~adellape/072618/gsg_310/getting_started/install_openshift.html

cc @sdodson 