### PR TITLE
BZ-1714462: Updated GitHub URL.

### DIFF
--- a/modules/identity-provider-registering-github.adoc
+++ b/modules/identity-provider-registering-github.adoc
@@ -17,8 +17,8 @@ https://github.com/settings/applications/new[Register a new OAuth application].
 ** For GitHub Enterprise, go to your GitHub Enterprise home page and then click
 *Settings -> Developer settings -> Register a new application*.
 . Enter an application name, for example `My OpenShift Install`.
-. Enter a homepage URL, such as 
-`https://console-openshift-console.apps.example-openshift-cluster.com/`.
+. Enter a homepage URL, such as
+`\https://oauth-openshift.apps.<cluster-name>.<cluster-domain>`.
 . Optionally, enter an application description.
 . Enter the authorization callback URL, where the end of the URL contains the
 identity provider `name`:


### PR DESCRIPTION
BZ-1714462: Updated GitHub URL to use the generic format instead of a literal.

This is for OS 4.x.