### PR TITLE
CNV1610 - Installing VirtIO drivers for Windows VMs

### DIFF
--- a/cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+++ b/cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
@@ -1,0 +1,18 @@
+[id="cnv-installing-virtio-drivers-on-existing-windows-vm"]
+= Installing VirtIO driver on an existing Windows virtual machine
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-installing-virtio-drivers-on-existing-windows-vm
+toc::[]
+
+include::modules/cnv-understanding-virtio-drivers.adoc[leveloffset=+1]
+
+See also: xref:../../cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc#cnv-installing-virtio-drivers-on-new-windows-vm[Installing Virtio drivers on a new Windows virtual machine].
+
+include::modules/cnv-supported-virtio-drivers.adoc[leveloffset=+1]
+
+include::modules/cnv-adding-virtio-drivers-vm-yaml.adoc[leveloffset=+1]
+
+include::modules/cnv-installing-virtio-drivers-existing-windows.adoc[leveloffset=+1]
+
+include::modules/cnv-removing-virtio-disk-from-vm.adoc[leveloffset=+1]
+

--- a/cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+++ b/cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
@@ -1,0 +1,23 @@
+[id="cnv-installing-virtio-drivers-on-new-windows-vm"]
+= Installing VirtIO driver on a new Windows virtual machine
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-installing-virtio-drivers-on-new-windows-vm"
+toc::[]
+
+.Prerequisites
+
+* Windows installation media accessible by the virtual machine, such as 
+xref:../../cnv/cnv_users_guide/cnv-importing-virtual-machines.adoc#cnv-importing-vm-datavolume_cnv-importing-virtual-machines[importing an ISO into a data volume] 
+and attaching it to the virtual machine.
+
+include::modules/cnv-understanding-virtio-drivers.adoc[leveloffset=+1]
+
+See also: xref:../../cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc#cnv-installing-virtio-drivers-on-existing-windows-vm[Installing VirtIO driver on an existing Windows virtual machine].
+
+include::modules/cnv-supported-virtio-drivers.adoc[leveloffset=+1]
+
+include::modules/cnv-adding-virtio-drivers-vm-yaml.adoc[leveloffset=+1]
+
+include::modules/cnv-installing-virtio-drivers-installing-windows.adoc[leveloffset=+1]
+
+include::modules/cnv-removing-virtio-disk-from-vm.adoc[leveloffset=+1]

--- a/modules/cnv-adding-virtio-drivers-vm-yaml.adoc
+++ b/modules/cnv-adding-virtio-drivers-vm-yaml.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+
+[id="cnv-adding-virtio-drivers-vm-yaml_{context}"]
+= Adding VirtIO drivers container disk to a virtual machine
+
+{ProductName} distributes VirtIO drivers for Microsoft Windows as a 
+container disk, which is available from the 
+link:https://access.redhat.com/containers/?count=50#/product/5be1983a5a13463a3e1d8ef4[Red Hat Container Catalog]. 
+To install these drivers to a Windows virtual machine, attach the 
+`cnv-tech-preview/virtio-win` container disk to the virtual machine as a SATA CD drive 
+in the virtual machine configuration file. 
+
+.Prerequisites
+
+* Download the `cnv-tech-preview/virtio-win` container disk from the 
+link:https://access.redhat.com/containers/?count=50#/product/5be1983a5a13463a3e1d8ef4[Red Hat Container Catalog].
+This is not mandatory, because the container disk will be downloaded from the Red Hat registry 
+if it not already present in the cluster, but it can reduce installation time.
+
+.Procedure
+
+. Add the `cnv-tech-preview/virtio-win` container disk as a `cdrom` disk in the 
+Windows virtual machine configuration file. The container disk will be 
+downloaded from the registry if it is not already present in the cluster. 
++
+[source,yaml]
+----
+spec:
+  domain:
+    devices:
+      disks:
+        - name: virtiocontainerdisk
+          bootOrder: 2 <1>
+          cdrom:
+            bus: sata
+volumes:
+  - containerDisk:
+      image: cnv-tech-preview/virtio-win
+    name: virtiocontainerdisk
+----
+<1> {ProductName} boots virtual machine disks in the order defined in the 
+`VirtualMachine` configuration file. You can either define other disks for the 
+virtual machine before the `cnv-tech-preview/virtio-win` container disk or use the optional 
+`bootOrder` parameter to ensure the virtual machine boots from the correct disk.
+ If you specify the `bootOrder` for a disk, it must be specified for all disks 
+in the configuration.
+
+. The disk is available once the virtual machine has started:
+** If you add the container disk to a running virtual machine, use 
+`oc apply -f <vm.yaml>` in the CLI or reboot the virtual machine for the changes 
+to take effect.
+** If the virtual machine is not running, use `virtctl start <vm>`.
+
+After the virtual machine has started, the VirtIO drivers can be installed from 
+the attached SATA CD drive.
+

