### PR TITLE
Install Node Problem Detector operator does not require selecting Operator Group anymore

### DIFF
--- a/modules/nodes-nodes-problem-detector-installing.adoc
+++ b/modules/nodes-nodes-problem-detector-installing.adoc
@@ -40,7 +40,11 @@ To install the Node Problem Detector:
 
 . Choose  *node-problem-detector* from the list of available Operators, and click Install.
 
-. On the *Create Operator Subscription* page change the *Target* to the *global-operators* Operator Group. This makes the Operator available to all users and projects that use this OpenShift Container Platform cluster.
+. On the *Create Operator Subscription* page: 
+
+.. Select the `openshift-node-problem-detector` project from the *A specific namespace on the cluster* drop-down list.
+
+.. Click *Subscribe*.
 
 . On the *Catalog* → *Installed Operators* page, verify that the NodeProblemDetector (CSV) eventually shows up and its *Status* ultimately resolves to *InstallSucceeded*.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1684405