### PR TITLE
Change Operator-SDK required min k8s version

### DIFF
--- a/modules/installing-operator-sdk-cli.adoc
+++ b/modules/installing-operator-sdk-cli.adoc
@@ -15,8 +15,8 @@ workstation so you are prepared to start authoring your own Operators.
 - link:https://git-scm.com/downloads[Git]
 - link:https://golang.org/dl/[Go] v1.10+
 - link:https://docs.docker.com/install/[Docker] v17.03+
-- link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[`kubectl`] v1.9.0+
-- Access to a cluster based on Kubernetes v1.9.0+
+- link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[`kubectl`] v1.11.0+
+- Access to a cluster based on Kubernetes v1.11.0+
 - Access to a container image registry
 
 [NOTE]


### PR DESCRIPTION
Operator-SDK now utilizes CRD Subresources and therefore requires deployment to Kubernetes Cluster v1.11.0+. See https://github.com/operator-framework/operator-sdk/blob/master/README.md