### PR TITLE
[WIP] cd into openshfit-ansible for all ansible-playbook

### DIFF
--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -148,7 +148,7 @@ If there are any errors, this diagnostic stores results and retrieved files in a
 [[admin-guide-diagnostics-tool-server-environment]]
 == Running Diagnostics in a Server Environment
 
-An Ansible-deployed cluster provides additional diagnostic benefits for 
+An Ansible-deployed cluster provides additional diagnostic benefits for
 nodes within an {product-title} cluster. These include:
 
 * Master and node configuration is based on a configuration file in a standard
@@ -234,7 +234,7 @@ circumstances, additional system components, such as `docker` or networking
 configurations, can change if their current state differs from the configuration
 in the inventory file. You should run these health checks only if you do not
 expect the inventory file to make any changes to the existing cluster
-configuration. 
+configuration.
 ====
 
 [[admin-guide-diagnostics-tool-ansible-checks]]
@@ -347,27 +347,19 @@ command, specify your cluster's inventory file and run the *_health.yml_*
 playbook:
 
 ----
-# ansible-playbook -i <inventory_file> \
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
-ifdef::openshift-origin[]
-    ~/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> \
+    playbooks/openshift-checks/health.yml
 ----
 
 To set variables in the command line, include the `-e` flag with any desired
 variables in `key=value` format. For example:
 
 ----
-# ansible-playbook -i <inventory_file> \
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
-ifdef::openshift-origin[]
-    ~/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
-    -e openshift_check_logging_index_timeout_seconds=45
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> \
+    playbooks/openshift-checks/health.yml \
+    -e openshift_check_logging_index_timeout_seconds=45 \
     -e etcd_max_image_data_size_bytes=40000000000
 ----
 
@@ -445,4 +437,3 @@ Mounting an entire *_.ssh_* directory can be helpful for:
 * Allowing you to use an SSH configuration to match keys with hosts or
 modify other connection parameters.
 * Allowing a user to provide a *_known_hosts_* file and have SSH validate host keys. This is disabled by the default configuration and can be re-enabled with an environment variable by adding `-e ANSIBLE_HOST_KEY_CHECKING=True` to the `docker` command line.
-

--- a/admin_guide/node_problem_detector.adoc
+++ b/admin_guide/node_problem_detector.adoc
@@ -34,13 +34,13 @@ endif::[]
 ====
 
 The Node Problem Detector reads system logs and watches for specific entries and makes these problems visible to the control plane,
-which you can view using {product-title} commands, such as `oc get node` and `oc get event`. 
-You could then take action to correct these problems as appropriate or capture the messages using a tool of your choice, 
+which you can view using {product-title} commands, such as `oc get node` and `oc get event`.
+You could then take action to correct these problems as appropriate or capture the messages using a tool of your choice,
 such as the {product-title} xref:../security/monitoring.adoc#security-monitoring[log monitoring].
 
 Detected problems can be in one of the following categories:
 
-* `NodeCondition`: A permanent problem that makes the node unavailable for pods. 
+* `NodeCondition`: A permanent problem that makes the node unavailable for pods.
 The node condition will not be cleared until the host is rebooted.
 * `Event`: A temporary problem that has limited impact on a node, but is informative.
 
@@ -50,7 +50,7 @@ The Node Problem Detector can detect:
 ** unresponsive runtime daemons
 
 * hardware issues:
-** bad CPU 
+** bad CPU
 ** bad memory
 ** bad disk
 
@@ -59,20 +59,20 @@ The Node Problem Detector can detect:
 ** corrupted file systems
 ** unresponsive runtime daemons
 
-* infrastructure daemon issues: 
+* infrastructure daemon issues:
 ** NTP service outages
 
 [[admin-guide-node-problem-detector-example]]
 == Example Node Problem Detector Output
 
-The following examples show output from the Node Problem Detector watching for kernel deadlock node condition on a specific node. The command 
-uses `oc get node` to watch a specific node filtering for a `KernelDeadlock` entry in a log. 
+The following examples show output from the Node Problem Detector watching for kernel deadlock node condition on a specific node. The command
+uses `oc get node` to watch a specific node filtering for a `KernelDeadlock` entry in a log.
 
 ----
 # oc get node <node> -o yaml | grep -B5 KernelDeadlock
 ----
 
