### PR TITLE
Build changes and fixes

### DIFF
--- a/applications/pruning-objects.adoc
+++ b/applications/pruning-objects.adoc
@@ -30,5 +30,5 @@ include::modules/pruning-hard-pruning-registry.adoc[leveloffset=+1]
 include::modules/pruning-cronjobs.adoc[leveloffset=+1]
 .Additional resources
 - xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs_nodes-nodes-jobs[Running tasks in pods using jobs]
-- xref:../applications/quotas/quotas-setting-across-multiple-projects.adoc[Resource quotas across multiple projects]
+- xref:../applications/quotas/quotas-setting-across-multiple-projects.adoc#setting-quotas-across-multiple-projects[Resource quotas across multiple projects]
 - xref:../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]

--- a/authentication/understanding-identity-provider.adoc
+++ b/authentication/understanding-identity-provider.adoc
@@ -23,45 +23,45 @@ You can configure the following types of identity providers:
 |Identity provider
 |Description
 
-|xref:../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc[HTPasswd]
+|xref:../authentication/identity_providers/configuring-htpasswd-identity-provider.adoc#configuring-htpasswd-identity-provider[HTPasswd]
 |Configure the `htpasswd` identity provider to validate user names and passwords
 against a flat file generated using
 link:http://httpd.apache.org/docs/2.4/programs/htpasswd.html[`htpasswd`].
 
-|xref:../authentication/identity_providers/configuring-keystone-identity-provider.adoc[Keystone]
+|xref:../authentication/identity_providers/configuring-keystone-identity-provider.adoc#configuring-keystone-identity-provider[Keystone]
 |Configure the `keystone` identity provider to integrate
 your {product-title} cluster with Keystone to enable shared authentication with
 an OpenStack Keystone v3 server configured to store users in an internal
 database.
 
-|xref:../authentication/identity_providers/configuring-ldap-identity-provider.adoc[LDAP]
+|xref:../authentication/identity_providers/configuring-ldap-identity-provider.adoc#configuring-ldap-identity-provider[LDAP]
 |Configure the `ldap` identity provider to validate user names and passwords
 against an LDAPv3 server, using simple bind authentication.
 
-|xref:../authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc[Basic authentication]
+|xref:../authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc#configuring-basic-authentication-identity-provider[Basic authentication]
 |Configure a `basic-authentication` identity provider for users to log in to
 {product-title} with credentials validated against a remote identity provider.
 Basic authentication is a generic backend integration mechanism.
 
-|xref:../authentication/identity_providers/configuring-request-header-identity-provider.adoc[Request header]
+|xref:../authentication/identity_providers/configuring-request-header-identity-provider.adoc#configuring-request-header-identity-provider[Request header]
 |Configure a `request-header` identity provider to identify users from request
 header values, such as `X-Remote-User`. It is typically used in combination with
 an authenticating proxy, which sets the request header value.
 
-|xref:../authentication/identity_providers/configuring-github-identity-provider.adoc[GitHub or GitHub Enterprise]
+|xref:../authentication/identity_providers/configuring-github-identity-provider.adoc#configuring-github-identity-provider[GitHub or GitHub Enterprise]
 |Configure a `github` identity provider to validate user names and passwords
 against GitHub or GitHub Enterprise's OAuth authentication server.
 
-|xref:../authentication/identity_providers/configuring-gitlab-identity-provider.adoc[GitLab]
+|xref:../authentication/identity_providers/configuring-gitlab-identity-provider.adoc#configuring-gitlab-identity-provider[GitLab]
 |Configure a `gitlab` identity provider to use
 link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity
 provider.
 
-|xref:../authentication/identity_providers/configuring-google-identity-provider.adoc[Google]
+|xref:../authentication/identity_providers/configuring-google-identity-provider.adoc#configuring-google-identity-provider[Google]
 |Configure a `google` identity provider using
 link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].
 
