### PR TITLE
[enterprise-3.6] Update repos orgazation to sclorg

### DIFF
--- a/dev_guide/dev_tutorials/ruby_on_rails.adoc
+++ b/dev_guide/dev_tutorials/ruby_on_rails.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 == Overview
 
-Ruby on Rails is a popular web framework written in https://github.com/openshift/mysql/tree/master/5.5[Ruby].
+Ruby on Rails is a popular web framework written in https://github.com/sclorg/mysql-container/tree/master/5.5[Ruby].
 This guide covers using Rails 4 on {product-title}.
 
 [WARNING]

--- a/getting_started/beyond_the_basics.adoc
+++ b/getting_started/beyond_the_basics.adoc
@@ -408,11 +408,11 @@ and try out Quickstart templates for the following languages:
 
 Other images provided by {product-title} include:
 
-* https://github.com/openshift/mysql[MySQL]
+* https://github.com/sclorg/mysql-container[MySQL]
 
-* https://github.com/openshift/mongodb[MongoDB]
+* https://github.com/sclorg/mongodb-container[MongoDB]
 
-* https://github.com/openshift/postgresql[PostgreSQL]
+* https://github.com/sclorg/postgresql-container[PostgreSQL]
 
 * https://github.com/openshift/jenkins[Jenkins]
 

--- a/getting_started/developers_cli.adoc
+++ b/getting_started/developers_cli.adoc
@@ -82,11 +82,11 @@ endif::[]
 
 Other images provided by {product-title} include:
 
-* https://github.com/openshift/mysql[MySQL]
+* https://github.com/sclorg/mysql-container[MySQL]
 
-* https://github.com/openshift/mongodb[MongoDB]
+* https://github.com/sclorg/mongodb-container[MongoDB]
 
-* https://github.com/openshift/postgresql[PostgreSQL]
+* https://github.com/sclorg/postgresql-container[PostgreSQL]
 
 * https://github.com/openshift/jenkins[Jenkins]
 

--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -18,8 +18,9 @@ settings provided via configuration.
 
 == Versions
 Currently, {product-title} provides versions
-link:https://github.com/openshift/mongodb/tree/master/2.6[2.6] and
-link:https://github.com/openshift/mongodb/tree/master/3.2[3.2] of MongoDB.
+link:https://github.com/sclorg/mongodb-container/tree/master/2.6[2.6],
+link:https://github.com/sclorg/mongodb-container/tree/master/3.2[3.2], and
+link:https://github.com/sclorg/mongodb-container/tree/master/3.4[3.4] of MongoDB.
 
 == Images
 

--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -18,8 +18,8 @@ settings provided via configuration.
 
 == Versions
 Currently, {product-title} provides versions
-link:https://github.com/openshift/mysql/tree/master/5.6[5.6] and
-link:https://github.com/openshift/mysql/tree/master/5.7[5.7] of MySQL.
+link:https://github.com/sclorg/mysql-container/tree/master/5.6[5.6] and
+link:https://github.com/sclorg/mysql-container/tree/master/5.7[5.7] of MySQL.
 
 == Images
 


### PR DESCRIPTION
CP from https://github.com/openshift/openshift-docs/pull/12517

@liangxia This added the following version to 3.6:

link:https://github.com/sclorg/mongodb-container/tree/master/3.4[3.4] of MongoDB.

Is this version supported in 3.6?