### PR TITLE
improvement in logging-elasticsearch-exposing

### DIFF
--- a/logging/efk-logging-fluentd.adoc
+++ b/logging/efk-logging-fluentd.adoc
@@ -29,7 +29,7 @@ include::modules/efk-logging-fluentd-limits.adoc[leveloffset=+1]
 
 ////
 4.1
-include::modules/efk-logging-fluentd-collector.adoc[leveloffset=+1]
+::modules/efk-logging-fluentd-collector.adoc[leveloffset=+1]
 ////
 
 include::modules/efk-logging-fluentd-log-rotation.adoc[leveloffset=+1]

--- a/modules/efk-logging-elasticsearch-exposing.adoc
+++ b/modules/efk-logging-elasticsearch-exposing.adoc
@@ -9,11 +9,8 @@ By default, Elasticsearch deployed with cluster logging is not
 accessible from outside the logging cluster. You can enable a route with re-encryption termination 
 for external access to Elasticsearch for those tools that want to access its data.
 
-Internally, you can access Elasticsearch using your {product-title} token, and
-you can provide the external Elasticsearch and Elasticsearch Ops
-hostnames using the server certificate (similar to Kibana).
-
-* The request must contain three HTTP headers:
+Externally, you can access Elasticsearch by creating a reencrypt route, your {product-title} token and the installed
+Elasticsearch CA certificate. The request must contain three HTTP headers:
 +
 ----
 Authorization: Bearer $token
@@ -21,11 +18,26 @@ X-Proxy-Remote-User: $username
 X-Forwarded-For: $ip_address
 ----
 
+Internally, you can access Elastiscearch using the Elasticsearch cluster IP:
+
+----
+$ oc get service elasticsearch -o jsonpath={.spec.clusterIP} -n openshift-logging
+172.30.183.229
+
+oc get service elasticsearch
+NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+elasticsearch   ClusterIP   172.30.183.229   <none>        9200/TCP   22h
+
+$ oc exec elasticsearch-clientdatamaster-0-1-858c8f-hhnkn -- curl -tlsv1.2 --insecure -H "Authorization: Bearer ${token}" "https://172.30.183.229:9200/_cat/health"
+
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100    29  100    29    0     0    108      0 --:--:-- --:--:-- --:--:--   108
+----
+
 .Prerequisites
 
 * Cluster logging and Elasticsearch must be installed.
-
-* Set cluster logging to the unmanaged state.
 
 * You must have access to the project in order to be able to access to the logs. For example:
 +
@@ -37,10 +49,12 @@ $ oc new-app <httpd-example>
 
 .Procedure
 
-. Use the following command to set name of the Elasticsearch pod in a variable for use in a cURL command:
+To expose Elasticsearch externally:
+
+. Change to the `openshift-logging` project:
 +
 ----
-ESPOD=$( oc get pods -l component=elasticsearch -o name | sed -e "s/pod\///" )
+$ oc project openshift-logging
 ----
 
 . Use the following command to extract the CA certificate from Elasticsearch and write to the *_admin-ca_* file:
@@ -68,9 +82,9 @@ spec:
     name: elasticsearch
   tls:
     termination: reencrypt
-    destinationCACertificate: <1>
+    destinationCACertificate: | <1>
 ----
-<1> Add the Elasticsearch CA ceritifcate or use the command in the next step. You do not need to set the `spec.tls.key`, `spec.tls.certificate` and `spec.tls.caCertificate` parameters
+<1> Add the Elasticsearch CA ceritifcate or use the command in the next step. You do not need to set the `spec.tls.key`, `spec.tls.certificate`, and `spec.tls.caCertificate` parameters
 required by some reencrypt routes.
 
 .. Run the following command to add the Elasticsearch CA certificate to the route YAML you created:
@@ -99,20 +113,73 @@ route.route.openshift.io/elasticsearch created
 $ token=$(oc whoami -t)
 ----
 
-.. Run a command similar to the following, using your cluster address to access Elasticsearch through the exposed route:
+.. Set the *elasticsearch* route you created as an environment variable.
 +
 ----
-curl -tlsv1.2 -v --insecure -H "Authorization: Bearer me3IL_WmD_I_McBUm2uhxIayUKped-H3L1njlRRxPlE" "https://elasticsearch-openshift-logging.apps.<cluster-address>.openshift.com/.operations.*/_search?size=1" | jq
+$ routeES=`oc get route elasticsearch -o jsonpath={.spec.host}`
+----
 
