### PR TITLE
Fixed Route-specific Annotations heading in 3.10

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -581,6 +581,7 @@ include::architecture/topics/alternate_backends_weights.adoc[]
 endif::openshift-origin,openshift-enterprise,openshift-dedicated[]
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 [[route-specific-annotations]]
+
 == Route-specific Annotations
 
 Using environment variables, a router can set the default


### PR DESCRIPTION
This issue is not in master; it's only in 3.9, 3.10, and 3.11 branches.