### PR TITLE
Add cluster auto-scaler documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -675,6 +675,9 @@ Topics:
 - Name: Analyzing Cluster Capacity
   File: cluster_capacity
   Distros: openshift-origin,openshift-enterprise
+- Name: Configuring the cluster auto-scaler in AWS
+  File: cluster-autoscaler
+  Distros: openshift-origin,openshift-enterprise
 - Name: Kuryr SDN Administration
   File: kuryr
   Distros: openshift-origin,openshift-enterprise

--- a/admin_guide/cluster-autoscaler.adoc
+++ b/admin_guide/cluster-autoscaler.adoc
@@ -1,0 +1,34 @@
+[[configuring-cluster-auto-scaler-AWS]]
+= Configuring the cluster auto-scaler in AWS
+{product-author}
+{product-version}
+:data-uri:
+:icons: font
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+:context: cluster-auto-scaler
+
+toc::[]
+
+You can configure an auto-scaler on your {product-title} cluster in
+Amazon Web Services (AWS) to provide elasticity for yor application
+workload. The auto-scaler ensures that enough nodes are active to run
+your pods and that the number of active nodes is proportional to
+current demand.
+
+[NOTE]
+====
+You can run the auto-scaler only on Amazon Web Services (AWS).
+====
+
+include::admin_guide/topics/about-cluster-auto-scaler.adoc[leveloffset=+1]
+
+include::admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc[leveloffset=+1]
+
+include::admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc[leveloffset=+1]
+
+include::admin_guide/topics/deploying-cluster-auto-scaler.adoc[leveloffset=+1]
+
+include::admin_guide/topics/testing-auto-scaler.adoc[leveloffset=+1]

--- a/admin_guide/topics/about-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/about-cluster-auto-scaler.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * admin_guide/cluster-autoscaler.adoc
+
+[id='about-cluster-auto-scaler-{context}']
+= About the {product-title} auto-scaler
+
+The auto-scaler in {product-title} repeatedly checks to see how many
+pods are pending node allocation. If pods are pending allocation and
+the auto-scaler has not met its maximum capacity, then new nodes are
+continuously provisioned to accommodate the current demand. When
+demand drops and fewer nodes are required, the auto-scaler removes
+unused nodes. The behaviour of the auto-scaler is automatic - there's
+nothing additional to add to existing deployment beyond setting the
+desired number of replicas.
+
+In {product-title} version {product-version}, you can deploy the
+auto-scaler only on Amazon Web Services (AWS). The auto-scaler uses
+some standard AWS objects to manage your cluster size, including Auto
+Scaling Groups (ASGs) and Launch Configurations (LCs).
+
+The auto-scaler uses the following assets:
+
+Auto Scaling groups:: An Auto Scaling group (ASG) is a logical
+representation of a set of machines. You configure an ASG with a
+minimum number of instances to run, the maximum number of instances
+that can run, and your desired number of instances to run. An ASG
+starts by launching enough instances to meet your desired capacity.
+You can configure an ASGs to start with zero instances.
+
+Launch Configurations::
+A Launch Configuration (LC) is a template that an ASG uses to launch
+instances; you specify information such as the ID of the Amazon
+Machine Image (AMI); the instance type, such as *m4.large*; a key pair;
+one or more security groups; or subnets.
+
+{product-title} primed images::
+When the ASG provisions a new instance, the image that runs must have
+{product-name} already prepared. The ASG uses this image to both automatically
+bootstrap the node and enroll it within the cluster without any manual
+intervention.

--- a/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
@@ -42,8 +42,14 @@ runcmd:
 - [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]
 - [ systemctl, restart, systemd-hostnamed]
 - [ systemctl, restart, NetworkManager]
+ifdef::openshift-enterprise[]
 - [ systemctl, enable, atomic-openshift-node]
 - [ systemctl, start, atomic-openshift-node]
+endif::[]
+ifdef::openshift-origin[]
+- [ systemctl, enable, origin-node]
+- [ systemctl, start, origin-node]
+endif::[]
 EOF
 ----
 

