### PR TITLE
Logging fix ascibinder warns

### DIFF
--- a/logging/efk-logging-curator.adoc
+++ b/logging/efk-logging-curator.adoc
@@ -13,8 +13,8 @@ to be performed automatically on a per-project basis.
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-curator-configure.adoc[leveloffset=+2]
+include::modules/efk-logging-curator-configure.adoc[leveloffset=+1]
 
-include::modules/efk-logging-curator-actions.adoc[leveloffset=+2]
+include::modules/efk-logging-curator-actions.adoc[leveloffset=+1]
 
-include::modules/efk-logging-curator-configuration.adoc[leveloffset=+2]
+include::modules/efk-logging-curator-configuration.adoc[leveloffset=+1]

--- a/logging/efk-logging-deploy.adoc
+++ b/logging/efk-logging-deploy.adoc
@@ -22,23 +22,23 @@ The process for deploying the EFK into {prouct-title} involves:
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-deploy-pre.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-pre.adoc[leveloffset=+1]
 
-include::modules/efk-logging-storage-considerations.adoc[leveloffset=+2]
+include::modules/efk-logging-storage-considerations.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-variables.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-variables.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-ops-cluster.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-ops-cluster.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-eventrouter.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-eventrouter.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-memory.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-memory.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-certificates.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-certificates.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-playbook.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-playbook.adoc[leveloffset=+1]
 
-include::modules/efk-logging-deploy-label.adoc[leveloffset=+2]
+include::modules/efk-logging-deploy-label.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-driver.adoc
+++ b/logging/efk-logging-driver.adoc
@@ -15,9 +15,9 @@ If you are using EFK logging, you should use the *json-file* log driver.
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-driver-viewing.adoc[leveloffset=+2]
+include::modules/efk-logging-driver-viewing.adoc[leveloffset=+1]
 
-include::modules/efk-logging-driver-changing.adoc[leveloffset=+2]
+include::modules/efk-logging-driver-changing.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-elasticsearch.adoc
+++ b/logging/efk-logging-elasticsearch.adoc
@@ -12,13 +12,13 @@ toc::[]
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-elasticsearch-ha.adoc[leveloffset=+2]
+include::modules/efk-logging-elasticsearch-ha.adoc[leveloffset=+1]
 
-include::modules/efk-logging-elasticsearch-persistent-storage.adoc[leveloffset=+2]
+include::modules/efk-logging-elasticsearch-persistent-storage.adoc[leveloffset=+1]
 
-include::modules/efk-logging-elasticsearch-scaling.adoc[leveloffset=+2]
+include::modules/efk-logging-elasticsearch-scaling.adoc[leveloffset=+1]
 
-include::modules/efk-logging-elasticsearch-exposing.adoc[leveloffset=+2]
+include::modules/efk-logging-elasticsearch-exposing.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-exported-fields.adoc
+++ b/logging/efk-logging-exported-fields.adoc
@@ -31,21 +31,21 @@ The fields are grouped in the following categories:
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-exported-fields-default.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-default.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-rsyslog.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-rsyslog.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-systemd.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-systemd.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-kubernetes.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-kubernetes.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-docker.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-docker.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-ovirt.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-ovirt.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-aushape.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-aushape.adoc[leveloffset=+1]
 
-include::modules/efk-logging-exported-fields-tlog.adoc[leveloffset=+2]
+include::modules/efk-logging-exported-fields-tlog.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-external.adoc
+++ b/logging/efk-logging-external.adoc
@@ -13,11 +13,11 @@ or an external syslog server. You can also configure Fluentd to send logs to an 
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-external-elasticsearch.adoc[leveloffset=+2]
+include::modules/efk-logging-external-elasticsearch.adoc[leveloffset=+1]
 
-include::modules/efk-logging-external-syslog.adoc[leveloffset=+2]
+include::modules/efk-logging-external-syslog.adoc[leveloffset=+1]
 
-include::modules/efk-logging-external-fluentd.adoc[leveloffset=+2]
+include::modules/efk-logging-external-fluentd.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-fluentd.adoc
+++ b/logging/efk-logging-fluentd.adoc
@@ -13,11 +13,11 @@ toc::[]
 // assemblies.
 
 
