### PR TITLE
[enterprise-3.11] auditFilePath value is set to wrong path

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1181,7 +1181,7 @@ auditConfig:
   maximumRetainedFiles: 10
 ----
 
-.Advanced Setup for the Audit Log
+.Basic Audit for the Audit Log
 
 The directory *_/var/lib/origin_* will be created if it does not exist.
 
@@ -1189,7 +1189,7 @@ You can specify advanced audit log parameters by using the following parameter
 value format:
 
 ----
-openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/openpaas-oscp-audit.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5}
+openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/audit-ocp.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5}
 ----
 
 [[master-node-config-advanced-audit]]
@@ -1203,7 +1203,7 @@ To enable the advanced audit feature, provide the following values in the
 `openshift_master_audit_config` parameter:
 
 ----
-openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/oscp-audit.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5, "policyFile": "/etc/origin/master/adv-audit.yaml", "logFormat":"json"}
+openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/audit-ocp.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5, "policyFile": "/etc/origin/master/adv-audit.yaml", "logFormat":"json"}
 ----
 
 [IMPORTANT]

--- a/security/monitoring.adoc
+++ b/security/monitoring.adoc
@@ -135,7 +135,7 @@ of nodes:
 It might be useful to poll the log periodically for the number of recent requests per response code, as shown in the following example:
 
 ----
-$ tail -5000 /var/log/openshift-audit.log \
+$ tail -5000 /var/lib/origin/audit-ocp.log \
   | grep -Po 'response="..."' \
   | sort | uniq -c | sort -rn
 
@@ -165,7 +165,7 @@ It can be useful to look for unusual numbers of requests by a particular user or
 The following example lists the top 10 users by number of requests in the last 5000 lines of the audit log:
 
 ----
-$ tail -5000 /var/log/openshift-audit.log \
+$ tail -5000 /var/lib/origin/audit-ocp.log \
   | grep -Po ' user="(.*?)(?<!\\)"' \
   | sort | uniq -c | sort -rn | head -10
 


### PR DESCRIPTION
As of v3.10, openshift apiserver is running as static pod which is configured with limited mount point, such as "/var/lib/origin", not "/var/log".
- Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1622044

Included inputs from #14215 