### PR TITLE
Remove fast-datapath

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -98,7 +98,6 @@ the first two repositories in this example.
 $ subscription-manager repos --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms" \
-    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.6-rpms"
 ----
 

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -131,7 +131,6 @@ $ subscription-manager repos --disable="*"
 $ subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.6-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms"
 ----
@@ -167,7 +166,6 @@ modify the command for the appropriate path you created above:
 $ for repo in \
 rhel-7-server-rpms \
 rhel-7-server-extras-rpms \
-rhel-7-fast-datapath-rpms \
 rhel-7-server-ansible-2.6-rpms \
 rhel-7-server-ose-3.10-rpms
 do
@@ -574,11 +572,6 @@ gpgcheck=0
 [rhel-7-server-extras-rpms]
 name=rhel-7-server-extras-rpms
 baseurl=http://<server_IP>/repos/rhel-7-server-extras-rpms
-enabled=1
-gpgcheck=0
-[rhel-7-fast-datapath-rpms]
-name=rhel-7-fast-datapath-rpms
-baseurl=http://<server_IP>/repos/rhel-7-fast-datapath-rpms
 enabled=1
 gpgcheck=0
 [rhel-7-server-ansible-2.6-rpms]

--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -172,7 +172,6 @@ Note that this could take a few minutes if you have a large number of available 
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms" \
-    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.6-rpms"
 ----
 endif::[]

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -318,8 +318,7 @@ repository, if it is not already:
     --enable="rhel-7-server-ose-3.10-rpms" \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-ansible-2.6-rpms" \
-    --enable="rhel-7-fast-datapath-rpms"
+    --enable="rhel-7-server-ansible-2.6-rpms"
 # yum clean all
 ----
 


### PR DESCRIPTION
This is no longer necessary in OCP 3.10+ as those components now run as pods.