### PR TITLE
BZ-1711090: Adjusted ingress usage.

### DIFF
--- a/modules/architecture-overview.adoc
+++ b/modules/architecture-overview.adoc
@@ -17,7 +17,7 @@ and managing utilities that your apps use.
 {product-title} 4 runs on top of a Kubernetes cluster, with data about the
 objects stored in etcd, a reliable clustered key-value store. The cluster is
 enhanced with standard components that are required to run your cluster, including
-network, ingress, logging, and monitoring, that run as Operators to increase the
+network, Ingress, logging, and monitoring, that run as Operators to increase the
 ease and automation of installation, scaling, and maintenance.
 
 ////

--- a/modules/baseline-router-performance.adoc
+++ b/modules/baseline-router-performance.adoc
@@ -1,7 +1,7 @@
 [id="baseline-router-performance_{context}"]
 = Baseline router performance
 
-The {product-title} router is the ingress point for all external traffic
+The {product-title} router is the Ingress point for all external traffic
 destined for {product-title} services.
 
 When evaluating a single HAProxy router performance in terms of

--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -174,7 +174,7 @@ endpoint that references the route tables for each subnet.
 |* `AWS::EC2::Subnet`
 * `AWS::EC2::SubnetNetworkAclAssociation`
 2+|Your VPC must have public subnets for between 1 and 3 availability zones
-and associate them with appropriate ingress rules.
+and associate them with appropriate Ingress rules.
 
 |Internet gateway
 |
@@ -346,9 +346,9 @@ The control plane and worker machines require access to the following ports:
 
 |===
 
-.Control plane ingress
+.Control plane Ingress
 
-The control plane machines require the following ingress groups. Each ingress group is
+The control plane machines require the following Ingress groups. Each Ingress group is
 a `AWS::EC2::SecurityGroupIngress` resource.
 
 [cols="2a,5a,2a,2a",options="header"]
@@ -396,21 +396,21 @@ a `AWS::EC2::SecurityGroupIngress` resource.
 |`10250` - `10259`
 
 |`MasterIngressIngressServices`
-|Kubernetes ingress services
+|Kubernetes Ingress services
 |`tcp`
 |`30000` - `32767`
 
 |`MasterIngressWorkerIngressServices`
-|Kubernetes ingress services
+|Kubernetes Ingress services
 |`tcp`
 |`30000` - `32767`
 
 |===
 
 
-.Worker ingress
+.Worker Ingress
 
-The worker machines require the following ingress groups. Each ingress group is
+The worker machines require the following Ingress groups. Each Ingress group is
 a `AWS::EC2::SecurityGroupIngress` resource.
 
 [cols="2a,5a,2a,2a",options="header"]
@@ -453,12 +453,12 @@ a `AWS::EC2::SecurityGroupIngress` resource.
 |`10250`
 
 |`WorkerIngressIngressServices`
-|Kubernetes ingress services
+|Kubernetes Ingress services
 |`tcp`
 |`30000` - `32767`
 
 |`WorkerIngressWorkerIngressServices`
-|Kubernetes ingress services
+|Kubernetes Ingress services
 |`tcp`
 |`30000` - `32767`
 

--- a/modules/installation-dns-user-infra.adoc
+++ b/modules/installation-dns-user-infra.adoc
@@ -33,7 +33,7 @@ nodes within the cluster.
 |Routes
 |`*.apps.<cluster_name>.<base_domain>`
 |A wildcard DNS record that points to the load balancer that targets the
-machines that  run the ingress router pods, which are the worker nodes by
+machines that  run the Ingress router pods, which are the worker nodes by
 default. This record must be resolvable by both clients external to the cluster
 and from all the nodes within the cluster.
 

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -86,13 +86,13 @@ balancer after the bootstrap machine initializes the cluster control plane.
 |Machine Config server
 
 |`443`
-|The machines that run the ingress router pods, compute, or worker, by default.
+|The machines that run the Ingress router pods, compute, or worker, by default.
 |x
 |x
 |HTTPS traffic
 
 |`80`
-|The machines that run the ingress router pods, compute, or worker by default.
+|The machines that run the Ingress router pods, compute, or worker by default.
 |x
 |x
 |HTTP traffic
