### PR TITLE
Update apiserver.doc

### DIFF
--- a/authentication/certificates/api-server.adoc
+++ b/authentication/certificates/api-server.adoc
@@ -10,6 +10,4 @@ cluster CA. Clients outside of the cluster will not be able to verify the
 API server's certificate by default. This certificate can be replaced
 by one that is issued by a CA that clients trust.
 
-include::modules/customize-certificates-api-add-default.adoc[leveloffset=+1]
-
 include::modules/customize-certificates-api-add-named.adoc[leveloffset=+1]

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -18,6 +18,13 @@ client's URL.
 reach the API server.
 * The certificate must have the `subjectAltName` extension for the URL.
 
+[WARNING]
+====
+Do not provide a named certificate for the internal load balancer (host
+name `api-int.<cluster_name>.<base_domain>`). Doing so will leave your
+cluster in a degraded state.
+====
+
 .Procedure
 
 . Create a secret that contains the certificate and key in the


### PR DESCRIPTION
Remove the instructions on replacing the default certificate because if followed, as written, will also replace the internal serving certificates and leave the cluster in a degraded state.

Following the instructions for adding a named certificate would be the appropriate way to override the certificate used to serve traffic over the external `api.{cluster}.{domain}` name.