### PR TITLE
Document HAProxy behavior when APIServer LB is down, and provide 3rd party recommendations.

### DIFF
--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -184,9 +184,6 @@ ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 
 === High Availability Masters
 
-The availability of running applications remains if the master or any of its services fail.
-However, failure of master services reduces the ability of the system to respond to
-application failures or creation of new applications.
 endif::[]
 ifdef::openshift-origin,openshift-enterprise[]
 You can optionally configure your masters for high
@@ -208,6 +205,22 @@ xref:../../install/example_inventories.adoc#multiple-masters[cluster
 installation documentation] provides specific examples using the `native` HA method and
 configuring HAProxy. You can also take the concepts and apply them towards your
 existing HA solutions using the `native` method instead of HAProxy.
+
+[NOTE]
+====
+In production {product-title} clusters, you must maintain high availability
+of the API Server load balancer. If the API Server load balancer is not
+available, nodes cannot report their status, all their pods are marked dead,
+and the pods' endpoints are removed from the service.
+
+In addition to configuring HA for {product-title}, you must separately configure 
+HA for the API Server load balancer. To configure HA, it is much preferred to 
+integrate an enterprise load balancer (LB) such as an F5 Big-IP™ or a Citrix 
+Netscaler™ appliance. If such solutions are not available, it is possible to 
+run multiple HAProxy load balancers and use Keepalived to provide a floating 
+virtual IP address for HA. However, this solution is not recommended for 
+production instances.
+====
 
 endif::[]
 


### PR DESCRIPTION
Masters HA section needs re-writing, since it does not take into account what happens when the APIserver goes down.
The following PR has been discussed within the organization. Reach out to me privately if need more info.
https://bugzilla.redhat.com/1641896