### PR TITLE
BZ1637616 -so it builds correctly in master,3-10,and 3.11.

### DIFF
--- a/install_config/persistent_storage/persistent_storage_manila.adoc
+++ b/install_config/persistent_storage/persistent_storage_manila.adoc
@@ -184,7 +184,7 @@ data:
 
 [NOTE]
 ====
-Newer OpenStack versions use "project" instead of "tenant," however, the
+Newer OpenStack versions use "project" instead of "tenant." However, the
 environment variables used by the provisioner must use `TENANT` in their
 names.
 ====


### PR DESCRIPTION
This is a new PR for bug BZ1637616.  There have been 3 previous PRs that need to have data corrected. Previous PRs are here:

https://github.com/openshift/openshift-docs/pull/13479 ,  https://github.com/openshift/openshift-docs/pull/13379,  https://github.com/openshift/openshift-docs/pull/13378 .  Each one had different issue to be resolved.
The last PR got the correct information into master, it was not set up to CP to 3.10 3.11. So material got into master, but in the end, it failed to build correctly because it had originally been based on 3.10, etc. 
In order to cause a change so I could create this new PR, I made a grammatical correction that had been in the asciidoc file for some time, but I had not noticed it when I entered the correct data for this bug. This PR corrects that error, but is based correctly on master, and should CP OK to 3.10 and 3.11.



