### PR TITLE
Add deprecated oc adm cmds

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -93,14 +93,15 @@ now deprecated.
 |System containers
 |Replaced by Red Hat Enterprise Linux CoreOS.
 
-|projectatomic/docker-1.13 additional search registries
-|CRI-O is the default container runtime for 4.x on RHCOS and Red Hat Enterprise Linux.
+|`projectatomic/docker-1.13` additional search registries
+|CRI-O is the default container runtime for {product-title} 4.x on RHCOS and Red
+Hat Enterprise Linux.
 
 |`oc adm diagnostics`
 |Operator-based diagnostics.
 
 |`oc adm registry`
-|Replaced by the registry operator.
+|Replaced by the Image Registry Operator.
 
 |Custom strategy builds using Docker
 |If you want to continue using custom builds, you should replace your Docker
@@ -110,14 +111,14 @@ removed, but the functionality changed significantly in {product-title} 4.1.
 |Cockpit
 |Improved {product-title} 4.1 web console.
 
-|Standalone Registry Installations
-|Quay is our enterprise container image registry.
+|Stand-alone registry installations
+|Quay is Red Hat's enterprise container image registry.
 
 |DNSmasq
-|CoreDNS will be the default.
+|CoreDNS is the default.
 
 |External etcd nodes
-|For 4.1, etcd is on the cluster always.
+|etcd is always on the cluster in {product-title} 4.1.
 
 |CloudForms OpenShift Provider and Podified CloudForms
 |Replaced by built-in management tooling.
@@ -126,7 +127,7 @@ removed, but the functionality changed significantly in {product-title} 4.1.
 |Replaced by dynamic volumes or, if NFS is required, NFS provisioner.
 
 |Blue-green installation method
-|Ease of upgrade is a core value of 4.1.
+|Ease of upgrade is a core value of {product-title} 4.1.
 
 |OpenShift Service Broker and Service Catalog
 |The Service Catalog and the OpenShift service brokers are being replaced over
@@ -136,9 +137,14 @@ applications to OpenShift 4 clusters. These new technologies provide many
 benefits around complete management of the lifecycle of your application.
 
 |`oc adm ca`
-|Certificates are managed internally.
+|Certificates are managed by Operators internally.
 
-|Web Console
+|`oc adm create-api-client-config`
+.2+.^|Functions are managed by Operators internally.
+
+|`oc adm create-bootstrap-policy-file`
+
+|Web console
 |The web console from {product-title} 3.11 has been replaced by a new web
 console in {product-title} 4.1.
 


### PR DESCRIPTION
Adds the remaining deprecated commands from https://github.com/openshift/origin/pull/23042, plus other minor formatting suggestions for consistency across the table.

cc @damemi @sheriff-rh 	

Preview (internal): http://file.rdu.redhat.com/~adellape/060619/41_dep_cmds/release_notes/ocp-4-1-release-notes.html#ocp-41-deprecated-features