### PR TITLE
 Manually Redeploy Certificates: Fix the overwrite secret command

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1061,7 +1061,7 @@ If the certificate secret was added to the router, overwrite the secret. If not,
 To overwrite the secret, run the following command:
 +
 ----
-$ oc create secret generic router-certs --from-file=tls.crt=custom-router.crt --from-file=tls.key=custom-router.key --type=kubernetes.io/tls -o json | oc replace -f -
+$ oc create secret generic router-certs --from-file=tls.crt=custom-router.crt --from-file=tls.key=custom-router.key --type=kubernetes.io/tls -o json --dry-run | oc replace -f -
 ----
 +
 To create a new secret, run the following commands:


### PR DESCRIPTION
The command to create the secret must have the `--dry-run` parameter as the secret already exists (you are overwriting it).
If the *dry* parameter is missed an error like the following will be thrown:
```
Error from server (AlreadyExists): secrets "router-certs" already exists
```