### PR TITLE
bug 1677623 added openshift_release pre-install descriptions

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1220,6 +1220,39 @@ to accept any connection allowed by each policy. That is,  connections on any
 port from pods in the *_same_* namespace, and connections on ports `80` and
 `443` from pods in *_any_* namespace.
 
+[[admin-guide-networking-using-networkpolicy-efficiently]]
+=== Using NetworkPolicy Efficiently
+
+`NetworkPolicy` objects allow you to isolate pods that are differentiated from
+one another by labels, within a namespace.
+
+It is inefficient to apply `NetworkPolicy` objects
+to large numbers of individual pods in a single namespace.
+Pod labels do not exist at the IP level, so `NetworkPolicy` objects generate
+a separate OVS flow rule for every single possible link between every pod
+selected with `podSelector`.
+
+For example, if the `_spec_` `podSelector` and
+the `_ingress_` `podSelector` within a `NetworkPolicy` object each match 200
+pods, then 40000 (200*200) OVS flow rules are generated.
+This might slow down the machine.
+
+To reduce the amount of OVS flow rules, use namespaces to contain groups
+of pods that need to be isolated.
+
+`NetworkPolicy` objects that select a whole namespace, by using
+`namespaceSelectors`
+or empty `podSelectors`, only generate a single OVS flow rule that matches the
+VXLAN VNID of the namespace.
+
+Keep the pods that do not need
+to be isolated in their original namespace, and
+move the pods that require isolation into one or more different namespaces.
+
+Create additional
+targeted cross-namespace policies to allow the specific traffic that you do want
+to allow from the isolated pods.
+
 [[admin-guide-networking-networkpolicy-routers]]
 === NetworkPolicy and Routers
 

--- a/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
+++ b/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
@@ -66,12 +66,12 @@ etcd0.example.com
 
 . If you use the service catalog, you must update its list of etcd servers:
 +
-[source,bash]
 ----
 $ oc edit ds apiserver -n kube-service-catalog
 ----
 +
-In the `--etcd-servers` parameter, add the new etcd node to the list.
+Add the FQDN for the new etcd node to the `--etcd-servers` argument. This
+argument contains a comma-separated list.
 
 . If you use Flannel, modify the `flanneld` service configuration on every
 {product-title} host, located at `/etc/sysconfig/flanneld`, to include the new

--- a/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
+++ b/day_two_guide/topics/proc_scaling-etcd-ansible.adoc
@@ -44,8 +44,8 @@ file, run the etcd `scaleup` playbook:
 $ ansible-playbook  /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/scaleup.yml
 ----
 
-. After the playbook runs, modify the inventory file to reflect the current 
-status by moving the new etcd host from the `[new_etcd]` group to the `[etcd]` 
+. After the playbook runs, modify the inventory file to reflect the current
+status by moving the new etcd host from the `[new_etcd]` group to the `[etcd]`
 group:
 +
 ----
@@ -64,8 +64,17 @@ master-2.example.com
 etcd0.example.com
 ----
 
+. If you use the service catalog, you must update its list of etcd servers:
++
+[source,bash]
+----
+$ oc edit ds apiserver -n kube-service-catalog
+----
++
+In the `--etcd-servers` parameter, add the new etcd node to the list.
+
 . If you use Flannel, modify the `flanneld` service configuration on every
-{product-title} host, located at `/etc/sysconfig/flanneld`, to include the new 
+{product-title} host, located at `/etc/sysconfig/flanneld`, to include the new
 etcd host:
 +
 ----

--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -852,6 +852,9 @@ Use the Device Mapper Storage Driver guide].
 available either locally or in at least one of the configured container image
 registries on the host machine.
 
+|`openshift_release`
+|Specifies the generic release of {product-title} for containerized installations. For RPM installations, set a`package_availability` value.
+
 |`package_version`
 |Runs on `yum`-based systems determining if multiple releases of a required
 {product-title} package are available. Having multiple releases of a package

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -152,6 +152,15 @@ $ ansible-playbook [-i /path/to/file] \
   /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/scaleup.yml
 ----
 
+. If you use the service catalog, you must update its list of etcd servers:
++
+[source,bash]
+----
+$ oc edit ds apiserver -n kube-service-catalog
+----
++
+In the `--etcd-servers` parameter, add the new etcd node to the list.
+
 . After the playbook completes successfully,
 xref:../install_config/install/advanced_install.adoc#advanced-verifying-the-installation[verify the installation].
 

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -154,12 +154,12 @@ $ ansible-playbook [-i /path/to/file] \
 
 . If you use the service catalog, you must update its list of etcd servers:
 +
-[source,bash]
 ----
 $ oc edit ds apiserver -n kube-service-catalog
 ----
 +
-In the `--etcd-servers` parameter, add the new etcd node to the list.
+Add the FQDN for the new etcd node to the `--etcd-servers` argument. This
+argument contains a comma-separated list.
 
 . After the playbook completes successfully,
 xref:../install_config/install/advanced_install.adoc#advanced-verifying-the-installation[verify the installation].

--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -661,6 +661,9 @@ Use the Device Mapper Storage Driver guide].
 available either locally or in at least one of the configured container image
 registries on the host machine.
 
+|`openshift_release`
+|Specifies the generic release of {product-title} for containerized installations. For RPM installations, refer to `package_availability`.
+
 |`package_version`
 |Runs on `yum`-based systems determining if multiple releases of a required
 {product-title} package are available. Having multiple releases of a package


### PR DESCRIPTION
Duplicate of #13865 due to commit errors, which is now closed. 

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1677623

This PR is for 3.9 and below (to 3.4), adding a descriptor for `openshift_release in the `pre-install checks` table, which is in two locations.

@wmengRH PTAL, thanks. 