### PR TITLE
Bump ansible repo to 2.6

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -99,7 +99,7 @@ $ subscription-manager repos --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms" \
     --enable="rhel-7-fast-datapath-rpms" \
-    --enable="rhel-7-server-ansible-2.4-rpms"
+    --enable="rhel-7-server-ansible-2.6-rpms"
 ----
 
 This command tells your RHEL system that the tools required to install

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -132,7 +132,7 @@ $ subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-fast-datapath-rpms" \
-    --enable="rhel-7-server-ansible-2.4-rpms" \
+    --enable="rhel-7-server-ansible-2.6-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms"
 ----
 
@@ -168,7 +168,7 @@ $ for repo in \
 rhel-7-server-rpms \
 rhel-7-server-extras-rpms \
 rhel-7-fast-datapath-rpms \
-rhel-7-server-ansible-2.4-rpms \
+rhel-7-server-ansible-2.6-rpms \
 rhel-7-server-ose-3.10-rpms
 do
   reposync --gpgcheck -lm --repoid=${repo} --download_path=/path/to/repos
@@ -581,9 +581,9 @@ name=rhel-7-fast-datapath-rpms
 baseurl=http://<server_IP>/repos/rhel-7-fast-datapath-rpms
 enabled=1
 gpgcheck=0
-[rhel-7-server-ansible-2.4-rpms]
-name=rhel-7-server-ansible-2.4-rpms
-baseurl=http://<server_IP>/repos/rhel-7-server-ansible-2.4-rpms
+[rhel-7-server-ansible-2.6-rpms]
+name=rhel-7-server-ansible-2.6-rpms
+baseurl=http://<server_IP>/repos/rhel-7-server-ansible-2.6-rpms
 enabled=1
 gpgcheck=0
 [rhel-7-server-ose-3.10-rpms]

--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -173,7 +173,7 @@ Note that this could take a few minutes if you have a large number of available 
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms" \
     --enable="rhel-7-fast-datapath-rpms" \
-    --enable="rhel-7-server-ansible-2.4-rpms"
+    --enable="rhel-7-server-ansible-2.6-rpms"
 ----
 endif::[]
 

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -310,7 +310,7 @@ are described in the
 xref:../day_two_guide/environment_backup.adoc#etcd-backup_environment-backup[Day Two Operations Guide].
 
 .. Manually disable the 3.9 repository and enable the 3.10 repository on each
-master and node host. You must also enable the *rhel-7-server-ansible-2.4-rpms*
+master and node host. You must also enable the *rhel-7-server-ansible-2.6-rpms*
 repository, if it is not already:
 +
 ----
@@ -318,7 +318,7 @@ repository, if it is not already:
     --enable="rhel-7-server-ose-3.10-rpms" \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-ansible-2.4-rpms" \
+    --enable="rhel-7-server-ansible-2.6-rpms" \
     --enable="rhel-7-fast-datapath-rpms"
 # yum clean all
 ----


### PR DESCRIPTION
OCP 3.11 will require ansible 2.6 so change the repos we tell them to enable.
This change is only relevant to 3.11+