### PR TITLE
Reveal openshift_master_manage_htpasswd variable in upgrade preparations

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -213,6 +213,7 @@ xref:../install_config/configuring_red_hat_registry.adoc#install-config-configur
 
 . Review and update your
 xref:../install/configuring_inventory_file.adoc#configuring-ansible[inventory file].
+
 .. Ensure that any manual configuration changes you made to your master or node
 configuration files since your last Ansible playbook run, whether that was
 initial installation or your most recent cluster upgrade, are in the inventory
@@ -247,6 +248,10 @@ you used in previous versions.
 You must not remove the `openshift_kubelet_name_override` parameter from your
 inventory file after you upgrade.
 ====
+.. If you manually manage the cluster's *_/etc/origin/master/htpasswd_* file,
+add `openshift_master_manage_htpasswd=false` to your inventory file to prevent
+the upgrade process from overwriting the *_htpasswd_* file.
+
 
 
 [[updating-policy-definitions]]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1666644

The goal of this PR is to address the issue described in the bug linked above and described succinctly in this[0] solution. I'd appreciate suggestions on better ways to surface this information. I included it under 3. rather than 2. because it affects upgrading z-stream releases as well.

Thank you.

[0] https://access.redhat.com/solutions/3811271