### PR TITLE
Expanding Persistent Volumes - Removing unnecessary configuration steps.

### DIFF
--- a/dev_guide/expanding_persistent_volumes.adoc
+++ b/dev_guide/expanding_persistent_volumes.adoc
@@ -24,27 +24,7 @@ Apart from that, {product-title} administrators must enable the
 xref:../architecture/additional_concepts/admission_controllers.adoc#architecture-additional-concepts-admission-controllers[Admission Controllers]
 for more information on the `PersistentVolumeClaimResize` admission controller.
 
-To enable the feature gate, set `ExpandPersistentVolumes` to `true` across the system:
-
-. Configure the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]:
-+
-----
-# oc edit configmaps <name> -n openshift-node
-----
-+
-For example:
-+
-----
-oc edit cm node-config-compute -n openshift-node
-...
-kubeletArguments:
-...
-  feature-gates:
-  - ExpandPersistentVolumes=true
-----
-
-. Enable the `ExpandPersistentVolumes` feature gate on the master API and controller manager:
-+
+To enable the feature gate, set `ExpandPersistentVolumes` to `true` across the system, enable the `ExpandPersistentVolumes` feature gate on the master API and controller manager:
 ----
 # cat /etc/origin/master/master-config.yaml
 ...
@@ -57,6 +37,12 @@ kubernetesMasterConfig:
 # master-restart api
 # master-restart controllers
 ----
+
+Then you should restart the master services
+----
+systemctl restart atomic-openshift-master-*
+----
+
 
 [[expanding_glusterfs_pvc]]
 == Expanding GlusterFS-Based Persistent Volume Claims


### PR DESCRIPTION
The configuration regarding the nodes are not necessary.

I've tested it with `Trident` and `GlusterFS` on a Openshift 3.9 cluster.