### PR TITLE
[enterprise-3.11] bug 1670229 Use node-bootstrapper ServiceAccount token

### DIFF
--- a/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
@@ -17,11 +17,11 @@ the existing cluster when it starts.
 
 .Procedure
 
-. Create the *_bootstrap.kubeconfig_* file by copying it from the master node:
+. Create the *_bootstrap.kubeconfig_* file by generating it from a master node:
 +
 [source,bash]
 ----
-$ ssh master "sudo cat /etc/origin/master/bootstrap.kubeconfig" > ~/bootstrap.kubeconfig
+$ ssh master "sudo oc serviceaccounts create-kubeconfig -n openshift-infra node-bootstrapper" > ~/bootstrap.kubeconfig
 ----
 
 . Create the *_user-data.txt_* cloud-init file from the *_bootstrap.kubeconfig_*


### PR DESCRIPTION
The `node-bootstrapper` ServiceAccount token from the `openshift-infra` project is revokable without affecting the master's client TLS authentication and contains a lower level of privilege than the `system:admin` credentials from the master's bootstrap kubeconfig and is recommended over using a higher privilege account.

See https://bugzilla.redhat.com/show_bug.cgi?id=1670229 for more details.