### PR TITLE
BZ1666101: Corrected RBAC to SCC example.

### DIFF
--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -895,7 +895,7 @@ the definition of the role:
 [source,yaml]
 ----
 rules:
-  apiGroups:
+- apiGroups:
   - security.openshift.io <1>
   resources:
   - securitycontextconstraints <2>
@@ -915,7 +915,7 @@ rolebinding or a clusterrolebinding to use the user-defined SCC called
 
 [NOTE]
 ====
-Because RBAC is deisgned to prevent escalation, even project administrators will be
+Because RBAC is designed to prevent escalation, even project administrators will be
 unable to grant access to an SCC because they are not allowed, by default,
 to use the verb *use* on SCC resources, including the *restricted* SCC.
 ====


### PR DESCRIPTION
BZ1666101: Corrected RBAC to SCC example.

I also corrected a typo in the same location.

This is for 3.11.