### PR TITLE
fixed [source-yaml] formatting

### DIFF
--- a/modules/nodes-containers-init-creating.adoc
+++ b/modules/nodes-containers-init-creating.adoc
@@ -11,7 +11,7 @@ The following example outlines a simple Pod which has two Init Containers. The f
 
 . Create a YAML file for the Init Container:
 +
-[source-yaml]
+[source,yaml]
 ----
 apiVersion: v1
 kind: Pod
@@ -35,7 +35,7 @@ spec:
 
 . Create a YAML file for the `myservice` service.
 +
-[source-yaml]
+[source,yaml]
 ----
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
Replaced [source-yaml] with [source,yaml] to fix `asciibinder build` error.