### PR TITLE
[enterprise-4.1] Multi-stage Dockerfile Builds GA

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -343,6 +343,11 @@ cluster` commands, Minishift, and CDK. {product-title} 4.1 focuses on ease of
 access and native experience, with a native installer on macOS and Microsoft
 Windows, native hypervisor support, and tray icon integration.
 
+[id="ocp-4-1-multistage-builds"]
+==== Multi-stage Dockerfile Builds Generally Available
+
+Multi-stage Dockerfiles are now supported in all `Docker` strategy builds.
+
 [id="ocp-4-1-registry"]
 === Registry
 


### PR DESCRIPTION
Add a note (in addition to GA table entry) indicating multi-stage
Dockerfiles are supported in all `Docker` strategy builds.