### PR TITLE
Fix typos and standardize F5 router plug-in name

### DIFF
--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -23,9 +23,8 @@ endif::[]
 
 [WARNING]
 ====
-The F5 router plug-in will be deprecated in {product_title} version 3.11. It
-will be replaced by the F5 BIG-IP Controller. For more information, see link:http://clouddocs.f5.com/containers/v2/openshift/[F5 Container Connector - OpenShift]. For information about migrating to the BIG-IP Controller, see
-link:http://clouddocs.f5.com/containers/v2/openshift/replace-f5-router.html[Replace the F5 Router in OpenShift].
+The F5 router plug-in will be deprecated in {product-title} version 3.11. The functionality of the F5 router plug-in has been replaced in the F5 BIG-IP® Controller for OpenShift, and it is now recommended for greenfield deployments. For more information, see link:http://clouddocs.f5.com/containers/v2/openshift/[F5 BIG-IP Controller for OpenShift]. For information about migrating existing deployments from the F5 router plug-in to the BIG-IP Controller for OpenShift, see
+link:http://clouddocs.f5.com/containers/v2/openshift/replace-f5-router.html[Replace the F5 Router with the F5 BIG-IP Controller for OpenShift in OpenShift].
 ====
 
 The F5 router plug-in is provided as a container image and run as a pod, just
@@ -35,11 +34,8 @@ HAProxy router].
 
 [IMPORTANT]
 ====
-Support relationships between F5 and Red Hat provide a full scope of support for
-F5 integration. F5 provides support for the *F5 BIG-IP®* product. Both F5 and
-Red Hat jointly support the integration with Red Hat OpenShift. While Red Hat
-helps with bug fixes and feature enhancements, all get communicated to F5
-Networks where they are managed as part of their development cycles.
+Support relationships between F5 and Red Hat provide a full scope of support for both models of 
+F5 integration (F5 router plug-in and the F5 BIG-IP Controller for OpenShift).
 ====
 
 [[install-router-f5-prerequisites]]
@@ -68,14 +64,16 @@ ifdef::openshift-origin[]
 * Ensure you have xref:../../install_config/router/index.adoc#creating-the-router-service-account[created the router service account].
 endif::[]
 
-{product-title} supports only the following *F5 BIG-IP®* versions:
+The F5 router plug-in for {product-title} supports only the following *F5 BIG-IP* versions:
 
 * 11.x
 * 12.x
 
+The F5 BIG-IP Controller for OpenShift supports the versions found in this matrix on Clouddocs.f5.com. see link:https://clouddocs.f5.com/containers/v2/releases_and_versioning.html[F5 BIG-IP Controller for OpenShift releases and versioning]
+
 [IMPORTANT]
 ====
-The following features are not supported with *F5 BIG-IP®*:
+The following features are not supported with *F5 BIG-IP* using the F5 router plug-in:
 
 * Wildcard routes together with re-encrypt routes - you must supply a certificate and a key in the route. If you provide a certificate, a key, and a certificate authority (CA), the CA is never used.
 * A pool is created for all services, even for the ones with no associated route.
@@ -88,17 +86,17 @@ The following features are not supported with *F5 BIG-IP®*:
 * Specifying a different target port (`PreferPort`/`TargetPort`) rather than the ones specified in the service.
 * Customizing the source IP whitelists, that is, allowing traffic for a route only from specific IP addresses.
 * Customizing timeout values, such as `max connect time`, or `tcp FIN timeout`.
-* HA mode for the *F5 BIG-IP®*.
+* HA mode for the *F5 BIG-IP*.
 ====
 
 [[f5-configuring-the-virtual-servers]]
 === Configuring the Virtual Servers
 
-As a prerequisite to working with the *openshift-F5* integrated router, two
+As a prerequisite to working with the F5 router plug-in, two
 virtual servers (one virtual server each for HTTP and HTTPS profiles,
-respectively) need to be set up in the *F5 BIG-IP®* appliance.
+respectively) need to be set up in the *F5 BIG-IP* appliance.
 
-To set up a virtual server in the *F5 BIG-IP®* appliance, follow the
+To set up a virtual server in the *F5 BIG-IP* appliance, follow the
 link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/ltm-basics-12-1-0/2.html[instructions
 from F5].
 
@@ -116,7 +114,7 @@ discusses that the certificate/key pair is the default that will be served in
 the case that custom certificates are not provided for a route or server name.
 
 [[deploying-the-f5-router]]
