### PR TITLE
 Mention that docker gc should only be installed on overlay2

### DIFF
--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -118,18 +118,12 @@ detected.
 When CRI-O use is enabled, it is installed alongside `docker`, which currently
 is required to perform build and push operations to the registry. Over time,
 temporary `docker` builds can accumulate on nodes. You can optionally set the
-following to enable garbage collection, which adds a daemonset to clean out the
-builds:
+following parameter to enable garbage collection. You must configure the node
+selector so that the garbage collector runs only on nodes where `docker` is
+configured for `overlay2` storage.
 
 ----
 openshift_crio_enable_docker_gc=true
-----
-
-When enabled, it will run garbage collection on all nodes by default. You can
-also limit the running of the daemonset on specific nodes by setting the
-following:
-
-----
 openshift_crio_docker_gc_node_selector={'runtime': 'cri-o'}
 ----
 

--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -133,18 +133,12 @@ detected.
 When CRI-O use is enabled, it is installed alongside `docker`, which currently
 is required to perform build and push operations to the registry. Over time,
 temporary `docker` builds can accumulate on nodes. You can optionally set the
-following to enable garbage collection, which adds a daemonset to clean out the
-builds:
+following parameter to enable garbage collection. You must configure the node
+selector so that the garbage collector runs only on nodes where `docker` is
+configured for `overlay2` storage.
 
 ----
 openshift_crio_enable_docker_gc=true
-----
-
-When enabled, it will run garbage collection on all nodes by default. You can
-also limit the running of the daemonset on specific nodes by setting the
-following:
-
-----
 openshift_crio_docker_gc_node_selector={'runtime': 'cri-o'}
 ----
 


### PR DESCRIPTION
Starting in RHEL 7.5 we support 'overlay2' and 'devicemapper' based storage for docker. By default docker will be provisioned with overlay2 storage unless the admin takes special steps to use devicemapper. The dockergc component is only compatible with hosts configured for overlay2.

The release notes are the only place we mention docker gc or crio in general. We should probably consider having the runtimes team submit a section related to crio configuration to the install guide.

/cc @kalexand-rh @mrunalp 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568772