### PR TITLE
osdocs427 _context

### DIFF
--- a/modules/configmap-adding-ca.adoc
+++ b/modules/configmap-adding-ca.adoc
@@ -2,7 +2,7 @@
 //
 // * builds/setting-up-trusted-ca
 
-[id="configmap-adding-ca-{context}"]
+[id="configmap-adding-ca_{context}"]
 = Adding certifying authorities to a ConfigMap
 
 You can add certifying authorities (CAs) to a ConfigMap with the following

--- a/modules/configmap-create.adoc
+++ b/modules/configmap-create.adoc
@@ -2,7 +2,7 @@
 //
 // * builds/setting-up-trusted-ca
 
-[id="configmap-create-{context}"]
+[id="configmap-create_{context}"]
 = Creating a ConfigMap
 
 You can use the following command to create a ConfigMap from

--- a/modules/configmap-overview.adoc
+++ b/modules/configmap-overview.adoc
@@ -2,7 +2,7 @@
 //
 // * builds/setting-up-trusted-ca
 
-[id="configmap-overview-{context}"]
+[id="configmap-overview_{context}"]
 = Understanding ConfigMaps
 
 Many applications require configuration using some combination of configuration

--- a/modules/configuring-hpa-based-on-application-metrics.adoc
+++ b/modules/configuring-hpa-based-on-application-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * machine_management/configuring-hpa-for-an-application.adoc
 
-[id="configuring-hpa-based-on-application-metrics-{context}"]
+[id="configuring-hpa-based-on-application-metrics_{context}"]
 = Configuring HPA based on application metrics
 
 If you configure an application to export metrics, you can set up Horizontal Pod Autoscaling (HPA) based on these metrics.

--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/installing_aws_user_infra/installing-aws-user-infra.adoc
 
-[id="installation-aws-user-infra-rhcos-ami-{context}"]
+[id="installation-aws-user-infra-rhcos-ami_{context}"]
 = {op-system} AMIs for the AWS infrastructure
 
 You must use a valid {op-system-first} AMI for your Amazon Web Services

--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -2,10 +2,10 @@
 //
 // * nodes/nodes-pods-autoscaling-about.adoc
 
-[id='nodes-pods-autoscaling-about_{context}']
+[id="nodes-pods-autoscaling-about_{context}"]
 = Understanding horizontal pod autoscalers
 
-You can create a horizontal pod autoscaler to specify the minimum and maximum number of pods 
+You can create a horizontal pod autoscaler to specify the minimum and maximum number of pods
 you want to run, as well as the CPU utilization or memory utilization your pods should target.
 
 [IMPORTANT]
@@ -13,7 +13,7 @@ you want to run, as well as the CPU utilization or memory utilization your pods 
 Autoscaling for Memory Utilization is a Technology Preview feature only.
 ====
 
-After you create a horizontal pod autoscaler, {product-title} begins to query the CPU and/or memory resource metrics on the pods. 
+After you create a horizontal pod autoscaler, {product-title} begins to query the CPU and/or memory resource metrics on the pods.
 This query can take one to two minutes before obtaining the initial metrics.
 
 After these metrics are available, the horizontal pod autoscaler computes

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -2,18 +2,18 @@
 //
 // * nodes/nodes-pods-autoscaling-about.adoc
 
-[id='nodes-pods-autoscaling-creating-cpu_{context}']
+[id="nodes-pods-autoscaling-creating-cpu_{context}"]
 
 = Creating a horizontal pod autoscaler for CPU utilization
 
 You can create a horizontal pod autoscaler (HPA) to automatically scale pods when CPU usage exceeds a specified percentage.
-You create the HPA for a replication controller or deployment controller, based on how your pods were created. 
+You create the HPA for a replication controller or deployment controller, based on how your pods were created.
 
 .Prerequisites
 
 In order to use horizontal pod autoscalers, your cluster administrator must have properly configured cluster metrics.
 You can use the `oc describe PodMetrics <pod-name>` command to determine if metrics are configured. If metrics are