-|xref:../authentication/identity_providers/configuring-oidc-identity-provider.adoc[OpenID Connect]
+|xref:../authentication/identity_providers/configuring-oidc-identity-provider.adoc#configuring-oidc-identity-provider[OpenID Connect]
 |Configure an `oidc` identity provider to integrate with an OpenID Connect
 identity provider using an
 link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].

--- a/build.py
+++ b/build.py
@@ -20,7 +20,8 @@ cli.init_logging(False, True)
 has_errors = False
 CLONE_DIR = "."
 BASE_PORTAL_URL = "https://access.redhat.com/documentation/en-us/"
-ID_RE = re.compile("^\[(?:\[|id=\'|#)(.*?)(\'?,.*?)?(?:\]|\')?\]", re.M | re.DOTALL)
+# ID_RE = re.compile("^\[(?:\[|id=\'|#)(.*?)(\'?,.*?)?(?:\]|\')?\]", re.M | re.DOTALL)
+ID_RE = re.compile("^\[(?:\[|id=\'|#|id=\")(.*?)(\'?,.*?)?(?:\]|\'|\")?\]", re.M | re.DOTALL)
 LINKS_RE = re.compile("(?:xref|link):([\./\w_-]*/?[\w_.-]*\.(?:html|adoc))?(#[\w_-]*)?(\[.*?\])", re.M | re.DOTALL)
 EXTERNAL_LINK_RE = re.compile("[\./]*([\w_-]+)/[\w_/-]*?([\w_.-]*\.(?:html|adoc))", re.DOTALL)
 INCLUDE_RE = re.compile("include::(.*?)\[(.*?)\]", re.M)

--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -21,6 +21,6 @@ include::modules/installation-aws-regions.adoc[leveloffset=+1]
 .Next steps
 
 * Install an {product-title} cluster. You can
-xref:../../installing/installing_aws/installing-aws-customizations.adoc[install a customized cluster]
-or xref:../../installing/installing_aws/installing-aws-default.adoc[quickly install a cluster]
+xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[install a customized cluster]
+or xref:../../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[quickly install a cluster]
 with default options.

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -10,10 +10,10 @@ cluster on Amazon Web Services (AWS).
 
 .Prerequisites
 
-* xref:../../installing/installing_aws/installing-aws-account.adoc[Configure an AWS account]
+* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc[configure it to access Red Hat Insights].
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
 
 include::modules/installation-overview.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-default.adoc
+++ b/installing/installing_aws/installing-aws-default.adoc
@@ -10,10 +10,10 @@ Amazon Web Services (AWS) that uses the default configuration options.
 
 .Prerequisites
 
-* xref:../../installing/installing_aws/installing-aws-account.adoc[Configure an AWS account]
+* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc[configure it to access Red Hat Insights].
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
 
 include::modules/installation-overview.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -17,10 +17,10 @@ cluster.
 
 .Prerequisites
 
-* xref:../../installing/installing_aws/installing-aws-account.adoc[Configure an AWS account]
+* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc[configure it to access Red Hat Insights].
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
 
 // TODO
 // Concept that describes networking

--- a/installing/installing_aws_user_infra/installing-aws-user-infra.adoc
+++ b/installing/installing_aws_user_infra/installing-aws-user-infra.adoc
@@ -15,10 +15,10 @@ according to your company's policies.
 
 .Prerequisites
 
-* xref:../../installing/installing_aws/installing-aws-account.adoc[Configure an AWS account]
+* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc[configure it to access Red Hat Insights].
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
 
 
 include::modules/installation-overview.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -10,7 +10,7 @@ bare metal infrastructure that you provision.
 
 .Prerequisites
 * If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc[configure it to access Red Hat Insights].
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
 
 include::modules/installation-overview.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -10,7 +10,7 @@ vSphere infrastructure that you provision.
 
 .Prerequisites
 * If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc[configure it to access Red Hat Insights].
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
 
 include::modules/installation-overview.adoc[leveloffset=+1]
 

