### PR TITLE
OSDOCS-330: Included details on dynamic provisioning.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -326,6 +326,8 @@ Topics:
     File: persistent-storage-aws
   - Name: Persistent Storage using iSCSI
     File: persistent-storage-iscsi
+- Name: Dynamic provisioning
+  File: dynamic-provisioning
 ---
 Name: Nodes
 Dir: nodes

--- a/modules/dynamic-provisioning-about.adoc
+++ b/modules/dynamic-provisioning-about.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// storage/dynamic-provisioning.adoc
+
+[id="about-{context}"]
+= About dynamic provisioning
+
+The StorageClass resource object describes and classifies storage that can 
+be requested, as well as provides a means for passing parameters for
+dynamically provisioned storage on demand. StorageClass objects can also 
+serve as a management mechanism for controlling different levels of 
+storage and access to the storage. Cluster Administrators (`cluster-admin`)
+ or Storage Administrators (`storage-admin`) define and create the 
+StorageClass objects that users can request without needing any intimate 
+knowledge about the underlying storage volume sources.
+
+The {product-title} persistent volume framework enables this functionality 
+and allows administrators to provision a cluster with persistent storage. 
+The framework also gives users a way to request those resources without 
+having any knowledge of the underlying infrastructure.
+
+Many storage types are available for use as persistent volumes in
+{product-title}. While all of them can be statically provisioned by an
+administrator, some types of storage are created dynamically using the
+built-in provider and plug-in APIs.

