### PR TITLE
Fix typo in Service Catalog docs

### DIFF
--- a/architecture/service_catalog/index.adoc
+++ b/architecture/service_catalog/index.adoc
@@ -134,7 +134,7 @@ endif::openshift-enterprise,openshift-origin[]
 
 Cluster Service Broker::
 A _cluster service broker_ is a server that conforms to the OSB API specification
-and manages a set of one or more services. The software could be hosted within|
+and manages a set of one or more services. The software could be hosted within
 your own {product-title} cluster or elsewhere.
 +
 Cluster administrators can create `ClusterServiceBroker` API resources


### PR DESCRIPTION
Applicable to enterprise-3.7 and above.