### PR TITLE
Remove nodeSelector from the default DaemonSet

### DIFF
--- a/install_config/persistent_storage/persistent_storage_csi.adoc
+++ b/install_config/persistent_storage/persistent_storage_csi.adoc
@@ -253,9 +253,8 @@ spec:
     metadata:
       labels:
         app: cinder-csi-driver
-    spec:
-      nodeSelector:
-          role: node
+    spec: 
+      <2>
       serviceAccount: cinder-csi
       containers:
         - name: csi-driver-registrar
@@ -327,6 +326,7 @@ spec:
 ----
 <1> Replace with `cloud.conf` for your OpenStack deployment, as described in
  xref:../../install_config/configuring_openstack.adoc#configuring-openstack-variables[OpenStack configuration]. For example, the Secret can be generated using the `oc create secret generic cloudconfig --from-file cloud.conf --dry-run -o yaml`.
+<2> Optionally, add `nodeSelector` to CSI driver pod template to configure on which nodes should be the CSI driver started. Only nodes matching the selector will be able to run pods that use volumes served by the CSI driver. Without `nodeSelector`, the driver will run on all nodes in the cluster.
 
 [[install-config-persistent-storage-csi-dynamic-provisioning]]
 == Dynamic Provisioning


### PR DESCRIPTION
By default, CSI drivers should run on all nodes. Add a note that it's
possible to narrow down the nodes in special cases.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610709