### PR TITLE
Follow-up: Changes to Agg Logging per jcantrill slack comments

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -63,7 +63,7 @@ to determine how best to configure your deployment.
 . Ensure that you have deployed a router for the cluster.
 . Ensure that you have
 xref:../install_config/persistent_storage/index.adoc#install-config-persistent-storage-index[the
-necessary storage] for Elasticsearch. Note that each Elasticsearch replica
+necessary storage] for Elasticsearch. Note that each Elasticsearch node
 requires its own storage volume. See
 xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
 . Determine if you need xref:ha-elasticsearch[highly-available Elasticsearch]. A highly-available environment requires
@@ -71,27 +71,6 @@ multiple replicas of each shard. By default, {product-title} creates one shard f
 zero replicas of those shards. To create high availability, set the xref:aggregate-logging-ansible-variables[`openshift_logging_es_number_of_replicas` Ansible variable]
 to a value higher than `1`. High availability also requires at least three Elasticsearch nodes,
 each on a different host. See xref:../install_config/aggregate_logging.adoc#aggregated-elasticsearch[Elasticsearch] for more information.
-. Choose a project. Once deployed, the EFK stack collects logs for every
-project within your {product-title} cluster. The examples in this section use the
-default project *openshift-logging*. The Ansible playbook creates the project for you
-if it does not already exist. You will only need to create a project if you want
-to specify a node-selector on it. Otherwise, the `openshift-logging` role will
-create a project.
-+
-----
-$ oc adm new-project openshift-logging --node-selector=""
-$ oc project openshift-logging
-----
-+
-[NOTE]
-====
-Specifying an empty
-xref:../admin_guide/managing_projects.adoc#using-node-selectors[node
-selector] on the project is recommended, as Fluentd should be deployed
-throughout the cluster and any selector would restrict where it is
-deployed. To control component placement, specify node selectors per component to
-be applied to their deployment configurations.
-====
 
 [[aggregate-logging-ansible-variables]]
 == Specifying Logging Ansible Variables
@@ -245,7 +224,7 @@ when `openshift_logging_use_ops` is set to `true`.
 |The amount of memory to allocate to Kibana proxy.
 
 |`openshift_logging_kibana_replica_count`
-|The number of to which Kibana should be scaled up.
+|The number of nodes to which Kibana should be scaled up.
 
 |`openshift_logging_kibana_nodeselector`
 |A node selector that specifies
