### PR TITLE
Update Device Manager and Plugins for 4.1

### DIFF
--- a/modules/nodes-pods-plugins-about.adoc
+++ b/modules/nodes-pods-plugins-about.adoc
@@ -17,7 +17,7 @@ Containers are supported by individual vendors.
 ====
 
 A device plug-in is a gRPC service running on the nodes (external to
-`atomic-openshift-node.service`) that is responsible for managing specific
+the `kubelet`) that is responsible for managing specific
 hardware resources. Any device plug-in must support following remote procedure
 calls (RPCs):
 

--- a/modules/nodes-pods-plugins-install.adoc
+++ b/modules/nodes-pods-plugins-install.adoc
@@ -47,7 +47,7 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-       machine.openshift.io/cluster-api-machine-type: devicemgr <2>
+       machineconfiguration.openshift.io: devicemgr <2>
   kubeletConfig:
     feature-gates:
       - DevicePlugins=true <3>


### PR DESCRIPTION
Per @sjenning in Slack: "any docs on how to install a device plugin will need to be rewritten for 4.x."
https://coreos.slack.com/archives/GBF4GNEFM/p1555946550029500

cc @vikaschoudhary16 