### PR TITLE
Add missing registry examples to Ansible Broker Configuration

### DIFF
--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -569,14 +569,14 @@ registry:
       - ".*"
 ----
 
-*Note:* A heavy percentage of helm charts from the stable repository are not well suited for OpenShift.
-For more information see link:https://github.com/ansibleplaybookbundle/helm2bundle/wiki/Known-Issues[here].
+NOTE: A heavy percentage of helm charts from the stable repository are not well suited for OpenShift.
+See the link:https://github.com/ansibleplaybookbundle/helm2bundle/wiki/Known-Issues[Known Issues] for more information.
 
 [[oab-config-api-v2-registry]]
 === API V2 Docker Registry
 
 Using the `apiv2` type allows you to consume images from docker registries that implement the Docker Registry
-HTTP API V2 protocol can be configured with the apiv2 registry adapter.
+HTTP API V2 protocol.
 
 [source,yaml]
 ----
@@ -593,17 +593,16 @@ registry:
 If the registry requires authentication for pulling images, this can be achieved by running the following
 command on every node in your existing cluster:
 
-[source,yaml]
 ----
-docker --config=/var/lib/origin/.docker login -u <registry-user> -p <registry-password> <registry_url>
+$ docker --config=/var/lib/origin/.docker login -u <registry-user> -p <registry-password> <registry_url>
 ----
 
 [[oab-config-quay-registry]]
 === Quay Docker Registry
 
 Using the `quay` type allows you to load APBs that are published to the link:https://quay.io/about/[CoreOS Quay Registry].
-If an authentication token is provided, private repositories (which the token is configured to access) will
-also load as well as any public repositories in the specified org.
+If an authentication token is provided, private repositories that the token is configured to access will load.
+Public repositories in the specified organization do not require a token to load.
 
 [source,yaml]
 ----
@@ -620,9 +619,8 @@ registry:
 If the Quay registry requires authentication for pulling images, this can be achieved by running the following
 command on every node in your existing cluster:
 
-[source,yaml]
 ----
-docker --config=/var/lib/origin/.docker login -u <registry-user> -p <registry-password> quay.io
+$ docker --config=/var/lib/origin/.docker login -u <registry-user> -p <registry-password> quay.io
 ----
 
 [[oab-configmultiple-registries]]

--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -341,59 +341,6 @@ registry:
 ----
 --
 
-[[oab-config-registry-mock]]
-=== Mock Registry
-
-A mock registry is useful for reading local APB specs. Instead of going out to a
-registry to search for image specs, this uses a list of local specs. Set the
-name of the registry to `mock` to use the mock registry.
-
-[source,yaml]
-----
-registry:
-  - name: mock
-    type: mock
-----
-
-[[oab-config-registry-dockerhub]]
-=== Dockerhub Registry
-
-The `dockerhub` type allows you to load APBs from a specific organization in
-the DockerHub. For example, the
-link:https://hub.docker.com/u/ansibleplaybookbundle/[*ansibleplaybookbundle*]
-organization.
-
-[source,yaml]
-----
-registry:
-  - name: dockerhub
-    type: dockerhub
-    org: ansibleplaybookbundle
-    user: <user>
-    pass: <password>
-    white_list:
-      - ".*-apb$"
-----
-
-[[oab-config-registry-galaxy]]
-=== Ansible Galaxy Registry
-
-The `galaxy` type allows you to use APB roles from
-link:https://galaxy.ansible.com[Ansible Galaxy]. You can also optionally
-specify an organization.
-
-[source,yaml]
-----
-registry:
-  - name: galaxy
-    type: galaxy
-    # Optional:
-    # org: ansibleplaybookbundle
-    runner: docker.io/ansibleplaybookbundle/apb-base:latest
-    white_list:
-      - ".*$"
-----
-
 [[oab-config-apb-filtering]]
 === APB Filtering
 
@@ -485,6 +432,59 @@ registry:
       - "^foobar-apb$"
 ----
 
