### PR TITLE
OSDOCS-316: Updated OperatorGroup docs

### DIFF
--- a/modules/olm-operator-lifecycle-manager.adoc
+++ b/modules/olm-operator-lifecycle-manager.adoc
@@ -55,7 +55,7 @@ CRDs::
 * Descriptors: Annotate CRD spec and status fields to provide semantic information
 
 [id="olm-architecture-{context}"]
-== Architecture
+== Operator Lifecycle Manager Architecture
 
 The Operator Lifecycle Manager is composed of two Operators: the OLM Operator
 and the Catalog Operator.
@@ -93,7 +93,7 @@ upgrade a CSV.
 |OperatorGroup
 |`og`
 |OLM
-|Method to group multiple namespaces and prepare for use by an Operator.
+|Used to group multiple namespaces and prepare them for use by an Operator.
 |===
 
 Each of these Operators are also responsible for creating resources:
@@ -116,7 +116,7 @@ Each of these Operators are also responsible for creating resources:
 |===
 
 [id="olm-architecture-olm-operator-{context}"]
-=== OLM Operator
+== OLM Operator
 
 The OLM Operator is responsible for deploying applications defined by CSV
 resources after the required resources specified in the CSV are present in the
@@ -135,9 +135,12 @@ namespaces.
 .OLM Operator workflow
 * Watches for ClusterServiceVersion (CSVs) in a namespace and checks that
 requirements are met. If so, runs the install strategy for the CSV.
++
+NOTE: A CSV must be an active member of an OperatorGroup in order for the
+install strategy to be run.
 
 [id="olm-architecture-catalog-operator-{context}"]
-=== Catalog Operator
+== Catalog Operator
 
 The Catalog Operator is responsible for resolving and installing CSVs and the
 required resources they specify. It is also responsible for watching
@@ -166,7 +169,7 @@ the CSVs.
 * Watches for CatalogSources and Subscriptions and creates InstallPlans based on them.
 
 [id="olm-architecture-catalog-registry-{context}"]
-=== Catalog Registry
+== Catalog Registry
 
 The Catalog Registry stores CSVs and CRDs for creation in a cluster and stores
 metadata about packages and channels.
@@ -179,38 +182,421 @@ required to update a CSV to the latest version in a channel (stepping through
 each intermediate version).
 
 [id="olm-architecture-operatorgroups-{context}"]
-=== OperatorGroups
+== OperatorGroups
 
-The goal of _OperatorGroups_ is to bring multitenancy features to running
-Operators in a cluster in the easiest, most automated way.
+An _OperatorGroup_ is an OLM resource that provides multitenant configuration to
+OLM-installed Operators. An OperatorGroup selects a set of target namespaces in
+which to generate required RBAC access for its member Operators. The set of
+target namespaces is provided by a comma-delimited string stored in the CSV's
+`olm.targetNamespaces` annotation. This annotation is applied to member
+Operator's CSV instances and is projected into their deployments.
 
-An OperatorGroup consists of a group of target namespaces as specified by the
-label selector in the spec, plus the namespace that the OperatorGroup is created
-within, known as the _Operator namespace_. The Operator namespace is always
-considered to also be a target namespace, without regard to matching the label
-selector. The Operator namespace is where the Operator actually runs and the
-target namespace(s) are namespaces within which the Operator has permissions to
-operate.
+[discrete]
+=== OperatorGroup membership
 
-After an OperatorGroup has been created, the focus is around the target
-namespaces and the resources contained in those namespaces. The status for an
-OperatorGroup is constantly updated to always list the namespaces matching the
-label selector as specified in the spec. In addition to maintaining an updated
-status, the OperatorGroup control loop also maintains creating RBAC rules and
-providing OperatorGroup knowledge to Operators. Some operations, such as copying
-CSVs and creating additional RBAC rules, are handled by the CSV control loop.
+An Operator is considered a _member_ of an OperatorGroup if the following
+conditions are true:
 
