### PR TITLE
FINALBZ1647168 -fixed xref to adoc from html

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1010,7 +1010,7 @@ $ oc label node <nodename3> logging-es-node=3
 ----
 
 For information about adding a label to a node, see
-xref:../admin_guide/manage_nodes.html#updating-labels-on-nodes[Updating Labels on Nodes].
+xref:../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[Updating Labels on Nodes].
 
 To automate applying the node selector you can instead use the `oc patch` command:
 


### PR DESCRIPTION
Fixed cross-reference format to citing ".adoc" file rather than ".html" file.

NOTE: Previous edits (based on Peer Review, CSS review, QE review) have already been incorporated. This PR is only for correcting the xref.