### PR TITLE
Replaced glusterfs-registry for glusterfs_registry

### DIFF
--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -122,7 +122,7 @@ The xref:../../install/index.adoc#install-planning[cluster installation] process
 can be used to install one or both of two GlusterFS node groups:
 
 - `glusterfs`: A general storage cluster for use by user applications.
-- `glusterfs-registry`: A dedicated storage cluster for use by infrastructure
+- `glusterfs_registry`: A dedicated storage cluster for use by infrastructure
 applications such as an integrated OpenShift Container Registry.
 
 It is recommended to deploy both groups to avoid potential impacts on
@@ -133,7 +133,7 @@ The definition of the clusters is done by including the relevant names in the
 `[OSEv3:children]` group, creating similarly named groups, and then populating
 the groups with the node information. The clusters can then be configured
 through a variety of variables in the `[OSEv3:vars]` group. `glusterfs`
-variables begin with `openshift_storage_glusterfs_` and `glusterfs-registry`
+variables begin with `openshift_storage_glusterfs_` and `glusterfs_registry`
 variables begin with `openshift_storage_glusterfs_registry_`. A few other
 variables, such as `openshift_hosted_registry_storage_kind`, interact with the
 GlusterFS clusters.


### PR DESCRIPTION
Under "Using the Installer" section
The right name for that group is with an underscore

Replacement for https://github.com/openshift/openshift-docs/pull/13995

@luigiaparicio, FYI

This change was approved on the original PR.