### PR TITLE
Fix missing backslash from commands in logging restart

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -4000,8 +4000,8 @@ if `openshift_logging_use_ops` was configured to be `True`.
 . Prevent shard balancing when purposely bringing down nodes:
 +
 ----
-$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
-          curl -s
+$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> -- \
+          curl -s \
           --cacert /etc/elasticsearch/secret/admin-ca \
           --cert /etc/elasticsearch/secret/admin-cert \
           --key /etc/elasticsearch/secret/admin-key \
@@ -4022,8 +4022,8 @@ move on to the next `dc`.
 . Once all `dc`s for the cluster have been rolled out, re-enable shard balancing:
 +
 ----
-$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
-          curl -s
+$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> -- \
+          curl -s \
           --cacert /etc/elasticsearch/secret/admin-ca \
           --cert /etc/elasticsearch/secret/admin-cert \
           --key /etc/elasticsearch/secret/admin-key \
@@ -4061,8 +4061,8 @@ $  oc patch svc/logging-es -p '{"spec":{"selector":{"component":"es-blocked","pr
 to be written to disk prior to shutting down:
 +
 ----
-$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
-          curl -s
+$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> -- \
+          curl -s \
           --cacert /etc/elasticsearch/secret/admin-ca \
           --cert /etc/elasticsearch/secret/admin-cert \
           --key /etc/elasticsearch/secret/admin-key \
@@ -4072,8 +4072,8 @@ $ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
 . Prevent shard balancing when purposely bringing down nodes:
 +
 ----
-$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> --
-          curl -s
+$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> -- \
+          curl -s \
           --cacert /etc/elasticsearch/secret/admin-ca \
           --cert /etc/elasticsearch/secret/admin-cert \
           --key /etc/elasticsearch/secret/admin-key \


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1665328

@openshift/team-documentation 
Applies to enterprise-3.7 and above.