### PR TITLE
clarified Curator description

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1682,8 +1682,9 @@ Where `$espod` is the name of any one of your Elasticsearch pods.
 Curator allows administrators to configure scheduled Elasticsearch maintenance
 operations to be performed automatically on a per-project basis. It is scheduled
 to perform actions daily based on its configuration. Only one Curator pod is
-recommended per Elasticsearch cluster. Curator is configured via a YAML
-configuration file with the following structure:
+recommended per Elasticsearch cluster. Curator pods only run at the time stated
+in the cronjob and then the pod terminates upon completion. Curator is
+configured via a YAML configuration file with the following structure:
 
 [NOTE]
 ====


### PR DESCRIPTION
Added some clarification around Curator function, describing that the pod only exists while the cronjob is active. This functionality is only in enterprise-3.11.

@openshift/team-documentation please review :) 