### PR TITLE
3.10.111 release notes stub added

### DIFF
--- a/release_notes/ocp_3_10_release_notes.adoc
+++ b/release_notes/ocp_3_10_release_notes.adoc
@@ -2647,3 +2647,22 @@ To upgrade an existing {product-title} 3.9 or 3.10 cluster to this latest
 release, use the automated upgrade playbook. See
 xref:../upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[Performing
 Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-10-111]]
+=== RHBA-2019:0206 - {product-title} 3.10.111 Bug Fix Update
+
+Issued: 2019-02-20
+
+{product-title} release 3.10.111 is now available. The list of packages and
+bug fixes included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:0328[RHBA-2019:0328] advisory.
+The container images included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2019:0329[RHBA-2019:0329] advisory.
+
+[[ocp-3-10-111-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.9 or 3.10 cluster to this latest
+release, use the automated upgrade playbook. See
+xref:../upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[Performing
+Automated In-place Cluster Upgrades] for instructions.


### PR DESCRIPTION
This is shipping 2019-02-20.

[PR 13657](https://github.com/openshift/openshift-docs/pull/13657) has latest tags and release notes against 3.10, so not adding enterprise-3.10 to the labels for this PR. (Sorry for the confusion!)