### PR TITLE
Cluster Loader: use 4.1 image for tests

### DIFF
--- a/modules/installing-cluster-loader.adoc
+++ b/modules/installing-cluster-loader.adoc
@@ -11,5 +11,5 @@ Cluster Loader is included in the `origin-tests` container image.
 . To pull the `origin-tests` container image, run:
 +
 ----
-$ sudo podman pull quay.io/openshift/origin-tests:v4.0
+$ sudo podman pull quay.io/openshift/origin-tests:4.1
 ----

--- a/modules/running-cluster-loader.adoc
+++ b/modules/running-cluster-loader.adoc
@@ -12,7 +12,7 @@ template builds and waits for them to complete:
 +
 ----
 $ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config -i
-quay.io/openshift/origin-tests:v4.0 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
+quay.io/openshift/origin-tests:4.1 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
 openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the \
 cluster [Suite:openshift]"'
 ----
@@ -22,7 +22,7 @@ setting the environment variable for `VIPERCONFIG`:
 +
 ----
 $ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config -i
-quay.io/openshift/origin-tests:v4.0 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
+quay.io/openshift/origin-tests:4.1 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
 export VIPERCONFIG=config/test && \
 openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the \
 cluster [Suite:openshift]"'


### PR DESCRIPTION
Don't mention 4.0 in Cluster Loader