### PR TITLE
OSDOCS-241: Adding installing CLI plugins

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -463,6 +463,11 @@ Name: CLI reference
 Dir: cli_reference
 Distros: openshift-*
 Topics:
+- Name: Configuring the CLI
+  File: configuring-cli
+- Name: Extending the CLI with plug-ins
+  File: extending-cli-plugins
+  Distros: openshift-enterprise,openshift-origin
 - Name: Developer CLI commands
   File: developer-cli-commands
 - Name: Administrator CLI commands

--- a/cli_reference/configuring-cli.adoc
+++ b/cli_reference/configuring-cli.adoc
@@ -1,0 +1,9 @@
+[id='cli-configuring-cli']
+= Configuring the CLI
+include::modules/common-attributes.adoc[]
+:context: cli-configuring-cli
+
+toc::[]
+
+// Enabling tab completion
+include::modules/cli-configuring-completion.adoc[leveloffset=+1]

--- a/cli_reference/extending-cli-plugins.adoc
+++ b/cli_reference/extending-cli-plugins.adoc
@@ -1,0 +1,15 @@
+[id='cli-extend-plugins']
+= Extending the CLI with plug-ins
+include::modules/common-attributes.adoc[]
+:context: cli-extend-plugins
+
+toc::[]
+
+You can write and install plug-ins to build on the default `oc` commands,
+allowing you to peform new and more complex tasks with the {product-title} CLI.
+
+// Writing CLI plug-ins
+include::modules/cli-extending-plugins-writing.adoc[leveloffset=+1]
+
+// Installing and using CLI plug-ins
+include::modules/cli-extending-plugins-installing.adoc[leveloffset=+1]

--- a/modules/cli-configuring-completion.adoc
+++ b/modules/cli-configuring-completion.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/configuring-cli.adoc
+
+[id='cli-enabling-tab-completion-{context}']
+= Enabling tab completion
+
+After you install the `oc` CLI tool, you can enable tab completion to
+automatically complete `oc` commands or suggest options when you press Tab.
+
+.Prerequisites
+
+* You must have the `oc` CLI tool installed.
+
+.Procedure
+
+The following procedure enables tab completion for Bash.
+
+. Save the Bash completion code to a file.
++
+----
+$ oc completion bash > oc_bash_completion
+----
+
+. Copy the file to `/etc/bash_completion.d/`.
++
+----
+$ sudo cp oc_bash_completion /etc/bash_completion.d/
+----
++
+You can also save the file to a local directory and source it from your
+`.bashrc` file instead.
+
+Tab completion is enabled when you open a new terminal.

--- a/modules/cli-extending-plugins-installing.adoc
+++ b/modules/cli-extending-plugins-installing.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/extending-cli-plugins.adoc
+
+[id='cli-installing-plugins-{context}']
+= Installing and using CLI plug-ins
+
+After you write a custom plug-in for the {product-title} CLI, you can install it
+to use the additional functionality that it introduces.
+
+[IMPORTANT]
+====
+OpenShift CLI plug-ins are currently a Technology Preview feature.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
+Technology Preview features support scope] for more information.
+endif::[]
+====
+
+.Prerequisites
+
+* You must have the `oc` CLI tool installed.
+* You must have a CLI plug-in file that begins with `oc-` or `kubectl-`.
+
+.Procedure
+
+. If necessary, update the plug-in file to be executable.
++
+----
+$ chmod +x <plugin_file>
+----
+. Place the file anywhere in your `PATH`, such as `/usr/local/bin/`.
++
+----
+$ sudo mv <plugin_file> /usr/local/bin/.
+----
+. Run `oc plugin list` to make sure that the plug-in file is listed.
++
+----
+$ oc plugin list
+The following compatible plugins are available:
+
+/usr/local/bin/<plugin_file>
+----
++
+If your plug-in is not listed here, verify that the file name begins with `oc-`
+or `kubectl-`, is executable, and is on your `PATH`.
+. Invoke the new command or option introduced by the plug-in.
++
+For example, if you built and installed the `kubectl-ns` plug-in from the
+ link:https://github.com/kubernetes/sample-cli-plugin[Sample plug-in repository],
+  you can use the following command to view the current namespace.
++
+----
+$ oc ns
+----
++
+Note that the command to invoke the plug-in depends on the plug-in file name.
+For example, a plug-in with the file name of `oc-foo-bar` is invoked by the `oc foo bar`
+command.

--- a/modules/cli-extending-plugins-writing.adoc
+++ b/modules/cli-extending-plugins-writing.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/extending-cli-plugins.adoc
+
+[id='cli-writing-plugins-{context}']
+= Writing CLI plug-ins
+
+You can write a plug-in for the {product-title} CLI in any programming language
+or script that allows you to write command-line commands. Note that you can not
+use a plug-in to overwrite an existing `oc` command.
+
+[IMPORTANT]
+====
+OpenShift CLI plug-ins are currently a Technology Preview feature.
+ifdef::openshift-enterprise[]
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
+Technology Preview features support scope] for more information.
+endif::[]
+====
+
+.Procedure
+
+This procedure creates a simple Bash plug-in that prints a message to the
+terminal when the `oc foo` command is issued.
+
+. Create a file called `oc-foo`.
++
+When naming your plug-in file, keep the following in mind:
+
+* The file must begin with `oc-` or `kubectl-`.
+* The file name determines the command that invokes the plug-in. For example, a
+plug-in with the file name `oc-foo-bar` can be invoked by a command of
+`oc foo bar`. You can also use underscores if you want the command to contain
+dashes. For example, a plug-in with the file name `oc-foo_bar` can be invoked
+by a command of `oc foo-bar`.
+
+. Add the following contents to the file.
++
+----
+#!/bin/bash
+
+# optional argument handling
+if [[ "$1" == "version" ]]
+then
+    echo "1.0.0"
+    exit 0
+fi
+
+# optional argument handling
+if [[ "$1" == "config" ]]
+then
+    echo $KUBECONFIG
+    exit 0
+fi
+
+echo "I am a plugin named kubectl-foo"
+----
+
+After you install this plug-in for the {product-title} CLI, it can be invoked
+using the `oc foo` command.
+
+.Additional resources
+
+* Review the link:https://github.com/kubernetes/sample-cli-plugin[Sample plug-in repository]
+for an example of a plug-in written in Go.
+* Review the link:https://github.com/kubernetes/cli-runtime/[CLI runtime repository] for a set of utilities to assist in writing plug-ins in Go.


### PR DESCRIPTION
@kalexand-rh Would you mind peer reviewing this, since we were chatting earlier today about ending a module when you know there's a next step but can't xref?

@soltysh Can you please review these sections on enabling tab completion and working with plug-ins? I didn't use everything from [here](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/), so can you make sure I didn't leave out anything critical?

Preview:
* http://file.rdu.redhat.com/~ahoffer/2019/OSDOCS-241-plugins/cli_reference/extending-cli-plugins.html
* http://file.rdu.redhat.com/~ahoffer/2019/OSDOCS-241-plugins/cli_reference/configuring-cli.html

Note that in the source, these new files are commented out for now, since they're not part of the stage 1 review. 