### PR TITLE
Fixes from 1.3 OCP docs feedback, mostly language, markup, formatting

### DIFF
--- a/modules/cnv_accessing_serial_console.adoc
+++ b/modules/cnv_accessing_serial_console.adoc
@@ -9,7 +9,7 @@ machine instance.
 
 .Procedure
 
-. Connect to the serial console with `virtctl`:
+. Connect to the serial console with *virtctl*:
 +
 ....
 $ virtctl console <VMI>

--- a/modules/cnv_accessing_vmi_ssh.adoc
+++ b/modules/cnv_accessing_vmi_ssh.adoc
@@ -6,17 +6,17 @@ You can use SSH to access a virtual machine, but first you must expose port
 
 The `virtctl expose` command forwards a virtual machine instance port to a node 
 port and creates a service for enabled access. The following example creates 
-the `fedora-vm-ssh` service which forwards port 22 of the `fedora-vm` virtual 
+the *fedora-vm-ssh* service which forwards port 22 of the `<fedora-vm>` virtual 
 machine to a port on the node:
 
 .Prerequisites
 * The virtual machine instance you want to access must be running.
 
 .Procedure
-. Run the following command to create the `fedora-vm-ssh` service: 
+. Run the following command to create the *fedora-vm-ssh* service: 
 +
 ----
-$ virtctl expose vm fedora-vm --port=20022 --target-port=22 --name=fedora-vm-ssh --type=NodePort 
+$ virtctl expose vm <fedora-vm> --port=20022 --target-port=22 --name=fedora-vm-ssh --type=NodePort 
 ----
 
 . Check the service to find out which port the service acquired:

--- a/modules/cnv_accessing_vnc_console.adoc
+++ b/modules/cnv_accessing_vnc_console.adoc
@@ -1,31 +1,28 @@
 [[access-vnc-console]]
 === Accessing the graphical console of a VMI with VNC
 
-The `virtctl` client utility can use `remote-viewer` to open a graphical console 
-to a running virtual machine instance. This is installed with the `virt-viewer` 
+The *virtctl* client utility can use *remote-viewer* to open a graphical console 
+to a running virtual machine instance. This is installed with the *virt-viewer* 
 package.
 
 .Prerequisites
 
-* `virt-viewer` must be installed.
+* *virt-viewer* must be installed.
 * The virtual machine instance you want to access must be running.
 
 [NOTE]
 ====
-If you use `virtctl` via `ssh` on a remote machine, you must 
+If you use *virtctl* via *SSH* on a remote machine, you must 
 forward the X session to your machine for this procedure to work.
 ====
 
 .Procedure
 
-. Connect to the graphical interface with the `virtctl` utility: 
+. Connect to the graphical interface with the *virtctl* utility: 
 +
 ----
 $ virtctl vnc <VMI>
 ----
-+
-If this command is successful, you will now be connected to the graphical 
-interface.
 
 . If the command failed, try using the `-v` flag to collect 
 troubleshooting information:

--- a/modules/cnv_clone_vm_template_gui.adoc
+++ b/modules/cnv_clone_vm_template_gui.adoc
@@ -1,7 +1,7 @@
 [[clone-vm-template-web-console]]
 === Creating a virtual machine from a template using the web console
 
-Templates can be used to create virtual machines, removing the need to download a disk image for each virtual 
+You can use templates to create virtual machines, removing the need to download a disk image for each virtual 
 machine. The PVC created for the template is cloned, allowing you to 
 change the resource parameters for each new virtual machine.
 
@@ -12,29 +12,31 @@ change the resource parameters for each new virtual machine.
 
 .Procedure
 
-. Ensure you are in the correct project. If not, click the `Project` drop-down 
-menu and select the appropriate project or create a new one.
-. Click the `Catalog` button on the side menu.
-. Click the `Virtualization` tab to filter the catalog.
-. Select the template and click `Next`.
+. Ensure you are in the correct project. If not, click the *Project* list and select the appropriate project or create a new one.
+. Click *Catalog* on the side menu.
+. Click the *Virtualization* tab to filter the catalog.
+. Select the template and click *Next*.
 . Enter the required parameters. For example: +
 +
 ----
-Add to Project: template-test
-NAME: fedora-1
-MEMORY: 2048Mi
-CPU_CORES: 2
+Add to Project: <template-test>
+NAME: <fedora-1>
+MEMORY: <2048Mi>
+CPU_CORES: <2>
 ----
 
-. Click `Next`.
+. Click *Next*.
 . Choose whether or not to create a binding for the virtual machine. Bindings 
 create a secret containing the necessary information for another application 
 to use the virtual machine service. Bindings can also be added after the virtual 
 machine has been created.
-. Click `Create` to begin creating the virtual machine.
+. Click *Create* to begin creating the virtual machine.
 
-NOTE: Temporary pods with the generated names of `clone-source-pod-<random>` and `clone-target-pod-<random>`, 
+[NOTE] 
+====
+Temporary pods with the generated names of `clone-source-pod-<random>` and `clone-target-pod-<random>`, 
 are built, in the template project and the virtual machine project respectively, to handle the creation of the virtual machine and the corresponding PVC.
 The PVC is given a generated name of `vm-<vm-name>-disk-01` or `vm-<vm-name>-dv-01`. Upon completion, the 
-temporary pods are discarded and the virtual machine (`fedora-1` in the above example) 
-is ready in a `Stopped` state.
+temporary pods are discarded, and the virtual machine (`<fedora-1>` in the above example) 
+is ready in a *Stopped* state.
+====

--- a/modules/cnv_cloning_pvc_datavolume.adoc
+++ b/modules/cnv_cloning_pvc_datavolume.adoc
@@ -3,8 +3,6 @@
 
 You can clone a PVC of an existing virtual machine disk into a new DataVolume. The new DataVolume can then be used for a new virtual machine.
 
-To clone a DataVolume, examine it to identify the associated PVC. Use the details of the identified PVC as the `source`.
-
 [NOTE]
 When a DataVolume is created independently of a virtual machine, the lifecycle of the DataVolume is independent of the virtual machine: If the virtual machine is deleted, neither the DataVolume nor its associated PVC will be deleted.
 
@@ -13,12 +11,13 @@ When a DataVolume is created independently of a virtual machine, the lifecycle o
 
 .Procedure
 
+. Examine the DataVolume you want to clone to identify the name and namespace of the associated PVC. 
 . Create a YAML file for a DataVolume object that specifies the following parameters:
 [horizontal]
-`metadata: name`:: The name of the new DataVolume
-`source: pvc: namespace`:: The namespace in which the source PVC exists
-`source: pvc: name`:: The name of the source PVC
-`storage`:: The size of the new DataVolume. Be sure to allocate enough space or the cloning operation will not complete.  The size should be the same or larger as the source PVC.
+*metadata: name*:: The name of the new DataVolume.
+*source: pvc: namespace*:: The namespace in which the source PVC exists.
+*source: pvc: name*:: The name of the source PVC.
+*storage*:: The size of the new DataVolume. Be sure to allocate enough space or the cloning operation fails. The size must be the same or larger as the source PVC.
 +
 For example:
 +
@@ -30,8 +29,8 @@ metadata:
 spec:
   source:
     pvc:
-      namespace: "source-namespace"
-      name: "my-favorite-vm-disk"
+      namespace: "<source-namespace>"
+      name: "<my-favorite-vm-disk>"
   pvc:
     accessModes:
       - ReadWriteOnce
@@ -43,8 +42,8 @@ storage: 500Mi
 . Start the PVC clone by creating the DataVolume:
 +
 ----
-oc create -f <datavolume>.yaml
+$ oc create -f <datavolume>.yaml
 ----
 
-DataVolumes prevent a virtual machine from being started before the PVC has been prepared so you can link:#createvm[create a virtual machine] that references the new DataVolume while the PVC is being cloned.
+DataVolumes prevent a virtual machine from starting before the PVC is prepared so you can create a virtual machine that references the new DataVolume while the PVC clones.
 

--- a/modules/cnv_cloning_pvc_virtualmachine.adoc
+++ b/modules/cnv_cloning_pvc_virtualmachine.adoc
@@ -1,8 +1,6 @@
 === Cloning an existing PVC and creating a virtual machine using a dataVolumeTemplate
 
-You can create a new virtual machine that clones the PVC of an existing virtual machine into a new DataVolume. Referencing a `dataVolumeTemplate` in the virtual machine spec, the `source` PVC is cloned to a new DataVolume, which is then automatically used for the creation of the virtual machine.
-
-To clone a DataVolume, examine it to identify the associated PVC. Use the details of the identified PVC as the `source`.
+You can create a virtual machine that clones the PVC of an existing virtual machine into a DataVolume. By referencing a *dataVolumeTemplate* in the virtual machine spec, the *source* PVC is cloned to a DataVolume, which is then automatically used for the creation of the virtual machine.
 
 [NOTE]
 When a DataVolume is created as part of the DataVolumeTemplate of a virtual machine, the lifecycle of the DataVolume is then dependent on the virtual machine: If the virtual machine is deleted, the DataVolume and associated PVC will also be deleted.
