### PR TITLE
OSDOCS-241: Add the admin CLI commands

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -443,6 +443,9 @@ Topics:
 #Topics:
 #- Name: Developer CLI commands
 #  File: developer-cli-commands
+#- Name: Administrator CLI commands
+#  File: administrator-cli-commands
+#  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
 ---
 Name: Monitoring
 Dir: monitoring

--- a/cli_reference/administrator-cli-commands.adoc
+++ b/cli_reference/administrator-cli-commands.adoc
@@ -1,0 +1,24 @@
+[id='cli-administrator-commands']
+= Administrator CLI commands
+include::modules/common-attributes.adoc[]
+:context: cli-administrator-commands
+
+toc::[]
+
+// Cluster management CLI commands
+include::modules/cli-administrator-cluster-management.adoc[leveloffset=+1]
+
+// Node management CLI commands
+include::modules/cli-administrator-node-management.adoc[leveloffset=+1]
+
+// Security and policy CLI commands
+include::modules/cli-administrator-security-policy.adoc[leveloffset=+1]
+
+// Maintenance CLI commands
+include::modules/cli-administrator-maintenance.adoc[leveloffset=+1]
+
+// Configuration CLI commands
+include::modules/cli-administrator-configuration.adoc[leveloffset=+1]
+
+// Other administrator CLI commands
+include::modules/cli-administrator-other.adoc[leveloffset=+1]

--- a/modules/cli-administrator-cluster-management.adoc
+++ b/modules/cli-administrator-cluster-management.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/administrator-cli-commands.adoc
+
+[id='cli-cluster-management-commands-{context}']
+= Cluster management CLI commands
+
+== top
+
+Show usage statistics of resources on the server.
+
+.Example: Show CPU and memory usage for Pods
+----
+$ oc adm top pods
+----
+
+.Example: Show usage statistics for images
+----
+$ oc adm top images
+----
+
+== upgrade
+
+Upgrade the cluster to a newer version.
+
+.Example: Upgrade the cluster to version 4.0.1
+----
+$ oc adm upgrade --to=4.0.1
+----

--- a/modules/cli-administrator-configuration.adoc
+++ b/modules/cli-administrator-configuration.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/administrator-cli-commands.adoc
+
+[id='cli-configuration-commands-{context}']
+= Configuration CLI commands
+
+== create-api-client-config
+
+Create a client configuration for connecting to the server. This creates a
+folder containing a client certificate, a client key, a server certificate
+authority, and a `kubeconfig` file for connecting to the master as the provided
+user.
+
+.Example: Generate a client certificate for a proxy
+----
+$ oc adm create-api-client-config \
+  --certificate-authority='/etc/origin/master/proxyca.crt' \
+  --client-dir='/etc/origin/master/proxy' \
+  --signer-cert='/etc/origin/master/proxyca.crt' \
+  --signer-key='/etc/origin/master/proxyca.key' \
+  --signer-serial='/etc/origin/master/proxyca.serial.txt' \
+  --user='system:proxy'
+----
+
+== create-bootstrap-policy-file
+
+Create the default bootstrap policy.
+
+.Example: Create a file called `policy.json` with the default bootstrap policy
+----
+$ oc adm create-bootstrap-policy-file --filename=policy.json
+----
+
+== create-bootstrap-project-template
+
+Create a bootstrap project template.
+
+.Example: Output a bootstrap project template in YAML format to stdout
+----
+$ oc adm create-bootstrap-project-template -o yaml
+----
+
+== create-error-template
+
+Create a template for customizing the error page.
+
+.Example: Output a template for the error page to stdout
+----
+$ oc adm create-error-template
+----
+
+== create-kubeconfig
+
+Creates a basic `.kubeconfig` file from client certificates.
+
+.Example: Create a `.kubeconfig` file with the provided client certificates
+----
+$ oc adm create-kubeconfig \
+  --client-certificate=/path/to/client.crt \
+  --client-key=/path/to/client.key \
+  --certificate-authority=/path/to/ca.crt
+----
+
+== create-login-template
+
+Create a template for customizing the login page.
+
+.Example: Output a template for the login page to stdout
+----
+$ oc adm create-login-template
+----
+
+== create-provider-selection-template
+
+Create a template for customizing the provider selection page.
+
+.Example: Output a template for the provider selection page to stdout
+----
+$ oc adm create-provider-selection-template
+----

--- a/modules/cli-administrator-maintenance.adoc
+++ b/modules/cli-administrator-maintenance.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/administrator-cli-commands.adoc
+
+[id='cli-maintenance-commands-{context}']
+= Maintenance CLI commands
+
+== migrate
+
+Migrate resources on the cluster to a new version or format depending on the
+subcommand used.
+
+.Example: Perform an update of all stored objects
+----
+$ oc adm migrate storage
+----
+
+.Example: Perform an update of only Pods
+----
+$ oc adm migrate storage --include=pods
+----
+
+== prune
+
+Remove older versions of resources from the server.
+
+.Example: Prune older builds including those whose BuildConfigs no longer exist
+----
+$ oc adm prune builds --orphans
+----

