### PR TITLE
Changes for haproxy dynamic configuration manager support.

### DIFF
--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -89,6 +89,12 @@ endif::[]
 |`ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK` |  | Set to `true` to relax the namespace ownership policy.
 |`ROUTER_STRICT_SNI` |  | xref:strict-sni[strict-sni]
 |`ROUTER_CIPHERS` | intermediate  | Specify the set of xref:ciphers[ciphers] supported by bind.
+|`ROUTER_HAPROXY_CONFIG_MANAGER` | | When set to `true` or `TRUE`, enables a dynamic configuration manager with HAproxy, which can manage certain types of routes and reduce the amount of HAproxy router reloads. See xref:../../install_config/router/default_haproxy_router.adoc#using-the-dynamic-configuration-manager[Using the Dynamic Configuration Manager] for more information.
+|`COMMIT_INTERVAL` | 3600 | Specifies how often to commit changes made with the dynamic configuration manager. This causes the underlying template router implementation to reload the configuration.
+|`ROUTER_BLUEPRINT_ROUTE_NAMESPACE` | | Set to the namespace that contain the routes that serve as blueprints for the dynamic configuration manager. This allows the dynamic configuration manager to support custom routes with any custom annotations, certificates, or configuration files.
+|`ROUTER_BLUEPRINT_ROUTE_LABELS` | | Set to a label selector to apply to the routes in the blueprint route namespace. This allows you to specify the routes in a namespace that can serve as blueprints for the dynamic configuration manager.
+|`ROUTER_BLUEPRINT_ROUTE_POOL_SIZE` | 10 | Specifies the size of the pre-allocated pool for each route blueprint that is managed by the dynamic configuration manager. This can be overriden on an individual route basis using the `router.openshift.io/pool-size` annotation on any blueprint route.
+|`ROUTER_MAX_DYNAMIC_SERVERS` | 5 | Specifies the maximum number of dynamic servers added to each route for use by the dynamic configuration manager.
 |===
 
 [NOTE]

--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1457,6 +1457,131 @@ access any pod in the cluster. If isolation is needed in this case, then do not
 add routes across the namespaces.
 ====
 
+[[using-the-dynamic-configuration-manager]]
+== Using the Dynamic Configuration Manager
+
+You can configure the HAProxy router to support the dynamic configuration
+manager.
+
+The dynamic configuration manager brings certain types of routes online without
+requiring HAProxy reload downtime. It handles any route and endpoint life-cycle
+events such as route and endpoint `addition|deletion|update`.
+
+Enable the dynamic configuration manager by setting the
+`ROUTER_HAPROXY_CONFIG_MANAGER` environment variable to `true`:
+
+----
+$ oc set env dc/<router_name> ROUTER_HAPROXY_CONFIG_MANAGER='true'
+----
+
+If the dynamic configuration manager cannot dynamically configure HAProxy, it
+rewrites the configuration and reloads the HAProxy process. For example, if a
+new route contains custom annotations, such as custom timeouts, or if the route
+requires custom TLS configuration.
+
+The dynamic configuration internally uses the HAProxy socket and configuration
+API with a pool of pre-allocated routes and back end servers. The pre-allocated
+pool of routes is created using route blueprints. The default set of blueprints
+supports unsecured routes, edge secured routes without any custom TLS
+configuration, and passthrough routes.
+
+[IMPORTANT]
+====
+`re-encrypt` routes require custom TLS configuration information, so extra
+configuration is needed in order to use them with the dynamic configuration
+manager.
+
+Extend the blueprints that the dynamic configuration manager can use by setting
+the `ROUTER_BLUEPRINT_ROUTE_NAMESPACE` and optionally the
+`ROUTER_BLUEPRINT_ROUTE_LABELS` environment variables.
+
+All routes, or the routes that match the route labels, in the blueprint route
+namespace are processed as custom blueprints similar to the default set of
+blueprints. This includes `re-encrypt` routes or routes that use custom
+annotations or routes with custom TLS configuration.
+====
+
+The following procedure assumes you have created three route objects:
+`reencrypt-blueprint`, `annotated-edge-blueprint`, and
+`annotated-unsecured-blueprint`. See xref:../../architecture/networking/routes.adoc#route-types[Route Types] for an example of the different route type objects.
+
+.Procedure
+
+. Create a new project:
++
+----
+$ oc new-project namespace_name
+----
+
+. Create a new route. This method exposes an existing service:
++
+----
+$ oc create route edge edge_route_name --key=/path/to/key.pem \
+      --cert=/path/to/cert.pem --service=<service> --port=8443
+----
+
+. Label the route:
++
+----
+$ oc label route edge_route_name type=route_label_1
+----
+
+. xref:../../dev_guide/routes.adoc#creating-routes[Create three different routes from route object definitions]. All have the label `type=route_label_1`:
++
+----
+$ oc create -f reencrypt-blueprint.yaml
+$ oc create -f annotated-edge-blueprint.yaml
+$ oc create -f annotated-unsecured-blueprint.json
+----
++
+You can also remove a label from a route, which prevents it from being used as a
+blueprint route. For example, to prevent the `annotated-unsecured-blueprint`
+from being used as a blueprint route:
++
+----
+$ oc label route annotated-unsecured-blueprint type-
+----
+
+. Create a new router to be used for the blueprint pool:
+----
+$ oc adm router
+----
+
+. Set the environment variables for the new router:
++
+----
+$ oc set env dc/router ROUTER_HAPROXY_CONFIG_MANAGER=true      \
+                       ROUTER_BLUEPRINT_ROUTE_NAMESPACE=namespace_name  \
+                       ROUTER_BLUEPRINT_ROUTE_LABELS="type=route_label_1"
+----
++
+All routes in the namespace or project `namespace_name` with label
+`type=route_label_1` can be processed and used as custom blueprints.
++
+Note that you can also add, update, or remove blueprints by managing the routes
+as you would normally in that namespace `namespace_name`. The dynamic
+configuration manager watches for changes to routes in the namespace
+`namespace_name` similar to how the router watches for `routes` and `services`.
+
+. The pool sizes of the pre-allocated routes and back end servers can be
+controlled with the `ROUTER_BLUEPRINT_ROUTE_POOL_SIZE`, which defaults to `10`,
+and `ROUTER_MAX_DYNAMIC_SERVERS`, which defaults to `5`, environment variables.
+You can also control how often changes made by the dynamic configuration manager
+are committed to disk, which is when the HAProxy configuration is re-written and
+the HAProxy process is reloaded. The default is one hour, or 3600 seconds, or
+when the dynamic configuration manager runs out of pool space. The
+`COMMIT_INTERVAL` environment variable controls this setting:
++
+----
+$ oc set env dc/router -c router ROUTER_BLUEPRINT_ROUTE_POOL_SIZE=20  \
+      ROUTER_MAX_DYNAMIC_SERVERS=3 COMMIT_INTERVAL=6h
+----
++
+The example increases the pool size for each blueprint route to `20`, reduces
+the number of dynamic servers to `3`, and increases the commit interval to `6`
+hours.
+
+
 [[exposing-the-router-metrics]]
 == Exposing Router Metrics
 


### PR DESCRIPTION
  o Add docs for the haproxy config manager to reduce reloads.
  o Document env variables for blueprint route config and dynamic config manager.
  o Add haproxy specific dynamic config manager info.

Pulls content and fixes typos from https://github.com/openshift/openshift-docs/pull/11712/.

(Also squashes commits)
