### PR TITLE
GitLab can use OIDC

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -1543,9 +1543,11 @@ xref:../admin_guide/manage_rbac.adoc#admin-guide-manage-rbac[control user roles]
 === GitLab
 
 Set `GitLabIdentityProvider` in the `identityProviders` stanza to use
-link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity provider, using the
+link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity
+provider. If you use GitLab version 7.7.0 to 11.0, you connect using the
 link:http://doc.gitlab.com/ce/integration/oauth_provider.html[OAuth integration].
-The OAuth provider feature requires GitLab version 7.7.0 or higher.
+If you use GitLab version 11.1 or later, you can use link:https://docs.gitlab.com/ce/integration/openid_connect_provider.html[OpenID Connect] (OIDC)
+to connect instead of OAuth.
 
 .Master configuration using `GitLabIdentityProvider`
 ====
@@ -1561,10 +1563,11 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: GitLabIdentityProvider
-      url: ... <5>
-      clientID: ... <6>
-      clientSecret: ... <7>
-      ca: ... <8>
+      legacy: <5>
+      url: ... <6>
+      clientID: ... <7>
+      clientSecret: ... <8>
+      ca: ... <9>
 ----
 <1> This provider name is prefixed to the GitLab numeric user ID to form an
 identity name. It is also used to build the callback URL.
@@ -1576,16 +1579,21 @@ grant flow to obtain an access token from GitLab.
 console) are redirected to GitLab to log in.
 <4> Controls how mappings are established between this provider's identities and user objects,
 xref:identity-providers_parameters[as described above].
-<5> The host URL of a GitLab OAuth provider. This could either be `\https://gitlab.com/`
+<5> Determines whether to use OAuth or OIDC as the authentication provider. Set
+to `true` to use OAuth and `false` to use OIDC. You must use GitLab.com or
+GitLab version 11.1 or later to use OIDC. If you do not provide a value, OAuth
+is used to connect to your GitLab instance, and OIDC is used to connect to
+GitLab.com.
+<6> The host URL of a GitLab provider. This could either be `\https://gitlab.com/`
 or any other self hosted instance of GitLab.
-<6> The client ID of a
-link:https://docs.gitlab.com/ce/api/oauth2.html[registered GitLab OAuth
-application]. The application must be configured with a callback URL of
+<7> The client ID of a
+link:https://docs.gitlab.com/ce/api/oauth2.html[registered GitLab OAuth application].
+The application must be configured with a callback URL of
 `<master>/oauth2callback/<identityProviderName>`.
-<7> The client secret issued by GitLab. This value may also be provided in an
+<8> The client secret issued by GitLab. This value may also be provided in an
 xref:../install_config/master_node_configuration.adoc#master-node-configuration-passwords-and-other-data[environment
 variable, external file, or encrypted file].
-<8> CA is an optional trusted certificate authority bundle to use when making
+<9> CA is an optional trusted certificate authority bundle to use when making
 requests to the GitLab instance. If empty, the default system roots are used.
 ====
 


### PR DESCRIPTION
From https://trello.com/c/HruwzLtI/923-document-move-gitlab-to-oidc

@enj, PTAL