### PR TITLE
pipeline: fix typo in strategy name

### DIFF
--- a/modules/builds-strategy-pipeline-providing-jenkinsfile.adoc
+++ b/modules/builds-strategy-pipeline-providing-jenkinsfile.adoc
@@ -20,7 +20,7 @@ applications source code repository at one of the following locations:
 * A file named `jenkinsfile` at the root of the source `contextDir` of your
 repository.
 * A file name specified via the `jenkinsfilePath` field of the
-`JenkinsPiplineStrategy` section of your BuildConfig, which is relative to the
+`JenkinsPipelineStrategy` section of your BuildConfig, which is relative to the
 source `contextDir` if supplied, otherwise it defaults to the root of the
 repository.
 


### PR DESCRIPTION
`JenkinsPiplineStrategy` -> `JenkinsPipelineStrategy`