### PR TITLE
Remove deprecated "system:openshift-registry" system user

### DIFF
--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -43,7 +43,7 @@ with the `*User*` object. Examples: `joe` `alice`
  (with access to everything), a per-node user, users for use by routers
  and registries, and various others. Finally, there is an `*anonymous*`
  system user that is used by default for unauthenticated requests. Examples:
-`system:admin` `system:openshift-registry` `system:node:node1.example.com`
+`system:admin` `system:node:node1.example.com`
 
 |*Service accounts*
 |These are special system users associated with projects; some are created automatically when


### PR DESCRIPTION
- Version: `v3.11`

- Description: 
   As of `v3.5` the `system:openshift-registry` system user has been deprecated and removed from the codes, but the system user has described on `v3.11` docs. 

[0] [https://github.com/openshift/origin/blob/release-1.4/pkg/cmd/server/bootstrappolicy/constants.go#L17-L21]
~~~
	RegistryUnqualifiedUsername = "openshift-registry"
...
	RegistryUsername    = "system:" + RegistryUnqualifiedUsername
~~~

[1] [https://github.com/openshift/origin/blob/release-3.11/pkg/cmd/server/bootstrappolicy/constants.go#L10-L32]
~~~
"system:openshift-registry" has been removed from the codes.
~~~