### PR TITLE
[enterprise-3.11] Update disconnected install version tag

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -3,9 +3,9 @@
 {product-author}
 {product-version}
 :major-tag: v3.11
-:latest-tag: v3.11.59
-:latest-int-tag: v3.11.59
-:latest-registry-console-tag: v3.11.59
+:latest-tag: v3.11.69
+:latest-int-tag: v3.11.69
+:latest-registry-console-tag: v3.11.69
 :data-uri:
 :icons:
 :experimental:

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -3,9 +3,9 @@
 {product-author}
 {product-version}
 :major-tag: v3.11
-:latest-tag: v3.11.16
-:latest-int-tag: v3.11.16
-:latest-registry-console-tag: v3.11.16
+:latest-tag: v3.11.59
+:latest-int-tag: v3.11.59
+:latest-registry-console-tag: v3.11.59
 :data-uri:
 :icons:
 :experimental:


### PR DESCRIPTION
Using a proper branch this time rather than enterprise-3.11 directly.

Original PR: https://github.com/openshift/openshift-docs/pull/13413
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1666540