--- a/modules/cnv-installing-virtio-drivers-existing-windows.adoc
+++ b/modules/cnv-installing-virtio-drivers-existing-windows.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+
+[id="cnv-installing-virtio-drivers-existing-windows_{context}"]
+= Installing VirtIO drivers on an existing Windows virtual machine
+
+Install the VirtIO drivers from the attached SATA CD drive to an 
+existing Windows virtual machine. 
+
+[NOTE]
+====
+This procedure uses a generic approach to adding drivers to Windows. The process
+ might differ slightly between versions of Windows. Refer to the documentation for
+ the version of Windows that you are installing.
+====
+
+.Procedure
+
+. Start the virtual machine and connect to a graphical console.
+. Log in to a Windows user session.
+. Open *Device Manager* and expand *Other devices* to list any *Unknown device*.
+.. You might need to open the `Device Properties` to identify the unknown device. 
+Right-click the device and select *Properties*.
+.. Click the *Details* tab and select *Hardware Ids* in the *Property* list.
+.. Compare the *Value* for the *Hardware Ids* with the supported VirtIO drivers.
+. Right-click the device and select *Update Driver Software*.
+. Click *Browse my computer for driver software* and browse to the attached 
+SATA CD drive, where the VirtIO drivers are located. The drivers are arranged 
+hierarchically according to their driver type, operating system, 
+and CPU architecture.
+. Click *Next* to install the driver. 
+. Repeat this process for all the necessary VirtIO drivers. 
+. After the driver installs, click *Close* to close the window.
+. Reboot the virtual machine to complete the driver installation. 
+

--- a/modules/cnv-installing-virtio-drivers-installing-windows.adoc
+++ b/modules/cnv-installing-virtio-drivers-installing-windows.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+
+[id="cnv-installing-virtio-drivers-installing-windows_{context}"]
+= Installing VirtIO drivers during Windows installation
+
+Install the VirtIO drivers from the attached SATA CD driver during Windows installation. 
+
+[NOTE]
+====
+This procedure uses a generic approach to the Windows installation and the 
+installation method might differ between versions of Windows. Refer to the 
+documentation for the version of Windows that you are installing.
+====
+
+.Procedure
+
+. Start the virtual machine and connect to a graphical console.
+. Begin the Windows installation process. 
+. Select the *Advanced* installation.
+. The storage destination will not be recognized until the driver is loaded. 
+Click `Load driver`. 
+. The drivers are attached as a SATA CD drive. Click *OK* and browse the CD drive
+ for the storage driver to load. The drivers are arranged hierarchically 
+according to their driver type, operating system, and CPU architecture. 
+. Repeat the previous two steps for all required drivers. 
+. Complete the Windows installation. 
+

--- a/modules/cnv-removing-virtio-disk-from-vm.adoc
+++ b/modules/cnv-removing-virtio-disk-from-vm.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+
+[id="cnv-removing-virtio-disk-from-vm_{context}"]
+= Removing the VirtIO container disk from a virtual machine
+
+After installing all required VirtIO drivers to the virtual machine, the
+ `cnv-tech-preview/virtio-win` container disk no longer needs to be attached to the virtual machine. 
+Remove the `cnv-tech-preview/virtio-win` container disk from the virtual machine configuration file. 
+
+.Procedure
+. Edit the configuration file and remove the `disk` and the `volume`.
++
+----
+$ oc edit vm <vm-name>
+----
++
+[source,yaml]
+----
+spec:
+  domain:
+    devices:
+      disks:
+        - name: virtiocontainerdisk
+          bootOrder: 2
+          cdrom:
+            bus: sata
+volumes:
+  - containerDisk:
+      image: cnv-tech-preview/virtio-win
+    name: virtiocontainerdisk
+----
+
+. Reboot the virtual machine for the changes to take effect. 
+

--- a/modules/cnv-supported-virtio-drivers.adoc
+++ b/modules/cnv-supported-virtio-drivers.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+
+[id="cnv-supported-virtio-drivers_{context}"]
+= Supported VirtIO drivers for Microsoft Windows virtual machines in {ProductName}
+
+.Supported drivers
+|===
+|Driver name | Hardware ID | Description
+
+|*viostor*
+|VEN_1AF4&DEV_1001 +
+VEN_1AF4&DEV_1042
+|The block driver. Sometimes displays as an *SCSI Controller* in the *Other devices* 
+group.
+
+|*viorng*
+|VEN_1AF4&DEV_1005 +
+VEN_1AF4&DEV_1044
+|The entropy source driver. Sometimes displays as a *PCI Device* in the 
+*Other devices* group.
+
+|*NetKVM*
+|VEN_1AF4&DEV_1000 +
+VEN_1AF4&DEV_1041
+|The network driver. Sometimes displays as an *Ethernet Controller* in the 
+*Other devices* group. Available only if a VirtIO NIC is configured.
+|===
+
+

--- a/modules/cnv-understanding-virtio-drivers.adoc
+++ b/modules/cnv-understanding-virtio-drivers.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+
+[id="cnv-understanding-virtio-drivers_{context}"]
+= Understanding VirtIO drivers
+
+VirtIO drivers are paravirtualized device drivers required for Microsoft Windows
+ virtual machines to run in {ProductName}. The supported drivers are 
+available in the `cnv-tech-preview/virtio-win` container disk of the 
+link:https://access.redhat.com/containers/?count=50#/product/5be1983a5a13463a3e1d8ef4[Red Hat Container Catalog].
+
+The `cnv-tech-preview/virtio-win` container disk must be attached to the virtual machine as a 
+SATA CD drive to enable driver installation. You can install VirtIO drivers during 
+Windows installation on the virtual machine or added to an 
+existing Windows installation.
+
+After the drivers are installed, the `cnv-tech-preview/virtio-win` container disk can be removed 
+from the virtual machine.
+


### PR DESCRIPTION
Two assemblies covering the user stories for installing virtio drivers to Win VMs - migrated from 1.4 content:
- Installing the drivers as part of an existing (Windows already installed on VM) VM
- Installing the drivers on a VM during installation of Windows on VM
Heavy content duplication between the two assemblies. 