### PR TITLE
[enterprise-3.11] Added inventory variables to install using Satellite image registry

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -622,7 +622,15 @@ standard installation method to install {product-title}:
 inventory file] to reference your internal registry:
 +
 ----
+# For a internal registry
 oreg_url=registry.example.com/openshift3/ose-${component}:${version}
+openshift_examples_modify_imagestreams=true
+----
++
+----
+# For a Sateliite image registry 
+oreg_url=satellite.example.com/oreg-prod-openshift3_ose-${component}:${version}
+osm_etcd_image=satellite.example.com/oreg-prod-rhel7_etcd:3.2.22
 openshift_examples_modify_imagestreams=true
 ----
 


### PR DESCRIPTION
- Fix: ["oreg_url" does not work on disconnected installation using Satellite](https://bugzilla.redhat.com/show_bug.cgi?id=1689796)

- Version: `v3.11`

- Description: 
  `Satellite` provides container images through `<HOSTNAME>/<ORGANIZATION>-<PRODUCT>-<REPOSITORY>` format.
  It would convert `/` to `_` in the `<REPOSITORY>` part when you import `external images` to `Satellite` registry. 
And `etcd` is image path is different with others, so you should specify the image path using `osm_etcd_image`.