-configured, the output appears similar to the following, with `Cpu` and `Memory` displayed under `Usage`. 
+configured, the output appears similar to the following, with `Cpu` and `Memory` displayed under `Usage`.
 
 ----
 $ oc describe PodMetrics openshift-kube-scheduler-ip-10-0-135-131.ec2.internal
@@ -46,9 +46,9 @@ Events:                <none>
 for a deployment controller or a replication controller:
 +
 ----
-oc autoscale dc/<deployment-name> \//<1> 
-  --min <number> \//<2> 
-  --max <number> \//<3> 
+oc autoscale dc/<deployment-name> \//<1>
+  --min <number> \//<2>
+  --max <number> \//<3>
   --cpu-percent=<percent> <4>
 
 oc autoscale rc/<file-name> --min <number> --max <number> --cpu-percent=<percent>
@@ -79,4 +79,3 @@ $ oc get dc
 NAME      REVISION   DESIRED   CURRENT   TRIGGERED BY
 example   1          5         5         config
 ----
-

--- a/modules/nodes-pods-autoscaling-creating-memory.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/nodes-pods-autoscaling-about.adoc
 
-[id='nodes-pods-autoscaling-creating-memory_{context}']
+[id="nodes-pods-autoscaling-creating-memory_{context}"]
 
 = Creating a horizontal pod autoscaler object for memory utilization
 
@@ -109,7 +109,7 @@ spec:
   metrics:
   - type: Resource
     resource:
-      name: memory 
+      name: memory
       target:
         name: memory-percent
         type: Utilization
@@ -163,4 +163,3 @@ Max replicas:                                          10
 DeploymentConfig pods:                                 0 current / 0 desired
 Events:                                                <none>
 ----
-

--- a/modules/nodes-pods-autoscaling-creating.adoc
+++ b/modules/nodes-pods-autoscaling-creating.adoc
@@ -2,14 +2,14 @@
 //
 // * nodes/nodes-pods-autoscaling-about.adoc
 
-[id='nodes-pods-autoscaling-creating_{context}']
+[id="nodes-pods-autoscaling-creating_{context}"]
 = Understanding how to create a horizontal pod autoscaler
 
 How you create the horizontal pod autoscaler (HPA) depends on whether you want to scale for CPU or memory utilization.
 
-CPU utilization:: 
+CPU utilization::
 For CPU utilization:, you can create a horizontal pod autoscaler using the command line or by
-creating a `HorizontalPodAutoscaler` object. 
+creating a `HorizontalPodAutoscaler` object.
 
 When creating an HPA to control pod scaling based on CPU utilization, you specify the maximum number of pods
 you want to run at any given time. You can also specify a minimum number of pods.
@@ -66,8 +66,8 @@ For memory utilization, you can specify the minimum number of pods and the avera
 your pods should target as well, otherwise those are given default values from
 the {product-title} server.
 
-You can specify resource metrics in terms of direct values, instead of as percentages 
-of the requested value, by using a target type of `AverageValue` instead of `AverageUtilization`, 
+You can specify resource metrics in terms of direct values, instead of as percentages
+of the requested value, by using a target type of `AverageValue` instead of `AverageUtilization`,
 and setting the corresponding `target.averageValue` field instead of the `target.averageUtilization`.
 
 .Horizontal Pod Autoscaler Object Definition for memory utilization
@@ -100,4 +100,3 @@ spec:
 <5> The lower limit for the number of pods that can be set by the autoscaler. If not specified or negative, the server will apply a default value.
 <6> The upper limit for the number of pods that can be set by the autoscaler. This value is required.
 <7> The type of must be either Utilization, Value, or AverageValue.
-

--- a/modules/nodes-pods-autoscaling-status-about.adoc
+++ b/modules/nodes-pods-autoscaling-status-about.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/nodes-pods-autoscaling-about.adoc
 
-[id='nodes-pods-autoscaling-status-about_{context}']
+[id="nodes-pods-autoscaling-status-about_{context}"]
 
 = Understanding horizontal pod autoscaler status conditions
 
