### PR TITLE
Fixed API version for autoscaling ReplicationController examples

### DIFF
--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -148,7 +148,7 @@ metadata:
   name: hpa-resource-metrics-cpu <1>
 spec:
   scaleTargetRef:
-    apiVersion: apps.openshift.io/v1 <2>
+    apiVersion: v1 <2>
     kind: ReplicationController <3>
     name: hello-hpa-cpu <4>
   minReplicas: 1 <5>
@@ -199,7 +199,7 @@ metadata:
   name: hpa-resource-metrics-memory <1>
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1 <2>
+    apiVersion: v1 <2>
     kind: ReplicationController <3>
     name: hello-hpa-memory <4>
   minReplicas: 1 <5>


### PR DESCRIPTION
API version for HPA examples using replication controllers is wrong. `ReplicationController` objects belong to `v1` API version, not `apps.openshift.io/v1`.