### PR TITLE
BZ1643492 edited Adding Hosts section

### DIFF
--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -45,11 +45,11 @@ limits] section for the recommended maximum number of nodes.
 [discrete]
 == Procedure
 
-. Ensure you have the latest playbooks by updating the *atomic-openshift-utils*
+. Ensure you have the latest playbooks by updating the *openshift-ansible*
 package:
 +
 ----
-# yum update atomic-openshift-utils
+# yum update 'openshift-ansible*'
 ----
 
 . Edit your *_/etc/ansible/hosts_* file and add *new_<host_type>* to the


### PR DESCRIPTION
BZ1643492: In OCP 3.11, we do not install atomic-openshift-utils. Use openshift-ansible.