### PR TITLE
Fix the broken Atomic Registry link

### DIFF
--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -30,9 +30,9 @@ developer-focused web console and application build and deployment tools.
 
 [NOTE]
 ====
-OCR should not be confused with the upstream project
-link:https://www.projectatomic.io/blog/2017/05/oo-standalone-registry/[Atomic Registry], which is a
-different implementation using a non-Kubernetes deployment method that leverages
+OCR has replaced the upstream
+link:https://www.projectatomic.io/blog/2017/05/oo-standalone-registry/[Atomic Registry] project, which was a
+different implementation that used a non-Kubernetes deployment method that leveraged
 `systemd` and local configuration files to manage services.
 ====
 

--- a/install_config/install/stand_alone_registry.adoc
+++ b/install_config/install/stand_alone_registry.adoc
@@ -31,7 +31,7 @@ developer-focused web console and application build and deployment tools.
 [NOTE]
 ====
 OCR should not be confused with the upstream project
-link:http://www.projectatomic.io/registry/[Atomic Registry], which is a
+link:https://www.projectatomic.io/blog/2017/05/oo-standalone-registry/[Atomic Registry], which is a
 different implementation using a non-Kubernetes deployment method that leverages
 `systemd` and local configuration files to manage services.
 ====


### PR DESCRIPTION
Related issue: https://github.com/openshift/openshift-docs/issues/12758

I would suggest new hyperlink of `Atomic Registry` instead of the broken one, because original link does not exist no more.

- New link:
[Update: Removed links to Atomic Registry as discontinued.](https://www.projectatomic.io/blog/2017/05/oo-standalone-registry/)
  - I seems good because this page inform users that `Atomic Registry` is not valid and provides more details about it.
- Target version: `v3.3` ~ `v3.7` have the section which was included the broken links.