### PR TITLE
Fix company name

### DIFF
--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -390,7 +390,7 @@ Cinder snapshotting API. This Technology Preview feature has tested EBS and
 HostPath. The tenant must stop the pods and start them manually.
 
 . The administrator runs an external provisioner for the cluster. These are images
-from the Red hat Container Catalog.
+from the Red Hat Container Catalog.
 
 . The tenant made a PVC and owns a PV from one of the supported storage
 solutions.The administrator must create a new `StorageClass` in the cluster with:

--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -233,7 +233,7 @@ Cinder snapshotting API. This Technology Preview feature has tested EBS and
 HostPath. The tenant must stop the pods and start them manually.
 
 . The administrator runs an external provisioner for the cluster. These are images
-from the Red hat Container Catalog.
+from the Red Hat Container Catalog.
 
 . The tenant made a PVC and owns a PV from one of the supported storage
 solutions.The administrator must create a new `StorageClass` in the cluster with:


### PR DESCRIPTION
@openshift/team-documentation Please take a look.

It should be cherry-picked to enterprise-3.7 and enterprise-3.9.