### PR TITLE
Bump the pods per namespace limit to 25k

### DIFF
--- a/scaling_performance/cluster_limits.adoc
+++ b/scaling_performance/cluster_limits.adoc
@@ -69,11 +69,13 @@ It does not necessarily mean that the cluster will fail.
 a number of control loops in the system that need to iterate over all objects
 in a given namespace as a reaction to some changes in state. Having a large
 number of objects of a given type in a single namespace can make those loops
-expensive and slow down processing given state changes.]
+expensive and slow down processing given state changes. The limit 
+assumes that the system has enough CPU, memory, and disk to satifty the 
+application requirements.]
 | 3,000
 | 3,000
 | 3,000
-| 3,000
+| 25,000
 
 | Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
 | 10,000
@@ -109,6 +111,12 @@ expensive and slow down processing given state changes.]
 Oversubscribing the physical resources on a node affects resource guarantees the
 Kubernetes scheduler makes during pod placement. Learn what measures you can
 take to xref:../admin_guide/overcommit.adoc#disabling-swap-memory[avoid memory swapping].
+====
+
+[IMPORTANT]
+====
+Some of the limits are streched only in a single dimension, so the they might
+vary when a lot of objects are running on the cluster.
 ====
 
 While


### PR DESCRIPTION
We tested the pods per namespace limit on a 3.11 cluster and found
out that there are no abnormal spikes in the resource usage of control
plane as we increase the number of pods per ns to 25k provided the cluster
has sufficient CPU, memory and disk resources to meet the application
needs. The time taken to create the pods is not exactly linear but it doesn’t 
vary much.