@@ -101,7 +101,7 @@ balancer after the bootstrap machine initializes the cluster control plane.
 
 [NOTE]
 ====
-A working configuration for the ingress router is required for an
-{product-title} cluster. You must configure the ingress router after the control
+A working configuration for the Ingress router is required for an
+{product-title} cluster. You must configure the Ingress router after the control
 plane initializes.
 ====

--- a/modules/nodes-containers-events-list.adoc
+++ b/modules/nodes-containers-events-list.adoc
@@ -390,7 +390,7 @@ This section describes the events of {product-title}.
 |Created new replication controller.
 
 |`*IngressIPRangeFull*`
-|No available ingress IP to allocate to service.
+|No available Ingress IP to allocate to service.
 
 |===
 

--- a/modules/nw-configuring-route-timeouts.adoc
+++ b/modules/nw-configuring-route-timeouts.adoc
@@ -11,7 +11,7 @@ Availability (SLA) purposes, or a high timeout, for cases with a slow
 back end.
 
 .Prerequisites
-* You need a deployed ingress controller on a running cluster.
+* You need a deployed Ingress controller on a running cluster.
 
 .Procedure
 . Using the `oc annotate` command, add the timeout to the route:

--- a/modules/nw-creating-secured-routes.adoc
+++ b/modules/nw-creating-secured-routes.adoc
@@ -6,9 +6,9 @@
 = Creating secured edge terminated routes
 
 You can create a secure edge terminated route where TLS termination occurs on
-the ingress controller before the traffic is proxied to the destination. The
+the Ingress controller before the traffic is proxied to the destination. The
 secure edge terminated route specifies the TLS certificate and key information.
-The TLS certificate is served by the ingress controller front end.
+The TLS certificate is served by the Ingress controller front end.
 
 .Procedure
 . Create a private key for the edge secured route.
@@ -80,7 +80,7 @@ spec:
       -----END CERTIFICATE-----
 ----
 
-. Verify that the DNS entry for `www.example.test` points to the ingress
+. Verify that the DNS entry for `www.example.test` points to the Ingress
 controller endpoint and that the route to your domain is available.
 +
 The example below uses curl and a local resolver to simulate the
@@ -90,5 +90,5 @@ DNS lookup:
 $ routerip="4.1.1.1"  <1>
 $ curl -k --resolve www.example.test:443:$routerip https://www.example.test/
 ----
-<1> Replace the IP address with the IP address or addresses at which the ingress
+<1> Replace the IP address with the IP address or addresses at which the Ingress
 controller endpoint is published.

--- a/modules/nw-ingress-controller-status.adoc
+++ b/modules/nw-ingress-controller-status.adoc
@@ -3,13 +3,13 @@
 // * ingress/configure-ingress-operator.adoc
 
 [id="nw-ingress-controller-status_{context}"]
-= View ingress controller status
+= View Ingress controller status
 
-Your can view the status of a particular ingress controller.
+Your can view the status of a particular Ingress controller.
 
 .Procedure
 
-* View the status of an ingress controller:
+* View the status of an Ingress controller:
 +
 ----
 $ oc describe --namespace=openshift-ingress-operator ingresscontroller/<name>

--- a/modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate.adoc
+++ b/modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate.adoc
@@ -34,7 +34,7 @@ $ openssl rsa -in password_protected_tls.key -out tls.key
 This procedure creates a `Route` resource with a custom certificate and
 reencrypt TLS termination. The following assumes that the certificate/key pair
 are in the `tls.crt` and `tls.key` files in the current working directory. You
-must also specify a destination CA certificate to enable the ingress controller
+must also specify a destination CA certificate to enable the Ingress controller
 to trust the service's certificate. You may also specify a CA certificate if
 needed to complete the certificate chain. Substitute the actual path names for
 `tls.crt`, `tls.key`, `cacert.crt`, and (optionally) `ca.crt`. Substitute the

--- a/modules/nw-ingress-operator-logs.adoc
+++ b/modules/nw-ingress-operator-logs.adoc
@@ -3,13 +3,13 @@
 // * ingress/configure-ingress-operator.adoc
 
 [id="nw-ingress-operator-logs_{context}"]
-= View ingress controller logs
+= View Ingress controller logs
 
