### PR TITLE
Modules for Entitled Builds

### DIFF
--- a/modules/builds-source-input-satellite-config.adoc
+++ b/modules/builds-source-input-satellite-config.adoc
@@ -1,0 +1,32 @@
+[id='builds-source-input-satellite-config-{context}']
+= Adding satellite configurations to builds
+
+Builds which use Satellite to install content must provide appropriate 
+configurations to obtain content from Satellite repositories.
+
+.Prerequisites
+
+You must provide or create a yum-compatible repository configuration file which
+downloads content from your Satellite instance.
+
+.Procedure
+
+. Create a ConfigMap containing the Satellite repository configuration file:
++
+[source, bash]
+----
+$ oc create configmap yum-repos-d --from-file /path/to/satellite.repo
+----
++
+
+. Add the Satellite repository configuration to the BuildConfig:
++
+[source, yaml]
+----
+source:
+    configMaps:
+    - configMap:
+        name: yum-repos-d
+      destinationDir: yum.repos.d
+----
++

--- a/modules/builds-source-input-subman-config.adoc
+++ b/modules/builds-source-input-subman-config.adoc
@@ -1,0 +1,45 @@
+[id='builds-source-input-subman-config-{context}']
+= Adding Subscription Manager configurations to builds
+
+Builds which use the Subscription Manager to install content must provide 
+appropriate configuration files and certificate authorities for subscribed 
+repositories.
+
+.Prerequisites
+
+You must have access to the Subscription Manager's configuration and 
+certificate authority files.
+
+.Procedure
+
+. Create a ConfigMap for the Subscription Manager configuration:
++
+[source, bash]
+----
+$ oc create configmap rhsm-conf --from-file /path/to/rhsm/rhsm.conf
+----
++
+
+. Create a ConfigMap for the certificate authority:
+[source, bash]
++
+----
+$ oc create configmap rhsm-ca --from-file /path/to/rhsm/ca/redhat-uep.pem
+----
++
+
+. Add the Subscription Manager configuration and certificate authority to the 
+BuildConfig:
++
+[source, yaml]
+----
+source:
+    configMaps:
+    - configMap:
+        name: rhsm-conf
+      destinationDir: rhsm-conf
+    - configMap:
+        name: rhsm-ca
+      destinationDir: rhsm-ca
+----
++

--- a/modules/builds-source-secrets-entitlements.adoc
+++ b/modules/builds-source-secrets-entitlements.adoc
@@ -1,0 +1,34 @@
+[id='builds-source-secrets-entitlements-{context}']
+= Adding entitlements as a build secret
+
+Builds which use entitlements to install subscription content must include the 
+entitlement keys as a build secret.
+
+.Prerequisites
+
+You must have access to Red Hat entitlements, and the entitlement must have 
+separate public and private key files.
+
+.Procedure
+
+. Create a secret containing your entitlements, ensuring that there are separate 
+files containing the entitlement public and private keys:
++
+[source, bash]
+----
+$  oc create secret generic etc-pki-entitlement --from-file /path/to/entitlement/{ID}.pem \
+> --from-file /path/to/entitlement/{ID}-key.pem ...
+----
++
+
+. Add the secret as a build input in the build configuration:
++
+[source, yaml]
+----
+source:
+  secrets:
+  - secret:
+      name: etc-pki-entitlement
+    destinationDir: etc-pki-entitlement
+----
++

--- a/modules/builds-strategy-docker-entitled-satellite.adoc
+++ b/modules/builds-strategy-docker-entitled-satellite.adoc
@@ -1,0 +1,34 @@
+[id='builds-strategy-docker-entitled-satellite-{context}']
+= Entitled docker builds using Satellite
+
+Docker strategy builds can use Satellite repositories to install subscription 
+content.
+
+.Prerequisites
+
+The entitlement keys and Satellite repository configurations must be added as 
+build inputs.
+
+.Procedure
+
+Use the following as an example *_Dockerfile_* to install content via 
+Satellite:
+
+----
+FROM registry.redhat.io/rhel7:latest
+USER root
+# Copy entitlements
+COPY ./etc-pki-entitlement /etc/pki/entitlement
+# Copy repository configuration
+COPY ./yum.repos.d /etc/yum.repos.d
+# Delete /etc/rhsm-host to use entitlements from the build container
+RUN rm /etc/rhsm-host && \
+    # yum repository info provided by Satellite
+    yum -y update && \
+    yum -y install <rpms> && \
+    # Remove entitlements 
+    rm -rf /etc/pki/entitlement
+# OpenShift requires images to run as non-root by default
+USER 1001
+ENTRYPOINT ["/bin/bash"]
+----

--- a/modules/builds-strategy-docker-entitled-subman.adoc
+++ b/modules/builds-strategy-docker-entitled-subman.adoc
@@ -1,0 +1,39 @@
+[id='builds-strategy-docker-entitled-subman-{context}']
+= Entitled docker builds using Subscription Manager
+
+Docker strategy builds can use the Subscription Manager to install subscription 
+content.
+
+.Prerequisites
+
+The entitlement keys, subscription manager configuration, and subscription 
+manager certificate authority must be added as build inputs.
+
+.Procedure
+
+Use the following as an example *_Dockerfile_* to install content via the 
+Subscription Manager:
+
+----
+FROM registry.redhat.io/rhel7:latest
+USER root
+# Copy entitlements
+COPY ./etc-pki-entitlement /etc/pki/entitlement
+# Copy subscription manager configurations
+COPY ./rhsm-conf /etc/rhsm
+COPY ./rhsm-ca /etc/rhsm/ca
+# Delete /etc/rhsm-host to use entitlements from the build container
+RUN rm /etc/rhsm-host && \
+    # Initialize /etc/yum.repos.d/redhat.repo
+    # See https://access.redhat.com/solutions/1443553
+    yum repolist --disablerepo=* && \
+    subscription-manager repos --enable <enabled-repo> && \
+    yum -y update && \
+    yum -y install <rpms> && \
+    # Remove entitlements and Subscription Manager configs
+    rm -rf /etc/pki/entitlement && \
+    rm -rf /etc/rhsm
+# OpenShift requires images to run as non-root by default
+USER 1001
+ENTRYPOINT ["/bin/bash"]
+----

--- a/modules/builds-strategy-docker-squash-layers.adoc
+++ b/modules/builds-strategy-docker-squash-layers.adoc
@@ -1,0 +1,18 @@
+[id='builds-strategy-docker-squash-layers-{context}']
+= Squash layers with docker builds
+
+Docker builds normally create a layer representing each instruction in a 
+*_Dockerfile_*. Setting the `imageOptimizationPolicy` to `SkipLayers` will merge 
+all instructions into a single layer on top of the base image.
+
+.Procedure
+
+To set the `imageOptimizationPolicy` to `SkipLayers`:
+[source, yaml]
+----
+strategy:
+  dockerStrategy:
+    imageOptimizationPolicy: SkipLayers <1>
+----
+<1> Layers are always squashed in OpenShift 4.0 at present, but this is subject to change 
+in a future release.


### PR DESCRIPTION
In 4.0, builds which use subscription content will not be able to load entitlements and other configurations from the host node. This provides instruction/tutorials on how to add entitlements to builds.

Original Google doc (Red Hat internal only): https://docs.google.com/document/d/1udIkiF_-R6LUEzIFCnoafu4dFpQnz04zFePFBu7RwTM/edit?usp=sharing