### PR TITLE
[enterprise-3.5] Took NOTE box out of a table because it skewed Portal doc formatting

### DIFF
--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -200,13 +200,14 @@ MongoDB settings can be configured with the following environment variables:
 |`*MONGODB_TEXT_SEARCH_ENABLED*`
 |(MongoDB version 2.4 only) Enables the https://docs.mongodb.org/v2.4/core/index-text/#text-search-text-command[text search] feature.
 
-[NOTE]
-====
-Text search is enabled by default in MongoDB versions 2.6 and higher, and therefore has no configurable parameter.
-====
-
 |`*false*`
 |===
+
+[NOTE]
+====
+Text search is enabled by default in MongoDB versions 2.6 and higher, and
+therefore has no configurable parameter.
+====
 
 === Volume Mount Points
 


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/pull/13331