### PR TITLE
OSDOCS-395: Include the Manila PV.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -345,6 +345,8 @@ Topics:
     File: persistent-storage-iscsi
   - Name: Persistent storage using Container Storage Interface (CSI)
     File: persistent-storage-csi
+  - Name: Persistent storage using OpenStack Manila
+    File: persistent-storage-manila
 - Name: Dynamic provisioning
   File: dynamic-provisioning
 ---

--- a/modules/persistent-storage-manila-install.adoc
+++ b/modules/persistent-storage-manila-install.adoc
@@ -1,0 +1,150 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-manila.adoc
+
+[id="persistent-storage-manila-install-{context}"]
+= Installing the external provisioner
+
+To use OpenStack Manila persistent storage you must install
+and configure an external provisioner in the {product-title}
+cluster.
+
+The external provisioner is distributed as a container image
+and can be run in the {product-title} cluster as usual.
+
+.Procedure
+
+. Create a service account:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-provisioner-runner
+----
+
+. Create a ClusterRole:
++ 
+[source,yaml]
+----
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manila-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "endpoints"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["v1"]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+----
+
+. Bind the rules via ClusterRoleBinding:
++ 
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manila-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manila-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: manila-provisioner-runner
+  namespace: default
+----
+
+. Create a new secret:
++ 
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-secret <1>
+  namespace: default <2>
+data:
+  os-authURL: <base64 encoded OpenStack Keystone URL>
+  os-userName: <base64 encoded Manila username>
+  os-password: <base64 encoded password>
+  os-projectName: <base64 encoded OpenStack project (tenant) name>
+  os-domainName: <base64 encoded OpenStack Manila service domain>
+  os-region: <base64 encoded OpenStack region>
+----
+<1> The secret name will be referenced by the Manila volume's
+StorageClass.
+<2> The secret namespace will be referenced by the Manila 
+volume's StorageClass.
+
+. Create a new StorageClass:
++ 
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "manila-share"
+provisioner: "externalstorage.k8s.io/manila"
+parameters:
+  type: "default" <1>
+  zones: "nova" <2>
+  protocol: "NFS" <3>
+  backend: "nfs" <4>
+  osSecretName: "manila-secret" <5>
+  osSecretNamespace: "default" <6>
+  nfs-share-client: "0.0.0.0" <7>
+----
+<1> The link:https://docs.openstack.org/manila/latest/admin/shared-file-systems-share-types.html[Manila share type]
+the provisioner will create for the volume. This field is optional,
+and defaults to `default`.
+<2> Set of Manila availability zones that the volume might be created
+in. This field is optional, and defaults to `nova`.
+<3> Protocol used when provisioning a share. Valid options are
+`NFS` and `CEPHFS`. This field is required. 
+<4> Backend share used for granting access and creating the
+`PersistentVolumeSource`. Valid options are `nfs` and `cephfs`.
+This field is required.
+<5> Name of the secret object containing OpenStack credentials.
+This field is required.
+<6> Namespace of the OpenStack credentials secret object. This field
+is optional, and defaults to `default`.
+<7> Default NFS client for the share exported. This field is optional,
+and is only used for the `NFS` protocol. Defaults to `0.0.0.0`. 
+
+. Start the provisioner itself. The following example uses a Deployment:
++
+[source, yaml]
+----
+kind: Deployment
+apiVersion: apps/v1 
+metadata:
+  name: manila-provisioner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: manila-provisioner
+    spec:
+      serviceAccountName: manila-provisioner-runner
+      containers:
+        - image: "registry.redhat.io/openshift/manila-provisioner:latest"
+          imagePullPolicy: "IfNotPresent"
+          name: manila-provisioner
+----

--- a/modules/persistent-storage-manila-usage.adoc
+++ b/modules/persistent-storage-manila-usage.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-manila.adoc
+
+[id="persistent-storage-manila-usage-{context}"]
+= Provisioning an OpenStack Manila persistent volume
+
+OpenStack Manila shares are dynamically provisioned as needed. When the
+PersistentVolumeClaim is deleted the provisioner will automatically 
+delete and unexport the OpenStack Manila share.
+
+.Prerequisites
+
+* The OpenStack Manila external provisioner must be installed.
+
+.Procedure
+
+* Create a PersistentVolumeClaim using the corresponding
+StorageClass.
++
+[source,yaml]
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: manila-nfs-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2G
+  storageClassName: manila-share
+----

--- a/storage/persistent-storage/persistent-storage-manila.adoc
+++ b/storage/persistent-storage/persistent-storage-manila.adoc
@@ -1,0 +1,28 @@
+[id="persistent-storage-using-manila"]
+= Persistent storage using OpenStack Manila
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-manila
+
+toc::[]
+
+{product-title} is capable of provisioning PVs using the
+link:https://wiki.openstack.org/wiki/Manila[OpenStack Manila] shared 
+file system service.
+
+It is assumed the OpenStack Manila service has been correctly set up and is
+accessible from the {product-title} cluster. Only the NFS share type can be
+provisioned.
+
+:FeatureName: OpenStack Manila persistent storage
+include::modules/technology-preview.adoc[leveloffset=+0]
+
+.Additional resources
+
+* link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/[Persistent volumes (PV)]
+* link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[Persistent volume claims (PVCs)]
+* link:https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/[Dynamic provisioning]
+* link:https://kubernetes.io/docs/admin/authorization/rbac/[RBAC authorization]
+
+include::modules/persistent-storage-manila-install.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-manila-usage.adoc[leveloffset=+1]


### PR DESCRIPTION
Included the 3.x OpenStack Manila instructions in 4.x. This also includes the changes highlighted in [PR 13272](https://github.com/openshift/openshift-docs/pull/13272/).

@tsmetana,

I've reworked the content to use our current processes and standards, but left the technical bits unchanged. I did have a couple of questions regarding them, though:

1. The current instructions never have the user create or apply any of the files in the procedure. Should we wrap these in an `oc create -f << EOF` block? If so, is there a specific namespace we need to specify?
2. The apiVersion in the Deployment block (near the end of the assembly) is `extensions/v1beta1`. Should this be changed to be a non-beta version?
3. When creating the Secret (step 4) we ask the user to supply several base64 encoded values. Would it make sense to use the `oc create secret` command so that the base64 encoding is done for the user? Something like:

`oc create secret generic manila-secret -n default --from-literal=os-authURL=$VALUE1 --from-literal=os-userName=$VALUE2 ...`