### PR TITLE
Adjusted spacing in Tech Preview table

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -522,7 +522,7 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview
 Features Support Scope]
 
 In the table below, features marked *TP* indicate _Technology Preview_ and
-￼	features marked *GA* indicate _General Availability_.
+features marked *GA* indicate _General Availability_.
 
 .Technology Preview Tracker
 [cols="3",options="header"]


### PR DESCRIPTION
@bergerhoffer  noticed that an additional space near a text wrap created an `obj` box in Firefox only. Removed the space. Will merge/CP ASAP. 

Adding peer review flag. 