### PR TITLE
GlusterFS: modifying installation verbiage to deploy clusters

### DIFF
--- a/install_config/persistent_storage/topics/glusterfs_run_installer.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_run_installer.adoc
@@ -1,4 +1,4 @@
-. Run the installer.
+. The preceding steps detail options that need to be added to a larger, complete inventory file. To use the complete inventory file to deploy {gluster} provide the file path as an option to the following playbooks:
 +
 ** For an initial {product-title} installation:
 +


### PR DESCRIPTION
Modify verbiage to deploy GlusterFS clusters with OpenShift deployment. 