### PR TITLE
Shouldn't this permission be present out of the box

### DIFF
--- a/admin_guide/topics/deploying-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/deploying-cluster-auto-scaler.adoc
@@ -83,6 +83,13 @@ kind: ClusterRole
 metadata:
   name: cluster-autoscaler
 rules:
+- apiGroups: <1>
+  - ""
+  resources: 
+  - pods/eviction
+  verbs: 
+  - create
+  attributeRestrictions: null
 - apiGroups:
   - ""
   resources:
@@ -141,6 +148,7 @@ rules:
   attributeRestrictions: null
 EOF
 ----
+<1> If the `cluster-autoscaler` object exists, ensure that the `pods/eviction` rule exists with the verb `create`.
 
 . Create a role for the deployment auto-scaler:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1705233

"openshift-ansible provides means to deploy cluster autoscaler since 3.8+. "
https://coreos.slack.com/archives/CBZHF4DHC/p1559936085012200?thread_ts=1559935044.010300&cid=CBZHF4DHC