### PR TITLE
Follow-up edits to Samples Operator documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -177,6 +177,8 @@ Name: Images
 Dir: openshift_images
 Distros: openshift-*
 Topics:
+- Name: Configuring the Samples Operator
+  File: configuring-samples-operator
 - Name: Understanding containers, images, and image streams
   File: images-understand
 - Name: Creating images
@@ -187,8 +189,6 @@ Topics:
   File: using-templates
 - Name: Using Ruby on Rails
   File: templates-using-ruby-on-rails
-- Name: Configuring the Samples Operator
-  File: configuring-samples-operator
 ---
 Name: Authentication
 Dir: authentication

--- a/modules/samples-operator-configuration.adoc
+++ b/modules/samples-operator-configuration.adoc
@@ -9,25 +9,24 @@
 
 The samples resource offers the following configuration fields:
 
-* *ManagementState:*
-** *Managed.* The operator updates the samples as the configuration dictates.
-** *Unmanaged.* The operator ignores updates to the samples resource object and
-any image streams or templates in the OpenShift namespace.
-** *Removed.* The operator removes the set of `Managed` image streams and templates
-in the OpenShift namespace. It ignores new samples created by the cluster
-administator or any samples in the skipped lists. After the removals are
-complete, the operator works like it is in the `Unmanaged` state and ignores
-any watch events on the sample resources, image streams, or templates. It
-operates on secrets to facilitate the  CENTOS to RHEL switch. There are some
-caveats around concurrent create and removal.
+* *Management State:*
+** *Managed.* The Samples Operator updates the samples as the configuration
+dictates.
+** *Unmanaged.* The Samples Operator ignores updates to its configuration
+resource object and any imagestreams or templates in the OpenShift namespace.
+** *Removed.* The Samples Operator removes the set of `Managed` imagestreams
+and templates in the OpenShift namespace. It ignores new samples created by the
+cluster administrator or any samples in the skipped lists. After the removals are
+complete, the Samples Operator works like it is in the `Unmanaged` state and ignores
+any watch events on the sample resources, imagestreams, or templates.
 +
 [NOTE]
 ====
-Neither deletion nor setting the `ManagementState` to `Removed` are completed
-while image stream imports are still in progress. Once progress has completed,
+Neither deletion nor setting the `Management State` to `Removed` are completed
+while imagestream imports are still in progress. Once progress has completed,
 either in success or in error, the deletion or removal commences.
 
-Secret, image stream, and template watch events are ignored once deletion or
+Secret, imagestream, and template watch events are ignored once deletion or
 removal has started.
 ====
 +
@@ -36,43 +35,44 @@ removal has started.
 [NOTE]
 ====
 Creation or update of RHEL content does not commence if the secret for pull
-access is not in place when using the default, registry.redhat.io, when
-`SamplesRegistry` is not explicitly set.
+access is not in place when either `Samples Registry` is not explicitly set (i.e.,
+the empty string), or when it is set to registry.redhat.io. In both cases, image
+imports will work off of registry.redhat.io, which requires credentials.
 
-Creation or update of RHEL content is not be gated if the `SamplesRegistry` has
-been overridden.
+Creation or update of RHEL content is not gated by the existence of the pull
+secret if the `Samples Registry` is overridden to a value other than the empty
+string or registry.redhat.io.
 ====
 +
-* *Architecture:* Place holder to choose an architecture type. Currently only x86
+* *Architectures:* Place holder to choose an architecture type. Currently only x86
 is supported.
-* *Skipped Image streams:* Image streams that are in the operator’s
+* *Skipped Imagestreams:* Imagestreams that are in the Samples Operator’s
 inventory, but that the cluster administrator wants the operator to ignore or not manage.
-* *Skipped Templates:* Templates that are in the operator’s inventory, but that
+* *Skipped Templates:* Templates that are in the Samples Operator's inventory, but that
 the cluster administrator wants the operator to ignore or not manage.
 
-Secret, image stream, and template watch events can come in before the initial
-samples resource object is created, the operator detects and re-queues the
+Secret, imagestream, and template watch events can come in before the initial
+samples resource object is created, the Samples Operator detects and re-queues the
 event.
 
 == Configuration restrictions
 
-When supporting multiple architectures, the architecture list is not allowed to
-be changed while in the `Managed` state.
+When the Samples Operator starts supporting multiple architectures, the
+architecture list is not allowed to be changed while in the `Managed` state.
 
 In order to change the architectures values, a cluster administrator must:
 
-* Mark the `ManagementState` as `Removed`, saving the change.
-* In a subsequent change, edit the architecture and change the `ManagementState`
+* Mark the `Management State` as `Removed`, saving the change.
+* In a subsequent change, edit the architecture and change the `Management State`
 back to `Managed`.
 
