### PR TITLE
[3.9] Correct size unit for docker log option max-size

### DIFF
--- a/install_config/install/host_preparation.adoc
+++ b/install_config/install/host_preparation.adoc
@@ -641,11 +641,11 @@ of log files.
 |===
 
 For example, to set the maximum file size to 1MB and always keep the last three
-log files, edit the *_/etc/sysconfig/docker_* file to configure `max-size=1M`
+log files, edit the *_/etc/sysconfig/docker_* file to configure `max-size=1m`
 and `max-file=3`:
 
 ----
-OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1M --log-opt max-file=3'
+OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1m --log-opt max-file=3'
 ----
 
 Next, restart the Docker service:


### PR DESCRIPTION
* Version: between `v3.3` and  `v3.9`

* Descrtipion: a little confusing because `max-size` `unit` not matched with docker documentation. But both units would work.
  - Docker documentation related with it.
    https://docs.docker.com/config/containers/logging/json-file/#options

Option | Description | Example value
-- | -- | --
max-size | The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g). Defaults to -1 (unlimited). | --log-opt max-size=10m


https://github.com/docker/go-units/blob/master/size.go#L31-L35
~~~
var (
	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[iI]?[bB]?$`)
)
~~~
         