### PR TITLE
BZ-1699700: Fixing default OpenShift Ansible Broker options

### DIFF
--- a/modules/sb-configuring-ansible-service-broker-options.adoc
+++ b/modules/sb-configuring-ansible-service-broker-options.adoc
@@ -23,7 +23,7 @@ You can set the following options for your {asb-name}.
 
 |`brokerImage`
 |The fully qualified image used for the broker.
-|`docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v3.11`
+|`docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v4.0`
 
 |`brokerImagePullPolicy`
 |The pull policy used for the broker image itself.
@@ -47,7 +47,7 @@ You can set the following options for your {asb-name}.
 
 |`sandboxRole`
 |The role granted to the service account used to execute APBs.
-|`admin`
+|`edit`
 
 |`keepNamespace`
 |Whether the transient namespace created to run the APB is deleted after the conclusion of the APB, regardless of the result.


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~ahoffer/2019/BZ-1699700/applications/service_brokers/configuring-ansible-service-broker.html#sb-ansible-service-broker-config-options-sb-configuring-asb