### PR TITLE
Minor additions/fixes to ingress operator docs

### DIFF
--- a/modules/nw-ingress-view.adoc
+++ b/modules/nw-ingress-view.adoc
@@ -9,8 +9,9 @@ The Ingress Operator is a core feature of {product-title} and is enabled out of 
 box.
 
 Every new {product-title} installation has an `ingresscontroller` named default. It
-can be customized, replaced, or supplemented with additional ingress
-controllers.
+can be supplemented with additional ingress controllers. If the default
+`ingresscontroller` is deleted, the Ingress Operator will automatically recreate it
+within a minute.
 
 .Procedure
 

--- a/networking/ingress/configuring-ingress-operator.adoc
+++ b/networking/ingress/configuring-ingress-operator.adoc
@@ -5,15 +5,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The Ingress Operator is an OpenShift component that enables external access to
-cluster services by configuring Ingress Controllers. You can use the Ingress
-Operator to route traffic by specifying OpenShift `Route` and Kubernetes `Ingress`
-resources.
-
-The Ingress Operator deploys and manages an OpenShift router, which is a
-HAProxy-based Kubernetes Ingress controller.
-
-Ingress Operator implements the OpenShift `ingresscontroller` API.
+The Ingress Operator implements the `ingresscontroller` API and is the
+component responsible for enabling external access to OpenShift
+cluster services. The operator makes this possible by deploying and
+managing one or more HAProxy-based
+link:https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/[Ingress Controllers].
+You can use the Ingress Operator to route traffic by specifying OpenShift
+`Route` and Kubernetes `Ingress` resources.
 
 include::modules/nw-installation-ingress-config-asset.adoc[leveloffset=+1]
 


### PR DESCRIPTION
- Explains that the default `ingresscontroller` will be auto recreated.
- Modifies the Ingress Operator intro in `configuring-ingress-operator.adoc`
