### PR TITLE
Fix typos and standardize name - F5 router plug-in

### DIFF
--- a/architecture/topics/f5_big_ip.adoc
+++ b/architecture/topics/f5_big_ip.adoc
@@ -1,5 +1,5 @@
 ////
-F5 BIG-IP® Router plug-in
+F5 BIG-IP® Router Plug-in
 Module included in the following assemblies:
 
 * architecture/networking/assembly_available_router_plugins.adoc
@@ -18,25 +18,17 @@ The F5 router plug-in is available starting in OpenShift Enterprise 3.0.2.
 ====
 endif::[]
 
-The F5 router plug-in integrates with an existing *F5 BIG-IP®* system in your
-environment. *F5 BIG-IP®* version 11.4 or newer is required in order to have the
+The F5 router plug-in integrates with an existing *F5 BIG-IP* system in your
+environment. *F5 BIG-IP* version 11.4 or newer is required in order to have the
 F5 iControl REST API. The F5 router supports xref:../../architecture/networking/routes.adoc#route-types[unsecured],
 xref:../../architecture/networking/routes.adoc#edge-termination[edge terminated],
 xref:../../architecture/networking/routes.adoc#re-encryption-termination[re-encryption terminated], and
 xref:../../architecture/networking/routes.adoc#passthrough-termination[passthrough terminated] routes matching on HTTP
 vhost and request path.
 
-The F5 router has feature parity with the
+The F5 router plug-in has feature parity with the
 xref:../../architecture/networking/assembly_available_router_plugins.adoc#architecture-haproxy-router[HAProxy
-template router], and has additional features over the *F5 BIG-IP®* support in
-ifdef::openshift-enterprise[]
-OpenShift Enterprise 2.
-endif::[]
-ifdef::openshift-origin[]
-OpenShift v2.
-endif::[]
-Compared with the *routing-daemon* used in earlier
-versions, the F5 router additionally supports:
+template router]. The F5 router plug-in additionally supports:
 
 - path-based routing (using policy rules),
 - re-encryption (implemented using client and server SSL profiles)
@@ -47,7 +39,7 @@ the servername lookup).
 [NOTE]
 ====
 Passthrough routes are a special case: path-based routing is technically
-impossible with passthrough routes because *F5 BIG-IP®* itself does not see the
+impossible with passthrough routes because *F5 BIG-IP* itself does not see the
 HTTP request, so it cannot examine the path. The same restriction applies to the
 template router; it is a technical limitation of passthrough encryption, not a
 technical limitation of {product-title}.
@@ -56,13 +48,13 @@ technical limitation of {product-title}.
 [[routing-traffic-to-pods-through-the-sdn]]
 == Routing Traffic to Pods Through the SDN
 
-Because *F5 BIG-IP®* is external to the
+Because *F5 BIG-IP* is external to the
 xref:../../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[OpenShift SDN], a
-cluster administrator must create a peer-to-peer tunnel between *F5 BIG-IP®* and
+cluster administrator must create a peer-to-peer tunnel between *F5 BIG-IP* and
 a host that is on the SDN, typically an {product-title} node host.
 ifdef::openshift-dedicated[]
 This _ramp node_ can be configured as unschedulable for pods so that it will not
-be doing anything except act as a gateway for the *F5 BIG-IP®* host.
+be doing anything except act as a gateway for the *F5 BIG-IP* host.
 endif::[]
 ifdef::openshift-enterprise,openshift-origin[]
 This
@@ -70,7 +62,7 @@ xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-
 node_] can be configured as
 xref:../../admin_guide/manage_nodes.adoc#marking-nodes-as-unschedulable-or-schedulable[unschedulable]
 for pods so that it will not be doing anything except act as a gateway for the
-*F5 BIG-IP®* host.
+*F5 BIG-IP* host.
 endif::[]
 You can also configure multiple such hosts and use
 the {product-title} *ipfailover* feature for redundancy; the *F5 BIG-IP®* host would
@@ -80,7 +72,7 @@ endpoint.
 [[f5-integration-details]]
 == F5 Integration Details
 
-The operation of the F5 router is similar to that of the {product-title}
+The operation of the F5 router plug-in is similar to that of the {product-title}
 *routing-daemon* used in earlier versions. Both use REST API calls to:
 
 - create and delete pools,
@@ -88,12 +80,12 @@ The operation of the F5 router is similar to that of the {product-title}
 - configure policy rules to route to pools based on vhost.
 
 Both also use `scp` and `ssh` commands to upload custom TLS/SSL certificates to
-*F5 BIG-IP®*.
+*F5 BIG-IP*.
 
