### PR TITLE
Command to validate the event router is installed contains extraneous back tick

### DIFF
--- a/modules/efk-logging-eventrouter-deploy.adoc
+++ b/modules/efk-logging-eventrouter-deploy.adoc
@@ -150,7 +150,7 @@ deployment.apps/cluster-logging-eventrouter created
 . Validate that the Event Router installed:
 +
 ----
-$ oc get pods --selector  component=eventrouter -o name`
+$ oc get pods --selector  component=eventrouter -o name
 
 pod/cluster-logging-eventrouter-d649f97c8-qvv8r
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1704935