### PR TITLE
FIX:1664191:Add cri-o default configmap list

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -505,6 +505,14 @@ The following ConfigMaps are also created, which label nodes into multiple roles
 - `node-config-all-in-one`
 - `node-config-master-infra`
 
+The following ConfigMaps are *CRI-O* variants for each of the existing default node groups:
+
+- `node-config-master-crio`
+- `node-config-infra-crio`
+- `node-config-compute-crio`
+- `node-config-all-in-one-crio`
+- `node-config-master-infra-crio`
+
 [IMPORTANT]
 ====
 You must not modify a node host's


### PR DESCRIPTION
* Fix: [[DOCS] CRI-O default configmap list is not mentioned](https://bugzilla.redhat.com/show_bug.cgi?id=1664191)

* Version: `v3.11`

* Description:
  The `CRI-O` default configmap is not mentioned in the documentation, though the list is added.
  Refer [this commit history](https://github.com/openshift/openshift-ansible/commit/379c1ed85c75c4e60b3c9c145b748c04659e5d52#diff-23ff377caf1c3db9840ce07eede4eda0R152) for more details.
~~~
  - name: node-config-master-crio
...
  - name: node-config-infra-crio
...
  - name: node-config-compute-crio
...
  - name: node-config-master-infra-crio
...
  - name: node-config-all-in-one-crio
...
~~~