--- a/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * admin_guide/cluster-autoscaler.adoc
+
+[id='creating-LC-and-ASG-cluster-auto-scaler-{context}']
+= Creating Launch Configuration and Auto Scale Group
+
+Before we can run the cluster-autoscaler deployment we need to create
+a LC and an ASG that reference a primed image. The LC that we create
+must be configured so that on first boot the new node will
+automatically join the existing cluster.
+
+.Procedure
+
+. Create the *_bootstrap.kubeconfig_* by copying it from the master node
++
+[source,bash]
+----
+$ ssh master "sudo cat /etc/origin/master/bootstrap.kubeconfig" > ~/bootstrap.kubeconfig
+----
+
+. Create the *_user-data.txt_* cloud-init stanza from the *_bootstrap.kubeconfig_* file
++
+[source,bash]
+----
+$ cat <<EOF > user-data.txt
+#cloud-config
+write_files:
+- path: /root/openshift_bootstrap/openshift_settings.yaml
+  owner: 'root:root'
+  permissions: '0640'
+  content: |
+    openshift_node_config_name: node-config-compute 
+- path: /etc/origin/node/bootstrap.kubeconfig
+  owner: 'root:root'
+  permissions: '0640'
+  encoding: b64
+  content: |
+    $(base64 ~/bootstrap.kubeconfig | sed '2,$s/^/    /')
+
+runcmd:
+- [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]
+- [ systemctl, restart, systemd-hostnamed]
+- [ systemctl, restart, NetworkManager]
+- [ systemctl, enable, atomic-openshift-node]
+- [ systemctl, start, atomic-openshift-node]
+EOF
+----
+
+. Create the Launch Configuration using the AWS CLI
++
+[source,bash]
+----
+$ aws autoscaling create-launch-configuration \
+    --launch-configuration-name mycluster-LC \ <1>
+    --region us-east-1 \ <2>
+    --image-id ami-987654321 \ <3>
+    --instance-type m4.large \ <4>
+    --security-groups sg-12345678 \ <5>
+    --user-data file://user-data.txt \ <6>
+    --key-name production-key \ <7>
+----
+<1> The name of the Launch Configuration
+<2> The region to launch the image in
+<3> The primed image AMI
+<4> The type of instance to launch
+<5> The security groups to attach to the launched image
+<6> The cloud-init user-data stanza
+<7> The SSH key-pair name
+
+. Create the Auto Scale Group using the AWS CLI
++
+[source,bash]
+----
+$ aws autoscaling create-auto-scaling-group \
+      --auto-scaling-group-name mycluster-ASG \ <1>
+      --launch-configuration-name mycluster-LC \ <2>
+      --min-size 0 \ <3>
+      --max-size 6 \ <4>
+      --vpc-zone-identifier subnet-12345678 \ <5>
+      --tags ResourceId=mycluster-ASG,ResourceType=auto-scaling-group,Key=Name,Value=mycluster-ASG-node,PropagateAtLaunch=true ResourceId=mycluster-ASG,ResourceType=auto-scaling-group,Key=kubernetes.io/cluster/mycluster,Value=true,PropagateAtLaunch=true ResourceId=mycluster-ASG,ResourceType=auto-scaling-group,Key=k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/compute,Value=true,PropagateAtLaunch=true <6>
+----
+<1> the name of the ASG, used later when running the deployment
+<2> the name of the LC, as created in the previous step
+<3> the minimum number of nodes the scale group should maintain
+<4> the maximum number of nodes the scale group can expand to
+<5> the VPC subnet-id, this is the same subnet the cluster is using
+<6> ensure that ASG tags are propagated to the nodes when they launch

--- a/admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc
@@ -80,10 +80,22 @@ openshift_aws_vpc: <11>
     - cidr: 172.18.0.0/20
       az: "us-east-1d"
 
+container_runtime_docker_storage_type: overlay2 <12>
+container_runtime_docker_storage_setup_device: /dev/xvdb <13>
+
 ifdef::openshift-enterprise[]
