### PR TITLE
Update machine api docs

### DIFF
--- a/modules/machine-api-overview.adoc
+++ b/modules/machine-api-overview.adoc
@@ -14,15 +14,12 @@ The Machine API is a combination of primary resources that are based on the upst
 link:https://github.com/kubernetes-sigs/cluster-api[Cluster API] project and
 custom {product-title} resources.
 
-The three primary resources are:
+The two primary resources are:
 
 `Machines`:: A fundamental unit that describes a `Node`. A `machine` has a
-class, which describes the types of compute nodes that are offered for different
+providerSpec, which describes the types of compute nodes that are offered for different
 cloud platforms. For example, a `machine` type for a worker node on Amazon Web
 Services (AWS) might define a specific machine type and required metadata.
-`MachineClasses`:: A unit that defines a class of `machines` and facilitates
-configuration reuse across `machines` of the same class. This unit functions
-like a `StorageClass` for PersistentVolumeClaims.
 `MachineSets`:: Groups of machines. `MachineSets` are to `machines` as
 `ReplicaSets` are to `Pods`. If you need more `machines` or need to scale them down,
 you change the *replicas* field on the `MachineSet` to meet your compute need.
@@ -36,19 +33,16 @@ specified `MachineSet`, and the `MachineAutoscaler` maintains that range of node
 The `MachineAutoscaler` object takes effect after a `ClusterAutoscaler` object
 exists. Both `ClusterAutoscaler` and `MachineAutoscaler` resources are made
 available by the `ClusterAutoscalerOperator`.
-`MachineHealthChecker`:: This resource detects when a machine is unhealthy,
-deletes it, and, on supported platforms, makes a new machine.
 `ClusterAutoscaler`:: This resource is based on the upstream
 link:https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler[ClusterAutoscaler]
 project. In the {product-title} implementation, it is integrated with the
-Cluster API by extending the `MachineSet` API.
-`ClusterAutoscalerOperator`:: Instead of interacting with the `ClusterAutoscaler`
-itself, you use its Operator. The `ClusterAutoscalerOperator` manages
-the `ClusterAutoscaler` deployment. With this Operator, you can set cluster-wide
+Cluster API by extending the `MachineSet` API. You can set cluster-wide
 scaling limits for resources such as cores, nodes, memory, and GPU.
 and so on. You can set the priority so that the cluster prioritizes pods so that
 new nodes are not brought online for less important pods. You can also set the
 ScalingPolicy so you can scale up nodes but not scale them down.
+`MachineHealthChecker`:: This resource detects when a machine is unhealthy,
+deletes it, and, on supported platforms, makes a new machine.
 
 
 In {product-title} version 3.11, you could not roll out a multi-zone architecture easily because the cluster

--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -15,7 +15,7 @@ apiVersion: "autoscaling.openshift.io/v1beta1"
 kind: "MachineAutoscaler"
 metadata:
   name: "worker" <1>
-  namespace: "openshift-cluster-api"
+  namespace: "openshift-machine-api"
 spec:
   minReplicas: 1 <2>
   maxReplicas: 12 <3>

--- a/modules/machineset-cr.adoc
+++ b/modules/machineset-cr.adoc
@@ -17,9 +17,9 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: <machine_label> <2>
     sigs.k8s.io/cluster-api-machine-type: <machine_label> <2>
   name: <cluster_name>-<machine_label>-<AWS-availability-zone> <3>
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   resourceVersion: "9249"
-  selfLink: /apis/cluster.k8s.io/v1alpha1/namespaces/openshift-cluster-api/machinesets/<cluster_name>-<machine_label>-<AWS-availability-zone> <3>
+  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/<cluster_name>-<machine_label>-<AWS-availability-zone> <3>
   uid: 59ba0425-313f-11e9-861e-0a18047f0a28
 spec:
   replicas: 1

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -20,7 +20,7 @@ you copy an existing MachineSet from your cluster and modify it.
 +
 [source,bash]
 ----
-$ oc get machinesets -n openshift-cluster-api
+$ oc get machinesets -n openshift-machine-api
 
 NAME                         DESIRED   CURRENT   READY     AVAILABLE   AGE
 190125-3-worker-us-west-1b   2         2         2         2           3h
