### PR TITLE
Removed tech preview status from kuryr

### DIFF
--- a/admin_guide/kuryr.adoc
+++ b/admin_guide/kuryr.adoc
@@ -13,20 +13,6 @@ toc::[]
 
 == Overview
 
-[IMPORTANT]
-====
-Kuryr SDN Administration is a Technology Preview feature.
-ifdef::openshift-enterprise[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-For more information on Red Hat Technology Preview features support scope, see
-https://access.redhat.com/support/offerings/techpreview/.
-endif::[]
-====
 
 xref:../install_config/configuring_kuryrsdn.adoc#install-config-configuring-kuryr-sdn[Kuryr]
 (or Kuryr-Kubernetes) is one of the SDN choices for {product-title}. Kuryr uses

--- a/install_config/configuring_kuryrsdn.adoc
+++ b/install_config/configuring_kuryrsdn.adoc
@@ -13,20 +13,6 @@ toc::[]
 [[kuryr-sdn-and-openshift]]
 == Kuryr SDN and {product-title}
 
-[IMPORTANT]
-====
-The ability to configure Kuryr SDN is a Technology Preview feature.
-ifdef::openshift-enterprise[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-For more information on Red Hat Technology Preview features support scope, see
-https://access.redhat.com/support/offerings/techpreview/.
-endif::[]
-====
 
 link:https://docs.openstack.org/kuryr-kubernetes/latest/[Kuryr] (or more
 specifically Kuryr-Kubernetes) is an SDN solution built using

--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -550,9 +550,6 @@ Registry] for more information.
 [[ocp-311-kuryr]]
 ==== Improved {product-title} and Red Hat OpenStack Integration with Kuryr (Technology Preview)
 
-This feature is currently in xref:ocp-311-technology-preview[Technology Preview]
-and not for production workloads.
-
 See xref:../admin_guide/kuryr.adoc#admin-guide-kuryr[Kuryr SDN Administration]
 and
 xref:../install_config/configuring_kuryrsdn.adoc#install-config-configuring-kuryr-sdn[Configuring
@@ -1521,7 +1518,7 @@ features marked *GA* indicate _General Availability_.
 |xref:ocp-311-kuryr[Kuryr CNI Plug-in]
 |-
 |TP
-|TP
+|GA
 
 |xref:ocp-311-control-sharing-pid-namespace-between-containers[Sharing Control of the PID Namespace]
 |-


### PR DESCRIPTION
[BZ 1660517](https://bugzilla.redhat.com/show_bug.cgi?id=1660517)
Removed tech preview status for Kuryr docs
Changes apply to 3.11 only.
