### PR TITLE
BZ-1708731: Removed unconventional markup

### DIFF
--- a/applications/operators/olm-what-operators-are.adoc
+++ b/applications/operators/olm-what-operators-are.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-[.lead]
 Conceptually, _Operators_ take human operational knowledge and encode it into
 software that is more easily shared with consumers.
 
@@ -17,7 +16,6 @@ Advanced Operators are designed to handle upgrades seamlessly, react to failures
 automatically, and not take shortcuts, like skipping a software backup process
 to save time.
 
-[.lead]
 More technically, _Operators_ are a method of packaging, deploying, and managing a
 Kubernetes application.
 


### PR DESCRIPTION
@adellape Would you mind peer reviewing this? It's a request to remove the [.lead] markup, which we don't really seem to use like this elsewhere in the docs.