### PR TITLE
changed publish date of 3.9.71

### DIFF
--- a/release_notes/ocp_3_9_release_notes.adoc
+++ b/release_notes/ocp_3_9_release_notes.adoc
@@ -2651,25 +2651,6 @@ release, use the automated upgrade playbook. See
 xref:../upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
 Automated In-place Cluster Upgrades] for instructions.
 
-[[ocp-3.9.71]]
-=== RHBA-2019:0403 - {product-title} 3.9.71 Bug Fix Update
-
-Issued: 2019-03-13
-
-{product-title} release 3.9.71 is now available. The packages and bug fixes
-included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2019:0403[RHBA-2019:0403] advisory.
-The list of container images included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2019:0402[RHBA-2019:0402] advisory.
-
-[[ocp-3.9.71-upgrading]]
-==== Upgrading
-
-To upgrade an existing {product-title} 3.7 or 3.9 cluster to this latest
-release, use the automated upgrade playbook. See
-xref:../upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
-Automated In-place Cluster Upgrades] for instructions.
-
 [[RHSA-2019-40105]]
 === RHSA-2019:40105 -	Moderate: {product-title} 3.9 haproxy security update
 
@@ -2681,6 +2662,25 @@ link:https://access.redhat.com/errata/RHSA-2019:40105[RHSA-2019:401051]
 advisory.
 
 [[RHSA-2019-40105-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.7 or 3.9 cluster to this latest
+release, use the automated upgrade playbook. See
+xref:../upgrading/automated_upgrades.adoc#running-the-upgrade-playbook-directly[Performing
+Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3.9.71]]
+=== RHBA-2019:0403 - {product-title} 3.9.71 Bug Fix Update
+
+Issued: 2019-03-14
+
+{product-title} release 3.9.71 is now available. The packages and bug fixes
+included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:0403[RHBA-2019:0403] advisory.
+The list of container images included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:0402[RHBA-2019:0402] advisory.
+
+[[ocp-3.9.71-upgrading]]
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.7 or 3.9 cluster to this latest


### PR DESCRIPTION
Adjusted publication date of 3.9.71, which published after the security advisory. Moved the 3.9.71 bug advisory below the security advisory. 