### PR TITLE
bug 1479700 changed version to 3.3

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -3,7 +3,7 @@
 {product-author}
 {product-version}
 ifdef::openshift-enterprise[]
-:latest-tag: v3.3.1.25
+:latest-tag: v3.3
 endif::[]
 ifdef::openshift-origin[]
 :latest-tag: v1.4.1

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -2,7 +2,7 @@
 = Performing Manual In-place Cluster Upgrades
 {product-author}
 {product-version}
-:latest-tag: v3.3.1.25
+:latest-tag: v3.3
 :data-uri:
 :icons:
 :experimental:


### PR DESCRIPTION
Changed latest-tag to V3.3 per most recent instructions in the BZ. Applied in enterprise-3.3 release.

https://bugzilla.redhat.com/show_bug.cgi?id=1479700

@vikram-redhat, will you PTAL?
