### PR TITLE
Add basic/bearer auth to OAB config

### DIFF
--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -7,6 +7,12 @@
 :toc: macro
 :toc-title:
 :prewrap!:
+ifdef::openshift-enterprise[]
+:oab-ns: openshift-ansible-service-broker
+endif::[]
+ifdef::openshift-origin[]
+:oab-ns: ansible-service-broker
+endif::[]
 
 toc::[]
 
@@ -17,7 +23,7 @@ xref:../architecture/service_catalog/ansible_service_broker.adoc#arch-ansible-se
 Ansible broker] (OAB) is deployed in a cluster, its behavior is largely dictated
 by the broker's configuration file loaded on startup. The broker's configuration
 is stored as a ConfigMap object in the broker's namespace
-(*openshift-ansible-service-broker* by default).
+(*{oab-ns}* by default).
 
 .Example OpenShift Ansible Broker Configuration File
 [source,yaml]
@@ -92,15 +98,17 @@ To modify the OAB's default broker configuration after it has been deployed:
 . Edit the *broker-config* ConfigMap object in the OAB's namespace as a user
 with *cluster-admin* privileges:
 +
+[subs=attributes+]
 ----
-$ oc edit configmap broker-config -n openshift-ansible-service-broker
+$ oc edit configmap broker-config -n {oab-ns}
 ----
 
 . After saving any updates, redeploy the OAB's deployment configuration for the
 changes to take effect:
 +
+[subs=attributes+]
 ----
-$ oc rollout latest dc/asb -n openshift-ansible-service-broker
+$ oc rollout latest dc/asb -n {oab-ns}
 ----
 
 [[oab-config-registry]]
@@ -239,7 +247,7 @@ been mounted as a volume.
 To use the `secret` or `file` type:
 
 . The associated secret should have the values `username` and `password` defined.
-When using a secret, you must ensure that the `openshift-ansible-service-broker`
+When using a secret, you must ensure that the `{oab-ns}`
 namespace exists, as this is where the secret will be read from.
 +
 For example, create a *_reg-creds.yaml_* file:
@@ -247,18 +255,19 @@ For example, create a *_reg-creds.yaml_* file:
 ----
 $ cat reg-creds.yaml
 ---
-username: <username>
+username: <user_name>
 password: <password>
 ----
 
-. Create a secret from this file in the `openshift-ansible-service-broker`
+. Create a secret from this file in the `{oab-ns}`
 namespace:
 +
+[subs=attributes+]
 ----
 $ oc create secret generic \
     registry-credentials-secret \
     --from-file reg-creds.yaml \
-    -n openshift-ansible-service-broker
+    -n {oab-ns}
 ----
 
 . Choose whether you want to use the `secret` or `file` type:
@@ -281,10 +290,11 @@ registry:
 
 .. Set the namespace where the secret is located:
 +
+[subs=attributes+]
 [source,yaml]
 ----
 openshift:
-  namespace: openshift-ansible-service-broker
+  namespace: {oab-ns}
 ----
 
 - To use the `file` type:
@@ -292,8 +302,9 @@ openshift:
 .. Edit the `asb` deployment configuration to mount your file into
 *_/tmp/registry-credentials/reg-creds.yaml_*:
 +
+[subs=attributes+]
 ----
-$ oc edit dc/asb -n openshift-ansible-service-broker
+$ oc edit dc/asb -n {oab-ns}
 ----
 +
 In the `containers.volumeMounts` section, add:
@@ -519,7 +530,7 @@ is also required to configure the broker to use the Partner Registry URL:
 +
 ----
 # docker --config=/var/lib/origin/.docker \
-    login -u <registry_user> -p <registry-password> \
+    login -u <registry_user> -p <registry_password> \
     registry.connect.redhat.com
 ----
 
@@ -546,6 +557,275 @@ registry:
     url: <rhcc_url>
     white_list:
       - ".*-apb$"
