### PR TITLE
etcd restore for static pods

### DIFF
--- a/admin_guide/assembly_replace-master-host.adoc
+++ b/admin_guide/assembly_replace-master-host.adoc
@@ -17,7 +17,7 @@ You can replace a failed master host.
 
 First, remove the failed master host from your cluster, and then add a replacement
 master host. If the failed master host ran etcd, scale up etcd by adding etcd
-to the new master host.
+to the new master host. 
 
 [IMPORTANT]
 ====

--- a/admin_guide/assembly_restore-etcd-quorum.adoc
+++ b/admin_guide/assembly_restore-etcd-quorum.adoc
@@ -13,9 +13,13 @@
 toc::[]
 
 
-If you lose etcd quorum, you must back up etcd, take down your etcd cluster,
-and form a new one. You can use one healthy etcd node to form a new cluster, 
-but you must remove all other healthy nodes.
+If you lose etcd quorum, you can restore it.
+
+* If you run etcd on a separate host, you must back up etcd, take down
+your etcd cluster, and form a new one. You can use one healthy etcd node to form
+a new cluster, but you must remove all other healthy nodes.
+* If you run etcd as static pods on your master nodes, you stop the etcd pods,
+create a temporary cluster, and then restart the etcd pods.
 
 [NOTE]
 ====
@@ -46,10 +50,14 @@ cluster is unhealthy
 Note the member IDs and host names of the hosts. You use one of the nodes that
 can be reached to form a new cluster.
 
-include::day_two_guide/topics/proc_backing-up-etcd.adoc[leveloffset=+1]
+== Restoring etcd quorum for separate services
 
-include::day_two_guide/topics/proc_removing-etcd-host.adoc[leveloffset=+1]
+include::day_two_guide/topics/proc_backing-up-etcd.adoc[leveloffset=+2]
 
-include::admin_guide/topics/proc_etcd-quorum-single-node-v2-v3.adoc[leveloffset=+1]
+include::day_two_guide/topics/proc_removing-etcd-host.adoc[leveloffset=+2]
 
-include::day_two_guide/topics/proc_adding-etcd-after-restoring.adoc[leveloffset=+]
+include::admin_guide/topics/proc_etcd-quorum-single-node-v2-v3.adoc[leveloffset=+2]
+
+include::day_two_guide/topics/proc_adding-etcd-after-restoring.adoc[leveloffset=+2]
+
+include::admin_guide/topics/proc_etcd-quorum-static-pod.adoc[leveloffset=+1]

--- a/admin_guide/assembly_restoring-cluster.adoc
+++ b/admin_guide/assembly_restoring-cluster.adoc
@@ -30,6 +30,7 @@ include::admin_guide/topics/proc_restoring-cluster.adoc[leveloffset=+1]
 
 include::day_two_guide/topics/proc_restoring-master.adoc[leveloffset=+1]
 
+
 include::day_two_guide/topics/proc_restoring-node.adoc[leveloffset=+1]
 
 include::day_two_guide/topics/proc_restoring-etcd.adoc[leveloffset=+1]

--- a/admin_guide/topics/proc_etcd-quorum-static-pod.adoc
+++ b/admin_guide/topics/proc_etcd-quorum-static-pod.adoc
@@ -1,0 +1,49 @@
+////
+Restoring etcd quorum if you use static pods
+
+Module included in the following assemblies:
+
+* admin_guide/assembly_restore-etcd-quorum.adoc
+////
+
+[id='cluster-restore-etcd-quorum-static-pod_{context}']
+= Restoring etcd quorum for static pods
+
+If you lose etcd quorum on a cluster that uses static pods for etcd, take the
+following steps:
+
+[discrete]
+== Procedure
+
+. Stop the etcd pod:
++
+----
+mv /etc/origin/node/pods/etcd.yaml .
+----
+
+. Temporarily force a new cluster on the etcd host:
++
+----
+$ cp /etc/etcd/etcd.conf etcd.conf.bak
+$ echo "ETCD_FORCE_NEW_CLUSTER=true" >> /etc/etcd/etcd.conf
+----
+
+. Restart the etcd pod:
++
+----
+$ mv etcd.yaml /etc/origin/node/pods/.
+----
+
+. Stop the etcd pod and remove the `FORCE_NEW_CLUSTER` command:
++
+----
+$ mv /etc/origin/node/pods/etcd.yaml .
+$ rm /etc/etcd/etcd.conf
+$ mv etcd.conf.bak /etc/etcd/etcd.conf
+----
+
+. Restart the etcd pod:
++
+----
+$ mv etcd.yaml /etc/origin/node/pods/.
+----

