### PR TITLE
bz:1644046 Remove 'or later' from Ansible version recommendation

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -59,7 +59,7 @@ and
 xref:../../install_config/install/host_preparation.adoc#install-config-install-host-preparation[Host
 Preparation] topics to prepare your hosts. This includes verifying system and
 environment requirements per component type and properly installing and
-configuring Docker. It also includes installing Ansible version 2.4 or later,
+configuring Docker. It also includes installing Ansible version 2.4,
 as the advanced installation method is based on Ansible playbooks and as such
 requires directly invoking Ansible.
 


### PR DESCRIPTION
Ansible versions greater than 2.4 do not work with the playbooks for 3.9.

https://bugzilla.redhat.com/show_bug.cgi?id=1644046