### PR TITLE
FIX:1614176:Add openshift_sdn_vxlan_port to networking variable list table.

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -382,6 +382,9 @@ the default SDN. If enabling *flannel*, disable the default SDN with the
 |`openshift_use_openshift_sdn`
 |Set to `false` to disable the OpenShift SDN plug-in.
 
+|`openshift_sdn_vxlan_port`
+|This variable sets the `vxlan port` number for `cluster network`. Defaults to `4789`. See xref:../install_config/configuring_sdn.html#config-changing-vxlan-port-for-cluster-network[Changing the VXLAN PORT for the cluster network] for more information.
+
 |===
 
 [[advanced-install-deployment-types]]


### PR DESCRIPTION
* Fix: [[RFE] Allow vxlan port to be configurable in openshift-ansible when setup OCP cluster](https://bugzilla.redhat.com/show_bug.cgi?id=1614176)

* Version: `v3.11` or later

* Description: 
  This `RFE` feature is merged through [this PR](https://github.com/openshift/openshift-ansible/pull/10950), so we should add new variable to `networking variables` table.