### PR TITLE
Fixes #11299 - Replace selectors based on old openshift_node_labels

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -97,7 +97,6 @@ Labels:             beta.kubernetes.io/arch=amd64 <3>
                     node-role.kubernetes.io/compute=true
                     node-role.kubernetes.io/infra=true
                     node-role.kubernetes.io/master=true
-                    region=infra
                     zone=default
 Annotations:        volumes.kubernetes.io/controller-managed-attach-detach=true  <4>
 CreationTimestamp:  Thu, 24 May 2018 11:46:56 -0400

--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -269,7 +269,7 @@ You can also override the default value for an existing project namespace by usi
 
 ----
 # oc patch namespace myproject -p \
-    '{"metadata":{"annotations":{"openshift.io/node-selector":"region=infra"}}}'
+    '{"metadata":{"annotations":{"openshift.io/node-selector":"node-role.kubernetes.io/infra=true"}}}'
 ----
 
 If `openshift.io/node-selector` is set to an empty string (`oc adm new-project

--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -110,7 +110,7 @@ master3.example.com
 +
 [IMPORTANT]
 ====
-If you label a master host with the `region=infra` label and have no other
+If you label a master host with the `node-role.kubernetes.io/infra=true` label and have no other
 dedicated infrastructure nodes, you must also explicitly mark the host as
 schedulable by adding `openshift_schedulable=true` to the entry. Otherwise, the
 registry and router pods cannot be placed anywhere.

--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -220,7 +220,7 @@ namespaces whose templates will be served by the broker.
 
 |`template_service_broker_selector`
 |Default node selector for automatically deploying template service broker pods,
-defaults `{"region": "infra"}`. See
+defaults `{"node-role.kubernetes.io/infra":"true"}`. See
 xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 
 |`osm_default_node_selector`
@@ -702,7 +702,7 @@ in the  *_/etc/ansible/hosts_* file.
 
 As described in xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Masters],
 master hosts are marked schedulable by default. If
-you label a master host with `region=infra` and have no other dedicated
+you label a master host with `node-role.kubernetes.io/infra=true` and have no other dedicated
 infrastructure nodes, the master hosts must also be marked as schedulable.
 Otherwise, the registry and router pods cannot be placed anywhere.
 
@@ -1866,12 +1866,12 @@ file's `[OSEv3:vars]` section:
 openshift_template_service_broker_namespaces=['openshift','myproject']
 ----
 
-By default, the TSB will use the nodeselector `{"region": "infra"}` for deploying its pods.
+By default, the TSB will use the nodeselector `{"node-role.kubernetes.io/infra":"true"}` for deploying its pods.
 You can modify this by setting the desired nodeselector in your inventory file's
 `[OSEv3:vars]` section:
 
 ----
-template_service_broker_selector={"region": "infra"}
+template_service_broker_selector={"node-role.kubernetes.io/infra":"true"}
 ----
 
 .Template service broker customization variables

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -339,7 +339,7 @@ appended to the prefix starting from 1.
 |`openshift_metrics_cassandra_pvc_size`
 |The persistent volume claim size for each of the Cassandra nodes.
 
-|`openshift_metrics_cassandra_storage_class_name`
+|`openshift_metrics_cassandra_pvc_storage_class_name`
 |If you want to explicitly set the storage class, you must not set
 `openshift_metrics_cassandra_storage_type` to `emptydir` or `dynamic`.
 

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -376,7 +376,7 @@ millicores) would request 4 CPUs.
 |Set to the desired, existing
 xref:../admin_guide/scheduling/node_selector.adoc#admin-guide-sched-selector[node selector] to ensure that
 pods are placed onto nodes with specific labels. For example,
-`{"region":"infra"}`.
+`{"node-role.kubernetes.io/infra":"true"}`.
 
 |`openshift_metrics_hawkular_ca`
 |An optional certificate authority (CA) file used to sign the Hawkular certificate.
@@ -414,7 +414,7 @@ millicores) would request 4 CPUs.
 |Set to the desired, existing
 xref:../admin_guide/scheduling/node_selector.adoc#admin-guide-sched-selector[node selector] to ensure that
 pods are placed onto nodes with specific labels. For example,
-`{"region":"infra"}`.
+`{"node-role.kubernetes.io/infra":"true"}`.
 
 |`openshift_metrics_heapster_allowed_users`
 |A comma-separated list of CN to accept. By default, this is set to allow the
@@ -446,7 +446,7 @@ millicores) would request 4 CPUs.
 |Set to the desired, existing
 xref:../admin_guide/scheduling/node_selector.adoc#admin-guide-sched-selector[node selector] to ensure that
 pods are placed onto nodes with specific labels. For example,
-`{"region":"infra"}`.
+`{"node-role.kubernetes.io/infra":"true"}`.
 
 |`openshift_metrics_hawkular_hostname`
 |Set when executing the `openshift_metrics` Ansible role, since it uses the host
@@ -813,7 +813,7 @@ Add label to your node:
 # Inventory file
 openshift_prometheus_namespace=openshift-metrics
 
-openshift_prometheus_node_selector={"region":"infra"}
+openshift_prometheus_node_selector={"node-role.kubernetes.io/infra":"true"}
 ----
 
 Run the playbook:
@@ -850,7 +850,7 @@ $ ansible-playbook -vvv -i ${INVENTORY_FILE} playbooks/openshift-prometheus/conf
 Identify your namespace:
 ----
 # Inventory file
-openshift_prometheus_node_selector={"region":"infra"}
+openshift_prometheus_node_selector={"node-role.kubernetes.io/infra":"true"}
 
 # Set non-default openshift_prometheus_namespace
 openshift_prometheus_namespace=${USER_PROJECT}

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -179,10 +179,10 @@ $ oc adm router <router_name> --replicas=<number> --selector=<label> \
     --service-account=router
 ----
 
-For example, if you want to create a router named `router` and have it placed on a node labeled with `region=infra`:
+For example, if you want to create a router named `router` and have it placed on a node labeled with `node-role.kubernetes.io/infra=true`:
 
 ----
-$ oc adm router router --replicas=1 --selector='region=infra' \
+$ oc adm router router --replicas=1 --selector='node-role.kubernetes.io/infra=true' \
   --service-account=router
 ----
 endif::[]
@@ -192,18 +192,18 @@ $ oc adm router <router_name> --replicas=<number> --selector=<label> \
     --service-account=router
 ----
 
-For example, if you want to create a router named `router` and have it placed on a node labeled with `region=infra`:
+For example, if you want to create a router named `router` and have it placed on a node labeled with `node-role.kubernetes.io/infra=true`:
 
 ----
-$ oc adm router router --replicas=1 --selector='region=infra' \
+$ oc adm router router --replicas=1 --selector='node-role.kubernetes.io/infra=true' \
   --service-account=router
 ----
 endif::[]
 
 During cluster installation, the `openshift_router_selector` and
-`openshift_registry_selector` Ansible settings are set to `region=infra` by
+`openshift_registry_selector` Ansible settings are set to `node-role.kubernetes.io/infra=true` by
 default. The default router and registry will only be automatically deployed if
-a node exists that matches the `region=infra` label.
+a node exists that matches the `node-role.kubernetes.io/infra=true` label.
 
 For information on updating labels, see
 xref:../../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[Updating Labels


### PR DESCRIPTION
Many parts of the documentation still uses {"region":"infra"}, {"region": "infra"} or region=infra as node selector for Infra nodes. Starting on 3.10, we should be using {"node-role.kubernetes.io/infra":"true"} or node-role.kubernetes.io/infra=true configured by openshift_node_group_name variable.