### PR TITLE
Add note about not persisting node labels

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -460,8 +460,12 @@ Topics:
   - Name: Including pod priority in Pod scheduling decisions
     File: nodes-pods-priority
     Distros: openshift-enterprise,openshift-origin
+  - Name: Placing pods on specific nodes using node selectors
+    File: nodes-pods-node-selectors
+    Distros: openshift-enterprise,openshift-origin
 - Name: Controlling pod placement onto nodes (scheduling)
   Dir: scheduling
+  Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: About pod placement using the scheduler
     File: nodes-scheduler-about
@@ -475,14 +479,14 @@ Topics:
     File: nodes-scheduler-overcommit
   - Name: Controlling pod placement using node taints
     File: nodes-scheduler-taints-tolerations
-#  - Name: Placing a pod on a specific node by name
-#    File: nodes-scheduler-node-names
-#  - Name: Placing a pod in a specific project
-#    File: nodes-scheduler-node-projects
-#  - Name: Constraining pod placement using node selectors
-#    File: nodes-scheduler-node-selectors
-#  - Name: Keeping your cluster balanced using the descheduler
-#    File: nodes-scheduler-descheduler
+  - Name: Placing pods on specific nodes using node selectors
+    File: nodes-scheduler-node-selectors
+# - Name: Placing a pod on a specific node by name
+#   File: nodes-scheduler-node-names
+# - Name: Placing a pod in a specific project
+#   File: nodes-scheduler-node-projects
+# - Name: Keeping your cluster balanced using the descheduler
+#   File: nodes-scheduler-descheduler
 - Name: Using Jobs and DaemonSets
   Dir: jobs
   Topics:

--- a/modules/nodes-nodes-working-updating.adoc
+++ b/modules/nodes-nodes-working-updating.adoc
@@ -7,6 +7,12 @@
 
 You can update any label on a node.
 
+[NOTE]
+====
+Node labels are not persisted after a node is deleted even if the node is backed up by a Machine.
+If you need to ensure that the labels persist, add the labels to the MachineSet that controls the Machine instead.
+====
+
 * The following command adds or updates labels on a node:
 +
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-scheduler-node-selector.adoc
+
+[id="nodes-scheduler-node-selectors-pod-{context}"]
+= Using node selectors to control pod placement  
+
+You can use node selector labels on pods to control where the pod is scheduled.
+
+You then add labels to the MachineSet that controls the nodes where you want the pods scheduled. 
+
+You can add labels to a NodeConfig or MachineConfig, but the labels will not persist if the node or machine goes down. Adding the label to the MachineSet ensures that new nodes or machines will have the label.
+
+.Procedure
+
+. Add the desired node selector on your pod. 
++
+For example, make sure that your pod configuration features the `nodeSelector`
+value indicating the desired label:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+spec:
+  nodeSelector:
+    <key>: <value>
+...
+----
+
+. Add a label to your nodes:
++
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  creationTimestamp: '2019-04-29T16:28:26Z'
+  generation: 1
+  labels:
+    <key>: <value> <1>
+    machine.openshift.io/cluster-api-cluster: mburke429-2pk6l
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+    name: 2pk6l-worker-us-east-1c
+----
+<1> Custom label added to a node. The example is a MachineSet configuration.
++
+For example, the following pod will be scheduled on node controlled by the `2pk6l-worker-us-east-1c` MachineSet. 
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+spec:
+  nodeSelector:
+    env: test
+...
+----
++
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  creationTimestamp: '2019-04-29T16:28:26Z'
+  generation: 1
+  labels:
+    env: test
+    machine.openshift.io/cluster-api-cluster: mburke429-2pk6l
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+    name: 2pk6l-worker-us-east-1c
+----
+
+[NOTE] 
+====
+If you are using node selectors and node affinity in the same pod configuration, note the following:
+
+* If you configure both `nodeSelector` and `nodeAffinity`, both conditions must be satisfied for the pod to be scheduled onto a candidate node.
+
+* If you specify multiple `nodeSelectorTerms` associated with `nodeAffinity` types, then the pod can be scheduled onto a node if one of the `nodeSelectorTerms` is satisfied.
+
+* If you specify multiple `matchExpressions` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node only if all `matchExpressions` are satisfied.
+====
+

--- a/nodes/pods/nodes-pods-node-selectors.adoc
+++ b/nodes/pods/nodes-pods-node-selectors.adoc
@@ -1,5 +1,5 @@
-:context: nodes-scheduler-node-selectors
-[id="nodes-scheduler-node-selectors-{context}"]
+:context: nodes-pods-node-selectors
+[id="nodes-pods-node-selectors-{context}"]
 = Placing pods on specific nodes using node selectors
 include::modules/common-attributes.adoc[]
 :relfileprefix: ../
@@ -20,8 +20,4 @@ If you are using node affinity and node selectors in the same pod configuration,
 // assemblies.
 
 include::modules/nodes-scheduler-node-selectors-pod.adoc[leveloffset=+1]
-
-// include::modules/nodes-scheduler-node-selectors-about.adoc[leveloffset=+1]
-
-// include::modules/nodes-scheduler-node-selectors-configuring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Per [Jan Chaloupka in Slack](https://coreos.slack.com/archives/CDDEUQV8X/p1556289956332400?thread_ts=1556287795.324900&cid=CDDEUQV8X):
_...if you leave a very short note saying "node labels are not persisted after a node is deleted even though the node is backup by a machine". That might do the trick._