### PR TITLE
BZ-1699270: Updating tech preview feature notice for Block Volumes

### DIFF
--- a/modules/nodes-cluster-disabling-features-cluster.adoc
+++ b/modules/nodes-cluster-disabling-features-cluster.adoc
@@ -20,6 +20,9 @@ The following features are affected by Feature Gates.
 |===
 | Feature gate| Description
 
+| *CSIBlockVolume*
+| Enables external CSI drivers to implement raw block volume support.
+
 | *ExperimentalCriticalPodAnnotation*
 | Enables annotating specific pods as critical so that their scheduling is guaranteed.
 
@@ -71,7 +74,7 @@ spec:
   featureSet: TechPreviewNoUpgrade <1>
 ----
 +
-<1> Add `featureSet: TechPreviewNoUpgrade` to enable the `ExperimentalCriticalPodAnnotation`, `RotateKubeletServerCertificate`, and `SupportPodPidsLimit` features.
+<1> Add `featureSet: TechPreviewNoUpgrade` to enable the `CSIBlockVolume`, `ExperimentalCriticalPodAnnotation`, `RotateKubeletServerCertificate`, and `SupportPodPidsLimit` features.
 +
 [NOTE]
 ====

--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -11,14 +11,3 @@
 You can statically provision raw block volumes by including API fields
 in your PV and PVC specifications. This functionality is only available for
 manually provisioned PVs.
-
-To use a block volume, you must first enable the `BlockVolume` feature 
-gate. To enable the feature gates for master(s), add `feature-gates` to
-`apiServerArguments` and `controllerArguments`. To enable the feature 
-gates for node(s), add `feature-gates` to `kubeletArguments`. For example:
-
-----
-kubeletArguments:
-   feature-gates:
-     - BlockVolume=true
-----


### PR DESCRIPTION
BZ-1699270: Updating tech preview feature notice for Block Volumes.

Note that due to our modularization guidelines we cannot link to the section on enabling TP features. Instead, I have included the module in the assembly. From discussions with other writers this is the encouraged method of reusing content.

This is for OS 4.x.