### PR TITLE
[enterprise-3.6] removed duplicate node.alpha.kubernetes.io/notReady:NoExecute

### DIFF
--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -192,7 +192,7 @@ Here, if this pod is running but does not have a matching taint, the pod stays b
 [[admin-guide-taints-tolsec-default]]
 ==== Setting a Default Value for Toleration Seconds
 
-This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.alpha.kubernetes.io/notReady:NoExecute` and `node.alpha.kubernetes.io/notReady:NoExecute` taints for five minutes.
+This plug-in sets the default forgiveness toleration for pods, to tolerate the `node.alpha.kubernetes.io/not-ready:NoExecute` and `node.alpha.kubernetes.io/unreachable:NoExecute` taints for five minutes.
 
 If the pod configuration provided by the user already has either toleration, the default is not added.
 
@@ -249,7 +249,7 @@ For example:
 +
 ----
 $ oc describe pod hello-pod |grep -i toleration
-Tolerations:    node.alpha.kubernetes.io/notReady=:Exists:NoExecute for 300s
+Tolerations:    node.alpha.kubernetes.io/not-ready=:Exists:NoExecute for 300s
 ----
 
 
@@ -261,7 +261,7 @@ Tolerations:    node.alpha.kubernetes.io/notReady=:Exists:NoExecute for 300s
 
 When the Taint Based Evictions feature is enabled, the taints are automatically added by the node controller and the normal logic for evicting pods from `Ready` nodes is disabled.
 
-* If a node enters a not ready state, the `node.alpha.kubernetes.io/notReady:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
+* If a node enters a not ready state, the `node.alpha.kubernetes.io/not-ready:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 * If a node enters a not reachable state, the `node.alpha.kubernetes.io/unreachable:NoExecute` taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
 
 To enable Taint Based Evictions:
@@ -280,7 +280,7 @@ kubernetesMasterConfig:
 ----
 oc describe node $node | grep -i taint
 
-Taints: node.alpha.kubernetes.io/notReady:NoExecute
+Taints: node.alpha.kubernetes.io/not-ready:NoExecute
 ----
 
 . Restart OpenShift for the changes to take effect:
@@ -312,7 +312,7 @@ or
 [source, yaml]
 ----
 tolerations:
-- key: "node.alpha.kubernetes.io/notReady"
+- key: "node.alpha.kubernetes.io/not-ready"
   operator: "Exists"
   effect: "NoExecute"
   tolerationSeconds: 6000
@@ -327,7 +327,7 @@ To maintain the existing link:https://kubernetes.io/docs/admin/node/#node-contro
 [[admin-guide-taints-daemonsets]]
 == Daemonsets and Tolerations
 
-link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.alpha.kubernetes.io/unreachable` and `node.alpha.kubernetes.io/notReady`
+link:https://kubernetes.io/docs/admin/daemons/[DaemonSet] pods are created with `NoExecute` tolerations for `node.alpha.kubernetes.io/unreachable` and `node.alpha.kubernetes.io/not-ready`
 with no `tolerationSeconds` to ensure that DaemonSet pods are never evicted due to these problems, even when the Default Toleration Seconds feature is disabled.
 
 [[admin-guide-taints-use-cases]]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1610663

Also, Changed all instances of node.kubernetes.io/notReady to node.kubernetes.io/not-ready per @avesh comment in https://github.com/openshift/openshift-docs/pull/11483#discussion_r209084472