### PR TITLE
OSDOCS-286: Updated output of RBAC commands.

### DIFF
--- a/modules/rbac-adding-roles.adoc
+++ b/modules/rbac-adding-roles.adoc
@@ -23,7 +23,6 @@ project.
 
 . Add a role to a user in a specific project:
 +
-[source,bash]
 ----
 $ oc adm policy add-role-to-user <role> <user> -n <project>
 ----
@@ -31,69 +30,86 @@ $ oc adm policy add-role-to-user <role> <user> -n <project>
 For example, you can add the `admin` role to the `alice` user in `joe` project
 by running:
 +
-[source,bash]
 ----
 $ oc adm policy add-role-to-user admin alice -n joe
 ----
 
 . View the local role bindings and verify the addition in the output:
 +
-[source,bash]
 ----
 $ oc describe rolebinding.rbac -n <project>
 ----
 +
 For example, to view the local role bindings for the `joe` project:
 +
-[source,bash]
 ----
 $ oc describe rolebinding.rbac -n joe
-Name:		admin
-Labels:		<none>
-Annotations:	<none>
+Name:         admin
+Labels:       <none>
+Annotations:  <none>
 Role:
-  Kind:	ClusterRole
-  Name:	admin
+  Kind:  ClusterRole
+  Name:  admin
 Subjects:
-  Kind	Name	Namespace
-  ----	----	---------
-  User	joe
-  User	alice <1>
+  Kind  Name        Namespace
+  ----  ----        ---------
+  User  kube:admin
 
 
-Name:		system:deployers
-Labels:		<none>
-Annotations:	<none>
+Name:         admin-0
+Labels:       <none>
+Annotations:  <none>
 Role:
-  Kind:	ClusterRole
-  Name:	system:deployer
+  Kind:  ClusterRole
+  Name:  admin
 Subjects:
-  Kind			Name		Namespace
-  ----			----		---------
-  ServiceAccount	deployer	joe
+  Kind  Name   Namespace
+  ----  ----   ---------
+  User  alice <1>
 
 
-Name:		system:image-builders
-Labels:		<none>
-Annotations:	<none>
+Name:         system:deployers
+Labels:       <none>
+Annotations:  openshift.io/description:
+                Allows deploymentconfigs in this namespace to rollout pods in
+                this namespace.  It is auto-managed by a controller; remove
+                subjects to disa...
 Role:
-  Kind:	ClusterRole
-  Name:	system:image-builder
+  Kind:  ClusterRole
+  Name:  system:deployer
 Subjects:
-  Kind			Name	Namespace
-  ----			----	---------
-  ServiceAccount	builder	joe
+  Kind            Name      Namespace
+  ----            ----      ---------
+  ServiceAccount  deployer  joe
 
 
-Name:		system:image-pullers
-Labels:		<none>
-Annotations:	<none>
+Name:         system:image-builders
+Labels:       <none>
+Annotations:  openshift.io/description:
+                Allows builds in this namespace to push images to this
+                namespace.  It is auto-managed by a controller; remove subjects
+                to disable.
 Role:
-  Kind:	ClusterRole
-  Name:	system:image-puller
+  Kind:  ClusterRole
+  Name:  system:image-builder
 Subjects:
-  Kind	Name					Namespace
-  ----	----					---------
-  Group	system:serviceaccounts:joe
+  Kind            Name     Namespace
+  ----            ----     ---------
+  ServiceAccount  builder  joe
+
+
+Name:         system:image-pullers
+Labels:       <none>
+Annotations:  openshift.io/description:
+                Allows all pods in this namespace to pull images from this
+                namespace.  It is auto-managed by a controller; remove subjects
+                to disable.
+Role:
+  Kind:  ClusterRole
+  Name:  system:image-puller
+Subjects:
+  Kind   Name                                Namespace
+  ----   ----                                ---------
+  Group  system:serviceaccounts:joe
 ----
 <1> The `alice` user has been added to the `admins` `RoleBinding`.

--- a/modules/rbac-creating-cluster-role.adoc
+++ b/modules/rbac-creating-cluster-role.adoc
@@ -12,7 +12,6 @@ You can create a cluster role.
 
 . To create a cluster role, run the following command:
 +
-[source,bash]
 ----
 $ oc create clusterrole <name> --verb=<verb> --resource=<resource>
 ----

--- a/modules/rbac-creating-local-role.adoc
+++ b/modules/rbac-creating-local-role.adoc
@@ -12,7 +12,6 @@ You can create a local role for a project and then bind it to a user.
 
 . To create a local role for a project, run the following command:
 +
-[source,bash]
 ----
 $ oc create role <name> --verb=<verb> --resource=<resource> -n <project>
 ----
@@ -26,14 +25,12 @@ In this command, specify:
 For example, to create a local role that allows a user to view pods in the
 `blue` project, run the following command:
 +
-[source,bash]
 ----
 $ oc create role podview --verb=get --resource=pod -n blue
 ----
 
 . To bind the new role to a user, run the following command:
 +
-[source,bash]
 ----
 $ oc adm policy add-role-to-user podview user2 --role-namespace=blue -n blue
 ----

--- a/modules/rbac-viewing-cluster-roles.adoc
+++ b/modules/rbac-viewing-cluster-roles.adoc
@@ -13,7 +13,7 @@ You can use the `oc` CLI to view cluster roles and bindings by using the
 * Install the `oc` CLI.
 * Obtain permission to view the cluster roles and bindings.
 ifdef::openshift-dedicated[]