-You can view your ingress controller logs.
+You can view your Ingress controller logs.
 
 .Procedure
 
-* View your ingress controller logs:
+* View your Ingress controller logs:
 +
 ----
 $ oc logs --namespace=openshift-ingress-operator deployments/ingress-operator

--- a/modules/nw-ingress-select-route.adoc
+++ b/modules/nw-ingress-select-route.adoc
@@ -3,6 +3,6 @@
 // * ingress/configure-ingress.adoc
 
 [id="nw-ingress-select-route_{context}"]
-= Configure ingress to use routes
+= Configure Ingress to use routes
 
 //PLACEHOLDER

--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -5,7 +5,7 @@
 [id="nw-ingress-setting-a-custom-default-certificate_{context}"]
 = Setting a custom default certificate
 
-As an administrator, you can configure an ingress controller to use a custom
+As an administrator, you can configure an Ingress controller to use a custom
 certificate by creating a `Secret` resource and editing the `IngressController`
 custom resource (CR).
 
@@ -13,7 +13,7 @@ custom resource (CR).
 
 * You must have a certificate/key pair in PEM-encoded files, where the
 certificate is signed by a trusted certificate authority and valid for the
-ingress domain.
+Ingress domain.
 
 * You must have an `IngressController` CR. You may use the default one:
 +
@@ -33,7 +33,7 @@ referencing it in the `IngressController` CR.
 
 [NOTE]
 ====
-This action will cause the ingress controller to be redeployed, using a rolling deployment strategy.
+This action will cause the Ingress controller to be redeployed, using a rolling deployment strategy.
 ====
 
 . Create a `Secret` resource containing the custom certificate in the
@@ -64,5 +64,5 @@ map[name:custom-certs-default]
 +
 The certificate secret name should match the value used to update the CR.
 
-Once the `IngressController` CR has been modified, the ingress operator
-will update the ingress controller's deployment to use the custom certificate.
+Once the `IngressController` CR has been modified, the Ingress Operator
+will update the Ingress controller's deployment to use the custom certificate.

--- a/modules/nw-ingress-view.adoc
+++ b/modules/nw-ingress-view.adoc
@@ -3,19 +3,19 @@
 // * ingress/configure-ingress-operator.adoc
 
 [id="nw-ingress-view_{context}"]
-= View the default ingress controller
+= View the default Ingress controller
 
 The Ingress Operator is a core feature of {product-title} and is enabled out of the
 box.
 
 Every new {product-title} installation has an `ingresscontroller` named default. It
-can be supplemented with additional ingress controllers. If the default
+can be supplemented with additional Ingress controllers. If the default
 `ingresscontroller` is deleted, the Ingress Operator will automatically recreate it
 within a minute.
 
 .Procedure
 
-* View the default ingress controller:
+* View the default Ingress controller:
 +
 ----
 $ oc describe --namespace=openshift-ingress-operator ingresscontroller/default

--- a/modules/nw-installation-ingress-config-asset.adoc
+++ b/modules/nw-installation-ingress-config-asset.adoc
@@ -5,7 +5,7 @@
 
 
 [id="nw-installation-ingress-config-asset_{context}"]
-= The ingress configuration asset
+= The Ingress configuration asset
 
 The installer generates an asset with an `Ingress` resource in the
 `config.openshift.io` API group, `cluster-ingress-02-config.yml`.
@@ -23,11 +23,11 @@ spec:
 
 The installer stores this asset in the `cluster-ingress-02-config.yml` file in
 the `manifests/` directory. This `Ingress` resource defines the cluster-wide
-configuration for ingress. This ingress configuration is used as follows:
+configuration for Ingress. This Ingress configuration is used as follows:
 
-* The ingress operator uses the domain from the cluster ingress configuration as
-the domain for the default ingress controller.
+* The Ingress Operator uses the domain from the cluster Ingress configuration as
+the domain for the default Ingress controller.
 
-* The OpenShift API server operator uses the domain from the cluster ingress
+* The OpenShift API server operator uses the domain from the cluster Ingress
 configuration as the domain used when generating a default host for a `Route`
 resource that does not specify an explicit host.

--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -50,9 +50,9 @@ spec:
 
 // Blocked on https://github.com/openshift/cluster-ingress-operator/pull/218
 
