### PR TITLE
Deprecation of openshift_logging_curator_run_timezone isn't documented

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1581,7 +1581,7 @@ configuration file with the following structure:
 
 [NOTE]
 ====
-The time zone is set based on the {product-title} master node.
+The time zone is set based on the host node where the curator pod runs.
 ====
 
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1679248