### PR TITLE
BZ1711835: Incorporated QE's feedback.

### DIFF
--- a/modules/identity-provider-github-CR.adoc
+++ b/modules/identity-provider-github-CR.adoc
@@ -50,8 +50,9 @@ application]. The application must be configured with a callback URL of
 issued by GitHub.
 <6> For GitHub Enterprise, you must provide the host name of your instance, such as
 `example.com`. This value must match the GitHub Enterprise `hostname` value in
-in the *_/setup/settings_* file and cannot include a port number. For GitHub,
-omit this parameter.
+in the *_/setup/settings_* file and cannot include a port number. If this
+value is not set, then either `teams` or `organizations` must be defined.
+For GitHub, omit this parameter.
 <7> Optional list of organizations. If specified, only GitHub users that are members of
 at least one of the listed organizations will be allowed to log in. If the GitHub OAuth
 application configured in `clientID` is not owned by the organization, an organization

--- a/modules/identity-provider-google-CR.adoc
+++ b/modules/identity-provider-google-CR.adoc
@@ -25,7 +25,7 @@ spec:
       clientID: {...} <3>
       clientSecret: <4>
         name: google-secret
-      hostedDomain: "" <5>
+      hostedDomain: "example.com" <5>
 ----
 <1> This provider name is prefixed to the Google numeric user ID to form an
 identity name. It is also used to build the redirect URL.
@@ -35,7 +35,7 @@ Google project]. The project must be configured with a redirect URI of
 `\https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp-provider-name>`.
 <4> Reference to an {product-title} Secret containing the client secret
 issued by Google.
-<5> Optional
+<5> A
 link:https://developers.google.com/identity/protocols/OpenIDConnect#hd-param[hosted domain]
-to restrict sign-in accounts to. If empty, any Google account is allowed
-to authenticate.
+used to restrict sign-in accounts. Optional if the `lookup` `mappingMethod`
+is used. If empty, any Google account is allowed to authenticate.

--- a/modules/identity-provider-keystone-CR.adoc
+++ b/modules/identity-provider-keystone-CR.adoc
@@ -23,7 +23,7 @@ spec:
     type: Keystone
     keystone:
       domainName: default <3>
-      url: http://keystone.example.com:5000 <4>
+      url: https://keystone.example.com:5000 <4>
       ca: <5>
         name: ca-config-map
       tlsClientCert: <6>
@@ -34,7 +34,8 @@ spec:
 <1> This provider name is prefixed to provider user names to form an identity name.
 <2> Controls how mappings are established between this provider's identities and user objects.
 <3> Keystone domain name. In Keystone, usernames are domain-specific. Only a single domain is supported.
-<4> The URL to use to connect to the Keystone server (required).
+<4> The URL to use to connect to the Keystone server (required). This must
+use https.
 <5> Optional: Reference to an {product-title} ConfigMap containing the
 PEM-encoded certificate authority bundle to use in validating server
 certificates for the configured URL.

--- a/modules/identity-provider-ldap-CR.adoc
+++ b/modules/identity-provider-ldap-CR.adoc
@@ -43,17 +43,19 @@ spec:
 name.
 <2> Controls how mappings are established between this provider's identities and user objects.
 <3> List of attributes to use as the identity. First non-empty attribute is
-used. At least one attribute is required. If none of the listed attribute have a
-value, authentication fails.
-<4> List of attributes to use as the email address. First non-empty attribute is
-used.
-<5> List of attributes to use as the display name. First non-empty attribute is
-used.
+used. At least one attribute is required. If none of the listed attribute
+have a value, authentication fails. Defined attributes are retrieved as raw,
+allowing for binary values to be used.
+<4> List of attributes to use as the email address. First non-empty
+attribute is used.
+<5> List of attributes to use as the display name. First non-empty
+attribute is used.
 <6> List of attributes to use as the preferred user name when provisioning a
 user for this identity. First non-empty attribute is used.
-<7> Optional DN to use to bind during the search phase.
+<7> Optional DN to use to bind during the search phase. Must be set if
+`bindPassword` is defined.
 <8> Optional reference to an {product-title} Secret containing the bind
-password.
+password. Must be set if `bindDN` is defined.
 <9> Optional: Reference to an {product-title} ConfigMap containing the
 PEM-encoded certificate authority bundle to use in validating server
 certificates for the configured URL. Only used when `insecure` is `false`.

