### PR TITLE
Removed instances of the deprecated openshift_set_node_ip and openshift_ip values

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -196,9 +196,6 @@ options] in the OAuth configuration. See xref:advanced-install-session-options[C
 
 |`openshift_master_session_encryption_secrets`
 
-|`openshift_set_node_ip`
-|This variable configures `nodeIP` in the node configuration. This variable is needed in cases where it is desired for node traffic to go over an interface other than the default network interface. The host variable `openshift_ip` can also be configured on each node to set a specific IP that might not be the IP of the default route.
-
 |`openshift_master_image_policy_config`
 |Sets `imagePolicyConfig` in the master configuration. See xref:../install_config/master_node_configuration.adoc#master-config-image-config[Image Configuration] for details.
 
@@ -404,11 +401,6 @@ when the system's default IP address does not resolve to the system host name.
 |This variable overrides the system's public host name. Use this for cloud
 installations, or for hosts on networks using a network address translation
 (NAT).
-
-|`openshift_ip`
-|This variable overrides the cluster internal IP address for the system. Use this
-when using an interface that is not configured with the default
-route.`openshift_ip` can be used for etcd.
 
 |`openshift_public_ip`
 |This variable overrides the system's public IP address. Use this for cloud

--- a/install/prerequisites.adoc
+++ b/install/prerequisites.adoc
@@ -626,7 +626,7 @@ connections, and is only required if you have clustered etcd.
 
 * In the above examples, port *4789* is used for User Datagram Protocol (UDP).
 * When deployments are using the SDN, the pod network is accessed via a service proxy, unless it is accessing the registry from the same node the registry is deployed on.
-* {product-title} internal DNS cannot be received over SDN. Depending on the detected values of `*openshift_facts*`, or if the `*openshift_ip*` and `*openshift_public_ip*` values are overridden, it will be the computed value of `*openshift_ip*`. For non-cloud deployments, this will default to the IP address associated with the default route on the master host. For cloud deployments, it will default to the IP address associated with the first internal interface as defined by the cloud metadata.
+* {product-title} internal DNS cannot be received over SDN. For non-cloud deployments, this will default to the IP address associated with the default route on the master host. For cloud deployments, it will default to the IP address associated with the first internal interface as defined by the cloud metadata.
 * The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed values of `*openshift_hostname*` and `*openshift_public_hostname*`.
 * Port *1936* can still be inaccessible due to your iptables rules. Use the following to configure iptables to open port *1936*:
 +
@@ -727,7 +727,6 @@ a| - Should resolve to the internal IP from the instances themselves.
 
 |`*ip*`
 a| - Should be the internal IP of the instance.
-- `*openshift_ip*` will overrides.
 
 |`*public_hostname*`
 a| - Should resolve to the external IP from hosts outside of the cloud.

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -85,9 +85,7 @@ a|The user is installing in a VPC that is not configured for both `*DNS hostname
 
 |`*ip*`
 a|You have multiple network interfaces configured and want to
-use one other than the default. You must also set the
-`*openshift_set_node_ip*` parameter to `True`, or the SDN attempts to
-use the `*hostname*` setting or tries to resolve the host name for the IP address.
+use one other than the default.
 
 |`*public_hostname*`
 a| - A master instance where the VPC subnet is not configured for `*Auto-assign

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -111,28 +111,8 @@ xref:../install/host_preparation.adoc#ensuring-host-access[SSH keys] to all the 
 
 To modify the Ansible inventory and make configuration changes:
 
-. Open the *_./hosts_* inventory file:
-+
-.Sample inventory file:
-====
-----
-[OSEv3:children]
-masters
-nodes
+. Open the *_./hosts_* inventory file.
 
-[OSEv3:vars]
-ansible_ssh_user=cloud-user
-ansible_become=true
-openshift_deployment_type=openshift-enterprise
-
-[masters]
-ec2-52-6-179-239.compute-1.amazonaws.com  openshift_ip=172.17.3.88 openshift_public_ip=52-6-179-239 openshift_hostname=master.example.com  openshift_public_hostname=ose3-master.public.example.com containerized=True
-[nodes]
-ec2-52-6-179-239.compute-1.amazonaws.com  openshift_ip=172.17.3.88 openshift_public_ip=52-6-179-239 openshift_hostname=master.example.com  openshift_public_hostname=ose3-master.public.example.com containerized=True openshift_schedulable=False
-ec2-52-95-5-36.compute-1.amazonaws.com  openshift_ip=172.17.3.89 openshift_public_ip=52.3.5.36 openshift_hostname=node.example.com openshift_public_hostname=ose3-node.public.example.com containerized=True
-----
-====
-+
 . Add the following new variables to the `[OSEv3:vars]` section of the file:
 +
 ----

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -247,7 +247,6 @@ cluster configuration:
 
 - `openshift_hostname`
 - `openshift_public_hostname`
-- `openshift_ip`
 - `openshift_public_ip`
 - `openshift_master_cluster_hostname`
 - `openshift_master_cluster_public_hostname`


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1584486

@sjenning @sdodson PTAL

Now that these values are removed, is there updated guidance for this? 
See https://github.com/openshift/openshift-docs/pull/9702#issuecomment-393619514