### PR TITLE
Discuss behavior different for multicast in multitenant mode

### DIFF
--- a/modules/nw-about-multicast.adoc
+++ b/modules/nw-about-multicast.adoc
@@ -14,14 +14,22 @@ discovery and not a high-bandwidth solution.
 ====
 
 Multicast traffic between {product-title} Pods is disabled by default. If you
-are using the OpenShiftSDN network plug-in, you can enable multicast on a
+are using the OpenShift SDN network plug-in, you can enable multicast on a
 per-project basis.
 
-When using the OpenShiftSDN network plug-in:
+When using the OpenShift SDN network plug-in in `networkpolicy` isolation mode:
 
 * Multicast packets sent by a Pod will be delivered to all other Pods in the
-project, regardless of `NetworkPolicy` objects. Pods may be able to communicate
+project, regardless of NetworkPolicy objects. Pods might be able to communicate
 over multicast even when they cannot communicate over unicast.
 * Multicast packets sent by a Pod in one project will never be delivered to Pods
-in any other project, even if there are `NetworkPolicy` objects allowing
+in any other project, even if there are NetworkPolicy objects that allow
 communication between the projects.
+
+When using the OpenShift SDN network plug-in in `multitenant` isolation mode:
+
+* Multicast packets sent by a Pod will be delivered to all other Pods in the
+project.
+* Multicast packets sent by a Pod in one project will be delivered to Pods in
+other projects only if each project is joined together and multicast is enabled
+in each joined project.


### PR DESCRIPTION
This PR adds missing context for how multicast traffic works when using OpenShift SDN in _multitenant_ isolation mode.

- OSDOCS-428