### PR TITLE
osdocs-227 securing and exposing the registry

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -157,6 +157,8 @@ Topics:
   File: registry-options
 - Name: Accessing the registry
   File: accessing-the-registry
+- Name: Securing and exposing the registry
+  File: securing-exposing-registry
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/modules/registry-accessing-directly.adoc
+++ b/modules/registry-accessing-directly.adoc
@@ -5,10 +5,10 @@
 [id='registry-accessing-directly-{context}']
 = Accessing registry directly
 
-You can access the registry directly to invoke `docker` commands. This allows
+You can access the registry directly to invoke `podman` commands. This allows
 you to push images to or pull them from the integrated registry directly using
-operations like `docker push` or `docker pull`. To do so, you must be logged in
-to the registry using the `docker login` command. The operations you can perform
+operations like `podman push` or `podman pull`. To do so, you must be logged in
+to the registry using the `oc registry login` command. The operations you can perform
 depend on your user permissions, as described in the following sections.
 
 .Prerequisites
@@ -27,14 +27,14 @@ using the following command:
 # htpasswd /etc/origin/openshift-htpasswd <user_name>
 ----
 
-* For pulling images, for example when using the `docker pull` command,
+* For pulling images, for example when using the `podman pull` command,
 the user must have the *registry-viewer* role. To add this role:
 +
 ----
 $ oc policy add-role-to-user registry-viewer <user_name>
 ----
 
-* For writing or pushing images, for example when using the `docker push` command,
+* For writing or pushing images, for example when using the `podman push` command,
 the user must have the *registry-editor* role. To add this role:
 +
 ----
@@ -54,7 +54,7 @@ $ oc login
 .. Log in to the container image registry by using your access token:
 +
 ----
-docker login -u openshift -p $(oc whoami -t) <registry_ip>:<port>
+podman login -u openshift -p $(oc whoami -t) <registry_ip>:<port>
 ----
 +
 [NOTE]
@@ -64,7 +64,7 @@ information. Passing a username that contains colons will result in a login
 failure.
 ====
 +
-. Perform `docker pull` and `docker push` operations against your registry:
+. Perform `podman pull` and `podman push` operations against your registry:
 +
 [IMPORTANT]
 ====
@@ -96,7 +96,7 @@ In the following examples, we use:
 .. Pull an arbitrary image:
 +
 ----
-$ docker pull docker.io/busybox
+$ podman pull podman.io/busybox
 ----
 
 .. Tag the new image with the form `<registry_ip>:<port>/<project>/<image>`.
@@ -104,13 +104,13 @@ The project name *must* appear in this pull specification for {product-title} to
 correctly place and later access the image in the registry:
 +
 ----
-$ docker tag docker.io/busybox 172.30.124.220:5000/openshift/busybox
+$ podman tag podman.io/busybox 172.30.124.220:5000/openshift/busybox
 ----
 +
 [NOTE]
 ====
 Your regular user must have the *system:image-builder* role for the specified
