### PR TITLE
Add a note about the lowered node count

### DIFF
--- a/modules/openshift-cluster-limits.adoc
+++ b/modules/openshift-cluster-limits.adoc
@@ -84,3 +84,6 @@ the system has enough CPU, memory, and disk to satisfy the application requireme
 
 In {product-title} {product-version}, half of a CPU core (500 millicore) is now reserved by
 the system compared to {product-title} 3.11 and previous versions.
+
+In {product-title} 4.1, the tested node limit has been lowered until scale tests can be run at
+a higher node count.


### PR DESCRIPTION
This commit adds a note in the cluster limits page about why we lowered
the number of nodes limit and the plan to bump it up it when we get
an opportunity to run scale tests at higher node count.