### PR TITLE
Fix bug 1690770

### DIFF
--- a/dev_guide/expanding_persistent_volumes.adoc
+++ b/dev_guide/expanding_persistent_volumes.adoc
@@ -18,50 +18,6 @@ To allow expansion of persistent volume claims (PVC) by {product-title} users,
 `allowVolumeExpansion` set to `true`. Only PVCs created from that class are
 allowed to expand.
 
-Apart from that, {product-title} administrators must enable the
-`ExpandPersistentVolumes` feature flag and turn on the
-`PersistentVolumeClaimResize` admission controller. Refer to
-xref:../architecture/additional_concepts/admission_controllers.adoc#architecture-additional-concepts-admission-controllers[Admission Controllers]
-for more information on the `PersistentVolumeClaimResize` admission controller.
-
-To enable the feature gate, set `ExpandPersistentVolumes` to `true` across the system:
-
-. Configure the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]:
-+
-----
-# oc edit configmaps <name> -n openshift-node
-----
-+
-For example:
-+
-----
-oc edit cm node-config-compute -n openshift-node
-...
-kubeletArguments:
-...
-  feature-gates:
-  - ExpandPersistentVolumes=true
-----
-
-. Enable the `ExpandPersistentVolumes` feature gate on the master API and controller manager:
-+
-----
-# cat /etc/origin/master/master-config.yaml
-...
-kubernetesMasterConfig:
-  apiServerArguments:
-  ...
-    feature-gates:
-    - ExpandPersistentVolumes=true
-  controllerArguments:
-    ...
-    feature-gates:
-    - ExpandPersistentVolumes=true
-
-# master-restart api
-# master-restart controllers
-----
-
 [[expanding_glusterfs_pvc]]
 == Expanding GlusterFS-Based Persistent Volume Claims
 


### PR DESCRIPTION
Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1690770
Remove manual steps to enable feature gate ExpandPersistentVolumes and configuration of admission controller PersistentVolumeClaimResize as they defaults to enabled since 3.11

@openshift/team-documentation 

Apply to enterprise-3.11 and above.