### PR TITLE
Clarify s2i Secrets/ConfigMap Behavior

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -853,9 +853,9 @@ respective `destinationDir`. If you left `destinationDir` empty, then the
 secrets are placed in the working directory of the builder image.
 
 The same rule is used when a `destinationDir` is a relative path; the secrets
-are placed in the paths that are relative to the image's working directory. The
-`destinationDir` must exist or an error will occur. No directory paths are
-created during the copy process.
+are placed in the paths that are relative to the image's working directory.
+The final directory in the `destinationDir` path is created if it does not exist in the builder image.
+All preceding directories in the `destinationDir` must exist, or an error will occur.
 
 [NOTE]
 ====


### PR DESCRIPTION
When Secrets and ConfigMaps are added to an s2i build, the `destinationDir` is created if it does not exist.

Bug [1613744](https://bugzilla.redhat.com/show_bug.cgi?id=1613744)