### PR TITLE
search: avoid iframe

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -1,51 +1,105 @@
 function hcSearchCategory(label, version) {
 // optional version filters search results for a single specific product version
-// currently can be used with OCP and Origin only
+// currently can be used with OCP and OKD docs only
 
-  var modalSearch = document.getElementById("hc-search-modal");
-  var searchBtn = document.getElementById("hc-search-btn");
-  var closeModal = document.getElementById("hc-modal-close");
-  var searchResults = document.getElementById("hc-search-results");
-  var query = document.getElementById("hc-search-input");
+  // elements used repeatedly:
+  var modalSearch = $("#hc-search-modal");
+  var searchBtn = $("#hc-search-btn");
+  var closeModal = $("#hc-modal-close");
+  var query = $("#hc-search-input");
 
   // pressing enter in the input = search btn click
-  query.addEventListener("keyup", function(event) {
+  query.keyup( function(event) {
     event.preventDefault();
     if (event.keyCode == 13) {
         searchBtn.click();
     }
   });
 
-  //prepare iframe (without source)
-  var iframe = document.createElement("iframe");
-  iframe.frameBorder=0;
-  iframe.width="100%";
-  iframe.height=0.7*window.innerHeight;
-  iframe.id="search-result-iframe";
-
-  // open the modal and finalize the iframe on click
-  searchBtn.onclick = function() {
-    if (query.value) {
-  	modalSearch.style.display = "block";
-    // limit search to a signle version, if specified
-    var urlFilter = (typeof version === "undefined" || version == "Branch Build") ? "" : (" url:*\\/" + version + "\\/*");
-    var iframeSrc = "https://help.openshift.com/customsearch.html?q=" +
-                    encodeURIComponent(query.value) +
-                    encodeURIComponent(urlFilter) +
-                    "&l=" + encodeURIComponent(label);
-  	iframe.setAttribute("src", iframeSrc);
-          searchResults.appendChild(iframe);
+  // open the modal and fetch the first set of results on click
+  searchBtn.click(function() {
+    if (query.val()) {
+      // remove any results from previous searches
+      $("#hc-search-results").empty();
+      var searchParams = {
+        si: 0,
+        q: query.val(),
+        label: label,
+        urlFilter: (typeof version === "undefined" || version == "Branch Build") ? "" : (" url:*\\/" + version + "\\/*")
+      };
+      modalSearch.show();
+      hcsearch(searchParams);
     }
-  }
-
-  // hide search modal
-  closeModal.onclick = function() {
-    modalSearch.style.display = "none";
-  }
-
-  window.onclick = function(event) {
-    if (event.target == modalSearch) {
-      modalSearch.style.display = "none";
+  });
+  
+  // hide search modal by 'X' or by clicking outside of the modal
+  closeModal.click(function() {
+    modalSearch.hide();
+  });
+  $(window).click(function(event) {
+    if ($(event.target).is(modalSearch)) {
+      modalSearch.hide();
     }
-  }
-}  // hcSearchCategory(label)
+  });
+}  // hcSearchCategory(label, version)
+
+// fetch search results
+function hcsearch(searchParams) {
+  // elements used repeatedly
+  var hcMoreBtn = $("#hc-search-more-btn");
+  var hcSearchIndicator = $("#hc-search-progress-indicator");
+  var hcSearchResult = $("#hc-search-results");
+
+  // the "searchprovider" is to return a JSON response in the expected format
+  var searchprovider = "https://help.openshift.com/search/search_custom.php";
+  var searchReq = { "q" : searchParams.q + searchParams.urlFilter,
+                    "l" : searchParams.label,
+                    "si" : searchParams.si }  // q = query, l = label
+
+  hcMoreBtn.hide();
+  hcSearchIndicator.show();
+  $.get(searchprovider, searchReq).done(function (hcsearchresults) {
+    // GET success
+    if (hcsearchresults == "") {
+      // success, but no response (response code mismatch)
+      $("#hc-search-result").append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+      hcSearchIndicator.hide();
+    }
+    if (hcsearchresults.response.result) {
+      // if there are any results
+      $(hcsearchresults.response.result).each(function () {
+        var row = '<div class="search-result-item"><a href="' + this.url +
+          '" target="_blank">' + this.title + '</a>';
+        row += '<p class="excerpt">' + this.content_description.replace(/\<br\>/g, ' ') + '</p></div>';
+        hcSearchResult.append(row);
+      });
+      if (hcsearchresults.response.page_number < hcsearchresults.response.page_count) {
+        // if there are more results beyond the retrieved ones
+        // index of the first item on the next page (first item = 0, first page = 1)
+        searchParams.si = hcsearchresults.response.page_number * hcsearchresults.response.page_size;
+        // replace any existing click handler with one to fetch the next set of results
+        hcMoreBtn.off('click');
+        hcMoreBtn.click(function() {
+          hcsearch(searchParams); 
+        });
+        hcMoreBtn.show();
+      } else {
+        // no more results beyond the retrieved ones
+        hcSearchResult.append("<p><strong>No more results.</strong></p>");
+      }
+    } else {
+      if (searchParams.si > 0) {
+          // no results reurned, but some already displayed
+          hcSearchResult.append("<p><strong>No more results.</strong></p>");
+      } else {
+        // no results on initial search
+        hcSearchResult.append("<p><strong>No results found. Try rewording your search.</strong></p>");
+      }
+    }
+    hcSearchIndicator.hide();
+  }).fail(function(response) {
+    // GET error
+    hcSearchResult.append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+    hcSearchIndicator.hide();
+  });
+}  // function hcsearch()

--- a/_stylesheets/search.css
+++ b/_stylesheets/search.css
@@ -11,26 +11,45 @@
 }
 
 #hc-search-modal {
+    background-color: rgb(0,0,0);
+    background-color: rgba(0,0,0,0.4);
     display: none;
     position: fixed;
-    z-index: 1;
-    padding-top: 5%;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
     overflow: auto;
-    background-color: rgb(0,0,0);
-    background-color: rgba(0,0,0,0.4);
+    z-index: 10000;
+}
+@media screen and (max-width: 767px) {
+    #hc-search-modal {
+        padding-top: 80px;
+    }
+}
+@media screen and (min-width: 768px) {
+    #hc-search-modal {
+        padding-top: 5%;
+    }
 }
 
 #hc-modal-content {
     background-color: #fefefe;
