### PR TITLE
Drop oc types command

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -118,12 +118,6 @@ If you want to know the full list of resources the server supports, use `oc api-
 == Basic CLI Operations
 The following table describes basic `oc` operations and their general syntax:
 
-=== types
-Display an introduction to some core {product-title} concepts:
-----
-$ oc types
-----
-
 === login
 Log in to the {product-title} server:
 ----


### PR DESCRIPTION
In https://github.com/openshift/origin/pull/21018 I'm removing `oc types` entirely. This PR updates docs accordingly.

IMPORTANT: this applies only to 4.0 and up.

