### PR TITLE
disconnected_install: fix typo (orge_url->oreg_url)

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -639,7 +639,7 @@ standard installation method to install {product-title}:
 inventory file] to reference your internal registry:
 +
 ----
-orge_url=registry.example.com/openshift3/ose-${component}:${version}
+oreg_url=registry.example.com/openshift3/ose-${component}:${version}
 openshift_examples_modify_imagestreams=true
 ----
 


### PR DESCRIPTION
This applies to enterprise-3.10 and enterprise-3.11 as well.