-rhsub_user: user@example.com <12>
-rhsub_pass: password <13>
-rhsub_pool: pool-id <14>
+# atomic-openshift-node service requires gquota to be set on the
+# filesystem that hosts /var/lib/origin/openshift.local.volumes (OCP
+# emptydir). Often is it not ideal or cost effective to deploy a vol
+# for emptydir. This pushes emptydir up to the / filesystem. Base ami
+# often does not ship with gquota enabled for /. Set this bool true to
+# enable gquota on / filesystem when using Red Hat Cloud Access RHEL7
+# AMI or Amazon Market RHEL7 AMI.
+openshift_aws_ami_build_set_gquota_on_slashfs: true <14>
+
+rhsub_user: user@example.com <15>
+rhsub_pass: password <16>
+rhsub_pool: pool-id <17>
 endif::[]
 ----
 <1> The name of the existing cluster
@@ -98,9 +110,12 @@ endif::[]
 <10> The security group name
 <11> The VPC subnets the existing cluster is running in
 ifdef::openshift-enterprise[]
-<12> Red Hat subscription-manager email address
-<13> Red Hat subscription-manager password
-<14> Red Hat subscription-manager Pool ID
+<12> Use overlay2 storage type for docker
+<13> Mountpoint for LVM and /var/lib/docker; block device created by build_ami playbook
+<14> Enable gquota on / filesystem when using Red Hat Cloud
+<15> Red Hat subscription-manager email address
+<16> Red Hat subscription-manager password
+<17> Red Hat subscription-manager Pool ID
 endif::[]
 
 . Run the AWS-specific playbook to generate a primed image