--- a/modules/dynamic-provisioning-annotations.adoc
+++ b/modules/dynamic-provisioning-annotations.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="storage-class-annotations-{context}"]
+= StorageClass annotations
+
+To set a StorageClass as the cluster-wide default, add
+the following annotation to your StorageClass's metadata:
+
+[source.yaml]
+----
+storageclass.kubernetes.io/is-default-class: "true"
+----
+
+For example:
+
+[source.yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+...
+----
+
+This enables any Persistent Volume Claim (PVC) that does not specify a 
+specific volume to automatically be provisioned through the 
+default StorageClass.
+
+[NOTE]
+====
+The beta annotation `storageclass.beta.kubernetes.io/is-default-class` is 
+still working; however, it will be removed in a future release.
+====
+
+To set a StorageClass description, add the following annotation
+to your StorageClass's metadata:
+
+[source.yaml]
+----
+kubernetes.io/description: My StorageClass Description
+----
+
+For example:
+
+[source.yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    kubernetes.io/description: My StorageClass Description
+...
+----

--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="available-plug-ins-{context}"]
+= Available dynamic provisioning plug-ins
+
+{product-title} provides the following provisioner plug-ins, which have
+generic implementations for dynamic provisioning that use the cluster's
+configured provider's API to create new storage resources:
+
+
+[options="header",cols="1,1,1"]
+|===
+
+|Storage type 
+|Provisioner plug-in name 
+|Notes
+
+//|OpenStack Cinder
+//|`kubernetes.io/cinder`
+//|
+
+|AWS Elastic Block Store (EBS)
+|`kubernetes.io/aws-ebs`
+|For dynamic provisioning when using multiple clusters in different zones, 
+tag each node with `Key=kubernetes.io/cluster/<cluster_name>,Value=<cluster_id>` 
+where `<cluster_name>` and `<cluster_id>` are unique per cluster.
+
+//|GCE Persistent Disk (gcePD)
+//|`kubernetes.io/gce-pd`
+//|In multi-zone configurations, it is advisable to run one {product-title} 
+//cluster per GCE project to avoid PVs from getting created in zones where 
+//no node from current cluster exists.
+
+//|GlusterFS
+//|`kubernetes.io/glusterfs`
+//|
+
+|Ceph RBD
+|`kubernetes.io/rbd`
+|
+
+//|Trident from NetApp
+//|`netapp.io/trident`
+//|Storage orchestrator for NetApp ONTAP, SolidFire, and E-Series storage.
+
+//|link:https://www.vmware.com/support/vsphere.html[VMware vSphere]
+//|`kubernetes.io/vsphere-volume`
+//|
+
+//|Azure Disk
+//|`kubernetes.io/azure-disk`
+//|
+
+//|HPE Nimble Storage
+//|`hpe.com/nimble`
+//|Dynamic provisioning of HPE Nimble Storage resources using the 
+//HPE Nimble Kube Storage Controller.
+
+|===
+
+[IMPORTANT]
+====
+Any chosen provisioner plug-in also requires configuration for the relevant
+cloud, host, or third-party provider as per the relevant documentation.
+====

--- a/modules/dynamic-provisioning-aws-definition.adoc
+++ b/modules/dynamic-provisioning-aws-definition.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="aws-definition-{context}"]
+= AWS Elastic Block Store (EBS) object definition
+
+.aws-ebs-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: io1 <1>
+  zone: us-east-1d <2>
+  iopsPerGB: "10" <3>
+  encrypted: "true" <4>
+  kmsKeyId: keyvalue <5>
+  fsType: ext4 <6>
+----
+<1> (required) Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`.
+See the
+link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] 
+for valid Amazon Resource Name (ARN) values.
+<2> (optional) The AWS zone. If no zone is specified, volumes are generally 
+round-robined across all active zones where the {product-title} cluster 
+has a node. The `zone` and `zones` parameters must not be used at the 
+same time.
+<3> (optional) Only for *io1* volumes. I/O operations per second per GiB. 
+The AWS volume plug-in multiplies this with the size of the requested 
+volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which 
+is the maximum supported by AWS. See the 
+link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] 
+for further details.
+<4> (optional) Denotes whether to encrypt the EBS volume. Valid values 
+are `true` or `false`.
+<5> (optional) The full ARN of the key to use when encrypting the volume. 
+If none is supplied, but `encypted` is set to `true`, then AWS generates a 
+key. See the
+link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] 
+for a valid ARN value.
+<6> (optional) File system that is created on dynamically provisioned 
+volumes. This value is copied to the `fsType` field of dynamically 
+provisioned persistent volumes and the file system is created when the 
+volume is mounted for the first time. The default value is `ext4`.

--- a/modules/dynamic-provisioning-azure-disk-definition.adoc
+++ b/modules/dynamic-provisioning-azure-disk-definition.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="azure-disk-definition-{context}"]
+= Azure Disk object definition
+
+.azure-advanced-disk-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow
+provisioner: kubernetes.io/azure-disk
+parameters:
+  storageAccount: azure_storage_account_name  <1>
+  storageaccounttype: Standard_LRS  <2>
+  kind: Dedicated  <3>
+----
+<1> Azure storage account name. This must reside in the same resource 
+group as the cluster. If a storage account is specified, the `location` 
+is ignored. If a storage account is not specified, a new storage 
+account gets created in the same resource group as the cluster. If you 
+are specifying a `storageAccount`, the value for `kind` must be `Dedicated`.
+<2> Azure storage account SKU tier. Default is empty. Note that Premium 
+VMs can attach both _Standard_LRS_ and _Premium_LRS_ disks, Standard VMs 
+can only attach _Standard_LRS_ disks, Managed VMs can only attach 
+managed disks, and unmanaged VMs can only attach unmanaged disks.
+<3> Possible values are `Shared` (default), `Dedicated`, and `Managed`.
++
+.. If `kind` is set to `Shared`, Azure creates all unmanaged disks in a 
+few shared storage accounts in the same resource group as the cluster.
+.. If `kind` is set to `Managed`, Azure creates new managed disks.
+.. If `kind` is set to `Dedicated` and a `storageAccount` is specified, 
+Azure uses the specified storage account for the new unmanaged disk in 
+the same resource group as the cluster. For this to work:
+ * The specified storage account must be in the same region.
+ * Azure Cloud Provider must have a write access to the storage account.
+.. If `kind` is set to `Dedicated` and a `storageAccount` is not 
+specified, Azure creates a new dedicated storage account for the new 
+unmanaged disk in the same resource group as the cluster.

--- a/modules/dynamic-provisioning-ceph-rbd-definition.adoc
+++ b/modules/dynamic-provisioning-ceph-rbd-definition.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="ceph-rbd-definition-{context}"]
+= Ceph RBD object definition
+
+.ceph-storageclass.yaml
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cephfs
+provisioner: kubernetes.io/rbd
+parameters:
+  monitors: 10.16.153.105:6789  <1>
+  adminId: admin  <2>
+  adminSecretName: ceph-secret  <3>
+  adminSecretNamespace: kube-system  <4>
+  pool: kube  <5>
+  userId: kube  <6>
+  userSecretName: ceph-secret-user  <7>
+  fsType: ext4 <8>
+  imageFormat: "2" <9>
+----
+<1> (required) A comma-delimited list of Ceph monitors.
+<2> (optional) Ceph client ID that is capable of creating images in the 
+pool. Default is `admin`.
+<3> (required) Secret Name for `adminId`. The provided secret must have 
+type `kubernetes.io/rbd`.
+<4> (optional) The namespace for `adminSecret`. Default is `default`.
+<5> (optional) Ceph RBD pool. Default is `rbd`.
+<6> (optional) Ceph client ID that is used to map the Ceph RBD image. 
+Default is the same as `adminId`.
+<7> (required) The name of Ceph Secret for `userId` to map Ceph RBD image. 
+It must exist in the same namespace as PVCs. 
+<8> (optional) File system that is created on dynamically provisioned 
+volumes. This value is copied to the `fsType` field of dynamically 
+provisioned persistent volumes and the file system is created when the 
+volume is mounted for the first time. The default value is `ext4`.
+<9> (optional) Ceph RBD image format. The default value is `2`.

--- a/modules/dynamic-provisioning-change-default-class.adoc
+++ b/modules/dynamic-provisioning-change-default-class.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="change-default-storage-class-{context}"]
+= Changing the default StorageClass
+
+If you are using GCE and AWS, use the following process to change the 
+default StorageClass. This process assumes you have two StorageClasses
+defined, `gp2` and `standard`, and you want to change the default
+StorageClass from `gp2` to `standard`.
+
+. List the StorageClass:
++
+----
+$ oc get storageclass
+
+NAME                 TYPE
+gp2 (default)        kubernetes.io/aws-ebs <1>
+standard             kubernetes.io/gce-pd
+----
+<1> `(default)` denotes the default StorageClass.
+
+. Change the value of the annotation 
+`storageclass.kubernetes.io/is-default-class` to `false` for the default 
+StorageClass:
++ 
+----
+$ oc patch storageclass gp2 -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "false"}}}'
+----
+
+. Make another StorageClass the default by adding or modifying the 
+annotation as `storageclass.kubernetes.io/is-default-class=true`.
++ 
+----
+$ oc patch storageclass standard -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}'
+----
+
+. Verify the changes:
++
+----
+$ oc get storageclass
+
+NAME                 TYPE
+gp2                  kubernetes.io/aws-ebs
+standard (default)   kubernetes.io/gce-pd
+----
+

--- a/modules/dynamic-provisioning-cinder-definition.adoc
+++ b/modules/dynamic-provisioning-cinder-definition.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="openstack-cinder-storage-class-{context}"]
+= OpenStack Cinder object definition
+
+.cinder-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gold
+provisioner: kubernetes.io/cinder
+parameters:
+  type: fast  <1>
+  availability: nova <2>
+  fsType: ext4 <3>
+----
+<1> Volume type created in Cinder. Default is empty.
+<2> Availability Zone. If not specified, volumes are generally 
+round-robined across all active zones where the {product-title} cluster 
+has a node.
+<3> File system that is created on dynamically provisioned volumes. This 
+value is copied to the `fsType` field of dynamically provisioned 
+persistent volumes and the file system is created when the volume is 
+mounted for the first time. The default value is `ext4`.
+

--- a/modules/dynamic-provisioning-defining-storage-class.adoc
+++ b/modules/dynamic-provisioning-defining-storage-class.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="defining-storage-classes-{context}"]
+= Defining a StorageClass
+
+StorageClass objects are currently a globally scoped object and need to be
+created by `cluster-admin` or `storage-admin` users.
+
+[NOTE]
+====
+For GCE and AWS, a default StorageClass is created during {product-title} 
+installation. You can change the default StorageClass or delete it.
+====
+
+The following sections describe the basic object definition for a 
+StorageClass and specific examples for each of the supported plug-in types. 

--- a/modules/dynamic-provisioning-gce-definition.adoc
+++ b/modules/dynamic-provisioning-gce-definition.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="gce-persistentdisk-storage-class-{context}"]
+= GCE PersistentDisk (gcePD) object definition
+
+.gce-pd-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard  <1>
+  zone: us-central1-a  <2>
+  zones: us-central1-a, us-central1-b, us-east1-b  <3>
+  fsType: ext4 <4>
+----
+<1> Select either `pd-standard` or `pd-ssd`. The default is `pd-ssd`.
+<2> GCE zone. If no zone is specified, volumes are generally round-robined
+across all active zones where the {product-title} cluster has a node. 
+Zone and zones parameters must not be used at the same time.
+<3> A comma-separated list of GCE zone(s). If no zone is specified, 
+volumes are generally round-robined across all active zones where the 
+{product-title} cluster has a node. Zone and zones parameters must not 
+be used at the same time.
+<4> File system that is created on dynamically provisioned volumes. This 
+value is copied to the `fsType` field of dynamically provisioned 
+persistent volumes and the file system is created when the volume is 
+mounted for the first time. The default value is `ext4`.

--- a/modules/dynamic-provisioning-gluster-definition.adoc
+++ b/modules/dynamic-provisioning-gluster-definition.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="gluster-definition-{context}"]
+= GlusterFS object definition
+
+.glusterfs-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow
+provisioner: kubernetes.io/glusterfs
+parameters: <1>
+  resturl: http://127.0.0.1:8081 <2>
+  restuser: admin <3>
+  secretName: heketi-secret <4>
+  secretNamespace: default <5>
+  gidMin: "40000" <6>
+  gidMax: "50000" <7>
+  volumeoptions: group metadata-cache, nl-cache on <8>
+  volumetype: replicate:3 <9>
+----
+<1> Listed are mandatory and a few optional parameters. Please refer to
+link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.10/html-single/operations_guide/#sect_file_reg_storageclass[Registering a Storage Class] for additional parameters.
+<2> link:https://github.com/heketi/heketi[heketi] (volume management REST
+service for Gluster) URL that provisions GlusterFS volumes on demand. The
+general format should be `{http/https}://{IPaddress}:{Port}`. This is a
+mandatory parameter for the GlusterFS dynamic provisioner. If the heketi
+service is exposed as a routable service in the {product-title}, it will 
+have a resolvable fully qualified domain name (FQDN) and heketi service URL.
+<3> heketi user who has access to create volumes. This is typically `admin`.
+<4> Identification of a Secret that contains a user password to use when
+talking to heketi. An empty password will be used
+when both `secretNamespace` and `secretName` are omitted. 
+The provided secret must be of type `"kubernetes.io/glusterfs"`.
+<5> The namespace of mentioned `secretName`. An empty password will be used
+when both `secretNamespace` and `secretName` are omitted. The provided 
+Secret must be of type `"kubernetes.io/glusterfs"`.
+<6> Optional. The minimum value of the GID range for volumes of this 
+StorageClass.
+<7> Optional. The maximum value of the GID range for volumes of this 
+StorageClass.
+<8> Optional. Options for newly created volumes. It allows for 
+performance tuning. See
+link:https://docs.gluster.org/en/v3/Administrator%20Guide/Managing%20Volumes/#tuning-volume-options[Tuning Volume Options] 
+for more GlusterFS volume options.
+<9> Optional. The
+link:https://docs.gluster.org/en/v3/Quick-Start-Guide/Architecture/[type of volume]
+to use.
+
+[NOTE]
+====
+When the `gidMin` and `gidMax` values are not specified, their defaults are
+2000 and 2147483647 respectively. Each dynamically provisioned volume 
+will be given a GID in this range (`gidMin-gidMax`). This GID is released 
+from the pool when the respective volume is deleted. The GID pool is 
+per StorageClass.
+If two or more storage classes have GID ranges that overlap there may be
+duplicate GIDs dispatched by the provisioner.
+====
+
+When heketi authentication is used, a Secret containing the admin key must
+also exist.
+
+----
+oc create secret generic heketi-secret --from-literal=key=<password> -n <namespace> --type=kubernetes.io/glusterfs
+----
+
+This results in the following configuration:
+
+.heketi-secret.yaml
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: heketi-secret
+  namespace: namespace
+  ...
+data:
+  key: cGFzc3dvcmQ= <1>
+type: kubernetes.io/glusterfs
+----
+<1> base64 encoded password
+
+[NOTE]
+====
+When the PVs are dynamically provisioned, the GlusterFS plug-in 
+automatically creates an Endpoints and a headless Service named 
+`gluster-dynamic-<claimname>`. When the PVC is deleted, these dynamic 
+resources are deleted automatically.
+====

