### PR TITLE
Fixed Bug 1683188, wrong link

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -31,7 +31,7 @@ As a cluster administrator, with tasks from deploying {product-title} 4.0 to man
 
 - **xref:../installing-aws/installing-aws-account.adoc[Choose a deployment platform]**: Amazon AWS is the first supported platform for {product-title} 4.0. However, you can expect support for other cloud and on-premise platforms to follow soon.
 
-- **xref:../installing-aws/installing-quickly-cloud.adoc[Deploy {product-title}]**: Choose between an xref:../installing-aws/installing-aws-account.adoc[AWS quick cluster install] or xref:../installing-aws/installing-customizations-cloud.adoc[AWS install with customizations].
+- **xref:../installing-aws/installing-aws-account.adoc[Deploy {product-title}]**: Choose between an xref:../installing-aws/installing-quickly-cloud.adoc[AWS quick cluster install] or xref:../installing-aws/installing-customizations-cloud.adoc[AWS install with customizations].
 
 - **xref:../machine_management/creating-machineset.adoc[Manage machines]**: Manage machines in your OpenShift cluster by xref:../machine_management/deploying-machine-health-checks.adoc[deploying health checks] and xref:../machine_management/deploying-machine-health-checks.adoc[applying autoscaling to machines].
 


### PR DESCRIPTION
Actually, the two links in that bullet were out of order.
The first (installing-aws/installing-aws-account.html) was to do
some preparation for the install. The second
(installing-aws/installing-quickly-cloud.html) was to do a quick
install.