### PR TITLE
modules/installation*: Suggest per-cluster asset directories

### DIFF
--- a/modules/following-installation.adoc
+++ b/modules/following-installation.adoc
@@ -78,7 +78,7 @@ With a https://docs.openshift.com/container-platform/4.1/installing/installing_a
 
 [IMPORTANT]
 ====
-Although not required, you should create a directory to hold your installation configuration files and identify it when you run the installation. Don’t delete that directory when you have created your cluster, since it can be used to delete your cluster later.
+Although not required, you should create a directory to hold your installation configuration files and identify it when you run the installation. Don’t delete that directory when you have created your cluster, since it can be used to delete your cluster later.  Use separate directories for each cluster.
 ====
 
 [id="running-default-install_{context}"]

--- a/modules/installation-generate-aws-user-infra.adoc
+++ b/modules/installation-generate-aws-user-infra.adoc
@@ -32,6 +32,16 @@ $ ./openshift-install create install-config --dir=<installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.
++
+[IMPORTANT]
+====
+Specify an empty directory. Some installation assets, like bootstrap X.509
+certificates have short expiration intervals, so you must not reuse an
+installation directory. If you want to reuse individual files from another
+cluster installation, you can copy them into your directory. However, the file
+names for the installation assets might change between releases. Use caution
+when copying installation files from an earlier {product-title} version.
+====
 .. At the prompts, provide the configuration details for your cloud:
 ... Optionally, select an SSH key to use to access your cluster machines.
 +

--- a/modules/installation-generate-ignition-configs.adoc
+++ b/modules/installation-generate-ignition-configs.adoc
@@ -30,6 +30,17 @@ $ ./openshift-install create ignition-configs --dir=<installation_directory> <1>
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.
 +
+[IMPORTANT]
+====
+If you created an `install-config.yaml` file, specify the directory that contains
+it. Otherwise, specify an empty directory. Some installation assets, like
+bootstrap X.509 certificates have short expiration intervals, so you must not
+reuse an installation directory. If you want to reuse individual files from another
+cluster installation, you can copy them into your directory. However, the file
+names for the installation assets might change between releases. Use caution
+when copying installation files from an earlier {product-title} version.
+====
++
 The following files are generated
 in the directory:
 +

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -22,6 +22,16 @@ in:
 ----
 $ mkdir <installation_directory>
 ----
++
+[IMPORTANT]
+====
+You must create a directory. Some installation assets, like bootstrap X.509
+certificates have short expiration intervals, so you must not reuse an
+installation directory. If you want to reuse individual files from another
+cluster installation, you can copy them into your directory. However, the file
+names for the installation assets might change between releases. Use caution
+when copying installation files from an earlier {product-title} version.
+====
 
 . Customize the following `install-config.yaml` file template and save the
 it in the `<installation_directory>`.

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -23,6 +23,16 @@ $ ./openshift-install create install-config --dir=<installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.
++
+[IMPORTANT]
+====
+Specify an empty directory. Some installation assets, like bootstrap X.509
+certificates have short expiration intervals, so you must not reuse an
+installation directory. If you want to reuse individual files from another
+cluster installation, you can copy them into your directory. However, the file
+names for the installation assets might change between releases. Use caution
+when copying installation files from an earlier {product-title} version.
+====
 .. At the prompts, provide the configuration details for your cloud:
 ... Optionally, select an SSH key to use to access your cluster machines.
 +

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -39,6 +39,16 @@ ifeval::["{context}" == "installing-aws-default"]
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.
 +
+[IMPORTANT]
+====
+Specify an empty directory. Some installation assets, like bootstrap X.509
+certificates have short expiration intervals, so you must not reuse an
+installation directory. If you want to reuse individual files from another
+cluster installation, you can copy them into your directory. However, the file
+names for the installation assets might change between releases. Use caution
+when copying installation files from an earlier {product-title} version.
+====
++
 --
 Provide values at the prompts:
 


### PR DESCRIPTION
Users occasionally have trouble with installations where they recycled
an asset directory from a previous cluster, and so pick up state like
expired X.509 certificates [1] or unexpected release images [2].
While current installers attempt to remove most assets upon successful
cluster deletion, there are still some outstanding issues with that
[3].  It's safer to just use a fresh directory, and this commit tries
to get wording to that effect into each flow that passes through
'openshift-install create ...'.  The analogous upstream docs are in
[4].

I'm not adjusting installation-generate-ignition-configs.adoc, because
it is only consumed by the metal and vSphere flows, and they both go
through modules/installation-initializing-manual first.
installation-initializing-manual.adoc suggests a mkdir, which will
fail if the directory already exists, and these folks are already
thinking about the installer loading information from their asset
directory, so it didn't seem like they needed the same warning.

[1]: https://github.com/openshift/installer/issues/522
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1713016#c4
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1673251
[4]: https://github.com/openshift/installer/blame/8811e63e3f70196f088d6bbf3993ca9043ac3909/README.md#L53-L55

From https://github.com/openshift/openshift-docs/pull/15011