### PR TITLE
BZ-1683088: Updating secret definitions for IDPs.

### DIFF
--- a/modules/identity-provider-htpasswd-secret.adoc
+++ b/modules/identity-provider-htpasswd-secret.adoc
@@ -14,32 +14,8 @@ contains the HTPasswd user file.
 
 .Procedure
 
-. Create a base64 encoding of the HTPasswd users file.
+. Create an {product-title} Secret that contains the HTPasswd users file.
 +
-[source,bash]
 ----
-$ base64 </path/to/users.htpasswd>
-----
-
-. Define a Custom Resource Definition (CRD) secret that contains the 
-encoding.
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: htpass-secret <1>
-  namespace: openshift-config
-data:
-  htpasswd: <base64-encoding> <2>
-----
-<1> This secret name is passed to providers to identify the encoding.
-<2> An existing encoding created during the previous step.
-
-. Apply the CRD to create the secret in {product-title}.
-+
-[source,bash]
-----
-$ oc apply -f </path/to/created.CRD>
+$ oc create secret generic htpass-secret --from-file=htpasswd=</path/to/users.htpasswd> -n openshift-config
 ----

--- a/modules/identity-provider-ldap-secret.adoc
+++ b/modules/identity-provider-ldap-secret.adoc
@@ -10,25 +10,8 @@ that contains the bindPassword.
 
 .Procedure
 
-. Define a Custom Resource Definition (CRD) secret that contains the 
-encoding.
+. Define an {product-title} Secret that contains the bindPassword.
 +
-[source,yaml]
 ----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ldap-secret <1>
-  namespace: openshift-config
-data:
-  bindPassword: ... <2>
-----
-<1> This secret name is passed to providers to identify the encoding.
-<2> The password to use to bind during the search phrase.
-
-. Apply the CRD to create the secret in {product-title}.
-+
-[source,bash]
-----
-$ oc apply -f </path/to/created.CRD>
+$ oc create secret generic ldap-secret --from-literal=bindPassword=<secret> -n openshift-config
 ----

--- a/modules/identity-provider-secret.adoc
+++ b/modules/identity-provider-secret.adoc
@@ -16,25 +16,8 @@ that contains the client secret obtained from the identity provider.
 
 .Procedure
 
-. Define a Custom Resource Definition (CRD) secret that contains 
-the encoding.
+. Define an {product-title} Secret containing the client secret.
 +
-[source,yaml]
 ----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: idp-secret <1>
-  namespace: openshift-config
-data:
-  clientSecret: ... <2>
-----
-<1> This secret name is passed to providers to identify the encoding.
-<2> The client secret obtained from the identity provider.
-
-. Apply the CRD to create the secret in {product-title}.
-+
-[source,bash]
-----
-$ oc apply -f </path/to/created.CRD>
+$ oc client secret generic idp-secret --from-literal=clientSecret=<secret> -n openshift-config
 ----


### PR DESCRIPTION
BZ-1683088: Updating secret definitions for IDPs. Updating these sections to use the `oc` commands instead of manually applying a CR.

This is for 4.0.