### PR TITLE
CNV1607 CLI tools

### DIFF
--- a/cnv/cnv_install/cnv-installing-virtctl.adoc
+++ b/cnv/cnv_install/cnv-installing-virtctl.adoc
@@ -1,0 +1,17 @@
+[id="cnv-installing-virtctl"]
+= Installing the `virtctl` client
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-installing-virtctl
+toc::[]
+
+The `virtctl` client is a command-line utility for managing {ProductName}
+resources. 
+
+Install the client to your system by enabling the {ProductName} repository and 
+installing the `kubevirt-virtctl` package.
+
+include::modules/cnv-enabling-cnv-repos.adoc[leveloffset=+1]
+include::modules/cnv-installing-virtctl-client.adoc[leveloffset=+1]
+
+See also:
+xref:../cnv/cnv_users_guide/cnv-using-the-cli-tools.adoc[Using the CLI tools] for {ProductName}.

--- a/cnv/cnv_users_guide/cnv-using-the-cli-tools.adoc
+++ b/cnv/cnv_users_guide/cnv-using-the-cli-tools.adoc
@@ -1,0 +1,21 @@
+[id="cnv-using-the-cli-tools"]
+= Using the CLI tools
+include::modules/cnv-document-attributes.adoc[]
+:context: using-the-cli-tools
+toc::[]
+
+The two primary CLI tools used for managing resources in the cluster are:
+
+* The {ProductName} `virtctl` client
+* The {product-title} `oc` client
+
+.Prerequisites
+
+* You must xref:../../cnv/cnv_install/cnv-installing-virtctl.adoc#cnv-installing-virtctl[install the `virtctl` client].
+
+include::modules/cnv-virtctl-commands.adoc[leveloffset=+1]
+include::modules/cnv-openshift-client-commands.adoc[leveloffset=+1]
+
+For more comprehensive information on `oc` client commands, see the 
+xref:../../cli_reference/developer-cli-commands.adoc#cli_reference[{product-title} CLI reference].
+

--- a/modules/cnv-enabling-cnv-repos.adoc
+++ b/modules/cnv-enabling-cnv-repos.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// cnv_install/cnv-installing-virtctl.adoc
+
+[id="cnv-enabling-cnv-repos_{context}"]
+= Enabling {ProductName} repositories
+
+Red Hat offers {ProductName} repositories for both Red Hat Enterprise Linux 8
+and Red Hat Enterprise Linux 7:
+
+* Red Hat Enterprise Linux 8 repository: `cnv-2.0-for-rhel-8-x86_64-rpms`
+
+* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.0-tech-preview-rpms`
+
+The process for enabling the repository in `subscription-manager` is the same 
+in both platforms. 
+
+.Procedure
+
+* Use `subscription manager` to enable the appropriate {ProductName} repository for
+ your system:
++
+----
+# subscription-manager repos --enable <repository>
+----
+

--- a/modules/cnv-installing-virtctl-client.adoc
+++ b/modules/cnv-installing-virtctl-client.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// cnv_install/cnv-installing-virtctl.adoc
+
+[id="cnv-installing-virtctl-client_{context}"]
+= Installing the `virtctl` client
+
+Install the `virtctl` client from the `kubevirt-virtctl` package.
+
+.Procedure
+
+* Install the `kubevirt-virtctl` package:
++
+----
+# yum install kubevirt-virtctl
+----
+

--- a/modules/cnv-openshift-client-commands.adoc
+++ b/modules/cnv-openshift-client-commands.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-using-the-cli-tools.adoc
+
+[id="cnv-openshift-client-commands_{context}"]
+= {product-title} client commands
+
+The {product-title} `oc` client is a command-line utility for managing 
+{product-title} resources. The following table contains the *oc* commands
+ used throughout the {ProductName} documentation.
+
+.`oc` commands
+
+[width="100%",cols="42%,58%",options="header",]
+|===
+|Command |Description
+
+|`oc login -u <user_name>`
+|Log in to the {product-title} cluster as `<user_name>`.
+
+|`oc get <object_type>` 
+|Display a list of objects for the specified
+object type in the project.
+
+|`oc describe <object_type> <resource_name>` 
+|Display details of the
+specific resource in the project.
+
+|`oc create  -f <object_config>` 
+|Create a resource in the project from a filename or from stdin.
+
+|`oc edit <resource>`
+|Edit a resource in the project.
+
+|`oc delete <resource>`
+|Delete a resource in the project.
+|===
+

--- a/modules/cnv-virtctl-commands.adoc
+++ b/modules/cnv-virtctl-commands.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// cnv_users_guide/cnv-using-the-cli-tools.adoc
+
+[id="cnv-virtctl-commands_{context}"]
+= Virtctl client commands
+
+The `virtctl` client is a command-line utility for managing {ProductName}
+resources. The following table contains the `virtctl` commands used throughout
+the {ProductName} documentation.
+
+.`virtctl` client commands
+
+[width="100%",cols="42%,58%",options="header",]
+|===
+|Command |Description
+
+|`virtctl start <vm>` 
+|Start a virtual machine.
+
+|`virtctl stop <vm>` 
+|Stop a virtual machine.
+
+|`virtctl restart <vm>` 
+|Restart a virtual machine.
+
+|`virtctl expose <vm>` 
+|Create a service that forwards a designated port
+of a virtual machine or virtual machine instance and expose the service on
+the specified port of the node.
+
+|`virtctl console <vmi>` 
+|Connect to a serial console of a virtual machine instance.
+
+|`virtctl vnc <vmi>` 
+|Open a VNC connection to a virtual machine instance.
+
+|`virtctl image-upload <...>` 
+|Upload a virtual machine disk from a client machine to the cluster.
+|===
+


### PR DESCRIPTION
This is content primarily migrated (and updated) from the 1.4 guides. 
It covers the procedure for installing the CNV virtctl client, and reference material for the virtctl and oc clients, to help new users.

The built versions are here:
http://file.bne.redhat.com/aburden/CNV-docs-preview/cli/cnv_install/cnv-installing-virtctl.html
http://file.bne.redhat.com/aburden/CNV-docs-preview/cli/cnv_users_guide/cnv-using-the-cli-tools.html
(Keep in mind that the css gets a bit skewiff when I copy to the fileserver; navigation and rendering are messier than they will be in the merged docs)
