### PR TITLE
BZ-1691207: Corrected typo.

### DIFF
--- a/modules/storage-persistent-storage-iscsi-custom-initiator.adoc
+++ b/modules/storage-persistent-storage-iscsi-custom-initiator.adoc
@@ -31,5 +31,5 @@ spec:
     fsType: ext4
     readOnly: false
 ----
-<1> Specify the name of the inquisitor.
+<1> Specify the name of the initiator.
 ====


### PR DESCRIPTION
BZ-1691207: Corrected typo in iSCSI custom initiator.

This is for OS 4.x.