### PR TITLE
 Adding some configuration tips

### DIFF
--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -89,7 +89,7 @@ entities. vSphere Cloud Provider requires the following privileges to interact
 with vCenter. See the
 link:https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html[vSphere
 Documentation Center] for steps to create a custom role, user and role
-assignment.
+assignment. 
 +
 [cols="4*", width="100%",options="header"]
 |===
@@ -141,6 +141,11 @@ Datastore Storage Folder
 |No
 
 |===
+
+[NOTE]
+====
+See the link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html#step-4-create-roles-add-privileges-to-roles-and-assign-them-to-the-vsphere-cloud-provider-user-and-vsphere-entities[Configurations on Existing Kubernetes Cluster] article for changes or updates to required roles.
+====
 
 [NOTE]
 ====
@@ -209,6 +214,11 @@ If the file does not exist, create it, and add the following:
 <13> Set to the network port group for vSphere to access the node, which is called VM Network by default. This is the node host's ExternalIP that is registered with Kubernetes.
 
 
+[NOTE]
+====
+Don't forget to escape special characters from the `username` and `password` fields, ex. user = "domain\\username" 
+====
+
 [[vsphere-configuring-masters]]
 == Configuring Masters
 Edit or
@@ -225,7 +235,13 @@ kubernetesMasterConfig:
     pluginConfig:
       {}
   apiServerArguments:
-    cloud-provider:
+    runtime-config:
+    - apis/settings.k8s.io/v1alpha1=true
+    storage-backend:
+    - etcd3
+    storage-media-type:
+    - application/vnd.kubernetes.protobuf  
+    cloud-provider: <1> 
     - "vsphere"
     cloud-config:
     - "/etc/origin/cloudprovider/vsphere.conf"
@@ -235,6 +251,7 @@ kubernetesMasterConfig:
     cloud-config:
     - "/etc/origin/cloudprovider/vsphere.conf"
 ----
+<1> Don't remove your current `apiServerArguments` params just add the `cloud-provider` and `cloud-config` after all of them.
 
 [IMPORTANT]
 ====
@@ -259,6 +276,11 @@ kubeletArguments:
     - "/etc/origin/cloudprovider/vsphere.conf"
 
 ----
++
+[NOTE]
+====
+`cloud-config` field and deploy `vsphere.conf` file to all the nodes is only needed for Openshift versions lower than 3.9.
+====
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
**Tips**:
- Tip about vSphere roles: Link to the official VMware installation article (Configurations on Existing Kubernetes Cluster)
- Tip about master / master-config-yaml: friendly reminder to protect current apiServerArguments config
- Tip about node / node-config.yaml: OCP >=3.9 doesn't need to deploy and config credentials / `cloud-config`