### PR TITLE
Remove `remove-cluster-role-from-group` part

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -131,13 +131,6 @@ following command:
 $ oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
 ----
 +
-** If the `self-provisioners` clusterrolebinding binds the `self-provisioner`
-role to more users, groups, or serviceaccounts than the
-`system:authenticated:oauth` group, run the following command:
-+
-----
-$ oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth
-----
 
 . Set the `projectRequestMessage` parameter value in the
 *_master-config.yaml_* file to instruct developers how to request a new


### PR DESCRIPTION
Justification: if you run the `oc adm policy` the object ClusterRoleBinding is deleted. As this object is on the OCP bootstrap, next time the api is restarted the object will back to the current configuration so you have to do the previous steps again.