### PR TITLE
Update OSDK CLI to v0.8.0 usage

### DIFF
--- a/modules/building-memcached-operator-using-osdk.adoc
+++ b/modules/building-memcached-operator-using-osdk.adoc
@@ -31,7 +31,7 @@ Use the CLI to create a new `memcached-operator` project:
 ----
 $ mkdir -p $GOPATH/src/github.com/example-inc/
 $ cd $GOPATH/src/github.com/example-inc/
-$ operator-sdk new memcached-operator
+$ operator-sdk new memcached-operator --dep-manager dep
 $ cd memcached-operator
 ----
 
@@ -223,11 +223,6 @@ at `$HOME/.kube/config`:
 +
 ----
 $ operator-sdk up local --namespace=default
-2018/09/30 23:10:11 Go Version: go1.10.2
-2018/09/30 23:10:11 Go OS/Arch: darwin/amd64
-2018/09/30 23:10:11 operator-sdk Version: 0.0.6+git
-2018/09/30 23:10:12 Registering Components.
-2018/09/30 23:10:12 Starting the Cmd.
 ----
 +
 You can use a specific `kubeconfig` using the flag

--- a/modules/osdk-ansible-k8s-module-inside-operator.adoc
+++ b/modules/osdk-ansible-k8s-module-inside-operator.adoc
@@ -62,11 +62,8 @@ $ oc create -f deploy/role_binding.yaml
 +
 ----
 $ operator-sdk up local
-INFO[0000] Go Version: go1.10.3
-INFO[0000] Go OS/Arch: linux/amd64
-INFO[0000] operator-sdk Version: 0.0.6+git
+[...]
 INFO[0000] Starting to serve on 127.0.0.1:8888
-
 INFO[0000] Watching foo.example.com/v1alpha1, Foo, default
 ----
 

--- a/modules/osdk-building-ansible-operator.adoc
+++ b/modules/osdk-building-ansible-operator.adoc
@@ -289,18 +289,12 @@ present at `$HOME/.kube/config`:
 +
 ----
 $ operator-sdk up local
-INFO[0000] Go Version: go1.10
-INFO[0000] Go OS/Arch: darwin/amd64
-INFO[0000] operator-sdk Version: 0.0.5+git
 ----
 +
 To run the Operator locally with a provided Kubernetes configuration file:
 +
 ----
 $ operator-sdk up local --kubeconfig=config
-INFO[0000] Go Version: go1.10
-INFO[0000] Go OS/Arch: darwin/amd64
-INFO[0000] operator-sdk Version: 0.0.5+git
 ----
 
 . *Create a `Memcached` CR.*

--- a/modules/osdk-building-helm-operator.adoc
+++ b/modules/osdk-building-helm-operator.adoc
@@ -250,18 +250,12 @@ present at `$HOME/.kube/config`:
 +
 ----
 $ operator-sdk up local
-INFO[0000] Go Version: go1.10.3
-INFO[0000] Go OS/Arch: linux/amd64
-INFO[0000] operator-sdk Version: v0.3.0+git
 ----
 +
 To run the Operator locally with a provided Kubernetes configuration file:
 +
 ----
 $ operator-sdk up local --kubeconfig=<path_to_config>
-INFO[0000] Go Version: go1.10.3
-INFO[0000] Go OS/Arch: linux/amd64
-INFO[0000] operator-sdk Version: v0.3.0+git
 ----
 
 . *Deploy the `Nginx` CR.*

--- a/modules/osdk-cli-reference-add.adoc
+++ b/modules/osdk-cli-reference-add.adoc
@@ -33,7 +33,7 @@ Operator application.
 * Generated CR  filename: `<project-name>/deploy/crds/<group>_<version>_<kind>_cr.yaml`
 |===
 
-.`add` flags
+.`add api` flags
 [options="header",cols="1,3"]
 |===
 |Flag |Description

--- a/modules/osdk-cli-reference-new.adoc
+++ b/modules/osdk-cli-reference-new.adoc
@@ -19,20 +19,39 @@ The `operator-sdk new` command creates a new Operator application and generates
 |===
 |Flag |Description
 