-project, which allows the user to write or push an image. Otherwise, the `docker
+project, which allows the user to write or push an image. Otherwise, the `podman
 push` in the next step will fail. To test, you can create a new project to
 push the *busybox* image.
 ====
@@ -118,7 +118,7 @@ push the *busybox* image.
 .. Push the newly-tagged image to your registry:
 +
 ----
-$ docker push 172.30.124.220:5000/openshift/busybox
+$ podman push 172.30.124.220:5000/openshift/busybox
 ...
 cf2616975b4a: Image successfully pushed
 Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55

--- a/modules/registry-authentication-enabled-registry-overview.adoc
+++ b/modules/registry-authentication-enabled-registry-overview.adoc
@@ -35,7 +35,7 @@ While it is possible to use this authentication method with {product-title}, it 
 production deployments. Restrict this authentication method to
 stand-alone projects outside {product-title}.
 
-You can use `docker login` with your credentials, either username and password
+You can use `podman login` with your credentials, either username and password
 or authentication token, to access content on the new registry.
 
 All image streams point to the new registry. Because the new registry requires

--- a/modules/registry-exposing-non-secure-registry-manually.adoc
+++ b/modules/registry-exposing-non-secure-registry-manually.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * assembly/registry
+
+[id='registry-exposing-non-secure-registry-manually-{context}']
+= Exposing a non-secure registry manually
+
+Instead of securing the registry in order to expose the registry, you can simply
+expose a non-secure registry for non-production {product-title} environments.
+This allows you to have an external route to the registry without using SSL
+certificates.
+
+[WARNING]
+====
+Only non-production environments should expose a non-secure registry to external access.
+====
+
+.Procedure
+
+To expose a non-secure registry:
+
+. Expose the registry:
++
+----
+# oc expose service podman-registry --hostname=<hostname> -n default
+----
++
+This creates the following JSON file:
++
+----
+apiVersion: v1
+kind: Route
+metadata:
+  creationTimestamp: null
+  labels:
+    podman-registry: default
+  name: podman-registry
+spec:
+  host: registry.example.com
+  port:
+    targetPort: "5000"
+  to:
+    kind: Service
+    name: podman-registry
+status: {}
+----
+. Verify that the route has been created successfully:
++
+----
+# oc get route
+NAME              HOST/PORT                    PATH      SERVICE           LABELS                    INSECURE POLICY   TLS TERMINATION
+podman-registry   registry.example.com            podman-registry   podman-registry=default
+----
+. Check the health of the registry:
++
+----
+$ curl -v http://registry.example.com/healthz
+----
++
+Expect an HTTP 200/OK message.
++
+After exposing the registry, update your *_/etc/sysconfig/podman_* file by
+adding the port number to the `OPTIONS` entry. For example:
++
+----
+OPTIONS='--selinux-enabled --insecure-registry=172.30.0.0/16 --insecure-registry registry.example.com:80'
+----
++
+[IMPORTANT]
+====
+The options in the previous example should be added on the client from which you
+are trying to log in.
+
+Also, ensure that Podman is running on the client.
+====
+
+When logging in to the non-secured and exposed registry, make sure you specify the registry
+in the `podman login` command. For example:
+
+----
+# podman login -e user@company.com \
+    -u f83j5h6 \
+    -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 \
+    <host>
+----

--- a/modules/registry-exposing-secure-registry-manually.adoc
+++ b/modules/registry-exposing-secure-registry-manually.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// * assembly/registry
+
+[id='registry-exposing-secure-registry-manually-{context}']
+= Exposing a secure registry manually
+
+Instead of logging in to the {product-title} registry from within the
+{product-title} cluster, you can gain external access to it by first securing
+the registry and then exposing it with a route. This allows you to log in to the
+registry from outside the cluster using the route address, and to tag and push
+images using the route host.
+
+.Prerequisites:
+
+* The following prerequisites are automatically preformed:
+** Deploy the registry.
+** Secure the registry.
+** Deploy a router.
+
+.Procedure
+
+. Verify whether a passthrough route exists, the route should have been created by
+default for the registry during the initial cluster installation:
++
+----
+$ oc get route/pod-registry -o yaml
+apiVersion: v1
+kind: Route
+metadata:
+  name: podman-registry
+spec:
+  host: <host> <1>
+  to:
+    kind: Service
+    name: podman-registry <2>
+  tls:
+    termination: passthrough <3>
+----
+<1> The host for your route. You must be able to resolve this name externally by
+DNS to the router's IP address.
+<2> The service name for your registry.
+<3> Specifies this route as a passthrough route.
++
+[NOTE]
+====
+Re-encrypt routes are also supported for exposing the secure registry.
+====
+
+.. If it does not exist, create the route with the `oc create route passthrough`
+command, specifying the registry as the route’s service. By default, the name of
+the created route is the same as the service name:
+
+... Get the *podman-registry* service details:
++
+----
+$ oc get svc
+NAME              CLUSTER_IP       EXTERNAL_IP   PORT(S)                 SELECTOR                  AGE
+podman-registry   172.30.69.167    <none>        5000/TCP                podman-registry=default   4h
+kubernetes        172.30.0.1       <none>        443/TCP,53/UDP,53/TCP   <none>                    4h
+router            172.30.172.132   <none>        80/TCP                  router=router             4h
+----
+
+... Create the route:
++
+----
+$ oc create route passthrough    \
+    --service=podman-registry    \//<1>
+    --hostname=<host>
+route "podman-registry" created     <2>
+----
+<1> Specifies the registry as the route's service.
+<2> The route name is identical to the service name.
+
+. Trust the certificates being used for the registry on your host
+system to allow the host to push and pull images. The certificates referenced
+were created when you secured your registry:
++
+----
+$ sudo mkdir -p /etc/podman/certs.d/<host>
+$ sudo cp <ca_certificate_file> /etc/podman/certs.d/<host>
+$ sudo systemctl restart podman
+----
+
+. Log in to the registry using the information from securing the registry.
+However, this time point to the host name used in the route rather than your
+service IP. When logging in to a secured and exposed registry, make sure you
+specify the registry in the `podman login` command:
++
+----
+# podman login -e user@company.com \
+    -u f83j5h6 \
+    -p Ju1PeM47R0B92Lk3AZp-bWJSck2F7aGCiZ66aFGZrs2 \
+    <host>
+----
+
+. You can now tag and push images using the route host. For example, to tag and
+push a `busybox` image in a project called `test`:
++
+----
+$ oc get imagestreams -n test
+NAME      PODMAN REPO   TAGS      UPDATED
+
+$ podman pull busybox
+$ podman tag busybox <host>/test/busybox
+$ podman push <host>/test/busybox
+The push refers to a repository [<host>/test/busybox] (len: 1)
+8c2e06607696: Image already exists
+6ce2e90b0bc7: Image successfully pushed
+cf2616975b4a: Image successfully pushed
+Digest: sha256:6c7e676d76921031532d7d9c0394d0da7c2906f4cb4c049904c4031147d8ca31
+
+$ podman pull <host>/test/busybox
+latest: Pulling from <host>/test/busybox
+cf2616975b4a: Already exists
+6ce2e90b0bc7: Already exists
+8c2e06607696: Already exists
+Digest: sha256:6c7e676d76921031532d7d9c0394d0da7c2906f4cb4c049904c4031147d8ca31
+Status: Image is up to date for <host>/test/busybox:latest
+
+$ oc get imagestreams -n test
+NAME      PODMAN REPO                       TAGS      UPDATED
+busybox   172.30.11.215:5000/test/busybox   latest    2 seconds ago
+----
++
+[NOTE]
+====
+Your image streams will have the IP address and port of the registry service,
+not the route name and port. See `oc get imagestreams` for details.
+====

--- a/modules/registry-securing-manually.adoc
+++ b/modules/registry-securing-manually.adoc
@@ -1,0 +1,203 @@
+// Module included in the following assemblies:
+//
+// * assembly/registry
+
+[id='registry-securing-manually-{context}']
+= Securing the registry manually
+
+If for any reason your registry has not been secured, see the following
+sections for steps on how to manually do so.
+
+.Procedure
+
+Manually secure the registry to serve traffic via TLS:
+
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+. Deploy the registry using the `oc adm registry` command as a
+user with cluster administrator privileges, for example:
++
+----
+$ oc adm registry --config=/etc/origin/master/admin.kubeconfig \//<1>
+    --service-account=registry \//<2>
+    --images='registry.redhat.io/openshift3/ose-${component}:${version}' <3>
+----
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+<1> `--config` is the path to the CLI configuration file for
+the cluster administrator.
+<2> `--service-account` is the service account used to run the registry's pod.
+endif::[]
+ifdef::openshift-enterprise[]
+<3> Required to pull the correct image for {product-title}.
+endif::[]
+//Update procedure with operator info.
++
+endif::[]
+. Fetch the service IP and port of the registry:
++
+----
+$ oc get svc/podman-registry
+NAME              LABELS                                    SELECTOR                  IP(S)            PORT(S)
+podman-registry   podman-registry=default                   podman-registry=default   172.30.124.220   5000/TCP
+----
++
+. You can use an existing server certificate, or create a key and server
+certificate valid for specified IPs and host names, signed by a specified CA. To
+create a server certificate for the registry service IP and the
+*podman-registry.default.svc.cluster.local* host name,
+run the following command from the first master listed in the Ansible host inventory file,
+by default *_/etc/ansible/hosts_*:
++
+----
+$ oc adm ca create-server-cert \
+    --signer-cert=/etc/origin/master/ca.crt \
+    --signer-key=/etc/origin/master/ca.key \
+    --signer-serial=/etc/origin/master/ca.serial.txt \
+    --hostnames='podman-registry.default.svc.cluster.local,podman-registry.default.svc,172.30.124.220' \
+    --cert=/etc/secrets/registry.crt \
+    --key=/etc/secrets/registry.key
+----
++
+If the router will be exposed externally, add the public route host name in the
+`--hostnames` flag:
++
+----
+--hostnames='mypodman-registry.example.com,podman-registry.default.svc.cluster.local,172.30.124.220 \
+----
++
+//See Redeploying Registry and Router Certificates for additional details on updating the
+//default certificate so that the route is externally accessible.
++
+[NOTE]
+====
+The `oc adm ca create-server-cert` command generates a certificate that is valid
+for two years. This can be altered with the `--expire-days` option, but for
+security reasons, it is recommended to not make it greater than this value.
+====
++
+. Create the secret for the registry certificates:
++
+----
+$ oc create secret generic registry-certificates \
+    --from-file=/etc/secrets/registry.crt \
+    --from-file=/etc/secrets/registry.key
+----
++
+. Add the secret to the registry pod's service accounts (including the *default*
+service account):
++
+----
+$ oc secrets link registry registry-certificates
+$ oc secrets link default  registry-certificates
+----
++
+[NOTE]
+====
+Limiting secrets to only the service accounts that reference them is disabled by
+default. This means that if `serviceAccountConfig.limitSecretReferences` is set
+to `false` (the default setting) in the master configuration file, linking
+secrets to a service is not required.
+====
++
+. Pause the `podman-registry` service:
++
+----
+$ oc rollout pause dc/podman-registry
+----
++
+. Add the secret volume to the registry deployment configuration:
++
+----
+$ oc set volume dc/podman-registry --add --type=secret \
+    --secret-name=registry-certificates -m /etc/secrets
+----
++
+. Enable TLS by adding the following environment variables to the registry
+deployment configuration:
++
+----
+$ oc set env dc/podman-registry \
+    REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt \
+    REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key
+----
++
+. Update the scheme used for the registry's liveness probe from HTTP to HTTPS:
++
+----
+$ oc patch dc/podman-registry -p '{"spec": {"template": {"spec": {"containers":[{
+    "name":"registry",
+    "livenessProbe":  {"httpGet": {"scheme":"HTTPS"}}
+  }]}}}}'
+----
++
+. Resume the `podman-registry` service:
++
+----
+$ oc rollout resume dc/podman-registry
+----
++
+. Validate the registry is running in TLS mode. Wait until the latest *podman-registry*
+deployment completes and verify the Podman logs for the registry container. You should
+find an entry for `listening on :5000, tls`.
++
+----
+$ oc logs dc/podman-registry | grep tls
+time="2015-05-27T05:05:53Z" level=info msg="listening on :5000, tls" instance.id=deeba528-c478-41f5-b751-dc48e4935fc2
+----
++
+. Copy the CA certificate to the Podman certificates directory. This must be
+done on all nodes in the cluster:
++
+----
+$ dcertsdir=/etc/podman/certs.d
+$ destdir_addr=$dcertsdir/172.30.124.220:5000
+$ destdir_name=$dcertsdir/podman-registry.default.svc.cluster.local:5000
+
+$ sudo mkdir -p $destdir_addr $destdir_name
+$ sudo cp ca.crt $destdir_addr    //<1>
+$ sudo cp ca.crt $destdir_name
+----
+<1> The *_ca.crt_* file is a copy
+    of *_/etc/origin/master/ca.crt_* on the master.
++
+. When using authentication, some versions of `podman` also require you to
+configure your cluster to trust the certificate at the OS level.
+
+.. Copy the certificate:
++
+----
+$ cp /etc/origin/master/ca.crt /etc/pki/ca-trust/source/anchors/myregistrydomain.com.crt
+----
+
+.. Run:
++
+----
+$ update-ca-trust enable
+----
+
+. Remove the `--insecure-registry` option only for this particular registry in
+the *_/etc/sysconfig/podman_* file. Then, reload the daemon and restart the
+*podman* service to reflect this configuration change:
++
+----
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart podman
+----
++
+. Validate the `podman` client connection. Running `podman push`
+to the registry or `podman pull` from the registry should succeed. Make sure you have
+logged into the registry.
++
+----
+$ podman tag|push <registry/image> <internal_registry/project/image>
+----
++
+For example:
++
+----
+$ podman pull busybox
+$ podman tag podman.io/busybox 172.30.124.220:5000/openshift/busybox
+$ podman push 172.30.124.220:5000/openshift/busybox
+...
+cf2616975b4a: Image successfully pushed
+Digest: sha256:3662dd821983bc4326bee12caec61367e7fb6f6a3ee547cbaff98f77403cab55
+----

--- a/modules/registry-viewing-contents.adoc
+++ b/modules/registry-viewing-contents.adoc
@@ -9,7 +9,7 @@ Tag and image metadata is stored in {product-title}, but the registry stores
 layer and signature data in a volume that is mounted into the registry container
 at *_/registry_*. As `oc exec` does not work on privileged containers, to view a
 registry's contents you must manually SSH into the node housing the registry
-pod's container, then run `docker exec` on the container itself.
+pod's container, then run `podman exec` on the container itself.
 
 .Procedure
 
@@ -36,45 +36,45 @@ container:
 the container image registry:
 +
 ----
-# docker ps --filter=name=registry_docker-registry.*_default_
+# podman ps --filter=name=registry_podman-registry.*_default_
 ----
 
 . List the registry contents using the `oc rsh` command:
 +
 ----
-# oc rsh dc/docker-registry find /registry
-/registry/docker
-/registry/docker/registry
-/registry/docker/registry/v2
-/registry/docker/registry/v2/blobs <1>
-/registry/docker/registry/v2/blobs/sha256
-/registry/docker/registry/v2/blobs/sha256/ed
-/registry/docker/registry/v2/blobs/sha256/ed/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810
-/registry/docker/registry/v2/blobs/sha256/ed/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810/data <2>
-/registry/docker/registry/v2/blobs/sha256/a3
-/registry/docker/registry/v2/blobs/sha256/a3/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
-/registry/docker/registry/v2/blobs/sha256/a3/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4/data
-/registry/docker/registry/v2/blobs/sha256/f7
-/registry/docker/registry/v2/blobs/sha256/f7/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845
-/registry/docker/registry/v2/blobs/sha256/f7/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845/data
-/registry/docker/registry/v2/repositories <3>
-/registry/docker/registry/v2/repositories/p1
-/registry/docker/registry/v2/repositories/p1/pause <4>
-/registry/docker/registry/v2/repositories/p1/pause/_manifests
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions/sha256
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures <5>
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures/sha256
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures/sha256/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810
-/registry/docker/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures/sha256/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810/link <6>
-/registry/docker/registry/v2/repositories/p1/pause/_uploads <7>
-/registry/docker/registry/v2/repositories/p1/pause/_layers <8>
-/registry/docker/registry/v2/repositories/p1/pause/_layers/sha256
-/registry/docker/registry/v2/repositories/p1/pause/_layers/sha256/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
-/registry/docker/registry/v2/repositories/p1/pause/_layers/sha256/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4/link <9>
-/registry/docker/registry/v2/repositories/p1/pause/_layers/sha256/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845
-/registry/docker/registry/v2/repositories/p1/pause/_layers/sha256/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845/link
+# oc rsh dc/podman-registry find /registry
+/registry/podman
+/registry/podman/registry
+/registry/podman/registry/v2
+/registry/podman/registry/v2/blobs <1>
+/registry/podman/registry/v2/blobs/sha256
+/registry/podman/registry/v2/blobs/sha256/ed
+/registry/podman/registry/v2/blobs/sha256/ed/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810
+/registry/podman/registry/v2/blobs/sha256/ed/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810/data <2>
+/registry/podman/registry/v2/blobs/sha256/a3
+/registry/podman/registry/v2/blobs/sha256/a3/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
+/registry/podman/registry/v2/blobs/sha256/a3/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4/data
+/registry/podman/registry/v2/blobs/sha256/f7
+/registry/podman/registry/v2/blobs/sha256/f7/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845
+/registry/podman/registry/v2/blobs/sha256/f7/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845/data
+/registry/podman/registry/v2/repositories <3>
+/registry/podman/registry/v2/repositories/p1
+/registry/podman/registry/v2/repositories/p1/pause <4>
+/registry/podman/registry/v2/repositories/p1/pause/_manifests
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions/sha256
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures <5>
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures/sha256
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures/sha256/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810
+/registry/podman/registry/v2/repositories/p1/pause/_manifests/revisions/sha256/e9a2ac6418981897b399d3709f1b4a6d2723cd38a4909215ce2752a5c068b1cf/signatures/sha256/ede17b139a271d6b1331ca3d83c648c24f92cece5f89d95ac6c34ce751111810/link <6>
+/registry/podman/registry/v2/repositories/p1/pause/_uploads <7>
+/registry/podman/registry/v2/repositories/p1/pause/_layers <8>
+/registry/podman/registry/v2/repositories/p1/pause/_layers/sha256
+/registry/podman/registry/v2/repositories/p1/pause/_layers/sha256/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
+/registry/podman/registry/v2/repositories/p1/pause/_layers/sha256/a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4/link <9>
+/registry/podman/registry/v2/repositories/p1/pause/_layers/sha256/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845
+/registry/podman/registry/v2/repositories/p1/pause/_layers/sha256/f72a00a23f01987b42cb26f259582bb33502bdb0fcf5011e03c60577c4284845/link
 ----
 <1> This directory stores all layers and signatures as blobs.
 <2> This file contains the blob's contents.

--- a/modules/registry-viewing-logs.adoc
+++ b/modules/registry-viewing-logs.adoc
@@ -13,7 +13,7 @@ You can view the logs for the registry by using the `oc logs` command.
 for the container image registry:
 +
 ----
-$ oc logs dc/docker-registry
+$ oc logs dc/podman-registry
 2015-05-01T19:48:36.300593110Z time="2015-05-01T19:48:36Z" level=info msg="version=v2.0.0+unknown"
 2015-05-01T19:48:36.303294724Z time="2015-05-01T19:48:36Z" level=info msg="redis not configured" instance.id=9ed6c43d-23ee-453f-9a4b-031fea646002
 2015-05-01T19:48:36.303422845Z time="2015-05-01T19:48:36Z" level=info msg="using inmemory layerinfo cache" instance.id=9ed6c43d-23ee-453f-9a4b-031fea646002

--- a/registry/securing-exposing-registry.adoc
+++ b/registry/securing-exposing-registry.adoc
@@ -1,0 +1,18 @@
+:context: securing-exposing-registry
+= Securing and exposing the registry
+include::modules/common-attributes.adoc[]
+toc::[]
+
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+
+By default, the {product-title} registry is secured during cluster
+installation so that it serves traffic via TLS. A passthrough route is also
+created by default to expose the service externally.
+
+endif::[]
+
+include::modules/registry-securing-manually.adoc[leveloffset=+1]
+
+include::modules/registry-exposing-secure-registry-manually.adoc[leveloffset=+1]
+
+include::modules/registry-exposing-non-secure-registry-manually.adoc[leveloffset=+1]


### PR DESCRIPTION
https://jira.coreos.com/browse/OSDOCS-227 (part 3)

Need to follow up and update with `oc registry` (e.g., `oc registry login`, which applies to some specific cases such as logging into the internal registry) and podman commands. 

Will address follow-up edits for https://github.com/openshift/openshift-docs/pull/13425 in this PR.