--- a/logging/efk-logging-deploying.adoc
+++ b/logging/efk-logging-deploying.adoc
@@ -8,7 +8,7 @@ toc::[]
 The process for deploying cluster Logging to {product-title} involves:
 
 
-* Review the installation options in xref:../logging/efk-logging-deploying-about.adoc[About deploying cluster logging].
+* Review the installation options in xref:../logging/efk-logging-deploying-about.adoc#efk-logging-deploying-about[About deploying cluster logging].
 
 * Review the xref:../logging/efk-logging-deploying-about.adoc#efk-logging-deploy-storage-considerations_efk-logging-deploying-about[cluster logging storage considerations].
 

--- a/machine_management/deploying-machine-health-checks.adoc
+++ b/machine_management/deploying-machine-health-checks.adoc
@@ -12,7 +12,7 @@ include::modules/technology-preview.adoc[leveloffset=+1]
 
 .Prerequistes
 
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc[Enable a FeatureGate]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cluster_nodes-cluster-enabling[Enable a FeatureGate]
 so you can access Technology Preview features.
 +
 [NOTE]

--- a/monitoring/cluster-monitoring/about-cluster-monitoring.adoc
+++ b/monitoring/cluster-monitoring/about-cluster-monitoring.adoc
@@ -1,4 +1,4 @@
-[id="about-cluster-monitoring_{context}"]
+[id="about-cluster-monitoring"]
 = About cluster monitoring
 include::modules/common-attributes.adoc[]
 :context: about-monitoring

--- a/nodes/clusters/nodes-cluster-disabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-disabling-features.adoc
@@ -20,7 +20,7 @@ cluster.
 
 .Prerequisites
 
-* You xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc[enabled a FeatureGate]
+* You xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cluster_nodes-cluster-enabling[enabled a FeatureGate]
 to access Technology Preview features.
 
 include::modules/nodes-cluster-features-about.adoc[leveloffset=+1]
@@ -30,4 +30,3 @@ include::modules/nodes-cluster-disabling-features-cluster.adoc[leveloffset=+1]
 include::modules/feature-gate-features.adoc[leveloffset=+1]
 
 // modules/nodes-cluster-disabling-features-list.adoc[leveloffset=+1]
-

--- a/nodes/pods/nodes-pods-using.adoc
+++ b/nodes/pods/nodes-pods-using.adoc
@@ -1,5 +1,5 @@
-:context: nodes-pods-using
-[id="nodes-pods-using"]
+:context: nodes-pods-using-ssy
+[id="nodes-pods-using-pp"]
 = Using pods in {product-title}
 include::modules/common-attributes.adoc[]
 
@@ -17,4 +17,3 @@ deployed, and managed.
 include::modules/nodes-pods-using-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-using-example.adoc[leveloffset=+1]
-

--- a/nodes/scheduling/nodes-scheduler-about.adoc
+++ b/nodes/scheduling/nodes-scheduler-about.adoc
@@ -21,15 +21,14 @@ creates bindings (pod to node bindings) for the pods using the master API.
 // assemblies.
 
 Default pod scheduling::
-OpenShift Container Platform comes with a xref:../../nodes/scheduling/nodes-scheduler-default.adoc[default scheduler] that serves the needs of most users. The default scheduler uses both inherent and customization tools to determine the best fit for a pod. 
+OpenShift Container Platform comes with a xref:../../nodes/scheduling/nodes-scheduler-default.adoc#nodes-scheduler-default[default scheduler] that serves the needs of most users. The default scheduler uses both inherent and customization tools to determine the best fit for a pod.
 
 Advanced pod scheduling::
 In situations where you might want more control over where new pods are placed, the OpenShift Container Platform advanced scheduling features allow you to configure a pod so that the pod is required or has a preference to run on a particular node or alongside a specific pod by.
 
