### PR TITLE
Add cloud-config for vsphere nodes (bz 1663385)

### DIFF
--- a/install_config/configuring_vsphere.adoc
+++ b/install_config/configuring_vsphere.adoc
@@ -278,6 +278,8 @@ by default) and update the contents of the `kubeletArguments` section:
 kubeletArguments:
   cloud-provider:
     - "vsphere"
+  cloud-config:
+    - "/etc/origin/cloudprovider/vsphere.conf"
 
 ----
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1663385

@openshift/team-documentation 

Apply to enterprise-3.9 ONLY.

Reference docs,

[3.10 VSphere] https://docs.openshift.com/container-platform/3.10/install_config/configuring_vsphere.html#manually-configuring-node-hosts-for-vsphere
[3.11 VSphere] https://docs.openshift.com/container-platform/3.11/install_config/configuring_vsphere.html#manually-configuring-node-hosts-for-vsphere
[3.9 AWS] https://docs.openshift.com/container-platform/3.9/install_config/configuring_aws.html#aws-configuring-nodes-manually