### PR TITLE
modifying some include notes

### DIFF
--- a/builds/creating-build-inputs.adoc
+++ b/builds/creating-build-inputs.adoc
@@ -1,6 +1,3 @@
-// This assembly is included in the following assemblies:
-//* assembly/builds
-
 :context: creating-build-inputs
 = Creating build inputs
 include::modules/common-attributes.adoc[]

--- a/builds/understanding-builds.adoc
+++ b/builds/understanding-builds.adoc
@@ -1,6 +1,3 @@
-// This assembly is included in the following assemblies:
-// * assembly/builds
-
 [id='understanding-build']
 = How builds work
 include::modules/common-attributes.adoc[]

--- a/installation/installing-customizations-cloud.adoc
+++ b/installation/installing-customizations-cloud.adoc
@@ -1,8 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
-
 [id='installing-customizations-cloud']
 = Installing a cluster on AWS with customizations
 include::modules/common-attributes.adoc[]

--- a/installation/installing-quickly-cloud.adoc
+++ b/installation/installing-quickly-cloud.adoc
@@ -1,8 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
-
 [id='installing-quickly-cloud']
 = Installing a cluster quickly on AWS
 include::modules/common-attributes.adoc[]

--- a/modules/glusterfs-installing-node-prerequisites.adoc
+++ b/modules/glusterfs-installing-node-prerequisites.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * 
+// * orphaned
 
 [id='glusterfs-installing-node-prerequisites-{context}']
 = Installing {gluster} prerequisites

--- a/modules/pod-using-a-different-service-account.adoc
+++ b/modules/pod-using-a-different-service-account.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * 
+// * orphaned
 
 [id='pod-using-a-different-service-account-{context}']
 = Running a pod with a different service account

--- a/modules/rbac-updating-policy-definitions.adoc
+++ b/modules/rbac-updating-policy-definitions.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * 
+// * orphaned
 
 ifdef::openshift-enterprise,openshift-origin[]
 [id='updating-policy-definitions-{context}']

--- a/operators/migrating-to-osdk-v0-1-0.adoc
+++ b/operators/migrating-to-osdk-v0-1-0.adoc
@@ -1,7 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
 [id='osdk-migrating-to-osdk-v0-1-0']
 = Migrating to Operator SDK v0.1.0
 {product-author}

--- a/operators/osdk-cli-reference.adoc
+++ b/operators/osdk-cli-reference.adoc
@@ -1,7 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
 [id='osdk-cli-reference']
 = Operator SDK CLI Reference
 {product-author}

--- a/operators/osdk-getting-started.adoc
+++ b/operators/osdk-getting-started.adoc
@@ -1,7 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
 [id='getting-started-osdk']
 = Getting started with the Operator SDK
 {product-author}

--- a/scalability_and_performance/scaling-cluster-monitoring-operator.adoc
+++ b/scalability_and_performance/scaling-cluster-monitoring-operator.adoc
@@ -1,8 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
-
 [id='scaling-cluster-monitoring-operator']
 = Scaling the cluster monitoring Operator
 {product-author}

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -1,8 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// * n/a
-
-
 [id='using-node-tuning-operator']
 = Using the node tuning operator
 {product-author}


### PR DESCRIPTION
When I was converting content, I created a few modules that were part of the source files but didn't fit my stories. I added `orphaned` to the "include" notes so I can find them again.