### PR TITLE
Fix:BZ1656032:Change the path of openstack cloud provider conf file for static pods

### DIFF
--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -70,7 +70,7 @@ include::install_config/topics/applying_configuration_changes.adoc[]
 [[configuring-openstack-variables]]
 === Configuring OpenStack Variables on an existing OpenShift Environment
 
-To set the required OpenStack variables, modify the *_/etc/cloud.conf_* file with
+To set the required OpenStack variables, modify the *_/etc/origin/cloudprovider/openstack.conf_* file with
 the following contents on all of your {product-title} hosts, both masters and
 nodes:
 
@@ -109,7 +109,7 @@ pvc-1faa6f93-64ac-11e8-930c-fa163e3c373c   1Gi        RWO            Delete     
 
 The default setting is enabled. Using the `oc get pv --show-labels` command returns the `failure-domain.beta.kubernetes.io/zone=nova` label.
 
-To disable the zone label, update the cloud.conf file by adding:
+To disable the zone label, update the *_openstack.conf_* file by adding:
 
 ----
 [BlockStorage]


### PR DESCRIPTION
**I had closed original `PR` about this one, so I would open as new one.**
* Original `PR`: https://github.com/openshift/openshift-docs/pull/13088

* Fix: [[DOCS] cloud provider config file must be located into "/etc/origin/cloudprovider"](https://bugzilla.redhat.com/show_bug.cgi?id=1656032)

* Version: `v3.10` and `v3.11+`

* Description:
 As of `v3.10`, the master service (API / Controllers) are provided by [control plane static pods](https://docs.openshift.com/container-platform/3.10/architecture/infrastructure_components/kubernetes_infrastructure.html#control-plane-static-pods), and the pods would be mounted limited directories for config files and certificates and so on. But `/etc` directory is not mounted by static pods.

[https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_cloud_provider/tasks/openstack.yml#L10]
~~~
- name: Create cloud config from template
  template:
    dest: "{{ openshift.common.config_base }}/cloudprovider/openstack.conf"
    src: openstack.conf.j2
~~~
above `dest` path would be `/etc/origin/cloudprovider`, so it should not be mounted /etc, and only openstack cloud provider pages are used `/etc/cloud.conf` file as example, it's wrong and confusing, refer other cloud provider's pages. (`Google Cloud Engine`, `Azure` ... their path prefix is `/etc/origin/cloudprovider`).  Refer the related BZ for more details. In reality, `/etc/cloud.conf` did not work.