### PR TITLE
Fix capitalization of RHEL and CentOS

### DIFF
--- a/using_images/other_images/jenkins.adoc
+++ b/using_images/other_images/jenkins.adoc
@@ -270,7 +270,7 @@ that extends this image and updates plugins in the custom image after
 the initial startup, by default they are not copied over, unless you set this
 environment variable to `true`.
 
-* `ENABLE_FATAL_ERROR_LOG_FILE` (default: `false`) 
+* `ENABLE_FATAL_ERROR_LOG_FILE` (default: `false`)
 +
 When running this image with an {product-title} persistent claim for the Jenkins
 config directory, this environment variable allows the fatal error log file to
@@ -282,7 +282,7 @@ persist when a fatal error occurs. The fatal error file is saved at
 Setting this value overrides the image used for the default NodeJS agent pod configuration.
 The default NodeJS agent pod uses `docker.io/openshift/jenkins-agent-nodejs-8-centos7` or
 `registry.redhat.io/openshift3/jenkins-agent-nodejs-8-rhel7` depending whether you are running
-the centos or rhel version of the Jenkins image.  This variable must be set before Jenkins starts
+the CentOS or RHEL version of the Jenkins image. This variable must be set before Jenkins starts
 the first time for it to have an effect.
 
 * `MAVEN_SLAVE_IMAGE`
@@ -290,7 +290,7 @@ the first time for it to have an effect.
 Setting this value overrides the image used for the default maven agent pod configuration.
 The default maven agent pod uses `docker.io/openshift/jenkins-agent-maven-35-centos7` or
 `registry.redhat.io/openshift3/jenkins-agent-maven-35-rhel7` depending whether you are running
-the centos or rhel version of the Jenkins image.  This variable must be set before Jenkins starts
+the CentOS or RHEL version of the Jenkins image. This variable must be set before Jenkins starts
 the first time for it to have an effect.
 
 
@@ -568,21 +568,21 @@ are allowed from the Pod.
 Consider the following with service accounts used for the Pod, launched by the Kubernetes
 Plug-in running in the {product-title} Jenkins image:
 
-- If you use the example template for Jenkins provided by {product-title}, the `jenkins` service 
+- If you use the example template for Jenkins provided by {product-title}, the `jenkins` service
 account is defined with the `edit` role for the project Jenkins is running in, and the master Jenkins
 Pod has that service account mounted.
-- The two default Maven and NodeJS Pod Templates injected into the Jenkins configuration are also 
+- The two default Maven and NodeJS Pod Templates injected into the Jenkins configuration are also
 set to use the same service account as the master.
 - Any Pod Templates auto-discovered by the link:https://github.com/openshift/jenkins-sync-plugin[OpenShift Sync plug-in]
-as a result of Image streams or Image stream tags having the required label or annotations have 
+as a result of Image streams or Image stream tags having the required label or annotations have
 their service account set to the master's service account.
 - For the other ways you can provide a Pod Template definition into Jenkins and the Kubernetes plug-in,
-you have to explicitly specify the service account to use. 
+you have to explicitly specify the service account to use.
 - Those other ways include the Jenkins console, the `podTemplate` pipeline DSL provided by the Kubernetes
 plug-in, or labeling a ConfigMap whose data is the XML configuration for a Pod Template.
 - If you do not specify a value for the service account, the `default` service account is used.
 - You need to ensure that whatever service account is used has the necessary permissions, roles, and so on defined within
-{product-title} to manipulate whatever projects you choose to manipulate from the within the Pod 
+{product-title} to manipulate whatever projects you choose to manipulate from the within the Pod
 
 [[jenkins-usage]]
 == Usage
@@ -798,7 +798,7 @@ specified.
 ====
 
 By default the pod is deleted when the build completes.
-This behavior can be modified via the plug-in or within a pipeline Jenkinsfile - see 
+This behavior can be modified via the plug-in or within a pipeline Jenkinsfile - see
 xref:../../using_images/other_images/jenkins_slaves.adoc#agent-pod-retention[Agent Pod Retention]
 for further details.
 
@@ -875,7 +875,7 @@ The {product-title} Pipeline Plug-in is a prior integration between Jenkins and
 {product-title} which provides less functionality than the {product-title}
 Client Plug-in. It has been deprecated but continues to work with {product-title}
 versions up to v3.11.  For later verions of {product-title}, either use the
-`oc` binary directly from your Jenkins Pipelines, or use the 
+`oc` binary directly from your Jenkins Pipelines, or use the
 xref:#client-plug-in[{product-title} Client Plug-in].
 
 See link:https://github.com/openshift/jenkins-plugin[the plug-in's README] for


### PR DESCRIPTION
This PR fixes the capitalization of RHEL and CentOS in two paragraphs. This is a simple formatting fix and does not require review. 