@@ -13,17 +11,19 @@ When a DataVolume is created as part of the DataVolumeTemplate of a virtual mach
 
 .Procedure
 
-. Create a YAML file for a `VirtualMachine` object. The following virtual machine example, `vm-dv-clone`, clones `my-favorite-vm-disk` (located in the `source-namespace` namespace) and creates the `2Gi` `favorite-clone` DataVolume, referenced in the virtual machine as the `dv-clone` volume.
+. Examine the DataVolume you want to clone to identify the name and namespace of the associated PVC.
+. Create a YAML file for a *VirtualMachine* object. The following virtual machine example, `<vm-dv-clone>`, clones `<my-favorite-vm-disk>` (located in the `<source-namespace>` namespace) and creates the `2Gi` `<favorite-clone>` DataVolume, referenced in the virtual machine as the `<dv-clone>` volume.
 +
 For example:
 +
+[source,yaml]
 ----         
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachine
 metadata:
   labels:
     kubevirt.io/vm: vm-dv-clone
-  name: vm-dv-clone
+  name: vm-dv-clone <1>
 spec:
   running: false
   template:
@@ -60,10 +60,11 @@ spec:
           namespace: "source-namespace"
           name: "my-favorite-vm-disk"
 ----
+<1> The virtual machine to create.
 
 . Create the virtual machine with the PVC-cloned DataVolume:
 +
 ----
-oc create -f <vm-clone-dvt>.yaml
+$ oc create -f <vm-clone-dvt>.yaml
 ----
 

--- a/modules/cnv_configuring_guest_memory_overcommit.adoc
+++ b/modules/cnv_configuring_guest_memory_overcommit.adoc
@@ -22,8 +22,8 @@ has been requested from the cluster, set `spec.domain.memory.guest` to a
 higher value than `spec.domain.resources.requests.memory`. This process
 is called memory overcommitment.
 
-In this example, 1024M is requested from the cluster, but the VMI is
-told that it has 2048M available. As long as there is enough free memory
+In this example, `<1024M>` is requested from the cluster, but the VMI is
+told that it has `<2048M>` available. As long as there is enough free memory
 available on the node, the VMI will consume up to 2048M.
 
 ----
@@ -33,10 +33,13 @@ spec:
     domain:
     resources:
         requests:
-          memory: 1024M
+          memory: <1024M>
     memory:
-        guest: 2048M
+        guest: <2048M>
 ----
 
-NOTE: The same eviction rules as those for pods apply to the VMI if
+[NOTE]
+====
+The same eviction rules as those for pods apply to the VMI if
 the node gets under memory pressure.
+====

--- a/modules/cnv_configuring_rbac_permissions.adoc
+++ b/modules/cnv_configuring_rbac_permissions.adoc
@@ -1,14 +1,13 @@
 [[configuring-rbac-permissions]]
-=== Configuring RBAC Permissions
+=== Configuring RBAC Permissions for {ProductName} Service Accounts
 
-The `privileged` RBAC permission needs to be applied to the service
+The *privileged* RBAC permission needs to be applied to the service
 accounts associated with the {ProductName} controllers
 to ensure they have appropriate access to the cluster.
 
 .Procedure 
 
-* Add the `privileged` permission to the necessary service accounts within the 
-`kube-system` namespace. The `-z` flag is used in the following example to 
+* Apply the *privileged* RBAC permission to the service accounts associated with the {ProductName} controllers in the *kube-system* namespace. The `-z` flag is used in the following example to 
 specify each service account:
 ----
 $ oc adm policy add-scc-to-user privileged -n kube-system -z kubevirt-privileged -z kubevirt-controller -z kubevirt-apiserver -z cdi-sa

--- a/modules/cnv_controlling_vms.adoc
+++ b/modules/cnv_controlling_vms.adoc
@@ -5,11 +5,11 @@ Virtual machines can be started and stopped, depending on the
 current state of the virtual machine. The option to restart VMs
 is available in the Web Console only.
 
-The `virtctl` client utility is used to change the state of the virtual
+Use the *virtctl* client utility to change the state of the virtual
 machine, open virtual console sessions with the virtual
 machines, and expose virtual machine ports as services.
 
-The `virtctl` syntax is: `virtctl <action> <VM-name>`
+The *virtctl* syntax is: `virtctl <action> <VM-name>`
 
 You can only control objects in the project you are currently working
 in, unless you specify the `-n <project_name>` option.

--- a/modules/cnv_creating_cluster_admin_user.adoc
+++ b/modules/cnv_creating_cluster_admin_user.adoc
@@ -2,35 +2,34 @@
 === Creating a cluster admin user
 
 {ProductName} is installed across the existing
-{product-title} cluster. This requires a user with the `cluster-admin` cluster
-role. Ensure you have a user with with this cluster role, or create one
-using the default `system:admin` user on the master.
+{product-title} cluster. This requires a user with the *cluster-admin* cluster
+role. Create a user with this cluster role using the default *system:admin* user on the master.
 
 .Prerequisite
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/configuring_clusters/install-config-configuring-authentication[Configured an identity provider] for your {product-title} cluster.
+* xref:../install_config/configuring_authentication.adoc#identity-providers-configuring[Configured an identity provider] for your {product-title} cluster.
 
 .Procedure
 
-. Log in to the master as the `system:admin` user:
+. Log in to the master as the *system:admin* user:
 +
 ----
 $ oc login -u system:admin
 ----
 
-. Create a new user as per the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/configuring_clusters/#identity-providers-configuring[configured identity provider]. The following example uses the command for the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/configuring_clusters/install-config-configuring-authentication#HTPasswdPasswordIdentityProvider[`HTPasswd`] identity provider to create a `cnv-admin` user.
+. Create a new user as per the xref:../install_config/configuring_authentication.adoc#identity-providers-configuring[configured identity provider]. The following example uses the command for the xref:../install_config/configuring_authentication.adoc#HTPasswdPasswordIdentityProvider[`HTPasswd`] identity provider to create a *cnv-admin* user.
 +
 ----
 $ htpasswd -c </path/to/users.htpasswd> cnv-admin
 ----
 
-. Add the `cluster-admin` cluster role to the new user:
+. Add the *cluster-admin* cluster role to the new user:
 +
 ----
 $ oc adm policy add-cluster-role-to-user cluster-admin cnv-admin
 ----
 
-. You can now log in as the `cnv-admin` user to install the
+. You can now log in as the *cnv-admin* user to install the
 {ProductName} components across the cluster:
 +
 ----

