### PR TITLE
Added Network optimization content to 4.0 docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -188,6 +188,8 @@ Topics:
   File: understanding-networking
 - Name: Using cookies to keep route statefulness
   File: using-cookies-to-keep-route-statefulness
+- Name: Network optimization
+  File: network-optimization
 ---
 Name: Registry
 Dir: registry

--- a/modules/configuring-network-subnets.adoc
+++ b/modules/configuring-network-subnets.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// networking/network-optimization.adoc
+
+[id='Configuring-network-subnets-{context}']
+= Configuring network subnets
+
+All Pods are assigned IPs. This enables Pod to Pod communication and Pod to node
+communication without network address translation (NAT). For a CIDR in the range
+of 10.128.0.0/14, IPs in this range are, by default, assigned to the Pods. If
+you want to change this, you must adjust the `ClusterNetwork`. If you want to
+customize the IPs rolled out to services, then you must adjust the
+`ServiceNetwork`.
+
+.Procedure
+
+To configure a custom IP range, also called a _subnet_, complete the following.
+
+. Run:
++
+----
+$ ./openshift-install --dir=new-install create install-config
+----
+
+. Change to the `new-install` directory:
++
+----
+$ cd new-install
+----
+
+. Edit the `install-config.yaml` file, setting the required fields under
+`networking`:
++
+----
+networking:
+      clusterNetworks:
+        - cidr: 10.128.0.0/14
+          hostSubnetLength: 9
+      machineCIDR: 10.0.0.0/16
+      serviceCIDR: 172.30.0.0/16
+     type: OpenshiftSDN
+----
+
+. Consume the customized `install-config.yaml` file to deploy the cluster:
++
+----
+$ ./openshift-install --dir=new-install create cluster
+----

--- a/modules/optimizing-the-MTU-for-your-network.adoc
+++ b/modules/optimizing-the-MTU-for-your-network.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// networking/network-optimization.adoc
+
+[id='optimizing-the-mtu-for-your-network-{context}']
+= Optimizing the MTU for your network
+
+There are two important maximum transmission units (MTUs): the network
+interface card (NIC) MTU and the SDN overlay's MTU.
+
+MTUs are now autodetected, so you do not need to adjust MTU settings. When the
+Cluster Network Operator runs, it determines the MTU used by the default route,
+then sets the MTU accordingly. If you want to have a fixed MTU size for your
+workloads, then you must set the MTU explicitly, then set the network
+configuration before installation.
+
+.Procedure
+
+To set the MTU explicitly, complete the following.
+
+. Run:
++
+----
+$ openshift-installer create install-config
+----
+
+. Run the following to generate the required manifests:
++
+----
+$ openshift-installer create manifests
+----
+
+. Edit the `manifests/cluster-network-02-config.yml` file.
+
+. Run the following to use the manifests to create a cluster:
++
+----
+$ openshift-installer create cluster
+----
+
+. The following is the default state of the `cluster-network-02-config.yaml` file.
+Adjust the settings as necessary:
++
+----
+apiVersion: networkoperator.openshift.io/v1
+kind: NetworkConfig
+metadata:
+  creationTimestamp: null
+  name: default
+spec:
+  additionalNetworks: null
+  clusterNetworks:
+  - cidr: 10.128.0.0/14
+    hostSubnetLength: 9
+  defaultNetwork:
+    openshiftSDNConfig:
+      mode: Networkpolicy <1>
+    otherConfig: null
+    type: OpenshiftSDN
+  serviceNetwork: 172.30.0.0/16
+status: {}
+----
++
+<1> `Networkpolicy` is the default.
++
+You can also set the `Multitenant` or `Subnet`, `vxlanPort`, and  `mtu`:
++
+----
+spec:
+  defaultNetwork:
+    type: OpenShiftSDN
+    openshiftSDNConfig:
+      mode: NetworkPolicy
+      vxlanPort: 4789
+      mtu: 1450
+      useExternalOpenvswitch: false
+----

--- a/networking/PLACEHOLDER
+++ b/networking/PLACEHOLDER
@@ -1,2 +1,0 @@
-Please delete this file once you have assemblies here.
-

--- a/networking/network-optimization.adoc
+++ b/networking/network-optimization.adoc
@@ -1,0 +1,47 @@
+[id='network-optimization']
+= Network optimization
+include::modules/common-attributes.adoc[]
+:context: networking
+
+toc::[]
+
+{nbsp} +
+The OpenShift SDN uses Open vSwitch, Virtual Extensible LAN (VXLAN) tunnels,
+OpenFlow rules, and iptables. This network can be tuned by using jumbo frames,
+network interface cards (NIC) offloads, multi-queue, and ethtool settings.
+
+VXLAN provides benefits over VLANs, such as an increase in networks from 4096 to
+over 16 million, and layer 2 connectivity across physical networks. This allows
+for all Pods behind a service to communicate with each other, even if they are
+running on different systems.
+
+VXLAN encapsulates all tunneled traffic in user datagram protocol (UDP) packets.
+However, this leads to increased CPU utilization. Both these outer- and
+inner-packets are subject to normal checksumming rules to guarantee data has not
+been corrupted during transit. Depending on CPU performance, this additional
+processing overhead can cause a reduction in throughput and increased latency
+when compared to traditional, non-overlay networks.
+
+Cloud, VM, and bare metal CPU performance can be capable of handling much more
+than one Gbps network throughput. When using higher bandwidth links such as 10
+or 40 Gbps, reduced performance can occur. This is a known issue in VXLAN-based
+environments and is not specific to containers or {product-title}. Any network
+that relies on VXLAN tunnels performs similarly because of the VXLAN
+implementation.
+
+If you are looking to push beyond one Gbps, you can:
+
+* Evaluate network plug-ins that implement different routing techniques, such as
+border gateway protocol (BGP).
+* Use VXLAN-offload capable network adapters. VXLAN-offload moves the packet
+checksum calculation and associated CPU overhead off of the system CPU and onto
+dedicated hardware on the network adapter. This frees up CPU cycles for use by
+Pods and applications, and allows users to utilize the full bandwidth of their
+network infrastructure.
+
+VXLAN-offload does not reduce latency. However, CPU utilization is reduced even
+in latency tests.
+
+include::modules/configuring-network-subnets.adoc[leveloffset=+1]
+
+include::modules/optimizing-the-MTU-for-your-network.adoc[leveloffset=+1]


### PR DESCRIPTION
Preview Build:
http://file.rdu.redhat.com/~ahardin/01152019/4-0-networking-optimization/networking/network-optimization.html

Some questions/notes from an earlier team conversation:

- Is NCR still a thing?

- MTU settings will be different with the new operators, right?

- Optimizing the MTU for your network - this has to account for new automagic MTU PR

- How to edit node configmap for subnet option probably needs to be dropped.

- Subnet configuration will need to be re-written for new installer configs
 
- Is IPSEC still supported?
