### PR TITLE
Update host_health.adoc

### DIFF
--- a/day_two_guide/topics/host_health.adoc
+++ b/day_two_guide/topics/host_health.adoc
@@ -14,9 +14,9 @@ NAME                  STATUS                     AGE       VERSION
 ocp-infra-node-1clj   Ready                      1h        v1.6.1+5115d708d7
 ocp-infra-node-86qr   Ready                      1h        v1.6.1+5115d708d7
 ocp-infra-node-g8qw   Ready                      1h        v1.6.1+5115d708d7
-ocp-master-94zd       Ready,SchedulingDisabled   1h        v1.6.1+5115d708d7
-ocp-master-gjkm       Ready,SchedulingDisabled   1h        v1.6.1+5115d708d7
-ocp-master-wc8w       Ready,SchedulingDisabled   1h        v1.6.1+5115d708d7
+ocp-master-94zd       Ready                      1h        v1.6.1+5115d708d7
+ocp-master-gjkm       Ready                      1h        v1.6.1+5115d708d7
+ocp-master-wc8w       Ready                      1h        v1.6.1+5115d708d7
 ocp-node-c5dg         Ready                      1h        v1.6.1+5115d708d7
 ocp-node-ghxn         Ready                      1h        v1.6.1+5115d708d7
 ocp-node-w135         Ready                      1h        v1.6.1+5115d708d7


### PR DESCRIPTION
Removing "Scheduling Disabled" from 'oc get nodes' example output, inside STATUS column. This is not valid anymore for Masters servers, since every service runs containerized