### PR TITLE
[enterprise-3.11] Remove  deprecated "Recycle" reclaim policy term

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -123,7 +123,7 @@ to policy.
 === Reclaim volumes
 
 The reclaim policy of a `PersistentVolume` tells the cluster what to do with
-the volume after it is released. Volumes reclaim policy can either be `Retain`, `Recycle`, or `Delete`.
+the volume after it is released. Volumes reclaim policy can either be `Retain` or `Delete`.
 
 `Retain` reclaim policy allows manual reclamation of the resource for those volume plug-ins that support it. `Delete` reclaim policy deletes both the `PersistentVolume` object from {product-title} and the associated storage asset in external infrastructure, such as AWS EBS, GCE PD, or Cinder volume.
 


### PR DESCRIPTION
- Version: only `v3.11`

- Description:
  `Recycle` reclaim policy is deprecated as of `v3.6`.
  Until `v3.10`, there is a alert message about `recycler is deprecated`.
  But it's removed now. So we should remove this deprecated term either for not being confusing.

- Related Information:
  [Openshift Volume Recycler Now Deprecated](https://docs.openshift.com/container-platform/3.6/release_notes/ocp_3_6_release_notes.html)
~~~
Openshift Volume Recycler is being deprecated. Anyone using recycler should use dynamic provision and volume deletion instead.
~~~