### PR TITLE
No documentation about how to get and modify elasticsearch alerting rules

### DIFF
--- a/modules/efk-logging-elasticsearch-rules.adoc
+++ b/modules/efk-logging-elasticsearch-rules.adoc
@@ -5,6 +5,8 @@
 [id="efk-logging-elasticsearch-rules-{context}"]
 = About Elasticsearch alerting rules
 
+You can view these alerting rules in Prometheus.
+
 [cols="3,6,1",options="header"]
 |===
 |Alert
@@ -33,10 +35,6 @@ consider adding more disk to the node.
 |Disk High Watermark Reached at node in cluster. Some shards will be re-allocated to different
 nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
 |high
-
-|ElasticsearchNodeDiskLowForSegmentMerges
-|Free disk at node in  cluster may be low for optimal segment merges
-|warning
 
 |ElasticsearchJVMHeapUseHigh
 |JVM Heap usage on the node in cluster is <value>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1699238

Also: Should deprecate `ElasticsearchNodeDiskLowForSegmentMerges` in "About Elasticsearch alerting rules" part.
https://bugzilla.redhat.com/show_bug.cgi?id=1699223