### PR TITLE
Fixes #11370 - Wrong variable for defining Storage Class for Metrics Cassandra

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -310,7 +310,7 @@ appended to the prefix starting from 1.
 |`openshift_metrics_cassandra_pvc_size`
 |The persistent volume claim size for each of the Cassandra nodes.
 
-|`openshift_metrics_cassandra_storage_class_name`
+|`openshift_metrics_cassandra_pvc_storage_class_name`
 |If you want to explicitly set the storage class, you must not set
 `openshift_metrics_cassandra_storage_type` to `emptydir` or `dynamic`.
 


### PR DESCRIPTION
According the https://github.com/openshift/openshift-ansible/blob/release-3.10/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml, the variable name for defining Storage Class on PVC for Metrics Cassandra should be `openshift_metrics_cassandra_pvc_storage_class_name` and not `openshift_metrics_cassandra_storage_class_name` as mentioned in the docs for `release-3.10`.