+----
+
+[[oab-config-auth]]
+== Broker Authentication
+
+The broker supports authentication, meaning when connecting to the broker, the
+caller must supply the Basic Auth or Bearer Auth credentials for each request.
+Using `curl`, it is as simple as supplying:
+
+----
+-u <user_name>:<password>
+----
+
+or
+
+----
+-h "Authorization: bearer <token>
+----
+
+to the command. The service catalog must be configured with a secret containing
+the user name and password combinations or the bearer token.
+
+[[oab-config-basic-auth]]
+=== Basic Auth
+
+To enable Basic Auth usage, set the following in the broker configuration:
+
+[source,yaml]
+----
+broker:
+   ...
+   auth:
+     - type: basic <1>
+       enabled: true <2>
+----
+<1> The `type` field specifies the type of authentication to use.
+<2> The `enabled` field allows you to disable a particular authentication type. This
+keeps you from having to delete the entire section of `auth` just to disable it.
+
+[[oab-config-basic-auth-deployment-template-secrets]]
+==== Deployment Template and Secrets
+
+Typically the broker is configured using a
+xref:../dev_guide/configmaps.adoc#dev-guide-configmaps[ConfigMap] in a
+deployment template. You supply the authentication configuration the same way as
+in the file configuration.
+
+The following is an example of the link:https://github.com/openshift/ansible-service-broker/blob/master/templates/deploy-ansible-service-broker.template.yaml#L220-L222[deployment template]:
+
+[source,yaml]
+----
+auth:
+  - type: basic
+    enabled: ${ENABLE_BASIC_AUTH}
+----
+
+Another part to Basic Auth is the user name and password used to authenticate
+against the broker. While the Basic Auth implementation can be backed by
+different back-end services, the currently supported one is backed by a _secret_.
+The secret must be injected into the pod via a volume mount at the
+*_/var/run/asb_auth_* location. This is from where the broker will read the user
+name and password.
+
+In the
+link:https://github.com/openshift/ansible-service-broker/blob/61a7fc80e40a7d7ddd836a2216394185094b1b0b/templates/deploy-ansible-service-broker.template.yaml#L168-L175[deployment template],
+a secret must be specified. For example:
+
+[subs=attributes+]
+[source,yaml]
+----
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: asb-auth-secret
+    namespace: {oab-ns}
+  data:
+    username: ${BROKER_USER}
+    password: ${BROKER_PASS}
+----
+
+The secret must contain a user name and password. The values must be base64
+encoded. The easiest way to generate the values for those entries is to use the
+`echo` and `base64` commands:
+
+[source,bash]
+----
+$ echo -n admin | base64 <1>
+YWRtaW4=
+----
+<1> The `-n` option is very important.
+
+This secret must now be injected to the pod via a volume mount. This is
+configured in the deployment template as well:
+
+[source,yaml]
+----
+spec:
+  serviceAccount: asb
+  containers:
+  - image: ${BROKER_IMAGE}
+    name: asb
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      ...
+      - name: asb-auth-volume
+        mountPath: /var/run/asb-auth
+----
+
+Then, in the `volumes` section, mount the secret:
+
+[source,yaml]
+----
+volumes:
+  ...
+  - name: asb-auth-volume
+    secret:
+      secretName: asb-auth-secret
+----
+
+The above will have created a volume mount located at *_/var/run/asb-auth_*.
+This volume will have two files: a user name and password written by the
+*asb-auth-secret* secret.
+
+[[oab-config-basic-auth-service-catalog-broker-communication]]
+==== Configuring Service Catalog and Broker Communication
+
+Now that the broker is configured to use Basic Auth, you must tell the service
+catalog how to communicate with the broker. This is accomplished by the
+`authInfo` section of the broker resource.
+
+The following is an example of creating a `broker` resource in the service
+catalog. The `spec` tells the service catalog what URL the broker is listening
+at. The `authInfo` tells it what secret to read to get the authentication
+information.
+
+[subs=attributes+]
+[source,yaml]
+----
+apiVersion: servicecatalog.k8s.io/v1alpha1
+kind: Broker
+metadata:
+  name: ansible-service-broker
+spec:
+  url: https://asb-1338-{oab-ns}.172.17.0.1.nip.io
+  authInfo:
+    basicAuthSecret:
+      namespace: {oab-ns}
+      name: asb-auth-secret
+----
+
+Starting with v0.0.17 of the service catalog, the broker resource configuration
+changes:
+
+[subs=attributes+]
+[source,yaml]
+----
+apiVersion: servicecatalog.k8s.io/v1alpha1
+kind: ServiceBroker
+metadata:
+  name: ansible-service-broker
+spec:
+  url: https://asb-1338-{oab-ns}.172.17.0.1.nip.io
+  authInfo:
+    basic:
+      secretRef:
+        namespace: {oab-ns}
+        name: asb-auth-secret
+----
+
+[[oab-config-bearer-auth]]
+=== Bearer Auth
+
+By default, if no authentication is specified the broker will use bearer token
+authentication (Bearer Auth). Bearer Auth uses delegated authentication from the
+link:https://github.com/kubernetes/apiserver[Kubernetes *apiserver*] library.
+
+[NOTE]
+====
+Bearer Auth is only available starting in {product-title} 3.7.
+====
+
+The configuration grants access, through
+link:https://kubernetes.io/docs/admin/authorization/rbac/[Kubernetes RBAC] roles
+and role bindings, to the URL prefix. The broker has added a configuration
+option `cluster_url` to specify the `url_prefix`. This value defaults to
+`{oab-ns}`.
+
+.Example Cluster Role
+[source,yaml]
+----
+- apiVersion: authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: access-asb-role
+  rules:
+  - nonResourceURLs: ["/ansible-service-broker", "/ansible-service-broker/*"]
+    verbs: ["get", "post", "put", "patch", "delete"]
+----
+
+[[oab-config-bearer-auth-deployment-secrets]]
+==== Deployment Template and Secrets
+
+The following is an example of creating a secret that the service catalog can
+use. This example assumes that the role, *access-asb-role*, has been created
+already. From the
+link:https://github.com/openshift/ansible-service-broker/blob/61a7fc80e40a7d7ddd836a2216394185094b1b0b/templates/deploy-ansible-service-broker.template.yaml#L224-L248[deployment template]:
+
+[subs=attributes+]
+[source,yaml]
+----
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ansibleservicebroker-client
+    namespace: {oab-ns}
+
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ansibleservicebroker-client
+  subjects:
+  - kind: ServiceAccount
+    name: ansibleservicebroker-client
+    namespace: {oab-ns}
+  roleRef:
+    kind: ClusterRole
+    name: access-asb-role
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ansibleservicebroker-client
+    annotations:
+      kubernetes.io/service-account.name: ansibleservicebroker-client
+  type: kubernetes.io/service-account-token
+----
+
+The above example creates a service account, granting access to
+*access-asb-role* and
+link:https://kubernetes.io/docs/admin/service-accounts-admin/[creating a secret]
+for that service accounts token.
+
+[[oab-config-bearer-auth-service-catalog-broker-communication]]
+==== Configuring Service Catalog and Broker Communication
+
+Now that the broker is configured to use Bearer Auth tokens, you must tell the
+service catalog how to communicate with the broker. This is accomplished by the
+`authInfo` section of the `broker` resource.
+
+The following is an example of creating a `broker` resource in the service
+catalog. The `spec` tells the service catalog what URL the broker is listening
+at. The `authInfo` tells it what secret to read to get the authentication
+information.
+
+[subs=attributes+]
+[source,yaml]
+----
+apiVersion: servicecatalog.k8s.io/v1alpha1
+kind: ServiceBroker
+metadata:
+  name: ansible-service-broker
+spec:
+  url: https://asb.{oab-ns}.svc:1338${BROKER_URL_PREFIX}/
+  authInfo:
+    bearer:
+      secretRef:
+        kind: Secret
+        namespace: {oab-ns}
+        name: ansibleservicebroker-client
 ----
 
 [[oab-config-dao]]
