### PR TITLE
[release-3.11] Remove the deprecated "openshift_logging_curator_run_timezone "

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -176,11 +176,6 @@ secret to be used for pulling component images from an authenticated registry.
 |`openshift_logging_curator_run_minute`
 | The minute of the hour Curator will run.
 
-|`openshift_logging_curator_run_timezone`
-|The timezone Curator uses for figuring out its run time. Provide the
-timezone as a string in the tzselect(8) or timedatectl(1) "Region/Locality"
-format, for example `America/New_York` or `UTC`.
-
 |`openshift_logging_curator_script_log_level`
 |The script log level for Curator.
 


### PR DESCRIPTION
- Fix: [Remove the deprecated "openshift_logging_curator_run_timezone variable" on v3.11](https://bugzilla.redhat.com/show_bug.cgi?id=1680271)

- Version: `v3.11`

- Description:
  As of `v3.11`, the `curator` is triggered by `CronJob`, so the times are based the `timezone` of the master where the job is initiated. `openshift_logging_curator_run_timezone` variable is not used to control where the job is initiated.

