### PR TITLE
[enterprise-3.11] cd into openshfit-ansible for all ansible-playbook

### DIFF
--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -343,31 +343,23 @@ xref:../install_config/redeploying_certificates.adoc#install-config-redeploying-
 === Running Health Checks via ansible-playbook
 
 To run the *openshift-ansible* health checks using the `ansible-playbook`
-command, specify your cluster's inventory file and run the *_health.yml_*
+command, change to the playbook directory, specify your cluster's inventory file, and run the *_health.yml_*
 playbook:
 
 ----
-# ansible-playbook -i <inventory_file> \
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
-ifdef::openshift-origin[]
-    ~/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> \
+    playbooks/openshift-checks/health.yml
 ----
 
 To set variables in the command line, include the `-e` flag with any desired
 variables in `key=value` format. For example:
 
 ----
-# ansible-playbook -i <inventory_file> \
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
-ifdef::openshift-origin[]
-    ~/openshift-ansible/playbooks/openshift-checks/health.yml
-endif::[]
-    -e openshift_check_logging_index_timeout_seconds=45
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> \
+    playbooks/openshift-checks/health.yml \
+    -e openshift_check_logging_index_timeout_seconds=45 \
     -e etcd_max_image_data_size_bytes=40000000000
 ----
 

--- a/admin_guide/node_problem_detector.adoc
+++ b/admin_guide/node_problem_detector.adoc
@@ -155,10 +155,12 @@ Because the Node Problem Detector is in Technology Preview, the `openshift_node_
 You must manually change the parameter to `true` when installing the Node Problem Detector.
 ====
 
-If xref:admin-guide-node-problem-detector-verify[the Node Problem Detector is not installed], run the *openshift-node-problem-detector/config.yml* playbook to install Node Problem Detector:
+If xref:admin-guide-node-problem-detector-verify[the Node Problem Detector is not installed],
+change to the playbook directory and run the *openshift-node-problem-detector/config.yml* playbook to install Node Problem Detector:
 
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-node-problem-detector/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
 ----
 
 
@@ -386,11 +388,12 @@ To uninstall the Node Problem Detector:
 openshift_node_problem_detector_state=absent
 ----
 
-. Run the following Ansible playbook:
+. Change to the playbook directory and run the *_config.yml_* Ansible playbook:
 +
 [source,bash]
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-node-problem-detector/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
 ----
 
 ////

--- a/admin_guide/topics/deploying-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/deploying-cluster-auto-scaler.adoc
@@ -26,11 +26,12 @@ cluster, by default *_/etc/ansible/hosts_*:
 openshift_master_bootstrap_auto_approve=true
 ----
 
-.. To obtain the auto-scaler components, run the playbook again:
+.. To obtain the auto-scaler components, change to the playbook directory and run the playbook again:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+    playbooks/deploy_cluster.yml
 ----
 
 .. Confirm that the `bootstrap-autoapprover` pod is running:

--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -116,20 +116,23 @@ schedulable by adding `openshift_schedulable=true` to the entry. Otherwise, the
 registry and router pods cannot be placed anywhere.
 ====
 
-. Run the *_scaleup.yml_* playbook. If your inventory file is located somewhere
+. Change to the playbook directory and run the *_scaleup.yml_* playbook.
+If your inventory file is located somewhere
 other than the default of *_/etc/ansible/hosts_*, specify the location with the
 `-i` option.
 ** For additional nodes:
 +
 ----
-# ansible-playbook [-i /path/to/file] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-node/scaleup.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/file] \
+    playbooks/openshift-node/scaleup.yml
 ----
 ** For additional masters:
 +
 ----
-# ansible-playbook [-i /path/to/file] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-master/scaleup.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/file] \
+    playbooks/openshift-master/scaleup.yml
 ----
 
 . After the playbook runs,

--- a/day_two_guide/topics/adding_master_host.adoc
+++ b/day_two_guide/topics/adding_master_host.adoc
@@ -97,11 +97,12 @@ master3.example.com | SUCCESS | rc=0 >>
 *Scaleup Playbook*
 
 Once the inventory has been defined, the scale up process is performed by an `Ansible` playbook included in the `atomic-openshift-utils`
-using the `Ansible` host file:
+using the `Ansible` host file. Change to the playbook directory and run the *_scaleup.yml_* playbook:
 
 [subs=+quotes]
 ----
-$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/openshift-master/scaleup.yml*
+$ cd /usr/share/ansible/openshift-ansible
+$ *ansible-playbook -i /path/to/host/file playbooks/openshift-master/scaleup.yml*
 ----
 
 NOTE: The scale up procedure for masters include the scale up procedure for nodes as well.

--- a/day_two_guide/topics/adding_node_host.adoc
+++ b/day_two_guide/topics/adding_node_host.adoc
@@ -89,12 +89,14 @@ node05.example.com | SUCCESS | rc=0 >>
  16:05:21 up 53 min,  1 user,  load average: 0,00, 0,02, 0,05
 ----
 
-Once the inventory has been updated, the scale up process can be performed
-by an `Ansible` playbook included in the `atomic-openshift-utils` using the `Ansible` host file:
+After the inventory has been updated, the scale up process can be performed
+by an `Ansible` playbook included in the `atomic-openshift-utils` using the `Ansible` host file.
+Change to the playbook directory and run the *_scaleup.yml_* playbook:
 
 [subs=+quotes]
 ----
-$ *ansible-playbook -i /path/to/host/file /usr/share/ansible/openshift-ansible/playbooks/openshift-node/scaleup.yml*
+$ cd /usr/share/ansible/openshift-ansible
+$ *ansible-playbook -i /path/to/host/file playbooks/openshift-node/scaleup.yml*
 ----
 
 In the event of scaling up an infrastructure node running a {rhocp} router, the

--- a/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
+++ b/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
@@ -38,14 +38,15 @@ etcd0.example.com <1>
 <1> Add these lines.
 
 . From the host that installed {product-title} and hosts the Ansible inventory
-file, run the etcd `scaleup` playbook:
+file, change to the playbook directory and run the etcd `scaleup` playbook:
 +
 ----
-$ ansible-playbook  /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/scaleup.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  playbooks/openshift-etcd/scaleup.yml
 ----
 
-. After the playbook runs, modify the inventory file to reflect the current 
-status by moving the new etcd host from the `[new_etcd]` group to the `[etcd]` 
+. After the playbook runs, modify the inventory file to reflect the current
+status by moving the new etcd host from the `[new_etcd]` group to the `[etcd]`
 group:
 +
 ----
@@ -65,7 +66,7 @@ etcd0.example.com
 ----
 
 . If you use Flannel, modify the `flanneld` service configuration on every
-{product-title} host, located at `/etc/sysconfig/flanneld`, to include the new 
+{product-title} host, located at `/etc/sysconfig/flanneld`, to include the new
 etcd host:
 +
 ----

--- a/day_two_guide/topics/pruning_images_and_containers.adoc
+++ b/day_two_guide/topics/pruning_images_and_containers.adoc
@@ -122,7 +122,7 @@ Where `node.fs` is the file system hosting the
 triggers garbage collection processes to clean up the unused ones.
 
 There are some default values that can be tweaked if required in every node's
-configuration file using the `kubeletArguments` section of the 
+configuration file using the `kubeletArguments` section of the
 appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map].
 
 ==== Image Garbage Collection
@@ -164,10 +164,12 @@ openshift_node_kubelet_args={'image-gc-high-threshold': ['*75*'], 'image-gc-low-
 ----
 
 After modifying the `Ansible` variable content, running the installer again
-may configure the new settings and restart the services:
+may configure the new settings and restart the services. To run the installer
+again, change to the playbook directory and run the *_config.yml_* playbook:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/deploy_cluster.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the
@@ -206,7 +208,7 @@ $ sudo docker rmi $(sudo docker images -f "dangling=true" -q)
 ----
 
 WARNING: While not recommended, a more aggressive clean up can be performed
-by attempting to delete all the images. 
+by attempting to delete all the images.
 `docker` protects images it is using; this can be performed as `sudo docker rmi $(sudo docker images -q)`
 
 ==== Container Garbage Collection
@@ -243,7 +245,7 @@ Every iteration of the container garbage collection process performs the followi
 
 As noticed, the `maximum-dead-containers` setting takes precedence over the `maximum-dead-containers-per-container` setting when there is a conflict.
 
-To modify this settings, manually edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
+To modify this settings, manually edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]
 and modify the following section:
 
 [subs=+quotes]
@@ -267,10 +269,12 @@ openshift_node_kubelet_args={'minimum-container-ttl-duration': ['*1h*'], 'maximu
 ----
 
 After modifying the `Ansible` variable content, running the installer again
-may configure the new settings and restart the services:
+may configure the new settings and restart the services. To run the installer
+again, change to the playbook directory and run the *_config.yml_* playbook:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/deploy_cluster.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the
@@ -305,7 +309,7 @@ $ sudo docker rm $(sudo docker ps -a -q -f status=exited)
 ----
 
 WARNING: While not recommended, a more aggressive clean up can be performed
-by attempting to delete all containers. `docker` protects its running containers 
+by attempting to delete all containers. `docker` protects its running containers
 from deletion. This can be performed as `sudo docker rm $(docker ps -a -q)`
 
 NOTE: In future {rhocp} releases, garbage collection will be deprecated in
@@ -333,7 +337,7 @@ are made.
 The node continues to report node status updates at the frequency specified by
 the node-status-update-frequency argument, which defaults to 10s.
 
-Configure disk thresholds in the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
+Configure disk thresholds in the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]
 by modifying the following section:
 
 ----
@@ -367,10 +371,12 @@ openshift_node_kubelet_args={"eviction-soft":["nodefs.available<500Mi","nodefs.i
 ----
 
 After modifying the `Ansible` variable content, running the installer again
-may configure the new settings and restart the services:
+may configure the new settings and restart the services. To run the installer
+again, change to the playbook directory and run the *_config.yml_* playbook:
 
 ----
-$ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/deploy_cluster.yml
 ----
 
 WARNING: The `kubeletArguments` section is overwritten with the content of the

--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -163,16 +163,18 @@ for full documentation on available inventory variables.
 . Edit the example inventory to use your host names, then save it to a file
 (default location is *_/etc/ansible/hosts_*).
 
-. Run the *_prerequisites.yml_* playbook using your inventory file:
+. Change to the playbook directory and run the *_prerequisites.yml_* playbook using your inventory file:
 +
 ----
-$ ansible-playbook -i <inventory_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> playbooks/prerequisites.yml
 ----
 
-. Run the *_deploy_cluster.yml_* playbook using your inventory file:
+. Change to the playbook directory and run the *_deploy_cluster.yml_* playbook using your inventory file:
 +
 ----
-$ ansible-playbook -i <inventory_file> /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <inventory_file> playbooks/deploy_cluster.yml
 ----
 
 After a successful install, but before you add a new project, you must set up

--- a/install/prerequisites.adoc
+++ b/install/prerequisites.adoc
@@ -709,17 +709,13 @@ xref:../install_config/configuring_openstack.adoc#configuring-a-security-group-o
 ==== Overriding Detected IP Addresses and Host Names
 
 Some deployments require that the user override the detected host names and IP
-addresses for the hosts. To see the default values, run the `*openshift_facts*`
+addresses for the hosts. To see the default values, change to the playbook directory and run the `*openshift_facts*`
 playbook:
 
 ----
-# ansible-playbook  [-i /path/to/inventory] \
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift_facts.yml
-endif::[]
-ifdef::openshift-origin[]
-    ~/openshift-ansible/playbooks/byo/openshift_facts.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  [-i /path/to/inventory] \
+  playbooks/byo/openshift_facts.yml
 ----
 
 [IMPORTANT]

--- a/install/running_install.adoc
+++ b/install/running_install.adoc
@@ -121,35 +121,25 @@ system can run out of files to open and the playbook fails.
 
 To run the RPM-based installer:
 
-. Run the *_prerequisites.yml_* playbook. This playbook installs required software
+. Change to the playbook directory and run the *_prerequisites.yml_* playbook. This playbook installs required software
 packages, if any, and modifies the container runtimes. Unless you need to
 configure the container runtimes, run this playbook only once, before you
 deploy a cluster the first time:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/inventory] \ <1>
+  playbooks/prerequisites.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory,
 specify `-i` and the path to the inventory file.
 
-. Run the *_deploy_cluster.yml_* playbook to initiate the cluster installation:
+. Change to the playbook directory and run the *_deploy_cluster.yml_* playbook to initiate the cluster installation:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook [-i /path/to/inventory] \
+    playbooks/deploy_cluster.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory,
 specify `-i` and the path to the inventory file.

--- a/install/stand_alone_registry.adoc
+++ b/install/stand_alone_registry.adoc
@@ -235,34 +235,24 @@ The host that you run the Ansible playbook on must have at least 75MiB of free
 memory per host in the inventory file.
 ====
 +
-.. Before you deploy a new cluster, run the *_prerequisites.yml_* playbook:
+.. Before you deploy a new cluster, change to the cluster directory and run the *_prerequisites.yml_* playbook:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook  [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/prerequisites.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  [-i /path/to/inventory] \ <1>
+    playbooks/prerequisites.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory, 
 specify `-i` and the path to the inventory file.
 +
 You must run this playbook only one time.
 
-.. To initiate installation, run the *_deploy_cluster.yml_* playbook:
+.. To initiate installation, change to the playbook directory and run the *_deploy_cluster.yml_* playbook:
 +
 ----
-ifdef::openshift-enterprise[]
-# ansible-playbook  [-i /path/to/inventory] \ <1>
-    /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
-ifdef::openshift-origin[]
-# ansible-playbook [-i /path/to/inventory] \ <1>
-    ~/openshift-ansible/playbooks/deploy_cluster.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook  [-i /path/to/inventory] \ <1>
+    playbooks/deploy_cluster.yml
 ----
 <1> If your inventory file is not in the *_/etc/ansible/hosts_* directory, 
 specify `-i` and the path to the inventory file.

--- a/install/uninstalling_cluster.adoc
+++ b/install/uninstalling_cluster.adoc
@@ -35,7 +35,7 @@ that you specify when running the playbook.
 = Uninstalling a {product-title} cluster
 
 To uninstall
-{product-title} across all hosts in your cluster, run the playbook using the
+{product-title} across all hosts in your cluster, change to the playbook directory and run the playbook using the
 inventory file you used most recently:
 
 ----
@@ -90,7 +90,7 @@ node3.example.com openshift_node_group_name='node-config-infra' <2>
 <1> Include only the sections that apply to the hosts to uninstall.
 <2> Include only the hosts to uninstall.
 
-. Run the *_uninstall.yml_* playbook:
+. Change to the playbook directory and run the *_uninstall.yml_* playbook:
 +
 ----
 ifdef::openshift-enterprise[]

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -54,12 +54,13 @@ etcd2.example.com
 etcd3.example.com
 ----
 
-. Run the etcd *_scaleup.yml_* playbook. If your inventory file is located somewhere other than the default of *_/etc/ansible/hosts_*, specify the location with the `-i` option.
+. Change to the playbook directory and run the etcd *_scaleup.yml_* playbook. If your inventory file is located somewhere other than the default of *_/etc/ansible/hosts_*, specify the location with the `-i` option.
 +
 [source, bash]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i /path/to/file] \
-  /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/scaleup.yml
+  playbooks/openshift-etcd/scaleup.yml
 ----
 +
 . Set the node label to `logging-infra-fluentd: "true"`.

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -607,8 +607,9 @@ endif::openshift-origin[]
 
 ifdef::openshift-enterprise[]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 endif::openshift-enterprise[]
 
@@ -860,11 +861,12 @@ openshift_logging_es_allow_external=True
 openshift_logging_es_hostname=elasticsearch.example.com
 ----
 
-. Run the following Ansible playbook:
+. Change to the playbook directory and run the following Ansible playbook:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 
 . To log in to Elasticsearch remotely, the request must contain three HTTP headers:
@@ -1533,8 +1535,9 @@ endif::openshift-origin[]
 
 ifdef::openshift-enterprise[]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml \
+    playbooks/openshift-logging/config.yml \
     -e openshift_logging_install_logging=False
 ----
 endif::openshift-enterprise[]
@@ -1554,14 +1557,15 @@ host's OAuth2 server. If the secret is not identical on both servers, it can
 cause a login loop where you are continuously redirected back to the Kibana
 login page.
 
-To fix this issue, delete the current OAuthClient, and use `openshift-ansible`
+To fix this issue, delete the current OAuthClient, change to the playbook directory and use `openshift-ansible`
 to re-run the `openshift_logging` role:
 
 ====
 ----
 $ oc delete oauthclient/kibana-proxy
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 ====
 
@@ -1581,13 +1585,15 @@ This can be caused by a mismatch between the OAuth2 client and server. The
 return address for the client must be in a whitelist so the server can securely
 redirect back after logging in.
 
-Fix this issue by replacing the OAuthClient entry:
+Fix this issue by replacing the OAuthClient entry. Change to the playbook directory
+and run the *_config.yml_* playbook again:
 
 ====
 ----
 $ oc delete oauthclient/kibana-proxy
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
+    playbooks/openshift-logging/config.yml
 ----
 ====
 

--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -224,7 +224,7 @@ Where the parameter values are:
 
 * *cafile* is the path to the file that contains the root CA for this key and certificate. If an intermediate CA is in use, the file should contain both the intermediate and root CA.
 
-If these certificate files are new to your {product-title} cluster, run the Ansible *_deploy_router.yml_* playbook to add these files to the {product-title} configuration files. 
+If these certificate files are new to your {product-title} cluster, change to the playbook directory and run the Ansible *_deploy_router.yml_* playbook to add these files to the {product-title} configuration files. 
 The playbook adds the certificate files to the *_/etc/origin/master/_* directory.
 
 ----
@@ -239,7 +239,7 @@ endif::[]
 ----
 
 If xref:../install_config/redeploying_certificates.adoc#redeploying-all-certificates-current-ca[the certificates are not new], 
-for example, you want to change existing certificates or replace expired certificates, run the following playbook:
+for example, you want to change existing certificates or replace expired certificates, change to the playbook directory and run the following playbook:
 
 ----
 ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/redeploy-certificates.yml
@@ -363,7 +363,7 @@ openshift_master_named_certificates=[{"certfile": "/path/on/host/to/crt-file", "
 +
 <1> Path to a xref:configuring-custom-certificates-master[master API certificate]. 
 
-. Run the following playbook:
+. Change to the playbook directory and run the following playbook:
 +
 ----
 ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/redeploy-certificates.yml
@@ -386,10 +386,11 @@ openshift_hosted_router_certificate={"certfile": "/path/on/host/to/app-crt-file"
 +
 <1> Path to a xref:configuring-custom-certificates-wildcard[wildcard API certificate].
 
-. Run the following playbook:
+. Change to the playbook directory and run the following playbook:
 +
 ----
-ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-hosted/redeploy-router-certificates.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-hosted/redeploy-router-certificates.yml
 ----
 
 [[ansible-configuring-custom-certificates-other]]

--- a/install_config/cfme/container_provider.adoc
+++ b/install_config/cfme/container_provider.adoc
@@ -51,16 +51,12 @@ This playbook:
 . Finds the public routes to the {mgmt-app} application and the cluster API.
 . Makes a REST call to add the {product-title} cluster as a container provider.
 
-To run the container provider playbook:
+Change to the playbook directory and run the container provider playbook:
 
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
-ifdef::openshift-origin[]
-    playbooks/openshift-management/add_container_provider.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/add_container_provider.yml
-endif::[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
+    openshift-management/add_container_provider.yml
 ----
 
 [[cfme-container-provider-multiple]]
@@ -167,17 +163,14 @@ management_server:
 To run the multiple-providers integration script, you must provide the path to
 the container providers configuration file as an `EXTRA_VARS` parameter to the
 `ansible-playbook` command. Use the `-e` (or `--extra-vars`) parameter to set
-`container_providers_config` to the configuration file path:
+`container_providers_config` to the configuration file path. Change to the
+playbook directory and run the playbook:
 
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
     -e container_providers_config=/tmp/cp.yml \
-ifdef::openshift-origin[]
     playbooks/openshift-management/add_many_container_providers.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/add_many_container_providers.yml
-endif::[]
 ----
 
 After the playbook completes, you should find two new container providers in

--- a/install_config/cfme/installing.adoc
+++ b/install_config/cfme/installing.adoc
@@ -44,16 +44,12 @@ xref:../../install/running_install.adoc#running-the-installation-playbooks[Runni
 installation.
 
 .. If you want to install {mgmt-app} on an already provisioned {product-title}
-cluster, call the {mgmt-app} playbook directly to begin the installation:
+cluster, change to the playbook directory and call the {mgmt-app} playbook directly to begin the installation:
 +
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
-ifdef::openshift-origin[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
     playbooks/openshift-management/config.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/config.yml
-endif::[]
 ----
 
 [[cfme-example-inventory-files]]

--- a/install_config/cfme/uninstalling.adoc
+++ b/install_config/cfme/uninstalling.adoc
@@ -20,16 +20,12 @@ toc::[]
 [[cfme-uninstalling-running-the-playbook]]
 == Running the Uninstall Playbook
 To uninstall and erase a deployed {mgmt-app} installation from
-{product-title}, run the following playbook:
+{product-title}, change to the playbook directory and run the *_uninstall.yml_* playbook:
 
 ----
-# ansible-playbook -v [-i /path/to/inventory] \
-ifdef::openshift-origin[]
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -v [-i /path/to/inventory] \
     playbooks/openshift-management/uninstall.yml
-endif::[]
-ifdef::openshift-enterprise[]
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-management/uninstall.yml
-endif::[]
 ----
 
 [IMPORTANT]

--- a/install_config/configuring_kuryrsdn.adoc
+++ b/install_config/configuring_kuryrsdn.adoc
@@ -122,12 +122,13 @@ playbooks can populate it automatically, if you add the following configuration:
 openshift_openstack_external_nsupdate_keys={private: {"key_secret": "<nsupdate key>", "key_algorithm": "<nsupdate key algorithm>", "key_name": "<nsupdate key name>", "server": 10.20.30.40}}
 ----
 
-Finally, install {product-title} by running the *_provision_install.yml_*
+Finally, install {product-title} by changing to the playbook directory and running the *_provision_install.yml_*
 playbook. You must specify the dynamic inventory file, *_inventory.py_*, and the
 the path to the Ansible nodes file that you created:
 
 ----
-$ ansible-playbook --user openshift -i /usr/share/ansible/openshift-ansible/playbooks/openstack/inventory.py -i ansible-nodes.txt /usr/share/ansible/openshift-ansible/playbooks/openstack/openshift-cluster/provision_install.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook --user openshift -i playbooks/openstack/inventory.py -i ansible-nodes.txt playbooks/openstack/openshift-cluster/provision_install.yml
 ----
 
 If you want to do any custom setup on the created nodes before the

--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -221,7 +221,7 @@ networkConfig:
 == Configuring the Pod Network on Nodes
 
 The cluster administrators can control pod network settings on nodes by modifying
-parameters in the `*networkConfig*` section of the 
+parameters in the `*networkConfig*` section of the
 appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]:
 
 ====
@@ -283,7 +283,8 @@ inventory file to the new CIDR:
 . Run the `*config.yml*` Ansible playbook to redeploy the cluster:
 +
 ----
-# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-master/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook playbooks/openshift-master/config.yml
 ----
 
 include::day_two_guide/topics/increasing_docker_storage.adoc[tag=evacuating-a-node]

--- a/install_config/persistent_storage/topics/glusterfs_run_installer.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_run_installer.adoc
@@ -7,19 +7,20 @@
 // - #install-example-infra
 // - #install-example-full
 // - #install-example-full-external
-. Run the installation playbook and provide the relative path for the inventory
+. Change to the playbook directory and run the installation playbook. Provide the relative path for the inventory
 file as an option.
 +
 ** For a new {product-title} installation:
 +
 ----
-ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-
-ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> playbooks/prerequisites.yml
+$ ansible-playbook -i <path_to_inventory_file> playbooks/deploy_cluster.yml
 ----
 +
 ** For an installation onto an existing {product-title} cluster:
 +
 ----
-ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/openshift-glusterfs/config.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> playbooks/openshift-glusterfs/config.yml
 ----

--- a/install_config/persistent_storage/topics/glusterfs_uninstall.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_uninstall.adoc
@@ -1,21 +1,24 @@
 For {gluster-native}, an {product-title} install comes with a
 playbook to uninstall all resources and artifacts from the cluster. To use the playbook,
 provide the original inventory file that was used to install the target instance
-of {gluster-native} and run the following playbook:
+of {gluster-native}, change to the playbook directory, and run the following playbook:
 
 ----
-# ansible-playbook -i <path_to_inventory_file> /usr/share/ansible/openshift-ansible/playbooks/openshift-glusterfs/uninstall.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> playbooks/openshift-glusterfs/uninstall.yml
 ----
 
 In addition, the playbook supports the use of a variable called
 `openshift_storage_glusterfs_wipe` which, when enabled, destroys any data on the
 block devices that were used for {gluster} backend storage. To use the
-`openshift_storage_glusterfs_wipe` variable:
+`openshift_storage_glusterfs_wipe` variable, change to the playbook directory
+and run the following playbook:
 
 ----
-# ansible-playbook -i <path_to_inventory_file> -e
-"openshift_storage_glusterfs_wipe=true"
-/usr/share/ansible/openshift-ansible/playbooks/openshift-glusterfs/uninstall.yml 
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i <path_to_inventory_file> -e \
+  "openshift_storage_glusterfs_wipe=true" \
+  playbooks/openshift-glusterfs/uninstall.yml
 ----
 
 [WARNING]

--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -163,11 +163,13 @@ configure a corresponding xref:../install_config/persistent_storage/dynamically_
 === Deploying the AWS EFS Provisioner
 The following command sets the directory in the EFS volume to
 `/data/persistentvolumes`. This directory must exist in the file system and must
-be mountable and writeable by the provisioner pod.
+be mountable and writeable by the provisioner pod. Change to the playbook 
+directory and run the following playbook:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-provisioners/config.yml \
+    playbooks/openshift-provisioners/config.yml \
    -e openshift_provisioners_install_provisioners=True \
    -e openshift_provisioners_efs=True \
    -e openshift_provisioners_efs_fsid=fs-47a2c22e \
@@ -217,7 +219,8 @@ You can remove everything deployed by the OpenShift Ansible `openshift_provision
 by running the following command:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-provisioners/config.yml \
