### PR TITLE
CNV reponame update

### DIFF
--- a/modules/cnv-enabling-cnv-repos.adoc
+++ b/modules/cnv-enabling-cnv-repos.adoc
@@ -10,7 +10,7 @@ and Red Hat Enterprise Linux 7:
 
 * Red Hat Enterprise Linux 8 repository: `cnv-2.0-for-rhel-8-x86_64-rpms`
 
-* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.0-tech-preview-rpms`
+* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.0-rpms`
 
 The process for enabling the repository in `subscription-manager` is the same 
 in both platforms. 


### PR DESCRIPTION
Minor update - the CNV repo name for rhel 7 was changed.
Removed 'tech-preview' from the RHEL 7 CNV repo name.