### PR TITLE
FIX:1646038 and 1649701:Change the htpasswd file path under /etc/origin/master

### DIFF
--- a/getting_started/configure_openshift.adoc
+++ b/getting_started/configure_openshift.adoc
@@ -30,7 +30,7 @@ any user from logging in. To change the authentication method to HTPasswd:
 `DenyAllPasswordIdentityProvider` to `HTPasswdPasswordIdentityProvider`
 provider.
 . Change the value of the name label to `htpasswd_auth` and add a
-new line `file: /etc/origin/openshift-passwd` in the provider section.
+new line `file: /etc/origin/master/htpasswd` in the provider section.
 +
 An example `identityProviders` section with `HTPasswdPasswordIdentityProvider`
 would look like the following.
@@ -45,7 +45,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: HTPasswdPasswordIdentityProvider
-      file: /etc/origin/openshift-passwd
+      file: /etc/origin/master/htpasswd
 ----
 
 . Save the file.
@@ -66,8 +66,8 @@ generate these accounts.
 . Create a user account.
 +
 ----
-# touch /etc/origin/openshift-passwd
-# htpasswd -b /etc/origin/openshift-passwd admin redhat
+# touch /etc/origin/master/htpasswd
+# htpasswd -b /etc/origin/master/htpasswd admin redhat
 ----
 +
 You have created a user, `admin`, with the password, `redhat`.


### PR DESCRIPTION
* Fix:
   - [htpasswd can not be placed at /etc/origin/ but only /etc/origin/master](https://bugzilla.redhat.com/show_bug.cgi?id=1646038)
   - [Configure Identity provider htpasswd](https://bugzilla.redhat.com/show_bug.cgi?id=1649701) 

* Version: `v3.10` and `v3.11+`

* Description:
  Refer the BZ summary first.

Change the `htpasswd` file path under `/etc/origin/master` directory for accessing by `master api/controllers` pods
And I would change the `/etc/origin/master/htpasswd` instead of `openshift-passwd` because the htpasswd file path is static in the playbooks as follows, [https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_control_plane/tasks/htpass_provider.yml#L13-L16]
~~~
- name: Create the htpasswd file if needed
  template:
    dest: "/etc/origin/master/htpasswd"
    src: htpasswd.j2
~~~
