### PR TITLE
Removed openshift_hostname

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -401,10 +401,6 @@ can be assigned to individual host entries:
 
 |Variable |Purpose
 
-|`openshift_hostname`
-|This variable overrides the internal cluster host name for the system. Use this
-when the system's default IP address does not resolve to the system host name.
-
 |`openshift_public_hostname`
 |This variable overrides the system's public host name. Use this for cloud
 installations, or for hosts on networks using a network address translation


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-ansible/issues/9665

Removed in OpenShift 3.10 as documented in the release notes. Cited as a documentation bug and no longer works as previously documented.