### PR TITLE
[enterprise-3.9] disconnected_install: registry-console is not optional

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -188,7 +188,20 @@ To sync the container images:
 $ systemctl start docker
 ----
 
-. Pull all of the required {product-title} containerized components.
+. If you are performing a xref:rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[containerized install],
+pull all of the required {product-title} host component images.
+ifdef::openshift-enterprise[]
+Replace `<tag>` with `{latest-tag}` for the latest version.
+endif::[]
++
+----
+# docker pull registry.access.redhat.com/rhel7/etcd
+# docker pull registry.access.redhat.com/openshift3/ose:<tag>
+# docker pull registry.access.redhat.com/openshift3/node:<tag>
+# docker pull registry.access.redhat.com/openshift3/openvswitch:<tag>
+----
+
+. Pull all of the required {product-title} infrastructure component images.
 ifdef::openshift-enterprise[]
 Replace `<tag>` with `{latest-tag}` for the latest version.
 endif::[]
@@ -200,6 +213,7 @@ $ docker pull registry.access.redhat.com/openshift3/ose-cluster-capacity:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-deployer:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-docker-builder:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-docker-registry:<tag>
+$ docker pull registry.access.redhat.com/openshift3/registry-console:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-egress-http-proxy:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-egress-router:<tag>
 $ docker pull registry.access.redhat.com/openshift3/ose-f5-router:<tag>
@@ -225,7 +239,7 @@ The recycle reclaim policy is deprecated in favor of dynamic provisioning, and i
 will be removed in future releases.
 ====
 
-. Pull all of the required {product-title} containerized components for the
+. Pull all of the required {product-title} component images for the
 additional centralized log aggregation and metrics aggregation components.
 ifdef::openshift-enterprise[]
 Replace `<tag>` with `{latest-int-tag}` for the latest version.
@@ -335,16 +349,6 @@ $ docker pull \
 registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.1
 ----
 
-. If you are using a stand-alone registry or plan to enable the registry console
-with the integrated registry, you must pull the *registry-console* image.
-+
-Replace `<tag>` with `{latest-registry-console-tag}` for the latest version.
-+
-[source, bash]
-----
-$ docker pull registry.access.redhat.com/openshift3/registry-console:<tag>
-----
-
 [[disconnected-preparing-images-for-export]]
 === Preparing Images for Export
 
@@ -359,7 +363,18 @@ $ mkdir </path/to/repos/images>
 $ cd </path/to/repos/images>
 ----
 
-. Export the {product-title} containerized components:
+. If you are performing a xref:rpm_vs_containerized.adoc#install-config-install-rpm-vs-containerized[containerized install],
+export the {product-title} host component images:
++
+----
+# docker save -o ose3-host-images.tar \
+    registry.access.redhat.com/rhel7/etcd \
+    registry.access.redhat.com/openshift3/ose \
+    registry.access.redhat.com/openshift3/node \
+    registry.access.redhat.com/openshift3/openvswitch
+----
+
+. Export the {product-title} infrastructure component images:
 +
 [source, bash]
 ----
@@ -370,6 +385,7 @@ $ docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/ose-deployer \
     registry.access.redhat.com/openshift3/ose-docker-builder \
     registry.access.redhat.com/openshift3/ose-docker-registry \
+    registry.access.redhat.com/openshift3/registry-console
     registry.access.redhat.com/openshift3/ose-egress-http-proxy \
     registry.access.redhat.com/openshift3/ose-egress-router \
     registry.access.redhat.com/openshift3/ose-f5-router \
@@ -405,7 +421,7 @@ $ docker save -o ose3-images.tar \
 For Red Hat support, a CNS subscription is required for `rhgs3/` images.
 ====
 
-. If you synchronized the metrics and log aggregation images, export:
+. If you synchronized the metrics and log aggregation images, export them:
 +
 [source, bash]
 ----
@@ -559,7 +575,7 @@ Skip the section titled *Host Registration* and start with *Installing Base Pack
 == Installing {product-title}
 
 [[disconnected-importing-containerized-components]]
-=== Importing {product-title} Containerized Components
+=== Importing {product-title} Component Images
 
 To import the relevant components, securely copy the images from the connected
 host to the individual {product-title} hosts:
@@ -568,20 +584,16 @@ host to the individual {product-title} hosts:
 ----
 $ scp /var/www/html/repos/images/ose3-images.tar root@<openshift_host_name>:
 $ ssh root@<openshift_host_name> "docker load -i ose3-images.tar"
-----
-
-If you prefer, you could use `wget` on each {product-title} host to fetch the
-tar file, and then perform the Docker import command locally. Perform the same
-steps for the metrics and logging images, if you synchronized them.
-
-On the host that will act as an {product-title} master, copy and import the
-builder images:
-
-[source, bash]
-----
 $ scp /var/www/html/images/ose3-builder-images.tar root@<openshift_master_host_name>:
 $ ssh root@<openshift_master_host_name> "docker load -i ose3-builder-images.tar"
 ----
+
+Perform the same steps for the host components if your install will be
+containerized. Perform the same steps for the metrics and logging images,
+if your cluster will use them.
+
+If you prefer, you could use `wget` on each {product-title} host to fetch the
+tar file, and then perform the Docker import command locally.
 
 [[disconnected-running-the-openshift-installer]]
 === Running the {product-title} Installer


### PR DESCRIPTION
At this time there is no option to not install registry-console, and the
install checks will look for its image to be there. So, just include it
in the images needed for a disconnected install.

See https://bugzilla.redhat.com/show_bug.cgi?id=1480195#c12

When doing a containerized install, the host components (master, node,
ovs, etcd) need to be synchronized as well.

This led to some confusing usage of the word "containerized" so that
needed some clearing up too.

See https://bugzilla.redhat.com/show_bug.cgi?id=1480195#c12

From https://github.com/openshift/openshift-docs/pull/5248. Because of the differences between this change and current master, this change should apply to only 3.9-3.6, not master. From https://github.com/openshift/openshift-docs/pull/5248.