### PR TITLE
Removed typo in 3.5 release notes

### DIFF
--- a/release_notes/ocp_3_5_release_notes.adoc
+++ b/release_notes/ocp_3_5_release_notes.adoc
@@ -2613,7 +2613,7 @@ Issued: 2018-12-05
 
 A security update to {product-title} 3.5 is now available. The list of packages
 included in the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2018:3624[RHSA-2018:3624] advisory.RHSA-2018-3624-for-3-5
+link:https://access.redhat.com/errata/RHSA-2018:3624[RHSA-2018:3624] advisory.
 
 [[ocp-3-5-rhsa-2018-3624-upgrading]]
 ==== Upgrading


### PR DESCRIPTION
The issue is in 3.5 only (not master)