+    playbooks/openshift-provisioners/config.yml \
    -e openshift_provisioners_install_provisioners=False
 ----

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -127,11 +127,12 @@ tweaking it to your specifications as needed. This playbook:
     - role: openshift_certificate_expiry
 ----
 
-To run the *_easy-mode.yaml_*  playbook:
+Change to the playbook directory and run the *_easy-mode.yaml_*  playbook:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/certificate_expiry/easy-mode.yaml
+    playbooks/openshift-checks/certificate_expiry/easy-mode.yaml
 ----
 
 [discrete]
@@ -165,8 +166,9 @@ directory.
 To run any of these example playbooks:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -v -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/certificate_expiry/<playbook>
+    playbooks/openshift-checks/certificate_expiry/<playbook>
 ----
 
 [[cert-expiry-output-formats]]
@@ -245,7 +247,9 @@ In particular, the inventory must specify or override all host names and IP
 addresses set via the following variables such that they match the current
 cluster configuration:
 
+- `openshift_hostname`
 - `openshift_public_hostname`
+- `openshift_ip`
 - `openshift_public_ip`
 - `openshift_master_cluster_hostname`
 - `openshift_master_cluster_public_hostname`
@@ -283,11 +287,12 @@ This also includes serial restarts of:
 - node services
 
 To redeploy master, etcd, and node certificates using the current