-The operator still processes secrets while in `Removed` state. You can create
-the secret before switching to `Removed`, while in `Removed` before
-switching to `Managed`, or after switching to `Managed` state (though
-there are delays in creating the samples until the secret event is processed if
-you create the secret after switching to `Managed`). This is done to
-help facilitate the changing of the registry, where you choose to remove all the
-samples before switching to insure a clean slate (removing before switching is
-not required).
+The Samples Operator still processes secrets while in `Removed` state. You can
+create the secret before switching to `Removed`, while in `Removed` before
+switching to `Managed`, or after switching to `Managed` state (though there are
+delays in creating the samples until the secret event is processed if you create
+the secret after switching to `Managed`). This is done to help facilitate the
+changing of the registry, where you choose to remove all the samples before
+switching to insure a clean slate (removing before switching is not required).
 
 == Conditions
 
@@ -81,20 +81,20 @@ The samples resource maintains the following conditions in its status:
 * *SamplesExists.* Indicates the samples are created in the OpenShift
 namespace.
 * *ImageChangesInProgress.*
-** `True` when image streams are created/updated, but
+** `True` when imagestreams are created/updated, but
 not all of the tag spec generations and tag status generations match.
 ** `False` when all of the generations match, or unrecoverable errors occurred during
 import, the last seen error is in the message field. The list of pending
-image streams is in the reason field.
+imagestreams is in the reason field.
 * *ImportCredentialsExist.* A 'samples-registry-credentials' secret is
 copied into the OpenShift namespace.
 * *ConfigurationValid.* `True` or `false` based on whether any of the restricted
     changes noted previously are submitted.
-* *RemovePending.* Indicator that there is a`ManagementState` `Removed` setting
-    pending, but are waiting for in progress image streams to complete.
-* *ImportImageErrorsExist.* Indicator of which image streams had errors during
+* *RemovePending.* Indicator that there is a`Management State` `Removed` setting
+    pending, but are waiting for in progress imagestreams to complete.
+* *ImportImageErrorsExist.* Indicator of which imagestreams had errors during
     the image import phase for one of their tags.
-** `True` when an error has occurred. The list of image streams with an error is
+** `True` when an error has occurred. The list of imagestreams with an error is
 in the reason field. The details of each error reported are in the
 message field.
 * *MigrationInProgress.* `True` when the Samples Operator detects that the

--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -7,37 +7,37 @@
 [id='samples-operator-overview-{context}']
 = Understanding the Samples Operator
 
-On initial startup, the operator creates the default samples resource to
-initiate the creation of the image streams and templates. The image streams are
-the RHEL based {product-title} image streams pointing to images on
-registry.redhat.io. The templates are those categorized as {product-title}
-templates.
-
-The Samples Operator and configuration resources, are contained within the
-`openshift-cluster-samples-operator` namespace. On startup, it copies the pull
-secret captured by the installation into the OpenShift namespace with the name
-`samples-registry-credentials` to facilitate image stream imports. A cluster
+On initial startup, the operator creates the default configuration object for
+itself and then creates the sample imagestreams and templates. The imagestreams
+are RHEL {product-title} based and point to images on registry.redhat.io. The
+templates are those categorized as {product-title} Templates. It also copies the
+pull secret captured by the installation into the OpenShift namespace with the
+name `samples-registry-credentials` to facilitate imagestream imports. A cluster
 administrator can create any additional secrets containing the content of a
 Docker `config.json` in the OpenShift namespace as needed to facilitate image
 import.
 
-The image for the Samples Operator contains image stream and template
-definitions for the associated OpenShift release. Each sample includes an
-annotation that denotes the OpenShift version with which it is compatible. The
-operator uses this annotation to ensure that each sample matches the release
-version. Samples outside of its inventory are ignored, as are skipped samples.
-Modifications to any samples that are managed by the operator will be reverted
+The Samples Operator configuration is a cluster-wide resource, and the deployment
+is contained within the `openshift-cluster-samples-operator` namespace.
+
+The image for the Samples Operator contains imagestream and template definitions
+for the associated OpenShift release. When each sample is created or updated,
+the Samples Operator includes an annotation that denotes the version of
+{product-title}. The operator uses this annotation to ensure that each sample
+matches the release version. Samples outside of its inventory are ignored, as
+are skipped samples. Modifications to any samples that are managed by the
+operator, where that version annotation is modified or deleted, will be reverted
 automatically. The Jenkins images are actually part of the image payload from
-installation and are tagged into the image streams directly.
+installation and are tagged into the imagestreams directly.
 
-The samples resource includes a finalizer which cleans up the following upon
-deletion:
+The Samples Operator configuration resource includes a finalizer which cleans up
+the following upon deletion:
 
-* Operator managed image streams
-* Operator managed templates
-* Operator generated configuration resources
-* Cluster status resources
-* The `samples-registry-credentials` secret
+* Operator managed imagestreams.
+* Operator managed templates.
+* Operator generated configuration resources.
+* Cluster status resources.
+//* The `samples-registry-credentials` secret.
 
 Upon deletion of the samples resource, the Samples Operator recreates the
 resource using the default configuration.


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/13625

This will include formatting changes to match the outlined template. 

Also addressing findings from https://bugzilla.redhat.com/show_bug.cgi?id=1680519. 