### PR TITLE
Fix authby value in the IPsec admin guide

### DIFF
--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -154,7 +154,7 @@ conn private
 	# their certificate transmitted via IKE
 	rightca=%same
 	ikev2=insist
-	authby=rsasig
+	authby=pubkey
 	failureshunt=drop
 	negotiationshunt=hold
 	auto=ondemand


### PR DESCRIPTION
Change the `authby` value from `rsasig` to `pubkey` in the IPsec configuration for the opportunistic group.

The combined certificate in the PKCS#12 format created by the `openssl` command result in a `cert key is not rsa type!` error in IPsec.