-{product-title} CA, run this playbook, specifying your inventory file:
+{product-title} CA, change to the playbook directory and run this playbook, specifying your inventory file:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/redeploy-certificates.yml
+    playbooks/redeploy-certificates.yml
 ----
 
 [[redeploying-new-custom-ca]]
@@ -315,13 +320,8 @@ still valid.
 
 To redeploy a newly generated or custom CA:
 
-. Optionally, specify a custom CA. The `certfile` that you specify as part of
-the custom CA parameter, `openshift_master_ca_certificate`, must contain only
-the single certificate that signs the {product-title} certificates. If you have
-intermediate certificates in your chain, you must bundle them into a different
-file.
-.. To specify a CA without intermediate certificates, set the following variable
-in your inventory file:
+. If you want to use a custom CA, set the following variable in your inventory
+file. To use the current CA, skip this step.
 +
 ----
 # Configure custom ca certificate
@@ -331,32 +331,23 @@ in your inventory file:
 # playbook.
 openshift_master_ca_certificate={'certfile': '</path/to/ca.crt>', 'keyfile': '</path/to/ca.key>'}
 ----
-.. To specify a CA certificate that is issued by an intermediate CA:
-... Create a bundled certificate that contains the full chain of intermediate
-and root certificates for the CA:
++
+If the CA certificate is issued by an intermediate CA, the bundled certificate must contain 
+the full chain (the intermediate and root certificates) for the CA in order to validate child certificates. 
++
+For example:
 +
 ----
