### PR TITLE
Fix Bug 1627616, default memory size changed from 8 to 16G on Elasticsearch.

### DIFF
--- a/install_config/aggregate_logging_sizing.adoc
+++ b/install_config/aggregate_logging_sizing.adoc
@@ -125,7 +125,7 @@ logging-fluentd-bh74n         1/1       Running     0          3d        ip-172-
 ----
 
 
-By default the amount of RAM allocated to each ES instance is 8GB.
+By default the amount of RAM allocated to each ES instance is 16GB.
 `*openshift_logging_es_memory_limit*` is the parameter used in the *openshift-ansible*
 host inventory file.
 Keep in mind that *half* of this value will be passed to the individual


### PR DESCRIPTION
Fix [BZ#1627616](https://bugzilla.redhat.com/show_bug.cgi?id=1627616).

The elasticsearch's template has configured default  memory size changed 8G to 16G.

[playbooks role: openshift_logging_elasticsearch - defaults/main.yml](https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_logging_elasticsearch/defaults/main.yml#L9)
~~~
openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('16Gi') }}"
~~~