### PR TITLE
sdn: document how to allow access from ingress

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -47,9 +47,6 @@ spec:
   podSelector:
   ingress: []
 ----
-////
-
-// Blocked on https://github.com/openshift/cluster-ingress-operator/pull/218
 
 * Only allow connections from the {product-title} ingress router:
 +
@@ -61,18 +58,17 @@ router, add the following `NetworkPolicy` object:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-from-openshift-ingress-namespace
+  name: allow-from-openshift-ingress
 spec:
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: openshift-ingress
+          network.openshift.io/policy-group: ingress
   podSelector: {}
   policyTypes:
   - Ingress
 ----
-////
 * Only accept connections from Pods within a project:
 +
 To make Pods accept connections from other Pods in the same project, but reject


### PR DESCRIPTION
Now that the ingress namespace is labeled appropriately, we can select for it.