### PR TITLE
Add "ansible_service_broker_node_selector" for v3.9

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -35,9 +35,12 @@ maintain state when recreated. Therefore pods should usually be managed by
 higher-level xref:../../architecture/core_concepts/deployments.adoc#replication-controllers[controllers],
 rather than directly by users.
 
-[IMPORTANT]
+[NOTE]
 ====
-The recommended maximum number of pods per {product-title} node host is 110.
+See the
+xref:../../scaling_performance/cluster_limits.adoc#scaling-performance-current-cluster-limits[Cluster
+Limits] page for the maximum number of pods per node supported limits for each version of
+{product-title}.
 ====
 
 [WARNING]

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -322,6 +322,11 @@ xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 |This variable enables the template service broker by specifying one or more
 namespaces whose templates will be served by the broker.
 
+|`ansible_service_broker_node_selector`
+|Default node selector for automatically deploying Ansible service broker pods,
+defaults `{"region": "infra"}`. See
+xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
+
 |`template_service_broker_selector`
 |Default node selector for automatically deploying template service broker pods,
 defaults `{"region": "infra"}`. See


### PR DESCRIPTION
Fix [[DOCS] Add to describe about ansible_service_broker_node_selector](https://bugzilla.redhat.com/show_bug.cgi?id=1638184) for v3.9.

The v3.9 is default value is different with v3.10 and v3.11, the vaule is `region=infra`.