### PR TITLE
Fixes wrong  Welcome page URLs in breadcrumbs

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -3,6 +3,9 @@ function versionSelector(list) {
   // the version we want
   newVersion = list[list.selectedIndex].value;
 
+  //decimal places in version
+  decimalPlaces = list.toString().split(".")[1].length
+
   // the new final link to load
   newLink = "";
 
@@ -21,7 +24,8 @@ function versionSelector(list) {
   // alert(fileRequested);
 
   // in 3.3 and above, we changed to container-platform
-  if(newVersion == 3.10 || newVersion >= 3.3) {
+  //count decimal places to diffrentiate between 3.10 and 3.1
+  if( (newVersion == 3.10 && decimalPlaces == 2)|| newVersion >= 3.3) {
     newLink = "https://docs.openshift.com/container-platform/" +
       newVersion +
       fileRequested;
@@ -40,4 +44,21 @@ function versionSelector(list) {
 function selectVersion(currentVersion) {
   document.getElementById("version-selector").value = currentVersion;
   // alert(currentVersion);
+
+  //decimal places in version
+  decimalPlaces = currentVersion.toString().split(".")[1].length
+
+  //hrefLink to load
+  hrefLink = "";
+
+  if( (currentVersion == 3.10 && decimalPlaces == 2)|| currentVersion >= 3.3) {
+    hrefLink = "https://docs.openshift.com/container-platform/" +
+    currentVersion + "/welcome/index.html";
+  } else {
+    hrefLink = "https://docs.openshift.com/enterprise/" +
+    currentVersion + "/welcome/index.html";
+  }
+
+  // update the welcome page URL
+  document.getElementById("welcome-page-link").href = hrefLink;
 }

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -52,11 +52,11 @@
       <li class="hidden-xs active">
         <% if (distro_key == "openshift-enterprise") %>
         <% if (version = "3.10" || version >= "3.3") %>
-          <a href="https://docs.openshift.com/container-platform/<%= version %>/welcome/index.html">
+          <a id="welcome-page-link" href="https://docs.openshift.com/container-platform/<%= version %>/welcome/index.html">
             <%= distro %>
           </a>
         <% else %>
-          <a href="https://docs.openshift.com/enterprise/<%= version %>/welcome/index.html">
+          <a id="welcome-page-link" href="https://docs.openshift.com/enterprise/<%= version %>/welcome/index.html">
             <%= distro %>
           </a>
         <% end %>


### PR DESCRIPTION
In current version, the welcome link always points to 3.10 Welcome page. This fixes the issue by updating the DOM with the current URL for selected version.