-    margin: auto;
-    padding: 20px;
     border: 1px solid #888;
-    width: 80%;
-    height: 80vh;
+    padding: 20px;
+}
+@media screen and (max-width: 767px) {
+    #hc-modal-content {
+        height: 100%;
+        width: 100%;
+    }
+}
+@media screen and (min-width: 768px) {
+    #hc-modal-content {
+        height: 80vh;
+        margin: auto;
+        width: 80%;
+    }
 }
 
 #hc-modal-close {
@@ -38,6 +57,8 @@
     float: right;
     font-size: 28px;
     font-weight: bold;
+    position: relative;
+    z-index: 10001;
 }
 
 #hc-modal-close:hover,
@@ -45,4 +66,16 @@
     color: #000;
     text-decoration: none;
     cursor: pointer;
+}
+
+#hc-search-results-wrapper {
+    height: 75vh;
+    padding-bottom: 15px;
+    overflow: auto;
+}
+
+@media screen and (max-width: 767px) {
+    #hc-search-more-btn, #hc-search-progress-indicator {
+        margin-bottom: 2em;
+    }
 }

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -94,7 +94,13 @@
           <div id="hc-search-modal">
             <div id="hc-modal-content">
               <span id="hc-modal-close">&times;</span>
-              <div id="hc-search-results"></div>
+              <div id="hc-search-results-wrapper">
+                <div id="hc-search-results"></div>
+                <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+                <div class="text-center">
+                  <button id="hc-search-more-btn">Show more results</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/_templates/_search_dedicated.html.erb
+++ b/_templates/_search_dedicated.html.erb
@@ -6,7 +6,13 @@
 <div id="hc-search-modal">
   <div id="hc-modal-content">
     <span id="hc-modal-close">&times;</span>
