### PR TITLE
Fix registry url and a typo

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -328,7 +328,7 @@ endif::[]
 +
 [source, bash]
 ----
-$ docker pull registry.access.redhat.com/openshift3/ofs-efs-provisioner:<tag>
+$ docker pull registry.redhat.io/openshift3/ose-efs-provisioner:<tag>
 ----
 
 . Pull all of the required {product-title} component images for the


### PR DESCRIPTION
For the registry url, refer to https://docs.openshift.com/container-platform/3.11/install/disconnected_install.html#disconnected-syncing-images . You can see that all other images are using registry.redhat.io except the one updated here.

@openshift/team-documentation 
Apply to enterprise-3.11 ONLY.