### PR TITLE
update weight default in route to service

### DIFF
--- a/architecture/topics/alternate_backends_weights.adoc
+++ b/architecture/topics/alternate_backends_weights.adoc
@@ -22,7 +22,7 @@ more than one  endpoint, the service's weight is distributed among the endpoints
 with each endpoint getting at least 1. If the service `weight` is 0 each
 of the service's endpoints will get 0.
 
-The `weight` must be in the range 0-256. The default is 1. When the `weight` is
+The `weight` must be in the range 0-256. The default is 100. When the `weight` is
 0, the service does not participate in load-balancing but continues to serve 
 existing persistent connections.
 


### PR DESCRIPTION
**What**
Update route default to 100.

Based on my investigations the default value for the Route -> spec -> to -> weight is 100 when unspecified.