### PR TITLE
Add info about crio node groups

### DIFF
--- a/modules/crio_get.adoc
+++ b/modules/crio_get.adoc
@@ -87,6 +87,19 @@ openshift_use_crio_only=False
 openshift_crio_enable_docker_gc=True
 ```
 
+. Set the openshift_node_group_name for each node to a configmap that configures
+the kubelet for the CRI-O runtime. There's a corresponding CRI-O configmap for
+all the default node groups. xref:../install/configuring_inventory_file.adoc#configuring-inventory-defining-node-group-and-host-mappings[Defining Node Groups and Host Mappings]
+covers node groups and mappings in detail.
+
+
++
+```
+[nodes]
+ocp-crio01 openshift_node_group_name='node-config-all-in-one-crio'
+ocp-docker01 openshift_node_group_name='node-config-all-in-one'
+```
+
 The resulting {product-title} configuration will be running the CRI-O container engine on
 the nodes of your {product-title} installation.
 Use the `oc` command to check the status of the nodes and identify the nodes running CRI-O:
@@ -95,4 +108,5 @@ Use the `oc` command to check the status of the nodes and identify the nodes run
 $ oc get nodes -o wide
 NAME         STATUS  ROLES                  AGE  ...   CONTAINER-RUNTIME
 ocp-crio01   Ready   compute,infra,master   16d  ...   cri-o://1.11.5
+ocp-docker01 Ready   compute,infra,master   16d  ...   docker://1.13.1
 ```


### PR DESCRIPTION
In 3.10 and later you now need to assign a host to a node group which is configured for crio.

/cc @chrisnegus 