### PR TITLE
BZ-1684750: Fixed file name to delete

### DIFF
--- a/modules/osdk-building-ansible-operator.adoc
+++ b/modules/osdk-building-ansible-operator.adoc
@@ -374,5 +374,5 @@ $ kubectl delete -f deploy/operator.yaml
 $ kubectl delete -f deploy/role_binding.yaml
 $ kubectl delete -f deploy/role.yaml
 $ kubectl delete -f deploy/service_account.yaml
-$ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
+$ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
 ----


### PR DESCRIPTION
@openshift/team-documentation For peer review.

Preview: http://file.rdu.redhat.com/~ahoffer/2019/BZ-1684750/applications/operator_sdk/osdk-ansible.html#osdk-building-ansible-operator-osdk-ansible