### PR TITLE
[enterprise-3.9] Storage Class fixes and improvements

### DIFF
--- a/install_config/persistent_storage/topics/glusterfs_storageclass.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_storageclass.adoc
@@ -6,30 +6,41 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: slow
 provisioner: kubernetes.io/glusterfs
-parameters:
-  resturl: "http://127.0.0.1:8081" <1>
-  restuser: "admin" <2>
-  secretName: "heketi-secret" <3>
-  secretNamespace: "default" <4>
-  gidMin: "40000" <5>
-  gidMax: "50000" <6>
+parameters: <1>
+  resturl: http://127.0.0.1:8081 <2>
+  restuser: admin <3>
+  secretName: heketi-secret <4>
+  secretNamespace: default <5>
+  gidMin: "40000" <6>
+  gidMax: "50000" <7>
+  volumeoptions: group metadata-cache, nl-cache on <8>
+  volumetype: replicate:3 <9>
 ----
-<1> link:https://github.com/heketi/heketi[heketi] (volume management REST
+<1> Listed are mandatory and a few optional parameters. Please refer to
+link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.10/html-single/operations_guide/#sect_file_reg_storageclass[Registering
+a Storage Class] for additional parameters.
+<2> link:https://github.com/heketi/heketi[heketi] (volume management REST
 service for Gluster) URL that provisions GlusterFS volumes on demand. The
 general format should be `{http/https}://{IPaddress}:{Port}`. This is a
 mandatory parameter for the GlusterFS dynamic provisioner. If the heketi
 service is exposed as a routable service in the {product-title}, it will have a
 resolvable fully qualified domain name (FQDN) and heketi service URL.
-<2> heketi user who has access to create volumes. Usually "admin".
-<3> Identification of a Secret that contains a user password to use when
+<3> heketi user who has access to create volumes. Usually "admin".
+<4> Identification of a Secret that contains a user password to use when
 talking to heketi. Optional; an empty password will be used
 when both `secretNamespace` and `secretName` are omitted. The provided secret
 must be of type `"kubernetes.io/glusterfs"`.
-<4> The namespace of mentioned `secretName`. Optional; an empty password will be used
+<5> The namespace of mentioned `secretName`. Optional; an empty password will be used
 when both `secretNamespace` and `secretName` are omitted. The provided secret
 must be of type `"kubernetes.io/glusterfs"`.
-<5> Optional. The minimum value of the GID range for volumes of this StorageClass.
-<6> Optional. The maximum value of the GID range for volumes of this StorageClass.
+<6> Optional. The minimum value of the GID range for volumes of this StorageClass.
+<7> Optional. The maximum value of the GID range for volumes of this StorageClass.
+<8> Optional. Options for newly created volumes. It allows for performance tuning. See
+link:https://docs.gluster.org/en/v3/Administrator%20Guide/Managing%20Volumes/#tuning-volume-options[Tuning
+Volume Options] for more GlusterFS volume options.
+<9> Optional. The
+link:https://docs.gluster.org/en/v3/Quick-Start-Guide/Architecture/[type of
+volume] to use.
 
 [NOTE]
 ====

--- a/install_config/storage_examples/ceph_rbd_dynamic_example.adoc
+++ b/install_config/storage_examples/ceph_rbd_dynamic_example.adoc
@@ -120,7 +120,7 @@ kind: StorageClass
 metadata:
   name: dynamic
   annotations:
-     storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/rbd
 parameters:
   monitors: 192.168.1.11:6789,192.168.1.12:6789,192.168.1.13:6789 <1>  
@@ -206,7 +206,7 @@ spec:
   volumes:
   - name: ceph-vol1         
     persistentVolumeClaim:
-      claimName: ceph-claim <5>  
+      claimName: ceph-claim-dynamic <5>  
 ----
 <1> The name of this pod as displayed by `oc get pod`.
 <2> The image run by this pod. In this case, `busybox` is set to `sleep`.


### PR DESCRIPTION
- Fixed ceph dynamic sc example
- Updated the default storage class annotation
- Added more GlusterFS parameters and options

Signed-off-by: Michal Minář <miminar@redhat.com>

From https://github.com/openshift/openshift-docs/pull/11914