### PR TITLE
bug 1562768 adding no_proxy host names

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -1190,10 +1190,21 @@ the Docker daemon.
 and the Docker daemon.
 
 |`openshift_no_proxy`
-|This variable is used to set the `NO_PROXY` environment variable for masters
+a|This variable is used to set the `NO_PROXY` environment variable for masters
 and the Docker daemon. Provide a comma-separated list of host names, domain
 names, or wildcard host names that do not use the defined proxy. By default,
 this list is augmented with the list of all defined {product-title} host names.
+
+The host names that do not use the defined proxy include:
+
+* Master and node host names. You must include the domain suffix.
+* Other internal host names. You must include the domain suffix.
+* etcd IP addresses. You must provide the IP address because etcd access is managed by IP address.
+* The Docker registry IP address.
+* The Kubernetes IP address. This value is `172.30.0.1` by default and the
+`openshift_portal_net` parameter value if you provided one.
+* The `cluster.local` Kubernetes internal domain suffix.
+* The `svc` Kubernetes internal domain suffix.
 
 |`openshift_generate_no_proxy_hosts`
 |This boolean variable specifies whether or not the names of all defined


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1562768 

I'll need to manually replicate this change for 3.9 and CP that to 3.7 because the content is in a different file.