-.Sample Node Problem Detector output with no issues 
+.Sample Node Problem Detector output with no issues
 ----
 message: kernel has no deadlock
 reason: KernelHasNoDeadlock
@@ -89,8 +89,8 @@ type: KernelDeadLock
 ----
 
 This example shows output from the Node Problem Detector watching for events on a node.
-The following command uses `oc get event` against the *default* project watching for 
-events listed in the `kernel-monitor.json` section of the 
+The following command uses `oc get event` against the *default* project watching for
+events listed in the `kernel-monitor.json` section of the
 xref:admin-guide-node-problem-detector-sample[Node Problem Detector configuration map].
 
 ----
@@ -101,12 +101,12 @@ xref:admin-guide-node-problem-detector-sample[Node Problem Detector configuratio
 ----
 LAST SEEN                       FIRST SEEN                    COUNT NAME     KIND  SUBOBJECT TYPE    REASON      SOURCE                   MESSAGE
 2018-06-27 09:08:27 -0400 EDT   2018-06-27 09:08:27 -0400 EDT 1     my-node1 node            Warning TaskHunk    kernel-monitor.my-node1  docker:1234 blocked for more than 300 seconds
-2018-06-27 09:08:27 -0400 EDT   2018-06-27 09:08:27 -0400 EDT 3     my-node2 node            Warning KernelOops  kernel-monitor.my-node2  BUG: unable to handle kernel NULL pointer deference at nowhere 
+2018-06-27 09:08:27 -0400 EDT   2018-06-27 09:08:27 -0400 EDT 3     my-node2 node            Warning KernelOops  kernel-monitor.my-node2  BUG: unable to handle kernel NULL pointer deference at nowhere
 2018-06-27 09:08:27 -0400 EDT   2018-06-27 09:08:27 -0400 EDT 1     my-node1 node            Warning KernelOops  kernel-monitor.my-node2  divide error 0000 [#0] SMP
 ----
 
 ////
-{product-title} supports the following problem daemons. Installation of these daemons is beyond the scope of this document.  
+{product-title} supports the following problem daemons. Installation of these daemons is beyond the scope of this document.
 
 |===
 | Problem Daemon | NodeCondition | Description
@@ -117,7 +117,7 @@ LAST SEEN                       FIRST SEEN                    COUNT NAME     KIN
 
 | link:https://github.com/abrt/abrt/wiki[AbrtAdaptor]
 | None
-| Monitors ABRT log messages. ABRT (Automatic Bug Report Tool) is a health monitoring daemon able 
+| Monitors ABRT log messages. ABRT (Automatic Bug Report Tool) is a health monitoring daemon able
 to catch kernel problems and application crashes on the host.
 
 | link:https://github.com/kubernetes/node-problem-detector/blob/master/config/custom-plugin-monitor.json[CustomPluginMonitor]
@@ -135,27 +135,28 @@ The Node Problem Detector consumes resources. If you use the Node Problem Detect
 [[admin-guide-node-problem-detector-install]]
 == Installing the Node Problem Detector
 
-If `openshift_node_problem_detector_install` was set to `true` in the *_/etc/ansible/hosts_* inventory file, 
-the xref:../install/index.adoc#install-planning[installation] creates 
-a Node Problem Detector daemonset by default and creates a project for the detector, called `openshift-node-problem-detector`. 
+If `openshift_node_problem_detector_install` was set to `true` in the *_/etc/ansible/hosts_* inventory file,
+the xref:../install/index.adoc#install-planning[installation] creates
+a Node Problem Detector daemonset by default and creates a project for the detector, called `openshift-node-problem-detector`.
 
 [NOTE]
 ====
 Because the Node Problem Detector is in Technology Preview, the `openshift_node_problem_detector_install` is set to `false` by default.
 You must manually change the parameter to `true` when installing the Node Problem Detector.
-====  
+====
 
-If xref:admin-guide-node-problem-detector-verify[the Node Problem Detector is not installed], run the *openshift-node-problem-detector/config.yml* playbook to install Node Problem Detector: 
+If xref:admin-guide-node-problem-detector-verify[the Node Problem Detector is not installed], run the *openshift-node-problem-detector/config.yml* playbook to install Node Problem Detector:
 
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-node-problem-detector/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
 ----
 
 
 [[admin-guide-node-problem-detector-configure]]
 == Customizing Detected Conditions
 
-You can configure the Node Problem Detector to watch for any log string by editing the Node Problem Detector configuration map. 
+You can configure the Node Problem Detector to watch for any log string by editing the Node Problem Detector configuration map.
 
 [[admin-guide-node-problem-detector-sample]]
 .Sample Node Problem Detector Configuration Map
@@ -184,7 +185,7 @@ data:
                 }
         ]
     }