-== Deploying the F5 Router
+== Deploying the F5 Router Plug-in
 
 [IMPORTANT]
 ====
@@ -129,9 +127,9 @@ $ oc adm policy add-scc-to-user privileged -z router
 ----
 ====
 
-Deploy the F5 router with the `oc adm router` command, but provide additional
+Deploy the F5 router plug-in with the `oc adm router` command, but provide additional
 flags (or environment variables) specifying the following parameters for the *F5
-BIG-IP®* host:
+BIG-IP* host:
 
 [[f5-router-flags]]
 [cols="1,4"]
@@ -139,19 +137,19 @@ BIG-IP®* host:
 |Flag |Description
 
 |`--type=f5-router`
-|Specifies that an F5 router should be launched (the default `--type` is
+|Specifies that an F5 router plug-in should be launched (the default `--type` is
 *haproxy-router*).
 
 |`--external-host`
-|Specifies the *F5 BIG-IP®* host's management interface's host name or IP
+|Specifies the *F5 BIG-IP* host's management interface's host name or IP
 address.
 
 |`--external-host-username`
-|Specifies the *F5 BIG-IP®* user name (typically *admin*).
+|Specifies the *F5 BIG-IP* user name (typically *admin*).
 The *F5 BIG-IP* user account must have access to the Advanced Shell (Bash) on the F5 BIG-IP system.
 
 |`--external-host-password`
-|Specifies the *F5 BIG-IP®* password.
+|Specifies the *F5 BIG-IP* password.
 
 |`--external-host-http-vserver`
 |Specifies the name of the F5 virtual server for HTTP
@@ -163,15 +161,15 @@ HTTPS connections. This must be configured by the user
 prior to launching the router pod.
 
 |`--external-host-private-key`
-|Specifies the path to the SSH private key file for the *F5 BIG-IP®* host.
+|Specifies the path to the SSH private key file for the *F5 BIG-IP* host.
 Required to upload and delete key and certificate files for routes.
 
 |`--external-host-insecure`
-|A Boolean flag that indicates that the F5 router should skip strict certificate
-verification with the *F5 BIG-IP®* host.
+|A Boolean flag that indicates that the F5 router plug-in should skip strict certificate
+verification with the *F5 BIG-IP* host.
 
 |`--external-host-partition-path`
-|Specifies the *F5 BIG-IP®* xref:f5-router-partition-paths[partition path] (the default is */Common*).
+|Specifies the *F5 BIG-IP* xref:f5-router-partition-paths[partition path] (the default is */Common*).
 |===
 
 For example:
@@ -211,24 +209,24 @@ endif::[]
 
 As with the HAProxy router, the `oc adm router` command creates the service and
 deployment configuration objects, and thus the replication controllers and
-pod(s) in which the F5 router itself runs. The replication controller restarts
-the F5 router in case of crashes. Because the F5 router is watching routes,
-endpoints, and nodes and configuring *F5 BIG-IP®* accordingly, running the F5
-router in this way, along with an appropriately configured *F5 BIG-IP®*
+pod(s) in which the F5 router plug-in itself runs. The replication controller restarts
+the F5 router plug-in in case of crashes. Because the F5 router plug-in is watching routes,
+endpoints, and nodes and configuring *F5 BIG-IP* accordingly, running the F5
+router in this way, along with an appropriately configured *F5 BIG-IP*
 deployment, should satisfy high-availability requirements.
 
 [[f5-router-partition-paths]]
-== F5 Router Partition Paths
+== F5 Router Plug-in Partition Paths
 Partition paths allow you to store your {product-title} routing configuration in
-a custom *F5 BIG-IP®* administrative partition, instead of the default */Common*
-partition. You can use custom administrative partitions to secure *F5 BIG-IP®*
+a custom *F5 BIG-IP* administrative partition, instead of the default */Common*
+partition. You can use custom administrative partitions to secure *F5 BIG-IP*
 environments. This means that an {product-title}-specific configuration stored
-in *F5 BIG-IP®* system objects reside within a logical container, allowing
+in *F5 BIG-IP* system objects reside within a logical container, allowing
 administrators to define access control policies on that specific administrative
 partition.
 
 See the
-link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_0_0/tmos_partitions.html[*F5 BIG-IP®* documentation] for more information about administrative partitions.
+link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_0_0/tmos_partitions.html[*F5 BIG-IP* documentation] for more information about administrative partitions.
 
 To configure your {product-title} for partition paths:
 
@@ -238,12 +236,12 @@ To configure your {product-title} for partition paths:
 .. Delete the static FDB of `vxlan5000`. See
 the
 link:https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-implementations-12-0-0/9.html[F5
-BIG-IP® documentation] for more information.
+BIG-IP documentation] for more information.
 
 . xref:f5-configuring-the-virtual-servers[Configure a virtual server] for the
 custom partition.
 