--- a/modules/cnv_creating_vm.adoc
+++ b/modules/cnv_creating_vm.adoc
@@ -14,7 +14,7 @@ https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/[ReplicaSet
 is not currently supported in {ProductName}.
 ====
 
-See the link:#volumes[Reference section] for information about volume types and 
+See the xref:cnv_vm_storage_volume_types.adoc#volumes[Reference section] for information about volume types and 
 sample configuration files.
 
 .Domain settings
@@ -25,7 +25,7 @@ sample configuration files.
 |The number of cores inside the virtual machine. Must be a value greater than or equal to 1.
 
 |memory 
-| The amount of RAM allocated to the virtual machine by the node. Specify the denomination with `M' for Megabyte or `Gi' for Gigabyte.
+| The amount of RAM allocated to the virtual machine by the node. Specify the denomination with *M* for Megabyte or *Gi* for Gigabyte.
 
 |disks: volumeName 
 |The Name of the volume which is referenced. Must match the name of a volume.
@@ -52,5 +52,5 @@ To create a virtual machine with the {product-title} client:
 $ oc create -f <vm.yaml>
 ----
 
-Virtual machines are created in a stopped state. Run a virtual machine
-instance by link:#controlvm[starting it].
+Virtual machines are created in a *Stopped* state. Run a virtual machine
+instance by xref:cnv_controlling_vms.adoc#controlvm[starting it].

--- a/modules/cnv_creating_vm_web_console.adoc
+++ b/modules/cnv_creating_vm_web_console.adoc
@@ -5,8 +5,11 @@ The {ProductName} user interface is a specific build of the {product-title} web
 console that contains the core features needed for virtualization use cases, 
 including a virtualization navigation item. 
 
-NOTE: `kubevirt-web-ui` is installed by default during the `kubevirt-apb` 
+[NOTE]
+====
+*kubevirt-web-ui* is installed by default during the *kubevirt-apb*
 deployment.
+====
 
 You can create a new virtual machine from the {ProductName} web console. The VM 
 can be configured with an interactive wizard, or you can bring your own YAML file.
@@ -15,18 +18,18 @@ can be configured with an interactive wizard, or you can bring your own YAML fil
 
 * A cluster running {product-title} 3.11 or newer
 * {ProductName}, version 1.3 or newer
+* (Optional) An existing PVC to attach to the virtual machine
 
 .Procedure
 
 . Access the web UI at
-`kubevirt-web-ui.your.app.subdomain.host.com`. Log in by using your
+`<kubevirt-web-ui.your.app.subdomain.host.com>`. Log in by using your
 {product-title} credentials.
 
 . Open the *Workloads* menu and select the *Virtual Machines*
-menu item. The list of available virtual machines will be shown.
+menu item to list all available virtual machines.
 
-. Click *Create Virtual Machine* and you will be
-presented with two options:
+. Click *Create Virtual Machine*, which has two options:
 [horizontal]
 *Create with YAML*:: allows you to paste and submit a YAML file describing the VM.
 *Create with Wizard*:: takes you through the process of VM creation.
@@ -36,33 +39,31 @@ namespace where you want the VM to be created.
 
 . Next, select the provisioning source from the following options:
 [horizontal]
-`PXE`:: The virtual machine will be booted over the network. The network
+*PXE*:: The virtual machine will be booted over the network. The network
 interface and logical network will be configured later in the
 *Networking* tab.
-`URL`:: Provide the address of a disk image accessible from 
+*URL*:: Provide the address of a disk image accessible from 
 {product-title}. RAW and QCOW2 formats are supported. Either 
-format may be compressed with `gzip` or `xz`.
-`Registry`:: Provide a container containing a bootable operating system in a
-registry accessible from {product-title}. A `registryDisk` 
+format can be compresed with *gzip* or *xz*.
+*Registry*:: Provide a container containing a bootable operating system in a
+registry accessible from {product-title}. A *registryDisk* 
 volume is ephemeral, and the volume will be discarded when the virtual machine 
 is stopped, restarted, or deleted.
-* Example: `kubevirt/fedora-cloud-registry-disk-demo`
-`Template`:: Create a new virtual machine from a VM template that you imported 
-by using the `Import VM` APB. No other templates are supported.
+* Example: `<kubevirt/fedora-cloud-registry-disk-demo>`
+*Template*:: Create a new virtual machine from a VM template that you imported 
+by using the *Import VM* APB. No other templates are supported.
 
 . Next, select the operating system, flavor, and workload profile
 for the VM. If you want to use cloud-init or start the virtual machine on 
 creation, select those options. Then, proceed to the next screen.
 
-. On the networking screen, you can create, delete or rearrange
+. (Optional) On the networking screen, you can create, delete, or rearrange
 network interfaces. The interfaces can be connected to the logical
-network using `NetworkAttachmentDefinition`. If you don’t need to configure 
-networking, you can skip this step and create the VM.
+network using `NetworkAttachmentDefinition`. 
 
-. On the storage screen, you can create, delete or rearrange the virtual 
-machine disks. Please note that if you want to attach a PVC from this screen, 
-it must already exist. If you don’t need to configure storage, you can skip 
-this step and create the VM.
+. (Optional) On the storage screen, you can create, delete, or rearrange the virtual 
+machine disks. If you want to attach a PVC from this screen, 
+it must already exist. 
 
 . Once you have created the VM, it will be visible under
 *Workloads > Virtual Machines*. You can start the new VM from the
@@ -70,4 +71,4 @@ this step and create the VM.
 about the VM, click its name.
 
 . To interact with the operating system, click the *Consoles*
-tab. This will connect to the VNC console of the virtual machine.
+tab. This connects to the VNC console of the virtual machine.

--- a/modules/cnv_deleting_pvcs_webconsole.adoc
+++ b/modules/cnv_deleting_pvcs_webconsole.adoc
@@ -1,10 +1,14 @@
 [[deletepvcweb]]
 ==== Deleting PVCs in the {product-title} web console
 
-1.  Ensure you are in the correct project. If not, click the Project
-drop-down menu and select the appropriate project.
-2.  Click `Storage` in the side menu to list the PVCs in the project.
-3.  Click on the PVC to delete.
-4.  Click the `Actions` drop-down menu for the PVC and click `Delete`.
-5.  Confirm the action to delete the PVC.
+.  Ensure you are in the correct project. If not, click the *Project*
+list and select the appropriate project.
+
+.  Click *Storage* in the side menu to list the PVCs in the project.
+
+.  Click on the PVC to delete.
+
+.  Click the *Actions* list for the PVC and click *Delete*.
+
+.  Confirm the action to delete the PVC.
 

--- a/modules/cnv_deleting_vms_webconsole.adoc
+++ b/modules/cnv_deleting_vms_webconsole.adoc
@@ -1,8 +1,8 @@
 [[deletevmweb]]
 ==== Deleting virtual machines in the {product-title} web console
 
-.  Ensure you are in the correct project. If not, click the Project
-drop-down menu and select the appropriate project.
+.  Ensure you are in the correct project. If not, click the *Project*
+list and select the appropriate project.
 .  Click *Applications* > *Virtual Machines* to display the virtual
 machines in the project.
 .  Click on the virtual machine to delete.

--- a/modules/cnv_disabling_guest_memory_overhead_accounting.adoc
+++ b/modules/cnv_disabling_guest_memory_overhead_accounting.adoc
@@ -6,7 +6,7 @@ only be attempted by advanced users.
 
 A small amount of memory is requested by each virtual machine instance in 
 addition to the amount that you request. This additional memory is used for 
-the infrastructure wrapping each `VirtualMachineInstance` process.
+the infrastructure wrapping each *VirtualMachineInstance* process.
 
 Though it is not usually advisable, it is possible to increase the VMI
 density on the node by disabling guest memory overhead accounting.
@@ -32,5 +32,8 @@ spec:
           memory: 1024M
 ----
 
-NOTE: If `overcommitGuestOverhead` is enabled, it adds the guest overhead
+[NOTE]
+====
+If `overcommitGuestOverhead` is enabled, it adds the guest overhead
 to memory limits (if present).
+====

--- a/modules/cnv_enabling_repo.adoc
+++ b/modules/cnv_enabling_repo.adoc
@@ -1,7 +1,7 @@
 [[enable_cnv_repo]]
 === Enabling {ProductName} repositories
 
-You must enable the `rhel-7-server-cnv-1.3-tech-preview-rpms` repository for the master to install the {ProductName} packages.
+You must enable the *rhel-7-server-cnv-1.3-tech-preview-rpms* repository for the master to install the {ProductName} packages.
 
 .Prerequisites
 

--- a/modules/cnv_events.adoc
+++ b/modules/cnv_events.adoc
@@ -5,18 +5,20 @@
 project and are useful for monitoring and troubleshooting resource
 scheduling, creation, and deletion issues.
 
-To retrieve the `events` for the project, run:
+To retrieve the *events* for the project, run:
 
-`$ oc get events`
+----
+$ oc get events
+----
 
 Events are also included in the resource description, which you can retrieve 
 by using the {product-title} client.
 
 ----
 $ oc describe <resource_type> <resource_name>
-$ oc describe vm fedora-vm
-$ oc describe vmi fedora-vm
-$ oc describe pod virt-launcher-fedora-vm-zzftf
+$ oc describe vm <fedora-vm>
+$ oc describe vmi <fedora-vm>
+$ oc describe pod virt-launcher-fedora-vm-<random>
 ----
 
 Resource descriptions also include configuration, scheduling, and status

--- a/modules/cnv_import_vm_gui.adoc
+++ b/modules/cnv_import_vm_gui.adoc
@@ -3,8 +3,8 @@
 
 WARNING: This procedure has been deprecated from 1.3 onwards.
 
-The `Import Virtual Machine` Ansible playbook has the option to import a 
-virtual machine as a `template` object, which you can use to create virtual 
+The *Import Virtual Machine* Ansible playbook has the option to import a 
+virtual machine as a *template* object, which you can use to create virtual 
 machines.
 
 Templates are useful when you want to create multiple virtual machines from the 
@@ -17,9 +17,8 @@ same base image with minor changes to resource parameters.
 
 .Procedure
 
-. Ensure you are in the correct project. If not, click the *Project* drop-down 
-menu and select the appropriate project or create a new one.
-. Click the *Catalog* button on the side menu.
+. Ensure you are in the correct project. If not, click the *Project* list and select the appropriate project or create a new one.
+. Click *Catalog* on the side menu.
 . Click the *Virtualization* tab to filter the catalog.
 . Click *Import Virtual Machine* and click *Next*.
 . Select *Import as a template from URL* and click *Next*.
@@ -39,13 +38,16 @@ Disk Size (GiB) (leave at 0 to auto detect size): 0
 Storage Class (leave empty to use the default storage class):
 ----
 
-. Click `Create` to begin importing the virtual machine.
+. Click *Create* to begin importing the virtual machine.
 
 A temporary pod, with the generated names of `importer-template-<name>-dv-01-<random>`, is built to handle the process of importing 
 the data and creating the template. Upon completion, this temporary pod is 
 discarded and the `<name>-template` (`fedora-template` in the previous step) 
-will be visible in the catalog and can be used to create virtual machines.
+becomes visible in the catalog and can be used to create virtual machines.
 
 
-NOTE: You may need to refresh your browser to see the template upon 
+[NOTE]
+====
+You may need to refresh your browser to see the template upon 
 completion. This is due to a limitation of the Template Service Broker.
+====

--- a/modules/cnv_importing_vm_disk_DVs.adoc
+++ b/modules/cnv_importing_vm_disk_DVs.adoc
@@ -8,26 +8,27 @@ prepared.
 
 .Prerequisites
 
-* The virtual machine disk can be RAW or QCOW2 format and may be compressed 
-using `xz` or `gz`. The disk image must be available at either an `HTTP` or `S3` 
+* The virtual machine disk can be RAW or QCOW2 format and can be compressed 
+using *xz* or *gz*. 
+* The disk image must be available at either an *HTTP* or *S3* 
 endpoint.
 
 .Procedure
 
-. Identify an `HTTP` or `S3` file server that hosts the virtual disk
+. Identify an *HTTP* or *S3* file server that hosts the virtual disk
 image that you want to import. You need the complete URL in the correct format:
 +
-* `http://www.example.com/path/to/data`
-* `s3://bucketName/fileName`
+* *_http://www.example.com/path/to/data_*
+* *_s3://bucketName/fileName_*
 +
 . If your data source requires authentication credentials, edit the
-`endpoint-secret.yaml` file and apply it to the cluster:
+*_endpoint-secret.yaml_* file and apply it to the cluster:
 +
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: endpoint-secret
+  name: <endpoint-secret>
   labels:
     app: containerized-data-importer
 type: Opaque
@@ -104,29 +105,28 @@ $ oc create -f vm-<name>-datavolume.yaml
 +
 The virtual machine and a DataVolume will now be created. The CDI controller 
 creates an underlying PVC with the correct annotation and begins the import 
-process. When the import completes, the DataVolume status will change to 
-`Succeeded` and the virtual machine will be allowed to start.
+process. When the import completes, the DataVolume status changes to 
+*Succeeded* and the virtual machine will be allowed to start.
 +
 DataVolume provisioning happens in the background, so there is no need to 
-monitor it. You can start the VM and it will only run when the import is 
-complete.
+monitor it. You can xref:cnv_controlling_vms.adoc#controlvm[start the VM] and it will not run until the import is complete.
 
 .Optional verification steps
 . Run `$ oc get pods` and look for the importer pod. This pod 
 downloads the image from the specified URL and stores it on the provisioned PV.
 
-. Monitor the DataVolume status until it shows `Succeeded`. In our example, we 
-would run the following command: 
+. Monitor the DataVolume status until it shows *Succeeded*. 
 +
 ----
-$ oc describe dv <vm-fedora-datavolume>
+$ oc describe dv <data-label> <1>
 ----
+<1> The data label for the DataVolume specified in the VirtualMachine configuration file. 
 
 . To verify that provisioning is complete and that the VMI has started, try 
 accessing its serial console:
 +
 ----
-$ virtctl console vm-fedora-datavolume
+$ virtctl console <vm-fedora-datavolume>
 ----
 
 

--- a/modules/cnv_importing_vm_disk_to_pvc.adoc
+++ b/modules/cnv_importing_vm_disk_to_pvc.adoc
@@ -9,24 +9,28 @@ disk image into the PV.
 
 .Prerequisites
 
-* The virtual machine disk can be RAW or QCOW2 format and may be compressed 
-using `xz` or `gzip`. The disk image must be available at either an `HTTP` or `S3` 
+* The virtual machine disk can be RAW or QCOW2 format and can be compressed 
+using *xz* or *gzip*. 
+* The disk image must be available at either an *HTTP* or *S3* 
 endpoint.
 
-NOTE: For locally provisioned storage, the PV needs to be created
+[NOTE]
+====
+For locally provisioned storage, the PV needs to be created
 before the PVC. This is not required for OpenShift Container Storage,
 for which the PVs are created dynamically.
+====
 
 .Procedure
 
-. Identify an `HTTP` or `S3` file server hosting the virtual disk
-image that you would like to import. You will need the complete URL, in
+. Identify an *HTTP* or *S3* file server hosting the virtual disk
+image that you want to import. You need the complete URL, in
 either format:
 +
-* `http://www.example.com/path/to/data`
-* `s3://bucketName/fileName`
+* *_http://www.example.com/path/to/data_*
+* *_s3://bucketName/fileName_*
 +
-You will use this URL as the `cdi.kubevirt.io/storage.import.endpoint`
+Use this URL as the `cdi.kubevirt.io/storage.import.endpoint`
 annotation value in your PVC configuration file.
 +
 For example: `cdi.kubevirt.io/storage.import.endpoint:
@@ -34,7 +38,7 @@ https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/ima
 
 
 . If the file server requires authentication credentials, edit the
-`endpoint-secret.yaml` file:
+*_endpoint-secret.yaml_* file:
 +
 ----
 apiVersion: v1
@@ -56,7 +60,7 @@ configuration file.
 For example: `cdi.kubevirt.io/storage.import.secret:
 endpoint-secret`
 
-. Apply `endpoint-secret.yaml` to the cluster:
+. Apply *_endpoint-secret.yaml_* to the cluster:
 +
 ----
 $ oc apply -f endpoint-secret.yaml
@@ -75,8 +79,8 @@ metadata:
   labels:
    app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2"
-    cdi.kubevirt.io/storage.import.secret: "endpoint-secret"
+    cdi.kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2" <1>
+    cdi.kubevirt.io/storage.import.secret: "endpoint-secret" <2>
 spec:
   accessModes:
   - ReadWriteOnce
@@ -84,17 +88,20 @@ spec:
     requests:
       storage: 5Gi
 ----
+<1> Endpoint annotation for the import image URL
+<2> Endpoint annotation for the authorization secret
 
 . Create the PVC using the `oc` CLI:
 +
 ----
-$ oc create -f <data-import.yaml>
+$ oc create -f <pvc.yaml> <1>
 ----
+<1> The PersistentVolumeClaim file name.
 +
-After the disk image has been successfully imported into the PV, the
+After the disk image is successfully imported into the PV, the
 import pod expires, and you can bind the PVC to a virtual machine object
 within {product-title}.
 
-Next, link:#createvm[create a virtual machine] object to
+Next, xref:cnv_creating_vm.adoc#createvm[create a virtual machine] object to
 bind to the PVC.
 

--- a/modules/cnv_install_cnv_apb.adoc
+++ b/modules/cnv_install_cnv_apb.adoc
@@ -7,8 +7,8 @@ This procedure is for {ProductName} v1.3. Future versions of
 {ProductName} will be installed using the Operators Framework.
 ====
 
-The `kubevirt-apb` APB installs all {ProductName} components to your 
-{product-title} cluster. You will need to import the APBs into your local 
+The *kubevirt-apb* APB installs all {ProductName} components to your 
+{product-title} cluster. You need to import the APBs into your local 
 registry before they can be used.
 
 This procedure installs the following components:
@@ -20,19 +20,19 @@ This procedure installs the following components:
 
 .Prerequisites
 * {product-title} 3.11 cluster 
-* User with `cluster-admin` privileges
+* User with *cluster-admin* privileges
 * xref:../apb_devel/cli_tooling.adoc#apb-devel-cli[APB tool]
-* `virtctl` client utility, installed
+* *virtctl* client utility, installed
 
 .Procedure
 
 . Import the {ProductName} APBs into the local registry.
-.. Import `kubevirt-apb`:
+.. Import *kubevirt-apb*:
 +
 ----
 $ oc import-image --from registry.access.redhat.com/cnv-tech-preview/kubevirt-apb --confirm kubevirt-apb -n openshift
 ----
-.. Import `import-vm-apb`:
+.. Import *import-vm-apb*:
 +
 ----
 $ oc import-image --from registry.access.redhat.com/cnv-tech-preview/import-vm-apb --confirm import-vm-apb  -n openshift
@@ -65,13 +65,11 @@ $ apb broker catalog | grep 'localregistry-import-vm-apb'
 [NOTE]
 ====
 If you do not see `localregistry-*`, the service class may be under a unique 
-name based on your ASB configuration. Refer to the 
-https://docs.openshift.com/container-platform/3.9/install_config/oab_broker_configuration.html#overview[OpenShift Ansible Broker 
+name based on your ASB configuration. Refer to the xref:../install_config/oab_broker_configuration.adoc#install-config-oab-config[OpenShift Ansible Broker 
 Configuration] documentation for more information.
 ====
 
-. Ensure that you are in the `kube-system` project. The current project will be 
-marked with an asterisk.
+. Ensure that you are in the *kube-system* project. The current project is marked with an asterisk.
 +
 ----
 $ oc projects
@@ -82,8 +80,8 @@ $ oc projects
 $ oc project kube-system
 ----
 
-. Edit your `kubevirt-apb.yaml` template to match the following example. Do not 
-provide the `admin_user` and `admin_password` parameter values.
+. Edit your *_kubevirt-apb.yaml_* template to match the following example. Do not 
+provide the *admin_user* and *admin_password* parameter values.
 +
 ----
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -102,22 +100,21 @@ spec:
     docker_tag: v1.3.0
 ----
 
-. Apply the `kubevirt-apb` template to install {ProductName} 
+. Apply the *kubevirt-apb* template to install {ProductName} 
 to your cluster. Use the `--edit` option to edit the file before it is applied, 
 which allows you to add the admin user credentials without storing them in 
 plaintext in the file.
 +
 [IMPORTANT]
 ====
-Unlike other passwords in {product-title}, the entered credentials will be 
-stored in *cleartext*. To improve security, 
+Unlike other passwords in {product-title}, the entered credentials are 
+stored in cleartext. To improve security, 
 link:#creating-a-cluster-admin-user[create a temporary admin account] for 
-this process. The account can be 
-https://docs.openshift.com/container-platform/3.11/admin_guide/manage_users.html#managing-users-deleting-a-user[deleted] 
+this process. The account can be xref:../admin_guide/manage_users.adoc#managing-users-deleting-a-user[deleted] 
 once installation is complete.
 
 If you don't create a temporary account, note that any user who has permissions 
-to view the `kubevirt-apb.yaml` file and the related ServiceInstance object 
+to view the *_kubevirt-apb.yaml_* file and the related ServiceInstance object 
 can also view the cleartext credentials when running commands like 
 `$ oc describe serviceinstance`.
 ====
@@ -144,14 +141,14 @@ spec:
 $ oc get pods -w --all-namespaces | grep 'virtualization-prov'
 ----
 
-.. Watch the `kubevirt` service instance until it is `Ready`:
+.. Watch the *kubevirt* service instance until it is *Ready*:
 +
 ----
 $ oc get serviceinstance -n kube-system -w
 ----
 
 .. Watch the {ProductName} pods (virt, cdi, multus, and ovs-cni) until they are 
-`Running`:
+*Running*:
 +
 ----
 $ oc get pods -n kube-system -w

--- a/modules/cnv_install_ovscni.adoc
+++ b/modules/cnv_install_ovscni.adoc
@@ -2,19 +2,19 @@
 === Enabling support for multiple interfaces
 
 To enable support for multiple interfaces, install the Multus and Open
-vSwitch (OVS) CNI plugins. First, install the `ovs-cni-manifests` RPM
-and then apply the manifests as shown below.
+vSwitch (OVS) CNI plugins via the *ovs-cni-manifests* RPM
+and then apply the manifests to your {product-title} cluster.
 
 WARNING: Multus is provided as a Developer Preview
-feature and is not currently supported in OpenShift Container Platform.
+feature and is not currently supported in {product-title}.
 
 .Prerequisites
 
-* A cluster running OpenShift Container Platform 3.11 or newer
+* A cluster running {product-title} 3.11 or newer
 
 .Procedure
 
-. Install the `ovs-cni-manifests` RPM:
+. Install the *ovs-cni-manifests* RPM:
 +
 ----
 $ yum install -y ovs-cni-manifests

--- a/modules/cnv_install_vmtemplates.adoc
+++ b/modules/cnv_install_vmtemplates.adoc
@@ -2,7 +2,7 @@
 
 === Installing KubeVirt templates
 
-The `kubevirt-templates` package includes the virtual machine templates 
+The *kubevirt-templates* package includes the virtual machine templates 
 compatible with {product-title}.
 
 .Prerequisites
@@ -10,7 +10,7 @@ compatible with {product-title}.
 
 .Procedure
 
-. Install the `kubevirt-templates` package:
+. Install the *kubevirt-templates* package:
 +
 ----
 # yum install -y kubevirt-templates

--- a/modules/cnv_installing_cdi_manifest.adoc
+++ b/modules/cnv_installing_cdi_manifest.adoc
@@ -1,15 +1,14 @@
 [[installing-the-cdi-manifest]]
 === Installing the CDI Manifest
 
-The CDI is the Container-native Virtualization controller responsible
-for importing virtual disks into OpenShift PVCs. The `kubevirt-cdi`
+The CDI is the {ProductName} controller that imports virtual disks into OpenShift PVCs. The *kubevirt-cdi*
 package installs the CDI manifest to
-`/usr/share/kubevirt-cdi/manifests/cdi-controller.yaml`
+*_/usr/share/kubevirt-cdi/manifests/cdi-controller.yaml_*
 on your system. 
 
 .Procedure
 
-. Download the `kubevirt-cdi-manifests` package:
+. Download the *kubevirt-cdi-manifests* package:
 +
 ----
 $ yum install -y kubevirt-cdi-manifests
@@ -22,13 +21,13 @@ $ oc apply -f /usr/share/kubevirt-cdi/manifests/cdi-controller.yaml
 ----
 
 . Verify the installation using the OpenShift client `get pods` command
-for the `kube-system` namespace:
+for the *kube-system* namespace:
 +
 ----
 $ oc get pods -n kube-system
 ----
 +
-A successful installation will show the `cdi-deployment`, `cdi-api`, and 
-`cdi-uploadproxy` pods running.
+A successful installation shows the *cdi-deployment*, *cdi-api*, and 
+*cdi-uploadproxy* pods running.
 
 

--- a/modules/cnv_installing_kubevirt_manifests.adoc
+++ b/modules/cnv_installing_kubevirt_manifests.adoc
@@ -1,9 +1,8 @@
 [[installing-kubevirt-manifests]]
 === Installing KubeVirt manifests
 
-The `kubevirt-manifests` package downloads the Container-native
-Virtualization core components manifest to
-`/usr/share/kubevirt/manifests/release/kubevirt.yaml` on your system.
+The *kubevirt-manifests* package downloads the {ProductName} core components manifest to
+*_/usr/share/kubevirt/manifests/release/kubevirt.yaml_* on your system.
 
 .Procedure
 
@@ -15,7 +14,7 @@ $ oc create configmap -n kube-system kubevirt-config --from-literal="feature-gat
 configmap "kubevirt-config" created
 ----
 
-. Download the `kubevirt-manifests` package:
+. Download the *kubevirt-manifests* package:
 +
 ----
 $ yum install -y kubevirt-manifests
@@ -28,11 +27,11 @@ $ oc apply -f /usr/share/kubevirt/manifests/release/kubevirt.yaml
 ----
 
 . Verify the installation using the OpenShift
-client `get pods` command for the `kube-system` namespace:
+client `get pods` command for the *kube-system* namespace:
 +
 ----
 $ oc get pods -n kube-system
 ----
 +
-A successful installation will show the `virt-handler`,
-`virt-controller`, and `virt-api` controller pods running.
+A successful installation shows the *virt-handler*,
+*virt-controller*, and *virt-api* controller pods running.

--- a/modules/cnv_installing_virtct_client.adoc
+++ b/modules/cnv_installing_virtct_client.adoc
@@ -1,13 +1,13 @@
 [[installing-virtctl-client]]
 === Installing virtctl client utility
 
-The `virtctl` client utility is used to manage the state of the virtual
+The *virtctl* client utility is used to manage the state of the virtual
 machine, forward ports from the virtual machine pod to the node, and
 open console access to the virtual machine.
 
 .Procedure
 
-. Install the `kubevirt-virtctl` package:
+. Install the *kubevirt-virtctl* package:
 +
 ----
 $ yum install kubevirt-virtctl
@@ -15,6 +15,6 @@ $ yum install kubevirt-virtctl
 
 [NOTE]
 ====
-The `virtctl` utility is also available for download from the Red Hat
+The *virtctl* utility is also available for download from the Red Hat
 Network.
 ====

--- a/modules/cnv_installing_web_console.adoc
+++ b/modules/cnv_installing_web_console.adoc
@@ -1,32 +1,32 @@
 [[install_web_console]]
-=== Installing the Container-native Virtualization web console
+=== Installing the {ProductName} web console
 
-The Container-native Virtualization user interface is a specific build
-of the OpenShift web console that contains the core features needed for
+The {ProductName}  user interface is a specific build
+of the {product-title} web console that contains the core features needed for
 virtualization use cases, including a virtualization navigation item.
 
 .Prerequisites
 
-* A cluster running OpenShift Container Platform 3.11
-* Container-native Virtualization, version 1.3
+* A cluster running {product-title} 3.11
+* {ProductName}, version 1.3
 
 .Procedure
 
-. SSH into the master node as the `ansible_ssh_user` defined in the inventory file 
+. SSH into the master node as the *ansible_ssh_user* defined in the inventory file 
 for {ProductName}. 
-This is `root` in the link:#single-master-inventory[OpenShift Single Master Inventory].
+This is *root* in the link:#single-master-inventory[OpenShift Single Master Inventory].
 +
 ----
 # ssh root@master_node.example.com
 ----
 
-. Install the `kubevirt-web-ui-ansible` RPM: +
+. Install the *kubevirt-web-ui-ansible* RPM: +
 +
 ----
 # yum install -y kubevirt-web-ui-ansible
 ----
 
-. Add the following parameters under the `[OSEv3:vars]` section in your Ansible inventory: 
+. Add the following parameters under the `[OSEv3:vars]` section in your Ansible inventory file. 
 +
 ----
 [OSEv3:vars]
@@ -38,7 +38,7 @@ registry_namespace=kubevirt
 docker_tag=v1.3
 ----
 
-.. If the OpenShift cluster does not have the xref:../install/configuring_inventory_file.adoc#configuring-the-admin-console[Cluster Console] installed, add the `public_master_hostname` and the `openshift_master_default_subdomain` parameters in the `[OSEv3:vars]` section of the inventory. The public hostname must be externally accessible.
+.. If the {product-title} cluster does not have the xref:../install/configuring_inventory_file.adoc#configuring-the-admin-console[Cluster Console] installed, add the *public_master_hostname* and the *openshift_master_default_subdomain* parameters in the `[OSEv3:vars]` section of the inventory file. The public hostname must be externally accessible.
 +
 ----
 [OSEv3:vars]
@@ -47,13 +47,13 @@ public_master_hostname=<master.example.com>
 openshift_master_default_subdomain=<apps.example.com>
 ----
 
-. Log in to the OpenShift cluster as a user with `cluster-admin` privileges to run the inventory:
+. Log in to the {product-title} cluster as a user with *cluster-admin* privileges.
 +
 ----
 # oc login -u <cnv-admin>
 ----
 
-. Invoke the `ansible-playbook` to install the web UI: 
+. Run the *ansible-playbook* to install the web UI: 
 +
 ----
 # ansible-playbook -i [INVENTORY_FILE] /usr/share/kubevirt-web-ui-ansible/playbooks/kubevirt-web-ui/config.yml
@@ -65,5 +65,5 @@ openshift_master_default_subdomain=<apps.example.com>
 exit
 ----
 
-. Verify the web console installation by navigating to you OpenShift cluster in a web browser. The console for the example master above is `https://kubevirt-web-ui.apps.master_node.example.com`.
+. Verify the web console installation by navigating to you {product-title} cluster in a web browser. The console for the example master above is `https://kubevirt-web-ui.apps.master_node.example.com`.
 

--- a/modules/cnv_introduction_to_cnv.adoc
+++ b/modules/cnv_introduction_to_cnv.adoc
@@ -18,8 +18,8 @@ containerized data importer (CDI) controller, or from scratch within
 
 {ProductName} introduces two new objects to {product-title}:
 
-* Virtual Machine: The virtual machine in {product-title}
-* Virtual Machine Instance: A running instance of the virtual machine
+* *Virtual Machine*: The virtual machine in {product-title}
+* *Virtual Machine Instance*: A running instance of the virtual machine
 
 With the {ProductName} add-on, virtual machines run in pods and have the same 
 network and storage capabilities as standard pods.

--- a/modules/cnv_logs.adoc
+++ b/modules/cnv_logs.adoc
@@ -11,12 +11,12 @@ $ oc logs virt-launcher-fedora-vm-zzftf
 The `-f` option follows the log output in real time, which is useful for
 monitoring progress and error checking.
 
-If the launcher pod is failing to start, you may need to use the
+If the launcher pod is failing to start, use the
 `--previous` option to see the logs of the last attempt.
 
 [WARNING]
 ====
-`ErrImagePull` and `ImagePullBackOff` errors could be caused by
+`ErrImagePull` and `ImagePullBackOff` errors can be caused by
 an incorrect deployment configuration or problems with the images being
 referenced.
 ====

--- a/modules/cnv_metrics.adoc
+++ b/modules/cnv_metrics.adoc
@@ -4,8 +4,7 @@
 {product-title} Metrics collects memory, CPU, and network performance
 information for nodes, components, and containers in the cluster. The
 specific information collected depends on how the Metrics subsystem is
-configured. For more information on configuring Metrics, see the
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/configuring_clusters/#install-config-cluster-metrics[OpenShift
+configured. For more information on configuring Metrics, see the xref:../install_config/cluster_metrics.adoc#install-config-cluster-metrics[OpenShift
 Container Platform Configuring Clusters Guide].
 
 The `oc` CLI command `adm top` uses the Heapster API to fetch

