### PR TITLE
clarify custom build w/ buildah title

### DIFF
--- a/builds/custom-builds-buildah.adoc
+++ b/builds/custom-builds-buildah.adoc
@@ -1,5 +1,5 @@
 [id="custom-builds-buildah"]
-= Adding a Docker socket to custom builds with Buildah
+= Custom image builds with Buildah
 include::modules/common-attributes.adoc[]
 :context: custom-builds-buildah
 toc::[]


### PR DESCRIPTION
buildah isn't adding a docker socket, it's replacing the need for a docker socket.
