### PR TITLE
Conditionalize admin/dev content

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -97,21 +97,29 @@ Topics:
   Topics:
   - Name: Extending the Kubernetes API with CRDs
     File: crd-extending-api-with-crds
+    Distros: openshift-origin,openshift-enterprise
   - Name: Managing resources from CRDs
     File: crd-managing-resources-from-crds
 - Name: Quotas
   Dir: quotas
+  Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Setting resource quotas per project
+  - Name: Resource quotas per project
     File: quotas-setting-per-project
-  - Name: Setting resource quotas across multiple projects
+  - Name: Resource quotas across multiple projects
     File: quotas-setting-across-multiple-projects
+- Name: Working with quotas
+  File: working-with-quotas
+  Distros: openshift-online,openshift-dedicated
 - Name: Idling applications
   File: idling-applications
+  Distros: openshift-origin,openshift-enterprise
 - Name: Pruning objects to reclaim resources
   File: pruning-objects
+  Distros: openshift-origin,openshift-enterprise
 - Name: Operator SDK
   Dir: operator_sdk
+  Distros: openshift-origin,openshift-enterprise
   Topics:
   - Name: Getting started with the Operator SDK
     File: osdk-getting-started
@@ -119,10 +127,10 @@ Topics:
     File: osdk-ansible
   - Name: Creating Helm-based Operators
     File: osdk-helm
-  - Name: Configuring built-in monitoring with Prometheus
-    File: osdk-monitoring-prometheus
   - Name: Generating a ClusterServiceVersion (CSV)
     File: osdk-generating-csvs
+  - Name: Configuring built-in monitoring with Prometheus
+    File: osdk-monitoring-prometheus
   - Name: Operator SDK CLI reference
     File: osdk-cli-reference
   - Name: Migrating to Operator SDK v0.1.0

--- a/applications/crds/crd-extending-api-with-crds.adoc
+++ b/applications/crds/crd-extending-api-with-crds.adoc
@@ -1,10 +1,13 @@
-:relfileprefix: ../
 [id='crd-extending-api-with-crds']
 = Extending the Kubernetes API with Custom Resource Definitions
 include::modules/common-attributes.adoc[]
 :context: crd-extending-api-with-crds
 
 toc::[]
+
+{nbsp} +
+This guide describes how cluster administrators can extend their {product-title}
+cluster by creating and managing Custom Resource Definitions (CRDs).
 
 include::modules/crd-custom-resource-definitions.adoc[leveloffset=+1]
 include::modules/crd-creating-crds.adoc[leveloffset=+1]

--- a/applications/crds/crd-managing-resources-from-crds.adoc
+++ b/applications/crds/crd-managing-resources-from-crds.adoc
@@ -1,10 +1,12 @@
-:relfileprefix: ../
 [id='crd-managing-resources-from-crds']
 = Managing resources from Custom Resource Definitions
 include::modules/common-attributes.adoc[]
 :context: crd-managing-resources-from-crds
 
 toc::[]
+{nbsp} +
+This guide describes how developers can manage Custom Resources (CRs) that come
+from Custom Resource Definitions (CRDs).
 
 include::modules/crd-custom-resource-definitions.adoc[leveloffset=+1]
 include::modules/crd-creating-custom-resources-from-file.adoc[leveloffset=+1]

--- a/applications/deployments/deployment-strategies.adoc
+++ b/applications/deployments/deployment-strategies.adoc
@@ -1,4 +1,3 @@
-:relfileprefix: ../
 [id='deployment-strategies']
 = Using DeploymentConfig strategies
 include::modules/common-attributes.adoc[]
@@ -18,8 +17,8 @@ routes that use the application. Strategies that use router features target
 individual routes.
 
 Many deployment strategies are supported through the DeploymentConfig, and some
-additional strategies are supported through router features.
-DeploymentConfig strategies are discussed in this section.
+additional strategies are supported through router features. DeploymentConfig
+strategies are discussed in this section.
 
 
 ////
@@ -28,7 +27,7 @@ This link keeps breaking Travis for some reason.
 [NOTE]
 ====
 See
-xref:../applications/deployments/route-based-deployment-strategies.adoc#route-based-deployment-strategies[Using route-based deployment strategies] for more on these additional strategies.
+xref:../../applications/deployments/route-based-deployment-strategies.adoc#route-based-deployment-strategies[Using route-based deployment strategies] for more on these additional strategies.
 ====
 ////
 

