### PR TITLE
BZ1698640 mixed environment upgrades

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -719,12 +719,24 @@ OpenShift upgrades] for further guidance.
 [[special-considerations-for-mixed-environments]]
 == Special Considerations for Mixed Environments
 
-Mixed environment upgrades (for example, those with Red Hat Enterprise Linux and
-Red Hat Enterprise Linux Atomic Host) require setting both
-`openshift_pkg_version` and `openshift_image_tag`. In mixed environments,  if
-you only specify `openshift_pkg_version`, then that number is used for the
-packages for Red Hat Enterprise Linux and the image for Red Hat Enterprise
-Linux Atomic Host.
+Before you upgrade a mixed environment, such as one with Red Hat Enterprise
+Linux (RHEL) and RHEL Atomic Host, set values in the inventory file
+for both the `openshift_pkg_version` and `openshift_image_tag` parameters.
+Setting these values ensures that all nodes in your cluster run the same
+version of {product-title}.
+
+For example, to upgrade from {product-title}
+3.9 to {product-title} 3.10, set the following parameters and values:
+
+----
+openshift_pkg_version=-3.10.16
+openshift_image_tag=v3.10.16
+----
+
+[NOTE]
+====
+These parameters can also be present in other, non-mixed, environments.
+====
 
 [[special-considerations-for-glusterfs]]
 == Special Considerations When Using Containerized GlusterFS
@@ -736,8 +748,8 @@ Special consideration must be taken when upgrading these nodes, as `drain` and
 running as part of a daemonset.
 
 There is also the potential for someone to run an upgrade on multiple nodes at
-the same time, which would lead to data availability issues if more than one was
-hosting GlusterFS pods.
+the same time, which would lead to data availability issues if more than one
+was hosting GlusterFS pods.
 
 Even if a serial upgrade is running, there is no guarantee sufficient time will
 be given for GlusterFS to complete all of its healing operations before


### PR DESCRIPTION
For bug BZ1698640. This fix applies only to release 3.9, because the fix was covered in enterprise-3.10 and enterprise-3.11 by [PR 14638](https://github.com/openshift/openshift-docs/pull/14638). 

This is a separate fix because the file structure had changed after enterprise-3.9, and  it was not able to be cherrypicked when enterprise-3.11 and enterprise-3.10 fixes were applied. My instructions were to create a separate PR for this bug's enterprise-3.9 fix. 