### PR TITLE
Add the related description of specifying each storageclass

### DIFF
--- a/install_config/monitoring/configuring-openshift-cluster-monitoring.adoc
+++ b/install_config/monitoring/configuring-openshift-cluster-monitoring.adoc
@@ -34,6 +34,12 @@ The {product-title} Ansible `openshift_cluster_monitoring_operator` role configu
 |`openshift_cluster_monitoring_operator_alertmanager_storage_enabled`
 | Enable persistent storage of Alertmanager notifications and silences. This variable is set to `false` by default.
 
+|`openshift_cluster_monitoring_operator_prometheus_storage_class_name`
+| If you enabled the `openshift_cluster_monitoring_operator_prometheus_storage_enabled` option, set a specific xref:../persistent_storage/dynamically_provisioning_pvs.html#defining-storage-classes[StorageClass] to ensure that pods are configured to use the `PVC` with that `storageclass`. Defaults to `none`, which applies the default storage class name.
+
+|`openshift_cluster_monitoring_operator_alertmanager_storage_class_name`
+| If you enabled the `openshift_cluster_monitoring_operator_alertmanager_storage_enabled` option, set a specific xref:../persistent_storage/dynamically_provisioning_pvs.html#defining-storage-classes[StorageClass] to ensure that pods are configured to use the `PVC` with that `storageclass`. Defaults to `none`, which applies the default storage class name.
+
 |===
 
 [[monitoring-prerequisites]]
@@ -83,6 +89,18 @@ Unless you use dynamically-provisioned storage, you need to make sure you have a
 === Enabling dynamically-provisioned storage
 
 Instead of statically-provisioned storage, you can use dynamically-provisioned storage. See https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/[Dynamic Volume Provisioning] for details.
+
+To enable dynamic storage for Prometheus and Alertmanager, set the following parameters to `true` in the Ansible inventory file:
+
+* `openshift_cluster_monitoring_operator_prometheus_storage_enabled`   (Default: false)
+* `openshift_cluster_monitoring_operator_alertmanager_storage_enabled` (Default: false)
+
+After you enable dynamic storage, you can also set the `storageclass` for the persistent volume claim for each component in the following parameters in the Ansible inventory file:
+
+* `openshift_cluster_monitoring_operator_prometheus_storage_class_name`   (default: "")
+* `openshift_cluster_monitoring_operator_alertmanager_storage_class_name` (default: "")
+
+Each of these variables applies only if its corresponding `storage_enabled` variable is set to `true`.
 
 [[supported-configuration]]
 === Supported configuration


### PR DESCRIPTION
Add the related documentation part about the enhancement from this BZ: [OpenShift Cluster monitoring Operator needs option to specify storageclass](https://bugzilla.redhat.com/show_bug.cgi?id=1639739)

* Version: `v3.11`

* Description: 
  New variables are added by  above `BZ`, the `PR` has merged and the variables are provided from `v3.11.31` later.