### PR TITLE
Update quantity of identity provider parameters

### DIFF
--- a/modules/identity-provider-parameters.adoc
+++ b/modules/identity-provider-parameters.adoc
@@ -5,7 +5,7 @@
 [id="identity-provider-parameters_{context}"]
 = Identity provider parameters
 
-Four parameters are common to all identity providers:
+The following parameters are common to all identity providers:
 
 [cols="2a,8a",options="header"]
 |===


### PR DESCRIPTION
@openshift/team-documentation, it was mentioned in an email that we state that four parameters are listed, but we only list two. Should it be _four_ or _two_ or just _several_ as I propose here?

Thanks.