@@ -693,7 +973,7 @@ will attempt to create one.
 
 |`cluster_url`
 |Sets the prefix for the URL that the broker is expecting.
-|`ansible-service-broker`
+|`{oab-ns}`
 |N
 |===
 
@@ -826,8 +1106,9 @@ running a broker with experimental proxy support in a cluster prior to
 
 . Edit the broker's `DeploymentConfig` as a user with *cluster-admin* privileges:
 +
+[subs=attributes+]
 ----
-$ oc edit dc/asb -n openshift-ansible-service-broker
+$ oc edit dc/asb -n {oab-ns}
 ----
 
 . Set the following environment variables:
@@ -847,8 +1128,9 @@ xref:../install_config/http_proxies.adoc#setting-environment-variables-in-pods[S
 . After saving any updates, redeploy the OAB's deployment configuration for the
 changes to take effect:
 +
+[subs=attributes+]
 ----
-$ oc rollout latest dc/asb -n openshift-ansible-service-broker
+$ oc rollout latest dc/asb -n {oab-ns}
 ----
 
 [[configuring-oab-proxy-pods]]


### PR DESCRIPTION
New "Broker Authentication" section with "Basic Auth" and "Bearer Auth" subsections.

Preview:

http://file.rdu.redhat.com/~adellape/072718/brokerauth/install_config/oab_broker_configuration.html#oab-config-auth

@shawn-hurley PTAL.