### PR TITLE
[enterprise-3.10] New command to launch service logs

### DIFF
--- a/day_two_guide/topics/proc_restoring-etcd.adoc
+++ b/day_two_guide/topics/proc_restoring-etcd.adoc
@@ -108,7 +108,7 @@ command adding the `--force-new-cluster` option:
 . Check for error messages:
 +
 ----
-$ journalctl -fu etcd.service
+$ master-logs etcd etcd
 ----
 
 . Check for health status:

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1774,8 +1774,8 @@ Use the `-r` option to show the newest entries first.
 For example:
 
 ----
-# journalctl -r -u atomic-openshift-master-controllers
-# journalctl -r -u atomic-openshift-master-api
+# master-logs controllers controllers
+# master-logs api api
 # journalctl -r -u atomic-openshift-node.service
 ----
 

--- a/security/monitoring.adoc
+++ b/security/monitoring.adoc
@@ -89,7 +89,7 @@ This section describes the types of operational logs produced on the cluster.
 [[security-monitoring-service-logs]]
 === Service Logs
 
-{product-title} produces logs with each *systemd* service that is running on a host:
+{product-title} produces logs for services that run on static pods in a cluster:
 
 ifdef::openshift-origin[]
 - origin-master-api
@@ -104,9 +104,9 @@ ifdef::openshift-enterprise[]
 - atomic-openshift-node (use `journalctl -u atomic-openshift-node.service`)
 endif::[]
 
-These logs are intended more for debugging purposes than for security auditing. You can retrieved logs per host or, 
-in clusters with the aggregated logging stack deployed, in the logging _.operations_ indexes (possibly
-in the xref:../install_config/aggregate_logging.adoc#aggregated-ops[Ops cluster]) as a cluster administrator.
+These logs are intended more for debugging purposes than for security auditing. You can retrieve logs for 
+each service with the `master-logs api api`, `master-logs controllers controllers`, or `master-logs etcd etcd` commands. 
+If your cluster runs an aggregated logging stack, like an xref:../install_config/aggregate_logging.adoc#aggregated-ops[Ops cluster], cluster administrators can retrieve logs from the logging _.operations_ indexes.
 
 [NOTE]
 ====


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/10313

Because I neglected to cherrypick this PR at the same time as 10313, changes to _day_two_guide/topics/proc_adding-etcd-after-restoring.adoc_ were overridden by later merge and not needed for this PR.