### PR TITLE
CNV1603 (+1612 +1615) Create, Edit, Delete VM Templates

### DIFF
--- a/cnv/cnv_users_guide/cnv-creating-vm-template.adoc
+++ b/cnv/cnv_users_guide/cnv-creating-vm-template.adoc
@@ -1,0 +1,23 @@
+[id="cnv-creating-vm-template"]
+= Creating virtual machine templates
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-creating-vm-template
+toc::[]
+
+Using Virtual machines templates is an easy way to create multiple virtual machines 
+with similar configuration. After a template is created, reference the template 
+when creating virtual machines.
+
+include::modules/cnv-creating-template-wizard-web.adoc[leveloffset=+1]
+
+[id="cnv-template-wizard-fields"]
+== Virtual machine template interactive wizard fields
+
+The following tables describe the fields for the *Basic Settings*, *Networking*, 
+and *Storage* panes in the *Create Virtual Machine Template* interactive wizard.
+
+include::modules/cnv-template-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/cnv-cloud-init-fields-web.adoc[leveloffset=+2]
+include::modules/cnv-networking-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/cnv-storage-wizard-fields-web.adoc[leveloffset=+2]
+

--- a/cnv/cnv_users_guide/cnv-deleting-vm-template.adoc
+++ b/cnv/cnv_users_guide/cnv-deleting-vm-template.adoc
@@ -1,0 +1,11 @@
+[id="cnv-deleting-vm-template"]
+= Deleting a virtual machine template
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-deleting-vm-template
+toc::[]
+
+You can delete a virtual machine template in the web console.
+
+include::modules/cnv-deleting-template-web.adoc[leveloffset=+1]
+
+

--- a/cnv/cnv_users_guide/cnv-editing-vm-template.adoc
+++ b/cnv/cnv_users_guide/cnv-editing-vm-template.adoc
@@ -1,0 +1,11 @@
+[id="cnv-editing-vm-template"]
+= Editing a virtual machine template
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-editing-vm-template
+toc::[]
+
+You can edit a virtual machine template in the web console.
+
+include::modules/cnv-editing-template-web.adoc[leveloffset=+1]
+
+

--- a/modules/cnv-creating-template-wizard-web.adoc
+++ b/modules/cnv-creating-template-wizard-web.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-creating-vm-template.adoc
+
+[id="cnv-creating-template-wizard-web_{context}"]
+= Creating a virtual machine template with the interactive wizard in the web console
+
+The web console features an interactive wizard that guides you through the *Basic Settings*, 
+*Networking*, and *Storage* screens to simplify the process of creating virtual machine templates. 
+All required fields are marked with a `*`. The wizard prevents you from moving to the next screen 
+until you provide values in the required fields.
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machine Templates*.
+. Click *Create Template* and select *Create with Wizard*. 
+. Fill in all required *Basic Settings*. 
+. Click *Next* to progress to the *Networking* screen. A NIC that is named `nic0` is attached by default. 
+.. Optional: Click *Create NIC* to create additional NICs. 
+.. Optional: You can remove any or all NICs by clicking the Options menu {kebab} and selecting *Remove NIC*. Virtual machines created from a template do not need a NIC attached. NICs can be created after a virtual machine has been created. 
+. Click *Next* to progress to the *Storage* screen.
+.. Optional: Click *Create Disk* to create additional disks.
+.. Optional: Click a disk to modify available fields. Click the &#10003; button to save the changes.
+.. Optional: Click *Attach Disk* to choose an available disk from the *Select Storage* list.
++
+[NOTE]
+====
+If either *URL* or *Container* are selected as the *Provision Source* in the *Basic Settings* screen, a `rootdisk` disk is created and attached to virtual machines as the *Bootable Disk*. You can modify the `rootdisk` but you cannot remove it.
+
+A *Bootable Disk* is not required for virtual machines provisioned from a *PXE* source if there are no disks attached to the virtual machine. If one or more disks are attached to the virtual machine, you must select one as the *Bootable Disk*.
+====
+
+. Click *Create Virtual Machine Template >*. The *Results* screen displays the JSON configuration file for the virtual machine template. 
++
+The template is listed in *Workloads* -> *Virtual Machine Templates*. 
+