--- a/admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * admin_guide/cluster-autoscaler.adoc
+
+[id='creating-golden-image-cluster-auto-scaler-{context}']
+= Creating prime image (aka golden images)
+
+You can use Ansible playbooks to automatically create and seal a
+primed image that is suitable for use by a LC and its ASG. All the
+attibutes in the following steps are from your existing AWS cluster.
+
+[NOTE]
+====
+If you already have a pre-existing primed image you can skip this
+procedure.
+====
+
+.Procedure
+
+. Create an Ansible *_inventory_* file
++
+----
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+openshift_deployment_type=openshift-enterprise
+ansible_ssh_user=ec2-user
+openshift_clusterid=mycluster
+ansible_become=yes
+
+[masters]
+[etcd]
+[nodes]
+----
+
+. Create provisioning file *_build-ami-provisioning-vars.yaml_*
++
+[source,yaml]
+----
+ifdef::openshift-enterprise[]
+openshift_deployment_type: openshift-enterprise
+endif::[]
+ifdef::openshift-origin[]
+openshift_deployment_type: origin
+endif::[]
+
+openshift_aws_clusterid: mycluster <1>
+
+openshift_aws_region: us-east-1 <2>
+
+openshift_aws_create_vpc: false <3>
+
+openshift_aws_vpc_name: production <4>
+
+openshift_aws_subnet_az: us-east-1d <5>
+
+openshift_aws_create_security_groups: false <6>
+
+openshift_aws_ssh_key_name: production-ssh-key <7>
+
+openshift_aws_base_ami: ami-12345678 <8>
+
+openshift_aws_create_s3: False <9>
+
+openshift_aws_build_ami_group: default <10>
+
+openshift_aws_vpc: <11>
+  name: "{{ openshift_aws_vpc_name }}"
+  cidr: 172.18.0.0/16
+  subnets:
+    us-east-1:
+    - cidr: 172.18.0.0/20
+      az: "us-east-1d"
+
+ifdef::openshift-enterprise[]
+rhsub_user: user@example.com <12>
+rhsub_pass: password <13>
+rhsub_pool: pool-id <14>
+endif::[]
+----
+<1> The name of the existing cluster
+<2> The region the existing cluster is currently running in
+<3> Disable the creation of a VPC
+<4> The existing VPC name that the cluster is running in
+<5> The name of one subnet the existing cluster is running in
+<6> Disable the creation of security groups
+<7> The key name to use for SSH access
+<8> The base AMI image (https://www.redhat.com/en/technologies/cloud-computing/cloud-access)
+<9> Disable the creation of an S3 bucket
+<10> The security group name
+<11> The VPC subnets the existing cluster is running in
+ifdef::openshift-enterprise[]
+<12> Red Hat subscription-manager email address
+<13> Red Hat subscription-manager password
+<14> Red Hat subscription-manager Pool ID
+endif::[]
+
+. Run the AWS-specific playbook to generate a primed image
++
+----
+# ansible-playbook -i inventory \
+ifdef::openshift-enterprise[]
+    /usr/openshift-ansible/playbooks/aws/openshift-cluster/build_ami.yml
+endif::[]
+ifdef::openshift-origin[]
+    ~/openshift-ansible/playbooks/aws/openshift-cluster/build_ami.yml
+endif::[]
+    -e @build-ami-provisioning-vars.yaml
+----
+
+Once this completes the image ID (AMI) that is generated can be
+specified when creating the LC. On completion, the output of the
+playbook identifies the new AMI by id.

--- a/admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-golden-images-cluster-auto-scaler.adoc
@@ -26,7 +26,12 @@ nodes
 etcd
 
 [OSEv3:vars]
-openshift_deployment_type=openshift-enterprise
+ifdef::openshift-enterprise[]
+openshift_deployment_type: openshift-enterprise
+endif::[]
+ifdef::openshift-origin[]
+openshift_deployment_type: origin
+endif::[]
 ansible_ssh_user=ec2-user
 openshift_clusterid=mycluster
 ansible_become=yes

--- a/admin_guide/topics/deploying-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/deploying-cluster-auto-scaler.adoc
@@ -1,0 +1,241 @@
+// Module included in the following assemblies:
+//
+// * admin_guide/cluster-autoscaler.adoc
+
+[id='deploying-cluster-auto-scaler-{context}']
+= Deploying the auto-scaler components on your cluster
+
+Once we have created the ASG and its associated LC we can deploy the
+auto-scaler components onto the cluster.
+
+.Procedure
+. Create namespace
++
+[source,bash]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-autoscaler
+  annotations:
+    openshift.io/node-selector: ""
+EOF
+----
+
+. Create service account
++
+[source,shell]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: cluster-autoscaler
+EOF
+----
+
+. Create cluster role
++
+[source,shell]
+----
+$ oc apply -n cluster-autoscaler -f - <<EOF
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  attributeRestrictions: null
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  attributeRestrictions: null
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  attributeRestrictions: null
+EOF
+----
+
+. Create role
++
+[source,shell]
+----
+$ oc apply -n cluster-autoscaler -f - <<EOF
+apiVersion: v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cluster-autoscaler
+  - cluster-autoscaler-status
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+  attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  attributeRestrictions: null
+EOF
+----
+
+. Create AWS *_creds_* file
++
+[source,shell]
+----
+cat <<EOF > creds
+[default]
+aws_access_key_id = your-aws-access-key-id
+aws_secret_access_key = your-aws-secret-accesskey
+EOF
+----
+
+. Create AWS secrets for deployment
++
+[source,shell]
+----
+oc create secret -n cluster-autoscaler generic autoscaler-credentials --from-file=creds
+----
+
+. Create and grant cluster-reader policy to cluster-autoscaler serviceaccount
++
+[source,shell]
+----
+$ oc adm policy add-cluster-role-to-user cluster-autoscaler system:serviceaccount:cluster-autoscaler:cluster-autoscaler -n cluster-autoscaler
+
+$ oc adm policy add-role-to-user cluster-autoscaler system:serviceaccount:cluster-autoscaler:cluster-autoscaler --role-namespace cluster-autoscaler -n cluster-autoscaler
+
+$ oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:cluster-autoscaler:cluster-autoscaler -n cluster-autoscaler
+----
+
+. Deploy the cluster-autoscaler
++
+[source,shell]
+----
+$ oc apply -n cluster-autoscaler -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+      role: infra
+  template:
+    metadata:
+      labels:
+	app: cluster-autoscaler
+	role: infra
+    spec:
+      containers:
+      - args:
+	- /bin/cluster-autoscaler
+	- --alsologtostderr
+	- --v=4
+	- --skip-nodes-with-local-storage=False
+	- --leader-elect-resource-lock=configmaps
+	- --namespace=cluster-autoscaler
+	- --cloud-provider=aws
+	- --nodes=0:6:mycluster-ASG
+	env:
+	- name: AWS_REGION
+	  value: us-east-1
+	- name: AWS_SHARED_CREDENTIALS_FILE
+	  value: /var/run/secrets/aws-creds/creds
+ifdef::openshift-enterprise[]
+	image: registry.redhat.io/openshift3/ose-cluster-autoscaler:v3.11.0
+endif::[]
+ifdef::openshift-origin[]
+	image: docker.io/openshift/origin-cluster-autoscaler:v3.11.0
+endif::[]
+	name: autoscaler
+	volumeMounts:
+	- mountPath: /var/run/secrets/aws-creds
+	  name: aws-creds
+	  readOnly: true
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+	node-role.kubernetes.io/infra: "true"
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: aws-creds
+	secret:
+	  defaultMode: 420
+	  secretName: autoscaler-credentials
+EOF
+----

--- a/admin_guide/topics/testing-auto-scaler.adoc
+++ b/admin_guide/topics/testing-auto-scaler.adoc
@@ -1,0 +1,155 @@
+// Module included in the following assemblies:
+//
+// * admin_guide/cluster-autoscaler.adoc
+
+[id='testing-AWS-cluster-auto-scaler_{context}']
+= Testing the auto-scaler
+
+After you install or upgrade your cluster that uses the auto-scaler, you can
+confirm that auto scaling works.
+
+.Prerequisites
+
+* Your {product-title} cluster on Amazon Web Services (AWS) uses the
+auto-scaler.
+
+
+. Create the *_scale-up.yaml_* file that contains the deployment configuration
+to test auto-scaling:
++
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale-up
+  labels:
+    app: scale-up
+spec:
+  replicas: 20 <1>
+  selector:
+    matchLabels:
+      app: scale-up
+  template:
+    metadata:
+      labels:
+        app: scale-up
+    spec:
+      containers:
+      - name: origin-base
+        image: openshift/origin-base
+        resources:
+          requests:
+            memory: 2Gi
+        command:
+        - /bin/sh
+        - "-c"
+        - "echo 'this should be in the logs' && sleep 86400"
+      terminationGracePeriodSeconds: 0
+----
++
+<1> This deployment specifies 20 replicas, but the initial size of the cluster
+cannot run all of the pods without first increasing the number of compute nodes.
+
+. Create namespace
++
+[source,bash]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: autoscaler-demo
+EOF
+----
+
+. Deploy the configuration:
++
+[source,bash]
+----
+$ oc apply -n autoscaler-demo -f scale-up.yaml
+----
++
+. View the pods in your namespace:
+.. View the running pods in your namespace:
++
+[source,bash]
+----
+$ oc get pods -n autoscaler-demo | grep Running
+cluster-autoscaler-5485644d46-ggvn5   1/1       Running   0          1d
+scale-up-79684ff956-45sbg             1/1       Running   0          31s
+scale-up-79684ff956-4kzjv             1/1       Running   0          31s
+scale-up-79684ff956-859d2             1/1       Running   0          31s
+scale-up-79684ff956-h47gv             1/1       Running   0          31s
+scale-up-79684ff956-htjth             1/1       Running   0          31s
+scale-up-79684ff956-m996k             1/1       Running   0          31s
+scale-up-79684ff956-pvvrm             1/1       Running   0          31s
+scale-up-79684ff956-qs9pp             1/1       Running   0          31s
+scale-up-79684ff956-zwdpr             1/1       Running   0          31s
+----
+.. View the pending pods in your namespace:
++
+[source,bash]
+----
+$ oc get pods -n autoscaler-demo | grep Pending
+scale-up-79684ff956-5jdnj             0/1       Pending   0          40s
+scale-up-79684ff956-794d6             0/1       Pending   0          40s
+scale-up-79684ff956-7rlm2             0/1       Pending   0          40s
+scale-up-79684ff956-9m2jc             0/1       Pending   0          40s
+scale-up-79684ff956-9m5fn             0/1       Pending   0          40s
+scale-up-79684ff956-fr62m             0/1       Pending   0          40s
+scale-up-79684ff956-q255w             0/1       Pending   0          40s
+scale-up-79684ff956-qc2cn             0/1       Pending   0          40s
+scale-up-79684ff956-qjn7z             0/1       Pending   0          40s
+scale-up-79684ff956-tdmqt             0/1       Pending   0          40s
+scale-up-79684ff956-xnjhw             0/1       Pending   0          40s
+----
++
+These pending pods have nowhere to run. In the background, the cluster
+auto-scaler automatically provisions new compute nodes to run the pods on. It
+can take up to 7 minutes before the new nodes have a `Ready` state in the
+cluster.
+
+. After several minutes, check the list of nodes to see if new nodes are ready:
++
+[source,bash]
+----
+$ oc get nodes
+NAME                            STATUS    ROLES     AGE       VERSION
+ip-172-31-49-172.ec2.internal   Ready     infra     1d        v1.11.0+d4cacc0
+ip-172-31-53-217.ec2.internal   Ready     compute   7m        v1.11.0+d4cacc0
+ip-172-31-55-89.ec2.internal    Ready     compute   9h        v1.11.0+d4cacc0
+ip-172-31-56-21.ec2.internal    Ready     compute   7m        v1.11.0+d4cacc0
+ip-172-31-56-71.ec2.internal    Ready     compute   7m        v1.11.0+d4cacc0
+ip-172-31-63-234.ec2.internal   Ready     master    1d        v1.11.0+d4cacc0
+----
+
+. When more nodes are ready, view the running pods in your namespace again:
++
+[source,bash]
+----
+$ oc get pods -n autoscaler-demo
+NAME                                  READY     STATUS    RESTARTS   AGE
+cluster-autoscaler-5485644d46-ggvn5   1/1       Running   0          1d
+scale-up-79684ff956-45sbg             1/1       Running   0          8m
+scale-up-79684ff956-4kzjv             1/1       Running   0          8m
+scale-up-79684ff956-5jdnj             1/1       Running   0          8m
+scale-up-79684ff956-794d6             1/1       Running   0          8m
+scale-up-79684ff956-7rlm2             1/1       Running   0          8m
+scale-up-79684ff956-859d2             1/1       Running   0          8m
+scale-up-79684ff956-9m2jc             1/1       Running   0          8m
+scale-up-79684ff956-9m5fn             1/1       Running   0          8m
+scale-up-79684ff956-fr62m             1/1       Running   0          8m
+scale-up-79684ff956-h47gv             1/1       Running   0          8m
+scale-up-79684ff956-htjth             1/1       Running   0          8m
+scale-up-79684ff956-m996k             1/1       Running   0          8m
+scale-up-79684ff956-pvvrm             1/1       Running   0          8m
+scale-up-79684ff956-q255w             1/1       Running   0          8m
+scale-up-79684ff956-qc2cn             1/1       Running   0          8m
+scale-up-79684ff956-qjn7z             1/1       Running   0          8m
+scale-up-79684ff956-qs9pp             1/1       Running   0          8m
+scale-up-79684ff956-tdmqt             1/1       Running   0          8m
+scale-up-79684ff956-xnjhw             1/1       Running   0          8m
+scale-up-79684ff956-zwdpr             1/1       Running   0          8m
+...
+----


### PR DESCRIPTION
Documents how to setup, deploy and validate that the cluster auto-scaler is
functioning correctly. Only for AWS.