### PR TITLE
updating docker pull commands

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -315,28 +315,37 @@ xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build
 (S2I)] builder images that you intend to use in your OpenShift environment. You
 can pull the following images:
 +
-* jboss-eap70-openshift
-* jboss-amq-62
-* jboss-datagrid65-openshift
-* jboss-decisionserver62-openshift
-* jboss-eap64-openshift
-* jboss-eap70-openshift
-* jboss-webserver30-tomcat7-openshift
-* jboss-webserver30-tomcat8-openshift
-* jenkins-1-rhel7
-* jenkins-2-rhel7
-* jenkins-slave-base-rhel7
-* jenkins-slave-maven-rhel7
-* jenkins-slave-nodejs-rhel7
-* mongodb
-* mysql
-* nodejs
-* perl
-* php
-* postgresql
-* python
-* redhat-sso70-openshift
-* ruby
+[source, bash]
+----
+$ docker pull registry.access.redhat.com/jboss-amq-6/amq63-openshift
+$ docker pull registry.access.redhat.com/jboss-datagrid-7/datagrid71-openshift
+$ docker pull registry.access.redhat.com/jboss-datagrid-7/datagrid71-client-openshift
+$ docker pull registry.access.redhat.com/jboss-datavirt-6/datavirt63-openshift
+$ docker pull registry.access.redhat.com/jboss-datavirt-6/datavirt63-driver-openshift
+$ docker pull registry.access.redhat.com/jboss-decisionserver-6/decisionserver64-openshift
+$ docker pull registry.access.redhat.com/jboss-processserver-6/processserver64-openshift
+$ docker pull registry.access.redhat.com/jboss-eap-6/eap64-openshift
+$ docker pull registry.access.redhat.com/jboss-eap-7/eap70-openshift
+$ docker pull registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat7-openshift
+$ docker pull registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat8-openshift
+$ docker pull registry.access.redhat.com/openshift3/jenkins-1-rhel7
+$ docker pull registry.access.redhat.com/openshift3/jenkins-2-rhel7
+$ docker pull registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+$ docker pull registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7
+$ docker pull registry.access.redhat.com/openshift3/jenkins-slave-nodejs-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mongodb-32-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mysql-57-rhel7
+$ docker pull registry.access.redhat.com/rhscl/perl-524-rhel7
+$ docker pull registry.access.redhat.com/rhscl/php-56-rhel7
+$ docker pull registry.access.redhat.com/rhscl/postgresql-95-rhel7
+$ docker pull registry.access.redhat.com/rhscl/python-35-rhel7
+$ docker pull registry.access.redhat.com/redhat-sso-7/sso70-openshift
+$ docker pull registry.access.redhat.com/rhscl/ruby-24-rhel7
+$ docker pull registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+$ docker pull registry.access.redhat.com/redhat-sso-7/sso71-openshift
+$ docker pull registry.access.redhat.com/rhscl/nodejs-6-rhel7
+$ docker pull registry.access.redhat.com/rhscl/mariadb-101-rhel7
+----
 +
 Make sure to indicate the correct tag specifying the desired version number. For
 example, to pull both the previous and latest version of the Tomcat image:


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/6740/files, this list of Docker pull commands should be in 3.9 and 3.7. Vikram confirmed this addition via email.

@vikram-redhat, FYI 