### PR TITLE
add fatal error log file

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -270,6 +270,13 @@ that extends this image and updates plugins in the custom image after
 the initial startup, by default they are not copied over, unless you set this
 environment variable to `true`.
 
+* `ENABLE_FATAL_ERROR_LOG_FILE` (default: `false`) 
++
+When running this image with an {product-title} persistent claim for the Jenkins
+config directory, this environment variable allows the fatal error log file to
+persist when a fatal error occurs. The fatal error file is saved at
+`/var/lib/jenkins/logs`.
+
 [[jenkins-cross-project-access]]
 === Cross Project Access
 


### PR DESCRIPTION
I was reading over the documentation and noticed this override is not in the documentation. Let me know if y'all want this in the official docs.