### PR TITLE
fixing RHCOS full name

### DIFF
--- a/modules/installation-clouds.adoc
+++ b/modules/installation-clouds.adoc
@@ -22,7 +22,7 @@ Kubernetes service network.
 [IMPORTANT]
 ====
 It is possible to modify Kubernetes and the Ignition Configs that control
-the underlying Red Hat CoreOS operating system during installation. However,
+the underlying RHEL CoreOS operating system during installation. However,
 no validation is available to confirm the suitability of any modifications that
 you make to these objects. If you modify these objects, you might render
 your cluster non-functional. Because of this risk, modifying Kubernetes and

--- a/modules/installation-options.adoc
+++ b/modules/installation-options.adoc
@@ -7,11 +7,11 @@
 
 In {product-title} version 4.0, you can install only clusters that use
 Installer Provisioned Infrastructure in Amazon Web Services (AWS).
-These clusters use Red Hat CoreOS
+These clusters use RHEL CoreOS
 nodes as the operating system. Future versions of {product-title} will support
 clusters that use both Installer Provisioned Infrastructure
 and User Provisioned Infrastructure on more cloud providers and on bare metal.
-With all cluster types, you must use Red Hat CoreOS as the operating system for
+With all cluster types, you must use RHEL CoreOS as the operating system for
 control plane nodes.
 ////
 If you want to

--- a/modules/node-management.adoc
+++ b/modules/node-management.adoc
@@ -7,7 +7,7 @@
 
 {product-title} version 4.0 integrates management of
 the container operating system and cluster management. Because the cluster manages
-its updates, including updates to Red Hat CoreOS on cluster nodes, {product-title} provides an opinionated
+its updates, including updates to RHEL CoreOS on cluster nodes, {product-title} provides an opinionated
 lifecycle management experience that simplifies the orchestration of upgrades.
 
 {product-title} employs three DaemonSets and controllers to simplify node management:

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -6,7 +6,7 @@
 == The {product-title} update service
 
 The {product-title} update service is the hosted service that provides over the air updates to both 
-{product-title} and Red Hat CoreOS. It provides a graph, or diagram that contain
+{product-title} and RHEL CoreOS. It provides a graph, or diagram that contain
 _vertices_ and the _edges_ that connect them, of component Operators. The edges
 in the graph show which versions you can safely upgrade to, and the vertices
 vertices are update payloads that specify the intended state of the managed cluster components.


### PR DESCRIPTION
Updating all references to "Red Hat CoreOS" per @chrisnegus. Per his email, RHCOS is still the acceptable short name. 