### PR TITLE
Disconnected Installation - Add missing images to docker save command

### DIFF
--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -401,6 +401,7 @@ $ docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/ose-haproxy-router \
     registry.access.redhat.com/openshift3/ose-keepalived-ipfailover \
     registry.access.redhat.com/openshift3/ose-pod \
+    registry.access.redhat.com/openshift3/ose-service-catalog \
     registry.access.redhat.com/openshift3/ose-sti-builder \
     registry.access.redhat.com/openshift3/ose-template-service-broker \
     registry.access.redhat.com/openshift3/ose-web-console \
@@ -412,6 +413,8 @@ $ docker save -o ose3-images.tar \
     registry.access.redhat.com/openshift3/prometheus-alert-buffer \
     registry.access.redhat.com/openshift3/prometheus-alertmanager \
     registry.access.redhat.com/openshift3/prometheus-node-exporter \
+    registry.access.redhat.com/openshift3/mediawiki-apb \
+    registry.access.redhat.com/openshift3/postgresql-apb \
     registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql \
     registry.access.redhat.com/cloudforms46/cfme-openshift-memcached \
     registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui \


### PR DESCRIPTION
For the Docker image export procedure, there are a handful of images that are specified should be pulled down, but are not specified to export into a tar file via the docker save command. This request adds the missing images.

This is applicable to enterprise-3.9 only. 3.10, 3.11 already specify to export these images.