### PR TITLE
Add OLM concepts/arch

### DIFF
--- a/applications/operator_sdk/osdk-generating-csvs.adoc
+++ b/applications/operator_sdk/osdk-generating-csvs.adoc
@@ -6,13 +6,13 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 {nbsp} +
-A _ClusterServiceVersion_ (CSV) is a YAML manifest created from a users'
-Operator metadata that assist the Operator Lifecycle Manager (OLM) in running
-the Operator in a cluster. It is the metadata that accompanies your Operator
-container image, used to populate user interfaces with information like your
-logo, description, and version. It is also a source of technical information
-needed to run the Operator, like the RBAC rules it requires and which Custom
-Resources (CRs) it manages or depends on.
+A _ClusterServiceVersion_ (CSV) is a YAML manifest created from Operator
+metadata that assists the Operator Lifecycle Manager (OLM) in running the
+Operator in a cluster. It is the metadata that accompanies an Operator container
+image, used to populate user interfaces with information like its logo,
+description, and version. It is also a source of technical information needed to
+run the Operator, like the RBAC rules it requires and which Custom Resources
+(CRs) it manages or depends on.
 
 The Operator SDK includes the `olm-catalog gen-csv` subcommand to generate a
 _ClusterServiceVersion_ (CSV) for the current Operator project customized using

--- a/applications/operators/olm-adding-operators-to-cluster.adoc
+++ b/applications/operators/olm-adding-operators-to-cluster.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 {nbsp} +
-This guide outlines the basics of the Operator Lifecycle Manager (OLM) and
+This guide outlines the architecture of the Operator Lifecycle Manager (OLM) and
 OperatorHub and walks cluster administrators through an example of installing
 and subscribing a cluster to Operators from the OperatorHub.
 

--- a/modules/olm-operator-lifecycle-manager.adoc
+++ b/modules/olm-operator-lifecycle-manager.adoc
@@ -25,3 +25,192 @@ cluster.
 For developers, a self-service experience allows provisioning and configuring
 instances of databases, monitoring, and big data services without having to be
 subject matter experts, because the Operator has that knowledge baked into it.
