### PR TITLE
Update basic audit log example

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1133,8 +1133,8 @@ Each audit log contains two entries:
 Example output for user *admin* asking for a list of pods:
 
 ----
-AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" ip="127.0.0.1" method="GET" user="admin" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
-AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" response="200"
+{"kind":"Event","apiVersion":"audit.k8s.io/v1beta1","metadata":{"creationTimestamp":"2018-10-09T10:59:51Z"},"level":"Metadata","timestamp":"2018-10-09T10:59:51Z","auditID":"61e4394c-6ebc-453b-84af-018c98443457","stage":"RequestReceived","requestURI":"/api/v1/namespaces/default/pods?limit=500","verb":"list","user":{"username":"admin","uid":"7d20a7d7-c79d-11e8-8149-5254000d4f44","groups":["system:authenticated:oauth","system:authenticated"],"extra":{"scopes.authorization.openshift.io":["user:full"]}},"sourceIPs":["192.168.42.1"],"objectRef":{"resource":"pods","namespace":"default","apiVersion":"v1"},"requestReceivedTimestamp":"2018-10-09T10:59:51.487911Z","stageTimestamp":"2018-10-09T10:59:51.487911Z"}
+{"kind":"Event","apiVersion":"audit.k8s.io/v1beta1","metadata":{"creationTimestamp":"2018-10-09T10:59:51Z"},"level":"Metadata","timestamp":"2018-10-09T10:59:51Z","auditID":"61e4394c-6ebc-453b-84af-018c98443457","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/default/pods?limit=500","verb":"list","user":{"username":"admin","uid":"7d20a7d7-c79d-11e8-8149-5254000d4f44","groups":["system:authenticated:oauth","system:authenticated"],"extra":{"scopes.authorization.openshift.io":["user:full"]}},"sourceIPs":["192.168.42.1"],"objectRef":{"resource":"pods","namespace":"default","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2018-10-09T10:59:51.487911Z","stageTimestamp":"2018-10-09T10:59:51.489830Z"}
 ----
 
 The `openshift_master_audit_config` variable enables API service auditing. It


### PR DESCRIPTION
When auditConfig is enabled, the logs found in /var/log/audit-ocp.log are different from the ones found in the docs examples. The same scenario was recreated to get the same results with the new log messages.