### PR TITLE
Add curl -k option as installer won't install OpenShift CA cert into …

### DIFF
--- a/day_two_guide/topics/network_connectivity.adoc
+++ b/day_two_guide/topics/network_connectivity.adoc
@@ -62,7 +62,7 @@ used by the internal cluster, and the `https://master.example.com:443` URL is
 used by external clients. On any node host:
 
 ----
-$ curl https://internal-master.example.com:443/version
+$ curl -k https://internal-master.example.com:443/version
 {
   "major": "1",
   "minor": "6",


### PR DESCRIPTION
…OS in 3.10 or later.

The curl command needs `-k` insecure option otherwise it failed with TLS error in 3.10+.