### PR TITLE
Added missing RHEL subscription reference

### DIFF
--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -143,6 +143,13 @@ Subscription Manager (RHSM) and attach an active {product-title} subscription.
 # subscription-manager attach --pool=<pool_id>
 ----
 
+List the attached subscriptions:
+----
+# subscription-manager list
+----
+
+OpenShift container platform should now be listed with a status of 'Subscribed'. Red Hat Enterprise Linux Server should also be listed with a status of 'Subscribed'. If it is not, then repeat the two steps above searching for '\*Red Hat Enterprise Linux*' instead of '\*OpenShift*'.
+
 . Disable all yum repositories:
 .. Disable all the enabled RHSM repositories:
 +


### PR DESCRIPTION
Currently, the step subscription-manager repos \
    --enable="rhel-7-server-rpms" \
    --enable="rhel-7-server-extras-rpms" \
    --enable="rhel-7-server-ose-3.11-rpms" \
    --enable="rhel-7-server-ansible-2.6-rpms" fails if the user follows the install guide due to the fact that the Red Hat Enterprise Linux subscription does not get attached. This fixes issue #12277.