### PR TITLE
BZ1676399 - Upgrade documentation if oreg_url changes

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -600,6 +600,15 @@ Otherwise, the service is restarted on HA masters, but the systems do not reboot
 xref:../install/configuring_inventory_file.adoc#configuring-cluster-variables[Configuring
 Cluster Variables] for details.
 
+. If you modified the `oreg_url` parameter to change the cluster image registry location,
+you must run the `imageconfig` playbook to update the image location:
++
+----
+$ cd /usr/share/ansible/openshift-ansible
+$ ansible-playbook -i </path/to/inventory/file> \
+    playbooks/openshift-node/imageconfig.yml \
+----
+
 . Upgrade your nodes.
 +
 If your inventory file is located somewhere other than the default
@@ -607,7 +616,7 @@ If your inventory file is located somewhere other than the default
 previously used the `atomic-openshift-installer` command to run your
 installation, you can check *_~/.config/openshift/hosts_* for the last inventory
 file that was used.
-+
+
 ** To upgrade control plane and nodes in a single phase, run the *_upgrade.yml_*
 playbook:
 +


### PR DESCRIPTION
Added an additional playbook that needs to ran if `oreg_url`
is change for the upgrade.

https://bugzilla.redhat.com/show_bug.cgi?id=1676399

From https://github.com/openshift/openshift-docs/pull/14253

@jiajliu, will you please confirm? 