### PR TITLE
BZ-1724311: Updated assemblies to include references.

### DIFF
--- a/authentication/understanding-identity-provider.adoc
+++ b/authentication/understanding-identity-provider.adoc
@@ -68,6 +68,10 @@ link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authoriza
 
 |===
 
+Once an identity provider has been defined, you can
+xref:../authentication/using-rbac.adoc#authorization-overview_using-rbac[use RBAC to define and apply permissions].
+
+include::modules/authentication-remove-kubeadmin.adoc[leveloffset=+1]
 
 include::modules/identity-provider-parameters.adoc[leveloffset=+1]
 

--- a/modules/authentication-remove-kubeadmin.adoc
+++ b/modules/authentication-remove-kubeadmin.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * authentication/understanding-authentication.adoc
+// * authentication/understanding-identity-provider.adoc
 
 [id="removing-kubeadmin_{context}"]
 = Removing the kubeadmin user
@@ -8,7 +9,7 @@
 After you define an identity provider and create a new `cluster-admin`
 user, you can remove the `kubeadmin` to improve cluster security.
 
-WARNING
+[WARNING]
 ====
 If you follow this procedure before another user is a `cluster-admin`,
 then {product-title} must be reinstalled. It is not possible to undo
@@ -21,7 +22,7 @@ this command.
 * You must have added the `cluster-admin` role to a user.
 * You must be logged in as an administrator.
 
-.Procedure 
+.Procedure
 
 * Remove the `kubeadmin` secrets:
 +


### PR DESCRIPTION
Updated the `understanding identity provider` assembly to include references to both RBAC and removing the default kubeadmin user.

This is for OS 4.x.