### PR TITLE
Fixed missing , on labelPreference example JSON

### DIFF
--- a/admin_guide/scheduling/scheduler.adoc
+++ b/admin_guide/scheduling/scheduler.adoc
@@ -667,7 +667,7 @@ If no label is specified, priority is given to nodes that do not have a label.
 "priorities":[
     {
         "name":"<name>", <1>
-        "weight" : 1 <2>
+        "weight" : 1, <2>
         "argument":{
             "labelPreference":{
                 "label": "<label>", <3> 


### PR DESCRIPTION
A single `,` was missing on labelPreference, which lead to an incorrect JSON.