### PR TITLE
Added validation of storage migration to 3.6 upgrade guidance

### DIFF
--- a/install_config/upgrading/automated_upgrades.adoc
+++ b/install_config/upgrading/automated_upgrades.adoc
@@ -57,6 +57,14 @@ Ensure that you have met all
 xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[prerequisites]
 before proceeding with an upgrade. Failure to do so can result in a failed
 upgrade.
+
+The day before the upgrade, validate {product-title} storage migration to ensure
+potential issues are resolved prior to the outage window:
+
+----
+$ oc adm migrate storage --include=* --loglevel=2 --confirm --config /etc/origin/master/admin.kubeconfig
+----
+
 ====
 
 ifdef::openshift-origin[]

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -47,6 +47,14 @@ Ensure that you have met all
 xref:../../install_config/install/prerequisites.adoc#install-config-install-prerequisites[prerequisites]
 before proceeding with an upgrade. Failure to do so can result in a failed
 upgrade.
+
+The day before the upgrade, validate {product-title} storage migration to ensure
+potential issues are resolved prior to the outage window:
+
+----
+$ oc adm migrate storage --include=* --loglevel=2 --confirm --config /etc/origin/master/admin.kubeconfig
+----
+
 ====
 
 [[preparing-for-a-manual-upgrade]]


### PR DESCRIPTION
Related issue: https://github.com/openshift/openshift-docs/issues/10015
Related BZs: https://bugzilla.redhat.com/show_bug.cgi?id=1566438 and https://bugzilla.redhat.com/show_bug.cgi?id=1613759