### PR TITLE
removing {nbsp}

### DIFF
--- a/applications/crds/crd-extending-api-with-crds.adoc
+++ b/applications/crds/crd-extending-api-with-crds.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide describes how cluster administrators can extend their {product-title}
 cluster by creating and managing Custom Resource Definitions (CRDs).
 

--- a/applications/crds/crd-managing-resources-from-crds.adoc
+++ b/applications/crds/crd-managing-resources-from-crds.adoc
@@ -4,7 +4,7 @@ include::modules/common-attributes.adoc[]
 :context: crd-managing-resources-from-crds
 
 toc::[]
-{nbsp} +
+
 This guide describes how developers can manage Custom Resources (CRs) that come
 from Custom Resource Definitions (CRDs).
 

--- a/applications/deployments/deployment-strategies.adoc
+++ b/applications/deployments/deployment-strategies.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 A _deployment strategy_ is a way to change or upgrade an application. The aim
 is to make the change without downtime in a way that the user barely notices the
 improvements.

--- a/applications/deployments/managing-deployment-processes.adoc
+++ b/applications/deployments/managing-deployment-processes.adoc
@@ -4,7 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: deployment-operations
 
 toc::[]
-{nbsp} +
 
 [id='deploymentconfig-operations']
 == Managing DeploymentConfigs

--- a/applications/deployments/route-based-deployment-strategies.adoc
+++ b/applications/deployments/route-based-deployment-strategies.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Deployment strategies provide a way for the application to evolve. Some
 strategies use DeploymentConfigs to make changes that are seen by users of all
 routes that resolve to the application. Other advanced strategies, such as the

--- a/applications/deployments/what-deployments-are.adoc
+++ b/applications/deployments/what-deployments-are.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 _Deployments_ and _DeploymentConfigs_ in {product-title} are API objects that
 provide two similar but different methods for fine-grained management over
 common user applications. They are comprised of the following separate API

--- a/applications/idling-applications.adoc
+++ b/applications/idling-applications.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Cluster administrators can idle applications to reduce resource consumption.
 This is useful when the cluster is deployed on a public cloud where cost is
 related to resource consumption.

--- a/applications/operator_sdk/osdk-ansible.adoc
+++ b/applications/operator_sdk/osdk-ansible.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide outlines Ansible support in the Operator SDK and walks Operator
 authors through examples building and running Ansible-based Operators with the
 `operator-sdk` CLI tool that use Ansible playbooks and modules.

--- a/applications/operator_sdk/osdk-cli-reference.adoc
+++ b/applications/operator_sdk/osdk-cli-reference.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide documents the Operator SDK CLI commands and their syntax:
 
 ----

--- a/applications/operator_sdk/osdk-generating-csvs.adoc
+++ b/applications/operator_sdk/osdk-generating-csvs.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 A _ClusterServiceVersion_ (CSV) is a YAML manifest created from Operator
 metadata that assists the Operator Lifecycle Manager (OLM) in running the
 Operator in a cluster. It is the metadata that accompanies an Operator container

--- a/applications/operator_sdk/osdk-getting-started.adoc
+++ b/applications/operator_sdk/osdk-getting-started.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide outlines the basics of the Operator SDK and walks Operator authors
 with cluster administrator access to a Kubernetes-based cluster (such as
 {product-title}) through an example of building a simple Go-based Memcached

--- a/applications/operator_sdk/osdk-helm.adoc
+++ b/applications/operator_sdk/osdk-helm.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide outlines Helm chart support in the Operator SDK and walks Operator
 authors through an example of building and running an Nginx Operator with the
 `operator-sdk` CLI tool that uses an existing Helm chart.

--- a/applications/operator_sdk/osdk-migrating-to-v0-1-0.adoc
+++ b/applications/operator_sdk/osdk-migrating-to-v0-1-0.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide describes how to migrate an Operator project built using Operator SDK
 v0.0.x to the project structure required by
 link:https://github.com/operator-framework/operator-sdk/releases[Operator SDK v0.1.0].

--- a/applications/operator_sdk/osdk-monitoring-prometheus.adoc
+++ b/applications/operator_sdk/osdk-monitoring-prometheus.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide describes the built-in monitoring support provided by the Operator
 SDK using the Prometheus Operator and details usage for Operator authors.
 

--- a/applications/operators/olm-adding-operators-to-cluster.adoc
+++ b/applications/operators/olm-adding-operators-to-cluster.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide outlines the architecture of the Operator Lifecycle Manager (OLM) and
 OperatorHub and walks cluster administrators through an example of installing
 and subscribing a cluster to Operators from the OperatorHub.

--- a/applications/operators/olm-creating-apps-from-installed-operators.adoc
+++ b/applications/operators/olm-creating-apps-from-installed-operators.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This guide walks developers through an example of creating applications from an
 installed Operator using the {product-title} 4.0 web console.
 