-  kernel-monitor.json: |  <8>  
+  kernel-monitor.json: |  <8>
     {
         "plugin": "journald", <2>
         "pluginConfig": {
@@ -201,7 +202,7 @@ data:
                         "message": "kernel has no deadlock"  <7>
                 }
         ],
-        "rules": [                      
+        "rules": [
                 {
                         "type": "temporary",
                         "reason": "OOMKilling",
@@ -249,7 +250,7 @@ data:
 <4> List of events to be monitored.
 <5> Label to indicate the error is an event (`temporary`) or NodeCondition (`permanent`).
 <6> Text message to describe the error.
-<7> Error message that the Node Problem Detector watches for. 
+<7> Error message that the Node Problem Detector watches for.
 <8> Rules and conditions that apply to the kernel.
 
 ////
@@ -266,7 +267,7 @@ To configure the Node Problem Detector, add or remove problem conditions and eve
 oc edit configmap -n openshift-node-problem-detector node-problem-detector
 ----
 
-. Remove, add, or edit any node conditions or events as needed. 
+. Remove, add, or edit any node conditions or events as needed.
 +
 [source,yaml]
 ----
@@ -295,7 +296,7 @@ For example:
 # oc delete pods -n openshift-node-problem-detector -l name=node-problem-detector
 ----
 
-. To display Node Problem Detector output to standard output (stdout) and standard error (stderr) 
+. To display Node Problem Detector output to standard output (stdout) and standard error (stderr)
 add the following to the configuration map:
 +
 [source,yaml]
@@ -320,7 +321,7 @@ spec:
 [[admin-guide-node-problem-detector-verify]]
 == Verifying that the Node Problem Detector is Running
 
-To verify that the Node Problem Detector is active: 
+To verify that the Node Problem Detector is active:
 
 * Run the following command to get the name of the Problem Node Detector pod:
 +
@@ -380,7 +381,8 @@ openshift_node_problem_detector_state=absent
 +
 [source,bash]
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-node-problem-detector/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
 ----
 
 ////

--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -122,14 +122,16 @@ other than the default of *_/etc/ansible/hosts_*, specify the location with the
 ** For additional nodes:
 +
 ----
-# ansible-playbook [-i /path/to/file] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-node/scaleup.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/file] \
+    playbooks/openshift-node/scaleup.yml
 ----
 ** For additional masters:
 +
 ----
-# ansible-playbook [-i /path/to/file] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-master/scaleup.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/file] \
+    playbooks/openshift-master/scaleup.yml
 ----
 
 . After the playbook runs,

--- a/day_two_guide/topics/adding_master_host.adoc
+++ b/day_two_guide/topics/adding_master_host.adoc
@@ -101,7 +101,8 @@ using the `Ansible` host file:
 
 [subs=+quotes]
 ----
-$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-master/scaleup.yml*
+$ cd /usr/share/ansible/openshift-ansible
+$ *ansible-playbook -i /path/to/host/file playbooks/byo/openshift-master/scaleup.yml*
 ----
 
 NOTE: The scale up procedure for masters include the scale up procedure for nodes as well.

--- a/day_two_guide/topics/adding_node_host.adoc
+++ b/day_two_guide/topics/adding_node_host.adoc
@@ -94,7 +94,8 @@ by an `Ansible` playbook included in the `atomic-openshift-utils` using the `Ans
 
 [subs=+quotes]
 ----
-$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml*
+$ cd /usr/share/ansible/openshift-ansible
+$ *ansible-playbook -i /path/to/host/file playbooks/byo/openshift-node/scaleup.yml*
 ----
 
 In the event of scaling up an infrastructure node running a {rhocp} router, the

--- a/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
+++ b/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
@@ -41,11 +41,12 @@ etcd0.example.com <1>
 file, run the etcd `scaleup` playbook:
 +
 ----
-$ ansible-playbook  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-etcd/scaleup.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  playbooks/byo/openshift-etcd/scaleup.yml
 ----
 
-. After the playbook runs, modify the inventory file to reflect the current 
-status by moving the new etcd host from the `[new_etcd]` group to the `[etcd]` 
+. After the playbook runs, modify the inventory file to reflect the current
+status by moving the new etcd host from the `[new_etcd]` group to the `[etcd]`
 group:
 +
 ----
@@ -65,7 +66,7 @@ etcd0.example.com
 ----
 
 . If you use Flannel, modify the `flanneld` service configuration on every
-{product-title} host, located at `/etc/sysconfig/flanneld`, to include the new 
+{product-title} host, located at `/etc/sysconfig/flanneld`, to include the new
 etcd host:
 +
 ----

--- a/day_two_guide/topics/pruning_images_and_containers.adoc
+++ b/day_two_guide/topics/pruning_images_and_containers.adoc
@@ -122,7 +122,7 @@ Where `node.fs` is the file system hosting the
 triggers garbage collection processes to clean up the unused ones.
 
 There are some default values that can be tweaked if required in every node's
-configuration file using the `kubeletArguments` section of the 
+configuration file using the `kubeletArguments` section of the
 appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map].
 
 ==== Image Garbage Collection
@@ -173,7 +173,8 @@ After modifying the `Ansible` variable content, running the installer again
 may configure the new settings and restart the services:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/byo/config.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the
@@ -212,7 +213,7 @@ $ sudo docker rmi $(sudo docker images -f "dangling=true" -q)
 ----
 
 WARNING: While not recommended, a more aggressive clean up can be performed
-by attempting to delete all the images. 
+by attempting to delete all the images.
 `docker` protects images it is using; this can be performed as `sudo docker rmi $(sudo docker images -q)`
 
 ==== Container Garbage Collection
@@ -249,7 +250,7 @@ Every iteration of the container garbage collection process performs the followi
 
 As noticed, the `maximum-dead-containers` setting takes precedence over the `maximum-dead-containers-per-container` setting when there is a conflict.
 
-To modify this settings, manually edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
+To modify this settings, manually edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]
 and modify the following section:
 
 [subs=+quotes]
@@ -282,7 +283,8 @@ After modifying the `Ansible` variable content, running the installer again
 may configure the new settings and restart the services:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/byo/config.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the
@@ -317,7 +319,7 @@ $ sudo docker rm $(sudo docker ps -a -q -f status=exited)
 ----
 
 WARNING: While not recommended, a more aggressive clean up can be performed
-by attempting to delete all containers. `docker` protects its running containers 
+by attempting to delete all containers. `docker` protects its running containers
 from deletion. This can be performed as `sudo docker rm $(docker ps -a -q)`
 
 NOTE: In future {rhocp} releases, garbage collection will be deprecated in
@@ -345,7 +347,7 @@ are made.
 The node continues to report node status updates at the frequency specified by
 the node-status-update-frequency argument, which defaults to 10s.
 
-Configure disk thresholds in the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
+Configure disk thresholds in the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]
 by modifying the following section:
 
 ----
@@ -388,7 +390,8 @@ After modifying the `Ansible` variable content, running the installer again
 may configure the new settings and restart the services:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/byo/config.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the

--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -166,13 +166,15 @@ for full documentation on available inventory variables.
 . Run the *_prerequisites.yml_* playbook using your inventory file:
 +
 ----
-$ ansible-playbook -i <inventory_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> playbooks/prerequisites.yml
 ----
 
 . Run the *_deploy_cluster.yml_* playbook using your inventory file:
 +
 ----
-$ ansible-playbook -i <inventory_file> /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> playbooks/deploy_cluster.yml
 ----
 
 After a successful install, but before you add a new project, you must set up

--- a/install/prerequisites.adoc
+++ b/install/prerequisites.adoc
@@ -692,13 +692,9 @@ addresses for the hosts. To see the default values, run the `*openshift_facts*`
 playbook:
 
 ----
-# ansible-playbook  [-i /path/to/inventory] \
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift_facts.yml
-endif::[]
-ifdef::openshift-origin[]
-    ~/openshift-ansible/playbooks/byo/openshift_facts.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  [-i /path/to/inventory] \
+  playbooks/byo/openshift_facts.yml
 ----
 
 [IMPORTANT]

--- a/install/running_install.adoc
+++ b/install/running_install.adoc
@@ -127,14 +127,9 @@ configure the container runtimes, run this playbook only once, before you
 deploy a cluster the first time:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/inventory] \ <1>
+  playbooks/prerequisites.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory, 
 specify `-i` and the path to the inventory file.
@@ -142,14 +137,9 @@ specify `-i` and the path to the inventory file.
 . Run the *_deploy_cluster.yml_* playbook to initiate the cluster installation:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/inventory] \
+    playbooks/deploy_cluster.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory, 
 specify `-i` and the path to the inventory file.

--- a/install/stand_alone_registry.adoc
+++ b/install/stand_alone_registry.adoc
@@ -238,14 +238,9 @@ memory per host in the inventory file.
 .. Before you deploy a new cluster, run the *_prerequisites.yml_* playbook:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook  [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  [-i /path/to/inventory] \ <1>
+    playbooks/prerequisites.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory, 
 specify `-i` and the path to the inventory file.
@@ -255,14 +250,9 @@ You must run this playbook only one time.
 .. To initiate installation, run the *_deploy_cluster.yml_* playbook:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook  [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  [-i /path/to/inventory] \ <1>
+    playbooks/deploy_cluster.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory, 
 specify `-i` and the path to the inventory file.

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -58,8 +58,9 @@ etcd3.example.com
 +
 [source, bash]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i /path/to/file] \
-  /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/scaleup.yml
+  playbooks/openshift-etcd/scaleup.yml
 ----
 +
 . Set the node label to `logging-infra-fluentd: "true"`.

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -600,8 +600,9 @@ endif::openshift-origin[]
 
 ifdef::openshift-enterprise[]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 endif::openshift-enterprise[]
 
@@ -857,8 +858,9 @@ openshift_logging_es_hostname=elasticsearch.example.com
 . Run the following Ansible playbook:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 
 . To log in to Elasticsearch remotely, the request must contain three HTTP headers:
@@ -1527,8 +1529,9 @@ endif::openshift-origin[]
 
 ifdef::openshift-enterprise[]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml \
+    playbooks/openshift-logging/config.yml \
     -e openshift_logging_install_logging=False
 ----
 endif::openshift-enterprise[]
@@ -1554,8 +1557,9 @@ to re-run the `openshift_logging` role:
 ====
 ----
 $ oc delete oauthclient/kibana-proxy
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 ====
 
@@ -1580,8 +1584,9 @@ Fix this issue by replacing the OAuthClient entry:
 ====
 ----
 $ oc delete oauthclient/kibana-proxy
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 ====
 

--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -389,7 +389,8 @@ openshift_hosted_router_certificate={"certfile": "/path/on/host/to/app-crt-file"
 . Run the following playbook:
 +
 ----
-ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-hosted/redeploy-router-certificates.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-hosted/redeploy-router-certificates.yml
 ----
 
 [[ansible-configuring-custom-certificates-other]]

--- a/install_config/cfme/container_provider.adoc
+++ b/install_config/cfme/container_provider.adoc
@@ -54,13 +54,9 @@ This playbook:
 To run the container provider playbook:
 
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
-ifdef::openshift-origin[]
-    playbooks/openshift-management/add_container_provider.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/add_container_provider.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
+    openshift-management/add_container_provider.yml
 ----
 
 [[cfme-container-provider-multiple]]
@@ -170,14 +166,10 @@ the container providers configuration file as an `EXTRA_VARS` parameter to the
 `container_providers_config` to the configuration file path:
 
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
     -e container_providers_config=/tmp/cp.yml \
-ifdef::openshift-origin[]
     playbooks/openshift-management/add_many_container_providers.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/add_many_container_providers.yml
-endif::[]
 ----
 
 After the playbook completes, you should find two new container providers in

--- a/install_config/cfme/installing.adoc
+++ b/install_config/cfme/installing.adoc
@@ -52,13 +52,9 @@ installation.
 cluster, call the {mgmt-app} playbook directly to begin the installation:
 +
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
-ifdef::openshift-origin[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
     playbooks/openshift-management/config.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/config.yml
-endif::[]
 ----
 
 [[cfme-example-inventory-files]]

--- a/install_config/cfme/uninstalling.adoc
+++ b/install_config/cfme/uninstalling.adoc
@@ -23,13 +23,9 @@ To uninstall and erase a deployed {mgmt-app} installation from
 {product-title}, run the following playbook:
 
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
-ifdef::openshift-origin[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
     playbooks/openshift-management/uninstall.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/uninstall.yml
-endif::[]
 ----
 
 [IMPORTANT]

--- a/install_config/configuring_kuryrsdn.adoc
+++ b/install_config/configuring_kuryrsdn.adoc
@@ -130,7 +130,8 @@ playbook. You must pass in the dynamic inventory (*_inventory.py_*) as well as
 the path to the Ansible nodes file above:
 
 ----
-$ ansible-playbook --user openshift -i /usr/share/ansible/openshift-ansible/playbooks/openstack/inventory.py -i ansible-nodes.txt /usr/share/ansible/openshift-ansible/playbooks/openstack/openshift-cluster/provision_install.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook --user openshift -i playbooks/openstack/inventory.py -i ansible-nodes.txt playbooks/openstack/openshift-cluster/provision_install.yml
 ----
 
 If you want to do any custom setup on the created nodes before the

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -217,7 +217,7 @@ networkConfig:
 == Configuring the Pod Network on Nodes
 
 The cluster administrators can control pod network settings on nodes by modifying
-parameters in the `*networkConfig*` section of the 
+parameters in the `*networkConfig*` section of the
 appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]:
 
 ====
@@ -279,7 +279,8 @@ inventory file to the new CIDR:
 . Run the `*config.yml*` Ansible playbook to redeploy the cluster:
 +
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-master/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/byo/openshift-master/config.yml
 ----
 
 include::day_two_guide/topics/increasing_docker_storage.adoc[tag=evacuating-a-node]

--- a/install_config/persistent_storage/topics/glusterfs_run_installer.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_run_installer.adoc
@@ -13,13 +13,14 @@ file as an option.
 ** For a new {product-title} installation:
 +
 ----
-ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-
-ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> playbooks/prerequisites.yml
+$ ansible-playbook -i <path_to_inventory_file> playbooks/deploy_cluster.yml
 ----
 +
 ** For an installation onto an existing {product-title} cluster:
 +
 ----
-ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/openshift-glusterfs/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> playbooks/openshift-glusterfs/config.yml
 ----

--- a/install_config/persistent_storage/topics/glusterfs_uninstall.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_uninstall.adoc
@@ -4,7 +4,8 @@ provide the original inventory file that was used to install the target instance
 of {gluster-native} and run the following playbook:
 
 ----
-# ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/openshift-glusterfs/uninstall.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> playbooks/openshift-glusterfs/uninstall.yml
 ----
 
 In addition, the playbook supports the use of a variable called
@@ -13,9 +14,10 @@ block devices that were used for {gluster} backend storage. To use the
 `openshift_storage_glusterfs_wipe` variable:
 
 ----
-# ansible-playbook -i <path_to_inventory_file> -e
-"openshift_storage_glusterfs_wipe=true"
-/usr/share/ansible/openshift-ansible/playbooks/openshift-glusterfs/uninstall.yml 
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> -e \
+  "openshift_storage_glusterfs_wipe=true" \
+  playbooks/openshift-glusterfs/uninstall.yml
 ----
 
 [WARNING]

--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -167,8 +167,9 @@ The following command sets the directory in the EFS volume to
 be mountable and writeable by the provisioner pod.
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-provisioners/config.yml \
+    playbooks/openshift-provisioners/config.yml \
    -e openshift_provisioners_install_provisioners=True \
    -e openshift_provisioners_efs=True \
    -e openshift_provisioners_efs_fsid=fs-47a2c22e \
@@ -218,7 +219,8 @@ You can remove everything deployed by the OpenShift Ansible `openshift_provision
 by running the following command:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-provisioners/config.yml \
+    playbooks/openshift-provisioners/config.yml \
    -e openshift_provisioners_install_provisioners=False
 ----

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -130,8 +130,9 @@ tweaking it to your specifications as needed. This playbook:
 To run the *_easy-mode.yaml_*  playbook:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/certificate_expiry/easy-mode.yaml
+    playbooks/openshift-checks/certificate_expiry/easy-mode.yaml
 ----
 
 [discrete]
@@ -245,7 +246,9 @@ In particular, the inventory must specify or override all host names and IP
 addresses set via the following variables such that they match the current
 cluster configuration:
 
+- `openshift_hostname`
 - `openshift_public_hostname`
+- `openshift_ip`
 - `openshift_public_ip`
 - `openshift_master_cluster_hostname`
 - `openshift_master_cluster_public_hostname`
@@ -315,13 +318,8 @@ still valid.
 
 To redeploy a newly generated or custom CA:
 
-. Optionally, specify a custom CA. The `certfile` that you specify as part of
-the custom CA parameter, `openshift_master_ca_certificate`, must contain only
-the single certificate that signs the {product-title} certificates. If you have
-intermediate certificates in your chain, you must bundle them into a different
-file.
-.. To specify a CA without intermediate certificates, set the following variable
-in your inventory file:
+. If you want to use a custom CA, set the following variable in your inventory
+file. To use the current CA, skip this step.
 +
 ----
 # Configure custom ca certificate
@@ -331,25 +329,15 @@ in your inventory file:
 # playbook.
 openshift_master_ca_certificate={'certfile': '</path/to/ca.crt>', 'keyfile': '</path/to/ca.key>'}
 ----
-.. To specify a CA certificate that is issued by an intermediate CA:
-... Create a bundled certificate that contains the full chain of intermediate
-and root certificates for the CA:
++
+If the CA certificate is issued by an intermediate CA, the bundled certificate must contain 
+the full chain (the intermediate and root certificates) for the CA in order to validate child certificates. 
++
+For example:
 +
 ----
-# cat intermediate/certs/<intermediate.cert.pem> \
+$ cat intermediate/certs/intermediate.cert.pem \
       certs/ca.cert.pem >> intermediate/certs/ca-chain.cert.pem
-----
-
-... Set the following variables in your inventory file:
-+
-----
-# Configure custom ca certificate
-# NOTE: CA certificate will not be replaced with existing clusters.
-# This option may only be specified when creating a new cluster or
-# when redeploying cluster certificates with the redeploy-certificates
-# playbook.
-openshift_master_ca_certificate={'certfile': '</path/to/ca.crt>', 'keyfile': '</path/to/ca.key>'}
-openshift_additional_ca=intermediate/certs/ca-chain.cert.pem
 ----
 
 . Run the *_openshift-master/redeploy-openshift-ca.yml_* playbook, specifying your inventory file:
@@ -405,8 +393,8 @@ $ ansible-playbook -i <inventory_file> \
 
 [IMPORTANT]
 ====
-After running this playbook, you need to regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs]
-by deleting existing secrets that contain service serving certificates or removing and re-adding
+After running this playbook, you need to regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs] 
+by deleting existing secrets that contain service serving certificates or removing and re-adding 
 annotations to appropriate services.
 ====
 
@@ -510,7 +498,7 @@ deprecated in favor of using secrets).
 variables:
 +
 ----
