### PR TITLE
Changing Operator name back so that it is correct for betas

### DIFF
--- a/modules/sb-configuring-ansible-service-broker.adoc
+++ b/modules/sb-configuring-ansible-service-broker.adoc
@@ -16,7 +16,8 @@ The following procedure customizes the settings for your {asb-name}.
 This procedure assumes that you used `ansible-service-broker` both as the {asb-name} name and the project that it was installed into.
 
 . Navigate in the web console to *Catalog* -> *Installed Operators* and select the `ansible-service-broker` project.
-. Select the *OpenShift Ansible Service Broker Operator*.
+// TODO: Change to *OpenShift Ansible Service Broker Operator* by GA (3 of 3)
+. Select the *Automation Broker Operator*.
 . On the *Automation Broker* tab, select `ansible-service-broker`.
 . On the *YAML* tab, add or update any {asb-name} configuration options under the `spec` field.
 +

--- a/modules/sb-install-asb-operator.adoc
+++ b/modules/sb-install-asb-operator.adoc
@@ -26,14 +26,15 @@ The following procedure installs the {asb-name} Operator using the web console.
  *Subject Name* field.
 .. Click *Create*.
 . Navigate to the *Catalog* -> *OperatorHub* page. Verify that the `ansible-service-broker` project is selected.
-. Select *OpenShift Ansible Service Broker Operator*.
+// TODO: Change to *OpenShift Ansible Service Broker Operator* by GA (1 of 3)
+. Select *Automation Broker Operator*.
 +
 A pop-up window appears, warning you that you are installing a Community
 Operator. Click *Continue* to acknowledge the *Show Community Operator* warning.
 +
 [NOTE]
 ====
-This Operator will be available under the *Red Hat* category in the GA release.
+This Operator will be named *OpenShift Ansible Service Broker Operator* and will be available under the *Red Hat* category in the GA release.
 ====
 . Read the information about the Operator and click *Install*.
 . Review the default selections and click *Subscribe*.

--- a/modules/sb-start-asb.adoc
+++ b/modules/sb-start-asb.adoc
@@ -16,7 +16,8 @@ using the following procedure.
 .Procedure
 
 . Navigate in the web console to *Catalog* -> *Installed Operators* and select the `ansible-service-broker` project.
-. Select the *OpenShift Ansible Service Broker Operator*.
+// TODO: Change to *OpenShift Ansible Service Broker Operator* by GA (1 of 3)
+. Select the *Automation Broker Operator*.
 . Under *Provided APIs*, click *Create New* for *Automation Broker*.
 . Review the default YAML, set any additional {asb-name} configuration options,
 and click *Create*.


### PR DESCRIPTION
@openshift/team-documentation For peer review please.

The name will eventually be changed to "OpenShift Ansible Service Broker Operator", but not until closer to GA. Since we don't want to confuse beta users, am putting the name back for now so that the steps are currently correct.