### PR TITLE
[enterprise-3.10] add ansible_service_broker_node_selector

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -233,6 +233,11 @@ xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
 |This variable enables the template service broker by specifying one or more
 namespaces whose templates will be served by the broker.
 
+|`ansible_service_broker_node_selector`
+|Default node selector for automatically deploying Ansible service broker pods,
+defaults `{"node-role.kubernetes.io/infra":"true"}`. See
+xref:configuring-node-host-labels[Configuring Node Host Labels] for details.
+
 |`template_service_broker_selector`
 |Default node selector for automatically deploying template service broker pods,
 defaults `{"node-role.kubernetes.io/infra":"true"}`. See


### PR DESCRIPTION
add ansible_service_broker_node_selector to v3.11 cluster variables table.

From https://github.com/openshift/openshift-docs/pull/12464