### PR TITLE
UDP services not supported with Kuryr SDN

### DIFF
--- a/install_config/topics/ocp_osp_provisioning.adoc
+++ b/install_config/topics/ocp_osp_provisioning.adoc
@@ -202,7 +202,7 @@ openshift_openstack_user: openshift
 [NOTE]
 ====
 To enable namespace isolation, set 'openshift_kuryr_subnet_driver' to
-'namespace' so that a new Neutron subnet is created by kuryr for each
+'namespace' so that a new Neutron subnet is created by Kuryr for each
 namespace. Also set 'openshift_kuryr_sg_driver' to 'namespace' to ensure that
 the proper security groups are created and used to enforce isolation between
 the different namespaces.
@@ -210,8 +210,8 @@ the different namespaces.
 
 [NOTE]
 ====
-Use the latest supported kuryr images, regardless of the overcloud Red Hat
-OpenStack version. For instance, use kuryr images from OSP 14, whether the
+Use the latest supported Kuryr images, regardless of the overcloud Red Hat
+OpenStack version. For instance, use Kuryr images from OSP 14, whether the
 overcloud is OSP 14 or OSP 13. Kuryr is just another workload on top of the
 overcloud, and it aligns better with new OpenShift features if you use the
 latest images.
@@ -221,6 +221,13 @@ latest images.
 ====
 Network policies and nodeport services are not supported when Kuryr SDN is
 enabled.
+====
+
+[NOTE]
+====
+If Kuryr is enabled, {product-title} services are implemented through OpenStack Octavia Amphora VMs.
+
+Octavia does not support UDP load balancing. Services that expose UDP ports are not supported.
 ====
 
 Brief description of each variable in the table below:


### PR DESCRIPTION
* Add info about UDP services not being supported on Kuryr SDN due to missing support on the Octavia side.

* Rephrased admonition text.

Duplicating PR #15003, as the bot is down. 

@openshift/team-documentation for review.
