### PR TITLE
BZ1704859: Included note to indicate secret names for non-generic IDPs.

### DIFF
--- a/modules/identity-provider-htpasswd-secret.adoc
+++ b/modules/identity-provider-htpasswd-secret.adoc
@@ -19,3 +19,9 @@ contains the HTPasswd user file.
 ----
 $ oc create secret generic htpass-secret --from-file=htpasswd=</path/to/users.htpasswd> -n openshift-config
 ----
++
+[NOTE]
+====
+The secret key containing the users file must be named `htpasswd`. 
+The above command includes this name.
+====

--- a/modules/identity-provider-ldap-secret.adoc
+++ b/modules/identity-provider-ldap-secret.adoc
@@ -13,3 +13,9 @@ that contains the bindPassword.
 ----
 $ oc create secret generic ldap-secret --from-literal=bindPassword=<secret> -n openshift-config
 ----
++
+[NOTE]
+====
+The secret key containing the bindPassword must be called `bindPassword`.
+The above command includes this name.
+====


### PR DESCRIPTION
BZ1704859: Included note to indicate secret names for non-generic IDPs. While not a direct docs bug, this was a mistake a user made under BZ-1704859.

This is for OS 4.x.