### PR TITLE
[enterprise-3.11] Added "openshift_master_audit_policyfile" to specify a audit policy file

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -136,6 +136,11 @@ You must include the default `openshift_master_admission_plugin_config` value ev
 xref:../install_config/master_node_configuration.adoc#master-node-config-audit-config[Audit
 Configuration] for more information.
 
+|`openshift_master_audit_policyfile`
+|Provide the location of a audit policy file. See
+xref:../install_config/master_node_configuration.adoc#master-node-config-advanced-audit[Audit Policy
+Configuration] for more information.
+
 |`openshift_master_cluster_hostname`
 |This variable overrides the host name for the cluster, which defaults to the
 host name of the master.

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1199,18 +1199,18 @@ The advanced audit feature provides several improvements over the
 xref:master-node-config-audit-config[basic audit functionality], including
 fine-grained events filtering and multiple output back ends.
 
-To enable the advanced audit feature, provide the following values in the
-`openshift_master_audit_config` parameter:
+To enable the advanced audit feature, you create an audit policy file and specify the following values in the
+`openshift_master_audit_config` and `openshift_master_audit_policyfile` parameters:
 
 ----
 openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/audit-ocp.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5, "policyFile": "/etc/origin/master/adv-audit.yaml", "logFormat":"json"}
+openshift_master_audit_policyfile="/<path>/adv-audit.yaml"
 ----
 
 [IMPORTANT]
 ====
-The policy file *_/etc/origin/master/adv-audit.yaml_* must be available on each master node.
+You must create the *_adv-audit.yaml_* file before you install the cluster and specify its location in the cluster inventory file.
 ====
-
 
 The following table contains additional options you can use.
 


### PR DESCRIPTION
- Fix: [If Advanced Audit is configured during initial installation, Control plane pods didn't come up](https://bugzilla.redhat.com/show_bug.cgi?id=1710723)

- Version: only `v3.11`

- Description:
  new `openshift_master_audit_policyfile` variable has added to specify a user-defined `audit policy` file, and it will copy to a path configured as `policyFile` during initial installation.

- Related Information:
   - Merged PR is here : https://github.com/openshift/openshift-ansible/pull/11620