### PR TITLE
Correct the steps for redeploying router certificates

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -577,13 +577,7 @@ $ oc rollout latest dc/docker-registry
 [[redeploying-router-certificates-manually]]
 ==== Redeploying Router Certificates Manually
 
-When routers are initially deployed, an annotation is added to the router's
-service that automatically creates a
-xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service serving certificate secret].
-
-To redeploy router certificates manually, that service serving certificate can
-be triggered to be recreated by deleting the secret, removing and re-adding
-annotations to the `router` service, then redeploying the router:
+To redeploy router certificates manually, you must add new router certificates to a secret named `router-certs`, then redeploy the router:
 
 . Switch to the `default` project for the remainder of these steps:
 +
@@ -688,6 +682,18 @@ $ oc create secret tls router-certs --cert=router.pem \ <1>
 <1> *_router.pem_* is the file that contains the concatenation of the
 certificates that you generated.    
 
+. Redeploy the router:
++
+----
+$ oc rollout latest dc/router
+----
++
+When routers are initially deployed, an annotation is added to the router's
+service that automatically creates a
+xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service serving certificate secret] named `router-metrics-tls`.
++
+To redeploy `router-metrics-tls` certificates manually, that service serving certificate can be triggered to be recreated by deleting the secret, removing and re-adding annotations to the router service, then redeploying the `router-metrics-tls` secret:
+
 . Remove the following annotations from the `router` service:
 +
 ----
@@ -696,15 +702,15 @@ $ oc annotate service router \
     service.alpha.openshift.io/serving-cert-signed-by-
 ----
 
+. Remove the existing `router-metrics-tls` secret.
++
+----
+$ oc delete secret router-metrics-tls
+----
+
 . Re-add the annotations:
 +
 ----
 $ oc annotate service router \
-    service.alpha.openshift.io/serving-cert-secret-name=router-certs
-----
-
-. Redeploy the router:
-+
-----
-$ oc rollout latest dc/router
+    service.alpha.openshift.io/serving-cert-secret-name=router-metrics-tls
 ----


### PR DESCRIPTION
- Fix: ["redeploy-router-certificates.yml" makes changes to wrong "service serving certificate secrets" annotation](https://bugzilla.redhat.com/show_bug.cgi?id=1672011)

- Version: `v3.3` ~ `v3.11`

- Description:
  If your `router` installed initially with `router-metrics-tls` annotation in the `router Service`, `router-metrics-tls secret` should be `service serving certificates secret`.  In contrast, `router-certs secret` is using as `wild card certificates` and not `service serving certificates secret`.

