### PR TITLE
Removed Prometheus Alert Buffer references

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -407,8 +407,8 @@ $ docker save -o ose3-images.tar \
     registry.redhat.io/openshift3/snapshot-provisioner \
     registry.redhat.io/rhel7/etcd:3.2.22
 ----
-////
 +
+////
 [IMPORTANT]
 ====
 For Red Hat support, a {gluster-native} subscription is required for `rhgs3/` images.

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -432,7 +432,6 @@ $ docker save -o ose3-optional-imags.tar \
     registry.redhat.io/openshift3/ose-logging-fluentd \
     registry.redhat.io/openshift3/ose-logging-kibana5 \
     registry.redhat.io/openshift3/prometheus \
-    registry.redhat.io/openshift3/prometheus-alert-buffer \
     registry.redhat.io/openshift3/prometheus-alertmanager \
     registry.redhat.io/openshift3/prometheus-node-exporter \
     registry.redhat.io/cloudforms46/cfme-openshift-postgresql \

--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -261,7 +261,6 @@ $ docker pull registry.redhat.io/openshift3/ose-logging-eventrouter:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-fluentd:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-kibana5:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus:<tag>
-$ docker pull registry.redhat.io/openshift3/prometheus-alert-buffer:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus-alertmanager:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus-node-exporter:<tag>
 $ docker pull registry.redhat.io/cloudforms46/cfme-openshift-postgresql


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1690311

Removed the following line so users do not get docker errors when trying to pull the non existent images.
$ docker pull registry.redhat.io/openshift3/prometheus-alert-buffer:<tag>