### PR TITLE
BZ-1687082: Corrected sample IDP CR.

### DIFF
--- a/modules/identity-provider-default-CR.adoc
+++ b/modules/identity-provider-default-CR.adoc
@@ -6,27 +6,35 @@
 = Sample identity provider CR
 
 The following Custom Resource (CR) shows the parameters and default
-values for that you use to configure an identity provider.
+values that you use to configure an identity provider. This example
+uses the HTPasswd identity provider.
 
 .Sample identity provider CR
 
 [source,yaml]
 ----
-oauthConfig:
-  ...
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
   identityProviders:
-  - name: my_allow_provider <1>
+  - name: my_identity_provider <1>
     challenge: true <2>
     login: true <3>
     mappingMethod: claim <4>
-    provider:
-      apiVersion: v1
-      kind: AllowAllPasswordIdentityProvider
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: htpass-secret <5>
 ----
-<1> This provider name is prefixed to provider user names to form an identity
-name.
-<2> When `true`, unauthenticated token requests from non-web clients, like
+<1> This provider name is prefixed to provider user names to form an 
+identity name.
+<2> When `true`, unauthenticated token requests from non-web clients, like 
 the CLI, are sent a `WWW-Authenticate` challenge header for this provider.
-<3> When `true`, unauthenticated token requests from web clients, like the web
-console, are redirected to a login page backed by this provider.
-<4> Controls how mappings are established between this provider's identities and user objects.
+<3> When `true`, unauthenticated token requests from web clients, like the 
+web console, are redirected to a login page backed by this provider. 
+<4> Controls how mappings are established between this provider's 
+identities and user objects.
+<5> An existing secret containing a file generated using
+link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].


### PR DESCRIPTION
BZ-1687082: Corrected sample IDP CR from AllowAll, which is no longer supported, to HTPasswd.

This is for OS 4.0.