### PR TITLE
Docker builds are not supported in ARO

### DIFF
--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -12,7 +12,7 @@
 toc::[]
 
 
-ifdef::openshift-online[]
+ifdef::openshift-online,openshift-aro[]
 [IMPORTANT]
 ====
 The Docker build strategy is not supported in {product-title}.


### PR DESCRIPTION
This warning should be displayed on ARO as well.