-# cat intermediate/certs/<intermediate.cert.pem> \
+$ cat intermediate/certs/intermediate.cert.pem \
       certs/ca.cert.pem >> intermediate/certs/ca-chain.cert.pem
 ----
 
-... Set the following variables in your inventory file:
+. Change to the playbook directory and run the *_openshift-master/redeploy-openshift-ca.yml_* playbook, specifying your inventory file:
 +
 ----
-# Configure custom ca certificate
-# NOTE: CA certificate will not be replaced with existing clusters.
-# This option may only be specified when creating a new cluster or
-# when redeploying cluster certificates with the redeploy-certificates
-# playbook.
-openshift_master_ca_certificate={'certfile': '</path/to/ca.crt>', 'keyfile': '</path/to/ca.key>'}
-openshift_additional_ca=intermediate/certs/ca-chain.cert.pem
-----
-
-. Run the *_openshift-master/redeploy-openshift-ca.yml_* playbook, specifying your inventory file:
-+
-----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-master/redeploy-openshift-ca.yml
+    playbooks/openshift-master/redeploy-openshift-ca.yml
 ----
 
 With the new {product-title} CA in place, you can then use the
@@ -380,8 +371,9 @@ To redeploy a newly generated etcd CA:
 . Run the *_openshift-etcd/redeploy-ca.yml_* playbook, specifying your inventory file:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/redeploy-ca.yml
