### PR TITLE
Use `oc set env`, to replace removed `oc env`

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -505,7 +505,7 @@ deprecated in favor of using secrets).
 variables:
 +
 ----
-$ oc env dc/docker-registry --list
+$ oc set env dc/docker-registry --list
 ----
 
 .. If they do not exist, skip this step. If they do, create the following `ClusterRoleBinding`:
@@ -534,7 +534,7 @@ oc create -f -
 Then, run the following to remove the environment variables:
 +
 ----
-$ oc env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+$ oc set env dc/docker-registry OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
 ----
 
 . Set the following environment variables locally to make later commands less
@@ -600,7 +600,7 @@ deprecated in favor of using service serving certificate secret.
 variables:
 +
 ----
-$ oc env dc/router --list
+$ oc set env dc/router --list
 ----
 
 .. If those variables exist, create the following `ClusterRoleBinding`:
@@ -629,7 +629,7 @@ oc create -f -
 .. If those variables exist, run the following command to remove them:
 +
 ----
-$ oc env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
+$ oc set env dc/router OPENSHIFT_CA_DATA- OPENSHIFT_CERT_DATA- OPENSHIFT_KEY_DATA- OPENSHIFT_MASTER-
 ----
 
 . Obtain a certificate.


### PR DESCRIPTION
Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1667791

@openshift/team-documentation 

Apply to enterprise-3.11 and above.