### PR TITLE
BZ-1692856: Removing references to set-credentials.

### DIFF
--- a/cli_reference/cli_by_example_content.adoc
+++ b/cli_reference/cli_by_example_content.adoc
@@ -774,25 +774,6 @@ endif::[]
 ====
 
 
-== Set a user entry in kubeconfig
-
-====
-
-[options="nowrap"]
-----
-  // Set only the "client-key" field on the "cluster-admin"
-  // entry, without touching other values:
-  $ oc config set-credentials cluster-admin --client-key=~/.kube/admin.key
-
-  // Set basic auth for the "cluster-admin" entry
-  $ oc config set-credentials cluster-admin --username=admin --password=uXFGweU9l35qcif
-
-  // Embed client certificate data in the "cluster-admin" entry
-  $ oc config set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true
-----
-====
-
-
 == Set a context entry in kubeconfig
 
 ====

--- a/cli_reference/manage_cli_profiles.adoc
+++ b/cli_reference/manage_cli_profiles.adoc
@@ -170,16 +170,6 @@ command includes a number of helpful subcommands for this purpose:
 
 |Subcommand |Usage
 
-a|`set-credentials`
-a|Sets a user entry in the CLI configuration file. If the referenced user
-nickname already exists, the specified information is merged in.
-[options="nowrap"]
-----
-$ oc config set-credentials <user_nickname>
-[--client-certificate=<path/to/certfile>] [--client-key=<path/to/keyfile>]
-[--token=<bearer_token>] [--username=<basic_user>] [--password=<basic_password>]
-----
-
 a|`set-cluster`
 a|Sets a cluster entry in the CLI configuration file. If the referenced cluster
 nickname already exists, the specified information is merged in.
@@ -241,69 +231,57 @@ $ oc config view --config=<specific_filename>
 
 *Example Usage* [[example-usage]]
 
-Consider the following configuration workflow. First, set credentials for a user
-nickname *alice* that uses an
+Consider the following configuration workflow. First, login as a user
+that uses an
 xref:../architecture/additional_concepts/authentication.adoc#api-authentication[access
-token]:
+token]. This token is used by the *alice* user:
 
 [options="nowrap"]
 ----
-$ oc config set-credentials alice --token=NDM2N2MwODgtNjI1Yy10N3VhLTg1YmItYzI4NDEzZDUyYzVi
+$ oc login https://openshift1.example.com --token=ns7yVhuRNpDM9cgzfhhxQ7bM5s7N2ZVrkZepSRf4LC0
 ----
 
-Set a cluster entry named *openshift1*:
+View the cluster entry automatically created:
 
-----
-$ oc config set-cluster openshift1 --server=https://openshift1.example.com
-----
-
-Set a context named *alice* that uses the *alice* user and the
-*openshift1* cluster:
-
-----
-$ oc config set-context alice --cluster=openshift1 --user=alice
-----
-
-Now that the *alice* context has been created, switch to that context:
-
-----
-$ oc config use-context alice
-----
-
-Set the *aliceproject* namespace for the *alice* context:
-
-----
-$ oc config set contexts.alice.namespace aliceproject
-----
-
-You can now view the configuration that has been created:
-
-====
+[options="nowrap"]
 ----
 $ oc config view
 apiVersion: v1
 clusters:
 - cluster:
+    insecure-skip-tls-verify: true
     server: https://openshift1.example.com
-  name: openshift1
+  name: openshift1-example-com
 contexts:
 - context:
-    cluster: openshift1
-    namespace: aliceproject
-    user: alice
-  name: alice
-current-context: alice <1>
+    cluster: openshift1-example-com
+    namespace: default
+    user: alice/openshift1-example-com
+  name: default/openshift1-example-com/alice
+current-context: default/openshift1-example-com/alice
 kind: Config
 preferences: {}
 users:
-- name: alice
+- name: alice/openshift1.example.com
   user:
-    token: NDM2N2MwODgtNjI1Yy10N3VhLTg1YmItYzI4NDEzZDUyYzVi
+    token: ns7yVhuRNpDM9cgzfhhxQ7bM5s7N2ZVrkZepSRf4LC0
 ----
-<1> The current context is set to *alice*.
-====
 
-All subsequent CLI operations will use the *alice* context, unless otherwise
+Update the current context to have users login to the
+desired namespace:
+
+----
+$ oc config set-context `oc config current-context` --namespace=<project_name>
+----
+
+To confirm that the changes have taken effect, examine the current
+context:
+
+----
+$ oc whoami -c
+----
+
+All subsequent CLI operations will use the new context, unless otherwise
 specified by overriding CLI options or until the context is switched.
 
 [[loading-and-merging-rules]]


### PR DESCRIPTION
Removing references to set-credentials. The `oc login` command should be used instead.

This is for OS 3.x.