### PR TITLE
moving ifdef

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -340,6 +340,7 @@ installed for this step. However, starting with {product-title} 3.10, that
 package is removed, and the *openshift-ansible* package provides all
 requirements.
 ====
+endif::[]
 
 .. If you do not set the `openshift_node_groups` variable in the inventory file's
 `[OSEv3:vars]` group, the default set of node groups and ConfigMaps will be


### PR DESCRIPTION
I think the 3.10 upgrade topic is missing an ifdef. [The topic](https://docs.okd.io/3.10/upgrading/automated_upgrades.html#verifying-the-upgrade) is missing steps compared to 3.9.

Here's how origin would look with this change: http://file.rdu.redhat.com/kalexand/091418/fix-okd-upgrade/upgrading/automated_upgrades.html

@adellape, will you PTAL? 

