### PR TITLE
Group and version changes of Marketplace APIs

### DIFF
--- a/architecture/customizations.adoc
+++ b/architecture/customizations.adoc
@@ -92,7 +92,7 @@ that are based on many of these CRDs to add more functionality to your
 |
 
 |CatalogSourceConfig
-|marketplace.redhat.com
+|operators.coreos.com
 |
 |Namespaced
 |
@@ -357,7 +357,7 @@ new values. If it is deleted, it recreates automatically.
 |
 
 |OperatorSource
-|marketplace.redhat.com
+|operators.coreos.com
 |
 |Namespaced
 |

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -44,7 +44,7 @@ listed in the previous step (such as amp-streams or etcd). For example:
 .Example CatalogSourceConfig
 [source,yaml]
 ----
-apiVersion: marketplace.redhat.com/v1alpha1
+apiVersion: operators.coreos.com/v1
 kind: CatalogSourceConfig
 metadata:
   name: example
@@ -109,7 +109,7 @@ more packages. For example:
 .Example updated CatalogSourceConfig
 [source,yaml]
 ----
-apiVersion: marketplace.redhat.com/v1alpha1
+apiVersion: operators.coreos.com/v1
 kind: CatalogSourceConfig
 metadata:
   name: example


### PR DESCRIPTION
Change group/version of OperatorSource/CatalogSourceConfig to operators.coreos.com/v1 from marketplace.redhat.com/v1alpha1
Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1692209

@openshift/team-documentation 