### PR TITLE
[enterprise-3.10] Updating Kuryr related information

### DIFF
--- a/install_config/configuring_kuryrsdn.adoc
+++ b/install_config/configuring_kuryrsdn.adoc
@@ -157,3 +157,9 @@ kuryr-controller-59fc7f478b-qwk4k   1/1       Running   0          3d        192
 
 kuryr-cni pods should run on every {product-title} node. Single
 kuryr-controller instances should run on any of the nodes.
+
+[NOTE]
+====
+Network policies, namespace isolation and nodeport services are not supported when Kuryr SDN is
+enabled.
+====

--- a/install_config/topics/ocp_osp_admin_tasks.adoc
+++ b/install_config/topics/ocp_osp_admin_tasks.adoc
@@ -1,10 +1,10 @@
 [[osp_accounts]]
-==== Creating OpenStack User Accounts, Projects and Roles
+==== Creating OpenStack User Accounts, Projects, and Roles
 
-Before installing {product-title}, the Red Hat OpenStack Platform (RHOSP) 
+Before installing {product-title}, the Red Hat OpenStack Platform (RHOSP)
 environment requires a project, often referred to as a _tenant_,
 that stores the OpenStack instances that are to install the {product-title}. This project
-requires ownership by a user and role of that user to be set to `\_member_`.
+requires ownership by a user and the role of that user to be set to `\_member_`.
 
 The following steps show how to accomplish the above.
 
@@ -28,6 +28,13 @@ $ openstack user create --password *<password> <username>*
 +
 ----
 $ openstack role add --user <username> --project <project> _member_
+----
+
+The default quotas assigned to new RH OSP projects are not high enough for
+{product-title} installations. Increase the quotas to at least 30 security
+groups, 200 security group rules, and 200 ports.
+----
+$ openstack quota set --secgroups 30 --secgroup-rules 200 --ports 200 *<project>*
 ----
 
 Once the above is complete, an OpenStack administrator can create an RC file
@@ -58,6 +65,14 @@ if [ -z "${CLOUDPROMPT_ENABLED:-}" ]; then
 fi
 
 ----
+
+
+[NOTE]
+====
+Changing _OS_PROJECT_DOMAIN_NAME and _OS_USER_DOMAIN_NAME from the Default
+value is NOT currently supported.
+====
+
 
 As the user(s) implementing the {product-title} environment, within the OpenStack director
 node or workstation, ensure to `source` the credentials as follows:

--- a/install_config/topics/ocp_osp_enabling_octavia.adoc
+++ b/install_config/topics/ocp_osp_enabling_octavia.adoc
@@ -45,6 +45,12 @@ Verify that the created *_local_registry_images.yaml_* contains the Octavia imag
 ...
 ----
 
+[NOTE]
+====
+The versions of the Octavia containers will vary depending upon the specific Red
+Hat OpenStack Platform release installed.
+====
+
 The following step pulls the container images from registry.access.redhat.com
 to the undercloud node. This may take soem time depending on the speed of the
 network and undercloud disk.
@@ -56,6 +62,22 @@ network and undercloud disk.
 ----
 
 
+As an Octavia Load Balancer is used to access the OpenShift API, there is a
+need to increase their listeners default timeouts for the connections.
+The default timeout is 50 seconds. Increase the timeout to 20 minutes by
+passying the following file to the overcloud deploy command:
+
+----
+(undercloud) $ cat octavia_timeouts.yaml
+parameter_defaults:
+  OctaviaTimeoutClientData: 1200000
+  OctaviaTimeoutMemberData: 1200000
+----
+
+[NOTE]
+====
+This is not needed from Red Hat OpenStack Platform 14 and onwards.
+====
 
 Install or update your overcloud environment with Octavia:
 
@@ -65,13 +87,27 @@ openstack overcloud deploy --templates \
 .
 .
   -e /usr/share/openstack-tripleo-heat-templates/environments/services-docker/octavia.yaml \
+  -e octavia_timeouts.yaml
 .
 .
 .
 ----
 
