### PR TITLE
BZ-1717447: Indicated that no default strategy is provided.

### DIFF
--- a/modules/oauth-internal-options.adoc
+++ b/modules/oauth-internal-options.adoc
@@ -25,12 +25,12 @@ object definition.
 == OAuth grant options
 
 When the OAuth server receives token requests for a client to which the user
-has not previously granted permission, the action that the OAuth server takes
-is dependent on the OAuth client's grant strategy.
+has not previously granted permission, the action that the OAuth server
+takes is dependent on the OAuth client's grant strategy.
 
-When the OAuth client requesting token does not provide its own grant strategy,
-the server-wide default strategy is used. You can apply the following default
-methods:
+The OAuth client requesting token must provide its own grant strategy.
+
+You can apply the following default methods:
 
 [horizontal]
 `auto`:: Auto-approve the grant and retry the request.


### PR DESCRIPTION
Updated the OAuth grant information to indicate that no default strategy is provided. Clients must specify their grant strategy.

This is for OS 4.x.