### PR TITLE
Clarify descriptions of master certificate files

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -137,9 +137,9 @@ openshift_master_named_certificates=[{"certfile": "/path/to/console.ocp-c1.myorg
 
 Where the parameter values are: 
 
-* *certfile* is the path to the file that contains the {product-title} router certificate.
+* *certfile* is the path to the file that contains the {product-title} custom certificate.
 
-* *keyfile* is the path to the file that contains the {product-title} wildcard key.
+* *keyfile* is the path to the file that contains the {product-title} custom key.
 
 * *names* is the cluster public hostname.
 


### PR DESCRIPTION
Descriptions were copy/pasted from the Router section. Clarify the descriptions of these files so they're a little more relevant to the Master Host/Console configuration.