### PR TITLE
adding kebab to cnv attributes

### DIFF
--- a/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
+++ b/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
@@ -1,7 +1,6 @@
 [id="uninstalling-container-native-virtualization"]
 = Uninstalling {ProductName}
 include::modules/cnv-document-attributes.adoc[]
-include::modules/common-attributes.adoc[]
 :context: uninstalling-container-native-virtualization
 toc::[]
 

--- a/modules/cnv-document-attributes.adoc
+++ b/modules/cnv-document-attributes.adoc
@@ -14,6 +14,7 @@
 :ProductVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com
+:kebab: image:ellipsis-v.svg[opts=inline,5,title="Options menu"]
 //
 // Documentation publishing attributes used in the master-docinfo.xml file
 // Note that the DocInfoProductName generates the URL for the product page.


### PR DESCRIPTION
The `:kebab:` attribute was not in `cnv-document-attributes.adoc`, so I'm adding it. I'm also removing the `include::modules/common-attributes.adoc` from the CNV uninstall assembly, so that it doesn't depend on OCP.