### PR TITLE
Add --from-file to create secret

### DIFF
--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -425,7 +425,7 @@ If no certificate is found, a self-signed certificate is created using the
 +
 ----
 $ oc create secret generic console-secret \
-    /path/to/console.cert
+    --from-file=/path/to/console.cert
 ----
 +
 . Add the secrets to the *registry-console* deployment configuration:


### PR DESCRIPTION
A customer faced that this command, with --from-file it works fine. According to the docs of oc create secret generic it should include the --from-file.