### PR TITLE
moving install concept

### DIFF
--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -12,12 +12,13 @@ some parameters in the `install-config.yaml` file before you install the cluster
 
 .Prerequisites
 
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
 * xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
-
-include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-default.adoc
+++ b/installing/installing_aws/installing-aws-default.adoc
@@ -10,12 +10,13 @@ Amazon Web Services (AWS) that uses the default configuration options.
 
 .Prerequisites
 
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
 * xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
-
-include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -17,6 +17,9 @@ cluster.
 
 .Prerequisites
 
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
 * xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * If you use a firewall, you must
@@ -24,8 +27,6 @@ xref:../../installing/install_config/configuring-firewall.adoc#configuring-firew
 
 // TODO
 // Concept that describes networking
-
-include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_aws_user_infra/installing-aws-user-infra.adoc
+++ b/installing/installing_aws_user_infra/installing-aws-user-infra.adoc
@@ -15,6 +15,9 @@ according to your company's policies.
 
 .Prerequisites
 
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
 * xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
 to host the cluster.
 * Download the AWS CLI and install it on your computer. See
@@ -22,9 +25,6 @@ link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Instal
 in the AWS documentation.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
-
-
-include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -14,10 +14,11 @@ bare metal infrastructure that you provision.
 xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
 for your cluster. To deploy a private image registry, your storage must provide
 ReadWriteMany access modes.
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
-
-include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -14,10 +14,11 @@ VMware vSphere infrastructure that you provision.
 xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
 for your cluster. To deploy a private image registry, your storage must provide
 ReadWriteMany access modes.
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
-
-include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -1,12 +1,6 @@
 // Module included in the following assemblies:
 //
 // * architecture/architecture-installation.adoc
-// * installing/installing_aws/installing-aws-default.adoc
-// * installing/installing_aws/installing-aws-customizations.adoc
-// * installing/installing_aws/installing-aws-network-customizations.adoc
-// * installing/installing_aws_user_infra/installing-aws-user-infra.adoc
-// * installing/installing_bare_metal/installing-bare-metal.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
 
 [id="installation-overview_{context}"]
 = {product-title} installation overview


### PR DESCRIPTION
Jake Lucky, the PM for the OpenShift Cluster Manager, pinged me on Slack and said that the install concept at the start of each installation assembly made the topics seem intimidatingly long, even if they weren't.

I've removed the concept from each assembly and added a link to the arch guide topic instead.

@openshift/team-documentation, what do you think?

preview build here: http://file.rdu.redhat.com/kalexand/060519/install_concept/installing/installing_vsphere/installing-vsphere.html#installation-overview-installing-vsphere 