### PR TITLE
Remove extra '*' from master/node config

### DIFF
--- a/install_config/topics/manually_configuring_for_azure.adoc
+++ b/install_config/topics/manually_configuring_for_azure.adoc
@@ -25,12 +25,12 @@ kubernetesMasterConfig:
     cloud-provider:
       - "azure"
     cloud-config:
-      - "/etc/origin/cloudprovider/azure.conf"*
+      - "/etc/origin/cloudprovider/azure.conf"
   controllerArguments:
     cloud-provider:
       - "azure"
     cloud-config:
-      - "/etc/origin/cloudprovider/azure.conf"*
+      - "/etc/origin/cloudprovider/azure.conf"
 ----
 +
 [IMPORTANT]

--- a/install_config/topics/manually_configuring_for_gce.adoc
+++ b/install_config/topics/manually_configuring_for_gce.adoc
@@ -22,12 +22,12 @@ apiServerArguments:
   cloud-provider:
     - "gce"
   cloud-config:
-    - "/etc/origin/cloudprovider/gce.conf"*
+    - "/etc/origin/cloudprovider/gce.conf"
 controllerArguments:
   cloud-provider:
     - "gce"
   cloud-config:
-    - "/etc/origin/cloudprovider/gce.conf"*
+    - "/etc/origin/cloudprovider/gce.conf"
 ----
 
 . When you configure {product-title} for GCP using Ansible, the
@@ -100,10 +100,10 @@ section:
 [source,yaml]
 ----
 kubeletArguments:
-  *cloud-provider:
+  cloud-provider:
     - "gce"
   cloud-config:
-    - "/etc/origin/cloudprovider/gce.conf"*
+    - "/etc/origin/cloudprovider/gce.conf"
 ----
 +
 [IMPORTANT]


### PR DESCRIPTION
@openshift/team-documentation Applies to enterprise-3.10 and above.

@weherdh  @jhou1  Could you check if the change looks good ?

You can check how it looks like currently,
https://docs.openshift.com/container-platform/3.11/install_config/configuring_gce.html#manually-configuring-master-hosts-for-gce