### PR TITLE
3scale Adapter Prerequisites Update (Mixer Behavior Change)

### DIFF
--- a/servicemesh-install/topics/appendix-threescale-adapter.adoc
+++ b/servicemesh-install/topics/appendix-threescale-adapter.adoc
@@ -6,6 +6,7 @@ Prerequisites:
 * {ProductName} 0.7.0+
 * A working 3scale account (https://www.3scale.net/signup/[SaaS] or https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html/infrastructure/onpremises-installation[On-Premises])
 * https://docs.openshift.com/container-platform/3.11/servicemesh-install/servicemesh-install.html#service-mesh-install_prerequisites[{ProductName} prerequisites]
+* Ensure Mixer policy enforcement is enabled. The https://docs.openshift.com/container-platform/3.11/servicemesh-install/servicemesh-install.html#update-mixer-policy-enforcement[Update Mixer policy enforcement] provides instructions to check the current Mixer policy enforcement status and enable policy enforcement. 
 
 [NOTE]
 ====


### PR DESCRIPTION
The 3scale team requested this update to their Prerequisites for the Istio Adapter as a result of the change in Mixer behavior. I worked with @dfennessy on this update. Can @vramosp take a look at this for the 3scale team? And can @JStickler and @brian-avery just take a quick look?