### PR TITLE
cnv2068 - viewing IP addresses of additional networks

### DIFF
--- a/cnv/cnv_users_guide/cnv-viewing-ip-of-vm-vnic.adoc
+++ b/cnv/cnv_users_guide/cnv-viewing-ip-of-vm-vnic.adoc
@@ -1,0 +1,14 @@
+[id="cnv-viewing-ip-of-vm-vnic"]
+= Viewing the IP address of vNICs on a virtual machine
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-viewing-ip-of-vm-vnic
+toc::[]
+
+The QEMU guest agent runs on the virtual machine and passes the IP address of attached vNICs to the host, allowing you to view the IP address from both the web console and the `oc` client.
+
+.Prerequisites
+
+* The QEMU guest agent must be xref:cnv-installing-qemu-guest-agent.adoc#cnv-installing-qemu-guest-agent[installed and running] on the virtual machine.
+
+include::modules/cnv-viewing-vmi-ip-cli.adoc[leveloffset=+1]
+include::modules/cnv-viewing-vmi-ip-web.adoc[leveloffset=+1]

--- a/modules/cnv-viewing-vmi-ip-cli.adoc
+++ b/modules/cnv-viewing-vmi-ip-cli.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-viewing-ip-of-vm-vnic.adoc
+
+[id="cnv-viewing-vmi-ip-cli_{context}"]
+= Viewing the IP address of a virtual machine interface in the CLI
+
+The network interface configuration is included in the `oc describe vmi` command.
+
+You can also view the IP address information by running `ip addr` on the virtual
+machine, or by running `oc get vmi -o yaml`.
+
+.Procedure
+
+* Use the `oc describe` command to display the virtual machine interface configuration:
++
+[source]
+----
+$ oc describe vmi <vmi_name>
+
+...
+Interfaces:
+   Interface Name:  eth0
+   Ip Address:      10.244.0.37/24
+   Ip Addresses:
+     10.244.0.37/24
+     fe80::858:aff:fef4:25/64
+   Mac:             0a:58:0a:f4:00:25
+   Name:            default
+   Interface Name:  v2
+   Ip Address:      1.1.1.7/24
+   Ip Addresses:
+     1.1.1.7/24
+     fe80::f4d9:70ff:fe13:9089/64
+   Mac:             f6:d9:70:13:90:89
+   Interface Name:  v1
+   Ip Address:      1.1.1.1/24
+   Ip Addresses:
+     1.1.1.1/24
+     1.1.1.2/24
+     1.1.1.4/24
+     2001:de7:0:f101::1/64
+     2001:db8:0:f101::1/64
+     fe80::1420:84ff:fe10:17aa/64
+   Mac:             16:20:84:10:17:aa
+----
+

--- a/modules/cnv-viewing-vmi-ip-web.adoc
+++ b/modules/cnv-viewing-vmi-ip-web.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-viewing-ip-of-vm-vnic.adoc
+
+[id="cnv-viewing-vmi-ip-web_{context}"]
+= Viewing the IP address of a virtual machine interface in the web console
+
+The IP information displays in the *Virtual Machine Details* screen for the virtual machine. 
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
+. Click the virtual machine name to open the *Virtual Machine Details* screen.
+
+The information for each attached vNIC is displayed under *IP ADDRESSES*.


### PR DESCRIPTION
Small assembly with two modules. Once the QEMU guest agent is installed and running on the VM, the IP address of additional networks is passed to the host and displayed in the VM Details screen of the web console, or in a query to describe the vmi on the CLI.

https://jira.coreos.com/browse/CNV-2068