-$ oc set env dc/docker-registry --list
+$ oc env dc/docker-registry --list
 ----
 
 .. If they do not exist, skip this step. If they do, create the following `ClusterRoleBinding`:
@@ -539,7 +527,7 @@ oc create -f -
 Then, run the following to remove the environment variables:
 +
 ----
-$ oc set env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+$ oc env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
 ----
 
 . Set the following environment variables locally to make later commands less
@@ -563,7 +551,7 @@ $ oc adm ca create-server-cert \
 ----
 +
 Run `oc adm` commands only from the first master listed in the Ansible host inventory file,
-by default *_/etc/ansible/hosts_*.
+by default *_/etc/ansible/hosts_*. 
 
 . Update the `registry-certificates` secret with the new registry certificates:
 +
@@ -605,7 +593,7 @@ deprecated in favor of using service serving certificate secret.
 variables:
 +
 ----
-$ oc set env dc/router --list
+$ oc env dc/router --list
 ----
 
 .. If those variables exist, create the following `ClusterRoleBinding`:
@@ -634,7 +622,7 @@ oc create -f -
 .. If those variables exist, run the following command to remove them:
 +
 ----
-$ oc set env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+$ oc env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
 ----
 
 . Obtain a certificate.
@@ -682,7 +670,7 @@ $ cat router.crt /etc/origin/master/ca.crt router.key > router.pem
 $ oc export secret router-certs > ~/old-router-certs-secret.yaml
 ----
 