-    <div id="hc-search-results"></div>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/_templates/_search_enterprise.html.erb
+++ b/_templates/_search_enterprise.html.erb
@@ -6,7 +6,13 @@
 <div id="hc-search-modal">
   <div id="hc-modal-content">
     <span id="hc-modal-close">&times;</span>
-    <div id="hc-search-results"></div>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/_templates/_search_online.html
+++ b/_templates/_search_online.html
@@ -6,7 +6,13 @@
 <div id="hc-search-modal">
   <div id="hc-modal-content">
     <span id="hc-modal-close">&times;</span>
-    <div id="hc-search-results"></div>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/_templates/_search_origin.html.erb
+++ b/_templates/_search_origin.html.erb
@@ -6,7 +6,13 @@
 <div id="hc-search-modal">
   <div id="hc-modal-content">
     <span id="hc-modal-close">&times;</span>
-    <div id="hc-search-results"></div>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/_templates/_search_other.html
+++ b/_templates/_search_other.html
@@ -6,7 +6,13 @@
 <div id="hc-search-modal">
   <div id="hc-modal-content">
     <span id="hc-modal-close">&times;</span>
-    <div id="hc-search-results"></div>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/search-commercial.html
+++ b/search-commercial.html
@@ -24,10 +24,12 @@
     '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-PMDVKG');</script>
     <!-- End Google Tag Manager -->
-
     <!-- Adobe DTM -->
     <script src="//www.redhat.com/dtm.js" type="text/javascript"></script>
     <!-- End Adobe DTM -->
+    <!-- jQuery is required by Help Center search -->
+    <script src="https://assets.openshift.net/content/subdomain.js" type="text/javascript"></script>
+    <!-- -->
 </head>
 <body class="docs docs-search">
 <!-- Google Tag Manager (noscript) -->
@@ -155,6 +157,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="container">
     <h1>Search Results</h1>
     <div id="hc-search-results" class="search-results clearfix"></div>
+    <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+    <div class="text-center">
+      <button id="hc-search-more-btn" style="display:none;">Show more results</button>
+    </div>
   </div>
 </section>
 
@@ -181,29 +187,89 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </footer>
 
 <script type="text/javascript">
