### PR TITLE
Moving CNV document attributes file into 4.1

### DIFF
--- a/modules/cnv-document-attributes.adoc
+++ b/modules/cnv-document-attributes.adoc
@@ -1,0 +1,34 @@
+// Standard document attributes to be used in the documentation
+//
+// The following are shared by all documents:
+:toc:
+:toclevels: 4
+:experimental:
+//
+// Product content attributes, that is, substitution variables in the files.
+//
+:product-title: OpenShift Container Platform
+:ProductName: Container-native Virtualization
+:ProductShortName: CNV
+:ProductRelease:
+:ProductVersion:
+:product-build:
+:DownloadURL: registry.access.redhat.com
+//
+// Documentation publishing attributes used in the master-docinfo.xml file
+// Note that the DocInfoProductName generates the URL for the product page.
+// Changing the value changes the generated URL.
+//
+:DocInfoProductName: Container-native Virtualization
+:DocInfoProductNumber: 2.0
+//
+// Book Names:
+//     Defining the book names in document attributes instead of hard-coding them in
+//     the master.adoc files and in link references. This makes it easy to change the
+//     book name if necessary.
+//     Using the pattern ending in 'BookName' makes it easy to grep for occurrences
+//     throughout the topics
+//
+:Install_BookName: Installing Container-native Virtualization
+:Using_BookName: Using Container-native Virtualization
+:RN_BookName: Container-native Virtualization Release Notes


### PR DESCRIPTION
@vikram-redhat - I think we need to include this file in our assemblies as we did in 1.4. Please merge it (quickly, if possible), or let me know if there's a reason we shouldn't use this file in 2.0. Thanks!