### PR TITLE
Add recommendation for speeding up kubelet config changes

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -69,3 +69,24 @@ $ oc apply -f max-worker-pods.yaml
 ----
 $ oc get kubeletconfigs set-max-pods -o yaml
 ----
+
+By default, only one machine is allowed to be unavailable when applying the kubelet-related configuration to the available worker nodes. For a large cluster, it can take a long time for the configuration change to be reflected. At any time, you can adjust the number of machines that are updating to speed up the process.
+
+.Procedure
+. Run:
++
+----
+$ oc edit machineconfigpool worker
+----
++
+. Set `maxUnavailable` to the desired value.
++
+----
+spec:
+  maxUnavailable: <node_count>
+----
+
+[IMPORTANT]
+====
+When setting the value, consider the number of worker nodes that can be unavailable without affecting the applications running on the cluster.
+====


### PR DESCRIPTION
This commit adds the procedure to tweak the max number of machines
that can be unavailable at any given time during a config change.
The default is 1 and it's low for large clusters.