### PR TITLE
Correct a right parameter for creating a Headless service

### DIFF
--- a/using_images/db_images/mysql.adoc
+++ b/using_images/db_images/mysql.adoc
@@ -676,7 +676,7 @@ a headless service named *mysql-master* for this purpose. This service is not
 used only for replication, but the clients can also send the queries to
 *mysql-master:3306* as the MySQL host.
 
-To have a headless service, the `*portalIP*` parameter in the service definition
+To have a headless service, the `*clusterIP*` parameter in the service definition
 is set to *None*. Then you can use a DNS query to get a list of the pod IP
 addresses that represents the current endpoints for this service.
 
@@ -699,7 +699,7 @@ spec:
       nodePort: 0
   selector:
     name: "mysql-master"
-  portalIP: "None"
+  clusterIP: "None"
   type: "ClusterIP"
   sessionAffinity: "None"
 status:


### PR DESCRIPTION
- Version: `v3.11` ~ `v3.6`

- Descrtiption:
  Replace `portalIP` with `clusterIP` for preventing syntax error.
   `portalIP` is not a correct parameter for creating `Headless` Service. Look [Creating a Headless Service](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/pods_and_services.html#headless-service-creation) in other section of same version. Syntax is not consistent.
~~~
Creating a headless service is similar to creating a standard service, but you do not declare the ClusterIP address. To create a headless service, add the clusterIP: None parameter value to the service YAML definition.
~~~