### PR TITLE
CNV LiveMigrate eviction strategy and node maintenance mode 

### DIFF
--- a/cnv/cnv_users_guide/cnv-cancel-vmi-migration.adoc
+++ b/cnv/cnv_users_guide/cnv-cancel-vmi-migration.adoc
@@ -1,6 +1,7 @@
 [id="cnv-cancel-vmi-migration"]
 = Cancelling the live migration of a virtual machine instance
 include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
 :context: cnv-cancel-vmi-migration
 toc::[]
 

--- a/cnv/cnv_users_guide/cnv-configuring-vmi-eviction-strategy.adoc
+++ b/cnv/cnv_users_guide/cnv-configuring-vmi-eviction-strategy.adoc
@@ -1,0 +1,17 @@
+[id="cnv-configuring-vmi-eviction-strategy"]
+= Configuring virtual machine eviction strategy
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-configuring-vmi-eviction-strategy
+toc::[]
+
+The `LiveMigrate` eviction strategy ensures that a virtual machine instance is
+not interrupted if the node is placed into maintenance or drained. 
+Virtual machines instances with this eviction strategy will be live migrated to 
+another node. 
+
+.Prerequisites
+
+* The xref:../../cnv/cnv_users_guide/cnv-live-migration.adoc#cnv-live-migration[live migration feature] 
+must be enabled in the cluster.
+
+include::modules/cnv-configuring-vmi-live-migration-cli.adoc[leveloffset=+1]

--- a/cnv/cnv_users_guide/cnv-migrate-vmi.adoc
+++ b/cnv/cnv_users_guide/cnv-migrate-vmi.adoc
@@ -1,6 +1,7 @@
 [id="cnv-migrate-vmi"]
 = Migrating a virtual machine instance to another node
 include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
 :context: cnv-migrate-vmi
 toc::[]
 

--- a/cnv/cnv_users_guide/cnv-node-maintenance.adoc
+++ b/cnv/cnv_users_guide/cnv-node-maintenance.adoc
@@ -1,0 +1,12 @@
+[id="cnv-node-maintenance"]
+= Node maintenance mode
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-node-maintenance
+toc::[]
+
+include::modules/cnv-understanding-node-maintenance.adoc[leveloffset=+1]
+
+.Additional resources:
+
+* xref:../../cnv/cnv_users_guide/cnv-live-migration.adoc#cnv-live-migration[Virtual machine live migration]
+* xref:../../cnv/cnv_users_guide/cnv-configuring-vmi-eviction-strategy.adoc#cnv-configuring-vmi-eviction-strategy[Configuring virtual machine eviction strategy]

--- a/cnv/cnv_users_guide/cnv-resuming-node.adoc
+++ b/cnv/cnv_users_guide/cnv-resuming-node.adoc
@@ -1,0 +1,14 @@
+[id="cnv-resuming-node"]
+= Resuming a node from maintenance mode
+include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: cnv-resuming-node
+toc::[]
+
+Resuming a node brings it out of maintenance mode and schedulable again.
+
+Resume a node from maintenance from either the web console or the CLI.
+
+include::modules/cnv-resuming-node-maintenance-web.adoc[leveloffset=+1]
+include::modules/cnv-resuming-node-maintenance-cli.adoc[leveloffset=+1]
+

--- a/cnv/cnv_users_guide/cnv-setting-node-maintenance.adoc
+++ b/cnv/cnv_users_guide/cnv-setting-node-maintenance.adoc
@@ -1,0 +1,18 @@
+[id="cnv-setting-node-maintenance"]
+= Setting a node to maintenance mode
+include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: cnv-setting-node-maintenance
+toc::[]
+
+include::modules/cnv-understanding-node-maintenance.adoc[leveloffset=+1]
+
+Place a node into maintenance from either the web console or the CLI.
+
+include::modules/cnv-setting-node-maintenance-web.adoc[leveloffset=+1]
+include::modules/cnv-setting-node-maintenance-cli.adoc[leveloffset=+1]
+
+.Additional resources:
+
+* xref:../../cnv/cnv_users_guide/cnv-resuming-node.adoc#cnv-resuming-node[Resuming a node from maintenance mode]
+

--- a/modules/cnv-cancelling-vm-migration-web.adoc
+++ b/modules/cnv-cancelling-vm-migration-web.adoc
@@ -5,15 +5,16 @@
 [id="cnv-cancelling-vm-migration-web_{context}"]
 = Cancelling live migration of a virtual machine instance in the web console
 
