### PR TITLE
Missing hyphen in Route example

### DIFF
--- a/architecture/topics/alternate_backends_weights.adoc
+++ b/architecture/topics/alternate_backends_weights.adoc
@@ -55,7 +55,7 @@ spec:
   - kind: Service
     name: service-name2 <3>
     weight: 10          <4>
-    kind: Service
+  - kind: Service
     name: service-name3 <3>
     weight: 10          <4>
 ----


### PR DESCRIPTION
The Route example for alternate backends was missing a hyphen.