### PR TITLE
Edits to OLM status

### DIFF
--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -29,13 +29,16 @@ continuing. Information about the Operator is displayed.
 
 . Read the information about the Operator and click *Install*.
 
-. On the *Create Operator Subscription* page, select:
-.. *All namespaces on the cluster (default)* to install the Operator to all
-namespaces or *A specific namespace on the cluster* to choose a specific, single
-namespace on which to install the Operator. The *All namespaces...* option is
-not always available.
-.. An *Update Channel* (if more than one is available).
-.. *Automatic* or *Manual* approval strategy, as described earlier.
+. On the *Create Operator Subscription* page:
+.. Select one of the following:
+*** *All namespaces on the cluster (default)* installs the Operator in the default
+*openshift-operators* namespace to watch and be made available to all namespaces
+in the cluster. This option is not always available.
+*** *A specific namespace on the cluster* allows you to choose a specific, single
+namespace in which to install the Operator. The Operator will only watch and be
+made available for use in this single namespace.
+.. Select an *Update Channel* (if more than one is available).
+.. Select *Automatic* or *Manual* approval strategy, as described earlier.
 
 . Click *Subscribe* to make the Operator available to the selected namespaces on
 this {product-title} cluster.
@@ -58,11 +61,16 @@ resolve to *Up to date* without intervention.
 .Subscription upgrade status *Up to date*
 image::olm-uptodate.png[]
 
-. After the Subscription's upgrade status is *Up to date*, select *Catalog →
-Installed Operators* to verify that the *Couchbase* ClusterServiceVersion (CSV)
-eventually shows up and its *Status* ultimately resolves to either *Copied* (for
-*All namespaces...* Installation Mode) or *InstallSucceeded* (for *A specific namespace...*
-Installation Mode).
+. After the Subscription's upgrade status is *Up to date*, select *Catalog → Installed Operators*
+to verify that the *Couchbase* ClusterServiceVersion (CSV) eventually shows up
+and its *Status* ultimately resolves to *InstallSucceeded* in the relevant namespace.
++
+[NOTE]
+====
+For the *All namespaces...* Installation Mode, the status resolves to
+*InstallSucceeded* in the *openshift-operators* namespace, but the status is
+*Copied* if you check in other namespaces.
+====
 +
 If it does not:
 


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/15001.

Preview (internal):

http://file.rdu.redhat.com/~adellape/052819/statusolm2/applications/operators/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster