### PR TITLE
Replace deprecated export command with new one

### DIFF
--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -62,7 +62,7 @@ restricted         false     []        MustRunAs   MustRunAsRange     MustRunAs 
 [[examining-a-security-context-constraints-object]]
 == Examining a Security Context Constraints Object
 
-To examine a particular SCC, use `oc get`, `oc describe`, `oc export`, or `oc
+To examine a particular SCC, use `oc get`, `oc describe`, or `oc
 edit`. For example, to examine the *restricted* SCC:
 
 ----

--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -548,7 +548,7 @@ The definition for each SCC is also viewable by cluster administrators using the
 CLI. For example, for the privileged SCC:
 
 ----
-# oc export scc/privileged
+# oc get -o yaml --export scc/privileged
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true

--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -693,21 +693,20 @@ endif::[]
 
 == Export resources so they can be used elsewhere
 
+[NOTE]
+====
+`oc export` is deprecated. See link:https://docs.openshift.com/container-platform/3.11/release_notes/ocp_3_11_release_notes.html#ocp-311-notable-technical-changes[Notable Technical Changes] for more details.
+====
+
 ====
 
 [options="nowrap"]
 ----
   // export the services and deployment configurations labeled name=test
-  oc export svc,dc -l name=test
-
-  // export all services to a template
-  oc export service --as-template=test
+  oc get -o yaml --export svc,dc -l name=test
 
   // export to JSON
-  oc export service -o json
-
-  // convert a file on disk to the latest API version (in YAML, the default)
-  oc export -f a_v1beta3_service.json --output-version=v1 --exact
+  oc get -o json --export service
 ----
 ====
 

--- a/day_two_guide/topics/proc_backing-up-project.adoc
+++ b/day_two_guide/topics/proc_backing-up-project.adoc
@@ -66,12 +66,12 @@ po/ruby-ex-1-rxc74           1/1       Running     0          2m
 ** To export the project objects into a `project.yaml` file:
 +
 ----
-$ oc export all -o yaml > project.yaml
+$ oc get -o yaml --export all > project.yaml
 ----
 ** To export the project objects into a `project.json` file:
 +
 ----
-$ oc export all -o json > project.json
+$ oc get -o json --export all > project.json
 ----
 
 . Export the project's `role bindings`, `secrets`,
@@ -80,7 +80,7 @@ $ oc export all -o json > project.json
 ----
 $ for object in rolebindings serviceaccounts secrets imagestreamtags podpreset cms egressnetworkpolicies rolebindingrestrictions limitranges resourcequotas pvcs templates cronjobs statefulsets hpas deployments replicasets poddisruptionbudget endpoints
 do
-  oc export $object -o yaml > $object.yaml
+  oc get -o yaml --export $object > $object.yaml
 done
 ----
 
@@ -106,6 +106,6 @@ $ oc get dc ruby-ex -o jsonpath="{.spec.template.spec.containers[].image}"
 10.111.255.221:5000/myproject/ruby-ex@sha256:880c720b23c8d15a53b01db52f7abdcbb2280e03f686a5c8edfef1a2a7b21cee
 ----
 +
-If importing the `deploymentconfig` as it is exported with `oc export` it fails
+If importing the `deploymentconfig` as it is exported with `oc get --export` it fails
 if the image does not exist.
 +

--- a/dev_guide/application_lifecycle/promoting_applications.adoc
+++ b/dev_guide/application_lifecycle/promoting_applications.adoc
@@ -269,7 +269,7 @@ various labels or tags associated to versions.
 [[dev-guide-promoting-application-exporting-api-object-state]]
 ==== Exporting API Object State
 
-API object specifications should be captured with `oc export`. This operation
+API object specifications should be captured with `oc get --export`. This operation
 removes environment specific data from the object definitions (e.g., current
 namespace or assigned IP addresses), allowing them to be recreated in different
 environments (unlike `oc get` operations, which output an unfiltered state of
@@ -572,7 +572,7 @@ of your application's API objects:
 ----
 $ oc login <source_environment>
 $ oc project <source_project>
-$ oc export dc,is,svc,route,secret,sa -l promotion-group=<application_name> -o yaml > export.yaml
+$ oc get -o yaml --export dc,is,svc,route,secret,sa -l promotion-group=<application_name> > export.yaml
 $ oc login <target_environment>
 $ oc new-project <target_project> <1>
 $ oc create -f export.yaml
@@ -581,7 +581,7 @@ $ oc create -f export.yaml
 +
 [NOTE]
 ====
-On the `oc export` command, whether or not you include the `is` type for image
+On the `oc get --export` command, whether or not you include the `is` type for image
 streams depends on how you choose to manage images, image streams, and
 registries across the different environments in your pipeline. The caveats
 around this are discussed below. See also the
@@ -683,7 +683,7 @@ pipeline:
 ----
 $ oc login <source_environment>
 $ oc project <source_project>
-$ oc export dc,is,svc,route,secret,sa -l promotion-group=<application_name> -o yaml > export.yaml
+$ oc get -o yaml --export dc,is,svc,route,secret,sa -l promotion-group=<application_name> > export.yaml
 $ oc login <target_environment>
 $ oc <target_project>
 ----

--- a/dev_guide/compute_resources.adoc
+++ b/dev_guide/compute_resources.adoc
@@ -52,7 +52,7 @@ Quotas are set by cluster administrators and are scoped to a given project.
 
 include::admin_guide/quota.adoc[tag=admin_quota_viewing]
 
-Full quota definitions can be viewed by running `oc export` on the object. The
+Full quota definitions can be viewed by running `oc get --export` on the object. The
 following show some sample quota definitions:
 
 include::admin_guide/quota.adoc[tag=admin_quota_sample_definitions]
@@ -99,7 +99,7 @@ project.
 
 include::admin_guide/limits.adoc[tag=admin_limits_viewing]
 
-Full limit range definitions can be viewed by running `oc export` on the object.
+Full limit range definitions can be viewed by running `oc get --export` on the object.
 The following shows an example limit range definition:
 
 include::admin_guide/limits.adoc[tag=admin_limits_sample_definitions]

--- a/dev_guide/getting_traffic_into_cluster.adoc
+++ b/dev_guide/getting_traffic_into_cluster.adoc
@@ -353,10 +353,10 @@ service. Then, it is load balanced to the service's endpoints.
 To discover the node port automatically assigned, run:
 
 ----
-$ oc export svc postgresql-ingress
+$ oc get -o yaml --export svc postgresql-ingress
 ----
 
-.Example oc export Output
+.Example oc get --export Output
 ----
 apiVersion: v1
 kind: Service

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -266,7 +266,7 @@ You can view an image's object definition by retrieving an `*ImageStreamImage*`
 definition using the image stream name and ID:
 
 ----
-$ oc export isimage <image_stream_name>@<id>
+$ oc get -o yaml --export isimage <image_stream_name>@<id>
 ----
 
 [NOTE]
@@ -284,7 +284,7 @@ with the name and ID of *ruby@3a335d7*:
 .Definition of an Image Object Retrieved via `ImageStreamImage`
 
 ----
-$ oc export isimage ruby@3a335d7
+$ oc get -o yaml --export isimage ruby@3a335d7
 
 apiVersion: v1
 image:

--- a/dev_guide/migrating_applications/database_applications.adoc
+++ b/dev_guide/migrating_applications/database_applications.adoc
@@ -296,11 +296,11 @@ $ rhc scp -a <v2 appname> download mongodump \
 . Start a MongoDB pod in v3. Because the latest image (3.2.6) does not include
 *mongo-tools*, to use `mongorestore` or `mongoimport` commands you need to edit
 the default *mongodb-persistent* template to specify the image tag that contains
-the `*mongo-tools, “mongodb:2.4”*`. For that reason, the following `oc export`
+the `*mongo-tools, “mongodb:2.4”*`. For that reason, the following `oc get --export`
 command and edit are necessary:
 +
 ----
-$ oc export template mongodb-persistent -n openshift -o json > mongodb-24persistent.json
+$ oc get -o json --export template mongodb-persistent -n openshift > mongodb-24persistent.json
 ----
 +
 Edit L80 of *_mongodb-24persistent.json_*; replace `*mongodb:latest*` with `*mongodb:2.4*`.

--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -846,23 +846,23 @@ after the template is deployed.
 === Creating a Template from Existing Objects
 ifdef::openshift-online[]
 If you are upgrading from {product-title} Starter to {product-title} Pro, use
-`oc export all` to export all of your existing objects. {product-title} Pro does
+`oc get --export all` to export all of your existing objects. {product-title} Pro does
 not support per-object resource migration.
 endif::[]
 
 Rather than writing an entire template from scratch, you can export existing
-objects from your project in template form, and then modify the template from
-there by adding parameters and other customizations. To export objects in a
-project in template form, run:
+objects from your project in yaml form, and then modify the yaml from
+there by adding parameters and other customizations as template form. To export objects in a
+project in yaml form, run:
 
 ----
-$ oc export all --as-template=<template_name> > <template_filename>
+$ oc get -o yaml --export all > <yaml_filename>
 ----
 
 You can also substitute a particular resource type or multiple resources instead of `all`.
-Run `oc export -h` for more examples.
+Run `oc get -h` for more examples.
 
-The object types included in `oc export all` are:
+The object types included in `oc get --export all` are:
 
 - BuildConfig
 - Build

--- a/install_config/persistent_storage/pod_security_context.adoc
+++ b/install_config/persistent_storage/pod_security_context.adoc
@@ -148,8 +148,8 @@ this entails. The *restricted* SCC has the following characteristics:
 
 - User IDs are constrained due to the `runAsUser` strategy being set to
 *MustRunAsRange*. This forces user ID validation.
-- Because a range of allowable user IDs is not defined in the SCC (see `oc export
-scc restricted` for more details), the project's
+- Because a range of allowable user IDs is not defined in the SCC (see
+oc get -o yaml --export scc restricted` for more details), the project's
 `openshift.io/sa.scc.uid-range` range will be used for range checking and for
 a default ID, if needed.
 - A default user ID is produced when a user ID is not specified in the pod
