### PR TITLE
Fixed Route-specific Annotations heading in 3.9

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -580,6 +580,7 @@ ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 include::architecture/topics/alternate_backends_weights.adoc[]
 endif::openshift-origin,openshift-enterprise,openshift-dedicated[]
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+
 [[route-specific-annotations]]
 == Route-specific Annotations
 


### PR DESCRIPTION
This issue is not in master; it's only in 3.9, 3.10, and 3.11 branches.