### PR TITLE
[3.11]Correct the report files path about checking certificate expiration.

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -82,16 +82,16 @@ The `openshift_certificate_expiry` role uses the following variables:
 |Generate an HTML report of the expiry check results.
 
 |`openshift_certificate_expiry_html_report_path`
-|`/tmp/cert-expiry-report.html`
-|The full path for saving the HTML report.
+|`$HOME/cert-expiry-report.yyyymmddTHHMMSS.html`
+|The full path for saving the HTML report. Defaults to consist of home directory and timestamp suffix of the report file.
 
 |`openshift_certificate_expiry_save_json_results`
 |`no`
-|Save expiry check results as a JSON file.
+|Save expiry check results as a JSON file. 
 
 |`openshift_certificate_expiry_json_results_path`
-|`/tmp/cert-expiry-report.json`
-|The full path for saving the JSON report.
+|`$HOME/cert-expiry-report.yyyymmddTHHMMSS.json`
+|The full path for saving the JSON report. Defaults to consist of home directory and timestamp suffix of the report file.
 |===
 
 [[install-config-cert-expiry-running-playbooks]]
@@ -108,7 +108,7 @@ xref:../install/configuring_inventory_file.adoc#configuring-ansible[inventory fi
 Using the *_easy-mode.yaml_* example playbook, you can try the role out before
 tweaking it to your specifications as needed. This playbook:
 
-- Produces JSON and stylized HTML reports in *_/tmp/_*.
+- Produces JSON and stylized HTML reports in *_$HOME_* directory.
 - Sets the warning window very large, so you will almost always get results back.
 - Includes all certificates (healthy or not) in the results.
 
@@ -210,7 +210,7 @@ using a variety of command-line tools. For example, using `grep` you can look
 for the word `summary` and print out the two lines after the match (`-A2`):
 
 ----
-$ grep -A2 summary /tmp/cert-expiry-report.json
+$ grep -A2 summary $HOME/cert-expiry-report.yyyymmddTHHMMSS.json
     "summary": {
         "warning": 16,
         "expired": 0
@@ -221,13 +221,13 @@ first two examples below show how to select just one value, either `warning` or
 `expired`. The third example shows how to select both values at once:
 
 ----
-$ jq '.summary.warning' /tmp/cert-expiry-report.json
+$ jq '.summary.warning' $HOME/cert-expiry-report.yyyymmddTHHMMSS.json
 16
 
-$ jq '.summary.expired' /tmp/cert-expiry-report.json
+$ jq '.summary.expired' $HOME/cert-expiry-report.yyyymmddTHHMMSS.json
 0
 
-$ jq '.summary.warning,.summary.expired' /tmp/cert-expiry-report.json
+$ jq '.summary.warning,.summary.expired' $HOME/cert-expiry-report.yyyymmddTHHMMSS.json
 16
 0
 ----


### PR DESCRIPTION
* Fix BZ: [[DOCS] Correct the report file path of checking certificate expiration](https://bugzilla.redhat.com/show_bug.cgi?id=1666946)

* Related BZ: [Different users running upgrades from the same host causes conflict over file: /tmp/cert-expiry-report.html](https://bugzilla.redhat.com/show_bug.cgi?id=1612093)

* Version: only `v3.11`

* Description: 
  The report file path is changed to home directory as default value. 
  This change is caused by [this commit](https://github.com/openshift/openshift-ansible/commit/90c456e9098a2b4a7712c2c262a11d17b0111bef#diff-741d642cea9a5220e5564ba3e0c4e61f).
~~~
This commit ensures cert report is placed in user's
home directory + data-time stamp in filename to ensure
multiple runs and multiple users don't overwrite reports
by mistake.
~~~