--- a/applications/operators/olm-what-operators-are.adoc
+++ b/applications/operators/olm-what-operators-are.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 [.lead]
 Conceptually, _Operators_ take human operational knowledge and encode it into
 software that is more easily shared with consumers.

--- a/applications/pruning-objects.adoc
+++ b/applications/pruning-objects.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Over time, API objects created in {product-title} can accumulate in the
 cluster's etcd data store through normal user operations, such as when building
 and deploying applications.

--- a/applications/quotas/quotas-setting-across-multiple-projects.adoc
+++ b/applications/quotas/quotas-setting-across-multiple-projects.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 A multi-project quota, defined by a ClusterResourceQuota object, allows quotas
 to be shared across multiple projects. Resources used in each selected project
 are aggregated and that aggregate is used to limit resources across all the

--- a/applications/quotas/quotas-setting-per-project.adoc
+++ b/applications/quotas/quotas-setting-per-project.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 A _resource quota_, defined by a ResourceQuota object, provides constraints that
 limit aggregate resource consumption per project. It can limit the quantity of
 objects that can be created in a project by type, as well as the total amount of

--- a/applications/working-with-quotas.adoc
+++ b/applications/working-with-quotas.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 A _resource quota_, defined by a ResourceQuota object, provides constraints that
 limit aggregate resource consumption per project. It can limit the quantity of
 objects that can be created in a project by type, as well as the total amount of

--- a/architecture/architecture.adoc
+++ b/architecture/architecture.adoc
@@ -8,8 +8,6 @@ include::modules/common-attributes.adoc[]
 :context: architecture
 toc::[]
 
-{nbsp} +
-
 [IMPORTANT]
 ====
 This assembly is a temporary placeholder to port the valid information from

--- a/architecture/web-console.adoc
+++ b/architecture/web-console.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 :context: web-console
 toc::[]
 
-{nbsp}
-
 The {product-title} web console is a user interface accessible from a web browser.
 Developers can use the web console to visualize, browse, and manage the contents
 of projects.

--- a/authentication/configuring-internal-oauth.adoc
+++ b/authentication/configuring-internal-oauth.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-internal-oauth
 toc::[]
 
-{nbsp} +
-
 [IMPORTANT]
 ====
 Configuring these options will need to change because they're set in the master

--- a/authentication/configuring-ldap-failover.adoc
+++ b/authentication/configuring-ldap-failover.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 include::modules/ldap-failover-overview.adoc[]
 
 include::modules/ldap-failover-prereqs.adoc[leveloffset=+1]

--- a/authentication/configuring-user-agent.adoc
+++ b/authentication/configuring-user-agent.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-user-agent
 toc::[]
 
-{nbsp} +
-
 include::modules/user-agent-overview.adoc[leveloffset=+1]
 
 include::modules/user-agent-configuring.adoc[leveloffset=+1]

--- a/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-basic-authentication-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure a `basic-authentication` identity provider for users to log in to
 {product-title} with credentials validated against a remote identity provider.
 Basic authentication is a generic backend integration mechanism.

--- a/authentication/identity_providers/configuring-github-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-github-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-github-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure a `github` identity provider to validate user names and passwords
 against GitHub or GitHub Enterprise's OAuth authentication server. OAuth
 facilitates a token exchange flow between

--- a/authentication/identity_providers/configuring-gitlab-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-gitlab-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-gitlab-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure a `gitlab` identity provider to use
 link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity
 provider. If you use GitLab version 7.7.0 to 11.0, you connect using the

--- a/authentication/identity_providers/configuring-google-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-google-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-google-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure a `google` identity provider using
 link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].
 

--- a/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-htpasswd-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure the `htpasswd` identity provider to validate user names and passwords
 against a flat file generated using
 link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].

--- a/authentication/identity_providers/configuring-keystone-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-keystone-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-keystone-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure the `keystone` identity provider to integrate
 your {product-title} cluster with Keystone to enable shared authentication with
 an OpenStack Keystone v3 server configured to store users in an internal

--- a/authentication/identity_providers/configuring-ldap-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-ldap-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-ldap-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure the `ldap` identity provider to validate user names and passwords
 against an LDAPv3 server, using simple bind authentication.
 

--- a/authentication/identity_providers/configuring-oidc-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-oidc-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-oidc-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure an `oidc` identity provider to integrate with an OpenID Connect
 identity provider using an
 link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].

--- a/authentication/identity_providers/configuring-request-header-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-request-header-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-request-header-identity-provider
 toc::[]
 
-{nbsp} +
-
 Configure a `request-header` identity provider to identify users from request
 header values, such as `X-Remote-User`. It is typically used in combination with
 an authenticating proxy, which sets the request header value.

