### PR TITLE
Correct `self-provisioners` to `self-provisioner`

### DIFF
--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -102,15 +102,15 @@ You can prevent an authenticated user group from self-provisioning new projects.
 . Log in as a user with
 xref:../architecture/additional_concepts/authorization.adoc#roles[*cluster-admin*]
 privileges.
-. Review the `self-provisioners`
+. Review the `self-provisioner`
 xref:../admin_guide/manage_rbac.adoc#viewing-cluster-bindings[clusterrolebinding usage].
-Run the following command, then review the subjects in the `self-provisioners`
+Run the following command, then review the subjects in the `self-provisioner`
 section.
 +
 ----
-$ oc  describe clusterrolebinding.rbac self-provisioners
+$ oc  describe clusterrolebinding.rbac self-provisioner
 
-Name:		self-provisioners
+Name:		self-provisioner
 Labels:		<none>
 Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
 Role:
@@ -123,15 +123,15 @@ Subjects:
 ----
 
 . Remove the `self-provisioner` cluster role from the group `system:authenticated:oauth`.
-** If the `self-provisioners` cluster role binding binds only the
+** If the `self-provisioner` cluster role binding binds only the
 `self-provisioner` role to the `system:authenticated:oauth` group, run the
 following command:
 +
 ----
-$ oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
+$ oc patch clusterrolebinding.rbac self-provisioner -p '{"subjects": null}'
 ----
 +
-** If the `self-provisioners` clusterrolebinding binds the `self-provisioner`
+** If the `self-provisioner` clusterrolebinding binds the `self-provisioner`
 role to more users, groups, or serviceaccounts than the
 `system:authenticated:oauth` group, run the following command:
 +
@@ -161,13 +161,13 @@ projectConfig:
   ...
 ----
 
-. Edit the `self-provisioners` cluster role binding to prevent automatic updates
+. Edit the `self-provisioner` cluster role binding to prevent automatic updates
 to the role. Automatic updates reset the cluster roles to the default state.
 ** To update the role binding from the command line:
 ... Run the following command:
 +
 ----
-$ oc edit clusterrolebinding.rbac self-provisioners
+$ oc edit clusterrolebinding.rbac self-provisioner
 ----
 ... In the displayed role binding, set the `rbac.authorization.kubernetes.io/autoupdate` parameter
  value to `false`, as shown in the following example:
@@ -185,7 +185,7 @@ metadata:
  ** To update the role binding by using a single command:
 +
 ----
-$ oc patch clusterrolebinding.rbac self-provisioners -p '{ "metadata": { "annotations": { "rbac.authorization.kubernetes.io/autoupdate": "false" } } }'
+$ oc patch clusterrolebinding.rbac self-provisioner -p '{ "metadata": { "annotations": { "rbac.authorization.kubernetes.io/autoupdate": "false" } } }'
 ----
 
 [[using-node-selectors]]


### PR DESCRIPTION
When following the instructions verbatim, errors are produced due to the name of the clusterrolebinding not ending with `s`:

```
[root@master1 ~]# oc annotate clusterrolebinding.rbac self-provisioners 'rbac.authorization.kubernetes.io/autoupdate=false'
Error from server (NotFound): clusterrolebindings.rbac.authorization.k8s.io "self-provisioners" not found
[root@master1 ~]# oc annotate clusterrolebinding.rbac self-provisioner 'rbac.authorization.kubernetes.io/autoupdate=false'
clusterrolebinding.rbac.authorization.k8s.io/self-provisioner annotated
[root@master1 ~]# oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
Error from server (NotFound): clusterrolebindings.rbac.authorization.k8s.io "self-provisioners" not found
[root@master1 ~]# oc patch clusterrolebinding.rbac self-provisioner -p '{"subjects": null}'
clusterrolebinding.rbac.authorization.k8s.io/self-provisioner patched
```
The object within OpenShift 3.11 does not contain the trailing `s` in the name either:
```
[root@master1 ~]# oc export clusterrolebinding.rbac self-provisioner
Command "export" is deprecated, use the oc get --export
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    rbac.authorization.kubernetes.io/autoupdate: "false"
  creationTimestamp: null
  name: self-provisioner
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: self-provisioner
subjects:
- kind: ServiceAccount
  name: management-admin
  namespace: management-infra
```
Previous versions also used `self-provisioner` (without the `s`).