### PR TITLE
FIX:BZ1659352:Provide the available parameter sets for config of non-default storageclass

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -1569,7 +1569,14 @@ openshift_metrics_cassandra_storage_type=dynamic
 
 If there are multiple default dynamically provisioned volume types, such as
 gluster-storage and glusterfs-storage-block, you can specify the
-provisioned volume type by variable. For example, `openshift_metrics_cassandra_pvc_storage_class_name=glusterfs-storage-block`.
+provisioned volume type by variable, use the following variables:
+
+----
+[OSEv3:vars]
+
+openshift_metrics_cassandra_storage_type=pv
+openshift_metrics_cassandra_pvc_storage_class_name=glusterfs-storage-block
+----
 
 Check
 xref:../install_config/master_node_configuration.adoc#master-node-config-volume-config[Volume
@@ -1703,7 +1710,14 @@ openshift_logging_es_pvc_dynamic=true
 
 If there are multiple default dynamically provisioned volume types, such as
 gluster-storage and glusterfs-storage-block, you can specify the
-provisioned volume type by variable. For example, `openshift_logging_es_pvc_storage_class_name=glusterfs-storage-block`.
+provisioned volume type by variable, use the following variables:
+
+----
+[OSEv3:vars]
+
+openshift_logging_elasticsearch_storage_type=pvc
+openshift_logging_es_pvc_storage_class_name=glusterfs-storage-block
+----
 
 Check
 xref:../install_config/master_node_configuration.adoc#master-node-config-volume-config[Volume


### PR DESCRIPTION
* Fix: [[DOCS] not working the variables related with non-default storageclass](https://bugzilla.redhat.com/show_bug.cgi?id=1659352)

* Version: `v3.10` and `v3.11`, it seems available at `v3.9` either, but I could not verify the version. 

* Description:
  Because the non-default storageclass configurations are explained under `dynamic` config section, so the `dynamic` option seems requirements of the non-default storageclass config.
  But it's not correct, and it lead wrong parameter sets so it had better to provide the specific available parameter sets based on the installer implementation for suppressing the issues.