--- a/modules/cnv_metrics_events_logs_webconsole.adoc
+++ b/modules/cnv_metrics_events_logs_webconsole.adoc
@@ -1,21 +1,23 @@
 [[eventslogserrweb]]
 ==== Viewing Metrics, Events, and Logs using the Web Console
 
-The `Metrics` and `Events` are available as tabs for the specific
-resource in the web console. `Logs` are also available for virtual
+The *Metrics* and *Events* are available as tabs for the specific
+resource in the web console. *Logs* are also available for virtual
 machine launcher pods.
 
 To view this information using the web console:
 
-1.  Ensure you are in the correct project. If not, click the Project
-drop-down menu and select the appropriate project.
-2.  Click `Applications` > `Virtual Machines` to display the virtual
+.  Ensure you are in the correct project. If not, click the *Project*
+list and select the appropriate project.
+
+.  Click *Applications* > *Virtual Machines* to display the virtual
 machines in the project.
-3.  Select a virtual machine. `Metrics` and `Events` are available tabs.
+
+.  Select a virtual machine. *Metrics* and *Events* are available tabs.
 
 To navigate to the virtual machine interface or the launcher pod, click
-the relevant resource name in the `Status` body.
+the relevant resource name in the *Status* body.
 
 You can also navigate to the virtual machine launcher pod by clicking
