### PR TITLE
Adding new storage driver to the release notes

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -625,12 +625,21 @@ In {product-title} 3.11, `oc types` is now deprecated. It will be removed in a
 future release. Use official documentation instead.
 
 [discrete]
-[[ocp-311-ocp-uses-registry-redhat-io
-==== {product-title} Now Uses registry.redhat.io
+[[ocp-311-ocp-uses-registry-redhat-io]]
+==== New registry source for Red Hat images
 
 Instead of `registry.access.redhat.com`, {product-title} now uses
 `registry.redhat.io` as the source of images for version 3.11. For access,
 `registry.redhat.io` requires credentials.
+
+[discrete]
+[[ocp-311-new-storage-driver]]
+==== {product-title} New storage driver recommendation
+
+Red Hat strongly recommends xref:../scaling_performance/optimizing_storage.adoc#choosing-a-graph-driver[using the overlayFS storage driver over Device Mapper].
+For better performance, use overlayfs2 for Docker engine or overlayFS for CRI-O.
+Previously, we recommended using Device Mapper.
+
 
 [[ocp-311-bug-fixes]]
 == Bug Fixes


### PR DESCRIPTION
Per @Klaas- [request](https://github.com/openshift/openshift-docs/pull/11765#commitcomment-30531327), I am adding the new storage driver recommendation to the 3.11 release notes. 