### PR TITLE
Update Getting Started installation docs

### DIFF
--- a/getting_started/install_openshift.adoc
+++ b/getting_started/install_openshift.adoc
@@ -60,25 +60,25 @@ Once these are configured, use the following steps to set up a two-machine
 `subscription-manager` to register the systems with Red Hat.
 +
 ----
-$ subscription-manager register
+# subscription-manager register
 ----
 
 . Pull the latest subscription data from RHSM:
 +
 ----
-$ subscription-manager refresh
+# subscription-manager refresh
 ----
 
 . List the available subscriptions.
 +
 ----
-$ subscription-manager list --available
+# subscription-manager list --available
 ----
 
 . Find the pool ID that provides {product-title} subscription and attach it.
 +
 ----
-$ subscription-manager attach --pool=<pool_id>
+# subscription-manager attach --pool=<pool_id>
 ----
 
 . Replace the string `<pool_id>` with the pool ID of the pool that provides
@@ -95,7 +95,7 @@ that are necessary in order to install {product-title}. You may have already ena
 the first two repositories in this example.
 
 ----
-$ subscription-manager repos --enable="rhel-7-server-rpms" \
+# subscription-manager repos --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ose-3.11-rpms" \
     --enable="rhel-7-server-ansible-2.6-rpms"
@@ -109,13 +109,14 @@ This command tells your RHEL system that the tools required to install
 === Install the {product-title} Package
 
 The installer for {product-title} is provided by the
-*openshift-ansible* package. Install it using `yum` on both the master and
-the node, after running `yum update`.
+*openshift-ansible* package. Install it using `yum` on the master after running `yum update`.
 
 ----
-$ yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion kexec-tools sos psacct
-$ yum -y update
-$ yum -y install openshift-ansible
+# yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion kexec-tools sos psacct
+# yum -y update
+# reboot
+
+# yum -y install openshift-ansible
 ----
 
 Now install a container engine:
@@ -123,12 +124,12 @@ Now install a container engine:
 * To install CRI-O:
 +
 ----
-$ yum -y install cri-o
+# yum -y install cri-o
 ----
 * To install Docker:
 +
 ----
-$ yum -y install docker
+# yum -y install docker
 ----
 
 [[set-up-password-less-ssh]]

--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -937,6 +937,8 @@ see xref:../install_config/configuring_red_hat_registry.adoc#install-config-conf
 For example:
 ----
 oreg_url=example.com/openshift3/ose-${component}:${version}
+oreg_auth_user=${user_name}
+oreg_auth_password=${password}
 openshift_examples_modify_imagestreams=true
 ----
 

--- a/install/example_inventories.adoc
+++ b/install/example_inventories.adoc
@@ -101,10 +101,6 @@ ansible_ssh_user=root
 
 ifdef::openshift-enterprise[]
 openshift_deployment_type=openshift-enterprise
-oreg_url=example.com/openshift3/ose-${component}:${version}
-oreg_auth_user=${user_name}
-oreg_auth_password=${password}
-openshift_examples_modify_imagestreams=true
 endif::[]
 ifdef::openshift-origin[]
 openshift_deployment_type=origin
@@ -201,10 +197,6 @@ etcd
 ansible_ssh_user=root
 ifdef::openshift-enterprise[]
 openshift_deployment_type=openshift-enterprise
-oreg_url=example.com/openshift3/ose-${component}:${version}
-oreg_auth_user=${user_name}
-oreg_auth_password=${password}
-openshift_examples_modify_imagestreams=true
 endif::[]
 ifdef::openshift-origin[]
 openshift_deployment_type=origin
@@ -365,10 +357,6 @@ lb
 ansible_ssh_user=root
 ifdef::openshift-enterprise[]
 openshift_deployment_type=openshift-enterprise
-oreg_url=example.com/openshift3/ose-${component}:${version}
-oreg_auth_user=${user_name}
-oreg_auth_password=${password}
-openshift_examples_modify_imagestreams=true
 endif::[]
 ifdef::openshift-origin[]
 openshift_deployment_type=origin
@@ -482,10 +470,6 @@ lb
 ansible_ssh_user=root
 ifdef::openshift-enterprise[]
 openshift_deployment_type=openshift-enterprise
-oreg_url=example.com/openshift3/ose-${component}:${version}
-oreg_auth_user=${user_name}
-oreg_auth_password=${password}
-openshift_examples_modify_imagestreams=true
 endif::[]
 ifdef::openshift-origin[]
 openshift_deployment_type=origin


### PR DESCRIPTION
1. Remove oreg_url and openshift_examples_modify_imagestreams from the
example inventories as these are not requred for a default installation.

2. Add step to reboot hosts after performing yum update.

3. Add oreg_auth_user and oreg_auth_password to example in
configuring_inventory_file.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1656475

----
And s/^\$/# for and command line requiring root permissions.