### PR TITLE
Corrected project name for aggregated logging SCC

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -939,7 +939,7 @@ local volume:
 ====
 ----
 $ oc adm policy add-scc-to-user privileged  \
-       system:serviceaccount:logging:aggregated-logging-elasticsearch <1>
+       system:serviceaccount:openshift-logging:aggregated-logging-elasticsearch <1>
 ----
 <1> Use the project you created earlier (for example, *logging*) when running the
 logging playbook.


### PR DESCRIPTION
Corrected logging project (`openshift-logging`) for SCC command