### PR TITLE
Removing node-config.yaml references from Nodes bucket II Follow Up

### DIFF
--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -10,7 +10,7 @@ As an administrator, you can configure how {product-title} performs garbage coll
 
 .Prerequisites
 
-. Obtain the label associated with the static Machine Config Pool CRD for the type of node you want to configure.
+. Obtain the label associated with the static Machine Config Pool Custom Resource (CR) for the type of node you want to configure.
 	Perform one of the following steps:
 
 .. View the Machine Config Pool:


### PR DESCRIPTION
Addressing @weinliu comments in https://github.com/openshift/openshift-docs/pull/13756