### PR TITLE
BZ-1683136: Updated instructions to use route instead of master.

### DIFF
--- a/modules/identity-provider-about-request-header.adoc
+++ b/modules/identity-provider-about-request-header.adoc
@@ -13,33 +13,35 @@ You can also use the request header identity provider for advanced configuration
 such as link:https://github.com/openshift/request-header-saml-service-provider[SAML authentication].
 
 For users to authenticate using this identity provider, they must access
-`\https://<master>/oauth/authorize` (and subpaths) via an authenticating proxy.
+`https://_<namespace_route>_/oauth/authorize` (and subpaths) via an authenticating proxy.
 To accomplish this, configure the OAuth server to redirect unauthenticated
-requests for OAuth tokens to the proxy endpoint that proxies to `\https://<master>/oauth/authorize`.
+requests for OAuth tokens to the proxy endpoint that proxies to 
+`https://_<namespace_route>_/oauth/authorize`.
 
 To redirect unauthenticated requests from clients expecting browser-based login flows:
 
 1. Set the `login` parameter to `true`.
 2. Set the `provider.loginURL` parameter to the authenticating proxy URL that
-will authenticate interactive clients and then proxy the request to `\https://<master>/oauth/authorize`.
+will authenticate interactive clients and then proxy the request to 
+`https://_<namespace_route>_/oauth/authorize`.
 
 To redirect unauthenticated requests from clients expecting `WWW-Authenticate` challenges:
 
 1. Set the `challenge` parameter to `true`.
 2. Set the `provider.challengeURL` parameter to the authenticating proxy URL that
 will authenticate clients expecting `WWW-Authenticate` challenges and then proxy
-the request to `\https://<master>/oauth/authorize`.
+the request to `https://_<namespace_route>_/oauth/authorize`.
 
 The `provider.challengeURL` and `provider.loginURL` parameters can include
 the following tokens in the query portion of the URL:
 
 * `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 +
-For example: `\https://www.example.com/sso-login?then=${url}`
+For example: `https://www.example.com/sso-login?then=${url}`
 
 * `${query}` is replaced with the current query string, unescaped.
 +
-For example: `\https://www.example.com/auth-proxy/oauth/authorize?${query}`
+For example: `https://www.example.com/auth-proxy/oauth/authorize?${query}`
 
 [WARNING]
 ====

--- a/modules/identity-provider-request-header-CR.adoc
+++ b/modules/identity-provider-request-header-CR.adoc
@@ -50,13 +50,15 @@ login flow by redirecting to a configured `loginURL`. The configured URL should
 respond with a login flow.
 <4> Controls how mappings are established between this provider's identities and user objects.
 <5> Optional: URL to redirect unauthenticated `/oauth/authorize` requests to,
