### PR TITLE
Node section : podsPerCore/maxPods example and descriptive text don't match

### DIFF
--- a/modules/nodes-nodes-managing-max-pods-proc.adoc
+++ b/modules/nodes-nodes-managing-max-pods-proc.adoc
@@ -61,7 +61,7 @@ spec:
     matchLabels:
       custom-kubelet: small-pods <2>
   kubeletConfig:
-    podsPerCore: 100 <3>
+    podsPerCore: 10 <3>
     maxPods: 250 <4>
 ----
 <1> Assign a name to CR.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1704249