-. Create a new secret to hold the new certificate and key, and replace the
+. Create a new secret to hold the new certificate and key, and replace the 
 contents of the existing secret:
 +
 ----
@@ -691,7 +679,7 @@ $ oc create secret tls router-certs --cert=router.pem \ <1>
     oc replace -f -
 ----
 <1> *_router.pem_* is the file that contains the concatenation of the
-certificates that you generated.
+certificates that you generated.    
 
 . Remove the following annotations from the `router` service:
 +

--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -936,7 +936,7 @@ experiencing the insight and automations available to them in {product-title}.
 To install CFME 4.6:
 
 ----
-# ansible-playbook -v -i <YOUR_INVENTORY> \
+$ ansible-playbook -v -i <YOUR_INVENTORY> \
     playbooks/byo/openshift-management/config.yml
 ----
 
@@ -948,14 +948,14 @@ There is a link:https://bugzilla.redhat.com/show_bug.cgi?id=1506951[known issue]
 To configure CFME 4.6 to consume the {product-title} installation it is running on:
 
 ----
-# ansible-playbook -v -i <YOUR_INVENTORY> \
+$ ansible-playbook -v -i <YOUR_INVENTORY> \
     playbooks/byo/openshift-management/add_container_provider.yml
 ----
 
 You can also automate the configuration of the provider to point to multiple OpenShift clusters:
 
 ----
