### PR TITLE
add kubeletconfig management for 4.0

### DIFF
--- a/modules/node-management.adoc
+++ b/modules/node-management.adoc
@@ -46,3 +46,176 @@ the `machine-config-server` runs in the cluster.  It reads the `machine-config`
 custom resource definitions (CRDs) and serves the required Ignition configurations
 to new nodes when they join the cluster.
 ////
+
+When you perform node management operations, you will be creating or
+modifying a KubeletConfig Custom Resource (CR).
+
+[[machine-configs-and-pools]]
+== Machine Configs and Machine Config Pools
+Machine Config Pools manage a cluster of nodes and their corresponding
+Machine Configs. Machine Configs contain configuration information for a
+cluster.
+
+To list all Machine Config Pools that are known:
+
+----
+$ oc get machineconfigpools
+NAME     CONFIG                                    UPDATED   UPDATING   DEGRADED
+master   master-1638c1aea398413bb918e76632f20799   False     False      False
+worker   worker-2feef4f8288936489a5a832ca8efe953   False     False      False
+----
+
+To list all Machine Configs:
+----
+$ oc get machineconfig
+NAME                                      GENERATEDBYCONTROLLER        IGNITIONVERSION   CREATED   OSIMAGEURL
+00-master                                 3.11.0-572-g649451d6-dirty   2.2.0             16m
+00-master-ssh                             3.11.0-572-g649451d6-dirty                     16m
+00-worker                                 3.11.0-572-g649451d6-dirty   2.2.0             16m
+00-worker-ssh                             3.11.0-572-g649451d6-dirty                     16m
+01-master-kubelet                         3.11.0-572-g649451d6-dirty   2.2.0             16m
+01-worker-kubelet                         3.11.0-572-g649451d6-dirty   2.2.0             16m
+master-1638c1aea398413bb918e76632f20799   3.11.0-572-g649451d6-dirty   2.2.0             16m
+worker-2feef4f8288936489a5a832ca8efe953   3.11.0-572-g649451d6-dirty   2.2.0             16m
+----
+
+To list all KubeletConfigs:
+
+----
+$ oc get kubeletconfigs
+----
+
+To get more detailed information about a KubeletConfig, including the reason for
+the current condition:
+
+----
+$ oc describe kubeletconfig <name>
+----
+
+For example:
+
+----
+# oc describe kubeletconfig max-pods
+
+Name:         set-max-pods <1>
+Namespace:
+Labels:       <none>
+Annotations:  <none>
+API Version:  machineconfiguration.openshift.io/v1
+Kind:         KubeletConfig
+Metadata:
+  Creation Timestamp:  2019-02-05T16:27:20Z
+  Generation:          1
+  Resource Version:    19694
+  Self Link:           /apis/machineconfiguration.openshift.io/v1/kubeletconfigs/set-max-pods
+  UID:                 e8ee6410-2962-11e9-9bcc-664f163f5f0f
+Spec:
+  Kubelet Config: <2>
+    Max Pods:  100
+  Machine Config Pool Selector: <3>
+    Match Labels:
+      Custom - Kubelet:  small-pods
+Events:                    <none>
+----
+
+<1> The name of the KubeletConfig.
+<2> The user defined configuration.
+<3> The Machine Config Pool selector to apply the KubeletConfig to.
+
+[[modifying-nodes]]
+== Modifying Nodes
+
+{product-title} uses a KubeletConfig Custom Resource to manage the
+configuration of nodes. By creating an instance of a KubeletConfig, a managed
+MachineConfig is created to override setting on the node. 
+
+[NOTE]
+====
+*Logging into remote machines for the purpose of changing their configuration is not supported.*
+====
+
+To make configuration changes to a MachinePool, you need to create a KubeletConfig instance. The Machine Config Controller watches for 
+KubeletConfigs and applies the configuration.
+
+.Sample configuration for a *max-pods* KubeletConfig
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-max-pods <1>
+spec:
+  machineConfigPoolSelector:
+    matchLabels: <2>
+      custom-kubelet: small-pods
+  kubeletConfig: <3>
+    maxPods: 100
+----
+
+<1> The name of the KubeletConfig.
+<2> The MachineConfigPool selector to apply the KubeletConfig to.
+<3> https://github.com/kubernetes/kubernetes/blob/release-1.11/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go#L45[KubeletConfig Options]
+
+Most https://github.com/kubernetes/kubernetes/blob/release-1.11/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go#L45[KubeletConfig Options]  may be set by the user. The following options are not allowed to be overwritten:
+
+* CgroupDriver
+* ClusterDNS
+* ClusterDomain
+* RuntimeRequestTimeout
+* StaticPodPath
+
+[[admin-guide-max-pods-per-node]]
+=== Setting maximum pods per node
+
+////
+The following section is included in the Scaling and Performance Guide.
+////
+// tag::admin_guide_manage_nodes[]
+
+In the KubeletConfig, two parameters control the maximum number of pods that
+can be scheduled to a node: `podsPerCore` and `maxPods`. When both options
+are in use, the lower of the two limits the number of pods on a node.
+Exceeding these values can result in:
+
+* Increased CPU utilization on both {product-title} and Docker.
+* Slow pod scheduling.
+* Potential out-of-memory scenarios (depends on the amount of memory in the node).
+* Exhausting the pool of IP addresses.
+* Resource overcommitting, leading to poor user application performance.
+
+[NOTE]
+====
+In Kubernetes, a pod that is holding a single container actually uses two
+containers. The second container is used to set up networking prior to the
+actual container starting. Therefore, a system running 10 pods will actually
+have 20 containers running.
+====
+
+`podsPerCore` sets the number of pods the node can run based on the number of
+processor cores on the node. For example, if `podsPerCore` is set to `10` on
+a node with 4 processor cores, the maximum number of pods allowed on the node
+will be 40.
+
+----
+spec:
+  kubeletConfig:
+    podsPerCore: 100
+----
+
+[NOTE]
+====
+Setting `podsPerCore` to 0 disables this limit.
+====
+
+`maxPods` sets the number of pods the node can run to a fixed value, regardless
+of the properties of the node.
+
+----
+spec:
+  kubeletConfig:
+    maxPods: 250
+----
+
+Using the above example, the default value for `podsPerCore` is `10` and the
+default value for `maxPods` is `250`. This means that unless the node has 25
+cores or more, by default, `podsPerCore` will be the limiting factor.
+// end::admin_guide_manage_nodes[]


### PR DESCRIPTION
Initial pass of adding documentation for KubeletConfiguration with OSE 4.0.

/cc @openshift/team-documentation 