-`Monitoring` and selecting the launcher pod name under `Pods`.
+*Monitoring* and selecting the launcher pod name under *Pods*.
 

--- a/modules/cnv_openshift_commands.adoc
+++ b/modules/cnv_openshift_commands.adoc
@@ -1,11 +1,11 @@
 [[openshift-client-commands]]
 === {product-title} client commands
 
-The `oc` client is a command-line utility for
+The *oc* client is a command-line utility for
 managing {product-title} resources. The
-following table contains the `oc` commands that you use with {ProductName}.
+following table contains the *oc* commands that you use with {ProductName}.
 
-.`oc` commands
+.*oc* commands
 
 [width="100%",cols="42%,58%",options="header",]
 |=======================================================================
@@ -20,15 +20,14 @@ specific resource.
 stdin.
 
 |`oc process -f <config>` |Process a template into a configuration file.
-Templates have ``parameters'', which may either be generated on creation
+Templates have ``parameters'', which are either generated on creation
 or set by the user, as well as metadata describing the template.
 
 |`oc apply -f <file>` |Apply a configuration to a resource by filename
 or stdin.
 |=======================================================================
 
-See the
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/cli_reference/[OpenShift
+See the xref:../cli_reference/index.adoc#cli-reference-index[OpenShift
 Container Platform CLI Reference Guide], or run the `oc --help` command,
 for definitive information on the {product-title} client.
 

