### PR TITLE
Adds ingress nodeselector and tolerations examples

### DIFF
--- a/modules/nw-ingress-controller-nodeselector.adoc
+++ b/modules/nw-ingress-controller-nodeselector.adoc
@@ -1,0 +1,78 @@
+// Module filename: nw-ingress-controller-nodeselector.adoc
+// Module included in the following assemblies:
+// * networking/ingress-controller-configuration.adoc
+
+[id="nw-ingress-controller-configuration-{context}"]
+= Assigning ingress controller pods to nodes
+
+By default, ingress controller pods are scheduled to worker nodes by using nodeSelectors.
+nodeSelector is the simplest form of node selection constraint and is detailed
+xref:nodes-scheduler-node-selectors-about.adoc[here].
+If the default node selection does not suffice, the IngressController resource supports nodeSelectors
+to constrain ingress controller pods.
+
+.Example Procedure
+. One or more labels can be attached to a node. Run `oc get nodes` to get the node names of your cluster. Select one or
+more nodes to attach a label to. Run the following command, replacing `<node-name>` with your desired node name:
++
+----
+$ oc label nodes <node-name> <label-key>=<label-value>
+----
+The command specifies a map of one or more key-value pairs. You can verify the command worked by running
+`oc get nodes --show-labels` and checking for the label. You can also use `oc describe node <node-name>`
+to see the full list of labels for the given node.
+
+. Either update an existing IngressController or create an IngressController with a nodeSelector:
++
+----
+kind: IngressController
+apiVersion: operator.openshift.io/v1
+metadata:
+  name: example
+  namespace: openshift-ingress-operator
+spec:
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        <key>: <value>
+  replicas: 1
+  domain: example.domain.com
+----
+
+[NOTE]
+====
+`example.domain.com` is used for demonstration purposes and should be replaced with a domain unique to your cluster.
+====
+
+. Verify the IngressController contains the labels and the number of `availableReplicas` matches the desired number
+of replicas:
++
+----
+$ oc get ingresscontroller/example -n openshift-ingress-operator -o yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+<SNIP>
+spec:
+  domain: example.domain.com
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        <key>: <value>
+  replicas: 1
+status:
+  availableReplicas: 1
+<SNIP>
+----
+
+. Verify the node placement of the ingress controller pod by using the `oc describe node <node-name>` command and check
+for a pod with the prefix of `router-example` under `Non-terminated Pods`:
++
+----
+$ oc describe node <node-name>
+<SNIP>
+Non-terminated Pods:                      (1 in total)
+  Namespace                               Name                                   CPU Requests  CPU Limits  Memory Requests  Memory Limits
+  ---------                               ----                                   ------------  ----------  ---------------  -------------
+  openshift-ingress                       router-example-59d5b555d4-rjq4j        100m (6%)     0 (0%)      256Mi (3%)       0 (0%)
+<SNIP>
+----

--- a/modules/nw-ingress-controller-taints-tolerations.adoc
+++ b/modules/nw-ingress-controller-taints-tolerations.adoc
@@ -1,0 +1,83 @@
+// Module filename: nw-ingress-controller-taints-tolerations.adoc
+// Module included in the following assemblies:
+// * networking/ingress-controller-configuration.adoc
+
+[id="nw-ingress-controller-configuration-{context}"]
+= Ingress controller taints and tolerations
+
+Taints allow a node to repel a set of pods. xref:nodes-scheduler-taints-tolerations-about.adoc[Taints and tolerations]
+work together to ensure that pods are not scheduled onto undesired nodes. One or more taints are applied to
+a node, marking the node as not accepting any pods that do not tolerate the taints. The IngressController resource
+supports tolerations, allowing ingress controller pods to schedule onto nodes with matching taints.
+
+.Example Procedure
+. One or more taints can be attached to a node. Run `oc get nodes` to get the node names of your cluster.
+Select one or more nodes to apply a taint to. Run the following command, replacing `<node-name>` with your desired
+node name:
++
+----
+$ oc taint nodes <node-name> key1=value1:NoSchedule
+----
+The example taint contains the key-value pair of `key1=value1` and effect `NoSchedule`. This means that no pod can be
+scheduled onto the node unless it has a matching toleration. A toleration “matches” a taint if the keys and effects
+are the same. You can verify the command worked by running `oc describe node <node-name>` to see the full list of
+tolerations for the given node.
+
+. Either update an existing IngressController or create an IngressController with a toleration:
++
+----
+kind: IngressController
+apiVersion: operator.openshift.io/v1
+metadata:
+  name: example
+  namespace: openshift-ingress-operator
+spec:
+  nodePlacement:
+    tolerations:
+      - key: key1
+        operator: Equal
+        value: value1
+        effect: NoSchedule
+  replicas: 1
+  domain: example.domain.com
+----
+
+[NOTE]
+====
+`example.domain.com` is used for demonstration purposes and should be replaced with a domain unique to your cluster.
+====
+
+. Verify the IngressController contains the toleration and the number of `availableReplicas` matches the desired number
+of replicas:
++
+----
+$ oc get ingresscontroller/example -n openshift-ingress-operator -o yaml
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+<SNIP>
+spec:
+  domain: example.domain.com
+  nodePlacement:
+    tolerations:
+      - key: key1
+        operator: Equal
+        value: value1
+        effect: NoSchedule
+  replicas: 1
+status:
+  availableReplicas: 1
+<SNIP>
+----
+
+. Verify the node placement of the ingress controller pod by using the `oc describe node <node-name>` command and check
+for a pod with the prefix of `router-example` under `Non-terminated Pods`:
++
+----
+$ oc describe node <node-name>
+<SNIP>
+Non-terminated Pods:                      (1 in total)
+  Namespace                               Name                                   CPU Requests  CPU Limits  Memory Requests  Memory Limits
+  ---------                               ----                                   ------------  ----------  ---------------  -------------
+  openshift-ingress                       router-example-59d5b555d4-rjq4j        100m (6%)     0 (0%)      256Mi (3%)       0 (0%)
+<SNIP>
+----


### PR DESCRIPTION
Example procedures for configuring ingress controller `nodeSelector` and `tolerations` features.