### PR TITLE
osdocs432 removing upi/ipi

### DIFF
--- a/modules/installation-cloudformation-control-plane.adoc
+++ b/modules/installation-cloudformation-control-plane.adoc
@@ -86,16 +86,16 @@ Parameters:
     Description: Do you want to invoke NLB registration (requires Lambda ARN parameter to be supplied)?
     Type: String
   RegisterNlbIpTargetsLambdaArn:
-    Description: ARN for NLB IP target registration lambda (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for NLB IP target registration lambda. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB)
     Type: String
   ExternalApiTargetGroupArn:
-    Description: ARN for external API load balancer target group (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for external API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB)
     Type: String
   InternalApiTargetGroupArn:
-    Description: ARN for internal API load balancer target group (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for internal API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB)
     Type: String
   InternalServiceTargetGroupArn:
-    Description: ARN for internal service load balancer target group (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for internal service load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB)
     Type: String
 
 Metadata:

--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -52,20 +52,20 @@ address that the bootstrap machine can reach.
 .. Create the bucket:
 +
 ----
-$ aws s3 mb s3://<cluster-name>-upi <1>
+$ aws s3 mb s3://<cluster-name>-infra <1>
 ----
-<1> `<cluster-name>-upi` is the bucket name.
+<1> `<cluster-name>-infra` is the bucket name.
 
 .. Upload the `bootstrap.ign` Ignition config file to the bucket:
 +
 ----
-$ aws s3 cp bootstrap.ign s3://<cluster-name>-upi/bootstrap.ign
+$ aws s3 cp bootstrap.ign s3://<cluster-name>-infra/bootstrap.ign
 ----
 
 .. Verify that the file uploaded:
 +
 ----
-$ aws s3 ls s3://<cluster-name>-upi/
+$ aws s3 ls s3://<cluster-name>-infra/
 
 2019-04-03 16:15:16     314878 bootstrap.ign
 ----

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 
-[id="installation-upi-machines-pxe-{context}"]
+[id="installation-user-infra-machines-pxe_{context}"]
 = Creating {op-system-first} machines by PXE or iPXE booting
 
 Before you install a cluster on bare metal infrastructure that you provision,
@@ -102,4 +102,3 @@ You must create the boostrap and control plane machines at this time. Because
 some pods are deployed on compute machines by default, also create at least two
 compute machine before you install the cluster.
 ====
-

--- a/modules/registry-configuring-storage-aws-user-infra.adoc
+++ b/modules/registry-configuring-storage-aws-user-infra.adoc
@@ -2,7 +2,7 @@
 //
 //* architecture/installation-.adoc
 
-[id="registry-configuring-storage-aws-upi_{context}"]
+[id="registry-configuring-storage-aws-user-infra_{context}"]
 = Configuring registry storage for AWS with user-provisioned infrastructure
 
 During installation, your cloud credentials are sufficient to create an S3 bucket

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -3,7 +3,7 @@
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
-// * installing/installing_aws_upi/installing-aws-upi.adoc
+// * installing/installing_aws_upi/installing-aws-user-infra.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -38,7 +38,7 @@ include::modules/registry-operator-default-crd.adoc[leveloffset=+1]
 
 == Configuring Image Registry Storage
 
-include::modules/registry-configuring-storage-aws-upi.adoc[leveloffset=+2]
+include::modules/registry-configuring-storage-aws-user-infra.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://jira.coreos.com/browse/OSDOCS-423

These are the last instances of UPI that I see. The ones in the CloudFormation template will be permanently fixed when https://github.com/openshift/installer/pull/1794 merges.