### PR TITLE
Removing Understanding containers and ephemeral storage

### DIFF
--- a/modules/nodes-cluster-overcommit-resources-containers.adoc
+++ b/modules/nodes-cluster-overcommit-resources-containers.adoc
@@ -34,6 +34,8 @@ system tasks or daemons need more memory than was accounted for in the node's
 resource reservation. If a container specifies a limit on memory, it is
 immediately terminated if it exceeds the limit amount.
 
+////
+Ephemeral storage not in 4.1
 [id="containers-ephemeral_{context}"]
 == Understanding containers and ephemeral storage
 
@@ -56,3 +58,4 @@ terminated unless system tasks or daemons need more local ephemeral storage than
 was accounted for in the node's resource reservation. If a container specifies a
 limit on ephemeral storage, it is immediately terminated if it exceeds the limit
 amount.
+////


### PR DESCRIPTION
I noticed a section on _Understanding containers and ephemeral storage_. Ephemeral storage not supported in 4.1. Commenting-out the section.