### PR TITLE
[enterprise-3.6] Fix spelling typo in configuring_aws/configuring_vsphere

### DIFF
--- a/install_config/configuring_aws.adoc
+++ b/install_config/configuring_aws.adoc
@@ -127,7 +127,7 @@ following contents on all of your {product-title} hosts, both masters and nodes:
 Zone = us-east-1c <1>
 ----
 <1> This is the Availability Zone of your AWS Instance and where your EBS Volume
-resides; this information is obtained from the AWS Managment Console.
+resides; this information is obtained from the AWS Management Console.
 
 
 [[aws-configuring-masters]]


### PR DESCRIPTION
Signed-off-by: William Zhang <zhang.wanmin@zte.com.cn>

From https://github.com/openshift/openshift-docs/pull/12244