### PR TITLE
Update contrib doc to use a better example for root command

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -476,7 +476,7 @@ $ oc get endpoints --all-namespaces --template \
 +
 [source, bash]
 ----
-# sudo ./openshift start
+# subscription-manager list
 ----
 
 === Inline Code or Commands


### PR DESCRIPTION
Just updating the example used for a root command to a different one, since you would normally run sudo as a non-root user.

@openshift/team-documentation: A simple internal doc update for your review. Please let me know if I missed setting any labels or fields. Thanks!