--- a/modules/cli-administrator-node-management.adoc
+++ b/modules/cli-administrator-node-management.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/administrator-cli-commands.adoc
+
+[id='cli-node-management-commands-{context}']
+= Node management CLI commands
+
+== cordon
+
+Mark a node as unschedulable. Manually marking a node as unschedulable blocks
+any new pods from being scheduled on the node, but does not affect existing pods
+on the node.
+
+.Example: Mark `node1` as unschedulable
+----
+$ oc adm cordon node1
+----
+
+== drain
+
+Drain a node in preparation for maintenance.
+
+.Example: Drain `node1`
+----
+$ oc adm drain node1
+----
+
+== node-logs
+
+Display and filter node logs.
+
+.Example: Get logs for NetworkManager
+----
+$ oc adm node-logs --role master -u NetworkManager.service
+----
+
+== taint
+
+Update the taints on one or more nodes.
+
+.Example: Add a taint to dedicate a node for a set of users
+----
+$ oc adm taint nodes node1 dedicated=groupName:NoSchedule
+----
+
+.Example: Remove the taints with key `dedicated` from node `node1`
+----
+$ oc adm taint nodes node1 dedicated-
+----
+
+== uncordon
+
+Mark a node as schedulable.
+
+.Example: Mark `node1` as schedulable
+----
+$ $ oc adm uncordon node1
+----

--- a/modules/cli-administrator-other.adoc
+++ b/modules/cli-administrator-other.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/administrator-cli-commands.adoc
+
+[id='cli-other-administrator-commands-{context}']
+= Other Administrator CLI commands
+
+== build-chain
+
+Output the inputs and dependencies of any builds.
+
+.Example: Output dependencies for the `perl` image stream
+----
+$ oc adm build-chain perl
+----
+
+== completion
+
+Output shell completion code for the `oc adm` commands for the specified shell.
+
+.Example: Display `oc adm` completion code for Bash
+----
+$ oc adm completion bash
+----
+
+== config
+
+Manage the client configuration files. This command has the same behavior as the
+`oc config` command.
+
+.Example: Display the current configuration
+----
+$ oc adm config view
+----
+
+.Example: Switch to a different context
+----
+$ oc adm config use-context test-context
+----
+
+== verify-image-signature
+
+Verify the image signature of an image imported to the internal registry using
+the local public GPG key.
+
+.Example: Verify the `nodejs` image signature
+----
+$ oc adm verify-image-signature \
+    sha256:2bba968aedb7dd2aafe5fa8c7453f5ac36a0b9639f1bf5b03f95de325238b288 \
+    --expected-identity 172.30.1.1:5000/openshift/nodejs:latest \
+    --public-key /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release \
+    --save
+----

--- a/modules/cli-administrator-security-policy.adoc
+++ b/modules/cli-administrator-security-policy.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/administrator-cli-commands.adoc
+
+[id='cli-security-policy-commands-{context}']
+= Security and policy CLI commands
+
+== certificate
+
+Approve or reject certificate signing requests (CSRs).
+
+.Example: Approve a CSR
+----
+$ oc adm certificate approve csr-sqgzp
+----
+
+== groups
+
+Manage groups in your cluster.
+
+.Example: Create a new group
+----
+$ oc adm groups new my-group
+----
+
+== new-project
+
+Create a new project and specify administrative options.
+
+.Example: Create a new project using a node selector
+----
+$ oc adm new-project myproject --node-selector='type=user-node,region=east'
+----
+
+== pod-network
+
+Manage Pod networks in the cluster.
+
+.Example: Isolate project1 and project2 from other non-global projects
+----
+$ oc adm pod-network isolate-projects project1 project2
+----
+
+== policy
+
+Manage roles and policies on the cluster.
+
+.Example: Add the `edit` role to `user1` for all projects
+----
+$ oc adm policy add-cluster-role-to-user edit user1
+----
+
+.Example: Add the `privileged` security context constraint to a service account
+----
+$ oc adm policy add-scc-to-user privileged -z myserviceaccount
+----

--- a/modules/cli-developer-settings.adoc
+++ b/modules/cli-developer-settings.adoc
@@ -9,7 +9,7 @@
 
 Output shell completion code for the specified shell.
 
-.Example: Display completion code for bash
+.Example: Display completion code for Bash
 ----
 $ oc completion bash
 ----


### PR DESCRIPTION
@openshift/team-documentation For peer review. This section should apply to all distros except dedicated.

Marking WIP because we're commenting out CLI sections for the first round of reviews, and will need to update the _topic_map.yml once @vikram-redhat comments out all of the other existing sections that don't apply for the first round.

Preview: http://file.rdu.redhat.com/~ahoffer/2019/OSDOCS-241-cli-adm/cli_reference/administrator-cli-commands.html