### PR TITLE
Cnv 1602

### DIFF
--- a/cnv/cnv_users_guide/cnv-create-vms.adoc
+++ b/cnv/cnv_users_guide/cnv-create-vms.adoc
@@ -1,0 +1,37 @@
+[id="cnv-create-vms"]
+= Creating virtual machines
+include::modules/cnv_document_attributes.adoc[]
+:context: cnv-create-vms
+toc::[]
+
+Use one of these procedures to create a virtual machine:
+
+* Running the virtual machine wizard
+* Pasting a pre-configured YAML file with the virtual machine wizard
+* Using the CLI
+
+include::modules/cnv-creating-vm-wizard-web.adoc[leveloffset=+1]
+
+Refer to the Virtual machine wizard fields section when running the web console wizard.
+
+include::modules/cnv-vm-wizard-fields-web.adoc[leveloffset=+1]
+
+include::modules/cnv-creating-vm-yaml-web.adoc[leveloffset=+1]
+
+include::modules/cnv-creating-vm.adoc[leveloffset=+1]
+
+Virtual machine storage volume types are listed here, as well as domain and volume settings. See the
+https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinespec[kubevirt
+API Reference] for a definitive list of virtual machine settings.
+
+Refer to the following tables when creating a virtual machine with the CLI:
+
+* Storage volume types
+* Cloud-init fields
+* Networking fields
+* Storage fields
+
+include::modules/cnv-vm-storage-volume-types.adoc[leveloffset=+1]
+include::modules/cnv-cloud-init-fields-web.adoc[leveloffset=+1]
+include::modules/cnv-networking-wizard-fields-web.adoc[leveloffset=+1]
+include::modules/cnv-storage-wizard-fields-web.adoc[leveloffset=+1]

--- a/modules/cnv-cloud-init-fields-web.adoc
+++ b/modules/cnv-cloud-init-fields-web.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+
+[id="cnv-cloud-init-fields-web_{context}"]
+= Cloud-init fields
+
+|===
+|Name | Description
+
+|Hostname
+|Sets a specific host name for the virtual machine.
+
+|Authenticated SSH Keys
+|The user's public key that is copied to *_~/.ssh/authorized_keys_* on the virtual machine.
+
+|Use custom script
+|Replaces other options with a field in which you paste a custom cloud-init script.
+|===

--- a/modules/cnv-create-vms-ref-table-wizard-fields-web.adoc
+++ b/modules/cnv-create-vms-ref-table-wizard-fields-web.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-create-vms.adoc
+
+[id="cnv-create-vms-ref-table-wizard-fields-web_{context}"]
+= Virtual machine wizard fields
+
+|===
+|Name |Parameter |Description
+
+|Name
+|
+|Name of the virtual machine. Alphanumeric characters only, up to a maximum of 63.
+
+|Description
+|
+|Optional description field.
+
+|Template
+|
+|Template from which to create the virtual machine. Selecting a template will automatically complete other fields.
+
+.3+|Provision Source
+|PXE
+|Provision virtual machine from PXE menu. Requires a PXE-capable NIC in the cluster.
+
+|URL
+|Provision virtual machine from an image available from an *HTTP* or *S3* endpoint.
+
+|Container
+|Provision virtual machine from a bootable operating system container located in a registry accessible from the cluster. Example: `_kubevirt/cirros-registry-disk-demo_`
+
+|Operating System
+|
+|A list of operating systems available in the cluster. This is the primary operating system for the virtual machine.
+
+|Flavor
+|small, medium, large, tiny, Custom
+|Presets that determine the amount of CPU and memory allocated to the virtual machine.
+
+.2+|Workload Profile
+|generic
+|A general configuration that balances performance and compatibility for a broad range of workloads.
+
+|highperformance
+|The virtual machine has a more efficient configuration optimized for high performance loads.
+
+|Start virtual machine on creation
+|
+|Select this checkbox to automatically start the virtual machine upon creation.
+
+|cloud-init
+|
+|Select this checkbox to enable the cloud-init fields.
+|===

