### PR TITLE
disable ansible 2.4

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -179,6 +179,7 @@ repository, if it is not already enabled:
 +
 ----
 # subscription-manager repos --disable="rhel-7-server-ose-3.10-rpms" \
+    --disable="rhel-7-server-ansible-2.4-rpms" \
     --enable="rhel-7-server-ose-3.11-rpms" \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \


### PR DESCRIPTION
@jiajliu, @sdodson, I see at least one report on the mailing list that you need to disable ansible-2.4 during upgrade. Does this change sound right to you? 