--- a/modules/identity-provider-request-header-CR.adoc
+++ b/modules/identity-provider-request-header-CR.adoc
@@ -43,20 +43,21 @@ form an identity name.
 <2> Controls how mappings are established between this provider's identities and user objects.
 <3> Optional: URL to redirect unauthenticated `/oauth/authorize` requests to,
 that will authenticate browser-based clients and then proxy their request to
-`\https://_<namespace_route>_/oauth/authorize`.
-The URL that proxies to `\https://_<namespace_route>_/oauth/authorize` must end with `/authorize` (with no trailing slash),
+`https://_<namespace_route>_/oauth/authorize`.
+The URL that proxies to `https://_<namespace_route>_/oauth/authorize` must end with `/authorize` (with no trailing slash),
 and also proxy subpaths, in order for OAuth approval flows to work properly.
 `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 `${query}` is replaced with the current query string.
+If this attribute is not defined, then `loginURL` must be used.
 <4> Optional: URL to redirect unauthenticated `/oauth/authorize` requests to,
 that will authenticate clients which expect `WWW-Authenticate` challenges, and
-then proxy them to `\https://_<namespace_route>_/oauth/authorize`.
+then proxy them to `https://_<namespace_route>_/oauth/authorize`.
 `${url}` is replaced with the current URL, escaped to be safe in a query parameter.
 `${query}` is replaced with the current query string.
+If this attribute is not defined, then `challengeURL` must be used.
 <5> Reference to an {product-title} ConfigMap containing a PEM-encoded
 certificate bundle. Used as a trust anchor to validate the TLS
-certificates presented by the remote server. If this file is not
-present or valid the identity provider is not honored.
+certificates presented by the remote server.
 <6> Optional: list of common names (`cn`). If set, a valid client certificate with
 a Common Name (`cn`) in the specified list must be presented before the request headers
 are checked for user names. If empty, any Common Name is allowed. Can only be used in combination

--- a/modules/oauth-configuring-internal-oauth.adoc
+++ b/modules/oauth-configuring-internal-oauth.adoc
@@ -5,7 +5,7 @@
 [id="oauth-configuring-internal-oauth_{context}"]
 = Configuring options for the internal OAuth server
 
-You can configure default options for the internal OAuth server's 
+You can configure default options for the internal OAuth server's
 token duration.
 
 .Procedure
@@ -20,4 +20,5 @@ oauthConfig:
     accessTokenMaxAgeSeconds: 86400 <1>
 ----
 <1> Set `accessTokenMaxAgeSeconds` to control the lifetime of access tokens.
-The default lifetime is 24 hours, or 86400 seconds.
+The default lifetime is 24 hours, or 86400 seconds. This attribute cannot
+be negative.

--- a/modules/oauth-register-additional-client.adoc
+++ b/modules/oauth-register-additional-client.adoc
@@ -26,15 +26,15 @@ grantMethod: prompt <4>
 ')
 ----
 <1> The `name` of the OAuth client is used as the `client_id` parameter when
-making requests to `_<namespace_route>_/oauth/authorize` and 
+making requests to `_<namespace_route>_/oauth/authorize` and
 `_<namespace_route>_/oauth/token`.
 <2> The `secret` is used as the `client_secret` parameter when making requests
 to `_<namespace_route>_/oauth/token`.
 <3> The `redirect_uri` parameter specified in requests to
 `_<namespace_route>_/oauth/authorize` and `_<namespace_route>_/oauth/token`
- must be equal to or
-prefixed by one of the URIs listed in the `redirectURIs` parameter value.
-<4> The `grantMethod` is used to determine what action to take when this client
-requests tokens and has not yet been granted access by the user. Specify `auto`
-to automatically approve the grant and retry the request, or `prompt` to 
-prompt the user to approve or deny the grant
+ must be equal to or prefixed by one of the URIs listed in the
+`redirectURIs` parameter value.
+<4> The `grantMethod` is used to determine what action to take when this
+client requests tokens and has not yet been granted access by the user.
+Specify `auto` to automatically approve the grant and retry the request,
+or `prompt` to prompt the user to approve or deny the grant.


### PR DESCRIPTION
Incorporated QE's feedback. This updates descriptions in CRs to be a bit more explicit about expectations. Many of the attributes indicate if they are optional, and I believe it is a reasonable assumption that the user is required to provide the rest. Due to this, I have not felt necessary to list out which of these are required.

This is for OS 4.x.