### PR TITLE
Add important section when redeploying ca and certificates

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -293,6 +293,13 @@ $ ansible-playbook -i <inventory_file> \
     playbooks/redeploy-certificates.yml
 ----
 
+[IMPORTANT]
+====
+If the {product-title} CA was redeployed with the
+xref:redeploying-new-custom-ca[*_openshift-master/redeploy-openshift-ca.yml_* playbook]
+you must add `-e openshift_redeploy_openshift_ca=true` to the above command.
+====
+
 [[redeploying-new-custom-ca]]
 === Redeploying a New or Custom {product-title} CA
 
@@ -347,10 +354,17 @@ $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
     playbooks/openshift-master/redeploy-openshift-ca.yml
 ----
-
++
 With the new {product-title} CA in place, you can then use the
-xref:redeploying-all-certificates-current-ca[*_openshift-master/redeploy-certificates.yml_* playbook] at your discretion whenever you want to redeploy certificates signed
+xref:redeploying-all-certificates-current-ca[*_redeploy-certificates.yml_* playbook] at your discretion whenever you want to redeploy certificates signed
 by the new CA on all components.
+
+[IMPORTANT]
+====
+When using
+the xref:redeploying-all-certificates-current-ca[*_redeploy-certificates.yml_* playbook] after the new {product-title} CA is in
+place, you must add `-e openshift_redeploy_openshift_ca=true` to the playbook command.
+====
 
 [[redeploying-new-etcd-ca]]
 === Redeploying a New etcd CA


### PR DESCRIPTION
Adds an important section to the redeploying ca section
that informs the user that they must add
an extra var `openshift_redeploy_openshift_ca=true` to
the ansible-playbook command when running
`playbooks/redeploy-certificates.yml`

Related details:
openshift-ansible pr - https://github.com/openshift/openshift-ansible/pull/11483
bug 1652746 - https://bugzilla.redhat.com/show_bug.cgi?id=1652746

cc: @kalexand-rh