### PR TITLE
BZ-1693408: Consolidated references to the kubeadmin user.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -243,6 +243,8 @@ Topics:
     File: configuring-oidc-identity-provider
 - Name: Using RBAC to define and apply permissions
   File: using-rbac
+- Name: Removing the kubeadmin user
+  File: remove-kubeadmin
 - Name: Configuring LDAP failover
   File: configuring-ldap-failover
 - Name: Configuring the user agent

--- a/authentication/remove-kubeadmin.adoc
+++ b/authentication/remove-kubeadmin.adoc
@@ -1,0 +1,9 @@
+[id="removing-kubeadmin"]
+= Removing the kubeadmin user
+include::modules/common-attributes.adoc[]
+:context: removing-kubeadmin
+toc::[]
+
+include::modules/authentication-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/authentication-remove-kubeadmin.adoc[leveloffset=+1]

--- a/authentication/understanding-authentication.adoc
+++ b/authentication/understanding-authentication.adoc
@@ -25,5 +25,4 @@ include::modules/oauth-token-requests.adoc[leveloffset=+2]
 
 include::modules/authentication-api-impersonation.adoc[leveloffset=+3]
 
-
 include::modules/authentication-prometheus-system-metrics.adoc[leveloffset=+3]

--- a/modules/authentication-kubeadmin.adoc
+++ b/modules/authentication-kubeadmin.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assmeblies:
+//
+// * authentication/removing-kubeadmin.adoc
+
+[id="understanding-kubeadmin-{context}"]
+= The kubeadmin user
+
+{product-title} creates a cluster administrator, `kubeadmin`, after the
+installation process completes.
+
+This user has the `cluster-admin` role automatically applied and is treated
+as the root user for the cluster. The password is dynamically generated
+and unique to your {product-title} environment. After installation
+completes the password is provided in the installation program's output. 
+For example:
+
+----
+INFO Install complete!
+INFO Run 'export KUBECONFIG=<your working directory>/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI.
+INFO The cluster is ready when 'oc login -u kubeadmin -p <provided>' succeeds (wait a few minutes).
+INFO Access the OpenShift web-console here: https://console-openshift-console.apps.demo1.openshift4-beta-abcorp.com
+INFO Login to the console with user: kubeadmin, password: <provided>
+----

--- a/modules/authentication-remove-kubeadmin.adoc
+++ b/modules/authentication-remove-kubeadmin.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * authentication/understanding-authentication.adoc
+
+[id="removing-kubeadmin-{context}"]
+= Removing the kubeadmin user
+
+After you define an identity provider and create a new `cluster-admin`
+user, you can remove the `kubeadmin` to improve cluster security.
+
+WARNING
+====
+If you follow this procedure before another user is a `cluster-admin`,
+then {product-title} must be reinstalled. It is not possible to undo
+this command.
+====
+
+.Prerequisites
+
+* You must have configured at least one identity provider.
+* You must have added the `cluster-admin` role to a user.
+* You must be logged in as an administrator.
+
+.Procedure 
+
+* Remove the `kubeadmin` secrets:
++
+----
+$ oc delete secrets kubeadmin -n kube-system
+----
+

--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -22,15 +22,9 @@ users can authenticate.
 
 * Create an {product-title} cluster.
 * Create the Custom Resource (CR) for your identity providers.
+* You must be logged in as an administrator.
 
 .Procedure
-
-. Log in to the cluster as the `kube-admin` user, entering the password
-when prompted:
-+
-----
-$ oc login -u kubeadmin 
-----
 
 . Apply the defined CR:
 +

--- a/modules/identity-provider-overview.adoc
+++ b/modules/identity-provider-overview.adoc
@@ -16,7 +16,7 @@
 [id="identity-provider-overview-{context}"]
 = About identity providers in {product-title}
 
-By default, only a `kube-admin` user exists on your cluster. To specify an 
+By default, only a `kubeadmin` user exists on your cluster. To specify an 
 identity provider, you must create a Custom Resource (CR) that describes 
 that identity provider and add it to the cluster.
 

--- a/modules/rbac-users.adoc
+++ b/modules/rbac-users.adoc
@@ -27,7 +27,7 @@ with the `User` object. Examples: `joe` `alice`
  is defined, mainly for the purpose of enabling the infrastructure to
  interact with the API securely. They include a cluster administrator
  (with access to everything), a per-node user, users for use by routers
- and registries, and various others. Finally, there is an `anonymous
+ and registries, and various others. Finally, there is an `anonymous`
  system user that is used by default for unauthenticated requests. Examples:
 `system:admin` `system:openshift-registry` `system:node:node1.example.com`
 


### PR DESCRIPTION
I've removed the instruction in the IDP configuration to be logged in as the `kubeadmin` user, and also included details on removing this user from the cluster.

This issue came up when reviewing the docs with engineering, and is for OS 4.0.