### PR TITLE
Changed vm.overcommit to 1

### DIFF
--- a/modules/nodes-cluster-overcommit-configure-nodes.adoc
+++ b/modules/nodes-cluster-overcommit-configure-nodes.adoc
@@ -27,24 +27,17 @@ by setting the `vm.panic_on_oom` parameter to `0`. A setting of 0 instructs the
 kernel to call oom_killer in an Out of Memory (OOM) condition, which kills
 processes based on priority
 
-You can view the current setting by running the following commands on your node:
+You can view the current setting by running the following commands on your nodes:
 
 ----
 $ sysctl -a |grep commit
 
-vm.overcommit_memory = 0
+vm.overcommit_memory = 1
 ----
 
 ----
 $ sysctl -a |grep panic
 vm.panic_on_oom = 0
-----
-
-You can change these settings using:
-
-----
-$ sysctl -w vm.overcommit_memory=1
-$ sysctl -w vm.panic_on_oom=0
 ----
 
 [NOTE]

--- a/modules/nodes-cluster-overcommit-node-disable.adoc
+++ b/modules/nodes-cluster-overcommit-node-disable.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-cluster-overcommit.adoc
+
+[id="nodes-cluster-overcommit-node-disable_{context}"]
+= Disabling overcommitment for a node
+
+When enabled, overcommitment can be disabled on each node.
+
+.Procedure
+
+To disable overcommitment in a node run the following command on that node:
+
+----
+$ sysctl -w vm.overcommit_memory=0
+----
+

--- a/modules/nodes-cluster-overcommit-project-disable.adoc
+++ b/modules/nodes-cluster-overcommit-project-disable.adoc
@@ -5,7 +5,7 @@
 [id="nodes-cluster-overcommit-project-disable_{context}"]
 = Disabling overcommitment for a project
 
-When configured, overcommitment can be disabled per-project.
+When enabled, overcommitment can be disabled per-project.
 For example, you can allow infrastructure components to be configured independently of overcommitment.
 
 .Procedure

--- a/modules/nodes-cluster-overcommit-resource-requests.adoc
+++ b/modules/nodes-cluster-overcommit-resource-requests.adoc
@@ -26,7 +26,7 @@ of 2Gi, it is scheduled based on the 1Gi request being available on the node,
 but could use up to 2Gi; so it is 200% overcommitted.
 
 [id="understandin-fluentd-buffering_{context}"]
-== Understanding Fluentd file buffering
+== Understanding Buffer Chunk Limiting for Fluentd
 
 If the Fluentd logger is unable to keep up with a high number of logs, it will need
 to switch to file buffering to reduce memory usage and prevent data loss.

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -13,6 +13,11 @@ toc::[]
 In an _overcommited_ state, the sum of the container compute resource requests and limits exceeds the resources available on the system.
 Overcommitment might be desirable in development environments where a tradeoff of guaranteed performance for capacity is acceptable.  
 
+[NOTE]
+====
+In {product-title} overcommittment is enabled by default. 
+See xref:#nodes-cluster-overcommit-node-disable_nodes-cluster-overcommit[Disabling overcommitment for a node].
+====
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -32,6 +37,8 @@ include::modules/nodes-cluster-overcommit-configure-nodes.adoc[leveloffset=+1]
 include::modules/nodes-cluster-overcommit-node-enforcing.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-node-resources.adoc[leveloffset=+2]
+
+include::modules/nodes-cluster-overcommit-node-disable.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-overcommit-project-disable.adoc[leveloffset=+1]
 


### PR DESCRIPTION
The `vm.overcommit_memory = 0` parameter in 4.x should be `vm.overcommit_memory = 1` as overcommit is enabled by default in 4.x