### PR TITLE
Changes to Agg Logging per jcantrill slack comments

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -63,7 +63,7 @@ to determine how best to configure your deployment.
 . Ensure that you have deployed a router for the cluster.
 . Ensure that you have
 xref:../install_config/persistent_storage/index.adoc#install-config-persistent-storage-index[the
-necessary storage] for Elasticsearch. Note that each Elasticsearch replica
+necessary storage] for Elasticsearch. Note that each Elasticsearch n
 requires its own storage volume. See
 xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
 . Determine if you need xref:ha-elasticsearch[highly-available Elasticsearch]. A highly-available environment requires
@@ -71,27 +71,6 @@ multiple replicas of each shard. By default, {product-title} creates one shard f
 zero replicas of those shards. To create high availability, set the xref:aggregate-logging-ansible-variables[`openshift_logging_es_number_of_replicas` Ansible variable]
 to a value higher than `1`. High availability also requires at least three Elasticsearch nodes,
 each on a different host. See xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
-. Choose a project. Once deployed, the EFK stack collects logs for every
-project within your {product-title} cluster. The examples in this section use the
-default project *openshift-logging*. The Ansible playbook creates the project for you
-if it does not already exist. You will only need to create a project if you want
-to specify a node-selector on it. Otherwise, the `openshift-logging` role will
-create a project.
-+
-----
-$ oc adm new-project openshift-logging --node-selector=""
-$ oc project openshift-logging
-----
-+
-[NOTE]
-====
-Specifying an empty
-xref:../admin_guide/managing_projects.adoc#using-node-selectors[node
-selector] on the project is recommended, as Fluentd should be deployed
-throughout the cluster and any selector would restrict where it is
-deployed. To control component placement, specify node selectors per component to
-be applied to their deployment configurations.
-====
 
 [[aggregate-logging-ansible-variables]]
 == Specifying Logging Ansible Variables
@@ -623,6 +602,10 @@ endif::openshift-enterprise[]
 Running the playbook deploys all resources needed to support the stack; such as
 Secrets, ServiceAccounts, DeploymentConfigs, deployed to the project `openshift-logging`. 
 The playbook waits to deploy the component pods until the stack is running. If the wait steps fail, the
+
+The playbook waits to deploy
+the component pods until the stack is running. If the wait steps fail, the
+>>>>>>> Changes to Agg Logging per jcantrill slack comments
 deployment could still be successful; it may be retrieving the component images
 from the registry which can take up to a few minutes. You can watch the
 process with:
@@ -646,7 +629,7 @@ logging-kibana-1-zk94k                     2/2       Running   0          11h  <
 You can use the `oc get pods -o wide command to see the nodes where the Fluentd pod are deployed:
 
 ----
-oc get pods -o wide
+$ oc get pods -o wide
 NAME                                       READY     STATUS    RESTARTS   AGE       IP             NODE                         NOMINATED NODE
 logging-es-data-master-5av030lk-1-2x494    2/2       Running   0          38m       154.128.0.80   ip-153-12-8-6.wef.internal   <none>
 logging-fluentd-lqdxg                      1/1       Running   0          2m        154.128.0.85   ip-153-12-8-6.wef.internal   <none>
@@ -865,7 +848,7 @@ $ chown 1000:1000 /usr/local/es-storage
 ----
 
 Then, use *_/usr/local/es-storage_* as a host-mount as described below.
-Use a different backing file as storage for each Elasticsearch replica.
+Use a different backing file as storage for each Elasticsearch node.
 
 This loopback must be maintained manually outside of {product-title}, on the
 node. You must not maintain it from inside a container.
@@ -887,7 +870,7 @@ $ oc adm policy add-scc-to-user privileged  \
 logging playbook.
 ====
 
-. Each Elasticsearch replica definition must be patched to claim that privilege, for example (change to `--selector component=es-ops` for Ops cluster):
+. Each Elasticsearch node definition must be patched to claim that privilege, for example (change to `--selector component=es-ops` for Ops cluster):
 +
 ----
 $ for dc in $(oc get deploymentconfig --selector component=es -o name); do
@@ -899,7 +882,7 @@ $ for dc in $(oc get deploymentconfig --selector component=es -o name); do
 
 . The Elasticsearch replicas must be located on the correct nodes to use the local
 storage, and should not move around even if those nodes are taken down for a
-period of time. This requires giving each Elasticsearch replica a node selector
+period of time. This requires giving each Elasticsearch node a node selector
 that is unique to a node where an administrator has allocated storage for it. To
 configure a node selector, edit each Elasticsearch deployment configuration and
 add or edit the *nodeSelector* section to specify a unique label that you have
@@ -1088,7 +1071,7 @@ oc logs -f /var/log/fluentd/fluentd.log
 
 Fluentd writes logs to a specified file, by default `/var/log/fluentd/fluentd.log`, or to the console, based on the `LOGGING_FILE_PATH` environment variable.  
 
-To change the default output location for the Fluentd logs, use the `LOGGING_FILE_PATH` parameter 
+To set the output location for the Fluentd logs, use the LOGGING_FILE_PATH` parameter 
 in the xref:../install/configuring_inventory_file.html#configuring-ansible[default inventory file]. 
 You can specify a particular file or to STDOUT:
 

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -63,7 +63,7 @@ to determine how best to configure your deployment.
 . Ensure that you have deployed a router for the cluster.
 . Ensure that you have
 xref:../install_config/persistent_storage/index.adoc#install-config-persistent-storage-index[the
