### PR TITLE
bz#1685321: Remove image-inspector image from disconnected installation

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -194,7 +194,6 @@ $ docker pull registry.redhat.io/openshift3/csi-driver-registrar:<tag>
 $ docker pull registry.redhat.io/openshift3/csi-livenessprobe:<tag>
 $ docker pull registry.redhat.io/openshift3/csi-provisioner:<tag>
 $ docker pull registry.redhat.io/openshift3/grafana:<tag>
-$ docker pull registry.redhat.io/openshift3/image-inspector:<tag>
 $ docker pull registry.redhat.io/openshift3/mariadb-apb:<tag>
 $ docker pull registry.redhat.io/openshift3/mediawiki:<tag>
 $ docker pull registry.redhat.io/openshift3/mediawiki-apb:<tag>
@@ -380,7 +379,6 @@ $ docker save -o ose3-images.tar \
     registry.redhat.io/openshift3/csi-livenessprobe \
     registry.redhat.io/openshift3/csi-provisioner \
     registry.redhat.io/openshift3/grafana \
-    registry.redhat.io/openshift3/image-inspector \
     registry.redhat.io/openshift3/mariadb-apb \
     registry.redhat.io/openshift3/mediawiki \
     registry.redhat.io/openshift3/mediawiki-apb \


### PR DESCRIPTION
Please refer to https://bugzilla.redhat.com/show_bug.cgi?id=1685321#c3