### PR TITLE
removing openshift_hostname parameter

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -414,10 +414,6 @@ can be assigned to individual host entries:
 
 |Variable |Purpose
 
-|`openshift_hostname`
-|This variable overrides the internal cluster host name for the system. Use this
-when the system's default IP address does not resolve to the system host name.
-
 |`openshift_public_hostname`
 |This variable overrides the system's public host name. Use this for cloud
 installations, or for hosts on networks using a network address translation

--- a/install/prerequisites.adoc
+++ b/install/prerequisites.adoc
@@ -624,7 +624,7 @@ connections, and is only required if you have clustered etcd.
 * In the above examples, port *4789* is used for User Datagram Protocol (UDP).
 * When deployments are using the SDN, the pod network is accessed via a service proxy, unless it is accessing the registry from the same node the registry is deployed on.
 * {product-title} internal DNS cannot be received over SDN. For non-cloud deployments, this will default to the IP address associated with the default route on the master host. For cloud deployments, it will default to the IP address associated with the first internal interface as defined by the cloud metadata.
-* The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed values of `*openshift_hostname*` and `*openshift_public_hostname*`.
+* The master host uses port *10250* to reach the nodes and does not go over SDN. It depends on the target host of the deployment and uses the computed value of `*openshift_public_hostname*`.
 * Port *1936* can still be inaccessible due to your iptables rules. Use the following to configure iptables to open port *1936*:
 +
 ----
@@ -720,7 +720,6 @@ Installation] topic discusses the available Ansible variables in greater detail.
 
 |`*hostname*`
 a| - Resolves to the internal IP from the instances themselves.
-- `*openshift_hostname*` overrides.
 
 |`*ip*`
 a| - The internal IP address of the instance.
@@ -738,13 +737,6 @@ a| - For all clouds but GCE, set to `true`.
 - `*openshift_use_openshift_sdn*` overrides.
 
 |===
-
-[WARNING]
-====
-If `*openshift_hostname*` is set to a value other than the metadata-provided
-`*private-dns-name*` value, the native cloud integration for those providers
-will no longer work.
-====
 
 ==== Post-Installation Configuration for Cloud Providers
 

--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -102,16 +102,8 @@ a| - A master instance where the VPC subnet is not configured for `*Auto-assign 
 
 |===
 
-[WARNING]
-====
-If `*openshift_hostname*` is set to a value other than the metadata-provided
-`*private-dns-name*` value, the native cloud integration for those providers
-will no longer work.
-====
-
 For EC2 hosts in particular, they must be deployed in a VPC that has both
-`*DNS host names*` and `*DNS resolution*` enabled, and `*openshift_hostname*`
-should not be overridden.
+`*DNS host names*` and `*DNS resolution*` enabled.
 
 [[configuring-aws-variables]]
 == Configuring AWS Variables

--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -153,16 +153,6 @@ After enabling the vSphere Cloud Provider, node names are set to the VM names
 from the vCenter Inventory.
 ====
 
-[WARNING]
-====
-The `openshift_hostname` variable must match the virtual machine name and its
-host name. The `openshift_hostname` variable defines the `nodeName` value in the
-*_node-config.yaml_* file. This value is compared to the `nodeName` value
-determined by using the command `uname -n`. In case of a mismatch, the native
-cloud integration for those providers will not work.
-====
-
-
 [[vsphere-configuration-file]]
 == The VMware vSphere Configuration File
 Configuring {product-title} for VMware vSphere requires the

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -245,7 +245,6 @@ In particular, the inventory must specify or override all host names and IP
 addresses set via the following variables such that they match the current
 cluster configuration:
 
-- `openshift_hostname`
 - `openshift_public_hostname`
 - `openshift_public_ip`
 - `openshift_master_cluster_hostname`


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/12224

There are more references to this parameter on the master branch.

@bbeaudoin, FYI

@jianlinliu, let me know if you're still ok with this change. 