--- a/modules/cnv-creating-vm-wizard-web.adoc
+++ b/modules/cnv-creating-vm-wizard-web.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+
+[id="cnv-creating-vm-wizard-web_{context}"]
+= Running the virtual machine wizard to create a virtual machine
+
+The web console features an interactive wizard that guides you through *Basic Settings*, *Networking*, and *Storage* screens to simplify the process of creating virtual machines. All required fields are marked by a `*`. The wizard prevents you from moving to the next screen until the required fields have been completed.
+
+NICs and storage disks can be created and attached to virtual machines after they have been created.
+
+.*Bootable Disk*
+
+If either `URL` or `Container` are selected as the *Provision Source* in the *Basic Settings* screen, a `rootdisk` disk is created and attached to the virtual machine as the *Bootable Disk*. You can modify the `rootdisk` but you cannot remove it.
+
+A *Bootable Disk* is not required for virtual machines provisioned from a *PXE* source if there are no disks attached to the virtual machine. If one or more disks are attached to the virtual machine, you must select one as the *Bootable Disk*.
+
+.Procedure
+
+. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Create Virtual Machine* and select *Create with Wizard*.
+. Fill in all required *Basic Settings*. Selecting a *Template* automatically fills in these fields.
+. Click *Next* to progress to the *Networking* screen. A `nic0` NIC is attached by default.
+.. (Optional) Click *Create NIC* to create additional NICs.
+.. (Optional) You can remove any or all NICs by clicking the &#8942; button and selecting *Remove NIC*. A virtual machine does not need a NIC attached to be created. NICs can be created after the virtual machine has been created.
+. Click *Next* to progress to the *Storage* screen.
+.. (Optional) Click *Create Disk* to create additional disks. These disks can be removed by clicking the &#8942; button and selecting *Remove Disk*.
+.. (Optional) Click on a disk to modify available fields. Click the &#10003; button to save the update.
+.. (Optional) Click *Attach Disk* to choose an available disk from the *Select Storage* drop-down list.
+. Click *Create Virtual Machine >*. The *Results* screen displays the JSON configuration file for the virtual machine.
+
+The virtual machine is listed in *Workloads* -> *Virtual Machines*.

--- a/modules/cnv-creating-vm-yaml-web.adoc
+++ b/modules/cnv-creating-vm-yaml-web.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+
+[id="cnv-creating-vm-yaml-web_{context}"]
+= Pasting in a pre-configured YAML file to create a virtual machine
+
+.Procedure
+
+Create a virtual machine by writing or pasting a YAML configuration file in the web console in the *Workloads* -> *Virtual Machines* screen. A valid `example` virtual machine configuration is provided by default whenever you open the YAML edit screen.
+
+If your YAML configuration is invalid when you click *Create*, an error message indicates the parameter in which the error occurs. Only one error is shown at a time.
+
+[NOTE]
+====
+Navigating away from the YAML screen while editing cancels any changes to the configuration you have made.
+====
+
+.Procedure
+
+. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Create Virtual Machine* and select *Create from YAML*.
+. Write or paste your virtual machine configuration in the editable window.
+.. Alternatively, use the `example` virtual machine provided by default in the YAML screen.
+. (Optional) Click *Download* to download the YAML configuration file in its present state.
+. Click *Create* to create the virtual machine.
+
+The virtual machine is listed in *Workloads* -> *Virtual Machines*.

--- a/modules/cnv-creating-vm.adoc
+++ b/modules/cnv-creating-vm.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+
+[id="cnv-creating-vm_{context}"]
+= Using the CLI to create a virtual machine
+
+.Procedure
+
+The `spec` object of the VirtualMachine configuration file references
+the virtual machine settings, such as the number of cores and the amount
+of memory, the disk type, and the volumes to use.
+
+. Attach the virtual machine disk to the virtual machine by referencing
+the relevant PVC `claimName` as a volume.
+
+. To create a virtual machine with the {product-title} client, run this command:
++
+----
+$ oc create -f <vm.yaml>
+----
+
+. Since virtual machines are created in a *Stopped* state, run a virtual machine
+instance by starting it.
+
+[NOTE]
+====
+A https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/[ReplicaSet]’s purpose is often used to guarantee the availability of a specified number of identical Pods.
+ReplicaSet is not currently supported in {ProductName}.
+====
+
+
+
+.Domain settings
+|===
+|Setting | Description
+
+|Cores
+|The number of cores inside the virtual machine. Must be a value greater than or equal to 1.
+
+|Memory
+|The amount of RAM that is allocated to the virtual machine by the node. Specify a value in *M* for Megabyte or *Gi* for Gigabyte.
+
+|Disks: name
+|The name of the volume that is referenced. Must match the name of a volume.
+|===
+
+.Volume settings
+|===
+|Setting | Description
+
+|Name
+|The name of the volume, which must be a DNS label and unique within the virtual machine.
+
+|PersistentVolumeClaim
+|The PVC to attach to the virtual machine. The `claimName` of the PVC must be in the same project as the virtual machine.
+|===

