### PR TITLE
Fix optimizing_on_glusterfs_storage in topic_map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -731,10 +731,10 @@ Topics:
   File: using_cpu_manager
 - Name: Managing Huge Pages
   File: managing_hugepages
-- Name: Revision History
-  File: revhistory_scaling_performance
 - Name: Optimizing On GlusterFS Storage
   File: optimizing_on_glusterfs_storage
+- Name: Revision History
+  File: revhistory_scaling_performance
   Distros: openshift-enterprise
 ---
 Name: CLI Reference


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/11018 so that it appears in both OKD and OCP docs.

FYI @ahardin-rh 