### PR TITLE
Remove the deprecated openshift_ip and openshift_hostname parameters

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -247,9 +247,7 @@ In particular, the inventory must specify or override all host names and IP
 addresses set via the following variables such that they match the current
 cluster configuration:
 
-- `openshift_hostname`
 - `openshift_public_hostname`
-- `openshift_ip`
 - `openshift_public_ip`
 - `openshift_master_cluster_hostname`
 - `openshift_master_cluster_public_hostname`

--- a/install_config/topics/configuring_for_vsphere.adoc
+++ b/install_config/topics/configuring_for_vsphere.adoc
@@ -162,15 +162,15 @@ master-2.example.com
 haproxy-0.example.com vm_name=haproxy-0 ipv4addr=10.x.y.200
 
 [nodes]
-master-0.example.com openshift_node_group_name="node-config-master" openshift_schedulable=true openshift_hostname=master-0
-master-1.example.com openshift_node_group_name="node-config-master" openshift_schedulable=true openshift_hostname=master-1
-master-2.example.com openshift_node_group_name="node-config-master" openshift_schedulable=true openshift_hostname=master-2
-infra-0.example.com openshift_node_group_name="node-config-infra" openshift_hostname=infra-0
-infra-1.example.com openshift_node_group_name="node-config-infra" openshift_hostname=infra-1
-infra-2.example.com openshift_node_group_name="node-config-infra" openshift_hostname=infra-2
-app-0.example.com openshift_node_group_name="node-config-compute" openshift_hostname=app-0
-app-1.example.com openshift_node_group_name="node-config-compute" openshift_hostname=app-1
-app-2.example.com openshift_node_group_name="node-config-compute" openshift_hostname=app-2
+master-0.example.com openshift_node_group_name="node-config-master" openshift_schedulable=true
+master-1.example.com openshift_node_group_name="node-config-master" openshift_schedulable=true
+master-2.example.com openshift_node_group_name="node-config-master" openshift_schedulable=true
+infra-0.example.com openshift_node_group_name="node-config-infra"
+infra-1.example.com openshift_node_group_name="node-config-infra"
+infra-2.example.com openshift_node_group_name="node-config-infra"
+app-0.example.com openshift_node_group_name="node-config-compute"
+app-1.example.com openshift_node_group_name="node-config-compute"
+app-2.example.com openshift_node_group_name="node-config-compute"
 ----
 
 <1> If you use a container registry that requires authentication, such as the


### PR DESCRIPTION
* Fix the BZ: [[DOCS] Deprecated openshift_hostname and openshift_ip variables still in use](https://bugzilla.redhat.com/show_bug.cgi?id=1654536)

* Version: `v3.11` corresponds to all.
  - `v3.10` corresponds to only `install_config/topics/configuring_for_vsphere.adoc` commit.

* Description: 
`openshift_ip` and `openshift_hostname` has deprecated as of `v3.10`.
Refer [Notable Technical Changes
](https://docs.openshift.com/container-platform/3.10/release_notes/ocp_3_10_release_notes.html#ocp-310-notable-technical-changes)
~~~
Use of openshift_set_node_ip and openshift_ip Are No Longer Supported
  In OpenShift Container Platform 3.10, the use of openshift_set_node_ip and openshift_ip are no longer supported.
...
Removed openshift_hostname Variable
  The openshift_hostname variable is now removed.
~~~