@@ -382,7 +382,7 @@ the YAML file to meet the requirements of the new SCC. For example:
 . Use the *restricted* SCC as a template for the new SCC:
 +
 ----
-$ oc export scc restricted > new-scc.yaml
+$ oc get -o yaml --export scc restricted > new-scc.yaml
 ----
 
 . Edit the *_new-scc.yaml_* file to your desired specifications.
@@ -402,7 +402,7 @@ Here is a fragment of a new SCC named *nfs-scc*:
 
 ====
 ----
-$ oc export scc nfs-scc
+$ oc get -o yaml --export scc nfs-scc
 
 allowHostDirVolumePlugin: false <1>
 ...
@@ -507,7 +507,7 @@ the range of allowed IDs in the predefined projects.
 Consider the following fragment of a new SCC definition:
 
 ----
-# oc export scc new-scc
+# oc get -o yaml --export scc new-scc
 ...
 kind: SecurityContextConstraints
 ...
@@ -645,7 +645,7 @@ such that:
 For example:
 
 ----
-$ oc export scc nfs-scc
+$ oc get -o yaml --export scc nfs-scc
 
 allowHostDirVolumePlugin: false <1>
 ...
@@ -706,12 +706,12 @@ Here are fragments from an SCC and from the *default* project:
 
 
 ----
