### PR TITLE
Edit Options size to match enterprise 3-10 content for cherrypicking to enterprise 3-11.

### DIFF
--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -695,7 +695,8 @@ of log files.
 
 . To configure the log file, edit the *_/etc/sysconfig/docker_* file. For
 example, to set the maximum file size to 1 MB and always keep the last three
-log files, set the following options:
+log files, append `max-size=1M` and `max-file=3` to the `OPTIONS=` line,
+ensuring that the values maintain the single quotation mark formatting:
 +
 ----
 OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-opt max-size=1M --log-opt max-file=3'


### PR DESCRIPTION
Previous PR for this content was based on  enterprise-3.10, not master. The branch for this PR is based on master.

Previous PR is here: https://github.com/openshift/openshift-docs/pull/13073

Bug for this PR is here: https://bugzilla.redhat.com/show_bug.cgi?id=1635743