### PR TITLE
"Configuring Your Inventory File" section sync with v3.11

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -119,7 +119,11 @@ cluster from going out of sync, do not change the default value of this paramete
 ====
 
 |`openshift_master_admission_plugin_config`
-a|This variable sets the parameter and arbitrary JSON values as per the requirement in your inventory hosts file.
+a|This variable sets the parameter and arbitrary JSON values as per the requirement in your inventory hosts file. For example:
+
+----
+openshift_master_admission_plugin_config={"ClusterResourceOverride":{"configuration":{"apiVersion":"v1","kind":"ClusterResourceOverrideConfig","memoryRequestToLimitPercent":"25","cpuRequestToLimitPercent":"25","limitCPUToMemoryPercent":"200"}}}
+----
 
 |`openshift_master_audit_config`
 |This variable enables API service auditing. See
@@ -246,13 +250,13 @@ on an Amazon Web Services (AWS) cluster. The default value is `false`.
 
 |`template_service_broker_selector`
 |Default node selector for automatically deploying template service broker pods,
-defaults `{"region": "infra"}`. See
+defaults `{"node-role.kubernetes.io/infra":"true"}`. See
 xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 
 |`osm_default_node_selector`
 |This variable overrides the node selector that projects will use by default when
 placing pods, which is defined by the `projectConfig.defaultNodeSelector` field
-in the master configuration file. This defaults
+in the master configuration file. Starting in {product-title} 3.9, this defaults
 to `node-role.kubernetes.io/compute=true` if undefined.
 
 |`openshift_docker_additional_registries`
@@ -287,8 +291,6 @@ blocks everything not in the other variables.
 |This variable sets the host name for integration with the metrics console by
 overriding `metricsPublicURL` in the master configuration for cluster metrics.
 If you alter this variable, ensure the host name is accessible via your router.
-See xref:advanced-install-cluster-metrics[Configuring Cluster Metrics] for
-details.
 
 |`openshift_clusterid`
 |This variable is a cluster identifier unique to the AWS Availability Zone. Using this avoids potential issues in Amazon Web Services
@@ -474,6 +476,7 @@ xref:marking-masters-as-unschedulable-nodes[Configuring Schedulability on Master
 |`openshift_node_problem_detector_install`
 |This variable is used to activate the xref:../admin_guide/node_problem_detector.adoc#admin-guide-node-problem-detector[Node Problem Detector].
 If set to `false, the default`, the Node Problem Detector is not installed or started.
+
 |===
 
 [[configuring-inventory-defining-node-group-and-host-mappings]]
@@ -881,7 +884,7 @@ If you use an image registry other than the default at
 *_/etc/ansible/hosts_* file.
 
 ----
-oreg_url={registry}/openshift3/ose-${component}:${version}
+oreg_url=example.com/openshift3/ose-${component}:${version}
 openshift_examples_modify_imagestreams=true
 ----
 
@@ -895,7 +898,6 @@ openshift_examples_modify_imagestreams=true
 registry at `registry.redhat.io`. The default component inherits the image
 prefix and version from the `oreg_url` value. For the default registry, and registries
 that require authentication, you need to specify `oreg_auth_user` and
-
 `oreg_auth_password`.
 
 |`openshift_examples_modify_imagestreams`
@@ -939,25 +941,25 @@ outside of the {product-title} cluster, configure the registry route in the
 |===
 
 |Variable |Purpose
-|`*openshift_hosted_registry_routehost*`
-|Set to the value of the hosted registry route. The route contains either
+|`openshift_hosted_registry_routehost`
+|Set to the value of the desired registry route. The route contains either
 a name that resolves to an infrastructure node where a router manages
 communication or the subdomain that you set as the default application subdomain
 wildcard value. For example, if you set the `openshift_master_default_subdomain`
-parameter to `apps.example.com` and `*.apps.example.com` resolves to
+parameter to `apps.example.com` and `.apps.example.com` resolves to
 infrastructure nodes or a load balancer, you might use
 `registry.apps.example.com` as the registry route.
 
-|`*openshift_hosted_registry_routecertificates*`
+|`openshift_hosted_registry_routecertificates`
 a|Set the paths to the registry certificates. If you do not provide values for
 the certificate locations, certificates are generated. You can define locations
 for the following certificates:
 
-* `*certfile*`
-* `*keyfile*`
-* `*cafile*`
+* `certfile`
+* `keyfile`
+* `cafile`
 
-|`*openshift_hosted_registry_routetermination*`
+|`openshift_hosted_registry_routetermination`
 a| Set to one of the following values:
 
 * Set to `reencrypt` to terminate encryption at the edge
@@ -1250,25 +1252,6 @@ https proxy for `git clone` operations during a build regardless of the
 `openshift_https_proxy` value.
 |===
 
-[[advanced-install-no-proxy-list]]
-If any of:
-
-- `openshift_no_proxy`
-- `openshift_https_proxy`
-- `openshift_http_proxy`
-
-are set, then all cluster hosts will have an automatically generated `NO_PROXY`
-environment variable injected into several service configuration scripts. The
-default `.svc` domain and your cluster's `dns_domain` (typically
-`.cluster.local`) will also be added.
-
-[NOTE]
-====
-Setting `openshift_generate_no_proxy_hosts` to `false` in your inventory will
-not disable the automatic addition of the `.svc` domain and the cluster domain.
-These are required and added automatically if any of the above listed proxy
-parameters are set.
-====
 
 ifdef::openshift-enterprise,openshift-origin[]
 [[advanced-install-configuring-firewalls]]
