### PR TITLE
tempaltes: ocp version assignment fix

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -51,7 +51,7 @@
       </li>
       <li class="hidden-xs active">
         <% if (distro_key == "openshift-enterprise") %>
-        <% if (version = "3.10" || version >= "3.3") %>
+        <% if (version == "3.10" || version >= "3.3") %>
           <a href="https://docs.openshift.com/container-platform/<%= version %>/welcome/index.html">
             <%= distro %>
           </a>


### PR DESCRIPTION
* replaces the version assignment with the obviously intended comparison
* fixes the search scope, which is currently limited to OCP 3.10 results

Signed-off-by: Jiri Fiala <jfiala@redhat.com>