+    playbooks/openshift-etcd/redeploy-ca.yml
 ----
 
 With the new etcd CA in place, you can then use the
@@ -395,18 +387,19 @@ xref:redeploying-all-certificates-current-ca[*_redeploy-certificates.yml_* playb
 The *_openshift-master/redeploy-certificates.yml_* playbook only redeploys master
 certificates. This also includes serial restarts of master services.
 
-To redeploy master certificates, run this playbook, specifying your inventory
+To redeploy master certificates, change to the playbook directory and run this playbook, specifying your inventory
 file:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-master/redeploy-certificates.yml
+    playbooks/openshift-master/redeploy-certificates.yml
 ----
 
 [IMPORTANT]
 ====
-After running this playbook, you need to regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs]
-by deleting existing secrets that contain service serving certificates or removing and re-adding
+After running this playbook, you need to regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs] 
+by deleting existing secrets that contain service serving certificates or removing and re-adding 
 annotations to appropriate services.
 ====
 
@@ -422,12 +415,13 @@ This also include serial restarts of:
 - etcd
 - master services.
 
-To redeploy etcd certificates, run this playbook, specifying your inventory
+To redeploy etcd certificates, change to the playbook directory and run this playbook, specifying your inventory
 file:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/redeploy-certificates.yml
