### PR TITLE
OSDOCS-63: Including initial draft of certificate details.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -152,6 +152,15 @@ Topics:
     File: configuring-google-identity-provider
   - Name: Configuring an OpenID Connect identity provider
     File: configuring-oidc-identity-provider
+- Name: Configuring certificates
+  Dir: certificates
+  Topics:
+  - Name: Replacing the default ingress certificate
+    File: replacing-default-ingress-certificate
+  - Name: Adding API server certificates
+    File: api-server
+  - Name: Securing service traffic using service serving certificates
+    File: service-serving-certificate
 - Name: Using RBAC to define and apply permissions
   File: using-rbac
   Distros: openshift-enterprise,openshift-origin

--- a/authentication/certificates/api-server.adoc
+++ b/authentication/certificates/api-server.adoc
@@ -1,0 +1,15 @@
+[id="api-server-certificates"]
+= Adding API server certificates
+include::modules/common-attributes.adoc[]
+:context: api-server-certificates
+
+toc::[]
+
+The default API server certificate is issued by an internal {product-title}
+cluster CA. Clients outside of the cluster will not be able to verify the
+API server's certificate by default. This certificate can be replaced
+by one that is issued by a CA that clients trust.
+
+include::modules/customize-certificates-api-add-default.adoc[leveloffset=+1]
+
+include::modules/customize-certificates-api-add-named.adoc[leveloffset=+1]

--- a/authentication/certificates/replacing-default-ingress-certificate.adoc
+++ b/authentication/certificates/replacing-default-ingress-certificate.adoc
@@ -1,0 +1,10 @@
+[id="replacing-default-ingress"]
+= Replacing the default ingress certificate
+include::modules/common-attributes.adoc[]
+:context: replacing-default-ingress
+
+toc::[]
+
+include::modules/customize-certificates-understanding-default-router.adoc[leveloffset=+1]
+
+include::modules/customize-certificates-replace-default-router.adoc[leveloffset=+1]

--- a/authentication/certificates/service-serving-certificate.adoc
+++ b/authentication/certificates/service-serving-certificate.adoc
@@ -1,0 +1,24 @@
+[id="add-service-serving"]
+= Securing service traffic using service serving certificate secrets
+include::modules/common-attributes.adoc[]
+:context: service-serving-certificate
+
+toc::[]
+
+include::modules/customize-certificates-understanding-service-serving.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+The service CA certificate is automatically rotated during upgrades, but
+must be
+xref:../../authentication/certificates/service-serving-certificate.adoc#manually-rotate-service-ca_{context}[manually rotated]
+in the event that the cluster is not upgraded.
+====
+
+include::modules/customize-certificates-add-service-serving.adoc[leveloffset=+1]
+
+include::modules/customize-certificates-add-service-serving-configmap.adoc[leveloffset=+1]
+
+include::modules/customize-certificates-rotate-service-serving.adoc[leveloffset=+1]
+
+include::modules/customize-certificates-manually-rotate-service-ca.adoc[leveloffset=+1]

--- a/modules/customize-certificates-add-service-serving-configmap.adoc
+++ b/modules/customize-certificates-add-service-serving-configmap.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/service-serving-certificate.adoc
+
+[id="add-service-certificate-configmap_{context}"]
+= Add a service certificate to a ConfigMap
+
+A Pod can access the service CA certificate by mounting a ConfigMap that
+is annotated with `service.beta.openshift.io/inject-cabundle=true`.
+Once annotated, the cluster automatically injects the service CA
+certificate into the `service-ca.crt` key on the ConfigMap. Access to
+this CA certificate allows TLS clients to verify connections to
+services using service serving certificates.
+
+[IMPORTANT]
+====
+After adding this annotation to a ConfigMap all existing data in it is
+deleted. It is recommended to use a separate ConfigMap to contain the
+`service-ca.crt`, instead of using the same ConfigMap that stores your
+Pod's configuration.
+====
+
+.Procedure
+
+. Annotate the ConfigMap with `service.beta.openshift.io/inject-cabundle=true`.
++
+----
+$ oc annotate configmap <configmap-name> \//<1>
+     service.beta.openshift.io/inject-cabundle=true
+----
+<1> Replace `<configmap-name>` with the name of the ConfigMap to annotate.
++
+[NOTE]
+====
+Explicitly referencing the `service-ca.crt` key in a volumeMount will
+prevent a Pod from starting until the ConfigMap has been injected with
+the CA bundle.
+====
++
+For instance, to annotate the ConfigMap `foo` the following command would be
+used:
++
+----
+$ oc annotate configmap foo service.beta.openshift.io/inject-cabundle=true
+----
+
+. View the ConfigMap to ensure the certificate has been generated. This
+appears as a `service-ca.crt` in the YAML output.
++
+----
+$ oc get configmap <configmap-name> -o yaml
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+...
+----

