### PR TITLE
Bug BZ1442565 -- Do not use NFS storage in advanced install

### DIFF
--- a/install_config/install/advanced_install.adoc
+++ b/install_config/install/advanced_install.adoc
@@ -1311,11 +1311,19 @@ not set, then cluster logging data is stored in an `emptyDir` volume, which will
 be deleted when the Elasticsearch pod terminates.
 
 There are three options for enabling cluster logging storage when using the
-advanced install:
+advanced installation; however, for production environments, you should use only block storage.
+Do not attempt to use NFS storage. NFS storage is described below only to indicate how it might be
+used if you were not using block storage, or you were not in a production environment.
+
 
 [discrete]
 [[advanced-installation-logging-storage-nfs-host-group]]
 ===== Option A: NFS Host Group
+
+[NOTE]
+====
+Do not attempt to use NFS storage in a production environment.
+====
 
 When the following variables are set, an NFS volume is created during an
 advanced install with path *_<nfs_directory>/<volume_name>_* on the host within
@@ -1336,6 +1344,11 @@ openshift_hosted_logging_storage_volume_size=10Gi
 [discrete]
 [[advanced-installation-logging-storage-external-nfs]]
 ===== Option B: External NFS Host
+
+[NOTE]
+====
+Do not attempt to use NFS storage in a production environment.
+====
 
 To use an external NFS volume, one must already exist with a path of
 *_<nfs_directory>/<volume_name>_* on the storage host.
@@ -1846,7 +1859,7 @@ steps to run the advanced installation.
 
 [NOTE]
 ====
-Due to a known issue, after running the installation, if NFS volumes are provisioned for any component, 
+Due to a known issue, after running the installation, if NFS volumes are provisioned for any component,
 the following directories might be created whether their components are being deployed to NFS volumes or not:
 
 * *_/exports/logging-es_*


### PR DESCRIPTION
Edits are in this file:
https://docs.openshift.com/container-platform/3.5/install_config/install/advanced_install.html#advanced-installation-logging-storage

Bug is here:
https://bugzilla.redhat.com/show_bug.cgi?id=1442565