--- a/day_two_guide/topics/con_deprecating-master-host.adoc
+++ b/day_two_guide/topics/con_deprecating-master-host.adoc
@@ -16,8 +16,8 @@ or replacing the underlying infrastructure.
 
 Highly available {product-title} environments require at least three master
 hosts and three etcd nodes. Usually, the master hosts are colocated with the
-etcd services. If you deprecate a master host, you must also deprecate the
-etcd service on that host.
+etcd services. If you deprecate a master host, you also remove the
+etcd static pods from that host.
 
 [IMPORTANT]
 ====

--- a/day_two_guide/topics/con_etcd_backup.adoc
+++ b/day_two_guide/topics/con_etcd_backup.adoc
@@ -21,7 +21,7 @@ only use the v2 data model. In an etcd v3 server, the v2 and v3 data stores
 exist in parallel and are independent.
 
 For both v2 and v3 operations, you can use the `ETCDCTL_API` environment
-variable to use the proper API:
+variable to use the correct API:
 
 ----
 $ etcdctl -v
@@ -35,6 +35,11 @@ API version: 3.2
 See
 link:https://docs.openshift.com/container-platform/3.7/upgrading/migrating_etcd.html[Migrating etcd Data (v2 to v3) section] in the {product-title} 3.7 documentation for
 information about how to migrate to v3.
+
+In {product-title} version 3.10 and later, you can either install etcd on
+separate hosts or run it as a static pod on your master hosts. If you do not
+specify separate etcd hosts, etcd runs as a static pod on master hosts. Because
+of this difference, the backup process is different if you use static pods. 
 
 The etcd backup process is composed of two different procedures:
 

--- a/day_two_guide/topics/proc_backing-up-etcd.adoc
+++ b/day_two_guide/topics/proc_backing-up-etcd.adoc
@@ -50,15 +50,16 @@ The {product-title} installer creates aliases to avoid typing all the
 flags named `etcdctl2` for etcd v2 tasks and `etcdctl3` for etcd v3 tasks.
 
 However, the `etcdctl3` alias does not provide the full endpoint list to the
-`etcdctl` command, so the `--endpoints` option with all the endpoints must be
-provided.
+`etcdctl` command, so you must specify the `--endpoints` option and list all
+the endpoints.
 ====
 
 Before backing up etcd:
 
-* `etcdctl` binaries should be available or, in containerized installations, the `rhel7/etcd` container should be available
-* Ensure connectivity with the etcd cluster (port 2379/tcp)
-* Ensure the proper certificates to connect to the etcd cluster
+* `etcdctl` binaries must be available or, in containerized installations, the `rhel7/etcd` container must be available.
+* Ensure that the {product-title} API service is running.
+* Ensure connectivity with the etcd cluster (port 2379/tcp).
+* Ensure the proper certificates to connect to the etcd cluster.
 
 ifeval::["{context}" == "environment-backup"]
 . To ensure the etcd cluster is working, check its health.
@@ -186,7 +187,7 @@ joining an existing cluster.
 
 Back up the etcd data:
 
-* If you use the v2 API, take the following actions:
+* If you run etcd on standalone hosts and use the v2 API, take the following actions:
 .. Stop all etcd services:
 +
 ----
@@ -206,7 +207,7 @@ Back up the etcd data:
 ----
 # systemctl start etcd.service
 ----
-* If you use the v3 API, run the following commands:
+* If you run etcd on standalone hosts and use the v3 API, run the following commands:
 +
 [IMPORTANT]
 ====
@@ -247,3 +248,35 @@ any external storage location.
 In the case of an all-in-one cluster, the etcd data directory is located in
 the `/var/lib/origin/openshift.local.etcd` directory.
 --
