### PR TITLE
Followup 4.1 Release Notes Tracker

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -135,6 +135,13 @@ Framework and Operator Lifecycle Manager (OLM) to continue providing your
 applications to OpenShift 4 clusters. These new technologies provide many
 benefits around complete management of the lifecycle of your application.
 
+|`oc adm ca`
+|Certificates are managed internally.
+
+|Web Console
+|The web console from {product-title} 3.11 has been replaced by a new web
+console in {product-title} 4.1.
+
 |====
 
 [id="ocp-4-1-new-features-and-enhancements"]
@@ -505,7 +512,7 @@ configuration. Configuring it requires using the unsupported overrides
 mechanism.
 
 [id="ocp-4-1-technology-preview"]
-== Technology Preview features and feature gates
+== Technology Preview features
 
 Some features in this release are currently in Technology Preview. These
 experimental features are not intended for production use. Please note the
@@ -514,312 +521,243 @@ following scope of support on the Red Hat Customer Portal for these features:
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview
 Features Support Scope]
 
-Starting in {product-title} 4.1, some _feature gates_, a set of key=value pairs
-that describe Technology Preview features, will ship enabled. You can change the
-default feature gates, but doing so prevents you from upgrading your cluster.
-Any change to a feature gate stops an upgrade. Clusters with a changed feature
-gate must be re-installed to apply even an asynchronous release update.
-
 In the table below, features marked *TP* indicate _Technology Preview_ and
-features marked *GA* indicate _General Availability_.
-
-If a feature is marked *yes;on*, that feature is controlled by a feature gate
-that is enabled, or turned on, when shipped. If a feature is marked *yes;off*,
-that feature is controlled by a feature gate that is disabled, or turned off,
-when shipped.
+￼	features marked *GA* indicate _General Availability_.
 
 .Technology Preview Tracker
 [cols="4",options="header"]
 |====
-|Feature |Feature gate |OCP 3.11 |OCP 4.1
+|Feature |OCP 3.11 |OCP 4.1
 
 |Prometheus Cluster Monitoring
-|
 |GA
 |GA
 
 |Local Storage Persistent Volumes
-|
 |TP
 |TP
 
 |CRI-O for runtime pods
-|
 |GA* footnoteref:[disclaimer, Features marked with `*` indicate delivery in a z-stream patch.]
 |GA
 
 |Tenant Driven Snapshotting
-|
 |TP
 |TP
 
 |`oc` CLI Plug-ins
-|
 |TP
 |TP
 
 |Service Catalog
-|
 |GA
 |GA
 
 |Template Service Broker
-|
 |GA
 |GA
 
 |OpenShift Ansible Service Broker
-|
 |GA
 |GA
 
 |Network Policy
-|
 |GA
 |GA
 
 |Multus
-|
 |-
 |GA
 
 |Service Catalog Initial Experience
-|
 |GA
 |GA
 
 |New Add Project Flow
-|
 |GA
 |GA
 
 |Search Catalog
-|
 |GA
 |GA
 
 |Cron Jobs
-|
 |GA
 |GA
 
 |Kubernetes Deployments
-|
 |GA
 |GA
 
 |StatefulSets
-|
 |GA
 |GA
 
 |Explicit Quota
-|
 |GA
 |GA
 
 |Mount Options
-|
 |GA
 |GA
 
 |System Containers for Docker, CRI-O
-|
 |-
 |-
 
 |Hawkular Agent
-|
 |-
 |-
 
 |Pod PreSets
-|
 |-
 |-
 
 |experimental-qos-reserved
-|
 |TP
 |TP
 
 |Pod sysctls
-|
 |GA
 |GA. See xref:ocp-4-1-known-issues[Known issues] for current limitations.
 
 |Central Audit
-|
 |GA
 |GA
 
 |Static IPs for External Project Traffic
-|
 |GA
 |GA
 
 |Template Completion Detection
-|
 |GA
 |GA
 
 |`replicaSet`
-|
 |GA
 |GA
 
 |Fluentd Mux
-|
 |TP
 |TP
 
 |Clustered MongoDB Template
-|
 |-
 |-
 
 |Clustered MySQL Template
-|
 |-
 |-
 
 |Image Streams with Kubernetes Resources
-|
 |GA
 |GA
 
 |Device Manager
-|
 |GA
 |GA
 
 |Persistent Volume Resize
-|
 |GA
 |GA
 
 |Huge Pages
-|
 |GA
 |GA
 
 |CPU Pinning
-|
 |GA
 |GA
 
 |Admission Webhooks
-|
 |TP
 |GA
 
 |External provisoner for AWS EFS
-|
 |TP
 |TP
 
 |Pod Unidler
-|
 |TP
 |TP
 
 |Node Problem Detector
-|
 |TP
 |TP
 
 |Ephemeral Storage Limit/Requests
-|
 |TP
 |TP
 
 |Descheduler
-|
 |TP
 |TP
 
 |CephFS
-|
 |TP
 |TP
 
 |Podman
-|
 |TP
 |TP
 
 |Kuryr CNI Plug-in
-|
 |TP
 |TP
 
 |Istio
