### PR TITLE
BZ-1696310: Clarified post-installation usage.

### DIFF
--- a/install_config/topics/configuring_for_vsphere.adoc
+++ b/install_config/topics/configuring_for_vsphere.adoc
@@ -8,7 +8,8 @@
 You can configure {product-title} for VMware vSphere (VCP) by
 modifying the
 xref:../install/configuring_inventory_file.adoc#configuring-ansible[Ansible
-inventory file] at installation time or after installation.
+inventory file]. These changes can be made before installation, or
+to an existing cluster.
 
 .Procedure
 
@@ -27,6 +28,13 @@ openshift_cloudprovider_vsphere_datastore=<Datastore> <4>
 <2> The vCenter server address.
 <3> The vCenter Datacenter name where the {product-title} VMs are located.
 <4> The datastore used for creating VMDKs.
+
+. Run the `deploy_cluster.yml` playbook.
++
+----
+$ ansible-playbook -i <inventory_file> \
+  playbooks/deploy_cluster.yml
+----
 
 Installing with Ansible also creates and configures the following files to fit
 your vSphere environment:


### PR DESCRIPTION
Cleaned up instructions regarding using this section on an existing cluster. I also added the `ansible-playbook` command, as this procedure looked off having only a single step.

This is for OS 3.x.