### PR TITLE
Add apiserver qps and burst values recommendation for large clusters

### DIFF
--- a/scaling_performance/host_practices.adoc
+++ b/scaling_performance/host_practices.adoc
@@ -39,6 +39,21 @@ kubernetesMasterConfig:
     - "1000"
 ----
 
+For large and/or dense clusters, the API server might get overloaded because of the
+default QPS limits. Provided sufficient CPU and memory resources are available on the 
+API server system(s), this issue can be safely alleviated by doubling or quadrupling the 
+default API qps and burst values in the *_/etc/origin/master/master-config.yaml_* file:
+
+----
+masterClients:
+  externalKubernetesClientConnectionOverrides:
+    burst: 1600
+    qps: 800
+  openshiftLoopbackClientConnectionOverrides:
+    burst: 2400
+    qps: 1200
+----
+
 [[scaling-performance-capacity-host-practices-node]]
 == Recommended Practices for {product-title} Node Hosts
 


### PR DESCRIPTION
The apiserver might get overloaded because of low default values for
large and/or dense clusters. This commit adds a recommendation to
avoid this issue.