### PR TITLE
CNV Live migration of VMIs

### DIFF
--- a/cnv/cnv_users_guide/cnv-cancel-vmi-migration.adoc
+++ b/cnv/cnv_users_guide/cnv-cancel-vmi-migration.adoc
@@ -1,0 +1,14 @@
+[id="cnv-cancel-vmi-migration"]
+= Cancelling the live migration of a virtual machine instance
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-cancel-vmi-migration
+toc::[]
+
+Cancel the live migration so that the virtual machine instance remains 
+on the original node. 
+
+You can cancel a live migration from either the web console or the CLI. 
+
+include::modules/cnv-cancelling-vm-migration-web.adoc[leveloffset=+1]
+include::modules/cnv-cancelling-vm-migration-cli.adoc[leveloffset=+1]
+

--- a/cnv/cnv_users_guide/cnv-live-migration-limits.adoc
+++ b/cnv/cnv_users_guide/cnv-live-migration-limits.adoc
@@ -1,0 +1,14 @@
+[id="cnv-live-migration-limits"]
+= Live migration limits and timeouts
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-live-migration-limits
+toc::[]
+
+Live migration limits and timeouts are applied so that migration processes do 
+not overwhelm the cluster. Configure these settings by editing the 
+`kubevirt-config` configuration file. 
+
+include::modules/cnv-configuring-live-migration-limits.adoc[leveloffset=+1]
+include::modules/cnv-live-migration-limits-reftable.adoc[leveloffset=+1]
+
+

--- a/cnv/cnv_users_guide/cnv-live-migration.adoc
+++ b/cnv/cnv_users_guide/cnv-live-migration.adoc
@@ -1,0 +1,15 @@
+[id="cnv-live-migration"]
+= Virtual machine live migration
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-live-migration
+toc::[]
+
+include::modules/cnv-understanding-live-migration.adoc[leveloffset=+1]
+include::modules/cnv-enabling-vm-live-migration-cli.adoc[leveloffset=+1]
+
+.Additional resources:
+
+* xref:../../cnv/cnv_users_guide/cnv-migrate-vmi.adoc#cnv-migrate-vmi[Migrating a virtual machine instance to another node]
+* xref:../../cnv/cnv_users_guide/cnv-node-maintenance.adoc#cnv-node-maintenance[Node maintenance mode]
+* xref:../../cnv/cnv_users_guide/cnv-live-migration-limits.adoc#cnv-live-migration-limits[Live migration limiting]
+

--- a/cnv/cnv_users_guide/cnv-migrate-vmi.adoc
+++ b/cnv/cnv_users_guide/cnv-migrate-vmi.adoc
@@ -1,0 +1,20 @@
+[id="cnv-migrate-vmi"]
+= Migrating a virtual machine instance to another node
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-migrate-vmi
+toc::[]
+
+Manually initiate a live migration of a virtual machine instance to another node using either the web console or the CLI.
+
+.Prerequisites
+
+* The xref:../../cnv/cnv_users_guide/cnv-live-migration.adoc#cnv-live-migration[live migration feature] must be enabled in the cluster.
+
+include::modules/cnv-initiating-vm-migration-web.adoc[leveloffset=+1]
+include::modules/cnv-initiating-vm-migration-cli.adoc[leveloffset=+1]
+
+.Additional resources:
+
+* xref:../../cnv/cnv_users_guide/cnv-monitor-vmi-migration.adoc#cnv-monitor-vmi-migration[Monitoring live migration of a virtual machine instance]
+* xref:../../cnv/cnv_users_guide/cnv-cancel-vmi-migration.adoc#cnv-cancel-vmi-migration[Cancelling the live migration of a virtual machine instance]
+

--- a/cnv/cnv_users_guide/cnv-monitor-vmi-migration.adoc
+++ b/cnv/cnv_users_guide/cnv-monitor-vmi-migration.adoc
@@ -1,0 +1,11 @@
+[id="cnv-monitor-vmi-migration"]
+= Monitoring live migration of a virtual machine instance
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-monitor-vmi-migration
+toc::[]
+
+You can monitor the progress of a live migration of a virtual machine instance from either the web console or the CLI.
+
+include::modules/cnv-monitoring-vm-migration-web.adoc[leveloffset=+1]
+include::modules/cnv-monitoring-vm-migration-cli.adoc[leveloffset=+1]
+

--- a/modules/cnv-cancelling-vm-migration-cli.adoc
+++ b/modules/cnv-cancelling-vm-migration-cli.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-cancel-vmi-migration.adoc
+
+[id="cnv-cancelling-vm-migration-cli_{context}"]
+= Cancelling live migration of a virtual machine instance in the CLI
+
+Cancel the live migration of a virtual machine instance by deleting the 
+`VirtualMachineInstanceMigration` object associated with the migration.
+
+.Procedure
+
+* Delete the `VirtualMachineInstanceMigration` object that triggered the live 
+migration, `migration-job` in this example:
++
+----
+$ oc delete vmim migration-job
+----
+