-. Deploy the F5 router using the `--external-host-partition-path` flag to specify a partition path:
+. Deploy the F5 router plug-in using the `--external-host-partition-path` flag to specify a partition path:
 +
 ----
 $ oc adm router --external-host-partition-path=/OpenShift/zone1 ...
@@ -251,19 +249,19 @@ $ oc adm router --external-host-partition-path=/OpenShift/zone1 ...
 
 
 [[setting-up-f5-native-integration-with-openshift]]
-== Setting Up F5 Native Integration
+== Setting Up F5 Router Plug-in
 
 [NOTE]
 ====
-This section reviews how to set up F5 native integration with {product-title}.
+This section reviews how to set up F5 router plug-in with {product-title}.
 The concepts of F5 appliance and {product-title} connection and data flow of F5
-native integration are discussed in the
-xref:../../architecture/networking/assembly_available_router_plugins.adoc#architecture-f5-native-integration[F5 Native Integration] section of the Routes topic.
+router plug-in are discussed in the
+xref:../../architecture/networking/assembly_available_router_plugins.adoc#architecture-f5-native-integration[F5 Router Plug-in] section of the Routes topic.
 ====
 
 [NOTE]
 ====
-Only *F5 BIG-IP®* appliance version 12.x and above works with the native integration
+Only *F5 BIG-IP* appliance version 12.x and above works with the F5 router plug-in
 presented in this section. You also need sdn-services add-on license for the
 integration to work properly.
 For version 11.x, follow the instructions to set up a
@@ -272,17 +270,17 @@ node_].
 ====
 
 ifdef::openshift-enterprise[]
-As of {product-title} version 3.4, using native integration of F5 with
+As of {product-title} version 3.4, using F5 router plug-in with
 {product-title} does not require configuring a ramp node for F5 to be able to
 reach the pods on the overlay network as created by OpenShift SDN.
 endif::[]
 ifdef::openshift-origin[]
-With native integration of F5 with {product-title}, you do not need to
+With the F5 router plug-in for {product-title}, you do not need to
 configure a ramp node for F5 to be able to reach the pods on the overlay network
 as created by OpenShift SDN.
 endif::[]
 
-The F5 controller pod needs to be launched with enough information so that it can
+The F5 router plug-in pod needs to be launched with enough information so that it can
 successfully directly connect to pods.
 
 . Create a ghost `hostsubnet` on the {product-title} cluster:
@@ -334,14 +332,14 @@ this example).
 (for example, `10.131.0.5`). Use the mask of the pod network (`14`). The
 gateway address becomes: `10.131.0.5/14`.
 
-. Launch the F5 controller pod, following xref:deploying-the-f5-router[these instructions].
+. Launch the F5 router plug-in pod, following xref:deploying-the-f5-router[these instructions].
 Additionally, allow the access to 'node' cluster resource for the service account and
 use the two new additional options for VXLAN native integration.
 +
 ----
 $ # Add policy to allow router to access nodes using the sdn-reader role
 $ oc adm policy add-cluster-role-to-user system:sdn-reader system:serviceaccount:default:router
-$ # Launch the router pod with vxlan-gw and F5's internal IP as extra arguments
+$ # Launch the F5 router plug-in pod with vxlan-gw and F5's internal IP as extra arguments
 $ #--external-host-internal-ip=10.3.89.213
 $ #--external-host-vxlan-gw=10.131.0.5/14
 $ oc adm router \
@@ -363,4 +361,4 @@ $ oc adm router \
 The `external-host-username` is a *F5 BIG-IP* user account with access to the Advanced Shell (Bash) on the F5 BIG-IP system.
 ====
 
-The F5 setup is now ready, without the need to set up the ramp node.
+The F5 router plug-in is now ready, without the need to set up the ramp node.


### PR DESCRIPTION
Fix several typos {product_title} to {product-title}
Remove registered trademark symbol from all but first reference in document
standardize naming convention of F5 router plug-in, F5 BIG-IP Controller for OpenShift
added clarifying release and versioning verbiage around F5 router plug-in and the F5 BIG-IP controller for OpenShift.

There has been some field and customer confusion that we hope these standard naming conventions will alleviate.