### PR TITLE
Move web console content to appropriate bucket

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -44,13 +44,13 @@ Topics:
   File: architecture
 - Name: Available cluster customizations
   File: customizations
-- Name: Web console
-  File: web-console
 ---
 Name: Web console
 Dir: web-console
 Distros: openshift-*
 Topics:
+- Name: Accessing the web console
+  File: web-console
 - Name: Working with projects
   File: working-with-projects
 ---

--- a/web-console/web-console.adoc
+++ b/web-console/web-console.adoc
@@ -1,6 +1,6 @@
 
 [id='web-console']
-= Web console
+= Accessing the web console
 include::modules/common-attributes.adoc[]
 :context: web-console
 toc::[]


### PR DESCRIPTION
Moving web console content from the architecture bucket to the web console bucket 

@ahardin-rh - PTAL :four_leaf_clover: 