### PR TITLE
Setting kubelet_args does no good

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -641,14 +641,6 @@ To view all available kubelet options:
 ----
 $ hyperkube kubelet -h
 ----
-+
-You can also set these values during an
-xref:../install/configuring_inventory_file.adoc#configuring-ansible[cluster installation] 
-using the `openshift_node_kubelet_args` variable. For example:
-
-----
-openshift_node_kubelet_args={'max-pods': ['40'], 'resolv-conf': ['/etc/resolv.conf'],  'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}
-----
 
 [[admin-guide-max-pods-per-node]]
 === Setting maximum pods per node


### PR DESCRIPTION
Settings openshift_node_kubelet_args in the ansible inventory file does
not work anymore.

See https://github.com/openshift/openshift-ansible/commit/69dfc670650563f339ef409c675c69a88573102b