### PR TITLE
'Verify the install' does not appear to be complete

### DIFF
--- a/modules/efk-logging-deploy-subscription.adoc
+++ b/modules/efk-logging-deploy-subscription.adoc
@@ -165,24 +165,18 @@ can edit to make changes to your cluster logging cluster.
 
 .. Select the *openshift-logging* project.
 +
-You should see pods for cluster logging, Elasticsearch, and Fluentd, as shown in
-the following CLI output:
+You should see several pods for cluster logging, Elasticsearch, Fluentd, and Kibana similar to the following list:
 +
-----
-oc get pods -n openshift-logging
-
-NAME                                            READY   STATUS    RESTARTS   AGE
-cluster-logging-operator-cb795f8dc-xkckc        1/1     Running   0          32m
-elasticsearch-cdm-b3nqzchd-1-5c6797-67kfz       2/2     Running   0          14m
-elasticsearch-cdm-b3nqzchd-2-6657f4-wtprv       2/2     Running   0          14m
-elasticsearch-cdm-b3nqzchd-3-588c65-clg7g       2/2     Running   0          14m
-fluentd-2c7dg                                   1/1     Running   0          14m
-fluentd-9z7kk                                   1/1     Running   0          14m
-fluentd-br7r2                                   1/1     Running   0          14m
-fluentd-fn2sb                                   1/1     Running   0          14m
-fluentd-pb2f8                                   1/1     Running   0          14m
-fluentd-zqgqx                                   1/1     Running   0          14m
-kibana-7fb4fd4cc9-bvt4p                         2/2     Running   0          14m
-----
+* cluster-logging-operator-cb795f8dc-xkckc
+* elasticsearch-cdm-b3nqzchd-1-5c6797-67kfz
+* elasticsearch-cdm-b3nqzchd-2-6657f4-wtprv
+* elasticsearch-cdm-b3nqzchd-3-588c65-clg7g
+* fluentd-2c7dg
+* fluentd-9z7kk
+* fluentd-br7r2
+* fluentd-fn2sb
+* fluentd-pb2f8
+* fluentd-zqgqx
+* kibana-7fb4fd4cc9-bvt4p
 +
 .. Switch to the *Workloads* -> *Pods* page.


### PR DESCRIPTION
Changing the CLI list of cluster logging pods in the install verification section to a bullet list, per:
https://bugzilla.redhat.com/show_bug.cgi?id=1704873