### PR TITLE
Add a description about "ansible_service_broker_node_selector" for v3.11

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -248,6 +248,11 @@ automatically join the cluster when provided a bootstrap credential. Set to
 xref:../admin_guide/cluster-autoscaler.adoc#configuring-cluster-auto-scaler-AWS[cluster auto-scaler]
 on an Amazon Web Services (AWS) cluster. The default value is `false`.
 
+|`ansible_service_broker_node_selector`
+|Default node selector for automatically deploying Ansible service broker pods,
+defaults `{"node-role.kubernetes.io/infra":"true"}`. See
+xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
+
 |`template_service_broker_selector`
 |Default node selector for automatically deploying template service broker pods,
 defaults `{"node-role.kubernetes.io/infra":"true"}`. See


### PR DESCRIPTION
Fix a [[DOCS] Add to describe about ansible_service_broker_node_selector](https://bugzilla.redhat.com/show_bug.cgi?id=1638184).

This PR for v3.11.