### PR TITLE
OSDOCS-248: Including EBS Persistent Storage.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -268,6 +268,8 @@ Distros: openshift-*
 Topics:
 - Name: Optimizing storage
   File: optimizing-storage
+- Name: Persistent Storage Using AWS
+  File: persistent-storage-aws
 ---
 Name: Nodes
 Dir: nodes

--- a/modules/storage-create-storage-class.adoc
+++ b/modules/storage-create-storage-class.adoc
@@ -1,0 +1,40 @@
+// Be sure to set the :StorageClass: and :Provisioner: value in each assembly
+// on the line before the include statement for this module. For example, to
+// set the StorageClass value to "AWS EBS", add the following line to the
+// assembly:
+// :StorageClass: AWS EBS
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage-aws.adoc
+
+
+
+[id='storage-create-{StorageClass}-storage-class']
+= Creating the {StorageClass} Storage Class
+
+StorageClasses are used to differentiate and delineate storage levels and
+usages. By defining a storage class, users can obtain dynamically provisioned
+persistent volumes.
+
+.Procedure
+
+. In the {product-title} console, click *Storage* -> *Storage Classes*.
+
+. In the storage class overview, click *Create Storage Class*.
+
+. Define the desired options on the page that appears.
+
+.. Enter a name to reference the storage class.
+
+.. Enter an optional description.
+
+.. Select the reclaim policy.
+
+.. Select {Provisioner} from the drop down list.
+
+.. Enter additional parameters for the storage class as desired.
+
+. Click *Create* to create the storage class.
+
+// Undefine {StorageClass} attribute, so that any mistakes are easily spotted
+:!StorageClass:

--- a/modules/storage-persistent-storage-aws-maximum-volumes.adoc
+++ b/modules/storage-persistent-storage-aws-maximum-volumes.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage-aws.adoc
+
+[[maximum-number-of-ebs-volumes-on-a-node]]
+= Maximum Number of EBS Volumes on a Node
+
+By default, {product-title} supports a maximum of 39 EBS volumes attached to one
+node. This limit is consistent with the
+link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits[AWS
+volume limits].
+
+{product-title} can be configured to have a higher limit by setting the
+environment variable `KUBE_MAX_PD_VOLS`. However, AWS requires a particular
+naming scheme
+(link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html[AWS
+Device Naming]) for attached devices, which only supports a maximum of 52
+volumes. This limits the number of volumes that can be attached to a node via
+{product-title} to 52.

--- a/modules/storage-persistent-storage-aws-volume-format.adoc
+++ b/modules/storage-persistent-storage-aws-volume-format.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage-aws.adoc
+
+[[volume-format-aws]]
+= Volume Format
+Before {product-title} mounts the volume and passes it to a container, it checks
+that it contains a file system as specified by the `fsType` parameter in the
+persistent volume definition. If the device is not formatted with the file
+system, all data from the device is erased and the device is automatically
+formatted with the given file system.
+
+This allows using unformatted AWS volumes as persistent volumes, because
+{product-title} formats them before the first use.

--- a/modules/storage-persistent-storage-creating-volume-claim.adoc
+++ b/modules/storage-persistent-storage-creating-volume-claim.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage-aws.adoc
+
+= Creating the Persistent Volume Claim
+
+.Prerequisites
+
+Storage must exist in the underlying infrastructure before it can be mounted as
+a volume in {product-title}.
+
+.Procedure
+
+. In the {product-title} console, click *Storage* -> *Persistent Volume Claims*.
+
+. In the persistent volume claims overview, click *Create Persistent Volume
+Claim*.
+
+. Define the desired options on the page that appears.
+
+.. Select the storage class created previously from the drop-down menu.
+
+.. Enter a unique name for the storage claim.
+
+.. Select the access mode. This determines the read and write access for the
+created storage claim.
+
+.. Define the size of the storage claim.
+
+. Click *Create* to create the persistent volume claim and generate a persistent
+volume.

--- a/storage/persistent-storage-aws.adoc
+++ b/storage/persistent-storage-aws.adoc
@@ -1,0 +1,42 @@
+[id='persistent-storage-using-aws-ebs']
+= Persistent Storage Using AWS Elastic Block Store
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-aws
+
+toc::[]
+
+{product-title} supports AWS Elastic Block Store volumes (EBS). You can
+provision your {product-title} cluster with persistent storage using AWS EC2.
+Some familiarity with Kubernetes and AWS is assumed.
+
+The Kubernetes persistent volume framework allows administrators to provision a
+cluster with persistent storage and gives users a way to request those
+resources without having any knowledge of the underlying infrastructure.
+AWS Elastic Block Store volumes can be provisioned dynamically.
+Persistent volumes are not bound to a single project or namespace; they can be
+shared across the {product-title} cluster.
+Persistent volume claims are specific to a project or namespace and can be
+requested by users.
+
+[IMPORTANT]
+====
+High-availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
+.Additional References
+
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html[Amazon
+EC2]
+
+// Defining attributes required by the next module
+:StorageClass: EBS
+:Provisioner: kubernetes.io/aws-ebs
+
+include::modules/storage-create-storage-class.adoc[leveloffset=+1]
+
+include::modules/storage-persistent-storage-creating-volume-claim.adoc[leveloffset=+1]
+
+include::modules/storage-persistent-storage-aws-volume-format.adoc[leveloffset=+1]
+
+include::modules/storage-persistent-storage-aws-maximum-volumes.adoc[leveloffset=+1]


### PR DESCRIPTION
OSDOCS-248: This includes instructions for configuring AWS EBS persistent storage.

The current content is fairly minimal, and any suggestions or advice would be appreciated.

This is for 4.0.