### PR TITLE
Correct the cluster autoscaler image tag on enterprise version

### DIFF
--- a/admin_guide/topics/deploying-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/deploying-cluster-auto-scaler.adoc
@@ -256,7 +256,7 @@ spec:
 	- name: AWS_SHARED_CREDENTIALS_FILE
 	  value: /var/run/secrets/aws-creds/creds
 ifdef::openshift-enterprise[]
-	image: registry.redhat.io/openshift3/ose-cluster-autoscaler:v3.11.0
+	image: registry.redhat.io/openshift3/ose-cluster-autoscaler:v3.11
 endif::[]
 ifdef::openshift-origin[]
 	image: docker.io/openshift/origin-cluster-autoscaler:v3.11.0


### PR DESCRIPTION
* Version: only `v3.11`

* Description: 
  `v3.11` tag is correct on `OpenShift Container Platform` (enterprise version), it's not `v3.11.0`.
  Refer following container catalog's tags.

* [OpenShift Container Platform](https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/openshift3/ose-cluster-autoscaler)
~~~
v3.11
~~~

* [OKD](https://hub.docker.com/r/openshift/origin-cluster-autoscaler/tags)
~~~
v3.11.0
v3.11
~~~
  