### PR TITLE
Simplify custom ingress certificate procedure

### DIFF
--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -18,7 +18,7 @@ ingress domain.
 * You must have an `IngressController` CR. You may use the default one:
 +
 ----
-$ oc -n openshift-ingress-operator get ingresscontrollers
+$ oc --namespace openshift-ingress-operator get ingresscontrollers
 NAME      AGE
 default   10m
 ----
@@ -31,55 +31,38 @@ actual path names for `tls.crt` and `tls.key`. You also may substitute another
 name for `custom-certs-default` when creating the `Secret` resource and
 referencing it in the `IngressController` CR.
 
-. Create a `Secret` resource containing the custom certificate in the
-`openshift-ingress` namespace.
-+
-.. Create a `Secret` resource using the `tls.crt` and `tls.key` files.
-+
-----
-$ oc -n openshift-ingress create secret tls custom-certs-default --cert=tls.crt --key=tls.key
-----
-+
-. Modify the `IngressController` CR:
-+
-.. Open the `IngressController` CR for editing:
-+
-----
-$ oc -n openshift-ingress-operator edit ingresscontrollers/default
-----
-+
-For example:
-+
-----
-oc -n openshift-ingress-operator edit ingresscontrollers/default
+[NOTE]
+====
+This action will cause the ingress controller to be redeployed, using a rolling deployment strategy.
+====
 
-apiVersion: ingresscontroller.operator.openshift.io/v1
-kind: IngressController
-metadata:
-  creationTimestamp: 2019-03-04T00:18:48Z
-  generation: 1
-  name: default
-  namespace: openshift-ingress-operator
-  resourceVersion: "15872"
-  selfLink: /apis/operator.operator.openshift.io/v1/namespaces/openshift-ingress-operator/ingresscontrollers/default
-  uid: e8f5dc3c-5300-43d5-a0c7-48ebf228634f
-namespace: openshift-ingress-operator
+. Create a `Secret` resource containing the custom certificate in the
+`openshift-ingress` namespace using the `tls.crt` and `tls.key` files.
++
+----
+$ oc --namespace openshift-ingress create secret tls custom-certs-default --cert=tls.crt --key=tls.key
 ----
 +
-.. Change the `defaultCertificate` parameter:
+. Update the `IngressController` CR to reference the new certificate secret:
 +
-.Sample Ingress Controller
-[source,yaml]
 ----
-spec:
-  defaultCertificate:
-    name: "custom-certs-default" <1>
+$ oc patch --type=merge --namespace openshift-ingress-operator ingresscontrollers/default \
+  --patch '{"spec":{"defaultCertificate":{"name":"custom-certs-default"}}}'
 ----
 +
-<1> Name of the `Secret` resource in the `openshift-ingress` namespace with the
-TLS secret for the ingress controller.
+. Verify the update was effective:
 +
-As soon as the `IngressController` CR has been modified, the ingress operator
+----
+$ oc get --namespace openshift-ingress-operator ingresscontrollers/default \
+  --output jsonpath='{.spec.defaultCertificate}'
+----
+The output should look like:
++
+----
+map[name:custom-certs-default]
+----
++
+The certificate secret name should match the value used to update the CR.
+
+Once the `IngressController` CR has been modified, the ingress operator
 will update the ingress controller's deployment to use the custom certificate.
-Note that this action will cause the ingress controller to be redeployed, using
-a rolling deployment strategy.


### PR DESCRIPTION
Use `oc patch` to simplify the procedure. Make the rollout note more
visible.