### PR TITLE
Remove confusing node configuration map link for BZ 1690296

### DIFF
--- a/install_config/http_proxies.adoc
+++ b/install_config/http_proxies.adoc
@@ -26,8 +26,7 @@ when setting up the proxy or modifying it, you must update the files on each
 services on each host in the cluster.
 
 The `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables are found in
-each host's *_/etc/origin/master/master.env_* file
-and xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map].
+each host's *_/etc/origin/master/master.env_* and *_/etc/sysconfig/atomic-openshift-node_* files.
 
 [[configuring-no-proxy]]
 == Configuring NO_PROXY


### PR DESCRIPTION
Change for https://bugzilla.redhat.com/show_bug.cgi?id=1690296

This change is valid for docs in the 3.10 and 3.11 branches. 

Awaiting QE verification. 