### PR TITLE
UDP services not supported with Kuryr SDN

### DIFF
--- a/install_config/topics/ocp_osp_provisioning.adoc
+++ b/install_config/topics/ocp_osp_provisioning.adoc
@@ -223,6 +223,13 @@ Network policies and nodeport services are not supported when Kuryr SDN is
 enabled.
 ====
 
+[NOTE]
+====
+When Kuryr SDN is enabled, OpenShift services are implemented through Octavia
+Amphora VMs. As OSP Octavia does not yet support UDP load balancing, if Kuryr
+SDN is used services exposing UDP ports are not supported.
+====
+
 Brief description of each variable in the table below:
 
 


### PR DESCRIPTION
Add info about UDP services not being supported on Kuryr SDN
due to missing support on the Octavia side.