### PR TITLE
[enterprise-3.10] Remove fast-datapath

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -98,7 +98,6 @@ the first two repositories in this example.
 $ subscription-manager repos --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms" \
-    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.4-rpms"
 ----
 

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -131,7 +131,6 @@ $ subscription-manager repos --disable="*"
 $ subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.4-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms"
 ----
@@ -167,7 +166,6 @@ modify the command for the appropriate path you created above:
 $ for repo in \
 rhel-7-server-rpms \
 rhel-7-server-extras-rpms \
-rhel-7-fast-datapath-rpms \
 rhel-7-server-ansible-2.4-rpms \
 rhel-7-server-ose-3.10-rpms
 do
@@ -571,11 +569,6 @@ gpgcheck=0
 [rhel-7-server-extras-rpms]
 name=rhel-7-server-extras-rpms
 baseurl=http://<server_IP>/repos/rhel-7-server-extras-rpms
-enabled=1
-gpgcheck=0
-[rhel-7-fast-datapath-rpms]
-name=rhel-7-fast-datapath-rpms
-baseurl=http://<server_IP>/repos/rhel-7-fast-datapath-rpms
 enabled=1
 gpgcheck=0
 [rhel-7-server-ansible-2.4-rpms]

--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -176,7 +176,6 @@ Note that this could take a few minutes if you have a large number of available 
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.10-rpms" \
-    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-ansible-2.4-rpms"
 ----
 endif::[]

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -323,7 +323,6 @@ repository, if it is not already:
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ansible-2.4-rpms" \
-    --enable="rhel-7-fast-datapath-rpms"
 # yum clean all
 ----
 


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/11565/

Removing fast-datapath but keeping the right ansible version.