-RBAC rules are created to:
+* The Operator's CSV exists in the same namespace as the OperatorGroup.
+* The Operator's CSV's InstallModes support the set of namespaces targeted by
+the OperatorGroup.
 
-* Restrict access to the API (CRDs) of the installed Operators. It is possible
-that the administrator does not want the full functionality of the Operator to
-be granted in all cases.
-* Give the Operator the necessary permissions to operate. This is tied to the
-specified OperatorGroup service account.
+An InstallMode consists of an `InstallModeType` field and a boolean `Supported`
+field. A CSV's spec can contain a set of InstallModes of four distinct
+`InstallModeTypes`:
 
-OperatorGroup target namespace information is made available to Operators via
-annotations on the Deployment. Each CSV in the Operator namespace is copied into
-the target namespace(s), which is done in case a user does not have access to
-the Operator namespace. The copied CSV is annotated with the OperatorGroup name
-and the Operator namespace (the target namespace list is intentionally not
-included for security reasons).
+.InstallModes and supported OperatorGroups
+[cols="1,2",options="header"]
+|===
+|InstallModeType |Description
+
+|`OwnNamespace`
+|The Operator can be a member of an OperatorGroup that selects its own
+ namespace.
+
+|`SingleNamespace`
+|The Operator can be a member of an OperatorGroup that selects one namespace.
+
+|`MultiNamespace`
+|The Operator can be a member of an OperatorGroup that selects more than one
+namespace.
+
+|`AllNamespaces`
+|The Operator can be a member of an OperatorGroup that selects all namespaces
+(target namespace set is the empty string `""`).
+|===
+
+NOTE: If a CSV's spec omits an entry of `InstallModeType`, then that type is
+considered unsupported unless support can be inferred by an existing entry that
+implicitly supports it.
+
+[discrete]
+==== Troubleshooting OperatorGroup membership
+
+* If more than one OperatorGroup exists in a single namespace, any CSV created
+in that namespace will transition to a failure state with the reason
+`TooManyOperatorGroups`. CSVs in a failed state for this reason will
+transition to pending once the number of OperatorGroups in their namespaces
+reaches one.
+* If a CSV's InstallModes do not support the target namespace selection of the
+OperatorGroup in its namespace, the CSV will transition to a failure state
+with the reason `UnsupportedOperatorGroup`. CSVs in a failed state for this
+reason will transition to pending once either the OperatorGroup's target
+namespace selection changes to a supported configuration, or the CSV's
+InstallModes are modified to support the OperatorGroup's target namespace
+selection.
+
+[discrete]
+=== Target namespace selection
+
+Specify the set of namespaces for the OperatorGroup using a label
+selector with the `spec.selector` field:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: my-namespace
+  spec:
+    selector:
+      matchLabels:
+        cool.io/prod: "true"
+----
+
+You can also explicitly name the target namespaces using the
+`spec.targetNamespaces` field:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: my-namespace
+spec:
+  targetNamespaces:
+  - my-namespace
+  - my-other-namespace
+  - my-other-other-namespace
+----
+
+NOTE: If both `spec.targetNamespaces` and `spec.selector` are defined,
+`spec.selector` is ignored.
+
+Alternatively, you can omit both `spec.selector` and `spec.targetNamespaces` to
+specify a _global_ OperatorGroup, which selects all namespaces:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: my-namespace
+----
+
+The resolved set of selected namespaces is shown in an OperatorGroup's
+`status.namespaces` field. A global OperatorGroup's `status.namespace` contains
+the empty string (`""`), which signals to a consuming Operator that it should
+watch all namespaces.
+
+[discrete]
+=== OperatorGroup CSV annotations
+
+Member CSVs of an OperatorGroup have the following annotations:
+
+[cols="1,1",options="header"]
+|===
+|Annotation |Description
+
+|`olm.operatorGroup=<group_name>`
+|Contains the name of the OperatorGroup.
+
+|`olm.operatorGroupNamespace=<group_namespace>`
+|Contains the namespace of the OperatorGroup.
+
+|`olm.targetNamespaces=<target_namespaces>`
+|Contains a comma-delimited string that lists the OperatorGroup's target
+namespace selection.
+|===
+
+NOTE: All annotations except `olm.targetNamespaces` are included with copied
+CSVs. Omitting the `olm.targetNamespaces` annotation on copied CSVs prevents
+the duplication of target namespaces between tenants.
+
+[discrete]
+=== Provided APIs annotation
+
+Information about what `GroupVersionKinds` (GVKs) are provided by an
+OperatorGroup are shown in an `olm.providedAPIs` annotation. The annotation's
+value is a string consisting of `<kind>.<version>.<group>` delimited with
+commas. The GVKs of CRDs and APIServices provided by all active member CSVs of
+an OperatorGroup are included.
+
+Review the following example of an OperatorGroup with a single active member CSV
+that provides the PackageManifest resource:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: PackageManifest.v1alpha1.packages.apps.redhat.com
+  name: olm-operators
+  namespace: local
+  ...
+spec:
+  selector: {}
+  serviceAccount:
+    metadata:
+      creationTimestamp: null
+  targetNamespaces:
+  - local
+status:
+  lastUpdated: 2019-02-19T16:18:28Z
+  namespaces:
+  - local
+----
+
+[discrete]
+=== Role-based access control
+
+When an OperatorGroup is created, three ClusterRoles are generated. Each
+contains a single AggregationRule with a ClusterRoleSelector set to match a
+label, as shown below:
+
+[cols="1,1",options="header"]
+|===
+|ClusterRole |Label to match
+
+|`<operatorgroup_name>-admin`
+|`olm.opgroup.permissions/aggregate-to-admin: <operatorgroup_name>`
+
+|`<operatorgroup_name>-edit`
+|`olm.opgroup.permissions/aggregate-to-edit: <operatorgroup_name>`
+
+|`<operatorgroup_name>-view`
+|`olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
+|===
+
+The following RBAC resources are generated when a CSV becomes an active member of an OperatorGroup, as long as the CSV is watching all namespaces with the `AllNamespaces` InstallMode and is not in a failed state with reason `InterOperatorGroupOwnerConflict`.
+
+* xref:olm-resources-per-api-resource-crd-{context}[ClusterRoles for each API resource from a CRD]
+* xref:olm-resources-per-api-resource-api-{context}[ClusterRoles for each API resource from an APIService]
+* xref:olm-resources-additional-roles-rolebindings-{context}[Additional Roles and RoleBindings]
+
+[id='olm-resources-per-api-resource-crd-{context}']
+.ClusterRoles generated for each API resource from a CRD
+[cols="1,1a",options="header"]
+|===
+|ClusterRole |Settings
+
+|`<kind>.<group>-<version>-admin`
+|Verbs on `<kind>`:
+
+* `*`
+
+Aggregation labels:
+
+* `rbac.authorization.k8s.io/aggregate-to-admin: true`
+* `olm.opgroup.permissions/aggregate-to-admin: <operatorgroup_name>`
+
+|`<kind>.<group>-<version>-edit`
+|Verbs on `<kind>`:
+
+* `create`
+* `update`
+* `patch`
+* `delete`
+
+Aggregation labels:
+
+* `rbac.authorization.k8s.io/aggregate-to-edit: true`
+* `olm.opgroup.permissions/aggregate-to-edit: <operatorgroup_name>`
+
+|`<kind>.<group>-<version>-view`
+|Verbs on `<kind>`:
+
+* `get`
+* `list`
+* `watch`
+
+Aggregation labels:
+
+* `rbac.authorization.k8s.io/aggregate-to-view: true`
+* `olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
+
+|`<kind>.<group>-<version>-view-crdview`
+|Verbs on `apiextensions.k8s.io` `customresourcedefinitions` `<crd-name>`:
+
+* `get`
+
+Aggregation labels:
+
+* `rbac.authorization.k8s.io/aggregate-to-view: true`
+*  `olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
+
+|===
+
+[id='olm-resources-per-api-resource-api-{context}']
+.ClusterRoles generated for each API resource from an APIService
+[cols="1,1a",options="header"]
+|===
+|ClusterRole |Settings
+
+|`<kind>.<group>-<version>-admin`
+|Verbs on `<kind>`:
+
+* `*`
+
+Aggregation labels:
+
+* `rbac.authorization.k8s.io/aggregate-to-admin: true`
+* `olm.opgroup.permissions/aggregate-to-admin: <operatorgroup_name>`
+
+|`<kind>.<group>-<version>-edit`
+|Verbs on `<kind>`:
+
+* `create`
+* `update`
+* `patch`
+* `delete`
+
+Aggregation labels:
+
+ * `rbac.authorization.k8s.io/aggregate-to-edit: true`
+ * `olm.opgroup.permissions/aggregate-to-edit: <operatorgroup_name>`
+
+|`<kind>.<group>-<version>-view`
+|Verbs on `<kind>`:
+
+* `get`
+* `list`
+* `watch`
+
+Aggregation labels:
+
+* `rbac.authorization.k8s.io/aggregate-to-view: true`
+* `olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
+
+|===
+
+
+
+[id='olm-resources-additional-roles-rolebindings-{context}']
+.Additional Roles and RoleBindings
+* If the CSV defines exactly one target namespace that contains `*`, then a
+ClusterRole and corresponding ClusterRoleBinding are generated for each
+permission defined in the CSV's permissions field. All resources generated are
+given the `olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>`
+labels.
+* If the CSV does _not_ define exactly one target namespace that contains `*`,
+then all Roles and RoleBindings in the Operator namespace with the
+`olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>` labels are
+copied into the target namespace.
+
+[discrete]
+=== Copied CSVs
+
+OLM creates copies of all active member CSVs of an OperatorGroup in each of that
+OperatorGroup's target namespaces. The purpose of a copied CSV is to tell users
+of a target namespace that a specific Operator is configured to watch resources
+created there. Copied CSVs have a status reason `Copied` and are updated to
+match the status of their source CSV. The `olm.targetNamespaces` annotation is
+stripped from copied CSVs before they are created on the cluster. Omitting the
+target namespace selection avoids the duplication of target namespaces between
+tenants. Copied CSVs are deleted when their source CSV no longer exists or the
+OperatorGroup that their source CSV belongs to no longer targets the copied
+CSV's namespace.
+
+[discrete]
+=== Static OperatorGroups
+
+An OperatorGroup is _static_ if its `spec.staticProvidedAPIs` field is set to
+`true`. As a result, OLM does not modify the OperatorGroup's `olm.providedAPIs`
+annotation, which means that it can be set in advance. This is useful when a
+user wants to use an OperatorGroup to prevent resource contention in a set of
+namespaces but does not have active member CSVs that provide the APIs for those
+resources.
+
+Below is an example of an OperatorGroup that protects Prometheus resources in
+all namespaces with the `something.cool.io/cluster-monitoring: "true"`
+annotation:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: cluster-monitoring
+  namespace: cluster-monitoring
+  annotations:
+    olm.providedAPIs: Alertmanager.v1.monitoring.coreos.com,Prometheus.v1.monitoring.coreos.com,PrometheusRule.v1.monitoring.coreos.com,ServiceMonitor.v1.monitoring.coreos.com
+spec:
+  staticProvidedAPIs: true
+  selector:
+    matchLabels:
+      something.cool.io/cluster-monitoring: "true"
+----
+
+[discrete]
+=== OperatorGroup intersection
+
+Two OperatorGroups are said to have _intersecting provided APIs_ if the
+intersection of their target namespace sets is not an empty set and the
+intersection of their provided API sets, defined by `olm.providedAPIs`
+annotations, is not an empty set.
+
+A potential issue is that OperatorGroups with intersecting provided APIs can
+compete for the same resources in the set of intersecting namespaces.
+
+NOTE: When checking intersection rules, an OperatorGroup's namespace is always
+included as part of its selected target namespaces.
+
+[discrete]
+==== Rules for intersection
+
+Each time an active member CSV synchronizes, OLM queries the cluster for the set
+of intersecting provided APIs between the CSV's OperatorGroup and all others.
+OLM then checks if that set is an empty set:
+
+* If `true` and the CSV's provided APIs are a subset of the OperatorGroup's:
+** Continue transitioning.
+* If `true` and the CSV's provided APIs are _not_ a subset of the
+OperatorGroup's:
+** If the OperatorGroup is static:
+*** Clean up any deployments that belong to the CSV.
+*** Transition the CSV to a failed state with status reason
+`CannotModifyStaticOperatorGroupProvidedAPIs`.
+** If the OperatorGroup is _not_ static:
+*** Replace the OperatorGroup's `olm.providedAPIs` annotation with the union of
+itself and the CSV's provided APIs.
+* If `false` and the CSV's provided APIs are _not_ a subset of the
+OperatorGroup's:
+** Clean up any deployments that belong to the CSV.
+** Transition the CSV to a failed state with status reason
+`InterOperatorGroupOwnerConflict`.
+* If `false` and the CSV's provided APIs are a subset of the OperatorGroup's:
+** If the OperatorGroup is static:
+*** Clean up any deployments that belong to the CSV.
+*** Transition the CSV to a failed state with status reason
+`CannotModifyStaticOperatorGroupProvidedAPIs`.
+** If the OperatorGroup is _not_ static:
+*** Replace the OperatorGroup's `olm.providedAPIs` annotation with the
+difference between itself and the CSV's provided APIs.
+
+NOTE: Failure states caused by OperatorGroups are non-terminal.
+
+The following actions are performed each time an OperatorGroup synchronizes:
+
+* The set of provided APIs from active member CSVs is calculated from the
+cluster. Note that copied CSVs are ignored.
+* The cluster set is compared to `olm.providedAPIs`, and if `olm.providedAPIs`
+contains any extra APIs, then those APIs are pruned.
+* All CSVs that provide the same APIs across all namespaces are requeued. This
+notifies conflicting CSVs in intersecting groups that their conflict has
+possibly been resolved, either through resizing or through deletion of the
+conflicting CSV.

