### PR TITLE
Remove link to Google+ community from footer

### DIFF
--- a/_templates/_footer_origin.html.erb
+++ b/_templates/_footer_origin.html.erb
@@ -13,11 +13,6 @@
               <i class="fa fa-github fa-2x fa-inverse"></i>
             </span>
           </a>
-          <a href="https://plus.google.com/communities/114361859072744017486">
-            <span>
-              <i class="fa fa-google-plus-square fa-2x fa-inverse"></i>
-            </span>
-          </a>
           <a href="https://www.facebook.com/openshift">
             <span>
               <i class="fa fa-facebook-square fa-2x fa-inverse"></i>


### PR DESCRIPTION
**Why**
Google+ is no longer available for personal and brand accounts. (See https://plus.google.com)
The link in the footer that pointed to the OpenShift Google+ community is now broken. 

**What**
This PR removes the defunct link to the Google+ community in the footer.

---
(And by the way: Your documentation for OpenShift is amazing!)