--- a/modules/dynamic-provisioning-storage-class-definition.adoc
+++ b/modules/dynamic-provisioning-storage-class-definition.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="basic-storage-class-definition-{context}"]
+= Basic StorageClass object definition
+
+The following resource shows the parameters and default values that you 
+use to configure a StorageClass. This example uses the AWS 
+ElasticBlockStore (EBS) object definition.
+
+
+.Sample StorageClass definition
+[source,yaml]
+----
+kind: StorageClass <1>
+apiVersion: storage.k8s.io/v1 <2>
+metadata:
+  name: gp2 <3>
+  annotations: <4>
+    storageclass.kubernetes.io/is-default-class: 'true'
+    ...
+provisioner: kubernetes.io/aws-ebs <5>
+parameters: <6>
+  type: gp2
+...
+----
+<1> (required) The API object type.
+<2> (required) The current apiVersion.
+<3> (required) The name of the StorageClass.
+<4> (optional) Annotations for the StorageClass
+<5> (required) The type of provisioner associated with this storage class.
+<6> (optional) The parameters required for the specific provisioner, this
+will change from plug-in to plug-in.

--- a/modules/dynamic-provisioning-vsphere-definition.adoc
+++ b/modules/dynamic-provisioning-vsphere-definition.adoc
@@ -1,0 +1,25 @@
+// Module included in the following definitions:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="vsphere-definition-{context}"]
+= VMware vSphere object definition
+
+.vsphere-storageclass.yaml
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/vsphere-volume <1>
+parameters:
+  diskformat: thin <2>
+  
+----
+<1> For more information about using VMware vSphere with {product-title}, i
+see the 
+link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[VMware vSphere documentation].
+<2>  `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick` are all 
+valid disk formats. See vSphere docs for additional details regarding the
+disk format types. The default value is `thin`.

