### PR TITLE
Bug 1657326, Added Setting the Registry Host Name section to Deploying a Registry topic

### DIFF
--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -26,6 +26,9 @@ xref:../../install/stand_alone_registry.adoc#install-config-installing-stand-alo
 ====
 endif::[]
 
+
+include::install_config/registry/extended_registry_configuration.adoc[tag=settingregistryhostname]
+
 [[deploy-registry]]
 == Deploying the Registry
 
@@ -129,8 +132,8 @@ $ oc set volume deploymentconfigs/docker-registry --add --name=registry-storage 
 
 [IMPORTANT]
 ====
-Testing shows issues with using the RHEL NFS server as a storage backend for 
-the container image registry. This includes the OpenShift Container Registry and Quay. 
+Testing shows issues with using the RHEL NFS server as a storage backend for
+the container image registry. This includes the OpenShift Container Registry and Quay.
 Therefore, using the RHEL NFS server to back PVs used by core services is not recommended.
 
 Other NFS implementations on the marketplace might not have these issues. Contact

--- a/install_config/registry/extended_registry_configuration.adoc
+++ b/install_config/registry/extended_registry_configuration.adoc
@@ -116,16 +116,22 @@ Once the whitelist is configured, if a user tries to pull from a container image
 that is not on the whitelist, they will receive an error message stating that
 this registry is not allowed.
 
+
 [[setting-the-registry-hostname]]
-== Setting the Registry Hostname
+// tag::settingregistryhostname[]
+== Setting the Registry Host Name
 
-You can configure the hostname and port the registry is known by for both internal and external references.
-By doing this, image streams will provide hostname based push and pull specifications for images,
-allowing consumers of the images to be isolated from changes to the registry service ip and potentially
-allowing image streams and their references to be portable between clusters.
+You can configure the host name and port the registry is known by for both
+internal and external references. By doing this, image streams will provide
+hostname based push and pull specifications for images, allowing consumers of
+the images to be isolated from changes to the registry service IP and
+potentially allowing image streams and their references to be portable between
+clusters.
 
-To set the hostname used to reference the registry from within the cluster, set the `internalRegistryHostname`
-in the `imagePolicyConfig` section of the master configuration file.  The external hostname is controlled by setting the `externalRegistryHostname` value in the same location.
+To set the hostname used to reference the registry from within the cluster, set
+the `internalRegistryHostname` in the `imagePolicyConfig` section of the master
+configuration file.  The external host name is controlled by setting the
+`externalRegistryHostname` value in the same location.
 
 .Image Policy Configuration
 [source,yaml]
@@ -135,9 +141,12 @@ imagePolicyConfig:
   externalRegistryHostname: docker-registry.mycompany.com
 ----
 
-The registry itself must be configured with the same internal hostname value.  This can be accomplished by setting the
-`*REGISTRY_OPENSHIFT_SERVER_ADDR*` environment variable on the registry deployment configuration,
-or by setting the value in the xref:extended_registry_configuration#docker-registry-configuration-reference-openshift[OpenShift section] of the registry configuration.
+The registry itself must be configured with the same internal hostname value.
+This can be accomplished by setting the `*REGISTRY_OPENSHIFT_SERVER_ADDR*`
+environment variable on the registry deployment configuration, or by setting the
+value in the
+xref:extended_registry_configuration#docker-registry-configuration-reference-openshift[OpenShift
+section] of the registry configuration.
 
 [NOTE]
 ====
@@ -146,6 +155,7 @@ include the hostnames by which you expect the registry to be referenced.
 See xref:securing_and_exposing_registry.adoc#securing-the-registry[securing
 the registry] for instructions on adding hostnames to the server certificate.
 ====
+// end::settingregistryhostname[]
 
 [[advanced-overriding-the-registry-configuration]]
 == Overriding the Registry Configuration


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1657326

Preview Build: http://file.rdu.redhat.com/~ahardin/03262019/deploying-registry-variable/install_config/registry/deploy_registry_existing_clusters.html#setting-the-registry-hostname