### PR TITLE
[enterprise-3.7] eventrouter namespace is not created automatically when deploying a cluster

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -203,7 +203,14 @@ where the pod will land.
 |The memory limit for eventrouter pods. The default is set to '128Mi'.
 
 |`openshift_logging_eventrouter_namespace`
-|The namespace where eventrouter is deployed. The default is set to 'default'.
+a|The project where *eventrouter* is deployed. The default is set to 'default'.
+
+[IMPORTANT]
+====
+Do not set the project to anything other then `default` or `openshift-*`. If you specify a different project, 
+event information from the other project can leak into indices that are not restricted to operations users.
+To use a non-default project, create the project as usual using `oc new-project`.
+====
 
 |`openshift_logging_image_pull_secret`
 |Specify the name of an existing pull


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/12240/