+
+[id='olm-csv-{context}']
+== ClusterServiceVersions (CSVs)
+
+A _ClusterServiceVersion_ (CSV) is a YAML manifest created from Operator
+metadata that assists the OLM in running the Operator in a cluster. It is the
+metadata that accompanies an Operator container image, used to populate user
+interfaces with information like its logo, description, and version. It is also
+a source of technical information needed to run the Operator, like the RBAC
+rules it requires and which Custom Resources (CRs) it manages or depends on.
+
+A CSV is composed of:
+
+Metadata::
+* Application metadata:
+** Name, description, version, links, labels, icon, etc.
+
+Install strategy::
+* Type: Deployment
+** Set of service accounts and required permissions
+** Set of Deployments.
+
+CRDs::
+* Type
+* Owned: Managed by this service
+* Required: Must exist in the cluster for this service to run
+* Resources: A list of resources that the Operator interacts with
+* Descriptors: Annotate CRD spec and status fields to provide semantic information
+
+[id='olm-architecture-{context}']
+== Architecture
+
+The Operator Lifecycle Manager is composed of two Operators: the OLM Operator
+and the Catalog Operator.
+
+Each of these Operators are responsible for managing the CRDs that are the basis
+for the OLM framework:
+
+.CRDs managed by OLM and Catalog Operators
+[cols="2a,1a,1a,8a",options="header"]
+|===
+|Resource |Short name |Owner |Description
+
+|ClusterServiceVersion
+|`csv`
+|OLM
+|Application metadata: name, version, icon, required resources, installation,
+etc.
+
+|InstallPlan
+|`ip`
+|Catalog
+|Calculated list of resources to be created in order to automatically install or
+upgrade a CSV.
+
+|CatalogSource
+|`catsrc`
+|Catalog
+|A repository of CSVs, CRDs, and packages that define an application.
+
+|Subscription
+|`sub`
+|Catalog
+|Used to keep CSVs up to date by tracking a channel in a package.
+
+|OperatorGroup
+|`og`
+|OLM
+|Method to group multiple namespaces and prepare for use by an Operator.
+|===
+
+Each of these Operators are also responsible for creating resources:
+
+.Resources created by OLM and Catalog Operators
+[options="header"]
+|===
+|Resource |Owner
+
+|Deployments
+.4+.^|OLM
+
+|ServiceAccounts
+|(Cluster)Roles
+|(Cluster)RoleBindings
+
+|Custom Resource Definitions (CRDs)
+.2+.^|Catalog
+|ClusterServiceVersions (CSVs)
+|===
+
+[id='olm-architecture-olm-operator-{context}']
+=== OLM Operator
+
+The OLM Operator is responsible for deploying applications defined by CSV
+resources after the required resources specified in the CSV are present in the
+cluster.
+
+The OLM Operator is not concerned with the creation of the required resources;
+users can choose to manually create these resources using the CLI, or users can
+choose to create these resources using the Catalog Operator. This separation of
+concern enables users incremental buy-in in terms of how much of the OLM
+framework they choose to leverage for their application.
+
+While the OLM Operator is often configured to watch all namespaces, it can also
+be operated alongside other OLM Operators so long as they all manage separate
+namespaces.
+
+.OLM Operator workflow
+* Watches for ClusterServiceVersion (CSVs) in a namespace and checks that
+requirements are met. If so, runs the install strategy for the CSV.
+
+[id='olm-architecture-catalog-operator-{context}']
+=== Catalog Operator
+
+The Catalog Operator is responsible for resolving and installing CSVs and the
+required resources they specify. It is also responsible for watching
+CatalogSources for updates to packages in channels and upgrading them
+(optionally automatically) to the latest available versions.
+
+A user that wishes to track a package in a channel creates a Subscription
+resource configuring the desired package, channel, and the CatalogSource from
+which to pull updates. When updates are found, an appropriate InstallPlan is
+written into the namespace on behalf of the user.
+
+Users can also create an InstallPlan resource directly, containing the names of
+the desired CSV and an approval strategy, and the Catalog Operator creates an
+execution plan for the creation of all of the required resources. After it is
+approved, the Catalog Operator creates all of the resources in an InstallPlan;
+this then independently satisfies the OLM Operator, which proceeds to install
+the CSVs.
+
+.Catalog Operator workflow
+* Has a cache of CRDs and CSVs, indexed by name.
+* Watches for unresolved InstallPlans created by a user:
+** Finds the CSV matching the name requested and adds it as a resolved resource.
+** For each managed or required CRD, adds it as a resolved resource.
+** For each required CRD, finds the CSV that manages it.
+* Watches for resolved InstallPlans and creates all of the discovered resources for it (if approved by a user or automatically).
+* Watches for CatalogSources and Subscriptions and creates InstallPlans based on them.
+
+[id='olm-architecture-catalog-registry-{context}']
+=== Catalog Registry
+
+The Catalog Registry stores CSVs and CRDs for creation in a cluster and stores
+metadata about packages and channels.
+
+A _package manifest_ is an entry in the Catalog Registry that associates a
+package identity with sets of CSVs. Within a package, channels point to a
+particular CSV. Because CSVs explicitly reference the CSV that they replace, a
+package manifest provides the Catalog Operator all of the information that is
+required to update a CSV to the latest version in a channel (stepping through
+each intermediate version).
+
+[id='olm-architecture-operatorgroups-{context}']
+=== OperatorGroups
+
+The goal of _OperatorGroups_ is to bring multitenancy features to running
+Operators in a cluster in the easiest, most automated way.
+
+An OperatorGroup consists of a group of target namespaces as specified by the
+label selector in the spec, plus the namespace that the OperatorGroup is created
+within, known as the _Operator namespace_. The Operator namespace is always
+considered to also be a target namespace, without regard to matching the label
+selector. The Operator namespace is where the Operator actually runs and the
+target namespace(s) are namespaces within which the Operator has permissions to
+operate.
+
+After an OperatorGroup has been created, the focus is around the target
+namespaces and the resources contained in those namespaces. The status for an
+OperatorGroup is constantly updated to always list the namespaces matching the
+label selector as specified in the spec. In addition to maintaining an updated
+status, the OperatorGroup control loop also maintains creating RBAC rules and
+providing OperatorGroup knowledge to Operators. Some operations, such as copying
+CSVs and creating additional RBAC rules, are handled by the CSV control loop.
+
+RBAC rules are created to:
+
+* Restrict access to the API (CRDs) of the installed Operators. It is possible
+that the administrator does not want the full functionality of the Operator to
+be granted in all cases.
+* Give the Operator the necessary permissions to operate. This is tied to the
+specified OperatorGroup service account.
+
+OperatorGroup target namespace information is made available to Operators via
+annotations on the Deployment. Each CSV in the Operator namespace is copied into
+the target namespace(s), which is done in case a user does not have access to
+the Operator namespace. The copied CSV is annotated with the OperatorGroup name
+and the Operator namespace (the target namespace list is intentionally not
+included for security reasons).


### PR DESCRIPTION
Added "ClusterServiceVersions (CSVs)" and "Architecture" subsections under "Understanding the Operator Lifecycle Manager".

cc @chrisnegus 	@ecordell 	

Preview: http://file.rdu.redhat.com/~adellape/022419/olm_arch_concepts/applications/operators/olm-adding-operators-to-cluster.html