### PR TITLE
Added OCP 3.11 support statement for RHEL 7 nodes running in FIPS mode

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -39,6 +39,9 @@ that pertain to {product-title} 3.11 are included in this topic.
 the latest packages from Extras, including CRI-O 1.11 and Docker 1.13. It is
 also supported on Atomic Host 7.5 and later.
 
+{product-title} 3.11 is supported on Red Hat Enterprise Linux 7 nodes running in
+Federal Information Processing Standards (FIPS) mode.
+
 For initial installations, see the
 xref:../install/index.adoc#install-planning[Installing Clusters] documentation.
 


### PR DESCRIPTION
@vikram-redhat @sheriff-rh @aheslin adding this statement per the email discussion with @knewcomerRH 