-# ansible-playbook -v -e container_providers_config=/tmp/cp.yml \
+$ ansible-playbook -v -e container_providers_config=/tmp/cp.yml \
     playbooks/byo/openshift-management/add_many_container_providers.yml
 ----
 

--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -1299,16 +1299,18 @@ Administrators can now backup and redeploy cluster certificates using the
 following Ansible playbook:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/redeploy-certificates.yml
+    playbooks/byo/openshift-cluster/redeploy-certificates.yml
 ----
 +
 By default, the playbook retains the current OpenShift Enterprise CA. To replace
 the CA with a generated or custom CA:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/redeploy-certificates.yml \
+    byo/openshift-cluster/redeploy-certificates.yml \
     --extra-vars "openshift_certificates_redeploy_ca=true"
 ----
 +

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -550,8 +550,9 @@ file that was used.
 playbook:
 +
 ----
-# ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade.yml
 ----
 
 ** To upgrade the control plane and nodes in separate phases:
@@ -559,15 +560,17 @@ playbook:
 playbook:
 +
 ----
-# ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
 ----
 
 .. Upgrade the nodes by running the *_upgrade_nodes.yaml_* playbook:
 +
 ----
-# ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_nodes.yml \
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_nodes.yml \
     [-e <customized_node_upgrade_variables>] <1>
 ----
 <1> See xref:customizing-node-upgrades[Customizing Node Upgrades] for any desired


### PR DESCRIPTION
This ensures that we utilize ansible.cfg file from openshift-ansible
which defines critical configuration items.

This removes a fair amount of conditional documentation code that was
essentially
if origin
 ~/openshift-ansible
else
 /usr/share/ansible/openshift-ansible

I feel that while the admin of origin may be operating from a github
checkout when they read `$ cd /usr/share/ansible/openshift-ansible`
they'll be able to figure out that they should change directories to
their checkout.

This replaces all `# ansible-playbook` with `$ ansible-playbook`. You
should never need to be root to run our playbooks.

Related https://bugzilla.redhat.com/show_bug.cgi?id=1458018

/cc @kalexand-rh @adellape 