### PR TITLE
Rm monospace font from 'strong' element (4.x only)

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -615,7 +615,7 @@ span.footnote a:active, span.footnoteref a:active { text-decoration: underline; 
 div.unbreakable { page-break-inside: avoid; }
 code { color: #404040; background-color: #e7e7e7; font-weight: bold; font-family: "Roboto Mono", monospace;}
 h5 { color: #404040; }
-strong { color: #404040; font-weight: bold; font-family: "Roboto Mono", monospace; }
+strong { color: #404040; font-weight: bold; }
 a strong { color: inherit; }
 a code { color: inherit; }
 .replaceable { font-style: italic; font-color: inherit; font-family: inherit; }


### PR DESCRIPTION
Revert only the `<strong>` element changes from https://github.com/openshift/openshift-docs/pull/3702.
