### PR TITLE
removing BYO references

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -97,10 +97,6 @@ Topics:
   File: installing-quickly-cloud
 - Name: Installing a cluster on AWS with customizations
   File: installing-customizations-cloud
-- Name: Installing a cluster on existing hosts
-  File: installing-existing-hosts
-- Name: Uninstalling a cluster from existing hosts
-  File: uninstalling-existing-hosts
 ---
 Name: Networking
 Dir: networking


### PR DESCRIPTION
I'm removing the assemblies from the 4.0 TOC but retaining the draft source files for now. 

see https://jira.coreos.com/browse/OSDOCS-150