### PR TITLE
[enterprise-3.11] Removed docker pull cmd for Prometheus Alert Buffer

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -356,7 +356,6 @@ $ docker pull registry.redhat.io/openshift3/ose-logging-eventrouter:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-fluentd:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-kibana5:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus:<tag>
-$ docker pull registry.redhat.io/openshift3/prometheus-alert-buffer:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus-alertmanager:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus-node-exporter:<tag>
 $ docker pull registry.redhat.io/cloudforms46/cfme-openshift-postgresql
@@ -590,9 +589,8 @@ $ docker save -o ose3-images.tar \
     registry.redhat.io/openshift3/snapshot-provisioner
     registry.redhat.io/rhel7/etcd:3.2.22
 ----
---
-////
 +
+////
 [IMPORTANT]
 ====
 For Red Hat support, a {gluster-native} subscription is required for `rhgs3/` images.
@@ -619,7 +617,6 @@ $ docker save -o ose3-optional-imags.tar \
     registry.redhat.io/openshift3/ose-logging-fluentd \
     registry.redhat.io/openshift3/ose-logging-kibana5 \
     registry.redhat.io/openshift3/prometheus \
-    registry.redhat.io/openshift3/prometheus-alert-buffer \
     registry.redhat.io/openshift3/prometheus-alertmanager \
     registry.redhat.io/openshift3/prometheus-node-exporter \
     registry.redhat.io/cloudforms46/cfme-openshift-postgresql \


### PR DESCRIPTION
Removed 2nd docker pull cmd for Prometheus Alert Buffer

Corrected step numbering in Exporting Images section

xref: https://github.com/openshift/openshift-docs/pull/14234