### PR TITLE
When exposing haproxy metrics, we will need to also update the readiness probe

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -1752,6 +1752,12 @@ $ oc edit dc router
   value: haproxy
 ----
 +
+. Patch the router readiness probe to use the same path as the liveness probe as it is now served by the haproxy router:
++
+----
+$ oc patch dc router -p '"spec": {"template": {"spec": {"containers": [{"name": "router","readinessProbe": {"httpGet": {"path": "/healthz"}}}]}}}'
+----
++
 . Launch the stats window using the following URL in a browser, where the `STATS_PORT` value is `1936` by default:
 +
 ----


### PR DESCRIPTION
When exposing haproxy metrics directly out, need to update the readiness probe as the probe paths as they are now served by haproxy. And haproxy just has a single monitor-uri healthz path.

fixes bugz 1663268 (https://bugzilla.redhat.com/show_bug.cgi?id=1663268)

Creating a separate PR for master based on Vikram's comments in #13608 

@vikram-redhat  PTAL Thx

/cc @bmeng 