### PR TITLE
[enterprise-3.7] Correct annotation for overriding cookie name, and wrong explanation

### DIFF
--- a/dev_guide/routes.adoc
+++ b/dev_guide/routes.adoc
@@ -288,22 +288,20 @@ router which endpoint is handling the session, ensuring that client requests use
 the cookie so that they are routed to the same pod.
 
 You can set a cookie name to overwrite the default, auto-generated one for the
-route. This allows the application receiving route traffic to know the cookie
-name. By deleting the cookie it can force the next request to re-choose an
-endpoint. So, if a server was overloaded it tries to shed the requests from the
+route. By deleting the cookie it can force the next request to re-choose an
+endpoint. So, if a server was overloaded it tries to remove the requests from the
 client and redistribute them.
 
 . Annotate the route with the desired cookie name:
 +
 ----
-$ oc annotate route <route_name> router.openshift.io/<cookie_name>="-<cookie_annotation>"
+$ oc annotate route <route_name> router.openshift.io/cookie_name="<your_cookie_name>"
 ----
 +
-For example, to annotate the cookie name of `my_cookie` to the `my_route` with
-the annotation of `my_cookie_anno`:
+For example, to specify `my_cookie` as your new cookie name:
 +
 ----
-$ oc annotate route my_route router.openshift.io/my_cookie="-my_cookie_anno"
+$ oc annotate route my_route router.openshift.io/cookie_name="my_cookie"
 ----
 
 . Save the cookie, and access the route:


### PR DESCRIPTION
Correct a annotation for specifying custom cookie name of Route
- Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1697216

xref: https://github.com/openshift/openshift-docs/pull/14362