### PR TITLE
BZ-1717178: Corrected security information.

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -37,9 +37,9 @@ where `<cluster_name>` and `<cluster_id>` are unique per cluster.
 //|`kubernetes.io/glusterfs`
 //|
 
-|Ceph RBD
-|`kubernetes.io/rbd`
-|
+//|Ceph RBD
+//|`kubernetes.io/rbd`
+//|
 
 //|Trident from NetApp
 //|`netapp.io/trident`

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -110,7 +110,7 @@ A volume's `AccessModes` are descriptors of the volume's capabilities. They
 are not enforced constraints. The storage provider is responsible for
 runtime errors resulting from invalid use of the resource.
 
-For example, Ceph offers *ReadWriteOnce* access mode. You must
+For example, NFS offers *ReadWriteOnce* access mode. You must
 mark the claims as `read-only` if you want to use the volume's
 ROX capability. Errors in the provider show up at runtime as mount errors.
 

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -426,9 +426,9 @@ tolerations, and cluster settings.
 [id="ocp-4-1-security"]
 === Security
 
-In {product-title} 4.1, an Operator is utilized to install, configure, and manage
-the certificate signing server. Certificates are managed as secrets, and are
-stored and encrypted in etcd.
+In {product-title} 4.1, Operators are utilized to install, configure, and
+manage the various certificate signing servers. Certificates are managed
+as secrets stored within the cluster itself.
 
 [id="ocp-4-1-notable-technical-changes"]
 == Notable technical changes


### PR DESCRIPTION
I've updated the Security information in the release notes to remove the bit about being stored and encrypted in etcd. I've also adjusted the verbiage to indicate there are multiple Operators and CAs.

This is for OS 4.x.

@sheriff-rh ,

Since this is in the release notes, I've tagged you for review.