### PR TITLE
Fix spelling typo in configuring_aws/configuring_vsphere

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -125,7 +125,7 @@ following contents on all of your {product-title} hosts, both masters and nodes:
 Zone = us-east-1c <1>
 ----
 <1> This is the Availability Zone of your AWS Instance and where your EBS Volume
-resides; this information is obtained from the AWS Managment Console.
+resides; this information is obtained from the AWS Management Console.
 
 
 [[aws-configuring-masters]]

--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -89,7 +89,7 @@ entities. vSphere Cloud Provider requires the following privileges to interact
 with vCenter. See the
 link:https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html[vSphere
 Documentation Center] for steps to create a custom role, user and role
-assignment. 
+assignment.
 +
 [cols="4*", width="100%",options="header"]
 |===
@@ -177,15 +177,15 @@ If the file does not exist, create it, and add the following:
         port = "443" <4>
         insecure-flag = "1" <5>
         datacenter = "mydatacenter" <6>
-        
+
 [VirtualCenter "1.2.3.4"] <7>
         user = "myvCenterusername"
         password = "password"
-        
+
 [VirtualCenter "1.2.3.5"]
         port = "448"
         insecure-flag = "0"
-        
+
 [Workspace] <8>
         server = "10.10.0.2" <9>
         datacenter = "mydatacenter"
@@ -199,7 +199,7 @@ If the file does not exist, create it, and add the following:
 [Network]
         public-network = "VM Network" <13>
 ----
-<1> Any properties set in the `[Global]` section are used for all specified vcenters unless overriden by the settings in the individual `[VirtualCenter]` sections.
+<1> Any properties set in the `[Global]` section are used for all specified vcenters unless overridden by the settings in the individual `[VirtualCenter]` sections.
 <2> vCenter username for the vSphere cloud provider.
 <3> vCenter password for the specified user.
 <4> Optional. Port number for the vCenter server. Defaults to port `443`.
@@ -216,7 +216,7 @@ If the file does not exist, create it, and add the following:
 
 [NOTE]
 ====
-Don't forget to escape special characters from the `username` and `password` fields, ex. user = "domain\\username" 
+Don't forget to escape special characters from the `username` and `password` fields, ex. user = "domain\\username"
 ====
 
 [[vsphere-configuring-masters]]
@@ -240,8 +240,8 @@ kubernetesMasterConfig:
     storage-backend:
     - etcd3
     storage-media-type:
-    - application/vnd.kubernetes.protobuf  
-    cloud-provider: <1> 
+    - application/vnd.kubernetes.protobuf
+    cloud-provider: <1>
     - "vsphere"
     cloud-config:
     - "/etc/origin/cloudprovider/vsphere.conf"


### PR DESCRIPTION
@openshift/team-documentation

/cherrypick enterprise-3.11
/cherrypick enterprise-3.10
/cherrypick enterprise-3.9
/cherrypick enterprise-3.8
/cherrypick enterprise-3.7
/cherrypick enterprise-3.6
/cherrypick enterprise-3.5
/cherrypick enterprise-3.4
/cherrypick enterprise-3.3
/cherrypick enterprise-3.2
/cherrypick enterprise-3.1
