### PR TITLE
Remove a uncorrect reference link of CustomPodDNS

### DIFF
--- a/admin_guide/disabling_features.adoc
+++ b/admin_guide/disabling_features.adoc
@@ -161,8 +161,7 @@ see xref:../scaling_performance/using_cpu_manager.adoc#scaling-performance-using
 see the link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md[CSI Volume Plugins in Kubernetes Design Documentation].
 
 | *CustomPodDNS*
-| Enables customizing the DNS settings for a pod using the *dnsConfig* property. For more information, see
-xref:../install_config/master_node_configuration.adoc#master-config-serving-information-config[Serving Information Configuration].
+| Enables customizing the DNS settings for a pod using the *dnsConfig* property.
 
 | *CustomResourceSubresources*
 | Enables */status* and */scale* subresources on resources created from CustomResourceDefinition.


### PR DESCRIPTION
* Version: `v3.11` and `v3.10`

* Description:
The current reference link [Server Information Configuration](https://docs.openshift.com/container-platform/3.11/install_config/master_node_configuration.html#master-config-serving-information-config) is not correct for details of `CustomPodDNS`. The parameter name is same between `master-config.yaml` and `CustomPodDNS`, but it's NOT same feature. Refer [0] and [1] for more details of `CustomPodDNS`. 

[0] [[RFE] Support Pod’s DNS Config](https://bugzilla.redhat.com/show_bug.cgi?id=1568526)
[1] [Pod’s DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config)
~~~
apiVersion: v1
kind: Pod
metadata:
  namespace: default
  name: dns-example
spec:
  containers:
    - name: test
      image: nginx
  dnsPolicy: "None"
  dnsConfig:
    nameservers:
      - 1.2.3.4
    searches:
      - ns1.svc.cluster.local
      - my.dns.search.suffix
    options:
      - name: ndots
        value: "2"
      - name: edns0
~~~