### PR TITLE
modules/installation*: Suggest per-cluster asset directories

### DIFF
--- a/modules/following-installation.adoc
+++ b/modules/following-installation.adoc
@@ -78,7 +78,7 @@ With a https://docs.openshift.com/container-platform/4.1/installing/installing_a
 
 [IMPORTANT]
 ====
-Although not required, you should create a directory to hold your installation configuration files and identify it when you run the installation. Don’t delete that directory when you have created your cluster, since it can be used to delete your cluster later.
+Although not required, you should create a directory to hold your installation configuration files and identify it when you run the installation. Don’t delete that directory when you have created your cluster, since it can be used to delete your cluster later.  Use separate directories for each cluster.
 ====
 
 [id="running-default-install_{context}"]

--- a/modules/installation-generate-aws-user-infra.adoc
+++ b/modules/installation-generate-aws-user-infra.adoc
@@ -31,7 +31,11 @@ installation before the certificate expires.
 $ ./openshift-install create install-config --dir=<installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
+files that the installation program creates.  Do not use a directory which
+was used for previous installations unless you want to recycle assets from
+those earlier clusters.  Because some assets like bootstrap X.509 certificates
+have limited expiration times, it is usually better to use a fresh
+installation directory for each new cluster.
 .. At the prompts, provide the configuration details for your cloud:
 ... Optionally, select an SSH key to use to access your cluster machines.
 +

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -22,7 +22,11 @@ You can customize your installation of {product-title} on a compatible cloud.
 $ ./openshift-install create install-config --dir=<installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
+files that the installation program creates.  Do not use a directory which
+was used for previous installations unless you want to recycle assets from
+those earlier clusters.  Because some assets like bootstrap X.509 certificates
+have limited expiration times, it is usually better to start with a fresh
+installation directory for each new cluster.
 .. At the prompts, provide the configuration details for your cloud:
 ... Optionally, select an SSH key to use to access your cluster machines.
 +

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -37,7 +37,11 @@ customized `./install-config.yaml` file.
 endif::[]
 ifeval::["{context}" == "installing-aws-default"]
 <1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
+files that the installation program creates.  Do not use a directory which
+was used for previous installations unless you want to recycle assets from
+those earlier clusters.  Because some assets like bootstrap X.509 certificates
+have limited expiration times, it is usually better to start with a fresh
+installation directory for each new cluster.
 +
 --
 Provide values at the prompts:


### PR DESCRIPTION
Users occasionally have trouble with installations where they recycled an asset directory from a previous cluster, and so pick up state like [expired X.509 certificates][1] or [unexpected release images][2].  While current installers attempt to remove most assets upon successful cluster deletion, there are still some [outstanding issues with that][3].  It's safer to just use a fresh directory, and this commit tries to get wording to that effect into each flow that passes through `openshift-install create ...`.  The analogous upstream docs are [here][4].

I'm not adjusting `installation-generate-ignition-configs.adoc`, because it is only consumed by the metal and vSphere flows, and they both go through `modules/installation-initializing-manual.adoc` first.  `installation-initializing-manual.adoc` suggests a `mkdir`, which will fail if the directory already exists, and these folks are already thinking about the installer loading information from their asset directory, so it didn't seem like they needed the same warning.

[1]: https://github.com/openshift/installer/issues/522
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1713016#c4
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1673251
[4]: https://github.com/openshift/installer/blame/8811e63e3f70196f088d6bbf3993ca9043ac3909/README.md#L53-L55