### PR TITLE
BZ1694774: Included module to define a cluster admin.

### DIFF
--- a/authentication/using-rbac.adoc
+++ b/authentication/using-rbac.adoc
@@ -24,3 +24,5 @@ include::modules/rbac-creating-cluster-role.adoc[leveloffset=+1]
 include::modules/rbac-local-role-binding-commands.adoc[leveloffset=+1]
 
 include::modules/rbac-cluster-role-binding-commands.adoc[leveloffset=+1]
+
+include::modules/rbac-creating-cluster-admin.adoc[leveloffset=+1]

--- a/modules/rbac-creating-cluster-admin.adoc
+++ b/modules/rbac-creating-cluster-admin.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * authentication/using-rbac.adoc
+
+[id="creating-cluster-admin-{context}"]
+= Creating a cluster admin
+
+The `cluster-admin` role is required to perform administrator
+level tasks on the {product-title} cluster, such as modifying
+cluster resources. 
+
+.Prerequisites 
+
+* You must have created a user to define as the cluster admin.
+
+.Procedure
+
+* Define the user as a cluster admin:
++
+----
+$ oc adm policy add-cluster-role-to-user cluster-admin <user>
+----


### PR DESCRIPTION
Included a module in the RBAC section that includes an example of defining a cluster admin.

This is for OS 4.x.