-// custom help.openshift.com search
-function parseParamsFromUrl() {
-        var params = {};
-        var parts = window.location.search.substr(1).split('&');
-        for (var i = 0; i < parts.length; i++) {
-            var keyValuePair = parts[i].split('=');
-            var key = keyValuePair[0];
-            params[key] = keyValuePair[1];
+  // custom help.openshift.com search
+  function parseParamsFromUrl() {
+          var params = {};
+          var parts = window.location.search.substr(1).split('&');
+          for (var i = 0; i < parts.length; i++) {
+              var keyValuePair = parts[i].split('=');
+              var key = keyValuePair[0];
+              params[key] = keyValuePair[1];
+          }
+          return params;
+  }  // function parseParamsFromUrl()
+
+  function hcsearch(searchParams) {
+    // elements used repeatedly
+    var hcMoreBtn = $("#hc-search-more-btn");
+    var hcSearchIndicator = $("#hc-search-progress-indicator");
+    var hcSearchResult = $("#hc-search-results");
+
+    // the "searchprovider" is to return a JSON response in the expected format
+    var searchprovider = "https://help.openshift.com/search/search_custom.php";
+    var searchReq = { "q" : searchParams.q + searchParams.urlFilter,
+                      "l" : searchParams.label,
+                      "si" : searchParams.si }  // q = query, l = label
+
+    hcMoreBtn.hide();
+    hcSearchIndicator.show();
+    $.get(searchprovider, searchReq).done(function (hcsearchresults) {
+      // GET success
+      if (hcsearchresults == "") {
+        // success, but no response (response code mismatch)
+        $("#hc-search-result").append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+        hcSearchIndicator.hide();
+      }
+      if (hcsearchresults.response.result) {
+        // if there are any results
+        $(hcsearchresults.response.result).each(function () {
+          var row = '<div class="search-result-item"><a href="' + this.url +
+            '" target="_blank">' + this.title + '</a>';
+          row += '<p class="excerpt">' + this.content_description.replace(/\<br\>/g, ' ') + '</p></div>';
+          hcSearchResult.append(row);
+        });
+        if (hcsearchresults.response.page_number < hcsearchresults.response.page_count) {
+          // if there are more results beyond the retrieved ones
+          // index of the first item on the next page (first item = 0, first page = 1)
+          searchParams.si = hcsearchresults.response.page_number * hcsearchresults.response.page_size;
+          // replace any existing click handler with one to fetch the next set of results
+          hcMoreBtn.off('click');
+          hcMoreBtn.click(function() {
+            hcsearch(searchParams); 
+          });
+          hcMoreBtn.show();
+        } else {
+          // no more results beyond the retrieved ones
+          hcSearchResult.append("<p><strong>No more results.</strong></p>");
         }
-        return params;
-  }
+      } else {
+        if (searchParams.si > 0) {
+            // no results reurned, but some already displayed
+            hcSearchResult.append("<p><strong>No more results.</strong></p>");
+        } else {
+          // no results on initial search
+          hcSearchResult.append("<p><strong>No results found. Try rewording your search.</strong></p>");
+        }
+      }
+      hcSearchIndicator.hide();
+    }).fail(function(response) {
+      // GET error
+      hcSearchResult.append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+      hcSearchIndicator.hide();
+    });
+  }  // function hcsearch()
 
   var urlParams = parseParamsFromUrl();
   var queryParamName = 'query';
-  var searchLabel = 'docs';
 
   if (urlParams[queryParamName]) {
-        hciframe = document.createElement('iframe');
-        hciframe.width = '100%';
-        hciframe.height = 0.7 * window.innerHeight;
-        hciframe.frameBorder = '0';
-        hciframe.src = 'https://help.openshift.com/customsearch.html?q=' + urlParams[queryParamName] + '&l=' + searchLabel;
-        document.getElementById('hc-search-results').appendChild(hciframe);
+    var searchParams = {
+        si: 0,
+        q: urlParams[queryParamName],
+        label: "docs",
+        urlFilter: ""
+      };
+      hcsearch(searchParams);
   }
 </script>
 <!-- Adobe DTM -->


### PR DESCRIPTION
This replaces the current iframe search used in the modal window when searching via the input field above docs topic selection on the left hand side. The new style can be checked [here](http://httpd-test-pro.b9ad.pro-us-east-1.openshiftapps.com/container-platform/3.11/welcome/) (only the 3.11 OCP variant). Avoiding the iframe fixes rendering on iOS devices, which [ignore the iframe height](https://stackoverflow.com/questions/34320046/iframe-height-issues-on-ios-mobile-safari), thus prevent normal scrolling, with the current style that assumes limited iframe height in the modal window.

The main page search (that searches all the doc variants and is not rendered in a modal window) is adjusted in the same manner. This universal search style can be checked [here](http://httpd-test-pro.b9ad.pro-us-east-1.openshiftapps.com/index.html).

The `master` and `master-3` branch differs in regards of `_templates/_search_*` files presence, but the `_templates/_page_openshift.html.erb` is there in both cases (slightly different though; the `master-3` version has [this Beta notice](https://github.com/openshift/openshift-docs/blob/master-3/_templates/_page_openshift.html.erb#L110)). @vikram-redhat, please let me know if a separate `master-3` style PR is required.