### PR TITLE
Bring the retry topic back and switch to oc rollout

### DIFF
--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -59,7 +59,6 @@ xref:../../architecture/infrastructure_components/web_console.adoc#project-overv
 console] shows deployments in the *Browse* tab.
 ====
 
-////
 [[retrying-a-deployment]]
 
 == Retrying a Deployment
@@ -68,7 +67,7 @@ If the current revision of your deployment configuration failed to deploy, you c
 restart the deployment process with:
 
 ----
-$ oc deploy --retry dc/<name>
+$ oc rollout retry dc/<name>
 ----
 
 If the latest revision of it was deployed successfully, the command will display a
@@ -80,7 +79,6 @@ Retrying a deployment restarts the deployment process and does not create a new
 deployment revision. The restarted replication controller will have the same configuration
 it had when it failed.
 ====
-////
 
 [[rolling-back-a-deployment]]
 == Rolling Back a Deployment


### PR DESCRIPTION
https://github.com/openshift/origin/pull/20463 removes `oc deploy` entirely. This PR updates the last bit of the docs that was using it, although was commented out. I've updated it to use `oc rollout` instead. 

This is 3.11 item.

@adellape ptal