### PR TITLE
updating list of supported sysctls

### DIFF
--- a/admin_guide/sysctls.adoc
+++ b/admin_guide/sysctls.adoc
@@ -80,11 +80,12 @@ a pod.
 
 By far, most of the namespaced sysctls are not necessarily considered safe.
 
-For {product-title} 3.3.1, the following sysctls are supported (whitelisted) in
-the safe set:
+Currently, {product-title} supports, or whitelists, the following sysctls
+in the safe set:
 
 - *_kernel.shm_rmid_forced_*
 - *_net.ipv4.ip_local_port_range_*
+- *_net.ipv4.tcp_syncookies_*
 
 This list will be extended in future versions when the kubelet supports better
 isolation mechanisms.


### PR DESCRIPTION
Per @ingvagabund on https://github.com/openshift/openshift-docs/pull/10361/files#r206516726, *_net.ipv4.tcp_syncookies_* should be in the safe set going back to version 3.4.

@mdshuai, do you agree with this change? 