+.. To verify the route was successfully created, run the following command that accesses Elasticsearch through the exposed route:
++
+----
+curl -tlsv1.2 --insecure -H "Authorization: Bearer ${token}" "https://${routeES}/.operations.*/_search?size=1" | jq
+----
++
+The response appears similar to the following:
++
+----
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   944  100   944    0     0     62      0  0:00:15  0:00:15 --:--:--   204
 {
-  "took": 49,
+  "took": 441,
   "timed_out": false,
   "_shards": {
-    "total": 1,
-    "successful": 1,
+    "total": 3,
+    "successful": 3,
     "skipped": 0,
     "failed": 0
   },
-  ....
+  "hits": {
+    "total": 89157,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": ".operations.2019.03.15",
+        "_type": "com.example.viaq.common",
+        "_id": "ODdiNWIyYzAtMjg5Ni0TAtNWE3MDY1MjMzNTc3",
+        "_score": 1,
+        "_source": {
+          "_SOURCE_MONOTONIC_TIMESTAMP": "673396",
+          "systemd": {
+            "t": {
+              "BOOT_ID": "246c34ee9cdeecb41a608e94",
+              "MACHINE_ID": "e904a0bb5efd3e36badee0c",
+              "TRANSPORT": "kernel"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "0",
+              "SYSLOG_IDENTIFIER": "kernel"
+            }
+          },
+          "level": "info",
+          "message": "acpiphp: Slot [30] registered",
+          "hostname": "localhost.localdomain",
+          "pipeline_metadata": {
+            "collector": {
+              "ipaddr4": "10.128.2.12",
+              "ipaddr6": "fe80::xx:xxxx:fe4c:5b09",
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd",
+              "received_at": "2019-03-15T20:25:06.273017+00:00",
+              "version": "1.3.2 1.6.0"
+            }
+          },
+          "@timestamp": "2019-03-15T20:00:13.808226+00:00",
+          "viaq_msg_id": "ODdiNWIyYzAtMYTAtNWE3MDY1MjMzNTc3"
+        }
+      }
+    ]
+  }
+}
 ----
-

--- a/modules/nodes-pods-plugins-install.adoc
+++ b/modules/nodes-pods-plugins-install.adoc
@@ -14,33 +14,25 @@ with the help of plug-ins known as device plug-ins.
 . Obtain the label associated with the static Machine Config Pool CRD for the type of node you want to configure.
 Perform one of the following steps:
 
-.. View the Machine Config Pool:
+.. View the Machine Config:
 +
 ----
-$ oc describe machineconfigpool <name>
+# oc describe machineconfig <name>
 ----
 +
 For example:
 +
 [source,yaml]
 ----
-$ oc describe machineconfigpool worker
+# oc describe machineconfig 00-worker
 
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfigPool
-metadata:
-  creationTimestamp: 2019-02-08T14:52:39Z
-  generation: 1
-  labels:
-    custom-kubelet: small-pods <1>
+oc describe machineconfig 00-worker
+Name:         00-worker
+Namespace:    
+Labels:       machineconfiguration.openshift.io/role=worker <1>
 ----
-<1> If a label has been added it appears under `labels`.
+<1> Label required for the device manager.
 
-.. If the label is not present, add a key/value pair:
-+
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
 
 .Procedure
 
@@ -52,17 +44,24 @@ $ oc label machineconfigpool worker custom-kubelet=small-pods
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: deploy-device-manager <1>
+  name: devicemgr <1>
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: small-pods <2>
+       machine.openshift.io/cluster-api-machine-type: devicemgr <2>
   kubeletConfig:
     feature-gates:
-      - DevicePlugins=true <2>
+      - DevicePlugins=true <3>
 ----
 <1> Assign a name to CR.
-<2> Set `DevicePlugins` to 'true`.
+<2> Enter the label from the Machine Config Pool.
+<3> Set `DevicePlugins` to 'true`.
+
+. Create the device manager:
++
+----
+$ oc create -f devicemgr.yaml
+----
 
 . Ensure that Device Manager was actually enabled by confirming that
 *_/var/lib/kubelet/device-plugins/kubelet.sock_* is created on the node. This is


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1688607

Suggestions for improvement: 
1) The router is not controlled by operator. this step can be deleted
2) This step is useless now. Please delete it.
3) add the | at before (1)
    destinationCACertificate: |  #(1)
4) a) It is better to get router by command
      routeES=`oc get route elasticsearch -o jsonpath={.spec.host}`
   b) The token is not called.
   curl -tlsv1.2 -v --insecure -H "Authorization: Bearer ${token}" "https://${routeES}/.operations.*/_search?size=1" | jq