### PR TITLE
Remove 3.10 specific items from downgrade and restore documentation

### DIFF
--- a/day_two_guide/topics/proc_bringing-openshift-online.adoc
+++ b/day_two_guide/topics/proc_bringing-openshift-online.adoc
@@ -20,22 +20,12 @@ After you finish your changes, bring {product-title} back online.
 backup and enable and restart all relevant services:
 +
 ----
-# cp ${MYBACKUPDIR}/etc/sysconfig/atomic-openshift-master-api /etc/sysconfig/atomic-openshift-master-api
-# cp ${MYBACKUPDIR}/etc/sysconfig/atomic-openshift-master-controllers /etc/sysconfig/atomic-openshift-master-controllers
+# cp ${MYBACKUPDIR}/etc/origin/node/pods/* /etc/origin/node/pods/
+# cp ${MYBACKUPDIR}/etc/origin/master/master.env /etc/origin/master/master.env
 # cp ${MYBACKUPDIR}/etc/origin/master/master-config.yaml.<timestamp> /etc/origin/master/master-config.yaml
 # cp ${MYBACKUPDIR}/etc/origin/node/node-config.yaml.<timestamp> /etc/origin/node/node-config.yaml
 # cp ${MYBACKUPDIR}/etc/origin/master/scheduler.json.<timestamp> /etc/origin/master/scheduler.json
-ifeval::["{context}" == "downgrade"]
-# cp ${MYBACKUPDIR}/usr/lib/systemd/system/atomic-openshift-master-api.service /usr/lib/systemd/system/atomic-openshift-master-api.service
-# cp ${MYBACKUPDIR}/usr/lib/systemd/system/atomic-openshift-master-controllers.service /usr/lib/systemd/system/atomic-openshift-master-controllers.service
-# rm /etc/systemd/system/atomic-openshift-node.service
-# systemctl daemon-reload
-endif::[]
-# systemctl enable atomic-openshift-master-api
-# systemctl enable atomic-openshift-master-controllers
 # systemctl enable atomic-openshift-node
-# systemctl start atomic-openshift-master-api
-# systemctl start atomic-openshift-master-controllers
 # systemctl start atomic-openshift-node
 ----
 
@@ -44,10 +34,6 @@ and enable and restart the *atomic-openshift-node* service:
 +
 ----
 # cp /etc/origin/node/node-config.yaml.<timestamp> /etc/origin/node/node-config.yaml
-ifeval::["{context}" == "downgrade"]
-# rm /etc/systemd/system/atomic-openshift-node.service
-# systemctl daemon-reload
-endif::[]
 # systemctl enable atomic-openshift-node
 # systemctl start atomic-openshift-node
 ----


### PR DESCRIPTION
This updates the downgrade and restore documentation service restoration steps to be accurate for 3.11. 