### PR TITLE
BZ-1720781: Updated API examples to use oc get.

### DIFF
--- a/modules/customize-certificates-api-add-default.adoc
+++ b/modules/customize-certificates-api-add-default.adoc
@@ -46,11 +46,11 @@ the previous step.
 referenced.
 +
 ----
-$ oc describe apiserver cluster
+$ oc get apiserver cluster -o yaml
 ...
-Spec:
-  Serving Certs:
-    Default Serving Certificate:
-      Name:  <certificate>
+spec:
+  servingCerts:
+    defaultServingCertificate:
+      name: <certificate>
 ...
 ----

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -54,15 +54,15 @@ the previous step.
 referenced.
 +
 ----
-$ oc describe apiserver cluster
+$ oc get apiserver cluster -o yaml
 ...
-Spec:
-  Serving Certs:
-    Named Certificates:
-      Names:
-        <hostname>
-      Serving Certificate:
-        Name:  <certificate>
+spec:
+  servingCerts:
+    namedCertificates:
+    - names:
+      - <hostname>
+      servingCertificate:
+        name: <certificate>
 ...
 ----
 


### PR DESCRIPTION
Adjusted the API examples to use `oc get $RESOURCE -o yaml` instead of `oc describe $RESOURCE`.

This is for OS 4.x.