### PR TITLE
Use openshift-ansible rpm instead of atomic-openshift-utils rpm

### DIFF
--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -203,7 +203,7 @@ method used during
 xref:../install/running_install.adoc#install-running-installation-playbooks[cluster installations]) or as a link:https://github.com/openshift/openshift-ansible/blob/master/README_CONTAINER_IMAGE.md[containerized version] of *openshift-ansible*. For the `ansible-playbook` method, the checks
 are provided by the
 ifdef::openshift-enterprise[]
-*atomic-openshift-utils* RPM package.
+*openshift-ansible* RPM package.
 endif::[]
 ifdef::openshift-origin[]
 xref:../install/host_preparation.adoc#preparing-for-advanced-installations-origin[*openshift-ansible*]

--- a/day_two_guide/topics/adding_master_host.adoc
+++ b/day_two_guide/topics/adding_master_host.adoc
@@ -34,11 +34,11 @@ masters configuration file to customize the *{rhocp}* authentication provider as
 
 ==== Procedure
 The latest `Ansible` playbooks must be available on the host that is going to do
-the scale up procedure (a workstation or the bastion host) by updating the `atomic-openshift-utils` package:
+the scale up procedure (a workstation or the bastion host) by updating the `openshift-ansible` package:
 
 [subs=+quotes]
 ----
-# *yum update atomic-openshift-utils*
+# *yum update openshift-ansible*
 ----
 
 *Inventory File*
@@ -96,8 +96,9 @@ master3.example.com | SUCCESS | rc=0 >>
 
 *Scaleup Playbook*
 
-Once the inventory has been defined, the scale up process is performed by an `Ansible` playbook included in the `atomic-openshift-utils`
-using the `Ansible` host file. Change to the playbook directory and run the *_scaleup.yml_* playbook:
+Once the inventory has been defined, the scale up process is performed by an
+`Ansible` playbook included in the `openshift-ansible` using the `Ansible` host
+file. Change to the playbook directory and run the *_scaleup.yml_* playbook:
 
 [subs=+quotes]
 ----

--- a/day_two_guide/topics/adding_node_host.adoc
+++ b/day_two_guide/topics/adding_node_host.adoc
@@ -30,11 +30,11 @@ to the *{rhocp}* configuration files, for example, modifying the *{rhocp}* node 
 
 ==== Procedure
 The latest `Ansible` playbooks should be available on the host that is going to do
-the scale up procedure (a workstation or the bastion host) by updating the `atomic-openshift-utils` package:
+the scale up procedure (a workstation or the bastion host) by updating the `openshift-ansible` package:
 
 [subs=+quotes]
 ----
-# *yum update atomic-openshift-utils*
+# *yum update openshift-ansible*
 ----
 
 *Inventory File*
@@ -90,7 +90,7 @@ node05.example.com | SUCCESS | rc=0 >>
 ----
 
 After the inventory has been updated, the scale up process can be performed
-by an `Ansible` playbook included in the `atomic-openshift-utils` using the `Ansible` host file.
+by an `Ansible` playbook included in the `openshift-ansible` using the `Ansible` host file.
 Change to the playbook directory and run the *_scaleup.yml_* playbook:
 
 [subs=+quotes]

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -27,11 +27,11 @@ preparation] steps.
 
 To add an etcd host to an existing cluster:
 
-. Ensure you have the latest playbooks by updating the *atomic-openshift-utils* package:
+. Ensure you have the latest playbooks by updating the *openshift-ansible* package:
 +
 [source, bash]
 ----
-$ yum update atomic-openshift-utils
+$ yum update openshift-ansible
 ----
 
 . Edit your *_/etc/ansible/hosts_* file, add *new_<host_type>* to the

--- a/install_config/imagestreams_templates.adoc
+++ b/install_config/imagestreams_templates.adoc
@@ -161,7 +161,7 @@ $ git clone https://github.com/openshift/openshift-ansible
 ----
 endif::[]
 ifdef::openshift-enterprise[]
-- You must have installed the *atomic-openshift-utils* RPM package. See
+- You must have installed the *openshift-ansible* RPM package. See
 xref:../install/host_preparation.adoc#software-prerequisites[Software Prerequisites]
 for instructions.
 endif::[]

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -255,7 +255,7 @@ cluster configuration:
 The playbooks you need are provided by:
 
 ----
-# yum install atomic-openshift-utils
+# yum install openshift-ansible
 ----
 
 [NOTE]


### PR DESCRIPTION
@openshift/team-documentation, opening this PR based upon the following discussion on IRC:

> [13:29:30]  jboxman	So, at some point in the past, atomic-openshift-utils was renamed to openshift-ansible: We reference the former in a few places. Is this something that is a problem?
> [13:46:19]  alexd	https://docs.openshift.com/container-platform/3.10/install/host_preparation.html#installing-base-packages
> [13:46:25]  alexd	"    
> [13:46:25]  alexd	In previous OpenShift Container Platform releases, the atomic-openshift-utils package was installed for this step. However, starting with OpenShift Container Platform 3.10, that package is removed and the openshift-ansible package provides all requirements."
> [13:46:26]  alexd	^ jboxman 
> [13:46:48]  alexd	so yea, for 3.10+ we shouldn't refer to -utils anyomre
> 

PTAL, thanks!