### PR TITLE
modules/machineset-*: Drop openshiftClusterID

### DIFF
--- a/modules/machineset-cr.adoc
+++ b/modules/machineset-cr.adoc
@@ -70,8 +70,6 @@ spec:
               values:
               - <cluster_name>-<machine_label>-<AWS-availability-zone>
           tags:
-          - name: openshiftClusterID
-            value: 5a21bfc0-1c56-4400-81bb-7fd66644f871
           - name: kubernetes.io/cluster/<cluster_name>  <1>
             value: owned
           userDataSecret:

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -192,8 +192,6 @@ providerSpec:
         values:
         - <cluster_name>-<machine_label>-<AWS-availability-zone>
     tags:
-    - name: openshiftClusterID
-      value: 5a21bfc0-1c56-4400-81bb-7fd66644f871
     - name: kubernetes.io/cluster/<cluster_name>
       value: owned
     userDataSecret: <3>


### PR DESCRIPTION
The installer no longer sets this since openshift/installer@56f47611 (openshift/installer#1280).