### PR TITLE
BZ-1715395: Updated block volume support.

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -9,5 +9,18 @@
 = Block volume support
 
 You can statically provision raw block volumes by including API fields
-in your PV and PVC specifications. This functionality is only available for
-manually provisioned PVs.
+in your PV and PVC specifications.
+
+The following table displays which volume plug-ins support block volumes.
+
+.Block volume support
+[cols="1,1,1", width="100%",options="header"]
+|===
+|Volume Plug-in  |Manually provisioned  |Dynamically provisioned
+|AWS EBS  | ✅ | ✅
+|Fibre Channel | ✅ |
+|HostPath | |
+|iSCSI | ✅ |
+|NFS | |
+|VMWare vSphere  | ✅ | ✅
+|===


### PR DESCRIPTION
Updated the list of block volume support. I've removed the previous sentence regarding only manually provisioned volumes being supported, and added a table where it used to be.

This is for OS 4.x.