--- a/modules/cnv-deleting-template-web.adoc
+++ b/modules/cnv-deleting-template-web.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-deleting-vm-template.adoc
+
+[id="cnv-deleting-template-wizard-web_{context}"]
+= Deleting a virtual machine template in the web console
+
+Deleting a virtual machine template permanently removes it from the cluster. 
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machine Templates*.
+. You can delete the virtual machine template from this pane, which makes it 
+easier to perform actions on multiple templates in the one pane, or from the
+ *Virtual Machine Template Details* pane where you can view comprehensive 
+details of the selected template:
+** Click the Options menu {kebab} of the template to delete and select *Delete Template*.
+** Click the template name to open the *Virtual Machine Template Details*
+pane and click *Actions* -> *Delete Template*. 
+. In the confirmation pop-up window, click *Delete* to permanently delete the template.
+

--- a/modules/cnv-editing-template-web.adoc
+++ b/modules/cnv-editing-template-web.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-editing-vm-template.adoc
+
+[id="cnv-editing-template-web_{context}"]
+= Editing a virtual machine template in the web console
+
+You can edit the YAML configuration of a virtual machine template from the 
+web console. 
+
+Not all parameters can be modified. If you click *Save* with an invalid configuration,
+ an error message indicates the parameter that cannot be modified.
+
+[NOTE]
+====
+Navigating away from the YAML screen while editing cancels any changes to the
+ configuration that you made. 
+====
+
+.Procedure
+
+. In the {ProductName} console, click *Workloads* -> *Virtual Machine Templates*.
+. Select a template.
+. Click the *YAML* tab to display the editable configuration. 
+ state.
+. Edit the file and click *Save*. 
+
+A confirmation message, which includes the updated version number for the object, shows the modification has been successful.
+

--- a/modules/cnv-template-wizard-fields-web.adoc
+++ b/modules/cnv-template-wizard-fields-web.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-creating-vm-template.adoc
+
+[id="cnv-template-wizard-fields-web_{context}"]
+= Virtual machine template wizard fields
+
+|===
+|Name |Parameter |Description
+
+|*Name*
+|
+|The name can contain only alphanumeric characters and must be 63 or fewer characters long. 
+
+|*Description*
+|
+|Optional description field.
+
+.3+|*Provision Source*
+|*PXE*
+|Provision virtual machines from PXE menu. Requires a PXE-capable NIC in the cluster.
+
+|*URL*
+|Provision virtual machines from an image available from a HTTP or S3 endpoint. 
+
+|*Container*
+|Provision virtual machines from a bootable operating system container that is located 
+in a registry that is accessible from the cluster. Example: `_kubevirt/cirros-registry-disk-demo_`
+
+|*Operating System*
+|
+|A list of operating systems that are available in the cluster. This is to ensure the virtualized 
+hardware is compatible with the operating system that will be installed on the virtual machine.
+
+|*Flavor*
+|*small*, *medium*, *large*, *tiny*, *Custom*
+|Presets that determine the amount of CPU and memory that are allocated to the virtual machines. 
+
+.2+|*Workload Profile*
+|*generic*
+|A general configuration that balances performance and compatibility for a 
+broad range of workloads.
+
+|*highperformance*
+|Virtual machines have a more efficient configuration optimized for high performance loads.
+
+|*cloud-init*
+|
+|Select this checkbox to enable the cloud-init fields.
+|===
+
+


### PR DESCRIPTION
This content is to cover CNV-1603, CNV-1612, and CNV-1615. It is all migrated from 1.4 content, and only includes the web console methods. It does not include the RFE to include more information on what parameters can be edited in the virtual machine template YAML.
There are three reference tables included in the `cnv-creating-vm-template.adoc` assembly that are not added in this PR - these files are/will be included in #15529 (which shares content).