### PR TITLE
Format problem: the collectd.virt.disk_ops.read parameter doesn't follow the same style rest of paraemeters

### DIFF
--- a/modules/efk-logging-exported-fields-default.adoc
+++ b/modules/efk-logging-exported-fields-default.adoc
@@ -629,7 +629,7 @@ The `collectd` `disk_ops` type of virt plug-in.
 |Parameter
 |Description
 
-| collectd.virt.disk_ops.read
+| `collectd.virt.disk_ops.read`
 |type: float
 
 `TODO`


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1691850