### PR TITLE
BZ-1713290: Corrected link.

### DIFF
--- a/modules/persistent-storage-csi-architecture.adoc
+++ b/modules/persistent-storage-csi-architecture.adoc
@@ -5,18 +5,18 @@
 [id="persistent-storage-csi-architecture_{context}"]
 = CSI Architecture
 
-CSI drivers are typically shipped as container images. These containers 
-are not aware of {product-title} where they run. To use CSI-compatible 
-storage backend in {product-title}, the cluster administrator must deploy 
-several components that serve as a bridge between {product-title} and the 
+CSI drivers are typically shipped as container images. These containers
+are not aware of {product-title} where they run. To use CSI-compatible
+storage backend in {product-title}, the cluster administrator must deploy
+several components that serve as a bridge between {product-title} and the
 storage driver.
- 
-The following diagram provides a high-level overview about the components 
+
+The following diagram provides a high-level overview about the components
 running in pods in the {product-title} cluster.
 
 image::csi-arch.png["Architecture of CSI components"]
 
-It is possible to run multiple CSI drivers for different storage backends. 
-Each driver needs its own external controllers' deployment and DaemonSet 
+It is possible to run multiple CSI drivers for different storage backends.
+Each driver needs its own external controllers' deployment and DaemonSet
 with the driver and CSI registrar.
 

--- a/storage/persistent-storage/persistent-storage-csi.adoc
+++ b/storage/persistent-storage/persistent-storage-csi.adoc
@@ -5,9 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The Container Storage Interface (CSI) allows {product-title} to consume 
-storage from  storage backends that implement the 
-link:https://github.com/container-storage-interface/spec[CSI interface] 
+The Container Storage Interface (CSI) allows {product-title} to consume
+storage from  storage backends that implement the
+link:https://github.com/container-storage-interface/spec[CSI interface]
 as persistent storage.
 
 :FeatureName: Container Storage Interface
@@ -15,11 +15,11 @@ include::modules/technology-preview.adoc[leveloffset=+0]
 
 [NOTE]
 ====
-{product-title} does not ship with any CSI drivers. It is recommended to 
-use the CSI drivers provided by 
-link:https://kubernetes-csi.github.io/docs/Drivers.html[community or storage vendors].
+{product-title} does not ship with any CSI drivers. It is recommended to
+use the CSI drivers provided by
+link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors].
 
-{product-title} {product-version} supports version 0.4.0 of the 
+{product-title} {product-version} supports version 0.4.0 of the
 link:https://github.com/container-storage-interface/spec[CSI specification].
 ====
 


### PR DESCRIPTION
Corrected the link in the CSI introduction.

This is for OS 4.x.