### PR TITLE
[3.11] Correct size unit for docker log option max-size

### DIFF
--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -698,7 +698,7 @@ example, to set the maximum file size to 1 MB and always keep the last three
 log files, set the following options:
 +
 ----
-OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1M --log-opt max-file=3'
+OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1m --log-opt max-file=3'
 ----
 +
 See Docker's documentation for additional information on how to


### PR DESCRIPTION
* Version: `v3.10` and `v3.11`

* Descrtipion: a little confusing because `max-size` `unit` not matched with docker documentation. But both unit would work.

  - Docker documentation related with  it.
    https://docs.docker.com/config/containers/logging/json-file/#options

Option | Description | Example value
-- | -- | --
max-size | The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g). Defaults to -1 (unlimited). | --log-opt max-size=10m


https://github.com/docker/go-units/blob/master/size.go#L31-L35
~~~
var (
	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[iI]?[bB]?$`)
)
~~~
         