### PR TITLE
Fix Cluster Autoscaler Example

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -34,10 +34,10 @@ spec:
         max: 4 <9>
   scaleDown:
     enabled: true <10>
-    delayAfterAdd: 10s <11>
-    delayAfterDelete: 10s <12>
-    delayAfterFailure: 10s <13>
-    unneededTime: 10s <14>
+    delayAfterAdd: 10m <11>
+    delayAfterDelete: 5m <12>
+    delayAfterFailure: 30s <13>
+    unneededTime: 60s <14>
 ----
 <1> Specify the priority that a pod must exceed to cause the ClusterAutoscaler
 to deploy additional nodes. Enter a 32-bit integer value. The
@@ -53,8 +53,11 @@ are valid types.
 <8> Specify the minimum number of GPUs to deploy.
 <9> Specify the maximum number of GPUs to deploy.
 <10> Specify whether the ClusterAutoscaler can remove unnecessary nodes.
-<11> Specify the period, in seconds, to wait before deploying another node.
-<12> Specify the period, in seconds, to wait before deleting another node.
-<13> Specify the period, in seconds, to wait to deploy another node if the
-current deployment fails.
-<14> Specify the period, in seconds, before an unnecessary node is deleted.
+<11> Specify the period, in minutes, to wait before deleting a node after
+a node has recently been _added_.
+<12> Specify the period, in minutes, to wait before deleting a node after
+a node has recently been _deleted_.
+<13> Specify the period, in seconds, to wait before deleting a node after
+a scale down failure occured.
+<14> Specify the period, in seconds, before an unnecessary node is eligible
+for deletion.


### PR DESCRIPTION
- Correct wording for <11>
  - This example is for scaling down or deleting nodes...not deploying.
- Change examples in scaleDown section
  - Using 10s for all of these is probably not practical, even though it is only an example. Having such artificially low values would causing scale down actions to happen too quickly