-* Only allow connections from the {product-title} ingress router:
+* Only allow connections from the {product-title} Ingress router:
 +
-* To make a project allow only connections from the {product-title} ingress
+* To make a project allow only connections from the {product-title} Ingress
 router, add the following `NetworkPolicy` object: 
 +
 [source,yaml]

--- a/modules/nw-networkpolicy-create.adoc
+++ b/modules/nw-networkpolicy-create.adoc
@@ -6,7 +6,7 @@
 
 = Creating a `NetworkPolicy` object
 
-To define granular rules describing ingress network traffic allowed for projects
+To define granular rules describing Ingress network traffic allowed for projects
 in your cluster, you can create `NetworkPolicy` objects.
 
 .Prerequisites

--- a/modules/nw-scaling-ingress-controller.adoc
+++ b/modules/nw-scaling-ingress-controller.adoc
@@ -3,9 +3,9 @@
 // * networking/ingress-controller-configuration.adoc
 
 [id="nw-ingress-controller-configuration_{context}"]
-= Scaling an ingress controller
+= Scaling an Ingress controller
 
-An ingress controller can be manually scaled up or down based on
+An Ingress controller can be manually scaled up or down based on
 requirements such as the need to increase throughput. `oc`
 commands are used to scale the `IngressController` resource.
 The following procedure provides an example for scaling up the

--- a/modules/nw-using-cookies-keep-route-statefulness.adoc
+++ b/modules/nw-using-cookies-keep-route-statefulness.adoc
@@ -13,9 +13,9 @@ traffic by ensuring all traffic hits the same endpoint. However, if the endpoint
 Pod terminates, whether through restart, scaling, or a change in configuration,
 this statefulness can disappear.
 
-{product-title} can use cookies to configure session persistence. The ingress
+{product-title} can use cookies to configure session persistence. The Ingress
 controller selects an endpoint to handle any user requests, and creates a cookie
 for the session. The cookie is passed back in the response to the request and
 the user sends the cookie back with the next request in the session. The cookie
-tells the ingress controller which endpoint is handling the session, ensuring
+tells the Ingress controller which endpoint is handling the session, ensuring
 that client requests use the cookie so that they are routed to the same Pod.

--- a/modules/service-accounts-as-oauth-clients.adoc
+++ b/modules/service-accounts-as-oauth-clients.adoc
@@ -53,7 +53,7 @@ The `first` and `second` postfixes in the above example are used to separate the
 two valid redirect URIs.
 
 In more complex configurations, static redirect URIs may not be enough. For
-example, perhaps you want all ingresses for a route to be considered valid. This
+example, perhaps you want all Ingresses for a route to be considered valid. This
 is where dynamic redirect URIs via the
 `serviceaccounts.openshift.io/oauth-redirectreference.` prefix come into play.
 
@@ -80,7 +80,7 @@ to see in an expanded format:
 ----
 
 Now you can see that an `OAuthRedirectReference` allows us to reference the
-route named `jenkins`. Thus, all ingresses for that route will now be considered
+route named `jenkins`. Thus, all Ingresses for that route will now be considered
 valid.  The full specification for an `OAuthRedirectReference` is:
 
 ----
@@ -110,7 +110,7 @@ reference object. For example:
 ----
 
 The `first` postfix is used to tie the annotations together. Assuming that the
-`jenkins` route had an ingress of *_\https://example.com_*, now
+`jenkins` route had an Ingress of *_\https://example.com_*, now
 *_\https://example.com/custompath_* is considered valid, but
 *_\https://example.com_* is not.  The format for partially supplying override
 data is as follows:
@@ -143,7 +143,7 @@ The same object can be referenced more than once for more flexibility:
 "serviceaccounts.openshift.io/oauth-redirectreference.second": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"jenkins\"}}"
 ----
 
-Assuming that the route named `jenkins` has an ingress of
+Assuming that the route named `jenkins` has an Ingress of
 *_\https://example.com_*, then both *_\https://example.com:8000_* and
 *_\https://example.com/custompath_* are considered valid.
 


### PR DESCRIPTION
Adjusted `ingress` and `Ingress Operator` were used consistently throughout the documentation. I see several references to `router`, which I have yet to update.

This is for OS 4.x.

@bmcelvee,

Would you be willing to review this one?
