### PR TITLE
BZ-1693420: Removed unnecessary secret references.

### DIFF
--- a/authentication/identity_providers/configuring-request-header-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-request-header-identity-provider.adoc
@@ -12,8 +12,6 @@ include::modules/identity-provider-overview.adoc[leveloffset=+1]
 
 include::modules/identity-provider-about-request-header.adoc[leveloffset=+1]
 
-include::modules/identity-provider-secret.adoc[leveloffset=+1]
-
 include::modules/identity-provider-config-map.adoc[leveloffset=+1]
 
 include::modules/identity-provider-request-header-CR.adoc[leveloffset=+1]


### PR DESCRIPTION
Examining the current identity providers there are some unnecessary references to secrets. For instance, the RequestHeader IDP cannot configure a secret, but the instructions are in the assembly. This has been removed.

This is for OS 4.x.