-Users with the *dedicated-cluster-admin* role can view cluster roles and bindings. 
+Users with the *dedicated-cluster-admin* role can view cluster roles and bindings.
 endif::[]
 
 ifdef::openshift-enterprise,openshift-origin[]
@@ -26,216 +26,197 @@ endif::[]
 . To view the cluster roles and their associated rule sets:
 +
 ifdef::openshift-enterprise,openshift-origin[]
-[source,bash]
 ----
 $ oc describe clusterrole.rbac
-Name:		admin
-Labels:		<none>
-Annotations:	openshift.io/description=A user that has edit rights within the project and can change the projects membership.
-		rbac.authorization.kubernetes.io/autoupdate=true
+Name:         admin
+Labels:       kubernetes.io/bootstrapping=rbac-defaults
+Annotations:  rbac.authorization.kubernetes.io/autoupdate: true
 PolicyRule:
-  Resources							Non-Resource URLs	Resource Names	Verbs
-  ---------							-----------------	--------------	-----
-  appliedclusterresourcequotas					[]			[]		[get list watch]
-  appliedclusterresourcequotas.quota.openshift.io		[]			[]		[get list watch]
-  bindings							[]			[]		[get list watch]
-  buildconfigs							[]			[]		[create delete deletecollection get list patch update watch]
-  buildconfigs.build.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  buildconfigs/instantiate					[]			[]		[create]
-  buildconfigs.build.openshift.io/instantiate			[]			[]		[create]
-  buildconfigs/instantiatebinary				[]			[]		[create]
-  buildconfigs.build.openshift.io/instantiatebinary		[]			[]		[create]
-  buildconfigs/webhooks						[]			[]		[create delete deletecollection get list patch update watch]
-  buildconfigs.build.openshift.io/webhooks			[]			[]		[create delete deletecollection get list patch update watch]
-  buildlogs							[]			[]		[create delete deletecollection get list patch update watch]
-  buildlogs.build.openshift.io					[]			[]		[create delete deletecollection get list patch update watch]
-  builds							[]			[]		[create delete deletecollection get list patch update watch]
-  builds.build.openshift.io					[]			[]		[create delete deletecollection get list patch update watch]
-  builds/clone							[]			[]		[create]
-  builds.build.openshift.io/clone				[]			[]		[create]
-  builds/details						[]			[]		[update]
-  builds.build.openshift.io/details				[]			[]		[update]
-  builds/log							[]			[]		[get list watch]
-  builds.build.openshift.io/log					[]			[]		[get list watch]
-  configmaps							[]			[]		[create delete deletecollection get list patch update watch]
-  cronjobs.batch						[]			[]		[create delete deletecollection get list patch update watch]
-  daemonsets.extensions						[]			[]		[get list watch]
-  deploymentconfigrollbacks					[]			[]		[create]
-  deploymentconfigrollbacks.apps.openshift.io			[]			[]		[create]
-  deploymentconfigs						[]			[]		[create delete deletecollection get list patch update watch]
-  deploymentconfigs.apps.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  deploymentconfigs/instantiate					[]			[]		[create]
-  deploymentconfigs.apps.openshift.io/instantiate		[]			[]		[create]
-  deploymentconfigs/log						[]			[]		[get list watch]
-  deploymentconfigs.apps.openshift.io/log			[]			[]		[get list watch]
-  deploymentconfigs/rollback					[]			[]		[create]
-  deploymentconfigs.apps.openshift.io/rollback			[]			[]		[create]
-  deploymentconfigs/scale					[]			[]		[create delete deletecollection get list patch update watch]
-  deploymentconfigs.apps.openshift.io/scale			[]			[]		[create delete deletecollection get list patch update watch]
-  deploymentconfigs/status					[]			[]		[get list watch]
-  deploymentconfigs.apps.openshift.io/status			[]			[]		[get list watch]
-  deployments.apps						[]			[]		[create delete deletecollection get list patch update watch]
-  deployments.extensions					[]			[]		[create delete deletecollection get list patch update watch]
-  deployments.extensions/rollback				[]			[]		[create delete deletecollection get list patch update watch]
-  deployments.apps/scale					[]			[]		[create delete deletecollection get list patch update watch]
-  deployments.extensions/scale					[]			[]		[create delete deletecollection get list patch update watch]
-  deployments.apps/status					[]			[]		[create delete deletecollection get list patch update watch]
-  endpoints							[]			[]		[create delete deletecollection get list patch update watch]
-  events							[]			[]		[get list watch]
-  horizontalpodautoscalers.autoscaling				[]			[]		[create delete deletecollection get list patch update watch]
-  horizontalpodautoscalers.extensions				[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreamimages						[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreamimages.image.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreamimports						[]			[]		[create]
-  imagestreamimports.image.openshift.io				[]			[]		[create]
-  imagestreammappings						[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreammappings.image.openshift.io			[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreams							[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreams.image.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreams/layers						[]			[]		[get update]
-  imagestreams.image.openshift.io/layers			[]			[]		[get update]
-  imagestreams/secrets						[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreams.image.openshift.io/secrets			[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreams/status						[]			[]		[get list watch]
-  imagestreams.image.openshift.io/status			[]			[]		[get list watch]
-  imagestreamtags						[]			[]		[create delete deletecollection get list patch update watch]
-  imagestreamtags.image.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  jenkins.build.openshift.io					[]			[]		[admin edit view]
-  jobs.batch							[]			[]		[create delete deletecollection get list patch update watch]
-  limitranges							[]			[]		[get list watch]
-  localresourceaccessreviews					[]			[]		[create]
-  localresourceaccessreviews.authorization.openshift.io		[]			[]		[create]
-  localsubjectaccessreviews					[]			[]		[create]
-  localsubjectaccessreviews.authorization.k8s.io		[]			[]		[create]
-  localsubjectaccessreviews.authorization.openshift.io		[]			[]		[create]
-  namespaces							[]			[]		[get list watch]
-  namespaces/status						[]			[]		[get list watch]
-  networkpolicies.extensions					[]			[]		[create delete deletecollection get list patch update watch]
-  persistentvolumeclaims					[]			[]		[create delete deletecollection get list patch update watch]
-  pods								[]			[]		[create delete deletecollection get list patch update watch]
-  pods/attach							[]			[]		[create delete deletecollection get list patch update watch]
-  pods/exec							[]			[]		[create delete deletecollection get list patch update watch]
-  pods/log							[]			[]		[get list watch]
-  pods/portforward						[]			[]		[create delete deletecollection get list patch update watch]
-  pods/proxy							[]			[]		[create delete deletecollection get list patch update watch]
-  pods/status							[]			[]		[get list watch]
-  podsecuritypolicyreviews					[]			[]		[create]
-  podsecuritypolicyreviews.security.openshift.io		[]			[]		[create]
-  podsecuritypolicyselfsubjectreviews				[]			[]		[create]
-  podsecuritypolicyselfsubjectreviews.security.openshift.io	[]			[]		[create]
-  podsecuritypolicysubjectreviews				[]			[]		[create]
-  podsecuritypolicysubjectreviews.security.openshift.io		[]			[]		[create]
-  processedtemplates						[]			[]		[create delete deletecollection get list patch update watch]
-  processedtemplates.template.openshift.io			[]			[]		[create delete deletecollection get list patch update watch]
-  projects							[]			[]		[delete get patch update]
-  projects.project.openshift.io					[]			[]		[delete get patch update]
-  replicasets.extensions					[]			[]		[create delete deletecollection get list patch update watch]
-  replicasets.extensions/scale					[]			[]		[create delete deletecollection get list patch update watch]
-  replicationcontrollers					[]			[]		[create delete deletecollection get list patch update watch]
-  replicationcontrollers/scale					[]			[]		[create delete deletecollection get list patch update watch]
-  replicationcontrollers.extensions/scale			[]			[]		[create delete deletecollection get list patch update watch]
-  replicationcontrollers/status					[]			[]		[get list watch]
-  resourceaccessreviews						[]			[]		[create]
-  resourceaccessreviews.authorization.openshift.io		[]			[]		[create]
-  resourcequotas						[]			[]		[get list watch]
-  resourcequotas/status						[]			[]		[get list watch]
-  resourcequotausages						[]			[]		[get list watch]
-  rolebindingrestrictions					[]			[]		[get list watch]
-  rolebindingrestrictions.authorization.openshift.io		[]			[]		[get list watch]
-  rolebindings							[]			[]		[create delete deletecollection get list patch update watch]
-  rolebindings.authorization.openshift.io			[]			[]		[create delete deletecollection get list patch update watch]
-  rolebindings.rbac.authorization.k8s.io			[]			[]		[create delete deletecollection get list patch update watch]
-  roles								[]			[]		[create delete deletecollection get list patch update watch]
-  roles.authorization.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  roles.rbac.authorization.k8s.io				[]			[]		[create delete deletecollection get list patch update watch]
-  routes							[]			[]		[create delete deletecollection get list patch update watch]
-  routes.route.openshift.io					[]			[]		[create delete deletecollection get list patch update watch]
-  routes/custom-host						[]			[]		[create]
-  routes.route.openshift.io/custom-host				[]			[]		[create]
-  routes/status							[]			[]		[get list watch update]
-  routes.route.openshift.io/status				[]			[]		[get list watch update]
-  scheduledjobs.batch						[]			[]		[create delete deletecollection get list patch update watch]
-  secrets							[]			[]		[create delete deletecollection get list patch update watch]
-  serviceaccounts						[]			[]		[create delete deletecollection get list patch update watch impersonate]
-  services							[]			[]		[create delete deletecollection get list patch update watch]
-  services/proxy						[]			[]		[create delete deletecollection get list patch update watch]
-  statefulsets.apps						[]			[]		[create delete deletecollection get list patch update watch]
-  subjectaccessreviews						[]			[]		[create]
-  subjectaccessreviews.authorization.openshift.io		[]			[]		[create]
-  subjectrulesreviews						[]			[]		[create]
-  subjectrulesreviews.authorization.openshift.io		[]			[]		[create]
-  templateconfigs						[]			[]		[create delete deletecollection get list patch update watch]
-  templateconfigs.template.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
-  templateinstances						[]			[]		[create delete deletecollection get list patch update watch]
-  templateinstances.template.openshift.io			[]			[]		[create delete deletecollection get list patch update watch]
-  templates							[]			[]		[create delete deletecollection get list patch update watch]
-  templates.template.openshift.io				[]			[]		[create delete deletecollection get list patch update watch]
+  Resources                                                  Non-Resource URLs  Resource Names  Verbs
+  ---------                                                  -----------------  --------------  -----
+  .packages.apps.redhat.com                                  []                 []              [* create update patch delete get list watch]
+  imagestreams                                               []                 []              [create delete deletecollection get list patch update watch create get list watch]
+  imagestreams.image.openshift.io                            []                 []              [create delete deletecollection get list patch update watch create get list watch]
+  secrets                                                    []                 []              [create delete deletecollection get list patch update watch get list watch create delete deletecollection patch update]
+  buildconfigs/webhooks                                      []                 []              [create delete deletecollection get list patch update watch get list watch]
+  buildconfigs                                               []                 []              [create delete deletecollection get list patch update watch get list watch]
+  buildlogs                                                  []                 []              [create delete deletecollection get list patch update watch get list watch]
+  deploymentconfigs/scale                                    []                 []              [create delete deletecollection get list patch update watch get list watch]
+  deploymentconfigs                                          []                 []              [create delete deletecollection get list patch update watch get list watch]
+  imagestreamimages                                          []                 []              [create delete deletecollection get list patch update watch get list watch]
+  imagestreammappings                                        []                 []              [create delete deletecollection get list patch update watch get list watch]
+  imagestreamtags                                            []                 []              [create delete deletecollection get list patch update watch get list watch]
+  processedtemplates                                         []                 []              [create delete deletecollection get list patch update watch get list watch]
+  routes                                                     []                 []              [create delete deletecollection get list patch update watch get list watch]
+  templateconfigs                                            []                 []              [create delete deletecollection get list patch update watch get list watch]
+  templateinstances                                          []                 []              [create delete deletecollection get list patch update watch get list watch]
+  templates                                                  []                 []              [create delete deletecollection get list patch update watch get list watch]
+  deploymentconfigs.apps.openshift.io/scale                  []                 []              [create delete deletecollection get list patch update watch get list watch]
+  deploymentconfigs.apps.openshift.io                        []                 []              [create delete deletecollection get list patch update watch get list watch]
+  buildconfigs.build.openshift.io/webhooks                   []                 []              [create delete deletecollection get list patch update watch get list watch]
+  buildconfigs.build.openshift.io                            []                 []              [create delete deletecollection get list patch update watch get list watch]
+  buildlogs.build.openshift.io                               []                 []              [create delete deletecollection get list patch update watch get list watch]
+  imagestreamimages.image.openshift.io                       []                 []              [create delete deletecollection get list patch update watch get list watch]
+  imagestreammappings.image.openshift.io                     []                 []              [create delete deletecollection get list patch update watch get list watch]
+  imagestreamtags.image.openshift.io                         []                 []              [create delete deletecollection get list patch update watch get list watch]
+  routes.route.openshift.io                                  []                 []              [create delete deletecollection get list patch update watch get list watch]
+  processedtemplates.template.openshift.io                   []                 []              [create delete deletecollection get list patch update watch get list watch]
+  templateconfigs.template.openshift.io                      []                 []              [create delete deletecollection get list patch update watch get list watch]
+  templateinstances.template.openshift.io                    []                 []              [create delete deletecollection get list patch update watch get list watch]
+  templates.template.openshift.io                            []                 []              [create delete deletecollection get list patch update watch get list watch]
+  serviceaccounts                                            []                 []              [create delete deletecollection get list patch update watch impersonate create delete deletecollection patch update get list watch]
+  imagestreams/secrets                                       []                 []              [create delete deletecollection get list patch update watch]
+  rolebindings                                               []                 []              [create delete deletecollection get list patch update watch]
+  roles                                                      []                 []              [create delete deletecollection get list patch update watch]
+  rolebindings.authorization.openshift.io                    []                 []              [create delete deletecollection get list patch update watch]
+  roles.authorization.openshift.io                           []                 []              [create delete deletecollection get list patch update watch]
+  imagestreams.image.openshift.io/secrets                    []                 []              [create delete deletecollection get list patch update watch]
+  rolebindings.rbac.authorization.k8s.io                     []                 []              [create delete deletecollection get list patch update watch]
+  roles.rbac.authorization.k8s.io                            []                 []              [create delete deletecollection get list patch update watch]
+  networkpolicies.extensions                                 []                 []              [create delete deletecollection patch update create delete deletecollection get list patch update watch get list watch]
+  networkpolicies.networking.k8s.io                          []                 []              [create delete deletecollection patch update create delete deletecollection get list patch update watch get list watch]
+  configmaps                                                 []                 []              [create delete deletecollection patch update get list watch]
+  endpoints                                                  []                 []              [create delete deletecollection patch update get list watch]
+  persistentvolumeclaims                                     []                 []              [create delete deletecollection patch update get list watch]
+  pods                                                       []                 []              [create delete deletecollection patch update get list watch]
+  replicationcontrollers/scale                               []                 []              [create delete deletecollection patch update get list watch]
+  replicationcontrollers                                     []                 []              [create delete deletecollection patch update get list watch]
+  services                                                   []                 []              [create delete deletecollection patch update get list watch]
+  daemonsets.apps                                            []                 []              [create delete deletecollection patch update get list watch]
+  deployments.apps/scale                                     []                 []              [create delete deletecollection patch update get list watch]
+  deployments.apps                                           []                 []              [create delete deletecollection patch update get list watch]
+  replicasets.apps/scale                                     []                 []              [create delete deletecollection patch update get list watch]
+  replicasets.apps                                           []                 []              [create delete deletecollection patch update get list watch]
+  statefulsets.apps/scale                                    []                 []              [create delete deletecollection patch update get list watch]
+  statefulsets.apps                                          []                 []              [create delete deletecollection patch update get list watch]
+  horizontalpodautoscalers.autoscaling                       []                 []              [create delete deletecollection patch update get list watch]
+  cronjobs.batch                                             []                 []              [create delete deletecollection patch update get list watch]
+  jobs.batch                                                 []                 []              [create delete deletecollection patch update get list watch]
+  daemonsets.extensions                                      []                 []              [create delete deletecollection patch update get list watch]
+  deployments.extensions/scale                               []                 []              [create delete deletecollection patch update get list watch]
+  deployments.extensions                                     []                 []              [create delete deletecollection patch update get list watch]
+  ingresses.extensions                                       []                 []              [create delete deletecollection patch update get list watch]
+  replicasets.extensions/scale                               []                 []              [create delete deletecollection patch update get list watch]
+  replicasets.extensions                                     []                 []              [create delete deletecollection patch update get list watch]
+  replicationcontrollers.extensions/scale                    []                 []              [create delete deletecollection patch update get list watch]
+  poddisruptionbudgets.policy                                []                 []              [create delete deletecollection patch update get list watch]
+  deployments.apps/rollback                                  []                 []              [create delete deletecollection patch update]
+  deployments.extensions/rollback                            []                 []              [create delete deletecollection patch update]
+  catalogsources.operators.coreos.com                        []                 []              [create update patch delete get list watch]
+  clusterserviceversions.operators.coreos.com                []                 []              [create update patch delete get list watch]
+  installplans.operators.coreos.com                          []                 []              [create update patch delete get list watch]
+  packagemanifests.operators.coreos.com                      []                 []              [create update patch delete get list watch]
+  subscriptions.operators.coreos.com                         []                 []              [create update patch delete get list watch]
+  buildconfigs/instantiate                                   []                 []              [create]
+  buildconfigs/instantiatebinary                             []                 []              [create]
+  builds/clone                                               []                 []              [create]
+  deploymentconfigrollbacks                                  []                 []              [create]
+  deploymentconfigs/instantiate                              []                 []              [create]
+  deploymentconfigs/rollback                                 []                 []              [create]
+  imagestreamimports                                         []                 []              [create]
+  localresourceaccessreviews                                 []                 []              [create]
+  localsubjectaccessreviews                                  []                 []              [create]
+  podsecuritypolicyreviews                                   []                 []              [create]
+  podsecuritypolicyselfsubjectreviews                        []                 []              [create]
+  podsecuritypolicysubjectreviews                            []                 []              [create]
+  resourceaccessreviews                                      []                 []              [create]
+  routes/custom-host                                         []                 []              [create]
+  subjectaccessreviews                                       []                 []              [create]
+  subjectrulesreviews                                        []                 []              [create]
+  deploymentconfigrollbacks.apps.openshift.io                []                 []              [create]
+  deploymentconfigs.apps.openshift.io/instantiate            []                 []              [create]
+  deploymentconfigs.apps.openshift.io/rollback               []                 []              [create]
+  localsubjectaccessreviews.authorization.k8s.io             []                 []              [create]
+  localresourceaccessreviews.authorization.openshift.io      []                 []              [create]
+  localsubjectaccessreviews.authorization.openshift.io       []                 []              [create]
+  resourceaccessreviews.authorization.openshift.io           []                 []              [create]
+  subjectaccessreviews.authorization.openshift.io            []                 []              [create]
+  subjectrulesreviews.authorization.openshift.io             []                 []              [create]
+  buildconfigs.build.openshift.io/instantiate                []                 []              [create]
+  buildconfigs.build.openshift.io/instantiatebinary          []                 []              [create]
+  builds.build.openshift.io/clone                            []                 []              [create]
+  imagestreamimports.image.openshift.io                      []                 []              [create]
+  routes.route.openshift.io/custom-host                      []                 []              [create]
+  podsecuritypolicyreviews.security.openshift.io             []                 []              [create]
+  podsecuritypolicyselfsubjectreviews.security.openshift.io  []                 []              [create]
+  podsecuritypolicysubjectreviews.security.openshift.io      []                 []              [create]
+  jenkins.build.openshift.io                                 []                 []              [edit view view admin edit view]
+  builds                                                     []                 []              [get create delete deletecollection get list patch update watch get list watch]
+  builds.build.openshift.io                                  []                 []              [get create delete deletecollection get list patch update watch get list watch]
+  projects                                                   []                 []              [get delete get delete get patch update]
+  projects.project.openshift.io                              []                 []              [get delete get delete get patch update]
+  namespaces                                                 []                 []              [get get list watch]
+  pods/attach                                                []                 []              [get list watch create delete deletecollection patch update]
+  pods/exec                                                  []                 []              [get list watch create delete deletecollection patch update]
+  pods/portforward                                           []                 []              [get list watch create delete deletecollection patch update]
+  pods/proxy                                                 []                 []              [get list watch create delete deletecollection patch update]
+  services/proxy                                             []                 []              [get list watch create delete deletecollection patch update]
+  routes/status                                              []                 []              [get list watch update]
+  routes.route.openshift.io/status                           []                 []              [get list watch update]
+  appliedclusterresourcequotas                               []                 []              [get list watch]
+  bindings                                                   []                 []              [get list watch]
+  builds/log                                                 []                 []              [get list watch]
+  deploymentconfigs/log                                      []                 []              [get list watch]
+  deploymentconfigs/status                                   []                 []              [get list watch]
+  events                                                     []                 []              [get list watch]
+  imagestreams/status                                        []                 []              [get list watch]
+  limitranges                                                []                 []              [get list watch]
+  namespaces/status                                          []                 []              [get list watch]
+  pods/log                                                   []                 []              [get list watch]
+  pods/status                                                []                 []              [get list watch]
+  replicationcontrollers/status                              []                 []              [get list watch]
+  resourcequotas/status                                      []                 []              [get list watch]
+  resourcequotas                                             []                 []              [get list watch]
+  resourcequotausages                                        []                 []              [get list watch]
+  rolebindingrestrictions                                    []                 []              [get list watch]
+  deploymentconfigs.apps.openshift.io/log                    []                 []              [get list watch]
+  deploymentconfigs.apps.openshift.io/status                 []                 []              [get list watch]
+  controllerrevisions.apps                                   []                 []              [get list watch]
+  rolebindingrestrictions.authorization.openshift.io         []                 []              [get list watch]
+  builds.build.openshift.io/log                              []                 []              [get list watch]
+  imagestreams.image.openshift.io/status                     []                 []              [get list watch]
+  appliedclusterresourcequotas.quota.openshift.io            []                 []              [get list watch]
+  imagestreams/layers                                        []                 []              [get update get]
+  imagestreams.image.openshift.io/layers                     []                 []              [get update get]
+  builds/details                                             []                 []              [update]
+  builds.build.openshift.io/details                          []                 []              [update]
 
 
-Name:		basic-user
-Labels:		<none>
-Annotations:	openshift.io/description=A user that can get basic information about projects.
-		rbac.authorization.kubernetes.io/autoupdate=true
+Name:         basic-user
+Labels:       <none>
+Annotations:  openshift.io/description: A user that can get basic information about projects.
+	              rbac.authorization.kubernetes.io/autoupdate: true
 PolicyRule:
-  Resources						Non-Resource URLs	Resource Names	Verbs
-  ---------						-----------------	--------------	-----
-  clusterroles						[]			[]		[get list]
-  clusterroles.authorization.openshift.io		[]			[]		[get list]
-  clusterroles.rbac.authorization.k8s.io		[]			[]		[get list watch]
-  projectrequests					[]			[]		[list]
-  projectrequests.project.openshift.io			[]			[]		[list]
-  projects						[]			[]		[list watch]
-  projects.project.openshift.io				[]			[]		[list watch]
-  selfsubjectaccessreviews.authorization.k8s.io		[]			[]		[create]
-  selfsubjectrulesreviews				[]			[]		[create]
-  selfsubjectrulesreviews.authorization.openshift.io	[]			[]		[create]
-  storageclasses.storage.k8s.io				[]			[]		[get list]
-  users							[]			[~]		[get]
-  users.user.openshift.io				[]			[~]		[get]
+	Resources                                           Non-Resource URLs  Resource Names  Verbs
+	  ---------                                           -----------------  --------------  -----
+	  selfsubjectrulesreviews                             []                 []              [create]
+	  selfsubjectaccessreviews.authorization.k8s.io       []                 []              [create]
+	  selfsubjectrulesreviews.authorization.openshift.io  []                 []              [create]
+	  clusterroles.rbac.authorization.k8s.io              []                 []              [get list watch]
+	  clusterroles                                        []                 []              [get list]
+	  clusterroles.authorization.openshift.io             []                 []              [get list]
+	  storageclasses.storage.k8s.io                       []                 []              [get list]
+	  users                                               []                 [~]             [get]
+	  users.user.openshift.io                             []                 [~]             [get]
+	  projects                                            []                 []              [list watch]
+	  projects.project.openshift.io                       []                 []              [list watch]
+	  projectrequests                                     []                 []              [list]
+	  projectrequests.project.openshift.io                []                 []              [list]
 
-
-Name:		cluster-admin
-Labels:		<none>
-Annotations:	authorization.openshift.io/system-only=true
-		openshift.io/description=A super-user that can perform any action in the cluster. When granted to a user within a project, they have full control over quota and membership and can perform every action...
-		rbac.authorization.kubernetes.io/autoupdate=true
+Name:         cluster-admin
+Labels:       kubernetes.io/bootstrapping=rbac-defaults
+Annotations:  rbac.authorization.kubernetes.io/autoupdate: true
 PolicyRule:
-  Resources	Non-Resource URLs	Resource Names	Verbs
-  ---------	-----------------	--------------	-----
-  		[*]			[]		[*]
-  *.*		[]			[]		[*]
-
-
-Name:		cluster-debugger
-Labels:		<none>
-Annotations:	authorization.openshift.io/system-only=true
-		rbac.authorization.kubernetes.io/autoupdate=true
-PolicyRule:
-  Resources	Non-Resource URLs	Resource Names	Verbs
-  ---------	-----------------	--------------	-----
-  		[/debug/pprof]		[]		[get]
-  		[/debug/pprof/*]	[]		[get]
-  		[/metrics]		[]		[get]
-
-
-Name:		cluster-reader
-Labels:		<none>
-Annotations:	authorization.openshift.io/system-only=true
-		rbac.authorization.kubernetes.io/autoupdate=true
-PolicyRule:
-  Resources							Non-Resource URLs	Resource Names	Verbs
-  ---------							-----------------	--------------	-----
-  								[*]			[]		[get]
-  apiservices.apiregistration.k8s.io				[]			[]		[get list watch]
-  apiservices.apiregistration.k8s.io/status			[]			[]		[get list watch]
-  appliedclusterresourcequotas					[]			[]		[get list watch]
+Resources  Non-Resource URLs  Resource Names  Verbs
+---------  -----------------  --------------  -----
+*.*        []                 []              [*]
+           [*]                []              [*]
 
 ...
 
 ----
 endif::[]
 ifdef::openshift-dedicated[]
-[source,bash]
 ----
 $ oc describe clusterrole.rbac
 ----
@@ -245,215 +226,84 @@ endif::[]
 groups that are bound to various roles:
 +
 ifdef::openshift-enterprise,openshift-origin[]
-[source,bash]
 ----
 $ oc describe clusterrolebinding.rbac
-Name:		admin
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Name:         alertmanager-main
+Labels:       <none>
+Annotations:  <none>
 Role:
-  Kind:	ClusterRole
-  Name:	admin
+  Kind:  ClusterRole
+  Name:  alertmanager-main
 Subjects:
-  Kind			Name				Namespace
-  ----			----				---------
-  ServiceAccount	template-instance-controller	openshift-infra
+  Kind            Name               Namespace
+  ----            ----               ---------
+  ServiceAccount  alertmanager-main  openshift-monitoring
 
 
-Name:		basic-users
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Name:         basic-users
+Labels:       <none>
+Annotations:  rbac.authorization.kubernetes.io/autoupdate: true
 Role:
-  Kind:	ClusterRole
-  Name:	basic-user
+  Kind:  ClusterRole
+  Name:  basic-user
 Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
+  Kind   Name                  Namespace
+  ----   ----                  ---------
+  Group  system:authenticated
 
 
-Name:		cluster-admin
-Labels:		kubernetes.io/bootstrapping=rbac-defaults
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Name:         cloud-credential-operator-rolebinding
+Labels:       <none>
+Annotations:  <none>
 Role:
-  Kind:	ClusterRole
-  Name:	cluster-admin
+  Kind:  ClusterRole
+  Name:  cloud-credential-operator-role
 Subjects:
-  Kind			Name		Namespace
-  ----			----		---------
-  ServiceAccount	pvinstaller	default
-  Group			system:masters
+  Kind            Name     Namespace
+  ----            ----     ---------
+  ServiceAccount  default  openshift-cloud-credential-operator
 
 
-Name:		cluster-admins
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Name:         cluster-admin
+Labels:       kubernetes.io/bootstrapping=rbac-defaults
+Annotations:  rbac.authorization.kubernetes.io/autoupdate: true
 Role:
-  Kind:	ClusterRole
-  Name:	cluster-admin
+  Kind:  ClusterRole
+  Name:  cluster-admin
 Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:cluster-admins
-  User	system:admin
+  Kind   Name            Namespace
+  ----   ----            ---------
+  Group  system:masters
 
 
-Name:		cluster-readers
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Name:         cluster-admins
+Labels:       <none>
+Annotations:  rbac.authorization.kubernetes.io/autoupdate: true
 Role:
-  Kind:	ClusterRole
-  Name:	cluster-reader
+  Kind:  ClusterRole
+  Name:  cluster-admin
 Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:cluster-readers
+  Kind   Name                   Namespace
+  ----   ----                   ---------
+  Group  system:cluster-admins
+  User   system:admin
 
 
-Name:		cluster-status-binding
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+Name:         cluster-api-manager-rolebinding
+Labels:       <none>
+Annotations:  <none>
 Role:
-  Kind:	ClusterRole
-  Name:	cluster-status
+  Kind:  ClusterRole
+  Name:  cluster-api-manager-role
 Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
-  Group	system:unauthenticated
-
-
-Name:		registry-registry-role
-Labels:		<none>
-Annotations:	<none>
-Role:
-  Kind:	ClusterRole
-  Name:	system:registry
-Subjects:
-  Kind			Name		Namespace
-  ----			----		---------
-  ServiceAccount	registry	default
-
-
-Name:		router-router-role
-Labels:		<none>
-Annotations:	<none>
-Role:
-  Kind:	ClusterRole
-  Name:	system:router
-Subjects:
-  Kind			Name	Namespace
-  ----			----	---------
-  ServiceAccount	router	default
-
-
-Name:		self-access-reviewers
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	self-access-reviewer
-Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
-  Group	system:unauthenticated
-
-
-Name:		self-provisioners
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	self-provisioner
-Subjects:
-  Kind	Name				Namespace
-  ----	----				---------
-  Group	system:authenticated:oauth
-
-
-Name:		system:basic-user
-Labels:		kubernetes.io/bootstrapping=rbac-defaults
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	system:basic-user
-Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
-  Group	system:unauthenticated
-
-
-Name:		system:build-strategy-docker-binding
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	system:build-strategy-docker
-Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
-
-
-Name:		system:build-strategy-jenkinspipeline-binding
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	system:build-strategy-jenkinspipeline
-Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
-
-
-Name:		system:build-strategy-source-binding
-Labels:		<none>
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	system:build-strategy-source
-Subjects:
-  Kind	Name			Namespace
-  ----	----			---------
-  Group	system:authenticated
-
-
-Name:		system:controller:attachdetach-controller
-Labels:		kubernetes.io/bootstrapping=rbac-defaults
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	system:controller:attachdetach-controller
-Subjects:
-  Kind			Name			Namespace
-  ----			----			---------
-  ServiceAccount	attachdetach-controller	kube-system
-
-
-Name:		system:controller:certificate-controller
-Labels:		kubernetes.io/bootstrapping=rbac-defaults
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
-Role:
-  Kind:	ClusterRole
-  Name:	system:controller:certificate-controller
-Subjects:
-  Kind			Name			Namespace
-  ----			----			---------
-  ServiceAccount	certificate-controller	kube-system
-
-
-Name:		system:controller:cronjob-controller
-Labels:		kubernetes.io/bootstrapping=rbac-defaults
-Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
+  Kind            Name     Namespace
+  ----            ----     ---------
+  ServiceAccount  default  openshift-machine-api
 
 ...
 ----
 endif::[]
 ifdef::openshift-dedicated[]
-[source,bash]
 ----
 $ oc describe clusterrolebinding.rbac
 ----

--- a/modules/rbac-viewing-local-roles.adoc
+++ b/modules/rbac-viewing-local-roles.adoc
@@ -14,15 +14,15 @@ You can use the `oc` CLI to view local roles and bindings by using the
 * Obtain permission to view the local roles and bindings:
 
 ifdef::openshift-dedicated[]
-** Users with the *dedicated-cluster-admin* role can view and manage local roles and bindings. 
+** Users with the `dedicated-cluster-admin` role can view and manage local roles and bindings.
 endif::[]
 
 ifdef::openshift-enterprise,openshift-origin[]
-** Users with the *cluster-admin* default cluster role bound cluster-wide can
+** Users with the `cluster-admin` default cluster role bound cluster-wide can
 perform any action on any resource, including viewing local roles and bindings.
 endif::[]
 
-** Users with the *admin* default cluster role bound locally can view and manage
+** Users with the `admin` default cluster role bound locally can view and manage
 roles and bindings in that project.
 
 .Procedure
@@ -30,7 +30,6 @@ roles and bindings in that project.
 . To view the current set of local role bindings, which show the users and groups
 that are bound to various roles for the current project:
 +
-[source,bash]
 ----
 $ oc describe rolebinding.rbac
 ----
@@ -38,53 +37,61 @@ $ oc describe rolebinding.rbac
 . To view the local role bindings for a different project, add the `-n` flag
 to the command:
 +
-[source,bash]
 ----
 $ oc describe rolebinding.rbac -n joe-project
-Name:		admin
-Labels:		<none>
-Annotations:	<none>
+Name:         admin
+Labels:       <none>
+Annotations:  <none>
 Role:
-  Kind:	ClusterRole
-  Name:	admin
+  Kind:  ClusterRole
+  Name:  admin
 Subjects:
-  Kind	Name	Namespace
-  ----	----	---------
-  User	joe
+  Kind  Name        Namespace
+  ----  ----        ---------
+  User  kube:admin
 
 
-Name:		system:deployers
-Labels:		<none>
-Annotations:	<none>
+Name:         system:deployers
+Labels:       <none>
+Annotations:  openshift.io/description:
+                Allows deploymentconfigs in this namespace to rollout pods in
+                this namespace.  It is auto-managed by a controller; remove
+                subjects to disa...
 Role:
-  Kind:	ClusterRole
-  Name:	system:deployer
+  Kind:  ClusterRole
+  Name:  system:deployer
 Subjects:
-  Kind			Name		Namespace
-  ----			----		---------
-  ServiceAccount	deployer	joe-project
+  Kind            Name      Namespace
+  ----            ----      ---------
+  ServiceAccount  deployer  joe-project
 
 
-Name:		system:image-builders
-Labels:		<none>
-Annotations:	<none>
+Name:         system:image-builders
+Labels:       <none>
+Annotations:  openshift.io/description:
+                Allows builds in this namespace to push images to this
+                namespace.  It is auto-managed by a controller; remove subjects
+                to disable.
 Role:
-  Kind:	ClusterRole
-  Name:	system:image-builder
+  Kind:  ClusterRole
+  Name:  system:image-builder
 Subjects:
-  Kind			Name	Namespace
-  ----			----	---------
-  ServiceAccount	builder	joe-project
+  Kind            Name     Namespace
+  ----            ----     ---------
+  ServiceAccount  builder  joe-project
 
 
-Name:		system:image-pullers
-Labels:		<none>
-Annotations:	<none>
+Name:         system:image-pullers
+Labels:       <none>
+Annotations:  openshift.io/description:
+                Allows all pods in this namespace to pull images from this
+                namespace.  It is auto-managed by a controller; remove subjects
+                to disable.
 Role:
-  Kind:	ClusterRole
-  Name:	system:image-puller
+  Kind:  ClusterRole
+  Name:  system:image-puller
 Subjects:
-  Kind	Name					Namespace
-  ----	----					---------
-  Group	system:serviceaccounts:joe-project
+  Kind   Name                                Namespace
+  ----   ----                                ---------
+  Group  system:serviceaccounts:joe-project
 ----


### PR DESCRIPTION
Updated the RBAC outputs from a 4.0 cluster.

While the majority of outputs render fine locally, the ones under "Viewing cluster roles and bindings" are heinous. I've attempted to add the `options="nowrap"` attribute to this source block in an effort to increase readability. Suggestions for this block would be welcome.

This is for 4.0.