### PR TITLE
Bad command given in exposing HAProxy Router Metrics 

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1743,7 +1743,7 @@ haproxy_server_bytes_in_total{namespace="default",pod="hello-rc-vkjqx",route="he
 from the router deployment configuration file:
 +
 ----
-$ oc edit service router
+$ oc edit dc router
 
 - name: ROUTER_LISTEN_ADDR
   value: 0.0.0.0:1936


### PR DESCRIPTION
Fix: https://github.com/openshift/openshift-docs/issues/12669

I closed this PR by my mistake, so I open again this PR. 