### PR TITLE
doc: openshift_node_groups examples

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -545,12 +545,34 @@ and Node Configuration Files] for reference on configurable node variables.
 ====
 
 For example, the following entry in an inventory file defines groups named
-`node-config-master`, `node-config-infra`, and `node-config-compute`, and edits
-the ConfigMap for `node-config-compute` to set `kubeletArguments.pods-per-core`
-to `20`:
+`node-config-master`, `node-config-infra`, and `node-config-compute`.
 
 ----
-openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true',]}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.pods-per-core','value': ['20']}]}]
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true']}]
+----
+
+When you set an entry in the inventory file, you can also edit the ConfigMap for
+for a node group:
+
+* You can use a list, such as modifying the `node-config-compute` to set
+`kubeletArguments.pods-per-core` to `20`:
+
+----
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.pods-per-core','value': ['20']}]}]
+----
+
+* You can use a list to modify multiple key value pairs, such as modifying the
+`node-config-compute` group to add two parameters to the `kubelet`:
+
+----
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.experimental-allocatable-ignore-eviction','value': ['true']}, {'key': 'kubeletArguments.eviction-hard', 'value': ['memory.available<1Ki']}]}]
+----
+
+* You can use also use a dictionary as value, such as modifying the
+`node-config-compute` group to set `perFSGroup` to `512Mi`:
+
+----
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'volumeConfig.localQuota','value': {'perFSGroup':'512Mi'}}]}]
 ----
 
 Whenever the *_openshift_node_group.yml_* playbook is run, the changes defined


### PR DESCRIPTION
Current examples and details can leave the user a bit confused about how to handling keys other than the `kubeletArguments`.

* Add different examples for openshift_node_groups so it's clear how to
handle different data structures and multiple keys.