--- a/modules/customize-certificates-add-service-serving.adoc
+++ b/modules/customize-certificates-add-service-serving.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/service-serving-certificate.adoc
+
+[id="add-service-certificate_{context}"]
+= Add a service certificate
+
+To secure communication to your service, generate a
+signed serving certificate and key pair into a secret in the same
+namespace as the service.
+
+[IMPORTANT]
+====
+The generated certificate is only valid for the internal service DNS name
+`<service.name>.<service.namespace>.svc`, and are only valid for
+internal communications.
+====
+
+.Prerequisites:
+
+* You must have a service defined.
+
+.Procedure
+
+. Annotate the service with `service.beta.openshift.io/serving-cert-secret-name`.
++
+----
+$ oc annotate service <service-name> \//<1>
+     service.beta.openshift.io/serving-cert-secret-name=<secret-name> //<2>
+----
+<1> Replace `<service-name>` with the name of the service to secure.
+<2> `<secret-name>` will be the name of the generated secret containing the
+certificate and key pair. For convenience, it is recommended that this
+be the same as `<service-name>`.
++
+For instance, use the following command to annotate the service `foo`:
++
+----
+$ oc annotate service foo service.beta.openshift.io/serving-cert-secret-name=foo
+----
+
+. Examine the service to confirm the annotations are present.
++
+----
+$ oc describe service <service-name>
+...
+Annotations:              service.beta.openshift.io/serving-cert-secret-name: <service-name>
+                          service.beta.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1556850837
+...
+----
+
+. After the cluster generates a secret for your service, your PodSpec can
+mount it, and the Pod will run after it becomes available.

--- a/modules/customize-certificates-api-add-default.adoc
+++ b/modules/customize-certificates-api-add-default.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/api-server.adoc
+
+[id="add-default-api-server_{context}"]
+= Add an API server default certificate
+
+To allow clients outside the cluster to validate the API server's
+certificate, you can replace the default certificate
+with one that is issued by a public or organizational CA.
+
+.Prerequisites
+
+* You must have a valid certificate and key in the PEM format.
+
+.Procedure
+
+. Create a secret that contains the certificate and key in the
+`openshift-config` namespace.
++
+----
+$ oc create secret tls <certificate> \//<1>
+     --cert=</path/to/cert.crt> \//<2>
+     --key=</path/to/cert.key> \//<3>
+     -n openshift-config
+----
+<1> `<certificate>` is the name of the secret that will contain
+the certificate.
+<2> `</path/to/cert.crt>` is the path to the certificate on your
+local file system.
+<3> `</path/to/cert.key>` is the path to the private key associated
+with this certificate.
+
+. Update the API server to reference the created secret.
++
+----
+$ oc patch apiserver cluster \
+     --type=merge -p \
+     '{"spec": {"servingCerts": {"defaultServingCertificate":
+     {"name": "<certificate>"}}}}' <1>
+----
+<1> Replace `<certificate>` with the name used for the secret in
+the previous step.
+
+. Examine the `apiserver/cluster` object and confirm the secret is now
+referenced.
++
+----
+$ oc describe apiserver cluster
+...
+Spec:
+  Serving Certs:
+    Default Serving Certificate:
+      Name:  <certificate>
+...
+----

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/api-server.adoc
+
+[id="add-named-api-server_{context}"]
+= Add an API server named certificate
+
+The default API server certificate is issued by an internal {product-title}
+cluster CA. You can add additional certificates to the API server to send
+based on the client's requested URL, such as when a reverse proxy or
+load balancer is used.
+
+.Prerequisites
+
+* You must have the certificate and key, in the PEM format, for the
+client's URL.
+* The certificate must be issued for the URL used by the client to
+reach the API server.
+* The certificate must have the `subjectAltName` extension for the URL.
+
+.Procedure
+
+. Create a secret that contains the certificate and key in the
+`openshift-config` namespace.
++
+----
+$ oc create secret tls <certificate> \//<1>
+     --cert=</path/to/cert.crt> \//<2>
+     --key=</path/to/cert.key> \//<3>
+     -n openshift-config
+----
+<1> `<certificate>` is the name of the secret that will contain
+the certificate.
+<2> `</path/to/cert.crt>` is the path to the certificate on your
+local file system.
+<3> `</path/to/cert.key>` is the path to the private key associated
+with this certificate.
+
+. Update the API server to reference the created secret.
++
+----
+$ oc patch apiserver cluster \
+     --type=merge -p \
+     '{"spec":{"servingCerts": {"namedCertificates":
+     [{"names": ["<hostname>"], //<1>
+     "servingCertificate": {"name": "<certificate>"}}]}}}' <2>
+----
+<1> Replace `<hostname>` with the hostname that the API server
+should provide the certificate for.
+<2> Replace `<certificate>` with the name used for the secret in
+the previous step.
+
+. Examine the `apiserver/cluster` object and confirm the secret is now
+referenced.
++
+----
+$ oc describe apiserver cluster
+...
+Spec:
+  Serving Certs:
+    Named Certificates:
+      Names:
+        <hostname>
+      Serving Certificate:
+        Name:  <certificate>
+...
+----
+

