### PR TITLE
BZ-1682962: Updated htpasswd instructions.

### DIFF
--- a/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
@@ -4,13 +4,35 @@ include::modules/common-attributes.adoc[]
 :context: configuring-htpasswd-identity-provider
 toc::[]
 
-Configure the `htpasswd` identity provider to validate user names and passwords
-against a flat file generated using
-link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+[id="identity-provider-overview-{context}"]
+== About identity providers in {product-title}
 
-include::modules/identity-provider-overview.adoc[leveloffset=+1]
+By default, only a `kubeadmin` user exists on your cluster. To specify an
+identity provider, you must create a Custom Resource (CR) that describes
+that identity provider and add it to the cluster.
 
-include::modules/identity-provider-creating-htpasswd-file.adoc[leveloffset=+1]
+[NOTE]
+====
+{product-title} user names containing `/`, `:`, and `%` are not supported.
+====
+
+To define an HTPasswd identity provider you must perform the
+following steps:
+
+. Create an `htpasswd` file to store the user and password information. 
+Instructions are provided for
+xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-linux-{context}[Linux]
+and
+xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-windows-{context}[Windows].
+. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-secret-{context}[Create 
+an {product-title} secret to represent the `htpasswd` file].
+. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-htpasswd-CR-{context}[Define the HTPasswd identity provider resource].
+. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#add-identity-provider-{context}[Apply the resource to 
+the default OAuth configuration].
+
+include::modules/identity-provider-creating-htpasswd-file-linux.adoc[leveloffset=+1]
+
+include::modules/identity-provider-creating-htpasswd-file-windows.adoc[leveloffset=+1]
 
 include::modules/identity-provider-htpasswd-secret.adoc[leveloffset=+1]
 

--- a/modules/identity-provider-creating-htpasswd-file-linux.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-linux.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+
+[id="identity-provider-creating-htpasswd-file-linux-{context}"]
+= Creating an HTPasswd file using Linux
+
+To use the HTPasswd identity provider, you must generate a flat file that
+contains the user names and passwords for your cluster by using
+link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
+
+.Prerequisites
+
+* Have access to the `htpasswd` utility. On Red Hat Enterprise Linux
+this is available by installing the `httpd-tools` package.
+
+.Procedure
+
+. Create or update your flat file with a user name and hashed password:
++
+----
+$ htpasswd -c -B -b </path/to/users.htpasswd> <user_name> <password>
+----
++
+The command generates a hashed version of the password.
++
+For example:
++
+----
+$ htpasswd -c -B -b users.htpasswd user1 MyPassword!
+
+Adding password for user user1
+----
+
+. Continue to add or update credentials to the file:
++
+----
+$ htpasswd -b </path/to/users.htpasswd> <user_name> <password>
+----

--- a/modules/identity-provider-creating-htpasswd-file-windows.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-windows.adoc
@@ -2,25 +2,24 @@
 //
 // * authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
 
-[id="identity-provider-creating-htpasswd-file-{context}"]
-= Creating an HTPasswd file
+[id="identity-provider-creating-htpasswd-file-windows-{context}"]
+= Creating an HTPasswd file using Windows
 
 To use the HTPasswd identity provider, you must generate a flat file that
 contains the user names and passwords for your cluster by using
 link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
 
+.Prerequisites
+
+* Have access to `htpasswd.exe`. This file is included in the `\bin`
+directory of many Apache httpd distributions.
+
 .Procedure
 
-. Install the `htpasswd` utility by installing the `httpd-tools` package:
+. Create or update your flat file with a user name and hashed password:
 +
 ----
-# yum install httpd-tools
-----
-
-. Create or update your with a user name and hashed password:
-+
-----
-$ htpasswd -c -B -b </path/to/users.htpasswd> <user_name> <password>
+> htpasswd.exe -c -B -b <\path\to\users.htpasswd> <user_name> <password>
 ----
 +
 The command generates a hashed version of the password.
@@ -28,7 +27,7 @@ The command generates a hashed version of the password.
 For example:
 +
 ----
-$ htpasswd -c -B -b users.htpasswd user1 MyPassword!
+> htpasswd.exe -c -B -b users.htpasswd user1 MyPassword!
 
 Adding password for user user1
 ----
@@ -36,5 +35,5 @@ Adding password for user user1
 . Continue to add or update credentials to the file:
 +
 ----
-$ htpasswd -b </path/to/users.htpasswd> <user_name> <password>
+> htpasswd.exe -b <\path\to\users.htpasswd> <user_name> <password>
 ----

--- a/modules/identity-provider-htpasswd-secret.adoc
+++ b/modules/identity-provider-htpasswd-secret.adoc
@@ -14,7 +14,7 @@ contains the HTPasswd user file.
 
 .Procedure
 
-. Create an {product-title} Secret that contains the HTPasswd users file.
+* Create an {product-title} Secret that contains the HTPasswd users file.
 +
 ----
 $ oc create secret generic htpass-secret --from-file=htpasswd=</path/to/users.htpasswd> -n openshift-config


### PR DESCRIPTION
Updated htpasswd instructions. This was to ensure that users on non-RHEL systems can create the htpasswd file. It also cleaned up the flow of the assembly.

This is for OS 4.x.