-necessary storage] for Elasticsearch. Note that each Elasticsearch n
+necessary storage] for Elasticsearch. Note that each Elasticsearch node
 requires its own storage volume. See
 xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
 . Determine if you need xref:ha-elasticsearch[highly-available Elasticsearch]. A highly-available environment requires

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -605,7 +605,6 @@ The playbook waits to deploy the component pods until the stack is running. If t
 
 The playbook waits to deploy
 the component pods until the stack is running. If the wait steps fail, the
->>>>>>> Changes to Agg Logging per jcantrill slack comments
 deployment could still be successful; it may be retrieving the component images
 from the registry which can take up to a few minutes. You can watch the
 process with:
@@ -1071,7 +1070,7 @@ oc logs -f /var/log/fluentd/fluentd.log
 
 Fluentd writes logs to a specified file, by default `/var/log/fluentd/fluentd.log`, or to the console, based on the `LOGGING_FILE_PATH` environment variable.  
 
-To set the output location for the Fluentd logs, use the LOGGING_FILE_PATH` parameter 
+To set the output location for the Fluentd logs, use the `LOGGING_FILE_PATH` parameter 
 in the xref:../install/configuring_inventory_file.html#configuring-ansible[default inventory file]. 
 You can specify a particular file or to STDOUT:
 

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -63,7 +63,7 @@ to determine how best to configure your deployment.
 . Ensure that you have deployed a router for the cluster.
 . Ensure that you have
 xref:../install_config/persistent_storage/index.adoc#install-config-persistent-storage-index[the
-necessary storage] for Elasticsearch. Note that each Elasticsearch node
+necessary storage] for Elasticsearch. Note that each Elasticsearch replica
 requires its own storage volume. See
 xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
 . Determine if you need xref:ha-elasticsearch[highly-available Elasticsearch]. A highly-available environment requires
@@ -71,6 +71,27 @@ multiple replicas of each shard. By default, {product-title} creates one shard f
 zero replicas of those shards. To create high availability, set the xref:aggregate-logging-ansible-variables[`openshift_logging_es_number_of_replicas` Ansible variable]
 to a value higher than `1`. High availability also requires at least three Elasticsearch nodes,
 each on a different host. See xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
+. Choose a project. Once deployed, the EFK stack collects logs for every
+project within your {product-title} cluster. The examples in this section use the
+default project *openshift-logging*. The Ansible playbook creates the project for you
+if it does not already exist. You will only need to create a project if you want
+to specify a node-selector on it. Otherwise, the `openshift-logging` role will
+create a project.
++
+----
+$ oc adm new-project openshift-logging --node-selector=""
+$ oc project openshift-logging
+----
++
+[NOTE]
+====
+Specifying an empty
+xref:../admin_guide/managing_projects.adoc#using-node-selectors[node
+selector] on the project is recommended, as Fluentd should be deployed
+throughout the cluster and any selector would restrict where it is
+deployed. To control component placement, specify node selectors per component to
+be applied to their deployment configurations.
+====
 
 [[aggregate-logging-ansible-variables]]
 == Specifying Logging Ansible Variables
@@ -224,7 +245,7 @@ when `openshift_logging_use_ops` is set to `true`.
 |The amount of memory to allocate to Kibana proxy.
 
 |`openshift_logging_kibana_replica_count`
-|The number of replicas to which Kibana should be scaled up.
+|The number of to which Kibana should be scaled up.
 
 |`openshift_logging_kibana_nodeselector`
 |A node selector that specifies
@@ -602,9 +623,6 @@ endif::openshift-enterprise[]
 Running the playbook deploys all resources needed to support the stack; such as
 Secrets, ServiceAccounts, DeploymentConfigs, deployed to the project `openshift-logging`. 
 The playbook waits to deploy the component pods until the stack is running. If the wait steps fail, the
-
-The playbook waits to deploy
-the component pods until the stack is running. If the wait steps fail, the
 deployment could still be successful; it may be retrieving the component images
 from the registry which can take up to a few minutes. You can watch the
 process with:
@@ -628,7 +646,7 @@ logging-kibana-1-zk94k                     2/2       Running   0          11h  <
 You can use the `oc get pods -o wide command to see the nodes where the Fluentd pod are deployed:
 
 ----
