### PR TITLE
Corrected typo

### DIFF
--- a/modules/rbac-overview.adoc
+++ b/modules/rbac-overview.adoc
@@ -105,7 +105,7 @@ endif::[]
 Be mindful of the difference between local and cluster bindings. For example,
 if you bind the `cluster-admin` role to a user by using a local role binding,
 it might appear that this user has the privileges of a cluster administrator.
-This is not the case. Binding the `cluster-admin` to a user in a project 
+This is not the case. Binding the `cluster-admin` to a user in a project
 grants super administrator privileges for only that
 project to the user. That user has the permissions of the cluster role
 `admin`, plus a few additional permissions like the ability to edit rate limits,
@@ -148,7 +148,7 @@ their content in isolation from other communities.
 * *Verb* : The action itself:  `get`, `list`, `create`, `update`, `delete`, `deletecollection`, or `watch`.
 * *Resource Name*: The API endpoint that you access.
 Bindings:: The full list of bindings, the associations between users or groups
-with arole.
+with a role.
 
 {product-title} evaluates authorization by using the following steps:
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1692019
"Bug 1692019 - [DOCS] A typo in the word "arole""

Corrected typo.