--- a/modules/cnv_pxebooting.adoc
+++ b/modules/cnv_pxebooting.adoc
@@ -7,8 +7,8 @@ operating system or other program without requiring a locally attached
 storage device. For example, you can use it to choose your desired OS
 image from a PXE server when deploying a new host.
 
-We have provided a link:#pxetemplate[configuration file template] for
-PXE booting in the Reference section of this article.
+The Reference section has a xref:cnv_template_vmi_pxe_config.adoc#pxetemplate[configuration file template] for
+PXE booting.
 
 .Prerequisites
 
@@ -19,7 +19,7 @@ PXE booting in the Reference section of this article.
 
 . Configure a PXE network on the cluster:
 
-.. Create `NetworkAttachmentDefinition` of PXE network `pxe-net-conf`:
+.. Create *NetworkAttachmentDefinition* of PXE network `pxe-net-conf`:
 +
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -34,10 +34,13 @@ spec:
     }'
 ----
 +
-NOTE: In this example, the VMI will be attached through a trunk port
-to the Open vSwitch bridge `br1`.
+[NOTE]
+====
+In this example, the VMI will be attached through a trunk port
+to the Open vSwitch bridge `<br1>`.
+====
 
-.. Create Open vSwitch bridge `br1` and connect it to interface `eth1`,
+.. Create Open vSwitch bridge `<br1>` and connect it to interface `<eth1>`,
 which is connected to a network that allows for PXE booting:
 +
 ----
