### PR TITLE
[enterprise-3.9] Add note about log length in the web console

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1714,7 +1714,15 @@ $ openshift start node --config=/openshift.local.config/node-<node_hostname>/nod
 [[master-node-config-logging-levels]]
 == Configuring Logging Levels
 
-{product-title} uses the `systemd-journald.service` to collect log messages for debugging, using five log message severities. The logging levels are based on Kubernetes logging conventions, as follows:
+{product-title} uses the `systemd-journald.service` to collect log messages for debugging. 
+
+[NOTE]
+====
+The number of lines displayed in the web console is hard-coded at 5000 and cannot be changed. 
+To see the entire log, use the CLI.
+====
+
+The logging uses five log message severities based on Kubernetes logging conventions, as follows:
 
 .Log Level Options
 [cols="3a,6a",options="header"]


### PR DESCRIPTION
Follow up to manual cherrypick of https://github.com/openshift/openshift-docs/pull/15544. I missed one change that I should have made to solve the merge error. 