### PR TITLE
BZ-1719455: Removed references to Ceph.

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -37,9 +37,9 @@ where `<cluster_name>` and `<cluster_id>` are unique per cluster.
 //|`kubernetes.io/glusterfs`
 //|
 
-|Ceph RBD
-|`kubernetes.io/rbd`
-|
+//|Ceph RBD
+//|`kubernetes.io/rbd`
+//|
 
 //|Trident from NetApp
 //|`netapp.io/trident`

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -110,7 +110,7 @@ A volume's `AccessModes` are descriptors of the volume's capabilities. They
 are not enforced constraints. The storage provider is responsible for
 runtime errors resulting from invalid use of the resource.
 
-For example, Ceph offers *ReadWriteOnce* access mode. You must
+For example, NFS offers *ReadWriteOnce* access mode. You must
 mark the claims as `read-only` if you want to use the volume's
 ROX capability. Errors in the provider show up at runtime as mount errors.
 


### PR DESCRIPTION
Removed references to Ceph in the 4.1 docs, as these are not yet supported.

This is for OS 4.x.