-$ oc get pods -o wide
+oc get pods -o wide
 NAME                                       READY     STATUS    RESTARTS   AGE       IP             NODE                         NOMINATED NODE
 logging-es-data-master-5av030lk-1-2x494    2/2       Running   0          38m       154.128.0.80   ip-153-12-8-6.wef.internal   <none>
 logging-fluentd-lqdxg                      1/1       Running   0          2m        154.128.0.85   ip-153-12-8-6.wef.internal   <none>
@@ -847,7 +865,7 @@ $ chown 1000:1000 /usr/local/es-storage
 ----
 
 Then, use *_/usr/local/es-storage_* as a host-mount as described below.
-Use a different backing file as storage for each Elasticsearch node.
+Use a different backing file as storage for each Elasticsearch replica.
 
 This loopback must be maintained manually outside of {product-title}, on the
 node. You must not maintain it from inside a container.
@@ -869,10 +887,11 @@ $ oc adm policy add-scc-to-user privileged  \
 logging playbook.
 ====
 
-. Each Elasticsearch node definition must be patched to claim that privilege, for example (change to `--selector component=es-ops` for Ops cluster):
+. Each Elasticsearch replica definition must be patched to claim that privilege,
+for example:
 +
 ----
-$ for dc in $(oc get deploymentconfig --selector component=es -o name); do
+$ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
     oc scale $dc --replicas=0
     oc patch $dc \
        -p '{"spec":{"template":{"spec":{"containers":[{"name":"elasticsearch","securityContext":{"privileged": true}}]}}}}'
@@ -881,7 +900,7 @@ $ for dc in $(oc get deploymentconfig --selector component=es -o name); do
 
 . The Elasticsearch replicas must be located on the correct nodes to use the local
 storage, and should not move around even if those nodes are taken down for a
-period of time. This requires giving each Elasticsearch node a node selector
+period of time. This requires giving each Elasticsearch replica a node selector
 that is unique to a node where an administrator has allocated storage for it. To
 configure a node selector, edit each Elasticsearch deployment configuration and
 add or edit the *nodeSelector* section to specify a unique label that you have
@@ -909,11 +928,11 @@ $ oc patch dc/logging-es-<suffix> \
 ----
 ====
 
-. Once these steps are taken, a local host mount can be applied to each replica as in this example
-(where we assume storage is mounted at the same path on each node) (change to `--selector component=es-ops` for Ops cluster):
+. Once these steps are taken, a local host mount can be applied to each replica
+as in this example (where we assume storage is mounted at the same path on each node):
 +
 ----
-$ for dc in $(oc get deploymentconfig --selector component=es -o name); do
+$ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
     oc set volume $dc \
           --add --overwrite --name=elasticsearch-storage \
           --type=hostPath --path=/usr/local/es-storage
