### PR TITLE
[enterprise-3.11] Liveliness probe does not log a failure - Follow Up

### DIFF
--- a/dev_guide/application_health.adoc
+++ b/dev_guide/application_health.adoc
@@ -106,6 +106,32 @@ livenessProbe:
 ----
 ====
 
+[NOTE]
+====
+The `timeoutSeconds` parameter has no effect on the readiness and liveness
+probes for Container Execution Checks. You can implement a timeout 
+inside the probe itself, as {product-title} cannot time out on an exec call into
+the container. One way to implement a timeout in a probe is by using the `timeout` parameter to run your
+liveness or readiness probe:
+
+----
+[...]
+       livenessProbe:
+        exec:
+          command:
+            - /bin/bash
+            - '-c'
+            - timeout 60 /opt/eap/bin/livenessProbe.sh <1>
+        timeoutSeconds: 1
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 3
+[...] 
+----
+
+<1> Timeout value and path to the probe script.
+====
+
 *TCP Socket Checks*
 
 The kubelet attempts to open a socket to the container. The container is only


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/12084