### PR TITLE
replace  deprecated openshift_node_kubelet_args with new one in example

### DIFF
--- a/install/stand_alone_registry.adoc
+++ b/install/stand_alone_registry.adoc
@@ -195,8 +195,8 @@ openshift_master_cluster_method=native
 openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
-# apply updated node defaults
-openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}
+# apply updated node-config-compute group defaults
+openshift_node_groups=[{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{'key': 'kubeletArguments.pods-per-core','value': ['20']}, {'key': 'kubeletArguments.max-pods','value': ['250']}, {'key': 'kubeletArguments.image-gc-high-threshold', 'value':['90']}, {'key': 'kubeletArguments.image-gc-low-threshold', 'value': ['80']}]}]
 
 # enable ntp on masters to ensure proper failover
 openshift_clock_enabled=true
@@ -220,8 +220,8 @@ lb.example.com
 # host group for nodes, includes region info
 [nodes]
 master[1:3].example.com openshift_node_group_name='node-config-master-infra'
-node1.example.com openshift_node_group_name='node-config-compute'
-node2.example.com openshift_node_group_name='node-config-compute'
+node1.example.com       openshift_node_group_name='node-config-compute'
+node2.example.com       openshift_node_group_name='node-config-compute'
 ----
 <1> Set `deployment_subtype=registry` to ensure installation of stand-alone OCR and
 not a full {product-title} environment.


### PR DESCRIPTION
Fix `inventory` example included  deprecated `openshift_node_kubelet_args` as replacing with new one at `v3.11`. 

NOT merging to `v3.10`, it's some different with `v3.11`. I've opened new `PR` about `v3.10`. : Fix `inventory` example included  deprecated `openshift_node_kubelet_args` as replacing with new one at `v3.10`. 

NOT merging to `v3.11`, it's some different with `v3.10`. I'll open new `PR` about `v3.11`: https://github.com/openshift/openshift-docs/pull/12677

- Related info:
  - issues: https://github.com/openshift/openshift-docs/issues/12623
  - BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1569476
  - PR: https://github.com/openshift/openshift-docs/pull/12640
  - PR, the `v3.10` branch: https://github.com/openshift/openshift-docs/pull/12677