### PR TITLE
admin guide - note: not all net.* syscts are namespaced

### DIFF
--- a/admin_guide/sysctls.adoc
+++ b/admin_guide/sysctls.adoc
@@ -52,7 +52,19 @@ The following sysctls are known to be namespaced:
 - *_kernel.msg*_*
 - *_kernel.sem_*
 - *_fs.mqueue.*_*
-- *_net.*_*
+
+Additionally, most of the sysctls in the *_net.*_* group are known
+to be namespaced. Their namespace adoption differs based on the kernel
+version and distributor.
+
+To check which *_net.*_* sysctls are namespaced on your system, run the
+following command:
+
+----
+$ podman run --rm -ti docker.io/fedora \
+    /bin/sh -c "dnf install -y findutils && find /proc/sys/ \
+    | grep -e /proc/sys/net"
+----
 
 Sysctls that are not namespaced are called _node-level_ and must be set
 manually by the cluster administrator, either by means of the underlying Linux


### PR DESCRIPTION
Related to: https://github.com/openshift/origin/issues/20470