### PR TITLE
changed topic map to match bucket name

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -207,7 +207,7 @@ Topics:
 - Name: Appendices
   File: operators-appendices
 ---
-Name: Working with nodes
+Name: Nodes
 Dir: nodes
 Distros: openshift-*
 Topics:
@@ -231,7 +231,7 @@ Topics:
 - Name: Viewing system event information in a cluster
   File: nodes-containers-events
 ---
-Name: Cluster logging
+Name: Logging
 Dir: logging
 Distros: openshift-*
 Topics:


### PR DESCRIPTION
Changing the topic-map for the _Cluster Logging_ book to _Logging_ to match the buckets.