### PR TITLE
Fix incorrect deployment syntax

### DIFF
--- a/dev_guide/dev_tutorials/openshift_pipeline.adoc
+++ b/dev_guide/dev_tutorials/openshift_pipeline.adoc
@@ -171,7 +171,7 @@ pipeline {
         script {
             openshift.withCluster() {
                 openshift.withProject() {
-                  def rm = openshift.selector("dc", templateName).rollout()
+                  def rm = openshift.selector("dc", templateName).rollout().latest()
                   timeout(5) { <9>
                     openshift.selector("dc", templateName).related('pods').untilEach(1) {
                       return (it.object().status.phase == "Running")


### PR DESCRIPTION
Calling .rollout() on a selector returns a RolloutManager but does not actually trigger a deployment.  You must call .latest() on the RolloutManager. You can find the docs here, although it is an image so I can't link directly to it. It is the final section at the bottom of the page: https://github.com/openshift/jenkins-client-plugin

This commit fixes #14372