### PR TITLE
Add documentation for GCP shared network support.

### DIFF
--- a/install_config/topics/configuring_for_gce.adoc
+++ b/install_config/topics/configuring_for_gce.adoc
@@ -15,6 +15,7 @@ inventory file] at installation time or after installation.
 .Procedure
 . At minimum, you must define the `openshift_cloudprovider_kind`, `openshift_gcp_project` and
 `openshift_gcp_prefix` parameters, as well as the optional `openshift_gcp_multizone` for multizone deployments and `openshift_gcp_network_name` if you are not using the default network name.
+If you use a shared network that belongs to another GCP project you also need to set `openshift_gcp_network_project`.
 +
 Add the following section to the Ansible inventory file at installation to
 configure your {product-title} environment for GCP:
@@ -26,12 +27,14 @@ openshift_gcp_project=<projectid> <1>
 openshift_gcp_prefix=<uid> <2>
 openshift_gcp_multizone=False <3>
 openshift_gcp_network_name=<network name> <4>
+openshift_gcp_network_project=<projectid the network name belongs to> <5>
 ----
 <1> Provide the GCP project ID where the existing instances are running. This ID is generated when you create the project in the Google Cloud Platform Console.
 <2> Provide a unique string to identify each {product-title} cluster. This must be unique across GCP.
 <3> Optionally, set to `True` to trigger multizone deployments on GCP. Set to
 `False` by default.
 <4> Optionally, provide the network name if not using `default` network.
+<5> Optionally, provide the GCP project ID where the network name belongs to (shared network).
 +
 Installing with Ansible also creates and configures the following files to fit
 your GCP environment:
@@ -92,6 +95,7 @@ openshift_gcp_prefix=myocp
 # If deploying single zone cluster set to "False"
 openshift_gcp_multizone="True"
 openshift_gcp_network_name=myocp-net
+openshift_gcp_network_project=my-net-project
 
 openshift_master_api_port=443
 openshift_master_console_port=443


### PR DESCRIPTION
If we use a shared network on GCP than we also need to tell kubernetes the project-id of the network.
Please merge this to enterprise-3.9 , enterprise-3.10 and enterprise-3.11
Thanks =)