-NOTE: The command above only includes the files associated with Octavia. This
-command will vary based upon your specifc installation of OpenStack. See
-the official OpenStack documentation for further information. For more information
-on customizing your Octavia installation, see
-https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html-single/networking_guide/#planning_your_octavia_deployment[installation of Octavia using Director].
+[NOTE]
+====
+The command above only includes the files associated with Octavia. This command
+will vary based upon your specifc installation of OpenStack. See the official
+OpenStack documentation for further information. For more information on
+customizing your Octavia installation, see
+https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html-single/networking_guide/#planning_your_octavia_deployment[installation
+of Octavia using Director].
+====
+
+[NOTE]
+====
+If Kuryr SDN is used, the overcloud installation requires the "trunk" extension
+to be enabled at Neutron. This is enabled by default on Director deployments.
+Use the openvswitch firewall instead of the default ovs-hybrid when the Neutron
+backend is ML2/OVS. There is no need for modifications if the backend is
+ML2/OVN.
+====

--- a/install_config/topics/ocp_osp_install.adoc
+++ b/install_config/topics/ocp_osp_install.adoc
@@ -10,3 +10,10 @@ Run the installer playbook to install Red Hat OpenShift Container Platform:
 ----
 $ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openstack/openshift-cluster/install.yml
 ----
+
+[NOTE]
+====
+{product-tittle} version 3.11 is supported on RH OSP 14 and RH OSP 13.
+{product-tittle} version 3.10 is supported on RH OSP 13.
+====
+

--- a/install_config/topics/ocp_osp_provisioning.adoc
+++ b/install_config/topics/ocp_osp_provisioning.adoc
@@ -44,6 +44,15 @@ openshift_openstack_external_network_name: *"public"*
 
 openshift_openstack_default_image_name: *"rhel75"*
 
+## Optional (Recommended) - This removes the need for floating IPs
+## on the OpenShift Cluster nodes
+openshift_openstack_node_network_name: *<deployment-net-name>*
+openshift_openstack_node_subnet_name: *<deployment-subnet-name>*
+openshift_openstack_router_name: *<deployment-router-name>*
+openshift_openstack_master_floating_ip: *false*
+openshift_openstack_infra_floating_ip: *false*
+openshift_openstack_compute_floating_ip: *false*
+## End of Optional Floating IP section
 openshift_openstack_num_masters: *3*
 openshift_openstack_num_infra: *3*
 openshift_openstack_num_cns: *0*
