### PR TITLE
Update secrets docs for service CA bundle changes

### DIFF
--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -246,9 +246,46 @@ intraservice communication, and with re-encrypt routes.
 ====
 
 Other pods can trust cluster-created certificates (which are only signed for
-internal DNS names), by using the CA bundle in the
-*_/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt_* file that is
-automatically mounted in their pod.
+internal DNS names), by using a CA bundle that is automatically injected into
+any configMap annotated with `service.alpha.openshift.io/inject-cabundle=true`.
+The CA bundle will be made available as PEM-encoded data under the key
+`service-ca.crt`.
+
+[NOTE]
+====
+In some deployments, a pod might start before the annotated configMap is
+updated with the CA bundle. To ensure that pods only start once the CA bundle is
+available, you should reference the `service-ca.crt` key explicitly in the
+*PodSpec* volumeMount. See the following example.
+====
+
+.YAML of a Pod Starting With the Service CA Bundle Available
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-pod
+spec:
+  containers:
+    - name: test-container
+      image: busybox
+      command: [ "/bin/sh", "-c", "cat /opt/path/to/service-ca.crt" ]
+      volumeMounts:
+      - name: config-volume
+        mountPath: /opt
+  volumes:
+    - name: config-volume
+      configMap:
+        name: test-config
+        items:
+        - key: service-ca.crt
+          path: path/to/service-ca.crt
+  restartPolicy: Never
+----
+====
 
 The signature algorithm for this feature is `x509.SHA256WithRSA`. To manually
 rotate, delete the generated secret. A new certificate is created.


### PR DESCRIPTION
This is a 4.0 change in the way pods have to consume the service CA bundle. We will want to have a corresponding release note as well.
@openshift/sig-security @kalexand-rh 