### PR TITLE
Remove the specific version numbers to facilitate maintenance of different branches

### DIFF
--- a/scaling_performance/scaling_cluster_metrics.adoc
+++ b/scaling_performance/scaling_cluster_metrics.adoc
@@ -31,8 +31,8 @@ Autoscaling the metrics components, such as Hawkular and Heapster, is not suppor
 endif::[]
 
 
-[[metrics-recommendations-for-OCP-version-39]]
-== Recommendations for {product-title} Version 3.9
+[[metrics-recommendations-for-OCP]]
+== Recommendations for {product-title}
 
 * Run metrics pods on dedicated {product-title}
 xref:../admin_guide/manage_nodes.adoc#infrastructure-nodes[infrastructure


### PR DESCRIPTION
Remove the specific version numbers to facilitate maintenance of different branches.

For example, the description of 3.9 on the 3.10 branch is wrong.

/cherrypick enterprise-3.10
/cherrypick enterprise-3.11
