### PR TITLE
openshift_node_kubelet_args is deprecated in 3.10

### DIFF
--- a/install/example_inventories.adoc
+++ b/install/example_inventories.adoc
@@ -381,7 +381,7 @@ openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
 # apply updated node defaults
-openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}
+openshift_node_groups=[{'name': 'node-config-all-in-one', 'labels': ['node-role.kubernetes.io/master=true', 'node-role.kubernetes.io/infra=true', 'node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.pods-per-core','value': ['20']}]}]
 
 # enable ntp on masters to ensure proper failover
 openshift_clock_enabled=true


### PR DESCRIPTION
openshift_node_kubelet_args is deprecated in 3.10 see for instance:
https://github.com/openshift/openshift-docs/issues/12200
https://github.com/openshift/openshift-docs/pull/12677/files

This PR aligns the example with the one provided in 3.11

Regards,

Frédéric