### PR TITLE
[enterprise-3.11] Add a node labeling guide before creating the launch config

### DIFF
--- a/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
@@ -14,6 +14,7 @@ the existing cluster when it starts.
 
 * Install a {product-title} cluster in AWS.
 * Create a primed image.
+* Set the node label to `logging-infra-fluentd=true` in auto scaling node group, if you deployed the EFK stack in your cluster.
 
 .Procedure
 


### PR DESCRIPTION
* Fix: https://github.com/openshift/openshift-docs/issues/13939

* Version: only `v3.11`

* Description:
  If `EFK` and some feature that is depended on `labels` of running `nodes` are using on the `cluster`, it leads unexpected issues, such as not starting expected pods. We would guide about the node labeling requirement kindly before creating launch configuration.