-$ oc export scc scc-name
+$ oc get -o yaml --export scc scc-name
 ...
 seLinuxContext:
   type: MustRunAs <1>
 
-# oc export project default
+# oc get -o yaml --export namespace default
 ...
 metadata:
   annotations:

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -676,7 +676,7 @@ $ cat router.crt /etc/origin/master/ca.crt router.key > router.pem
 . Before you generate a new secret, back up the current one:
 +
 ----
-$ oc export secret router-certs > ~/old-router-certs-secret.yaml
+$ oc get -o yaml --export secret router-certs > ~/old-router-certs-secret.yaml
 ----
 
 . Create a new secret to hold the new certificate and key, and replace the 

--- a/install_config/storage_examples/privileged_pod_storage.adoc
+++ b/install_config/storage_examples/privileged_pod_storage.adoc
@@ -163,7 +163,7 @@ It can take several minutes for the pod to create.
 . Export the pod configuration:
 +
 ----
-$ oc export pod <pod_name>
+$ oc get -o yaml --export pod <pod_name>
 ----
 
 . Examine the output. Check that `openshift.io/scc` has the value of


### PR DESCRIPTION
`oc export` command is deprecated since `v3.10`.

Personally I think we should start to take effect new one in documentation at the moment.

At least, we should inform the deprecated status for users at the sections which used `oc export`, if the changes can not update on current documentation.

As far as I know, new `oc get --export` does not implement same feature with old `oc export`, such as `--as-template`, `--output-version` and so on. So we might provide workarounds, such as edit manually something the form, if we can.

Related info:
- issue: 
  - https://github.com/openshift/origin/issues/20813
  - https://github.com/openshift/openshift-docs/issues/12409
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1641309