### PR TITLE
fixing /byo/ in paths

### DIFF
--- a/day_two_guide/topics/adding_master_host.adoc
+++ b/day_two_guide/topics/adding_master_host.adoc
@@ -101,7 +101,7 @@ using the `Ansible` host file:
 
 [subs=+quotes]
 ----
-$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-master/scaleup.yml*
+$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/openshift-master/scaleup.yml*
 ----
 
 NOTE: The scale up procedure for masters include the scale up procedure for nodes as well.

--- a/day_two_guide/topics/adding_node_host.adoc
+++ b/day_two_guide/topics/adding_node_host.adoc
@@ -94,7 +94,7 @@ by an `Ansible` playbook included in the `atomic-openshift-utils` using the `Ans
 
 [subs=+quotes]
 ----
-$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml*
+$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/openshift-node/scaleup.yml*
 ----
 
 In the event of scaling up an infrastructure node running a {rhocp} router, the

--- a/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
+++ b/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
@@ -41,7 +41,7 @@ etcd0.example.com <1>
 file, run the etcd `scaleup` playbook:
 +
 ----
-$ ansible-playbook  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-etcd/scaleup.yml
+$ ansible-playbook  /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/scaleup.yml
 ----
 
 . After the playbook runs, modify the inventory file to reflect the current 

--- a/day_two_guide/topics/pruning_images_and_containers.adoc
+++ b/day_two_guide/topics/pruning_images_and_containers.adoc
@@ -173,7 +173,7 @@ After modifying the `Ansible` variable content, running the installer again
 may configure the new settings and restart the services:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the
@@ -282,7 +282,7 @@ After modifying the `Ansible` variable content, running the installer again
 may configure the new settings and restart the services:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the
@@ -388,7 +388,7 @@ After modifying the `Ansible` variable content, running the installer again
 may configure the new settings and restart the services:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -279,7 +279,7 @@ inventory file to the new CIDR:
 . Run the `*config.yml*` Ansible playbook to redeploy the cluster:
 +
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-master/config.yml
+# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-master/config.yml
 ----
 
 include::day_two_guide/topics/increasing_docker_storage.adoc[tag=evacuating-a-node]


### PR DESCRIPTION
In 3.9, many playbooks were moved out of the /byo/ folder. This PR is to the fix remaining incorrect references to that folder.