-include::modules/efk-logging-external-fluentd.adoc[leveloffset=+2]
+include::modules/efk-logging-external-fluentd.adoc[leveloffset=+1]
 
-include::modules/efk-logging-fluentd-connections.adoc[leveloffset=+2]
+include::modules/efk-logging-fluentd-connections.adoc[leveloffset=+1]
 
-include::modules/efk-logging-fluentd-throttling.adoc[leveloffset=+2]
+include::modules/efk-logging-fluentd-throttling.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-kibana.adoc
+++ b/logging/efk-logging-kibana.adoc
@@ -15,11 +15,11 @@ You can see the user interface by visiting the site specified by the `openshift_
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-kibana-console.adoc[leveloffset=+2]
+include::modules/efk-logging-kibana-console.adoc[leveloffset=+1]
 
-include::modules/efk-logging-kibana-scaling.adoc[leveloffset=+2]
+include::modules/efk-logging-kibana-scaling.adoc[leveloffset=+1]
 
-include::modules/efk-logging-kibana-visualize.adoc[leveloffset=+2]
+include::modules/efk-logging-kibana-visualize.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-manual-rollout.adoc
+++ b/logging/efk-logging-manual-rollout.adoc
@@ -1,5 +1,5 @@
-:context: efk-logging-driver
-[id='efk-logging-driver_{context}']
+:context: efk-logging-rollout
+[id='efk-logging-rollout_{context}']
 = Manually rolling out Elasticsearch
 include::modules/common-attributes.adoc[]
 
@@ -23,9 +23,9 @@ changes without risk to existing data.
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-manual-rollout-rolling.adoc[leveloffset=+2]
+include::modules/efk-logging-manual-rollout-rolling.adoc[leveloffset=+1]
 
-include::modules/efk-logging-manual-rollout-full.adoc[leveloffset=+2]
+include::modules/efk-logging-manual-rollout-full.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-systemd.adoc
+++ b/logging/efk-logging-systemd.adoc
@@ -11,9 +11,9 @@ toc::[]
 // assemblies.
 
 
-include::modules/efk-logging-systemd-rate-limiting.adoc[leveloffset=+2]
+include::modules/efk-logging-systemd-rate-limiting.adoc[leveloffset=+1]
 
-include::modules/efk-logging-systemd-scaling.adoc[leveloffset=+2]
+include::modules/efk-logging-systemd-scaling.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-troubleshooting.adoc
+++ b/logging/efk-logging-troubleshooting.adoc
@@ -16,13 +16,13 @@ Kibana on {product-title}.
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-troubleshooting-loop.adoc[leveloffset=+2]
+include::modules/efk-logging-troubleshooting-loop.adoc[leveloffset=+1]
 
-include::modules/efk-logging-troubleshooting-cryptic.adoc[leveloffset=+2]
+include::modules/efk-logging-troubleshooting-cryptic.adoc[leveloffset=+1]
 
-include::modules/efk-logging-troubleshooting-proxy.adoc[leveloffset=+2]
+include::modules/efk-logging-troubleshooting-proxy.adoc[leveloffset=+1]
 
-include::modules/efk-logging-troubleshooting-unknown.adoc[leveloffset=+2]
+include::modules/efk-logging-troubleshooting-unknown.adoc[leveloffset=+1]
 
 
 

--- a/logging/efk-logging-uninstall.adoc
+++ b/logging/efk-logging-uninstall.adoc
@@ -12,11 +12,11 @@ You can use an Ansible playbook to remove the EFK stack from your {product-title
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/efk-logging-uninstall-efk.adoc[leveloffset=+2]
+include::modules/efk-logging-uninstall-efk.adoc[leveloffset=+1]
 
-include::modules/efk-logging-uninstall-efk-eventrouter.adoc[leveloffset=+2]
+include::modules/efk-logging-uninstall-efk-eventrouter.adoc[leveloffset=+1]
 
-include::modules/efk-logging-uninstall-efk-ops.adoc[leveloffset=+2]
+include::modules/efk-logging-uninstall-efk-ops.adoc[leveloffset=+1]
 
 
 

--- a/modules/efk-logging-deploy-pre.adoc
+++ b/modules/efk-logging-deploy-pre.adoc
@@ -9,23 +9,23 @@ Before deploying the EFK stack into {product-title} perform the following tasks:
 
 [procedure]
 
-* Be familiar with the following:
+. Be familiar with the following:
 +
-** An Ansible playbook is available to deploy and upgrade aggregated logging. You
+.. An Ansible playbook is available to deploy and upgrade aggregated logging. You
 should familiarize yourself with the {product-title} installation process. The installation process
 includes information for preparing to use Ansible and using the Ansible inventory file to configure
 various areas of the EFK stack.
 +
-** Review the *Storage Considerations for EFK Logging and {product-title}* to determine how best to configure your deployment.
+.. Review the *Storage Considerations for EFK Logging and {product-title}* to determine how best to configure your deployment.
 
-* Make sure your environment meets the following requirements:
+. Make sure your environment meets the following requirements:
 +
-** Ensure that you have deployed a router for the cluster.
+.. Ensure that you have deployed a router for the cluster.
 +
 ** Ensure that you have the necessary persistent storage for Elasticsearch. Note that each Elasticsearch replica
 requires its own storage volume. 
 
-* Specify a node selector
+. Specify a node selector
 +
 In order for the logging pods to spread evenly across your cluster, an empty
 node selector should be used.

--- a/modules/efk-logging-elasticsearch-exposing.adoc
+++ b/modules/efk-logging-elasticsearch-exposing.adoc
@@ -38,8 +38,7 @@ X-Proxy-Remote-User: $username
 X-Forwarded-For: $ip_address
 ----
 
-. You must have access to the project in order to be able to access to the
-logs. For example:
+. You must have access to the project in order to be able to access to the logs. For example:
 +
 ----
 $ oc login <user1>
@@ -53,8 +52,7 @@ $ oc new-app <httpd-example>
 $ token=$(oc whoami -t)
 ----
 
-. Using the token previously configured, you should be able access Elasticsearch
-through the exposed route:
+. Using the token previously configured, you should be able access Elasticsearch through the exposed route:
 +
 ----
 $ curl -k -H "Authorization: Bearer $token" -H "X-Proxy-Remote-User: $(oc whoami)" -H "X-Forwarded-For: 127.0.0.1" https://es.example.test/project.my-project.*/_search?q=level:err | python -mjson.tool

--- a/modules/efk-logging-elasticsearch-persistent-storage.adoc
+++ b/modules/efk-logging-elasticsearch-persistent-storage.adoc
@@ -78,14 +78,12 @@ some preparation as follows.
 . The relevant service account must be given the privilege to mount and edit a
 local volume:
 +
-====
 ----
 $ oc adm policy add-scc-to-user privileged  \
        system:serviceaccount:logging:aggregated-logging-elasticsearch <1>
 ----
 <1> Use the project you created earlier (for example, *logging*) when running the
 logging playbook.
-====
 
 . Each Elasticsearch replica definition must be patched to claim that privilege,
 for example:
@@ -106,7 +104,6 @@ configure a node selector, edit each Elasticsearch deployment configuration and
 add or edit the *nodeSelector* section to specify a unique label that you have
 applied for each desired node:
 +
-====
 ----
 apiVersion: v1
 kind: DeploymentConfig
@@ -119,14 +116,13 @@ spec:
 <1> This label should uniquely identify a replica with a single node that bears that
 label, in this case `logging-es-node=1`. Use the `oc label` command to apply
 labels to nodes as needed.
-
++
 To automate applying the node selector you can instead use the `oc patch` command:
-
++
 ----
 $ oc patch dc/logging-es-<suffix> \
    -p '{"spec":{"template":{"spec":{"nodeSelector":{"logging-es-node":"1"}}}}}'
 ----
-====
 
 . Once these steps are taken, a local host mount can be applied to each replica
 as in this example (where we assume storage is mounted at the same path on each node):

--- a/modules/efk-logging-elasticsearch-scaling.adoc
+++ b/modules/efk-logging-elasticsearch-scaling.adoc
@@ -44,5 +44,5 @@ openshift_logging_es_cluster_size=<number-of-nodes>
 ----
 $ ansible-playbook [-i </path/to/inventory>] \
     /usr/share/ansible/openshift-ansible/playbooks/openshift-logging/config.yml
----
+----
 


### PR DESCRIPTION
Fixing warnings from asciibinder build from incorrect include statements having +2 with no +1. 
Fixed one formatting error. 