### PR TITLE
Installing an Operator using the command line and expanded OperatorHub (Marketplace) descriptions 

### DIFF
--- a/applications/operators/olm-adding-operators-to-cluster.adoc
+++ b/applications/operators/olm-adding-operators-to-cluster.adoc
@@ -14,3 +14,4 @@ cluster to Operators from the OperatorHub.
 include::modules/olm-operator-lifecycle-manager.adoc[leveloffset=+1]
 include::modules/olm-operatorhub.adoc[leveloffset=+1]
 include::modules/olm-installing-operator-using-operatorhub.adoc[leveloffset=+1]
+include::modules/olm-installing-operator-using-commands.adoc[leveloffset=+1]

--- a/modules/olm-installing-operator-using-commands.adoc
+++ b/modules/olm-installing-operator-using-commands.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * applications/operators/olm-adding-operators-to-cluster.adoc
+
+[id='olm-installing-operator-using-commands_{context}']
+
+= Installing an Operator using the command line
+
+Instead of using the {product-title} Web console, you can install an
+Operator from the command line. Use the `oc` command as follows to install
+(subscribe to) an Operator for a selected namespace.
+
+.Prerequisites
+
+- Access to an {product-title} 4 cluster using an account with `cluster-admin`
+permissions.
+
+.Procedure
+
+. To view a list of operators available from OperatorHub, type the following:
++
+----
+$ oc get packagemanifest
+----
+
+. To identify the Operators to install, create a CatalogSourceConfig object yaml file (for example, `csc.cr.yaml`)
+containing information similar to the following:
+
++
+.Example CatalogSourceConfig
+[source,yaml]
+----
+apiVersion: "marketplace.redhat.com/v1alpha1"
+kind: "CatalogSourceConfig"
+metadata:
+  name: "example"
+  namespace: "openshift-marketplace"
+spec:
+  targetNamespace: "global" <1>
+  packages: "operators/myoperator,operators/another-operator" <2>
+----
+<1> Set the `targetNamespace` to identify the namespace where you want the
+Operator to be available
+<2> Set `packages` to a comma-separated list of Operators to which
+you want to subscribe.
+
+. To install the Operator to the selected namespace, type the following:
++
+----
+$ oc apply -f csc.cr.yaml
+----
+
+. Later, if you want to install more operators, you can simply update your
+CatalogSourceConfig file (in this example, csc.cr.yaml) with more packages.
+For example:
++
+.Example updated CatalogSourceConfig
+[source,yaml]
+----
+apiVersion: "marketplace.redhat.com/v1alpha1"
+kind: "CatalogSourceConfig"
+metadata:
+  name: "example"
+  namespace: "openshift-marketplace"
+spec:
+  targetNamespace: "global"
+  packages: "operators/myoperator,operators/another-operator,operators/this-operator-too"
+ <1>
+----
+<1> Add new packages to existing package list.
+
+. To update the CatalogSourceConfig object, run the `oc apply` command again:
++
+----
+$ oc apply -f csc.cr.yaml
+----
++
+The Operator will generate a CatalogSource and ConfigMap from your
+CatalogSourceConfig in the specified namespace (targetNamespace).
+With the OLM aware of your selected Operator, follow the OLM workflow
+to use the Operator.
+
+Before you can install your own Operators to cluster, you need to upload your
+Operator artifacts to Quay.io, then add your own `OperatorSource` to your
+cluster. Optionally, you can add Secrets to your Operator to provide authentication. The general steps for doing this are:
+
+. link:https://github.com/operator-framework/operator-marketplace/blob/master/docs/how-to-upload-artifact.md[Pushing an Operator Artifact to an App Registry]
+. link:https://github.com/operator-framework/operator-marketplace/blob/master/docs/how-to-authenticate-private-repositories.md[Authenticating Operators in your Private App Registry Repositories]
+. link:https://github.com/operator-framework/operator-marketplace/blob/master/README.md#populating-your-own-app-registry-operatorsource[Adding OperatorSource to your cluster]
+
+
+After that, you can manage the Operator in your
+cluster as you would any other Operator.

--- a/modules/olm-installing-operator-using-operatorhub.adoc
+++ b/modules/olm-installing-operator-using-operatorhub.adoc
@@ -7,7 +7,29 @@
 
 As a cluster administrator, you can install an Operator using the OperatorHub in
 the {product-title} web console to make it available for all developers using
