### PR TITLE
Fixes Bug 1704610: Moves route config to it's own topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -369,6 +369,8 @@ Topics:
     File: ingress-controller-configuration
   - Name: Routing from edge load balancers
     File: routing-from-edge-load-balancer
+  - Name: Route configuration
+    File: route-configuration
 ---
 Name: Registry
 Dir: registry

--- a/networking/ingress/ingress-controller-configuration.adoc
+++ b/networking/ingress/ingress-controller-configuration.adoc
@@ -6,21 +6,5 @@ include::modules/common-attributes.adoc[]
 :context: ingress-controller-configuration
 toc::[]
 
-//Creating secured routes
-include::modules/nw-creating-secured-routes.adoc[leveloffset=+1]
-//
-//Creating route timeouts
-include::modules/nw-configuring-route-timeouts.adoc[leveloffset=+1]
-//
-//Enabling HTTP Strict Transport Security
-include::modules/nw-enabling-hsts.adoc[leveloffset=+1]
-//
-//Troubleshooting Throughput Issues
-include::modules/nw-throughput-troubleshoot.adoc[leveloffset=+1]
-//
-//Using cookies to keep route statefulness
-include::modules/nw-using-cookies-keep-route-statefulness.adoc[leveloffset=+1]
-include::modules/nw-annotating-a-route-with-a-cookie-name.adoc[leveloffset=+2]
-//
 //Scaling an Ingress Controller
 include::modules/nw-scaling-ingress-controller.adoc[leveloffset=+1]

--- a/networking/ingress/route-configuration.adoc
+++ b/networking/ingress/route-configuration.adoc
@@ -1,0 +1,23 @@
+// Assembly filename:route-configuration.adoc
+// Explains route configuration.
+[id="route-configuration"]
+= Route configuration
+include::modules/common-attributes.adoc[]
+:context: route-configuration
+toc::[]
+
+//Creating secured routes
+include::modules/nw-creating-secured-routes.adoc[leveloffset=+1]
+//
+//Creating route timeouts
+include::modules/nw-configuring-route-timeouts.adoc[leveloffset=+1]
+//
+//Enabling HTTP Strict Transport Security
+include::modules/nw-enabling-hsts.adoc[leveloffset=+1]
+//
+//Troubleshooting Throughput Issues
+include::modules/nw-throughput-troubleshoot.adoc[leveloffset=+1]
+//
+//Using cookies to keep route statefulness
+include::modules/nw-using-cookies-keep-route-statefulness.adoc[leveloffset=+1]
+include::modules/nw-annotating-a-route-with-a-cookie-name.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR does the following:
- Adds route config topic to topic map.
- Moves route adoc references from ingress config topic to route config topic. 