### PR TITLE
BZ-1699185: Removed reference of deleting default storageclass.

### DIFF
--- a/modules/dynamic-provisioning-defining-storage-class.adoc
+++ b/modules/dynamic-provisioning-defining-storage-class.adoc
@@ -10,8 +10,9 @@ created by `cluster-admin` or `storage-admin` users.
 
 [NOTE]
 ====
-For GCE and AWS, a default StorageClass is created during {product-title}
-installation. You can change the default StorageClass or delete it.
+For AWS, a default StorageClass is created during {product-title} 
+installation. You can change the default StorageClass after installation,
+but the created StorageClass cannot be deleted.
 ====
 
 The following sections describe the basic object definition for a


### PR DESCRIPTION
BZ-1699185: Removed reference of deleting default storageclass.

This is for OS 4.x.