### PR TITLE
Fixing formatting issue introduced by PR#12233.

### DIFF
--- a/servicemesh-install/servicemesh-install.adoc
+++ b/servicemesh-install/servicemesh-install.adoc
@@ -67,10 +67,4 @@ include::servicemesh-install/topics/install-remove.adoc[leveloffset=+2]
 
 include::servicemesh-install/topics/install-upgrade.adoc[leveloffset=+2]
 
-////
-// **********************************
-// * Appendix: Revision Information *
-// **********************************
-//include::topics/revision-info.adoc[]
 
-////

--- a/servicemesh-install/topics/install-prerequisites.adoc
+++ b/servicemesh-install/topics/install-prerequisites.adoc
@@ -9,7 +9,7 @@ Before you can install {ProductName}, you must meet the following prerequisites:
 
 
 [[preparing-openshift-installation]]
-= Preparing the {product-title} installation
+== Preparing the {product-title} installation
 
 Before you can install the {ProductShortName} into an {product-title} installation, you must modify the master configuration and each of the schedulable nodes. These changes enable the features that are required in the {ProductShortName} and also ensure that Elasticsearch features function correctly.
 
@@ -50,6 +50,7 @@ $ cp -p master-config.yaml master-config.yaml.prepatch
 $ oc ex config patch master-config.yaml.prepatch -p "$(cat master-config.patch)" > master-config.yaml
 $ master-restart api
 $ master-restart controllers
+```
 
 [[updating-node-configuration]]
 == Updating the node configuration


### PR DESCRIPTION
@vikram-redhat   PR#12233 included a formatting error that broke the Service Mesh installation guide.  This PR fixes that issue.  (I also removed the include that threw the build error, just so that problem doesn't crop up again.)