### PR TITLE
Enable caching for content per Google PageSpeed Insights recommendation

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -248,6 +248,36 @@ AddType text/vtt                            vtt
 </IfModule>
 
 # ----------------------------------------------------------------------
+# Specify cache retension policy
+# ----------------------------------------------------------------------
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresDefault "access plus 1 seconds"
+  ExpiresByType image/x-icon "access plus 2592000 seconds"
+  ExpiresByType image/jpeg "access plus 2592000 seconds"
+  ExpiresByType image/png "access plus 2592000 seconds"
+  ExpiresByType image/gif "access plus 2592000 seconds"
+  ExpiresByType text/css "access plus 604800 seconds"
+  ExpiresByType text/javascript "access plus 216000 seconds"
+  ExpiresByType application/x-javascript "access plus 216000 seconds"
+</IfModule>
+
+<IfModule mod_headers.c>
+  <FilesMatch "\\.(ico|jpe?g|png|gif)$">
+  Header set Cache-Control "max-age=2692000, public"
+  </FilesMatch>
+  <FilesMatch "\\.(css)$">
+  Header set Cache-Control "max-age=2692000, public"
+  </FilesMatch>
+  <FilesMatch "\\.(js)$">
+  Header set Cache-Control "max-age=216000, private"
+  </FilesMatch>
+  Header unset ETag
+  Header unset Last-Modified
+</IfModule>
+
+# ----------------------------------------------------------------------
 # Prevent 404 errors for non-existing redirected folders
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
So I've been thinking about this for a few months now. Currently, we don't provide an `Expires` header. An optimal strategy will require additional research and discussion, but I wanted to open this now anyway.

```
$ curl -I https://docs.openshift.com/

HTTP/1.1 200 OK
Date: Wed, 05 Jun 2019 18:17:01 GMT
Server: Apache/2.4.34 (Red Hat) OpenSSL/1.0.2k-fips
Last-Modified: Wed, 05 Jun 2019 14:41:49 GMT
ETag: "3c62-58a9498ecc540"
Accept-Ranges: bytes
Content-Length: 15458
Vary: Accept-Encoding
X-UA-Compatible: IE=Edge,chrome=1
Content-Type: text/html; charset=utf-8
Set-Cookie: 0831e0291a1cfb29457385c56afd1928=897d79a9d7e69f42f5e4e045077169e5; path=/; HttpOnly; Secure
Cache-control: private
```
