### PR TITLE
BZ1678855 Added namespace section in NetworkPolicy section

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1258,7 +1258,7 @@ that can be hosted. Namespaces that have requested egress IP addresses are match
 with nodes that are able to host those egress IP addresses, then the egress IP
 addresses are assigned to those nodes.
 
-High availability is automatic. If a node hosting egress IP addresses 
+High availability is automatic. If a node hosting egress IP addresses
 goes down and there are nodes that are able to host those egress IP addresses,
 based on the `egressCIDR` values of the `HostSubnet` resources, then the egress
 IP addresses will move to a new node. When the original egress IP address node
@@ -1469,6 +1469,39 @@ within the same project. Thus allowing the pods with the label `role=frontend`,
 to accept any connection allowed by each policy. That is,  connections on any
 port from pods in the *_same_* namespace, and connections on ports `80` and
 `443` from pods in *_any_* namespace.
+
+[[admin-guide-networking-using-networkpolicy-efficiently]]
+=== Using NetworkPolicy Efficiently
+
+`NetworkPolicy` objects allow you to isolate pods that are differentiated from
+one another by labels, within a namespace.
+
+It is inefficient to apply `NetworkPolicy` objects
+to large numbers of individual pods in a single namespace.
+Pod labels do not exist at the IP level, so `NetworkPolicy` objects generate
+a separate OVS flow rule for every single possible link between every pod
+selected with `podSelector`.
+
+For example, if the `_spec_` `podSelector` and
+the `_ingress_` `podSelector` within a `NetworkPolicy` object each match 200
+pods, then 40000 (200*200) OVS flow rules are generated.
+This might slow down the machine.
+
+To reduce the amount of OVS flow rules, use namespaces to contain groups
+of pods that need to be isolated.
+
+`NetworkPolicy` objects that select a whole namespace, by using
+`namespaceSelectors`
+or empty `podSelectors`, only generate a single OVS flow rule that matches the
+VXLAN VNID of the namespace.
+
+Keep the pods that do not need
+to be isolated in their original namespace, and
+move the pods that require isolation into one or more different namespaces.
+
+Create additional
+targeted cross-namespace policies to allow the specific traffic that you do want
+to allow from the isolated pods.
 
 [[admin-guide-networking-networkpolicy-routers]]
 === NetworkPolicy and Routers


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1656805

@squeed 
@danwinship 
@bmeng 

PTAL
Please advise if the title is not clear.

regarding:
"It is inefficient to apply `NetworkPolicy` objects
to large numbers of individual pods in a single namespace" - can we suggest a limit?

Which OCP releases does this apply to? The BZ flags it as a 3.7 issue.
