### PR TITLE
Adding note about managed/unmanaged CLO/EO

### DIFF
--- a/logging/config/efk-logging-elasticsearch.adoc
+++ b/logging/config/efk-logging-elasticsearch.adoc
@@ -19,7 +19,7 @@ or higher memory. Each Elasticsearch node can operate with a lower memory settin
 
 [NOTE]
 ====
-Procedures in this topic require your cluster to be in an unmanaged state. For more information, see Changing the cluster logging management state.
+If you set the Elasticsearch Operator (EO) to unmanaged and leave the Cluster Logging Operator (CLO) as managed, the CLO will revert changes you make to the EO, as the EO is managed by the CLO.
 ====
 
 // The following include statements pull in the module files that comprise

--- a/logging/config/efk-logging-management.adoc
+++ b/logging/config/efk-logging-management.adoc
@@ -14,9 +14,11 @@ In order to modify certain components managed by the Cluster Logging Operator or
 
 In Unmanaged state, the operators do not respond to changes in the CRs. The administrator assumes full control of individual component configurations and upgrades when in unmanaged state. 
 
+The {product-title} documentation indicates in a prerequisite step when you need to set the cluster to Unmanaged.
+
 [NOTE]
 ====
-The {product-title} documentation indictes in a prerequisite step when you need to set the cluster to Unmanaged.
+If you set the Elasticsearch Operator (EO) to unmanaged and leave the Cluster Logging Operator (CLO) as managed, the CLO will revert changes you make to the EO, as the EO is managed by the CLO.
 ====
 
 // The following include statements pull in the module files that comprise

--- a/modules/efk-logging-management-state-changing-es.adoc
+++ b/modules/efk-logging-management-state-changing-es.adoc
@@ -49,3 +49,8 @@ spec:
 ----
 
 <1> Specify the management state as `Managed` or `Unmanaged`.
+
+[NOTE]
+====
+If you set the Elasticsearch Operator (EO) to unmanaged and leave the Cluster Logging Operator (CLO) as managed, the CLO will revert changes you make to the EO, as the EO is managed by the CLO.
+====


### PR DESCRIPTION
Added note that if you set the Elasticsearch operator to unmanaged and leave the Cluster Logging Operator managed, the CLO will overwrite the EO. Based on scrum discussion on 4/29 