### PR TITLE
[enterprise-3.10] Fix spelling typo in configuring_aws/configuring_vsphere

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -117,7 +117,7 @@ following contents on all of your {product-title} hosts, both masters and nodes:
 Zone = us-east-1c <1>
 ----
 <1> This is the Availability Zone of your AWS Instance and where your EBS Volume
-resides; this information is obtained from the AWS Managment Console.
+resides; this information is obtained from the AWS Management Console.
 
 
 [[aws-configuring-masters]]

--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -162,15 +162,15 @@ If the file does not exist, create it, and add the following:
         port = "443" <4>
         insecure-flag = "1" <5>
         datacenter = "mydatacenter" <6>
-        
+
 [VirtualCenter "1.2.3.4"] <7>
         user = "myvCenterusername"
         password = "password"
-        
+
 [VirtualCenter "1.2.3.5"]
         port = "448"
         insecure-flag = "0"
-        
+
 [Workspace] <8>
         server = "10.10.0.2" <9>
         datacenter = "mydatacenter"
@@ -184,7 +184,7 @@ If the file does not exist, create it, and add the following:
 [Network]
         public-network = "VM Network" <13>
 ----
-<1> Any properties set in the `[Global]` section are used for all specified vcenters unless overriden by the settings in the individual `[VirtualCenter]` sections.
+<1> Any properties set in the `[Global]` section are used for all specified vcenters unless overridden by the settings in the individual `[VirtualCenter]` sections.
 <2> vCenter username for the vSphere cloud provider.
 <3> vCenter password for the specified user.
 <4> Optional. Port number for the vCenter server. Defaults to port `443`.


### PR DESCRIPTION
Signed-off-by: William Zhang <zhang.wanmin@zte.com.cn>

From https://github.com/openshift/openshift-docs/pull/12244