### PR TITLE
Logging manual eso intall

### DIFF
--- a/modules/efk-logging-deploy-subscription.adoc
+++ b/modules/efk-logging-deploy-subscription.adoc
@@ -15,11 +15,13 @@ creates and manages the Elasticsearch cluster used by cluster logging.
 The {product-title} cluster logging solution requires that you install both the
 Cluster Logging Operator and Elasticsearch Operator. There is no use case
 in {product-title} for installing the operators individually.
+You *must* install the Elasticsearch Operator using the CLI following the directions below. 
+You can install the Cluster Logging Operator using the web console or CLI.
 ====
 
 .Prerequisites
 
-. Ensure that you have the necessary persistent storage for Elasticsearch. Note that each Elasticsearch node
+Ensure that you have the necessary persistent storage for Elasticsearch. Note that each Elasticsearch node
 requires its own storage volume.
 +
 Elasticsearch is a memory-intensive application. Each Elasticsearch node needs 16G of memory for both memory requests and CPU limits.
@@ -27,9 +29,177 @@ The initial set of {product-title} nodes might not be large enough to support th
 {product-title} cluster to run with the recommended or higher memory. Each Elasticsearch node can operate with a lower
 memory setting though this is not recommended for production deployments.
 
-. Create a project for cluster logging. You must create the project with the CLI:
+[NOTE]
+====
+You *must* install the Elasticsearch Operator using the CLI following the directions below. 
+You can install the Cluster Logging Operator using the web console or CLI.
+====
 
-.. Create a YAML file with the following:
+
+.Procedure
+
+. Install the Elasticsearch Operator using the CLI to ensure the necessary values are set:
+
+.. Create a Namespace for the Elasticsearch operator (for example, `eo-project.yaml`):
++
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat <1>
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"
+----
+<1> You must specify the `openshift-operators-redhat` namespace.
+
+.. Create the Namespace object:
++
+----
+$ oc create -f eo-project.yaml
+----
+
+.. Create an Operator Group object YAML file (for example, `eo-og.yaml`) for the Elasticsearch operator:
++
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-operators-redhat 
+  namespace: openshift-operators-redhat <1>
+spec: {}
+----
+<1> You must specify the `openshift-operators-redhat` namespace.
+
+.. Create the Operator Group object:
++
+----
+$ oc create -f eo-og.yaml
+----
+
+.. Create a CatalogSourceConfig object YAML file (for example, `eo.csc.yaml`) to enable the Elasticsearch Operator on the cluster. 
++
+.Example CatalogSourceConfig
+[source,yaml]
+----
+apiVersion: "operators.coreos.com/v1"
+kind: "CatalogSourceConfig"
+metadata:
+  name: "elasticsearch"
+  namespace: "openshift-marketplace"
+spec:
+  targetNamespace: "openshift-operators-redhat" <1>
+  packages: "elasticsearch-operator"
+----
+<1> You must specify the `openshift-operators-redhat` namespace.
++
+The Operator generates a CatalogSource from your CatalogSourceConfig in the
+namespace specified in `targetNamespace`.
+
+.. Create the CatalogSourceConfig object:
++
+----
+$ oc create -f eo-csc.yaml
+----
+
+.. Use the following commands to get the `channel` and `currentCSV` values required for the next step. 
++
+----
+$ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath={.status.channels[].name}
+
+preview
+
+$ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath={.status.channels[].currentCSV}
+
+elasticsearch-operator.v4.1.0
+----
+
+.. Create a Subscription object YAML file (for example, `eo-sub.yaml`) to
+subscribe a Namespace to an Operator. 
++
+.Example Subscription
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  generateName: "elasticsearch-"
+  namespace: "openshift-operators-redhat" <1>
+spec:
+  channel: "preview" <2>
+  installPlanApproval: "Automatic"
+  source: "elasticsearch"
+  sourceNamespace: "openshift-operators-redhat" <1>
+  name: "elasticsearch-operator"
+  startingCSV: "elasticsearch-operator.v4.1.0" <3>
+----
+<1> You must specify the `openshift-operators-redhat` namespace for `namespace` and `sourceNameSpace`.
+<2> Specify the `.status.channels[].name` value from the previous step.
+<3> Specify the `.status.channels[].currentCSV` value from the previous step.
+
+.. Create the Subscription object:
++
+----
+$ oc create -f eo-sub.yaml
+----
+
+.. Change to the `openshift-operators-redhat` project:
++
+----
+$ oc project openshift-operators-redhat
+
+Now using project "openshift-operators-redhat"
+----
+
+.. Create a Role-based Access Control (RBAC) object file (for example, `eo-rbac.yaml`) to grant Prometheus permission to access the `openshift-operators-redhat` namespace:
++
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators-redhat
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators-redhat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+namespace: openshift-operators-redhat
+----
+
+.. Create the RBAC object:
++
+----
+$ oc create -f eo-rbac.yaml
+----
++
+The Elasticsearch operator is installed to each project in the cluster.
+
+
+. You can install the Cluster Logging Operator using the {product-title} web console for best results: 
+
+.. In the CLI, create a project for cluster logging. You must create the project with the CLI:
 +
 [source,yaml]
 ----
@@ -53,22 +223,7 @@ If you want the logging pods to run on specific nodes, you can specify a node se
 $ oc create -f <file-name>.yaml
 ----
 
-.Procedure
-
-. Install the Elasticsearch Operator:
-
-.. In the {product-title} console, click *Catalog* -> *OperatorHub*.
-
-.. Choose  *Elasticsearch Operator* from the list of available Operators, and click *Install*.
-
-.. On the *Create Operator Subscription* page, select *All namespaces on the cluster* under *Installation Mode*.
-Then, click *Subscribe*.
-+
-This makes the Operator available to all users and projects that use this {product-title} cluster.
-
-. Install the Cluster Logging Operator:
-
-.. Click *Catalog* -> *OperatorHub*.
+.. In the {product-title} web console, click *Catalog* -> *OperatorHub*.
 
 .. Choose  *Cluster Logging* from the list of available Operators, and click *Install*.
 
@@ -96,7 +251,7 @@ If either operator does not appear as installed, to troubleshoot further:
 the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors
 under *Status*.
 * Switch to the *Workloads* → *Pods* page and check the logs in any Pods in the
-`openshift-logging` and `openshift-operators` projects that are reporting issues.
+`openshift-logging` and `openshift-operators-red` projects that are reporting issues.
 
 . Create a cluster logging instance:
 


### PR DESCRIPTION
Per: https://github.com/openshift/origin-aggregated-logging/pull/1621

The elasticsearch-operator needs to watch all namespaces
for elasticsearch objects.
This means we cannot list the targetNamespaces in the operatorgroup... if you do not set targetNamespaces in the operatorgroup it will tell it to watch all namespaces: