### PR TITLE
Fix space and unicode quotes in oc annotate command

### DIFF
--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -295,14 +295,14 @@ client and redistribute them.
 . Annotate the route with the desired cookie name:
 +
 ----
-$ oc annotate route <route_name> router.openshift.io/<cookie_name>= “-<cookie_annotation>”
+$ oc annotate route <route_name> router.openshift.io/<cookie_name>="-<cookie_annotation>"
 ----
 +
 For example, to annotate the cookie name of `my_cookie` to the `my_route` with
 the annotation of `my_cookie_anno`:
 +
 ----
-$ oc annotate route my_route router.openshift.io/my_cookie= “-my_cookie_anno”
+$ oc annotate route my_route router.openshift.io/my_cookie="-my_cookie_anno"
 ----
 
 . Save the cookie, and access the route:


### PR DESCRIPTION
1. unicode quotes “ U+201C, ” U+201D will not work in a shell command
2. `oc annotate` takes `name=value` in a single argument, not `name=` and separate `value`.