--- a/authentication/managing-security-context-constraints.adoc
+++ b/authentication/managing-security-context-constraints.adoc
@@ -4,9 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: configuring-internal-oauth
 toc::[]
 
-{nbsp} +
-
-
 include::modules/security-context-constraints-about.adoc[leveloffset=+1]
 
 // I should add a module about installing the OC command line.

--- a/authentication/tokens-scoping.adoc
+++ b/authentication/tokens-scoping.adoc
@@ -4,6 +4,4 @@ include::modules/common-attributes.adoc[]
 :context: configuring-internal-oauth
 toc::[]
 
-{nbsp} +
-
 include::modules/tokens-scoping-about.adoc[leveloffset=+1]

--- a/authentication/understanding-and-creating-service-accounts.adoc
+++ b/authentication/understanding-and-creating-service-accounts.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: understanding-service-accounts
 toc::[]
 
-{nbsp} +
-
 include::modules/service-accounts-overview.adoc[leveloffset=+1]
 
 include::modules/service-accounts-dedicated-admin-role.adoc[leveloffset=+1]

--- a/authentication/understanding-authentication.adoc
+++ b/authentication/understanding-authentication.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: understanding-authentication
 toc::[]
 
-{nbsp} +
-
 For users to interact with {product-title}, they must first authenticate
 to the cluster. The authentication layer identifies the user associated with requests to the
 {product-title} API. The authorization layer then uses information about the

--- a/authentication/understanding-identity-provider.adoc
+++ b/authentication/understanding-identity-provider.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: understanding-identity-provider
 toc::[]
 
-{nbsp} +
-
 The {product-title} master includes a built-in OAuth server. Developers and
 administrators obtain OAuth access tokens to authenticate themselves to the API.
 

--- a/authentication/using-rbac.adoc
+++ b/authentication/using-rbac.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 include::modules/rbac-overview.adoc[leveloffset=+1]
 
 include::modules/rbac-projects-namespaces.adoc[leveloffset=+1]

--- a/authentication/using-service-accounts-as-oauth-client.adoc
+++ b/authentication/using-service-accounts-as-oauth-client.adoc
@@ -4,6 +4,4 @@ include::modules/common-attributes.adoc[]
 :context: using-service-accounts-as-oauth-client
 toc::[]
 
-{nbsp} +
-
 include::modules/service-accounts-as-oauth-clients.adoc[leveloffset=+1]

--- a/authentication/using-service-accounts-in-applications.adoc
+++ b/authentication/using-service-accounts-in-applications.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: using-service-accounts
 toc::[]
 
-{nbsp} +
-
 include::modules/service-accounts-overview.adoc[leveloffset=+1]
 
 include::modules/service-accounts-default.adoc[leveloffset=+1]

--- a/installing-aws/installing-aws-account.adoc
+++ b/installing-aws/installing-aws-account.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 Before you can install {product-title}, you must configure an
 Amazon Web Services (AWS) account.
 

--- a/installing-aws/installing-customizations-cloud.adoc
+++ b/installing-aws/installing-customizations-cloud.adoc
@@ -5,9 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
-
 In {product-title} version {product-version}, you can install a customized
 cluster on Amazon Web Services (AWS).
 

--- a/installing-aws/installing-quickly-cloud.adoc
+++ b/installing-aws/installing-quickly-cloud.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 In {product-title} version {product-version}, you can install a cluster on
 Amazon Web Services (AWS) that uses the default configuration options.
 

--- a/installing-aws/uninstalling-cluster-aws.adoc
+++ b/installing-aws/uninstalling-cluster-aws.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 You can remove a cluster that you deployed to Amazon Web Services (AWS).
 
 include::modules/installation-uninstall-aws.adoc[leveloffset=+1]

--- a/installing-byoh/installing-existing-hosts.adoc
+++ b/installing-byoh/installing-existing-hosts.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 You can install {product-title} version {product-version} on existing Red Hat
 Enterprise Linux (RHEL) hosts. This is a BYO, or bring-your-own hosts, installation.
 

--- a/installing-byoh/uninstalling-existing-hosts.adoc
+++ b/installing-byoh/uninstalling-existing-hosts.adoc
@@ -5,7 +5,5 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 We don't know how this will be managed at release of 4.0, but this topic
 will need to say something.

--- a/machine_management/applying-autoscaling.adoc
+++ b/machine_management/applying-autoscaling.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 Applying autoscaling to a {product-title} cluster involves deploying a
 ClusterAutoscaler and then deploying MachineAutoscalers for each Machine type
 in your cluster.

--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 You can create a MachineSet to host only infrastructure components.
 You apply specific Kubernetes labels to these Machines and then
 update the infrastructure components to run on only those Machines.These