@@ -646,7 +625,7 @@ logging-kibana-1-zk94k                     2/2       Running   0          11h  <
 You can use the `oc get pods -o wide command to see the nodes where the Fluentd pod are deployed:
 
 ----
-oc get pods -o wide
+$ oc get pods -o wide
 NAME                                       READY     STATUS    RESTARTS   AGE       IP             NODE                         NOMINATED NODE
 logging-es-data-master-5av030lk-1-2x494    2/2       Running   0          38m       154.128.0.80   ip-153-12-8-6.wef.internal   <none>
 logging-fluentd-lqdxg                      1/1       Running   0          2m        154.128.0.85   ip-153-12-8-6.wef.internal   <none>
@@ -865,7 +844,7 @@ $ chown 1000:1000 /usr/local/es-storage
 ----
 
 Then, use *_/usr/local/es-storage_* as a host-mount as described below.
-Use a different backing file as storage for each Elasticsearch replica.
+Use a different backing file as storage for each Elasticsearch node.
 
 This loopback must be maintained manually outside of {product-title}, on the
 node. You must not maintain it from inside a container.
@@ -887,7 +866,7 @@ $ oc adm policy add-scc-to-user privileged  \
 logging playbook.
 ====
 
-. Each Elasticsearch replica definition must be patched to claim that privilege,
+. Each Elasticsearch node definition must be patched to claim that privilege,
 for example:
 +
 ----
@@ -900,7 +879,7 @@ $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o 
 
 . The Elasticsearch replicas must be located on the correct nodes to use the local
 storage, and should not move around even if those nodes are taken down for a
-period of time. This requires giving each Elasticsearch replica a node selector
+period of time. This requires giving each Elasticsearch node a node selector
 that is unique to a node where an administrator has allocated storage for it. To
 configure a node selector, edit each Elasticsearch deployment configuration and
 add or edit the *nodeSelector* section to specify a unique label that you have
@@ -949,7 +928,7 @@ you can create a deployment configuration for each Elasticsearch node you want t
 
 Due to the nature of persistent volumes and how Elasticsearch is
 configured to store its data and recover the cluster, you cannot simply increase
-the replicas in an Elasticsearch deployment configuration.
+the nodes in an Elasticsearch deployment configuration.
 
 The simplest way to change the scale of Elasticsearch is to modify the inventory
 host file and re-run the logging playbook as described previously. If you
@@ -1022,7 +1001,7 @@ $ curl -k -H "Authorization: Bearer $token" -H "X-Proxy-Remote-User: $(oc whoami
 [[aggregated-fluentd]]
 === Fluentd
 
-Fluentd is deployed as a DaemonSet that deploys replicas according to a node
+Fluentd is deployed as a DaemonSet that deploys nodes according to a node
 label selector, which you can specify with the inventory parameter
 `openshift_logging_fluentd_nodeselector` and the default is `logging-infra-fluentd`.
 As part of the OpenShift cluster installation, it is recommended that you add the
@@ -1064,19 +1043,19 @@ How you view logs depends upon the xref:fluentd-file[`LOGGING_FILE_PATH` setting
 * If `LOGGING_FILE_PATH` points to a file, use the *logs* utility to print out the contents of Fluentd log files:
 +
 ----
-oc exec <pod> logs <1>
+oc exec <pod> -- logs <1>
 ----
-<1> Specify the name of the Fluentd pod.
+<1> Specify the name of the Fluentd pod. Note the space before `logs`.
 +
 For example:
 +
 ----
-oc exec logging-fluentd-lmvms logs
+oc exec logging-fluentd-lmvms -- logs
 ----
 +
 The contents of log files are printed out, starting with the oldest log.  Use `-f` option to follow what is being written into the logs.
 
-* If you are using `LOGGING_FILE_PATH=console`, fluentd to write logs to STDOUT. You can retrieve the logs with the `oc logs -f <pod_name>` command.
+* If you are using `LOGGING_FILE_PATH=console`, Fluentd writes logs to its default location, `/var/log/fluentd/fluentd.log`. You can retrieve the logs with the `oc logs -f <pod_name>` command.
 +
 For example
 +
@@ -1087,19 +1066,19 @@ oc logs -f /var/log/fluentd/fluentd.log
 [[fluentd-file]]
 *Configuring Fluentd Log Location*
 
-Fluentd writes logs to a specified file, by default `/var/log/fluentd/fluentd.log`, or to the console, based on the `LOGGING_FILE_PATH` environment variable.  
+Fluentd writes logs to a specified file or to the default location, `/var/log/fluentd/fluentd.log`, based on the `LOGGING_FILE_PATH` environment variable.  
 
-To change the default output location for the Fluentd logs, use the `LOGGING_FILE_PATH` parameter 
+To change the output location for the Fluentd logs, use the `LOGGING_FILE_PATH` parameter 
 in the xref:../install/configuring_inventory_file.html#configuring-ansible[default inventory file]. 
-You can specify a particular file or to STDOUT:
+You can specify a particular file or use the Fluentd default location:
 
 ----
 LOGGING_FILE_PATH=console <1>
 LOGGING_FILE_PATH=<path-to-log/fluentd.log> <2>
 ----
 
-<1> Sends the log output to STDOUT.
-<2> Sends the log output to the specified file.
+<1> Sends the log output to the Fluentd default location. Retrieve the logs with the `oc logs -f <pod_name>` command.
+<2> Sends the log output to the specified file. Retrieve the logs with the `oc exec <pod_name> -- logs` command.
  
 After changing these parameters, re-run the xref:../install_config/aggregate_logging.adoc#deploying-the-efk-stack[logging installer playbook]:
 
@@ -1108,11 +1087,6 @@ $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i </path/to/inventory>] \
     playbooks/openshift-logging/config.yml
 ----
-
-[NOTE]
-====
-How you xref:fluentd-view-logs[view log data] depends on the `LOGGING_FILE_PATH` setting, either`console` or file.
-====
 
 [[fluentd-rotation]]
 *Configuring Fluentd Log Rotation*
@@ -1150,8 +1124,13 @@ For example:
 $ oc set env ds/logging-fluentd LOGGING_FILE_AGE=30 LOGGING_FILE_SIZE=1024000"
 ----
 
-Turn off log rotation by setting LOGGING_FILE_PATH=console. 
-This causes Fluentd to write logs to STDOUT where they can be retrieved using the `oc logs -f <pod_name>` command.
+Turn off log rotation by setting `LOGGING_FILE_PATH=console`. 
+This causes Fluentd to write logs to the Fluentd default location, *_/var/log/fluentd/fluentd.log_*, where you can retrieve them using the `oc logs -f <pod_name>` command.
+
+----
+oc set env ds/fluentd LOGGING_FILE_PATH=console
+----
+
 
 [[fluentd-external-log-aggregator]]
 *Configuring Fluentd to Send Logs to an External Log Aggregator*
@@ -4025,7 +4004,7 @@ $ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
           -d '{ "transient": { "cluster.routing.allocation.enable" : "none" } }'
 ----
 
-. Once complete, for each `dc` you have for an Elasticsearch cluster, scale down all replicas:
+. Once complete, for each `dc` you have for an Elasticsearch cluster, scale down all nodes:
 +
 ----
 $ oc scale dc <dc_name> --replicas=0
@@ -4042,7 +4021,7 @@ You will see a new pod deployed. Once the pod has two ready containers, you can
 move on to the next `dc`.
 
 . Once deployment is complete, for each `dc` you have for an Elasticsearch cluster, scale up
-replicas:
+the nodes:
 +
 ----
 $ oc scale dc <dc_name> --replicas=1


### PR DESCRIPTION
Due to merge issues, I made the changes from https://github.com/openshift/openshift-docs/pull/13169 in this PR. I might have based the branch for the previous PR off the wrong branch or the branch got stale.

This PR changes _Elasticsearch replicas_ to _Elasticsearch nodes_ as appropriate and removes the _Choose a project_ step, as suggested in  https://github.com/openshift/openshift-docs/pull/13169.
It also clarifies the `LOGGING_FILE_PATH` parameter per Anping's comments in  https://github.com/openshift/openshift-docs/pull/13169.