### PR TITLE
Add cluster limits for OpenShift 4.1

### DIFF
--- a/modules/how-to-plan-your-environment-according-to-cluster-limits.adoc
+++ b/modules/how-to-plan-your-environment-according-to-cluster-limits.adoc
@@ -12,6 +12,12 @@ Kubernetes scheduler makes during pod placement. Learn what measures you can
 take to avoid memory swapping.
 ====
 
+[IMPORTANT]
+====
+Some of the limits are stretched only in a single dimension. They will vary
+when many objects are running on the cluster.
+====
+
 While planning your environment, determine how many pods are expected to fit per
 node:
 

--- a/modules/openshift-cluster-limits.adoc
+++ b/modules/openshift-cluster-limits.adoc
@@ -13,71 +13,72 @@
 | 2,000
 | 2,000
 | 2,000
-|TBD
+| 250
 
 | Number of pods footnoteref:[numberofpods,The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.]
 | 120,000
 | 150,000
 | 150,000
-|TBD
+| 150,000
 
 | Number of pods per node
 | 250
 | 250
 | 250
-|TBD
+| 250
 
 | Number of pods per core
 | 10 is the default value. The maximum supported value is the number of pods per node.
 | There is no default value. The maximum supported value is the number of pods per node.
 | There is no default value. The maximum supported value is the number of pods per node.
-|TBD
+| There is no default value. The maximum supported value is the number of pods per node.
 
-| Number of namespaces
+| Number of namespaces footnoteref:[numberofnamepaces, When there are a large number of active projects, etcd may suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.]
 | 10,000
 | 10,000
 | 10,000
-|TBD
+| 8,000
 
 | Number of builds: Pipeline Strategy
 | 10,000 (Default pod RAM 512 Mi)
 | 10,000 (Default pod RAM 512 Mi)
 | 10,000 (Default pod RAM 512 Mi)
-|TBD
+| 10,000 (Default pod RAM 512 Mi)
 
 | Number of pods per namespace footnoteref:[objectpernamespace,There are
 a number of control loops in the system that must iterate over all objects
 in a given namespace as a reaction to some changes in state. Having a large
 number of objects of a given type in a single namespace can make those loops
-expensive and slow down processing given state changes.]
+expensive and slow down processing given state changes. The limit assumes that 
+the system has enough CPU, memory, and disk to satisfy the application requirements.]
 | 3,000
 | 3,000
-| 3,000
-|TBD
+| 25,000
+| 25,000
 
 | Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
 | 10,000
 | 10,000
 | 10,000
-|TBD
+| 10,000
 
 | Number of services per namespace
 | N/A
 | 5,000
 | 5,000
-|TBD
+| 5,000
 
 | Number of back-ends per service
 | 5,000
 | 5,000
 | 5,000
-|TBD
+| 5,000
 
 | Number of deployments per namespace footnoteref:[objectpernamespace]
 | 2,000
 | 2,000
 | 2,000
-|TBD
+| 2,000
 
 |===
 


### PR DESCRIPTION
This commit:
- Updates the limits page for OpenShift 4.1 based on the large scale
  test run.
- Adds a note about the single dimentional analysis we used for
  determining/validating some of the limits.