### PR TITLE
Prevent overwriting the default value of "openshift_master_admission_plugin_config"

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -124,6 +124,12 @@ a|This variable sets the parameter and arbitrary JSON values as per the requirem
 ----
 openshift_master_admission_plugin_config={"ClusterResourceOverride":{"configuration":{"apiVersion":"v1","kind":"ClusterResourceOverrideConfig","memoryRequestToLimitPercent":"25","cpuRequestToLimitPercent":"25","limitCPUToMemoryPercent":"200"}}}
 ----
+In this value, `openshift_master_admission_plugin_config={"openshift.io/ImagePolicy":{"configuration":{"apiVersion":"v1","executionRules":[{"matchImageAnnotations":[{"key":"images.openshift.io/deny-execution","value":"true"}],"name":"execution-denied","onResources":[{"resource":"pods"},{"resource":"builds"}],"reject":true,"skipOnResolutionFailure":true}],"kind":"ImagePolicyConfig"}}}` is the default parameter value.
+
+[IMPORTANT]
+====
+You must include the default `openshift_master_admission_plugin_config` value even if you need to add a custom setting.
+====
 
 |`openshift_master_audit_config`
 |This variable enables API service auditing. See


### PR DESCRIPTION
- Version: `v3.10` and `v3.11`

- Description: 
  We should warn about overwriting the `default value` by configured value in order to prevent unexpected result and behavior by missing default value of `admission plugin` config.
If you configure `openshift_master_admission_plugin_config` in inventory file during installation, then `default value` is overwritten.

- Related BZ: [Setting openshift_master_admission_plugin_config overwrites default ImagePolicyConfig](https://bugzilla.redhat.com/show_bug.cgi?id=1702149)