### PR TITLE
Adding "restart" to virtctl commands

### DIFF
--- a/modules/cnv_controlling_vms.adoc
+++ b/modules/cnv_controlling_vms.adoc
@@ -5,15 +5,14 @@
 [[controlvm]]
 = Controlling virtual machines
 
-Virtual machines can be started and stopped, depending on the
-current state of the virtual machine. The option to restart VMs
-is available in the Web Console only.
+You can start, stop, or restart a virtual machine, depending on its current
+state.
 
 Use the *virtctl* client utility to change the state of the virtual
 machine, open virtual console sessions with the virtual
 machines, and expose virtual machine ports as services.
 
-The *virtctl* syntax is: `virtctl <action> <VM-name>`
+The *virtctl* syntax is: `virtctl <action> <vm_name> <options>`
 
 You can only control objects in the project you are currently working
 in, unless you specify the `-n <project_name>` option.
@@ -22,6 +21,10 @@ Examples:
 
 ----
 $ virtctl start example-vm
+----
+
+----
+$ virtctl restart example-vm
 ----
 
 ----

--- a/modules/cnv_virtctl_commands.adoc
+++ b/modules/cnv_virtctl_commands.adoc
@@ -5,7 +5,9 @@
 [[virtctl-commands]]
 = Virtctl commands
 
-The *virtctl* client is a command-line utility for managing {ProductName} resources. The following table contains the *virtctl* commands used throughout this document.
+The `virtctl` client is a command-line utility for managing {ProductName}
+resources. The following table contains the `virtctl` commands used throughout
+the {ProductName} documentation.
 
 .Virtctl client
 
@@ -17,8 +19,10 @@ machine instance.
 
 |`virtctl stop <vmi>` |Stop a virtual machine instance.
 
+|`virtctl restart <vmi>` |Restart a virtual machine instance.
+
 |`virtctl expose <vm>` |Create a service that forwards a designated port
-of a virtual machine or virtual machine instance and expose the service on 
+of a virtual machine or virtual machine instance and expose the service on
 the specified port of the node.
 
 |`virtctl console <vmi>` |Connect to a serial console of a virtual
@@ -27,7 +31,7 @@ machine instance.
 |`virtctl vnc <vmi>` |Open a VNC connection to a virtual machine
 instance.
 
-|`virtctl image-upload <...>` |Upload a virtual machine disk from a client 
+|`virtctl image-upload <...>` |Upload a virtual machine disk from a client
 machine to the cluster.
 |=======================================================================
 


### PR DESCRIPTION
CNV 1.4 docs erroneously stated that you could not use `virtctl restart` to restart a VM. This PR aims to fix this in the two places where available `virtctl` commands are listed.

Regarding QE: there is not a BZ for this issue. I emailed the cnv-devel mailing list, and Marcin Franczyk/Israel Pinto/Zhe Peng validated that the command works as expected in CNV 1.4. 