### PR TITLE
Corrected asciidoc syntax

### DIFF
--- a/modules/rbac-creating-local-role.adoc
+++ b/modules/rbac-creating-local-role.adoc
@@ -17,10 +17,13 @@ $ oc create role <name> --verb=<verb> --resource=<resource> -n <project>
 ----
 +
 In this command, specify:
++
+--
 * `<name>`, the local role's name
 * `<verb>`, a comma-separated list of the verbs to apply to the role
 * `<resource>`, the resources that the role applies to
 * `<project>`, the project name
+--
 +
 For example, to create a local role that allows a user to view pods in the
 `blue` project, run the following command:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1692022
"Bug 1692022 - [DOCS] Little typo including a "+" symbol in the middle of the page"