### PR TITLE
BZ-1707397: Removed deny OAuth grant option.

### DIFF
--- a/modules/oauth-internal-options.adoc
+++ b/modules/oauth-internal-options.adoc
@@ -35,4 +35,3 @@ methods:
 [horizontal]
 `auto`:: Auto-approve the grant and retry the request.
 `prompt`:: Prompt the user to approve or deny the grant.
-`deny`:: Auto-deny the grant and return a failure error to the client.

--- a/modules/oauth-register-additional-client.adoc
+++ b/modules/oauth-register-additional-client.adoc
@@ -36,6 +36,5 @@ to `_<namespace_route>_/oauth/token`.
 prefixed by one of the URIs listed in the `redirectURIs` parameter value.
 <4> The `grantMethod` is used to determine what action to take when this client
 requests tokens and has not yet been granted access by the user. Specify `auto`
-to automatically approve the grant and retry the request, `prompt` to prompt the
-user to approve or deny the grant, or `deny` to deny the grant and return a
-failure error to the client.
+to automatically approve the grant and retry the request, or `prompt` to 
+prompt the user to approve or deny the grant


### PR DESCRIPTION
Removed the `deny` OAuth grant option.

This is for OS 4.x.