--- a/applications/deployments/managing-deployment-processes.adoc
+++ b/applications/deployments/managing-deployment-processes.adoc
@@ -1,4 +1,3 @@
-:relfileprefix: ../
 [id='deployment-operations']
 = Managing deployment processes
 include::modules/common-attributes.adoc[]

--- a/applications/deployments/route-based-deployment-strategies.adoc
+++ b/applications/deployments/route-based-deployment-strategies.adoc
@@ -1,4 +1,3 @@
-:relfileprefix: ../
 [id='route-based-deployment-strategies']
 = Using route-based deployment strategies
 include::modules/common-attributes.adoc[]
@@ -19,7 +18,7 @@ This link keeps breaking Travis for some reason.
 [NOTE]
 ====
 See
-xref:../applications/deployments/deployment-strategies.adoc#deployment-strategies[Using DeploymentConfig strategies]
+xref:../../applications/deployments/deployment-strategies.adoc#deployment-strategies[Using DeploymentConfig strategies]
 for more on the basic strategy types.
 ====
 ////

--- a/applications/deployments/what-deployments-are.adoc
+++ b/applications/deployments/what-deployments-are.adoc
@@ -1,12 +1,11 @@
-:relfileprefix: ../
 [id='what-deployments-are']
 = What Deployments and DeploymentConfigs are
 include::modules/common-attributes.adoc[]
 :context: what-deployments-are
 
 toc::[]
-{nbsp} +
 
+{nbsp} +
 _Deployments_ and _DeploymentConfigs_ in {product-title} are API objects that
 provide two similar but different methods for fine-grained management over
 common user applications. They are comprised of the following separate API
@@ -24,14 +23,14 @@ application.
 ////
 Update when converted:
 
-.Additional resource
+.Additional resources
 
-xref:advanced_deployment_strategies.adoc#graceful-termination[graceful shutdown]
-xref:basic_deployment_operations.adoc#triggers[Triggers]
-xref:deployment_strategies.adoc#strategies[strategies]
-xref:deployment_strategies.adoc#lifecycle-hooks[hooks]
-xref:basic_deployment_operations.adoc#rolling-back-a-deployment[rollbacks]
-xref:basic_deployment_operations.adoc#scaling[scaling]
+xref:../../applications/deployments/advanced_deployment_strategies.adoc#graceful-termination[graceful shutdown]
+xref:../../applications/basic_deployment_operations.adoc#triggers[Triggers]
+xref:../../applications/deployment_strategies.adoc#strategies[strategies]
+xref:../../applications/deployment_strategies.adoc#lifecycle-hooks[hooks]
+xref:../../applications/basic_deployment_operations.adoc#rolling-back-a-deployment[rollbacks]
+xref:../../applications/basic_deployment_operations.adoc#scaling[scaling]
 xref:../../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[autoscaling]
 ////
 

--- a/applications/operator_sdk/osdk-getting-started.adoc
+++ b/applications/operator_sdk/osdk-getting-started.adoc
@@ -6,12 +6,14 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 {nbsp} +
-This guide walks Operator authors through an example of building a simple
-Go-based Memcached Operator and managing its lifecycle on a Kubernetes-based
-cluster (such as {product-title}) from installation to upgrade. This is
-accomplished using two centerpieces of the Operator Framework: the Operator SDK
-(the `operator-sdk` CLI tool and `controller-runtime` library API) and the
-Operator Lifecycle Manager (OLM).
+This guide outlines the basics of the Operator SDK and walks Operator authors
+with cluster administrator access to a Kubernetes-based cluster (such as
+{product-title}) through an example of building a simple Go-based Memcached
+Operator and managing its lifecycle from installation to upgrade.
+
+This is accomplished using two centerpieces of the Operator Framework: the
+Operator SDK (the `operator-sdk` CLI tool and `controller-runtime` library API)
+and the Operator Lifecycle Manager (OLM).
 
 include::modules/osdk-architecture.adoc[leveloffset=+1]
 include::modules/osdk-monitoring-prometheus-operator-support.adoc[leveloffset=+2]