+|`--api-version`
+|CRD `APIVersion` in the format `$GROUP_NAME/$VERSION`, for example `app.example.com/v1alpha1`. Used with `ansible` or `helm` types.
+
+|`--dep-manager [dep\|modules]`
+|Dependency manager the new project will use. Used with `go` type. (Default: `modules`)
+
+|`--generate-playbook`
+|Generate an Ansible playbook skeleton. Used with `ansible` type.
+
+|`--header-file <string>`
+|Path to file containing headers for generated Go files. Copied to `hack/boilerplate.go.txt`.
+
+|`--helm-chart <string>`
+|Initialize Helm operator with existing Helm chart: `<url>`, `<repo>/<name>`, or local path.
+
+|`--helm-chart-repo <string>`
+|Chart repository URL for the requested Helm chart.
+
+|`--helm-chart-version <string>`
+|Specific version of the Helm chart. (Default: latest version)
+
+|`--help, -h`
+|Usage and help output.
+
+|`--kind <string>`
+|CRD `Kind`, for example `AppService`. Used with `ansible` or `helm` types.
+
 | `--skip-git-init`
 |Do not initialize the directory as a Git repository.
 
 |`--type`
-a|Type of Operator to initialize: `ansible` or `go` (default: `go`). Also requires the following flags if `--type=ansible`:
+|Type of Operator to initialize: `go`, `ansible` or `helm`. (Default: `go`)
 
-* `--api-version`: CRD `APIVersion` in the format `$GROUP_NAME/$VERSION` (e.g., `app.example.com/v1alpha1`)
-* `--kind`: CRD `Kind` (e.g., `AppService`).
-
-|`--cluster-scoped`
-|Initialize the Operator to be cluster-scoped instead of namespace-scoped.
-
-|`-h, --help`
-|Usage help output.
 |===
 
 .Example usage for Go project

--- a/modules/osdk-cli-reference-test.adoc
+++ b/modules/osdk-cli-reference-test.adoc
@@ -1,8 +1,7 @@
 [id="osdk-cli-reference-test_{context}"]
 = test
 
-The `operator-sdk test` command has subcommands that can test the Operator
-locally or from within a cluster.
+The `operator-sdk test` command can test the Operator locally.
 
 == local
 
@@ -61,51 +60,4 @@ $ operator-sdk test local ./test/e2e/
 
 # Output:
 ok  	github.com/operator-framework/operator-sdk-samples/memcached-operator/test/e2e	20.410s
-----
-
-== cluster
-
-The `cluster` subcommand runs Go tests embedded in an Operator image built using
-the Operator SDK as a Pod in the cluster.
-
-.`test cluster` arguments
-[options="header",cols="1,3"]
-|===
-|Arguments |Description
-
-|`<image_name>` (string)
-|The Operator image that is used to run the tests in a Pod (e.g.,
-`quay.io/example/memcached-operator:v0.0.1`).
-|===
-
-.`test cluster` flags
-[options="header",cols="1,3"]
-|===
-|Flags |Description
-
-|`--kubeconfig` (string)
-|Location of `kubeconfig` for a cluster. Default: `~/.kube/config`.
-
-|`--image-pull-policy` (string)
-|Set test Pod image pull policy. Allowed values: `Always` (default), `Never`.
-
-|`--namespace` (string)
-|Namespace to run tests in. Default: `default`.
-
-|`--pending-timeout` (int)
-|Timeout in seconds for testing Pod to stay in pending state. Default: `60s`.
-
-|`--service-account` (string)
-|Service account to run tests on. Default: `default`.
-
-|`--help`
-|Usage help output.
-|===
-
-.Example output
-----
-$ operator-sdk test cluster quay.io/example/memcached-operator:v0.0.1
-
-# Output:
-Test Successfully Completed
 ----

--- a/modules/osdk-installing-cli.adoc
+++ b/modules/osdk-installing-cli.adoc
@@ -37,7 +37,7 @@ project on GitHub.
 . Set the release version variable:
 +
 ----
-RELEASE_VERSION=v0.7.0
+RELEASE_VERSION=v0.8.0
 ----
 
 . Download the release binary.


### PR DESCRIPTION
Preview (internal): http://file.rdu.redhat.com/~adellape/062719/update_sdk_cli/applications/operator_sdk/osdk-cli-reference.html

Follow-up to comments from https://github.com/openshift/openshift-docs/pull/13705#issuecomment-493891428:

