### PR TITLE
Remove useless SELinux section of provisioner doc

### DIFF
--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -166,10 +166,6 @@ $ ansible-playbook -v -i <inventory_file> \
    -e openshift_provisioners_efs_path=/data/persistentvolumes
 ----
 
-[[nfs-selinux-2]]
-==== SELinux
-For information on allowing the provisioner pod to write to EFS directory (which is a remote NFS directory), see the xref:../install_config/persistent_storage/persistent_storage_nfs.adoc#nfs-selinux[SELinux] section of NFS Volume Security topic. The same information applies for allowing other pods to consume the NFS volumes provisioned by the provisioner pod.
-
 [[aws-efs]]
 ==== AWS EFS Object Definition
 


### PR DESCRIPTION
We can assume openshift install will ensure pods can read/write nfs volumes, so this is irrelevant for readers of this doc. (The install task is here: https://github.com/openshift/openshift-ansible/blob/9c08d4232fadd7a80b01adb981941f809111db3e/roles/openshift_node/tasks/storage_plugins/nfs.yml)