--- a/storage/dynamic-provisioning.adoc
+++ b/storage/dynamic-provisioning.adoc
@@ -1,0 +1,31 @@
+[id='dynamic-provisioning']
+= Dynamic provisioning 
+include::modules/common-attributes.adoc[]
+:context: dynamic-provisioning
+toc::[]
+
+include::modules/dynamic-provisioning-about.adoc[leveloffset=+1]
+
+include::modules/dynamic-provisioning-available-plugins.adoc[leveloffset=+1]
+
+include::modules/dynamic-provisioning-defining-storage-class.adoc[leveloffset=+1]
+
+include::modules/dynamic-provisioning-storage-class-definition.adoc[leveloffset=+2]
+
+include::modules/dynamic-provisioning-annotations.adoc[leveloffset=+2]
+
+//include::modules/dynamic-provisioning-cinder-definition.adoc[leveloffset=+2]
+
+include::modules/dynamic-provisioning-aws-definition.adoc[leveloffset=+2]
+
+//include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
+
+//include::modules/dynamic-provisioning-gluster-definition.adoc[leveloffset=+2]
+
+include::modules/dynamic-provisioning-ceph-rbd-definition.adoc[leveloffset=+2]
+
+//include::modules/dynamic-provisioning-vsphere-definition.adoc[leveloffset=+2]
+
+//include::modules/dynamic-provisioning-azure-disk-definition.adoc[leveloffset=+2]
+
+include::modules/dynamic-provisioning-change-default-class.adoc[leveloffset=+1]


### PR DESCRIPTION
Include details on dynamic provisioning. Note that some of these modules are currently commented out; I've pulled them over from 3.x content and expect to include these over time as the persistent volumes types are also included.

This is for OS 4.0.