@@ -54,21 +57,24 @@ $ ovs-vsctl show
     ovs_version: "2.8.1"
 ----
 +
-NOTE: This bridge must be configured on all nodes. If it is only
-available on a subset of nodes, make sure that VMIs have `nodeSelector`
+[NOTE]
+====
+This bridge must be configured on all nodes. If it is only
+available on a subset of nodes, make sure that VMIs have *nodeSelector*
 constraints in place.
+====
 
 . Edit the virtual machine instance configuration file to include the
 details of the interface and network.
 
 .. Specify the network and MAC address, if required by the PXE server.
-If the MAC address is not specified, a value will be assigned
-automatically. However, please note that at this time, MAC addresses
-assigned automatically will not be persistent.
+If the MAC address is not specified, a value is assigned
+automatically. However, note that at this time, MAC addresses
+assigned automatically are not persistent.
 +
 Ensure that `bootOrder` is set to `1` so that the interface boots first.
 In this example, the interface is connected to a network called
-`pxe-net`:
+`<pxe-net>`:
 +
 ----
 interfaces:
@@ -80,12 +86,15 @@ interfaces:
   bootOrder: 1
 ----
 +
-NOTE: Boot order is global for interfaces and disks.
+[NOTE]
+====
+Boot order is global for interfaces and disks.
+====
 
 .. Assign a boot device number to the disk to ensure proper booting
 after OS provisioning.
 +
-Set the disk `bootOrder` value to 2:
+Set the disk `bootOrder` value to `2`:
 +
 ----
 devices:
@@ -98,8 +107,8 @@ devices:
 ----
 
 .. Specify that the network is connected to the previously created
-`NetworkAttachmentDefinition`. In this scenario, `pxe-net` is connected
-to the `NetworkAttachmentDefinition` called `pxe-net-conf`:
+*NetworkAttachmentDefinition*. In this scenario, `<pxe-net>` is connected
+to the *NetworkAttachmentDefinition* called `<pxe-net-conf>`:
 +
 ----
 networks:
@@ -126,16 +135,20 @@ $ oc get vmi vmi-pxe-boot -o yaml | grep -i phase
 
 . View the virtual machine instance using VNC:
 +
-`$ virtctl vnc vmi-pxe-boot`
+----
+$ virtctl vnc vmi-pxe-boot
+----
 
 . Watch the boot screen to verify that the PXE boot is successful.
 
-. Login to the VMI:
+. Log in to the VMI:
 +
-`$ virtctl console vmi-pxe-boot`
+----
+$ virtctl console vmi-pxe-boot
+----
 
-. Verify the interfaces and MAC address on the VM. The interface
-connected to the bridge will have the specified MAC address. In this
+. Verify the interfaces and MAC address on the VM, and that the interface
+connected to the bridge has the specified MAC address. In this
 case, we used `eth1` for the PXE boot, without an IP address. The other
 interface, `eth0`, got an IP address from {product-title}.
 +

--- a/modules/cnv_requirements.adoc
+++ b/modules/cnv_requirements.adoc
@@ -6,8 +6,7 @@ with the following configuration considerations:
 [[node-configuration]]
 == Node configuration
 
-See the
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/installing_clusters/#environment-scenarios[OpenShift
+See the xref:../install/index.adoc#environment-scenarios[OpenShift
 Container Platform Installing Clusters Guide] for planning
 considerations for different cluster configurations.
 
@@ -25,7 +24,7 @@ validation. Registering webhooks must be enabled during installation of the
 {product-title} cluster.
 
 To register the admission controller webhook, add the following under the 
-`[OSEv3:vars]` section in your Ansible inventory during {product-title} deployment:
+`[OSEv3:vars]` section in your Ansible inventory file during {product-title} deployment:
 
 ----
 openshift_master_admission_plugin_config={"ValidatingAdmissionWebhook":{"configuration":{"kind": "DefaultAdmissionConfig","apiVersion": "v1","disable": false}},"MutatingAdmissionWebhook":{"configuration":{"kind": "DefaultAdmissionConfig","apiVersion": "v1","disable": false}}}
@@ -37,8 +36,8 @@ openshift_master_admission_plugin_config={"ValidatingAdmissionWebhook":{"configu
 {ProductName} uses Ansible Playbook Bundles (APBs) for installation and additional functionality. APBs must be added to the whitelists for the OpenShift Ansible Broker Configuration to enable discovery of the following:
 
 [horizontal]
-`kubevirt-apb`:: installs {ProductName}.
-`import-vm-apb`:: imports a virtual machine or a template from URL.
+*kubevirt-apb*:: installs {ProductName}.
+*import-vm-apb*:: imports a virtual machine or a template from URL.
 
 To add APBs to the whitelists, include the following under the `[OSEv3:vars]` section in your Ansible inventory file during {product-title} deployment:
 
@@ -60,20 +59,19 @@ CRI-O.
 [[storage]]
 == Storage
 
-{ProductName} supports local volumes, block volumes and Red Hat OpenShift 
+{ProductName} supports local volumes, block volumes, and Red Hat OpenShift 
 Container Storage as storage backends.
 
 === Local volumes
 
-Local volumes are PVs that represent locally-mounted file systems. See the
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/configuring_clusters/#install-config-configuring-local[OpenShift
+Local volumes are PVs that represent locally-mounted file systems. See the xref:../install_config/configuring_local.adoc#install-config-configuring-local[OpenShift
 Container Platform Configuring Clusters Guide] for more information.
 
 === Block volumes
 
 {ProductName} 1.3 supports the use of block volume PVCs. In order to use 
-block volumes, the {product-title} cluster must be configured with the `BlockVolume` 
-feature gate enabled. See the https://docs.openshift.com/container-platform/3.11/architecture/additional_concepts/storage.html#block-volume-support[{product-title} Architecture Guide] for more information.
+block volumes, the {product-title} cluster must be configured with the *BlockVolume* 
+feature gate enabled. See the xref:../architecture/additional_concepts/storage.adoc#block-volume-support[{product-title} Architecture Guide] for more information.
 
 
 [IMPORTANT]
@@ -93,20 +91,18 @@ https://access.redhat.com/support/offerings/techpreview/.
 ====
 === Red Hat OpenShift Container Storage
 
-With Red Hat OpenShift Container Storage (RHOCS), Red Hat Gluster Storage can 
-be used to provide persistent storage and dynamic provisioning. 
+Red Hat OpenShift Container Storage uses Red Hat Gluster Storage to provide persistent storage and dynamic provisioning. 
 It can be used containerized within {product-title} (converged mode) and 
 non-containerized on its own nodes (independent mode).
 
 See the
-https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/[OpenShift Container Storage Product Documentation] or the
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/installing_clusters/#advanced-install-glusterfs-persistent-storage[OpenShift
+https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/[OpenShift Container Storage Product Documentation] or the xref:../install/configuring_inventory_file.adoc#advanced-install-glusterfs-persistent-storage[OpenShift
 Container Platform Installing Clusters Guide] for more information.
 
 [IMPORTANT]
 ====
 Requires Red Hat OpenShift Container Storage version 3.11.1 or later. 
-Earlier versions of RHOCS do not support CRI-O, the required container 
+Earlier versions of Red Hat OpenShift Container Storage do not support CRI-O, the required container 
 runtime for {ProductName}.
 ====
 
@@ -114,9 +110,7 @@ runtime for {ProductName}.
 == Metrics
 
 Metrics are not required, but are a recommended addition to your {product-title} 
-cluster as they provide additional information on {ProductName} resources. 
+cluster because they provide additional information about {ProductName} resources. 
 
-See the
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/installing_clusters/#advanced-install-cluster-metrics[OpenShift
-Container Platform Installing Clusters Guide] for comprehensive
+See the xref:../install/configuring_inventory_file.adoc#advanced-install-cluster-metrics[{product-title} Installing Clusters Guide] for comprehensive
 information on deploying metrics in your cluster.

--- a/modules/cnv_template_openshift_inventory.adoc
+++ b/modules/cnv_template_openshift_inventory.adoc
@@ -1,7 +1,7 @@
 [[example-inventory-file]]
 === {product-title} example inventory file
 
-You can use this example to see how you would modify your 
+You can use this example to see how to modify your 
 own Ansible inventory file to match your cluster configuration.
 
 [NOTE]

--- a/modules/cnv_upload_virtctl.adoc
+++ b/modules/cnv_upload_virtctl.adoc
@@ -1,23 +1,23 @@
 [[upload-vmdisk-virtctl]]
 === Uploading a local disk image to a new PVC
 
