### PR TITLE
openshift_logging_master_public_url is no longer used

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -110,11 +110,6 @@ xref:../install_config/aggregate_logging.adoc#aggregate-logging-creating-the-cur
 should be accessible from within the cluster. For example,
 https://<PRIVATE-MASTER-URL>:8443.
 
-|`openshift_logging_master_public_url`
-|The public facing URL for the Kubernetes master. This is used for Authentication
-redirection by the Kibana proxy. For example,
-https://<CONSOLE-PUBLIC-URL-MASTER>:8443.
-
 |`openshift_logging_install_logging`
 |Set to `true` to install logging. Set to `false` to uninstall logging.
 


### PR DESCRIPTION
openshift_logging_master_public_url got unused along with
introducing oauth-proxy in 3.11.