### PR TITLE
BZ-1528464: Added missing command option

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -798,19 +798,19 @@ specified as a python compatible dict. For example, `{"node-type":"infra",
 ==== Persistent Elasticsearch Storage ====
 
 By default, the `openshift_logging` Ansible role creates an ephemeral
-deployment in which all data in a pod is lost upon pod restart. 
+deployment in which all data in a pod is lost upon pod restart.
 
 For production environments, each Elasticsearch deployment configuration requires a persistent storage volume. You can specify an existing xref:../architecture/additional_concepts/storage.adoc#persistent-volume-claims[persistent
-volume claim] or allow {product-title} to create one. 
+volume claim] or allow {product-title} to create one.
 
-* *Use existing PVCs.* If you create your own PVCs for the deployment, {product-title} uses those PVCs. 
+* *Use existing PVCs.* If you create your own PVCs for the deployment, {product-title} uses those PVCs.
 +
 Name the PVCs to match the `openshift_logging_es_pvc_prefix` setting, which defaults to
 `logging-es`. Assign each PVC a name with a sequence number added to it: `logging-es-0`,
-`logging-es-1`, `logging-es-2`, and so on. 
+`logging-es-1`, `logging-es-2`, and so on.
 
-* *Allow {product-title} to create a PVC.* If a PVC for Elsaticsearch does not exist, {product-title} creates the PVC based on parameters 
-in the xref:../install/configuring_inventory_file.adoc#configuring-ansible[Ansible inventory file]. 
+* *Allow {product-title} to create a PVC.* If a PVC for Elsaticsearch does not exist, {product-title} creates the PVC based on parameters
+in the xref:../install/configuring_inventory_file.adoc#configuring-ansible[Ansible inventory file].
 +
 [cols="3,7",options="header"]
 |===
@@ -821,10 +821,10 @@ in the xref:../install/configuring_inventory_file.adoc#configuring-ansible[Ansib
 | Specify the size of the PVC request.
 
 |`openshift_logging_elasticsearch_storage_type`
-a|Specify the storage type as `pvc`. 
+a|Specify the storage type as `pvc`.
 [NOTE]
 ====
-This is an optional parameter. If you set the `openshift_logging_es_pvc_size` parameter to a value greater than 0, the logging installer automatically sets this parameter to `pvc` by default. 
+This is an optional parameter. If you set the `openshift_logging_es_pvc_size` parameter to a value greater than 0, the logging installer automatically sets this parameter to `pvc` by default.
 ====
 
 |`openshift_logging_es_pvc_prefix`
@@ -835,14 +835,14 @@ For example:
 +
 [source,bash]
 ----
-openshift_logging_elasticsearch_storage_type=pvc 
-openshift_logging_es_pvc_size=104802308Ki 
+openshift_logging_elasticsearch_storage_type=pvc
+openshift_logging_es_pvc_size=104802308Ki
 openshift_logging_es_pvc_prefix=es-logging
 ----
 
 If using xref:../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[dynamically provisioned PVs], the {product-title} logging installer creates PVCs that use the default storage class or the PVC specified with the `openshift_logging_elasticsearch_pvc_storage_class_name` parameter.
 
-If using NFS storage, the {product-title} installer creates the persistent volumes, based on the `openshift_logging_storage_*` parameters 
+If using NFS storage, the {product-title} installer creates the persistent volumes, based on the `openshift_logging_storage_*` parameters
 and the xref:#deploying-the-efk-stack[{product-title} logging installer] creates PVCs, using the `openshift_logging_es_pvc_*` paramters.
 Make sure you specify the correct parameters in order to use persistent volumes with EFK.
 Also set the `openshift_enable_unsupported_configurations=true` parameter in the Ansible inventory file, as the logging installer blocks the installation of NFS with core infrastructure by default.
@@ -852,19 +852,19 @@ Also set the `openshift_enable_unsupported_configurations=true` parameter in the
 Using NFS storage as a volume or a persistent volume, or using NAS such as
 Gluster, is not supported for Elasticsearch storage, as Lucene relies on file
 system behavior that NFS does not supply. Data corruption and other problems can
-occur. 
+occur.
 ====
 
-If your environment requires NFS storage, use one of the following methods: 
+If your environment requires NFS storage, use one of the following methods:
 
-* xref:aggregated-logging-nfs-persistent[NFS as a persistent volume] 
+* xref:aggregated-logging-nfs-persistent[NFS as a persistent volume]
 
 * xref:aggregated-logging-nfs-local[NFS storage as local storage]
 
 [[aggregated-logging-nfs-persistent]]
 ===== Using NFS as a persistent volume =====
 
-You can deploy NFS as an xref:aggregated-logging-nfs-auto[automatically provisioned persistent volume] 
+You can deploy NFS as an xref:aggregated-logging-nfs-auto[automatically provisioned persistent volume]
 or xref:aggregated-logging-nfs-volume[using a predefined NFS volume].
 
 For more information, see xref:../install_config/storage_examples/shared_storage.adoc#install-config-storage-examples-shared-storage[Sharing an NFS mount across two persistent volume claims] to leverage shared storage for use by two separate containers.
@@ -911,7 +911,7 @@ The installer playbook creates the NFS volume based on the `openshift_logging_st
 [[aggregated-logging-nfs-volume]]
 *Using a predefined NFS volume*
 
-To deploy logging alongside the {product-title} cluster using an existing NFS volume: 
+To deploy logging alongside the {product-title} cluster using an existing NFS volume:
 
 . Edit the Ansible inventory file to configure the NFS volume and set the PVC size:
 +
@@ -1630,6 +1630,7 @@ ifdef::openshift-enterprise[]
 ----
 $ ansible-playbook [-i </path/to/inventory>] \
     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
+    -e openshift_logging_install_logging=False
 ----
 endif::openshift-enterprise[]
 
@@ -3858,4 +3859,3 @@ cluster. Edit your non-cluster logging service (for example, `logging-es`,
 ----
 $ oc patch svc/logging-es -p '{"spec":{"selector":{"component":"es","provider":"openshift"}}}'
 ----
-


### PR DESCRIPTION
@openshift/team-documentation For peer review. In Atom, I have a setting to strip trailing whitespace (as seen in the diff). Let me know if that's not something you guys do and if I should turn that off.