### PR TITLE
BZ-1684463: Fixing duplicate words

### DIFF
--- a/modules/building-memcached-operator-using-osdk.adoc
+++ b/modules/building-memcached-operator-using-osdk.adoc
@@ -97,9 +97,9 @@ The example controller executes the following reconciliation logic for each
 --
 +
 The next two sub-steps inspect how the Controller watches resources and how the
-reconcile loop is triggered. You can skip
+reconcile loop is triggered. You can 
 xref:building-memcached-operator-using-osdk-build-and-run_{context}[skip these steps]
-step to go directly to building and running the Operator.
+to go directly to building and running the Operator.
 
 .. Inspect the Controller implementation at the
 `pkg/controller/memcached/memcached_controller.go` file to see how the


### PR DESCRIPTION
@openshift/team-documentation For peer review.

@jianzhangbjz Could you take a look at this? I fixed the duplicate words, but I believe that the link takes you to the appropriate step (skips steps 3c and 3d and goes to step 4).

Preview: http://file.rdu.redhat.com/~ahoffer/2019/BZ-1684463/applications/operator_sdk/osdk-getting-started.html#building-memcached-operator-using-osdk_osdk-getting-started