### PR TITLE
nodeName can not configure any more as of v3.10

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -140,24 +140,20 @@ container. Therefore, *_cloud.conf_* should be in *_/etc/origin/_* instead of
 === Manually Configuring {product-title} Nodes for OpenStack
 
 Edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]
-and update the contents of the `*kubeletArguments*` and `*nodeName*` sections:
+and update the contents of the `*kubeletArguments*` sections:
 
 [source,yaml]
 ----
-nodeName:
-  <instance_name> <1>
-
 kubeletArguments:
   cloud-provider:
     - "openstack"
   cloud-config:
     - "/etc/cloud.conf"
 ----
-<1> The RFC1123-compliant OpenStack instance name of the node host.
 
 [NOTE]
 ====
-If the `nodeName` does not match the OpenStack instance name, the cloud provider
+If the hostname of node hosts does not match the OpenStack instance name(The `RFC1123-compliant` OpenStack instance name), the cloud provider
 integration will not work.
 ====
 


### PR DESCRIPTION
* Fix: [[DOCS] nodeName can not configure any more as of v3.10](https://bugzilla.redhat.com/show_bug.cgi?id=1656246)

* Version: `v3.10` and `v3.11`

* Description: 
  As of `v3.10`, the hostname should match with `OpenStack` instance name, because `nodeName` parameter need not configure in `node configmap`.