--- a/modules/olm-operatorhub.adoc
+++ b/modules/olm-operatorhub.adoc
@@ -41,7 +41,7 @@ The OperatorHub component is installed and run as an Operator by default on
 {product-title} in the `openshift-marketplace` namespace.
 
 [id="olm-operatorhub-arch-{context}"]
-== Architecture
+== OperatorHub Architecture
 
 The OperatorHub component's Operator manages two Custom Resource Definitions
 (CRDs): an
@@ -57,7 +57,7 @@ by those who are creating their own Operators.
 ====
 
 [id="olm-operatorhub-arch-operatorsource-{context}"]
-=== OperatorSource
+== OperatorSource
 
 For each Operator, the OperatorSource is used to define the external data store
 used to store Operator bundles. A
@@ -91,7 +91,7 @@ can be displayed on the OperatorHub.
 |===
 
 [id="olm-operatorhub-arch-catalogsourceconfig-{context}"]
-=== CatalogSourceConfig
+== CatalogSourceConfig
 
 An Operator's CatalogSourceConfig is used to enable an Operator present in the
 OperatorSource on the cluster.


### PR DESCRIPTION
@openshift/team-documentation For peer review please.

@ecordell or @njhale Could you please review this? I mostly pulled in the updates from https://github.com/operator-framework/operator-lifecycle-manager/pull/721 with some minor rearrangements, tweaks, and formatting changes. I'm going to tag you in a few specific places that I had questions on. Thanks!

Preview: http://file.rdu.redhat.com/~ahoffer/2019/OSDOCS-316/applications/operators/olm-adding-operators-to-cluster.html#olm-architecture-operatorgroups-olm-adding-operators-to-a-cluster