+* If etcd runs as a static pod, run the following commands:
++
+[IMPORTANT]
+====
+If you use static pods, use the v3 API.
+====
+.. Obtain the etcd endpoint IP address from the static pod manifest:
++
+----
+$ export ETCD_POD_MANIFEST="/etc/origin/node/pods/etcd.yaml"
+$ export ETCD_EP=$(grep https ${ETCD_POD_MANIFEST} | cut -d '/' -f3)
+----
+
+.. Obtain the etcd pod name:
++
+----
+$ oc login -u system:admin
+$ export ETCD_POD=$(oc get pods -n kube-system | grep -o -m 1 '\S*etcd\S*')
+----
+
+.. Take a snapshot of the etcd data in the pod and store it locally:
++
+----
+$ oc project kube-system
+$ oc exec ${ETCD_POD} -c etcd -- /bin/bash -c "ETCDCTL_API=3 etcdctl \
+    --cert /etc/etcd/peer.crt \
+    --key /etc/etcd/peer.key \
+    --cacert /etc/etcd/ca.crt \
+    --endpoints <ETCD_EP> \ <1>
+    snapshot save /etc/etcd/backup/etcd/snapshot.db"
+----
+<1> Specify the etcd endpoint IP address that you obtained.

--- a/day_two_guide/topics/proc_deprecating-master.adoc
+++ b/day_two_guide/topics/proc_deprecating-master.adoc
@@ -17,7 +17,7 @@ master host, these services must be stopped.
 The {product-title} API service is an active/active service, so stopping the
 service does not affect the environment as long as the requests are sent to a
 separate master server. However, the {product-title} controllers service is an
-active/passive service, where the services leverage etcd to decide the active
+active/passive service, where the services use etcd to decide the active
 master. 
 
 ////

--- a/day_two_guide/topics/proc_restoring-etcd.adoc
+++ b/day_two_guide/topics/proc_restoring-etcd.adoc
@@ -12,7 +12,7 @@ Module included in the following assemblies:
 = Restoring etcd
 
 The restore procedure for etcd configuration files replaces the appropriate
-files, then restarts the service.
+files, then restarts the service or static pod.
 
 If an etcd host has become corrupted and the `/etc/etcd/etcd.conf` file is lost,
 restore it using:
@@ -29,6 +29,13 @@ endif::[]
 In this example, the backup file is stored in the
 `/backup/yesterday/master-0-files/etcd.conf` path where it can be used as an
 external NFS share, S3 bucket, or other storage solution.
+
+[NOTE]
+====
+If you run etcd as a static pod, follow only the steps in that section. If you
+run etcd as a separate service on either master or standalone nodes, follow the
+steps to restore v2 and v3 data as required.
+====
 
 ifeval::["{context}" != "downgrade"]
 == Restoring etcd v2 & v3 data
@@ -251,4 +258,66 @@ endif::[]
 ifeval::["{context}" == "downgrade"]
 # journalctl -fu etcd.service
 endif::[]
+----
+
+== Restoring etcd on a static pod
+
+Before restoring etcd on a static pod:
+
+* `etcdctl` binaries must be available or, in containerized installations,
+the `rhel7/etcd` container must be available.
++
+You can obtain etcd by running the following commands:
++
+----
+$ git clone https://github.com/coreos/etcd.git
+$ cd etcd
+$ ./build
+----
+
+
+To restore etcd on a static pod:
+
+. If the pod is running, stop the etcd pod by moving the pod manifest YAML file
+to another directory:
++
+----
+$ mv /etc/origin/node/pods/etcd.yaml .
+----
+
+. Clear all old data:
++
+----
+$ rm -rf /var/lib/etcd
+----
++
+You use the etcdctl to recreate the data in the node where you restore the pod.
+
+. Restore the etcd snapshot to the mount path for the etcd pod:
++
+----
+$ export ETCDCTL_API=3
+$ etcdctl snapshot restore /etc/etcd/backup/etcd/snapshot.db 
+	 --data-dir /var/lib/etcd/ 
+	 --name ip-172-18-3-48.ec2.internal 
+	 --initial-cluster "ip-172-18-3-48.ec2.internal=https://172.18.3.48:2380" 
+	 --initial-cluster-token "etcd-cluster-1" 
+	 --initial-advertise-peer-urls https://172.18.3.48:2380 
+	 --skip-hash-check=true
+----
++
+Obtain the values for your cluster from the *_$/backup_files/etcd.conf_* file.
+
+. Set required permissions and selinux context on the data directory:
++
+----
+$ chown -R etcd.etcd /var/lib/etcd/
+$ restorecon -Rv /var/lib/etcd/
+----
+
+. Restart the etcd pod by moving the pod manifest YAML file to the required
+directory:
++
+----
+$ mv etcd.yaml /etc/origin/node/pods/.
 ----