--- a/applications/operator_sdk/osdk-monitoring-prometheus.adoc
+++ b/applications/operator_sdk/osdk-monitoring-prometheus.adoc
@@ -5,6 +5,10 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+{nbsp} +
+This guide describes the built-in monitoring support provided by the Operator
+SDK using the Prometheus Operator and details usage for Operator authors.
+
 include::modules/osdk-monitoring-prometheus-operator-support.adoc[leveloffset=+1]
 
 include::modules/osdk-monitoring-prometheus-metrics-helper.adoc[leveloffset=+1]

--- a/applications/pruning-objects.adoc
+++ b/applications/pruning-objects.adoc
@@ -6,9 +6,9 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 {nbsp} +
-Over time, API objects created in {product-title} can accumulate in the etcd
-data store through normal user operations, such as when building and deploying
-applications.
+Over time, API objects created in {product-title} can accumulate in the
+cluster's etcd data store through normal user operations, such as when building
+and deploying applications.
 
 Cluster administrators can periodically prune older versions of objects from the
 cluster that are no longer needed. For example, by pruning images you can delete
@@ -31,5 +31,5 @@ include::modules/pruning-hard-pruning-registry.adoc[leveloffset=+1]
 include::modules/pruning-cronjobs.adoc[leveloffset=+1]
 .Additional resources
 - xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs_nodes-nodes-jobs[Running tasks in pods using jobs]
-- xref:../applications/quotas/quotas-setting-across-multiple-projects.adoc#setting-quotas-across-multiple-projects[Setting resource quotas across multiple projects]
+- xref:../applications/quotas/quotas-setting-across-multiple-projects.adoc#setting-quotas-across-multiple-projects[Resource quotas across multiple projects]
 - xref:../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]

--- a/applications/quotas/quotas-setting-across-multiple-projects.adoc
+++ b/applications/quotas/quotas-setting-across-multiple-projects.adoc
@@ -1,16 +1,18 @@
-:relfileprefix: ../
 [id='setting-quotas-across-multiple-projects']
-= Setting resource quotas across multiple projects
+= Resource quotas across multiple projects
 include::modules/common-attributes.adoc[]
 :context: setting-quotas-across-multiple-projects
 
 toc::[]
 
 {nbsp} +
-A multi-project quota, defined by a `ClusterResourceQuota` object, allows quotas
+A multi-project quota, defined by a ClusterResourceQuota object, allows quotas
 to be shared across multiple projects. Resources used in each selected project
-will be aggregated and that aggregate will be used to limit resources across all
-the selected projects.
+are aggregated and that aggregate is used to limit resources across all the
+selected projects.
+
+This guide describes how cluster administrators can set and manage resource
+quotas across multiple projects.
 
 include::modules/quotas-selecting-projects.adoc[leveloffset=+1]
 include::modules/quotas-viewing-clusterresourcequotas.adoc[leveloffset=+1]

--- a/applications/quotas/quotas-setting-per-project.adoc
+++ b/applications/quotas/quotas-setting-per-project.adoc
@@ -1,16 +1,19 @@
-:relfileprefix: ../
 [id='quotas-setting-per-project']
-= Setting resource quotas per project
+= Resource quotas per project
 include::modules/common-attributes.adoc[]
 :context: quotas-setting-per-project
 
 toc::[]
 
 {nbsp} +
-A resource quota, defined by a `ResourceQuota` object, provides constraints that
+A _resource quota_, defined by a ResourceQuota object, provides constraints that
 limit aggregate resource consumption per project. It can limit the quantity of
 objects that can be created in a project by type, as well as the total amount of
 compute resources and storage that may be consumed by resources in that project.
+
+This guide describes how resource quotas work, how cluster administrators can
+set and manage resource quotas on a per project basis, and how developers and
+cluster administrators can view them.
 
 include::modules/quotas-resources-managed.adoc[leveloffset=+1]
 include::modules/quotas-scopes.adoc[leveloffset=+1]

