### PR TITLE
Capitalize Imagestream Under Using imagestreams Section

### DIFF
--- a/modules/images-imagestream-use.adoc
+++ b/modules/images-imagestream-use.adoc
@@ -9,7 +9,7 @@ container images from within {product-title}. The imagestream and its tags
 allow you to see what images are available and ensure that you are using the
 specific image you need even if the image in the repository changes.
 
-imagestreams do not contain actual image data, but present a single virtual
+Imagestreams do not contain actual image data, but present a single virtual
 view of related images, similar to an image repository.
 
 You can  configure Builds and Deployments to watch an imagestream for


### PR DESCRIPTION
Closes #15510 

This pull request capitalizes `imagestreams` to begin a new sentence. 