@@ -1321,31 +1304,31 @@ endif::[]
 
 xref:../install_config/configuring_authentication.adoc#session-options[Session
 options] in the OAuth configuration are configurable in the inventory file. By
-default, Ansible populates a `*sessionSecretsFile*` with generated
+default, Ansible populates a `sessionSecretsFile` with generated
 authentication and encryption secrets so that sessions generated by one master
 can be decoded by the others. The default location is
 *_/etc/origin/master/session-secrets.yaml_*, and this file will only be
 re-created if deleted on all masters.
 
 You can set the session name and maximum number of seconds with
-`*openshift_master_session_name*` and `*openshift_master_session_max_seconds*`:
+`openshift_master_session_name` and `openshift_master_session_max_seconds`:
 
 ----
 openshift_master_session_name=ssn
 openshift_master_session_max_seconds=3600
 ----
 
-If provided, `*openshift_master_session_auth_secrets*` and
-`*openshift_master_encryption_secrets*` must be equal length.
+If provided, `openshift_master_session_auth_secrets` and
+`openshift_master_encryption_secrets` must be equal length.
 
-For `*openshift_master_session_auth_secrets*`, used to authenticate sessions
+For `openshift_master_session_auth_secrets`, used to authenticate sessions
 using HMAC, it is recommended to use secrets with 32 or 64 bytes:
 
 ----
 openshift_master_session_auth_secrets=['DONT+USE+THIS+SECRET+b4NV+pmZNSO']
 ----
 
-For `*openshift_master_encryption_secrets*`, used to encrypt sessions, secrets
+For `openshift_master_encryption_secrets`, used to encrypt sessions, secrets
 must be 16, 24, or 32 characters long, to select AES-128, AES-192, or AES-256:
 
 ----
@@ -1367,13 +1350,13 @@ Configure custom certificates for the host name associated with
 the `*publicMasterURL*`, which you set as the
 `*openshift_master_cluster_public_hostname*` parameter value. Using a custom serving certificate
 for the host name associated with the `*masterURL*`
-(*`openshift_master_cluster_hostname`*) results in TLS errors because
+(`openshift_master_cluster_hostname`) results in TLS errors because
 infrastructure components attempt to contact the master API using the
 internal `*masterURL*` host.
 ====
 
 Certificate and key file paths can be configured using the
-`*openshift_master_named_certificates*` cluster variable:
+`openshift_master_named_certificates` cluster variable:
 
 ----
 openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "cafile": "/path/to/custom-ca1.crt"}]
@@ -1384,21 +1367,21 @@ are copied to master hosts and are deployed in the
 *_/etc/origin/master/named_certificates/_* directory.
 
 Ansible detects a certificate's `Common Name` and `Subject Alternative Names`.
-Detected names can be overridden by providing the `*"names"*` key when setting
-`*openshift_master_named_certificates*`:
+Detected names can be overridden by providing the `"names"` key when setting
+`openshift_master_named_certificates`:
 
 ----
 openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"], "cafile": "/path/to/custom-ca1.crt"}]
 ----
 
-Certificates configured using `*openshift_master_named_certificates*` are cached
+Certificates configured using `openshift_master_named_certificates` are cached
 on masters, meaning that each additional Ansible run with a different set of
 certificates results in all previously deployed certificates remaining in place
 on master hosts and in the master configuration file.
 
 If you want to overwrite `*openshift_master_named_certificates*` with
 the provided value (or no value), specify the
-`*openshift_master_overwrite_named_certificates*` cluster variable:
+`openshift_master_overwrite_named_certificates` cluster variable:
 
 ----
 openshift_master_overwrite_named_certificates=true
@@ -1939,11 +1922,12 @@ file's `[OSEv3:vars]` section:
 openshift_template_service_broker_namespaces=['openshift','myproject']
 ----
 
-By default, the TSB uses the nodeselector `{"region": "infra"}` for deploying its pods.
+By default, the TSB uses the nodeselector `{"node-role.kubernetes.io/infra":"true"}` for deploying its pods.
 You can set a different nodeselector in your inventory file's
 `[OSEv3:vars]` section:
+
 ----
-template_service_broker_selector={"region": "infra"}
+template_service_broker_selector={"node-role.kubernetes.io/infra":"true"}
 ----
 
 .Template service broker customization variables


### PR DESCRIPTION
Fix the issue: https://github.com/openshift/openshift-docs/issues/12467

I found this page in `master` was older than `v3.11` same one, so I replace the page with `v3.11` one. 