@@ -15,15 +15,15 @@ autoscaling API.
 
 The HPA responds with the following status conditions:
 
-* The `AbleToScale` condition indicates whether HPA is able to fetch and update metrics, as well as whether any backoff-related conditions could prevent scaling. 
+* The `AbleToScale` condition indicates whether HPA is able to fetch and update metrics, as well as whether any backoff-related conditions could prevent scaling.
 ** A `True` condition indicates scaling is allowed.
 ** A `False` condition indicates scaling is not allowed for the reason specified.
 
-* The `ScalingActive` condition indicates whether the HPA is enabled (for example, the replica count of the target is not zero) and is able to calculate desired metrics. 
+* The `ScalingActive` condition indicates whether the HPA is enabled (for example, the replica count of the target is not zero) and is able to calculate desired metrics.
 ** A `True` condition indicates metrics is working properly.
 ** A `False` condition generally indicates a problem with fetching metrics.
 
-* The `ScalingLimited` condition indicates that the desired scale was capped by the maximum or minimum of the horizontal pod autoscaler. 
+* The `ScalingLimited` condition indicates that the desired scale was capped by the maximum or minimum of the horizontal pod autoscaler.
 ** A `True` condition indicates that you need to raise or lower the minimum or maximum replica count in order to scale.
 ** A `False` condition indicates that the requested scaling is allowed.
 +
@@ -86,4 +86,3 @@ Conditions:
   ScalingActive     True      ValidMetricFound    the HPA was able to successfully calculate a replica count from pods metric http_request
   ScalingLimited    False     DesiredWithinRange  the desired replica count is within the acceptable range
 ----
-

--- a/modules/nodes-pods-autoscaling-status-viewing.adoc
+++ b/modules/nodes-pods-autoscaling-status-viewing.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/nodes-pods-autoscaling-about.adoc
 
-[id='nodes-pods-autoscaling-status-viewing_{context}']
+[id="nodes-pods-autoscaling-status-viewing_{context}"]
 
 = Viewing horizontal pod autoscaler status conditions
 

--- a/modules/nodes-pods-daemonsets-pods.adoc
+++ b/modules/nodes-pods-daemonsets-pods.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/nodes-pods-daemonsets.adoc
 
-[id="nodes-pods-daemonsets-pods-{context}"]
+[id="nodes-pods-daemonsets-pods_{context}"]
 = About Scheduling DaemonSets with the default scheduler
 
 In {product-title}, the scheduler selects the Node that a Pod runs on. However, in previous versions of {product-title}, DaemonSet pods were created and scheduled by the DaemonSet controller. 

--- a/modules/nw-kube-proxy-config.adoc
+++ b/modules/nw-kube-proxy-config.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * networking/configuring-kubeproxy.adoc
 
-[id="nw-kube-proxy-config-{context}"]
+[id="nw-kube-proxy-config_{context}"]
 = kube-proxy configuration parameters
 
 You can modify the following `kubeProxyConfig` parameters:

--- a/modules/nw-kube-proxy-configuring.adoc
+++ b/modules/nw-kube-proxy-configuring.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * networking/configuring-kubeproxy.adoc
 
-[id="nw-kube-proxy-configuring-{context}"]
+[id="nw-kube-proxy-configuring_{context}"]
 = Modifying the kube-proxy configuration
 
 You can modify the Kubernetes network proxy configuration for your cluster.

--- a/modules/nw-kube-proxy-sync.adoc
+++ b/modules/nw-kube-proxy-sync.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * networking/configuring-kubeproxy.adoc
 
-[id="nw-kube-proxy-sync-{context}"]
+[id="nw-kube-proxy-sync_{context}"]
 = About iptables rules synchronization
 
 The synchronization period determines how frequently the Kubernetes network


### PR DESCRIPTION
https://jira.coreos.com/browse/OSDOCS-427

I found a few more -{context} and/or {context}' instances, so I fixed them.

@vikram-redhat, FYI. I hope more don't sneak in. 