### PR TITLE
OSDOCS-385: Commenting out old content.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -172,8 +172,8 @@ Topics:
 - Name: Removing the kubeadmin user
   File: remove-kubeadmin
   Distros: openshift-enterprise,openshift-origin
-- Name: Configuring LDAP failover
-  File: configuring-ldap-failover
+#- Name: Configuring LDAP failover
+#  File: configuring-ldap-failover
   Distros: openshift-enterprise,openshift-origin
 - Name: Configuring the user agent
   File: configuring-user-agent

--- a/authentication/understanding-and-creating-service-accounts.adoc
+++ b/authentication/understanding-and-creating-service-accounts.adoc
@@ -10,10 +10,10 @@ include::modules/service-accounts-dedicated-admin-role.adoc[leveloffset=+1]
 
 include::modules/dedicated-admin-role-overview.adoc[leveloffset=+1]
 
-include::modules/service-accounts-enabling-authentication.adoc[leveloffset=+1]
+// include::modules/service-accounts-enabling-authentication.adoc[leveloffset=+1]
 
 include::modules/service-accounts-creating.adoc[leveloffset=+1]
 
-include::modules/service-accounts-configuration-parameters.adoc[leveloffset=+1]
+// include::modules/service-accounts-configuration-parameters.adoc[leveloffset=+1]
 
 include::modules/service-accounts-granting-roles.adoc[leveloffset=+1]

--- a/authentication/using-service-accounts-in-applications.adoc
+++ b/authentication/using-service-accounts-in-applications.adoc
@@ -10,6 +10,6 @@ include::modules/service-accounts-default.adoc[leveloffset=+1]
 
 include::modules/service-accounts-creating.adoc[leveloffset=+1]
 
-include::modules/service-accounts-using-credentials-inside-a-container.adoc[leveloffset=+1]
+// include::modules/service-accounts-using-credentials-inside-a-container.adoc[leveloffset=+1]
 
 include::modules/service-accounts-using-credentials-externally.adoc[leveloffset=+1]


### PR DESCRIPTION
This removes references to the `master-config.xml` files that no longer exist. This content has been commented out for now, due to its proximity to the release.

This is for OS 4.x.