### PR TITLE
[enterprise-3.11] Correct typo and package name for openshift-ansible

### DIFF
--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -49,7 +49,7 @@ limits] section for the recommended maximum number of nodes.
 package:
 +
 ----
-# yum update 'openshift-ansible*'
+# yum update openshift-ansible
 ----
 
 . Edit your *_/etc/ansible/hosts_* file and add *new_<host_type>* to the

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -31,7 +31,7 @@ To add an etcd host to an existing cluster:
 +
 [source, bash]
 ----
-$ yum update openshift-ansible
+# yum update openshift-ansible
 ----
 
 . Edit your *_/etc/ansible/hosts_* file, add *new_<host_type>* to the


### PR DESCRIPTION
- Version: `v3.11`

- Description:
  `openshift-ansible` can be updated without `*`, because `openshift-ansible` will be installed with dependencies. And `yum` is required root permission, so `$` prompt is wrong, it should be `#`.