### PR TITLE
Changed openshift-ansible-utils package name

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -33,7 +33,7 @@ for details on the format of an inventory file, including basics
 on link:https://docs.ansible.com/ansible/2.4/YAMLSyntax.html[YAML syntax].
 ====
 
-When you install the *openshift-ansible-utils* RPM package as described in
+When you install the *openshift-ansible* RPM package as described in
 xref:host_preparation.adoc#installing-base-packages[Host Preparation], Ansible
 dependencies create a file at the default location of *_/etc/ansible/hosts_*.
 However, the file is simply the default Ansible example and has no variables


### PR DESCRIPTION
I think it just wants to say "openshift-ansible"