### PR TITLE
CNV-1598 install prereqs

### DIFF
--- a/cnv/cnv_install/preparing-cluster-for-cnv.adoc
+++ b/cnv/cnv_install/preparing-cluster-for-cnv.adoc
@@ -1,0 +1,14 @@
+[id="preparing-cluster-for-cnv"]
+= Preparing your {product-title} cluster for {ProductName}
+include::modules/cnv-document-attributes.adoc[]
+:context: preparing-cluster-for-cnv
+toc::[]
+
+{ProductName} 2.0 works with {product-title} by default, however the following 
+installation configurations are recommended:
+
+* The {product-title} cluster is installed on 
+xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal].
+* xref:../../monitoring/cluster-monitoring/about-cluster-monitoring.adoc#about-cluster-monitoring[Monitoring] 
+is configured in the cluster. 
+


### PR DESCRIPTION
As per jira cnv-1598, the only prerequisite for CNV 2.0 is an OpenShift 4.1 cluster.
There are two recommendations: bare metal, and monitoring configured.