### PR TITLE
Update for static pod images in 3.10

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -209,10 +209,8 @@ $ docker pull registry.access.redhat.com/openshift3/ose-pod:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-sti-builder:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-template-service-broker:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-web-console:<tag>
-$ docker pull registry.access.redhat.com/openshift3/ose:<tag>
-$ docker pull registry.access.redhat.com/openshift3/container-engine:<tag>
-$ docker pull registry.access.redhat.com/openshift3/node:<tag>
-$ docker pull registry.access.redhat.com/openshift3/openvswitch:<tag>
+$ docker pull registry.access.redhat.com/openshift3/ose-node:<tag>
+$ docker pull registry.access.redhat.com/openshift3/ose-control-plane:<tag>
 $ docker pull registry.access.redhat.com/rhel7/etcd
 ----
 


### PR DESCRIPTION
The openshift3/ose openshift3/node and openshift3/openvswitch images have been replaced with just openshift3/ose-node and openshift3/ose-control-plane.

/cc @ahardin-rh 