### PR TITLE
[enterprise-3.10] syslog-output-plugin-for-fluentd should be moved from

### DIFF
--- a/release_notes/ocp_3_10_release_notes.adoc
+++ b/release_notes/ocp_3_10_release_notes.adoc
@@ -588,26 +588,6 @@ and hook it up to Prometheus.
 See xref:../install_config/cluster_metrics.adoc#openshift-prometheus[Prometheus
 on OpenShift] for more information.
 
-[[ocp-310-syslog-output-plugin-for-fluentd]]
-==== syslog Output Plug-in for fluentd (Technology Preview)
-
-syslog Output Plug-in for fluentd is a feature currently in
-xref:ocp-310-technology-preview[Technology Preview] and not for production
-workloads.
-
-You can send system and container logs from {product-title} nodes to external
-endpoints using the syslog protocol. The fluentd syslog output plug-in supports
-this.
-
-[IMPORTANT]
-====
-Logs sent via syslog are not encrypted and, therefore, insecure.
-====
-
-See
-xref:../install_config/aggregate_logging.adoc#sending-logs-to-external-rsyslog[Sending
-Logs to an External Syslog Server] for more information.
-
 [[ocp-310-developer-experience]]
 === Developer Experience
 
@@ -1888,10 +1868,10 @@ features marked *GA* indicate _General Availability_.
 |TP
 |GA
 
-|xref:ocp-310-syslog-output-plugin-for-fluentd[syslog Output Plug-in for fluentd]
+|syslog Output Plug-in for fluentd
 |-
-|TP
-|TP
+|GA
+|GA
 
 |xref:ocp-310-CSI[Container Storage Interface (CSI)]
 |-


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/12234