### PR TITLE
BZ1693034: Fix wrong object name in backup steps

### DIFF
--- a/day_two_guide/topics/proc_backing-up-project.adoc
+++ b/day_two_guide/topics/proc_backing-up-project.adoc
@@ -78,7 +78,7 @@ $ oc get -o json --export all > project.json
 `service accounts`, and `persistent volume claims`:
 +
 ----
-$ for object in rolebindings serviceaccounts secrets imagestreamtags podpreset cms egressnetworkpolicies rolebindingrestrictions limitranges resourcequotas pvcs templates cronjobs statefulsets hpas deployments replicasets poddisruptionbudget endpoints
+$ for object in rolebindings serviceaccounts secrets imagestreamtags cm egressnetworkpolicies rolebindingrestrictions limitranges resourcequotas pvc templates cronjobs statefulsets hpa deployments replicasets poddisruptionbudget endpoints
 do
   oc get -o yaml --export $object > $object.yaml
 done


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1693034

This patch changes to:
- change cms, pvcs and hpas to singular form.
- remove podpreset as it is no longer supported.