### PR TITLE
Minor: "exiting" should be "existing" on line 533

### DIFF
--- a/release_notes/ocp_3_10_release_notes.adoc
+++ b/release_notes/ocp_3_10_release_notes.adoc
@@ -530,7 +530,7 @@ See xref:ocp-310-important-installation-changes[Important Changes] for more info
 
 [[ocp-310-new-node-configuration-process]]
 ==== New Node Configuration Process
-You can modify exiting nodes through a configuration map rather than the
+You can modify existing nodes through a configuration map rather than the
 *_node-config.yaml_*. The installation creates three node configuration groups:
 *node-config-master*, *node-config-infra*, and *node-config-compute* and creates
 a configuration map for each group.  A sync pod watches for changes to these


### PR DESCRIPTION
Correct typo in new node configuration process