### PR TITLE
BZ1711892: Removed Ceph RBD details.

### DIFF
--- a/storage/dynamic-provisioning.adoc
+++ b/storage/dynamic-provisioning.adoc
@@ -14,18 +14,18 @@ include::modules/dynamic-provisioning-storage-class-definition.adoc[leveloffset=
 
 include::modules/dynamic-provisioning-annotations.adoc[leveloffset=+2]
 
-//include::modules/dynamic-provisioning-cinder-definition.adoc[leveloffset=+2]
+// include::modules/dynamic-provisioning-cinder-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-aws-definition.adoc[leveloffset=+2]
 
-//include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
+// include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
 
-//include::modules/dynamic-provisioning-gluster-definition.adoc[leveloffset=+2]
+// include::modules/dynamic-provisioning-gluster-definition.adoc[leveloffset=+2]
 
-include::modules/dynamic-provisioning-ceph-rbd-definition.adoc[leveloffset=+2]
+// include::modules/dynamic-provisioning-ceph-rbd-definition.adoc[leveloffset=+2]
 
-//include::modules/dynamic-provisioning-vsphere-definition.adoc[leveloffset=+2]
+// include::modules/dynamic-provisioning-vsphere-definition.adoc[leveloffset=+2]
 
-//include::modules/dynamic-provisioning-azure-disk-definition.adoc[leveloffset=+2]
+// include::modules/dynamic-provisioning-azure-disk-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-change-default-class.adoc[leveloffset=+1]


### PR DESCRIPTION
Ceph RBD example has been removed from the dynamic provisioning section.

This is for OS 4.x.