+    playbooks/openshift-etcd/redeploy-certificates.yml
 ----
 
 [[redeploying-node-certificates]]
@@ -436,12 +430,13 @@ $ ansible-playbook -i <inventory_file> \
 The *_openshift-node/redeploy-certificates.yml_* playbook only redeploys node
 certificates. This also include serial restarts of node services.
 
-To redeploy node certificates, run this playbook, specifying your inventory
+To redeploy node certificates, change to the playbook directory and run this playbook, specifying your inventory
 file:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-node/redeploy-certificates.yml
+    playbooks/openshift-node/redeploy-certificates.yml
 ----
 
 [[redeploying-registry-router-certificates]]
@@ -457,23 +452,25 @@ Registry or Router Certificates] to replace them manually.
 [[redeploying-registry-certificates]]
 ==== Redeploying Registry Certificates Only
 
-To redeploy registry certificates, run the following playbook, specifying your
+To redeploy registry certificates, change to the playbook directory and run the following playbook, specifying your
 inventory file:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-hosted/redeploy-registry-certificates.yml
+    playbooks/openshift-hosted/redeploy-registry-certificates.yml
 ----
 
 [[redeploying-router-certificates]]
 ==== Redeploying Router Certificates Only
 
-To redeploy router certificates, run the following playbook, specifying your
+To redeploy router certificates, change to the playbook directory and run the following playbook, specifying your
 inventory file:
 
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/openshift-hosted/redeploy-router-certificates.yml
+    playbooks/openshift-hosted/redeploy-router-certificates.yml
 ----
 
 [[redeploying-custom-registry-or-router-certificates]]
