### PR TITLE
bug 1683710 correcting MachineAutoScaler CRD version

### DIFF
--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -11,7 +11,7 @@ values for the MachineAutoscaler.
 
 [source,yaml]
 ----
-apiVersion: "autoscaling.openshift.io/v1beta1"
+apiVersion: "autoscaling.openshift.io/v1alpha1"
 kind: "MachineAutoscaler"
 metadata:
   name: "worker" <1>


### PR DESCRIPTION
From https://bugzilla.redhat.com/show_bug.cgi?id=1683710

@jhou1, this looks right in the current console. Will you please confirm? 