### PR TITLE
Remove unnecessary HAProxy details from note

### DIFF
--- a/modules/nw-creating-secured-routes.adoc
+++ b/modules/nw-creating-secured-routes.adoc
@@ -19,9 +19,8 @@ $ sudo openssl genrsa -out example-test.key 2048
 +
 [NOTE]
 ====
-Currently, password protected key files are not supported. HAProxy prompts
-for a password upon starting and does not have a way to automate this process.
-To remove a passphrase from a keyfile, use the following command:
+Password protected key files are not supported. To remove a passphrase from a
+keyfile, use the following command:
 ----
 $ sudo openssl rsa -in <passwordProtectedKey.key> -out <new.key>
 ----


### PR DESCRIPTION
The reason why password protected key files are unsupported seems
irrelevant in this context. Shorten the note to simply indicate
the support status and workaround.