### PR TITLE
Aws s3 iam role

### DIFF
--- a/install_config/topics/configuring_for_aws_registry-proc.adoc
+++ b/install_config/topics/configuring_for_aws_registry-proc.adoc
@@ -29,7 +29,31 @@ in the region of `us-east-1`.
 The default policy
 [source,yaml]
 ----
-
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": "arn:aws:s3:::S3_BUCKET_NAME"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListMultipartUploadParts",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": "arn:aws:s3:::S3_BUCKET_NAME/*"
+    }
+  ]
+}
 ----
 
 
@@ -57,8 +81,8 @@ openshift_hosted_registry_acceptschema2=true
 openshift_hosted_registry_enforcequota=true
 openshift_hosted_registry_replicas=3
 ----
-<1> The access key for the IAM user.
-<2> The secret key for the IAM user.
+<1> The access key for the IAM user. (Not required with IAM Roles in place)
+<2> The secret key for the IAM user. (Not required with IAM Roles in place)
 <3> The S3 storage bucket name.
 <4> The region in which the bucket exists.
 


### PR DESCRIPTION
Currently on the docs the IAM role is a blank codeblock: https://docs.openshift.com/container-platform/3.11/install_config/configuring_aws.html

Here is the correct role, per: https://docs.docker.com/registry/storage-drivers/s3/#s3-permission-scopes