### PR TITLE
Fix the Journald typo

### DIFF
--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -598,7 +598,7 @@ Clusters] for more information.
 === Metrics and Logging
 
 [[ocp-37-journald-system-logs]]
-==== Jourald for System Logs and JSON File for Container Logs
+==== Journald for System Logs and JSON File for Container Logs
 
 Docker log driver is set to `json-file` as the default for all nodes. Docker
 `log-driver` can be set to `journal`, but there is no log rate throttling with


### PR DESCRIPTION
There is a typo in the title, however:

https://docs.openshift.com/container-platform/3.9/release_notes/ocp_3_9_release_notes.html#ocp-37-journald-system-logs

"Jourald for System Logs and JSON File for Container Logs" should be "Journald"