### PR TITLE
Adding in required section for scaling down and up ES dcs

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -3722,8 +3722,14 @@ $ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
           -d '{ "transient": { "cluster.routing.allocation.enable" : "none" } }'
 ----
 
-. Once complete, for each `dc` you have for an ES cluster, run `oc rollout latest`
-to deploy the latest version of the `dc` object:
+. Once complete, for each `dc` you have for an ES cluster, scale down all replicas:
++
+----
+$ oc scale dc <dc_name> --replicas=0
+----
+
+. Once scale down is complete, for each `dc` you have for an ES cluster, run
+`oc rollout latest` to deploy the latest version of the `dc` object:
 +
 ----
 $ oc rollout latest <dc_name>
@@ -3732,7 +3738,14 @@ $ oc rollout latest <dc_name>
 You will see a new pod deployed. Once the pod has two ready containers, you can
 move on to the next `dc`.
 
-. Once the restart is complete, enable all external communications to the ES
+. Once deployment is complete, for each `dc` you have for an ES cluster, scale up
+replicas:
++
+----
+$ oc scale dc <dc_name> --replicas=1
+----
+
+. Once the scale up is complete, enable all external communications to the ES
 cluster. Edit your non-cluster logging service (for example, `logging-es`,
 `logging-es-ops`) to match the ES pods running again:
 +


### PR DESCRIPTION
@mburke5678 PTAL
This affects the 3.10+ docs

As part of doing a manual full cluster ES restart, we need to have steps for scaling down the DC replicas. This was previously omitted somehow by myself.