### PR TITLE
Added procedure for configuring identity providers via the console

### DIFF
--- a/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
@@ -19,15 +19,15 @@ that identity provider and add it to the cluster.
 To define an HTPasswd identity provider you must perform the
 following steps:
 
-. Create an `htpasswd` file to store the user and password information. 
+. Create an `htpasswd` file to store the user and password information.
 Instructions are provided for
 xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-linux-{context}[Linux]
 and
 xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-file-windows-{context}[Windows].
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-secret-{context}[Create 
+. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-creating-htpasswd-secret-{context}[Create
 an {product-title} secret to represent the `htpasswd` file].
 . xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#identity-provider-htpasswd-CR-{context}[Define the HTPasswd identity provider resource].
-. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#add-identity-provider-{context}[Apply the resource to 
+. xref:../../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#add-identity-provider-{context}[Apply the resource to
 the default OAuth configuration].
 
 include::modules/identity-provider-creating-htpasswd-file-linux.adoc[leveloffset=+1]
@@ -39,3 +39,5 @@ include::modules/identity-provider-htpasswd-secret.adoc[leveloffset=+1]
 include::modules/identity-provider-htpasswd-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
+
+include::modules/identity-provider-configuring-using-web-console.adoc[leveloffset=+1]

--- a/authentication/identity_providers/configuring-oidc-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-oidc-identity-provider.adoc
@@ -66,3 +66,5 @@ include::modules/identity-provider-config-map.adoc[leveloffset=+1]
 include::modules/identity-provider-oidc-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
+
+include::modules/identity-provider-configuring-using-web-console.adoc[leveloffset=+1]

--- a/modules/identity-provider-configuring-using-web-console.adoc
+++ b/modules/identity-provider-configuring-using-web-console.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+//* authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+//* authentication/identity_providers/configuring-oidc-identity-provider.adoc
+
+[id="identity-provider-configuring-using-the-web-console-{context}"]
+= Configuring identity providers using the web console
+
+Configure your identity provider (IDP) through the web console instead of the CLI.
+
+.Prerequisites
+
+* You must be logged in to the web console as a cluster administrator.
+
+.Procedure
+
+. Navigate to *Administration* -> *Cluster Settings*.
+. Under the *Global Configuration* tab, click *OAuth*.
+. Under the *Identity Providers* section, select your identity provider from the
+*Add* drop-down menu.
+
+[NOTE]
+====
+You can specify multiple IDPs through the web console without overwriting
+existing IDPs.
+====


### PR DESCRIPTION
https://jira.coreos.com/browse/PROD-832

@spadgett PTAL

@huffmanca I am proposing that we add this to each of the assemblies you created for configuring specific identity providers. I think we can re-use this module across all of those assemblies by keeping this generic. Thoughts?