### PR TITLE
Hiding `defaultNodeSelector` topics

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -404,18 +404,18 @@ Topics:
     File: nodes-scheduler-pod-affinity
   - Name: Controlling pod placement on nodes using node affinity rules
     File: nodes-scheduler-node-affinity
-  - Name: Placing a pod on a specific node by name
-    File: nodes-scheduler-node-names
-  - Name: Placing a pod in a specific project
-    File: nodes-scheduler-node-projects
   - Name: Placing pods onto overcommited nodes
     File: nodes-scheduler-overcommit
   - Name: Controlling pod placement using node taints
     File: nodes-scheduler-taints-tolerations
-  - Name: Constraining pod placement using node selectors
-    File: nodes-scheduler-node-selectors
-#  - Name: Keeping your cluster balanced using the descheduler
-#    File: nodes-scheduler-descheduler
+#  - Name: Placing a pod on a specific node by name
+#    File: nodes-scheduler-node-names
+#  - Name: Placing a pod in a specific project
+#    File: nodes-scheduler-node-projects
+#  - Name: Constraining pod placement using node selectors
+#    File: nodes-scheduler-node-selectors
+  - Name: Keeping your cluster balanced using the descheduler
+    File: nodes-scheduler-descheduler
 - Name: Using Jobs and DaemonSets
   Dir: jobs
   Topics:

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -414,8 +414,8 @@ Topics:
 #    File: nodes-scheduler-node-projects
 #  - Name: Constraining pod placement using node selectors
 #    File: nodes-scheduler-node-selectors
-  - Name: Keeping your cluster balanced using the descheduler
-    File: nodes-scheduler-descheduler
+#  - Name: Keeping your cluster balanced using the descheduler
+#    File: nodes-scheduler-descheduler
 - Name: Using Jobs and DaemonSets
   Dir: jobs
   Topics:

--- a/modules/nodes-scheduler-node-projects-configuring.adoc
+++ b/modules/nodes-scheduler-node-projects-configuring.adoc
@@ -15,9 +15,9 @@ The Pod Node Selector admission controller uses a configuration file to set opti
 [source,yaml]
 ----
 podNodeSelectorPluginConfig:
- clusterDefaultNodeSelector: name-of-node-selector
- namespace1: name-of-node-selector
- namespace2: name-of-node-selector
+ clusterDefaultNodeSelector: <node-selector>
+ namespace1: <node-selector>
+ namespace2: <node-selector>
 ----
 +
 For example:
@@ -25,8 +25,8 @@ For example:
 [source,yaml]
 ----
 podNodeSelectorPluginConfig:
- clusterDefaultNodeSelector: ns1
- ns1: region=west,env=test,infra=fedora,os=fedora
+ clusterDefaultNodeSelector: region=west
+ ns1: os=centos,region=west
 ----
 
 . Create an *AdmissionConfiguration* object that references the file:


### PR DESCRIPTION
Per @sjenning the `defaultNodeSelector` is in the API but not wired up yet. I have commented-out the related topics in the `_topic.yaml` file until the feature is live in the code. Not clear if this will be in 4.1.
https://coreos.slack.com/archives/GBF4GNEFM/p1556218101038700

Jira for wiring up the parameter: https://jira.coreos.com/browse/POD-94