### PR TITLE
BZ-1717178: Updated security section in the release notes.

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -426,9 +426,9 @@ tolerations, and cluster settings.
 [id="ocp-4-1-security"]
 === Security
 
-In {product-title} 4.1, an Operator is utilized to install, configure, and manage
-the certificate signing server. Certificates are managed as secrets, and are
-stored and encrypted in etcd.
+In {product-title} 4.1, Operators are utilized to install, configure, and
+manage the various certificate signing servers. Certificates are managed
+as secrets stored within the cluster itself.
 
 [id="ocp-4-1-notable-technical-changes"]
 == Notable technical changes


### PR DESCRIPTION
This is the work from [PR 15248](https://github.com/openshift/openshift-docs/pull/15248), but based on the enterprise-4.1 branch instead of master.