### PR TITLE
[enterprise-3.5] removed .js from anchor id

### DIFF
--- a/dev_guide/migrating_applications/web_framework_applications.adoc
+++ b/dev_guide/migrating_applications/web_framework_applications.adoc
@@ -249,7 +249,7 @@ endif::[]
 ifdef::openshift-dedicated[]
 See link:https://www.openshift.com/features/containers.html#dedicated[Supported Container Images]
 endif::[]
-[[dev-guide-migrating-web-framework-applications-node.js]]
+[[dev-guide-migrating-web-framework-applications-node]]
 == Node.js
 
 . Set up a new GitHub repository and add it as a remote branch to the current,


### PR DESCRIPTION
Fixed ID string in file that caused build failure. See also: https://github.com/openshift/openshift-docs/pull/11971