### PR TITLE
cnv1887 - Install QEMU guest agent on VMs

### DIFF
--- a/cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
+++ b/cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
@@ -28,3 +28,6 @@ in the previous section.
 include::modules/cnv-vm-create-nic-web.adoc[leveloffset=+1]
 
 include::modules/cnv-networking-wizard-fields-web.adoc[leveloffset=+1]
+
+Install the optional xref:../../cnv/cnv_users_guide/cnv-installing-qemu-guest-agent.adoc[QEMU guest agent] on the virtual machine so that the host can display relevant information about the additional networks.
+                                                                

--- a/cnv/cnv_users_guide/cnv-installing-qemu-guest-agent.adoc
+++ b/cnv/cnv_users_guide/cnv-installing-qemu-guest-agent.adoc
@@ -1,0 +1,21 @@
+[id="cnv-installing-qemu-guest-agent"]
+= Installing the QEMU guest agent on virtual machines
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-installing-qemu-guest-agent
+toc::[]
+
+The QEMU guest agent is a daemon that runs on the virtual machine. The agent 
+passes network information on the virtual machine, notably the IP address of 
+additional networks, to the host.
+
+include::modules/cnv-installing-qemu-guest-agent-on-linux-vm.adoc[leveloffset=+1]
+
+You can also install and start the QEMU guest agent using the 
+*cloud-init*:*Use custom script* field of the wizard when creating either 
+virtual machines or virtual machines templates in the web console.
+
+For Windows virtual machines, the QEMU guest agent is included in the 
+VirtIO drivers, which can be installed on 
+xref:../../cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc#cnv-installing-virtio-drivers-on-existing-windows-vm[an existing Windows virtual machine] or 
+xref:../../cnv/cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vmi#cnv-installing-virtio-drivers-on-new-windows-vm.adoc[during the installation of Windows on the virtual machine].
+

--- a/modules/cnv-installing-qemu-guest-agent-on-linux-vm.adoc
+++ b/modules/cnv-installing-qemu-guest-agent-on-linux-vm.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-installing-qemu-guest-agent.adoc
+
+[id="cnv-installing-qemu-guest-agent-on-linux-vm_{context}"]
+= Installing QEMU guest agent on a Linux virtual machine
+
+The `qemu-guest-agent` is widely available and available by default in Red Hat 
+virtual machines. Install the agent and start the service 
+
+.Procedure
+
+. Access the virtual machine command line through one of the consoles or by SSH.
+
+. Install the QEMU guest agent on the virtual machine:
++
+----
+$ yum install -y qemu-guest-agent
+----
+
+. Start the QEMU guest agent service:
++
+----
+$ systemctl start qemu-guest-agent
+----
+
+. Ensure the service is persistent:
++
+----
+$ systemctl enable qemu-guest-agent
+----
+


### PR DESCRIPTION
The meat of the assembly is in one new module, but also points to the wizards(web console) and VirtIO drivers for Win VMs (separate PR). This assembly is then referenced in the 'additional networks' assembly to cover all bases.

This is content migrated from 1.4