### PR TITLE
Added openshift_service_catalog_image_prefix and openshift_service_catalog_image_version details

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -1764,6 +1764,23 @@ cluster variable in your inventory file:
 openshift_enable_service_catalog=false
 ----
 
+If you use your own registry, you must add:
+
+* `openshift_service_catalog_image_prefix`: When pulling the service catalog
+image, force the use of a specific prefix (for example, `registry`). You must
+provide the full registry name up to the image name.
+
+* `openshift_service_catalog_image_version`: When pulling the service catalog
+image, force the use of a specific image version.
+
+For example:
+
+----
+openshift_service_catalog_image="docker-registry.default.example.com/openshift/ose-service-catalog:${version}"
+openshift_service_catalog_image_prefix="docker-registry-default.example.com/openshift/ose-"
+openshift_service_catalog_image_version="v3.9.30"
+template_service_broker_selector={"role":"infra"}
+----
 
 [[configuring-openshift-ansible-broker]]
 === Configuring the OpenShift Ansible Broker


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1599976

I will need to open a separate PR against 3.9, since the files were moved around in later versions.

@miheer PTAL