### PR TITLE
BZ-1693405: Removed openshift-web-console.

### DIFF
--- a/modules/oauth-token-requests.adoc
+++ b/modules/oauth-token-requests.adoc
@@ -14,9 +14,6 @@ created when starting the {product-title} API:
 
 |OAuth Client |Usage
 
-|`openshift-web-console`
-|Requests tokens for the web console.
-
 |`openshift-browser-client`
 |Requests tokens at `_<namespace_route>_/oauth/token/request` with a user-agent that can handle interactive logins.
 


### PR DESCRIPTION
BZ-1693405: Removed openshift-web-console, as this client no longer exists.