### PR TITLE
[enterprise-3.9] Include 'openshift_logging_elasticsearch_storage_type=pvc' in the section of ' Persistent Elasticsearch Storage'

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -466,7 +466,10 @@ openshift_logging_es_pvc_dynamic value.
 |`openshift_logging_es_pvc_size`
 |Size of the persistent volume claim to
 create per Elasticsearch instance. For example, 100G. If omitted, no PVCs are
-created and ephemeral volumes are used instead.
+created and ephemeral volumes are used instead. If you set this parameter, the logging installer sets `openshift_logging_elasticsearch_storage_type` to `pvc`.
+
+|`openshift_logging_elasticsearch_storage_type`
+|Sets the Elasticsearch storage type. If you are using xref:aggregated-logging-persistent-storage[Persistent Elasticsearch Storage], the logging installer sets this to `pvc`.
 
 |`openshift_logging_es_pvc_prefix`
 a|Prefix for the names of persistent volume claims to be used as storage for
@@ -811,16 +814,47 @@ specified as a python compatible dict. For example, `{"node-type":"infra",
 *Persistent Elasticsearch Storage*
 
 By default, the `openshift_logging` Ansible role creates an ephemeral
-deployment in which all of a pod's data is lost upon restart. For production
-usage, specify a persistent storage volume for each Elasticsearch deployment
-configuration. You can create the necessary
-xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent
-volume claims] before deploying or have them created for you. The PVCs must be
-named to match the `openshift_logging_es_pvc_prefix` setting, which defaults to
-`logging-es`; each PVC name will have a sequence number added to it: `logging-es-0`,
-`logging-es-1`, `logging-es-2`, and so on. If a PVC needed for the deployment
-exists already, it is used; if not, and `openshift_logging_es_pvc_size` has been
-specified, it is created with a request for that size.
+deployment in which all data in a pod is lost upon pod restart. 
+
+For production environments, each Elasticsearch deployment configuration requires a persistent storage volume. You can specify an existing xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent
+volume claim] or allow {product-title} to create one. 
+
+* *Use existing PVCs.* If you create your own PVCs for the deployment, {product-title} uses those PVCs. 
++
+Name the PVCs to match the `openshift_logging_es_pvc_prefix` setting, which defaults to
+`logging-es`. Assign each PVC a name with a sequence number added to it: `logging-es-0`,
+`logging-es-1`, `logging-es-2`, and so on. 
+
+* *Allow {product-title} to create a PVC.* If a PVC for Elsaticsearch does not exist, {product-title} creates the PVC based on parameters 
+in the xref:../install/configuring_inventory_file.adoc#configuring-ansible[Ansible inventory file]. 
++
+[cols="3,7",options="header"]
+|===
+|Parameter
+|Description
+
+|`openshift_logging_es_pvc_size`
+| Specify the size of the PVC request.
+
+|`openshift_logging_elasticsearch_storage_type`
+a|Specify the storage type as `pvc`. 
+[NOTE]
+====
+This is an optional parameter. If you set the `openshift_logging_es_pvc_size` parameter to a value greater than 0, the logging installer automatically sets this parameter to `pvc` by default. 
+====
+
+|`openshift_logging_es_pvc_prefix`
+|Optionally, specify a custom prefix for the PVC.
+|===
++
+For example:
++
+[source,bash]
+----
+openshift_logging_elasticsearch_storage_type=pvc 
+openshift_logging_es_pvc_size=104802308Ki 
+openshift_logging_es_pvc_prefix=es-logging
+----
 
 If using xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned PVs], the {product-title} logging installer creates PVCs that use the default storage class or the PVC specified with the `openshift_logging_elasticsearch_pvc_storage_class_name` parameter.
 
@@ -834,7 +868,7 @@ Also set the `openshift_enable_unsupported_configurations=true` parameter in the
 Using NFS storage as a volume or a persistent volume, or using NAS such as
 Gluster, is not supported for Elasticsearch storage, as Lucene relies on file
 system behavior that NFS does not supply. Data corruption and other problems can
-occur. If NFS storage is a requirement, you can allocate a large file on a
+occur. If you must use NFS storage, allocate a large file on a
 volume to serve as a storage device and mount it locally on one host.
 For example, if your NFS storage volume is mounted at *_/nfs/storage_*:
 

--- a/install_config/persistent_storage/topics/glusterfs_example_full.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_example_full.adoc
@@ -17,6 +17,7 @@ openshift_logging_kibana_nodeselector={"role":"infra"}    <1>
 openshift_logging_curator_nodeselector={"role":"infra"}   <1>
 openshift_logging_storage_kind=dynamic
 openshift_logging_es_pvc_size=10Gi                        <3>
+openshift_logging_elasticsearch_storage_type=pvc              <4>
 openshift_logging_es_pvc_storage_class_name="glusterfs-registry-block"       <2>
 
 openshift_storage_glusterfs_block_deploy=false
@@ -34,6 +35,7 @@ generated from the name of the target GlusterFS cluster, for example
 `glusterfs-<name>-block`. In this example, `<name>` defaults to `registry`.
 <3> Specifying a PVC size is required for OpenShift Logging. The supplied value
 is only an example, not a recommendation.
+<4> If using Persistent Elasticsearch Storage, set the storage type to `pvc`.
 
 . Add `glusterfs` and `glusterfs_registry` in the `[OSEv3:children]` section to
 enable the `[glusterfs]` and `[glusterfs_registry]` groups:

--- a/install_config/persistent_storage/topics/glusterfs_example_full_external.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_example_full_external.adoc
@@ -17,6 +17,7 @@ openshift_logging_kibana_nodeselector={"role":"infra"}    <1>
 openshift_logging_curator_nodeselector={"role":"infra"}   <1>
 openshift_logging_storage_kind=dynamic
 openshift_logging_es_pvc_size=10Gi                        <3>
+openshift_logging_elasticsearch_storage_type              <4>
 openshift_logging_es_pvc_storage_class_name="glusterfs-registry-block"       <2>
 
 openshift_storage_glusterfs_is_native=false
@@ -49,6 +50,7 @@ generated from the name of the target GlusterFS cluster (e.g.,
 `glusterfs-<name>-block`). In this example, this defaults to `registry`.
 <3> OpenShift Logging requires that a PVC size be specified. The supplied value
 is only an example, not a recommendation.
+<4> If using Persistent Elasticsearch Storage, set the storage type to `pvc`.
 
 . Add `glusterfs` and `glusterfs_registry` in the `[OSEv3:children]` section to
 enable the `[glusterfs]` and `[glusterfs_registry]` groups:

--- a/install_config/persistent_storage/topics/glusterfs_example_infra.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_example_infra.adoc
@@ -14,6 +14,7 @@ openshift_logging_kibana_nodeselector={"role":"infra"}    <1>
 openshift_logging_curator_nodeselector={"role":"infra"}   <1>
 openshift_logging_storage_kind=dynamic
 openshift_logging_es_pvc_size=10Gi                        <3>
+openshift_logging_elasticsearch_storage_type=pvc             <4>
 openshift_logging_es_pvc_storage_class_name="glusterfs-registry-block"       <2>
 
 openshift_storage_glusterfs_registry_block_deploy=true
@@ -32,6 +33,7 @@ generated from the name of the target GlusterFS cluster (e.g.,
 `glusterfs-<name>-block`). In this example, this defaults to `registry`.
 <3> OpenShift Logging requires that a PVC size be specified. The supplied value
 is only an example, not a recommendation.
+<4> If using Persistent Elasticsearch Storage, set the storage type to `pvc`.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/12746