@@ -100,6 +109,109 @@ key "update-key" {
 
 NOTE: The key name may vary and the above is only an example.
 
+
+The following [filename]all.yaml file enables Kuryr SDN instead of the default
+openshift-sdn. Note that the example below is a condensed version and it is
+important to review the default template carefully.
+
+----
+$ cat ~/inventory/group_vars/all.yml
+---
+openshift_openstack_clusterid: "openshift"
+openshift_openstack_public_dns_domain: *"example.com"*
+openshift_openstack_dns_nameservers: *["10.19.115.228"]*
+openshift_openstack_public_hostname_suffix: "-public"
+openshift_openstack_nsupdate_zone: "{{ openshift_openstack_public_dns_domain }}"
+
+openshift_openstack_keypair_name: *"openshift"*
+openshift_openstack_external_network_name: *"public"*
+
+openshift_openstack_default_image_name: *"rhel75"*
+
+## Optional (Recommended) - This removes the need for floating IPs
+## on the OpenShift Cluster nodes
+openshift_openstack_node_network_name: *<deployment-net-name>*
+openshift_openstack_node_subnet_name: *<deployment-subnet-name>*
+openshift_openstack_router_name: *<deployment-router-name>*
+openshift_openstack_master_floating_ip: *false*
+openshift_openstack_infra_floating_ip: *false*
+openshift_openstack_compute_floating_ip: *false*
+## End of Optional Floating IP section
+
+openshift_openstack_num_masters: *3*
+openshift_openstack_num_infra: *3*
+openshift_openstack_num_cns: *0*
+openshift_openstack_num_nodes: *2*
+
+openshift_openstack_master_flavor: *"m1.master"*
+openshift_openstack_default_flavor: *"m1.node"*
+
+## Kuryr configuration
+openshift_use_kuryr: True
+openshift_use_openshift_sdn: False
+use_trunk_ports: True
+os_sdn_network_plugin_name: cni
+openshift_node_proxy_mode: userspace
+kuryr_openstack_pool_driver: nested
+openshift_kuryr_precreate_subports: 5
+
+kuryr_openstack_public_net_id: *<public_ID>*
+
+# Select kuryr image (always latest available)
+openshift_openstack_kuryr_controller_image: registry.access.redhat.com/rhosp14/openstack-kuryr-controller:latest
+openshift_openstack_kuryr_cni_image: registry.access.redhat.com/rhosp14/openstack-kuryr-cni:latest
+
+openshift_master_open_ports:
+- service: dns tcp
+  port: 53/tcp
+- service: dns udp
+  port: 53/udp
+openshift_node_open_ports:
+- service: dns tcp
+  port: 53/tcp
+- service: dns udp
+  port: 53/udp
+# End of Kuryr configuration
+
+openshift_openstack_use_lbaas_load_balancer: *true*
+
+openshift_openstack_docker_volume_size: "15"
+
+# # Roll-your-own DNS
+*openshift_openstack_external_nsupdate_keys:*
+  public:
+    *key_secret: '/alb8h0EAFWvb4i+CMA12w=='*
+    *key_name: "update-key"*
+    *key_algorithm: 'hmac-md5'*
+    *server: '<ip-of-DNS>'*
+  private:
+    *key_secret: '/alb8h0EAFWvb4i+CMA12w=='*
+    *key_name: "update-key"*
+    *key_algorithm: 'hmac-md5'*
+    *server: '<ip-of-DNS>'*
+
+ansible_user: openshift
+
+## cloud config
+openshift_openstack_disable_root: true
+openshift_openstack_user: openshift
+----
+
+[NOTE]
+====
+Use the latest supported kuryr images, regardless of the overcloud Red Hat
+OpenStack version. For instance, use kuryr images from OSP 14, whether the
+overcloud is OSP 14 or OSP 13. Kuryr is just another workload on top of the
+overcloud, and it aligns better with new OpenShift features if you use the
+latest images.
+====
+
+[NOTE]
+====
+Network policies, namespace isolation and nodeport services are not supported
+when Kuryr SDN is enabled.
+====
+
 Brief description of each variable in the table below:
 
 
@@ -129,6 +241,19 @@ Brief description of each variable in the table below:
 |ansible_user| Ansible user used to deploy {product-title}. "openshift" is the required name and must not be changed.
 |openshift_openstack_disable_root| Boolean value that disables root access
 |openshift_openstack_user| OCP instances created with this user
+|openshift_openstack_node_network_name | Name of existing OpenShift network to use for deployment. This should be the same network name used for your deployment host.
+|openshift_openstack_node_subnet_name | Name of existing OpenShift subnet to use for deployment. This should be the same subnet name used for your deployment host.
+|openshift_openstack_router_name | Name of existing OpenShift router to use for deployment. This should be the same router name used for your deployment host.
+|openshift_openstack_master_floating_ip | Default is `true`. Must set to `false` if you do not want floating IPs assigned to master nodes.
+|openshift_openstack_infra_floating_ip | Default is `true`. Must set to `false` if you do not want floating IPs assigned to infrastructure nodes.
+|openshift_openstack_compute_floating_ip | Default is `true`. Must set to `false` if you do not want floating IPs assigned to compute nodes.
+|openshift_use_openshift_sdn | Must set to `false` if you want to disable openshift-sdn
+|openshift_use_kuryr | Must set to `true` if you want to enable kuryr sdn
+|use_trunk_ports | Must be set to `true` to create the OpenStack VMs with trunk ports (required by kuryr)
+|os_sdn_network_plugin_name | selection of the SDN behavior. Must set to `cni` for kuryr
+|openshift_node_proxy_mode | Must set to `userspace` for Kuryr
+|openshift_master_open_ports | Ports to be opened on the VMs when using Kuryr
+|kuryr_openstack_public_net_id | Need by Kuryr. ID of the public OpenStack network from where FIPs are obtained
 |===
 
 ==== OSEv3.yml


### PR DESCRIPTION
This PR updates the information about installation and configuration
of Kuryr SDN, as well as their prerequisites.

@luis5tb - I am manually cherry picking this to the enterprise-3.10 branch since the automatic CP failed due to conflicts in the following files:

-- install_config/topics/ocp_osp_enabling_octavia.adoc
-- install_config/topics/ocp_osp_provisioning.adoc

Could you please confirm that the content in these two files after the manual CP is correct? If yes, I will merge this. If not, please suggest corrections.

xref: #14037