@@ -510,7 +507,7 @@ deprecated in favor of using secrets).
 variables:
 +
 ----
-$ oc set env dc/docker-registry --list
+$ oc env dc/docker-registry --list
 ----
 
 .. If they do not exist, skip this step. If they do, create the following `ClusterRoleBinding`:
@@ -539,7 +536,7 @@ oc create -f -
 Then, run the following to remove the environment variables:
 +
 ----
-$ oc set env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+$ oc env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
 ----
 
 . Set the following environment variables locally to make later commands less
@@ -563,7 +560,7 @@ $ oc adm ca create-server-cert \
 ----
 +
 Run `oc adm` commands only from the first master listed in the Ansible host inventory file,
-by default *_/etc/ansible/hosts_*.
+by default *_/etc/ansible/hosts_*. 
 
 . Update the `registry-certificates` secret with the new registry certificates:
 +
@@ -605,7 +602,7 @@ deprecated in favor of using service serving certificate secret.
 variables:
 +
 ----
-$ oc set env dc/router --list
+$ oc env dc/router --list
 ----
 
 .. If those variables exist, create the following `ClusterRoleBinding`:
@@ -634,7 +631,7 @@ oc create -f -
 .. If those variables exist, run the following command to remove them:
 +
 ----
-$ oc set env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+$ oc env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
 ----
 
 . Obtain a certificate.
