### PR TITLE
3.11 release notes - clarify ansible version

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -213,8 +213,8 @@ Your Inventory File] for more information.
 [[ocp-311-support-for-ansible-2-6]]
 ==== Support for Ansible 2.6
 
-`openshift-ansible` now supports Ansible 2.6 for both installation of
-{product-title} 3.11 and upgrading from verion 3.10.
+`openshift-ansible` now requires Ansible 2.6 for both installation of
+{product-title} 3.11 and upgrading from version 3.10.
 
 The minimum version of Ansible required for {product-title} 3.11 to run
 playbooks is now 2.6.x. On both master and node, use `subscription-manager` to
@@ -227,6 +227,8 @@ $ subscription-manager repos --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-ose-3.11-rpms" \
     --enable="rhel-7-server-ansible-2.6-rpms"
 ----
+
+Ansible 2.7 is not yet supported.
 
 [[ocp-311-registry-auth-credentials-required]]
 ==== Registry Auth Credentials Are Now Required


### PR DESCRIPTION
Ansible 2.6 minimum is required, ansible 2.7 is not supported