### PR TITLE
Fix a command typo

### DIFF
--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -277,7 +277,7 @@ with:
 ----
 $ oc logs dc/<name>
 ----
-- The `oc set env` and `oc volume` commands have been moved to `oc set env` and `oc
+- The `oc env` and `oc volume` commands have been moved to `oc set env` and `oc
 set volume`, and future commands that modify aspects of existing resources will
 be located under this command.
 - When a pod is crash-looping, meaning it is starting and exiting repeatedly, an


### PR DESCRIPTION
@openshift/team-documentation 

Applies to enterprise-3.2 and above.