### PR TITLE
Fix typo in image change trigger

### DIFF
--- a/dev_guide/builds/triggering_builds.adoc
+++ b/dev_guide/builds/triggering_builds.adoc
@@ -399,7 +399,7 @@ the image stream named `ruby-20-centos7` located within this namespace.
 ----
 type: "imageChange" <1>
 imageChange: {}
-type: "imagechange" <2>
+type: "imageChange" <2>
 imageChange:
   from:
     kind: "ImageStreamTag"


### PR DESCRIPTION
It's especially unpleasant as using `imagechange` instead of `imageChange` makes the trigger to be silently ignored on apply.