### PR TITLE
[enterprise-3.6] added a note that firewalld is not supported on Atomic Host

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -112,7 +112,7 @@ project. This parameter value is a string that will be presented to a user in
 the web console and command line when the user attempts to self-provision a project.
 You might use one of the following messages:
 +
-* To request a project, contact your system administrator at 
+* To request a project, contact your system administrator at
 projectname@example.com.
 * To request a new project, fill out the project request form located at
 https://internal.example.com/openshift-project-request.
@@ -127,7 +127,7 @@ projectConfig:
   ...
 ----
 
-. Edit the `self-provisioners` cluster role to prevent 
+. Edit the `self-provisioners` cluster role to prevent
 xref:../install_config/upgrading/manual_upgrades.adoc#updating-policy-definitions[automatic updates]
 to the role. Automatic updates reset the cluster roles to the default state.
 ** To update the role from the command line:
@@ -172,6 +172,7 @@ xref:../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[added to a node
 after installation].
 ====
 
+[[setting-the-cluster-wide-default-node-selector]]
 === Setting the Cluster-wide Default Node Selector
 
 As a cluster administrator, you can set the cluster-wide default node selector

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1240,8 +1240,10 @@ ifdef::openshift-enterprise,openshift-origin[]
 
 [IMPORTANT]
 ====
-If you are changing the default firewall, ensure that each host in your cluster
+* If you are changing the default firewall, ensure that each host in your cluster
 is using the same firewall type to prevent inconsistencies.
+* Do not use firewalld with the {product-title} installed on Atomic Host.
+firewalld is not supported on Atomic host.
 ====
 
 [NOTE]
@@ -1264,11 +1266,10 @@ the Ansible host file at install:
 
 ----
 [OSEv3:vars]
-os_firewall_use_firewalld=True
+os_firewall_use_firewalld=True <1>
 ----
-
-Setting this variable to `true` opens the required ports and adds rules to the
-default zone, ensuring that firewalld is configured correctly.
+<1> Setting this variable to `true` opens the required ports and adds rules to
+the default zone, ensuring that firewalld is configured correctly.
 
 [NOTE]
 ====
@@ -1865,7 +1866,7 @@ endif::[]
 
 If you have xref:enabling-service-catalog[enabled the service catalog], you can
 also enable the
-xref:../../architecture/service_catalog/template_service_broker.adoc#arch-template-service-broke[template service broker] (TSB).
+xref:../../architecture/service_catalog/template_service_broker.adoc#arch-template-service-broker[template service broker] (TSB).
 
 To configure the TSB:
 


### PR DESCRIPTION
includes changes from #11669 