### PR TITLE
Improving etcd backup procedure for consistency

### DIFF
--- a/day_two_guide/topics/proc_backing-up-etcd.adoc
+++ b/day_two_guide/topics/proc_backing-up-etcd.adoc
@@ -201,6 +201,11 @@ Back up the etcd data:
     --backup-dir /backup/etcd-$(date +%Y%m%d)
 # cp /var/lib/etcd/member/snap/db /backup/etcd-$(date +%Y%m%d)
 ----
+.. Start all etcd services:
++
+----
+# systemctl start etcd.service
+----
 * If you use the v3 API, run the following commands:
 +
 [IMPORTANT]
@@ -208,15 +213,24 @@ Back up the etcd data:
 Because clusters upgraded from previous versions of {product-title} might
 contain v2 data stores, back up both v2 and v3 datastores.
 ====
+
+.. Back up etcd v3 data: 
 +
 ----
+# systemctl show etcd --property=ActiveState,SubState
 # mkdir -p /backup/etcd-$(date +%Y%m%d)
 # etcdctl3 snapshot save /backup/etcd-$(date +%Y%m%d)/db
 Snapshot saved at /backup/etcd-<date>/db
+----
+
+.. Back up etcd v2 data:
++
+----
 # systemctl stop etcd.service
 # etcdctl2 backup \
     --data-dir /var/lib/etcd \
     --backup-dir /backup/etcd-$(date +%Y%m%d)
+# cp /var/lib/etcd/member/snap/db /backup/etcd-$(date +%Y%m%d)    
 # systemctl start etcd.service
 ----
 +


### PR DESCRIPTION
Added missing cp file from v2 schema procedure as well as doing some fixes for consistency between v2 and v3 procedure.


Merging https://github.com/openshift/openshift-docs/pull/11492 here.