### PR TITLE
In CNV 2.0 we no longer need to recreate the uploadproxy route

### DIFF
--- a/modules/cnv_upload_virtctl.adoc
+++ b/modules/cnv_upload_virtctl.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv_users_guide.adoc
+
+[[upload-vmdisk-virtctl]]
+= Uploading a local disk image to a new PVC
+
+You can use `virtctl image-upload` to upload a virtual machine disk image from
+a client machine to your {product-title} cluster. This creates a PVC that can be
+associated with a virtual machine after the upload has completed.
+
+.Prerequisites
+
+* A virtual machine disk image, in RAW or QCOW2 format. It can be compressed
+using *xz* or *gzip*.
+* *kubevirt-virtctl* must be installed on the client machine.
+* The client machine must be xref:../install_config/router/default_haproxy_router.html#overview[configured]
+to trust the OpenShift router's certificate.
+
+.Procedure
+
+. Identify the following items:
+* File location of the VM disk image you want to upload
+* Name and size desired for the resulting PVC
+
+. Remove the existing passthrough route:
++
+----
+$ oc delete route -n cdi cdi-uploadproxy-route
+----
+
+. Create a secured route using re-encryption termination:
++
+----
+$ oc get secret -n cdi cdi-upload-proxy-ca-key -o=jsonpath="{.data['tls\.crt']}" | base64 -d > ca.pem
+
+$ oc create route reencrypt cdi-uploadproxy-route -n cdi --service=cdi-uploadproxy --dest-ca-cert=ca.pem
+----
+
+. Use the `virtctl image-upload` command to upload your VM image,
+making sure to include your chosen parameters. For example:
++
+----
+$ virtctl image-upload --uploadproxy-url=https://$(oc get route cdi-uploadproxy-route -n cdi -o=jsonpath='{.status.ingress[0].host}') --pvc-name=upload-fedora-pvc --pvc-size=10Gi --image-path=/images/fedora28.qcow2
+----
++
+[CAUTION]
+====
+To allow insecure server connections when using HTTPS, use the `--insecure`
+parameter. Be aware that when you use the `--insecure` flag, the authenticity of
+the upload endpoint is *not* verified.
+====
+
+. To verify that the PVC was created, view all PVC objects:
++
+----
+$ oc get pvc
+----
+
+Next, you can create a virtual machine object to bind to the PVC.
+
+

--- a/modules/cnv_upload_virtctl.adoc
+++ b/modules/cnv_upload_virtctl.adoc
@@ -23,20 +23,6 @@ to trust the OpenShift router's certificate.
 * File location of the VM disk image you want to upload
 * Name and size desired for the resulting PVC
 
-. Remove the existing passthrough route:
-+
-----
-$ oc delete route -n cdi cdi-uploadproxy-route
-----
-
-. Create a secured route using re-encryption termination:
-+
-----
-$ oc get secret -n cdi cdi-upload-proxy-ca-key -o=jsonpath="{.data['tls\.crt']}" | base64 -d > ca.pem
-
-$ oc create route reencrypt cdi-uploadproxy-route -n cdi --service=cdi-uploadproxy --dest-ca-cert=ca.pem
-----
-
 . Use the `virtctl image-upload` command to upload your VM image,
 making sure to include your chosen parameters. For example:
 +


### PR DESCRIPTION
An issue has been fixed and the CNV operator creates the correct route during deployment so the user no longer needs to perform the mitigation steps outlined in the documentation.

This PR is split into two commits:
1. Import `modules/cnv_upload_virtctl.adoc` from master
2. Remove the no longer required text