### PR TITLE
Liveliness probe does not log a failure - Follow Up

### DIFF
--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -104,9 +104,31 @@ livenessProbe:
 ...
 ----
 ====
+
 [NOTE]
 ====
-The `timeoutSeconds` parameter has no effect on the readiness and liveness probes for Container Execution Checks.
+The `timeoutSeconds` parameter has no effect on the readiness and liveness
+probes for Container Execution Checks. You can implement a timeout 
+inside the probe itself, as {product-title} cannot time out on an exec call into
+the container. One way to implement a timeout in a probe is by using the `timeout` parameter to run your
+liveness or readiness probe:
+
+----
+[...]
+       livenessProbe:
+        exec:
+          command:
+            - /bin/bash
+            - '-c'
+            - timeout 60 /opt/eap/bin/livenessProbe.sh <1>
+        timeoutSeconds: 1
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 3
+[...] 
+----
+
+<1> Timeout value and path to the probe script.
 ====
 
 *TCP Socket Checks*


### PR DESCRIPTION
Adding a comment from BZ after initial merge of https://github.com/openshift/openshift-docs/pull/11916

https://bugzilla.redhat.com/show_bug.cgi?id=1625227#c9