### PR TITLE
Incorrect externalIPNetworkCIDRs example

### DIFF
--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -343,7 +343,8 @@ restarted.
 ====
 ----
 networkConfig:
-  externalIPNetworkCIDR: 192.0.1.0.0/24
+  externalIPNetworkCIDRs:
+  - 192.0.1.0.0/24
 ----
 ====
 


### PR DESCRIPTION
Some examples of `externalIPNetworkCIDRs:` at `/etc/origin/master/master-config.yaml` are not correct, as they omit the final `s` and setup a single value instead of an array.