-that will authenticate browser-based clients and then proxy their request to `\https://<master>/oauth/authorize`.
-The URL that proxies to `\https://<master>/oauth/authorize` must end with `/authorize` (with no trailing slash),
+that will authenticate browser-based clients and then proxy their request to 
+`\https://_<namespace_route>_/oauth/authorize`.
+The URL that proxies to `\https://_<namespace_route>_/oauth/authorize` must end with `/authorize` (with no trailing slash),
 and also proxy subpaths, in order for OAuth approval flows to work properly.
 `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 `${query}` is replaced with the current query string.
 <6> Optional: URL to redirect unauthenticated `/oauth/authorize` requests to,
-that will authenticate clients which expect `WWW-Authenticate` challenges, and then proxy them to `\https://<master>/oauth/authorize`.
+that will authenticate clients which expect `WWW-Authenticate` challenges, and 
+then proxy them to `\https://_<namespace_route>_/oauth/authorize`.
 `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 `${query}` is replaced with the current query string.
 <7> Reference to a {product-title} ConfigMap containing a PEM-encoded 

--- a/modules/oauth-register-additional-server.adoc
+++ b/modules/oauth-register-additional-server.adoc
@@ -26,11 +26,13 @@ grantMethod: prompt <4>
 ')
 ----
 <1> The `name` of the OAuth client is used as the `client_id` parameter when
-making requests to `_<master>_/oauth/authorize` and `_<master>_/oauth/token`.
+making requests to `_<namespace_route>_/oauth/authorize` and 
+`_<namespace_route>_/oauth/token`.
 <2> The `secret` is used as the `client_secret` parameter when making requests
-to `_<master>_/oauth/token`.
+to `_<namespace_route>_/oauth/token`.
 <3> The `redirect_uri` parameter specified in requests to
-`_<master>_/oauth/authorize` and `_<master>_/oauth/token` must be equal to or
+`_<namespace_route>_/oauth/authorize` and `_<namespace_route>_/oauth/token`
+ must be equal to or
 prefixed by one of the URIs listed in the `redirectURIs` parameter value.
 <4> The `grantMethod` is used to determine what action to take when this client
 requests tokens and has not yet been granted access by the user. Specify `auto`

--- a/modules/oauth-server-metadata.adoc
+++ b/modules/oauth-server-metadata.adoc
@@ -18,8 +18,8 @@ the following information:
 ----
 {
   "issuer": "https://<master>", <1>
-  "authorization_endpoint": "https://<master>/oauth/authorize", <2>
-  "token_endpoint": "https://<master>/oauth/token", <3>
+  "authorization_endpoint": "https://<namespace_route>/oauth/authorize", <2>
+  "token_endpoint": "https://<namespace_route>/oauth/token", <3>
   "scopes_supported": [ <4>
     "user:full",
     "user:info",

--- a/modules/oauth-token-requests.adoc
+++ b/modules/oauth-token-requests.adoc
@@ -6,8 +6,8 @@
 == OAuth token requests
 
 Every request for an OAuth token must specify the OAuth client that will
-receive and use the token. The following OAuth clients are automatically created
-when starting the {product-title} API:
+receive and use the token. The following OAuth clients are automatically 
+created when starting the {product-title} API:
 
 [options="header"]
 |===
@@ -18,36 +18,49 @@ when starting the {product-title} API:
 |Requests tokens for the web console.
 
 |`openshift-browser-client`
-|Requests tokens at `_<master>_/oauth/token/request` with a user-agent that can handle interactive logins.
+|Requests tokens at `_<namespace_route>_/oauth/token/request` with a user-agent that can handle interactive logins.
 
 |`openshift-challenging-client`
 |Requests tokens with a user-agent that can handle `WWW-Authenticate` challenges.
 
 |===
 
-All requests for OAuth tokens involve a request to `_<master>_/oauth/authorize`.
-Most authentication integrations place an authenticating proxy in front of this
-endpoint, or configure {product-title} to validate credentials against a backing
-identity provider.
-Requests to `_<master>_/oauth/authorize` can come from user-agents that cannot
-display interactive login pages, such as the CLI. Therefore, {product-title}
-supports authenticating using a `WWW-Authenticate` challenge in addition to
-interactive login flows.
+[NOTE]
+====
+_<namespace_route>_ refers to the namespace's route. This is found by 
+running the following command.
+
+----
+oc get route openshift-authentication -n openshift-authentication -o json | jq .spec.host
+----
+====
+
+All requests for OAuth tokens involve a request to 
+`_<namespace_route>_/oauth/authorize`. Most authentication integrations place an 
+authenticating proxy in front of this endpoint, or configure 
+{product-title} to validate credentials against a backing identity provider.
+Requests to `_<namespace_route>_/oauth/authorize` can come from user-agents that 
+cannot display interactive login pages, such as the CLI. Therefore, 
+{product-title} supports authenticating using a `WWW-Authenticate` 
+challenge in addition to interactive login flows.
 
 If an authenticating proxy is placed in front of the
-`_<master>_/oauth/authorize` endpoint, it sends unauthenticated,
-non-browser user-agents `WWW-Authenticate` challenges rather than displaying an
-interactive login page or redirecting to an interactive login flow.
+`_<namespace_route>_/oauth/authorize` endpoint, it sends unauthenticated,
+non-browser user-agents `WWW-Authenticate` challenges rather than 
+displaying an interactive login page or redirecting to an interactive 
+login flow.
 
 [NOTE]
 ====
-To prevent cross-site request forgery (CSRF) attacks against browser clients, 
-only send Basic authentication challenges with if a `X-CSRF-Token` header is
-on the request. Clients that expect
-to receive Basic `WWW-Authenticate` challenges must set this header to a non-empty value.
+To prevent cross-site request forgery (CSRF) attacks against browser 
+clients,  only send Basic authentication challenges with if a 
+`X-CSRF-Token` header is on the request. Clients that expect
+to receive Basic `WWW-Authenticate` challenges must set this header to a 
+non-empty value. 
 
-If the authenticating proxy cannot support `WWW-Authenticate` challenges, or if
-{product-title} is configured to use an identity provider that does not support
-WWW-Authenticate challenges, you must use a browser to manually obtain a token from
-`_<master>_/oauth/token/request`.
+If the authenticating proxy cannot support `WWW-Authenticate` challenges, 
+or if {product-title} is configured to use an identity provider that does 
+not support WWW-Authenticate challenges, you must use a browser to manually 
+obtain a token from
+`_<namespace_route>_/oauth/token/request`.
 ====

--- a/modules/rbac-api-authentication.adoc
+++ b/modules/rbac-api-authentication.adoc
@@ -5,7 +5,8 @@ methods:
 
 OAuth Access Tokens::
 * Obtained from the {product-title} OAuth server using the
-`_<master>_/oauth/authorize` and `_<master>_/oauth/token` endpoints.
+`_<namespace_route>_/oauth/authorize` and `_<namespace_route>_/oauth/token` 
+endpoints.
 * Sent as an `Authorization: Bearer...` header.
 * Sent as a websocket subprotocol header in the form
 `base64url.bearer.authorization.k8s.io.<base64url-encoded-token>` for websocket


### PR DESCRIPTION
BZ-1683136: Updated instructions to use route instead of master for token requests.

This is for OS 4.0.