### PR TITLE
Two small changes: mktplc-178, 174, 175

### DIFF
--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -21,7 +21,9 @@ permissions.
 +
 image::olm-operatorhub.png[]
 
-. Select the Operator. Information about the Operator is displayed.
+. Select the Operator. For a Community Operator, you are warned
+that Red Hat does not certify those Operators. You must acknowledge that
+warning before continuing. Information about the Operator is displayed.
 
 . Read the information about the Operator and click *Install*.
 

--- a/modules/olm-operatorhub.adoc
+++ b/modules/olm-operatorhub.adoc
@@ -30,6 +30,11 @@ ISVs to package and ship. Supported by the ISV.
 |Optionally-visible software maintained by relevant representatives in the
 link:https://github.com/operator-framework/community-operators[operator-framework/community-operators]
 GitHub repository. No official support.
+
+|Custom Operators
+|Operators you add to the cluster yourself.
+If you have not added any Custom Operators, the Custom category does not appear in
+the Web console on your OperatorHub.
 |===
 
 The OperatorHub component is installed and run as an Operator by default on


### PR DESCRIPTION
Added two small pieces of information to OperatorHub docs. The first notes Custom Operators as a potential fourth category of Operators that only appears in the Web UI is a custom Operator has been added. The second change notes that a warning appears if someone asks to install a Community Operator.