### PR TITLE
Remove `alpha` from node.alpha.kubernetes.io AND removed duplicate node.alpha.kubernetes.io/notReady:NoExecute

### DIFF
--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -192,7 +192,7 @@ Here, if this pod is running but does not have a matching taint, the pod stays b
 [[admin-guide-taints-tolsec-default]]
 ==== Setting a Default Value for Toleration Seconds
 
-This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/not-Ready:NoExecute` and `node.kubernetes.io/unreachable:NoExecute` taints for five minutes.
+This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/not-ready:NoExecute` and `node.kubernetes.io/unreachable:NoExecute` taints for five minutes.
 
 If the pod configuration provided by the user already has either toleration, the default is not added.
 
@@ -243,9 +243,8 @@ For example:
 +
 ----
 $ oc describe pod hello-pod |grep -i toleration
-Tolerations:    node.kubernetes.io/not-Ready=:Exists:NoExecute for 300s
+Tolerations:    node.kubernetes.io/not-ready=:Exists:NoExecute for 300s
 ----
-
 
 
 [[admin-guide-taints-pod-eviction]]
@@ -255,7 +254,7 @@ Tolerations:    node.kubernetes.io/not-Ready=:Exists:NoExecute for 300s
 
 When the Taint Based Evictions feature is enabled, the taints are automatically added by the node controller and the normal logic for evicting pods from `Ready` nodes is disabled.
 
-* If a node enters a not ready state, the `node.kubernetes.io/not-Ready:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
+* If a node enters a not ready state, the `node.kubernetes.io/not-ready:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 * If a node enters a not reachable state, the `node.kubernetes.io/unreachable:NoExecute` taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 
 To enable Taint Based Evictions:
@@ -274,7 +273,7 @@ kubernetesMasterConfig:
 ----
 oc describe node $node | grep -i taint
 
-Taints: node.kubernetes.io/not-Ready:NoExecute
+Taints: node.kubernetes.io/not-ready:NoExecute
 ----
 
 . Restart OpenShift for the changes to take effect:
@@ -300,7 +299,7 @@ or
 [source, yaml]
 ----
 tolerations:
-- key: "node.kubernetes.io/not-Ready"
+- key: "node.kubernetes.io/not-ready"
   operator: "Exists"
   effect: "NoExecute"
   tolerationSeconds: 6000
@@ -315,7 +314,7 @@ To maintain the existing link:https://kubernetes.io/docs/admin/node/#node-contro
 [[admin-guide-taints-daemonsets]]
 == Daemonsets and Tolerations
 
-link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-Ready`
+link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-ready`
 with no `tolerationSeconds` to ensure that DaemonSet pods are never evicted due to these problems, even when the Default Toleration Seconds feature is disabled.
 
 [[admin-guide-taints-use-cases]]

--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -192,7 +192,7 @@ Here, if this pod is running but does not have a matching taint, the pod stays b
 [[admin-guide-taints-tolsec-default]]
 ==== Setting a Default Value for Toleration Seconds
 
-This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/notReady:NoExecute` and `node.kubernetes.io/unreachable:NoExecute` taints for five minutes.
+This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/not-Ready:NoExecute` and `node.kubernetes.io/unreachable:NoExecute` taints for five minutes.
 
 If the pod configuration provided by the user already has either toleration, the default is not added.
 
@@ -243,7 +243,7 @@ For example:
 +
 ----
 $ oc describe pod hello-pod |grep -i toleration
-Tolerations:    node.kubernetes.io/notReady=:Exists:NoExecute for 300s
+Tolerations:    node.kubernetes.io/not-Ready=:Exists:NoExecute for 300s
 ----
 
 
@@ -255,7 +255,7 @@ Tolerations:    node.kubernetes.io/notReady=:Exists:NoExecute for 300s
 
 When the Taint Based Evictions feature is enabled, the taints are automatically added by the node controller and the normal logic for evicting pods from `Ready` nodes is disabled.
 
-* If a node enters a not ready state, the `node.kubernetes.io/notReady:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
+* If a node enters a not ready state, the `node.kubernetes.io/not-Ready:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 * If a node enters a not reachable state, the `node.kubernetes.io/unreachable:NoExecute` taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 
 To enable Taint Based Evictions:
@@ -274,7 +274,7 @@ kubernetesMasterConfig:
 ----
 oc describe node $node | grep -i taint
 
-Taints: node.kubernetes.io/notReady:NoExecute
+Taints: node.kubernetes.io/not-Ready:NoExecute
 ----
 
 . Restart OpenShift for the changes to take effect:
@@ -300,7 +300,7 @@ or
 [source, yaml]
 ----
 tolerations:
-- key: "node.kubernetes.io/notReady"
+- key: "node.kubernetes.io/not-Ready"
   operator: "Exists"
   effect: "NoExecute"
   tolerationSeconds: 6000