@@ -1045,19 +1064,19 @@ How you view logs depends upon the xref:fluentd-file[`LOGGING_FILE_PATH` setting
 * If `LOGGING_FILE_PATH` points to a file, use the *logs* utility to print out the contents of Fluentd log files:
 +
 ----
-oc exec <pod> logs <1>
+oc exec <pod> -- logs <1>
 ----
-<1> Specify the name of the Fluentd pod.
+<1> Specify the name of the Fluentd pod. Note the space before `logs`.
 +
 For example:
 +
 ----
-oc exec logging-fluentd-lmvms logs
+oc exec logging-fluentd-lmvms -- logs
 ----
 +
 The contents of log files are printed out, starting with the oldest log.  Use `-f` option to follow what is being written into the logs.
 
-* If you are using `LOGGING_FILE_PATH=console`, fluentd to write logs to STDOUT. You can retrieve the logs with the `oc logs -f <pod_name>` command.
+* If you are using `LOGGING_FILE_PATH=console`, Fluentd writes logs to its default location. You can retrieve the logs with the `oc logs -f <pod_name>` command.
 +
 For example
 +
@@ -1068,19 +1087,17 @@ oc logs -f /var/log/fluentd/fluentd.log
 [[fluentd-file]]
 *Configuring Fluentd Log Location*
 
-Fluentd writes logs to a specified file, by default `/var/log/fluentd/fluentd.log`, or to the console, based on the `LOGGING_FILE_PATH` environment variable.  
-
-To set the output location for the Fluentd logs, use the `LOGGING_FILE_PATH` parameter 
+To change the output location for the Fluentd logs, use the `LOGGING_FILE_PATH` parameter 
 in the xref:../install/configuring_inventory_file.html#configuring-ansible[default inventory file]. 
-You can specify a particular file or to STDOUT:
+You can specify a particular file or use the Fluentd default location:
 
 ----
 LOGGING_FILE_PATH=console <1>
 LOGGING_FILE_PATH=<path-to-log/fluentd.log> <2>
 ----
 
-<1> Sends the log output to STDOUT.
-<2> Sends the log output to the specified file.
+<1> Sends the log output to the Fluentd default location. Retrieve the logs with the `oc logs -f <pod_name>` command.
+<2> Sends the log output to the specified file. Retrieve the logs with the `oc exec <pod_name> -- logs` command.
  
 After changing these parameters, re-run the xref:../install_config/aggregate_logging.adoc#deploying-the-efk-stack[logging installer playbook]:
 
@@ -1131,9 +1148,13 @@ For example:
 $ oc set env ds/logging-fluentd LOGGING_FILE_AGE=30 LOGGING_FILE_SIZE=1024000"
 ----
 
-Turn off log rotation by setting LOGGING_FILE_PATH=console. 
-This causes Fluentd to write logs to STDOUT where they can be retrieved using the `oc logs -f <pod_name>` command.
+Turn off log rotation by setting `LOGGING_FILE_PATH=console`.
+This causes Fluentd to write logs to the Fluentd default location where they can be retrieved using the `oc logs -f <pod_name>` command.
 
+----
+oc set ds/fluentd LOGGING_FILE_PATH=console
+----
+ 
 [[fluentd-external-log-aggregator]]
 *Configuring Fluentd to Send Logs to an External Log Aggregator*
 
@@ -1433,7 +1454,7 @@ you need to log in:
 
 * on the first use
 * after logging out
-//* after 1 week from initial log in
+* after 1 week from initial log in
 ====
 
 You can scale the Kibana deployment as usual for redundancy:


### PR DESCRIPTION
i should read more often "...Ensure that you have the necessary storage for Elasticsearch. Note that each Elasticsearch replica requires its own ..." should be: ".... Elasticsearch node requires..."
https://coreos.slack.com/archives/CB3HXM2QK/p1545151496544800

Choose a project. Once deployed, the EFK stack collects logs for every project within your OKD cluster. The examples in this section use the default project openshift-logging. The Ansible playbook creates the project for you if it does not already exist. You will only need to create a project if you want to specify a node-selector on it. Otherwise, the openshift-logging role will create a project.
we should not encourage any other project name then 'openshift-logging' I'm even certain if its a matter of just setting the var any longer. We should re write this to just talk about the node selector with the guise that ... we'll create it for you if it doesnt exist, if for some... additional reading i think we should remove point 6 all together and the info block below it
https://coreos.slack.com/archives/CB3HXM2QK/p1545152483549400

3.11 only
https://coreos.slack.com/archives/CB3HXM2QK/p1545151853546400