### PR TITLE
changed publish date of 3.10.119

### DIFF
--- a/release_notes/ocp_3_10_release_notes.adoc
+++ b/release_notes/ocp_3_10_release_notes.adoc
@@ -2671,25 +2671,6 @@ release, use the automated upgrade playbook. See
 xref:../upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[Performing
 Automated In-place Cluster Upgrades] for instructions.
 
-[[ocp-3-10-119]]
-=== RHBA-2019:0405 - {product-title} 3.10.119 Bug Fix Update
-
-Issued: 2019-03-13
-
-{product-title} release 3.10.119 is now available. The list of packages and
-bug fixes included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2019:0405[RHBA-2019:0405] advisory.
-The container images included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2019:0404[RHBA-2019:0404] advisory.
-
-[[ocp-3-10-119-upgrading]]
-==== Upgrading
-
-To upgrade an existing {product-title} 3.9 or 3.10 cluster to this latest
-release, use the automated upgrade playbook. See
-xref:../upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[Performing
-Automated In-place Cluster Upgrades] for instructions.
-
 [[RHSA-2019-40133]]
 === RHSA-2019:40133 -	Moderate: {product-title} 3.10 haproxy security update
 
@@ -2700,6 +2681,25 @@ update are documented in the
 link:https://access.redhat.com/errata/RHSA-2019:40133[RHSA-2019:40133] advisory.
 
 [[RHSA-2019-40133-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.9 or 3.10 cluster to this latest
+release, use the automated upgrade playbook. See
+xref:../upgrading/automated_upgrades.adoc#install-config-upgrading-automated-upgrades[Performing
+Automated In-place Cluster Upgrades] for instructions.
+
+[[ocp-3-10-119]]
+=== RHBA-2019:0405 - {product-title} 3.10.119 Bug Fix Update
+
+Issued: 2019-03-14
+
+{product-title} release 3.10.119 is now available. The list of packages and
+bug fixes included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:0405[RHBA-2019:0405] advisory.
+The container images included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2019:0404[RHBA-2019:0404] advisory.
+
+[[ocp-3-10-119-upgrading]]
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.9 or 3.10 cluster to this latest


### PR DESCRIPTION
Adjusted publication date of 3.10.119, which published after the security advisory. Moved the 3.10.119 bug advisory below the security advisory.