### PR TITLE
Provide httpd pod naming convention in day two operations guide

### DIFF
--- a/day_two_guide/topics/network_connectivity.adoc
+++ b/day_two_guide/topics/network_connectivity.adoc
@@ -118,6 +118,12 @@ httpd-ex-1-build   0/1       Completed   0          1m
 . Connect to the running pod:
 +
 ----
+$ oc rsh po/<pod-name>
+----
++
+For example:
++
+----
 $ oc rsh po/httpd-ex-1-205hz
 ----
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1606134