### PR TITLE
syslog-output-plugin-for-fluentd should be moved from TP to GA

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -453,25 +453,6 @@ Prometheus cluster monitoring is now fully supported in {product-title} and depl
 
 See xref:../install_config/prometheus_cluster_monitoring.adoc#prometheus-cluster-monitoring[Configuring Prometheus Cluster Monitoring] for more information.
 
-[[ocp-311-syslog-output-plugin-for-fluentd]]
-==== syslog Output Plug-in for fluentd (Technology Preview)
-
-This feature is currently in xref:ocp-311-technology-preview[Technology Preview]
-and not for production workloads.
-
-You can send system and container logs from {product-title} nodes to external
-endpoints using the syslog protocol. The fluentd syslog output plug-in supports
-this.
-
-[IMPORTANT]
-====
-Logs sent via syslog are not encrypted and, therefore, insecure.
-====
-
-See
-xref:../install_config/aggregate_logging.adoc#sending-logs-to-external-rsyslog[Sending
-Logs to an External Syslog Server] for more information.
-
 [[ocp-311-elasticsearch-5-kibana-5]]
 ==== Elasticsearch 5 and Kibana 5
 
@@ -1503,10 +1484,10 @@ features marked *GA* indicate _General Availability_.
 |GA
 |GA
 
-|xref:ocp-311-syslog-output-plugin-for-fluentd[syslog Output Plug-in for fluentd]
-|TP
-|TP
-|TP
+|syslog Output Plug-in for fluentd
+|GA
+|GA
+|GA
 
 |xref:ocp-311-container-storage-Interface[Container Storage Interface (CSI)]
 |-


### PR DESCRIPTION
Per Tushar 9/25 email:
_I thought all blockers for above feature were fixed back in 3.9
z-stream. We should be moving this feature to GA - no?
If so below has to be updated to remove TP verbiage._

Jeff Cantrill in 9/28 scrum agreed to remove the TP 