### PR TITLE
Fluentd examples are using etcd pod names

### DIFF
--- a/modules/efk-logging-fluentd-log-viewing.adoc
+++ b/modules/efk-logging-fluentd-log-viewing.adoc
@@ -11,14 +11,14 @@ How you view logs depends upon the `LOGGING_FILE_PATH` setting.
 where the pod is located, to print out the contents of Fluentd log files:
 +
 ----
-$ oc exec <pod> -- logs <1>
+$ oc exec <any-fluentd-pod> -- logs <1>
 ----
-<1> Specify the name of the Fluentd pod. Note the space before `logs`.
+<1> Specify the name of a Fluentd pod. Note the space before `logs`.
 +
 For example:
 +
 ----
-$ oc exec etcd-member-ip-30.ec2.internal -n kube-system -- logs
+$ oc exec fluentd-ht42r -n openshift-logging -- logs
 ----
 +
 To view the current setting:
@@ -32,16 +32,14 @@ You can retrieve the logs with the `oc logs [-f] <pod_name>` command, where the 
 is optional, from the project where the pod is located.
 +
 ----
-$ oc logs -f <pod> <1>
+$ oc logs -f <any-fluentd-pod> <1>
 ----
-<1> Specify the name of the Fluentd pod. Use `-f` option to follow what is being written into the logs.
+<1> Specify the name of a Fluentd pod. Use the `-f` option to follow what is being written into the logs.
 +
 For example
 +
 ----
-$ oc logs -f etcd-member-ip-30.ec2.internal -n kube-system
+$ oc logs -f fluentd-ht42r -n openshift-logging
 ----
 +
 The contents of log files are printed out, starting with the oldest log. 
-
-


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1691800