### PR TITLE
Fixed broken link

### DIFF
--- a/openshift_images/images-understand.adoc
+++ b/openshift_images/images-understand.adoc
@@ -28,8 +28,8 @@ include::modules/images-imagestream-tag.adoc[leveloffset=+1]
 include::modules/images-imagestream-image.adoc[leveloffset=+1]
 include::modules/images-imagestream-trigger.adoc[leveloffset=+1]
 
-.Additional resources
+== Additional resources
 
 * For more information on using imagestreams, see
-xref../image-streams-manage.adoc#image-streams-managing[Managing image
+xref:image-streams-manage.adoc#managing-image-streams[Managing image
 streams].


### PR DESCRIPTION
Fixed a broken link and moved Additional Resources to Heading 2, per [mod docs guidelines for assemblies](https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc). 