--- a/install/example_inventories.adoc
+++ b/install/example_inventories.adoc
@@ -56,7 +56,7 @@ not supported.
 
 The following table describes an example environment for a single
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master]
-(with a single etcd on the same host), two
+(with a single etcd instance running as a static pod on the same host), two
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
 for hosting user applications, and two nodes with the `node-role.kubernetes.io/infra=true` label for hosting
 xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
@@ -426,7 +426,7 @@ The following describes an example environment for three
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[masters]
 using the `native` HA method (with
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[etcd]
-on each host), one HAProxy load balancer, two
+running as a static pod on each host), one HAProxy load balancer, two
 xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[nodes]
 for hosting user applications, and two nodes with the `node-role.kubernetes.io/infra=true` label for hosting
 xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
@@ -437,7 +437,8 @@ xref:configuring-dedicated-infrastructure-nodes[dedicated infrastructure]:
 |Host Name |Component/Role(s) to Install
 
 |*master1.example.com*
-.3+.^|Master (clustered using native HA) and node with etcd on each host
+.3+.^|Master (clustered using native HA) and node with etcd running as a static
+pod on each host
 
 |*master2.example.com*
 

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -90,9 +90,18 @@ instructions.
 . Provision as many new machines as there are masters to replace.
 
 . Add or expand the cluster. for example, if you want to add 3 masters with etcd
-colocated, scale up 3 master nodes or 3 etcd nodes.
+colocated, scale up 3 master nodes.
 
-.. Add a xref:../install_config/adding_hosts_to_existing_cluster.adoc#adding-cluster-hosts_adding-hosts-to-cluster[master]. In step 3 of that process, add the
+[IMPORTANT]
+====
+In the initial release of {product-title} version 3.11, the *_scaleup.yml_*
+playbook does not scale up etcd. This will be fixed in a
+future release on
+link:https://bugzilla.redhat.com/show_bug.cgi?id=1628201[BZ#1628201].
+====
+
+.. Add a xref:../install_config/adding_hosts_to_existing_cluster.adoc#adding-cluster-hosts_adding-hosts-to-cluster[master].
+In step 3 of that process, add the
 host of the new data center in `[new_masters]` and `[new_nodes]` and run the
 master *_scaleup.yml_* playbook.
 

--- a/scaling_performance/host_practices.adoc
+++ b/scaling_performance/host_practices.adoc
@@ -21,7 +21,8 @@ status, network configuration, secrets, and more.
 
 Optimize this traffic path by:
 
-* Co-locating master hosts and etcd servers.
+* Running etcd on master hosts. By default, etcd runs in a static pod on all
+master hosts.
 
 * Ensuring an uncongested, low latency LAN communication link between master hosts.
 

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -165,6 +165,13 @@ but ensure that you have a recent etcd backup at
 *_/backup/etcd-xxxxxx/backup.db_* before continuing. Manual etcd backup steps
 are described in the
 xref:../day_two_guide/environment_backup.adoc#etcd-backup_environment-backup[Day Two Operations Guide].
++
+[NOTE]
+====
+When you upgrade {product-title}, your etcd configuration does not change. 
+Whether you run etcd as static pods on master hosts or as a separate service on
+master hosts or separate hosts does not change after you upgrade.
+====
 
 .. Manually disable the 3.10 repository and enable the 3.11 repository on each
 master and node host. You must also enable the *rhel-7-server-ansible-2.6-rpms*

--- a/upgrading/downgrade.adoc
+++ b/upgrading/downgrade.adoc
@@ -63,7 +63,7 @@ On node and master hosts:
 /etc/origin/node/node-config.yaml
 ----
 +
-On etcd hosts (including masters that have etcd co-located on them):
+On etcd hosts, including masters that have etcd co-located on them:
 +
 ----
 /etc/etcd/etcd.conf


### PR DESCRIPTION
Draft of the changes for restoring etcd static pods. This change needs to be valid for both 3.10 and 3.11.