### PR TITLE
Fluentd label not being set on nodes during scaleup

### DIFF
--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -134,6 +134,12 @@ $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i /path/to/file] \
     playbooks/openshift-master/scaleup.yml
 ----
++
+. Set the node label to `logging-infra-fluentd: "true"`.
++
+----
+# oc label node/new-node.example.com logging-infra-fluentd: "true"
+----
 
 . After the playbook runs,
 xref:../install/running_install.adoc#advanced-verifying-the-installation[verify the installation].

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -62,12 +62,6 @@ $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i /path/to/file] \
   playbooks/openshift-etcd/scaleup.yml
 ----
-+
-. Set the node label to `logging-infra-fluentd: "true"`.
-+
-----
-# oc label node/new-node.example.com logging-infra-fluentd: "true"
-----
 
 . After the playbook completes successfully,
 xref:../install/running_install.adoc#advanced-verifying-the-installation[verify the installation].


### PR DESCRIPTION
Correct closed BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1609089

This BZ was closed with changes, but the changes have been updated in wrong section.
So I correct this.