### PR TITLE
Fixed env var name. Added namespace selector

### DIFF
--- a/day_two_guide/topics/verifying_mtu.adoc
+++ b/day_two_guide/topics/verifying_mtu.adoc
@@ -37,7 +37,7 @@ connectivity] section.
 . From a master host, get the HTTPS address:
 +
 ----
-$ oc get dc docker-registry -o jsonpath='{.spec.template.spec.containers[].env[?(@.name=="OPENSHIFT_DEFAULT_REGISTRY")].value}{"\n"}'
+$ oc -n default get dc docker-registry -o jsonpath='{.spec.template.spec.containers[].env[?(@.name=="REGISTRY_OPENSHIFT_SERVER_ADDR")].value}{"\n"}'
 docker-registry.default.svc:5000
 ----
 +


### PR DESCRIPTION
On 3.10 OPENSHIFT_DEFAULT_REGISTRY doesn't exist, the new name is REGISTRY_OPENSHIFT_SERVER_ADDR.

Below the DC for the registry on 3.10:
```
[cloud-user@ocp310-master-0 ~]$ oc -n default get dc docker-registry -o json
{
    "apiVersion": "apps.openshift.io/v1",
    "kind": "DeploymentConfig",
    "metadata": {
        "creationTimestamp": "2018-08-07T15:01:54Z",
        "generation": 2,
        "labels": {
            "docker-registry": "default"
        },
        "name": "docker-registry",
        "namespace": "default",
        "resourceVersion": "1050388",
        "selfLink": "/apis/apps.openshift.io/v1/namespaces/default/deploymentconfigs/docker-registry",
        "uid": "d2455064-9a52-11e8-b4f0-fa163e0d4482"
    },
    "spec": {
        "replicas": 1,
        "selector": {
            "docker-registry": "default"
        },
        "strategy": {
            "activeDeadlineSeconds": 21600,
            "resources": {},
            "rollingParams": {
                "intervalSeconds": 1,
                "maxSurge": "25%",
                "maxUnavailable": "25%",
                "timeoutSeconds": 600,
                "updatePeriodSeconds": 1
            },
            "type": "Rolling"
        },
        "template": {
            "metadata": {
                "creationTimestamp": null,
                "labels": {
                    "docker-registry": "default"
                }
            },
            "spec": {
                "containers": [
                    {
                        "env": [
                            {
                                "name": "REGISTRY_HTTP_ADDR",
                                "value": ":5000"
                            },
                            {
                                "name": "REGISTRY_HTTP_NET",
                                "value": "tcp"
                            },
                            {
                                "name": "REGISTRY_HTTP_SECRET",
                                "value": "OZDs7XTKnnbCuB4UbrK/tE/pCvMVGTVfYXGJcpFjFEU="
                            },
                            {
                                "name": "REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA",
                                "value": "false"
                            },
                            {
                                "name": "REGISTRY_OPENSHIFT_SERVER_ADDR",
                                "value": "docker-registry.default.svc:5000"
                            },
                            {
                                "name": "REGISTRY_HTTP_TLS_CERTIFICATE",
                                "value": "/etc/secrets/registry.crt"
                            },
                            {
                                "name": "REGISTRY_HTTP_TLS_KEY",
                                "value": "/etc/secrets/registry.key"
                            }
                        ],
                        "image": "registry.access.redhat.com/openshift3/ose-docker-registry:v3.10.14",
                        "imagePullPolicy": "IfNotPresent",
                        "livenessProbe": {
                            "failureThreshold": 3,
                            "httpGet": {
                                "path": "/healthz",
                                "port": 5000,
                                "scheme": "HTTPS"
                            },
                            "initialDelaySeconds": 10,
                            "periodSeconds": 10,
                            "successThreshold": 1,
                            "timeoutSeconds": 5
                        },
                        "name": "registry",
                        "ports": [
                            {
                                "containerPort": 5000,
                                "protocol": "TCP"
                            }
                        ],
                        "readinessProbe": {
                            "failureThreshold": 3,
                            "httpGet": {
                                "path": "/healthz",
                                "port": 5000,
                                "scheme": "HTTPS"
                            },
                            "periodSeconds": 10,
                            "successThreshold": 1,
                            "timeoutSeconds": 5
                        },
                        "resources": {
                            "requests": {
                                "cpu": "100m",
                                "memory": "256Mi"
                            }
                        },
                        "securityContext": {
                            "privileged": false
                        },
                        "terminationMessagePath": "/dev/termination-log",
                        "terminationMessagePolicy": "File",
                        "volumeMounts": [
                            {
                                "mountPath": "/registry",
                                "name": "registry-storage"
                            },
                            {
                                "mountPath": "/etc/secrets",
                                "name": "registry-certificates"
                            }
                        ]
                    }
                ],
                "dnsPolicy": "ClusterFirst",
                "nodeSelector": {
                    "node-role.kubernetes.io/infra": "true"
                },
                "restartPolicy": "Always",
                "schedulerName": "default-scheduler",
                "securityContext": {},
                "serviceAccount": "registry",
                "serviceAccountName": "registry",
                "terminationGracePeriodSeconds": 30,
                "volumes": [
                    {
                        "name": "registry-storage",
                        "persistentVolumeClaim": {
                            "claimName": "registry-claim"
                        }
                    },
                    {
                        "name": "registry-certificates",
                        "secret": {
                            "defaultMode": 420,
                            "secretName": "registry-certificates"
                        }
                    }
                ]
            }
        },
        "test": false,
        "triggers": [
            {
                "type": "ConfigChange"
            }
        ]
    },
    "status": {
        "availableReplicas": 1,
        "conditions": [
            {
                "lastTransitionTime": "2018-08-07T15:33:33Z",
                "lastUpdateTime": "2018-08-07T15:33:58Z",
                "message": "replication controller \"docker-registry-2\" successfully rolled out",
                "reason": "NewReplicationControllerAvailable",
                "status": "True",
                "type": "Progressing"
            },
            {
                "lastTransitionTime": "2018-08-12T01:27:02Z",
                "lastUpdateTime": "2018-08-12T01:27:02Z",
                "message": "Deployment config has minimum availability.",
                "status": "True",
                "type": "Available"
            }
        ],
        "details": {
            "causes": [
                {
                    "type": "ConfigChange"
                }
            ],
            "message": "config change"
        },
        "latestVersion": 2,
        "observedGeneration": 2,
        "readyReplicas": 1,
        "replicas": 1,
        "unavailableReplicas": 0,
        "updatedReplicas": 1
    }
}
```

