### PR TITLE
[enterprise-3.11] Add ARO to CLI install step

### DIFF
--- a/cli_reference/get_started_cli.adoc
+++ b/cli_reference/get_started_cli.adoc
@@ -44,7 +44,7 @@ endif::[]
 
 [[installing-the-cli]]
 == Installing the CLI
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-aro[]
 The easiest way to download the CLI is by accessing the *Command Line Tools* page on the web
 console:
 endif::[]
@@ -52,7 +52,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 The easiest way to download the CLI is by accessing the *About* page on the web
 console if your cluster administrator has enabled the download links:
 endif::[]
-ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated,openshift-aro[]
 
 image::ocp_37_cli_help.png["Command Line Tools"]
 endif::[]


### PR DESCRIPTION
Actual step & image was missing in ARO.