### PR TITLE
BZ-1662698: Corrected first note in configuring identity providers

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -161,13 +161,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # or
 #openshift_master_ldap_ca_file=<path to local ca file to use> <2>
 
-# Available variables for configuring certificates for other identity providers: <3>
+# Available variables for configuring certificates for other identity providers:
 #openshift_master_openid_ca
 #openshift_master_openid_ca_file <2>
 #openshift_master_request_header_ca
 #openshift_master_request_header_ca_file <2>
 ----
-<1> If you specified `'insecure': 'false'`
+<1> If you specified `'insecure': 'true'`
 in the `openshift_master_identity_providers` parameter for only an LDAP identity
 provider, you can omit the CA certificate.
 <2> If you specify a file on the host you run the playbook on, its contents are


### PR DESCRIPTION
@openshift/team-documentation,

[BZ-1662698](https://bugzilla.redhat.com/show_bug.cgi?id=1662698): Corrected first note in Configuring Identity Providers With Ansible.

One note about this section - in the example we have a pointer to a 3rd footnote, but there's no corresponding 3rd footnote. This isn't related to the existing BZ, but should be corrected as well.

This is for 3.10 and 3.11.