### PR TITLE
Add master node sizing recommendations

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+[id="master-node-sizing_{context}"]
+=  Master node sizing
+
+The master node resource requirements depend on the number of nodes in the cluster. The following master node size recommendations are based on the results of control plane density focused testing.
+
+[options="header",cols="3*"]
+|===
+| Number of worker nodes |CPU cores |Memory (GB)
+
+| 25
+| 4
+| 16
+
+| 100
+| 8
+| 32
+
+| 250
+| 16
+| 64
+
+|===
+
+[IMPORTANT]
+====
+Because you cannot modify the master node size in a running {product-title} {product-version} cluster, you must estimate your total node count and use the suggested master size during installation.
+====
+
+[NOTE]
+====
+In {product-title} {product-version}, half of a CPU core (500 millicore) is now reserved by the system by default compared to {product-title} 3.11 and previous versions. The sizes are determined taking that into consideration.
+====

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -9,6 +9,8 @@ This topic provides recommended host practices for {product-title}.
 
 include::modules/recommended-node-host-practices.adoc[leveloffset=+1]
 
+include::modules/master-node-sizing.adoc[leveloffset=+1]
+
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+1]
 
 include::modules/recommended-etcd-practices.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit adds information to the Scalabilty and Performance doc about the
size of master nodes based on the data collected during the control plane
density test runs at different node scale. This will help customers understand
the master node requirements depending on the number of nodes in the cluster.