### PR TITLE
Fix a small typo in the Initial Planning section

### DIFF
--- a/install/index.adoc
+++ b/install/index.adoc
@@ -38,7 +38,7 @@ environment needs to be.
 section provides multiple examples of Single Master and Multiple Master
 configurations.
 
-* _Does you need a xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#high-availability-masters[high availability] cluster?_
+* _Do you need a xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#high-availability-masters[high availability] cluster?_
 High availability configurations improve fault tolerance. In this situation, you
 might use the xref:multi-masters-using-native-ha-colocated[Multiple Masters Using Native HA]
 example to set up your environment.


### PR DESCRIPTION
This fixes a small typo in the Installation docs, where it should read "Do you need a high availability cluster"  instead of "Does you need...".