-A live migration of the virtual machine instance can be cancelled using the :kebab: 
-found on each virtual machine in the *Workloads* -> *Virtual Machines* 
-screen, or from the *Actions* menu on the *Virtual Machine Details* screen.
+A live migration of the virtual machine instance can be cancelled using the 
+Options menu {kebab} found on each virtual machine in the 
+*Workloads* -> *Virtual Machines* screen, or from the *Actions* menu 
+on the *Virtual Machine Details* screen.
 
 .Procedure
 
 . In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
 . You can cancel the migration from this screen, which makes it easier to perform actions on multiple virtual machines in the one screen, or from the *Virtual Machine Details* screen where you can view comprehensive details of the selected virtual machine:
-** Click :kebab: at the end of virtual machine and select
+** Click the Options menu {kebab} at the end of virtual machine and select
 *Cancel Virtual Machine Migration*.
 ** Click the virtual machine name to open the *Virtual Machine Details*
 screen and click *Actions* -> *Cancel Virtual Machine Migration*.

--- a/modules/cnv-configuring-vmi-live-migration-cli.adoc
+++ b/modules/cnv-configuring-vmi-live-migration-cli.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-configuring-vmi-eviction-strategy.adoc
+
+[id="cnv-configuring-vmi-live-migration-cli_{context}"]
+= Configuring custom virtual machine instances with the `LiveMigration` eviction strategy 
+
+You only need to configure the `LiveMigration` eviction strategy on custom 
+virtual machine instances. Common templates have this eviction strategy 
+configured by default.
+
+.Procedure
+
+* Add the `evictionStrategy: LiveMigrate` option to the `spec` section in the 
+virtual machine instance configuration file. This example uses `oc edit` to update 
+the relevant snippet of the `VirtualMachineInstance` configuration file: 
++
+----
+$ oc edit vmi <custom-vmi> -n <my-namespace>
+----
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: custom-vmi
+spec:
+  terminationGracePeriodSeconds: 30
+  evictionStrategy: LiveMigrate
+  domain:
+    resources:
+      requests:
+...
+----

--- a/modules/cnv-initiating-vm-migration-web.adoc
+++ b/modules/cnv-initiating-vm-migration-web.adoc
@@ -17,7 +17,7 @@ can initiate a virtual machine migration.
 
 . In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
 . You can initiate the migration from this screen, which makes it easier to perform actions on multiple virtual machines in the one screen, or from the *Virtual Machine Details* screen where you can view comprehensive details of the selected virtual machine:
-** Click :kebab: at the end of virtual machine and select
+** Click the Options menu {kebab} at the end of virtual machine and select
 *Migrate Virtual Machine Migration*.
 ** Click the virtual machine name to open the *Virtual Machine Details*
 screen and click *Actions* -> *Migrate Virtual Machine Migration*.

--- a/modules/cnv-resuming-node-maintenance-cli.adoc
+++ b/modules/cnv-resuming-node-maintenance-cli.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-maintenance-mode.adoc
+
+[id="cnv-resuming-node-maintenance-cli_{context}"]
+= Resuming a node from maintenance mode in the CLI
+
+Resume a node from maintenance mode and make it schedulable again by deleting 
+the `NodeMaintenance` object for the node. 
+
+.Procedure
+
+. Find the `NodeMaintenance` object:
++
+----
+$ oc get nodemaintenance
+----
+
+. (Optional) Insepct the `NodeMaintenance` object to ensure it is associated with the correct node:
++
+----
+$ oc describe nodemaintenance <node02-maintenance>
+----
++
+[source,yaml]
+----
+Name:         node02-maintenance
+Namespace:    
+Labels:       
+Annotations:  
+API Version:  kubevirt.io/v1alpha1
+Kind:         NodeMaintenance
+...
+Spec:
+  Node Name:  node02
+  Reason:     Replacing node02
+----
+
+. Delete the `NodeMaintenance` object:
++
+----
+$ oc delete nodemaintenance <node02-maintenance>
+----
+

