### PR TITLE
Kibana is unusable after upgrade to 3.9 if any searchguard indices use previous format

### DIFF
--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -614,26 +614,6 @@ See
 xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating
 Container Logs] for more information.
 
-[[ocp-39-syslog-output-plugin-for-fluentd]]
-==== syslog Output Plug-in for fluentd (Technology Preview)
-
-syslog Output Plug-in for fluentd is a feature currently in
-xref:ocp-39-technology-preview[Technology Preview] and not for production
-workloads.
-
-You can send system and container logs from {product-title} nodes to external
-endpoints using the syslog protocol. The fluentd syslog output plug-in supports
-this.
-
-[IMPORTANT]
-====
-Logs sent via syslog are not encrypted and, therefore, insecure.
-====
-
-See
-xref:../install_config/aggregate_logging.adoc#sending-logs-to-external-rsyslog[Sending
-Logs to an External Syslog Server] for more information.
-
 [[ocp-39-prometheus]]
 ==== Prometheus (Technology Preview)
 
@@ -1632,10 +1612,10 @@ features marked *GA* indicate _General Availability_.
 | -
 |TP
 
-|xref:ocp-39-syslog-output-plugin-for-fluentd[syslog Output Plug-in for fluentd]
+|syslog Output Plug-in for fluentd
 | -
 | -
-|TP
+|GA
 |====
 
 [[ocp-39-known-issues]]

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -591,6 +591,25 @@ Ansible playbook. This is the playbook to use if you were deploying logging for
 the first time on an existing cluster, but is also used to upgrade existing
 logging deployments.
 
+. If you have any Elasticsearch SearchGuard indices in the following naming format, you need to delete and reseed the indices because the naming format has changed. 
+Elastic search might not work as expected unless you update the indices:
++
+----
+.searchguard.logging-es-*
+----
++
+.. Run the following command to delete the SearchGuard indices:
++
+----
+# oc exec -c elasticsearch <pod> -- es_util --query=.searchguard* -XDELETE
+----
++
+.. Run the following command to reseed the SearchGuard indices:
++
+----
+# for p in (oc get pods -l component=es -o jsonpath={.items[*].metadata.name}); do oc exec -c elasticsearch <pod> -- es_seed_acl; done
+----
+
 . If you have not already done so, see
 xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Specifying Logging Ansible Variables] in the
 xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[Aggregating Container Logs] topic and update your Ansible inventory file to at least set the


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1641058