### PR TITLE
bug 1547893 updated etcd cert redployment description

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -87,7 +87,7 @@ The `openshift_certificate_expiry` role uses the following variables:
 
 |`openshift_certificate_expiry_save_json_results`
 |`no`
-|Save expiry check results as a JSON file. 
+|Save expiry check results as a JSON file.
 
 |`openshift_certificate_expiry_json_results_path`
 |`$HOME/cert-expiry-report.yyyymmddTHHMMSS.json`
@@ -330,8 +330,8 @@ file. To use the current CA, skip this step.
 openshift_master_ca_certificate={'certfile': '</path/to/ca.crt>', 'keyfile': '</path/to/ca.key>'}
 ----
 +
-If the CA certificate is issued by an intermediate CA, the bundled certificate must contain 
-the full chain (the intermediate and root certificates) for the CA in order to validate child certificates. 
+If the CA certificate is issued by an intermediate CA, the bundled certificate must contain
+the full chain (the intermediate and root certificates) for the CA in order to validate child certificates.
 +
 For example:
 +
@@ -379,6 +379,11 @@ xref:redeploying-etcd-certificates[*_openshift-etcd/redeploy-certificates.yml_* 
 by the new etcd CA on etcd peers and master clients. Alternatively, you can use the
 xref:redeploying-all-certificates-current-ca[*_redeploy-certificates.yml_* playbook] to redeploy certificates for {product-title} components in addition to etcd peers and master clients.
 
+[NOTE]
+====
+The `etcd` certificate redeployment can result in copying the `serial` to all master hosts.
+====
+
 [[redeploying-master-certificates]]
 === Redeploying Master Certificates Only
 
@@ -396,8 +401,8 @@ $ ansible-playbook -i <inventory_file> \
 
 [IMPORTANT]
 ====
-After running this playbook, you need to regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs] 
-by deleting existing secrets that contain service serving certificates or removing and re-adding 
+After running this playbook, you must regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs]
+by deleting existing secrets that contain service serving certificates or removing and re-adding
 annotations to appropriate services.
 ====
 
@@ -558,7 +563,7 @@ $ oc adm ca create-server-cert \
 ----
 +
 Run `oc adm` commands only from the first master listed in the Ansible host inventory file,
-by default *_/etc/ansible/hosts_*. 
+by default *_/etc/ansible/hosts_*.
 
 . Update the `registry-certificates` secret with the new registry certificates:
 +
@@ -677,7 +682,7 @@ $ cat router.crt /etc/origin/master/ca.crt router.key > router.pem
 $ oc get -o yaml --export secret router-certs > ~/old-router-certs-secret.yaml
 ----
 
-. Create a new secret to hold the new certificate and key, and replace the 
+. Create a new secret to hold the new certificate and key, and replace the
 contents of the existing secret:
 +
 ----
@@ -686,7 +691,7 @@ $ oc create secret tls router-certs --cert=router.pem \ <1>
     oc replace -f -
 ----
 <1> *_router.pem_* is the file that contains the concatenation of the
-certificates that you generated.    
+certificates that you generated.
 
 . Remove the following annotations from the `router` service:
 +


### PR DESCRIPTION
Bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1547893

The original docs request was to include statements regarding the `ca.serial.txt` file, however this was deemed to be satisfactory. We have instead included a statement about a known, WONTFIX `etcd` redeployment bug -- there is no actual bug on file to reference, however.

@openshift/team-documentation  - requesting peer review for statement clarity. 
@jiajliu - please take a look

Thanks!