### PR TITLE
BZ-1714182: Removed TP notice from NFS.

### DIFF
--- a/storage/persistent-storage/persistent-storage-nfs.adoc
+++ b/storage/persistent-storage/persistent-storage-nfs.adoc
@@ -6,18 +6,15 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 {product-title} clusters can be provisioned with persistent storage
-using NFS. Persistent volumes (PVs) and persistent volume claims (PVCs) 
+using NFS. Persistent volumes (PVs) and persistent volume claims (PVCs)
 provide a convenient method for sharing a volume across a project. While the
 NFS-specific information contained in a PV definition could also be defined
-directly in a Pod definition, doing so does not create the volume as a 
+directly in a Pod definition, doing so does not create the volume as a
 distinct cluster resource, making the volume more susceptible to conflicts.
 
 .Additional resources
 
 * https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-nfs[Network File System (NFS)]
-
-:FeatureName: Persistent storage using NFS
-include::modules/technology-preview.adoc[leveloffset=+1]
 
 include::modules/storage-persistent-storage-nfs-provisioning.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Removed technology preview notice from NFS. I also examined the other storage sections, and don't see any other references to this feature being TP.

This is for OS 4.x.