### PR TITLE
For 3.10 2 params for mixed environments

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -923,12 +923,24 @@ OpenShift upgrades] for further guidance.
 [[special-considerations-for-mixed-environments]]
 == Special Considerations for Mixed Environments
 
-Mixed environment upgrades (for example, those with Red Hat Enterprise Linux and
-Red Hat Enterprise Linux Atomic Host) require setting both
-`openshift_pkg_version` and `openshift_image_tag`. In mixed environments,  if
-you only specify `openshift_pkg_version`, then that number is used for the
-packages for Red Hat Enterprise Linux and the image for Red Hat Enterprise
-Linux Atomic Host.
+Before you upgrade a mixed environment, such as one with Red Hat Enterprise
+Linux (RHEL) and RHEL Atomic Host, set values in the inventory file
+for both the `openshift_pkg_version` and `openshift_image_tag` parameters.
+Setting these values ensures that all nodes in your cluster run the same
+version of {product-title}.
+
+For example, to upgrade from {product-title}
+3.9 to {product-title} 3.10, set the following parameters and values:
+
+----
+openshift_pkg_version=-3.10.16
+openshift_image_tag=v3.10.16
+----
+
+[NOTE]
+====
+These parameters can also be present in other, non-mixed, environments.
+====
 
 [[special-considerations-for-glusterfs]]
 == Special Considerations When Using Containerized GlusterFS


### PR DESCRIPTION
For bug https://bugzilla.redhat.com/show_bug.cgi?id=1698640.

This PR is for getting updates into enterprise-3.10. Previous PR (https://github.com/openshift/openshift-docs/pull/14638) was able to cherrypick to 3.11 only, but the update applies to 3.10 also. (See last comment from kalexand-rh to create new PRs to get the update into 3.10 and 3.9. This PR is for 3.10.)