### PR TITLE
Correct protocol from tcp to udp for a SDN FW rules.

### DIFF
--- a/install_config/configuring_sdn.adoc
+++ b/install_config/configuring_sdn.adoc
@@ -194,15 +194,16 @@ networkConfig:
   ingressIPNetworkCIDR: 172.29.0.0/16
   networkPluginName: redhat/openshift-ovs-multitenant
   serviceNetworkCIDR: 172.30.0.0/16
-  vxlanPort: 4789 <1>
+  vxlanPort: 4889 <1>
 ----
 <1> Set to the value used by the nodes for the VXLAN Port. It can be an integer between 1-65535. The default value is `4789`.
 
 . Add the new port to the iptables rule on each cluster node:
 +
 ----
-# iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 4889 -j ACCEPT
+# iptables -A OS_FIREWALL_ALLOW -p udp -m state --state NEW -m udp --dport 4889 -j ACCEPT <1>
 ----
+<1> `4889` is the `vxlanPort` value that you set in the master configuration file.
 
 . Restart the master services:
 +


### PR DESCRIPTION
Fix this BZ: [[DOCS] vxlan port iptables change should be udp not tcp](https://bugzilla.redhat.com/show_bug.cgi?id=1644741)

* Version: v3.11