### PR TITLE
Add information about allowed VXLAN ports on AWS

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -77,6 +77,11 @@ then you must set this explicitly to 50 less than the smallest node MTU value.
 <5> The port to use for all VXLAN packets. The default value is `4789`. If you
 are running in a virtualized environment with existing nodes that are part of
 another VXLAN network then you might be required to change this.
+ifdef::install[]
++
+On Amazon Web Services (AWS), you can select an alternate port for the VXLAN
+between port `9000` and port `9999`.
+endif::install[]
 
 <6> The parameters for this object specify the `kube-proxy` configuration. If
 you do not specify the parameter values, the Network Operator applies the


### PR DESCRIPTION
This is useful because the AWS SG is defined such that only a specific port range is valid for this configuration.

@openshift/team-documentation, PTAL. Thanks!