### PR TITLE
OpenShift Ansible Service Broker is not installed by default in 4.1

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -470,6 +470,13 @@ Cluster administrators can install the Template Service Broker if users will
 need access to template applications from the web console.
 
 [discrete]
+[[ocp-4-1-openshit-ansoble-service-broker-no-longer-installed-by-default]]
+==== OpenShift Ansible Service Broker no longer installed by default
+
+The OpenShift Ansible Service Broker is not installed by default in
+{product-title} 4.1.
+
+[discrete]
 [[ocp-4-1-oc-adm-commands-deprecated]]
 ==== Several `oc adm` commands are now deprecated
 
@@ -553,7 +560,7 @@ when shipped.
 |GA
 |GA
 
-|OpenShift Automation Broker
+|OpenShift Ansible Service Broker
 |
 |GA
 |GA


### PR DESCRIPTION
@jianzhangbjz These edits are per your comments in https://github.com/openshift/openshift-docs/pull/13726