### PR TITLE
528BZ1698198 remove daemonset label and add playbook name and reference

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -743,13 +743,13 @@ These parameters can also be present in other, non-mixed, environments.
 When upgrading  {product-title}, you must upgrade the set of nodes where
 GlusterFS pods are running.
 
-Special consideration must be taken when upgrading these nodes, as `drain` and
+Use care when upgrading these nodes, as `drain` and
 `unschedule` will not terminate and evacuate the GlusterFS pods because they are
 running as part of a daemonset.
 
 There is also the potential for someone to run an upgrade on multiple nodes at
-the same time, which would lead to data availability issues if more than one
-was hosting GlusterFS pods.
+the same time. If this occurs, it would lead to data availability issues if more
+than one node was hosting GlusterFS pods.
 
 Even if a serial upgrade is running, there is no guarantee sufficient time will
 be given for GlusterFS to complete all of its healing operations before
@@ -782,24 +782,22 @@ other nodes in their class (`app` versus `infra`), one at a time.
 .. Run `oc get daemonset` to verify the label found under `NODE-SELECTOR`. The
 default value is `storagenode=glusterfs`.
 
-.. Remove the daemonset label from the node:
-+
-----
-$ oc label node <node_name> <daemonset_label>-
-----
-+
-This will cause the GlusterFS pod to terminate on that node.
+.. Add a label (for example, `type=upgrade`) to the node you want to upgrade.
 
-.. Add an additional label (for example, `type=upgrade`) to the node you want to upgrade.
-
-.. To run the upgrade playbook on the single node where you terminated GlusterFS,
-use `-e openshift_upgrade_nodes_label="type=upgrade"`.
-
-.. When the upgrade completes, relabel the node with the daemonset selector:
+.. Using the *_upgrade_nodes.yml_* playbook on the node where you
+terminated GlusterFS, run `-e openshift_upgrade_nodes_label="type=upgrade"`.
 +
+[NOTE]
+====
+The *_upgrade_nodes.yml_* playbook is located here:
 ----
-$ oc label node <node_name> <daemonset_label>
+# ansible-playbook -i </path/to/inventory/file> \
+    /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml \
+    [-e <customized_node_upgrade_variables>] <1>
 ----
+<1> See xref:customizing-node-upgrades[Customizing Node Upgrades] for any desired
+`<customized_node_upgrade_variables>`.
+====
 
 .. Wait for the GlusterFS pod to respawn and appear.
 
@@ -814,8 +812,11 @@ Ensure all of the volumes are healed and there are no outstanding tasks. The
 `heal info` command lists all pending entries for a given volume's heal process.
 A volume is considered healed when `Number of entries` for that volume is `0`.
 
-.. Remove the upgrade label (for example, `type=upgrade`) and go to the next
-GlusterFS node.
+.. Remove the upgrade label and go to the next GlusterFS node:
++
+----
+$ oc label node <node_name> type-
+----
 
 [[special-considerations-for-gcepd]]
 == Special considerations when using gcePD


### PR DESCRIPTION
This PR is for [BZ1698198](https://bugzilla.redhat.com/show_bug.cgi?id=1698198). There were previous PRs related to this bug: 

- PR14812 (https://github.com/openshift/openshift-docs/pull/14812) 
- PR14809 (https://github.com/openshift/openshift-docs/pull/14809)
- PR14617 (https://github.com/openshift/openshift-docs/pull/14617).

Above were closed, unmerged, for several reasons:

- Additional material (playbook name and xref) needed after peer review.
- QE was passing the review around to several people to verify
- I thought it best to consolidate this information for ease of review and final approval from final QE engineer (@knarra@redhat.com), plus the length of time this Doc fix has been in the works due to above reasons. 

@knarra@redhat.com, will you PTAL?
