### PR TITLE
[enterprise-3.10] remove openshift_node_kubelet_args due to deprecated parameter

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -433,19 +433,6 @@ installations, or for hosts on networks using a network address translation
 xref:configuring-inventory-defining-node-group-and-host-mappings[Defining Node
 Groups and Host Mappings] for the current method of setting node labels.
 
-|`openshift_node_kubelet_args`
-|This variable is used to configure `kubeletArguments` on nodes, such as
-arguments used in xref:../admin_guide/garbage_collection.adoc#admin-guide-garbage-collection[container and
-image garbage collection], and to
-xref:../admin_guide/manage_nodes.adoc#configuring-node-resources[specify
-resources per node]. `kubeletArguments` are key value pairs that are passed
-directly to the Kubelet that match the
-https://kubernetes.io/docs/admin/kubelet/[Kubelet's command line
-arguments]. `kubeletArguments` are not migrated or validated and may become
-invalid if used. These values override other settings in node configuration
-which may cause invalid configurations. Example usage:
-*{'image-gc-high-threshold': ['90'],'image-gc-low-threshold': ['80']}*.
-
 |`openshift_docker_options`
 a|This variable configures additional `docker` options within
 *_/etc/sysconfig/docker_*, such as options used in


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/12640