-You can use `virtctl image-upload` to upload a virtual machine disk image from 
-a client machine to your {product-title} cluster. This will create a PVC that can be 
+You can use *virtctl image-upload* to upload a virtual machine disk image from 
+a client machine to your {product-title} cluster. This creates a PVC that can be 
 associated with a virtual machine after the upload has completed.
 
 .Prerequisites
 
-* A virtual machine disk image, in RAW or QCOW2 format. It may be compressed 
-using `xz` or `gzip`.
-* `kubevirt-virtctl` must be installed on the client machine.
+* A virtual machine disk image, in RAW or QCOW2 format. It can be compressed 
+using *xz* or *gzip*.
+* *kubevirt-virtctl* must be installed on the client machine.
 
 .Procedure
 
 . Identify the following items:
-* file location of the VM disk image you want to upload
-* name and size desired for the resulting PVC
+* File location of the VM disk image you want to upload
+* Name and size desired for the resulting PVC
  
-. Expose the `cdi-uploadproxy` service so that you can upload data to your cluster:
+. Expose the *cdi-uploadproxy* service so that you can upload data to your cluster:
 +
 ----
 cat <<EOF | oc apply -f -
@@ -35,7 +35,7 @@ spec:
 EOF
 ----
 
-. Use the `virtctl image-upload` command to begin uploading your VM image, 
+. Use the `virtctl image-upload` command to upload your VM image, 
 making sure to include your chosen parameters. For example:
 +
 ----
@@ -54,7 +54,7 @@ parameter.
 $ oc get pvc
 ----
 
-Next, you can link:#createvm[create a virtual machine] object to
+Next, you can xref:cnv_creating_vm.adoc#createvm[create a virtual machine] object to
 bind to the PVC.
 
 

--- a/modules/cnv_using_openvswitch_bridge.adoc
+++ b/modules/cnv_using_openvswitch_bridge.adoc
@@ -2,7 +2,7 @@
 === Using an Open vSwitch bridge as the network source for a VM
 
 With {ProductName}, you can connect a virtual machine
-instance to an Open vSwitch bridge configured on the node.
+instance to an Open vSwitch bridge that is configured on the node.
 
 .Prerequisites
 
@@ -13,7 +13,7 @@ instance to an Open vSwitch bridge configured on the node.
 . Prepare the cluster host networks (optional).
 +
 If the host network needs additional configuration changes, such as
-bonding, please refer to the
+bonding, refer to the
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/[Red
 Hat Enterprise Linux networking guide].
 
@@ -25,11 +25,14 @@ as the bridge’s port.
 +
 In this example, we create bridge `br1` and connect it to interface
 `eth1`. This bridge must be configured on all nodes. If it is only
-available on a subset of nodes, make sure that VMIs have `nodeSelector`
+available on a subset of nodes, make sure that VMIs have *nodeSelector*
 constraints in place.
 +
-NOTE: Any connections to `eth1` will be lost once the interface is
-assigned to the bridge, so another interface should exist on the host.
+[NOTE]
+====
+ Any connections to `eth1` are lost once the interface is
+assigned to the bridge, so another interface must be present on the host.
+====
 +
 ....
 $ ovs-vsctl add-br br1
@@ -47,11 +50,10 @@ $ ovs-vsctl show
 
 . Configure the network on the cluster.
 +
-L2 networks are treated as cluster-wide resources. The network should be
-defined in a network attachment definition YAML file. You can define the
-network using the `NetworkAttachmentDefinition` CRD.
+L2 networks are treated as cluster-wide resources. Define the network in a network attachment definition YAML file. You can define the
+network using the *NetworkAttachmentDefinition* CRD.
 +
-The `NetworkAttachmentDefinition` CRD object contains information about
+The *NetworkAttachmentDefinition* CRD object contains information about
 pod-to-network attachment. In the following example, there is an
 attachment to Open vSwitch bridge `br1` and traffic is tagged to VLAN
 100.
@@ -70,15 +72,18 @@ spec:
     }'
 ....
 +
-NOTE: `"vlan"` is optional. If omitted, the VMI will be attached
+[NOTE]
+====
+*"vlan"* is optional. If omitted, the VMI will be attached
 through a trunk.
+====
 
 . Edit the virtual machine instance configuration file to include the
 details of the interface and network.
 +
 Specify that the network is connected to the previously created
-`NetworkAttachmentDefinition`. In this scenario, `vlan-100-net` is
-connected to the `NetworkAttachmentDefinition` called
+*NetworkAttachmentDefinition*. In this scenario, `vlan-100-net` is
+connected to the *NetworkAttachmentDefinition* called
 `vlan-100-net-conf`:
 +
 ....
@@ -90,6 +95,6 @@ networks:
     networkName: vlan-100-net-conf
 ....
 +
-Once you start the VMI, it should have the `eth0` interface connected to
-the default cluster network and `eth1` connected to VLAN 100 using
+After you start the VMI, the `eth0` interface connects to
+the default cluster network and `eth1` connects to VLAN 100 using
 bridge `br1` on the node running the VMI.

--- a/modules/cnv_virtctl_commands.adoc
+++ b/modules/cnv_virtctl_commands.adoc
@@ -1,7 +1,7 @@
 [[virtctl-commands]]
 === Virtctl commands
 
-The `virtctl` client is a command-line utility for managing {ProductName} resources. The following table contains the `virtctl` commands used throughout this document.
+The *virtctl* client is a command-line utility for managing {ProductName} resources. The following table contains the *virtctl* commands used throughout this document.
 
 .Virtctl client
 

--- a/modules/cnv_vm_storage_volume_types.adoc
+++ b/modules/cnv_vm_storage_volume_types.adoc
@@ -3,15 +3,15 @@
 === Types of storage volumes for virtual machines
 
 [horizontal]
-`ephemeral`::
+*ephemeral*::
 A local copy-on-write (COW) image that uses a network volume as a
 read-only backing store. The backing volume
-must be a `PersistentVolumeClaim`. The ephemeral image is created when
+must be a *PersistentVolumeClaim*. The ephemeral image is created when
 the virtual machine starts, and stores all writes locally. The ephemeral
 image is discarded when the virtual machine is stopped, restarted, or
 deleted. The backing volume (PVC) is not mutated in any way.
 
-`persistentVolumeClaim`::
+*persistentVolumeClaim*::
 Attaches an available PV to a virtual machine. This allows for the
 virtual machine data to persist between sessions.
 +
@@ -21,38 +21,36 @@ recommended method for importing existing virtual machines into
 {product-title}. There are some requirements for the disk to be used within a
 PVC.
 
-`dataVolume`::
-DataVolumes build on the `persistentVolumeClaim` disk type by managing the process 
+*dataVolume*::
+DataVolumes build on the *persistentVolumeClaim* disk type by managing the process 
 of preparing the virtual machine disk via an import, clone, or upload operation.  
-VMs using this volume type are guaranteed not to start until the volume has been 
-successfully prepared.
+VMs using this volume type are guaranteed not to start until the volume is ready.
 
-`cloudInitNoCloud`::
+*cloudInitNoCloud*::
 Attaches a disk containing the referenced cloud-init NoCloud data
-source, providing user data and metadata to the virtual machine. A
-proper cloud-init installation is required inside the virtual machine
+source, providing user data and metadata to the virtual machine. A cloud-init installation is required inside the virtual machine
 disk.
 
-`registryDisk`::
+*registryDisk*::
 References an image, such as a virtual machine disk, that is stored in
 the container image registry. The image is pulled from the registry and
 embedded in a volume when the virtual machine is created. A
-`registryDisk` volume is ephemeral and the volume will be discarded when
+*registryDisk* volume is ephemeral, and the volume is discarded when
 the virtual machine is stopped, restarted, or deleted.
 +
-Registry disks are not limited to a single virtual machine, and are
+Registry disks are not limited to a single virtual machine and are
 useful for creating large numbers of virtual machine clones that do not
 require persistent storage.
 +
 Only RAW and QCOW2 formats are supported disk types for the container
 image registry. QCOW2 is recommended for reduced image size.
 
-`emptyDisk`::
+*emptyDisk*::
 Creates an additional sparse QCOW2 disk that is tied to the life-cycle
 of the virtual machine interface. The data survives guest-initiated
 reboots in the virtual machine but is discarded when the virtual machine
 stops or is restarted from the web console. The empty disk is used to
-store application dependencies and data that would otherwise exceed the
+store application dependencies and data that otherwise exceeds the
 limited temporary file system of an ephemeral disk.
 +
-The disk `capacity` size must also be provided.
+The disk *capacity* size must also be provided.


### PR DESCRIPTION
CNV docs received a good amount of feedback  (#12518)  ahead of 1.3 release that was unable to be incorporated. This PR is Part 1 of those updates, and covers the following:
- Markup and language edits to fit with OCP docs
- Replacing product names with attributes
- Removing '[c,sh,w]ould', 'may' (most), 'will' (most), and 'please'