### PR TITLE
CNV-2270: Adding a new blank disk image

### DIFF
--- a/cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
+++ b/cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
@@ -1,0 +1,14 @@
+[id="cnv-expanding-virtual-storage-with-blank-disk-images"]
+= Expanding virtual storage by adding blank disk images
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-expanding-virtual-storage-with-blank-disk-images
+toc::[]
+
+You can increase your storage capacity or create new data partitions by adding
+blank disk images to {ProductName}.
+
+include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
+
+include::modules/cnv-creating-blank-disk-datavolumes.adoc[leveloffset=+1]
+
+include::modules/cnv-template-blank-disk-datavolume.adoc[leveloffset=+1]

--- a/modules/cnv-about-datavolumes.adoc
+++ b/modules/cnv-about-datavolumes.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
 // * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
+// * cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
 
 [id="cnv-about-datavolumes_{context}"]
 = About DataVolumes
 
-`DataVolume` objects are custom resources provided by the Containerized Data
-Importer (CDI) project. DataVolumes orchestrate import, clone, and upload
-operations associated with an underlying PersistentVolumeClaim (PVC).
-DataVolumes are integrated with KubeVirt, and they can prevent a virtual machine
+`DataVolume` objects are custom resources that are provided by the Containerized
+Data Importer (CDI) project. DataVolumes orchestrate import, clone, and upload
+operations that are associated with an underlying PersistentVolumeClaim (PVC).
+DataVolumes are integrated with KubeVirt, and they prevent a virtual machine
 from being started before the PVC has been prepared.

--- a/modules/cnv-creating-blank-disk-datavolumes.adoc
+++ b/modules/cnv-creating-blank-disk-datavolumes.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
+
+[id="cnv-creating-blank-disk-datavolumes_{context}"]
+= Creating a blank disk image with DataVolumes
+
+You can create a new blank disk image in a PersistentVolumeClaim by
+customizing and deploying a DataVolume configuration file.
+
+.Prerequisites
+
+* At least one available PersistentVolume
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`
+
+.Procedure
+
+. Edit the DataVolume configuration file:
++
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: blank-image-datavolume
+spec:
+  source:
+      blank: {}
+  pvc:
+    # Optional: Set the storage class or omit to accept the default
+    # storageClassName: "hostpath"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 500Mi
+----
+
+. Create the blank disk image by running the following command:
++
+----
+$ oc create -f <file name>.yaml
+----

--- a/modules/cnv-template-blank-disk-datavolume.adoc
+++ b/modules/cnv-template-blank-disk-datavolume.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
+
+[id="cnv-template-blank-disk-datavolume_{context}"]
+= Template: DataVolume configuration file for blank disk images
+
+*blank-image-datavolume.yaml*
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: blank-image-datavolume
+spec:
+  source:
+      blank: {}
+  pvc:
+    # Optional: Set the storage class or omit to accept the default
+    # storageClassName: "hostpath"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 500Mi
+----


### PR DESCRIPTION
Jira: https://jira.coreos.com/browse/CNV-2270

Modularizing 1.4 content. New files for assembly, template, and concept (concept pulled from https://github.com/openshift/openshift-docs/pull/15487).

Latest preview build: http://file.bos.redhat.com/pousley/062119/cnv2270-blankdisk/cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.html