@@ -315,7 +315,7 @@ To maintain the existing link:https://kubernetes.io/docs/admin/node/#node-contro
 [[admin-guide-taints-daemonsets]]
 == Daemonsets and Tolerations
 
-link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.kubernetes.io/unreachable` and `node.kubernetes.io/notReady`
+link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-Ready`
 with no `tolerationSeconds` to ensure that DaemonSet pods are never evicted due to these problems, even when the Default Toleration Seconds feature is disabled.
 
 [[admin-guide-taints-use-cases]]

--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -192,7 +192,7 @@ Here, if this pod is running but does not have a matching taint, the pod stays b
 [[admin-guide-taints-tolsec-default]]
 ==== Setting a Default Value for Toleration Seconds
 
-This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.alpha.kubernetes.io/notReady:NoExecute` and `node.alpha.kubernetes.io/notReady:NoExecute` taints for five minutes.
+This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/notReady:NoExecute` and `node.kubernetes.io/notReady:NoExecute` taints for five minutes.
 
 If the pod configuration provided by the user already has either toleration, the default is not added.
 
@@ -243,7 +243,7 @@ For example:
 +
 ----
 $ oc describe pod hello-pod |grep -i toleration
-Tolerations:    node.alpha.kubernetes.io/notReady=:Exists:NoExecute for 300s
+Tolerations:    node.kubernetes.io/notReady=:Exists:NoExecute for 300s
 ----
 
 
@@ -255,8 +255,8 @@ Tolerations:    node.alpha.kubernetes.io/notReady=:Exists:NoExecute for 300s
 
 When the Taint Based Evictions feature is enabled, the taints are automatically added by the node controller and the normal logic for evicting pods from `Ready` nodes is disabled.
 
-* If a node enters a not ready state, the `node.alpha.kubernetes.io/notReady:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
-* If a node enters a not reachable state, the `node.alpha.kubernetes.io/unreachable:NoExecute` taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
+* If a node enters a not ready state, the `node.kubernetes.io/notReady:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
+* If a node enters a not reachable state, the `node.kubernetes.io/unreachable:NoExecute` taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 
 To enable Taint Based Evictions:
 
@@ -274,7 +274,7 @@ kubernetesMasterConfig:
 ----
 oc describe node $node | grep -i taint
 
-Taints: node.alpha.kubernetes.io/notReady:NoExecute
+Taints: node.kubernetes.io/notReady:NoExecute
 ----
 
 . Restart OpenShift for the changes to take effect:
@@ -289,7 +289,7 @@ Taints: node.alpha.kubernetes.io/notReady:NoExecute
 [source, yaml]
 ----
 tolerations:
-- key: "node.alpha.kubernetes.io/unreachable"
+- key: "node.kubernetes.io/unreachable"
   operator: "Exists"
   effect: "NoExecute"
   tolerationSeconds: 6000
@@ -300,7 +300,7 @@ or
 [source, yaml]
 ----
 tolerations:
-- key: "node.alpha.kubernetes.io/notReady"
+- key: "node.kubernetes.io/notReady"
   operator: "Exists"
   effect: "NoExecute"
   tolerationSeconds: 6000
@@ -315,7 +315,7 @@ To maintain the existing link:https://kubernetes.io/docs/admin/node/#node-contro
 [[admin-guide-taints-daemonsets]]
 == Daemonsets and Tolerations
 
-link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.alpha.kubernetes.io/unreachable` and `node.alpha.kubernetes.io/notReady`
+link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.kubernetes.io/unreachable` and `node.kubernetes.io/notReady`
 with no `tolerationSeconds` to ensure that DaemonSet pods are never evicted due to these problems, even when the Default Toleration Seconds feature is disabled.
 
 [[admin-guide-taints-use-cases]]

--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -192,7 +192,7 @@ Here, if this pod is running but does not have a matching taint, the pod stays b
 [[admin-guide-taints-tolsec-default]]
 ==== Setting a Default Value for Toleration Seconds
 
-This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/notReady:NoExecute` and `node.kubernetes.io/notReady:NoExecute` taints for five minutes.
+This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.kubernetes.io/notReady:NoExecute` and `node.kubernetes.io/unreachable:NoExecute` taints for five minutes.
 
 If the pod configuration provided by the user already has either toleration, the default is not added.
 


### PR DESCRIPTION
This PR covers two BZ issues in the same file for 3.11

https://bugzilla.redhat.com/show_bug.cgi?id=1610683
Remove all "node.alpha.kubernetes.io/notReady:NoExecute" and "node.alpha.kubernetes.io/unreachable:NoExecute" should remove "alpha". 
Because 3.11 has moved taints and tolerations from beta to v1.

https://bugzilla.redhat.com/show_bug.cgi?id=1610663
"node.alpha.kubernetes.io/notReady:NoExecute" duplicate twice.