### PR TITLE
Move Authentication back under Third Party Registries

### DIFF
--- a/architecture/infrastructure_components/image_registry.adoc
+++ b/architecture/infrastructure_components/image_registry.adoc
@@ -46,6 +46,14 @@ creation. Refreshing the fetched tags is as simple as running `oc import-image
 <stream>`. When new images are detected, the previously-described build and
 deployment reactions occur.
 
+[[authentication]]
+=== Authentication
+{product-title} can communicate with registries to access private image
+repositories using credentials supplied by the user. This allows {product-title}
+to push and pull images to and from private repositories. The
+xref:../additional_concepts/authentication.adoc#architecture-additional-concepts-authentication[Authentication] topic has more
+information.
+
 [[red-hat-quay]]
 == Red Hat Quay Registries
 
@@ -63,14 +71,6 @@ for information about setting up your own Red Hat Quay registry.
 You can access your Red Hat Quay registry from {product-title} like any remote
 container image registry. To learn how to set up credentials to access
 Red Hat Quay as a secured registry, refer to xref:../../dev_guide/managing_images.adoc#allowing-pods-to-reference-images-from-other-secured-registries[Allowing Pods to Reference Images from Other Secured Registries].
-
-[[authentication]]
-=== Authentication
-{product-title} can communicate with registries to access private image
-repositories using credentials supplied by the user. This allows {product-title}
-to push and pull images to and from private repositories. The
-xref:../additional_concepts/authentication.adoc#architecture-additional-concepts-authentication[Authentication] topic has more
-information.
 
 [[auth-enabled-registry]]
 == Authentication Enabled Red Hat Registry


### PR DESCRIPTION
I accidentally bumped the Authentication section down when I moved the Quay section. This PR corrects the order. 