@@ -682,7 +679,7 @@ $ cat router.crt /etc/origin/master/ca.crt router.key > router.pem
 $ oc export secret router-certs > ~/old-router-certs-secret.yaml
 ----
 
-. Create a new secret to hold the new certificate and key, and replace the
+. Create a new secret to hold the new certificate and key, and replace the 
 contents of the existing secret:
 +
 ----
@@ -691,7 +688,7 @@ $ oc create secret tls router-certs --cert=router.pem \ <1>
     oc replace -f -
 ----
 <1> *_router.pem_* is the file that contains the concatenation of the
-certificates that you generated.
+certificates that you generated.    
 
 . Remove the following annotations from the `router` service:
 +

--- a/modules/installing-olm-using-ansible.adoc
+++ b/modules/installing-olm-using-ansible.adoc
@@ -46,21 +46,23 @@ Hat Customer Portal at link:https://access.redhat.com[].
 The `test_image` represents an image that will be used to test the credentials
 you provided.
 
-. Run the registry authorization playbook using your inventory file to authorize
+. Change to the playbook directory and run the registry authorization playbook using your inventory file to authorize
 your nodes using your credentials from the previous step:
 +
 [subs=attributes+]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-   {pb-prefix}playbooks/updates/registry_auth.yml
+   playbooks/updates/registry_auth.yml
 ----
 
-. Run the OLM installation playbook using your inventory file:
+. Change to the playbook directory and run the OLM installation playbook using your inventory file:
 +
 [subs=attributes+]
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-   {pb-prefix}playbooks/olm/config.yml
+   playbooks/olm/config.yml
 ----
 
 . Navigate to the cluster's web console using a browser. A new section should now be available in the navigation on the left side of the page:

--- a/release_notes/ocp_3_7_release_notes.adoc
+++ b/release_notes/ocp_3_7_release_notes.adoc
@@ -925,7 +925,7 @@ experiencing the insight and automations available to them in {product-title}.
 To install CFME 4.6:
 
 ----
-# ansible-playbook -v -i <YOUR_INVENTORY> \
+$ ansible-playbook -v -i <YOUR_INVENTORY> \
     playbooks/byo/openshift-management/config.yml
 ----
 
@@ -937,14 +937,14 @@ There is a link:https://bugzilla.redhat.com/show_bug.cgi?id=1506951[known issue]
 To configure CFME 4.6 to consume the {product-title} installation it is running on:
 
 ----
-# ansible-playbook -v -i <YOUR_INVENTORY> \
+$ ansible-playbook -v -i <YOUR_INVENTORY> \
     playbooks/byo/openshift-management/add_container_provider.yml
 ----
 
 You can also automate the configuration of the provider to point to multiple OpenShift clusters:
 
 ----
-# ansible-playbook -v -e container_providers_config=/tmp/cp.yml \
+$ ansible-playbook -v -e container_providers_config=/tmp/cp.yml \
     playbooks/byo/openshift-management/add_many_container_providers.yml
 ----
 

--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -1316,16 +1316,18 @@ Administrators can now backup and redeploy cluster certificates using the
 following Ansible playbook:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/redeploy-certificates.yml
+    playbooks/byo/openshift-cluster/redeploy-certificates.yml
 ----
 +
 By default, the playbook retains the current OpenShift Enterprise CA. To replace
 the CA with a generated or custom CA:
 +
 ----
+$ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/redeploy-certificates.yml \
+    byo/openshift-cluster/redeploy-certificates.yml \
     --extra-vars "openshift_certificates_redeploy_ca=true"
 ----
 +

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -558,8 +558,9 @@ file that was used.
 playbook:
 +
 ----
-# ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade.yml
 ----
 
 ** To upgrade the control plane and nodes in separate phases:
@@ -567,15 +568,17 @@ playbook:
 playbook:
 +
 ----
-# ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
 ----
 
 .. Upgrade the nodes by running the *_upgrade_nodes.yaml_* playbook:
 +
 ----
-# ansible-playbook -i </path/to/inventory/file> \
-    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_nodes.yml \
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/byo/openshift-cluster/upgrades/v3_11/upgrade_nodes.yml \
     [-e <customized_node_upgrade_variables>] <1>
 ----
 <1> See xref:customizing-node-upgrades[Customizing Node Upgrades] for any desired


### PR DESCRIPTION
This ensures that we utilize ansible.cfg file from openshift-ansible
which defines critical configuration items.

This removes a fair amount of conditional documentation code that was
essentially
if origin
 ~/openshift-ansible
else
 /usr/share/ansible/openshift-ansible

I feel that while the admin of origin may be operating from a github
checkout when they read `$ cd /usr/share/ansible/openshift-ansible`
they'll be able to figure out that they should change directories to
their checkout.

This replaces all `# ansible-playbook` with `$ ansible-playbook`. You
should never need to be root to run our playbooks.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1458018


From https://github.com/openshift/openshift-docs/pull/12388