@@ -32,7 +32,7 @@ NAME                         DESIRED   CURRENT   READY     AVAILABLE   AGE
 [source,bash]
 ----
 $ oc get machineset <machineset_name> -n \
-     openshift-cluster-api -o yaml > <file_name>.yaml
+     openshift-machine-api -o yaml > <file_name>.yaml
 ----
 +
 In this command, `<machineset_name>` is the name of the current MachineSet that
@@ -52,9 +52,9 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: <machine_label> <3>
     sigs.k8s.io/cluster-api-machine-type: <machine_label> <3>
   name: <cluster_name>-<machine_label>-<AWS-availability-zone> <3> <4>
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   resourceVersion: "9249" <1>
-  selfLink: /apis/cluster.k8s.io/v1alpha1/namespaces/openshift-cluster-api/machinesets/<cluster_name>-<machine_label>-<AWS-availability-zone> <1>
+  selfLink: /apis/cluster.k8s.io/v1alpha1/namespaces/openshift-machine-api/machinesets/<cluster_name>-<machine_label>-<AWS-availability-zone> <1>
   uid: 59ba0425-313f-11e9-861e-0a18047f0a28 <1>
 ----
 <1> Remove this line.
@@ -73,7 +73,7 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: <new_machine_label>
     sigs.k8s.io/cluster-api-machine-type: <new_machine_label>
   name: <cluster_name>-<new_machine_label>-<AWS-availability-zone>
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 ----
 
 . In `<file_name>.yaml`, delete the `status` stanza:
@@ -218,7 +218,7 @@ $ oc create -f <file_name>.yaml
 +
 [source,bash]
 ----
-$ oc get machineset -n openshift-cluster-api
+$ oc get machineset -n openshift-machine-api
 
 
 NAME                         DESIRED   CURRENT   READY     AVAILABLE   AGE
@@ -234,7 +234,7 @@ If the MachineSet is not available, wait a few minutes and run the command again
 +
 [source,bash]
 ----
-$ oc get machine -n openshift-cluster-api
+$ oc get machine -n openshift-machine-api
 ----
 
 . View the new node:

--- a/modules/machineset-manually-scaling.adoc
+++ b/modules/machineset-manually-scaling.adoc
@@ -17,7 +17,7 @@ manually scale the MachineSet.
 +
 [source,bash]
 ----
-$ oc get machinesets -n openshift-cluster-api
+$ oc get machinesets -n openshift-machine-api
 ----
 +
 The MachineSets are listed in the form of `<clusterid>-worker-<aws-region-az>`.
@@ -26,7 +26,13 @@ The MachineSets are listed in the form of `<clusterid>-worker-<aws-region-az>`.
 +
 [source,bash]
 ----
-$ oc edit <machineset> -n openshift-cluster-api
+oc scale --replicas=2 machineset <machineset> -nopenshift-machine-api
+----
+Or:
++
+[source,bash]
+----
+$ oc edit <machineset> -n openshift-machine-api
 ----
 +
 You can scale the MachineSet up or down. It takes several minutes for the new


### PR DESCRIPTION
- https://docs.openshift.com/container-platform/4.0/machine_management/creating-infrastructure-machinesets.html
- https://docs.openshift.com/container-platform/4.0/architecture/architecture.html#machine-api-overview-architecture

Resources:
Primary:
- Machines
- MachineSets

Others:
- ClusterAutoscaler
- MachineAutoscaler
- MachineHealthChecker

The order should be as above. 
MachineHealthChecker is unrelated to autoscaling and it's experimental
MachineClasses won't be supported ion 4.0. They should not appear in the docs
ClusterAutoscalerOperator is not a resource, it's an implementation detail and should not be mentioned, or if so machine-api-operator should be as well.
Labels will need to be updated according to https://github.com/openshift/installer/pull/1263

https://docs.openshift.com/container-platform/4.0/machine_management/manually-scaling-machineset.html
This can be achieved with oc scale command

cc @kalexand-rh 