+[[oab-config-registry-mock]]
+=== Mock Registry
+
+A mock registry is useful for reading local APB specs. Instead of going out to a
+registry to search for image specs, this uses a list of local specs. Set the
+name of the registry to `mock` to use the mock registry.
+
+[source,yaml]
+----
+registry:
+  - name: mock
+    type: mock
+----
+
+[[oab-config-registry-dockerhub]]
+=== Dockerhub Registry
+
+The `dockerhub` type allows you to load APBs from a specific organization in
+the DockerHub. For example, the
+link:https://hub.docker.com/u/ansibleplaybookbundle/[*ansibleplaybookbundle*]
+organization.
+
+[source,yaml]
+----
+registry:
+  - name: dockerhub
+    type: dockerhub
+    org: ansibleplaybookbundle
+    user: <user>
+    pass: <password>
+    white_list:
+      - ".*-apb$"
+----
+
+[[oab-config-registry-galaxy]]
+=== Ansible Galaxy Registry
+
+The `galaxy` type allows you to use APB roles from
+link:https://galaxy.ansible.com[Ansible Galaxy]. You can also optionally
+specify an organization.
+
+[source,yaml]
+----
+registry:
+  - name: galaxy
+    type: galaxy
+    # Optional:
+    # org: ansibleplaybookbundle
+    runner: docker.io/ansibleplaybookbundle/apb-base:latest
+    white_list:
+      - ".*$"
+----
+
 [[oab-config-registry-local]]
 === Local OpenShift Container Registry
 
@@ -551,6 +551,78 @@ is also required to configure the broker to use the Partner Registry URL:
 # docker --config=/var/lib/origin/.docker \
     login -u <registry_user> -p <registry_password> \
     registry.connect.redhat.com
+----
+
+[[oab-config-helm-chart-registry]]
+=== Helm Chart Registry
+
+Using the `helm` type allows you to consume Helm Charts from a Helm Chart Repository.
+
+[source,yaml]
+----
+registry:
+  - name: stable
+    type: helm
+    url: "https://kubernetes-charts.storage.googleapis.com"
+    runner: "docker.io/automationbroker/helm-runner:latest"
+    white_list:
+      - ".*"
+----
+
+*Note:* A heavy percentage of helm charts from the stable repository are not well suited for OpenShift.
+For more information see link:https://github.com/ansibleplaybookbundle/helm2bundle/wiki/Known-Issues[here].
+
+[[oab-config-api-v2-registry]]
+=== API V2 Docker Registry
+
+Using the `apiv2` type allows you to consume images from docker registries that implement the Docker Registry
+HTTP API V2 protocol can be configured with the apiv2 registry adapter.
+
+[source,yaml]
+----
+registry:
+  - name: <registry_name>
+    type: apiv2
+    url:  <registry_url>
+    user: <registry-user>
+    pass: <registry-password>
+    white_list:
+      - ".*-apb$"
+----
+
+If the registry requires authentication for pulling images, this can be achieved by running the following
+command on every node in your existing cluster:
+
+[source,yaml]
+----
+docker --config=/var/lib/origin/.docker login -u <registry-user> -p <registry-password> <registry_url>
+----
+
+[[oab-config-quay-registry]]
+=== Quay Docker Registry
+
+Using the `quay` type allows you to load APBs that are published to the link:https://quay.io/about/[CoreOS Quay Registry].
+If an authentication token is provided, private repositories (which the token is configured to access) will
+also load as well as any public repositories in the specified org.
+
+[source,yaml]
+----
+registry:
+  - name: quay_reg
+    type: quay
+    url:  https://quay.io
+    token: <for_private_repos>
+    org: <your_org>
+    white_list:
+      - ".*-apb$"
+----
+
+If the Quay registry requires authentication for pulling images, this can be achieved by running the following
+command on every node in your existing cluster:
+
+[source,yaml]
+----
+docker --config=/var/lib/origin/.docker login -u <registry-user> -p <registry-password> quay.io
 ----
 
 [[oab-configmultiple-registries]]


### PR DESCRIPTION
Fixes #13920 