-* Using xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc[pod affinity and anti-affinity rules]  #nodes-scheduler-pod-affinity_nodes-scheduler-pod-affinity.
-* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc[pod affinity]. #nodes-scheduler-pod-affinity_nodes-scheduler-pod-affinity
-* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc[node affinity]. #nodes-scheduler-node-affinity_nodes-scheduler-node-affinity
-* Placing pods on xref:../../nodes/scheduling/nodes-scheduler-overcommit.adoc[overcomitted nodes]. #nodes-scheduler-overcommit_nodes-scheduler-overcommit
-* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc[node selectors]. #nodes-scheduler-node-selectors_nodes-scheduler-node-selectors
-* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc[taints and tolerations]. #nodes-scheduler-taints-tolerations_nodes-scheduler-taints-tolerations
-
+* Using xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[pod affinity and anti-affinity rules]  #nodes-scheduler-pod-affinity_nodes-scheduler-pod-affinity.
+* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity-about_nodes-scheduler-pod-affinity[pod affinity]. #nodes-scheduler-pod-affinity_nodes-scheduler-pod-affinity
+* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-about_nodes-scheduler-node-affinity[node affinity]. #nodes-scheduler-node-affinity_nodes-scheduler-node-affinity
+* Placing pods on xref:../../nodes/scheduling/nodes-scheduler-overcommit.adoc#nodes-scheduler-overcommit[overcomitted nodes]. #nodes-scheduler-overcommit_nodes-scheduler-overcommit
+* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[node selectors]. #nodes-scheduler-node-selectors_nodes-scheduler-node-selectors
+* Controlling pod placement with xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[taints and tolerations]. #nodes-scheduler-taints-tolerations_nodes-scheduler-taints-tolerations

--- a/nodes/scheduling/nodes-scheduler-overcommit.adoc
+++ b/nodes/scheduling/nodes-scheduler-overcommit.adoc
@@ -1,4 +1,4 @@
-:context: nodes-sceduler-overcommit
+:context: nodes-scheduler-overcommit
 [id="nodes-scheduler-overcommit"]
 = Placing pods onto overcommited nodes
 include::modules/common-attributes.adoc[]
@@ -11,10 +11,10 @@ toc::[]
 
 
 In an _overcommited_ state, the sum of the container compute resource requests and limits exceeds the resources available on the system.
-Overcommitment might be desirable in development environments where a trade-off of guaranteed performance for capacity is acceptable.  
+Overcommitment might be desirable in development environments where a trade-off of guaranteed performance for capacity is acceptable.
 
-Requests and limits enable administrators to allow and manage the overcommitment of resources on a node. 
-The scheduler uses requests for scheduling your container and providing a minimum service guarantee. 
+Requests and limits enable administrators to allow and manage the overcommitment of resources on a node.
+The scheduler uses requests for scheduling your container and providing a minimum service guarantee.
 Limits constrain the amount of compute resource that may be consumed on your node.
 
 // The following include statements pull in the module files that comprise
@@ -26,4 +26,3 @@ Limits constrain the amount of compute resource that may be consumed on your nod
 include::modules/nodes-cluster-overcommit-about.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-overcommit-configure-nodes.adoc[leveloffset=+1]
-

--- a/storage/dynamic-provisioning.adoc
+++ b/storage/dynamic-provisioning.adoc
@@ -1,4 +1,4 @@
-[id="dynamic-provisioning'"]
+[id="dynamic-provisioning"]
 = Dynamic provisioning
 include::modules/common-attributes.adoc[]
 :context: dynamic-provisioning


### PR DESCRIPTION
@openshift/team-documentation @openshift/team-aligned-docs FYI.

This fixes the current issue with the build where some links were not getting checked by Travis. This was due to our recent move to use "" for anchor ids instead of ''. The build script was just not equipped to handle that and the links were not getting properly checked.

I have fixed the script and fixed several anchor ids. 

Note that our guidance on xrefs hasn't changed. When using an xref you *must* link to an anchor id, not just the page/assembly, even if it is to the top of the page/assembly (https://github.com/openshift/openshift-docs/blob/enterprise-4.1/contributing_to_docs/doc_guidelines.adoc#links-to-internal-content).