### PR TITLE
Fix etcd backup and restore for API v2 and v3

### DIFF
--- a/day_two_guide/topics/proc_backing-up-etcd.adoc
+++ b/day_two_guide/topics/proc_backing-up-etcd.adoc
@@ -63,6 +63,10 @@ Before backing up etcd:
 
 ifeval::["{context}" == "environment-backup"]
 . To ensure the etcd cluster is working, check its health.
+You can use both etcd v2 and v3 API versions as both commands backup the whole v2 and v3 data.
+Also the etcd nodes information is the same in API v2 and v3, therefore you can do health checks and member related
+operations indistinctly.
+
 ** If you use the etcd v2 API, run the following command:
 +
 ----
@@ -222,8 +226,8 @@ the `/var/lib/origin/openshift.local.etcd` directory.
 +
 [IMPORTANT]
 ====
-Because clusters upgraded from previous versions of {product-title} might
-contain v2 data stores, back up both v2 and v3 datastores.
+Because etcd backup copies the whole database both v2 and v3 are included either way
+in both methods.
 ====
 
 .. Back up etcd v3 data: 

--- a/day_two_guide/topics/proc_restoring-etcd.adoc
+++ b/day_two_guide/topics/proc_restoring-etcd.adoc
@@ -34,7 +34,7 @@ external NFS share, S3 bucket, or other storage solution.
 ====
 If you run etcd as a static pod, follow only the steps in that section. If you
 run etcd as a separate service on either master or standalone nodes, follow the
-steps to restore v2 and v3 data as required.
+steps to restore v2 or v3 data as required.
 ====
 
 ifeval::["{context}" != "downgrade"]
@@ -183,8 +183,7 @@ endif::[]
 == Restoring etcd v3 snapshot
 
 ifeval::["{context}" != "downgrade"]
-The restore procedure for v3 data is similar to the restore procedure for the v2
-data.
+The restore procedure for v3 data is similar to the restore procedure for the v2.
 endif::[]
 
 Snapshot integrity may be optionally verified at restore time. If the snapshot
@@ -195,7 +194,7 @@ directory, there is no integrity hash and it will only restore by using
 
 [IMPORTANT]
 ====
-The procedure to restore only the v3 data must be performed on a single etcd
+The procedure to restore the data must be performed on a single etcd
 host. You can then add the rest of the nodes to the cluster.
 ====
 


### PR DESCRIPTION
Docs seem to say that v2 backup does not include v3 data and
vice versa. Both backup all the data, and when restoring, restore
one is enough.