### PR TITLE
Correct each storage class name as each component name in example

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -1496,8 +1496,7 @@ openshift_metrics_cassandra_storage_type=dynamic
 
 If there are multiple default dynamically provisioned volume types, such as
 gluster-storage and glusterfs-storage-block, you can specify the
-provisioned volume type by variable. For example, `openshift_logging_es_pvc_storage_class_name=glusterfs-storage-block
-openshift_metrics_cassandra_pvc_storage_class_name=glusterfs-storage-block`.
+provisioned volume type by variable. For example, `openshift_metrics_cassandra_pvc_storage_class_name=glusterfs-storage-block`.
 
 Check
 xref:../install_config/master_node_configuration.adoc#master-node-config-volume-config[Volume
@@ -1628,8 +1627,7 @@ openshift_logging_es_pvc_dynamic=true
 
 If there are multiple default dynamically provisioned volume types, such as
 gluster-storage and glusterfs-storage-block, you can specify the
-provisioned volume type by variable. For example, `openshift_logging_es_pvc_storage_class_name=glusterfs-storage-block
-openshift_metrics_cassandra_pvc_storage_class_name=glusterfs-storage-block`.
+provisioned volume type by variable. For example, `openshift_logging_es_pvc_storage_class_name=glusterfs-storage-block`.
 
 Check
 xref:../install_config/master_node_configuration.adoc#master-node-config-volume-config[Volume


### PR DESCRIPTION
The parameter names are duplicated/repeated same one in logging and metrics component sections in example.

I think just one correct parameter is need to each section in each example, and it's too long to display their page layout either.