### PR TITLE
Cnv1016 RDP console over L2 network

### DIFF
--- a/modules/cnv-accessing-rdp-console.adoc
+++ b/modules/cnv-accessing-rdp-console.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * TBD
+
+[id="cnv-accessing-rdp-console-{context}"]
+= Connecting to a Windows virtual machine with an RDP console
+
+The Remote Desktop Protocol (RDP) provides a better console experience for 
+connecting to Windows virtual machines. 
+
+To connect to a Windows virtual machine with RDP, specify the IP address of the 
+attached L2 vNIC to your RDP client. 
+
+.Prerequisites
+
+* A running Windows virtual machine with the QEMU guest agent installed. The 
+`qemu-guest-agent` is included in the VirtIO drivers.
+* A layer 2 vNIC attached to the virtual machine. 
+* An RDP client installed on a machine on the same network as the 
+Windows virtual machine. 
+
+.Procedure
+
+. Log in to the {ProductName} cluster through the `oc` CLI tool as a user with 
+an access token. 
++
+----
+$ oc login -u <user> https://<cluster.example.com>:8443
+----
+
+. Use `oc describe vmi` to display the configuration of the running 
+Windows virtual machine. 
++
+----
+$ oc describe vmi <windows-vmi-name>
+----
++
+[source,yaml]
+----
+...
+spec:
+  networks:
+  - name: default
+    pod: {}
+  - multus:
+      networkName: cnv-bridge
+    name: bridge-net
+...
+status:
+  interfaces:
+  - interfaceName: eth0
+    ipAddress: 198.51.100.0/24 
+    ipAddresses:
+      198.51.100.0/24 
+    mac: a0:36:9f:0f:b1:70
+    name: default
+  - interfaceName: eth1
+    ipAddress: 192.0.2.0/24 
+    ipAddresses:
+      192.0.2.0/24 
+      2001:db8::/32
+    mac: 00:17:a4:77:77:25
+    name: bridge-net
+...
+----
+
+. Identify and copy the IP address of the layer 2 network interface. This is 
+`192.0.2.0` in the above example, or `2001:db8::` if you prefer IPv6. 
+. Open an RDP client and use the IP address copied in the previous step for the 
+connection. 
+. Enter the *Administrator* user name and password to connect to the 
+Windows virtual machine.
+
+

--- a/modules/cnv-vm-rdp-console-web.adoc
+++ b/modules/cnv-vm-rdp-console-web.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * TBD
+
+[id="cnv-vm-rdp-console-web-{context}"]
+= Connecting to the RDP console
+
+The desktop viewer console, which utilizes the Remote Desktop Protocol (RDP), 
+provides a better console experience for connecting to Windows virtual machines.
+
+To connect to a Windows virtual machine with RDP, download the *_console.rdp_* 
+file for the virtual machine from the *Consoles* tab in the 
+*Virtual Machine Details* screen of the web console and supply it to your 
+preferred RDP client. 
+
+.Prerequisites
+
+* A running Windows virtual machine with the QEMU guest agent installed. The 
+`qemu-guest-agent` is included in the VirtIO drivers.
+* A layer 2 vNIC attached to the virtual machine. 
+* An RDP client installed on a machine on the same network as the 
+Windows virtual machine. 
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
+. Select a Windows virtual machine.
+. Click the *Consoles* tab. 
+. Click the *Consoles* list and select *Desktop Viewer*.
+. In the *Network Interface* list, select the layer 2 vNIC.
+. Click *Launch Remote Desktop* to download the *_console.rdp_* file.
+. Open an RDP client and reference the *_console.rdp_* file. For example, using 
+*remmina*:
++
+----
+$ remmina --connect /path/to/console.rdp
+----
+
+. Enter the *Administrator* user name and password to connect to the 
+Windows virtual machine.
+


### PR DESCRIPTION
This is CNV 2.0 content for [CNV-1016](https://jira.coreos.com/browse/CNV-1016).

You can now connect to Windows VMIs with the RDP console using both GUI and CLI. The VM needs qemu-guest-agent installed on it (so that the IP address of the NIC can be request/reported outside the VM), and a L2 network interface. 
