### PR TITLE
bug 1622044 fixed warning for auditFilePath

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1165,8 +1165,7 @@ Defaults to 100MB.
 [IMPORTANT]
 ====
 Because the {product-name} master API now runs as static pod, you must define
-the `auditFilePath` location in the *_/var/lib/origin_*, *_/var/log/origin_*,
-or *_/etc/origin/master/_* file.
+the `auditFilePath` location in the *_/var/lib/origin_* or *_/etc/origin/master/_* file.
 ====
 
 .Example Audit Configuration


### PR DESCRIPTION
bug 1622044:
https://bugzilla.redhat.com/show_bug.cgi?id=1622044

removed _/var/log/origin_ from the warning.