--- a/modules/cnv-networking-wizard-fields-web.adoc
+++ b/modules/cnv-networking-wizard-fields-web.adoc
@@ -1,10 +1,12 @@
 // Module included in the following assemblies:
 //
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_users_guide/cnv-creating-vm-template.adoc
 // * cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
-// * cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
 
 [id="cnv-networking-wizard-fields-web_{context}"]
 = Networking fields
+
 |===
 |Name | Description
 

--- a/modules/cnv-storage-wizard-fields-web.adoc
+++ b/modules/cnv-storage-wizard-fields-web.adoc
@@ -1,9 +1,11 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/TBD
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_users_guide/cnv-creating-vm-template.adoc
 
 [id="cnv-storage-wizard-fields-web_{context}"]
 = Storage fields
+
 |===
 |Name | Description
 

--- a/modules/cnv-vm-storage-volume-types.adoc
+++ b/modules/cnv-vm-storage-volume-types.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+
+[id="cnv-vm-storage-volume-types_{context}"]
+= Virtual machine storage volume types
+
+[horizontal]
+*ephemeral*::
+A local copy-on-write (COW) image that uses a network volume as a
+read-only backing store. The backing volume
+must be a *PersistentVolumeClaim*. The ephemeral image is created when
+the virtual machine starts and stores all writes locally. The ephemeral
+image is discarded when the virtual machine is stopped, restarted, or
+deleted. The backing volume (PVC) is not mutated in any way.
+
+*persistentVolumeClaim*::
+Attaches an available PV to a virtual machine. Attaching a PV allows for the
+virtual machine data to persist between sessions.
++
+Importing an existing virtual machine disk into a PVC by using
+CDI and attaching the PVC to a virtual machine instance is the
+recommended method for importing existing virtual machines into
+{product-title}. There are some requirements for the disk to be used within a
+PVC.
+
+*dataVolume*::
+DataVolumes build on the *persistentVolumeClaim* disk type by managing the process
+of preparing the virtual machine disk via an import, clone, or upload operation.
+VMs that use this volume type are guaranteed not to start until the volume is ready.
+
+*cloudInitNoCloud*::
+Attaches a disk that contains the referenced cloud-init NoCloud data
+source, providing user data and metadata to the virtual machine.
+A cloud-init installation is required inside the virtual machine
+disk.
+
+*containerDisk*::
+References an image, such as a virtual machine disk, that is stored in
+the container image registry. The image is pulled from the registry and
+embedded in a volume when the virtual machine is created. A
+*containerDisk* volume is ephemeral. It is discarded when
+the virtual machine is stopped, restarted, or deleted.
++
+Container disks are not limited to a single virtual machine and are
+useful for creating large numbers of virtual machine clones that do not
+require persistent storage.
++
+Only RAW and QCOW2 formats are supported disk types for the container
+image registry. QCOW2 is recommended for reduced image size.
+
+*emptyDisk*::
+Creates an additional sparse QCOW2 disk that is tied to the life-cycle
+of the virtual machine interface. The data survives guest-initiated
+reboots in the virtual machine but is discarded when the virtual machine
+stops or is restarted from the web console. The empty disk is used to
+store application dependencies and data that otherwise exceeds the
+limited temporary file system of an ephemeral disk.
++
+The disk *capacity* size must also be provided.

--- a/modules/cnv-vm-wizard-fields-web.adoc
+++ b/modules/cnv-vm-wizard-fields-web.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/TBD
+// * cnv/cnv_users_guide/cnv-create-vms.adoc
+
 [id="cnv-vm-wizard-fields-web_{context}"]
 = Virtual machine wizard fields
 


### PR DESCRIPTION
Adding assembly and modules for "Creating Virtual Machines" (CNV-1602) Jira story.

- I have gotten feedback from @aburdenthehand (Andrew) to delete the NOTE in the assembly (cnv-create-vms.adoc) as the Template info will be in another assembly altogether.

- @alexxa (Irina) had opened a bug (https://bugzilla.redhat.com/show_bug.cgi?id=1678782) against this content's presentation, so I anticipate she will have feedback as well.

- This assembly contains a number of reference tables. Right now they are all Level 2 headings under the last module (Using CLI to Create a VM), indicating they could apply to all three use cases (GUI, YAML, CLI). However, one who knows the content better may have a suggestion as to which reference modules best support each of the three use cases. Please let me know your recommendations as to whether they all should remain at the end (perhaps moved to Level 1) or structured differently.

**This PR is targeted for 2.0 release.

I will need a resource to merge the content, so please volunteer if you can do this for me. I will squash my commits prior.**

Thanks

Bob

 