### PR TITLE
[enterprise-3.5] Marking Masters as Unschedulable Nodes false needs to be False in doc

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -959,7 +959,7 @@ master.example.com
 In order to ensure that your masters are not burdened with running pods, they
 are automatically marked unschedulable by default by the installer, meaning that
 new pods cannot be placed on the hosts. This is the same as setting the
-`openshift_schedulable=false` host variable.
+`openshift_schedulable=False` host variable.
 
 You can manually set a master host to schedulable during installation using the
 `openshift_schedulable=true` host variable, though this is not recommended in

--- a/install_config/upgrading/blue_green_deployments.adoc
+++ b/install_config/upgrading/blue_green_deployments.adoc
@@ -172,7 +172,7 @@ can always adjust the labels after installation as well, if needed, using the
 
 - In order to delay workload scheduling until the nodes are deemed
 xref:../../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[healthy]
-(which you will verify in later steps), set the `openshift_schedulable=false`
+(which you will verify in later steps), set the `openshift_schedulable=False`
 variable for each node host to ensure they are unschedulable initially.
 
 .Example new_nodes Host Group
@@ -182,11 +182,11 @@ inventory previously should remain.
 
 ----
 [new_nodes]
-node4.example.com openshift_node_labels="{'region': 'primary', 'color':'green'}" openshift_schedulable=false
-node5.example.com openshift_node_labels="{'region': 'primary', 'color':'green'}" openshift_schedulable=false
-node6.example.com openshift_node_labels="{'region': 'primary', 'color':'green'}" openshift_schedulable=false
-infra-node3.example.com openshift_node_labels="{'region': 'infra', 'color':'green'}" openshift_schedulable=false
-infra-node4.example.com openshift_node_labels="{'region': 'infra', 'color':'green'}" openshift_schedulable=false
+node4.example.com openshift_node_labels="{'region': 'primary', 'color':'green'}" openshift_schedulable=False
+node5.example.com openshift_node_labels="{'region': 'primary', 'color':'green'}" openshift_schedulable=False
+node6.example.com openshift_node_labels="{'region': 'primary', 'color':'green'}" openshift_schedulable=False
+infra-node3.example.com openshift_node_labels="{'region': 'infra', 'color':'green'}" openshift_schedulable=False
+infra-node4.example.com openshift_node_labels="{'region': 'infra', 'color':'green'}" openshift_schedulable=False
 ----
 
 [[blue-green-verifying-green-nodes]]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/13187/