--- a/modules/customize-certificates-manually-rotate-service-ca.adoc
+++ b/modules/customize-certificates-manually-rotate-service-ca.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/service-signing-certificates.adoc
+
+[id="manually-rotate-service-ca_{context}"]
+= Manually rotate the service CA certificate
+
+The service CA is valid for one year after {product-title} is
+installed. If you have a cluster that has been running
+for one year without upgrades, then you must manually
+refresh the service CA.
+
+This process is automatically performed during an upgrade.
+Follow these steps only if you do not update your cluster.
+
+.Prerequisites
+
+* You must be logged in as a cluster admin.
+
+.Procedure
+
+. View the expiration date of the current service CA certificate by
+using the following command.
++
+----
+$ oc get secrets/signing-key -n openshift-service-ca \
+     -o template='{{index .data "tls.crt"}}' \
+     | base64 -d \
+     | openssl x509 -noout -enddate
+----
++
+If this certificate expires before a scheduled upgrade, then proceed
+through the following steps. Otherwise, there is no need to perform
+the rotation at this time.
+
+. Manually rotate the service CA. This process generates a new service CA
+which will be used to sign the new service certificates.
++
+----
+$ oc delete secret/signing-key -n openshift-service-ca
+----
+
+. To apply the new certificates to all services, restart all the Pods
+in your cluster. This command ensures that all services use the
+updated certificates.
++
+----
+$ for I in $(oc get ns -o jsonpath='{range .items[*]} {.metadata.name}{"\n"} {end}'); \
+      do oc delete pods --all -n $I; \
+      sleep 1; \
+      done
+----
++
+[WARNING]
+====
+This command will cause a service interruption, as it goes through and
+deletes every running pod in every namespace. These pods will automatically
+restart after they are deleted.
+====

