### PR TITLE
bug 1695625 -hostPath for Elasticsearch

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -998,9 +998,10 @@ $ oc patch dc/logging-es-<suffix> \
    -p '{"spec":{"template":{"spec":{"nodeSelector":{"logging-es-node":"1"}}}}}'
 ----
 
-. Once these steps are taken, a local host mount can be applied to each replica
-as in this example (where we assume storage is mounted at the same path on each node):
-+
+Once you have completed these steps, you can apply a local host mount to each
+replica. The following example assumes storage is mounted at the same path
+on each node.
+
 ----
 $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o name); do
     oc set volume $dc \
@@ -1009,6 +1010,121 @@ $ for dc in $(oc get deploymentconfig --selector logging-infra=elasticsearch -o 
     oc rollout latest $dc
     oc scale $dc --replicas=1
   done
+----
+
+[[aggregated-logging-hostPath-Elasticsearch]]
+===== Configuring hostPath storage for Elasticsearch =====
+
+You can provision {product-title} clusters using hostPath storage for Elasticsearch.
+
+To use a local disk volume on each node host as storage for an Elasticsearch replica:
+
+. Create a local mount point on each infrastructure node for the local Elasticsearch storage:
++
+----
+$ mkdir /usr/local/es-storage
+----
+
+. Create a filesystem on the Elasticsearch volume:
++
+----
+$ mkfs.ext4 /dev/xxx
+----
+
+. Mount the elasticsearch volume:
++
+----
+$ mount /dev/xxx /usr/local/es-storage
+----
+
+. Add the following line to `/etc/fstab`:
++
+----
+$ /dev/xxx /usr/local/es-storage ext4
+----
+
+. Change ownership for the mount point:
++
+----
+$ chown 1000:1000 /usr/local/es-storage
+----
+
+. Give the privilege to mount and edit a local volume to the relevant service account:
++
+----
+  $ oc adm policy add-scc-to-user privileged  \
+         system:serviceaccount:logging:aggregated-logging-elasticsearch
+----
+Use the project you created earlier (for example, logging) when running the logging playbook.
+
+. To claim that privilege, patch each Elasticsearch replica definition, as shown in the example,
+which specifies `--selector component=es-ops` for an Ops cluster:
++
+----
+  $ for dc in $(oc get deploymentconfig --selector component=es -o name);
+do
+    oc scale $dc --replicas=0
+    oc patch $dc \
+       -p '{"spec":{"template":{"spec":{"containers":[{"name":"elasticsearch","securityContext":{"privileged":
+true}}]}}}}'
+done
+----
++
+. Locate the Elasticsearch replicas on the correct nodes to use the local storage,
+and do not move them around, even if those nodes are taken down for a period of time.
+To specify the node location, give each Elasticsearch replica a node selector that is unique
+to a node where an administrator has allocated storage for it.
++
+To configure a node selector, edit each Elasticsearch deployment configuration, adding
+or editing the `nodeSelector` section to specify a unique label that you have applied
+for each node you desire:
++
+----
+apiVersion: v1
+kind: DeploymentConfig
+spec:
+  template:
+    spec:
+      nodeSelector:
+        logging-es-node: "1"
+----
++
+The label must uniquely identify a replica with a single node that bears that label,
+in this case `logging-es-node=1`.
++
+. Create a node selector for each required node. Use the `oc label` command to apply
+labels to as many nodes as needed.
++
+For example, if your deployment has three infrastructure nodes, you could add
+labels for those nodes as follows:
++
+----
+  $ oc label node <nodename1> logging-es-node=1
+  $ oc label node <nodename2> logging-es-node=2
+  $ oc label node <nodename3> logging-es-node=3
+----
++
+To automate application of the node selector, use the `oc patch` command
+instead of the `oc label` command, as follows:
++
+----
+  $ oc patch dc/logging-es-<suffix> \
+     -p '{"spec":{"template":{"spec":{"nodeSelector":{"logging-es-node":"1"}}}}}'
+----
++
+. Once you have completed these steps, you can apply a local host mount to each
+replica. The following example assumes storage is mounted at the same path
+on each node, and specifies `--selector component=es-ops` for an Ops cluster.
++
+----
+$ for dc in $(oc get deploymentconfig --selector component=es -o name);
+do
+    oc set volume $dc \
+          --add --overwrite --name=elasticsearch-storage \
+          --type=hostPath --path=/usr/local/es-storage
+    oc rollout latest $dc
+    oc scale $dc --replicas=1
+done
 ----
 
 [[scaling-elasticsearch]]


### PR DESCRIPTION
Changes are in file /openshift-docs/install_config/aggregate_logging.adoc

This BZ incorporates instructions for configuring hostPath storage for Elasticseach for OpenShift 3.10

