### PR TITLE
no github links

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -235,6 +235,8 @@ link:http://othersite.com/otherpath[friendly reference text]
 
 IMPORTANT: You must use `link:` before the start of the URL.
 
+IMPORTANT: You cannot link to a repository that is hosted on www.github.com.
+
 TIP: If you want to build a link from a URL _without_ changing the text from the actual URL, just print the URL without adding a `[friendly text]` block at the end; it will automatically be rendered as a link.
 
 === Links to Internal Topics


### PR DESCRIPTION
Moving https://github.com/openshift/openshift-docs/pull/13311 to 4.0.