### PR TITLE
[enterprise-3.9]Sizing guideline calculus is incorrect

### DIFF
--- a/install_config/aggregate_logging_sizing.adoc
+++ b/install_config/aggregate_logging_sizing.adoc
@@ -286,7 +286,7 @@ Assumptions:
 . Lines per second load on application: 1
 . Raw text data -> JSON
 
-Baseline (256 characters per minute -> 15KB/min)
+Baseline (256 characters per second -> 15KB/min)
 
 [cols="3,4",options="header"]
 |===
@@ -297,19 +297,19 @@ Baseline (256 characters per minute -> 15KB/min)
 1 kibana
 1 curator
 1 fluentd
-| 6 pods total: 90000 x 86400 = 7,7 GB/day
+| 6 pods total: 90000 x 1440 = 128,6 MB/day
 
 |3 es
 1 kibana
 1 curator
 11 fluentd
-| 16 pods total: 225000 x 86400 = 24,0 GB/day
+| 16 pods total: 240000 x 1440 = 345,6 MB/day
 
 |3 es
 1 kibana
 1 curator
 20 fluentd
-|25 pods total: 225000 x 86400 = 32,4 GB/day
+|25 pods total: 375000 x 1440 = 540 MB/day
 |===
 
 


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/pull/12971