--- a/modules/cnv-cancelling-vm-migration-web.adoc
+++ b/modules/cnv-cancelling-vm-migration-web.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-cancel-vmi-migration.adoc
+
+[id="cnv-cancelling-vm-migration-web_{context}"]
+= Cancelling live migration of a virtual machine instance in the web console
+
+A live migration of the virtual machine instance can be cancelled using the :kebab: 
+found on each virtual machine in the *Workloads* -> *Virtual Machines* 
+screen, or from the *Actions* menu on the *Virtual Machine Details* screen.
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
+. You can cancel the migration from this screen, which makes it easier to perform actions on multiple virtual machines in the one screen, or from the *Virtual Machine Details* screen where you can view comprehensive details of the selected virtual machine:
+** Click :kebab: at the end of virtual machine and select
+*Cancel Virtual Machine Migration*.
+** Click the virtual machine name to open the *Virtual Machine Details*
+screen and click *Actions* -> *Cancel Virtual Machine Migration*.
+. Click *Cancel Migration* to cancel the virtual machine live migration.

--- a/modules/cnv-configuring-live-migration-limits.adoc
+++ b/modules/cnv-configuring-live-migration-limits.adoc
@@ -1,0 +1,40 @@
+
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-live-migration-limits.adoc
+
+[id="cnv-configuring-live-migration-limits_{context}"]
+= Configuring live migration limits and timeouts
+
+Configure live migration limits and timeouts for the cluster by adding updated 
+key:value fields to the `kubevirt-config` configuration file, which is located in the 
+`kubevirt` namespace.
+
+.Procedure
+
+* Edit the `kubevirt-config` configuration file and add the necessary 
+live migration parameters. The following example shows the default values:
++
+----
+$ oc edit configmap kubevirt-config -n kubevirt
+----
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kubevirt
+  labels:
+    kubevirt.io: ""
+data:
+  feature-gates: "LiveMigration"
+  migrations: |-
+    parallelMigrationsPerCluster: 5
+    parallelOutboundMigrationsPerNode: 2
+    bandwidthPerMigration: 64Mi
+    completionTimeoutPerGiB: 800
+    progressTimeout: 150
+----
+

--- a/modules/cnv-enabling-vm-live-migration-cli.adoc
+++ b/modules/cnv-enabling-vm-live-migration-cli.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-live-migration.adoc
+// cnv_users_guide/cnv-maintenance-mode.adoc
+
+[id="cnv-enabling-vm-live-migration-cli_{context}"]
+= Enabling virtual machine live migration in the cluster 
+
+Enable the live migration feature by adding the 
+`data: feature-gates: "LiveMigration"` field to the 
+`kubevirt-config` configuration file, which is located in the 
+`kubevirt` namespace.
+
+.Procedure
+
+* Edit the `kubevirt-config` configuration file and add the `LiveMigration` 
+feature gate:
++
+----
+$ oc edit configmap kubevirt-config -n kubevirt
+----
++
+[source,yaml]
+----
+...
+data:
+  feature-gates: "LiveMigration"
+----

--- a/modules/cnv-initiating-vm-migration-cli.adoc
+++ b/modules/cnv-initiating-vm-migration-cli.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-migrate-vmi.adoc
+
+[id="cnv-initiating-vm-migration-cli_{context}"]
+= Initiating live migration of a virtual machine instance in the CLI
+
+Initiate a live migration of a running virtual machine instance by creating a 
+`VirtualMachineInstanceMigration` object in the cluster and referencing the name
+ of the virtual machine instance.
+
+.Procedure
+
+. Create a `VirtualMachineInstanceMigration` configuration file for the 
+virtual machine instance to migrate. For example, `vmi-migrate.yaml`:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstanceMigration
+metadata:
+  name: migration-job
+spec:
+  vmiName: vmi-fedora
+----
+
+. Create the object in the cluster:
++
+----
+$ oc create -f vmi-migrate.yaml
+----
+
+The `VirtualMachineInstanceMigration` object triggers a live migration of the 
+virtual machine instance. This object exists in the cluster for as long as the
+virtual machine instance is running, unless manually deleted.

--- a/modules/cnv-initiating-vm-migration-web.adoc
+++ b/modules/cnv-initiating-vm-migration-web.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-migrate-vmi.adoc
+
+[id="cnv-initiating-vm-migration-web_{context}"]
+= Initiating live migration of a virtual machine instance in the web console
+
+Migrate a running virtual machine instance to a different node in the cluster. 
+
+[NOTE]
+====
+The *Migrate Virtual Machine* action is visible to all users but only admin users 
+can initiate a virtual machine migration. 
+====
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
+. You can initiate the migration from this screen, which makes it easier to perform actions on multiple virtual machines in the one screen, or from the *Virtual Machine Details* screen where you can view comprehensive details of the selected virtual machine:
+** Click :kebab: at the end of virtual machine and select
+*Migrate Virtual Machine Migration*.
+** Click the virtual machine name to open the *Virtual Machine Details*
+screen and click *Actions* -> *Migrate Virtual Machine Migration*.
+. Click *Migrate* to migrate the virtual machine to another node.