-The F5 router configures pools and policy rules on virtual servers as follows:
+The F5 router plug-in configures pools and policy rules on virtual servers as follows:
 
 - When a user creates or deletes a route on {product-title}, the router creates a
-pool to *F5 BIG-IP®* for the route (if no pool already exists) and adds a rule to, or
+pool to *F5 BIG-IP* for the route (if no pool already exists) and adds a rule to, or
 deletes a rule from, the policy of the appropriate vserver: the HTTP vserver for
 non-TLS routes, or the HTTPS vserver for edge or re-encrypt routes. In the case
 of edge and re-encrypt routes, the router also uploads and configures the TLS
@@ -110,30 +102,29 @@ work the same way as other routes.
 ====
 
 - When a user creates a service on {product-title}, the router adds a pool to *F5
-BIG-IP®* (if no pool already exists). As endpoints on that service are created
+BIG-IP* (if no pool already exists). As endpoints on that service are created
 and deleted, the router adds and removes corresponding pool members.
 
 - When a user deletes the route and all endpoints associated with a particular
 pool, the router deletes that pool.
 
 [[architecture-f5-native-integration]]
-== F5 Native Integration
+== F5 Router Plug-in
 
 ifdef::openshift-enterprise,openshift-origin[]
 With
-xref:../../install_config/router/f5_router.adoc#setting-up-f5-native-integration-with-openshift[native
-integration of F5 with {product-title}], you do not need to configure a ramp
+xref:../../install_config/router/f5_router.adoc#setting-up-f5-native-integration-with-openshift[F5 router plug-in with {product-title}], you do not need to configure a ramp
 node for F5 to be able to reach the pods on the overlay network as created by
 OpenShift SDN.
 
-Also, only *F5 BIG-IP®* appliance version 12.x and above works with the native integration
+Also, only *F5 BIG-IP* appliance version 12.x and above works with the native integration
 presented in this section. You also need `sdn-services` add-on license for the
 integration to work properly.
 For version 11.x, xref:../../install_config/routing_from_edge_lb.adoc#establishing-a-tunnel-using-a-ramp-node[set up a ramp
 node].
 endif::[]
 ifdef::openshift-dedicated[]
-With native integration of F5 with {product-title},
+With F5 router plug-in with {product-title},
 you do not need to configure a ramp node for F5 to be able to reach the pods on
 the overlay network as created by OpenShift SDN.
 endif::[]
@@ -165,7 +156,7 @@ the VxLAN device.
 [NOTE]
 ====
 This section explains how the packets reach the pods, and vice versa. These
-actions are performed by the F5 controller pod and the F5 appliance, not the
+actions are performed by the F5 router plug-in pod and the F5 appliance, not the
 user.
 ====
 
@@ -198,7 +189,7 @@ annotation on the manually created `hostsubnet` -
 `pod.network.openshift.io/fixed-vnid-host: 0`.
 
 A ghost `hostsubnet` is manually created as part of the setup, which fulfills
-the third and forth listed requirements. When the F5 controller pod is launched,
+the third and forth listed requirements. When the F5 router plug-in pod is launched,
 this new ghost `hostsubnet` is provided so that the F5 appliance can be
 programmed suitably.
 
@@ -209,8 +200,8 @@ given to a node of the cluster. However, in reality, it is not a real node of
 the cluster. It is hijacked by an external appliance.
 ====
 
-The first requirement is fulfilled by the F5 controller pod once it is launched.
-The second requirement is also fulfilled by the F5 controller pod, but it is an
+The first requirement is fulfilled by the F5 router plug-in pod once it is launched.
+The second requirement is also fulfilled by the F5 router plug-in pod, but it is an
 ongoing process. For each new node that is added to the cluster, the controller
 pod creates an entry in the VxLAN device’s VTEP FDB. The controller pod needs
 access to the `nodes` resource in the cluster, which you can accomplish by
@@ -226,7 +217,7 @@ $ oc adm policy add-cluster-role-to-user system:sdn-reader system:serviceaccount
 
 [NOTE]
 ====
-These actions are performed by the F5 controller pod and the F5 appliance, not
+These actions are performed by the F5 router plug-in pod and the F5 appliance, not
 the user.
 ====
 


### PR DESCRIPTION
Fix several typos {product_title} to {product-title}
Remove registered trademark symbol from all but first reference in document
standardize naming convention of F5 router plug-in, F5 BIG-IP Controller for OpenShift
added clarifying release and versioning verbiage around F5 router plug-in and the F5 BIG-IP controller for OpenShift.
Also removed references to OpenShift v2

There has been some field and customer confusion that we hope these standard naming conventions will alleviate.