### PR TITLE
Bug 1647168 - base master for node labels

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -957,13 +957,13 @@ $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o 
 ----
 
 . The Elasticsearch replicas must be located on the correct nodes to use the local
-storage, and should not move around even if those nodes are taken down for a
-period of time. This requires giving each Elasticsearch node a node selector
+storage, and must not move around, even if those nodes are taken down for a
+period of time. This requires giving each Elasticsearch replica a node selector
 that is unique to a node where an administrator has allocated storage for it. To
-configure a node selector, edit each Elasticsearch deployment configuration and
-add or edit the *nodeSelector* section to specify a unique label that you have
+configure a node selector, edit each Elasticsearch deployment configuration, adding
+or editing the *nodeSelector* section to specify a unique label that you have
 applied for each desired node:
-+
+
 ----
 apiVersion: v1
 kind: DeploymentConfig
@@ -973,9 +973,23 @@ spec:
       nodeSelector:
         logging-es-node: "1" <1>
 ----
-<1> This label should uniquely identify a replica with a single node that bears that
-label, in this case `logging-es-node=1`. Use the `oc label` command to apply
-labels to nodes as needed.
+<1> This label must uniquely identify a replica with a single node that bears that
+label, in this case `logging-es-node=1`.
+
+
+. Create a node selector for each required node.
+. Use the `oc label` command to apply labels to as many nodes as needed.
+
+For example, if your deployment has three infrastructure nodes, you could add labels for those
+nodes as follows:
+----
+$ oc label node <nodename1> logging-es-node=1
+$ oc label node <nodename2> logging-es-node=2
+$ oc label node <nodename3> logging-es-node=3
+----
+
+For information about adding a label to a node, see
+xref:../admin_guide/manage_nodes.adoc#updating-labels-on-nodes[Updating Labels on Nodes].
 
 To automate applying the node selector you can instead use the `oc patch` command:
 


### PR DESCRIPTION
Creating new PR based on master to replace incorrect PR that had errors.

Previous (incorrect) PR was https://github.com/openshift/openshift-docs/pull/13503

Prior to that, an earlier PR was based on enterprise-3.10, not master. That prior PR was https://github.com/openshift/openshift-docs/pull/13438

@vikram-redhat PTAL