### PR TITLE
Fix documentation link customization code snippet

### DIFF
--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -199,7 +199,7 @@ attributes of existing links. For example:
 
 [source, javascript]
 ----
-window.OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES.push({
+window.OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES.links.push({
   title: 'Blog',
   href: 'https://blog.openshift.com'
 });


### PR DESCRIPTION
This PR fixes the code snippet in the documentation which is supposed to help in customizing the web console download links.

/closes #14825 

/cc @pweil- 