--- a/applications/working-with-quotas.adoc
+++ b/applications/working-with-quotas.adoc
@@ -1,0 +1,26 @@
+[id='working-with-quotas']
+= Working with quotas
+include::modules/common-attributes.adoc[]
+:context: working-with-quotas
+
+toc::[]
+
+{nbsp} +
+A _resource quota_, defined by a ResourceQuota object, provides constraints that
+limit aggregate resource consumption per project. It can limit the quantity of
+objects that can be created in a project by type, as well as the total amount of
+compute resources and storage that may be consumed by resources in that project.
+
+An _object quota count_ places a defined quota on all standard namespaced resource
+types. When using a resource quota, an object is charged against the quota if it
+exists in server storage. These types of quotas are useful to protect against
+exhaustion of storage resources.
+
+This guide describes how resource quotas work and how developers can work with
+and view them.
+
+include::modules/quotas-viewing-quotas.adoc[leveloffset=+1]
+include::modules/quotas-resources-managed.adoc[leveloffset=+1]
+include::modules/quotas-scopes.adoc[leveloffset=+1]
+include::modules/quotas-enforcement.adoc[leveloffset=+1]
+include::modules/quotas-requests-vs-limits.adoc[leveloffset=+1]

--- a/modules/olm-operatorhub.adoc
+++ b/modules/olm-operatorhub.adoc
@@ -54,7 +54,7 @@ by those who are creating their own Operators.
 [id='olm-operatorhub-arch-operatorsource-{context}']
 === OperatorSource
 
-For each Operator, the OperatorSource is used to define the external datastore
+For each Operator, the OperatorSource is used to define the external data store
 used to store Operator bundles. A
 link:https://github.com/operator-framework/operator-marketplace/blob/master/deploy/examples/operatorsource.cr.yaml[simple OperatorSource]
 includes:
@@ -66,10 +66,10 @@ includes:
 |Description
 
 |`type`
-|To identify the datastore as an application registry, `type` is set to `appregistry`.
+|To identify the data store as an application registry, `type` is set to `appregistry`.
 
 |`endpoint`
-|Currently, Quay is the external datastore used by the OperatorHub, so
+|Currently, Quay is the external data store used by the OperatorHub, so
 the endpoint is set to `https:/quay.io/cnr` for the Quay.io `appregistry`.
 
 |`registryNamespace`

--- a/modules/osdk-monitoring-prometheus-servicemonitor-creating.adoc
+++ b/modules/osdk-monitoring-prometheus-servicemonitor-creating.adoc
@@ -17,7 +17,7 @@ newly created Service.
 .Procedure
 
 . Add the `metrics.CreateServiceMonitor()` helper function to your Operator code,
-creating only one `ServiceMonitor` per application and namespace:
+creating only one ServiceMonitor per application and namespace:
 +
 [source,go]
 ----

--- a/modules/quotas-requiring-explicit-quota.adoc
+++ b/modules/quotas-requiring-explicit-quota.adoc
@@ -3,7 +3,7 @@
 // * applications/quotas/quotas-setting-per-project.adoc
 
 [id='quota-requiring-explicit-quota-{context}']
-== Requiring explicit quota to consume a resource
+= Requiring explicit quota to consume a resource
 
 If a resource is not managed by quota, a user has no restriction on the amount
 of resource that can be consumed.  For example, if there is no quota on storage

--- a/modules/quotas-selecting-projects.adoc
+++ b/modules/quotas-selecting-projects.adoc
@@ -19,7 +19,7 @@ $ oc create clusterquota for-user \
      --hard secrets=20
 ----
 +
-This creates the following `ClusterResourceQuota` object:
+This creates the following ClusterResourceQuota object:
 +
 [source,yaml]
 ----
@@ -73,10 +73,10 @@ $  oc create clusterresourcequota for-name \ <1>
 ----
 +
 <1> Both `clusterresourcequota` and `clusterquota` are aliases of the same
-command. `for-name` is the name of the `clusterresourcequota` object.
+command. `for-name` is the name of the ClusterResourceQuota object.
 <2> To select projects by label, provide a key-value pair by using the format `--project-label-selector=key=value`.
 +
-This creates the following `ClusterResourceQuota` object definition:
+This creates the following ClusterResourceQuota object definition:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Conditionalizing topics/subdirs for cluster administrator vs developer relevance. Also ensuring assemblies have appropriate lead-in descriptions that clearly state the audience for the topic.

Also creates a new developer-focused "Working with quotas" assembly under "Applications" (for OSD and OSO only), since the "Quotas" subdir is now set to OKD/OCP distros only (has admin-only procedures).

@vikram-redhat 	 - Also removed the remaining `:relfileprefix:` lines in my topics.

Preview: http://file.rdu.redhat.com/~adellape/022419/condtl_admin_dev/welcome/