### PR TITLE
BZ-1694686: Updated steps on the internal timeout.

### DIFF
--- a/modules/oauth-configuring-internal-oauth.adoc
+++ b/modules/oauth-configuring-internal-oauth.adoc
@@ -3,22 +3,58 @@
 // * authentication/configuring-internal-oauth.adoc
 
 [id="oauth-configuring-internal-oauth_{context}"]
-= Configuring options for the internal OAuth server
+= Configuring the internal OAuth server's token duration
 
 You can configure default options for the internal OAuth server's
 token duration.
 
+[IMPORTANT]
+====
+By default, tokens are only valid for 24 hours. Existing sessions
+expire after this time elapses.
+====
+
+If the default time is insufficient, then this can be modified using
+the following procedure.
+
 .Procedure
 
-. Set the token duration options:
+. Create a configuration file that contains the token duration options. The
+following file sets this to 48 hours, twice the default.
 +
 [source,yaml]
 ----
-oauthConfig:
-  ...
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
   tokenConfig:
-    accessTokenMaxAgeSeconds: 86400 <1>
+    accessTokenMaxAgeSeconds: 172800 <1>
 ----
 <1> Set `accessTokenMaxAgeSeconds` to control the lifetime of access tokens.
 The default lifetime is 24 hours, or 86400 seconds. This attribute cannot
 be negative.
+
+. Apply the new configuration file:
++
+[NOTE]
+====
+Because you update the existing OAuth server, you must use the `oc apply`
+command to apply the change.
+====
++
+----
+$ oc apply -f </path/to/file.yaml>
+----
+
+. Confirm that the changes are in effect:
++
+----
+$ oc describe oauth.config.openshift.io/cluster
+...
+Spec:
+  Token Config:
+    Access Token Max Age Seconds:  172800
+...
+----


### PR DESCRIPTION
Updated the section on configuring the internal OAuth's server token duration and renamed this section, as this is the only option that's configurable.

This is for OS 4.x.