--- a/machine_management/creating-machineset.adoc
+++ b/machine_management/creating-machineset.adoc
@@ -5,7 +5,4 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 include::modules/machineset-creating.adoc[leveloffset=+1]
-

--- a/machine_management/manually-scaling-machineset.adoc
+++ b/machine_management/manually-scaling-machineset.adoc
@@ -5,7 +5,4 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
-
 include::modules/machineset-manually-scaling.adoc[leveloffset=+1]
-

--- a/nodes/nodes/nodes-node-tuning-operator.adoc
+++ b/nodes/nodes/nodes-node-tuning-operator.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp}
 Learn about the Node Tuning Operator and how you can use it to manage node-level
 tuning by orchestrating the tuned daemon.
 

--- a/release_notes/comparing_3_4.adoc
+++ b/release_notes/comparing_3_4.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: comparing_v3_v4
 toc::[]
 
-{nbsp} +
-
 [IMPORTANT]
 ====
 This is a placeholder for the high-level information about {product-title} 4 that is

--- a/scalability_and_performance/network-optimization.adoc
+++ b/scalability_and_performance/network-optimization.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 The OpenShift SDN uses Open vSwitch, Virtual Extensible LAN (VXLAN) tunnels,
 OpenFlow rules, and iptables. This network can be tuned by using jumbo frames,
 network interface cards (NIC) offloads, multi-queue, and ethtool settings.

--- a/scalability_and_performance/optimizing-compute-resources.adoc
+++ b/scalability_and_performance/optimizing-compute-resources.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Containers can specify compute resource requests and limits. Requests are used
 for scheduling your container and provide a minimum service guarantee. Limits
 constrain the amount of compute resource that may be consumed on your node.

--- a/scalability_and_performance/optimizing-storage.adoc
+++ b/scalability_and_performance/optimizing-storage.adoc
@@ -18,7 +18,6 @@ ifdef::openshift-enterprise[]
 
 toc::[]
 
-{nbsp} +
 Optimizing storage helps to minimize storage use across all resources. By
 optimizing storage, administrators help ensure that existing storage resources
 are working in an efficient manner.

--- a/scalability_and_performance/planning-your-environment-according-to-object-limits.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-limits.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Consider the following object limits when you plan your {product-title} cluster.
 
 These limits are based on on the the largest possible cluster. For smaller

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 This topic provides recommended host practices for {product-title}.
 
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+1]

--- a/scalability_and_performance/scaling-cluster-monitoring-operator.adoc
+++ b/scalability_and_performance/scaling-cluster-monitoring-operator.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 {product-title} exposes metrics that can be collected and stored in back-ends by
 the
 link:https://github.com/openshift/cluster-monitoring-operator[*cluster-monitoring-operator*].

--- a/scalability_and_performance/using-cluster-loader.adoc
+++ b/scalability_and_performance/using-cluster-loader.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Cluster Loader is a tool that deploys large numbers of various objects to a
 cluster, which creates user-defined cluster objects. Build, configure, and run
 Cluster Loader to measure performance metrics of your {product-title} deployment

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 Learn about the Node Tuning Operator and how you can use it to manage node-level
 tuning by orchestrating the tuned daemon.
 
@@ -13,7 +12,7 @@ include::modules/node-tuning-operator.adoc[leveloffset=+1]
 
 include::modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc[leveloffset=+1]
 
-:FeatureName: Custom profiles for custom tuning specification 
+:FeatureName: Custom profiles for custom tuning specification
 include::modules/technology-preview.adoc[leveloffset=+1]
 
 include::modules/custom-tuning-specification.adoc[leveloffset=+1]

--- a/users_and_roles/creating-project-other-user.adoc
+++ b/users_and_roles/creating-project-other-user.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: creating-project-other-user
 toc::[]
 
-{nbsp} +
-
 Impersonation allows you to create a project as a different user.
 
 include::modules/authentication-api-impersonation.adoc[leveloffset=+1]

--- a/users_and_roles/impersonating-system-admin.adoc
+++ b/users_and_roles/impersonating-system-admin.adoc
@@ -4,8 +4,6 @@ include::modules/common-attributes.adoc[]
 :context: impersonating-system-admin
 toc::[]
 
-{nbsp} +
-
 include::modules/authentication-api-impersonation.adoc[leveloffset=+1]
 
 include::modules/impersonation-system-admin-user.adoc[leveloffset=+1]

--- a/web-console/working-with-projects.adoc
+++ b/web-console/working-with-projects.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{nbsp} +
 A _project_ allows a community of users to organize and manage their content in
 isolation from other communities.
 


### PR DESCRIPTION
Because @vikram-redhat  updated the padding on https://github.com/openshift/openshift-docs/pull/13706, we don't need \{nbsp\} in assemblies.

@openshift/team-documentation, any objections? 