### PR TITLE
Rm monospace font from 'strong' element

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -615,7 +615,7 @@ span.footnote a:active, span.footnoteref a:active { text-decoration: underline; 
 div.unbreakable { page-break-inside: avoid; }
 code { color: #404040; background-color: #e7e7e7; font-weight: bold; font-family: "Roboto Mono", monospace;}
 h5 { color: #404040; }
-strong { color: #404040; font-weight: bold; font-family: "Roboto Mono", monospace; }
+strong { color: #404040; font-weight: bold; }
 a strong { color: inherit; }
 a code { color: inherit; }
 .replaceable { font-style: italic; font-color: inherit; font-family: inherit; }


### PR DESCRIPTION
Revert only the `<strong>` element changes from https://github.com/openshift/openshift-docs/pull/3702.

The changes for `<strong>` in the previous PR helped us smooth things over while we deprecated our use of the bold markup for certain items. Now that we're pretty well synced across our repo content on just using backticks (which show as monospace), it would be better to return bold markup to just being bold. Otherwise the only way we can achieve that currently is with horizontal/vertical labels, or with deep subsection headings.

cc @vikram-redhat 

Here's what the latest changes look like rendered:

![screenshot from 2018-09-19 13-23-46](https://user-images.githubusercontent.com/3442316/45770123-8794b000-bc0f-11e8-8990-5a84a9cc379d.png)