-your cluster. This procedure uses the etcd Operator as an example.
+your cluster. The act of installing an Operator is also referred to as
+`subscribing` an Operator to a namespace.
+
+This procedure uses the etcd Operator as an example. Here are a
+few decisions you can make when you install an Operator to a namespace:
+
+* Target Namespace: A list of operator-group namespaces are presented for
+you to choose where the installed Operator will be available. This example
+chooses `global-operators`, to make the Operator available to all users and
+projects.
+
+* Update Channel: If an Operator is available through multiple channels,
+you can choose which channel you want to subscribe to. For example, to deploy
+from the `stable` channel, select `stable` from the Update Channel drop-down
+list.
+
+* Update Strategy: You can choose automatic or manual updates. If you choose Automatic updates for an
+installed Operator, when a new version of that Operator is available the
+OLM will automatically upgrade the running instance of your Operator
+without human intervention. If you select Manual updates, when a newer
+version of an Operator is available, the OLM will create an update request.
+As a cluster administrator, you need to manually approve that update request
+to have the Operator updated to the new version.
 
 .Prerequisites
 

--- a/modules/olm-operatorhub.adoc
+++ b/modules/olm-operatorhub.adoc
@@ -26,3 +26,36 @@ Community Operators::
 Optionally-visible software maintained by relevant representatives in the
 link:https://github.com/operator-framework/community-operators[operator-framework/community-operators]
 GitHub repository. No official support.
+
+OperatorHub itself is installed and run as an Operator by default on {product-title}.
+In particular, the OperatorHub runs in the
+openshift-marketplace namespace in OpenShift.
+
+Each operator in the OperatorHub is defined by two Custom Resource Definitions (CRDs):
+an link:https://github.com/operator-framework/operator-marketplace/blob/master/deploy/crds/operatorsource.crd.yaml[OperatorSource] and a link:https://github.com/operator-framework/operator-marketplace/blob/master/deploy/crds/catalogsourceconfig.crd.yaml[CatalogSourceConfig]:
+
+OperatorSource::
+For each operator, the OperatorSource identifies the location of its
+operator bundle. A link:https://github.com/operator-framework/operator-marketplace/blob/master/deploy/examples/operatorsource.cr.yaml[simple OperatorSource] could include:
+
+* _type_: To identify the datastore as an application registry, type is set to appregistry.
+* _endpoint_: Currently, Quay is the external datastore used by OperatorHub, so
+the endpoint is set to _https:/quay.io/cnr_ for the Quay.io appregistry.
+* _registryNamespace_: For a Community Operator, this is set to community-operator.
+* _displayName_: Optionally set to a name that appears in the OperatorHub
+user interface for the Operator.
+* _publisher_: Optionally, set to the person or organization publishing
+the Operator, so it can be displayed on the Operator Hub.
+
+CatalogSourceConfig::
+An operator's CatalogSourceConfig defines how an operator is installed to your
+cluster. A link:https://github.com/operator-framework/operator-marketplace/blob/master/deploy/examples/catalogsourceconfig.cr.yaml[simple CatalogSourceConfig] would need to identify:
+
+* _targetNamespace_: The location where the operator would be deployed and
+updated, such as openshift-marketplace. This is the namespace that OLM watches.
+* _packages_: A comma-separated list of packages that make up the content of
+the Operator.
+
+Although some OperatorSource and CatalogSourcConfig information is exposed
+through the OperatorHub user interface, those files are only used directly
+by those who are creating their own Operators.


### PR DESCRIPTION
I updated OperatorHub (Marketplace) docs based on these Jiras:
   https://jira.coreos.com/browse/MKTPLC-144
   https://jira.coreos.com/browse/MKTPLC-145
   https://jira.coreos.com/browse/MKTPLC-146
   https://jira.coreos.com/browse/MKTPLC-147
   https://jira.coreos.com/browse/MKTPLC-148
   https://jira.coreos.com/browse/MKTPLC-131

This included:
* Described the state of OperatorHub (running by default and its namespace)
* Added short descriptions of the two CRDs that make up each Operator
* Added descriptions of target namespace, auto vs. manual updates, and update strategy, when installing an Operator.
* Added new section on installing operators from the command line
* Added new section on installing your own operators. This consists mostly of pointers to upstream descriptions for pushing operators to Quay.io, authenticating private operators, and adding your operators to a cluster. For the next pass, I'll write this out in detail, instead of pointing to upstream.

Preview:

http://file.rdu.redhat.com/~adellape/022219/operator-hub-features-4.0/applications/operators/olm-adding-operators-to-cluster.html