### PR TITLE
Correct a annotation for overriding existing cookie name

### DIFF
--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -287,22 +287,20 @@ router which endpoint is handling the session, ensuring that client requests use
 the cookie so that they are routed to the same pod.
 
 You can set a cookie name to overwrite the default, auto-generated one for the
-route. This allows the application receiving route traffic to know the cookie
-name. By deleting the cookie it can force the next request to re-choose an
+route. By deleting the cookie it can force the next request to re-choose an
 endpoint. So, if a server was overloaded it tries to remove the requests from the
 client and redistribute them.
 
 . Annotate the route with the desired cookie name:
 +
 ----
-$ oc annotate route <route_name> router.openshift.io/<cookie_name>="-<cookie_annotation>"
+$ oc annotate route <route_name> router.openshift.io/cookie_name="<your_cookie_name>"
 ----
 +
-For example, to annotate the cookie name of `my_cookie` to the `my_route` with
-the annotation of `my_cookie_anno`:
+For example, to specify `my_cookie` as your new cookie name:
 +
 ----
-$ oc annotate route my_route router.openshift.io/my_cookie="-my_cookie_anno"
+$ oc annotate route my_route router.openshift.io/cookie_name="my_cookie"
 ----
 
 . Save the cookie, and access the route:


### PR DESCRIPTION
- Fix: [[DOCS] Correct a annotation for overriding existing cookie name](https://bugzilla.redhat.com/show_bug.cgi?id=1697216)

- Version: `v3.11`

- Description:
  Correct a annotation for specifying custom cookie name of Route.
  Refer the router's [haproxy-config.template](https://github.com/openshift/router/blob/master/images/router/haproxy/conf/haproxy-config.template#L440) as follows.
  The `cookie name` will be configured the value of `router.openshift.io/cookie_name` annotation.
~~~
 cookie {{firstMatch $cookieNamePattern (index $cfg.Annotations "router.openshift.io/cookie_name") (env "ROUTER_COOKIE_NAME" "") $cfg.RoutingKeyName}} insert indirect nocache httponly
~~~
  `This allows the application receiving route traffic to know the cookie route.` is wrong explanation, because the cookie is removed from transmitted request if `indirect` and `insert` options are configured.
[HAProxy 1.8 - coookie](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4.2-cookie):
~~~
indirect:
          ...
          In "insert" mode, this will additionally remove cookies from the
          requests transmitted to the server, making the persistence
          mechanism totally transparent from an application point of view.
~~~
Refer the router's [haproxy-config.template](https://github.com/openshift/router/blob/master/images/router/haproxy/conf/haproxy-config.template#L440) as follows.
~~~
 cookie {{..snip..}} insert indirect nocache httponly
~~~