### PR TITLE
Manila volumes provisioning update for 4.0

### DIFF
--- a/install_config/persistent_storage/persistent_storage_manila.adoc
+++ b/install_config/persistent_storage/persistent_storage_manila.adoc
@@ -78,8 +78,8 @@ metadata:
   name: manila-provisioner-role
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    resources: ["persistentvolumes", "endpoints"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
@@ -89,6 +89,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["v1"]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
 ----
 
 . Bind the rules via `ClusterRoleBinding`:
@@ -109,6 +112,28 @@ subjects:
   namespace: default
 ----
 
+. Create a new `Secret`:
+
+[source,yaml]
++
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-secret <1>
+  namespace: default <2>
+data:
+  os-authURL: <base64 encoded OpenStack Keystone URL>
+  os-userName: <base64 encoded Manila username>
+  os-password: <base64 encoded password>
+  os-projectName: <base64 encoded OpenStack project (tenant) name>
+  os-domainName: <base64 encoded OpensStack Manila service domain>
+  os-region: <base64 encoded OpenStack region>
+----
+<1> The `Secret` name will be referenced by the Manila volumes `StorageClass`
+(see below).
+<2> Dtto.
+
 . Create a new `StorageClass`:
 +
 [source,yaml]
@@ -121,73 +146,28 @@ provisioner: "externalstorage.k8s.io/manila"
 parameters:
   type: "default" <1>
   zones: "nova" <2>
+  protocol: "NFS" <3>
+  backend: "nfs" <4>
+  osSecretName: "manila-secret" <5>
+  osSecretNamespace: "defaulr" <6>
+  nfs-share-client: "0.0.0.0" <7>
 ----
 <1> The link:https://docs.openstack.org/manila/latest/admin/shared-file-systems-share-types.html[Manila share type]
-the provisioner will create for the volume.
-<2> Set of Manila availability zones that the volume might be created in.
-
-Configure the provisioner to connect, authenticate, and authorize to the Manila servic using
-environment variables. Select the appropriate combination of environment variables for your installation
-from the following list:
-[source]
-----
-OS_USERNAME
-OS_PASSWORD
-OS_AUTH_URL
-OS_DOMAIN_NAME
-OS_TENANT_NAME
-----
-
-[source]
-----
-OS_USERID
-OS_PASSWORD
-OS_AUTH_URL
-OS_TENANT_ID
-----
-
-[source]
-----
-OS_USERNAME
-OS_PASSWORD
-OS_AUTH_URL
-OS_DOMAIN_ID
-OS_TENANT_NAME
-----
-
-[source]
-----
-OS_USERNAME
-OS_PASSWORD
-OS_AUTH_URL
-OS_DOMAIN_ID
-OS_TENANT_ID
-----
-
-To pass the variables to the provisioner, use a `Secret`.
-The following example shows a `Secret` configured for the first variables combination
-
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: manila-provisioner-env
-type: Opaque
-data:
-  os_username: <base64 encoded Manila username>
-  os_password: <base64 encoded password>
-  os_auth_url: <base64 encoded OpenStack Keystone URL>
-  os_domain_name: <base64 encoded Manila service Domain>
-  os_tenant_name: <base64 encoded Manila service Tenant/Project name>
-----
-
-[NOTE]
-====
-Newer OpenStack versions use "project" instead of "tenant," however, the
-environment variables used by the provisioner must use `TENANT` in their
-names.
-====
+the provisioner will create for the volume. This field is optional, default
+value is `default`.
+<2> Set of Manila availability zones that the volume might be created in. This
+field is optional, default value is `nova`.
+<3> Protocol used when provisioning a share, valid options are `NFS` and `CEPHFS`.
+This field is required.
+<4> Share backend used for granting access and creating
+`PersistentVolumeSource`, valid options are `nfs`, `cephfs`. This filed is
+required.
+<5> Name of the Secret object containing OpenStack credentials. This field is
+required.
+<6> Namespace of the OpenStack credentials Secret object. This field is
+optional, default value is `default`.
+<7> Default NFS client for the share exported. This filed is optional and valid
+only for the NFS protocol. Default value is `0.0.0.0`.
 
 The last step is to start the provisioner itself, for example, using a deployment:
 
@@ -208,35 +188,9 @@ spec:
     spec:
       serviceAccountName: manila-provisioner-runner
       containers:
-        - image: "registry.redhat.io/openshift3/manila-provisioner:latest"
+        - image: "registry.redhat.io/openshift/manila-provisioner:latest"
           imagePullPolicy: "IfNotPresent"
           name: manila-provisioner
-          env:
-            - name: "OS_USERNAME"
-              valueFrom:
-                secretKeyRef:
-                  name: manila-provisioner-env
-                  key: os_username
-            - name: "OS_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: manila-provisioner-env
-                  key: os_password
-            - name: "OS_AUTH_URL"
-              valueFrom:
-                secretKeyRef:
-                  name: manila-provisioner-env
-                  key: os_auth_url
-            - name: "OS_DOMAIN_NAME"
-              valueFrom:
-                secretKeyRef:
-                  name: manila-provisioner-env
-                  key: os_domain_name
-            - name: "OS_TENANT_NAME"
-              valueFrom:
-                secretKeyRef:
-                  name: manila-provisioner-env
-                  key: os_tenant_name
 ----
 
 [[usage]]


### PR DESCRIPTION
There is a new Manila provisioner to be released in OCP-4.0: Here's my attempt to update the documentation accordingly.