> There are some places need to be updated in [docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-cli-reference.html#osdk-cli-reference-new_osdk-cli-reference](https://docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-cli-reference.html#osdk-cli-reference-new_osdk-cli-reference).
> For example, there is no `--cluster-scoped` flag for the `operator-sdk new` command.

Removed.

> The default command failed:
> 
> ```
> mac:example-inc jianzhang$ operator-sdk new app-operator
> INFO[0000] Creating new Go operator 'app-operator'.     
> FATA[0000] Dependency manager "modules" has been selected but go modules are not active. Activate modules then run "operator-sdk new app-operator". 
> ```
> 
> It works by adding the `--dep-manager=dep` flag:
> 
> ```
> mac:example-inc jianzhang$ operator-sdk new app-operator --dep-manager=dep
> INFO[0000] Creating new Go operator 'app-operator'.     
> INFO[0000] Created Gopkg.toml 
> ...
> ```

Added `--dep-manager` to CLI reference and in Getting Started procedure.
 
> The version of the `operator-sdk`:
> 
> ```
> mac:example-inc jianzhang$ operator-sdk version
> operator-sdk version: v0.8.0, commit: 78c472461e75e6c64589cfadf577a2004b8a26b3
> ```

Updated install procedure to use `v0.8.0` as the `RELEASE_VERSION`.

> And, `Table 11. add flags` should be `Table 11. crd flags`

Fixed.

> Got errors when running `add api` command:
> 
> ```
> mac:app-operator jianzhang$ operator-sdk add api --api-version app.example.com/v1alpha1 --kind AppService
> INFO[0000] Generating api version app.example.com/v1alpha1 for kind AppService. 
> INFO[0001] Created pkg/apis/app/v1alpha1/appservice_types.go 
> INFO[0001] Created pkg/apis/addtoscheme_app_v1alpha1.go 
> INFO[0001] Created pkg/apis/app/v1alpha1/register.go    
> INFO[0001] Created pkg/apis/app/v1alpha1/doc.go         
> INFO[0001] Created deploy/crds/app_v1alpha1_appservice_cr.yaml 
> W0520 16:21:17.525652   31004 parse.go:239] Ignoring child directory github.com/example-inc/app-operator/pkg/apis/app: No files for pkg "github.com/example-inc/app-operator/pkg/apis/app"
> INFO[0002] Created deploy/crds/app_v1alpha1_appservice_crd.yaml 
> Error: exit status 2
> Usage:
>   operator-sdk add api [flags]
> 
> Flags:
>       --api-version string   Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
>   -h, --help                 help for api
>       --kind string          Kubernetes resource Kind name. (e.g AppService)
> 
> Global Flags:
>       --verbose   Enable verbose logging
> mac:app-operator jianzhang$ tree pkg/apis/
> pkg/apis/
> ├── addtoscheme_app_v1alpha1.go
> ├── apis.go
> └── app
>     └── v1alpha1
>         ├── appservice_types.go
>         ├── doc.go
>         └── register.go
> ```

I didn't get those errors:

```
$ operator-sdk add api --api-version app.example.com/v1alpha1 --kind AppService
INFO[0000] Generating api version app.example.com/v1alpha1 for kind AppService. 
INFO[0000] Created pkg/apis/app/v1alpha1/appservice_types.go 
INFO[0000] Created pkg/apis/addtoscheme_app_v1alpha1.go 
INFO[0000] Created pkg/apis/app/v1alpha1/register.go    
INFO[0000] Created pkg/apis/app/v1alpha1/doc.go         
INFO[0000] Created deploy/crds/app_v1alpha1_appservice_cr.yaml 
W0627 15:33:08.795126   20888 parse.go:239] Ignoring child directory github.com/app-operator/pkg/apis/app: No files for pkg "github.com/app-operator/pkg/apis/app"
INFO[0000] Created deploy/crds/app_v1alpha1_appservice_crd.yaml 
INFO[0006] Running deepcopy code-generation for Custom Resource group versions: [app:[v1alpha1], ] 
INFO[0008] Code-generation complete.                    
INFO[0009] Running OpenAPI code-generation for Custom Resource group versions: [app:[v1alpha1], ] 
2019/06/27 15:33:19 Code for OpenAPI definitions generated
INFO[0011] Created deploy/crds/app_v1alpha1_appservice_crd.yaml 
INFO[0011] Code-generation complete.                    
INFO[0011] API generation complete. 


$ tree pkg/apis/
pkg/apis/
├── addtoscheme_app_v1alpha1.go
├── apis.go
└── app
    └── v1alpha1
        ├── appservice_types.go
        ├── doc.go
        ├── register.go
        ├── zz_generated.deepcopy.go
        └── zz_generated.openapi.go


$ operator-sdk version
operator-sdk version: v0.8.1, commit: 33b3bfe10176f8647f5354516fff29dea42b6342
```

Can you reproduce?

> For the [docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-cli-reference.html#cluster](https://docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-cli-reference.html#cluster), it has been removed. No `cluster` flag anymore.

Removed.