--- a/modules/cnv-live-migration-limits-reftable.adoc
+++ b/modules/cnv-live-migration-limits-reftable.adoc
@@ -1,0 +1,37 @@
+
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-live-migration-limits.adoc
+
+[id="cnv-live-migration-limits-ref_{context}"]
+= Cluster-wide live migration limits and timeouts
+
+.Migration parameters
+|===
+|Parameter |Description |Default
+
+|`parallelMigrationsPerCluster`
+|Number of migrations running in parallel in the cluster. 
+|5
+
+|`parallelOutboundMigrationsPerNode`
+|Maximum number of outbound migrations per node.
+|2
+
+|`bandwidthPerMigration`
+|Bandwidth limit of each migration, in MiB/s.
+|64Mi
+
+|`completionTimeoutPerGiB`
+|The migration will be cancelled if it has not completed in this time, in seconds 
+per GiB of memory. For example, a VMI with 6GiB memory will timeout if it has 
+not completed migration in 4800 seconds. If the `Migration Method` is 
+`BlockMigration`, the size of the migrating disks is included in the calculation. 
+|800
+
+|`progressTimeout`
+|The migration will be cancelled if memory copy fails to make progress in this 
+time, in seconds.
+|150
+|===
+

--- a/modules/cnv-monitoring-vm-migration-cli.adoc
+++ b/modules/cnv-monitoring-vm-migration-cli.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-monitor-vmi-migration.adoc
+
+[id="cnv-monitoring-vm-migration-cli_{context}"]
+= Monitoring live migration of a virtual machine instance in the CLI
+
+The status of the virtual machine migration is stored in the `Status` component 
+of the `VirtualMachineInstance` configuration. 
+
+.Procedure
+
+* Use the `oc describe` command on the migrating virtual machine instance:
+
+----
+$ oc describe vmi vmi-fedora
+----
++
+[source,yaml]
+----
+...
+Status:
+  Conditions:
+    Last Probe Time:       <nil>
+    Last Transition Time:  <nil>
+    Status:                True
+    Type:                  LiveMigratable
+  Migration Method:  LiveMigration
+  Migration State:
+    Completed:                    true
+    End Timestamp:                2018-12-24T06:19:42Z
+    Migration UID:                d78c8962-0743-11e9-a540-fa163e0c69f1
+    Source Node:                  node2.example.com
+    Start Timestamp:              2018-12-24T06:19:35Z
+    Target Node:                  node1.example.com
+    Target Node Address:          10.9.0.18:43891
+    Target Node Domain Detected:  true
+----
+

--- a/modules/cnv-monitoring-vm-migration-web.adoc
+++ b/modules/cnv-monitoring-vm-migration-web.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-monitor-vmi-migration.adoc
+
+[id="cnv-monitoring-vm-migration-web_{context}"]
+= Monitoring live migration of a virtual machine instance in the web console
+
+For the duration of the migration, the virtual machine has a status of 
+*Migrating*. This status is displayed in the *Virtual Machines* list or in the 
+*Virtual Machine Details* screen for the migrating virtual machine. 
+
+.Procedure
+
+* In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
+

--- a/modules/cnv-understanding-live-migration.adoc
+++ b/modules/cnv-understanding-live-migration.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-live-migration.adoc
+
+[id="cnv-understanding-live-migration_{context}"]
+= Understanding live migration
+
+Live migration is the process of moving a running virtual machine instance to 
+another node in the cluster without interruption to the virtual workload or 
+access. This can be a manual process, if you select a virtual machine instance 
+to migrate to another node, or an automatic process, if the 
+virtual machine instance has a `LiveMigrate` eviction strategy and the node on 
+which it is running is placed into maintenance. 
+
+[NOTE]
+====
+NFS shared volumes are the only shared data volume type supported for 
+live migration in {ProductName} 2.0.
+====
+
+


### PR DESCRIPTION
This PR covers the following stories:
CNV-757 (Basic live migration)
CNV-759 (Progress/monitoring)
CNV-761(Cancel migration)
CNV-1495 (UI for above) 

No changes to the topic map as yet as migrating 1.4 content and assembling the CNV User Guide will begin next week. 

Preview content hosted here:
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-live-migration.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-live-migration-limits.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-migrate-vmi.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-monitor-vmi-migration.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-cancel-vmi-migration.html