### PR TITLE
Typo using systemmd word instead systemd

### DIFF
--- a/modules/efk-logging-exported-fields-systemd.adoc
+++ b/modules/efk-logging-exported-fields-systemd.adoc
@@ -3,7 +3,7 @@
 // * logging/efk-logging-exported-fields.adoc
 
 [id="efk-logging-exported-fields-systemd-{context}"]
-= `systemmd` exported fields
+= `systemd` exported fields
 
 These are the `systemd` fields exported by the {product-title} cluster logging available for searching
 from Elasticsearch and Kibana.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1691845