--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/replacing-default-ingress-certificate.adoc
+
+[id="replacing-default-ingress_{context}"]
+= Replacing the default ingress certificate
+
+You can replace the default ingress certificate for all
+applications under the `.apps` subdomain. After you replace
+the certificate, all applications, including the web console
+and CLI, will have encryption provided by specified certificate.
+
+.Prerequisites
+
+* You must have a wildcard certificate and its private key,
+both in the PEM format, for use.
+* The certificate must have a `subjectAltName` extension of
+`*apps.<clustername>.<domain>`.
+
+.Procedure
+
+. Create a secret that contains the wildcard certificate and key:
++
+----
+$ oc create secret tls <certificate> \//<1>
+     --cert=</path/to/cert.crt> \//<2>
+     --key=</path/to/cert.key> \//<3>
+     -n openshift-ingress
+----
+<1> `<certificate>` is the name of the secret that will contain
+the certificate and private key.
+<2> `</path/to/cert.crt>` is the path to the certificate on your
+local file system.
+<3> `</path/to/cert.key>` is the path to the private key associated
+with this certificate.
+
+. Update the ingress controller configuration with the newly created
+secret:
++
+----
+$ oc patch ingresscontroller.operator default \
+     --type=merge -p \
+     '{"spec":{"defaultCertificate": {"name": "<certificate>"}}}' \//<1>
+     -n openshift-ingress-operator
+----
+<1> Replace `<certificate>` with the name used for the secret in
+the previous step.

--- a/modules/customize-certificates-rotate-service-serving.adoc
+++ b/modules/customize-certificates-rotate-service-serving.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/service-serving-certificate.adoc
+
+[id="rotate-service-serving_{context}"]
+= Manually rotate the generated service certificate
+
+You can rotate the service certificate by deleting the
+associated secret. Deleting the secret results in a new one
+being automatically created, resulting in a new certificate.
+
+.Prerequisites
+
+* A secret containing the certificate and key pair must
+have been generated for the service.
+
+.Procedure
+
+. Examine the service to determine the secret containing the
+certificate. This is found in the `serving-cert-secret-name`
+annotation, as seen below.
++
+----
+$ oc describe service <service-name>
+...
+service.beta.openshift.io/serving-cert-secret-name: <secret>
+...
+----
+
+. Delete the generated secret for the service. This process
+will automatically recreate the secret.
++
+----
+$ oc delete secret <secret> //<1>
+----
+<1> Replace `<secret>` with the name of the secret from the previous
+step.
+
+. Confirm that the certificate has been recreated
+by obtaining the new secret and examining the `AGE`.
++
+----
+$ oc get secret <service-name>
+
+NAME              TYPE                DATA   AGE
+<service.name>    kubernetes.io/tls   2      1s
+----

--- a/modules/customize-certificates-understanding-default-router.adoc
+++ b/modules/customize-certificates-understanding-default-router.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// authentication/certificates/replacing-default-ingress-certificate.adoc
+
+[id="understanding-default-ingress_{context}"]
+= Understanding the default ingress certificate
+
+By default {product-title} uses the Ingress Operator to
+create an internal CA and issue a wildcard certificate that is valid for
+applications under the `.apps` sub-domain. Both the web console and CLI
+use this certificate as well.
+
+The internal infrastructure CA certificates are self-signed.
+While this process might be perceived as bad practice by some security or
+PKI teams, any risk here is minimal. The only clients that implicitly
+trust these certificates are other components within the cluster.
+Replacing the default wildcard certificate with one that is issued by a
+public or organizational CA will allow external clients to connect
+securely to applications running under the `.apps` sub-domain.

--- a/modules/customize-certificates-understanding-service-serving.adoc
+++ b/modules/customize-certificates-understanding-service-serving.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * authentication/certificates/service-serving-certificate.adoc
+
+[id="understanding-service-serving_{context}"]
+= Understanding service serving certificates
+
+Service serving certificates are intended to support complex
+middleware applications that require encryption. These certificates are
+issued as TLS web server certificates.
+
+The `service-ca` controller uses the `x509.SHA256WithRSA` signature
+algorithm to generate service certificates.
+
+The generated certificate and key are in PEM format, stored in `tls.crt`
+and `tls.key` respectively, within a created secret. The
+certificate and key are automatically replaced when they get close to
+expiration. The service CA certificate, which signs the service
+certificates, is only valid for one year after {product-title} is installed.


### PR DESCRIPTION
This includes the details on how OpenShift creates and uses certificates. In addition, it includes how to specify custom certificates on the OpenShift server as needed.

This is for OS 4.x.

As this is a WIP, the following is still needed:

* Understand how infra/platform certs work in 4.1, are created, rotated, replaced, revoked
* Include details on adding API server named certificate

@mrogers950 ,

I've added you as a reviewer for SME reviews as they're applicable.