-|
 |TP
 |TP
 
 |Sharing Control of the PID Namespace
-|
 |TP
 |TP
 
 |Manila Provisioner
-|
 |TP
 |TP
 
 |Cluster Administrator console
-|
 |GA
 |GA
 
 |Cluster Autoscaling (AWS Only)
-|
 |GA
 |GA
 
 |Container Storage Interface (CSI)
-|
 |TP
 |TP
 
 |Operator Lifecycle Manager
-|
 |TP
 |GA
 
 |Red Hat OpenShift Service Mesh
-|
 |TP
 |TP
 
 |"Fully Automatic" Egress IPs
-|
 |GA
 |GA
 
 |Pod Priority and Preemption
-|
 |GA
 |GA
 
 |Multi-stage builds in Dockerfiles
-|
 |TP
 |GA
 
 |OVN
 |
-|
 |TP
 
 |HPA custom metrics adapter based on Prometheus
 |
-|
 |TP
 
 |Machine health checks
-|
 |
 |TP
 |====
@@ -847,6 +785,95 @@ by a cluster administrator), the machine-controller will fail to successfully
 delete the backing cloud instance, and the machine-object will be stuck in
 `deleting` status.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1713061[*BZ#1713061*])
+
+* Querying `Jolokia` on `JBoss EAP` images fails as the result of empty
+certificates presented to the client. The `Jolokia` SSL client authentication
+will fail and may require a username and password challenge if enabled.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1708640[*BZ#1708640*])
+
+* The `TokenRequest` API is not available in {product-title} 4.1. Requesting a
+`ServiceAccountTokenVolumeProjection` volume is not available in {product-title}
+4.1. The kubelet will present an error if a
+`ServiceAccountTokenVolumeProjection` is used.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1695196[*BZ#1695196*])
+
+* The `es nodeCount` in ElasticSearch CRD instances can not be scaled up if
+deployed with three nodes. Scaling works correctly if deployed with one, two,
+four, five or six ElasticSearch CRD instances.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1712955[*BZ#1712955*])
+
+* ElasticSearch instances created from OperatorHub deploy with a one CPU limit,
+even though no limits are specified.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1710657[*BZ#1710657*])
+
+* After an AWS installation, the `openshiftClustID` tag is not present.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1685089[*BZ#1685089*])
+
+* scc(CRD) resources can not be upgraded by using the `oc patch` and `oc edit`
+commands. As a result, strategic merges also fail.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1707679[*BZ#1707679*])
+
+* The {product-title} 4.1 registry service utilizes port 5000 instead of port 443.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1701422[*BZ#1701422*])
+
+* Machineset scaling in AWS environments may fail if the resources requested are
+unavailable in the chosen Availability Zone.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1713157[*BZ#1713157*])
+
+* Using `OAuth` endpoints after configuring ingress wildcard certificates from
+custom PKIs result in login errors.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1712525[*BZ#1712525*])
+
+* Source-to-Image (S2I) builds in {product-title} 4.1 may take longer to complete.
+This is because {product-title} 4.1 does not utilize a shared image cache for
+building images like in previous versions of {product-title}.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1685352[*BZ#1685352*])
+
+* The `cloud-credential-operator` may crash on clusters with large numbers of
+projects or namespaces due to memory limitations.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1711402[*BZ#1711402*])
+
+* The Marketplace can not detect `opsrc` after a cluster upgrade is performed. As
+a result, the `csc` packages are empty and can not download `packagemanifests`.
+Marketplace can repair this problem approximately one hour later when it syncs
+again.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1695550[*BZ#1695550*])
+
+* In {product-title} 4.1, `oc` and `openshift-install` version may have a dirty
+`GitTreeState:` when checking the `oc version`.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1715001[*BZ#1715001*])
+
+* In AWS environments, if a master node is stopped, the `kubeapiserver` cannot be
+deployed due a pod stuck in a `Pending` status.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1713292[*BZ#1713292*])
+
+* AWS IPI and UPI instances fail to verify
+(https://access.redhat.com/security/cve/cve-2019-11091[*CVE-2019-1109*]) using
+Broadwell CPU model 79 (type m4) because the `microcode_ctl` will not update.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1710981[*BZ#1710981*])
+
+* New ElasticSearch deployments can not be created if another ElasticSearch
+deployment is stuck in a deleting state.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1711044[*BZ#1711044*])
+
+* There is no _Open Java Console_ link available in the {product-title} 4.1 web
+console.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1713656[*BZ#1713656*])
+
+* The `openshift-cluster-node-tuning-operator` may generate a large number of
+secrets after several days of uptime.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1714484[*BZ#1714484*])
+
+* Autoscaling for Memory Utilization is not working as expected. Creating HPA for
+memory-based autoscaling is failing while looking for resources.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1707785[*BZ#1707785*])
+
+* After successfully performing updates, `oc clusterversion` may report that the
+update could not be applied.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1711964[*BZ#1711964*])
+
+* The installer may have a `0` return code when hitting a FATAL event.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1712409[*BZ#1712409*])
 
 [id="ocp-4-1-asynchronous-errata-updates"]
 == Asynchronous errata updates
@@ -883,3 +910,137 @@ For any {product-title} release, always review the instructions on
 xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster]
 properly.
 ====
+
+[[ocp-4-1]]
+=== RHBA-2019:0758 - {product-title} 4.1 Image Release advisory
+
+Issued: 2019-06-04
+
+{product-title} release 4.1 is now available. The list of packages and bug fixes
+includes in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:1173[RHBA-2019:1173] advisory.
+The container images included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2019:0758[RHBA-2019:0758] advisory.
+
+Space precluded documenting all of the container images for this release in the
+advisory. See the following sections for notes on the container images in this
+release.
+
+[[ocp-4-1-container-images]]
+==== Container images
+
+* openshift3/redhat-openshift4-apb-base:v4.1.0-201905291302
+* openshift3/redhat-openshift4-apb-tools:v4.1.0-201905221405
+* openshift3/redhat-openshift4-mariadb-apb:v4.1.0-201905291302
+* openshift3/redhat-openshift4-mediawiki-apb:v4.1.0-201905291302
+* openshift3/redhat-openshift4-mediawiki:v4.1.0-201905221405
+* openshift3/redhat-openshift4-mysql-apb:v4.1.0-201905291302
+* openshift3/redhat-openshift4-ose-ansible-operator:v4.1.0-201905291302
+* openshift3/redhat-openshift4-ose-ansible-service-broker-operator:v4.1.0-201905291711
+* openshift3/redhat-openshift4-ose-ansible-service-broker:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-aws-machine-controllers:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-azure-machine-controllers:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-baremetal-machine-controllers:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cli-artifacts:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cli:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cloud-credential-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-authentication-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-autoscaler-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-autoscaler:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-bootstrap:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-capacity:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-config-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-dns-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-image-registry-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-ingress-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-kube-apiserver-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-kube-controller-manager-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-kube-scheduler-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-logging-operator:v4.1.0-201905291736
+* openshift3/redhat-openshift4-ose-cluster-machine-approver:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-monitoring-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-network-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-node-tuned:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-node-tuning-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-openshift-apiserver-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-openshift-controller-manager-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-samples-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-storage-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-svcat-apiserver-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-svcat-controller-manager-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-cluster-update-keys:v4.1.0-201905311324
+* openshift3/redhat-openshift4-ose-cluster-version-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-configmap-reloader:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-console-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-console:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-container-networking-plugins-supported:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-container-networking-plugins-unsupported:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-coredns:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-deployer:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-descheduler-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-descheduler:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-docker-builder:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-docker-registry:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-egress-dns-proxy:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-egress-http-proxy:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-egress-router:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-elasticsearch-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-etcd:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-grafana:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-haproxy-router-base:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-haproxy-router:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-hyperkube:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-hypershift:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-installer-artifacts:v4.1.0-201905212232
+* openshift3/redhat-openshift4-ose-installer:v4.1.0-201905212232
+* openshift3/redhat-openshift4-ose-jenkins-agent-base:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-jenkins-agent-maven:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-jenkins-agent-nodejs:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-jenkins:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-k8s-prometheus-adapter:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-keepalived-ipfailover:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-kube-client-agent:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-kube-etcd-signer-server:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-kube-proxy:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-kube-rbac-proxy:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-kube-state-metrics:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-libvirt-machine-controllers:v4.1.0-201905232339
+* openshift3/redhat-openshift4-ose-logging-curator5:v4.1.0-201905221523
+* openshift3/redhat-openshift4-ose-logging-elasticsearch5:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-logging-eventrouter:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-logging-fluentd:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-logging-kibana5:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-machine-api-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-machine-config-controller:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-machine-config-daemon:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-machine-config-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-machine-config-server:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-multus-admission-controller:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-multus-cni:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-must-gather:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-node:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-oauth-proxy:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-openstack-machine-controllers:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-operator-lifecycle-manager:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-operator-marketplace:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-operator-registry:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-ovn-kubernetes:v4.1.0-201905231545
+* openshift3/redhat-openshift4-ose-pod:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-prom-label-proxy:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-prometheus-alertmanager:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-prometheus-config-reloader:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-prometheus-node-exporter:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-prometheus-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-prometheus:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-recycler:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-service-ca-operator:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-service-catalog:v4.1.0-201905221405
+* openshift3/redhat-openshift4-ose-setup-etcd-environment:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-sriov-cni:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-sriov-dp-admission-controller:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-sriov-network-device-plugin:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-telemeter:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-template-service-broker-operator:v4.1.0-201905291736
+* openshift3/redhat-openshift4-ose-template-service-broker:v4.1.0-201905191700
+* openshift3/redhat-openshift4-ose-tests:v4.1.0-201905191700
+* openshift3/redhat-openshift4-postgres-apb:v4.1.0-201905291302


### PR DESCRIPTION
This is the Release Notes tracker for 4.1 GA. This PR will function as a WIP until we get closer to release, then will be merged. 

Build preview:
http://file.rdu.redhat.com/~antaylor/05282019/4-1-release-notes/release_notes/ocp-4-1-release-notes.html