### PR TITLE
[enterprise-3.11] Correct reboot condition more clear

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -674,7 +674,7 @@ xref:customizing-node-upgrades[Customizing Node Upgrades], continue running the
 *_upgrade_nodes.yml_* playbook until all nodes are upgraded.
 // tag::automated_upgrade_after_reboot[]
 
-. After all master and node upgrades have completed, reboot all hosts.
+. After all master and node upgrades have completed, you can reboot all hosts if you required.
 
 . If you use aggregated logging, xref:upgrading-efk-logging-stack[upgrade the EFK logging stack].
 


### PR DESCRIPTION
- Version: `v3.11` 

- Description:
   Reboot does not happen by default during upgrade, but it's confusing like always rebooting after upgrade. [Upgrading to the latest OpenShift Container Platform release](https://docs.openshift.com/container-platform/3.11/upgrading/automated_upgrades.html#upgrading-ocp) is as follows. You can see reboot does not be required by default.

~~~
To enable rolling, full system restarts of the hosts, set the openshift_rolling_restart_mode parameter in your inventory file to system. Otherwise, the service is restarted on HA masters, but the systems do not reboot. See Configuring Cluster Variables for details.
~~~