### PR TITLE
BZ-1719359: Commenting out Manila references.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -269,8 +269,8 @@ Topics:
     File: persistent-storage-iscsi
   - Name: Persistent storage using Container Storage Interface (CSI)
     File: persistent-storage-csi
-  - Name: Persistent storage using OpenStack Manila
-    File: persistent-storage-manila
+#  - Name: Persistent storage using OpenStack Manila
+#    File: persistent-storage-manila
 - Name: Expanding persistent volumes
   File: expanding-persistent-volumes
   Distros: openshift-enterprise,openshift-origin

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -106,8 +106,8 @@ configure persistent storage using
 xref:../storage/persistent-storage/persistent-storage-aws.adoc[AWS Elastic Block Store],
 xref:../storage/persistent-storage/persistent-storage-nfs.adoc[NFS],
 xref:../storage/persistent-storage/persistent-storage-iscsi.adoc[iSCSI],
-xref:../storage/persistent-storage/persistent-storage-csi.adoc[Container Storage Interface (CSI)], and
-xref:../storage/persistent-storage/persistent-storage-manila.adoc[OpenStack Manila].
+and
+xref:../storage/persistent-storage/persistent-storage-csi.adoc[Container Storage Interface (CSI)].
 As needed, you can
 xref:../storage/expanding-persistent-volumes.adoc[expand persistent volumes]
 and configure xref:../storage/dynamic-provisioning.adoc[dynamic provisioning].


### PR DESCRIPTION
Removed the persistent storage using OpenStack Manila. Searching the rest of the storage sections I don't see any other references, so this should be it.

This is for OS 4.x.