### PR TITLE
Edit suggested in file nodes/scheduling/nodes-scheduler-default.adoc

### DIFF
--- a/modules/nodes-scheduler-default-about.adoc
+++ b/modules/nodes-scheduler-default-about.adoc
@@ -34,7 +34,7 @@ one of them is selected at random.
 
 The selection of the predicate and priorities defines the policy for the scheduler.
 
-The scheduler configuration file is a JSON file that specifies the predicates and priorities the scheduler
+The scheduler configuration file is a JSON file, which must be named `policy.cfg`, that specifies the predicates and priorities the scheduler
 will consider.
 
 In the absence of the scheduler policy file, the default scheduler behavior is used.
@@ -49,81 +49,69 @@ policy. If any of the default predicates and priorities are required,
 you must explicitly specify the functions in the policy configuration.
 ====
 
-.Sample scheduler configuration file
-[source,json]
+.Sample scheduler ConfigMap
+[source,yaml]
 ----
-{
-"kind" : "Policy",
-"apiVersion" : "v1",
-"predicates" : [
-	{"name" : "PodFitsHostPorts"},
-	{"name" : "PodFitsResources"},
-	{"name" : "NoDiskConflict"},
-	{"name" : "NoVolumeZoneConflict"},
-	{"name" : "MatchNodeSelector"},
-	{"name" : "HostName"}
-	],
-"priorities" : [
-	{"name" : "LeastRequestedPriority", "weight" : 1},
-	{"name" : "BalancedResourceAllocation", "weight" : 1},
-	{"name" : "ServiceSpreadingPriority", "weight" : 1},
-	{"name" : "EqualPriority", "weight" : 1}
-	]
-}
+apiVersion: v1
+data:
+  policy.cfg: |
+    {
+        "kind" : "Policy",
+        "apiVersion" : "v1",
+        "predicates" : [
+                {"name" : "MaxGCEPDVolumeCount"},
+                {"name" : "GeneralPredicates"},
+                {"name" : "MaxAzureDiskVolumeCount"},
+                {"name" : "MaxCSIVolumeCountPred"},
+                {"name" : "CheckVolumeBinding"},
+                {"name" : "MaxEBSVolumeCount"},
+                {"name" : "PodFitsResources"},
+                {"name" : "MatchInterPodAffinity"},
+                {"name" : "CheckNodeUnschedulable"},
+                {"name" : "NoDiskConflict"},
+                {"name" : "NoVolumeZoneConflict"},
+                {"name" : "MatchNodeSelector"},
+                {"name" : "HostName"},
+                {"name" : "PodToleratesNodeTaints"}
+                ],
+        "priorities" : [
+                {"name" : "LeastRequestedPriority", "weight" : 1},
+                {"name" : "BalancedResourceAllocation", "weight" : 1},
+                {"name" : "ServiceSpreadingPriority", "weight" : 1},
+                {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
+                {"name" : "NodeAffinityPriority", "weight" : 1},
+                {"name" : "TaintTolerationPriority", "weight" : 1},
+                {"name" : "ImageLocalityPriority", "weight" : 1},
+                {"name" : "SelectorSpreadPriority", "weight" : 1},
+                {"name" : "InterPodAffinityPriority", "weight" : 1},
+                {"name" : "EqualPriority", "weight" : 1}
+                ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2019-09-17T08:42:33Z"
+  name: scheduler-policy
+  namespace: openshift-config
+  resourceVersion: "59500"
+  selfLink: /api/v1/namespaces/openshift-config/configmaps/scheduler-policy
+  uid: 17ee8865-d927-11e9-b213-02d1e1709840`
 ----
 
-[id="nodes-scheduler-default-about-use-cases_{context}"]
-== Scheduler Use Cases
+////
+.Typical predicate string
+----
+\n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\"},
+----
+* `name` is the name of the predicate, such as `labelsPresence`. 
+* `label` and `<label>` is the node label:value pair to match to apply the predicate, such `label:rack`.
+* `<condition>` and `<state>` is when the predicate should be applied, such as `presence:true`.
 
-One of the important use cases for scheduling within {product-title} is to
-support flexible affinity and anti-affinity policies.
-ifdef::openshift-enterprise,openshift-origin[]
-
-[id="infrastructure-topological-levels_{context}"]
-=== Infrastructure Topological Levels
-
-Administrators can define multiple topological levels for their infrastructure
-(nodes) by specifying labels on nodes. For example: `region=r1`, `zone=z1`, `rack=s1`.
-
-These label names have no particular meaning and
-administrators are free to name their infrastructure levels anything, such as
-city/building/room. Also, administrators can define any number of levels
-for their infrastructure topology, with three levels usually being adequate
-(such as: `regions` -> `zones` -> `racks`).  Administrators can specify affinity
-and anti-affinity rules at each of these levels in any combination.
-endif::openshift-enterprise,openshift-origin[]
-
-[id="affinity_{context}"]
-=== Affinity
-
-Administrators should be able to configure the scheduler to specify affinity at
-any topological level, or even at multiple levels. Affinity at a particular
-level indicates that all pods that belong to the same service are scheduled
-onto nodes that belong to the same level. This handles any latency requirements
-of applications by allowing administrators to ensure that peer pods do not end
-up being too geographically separated. If no node is available within the same
-affinity group to host the pod, then the pod is not scheduled.
-
-If you need greater control over where the pods are scheduled, see Controlling pod placement on nodes using node affinity rules and
-Placing pods relative to other pods using affinity and anti-affinity rules.
-
-These advanced scheduling features allow administrators
-to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
-
-
-[id="anti-affinity_{context}"]
-=== Anti-Affinity
-
-Administrators should be able to configure the scheduler to specify
-anti-affinity at any topological level, or even at multiple levels.
-Anti-affinity (or 'spread') at a particular level indicates that all pods that
-belong to the same service are spread across nodes that belong to that
-level. This ensures that the application is well spread for high availability
-purposes. The scheduler tries to balance the service pods across all
-applicable nodes as evenly as possible.
-
-If you need greater control over where the pods are scheduled, see Controlling pod placement on nodes using node affinity rules and
-Placing pods relative to other pods using affinity and anti-affinity rules.
-
-These advanced scheduling features allow administrators
-to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
+.Typical priority string
+----
+\n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\", \"weight\" : <weight>},
+----
+* `name` is the name of the priority, such as `labelsPresence`. 
+* `label` and `<label>` is the node `label:value` pair to match to apply the priority, such `label:rack`.
+* `<condition>` and `<state>` is when the priority should be applied, such as `presence:true`.
+* `weight` and `<weight> is the numerical weight to apply to the priority.
+////

--- a/modules/nodes-scheduler-default-creating.adoc
+++ b/modules/nodes-scheduler-default-creating.adoc
@@ -2,69 +2,19 @@
 //
 // * nodes/nodes-scheduler-default.adoc
 
+
 [id="nodes-scheduler-default-creating_{context}"]
 = Creating a scheduler policy file
 
 //Made changes to this file to match https://github.com/openshift/openshift-docs/pull/13626/files#diff-ba6ab177a3e2867eaefe07f48bd6e158
 
-You can control change the default scheduling behavior using a ConfigMap in the `openshift-config` project.
-Add and remove predicates and priorities to the ConfigMap to create a _scheduler policy_.
-
-.Sample scheduler configuration map
-[source,yaml]
-----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: scheduler-policy
-  namespace: openshift-config
-  selfLink: /api/v1/namespaces/openshift-config/configmaps/mypolicy
-  uid: 83917dfb-4422-11e9-b2c9-0a5e37b2b12e
-  resourceVersion: '1049773'
-  creationTimestamp: '2019-03-11T17:24:23Z'
-data:
-  policy.cfg: |
-    {
-    "kind" : "Policy",
-    "apiVersion" : "v1",
-    "predicates" : [
-            {"name" : "MaxGCEPDVolumeCount"},
-            {"name" : "GeneralPredicates"},
-            {"name" : "MaxAzureDiskVolumeCount"},
-            {"name" : "MaxCSIVolumeCountPred"},
-            {"name" : "CheckVolumeBinding"},
-            {"name" : "MaxEBSVolumeCount"},
-            {"name" : "PodFitsResources"},
-            {"name" : "MatchInterPodAffinity"},
-            {"name" : "CheckNodeUnschedulable"},
-            {"name" : "NoDiskConflict"},
-            {"name" : "CheckServiceAffinity"},
-            {"name" : "NoVolumeZoneConflict"},
-            {"name" : "MatchNodeSelector"},
-            {"name" : "PodToleratesNodeNoExecuteTaints"},
-            {"name" : "HostName"},
-            {"name" : "PodToleratesNodeTaints"}
-            ],
-    "priorities" : [
-            {"name" : "LeastRequestedPriority", "weight" : 1},
-            {"name" : "BalancedResourceAllocation", "weight" : 1},
-            {"name" : "ServiceSpreadingPriority", "weight" : 1},
-            {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
-            {"name" : "NodeAffinityPriority", "weight" : 1},
-            {"name" : "TaintTolerationPriority", "weight" : 1},
-            {"name" : "ImageLocalityPriority", "weight" : 1},
-            {"name" : "SelectorSpreadPriority", "weight" : 1},
-            {"name" : "InterPodAffinityPriority", "weight" : 1},
-            {"name" : "EqualPriority", "weight" : 1}
-            ]
-    }
-----
+You can control change the default scheduling behavior by creating a JSON file with using the with the desired predicates and priorities. You then generate a ConfigMap from the JSON file and point the `cluster` Scheduler object to use the ConfigMap.
 
 .Procedure
 
-To create the scheduler policy:
+To configure the scheduler policy:
 
-. Create the a JSON file with the desired predicates and priorities.
+. Create the a JSON file named `policy.cfg` with the desired predicates and priorities. 
 +
 .Sample scheduler JSON file
 [source,json]
@@ -72,30 +22,38 @@ To create the scheduler policy:
 {
 "kind" : "Policy",
 "apiVersion" : "v1",
-"predicates" : [      <1>
-	{"name" : "PodFitsHostPorts"},
-	{"name" : "PodFitsResources"},
-	{"name" : "NoDiskConflict"},
-	{"name" : "NoVolumeZoneConflict"},
-	{"name" : "MatchNodeSelector"},
-	{"name" : "HostName"}
-	],
-"priorities" : [     <2>
-	{"name" : "LeastRequestedPriority", "weight" : 1},
-	{"name" : "BalancedResourceAllocation", "weight" : 1},
-	{"name" : "ServiceSpreadingPriority", "weight" : 1},
-	{"name" : "EqualPriority", "weight" : 1}
-	]
+"predicates" : [ <1>
+        {"name" : "PodFitsHostPorts"},
+        {"name" : "PodFitsResources"},
+        {"name" : "NoDiskConflict"},
+        {"name" : "NoVolumeZoneConflict"},
+        {"name" : "MatchNodeSelector"},
+        {"name" : "MaxEBSVolumeCount"},
+        {"name" : "MaxAzureDiskVolumeCount"},
+        {"name" : "checkServiceAffinity"},
+        {"name" : "PodToleratesNodeNoExecuteTaints"},
+        {"name" : "MaxGCEPDVolumeCount"},
+        {"name" : "MatchInterPodAffinity"},
+        {"name" : "PodToleratesNodeTaints"},
+        {"name" : "HostName"}
+        ],
+"priorities" : [<2>
+        {"name" : "LeastRequestedPriority", "weight" : 1},
+        {"name" : "BalancedResourceAllocation", "weight" : 1},
+        {"name" : "ServiceSpreadingPriority", "weight" : 1},
+        {"name" : "EqualPriority", "weight" : 1}
+        ]
 }
 ----
 <1> Add the predicates as needed.
 <2> Add the priorities as needed.
 
-. Create a ConfigMap based on the JSON file:
+. Create a ConfigMap based on the scheduler JSON file:
 +
 ----
-$ oc create configmap -n openshift-config --from-file=policy.cfg <configmap-name>
+$ oc create configmap -n openshift-config --from-file=policy.cfg <configmap-name> <1>
 ----
+<1> Enter a name for the ConfigMap.
 +
 For example:
 +
@@ -104,18 +62,82 @@ $ oc create configmap -n openshift-config --from-file=policy.cfg scheduler-polic
 
 configmap/scheduler-policy created
 ----
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  policy.cfg: |
+    {
+        "kind" : "Policy",
+        "apiVersion" : "v1",
+        "predicates" : [
+                {"name" : "MaxGCEPDVolumeCount"},
+                {"name" : "GeneralPredicates"},
+                {"name" : "MaxAzureDiskVolumeCount"},
+                {"name" : "MaxCSIVolumeCountPred"},
+                {"name" : "CheckVolumeBinding"},
+                {"name" : "MaxEBSVolumeCount"},
+                {"name" : "PodFitsResources"},
+                {"name" : "MatchInterPodAffinity"},
+                {"name" : "CheckNodeUnschedulable"},
+                {"name" : "NoDiskConflict"},
+                {"name" : "NoVolumeZoneConflict"},
+                {"name" : "MatchNodeSelector"},
+                {"name" : "HostName"},
+                {"name" : "PodToleratesNodeTaints"}
+                ],
+        "priorities" : [
+                {"name" : "LeastRequestedPriority", "weight" : 1},
+                {"name" : "BalancedResourceAllocation", "weight" : 1},
+                {"name" : "ServiceSpreadingPriority", "weight" : 1},
+                {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
+                {"name" : "NodeAffinityPriority", "weight" : 1},
+                {"name" : "TaintTolerationPriority", "weight" : 1},
+                {"name" : "ImageLocalityPriority", "weight" : 1},
+                {"name" : "SelectorSpreadPriority", "weight" : 1},
+                {"name" : "InterPodAffinityPriority", "weight" : 1},
+                {"name" : "EqualPriority", "weight" : 1}
+                ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2019-09-17T08:42:33Z"
+  name: scheduler-policy
+  namespace: openshift-config
+  resourceVersion: "59500"
+  selfLink: /api/v1/namespaces/openshift-config/configmaps/scheduler-policy
+  uid: 17ee8865-d927-11e9-b213-02d1e1709840`
+----
+
 . Edit the Scheduler Operator Custom Resource to add the ConfigMap:
 +
 ----
-$ oc edit scheduler cluster
+$ oc patch Scheduler cluster --type='merge' -p '{"spec":{"policy":{"name":"<configmap-name>"}}}' --type=merge <1>
 ----
 +
+<1> Specify the name of the ConfigMap.
++
+For example:
++
 ----
-apiVersion: config.openshift.io/v1
-kind: Scheduler
-metadata:
-  name: cluster
-spec: {}
-  policy:
-    name: scheduler-policy
+$ oc patch Scheduler cluster --type='merge' -p '{"spec":{"policy":{"name":"scheduler-policy"}}}' --type=merge
 ----
++
+After making the change to the Scheduler config resource, wait for the `opensift-kube-apiserver` pods to redeploy. This can take several minutes. Until the pods redeploy, new scheduler does not take effect.
+
+. Verify the scheduler policy is configured by viewing the log of a scheduler pod in the `openshift-kube-scheduler` namespace. The following command checks for the predoicates and priorites that are being registered by the scheduler:
++
+----
+$ oc logs <scheduler-pod> | grep predicates
+----
++
+For example:
++
+[options="wrap"]
+----
+$ oc logs openshift-kube-scheduler-ip-10-0-141-29.ec2.internal | grep predicates
+
+Creating scheduler with fit predicates 'map[MaxGCEPDVolumeCount:{} MaxAzureDiskVolumeCount:{} CheckNodeUnschedulable:{} NoDiskConflict:{} NoVolumeZoneConflict:{} MatchNodeSelector:{} GeneralPredicates:{} MaxCSIVolumeCountPred:{} CheckVolumeBinding:{} MaxEBSVolumeCount:{} PodFitsResources:{} MatchInterPodAffinity:{} HostName:{} PodToleratesNodeTaints:{}]' and priority functions 'map[InterPodAffinityPriority:{} LeastRequestedPriority:{} ServiceSpreadingPriority:{} ImageLocalityPriority:{} SelectorSpreadPriority:{} EqualPriority:{} BalancedResourceAllocation:{} NodePreferAvoidPodsPriority:{} NodeAffinityPriority:{} TaintTolerationPriority:{}]'
+----
+

--- a/modules/nodes-scheduler-default-modifying.adoc
+++ b/modules/nodes-scheduler-default-modifying.adoc
@@ -10,57 +10,138 @@
 You change scheduling behavior by creating or editing your scheduler policy ConfigMap in the `openshift-config` project.
 Add and remove predicates and priorities to the ConfigMap to create a _scheduler policy_.
 
-.Typical predicate string
-----
-\n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\"},
-----
-* `name` is the name of the predicate, such as `labelsPresence`. 
-* `label` and `<label>` is the node label:value pair to match to apply the predicate, such `label:rack`.
-* `<condition>` and `<state>` is when the predicate should be applied, such as `presence:true`.
-
-.Typical priority string
-----
-\n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\", \"weight\" : <weight>},
-----
-* `name` is the name of the priority, such as `labelsPresence`. 
-* `label` and `<label>` is the node `label:value` pair to match to apply the priority, such `label:rack`.
-* `<condition>` and `<state>` is when the priority should be applied, such as `presence:true`.
-* `weight` and `<weight> is the numerical weight to apply to the priority.
 
 .Procedure
 
-To modify the scheduler policy:
+To modify the current custom schedluling:
 
-Edit the scheduler configuration file to configure the desired
-predicates and priorities. 
-
-.Sample modified scheduler configuration map
-[source,yaml]
+* Edit the scheduler policy ConfigMap:
++
 ----
-kind: ConfigMap
+$ oc edit configmap <configmap-name>  -n openshift-config
+----
++
+For example:
++
+----
+$ oc edit configmap scheduler-policy -n openshift-config
+
 apiVersion: v1
-metadata:
-  name: scheduler-policy
-  namespace: openshift-config
-  selfLink: /api/v1/namespaces/openshift-config/configmaps/mypolicy
-  uid: 83917dfb-4422-11e9-b2c9-0a5e37b2b12e
-  resourceVersion: '1049773'
-  creationTimestamp: '2019-03-11T17:24:23Z'
 data:
-  policy.cfg: "{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"PodFitsHostPorts\"},\n\t{\"name\" : \"PodFitsResources\"},\n\t{\"name\" : \"NoDiskConflict\"},\n\t{\"name\" : \"NoVolumeZoneConflict\"},\n\t{\"name\" : \"MatchNodeSelector\"},\n\t{\"name\" : \"HostName\"}\n\t],\n\"priorities\" : [\n\t{\"name\" : \"LeastRequestedPriority\", \"weight\" : 10},\n\t{\"name\" : \"BalancedResourceAllocation\", \"weight\" : 1},\n\t{\"name\" : \"ServiceSpreadingPriority\", \"weight\" : 1},\n\t{\"name\" : \"EqualPriority\", \"weight\" : 1}\n\t]\n}\n"
+  policy.cfg: |
+    {
+        "kind" : "Policy",
+        "apiVersion" : "v1",
+        "predicates" : [ <1>
+                {"name" : "MaxGCEPDVolumeCount"},
+                {"name" : "GeneralPredicates"},
+                {"name" : "MaxAzureDiskVolumeCount"},
+                {"name" : "MaxCSIVolumeCountPred"},
+                {"name" : "CheckVolumeBinding"},
+                {"name" : "MaxEBSVolumeCount"},
+                {"name" : "PodFitsResources"},
+                {"name" : "MatchInterPodAffinity"},
+                {"name" : "CheckNodeUnschedulable"},
+                {"name" : "NoDiskConflict"},
+                {"name" : "NoVolumeZoneConflict"},
+                {"name" : "MatchNodeSelector"},
+                {"name" : "HostName"},
+                {"name" : "PodToleratesNodeTaints"}
+                ],
+        "priorities" : [ <2>
+                {"name" : "LeastRequestedPriority", "weight" : 1},
+                {"name" : "BalancedResourceAllocation", "weight" : 1},
+                {"name" : "ServiceSpreadingPriority", "weight" : 1},
+                {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
+                {"name" : "NodeAffinityPriority", "weight" : 1},
+                {"name" : "TaintTolerationPriority", "weight" : 1},
+                {"name" : "ImageLocalityPriority", "weight" : 1},
+                {"name" : "SelectorSpreadPriority", "weight" : 1},
+                {"name" : "InterPodAffinityPriority", "weight" : 1},
+                {"name" : "EqualPriority", "weight" : 1}
+                ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2019-09-17T17:44:19Z"
+  name: policy-configmap
+  namespace: openshift-kube-scheduler
+  resourceVersion: "15370"
+  selfLink: /api/v1/namespaces/openshift-kube-scheduler/configmaps/policy-configmap
+----
+<1> Add or remove predicates as needed.
+<2> Add, remove, or change the weight of predicates as needed.
++
+It can take a few minutes for the scheduler to restart the pods with the updated policy.
+
+* Change the policies and predicates being used:
+
+. Remove the scheduler policy CongifMap:
++
+----
+$ oc delete configmap -n openshift-config <name>
+----
++
+For example:
++
+----
+$ oc delete configmap -n openshift-config  scheduler-policy
 ----
 
-For example, the following strings add the `labelpresence` predicate requiring the `rack` label on the nodes and the `labelPreference` priority giving a weight of 2 to the `rack` label:
-
+. Edit the `policy.cfg` file to add and remove policies and predicates as needed.
++
+For example:
++
+----
+$ vi policy.cfg
+----
++
 [source,yaml]
 ----
-\n\t{\"name\" : \"labelPresence\", \"label\" : \"rack\",  \"presence\" : \"true\"},
-\n\t{\"name\" : \"labelPreference\", \"label\" : \"rack\", \"presence\" : \"true\", \"weight\" : 2},\n\t
+apiVersion: v1
+data:
+  policy.cfg: |
+    {
+    "kind" : "Policy",
+    "apiVersion" : "v1",
+    "predicates" : [
+            {"name" : "PodFitsHostPorts"},
+            {"name" : "PodFitsResources"},
+            {"name" : "NoDiskConflict"},
+            {"name" : "NoVolumeZoneConflict"},
+            {"name" : "MatchNodeSelector"},
+            {"name" : "MaxEBSVolumeCount"},
+            {"name" : "MaxAzureDiskVolumeCount"},
+            {"name" : "CheckVolumeBinding"},
+            {"name" : "CheckServiceAffinity"},
+            {"name" : "PodToleratesNodeNoExecuteTaints"},
+            {"name" : "MaxGCEPDVolumeCount"},
+            {"name" : "MatchInterPodAffinity"},
+            {"name" : "PodToleratesNodeTaints"},
+            {"name" : "HostName"}
+            ],
+    "priorities" : [
+            {"name" : "LeastRequestedPriority", "weight" : 2},
+            {"name" : "BalancedResourceAllocation", "weight" : 2},
+            {"name" : "ServiceSpreadingPriority", "weight" : 2},
+            {"name" : "EqualPriority", "weight" : 2}
+            ]
+    }
 ----
 
-The ConfigMap appears as following with the new priority:
+. Re-create the scheduler policy ConfigMap based on the scheduler JSON file:
++
+[options="nowrap"]
+----
+$ oc create configmap -n openshift-config --from-file=policy.cfg <configmap-name> <1>
+----
+<1> Enter a name for the ConfigMap.
++
+For example:
++
+----
+$ oc create configmap -n openshift-config --from-file=policy.cfg scheduler-policy
 
-[source,yaml]
+configmap/scheduler-policy created
 ----
-policy.cfg: "{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"PodFitsHostPorts\"},\n\t{\"name\" : \"PodFitsResources\"},\n\t{\"name\" : \"NoDiskConflict\"},\n\t{\"name\" : \"NoVolumeZoneConflict\"},\n\t{\"name\" : \"MatchNodeSelector\"},\n\t{\"name\" : \"HostName\"},\n\t{\"name\" : \"labelPresence\", \"label\" : \"rack\",  \"presence\" : \"true\"}\n\t],\n\"priorities\" : [\n\t{\"name\" : \"LeastRequestedPriority\", \"weight\" : 10},\n\t{\"name\" : \"BalancedResourceAllocation\", \"weight\" : 1},\n\t{\"name\" : \"ServiceSpreadingPriority\", \"weight\" : 1},\n\t{\"name\" : \"EqualPriority\", \"weight\" : 1},\n\t{\"name\" : \"labelPreference\", \"label\" : \"rack\", \"presence\" : \"true\", \"weight\" : 2},\n\t]\n}\n "
-----
+

--- a/modules/nodes-scheduler-default-predicates.adoc
+++ b/modules/nodes-scheduler-default-predicates.adoc
@@ -22,53 +22,34 @@ name.
 
 The default scheduler policy includes the following predicates:
 
-**_NoVolumeZoneConflict_** checks that the volumes a pod requests
+*NoVolumeZoneConflict* checks that the volumes a pod requests
 are available in the zone.
 ----
 {"name" : "NoVolumeZoneConflict"}
 ----
 
-**_MaxEBSVolumeCount_** checks the maximum number of volumes that can be attached to an AWS instance.
+*MaxEBSVolumeCount* checks the maximum number of volumes that can be attached to an AWS instance.
 ----
 {"name" : "MaxEBSVolumeCount"}
 ----
 
-**_MaxGCEPDVolumeCount_** checks the maximum number of Google Compute Engine (GCE) Persistent Disks (PD).
+*MaxAzureDiskVolumeCount*  checks the maximum number of Azure Disk Volumes.
 ----
-{"name" : "MaxGCEPDVolumeCount"}
-----
-
-**_MatchInterPodAffinity_** checks if the pod affinity/anti-affinity rules permit the pod.
-----
-{"name" : "MatchInterPodAffinity"}
+{"name" : "MaxAzureDiskVolumeCount"}
 ----
 
-**_NoDiskConflict_** checks if the volume requested by a pod is available.
-----
-{"name" : "NoDiskConflict"}
-----
-
-**_PodToleratesNodeTaints_** checks if a pod can tolerate the node taints.
+*PodToleratesNodeTaints* checks if a pod can tolerate the node taints.
 ----
 {"name" : "PodToleratesNodeTaints"}
 ----
 
-**_CheckNodeMemoryPressure_** checks if a pod can be scheduled on a node with a memory pressure condition.
+*CheckNodeUnschedulable* checks if a pod can be scheduled on a node with `Unschedulable` spec.
 ----
-{"name" : "CheckNodeMemoryPressure"}
-----
-
-[id="other-predicates_{context}"]
-=== Other Static Predicates
-
-{product-title} also supports the following predicates:
-
-**_CheckNodeDiskPressure_** checks if a pod can be scheduled on a node with a disk pressure condition.
-----
-{"name" : "CheckNodeDiskPressure"}
+{"name" : "CheckNodeUnschedulable"}
 ----
 
-**_CheckVolumeBinding_** evaluates if a pod can fit based on the volumes, it requests, for both bound and unbound PVCs.
+
+*CheckVolumeBinding* evaluates if a pod can fit based on the volumes, it requests, for both bound and unbound PVCs.
 * For PVCs that are bound, the predicate checks that the corresponding PV's node affinity is satisfied by the given node.
 * For PVCs that are unbound, the predicate searched for available PVs that can satisfy the PVC requirements and that
 the PV node affinity is satisfied by the given node.
@@ -78,31 +59,65 @@ The predicate returns true if all bound PVCs have compatible PVs with the node, 
 {"name" : "CheckVolumeBinding"}
 ----
 
-The `CheckVolumeBinding` predicate must be enabled in non-default schedulers.
+// The `CheckVolumeBinding` predicate must be enabled in non-default schedulers.
 
-**_CheckNodeCondition_** checks if a pod can be scheduled on a node reporting *out of disk*, *network unavailable*, or *not ready* conditions.
+*NoDiskConflict* checks if the volume requested by a pod is available.
+----
+{"name" : "NoDiskConflict"}
+----
+
+*MaxGCEPDVolumeCount* checks the maximum number of Google Compute Engine (GCE) Persistent Disks (PD).
+----
+{"name" : "MaxGCEPDVolumeCount"}
+----
+
+*MaxCSIVolumeCountPred*
+
+
+*MatchInterPodAffinity* checks if the pod affinity/anti-affinity rules permit the pod.
+----
+{"name" : "MatchInterPodAffinity"}
+----
+
+[id="other-predicates_{context}"]
+=== Other Static Predicates
+
+{product-title} also supports the following predicates:
+
+[NOTE]
+====
+The *CheckNode-** predicates cannot be used if the *Taint Nodes By Condition* feature is enabled.
+The *Taint Nodes By Condition* feature is enabled by default.  
+====
+
+*CheckNodeMemoryPressure* checks if a pod can be scheduled on a node with a memory pressure condition.
+----
+{"name" : "CheckNodeMemoryPressure"}
+----
+
+*CheckNodeDiskPressure* checks if a pod can be scheduled on a node with a disk pressure condition.
+----
+{"name" : "CheckNodeDiskPressure"}
+----
+
+*CheckNodeCondition* checks if a pod can be scheduled on a node reporting *out of disk*, *network unavailable*, or *not ready* conditions.
 ----
 {"name" : "CheckNodeCondition"}
 ----
 
-**_PodToleratesNodeNoExecuteTaints_** checks if a pod tolerations can tolerate a node *NoExecute* taints.
-----
-{"name" : "PodToleratesNodeNoExecuteTaints"}
-----
-
-**_CheckNodeLabelPresence_** checks if all of the specified labels exist on a node, regardless of their value.
+*CheckNodeLabelPresence* checks if all of the specified labels exist on a node, regardless of their value.
 ----
 {"name" : "CheckNodeLabelPresence"}
 ----
 
-**_checkServiceAffinity_** checks that ServiceAffinity labels are homogeneous for pods that are scheduled on a node.
+*checkServiceAffinity* checks that ServiceAffinity labels are homogeneous for pods that are scheduled on a node.
 ----
 {"name" : "checkServiceAffinity"}
 ----
 
-**_MaxAzureDiskVolumeCount_**  checks the maximum number of Azure Disk Volumes.
+*PodToleratesNodeNoExecuteTaints* checks if a pod tolerations can tolerate a node *NoExecute* taints.
 ----
-{"name" : "MaxAzureDiskVolumeCount"}
+{"name" : "PodToleratesNodeNoExecuteTaints"}
 ----
 
 [id="admin-guide-scheduler-general-predicates_{context}"]
@@ -116,7 +131,7 @@ _The default scheduler policy includes the general predicates._
 [discrete]
 === Non-critical general predicates
 
-**_PodFitsResources_** determines a fit based on resource availability
+*PodFitsResources* determines a fit based on resource availability
 (CPU, memory, GPU, and so forth). The
 nodes can declare their resource capacities and then pods can specify what
 resources they require. Fit is based on requested, rather than used
@@ -127,24 +142,25 @@ resources.
 [discrete]
 ==== Essential general predicates
 
-**_PodFitsHostPorts_** determines if a node has free ports for the requested pod ports (absence
+*PodFitsHostPorts* determines if a node has free ports for the requested pod ports (absence
 of port conflicts).
 ----
 {"name" : "PodFitsHostPorts"}
 ----
 
-**_HostName_** determines fit based on the presence of the Host parameter
+*HostName* determines fit based on the presence of the Host parameter
 and a string match with the name of the host.
 ----
 {"name" : "HostName"}
 ----
 
-**_MatchNodeSelector_** determines fit based on node selector (nodeSelector) queries
+*MatchNodeSelector* determines fit based on node selector (nodeSelector) queries
 defined in the pod.
 ----
 {"name" : "MatchNodeSelector"}
 ----
 
+////
 [id="configurable-predicates_{context}"]
 == Configurable Predicates
 
@@ -160,7 +176,7 @@ long as their user-defined names are different.
 
 For information on using these priorities, see Modifying Scheduler Policy.
 
-**_ServiceAffinity_** places pods on nodes based on the service running on that pod.
+*ServiceAffinity* places pods on nodes based on the service running on that pod.
 Placing pods of the same service on the same or co-located nodes can lead to higher efficiency.
 
 This predicate attempts to place pods with specific labels
@@ -254,3 +270,4 @@ For example:
             }
         }
 ----
+////

--- a/modules/nodes-scheduler-default-priorities.adoc
+++ b/modules/nodes-scheduler-default-priorities.adoc
@@ -29,6 +29,21 @@ The default scheduler policy includes the following priorities. Each of
 the priority function has a weight of `1` except `*NodePreferAvoidPodsPriority*`,
 which has a weight of `10000`.
 
+**_NodeAffinityPriority_** prioritizes nodes according to node affinity scheduling preferences
+----
+{"name" : "NodeAffinityPriority", "weight" : 1}
+----
+
+**_TaintTolerationPriority_** prioritizes nodes that have a fewer number of _intolerable_ taints on them for a pod. An intolerable taint is one which has key `PreferNoSchedule`.
+----
+{"name" : "TaintTolerationPriority", "weight" : 1}
+----
+
+**_ImageLocalityPriority_** prioritizes nodes that already have requested pod container's images.
+----
+{"name" : "ImageLocalityPriority", "weight" : 1}
+----
+
 **_SelectorSpreadPriority_** looks for services, replication controllers (RC),
 replication sets (RS), and stateful sets that match the pod,
 then finds existing pods that match those selectors.
@@ -64,16 +79,6 @@ each other. This should always be used together with `LeastRequestedPriority`.
 {"name" : "NodePreferAvoidPodsPriority", "weight" : 10000}
 ----
 
-**_NodeAffinityPriority_** prioritizes nodes according to node affinity scheduling preferences
-----
-{"name" : "NodeAffinityPriority", "weight" : 1}
-----
-
-**_TaintTolerationPriority_** prioritizes nodes that have a fewer number of _intolerable_ taints on them for a pod. An intolerable taint is one which has key `PreferNoSchedule`.
-----
-{"name" : "TaintTolerationPriority", "weight" : 1}
-----
-
 [id="other-priorities_{context}"]
 === Other Static Priorities
 
@@ -91,11 +96,6 @@ requested by pods scheduled on the node, and prioritizes based on the maximum of
 
 ----
 {"name" : "MostRequestedPriority", "weight" : 1}
-----
-
-**_ImageLocalityPriority_** prioritizes nodes that already have requested pod container's images.
-----
-{"name" : "ImageLocalityPriority", "weight" : 1}
 ----
 
 **_ServiceSpreadingPriority_** spreads pods by minimizing the number of pods
@@ -127,19 +127,22 @@ concentration of pods.
 
 [source,json]
 ----
+{
+"kind": "Policy",
+"apiVersion": "v1",
+
 "priorities":[
     {
         "name":"<name>", <1>
         "weight" : 1 <2>
         "argument":{
             "serviceAntiAffinity":{
-                "label":[
-                    "<label>" <3>
-                ]
-            }
-        }
-    }
-]
+                "label": "<label>" <3>
+                }
+           }
+       }
+   ]
+}
 ----
 <1> Specify a name for the priority.
 <2> Specify a weight. Enter a non-zero positive value.
@@ -149,17 +152,22 @@ For example:
 
 [source,json]
 ----
-        "name":"RackSpread", <1>
-        "weight" : 1 <2>
-        "argument":{
-            "serviceAntiAffinity":{
-                "label": "rack" <3>
-            }
-        }
+{
+"kind": "Policy",
+"apiVersion": "v1",
+"priorities": [
+    {
+        "name":"RackSpread", 
+        "weight" : 1,
+        "argument": {
+            "serviceAntiAffinity": {
+                "label": "rack"
+                }
+           }
+       }
+   ]
+}
 ----
-<1> Specify a name for the priority.
-<2> Specify a weight. Enter a non-zero positive value.
-<3> Specify a label to match.
 
 [NOTE]
 ====
@@ -173,6 +181,9 @@ If no label is specified, priority is given to nodes that do not have a label.
 
 [source,json]
 ----
+{
+"kind": "Policy",
+"apiVersion": "v1",
 "priorities":[
     {
         "name":"<name>", <1>
@@ -181,10 +192,12 @@ If no label is specified, priority is given to nodes that do not have a label.
             "labelPreference":{
                 "label": "<label>", <3>
                 "presence": true <4>
+                }
             }
         }
-    }
-]
+    ]
+}
+
 ----
 <1> Specify a name for the priority.
 <2> Specify a weight. Enter a non-zero positive value.

--- a/modules/nodes-scheduler-default-sample.adoc
+++ b/modules/nodes-scheduler-default-sample.adoc
@@ -10,18 +10,39 @@ were to be specified using the scheduler policy file.
 
 [source,yaml]
 ----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: mypolicy
-  namespace: openshift-config
-  selfLink: /api/v1/namespaces/openshift-config/configmaps/mypolicy
-  uid: 83917dfb-4422-11e9-b2c9-0a5e37b2b12e
-  resourceVersion: '1100851'
-  creationTimestamp: '2019-03-11T17:24:23Z'
-data:
-  policy.cfg: "{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"PodFitsHostPorts\"},\n\t{\"name\" : \"PodFitsResources\"},\n\t{\"name\" : \"NoDiskConflict\"},\n\t{\"name\" : \"NoVolumeZoneConflict\"},\n\t{\"name\" : \"MatchNodeSelector\"},\n\t{\"name\" : \"HostName\"}\n\t],\n\"priorities\" : [\n\t{\"name\" : \"LeastRequestedPriority\", \"weight\" : 10},\n\t{\"name\" : \"BalancedResourceAllocation\", \"weight\" : 1},\n\t{\"name\" : \"ServiceSpreadingPriority\", \"weight\" : 1},\n\t{\"name\" : \"EqualPriority\", \"weight\" : 1},\n\t{\"name\" : \"labelPreference\", \"label\" : \"rack\", \"presence\" : \"true\", \"weight\" : 2},\n\t]\n}\n "
+{
+"kind": "Policy",
+"apiVersion": "v1",
+"predicates": [
+    {
+        "name": "RegionZoneAffinity", <1>
+        "argument": {
+            "serviceAffinity": {  <2>
+              "labels": "region, zone"  <3>
+           }
+        }
+     }
+  ],
+"priorities": [
+    {
+        "name":"RackSpread", <4>
+        "weight" : 1,
+        "argument": {
+            "serviceAntiAffinity": {  <5>
+                "label": "rack"  <6>
+                }
+           }
+       }
+   ]
+}
 ----
+
+<1> The name for the predicate.
+<2> The type of predicate.
+<3> The labels for the predicate.
+<4> The name for the priority.
+<5> The type of priority.
+<6> The labels for the priority.
 
 
 In all of the sample configurations below, the list of predicates and priority
@@ -33,15 +54,73 @@ The following example defines three topological levels, region (affinity) -> zon
 
 [source,yaml]
 ----
-"{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"RegionZoneAffinity\", \"label\" : \"region\", \"label\" : \"zone\"}\n\t],\n\"priorities\" : [\n\t{\"name\" : \"serviceAntiAffinity\", \"label\" : \"rack\", \"weight\" : 1},\n\t]\n}\n"
+{
+"kind": "Policy",
+"apiVersion": "v1",
+"predicates": [
+    {
+        "name": "RegionZoneAffinity",
+        "argument": {
+            "serviceAffinity": {
+              "label": "region, zone"
+           }
+        }
+     }
+  ],
+"priorities": [
+    {
+        "name":"RackSpread",
+        "weight" : 1,
+        "argument": {
+            "serviceAntiAffinity": {
+                "label": "rack"
+                }
+           }
+       }
+   ]
+}
 ----
+
 
 The following example defines three topological levels, city (affinity) -> building
 (anti-affinity) -> room (anti-affinity):
 
 [source,yaml]
 ----
-"{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"serviceAffinityy\", \"label\" : \"city\"},\n\t],\n\"priorities\" : [\n\t{\"name\" : \"serviceAntiAffinity\", \"label\" : \"building\" \"weight\" : 1}, \n\t{\"name\" : \"serviceAntiAffinity\", \"label\" : \"room\" \"weight\" : 1},\n\t]\n}\n"
+{
+"kind": "Policy",
+"apiVersion": "v1",
+"predicates": [
+    {
+        "name": "CityAffinity",
+        "argument": {
+            "serviceAffinity": {
+              "label": "city"
+           }
+        }
+     }
+  ],
+"priorities": [
+    {
+        "name":"BuildingSpread",
+        "weight" : 1,
+        "argument": {
+            "serviceAntiAffinity": {
+                "label": "building"
+                }
+           }
+       },
+    {
+        "name":"RoomSpread",
+        "weight" : 1,
+        "argument": {
+            "serviceAntiAffinity": {
+                "label": "room"
+                }
+           }
+       }
+   ]
+}
 ----
 
 The following example defines a policy to only use nodes with the 'region' label defined and prefer nodes with the 'zone'
@@ -49,7 +128,33 @@ label defined:
 
 [source,yaml]
 ----
-"{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"labelsPresence\", \"label\" : \"region\", \"presence\" : \"true\"},\n\t],\n\"priorities\" : [\n\t{\"name\" : \"ZonePreferred\", \"label\" : \"zone\", \"presence\" : \"true\", \"weight\" : 1},\n\t]\n}\n"
+{
+"kind": "Policy",
+"apiVersion": "v1",
+"predicates": [
+    {
+        "name": "RequireRegion",
+        "argument": {
+            "labelPreference": {
+                "label": "region",
+                "presence": true
+           }
+        }
+     }
+  ],
+"priorities": [
+    {
+        "name":"ZonePreferred",
+        "weight" : 1,
+        "argument": {
+            "labelPreference": {
+                "label": "zone",
+                "presence": true
+                }
+           }
+       }
+   ]
+}
 ----
 
 The following example combines both static and configurable predicates and
@@ -57,6 +162,61 @@ also priorities:
 
 [source,yaml]
 ----
-"{\n\"kind\" : \"Policy\",\n\"apiVersion\" : \"v1\",\n\"predicates\" : [\n\t{\"name\" : \"labelsPresence\", \"label\" : \"building\", \"presence\" : \"true\"}, \n\t{\"name\" : \"PodFitsHostPorts\"},\n\t{\"name\" : \"MatchNodeSelector\"},\n\t],\n\"priorities\" : [\n\t{\"name\" : \"ZonePreferred\", \"label\" : \"zone\", \"presence\" : \"true\", \"weight\" : 1},\n\t]\n}\n \"
+{
+"kind": "Policy",
+"apiVersion": "v1",
+"predicates": [
+    {
+        "name": "RegionAffinity",
+        "argument": {
+            "serviceAffinity": {
+                "label": "region"
+           }
+        }
+     },
+    {
+        "name": "RequireRegion",
+        "argument": {
+            "labelsPresence": {
+                "label": "region",
+                "presence": true
+           }
+        }
+     },
+    {
+        "name": "BuildingNodesAvoid",
+        "argument": {
+            "labelsPresence": {
+                "label": "building",
+                "presence": false
+           }
+        }
+     },
+     {"name" : "PodFitsPorts"},
+     {"name" : "MatchNodeSelector"}
+     ],
+"priorities": [
+    {
+        "name": "ZoneSpread",
+        "weight" : 2,
+        "argument": {
+            "serviceAntiAffinity":{
+                "label": "zone"
+                }
+           }
+       },
+    {
+        "name":"ZonePreferred",
+        "weight" : 1,
+        "argument": {
+            "labelPreference":{
+                "label": "zone",
+                "presence": true
+                }
+           }
+       },
+    {"name" : "ServiceSpreadingPriority", "weight" : 1}
+    ]
+}
 ----
 

--- a/nodes/scheduling/nodes-scheduler-about.adoc
+++ b/nodes/scheduling/nodes-scheduler-about.adoc
@@ -32,3 +32,61 @@ In situations where you might want more control over where new pods are placed, 
 * Placing pods on xref:../../nodes/scheduling/nodes-scheduler-overcommit.adoc#nodes-scheduler-overcommit[overcomitted nodes].
 * Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[node selectors].
 * Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[taints and tolerations].
+
+[id="nodes-scheduler-about-use-cases_{context}"]
+== Scheduler Use Cases
+
+One of the important use cases for scheduling within {product-title} is to
+support flexible affinity and anti-affinity policies.
+ifdef::openshift-enterprise,openshift-origin[]
+
+[id="infrastructure-topological-levels_{context}"]
+=== Infrastructure Topological Levels
+
+Administrators can define multiple topological levels for their infrastructure
+(nodes) by specifying labels on nodes. For example: `region=r1`, `zone=z1`, `rack=s1`.
+
+These label names have no particular meaning and
+administrators are free to name their infrastructure levels anything, such as
+city/building/room. Also, administrators can define any number of levels
+for their infrastructure topology, with three levels usually being adequate
+(such as: `regions` -> `zones` -> `racks`).  Administrators can specify affinity
+and anti-affinity rules at each of these levels in any combination.
+endif::openshift-enterprise,openshift-origin[]
+
+[id="affinity_{context}"]
+=== Affinity
+
+Administrators should be able to configure the scheduler to specify affinity at
+any topological level, or even at multiple levels. Affinity at a particular
+level indicates that all pods that belong to the same service are scheduled
+onto nodes that belong to the same level. This handles any latency requirements
+of applications by allowing administrators to ensure that peer pods do not end
+up being too geographically separated. If no node is available within the same
+affinity group to host the pod, then the pod is not scheduled.
+
+If you need greater control over where the pods are scheduled, see Using Node Affinity and
+Using Pod Affinity and Anti-affinity.
+
+These advanced scheduling features allow administrators
+to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
+
+
+[id="anti-affinity_{context}"]
+=== Anti-Affinity
+
+Administrators should be able to configure the scheduler to specify
+anti-affinity at any topological level, or even at multiple levels.
+Anti-affinity (or 'spread') at a particular level indicates that all pods that
+belong to the same service are spread across nodes that belong to that
+level. This ensures that the application is well spread for high availability
+purposes. The scheduler tries to balance the service pods across all
+applicable nodes as evenly as possible.
+
+If you need greater control over where the pods are scheduled, see Using Node Affinity and
+Using Pod Affinity and Anti-affinity.
+
+These advanced scheduling features allow administrators
+to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
+
+>>>>>>> edits

--- a/nodes/scheduling/nodes-scheduler-default.adoc
+++ b/nodes/scheduling/nodes-scheduler-default.adoc
@@ -16,6 +16,8 @@ independent and exists as a standalone/pluggable solution. It does not modify
 the pod and just creates a binding for the pod that ties the pod to the
 particular node.
 
+A selection of xref:../nodes/scheduling/nodes-scheduler-default.adoc#nodes-scheduler-default-about-understanding_nodes-scheduler-default[predicates and priorities] defines the policy for the scheduler. See xref:../nodes/scheduling/nodes-scheduler-default.html#nodes-scheduler-default-modifying_nodes-scheduler-default[Modifying scheduler policy] for a list of predicates and priorities. 
+
 .Sample default scheduler object
 ----
 apiVersion: config.openshift.io/v1


### PR DESCRIPTION
I see scheduler named 'cluster' is already present in cluster and there would be no scheduler.yaml file.
I guess this statement meant to say that edit existing scheduler named 'cluster' to refer to newly created ConfigMap 'scheduler-policy'?
https://github.com/openshift/openshift-docs/issues/14564

Removing the step to create the `scheduler.yaml` file.