### PR TITLE
Fixed an typo in ordered list

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1618,6 +1618,7 @@ $ oc label route annotated-unsecured-blueprint type-
 ----
 
 . Create a new router to be used for the blueprint pool:
++
 ----
 $ oc adm router
 ----


### PR DESCRIPTION
Noticed a missing `+` in an ordered list. Feature is 3.11+