### PR TITLE
Remove note about enabling dynamic provisioning

### DIFF
--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -32,22 +32,6 @@ Many storage types are available for use as persistent volumes in
 administrator, some types of storage are created dynamically using the
 built-in provider and plug-in APIs.
 
-[NOTE]
-====
-To enable dynamic provisioning, add the
-`openshift_master_dynamic_provisioning_enabled` variable to the `[OSEv3:vars]`
-section of the Ansible inventory file and set its value to `True`.
-
-[source]
-----
-[OSEv3:vars]
-
-openshift_master_dynamic_provisioning_enabled=True
-----
-
-====
-
-
 [[available-dynamically-provisioned-plug-ins]]
 == Available dynamically provisioned plug-ins
 


### PR DESCRIPTION
Dynamic provisioning is on by default in 4.0 and cannot (should not?) be disabled.