--- a/modules/cnv-resuming-node-maintenance-web.adoc
+++ b/modules/cnv-resuming-node-maintenance-web.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-maintenance-mode.adoc
+
+[id="cnv-resuming-node-maintenance-web_{context}"]
+= Resuming a node from maintenance mode in the web console
+
+Resume a node from maintenance mode using the Options menu {kebab} found 
+on each node in the *Compute* -> *Nodes* list, or using the *Actions* control 
+of the *Node Details* screen.
+
+.Procedure
+
+. In the {ProductName} console, click *Compute* -> *Nodes*.
+. You can resume the node from this screen, which makes it easier to perform 
+actions on multiple nodes in the one screen, or from the *Node Details* screen 
+where you can view comprehensive details of the selected node:
+** Click the Options menu {kebab} at the end of the node and select
+*Stop Maintenance*.
+** Click the node name to open the *Node Details* screen and click 
+*Actions* -> *Stop Maintenance*.
+. Click *Stop Maintenance* in the confirmation window. 
+
+The node becomes schedulable, but virtual machine instances that were running on 
+the node prior to maintenance will not automatically migrate back to this node. 

--- a/modules/cnv-setting-node-maintenance-cli.adoc
+++ b/modules/cnv-setting-node-maintenance-cli.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-setting-node-maintenance.adoc
+
+[id="cnv-setting-node-maintenance-cli_{context}"]
+= Setting a node to maintenance mode in the CLI
+
+Set a node to maintenance mode by creating a `NodeMaintenance` Custom Resource 
+(CR) object that references the node name and the reason for setting it to 
+maintenance mode.  
+
+.Procedure
+
+. Create the node maintenance CR configuration. This example uses a CR that is 
+called `node02-maintenance.yaml`:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha1
+kind: NodeMaintenance
+metadata:
+  name: node02-maintenance
+spec:
+  nodeName: node02
+  reason: "Replacing node02"
+----
+
+. Create the `NodeMaintenance` object in the cluster:
++
+----
+$ oc apply -f <node02-maintenance.yaml>
+----
+
+The node live migrates virtual machine instances that have the 
+`liveMigration` eviction strategy, and taint the node so that it is no longer 
+schedulable. All other pods and virtual machines on the node are deleted and 
+recreated on another node.

--- a/modules/cnv-setting-node-maintenance-web.adoc
+++ b/modules/cnv-setting-node-maintenance-web.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-setting-node-maintenance.adoc
+
+[id="cnv-setting-node-maintenance-web_{context}"]
+= Setting a node to maintenance mode in the web console
+
+Set a node to maintenance mode using the Options menu {kebab} found on each node in the 
+*Compute* -> *Nodes* list, or using the *Actions* control of the *Node Details* 
+screen.
+
+.Procedure
+
+. In the {ProductName} console, click *Compute* -> *Nodes*.
+. You can set the node to maintenance from this screen, which makes it easier to perform 
+actions on multiple nodes in the one screen or from the *Node Details* screen
+where you can view comprehensive details of the selected node:
+** Click the Options menu {kebab} at the end of the node and select *Start Maintenance*.
+** Click the node name to open the *Node Details* screen and click 
+*Actions* -> *Start Maintenance*.
+. Click *Start Maintenance* in the confirmation window. 
+
+The node will live migrate virtual machine instances that have the 
+`liveMigration` eviction strategy, and the node is no longer schedulable. All 
+other pods and virtual machines on the node are deleted and recreated on another node. 

--- a/modules/cnv-understanding-node-maintenance.adoc
+++ b/modules/cnv-understanding-node-maintenance.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-node-maintenance.adoc
+
+[id="cnv-understanding-node-maintenance{context}"]
+= Understanding node maintenance mode
+
+Placing a node into maintenance marks the node as unschedulable and drains all 
+the virtual machines and pods from it. Virtual machine instances that have a 
+`LiveMigrate` eviction strategy are live migrated to another node without loss 
+of service. This eviction strategy is configured by default in virtual machine 
+created from common templates but must be configured manually for custom 
+virtual machines. 
+
+Virtual machine instances without an eviction strategy will be deleted on the 
+node and recreated on another node. 
+
+[NOTE]
+====
+NFS shared volumes are the only shared data volume type supported for
+live migration in {ProductName} 2.0.
+====
+
+
+


### PR DESCRIPTION
Covers content for: 
CNV-784, initially raised to cover node drain scenario but replaced by maintenance mode, which records a reason for the drain and can be cancelled. 

No changes to the topic map as yet as migrating 1.4 content and assembling the CNV User Guide will begin next week.

Preview content hosted here:
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-node-maintenance.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-configuring-vmi-eviction-strategy.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-setting-node-maintenance.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-resuming-node.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/migration/cnv_users_guide/cnv-live-migration.html