### PR TITLE
[enterprise-3.11] Correct a command to label "logging-infra-fluentd=true"

### DIFF
--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -135,10 +135,10 @@ $ ansible-playbook [-i /path/to/file] \
     playbooks/openshift-master/scaleup.yml
 ----
 +
-. Set the node label to `logging-infra-fluentd: "true"`.
+. Set the node label to `logging-infra-fluentd=true`, if you deployed the EFK stack in your cluster.
 +
 ----
-# oc label node/new-node.example.com logging-infra-fluentd: "true"
+# oc label node/new-node.example.com logging-infra-fluentd=true
 ----
 
 . After the playbook runs,


### PR DESCRIPTION
- Partial Fix: [ [Docs] three improvements requests to "Adding Hosts to an Existing Cluster"](https://bugzilla.redhat.com/show_bug.cgi?id=1669929)

- Version: `v3.11`

- Description:
  `logging-infra-fluentd` node label is required when you installed a `logging` component, and usage is not correct, the correct command is as follows. Refer [Updating labels on nodes
](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_nodes.html#updating-labels-on-nodes) for more details.
~~~
# oc label node/new-node.example.com logging-infra-fluentd=true
~~~

