### PR TITLE
OSDOCS-387: Included iSCSI on AWS note.

### DIFF
--- a/storage/persistent-storage/persistent-storage-iscsi.adoc
+++ b/storage/persistent-storage/persistent-storage-iscsi.adoc
@@ -21,6 +21,13 @@ High-availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====
 
+[IMPORTANT]
+====
+When you use iSCI on Amazon Web Services, you must update the default 
+security policy to include TCP traffic between nodes on the iSCSI ports. 
+By default, they are ports `860` and `3260`.
+====
+
 include::modules/storage-persistent-storage-iscsi-provisioning.adoc[leveloffset=+1]
 
 include::modules/storage-persistent-storage-iscsi-enforcing-disk-quota.adoc[leveloffset=+1]


### PR DESCRIPTION
Included iSCSI on AWS note, indicating that the default security policy must be updated.

This is for OS 4.x.