### PR TITLE
RHCOS URLS for beta6

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -17,49 +17,49 @@ You must use a valid {op-system-first} AMI for your Amazon Web Services
 |AWS AMI
 
 |`ap-northeast-1`
-|`ami-06153e8d5cf577a81`
+|`ami-0725cf3917ea24b16`
 
 |`ap-northeast-2`
-|`ami-0b75c8dbcc07363b9`
+|`ami-06ca8a15cddf2f380`
 
 |`ap-south-1`
-|`ami-08a07f507cd20aa23`
+|`ami-0ca2dc3826bbea1c7`
 
 |`ap-southeast-1`
-|`ami-030cd605c9d3eec03`
+|`ami-0b30cbdef9105a3c3`
 
 |`ap-southeast-2`
-|`ami-0140da25e0be718b2`
+|`ami-0ade0455bec41cd6d`
 
 |`ca-central-1`
-|`ami-027d77f6170fde18b`
+|`ami-07aad00e7ed4c491f`
 
 |`eu-central-1`
-|`ami-089595a0f4d60a839`
+|`ami-0e2df006870846a18`
 
 |`eu-west-1`
-|`ami-063ce7cafbc2a16df`
+|`ami-00d18cbff03587a41`
 
 |`eu-west-2`
-|`ami-06619611f27b0103a`
+|`ami-0562de84e022a949f`
 
 |`eu-west-3`
-|`ami-0ec28a762270a0d8f`
+|`ami-09f3057eaf405b08b`
 
 |`sa-east-1`
-|`ami-0845523ad10519ac4`
+|`ami-0462aea292c12e35b`
 
 |`us-east-1`
-|`ami-0678c4c4a53cd4680`
+|`ami-00fcb36a74c83cf10`
 
 |`us-east-2`
-|`ami-07e0e0e0035b5a3fe`
+|`ami-02bab3783586cc77f`
 
 |`us-west-1`
-|`ami-0c58a195b65f5250f`
+|`ami-0e52dafdb6762af40`
 
 |`us-west-2`
-|`ami-01e2758deb3135fb0`
+|`ami-06968ae32c4abc57a`
 
 |===
 

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -33,7 +33,7 @@ of installing operating system instances.
 .. Download the ISO file:
 +
 ----
-$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.3/rhcos-410.8.20190509.3-installer.iso
+$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.4/rhcos-410.8.20190516.0-installer.iso
 ----
 
 .. Download either the BIOS or UEFI file for your bare metal installation:
@@ -41,13 +41,13 @@ $ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos
 *** To download the BIOS file:
 +
 ----
-$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.3/rhcos-410.8.20190509.3-metal-bios.raw.gz
+$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.4/rhcos-410.8.20190516.0-metal-bios.raw.gz
 ----
 
 *** To download the UEFI file:
 +
 ----
-$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.3/rhcos-410.8.20190509.3-metal-uefi.raw.gz
+$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.4/rhcos-410.8.20190516.0-metal-uefi.raw.gz
 ----
 //From link:https://try.openshift.com[the OpenShift developer preview page], download both the ISO file and either the UEFI or BIOS file.
 . Upload either the BIOS or UEFI {op-system} image file to your HTTP server and

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -74,7 +74,7 @@ $ base64 -w0 <installation_directory>/append-bootstrap.ign > <installation_direc
 . Obtain the {op-system} OVA image:
 +
 ----
-$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.3/rhcos-410.8.20190509.3-vmware.ova
+$ curl -J -L -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.4/rhcos-410.8.20190516.0-vmware.ova
 ----
 
 . In the vSphere Client, create a folder in your datacenter to store your VMs.


### PR DESCRIPTION
@jianlinliu, since beta 6 was released, I updated the image URLs to match https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0-rc.4/.

Will you PTAL? 