### PR TITLE
Fix BZ#1644604: Add Ansible usage for vSphere provider in v3.9

### DIFF
--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -156,7 +156,28 @@ host name. The `openshift_hostname` variable defines the `nodeName` value in the
 determined by using the command `uname -n`. In case of a mismatch, the native
 cloud integration for those providers will not work.
 ====
+[[vsphere-configuring-ansible]]
+== Configuring {product-title} for vSphere using Ansible
 
+You can configure OpenShift Container Platform for VMware vSphere (VCP) by modifying the Ansible inventory file during installation or after installation.
+
+.Procedure
+
+. Add the following section to the Ansible inventory file:
++
+----
+[OSEv3:vars]
+openshift_cloudprovider_kind=vsphere
+openshift_cloudprovider_vsphere_username=administrator@vsphere.local <1>
+openshift_cloudprovider_vsphere_password=<password>
+openshift_cloudprovider_vsphere_host=10.x.y.32 <2>
+openshift_cloudprovider_vsphere_datacenter=<Datacenter> <3>
+openshift_cloudprovider_vsphere_datastore=<Datastore> <4>
+----
+<1> The user name with the appropriate permissions to create and attach disks in vSphere.
+<2> The vCenter server address.
+<3> The vCenter Datacenter name where the {product-title} VMs are located.
+<4> The datastore used for creating VMDKs.
 
 [[vsphere-configuration-file]]
 == The VMware vSphere Configuration File


### PR DESCRIPTION
Fix the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1644604

`v3.9` is not modular format unlike `v3.10` and `v3.11`, so personally I thought good to move just the `ansible` usage section's description to `v3.9` simply.

But if it's wrong, you can correct.