### PR TITLE
remove step1 from accessing internal registry

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -619,7 +619,7 @@ span.footnote a:active, span.footnoteref a:active { text-decoration: underline; 
 div.unbreakable { page-break-inside: avoid; }
 code { color: #404040; background-color: #e7e7e7; font-weight: bold; font-family: "Roboto Mono", monospace;}
 h5 { color: #404040; }
-strong { color: #404040; font-weight: bold; }
+strong { color: #404040; font-weight: bold; font-family: "Roboto Mono", monospace; }
 a strong { color: inherit; }
 a code { color: inherit; }
 .replaceable { font-style: italic; font-color: inherit; font-family: inherit; }

--- a/modules/registry-accessing-directly.adoc
+++ b/modules/registry-accessing-directly.adoc
@@ -11,14 +11,7 @@ You can access the registry from inside the cluster.
 
 Access the registry from the cluster by using internal routes:
 
-. Access the node by getting the node's address:
-+
-----
-$ oc get nodes
-$ oc debug nodes/<node_address>
-----
-+
-. Log in to the container image registry by using your access token:
+. SSH into one of the nodes in the OpenShift cluster and login to the container image registry by using your access token:
 +
 ----
 $ oc login -u kubeadmin -p <password_from_install_log>

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -1058,3 +1058,20 @@ penshift4/ose-multus-admission-controller
 openshift4/ose-openstack-machine-controllers
 openshift4/ose-sriov-dp-admission-controller
 ----
+
+[[ocp-4-1-2]]
+=== RHBA-2019:1381 - {product-title} 4.1.2 Image Release advisory
+
+Issued: 2019-06-18
+
+{product-title} release 4.1.2 is now available. The list of packages
+included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:1381[RHBA-2019:1381] advisory.
+The container images and bug fixes included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2019:1382[RHBA-2019:1382] advisory.
+
+Space precluded documenting all of the container images for this release in the
+advisory. See the following article for notes on the container images in this
+release:
+
+link:https://access.redhat.com/solutions/4222771[{product-title} 4.1.2 container image list]

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -1083,3 +1083,31 @@ advisory. See the following article for notes on the container images in this
 release:
 
 link:https://access.redhat.com/solutions/4222771[{product-title} 4.1.2 container image list]
+
+[[ocp-4-1-3]]
+=== RHBA-2019:1590 - {product-title} 4.1.3 Image Release advisory
+
+Issued: 2019-06-26
+
+{product-title} release 4.1.3 is now available. The list of packages
+included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:1590[RHBA-2019:1590] advisory.
+The container images and bug fixes included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2019:1589[RHBA-2019:1589] advisory.
+
+Space precluded documenting all of the container images for this release in the
+advisory. See the following article for notes on the container images in this
+release:
+
+link:https://access.redhat.com/solutions/4249391[{product-title} 4.1.3 container image list]
+
+[[RHSA-2019-1591]]
+
+=== RHSA-2019:1591 -	Low: {product-title} 3.11 image security update
+
+Issued: 2019-06-26
+
+An update for ose-cluster-kube-apiserver-operator-container and
+ose-cluster-openshift-apiserver-operator-container is now available for
+{product-title} 4.1. Details of the update are documented in the
+link:https://access.redhat.com/errata/RHSA-2019:1591[RHSA-2019:1591] advisory.

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -610,7 +610,7 @@ features marked *GA* indicate _General Availability_.
 |GA
 |GA
 
-|System Containers for Docker, CRI-O
+|System Containers for CRI-O
 |-
 |-
 

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -426,9 +426,9 @@ tolerations, and cluster settings.
 [id="ocp-4-1-security"]
 === Security
 
-In {product-title} 4.1, an Operator is utilized to install, configure, and manage
-the certificate signing server. Certificates are managed as secrets, and are
-stored and encrypted in etcd.
+In {product-title} 4.1, Operators are utilized to install, configure, and
+manage the various certificate signing servers. Certificates are managed
+as secrets stored within the cluster itself.
 
 [id="ocp-4-1-notable-technical-changes"]
 == Notable technical changes

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -1103,7 +1103,7 @@ link:https://access.redhat.com/solutions/4249391[{product-title} 4.1.3 container
 
 [[RHSA-2019-1591]]
 
-=== RHSA-2019:1591 -	Low: {product-title} 3.11 image security update
+=== RHSA-2019:1591 -	Low: {product-title} 4.1 image security update
 
 Issued: 2019-06-26
 

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -395,6 +395,14 @@ The default mode is now `NetworkPolicy`.
 Multus is a meta plug-in for Kubernetes Container Network Interface (CNI), which
 enables a user to create multiple network interfaces per pod.
 
+[id="ocp-4-1-sriov"]
+==== SR-IOV
+
+{product-title} 4.1 includes the Technical Preview capability to use specific
+SR-IOV hardware on {product-title} nodes, which enables the user to
+attach SR-IOV virtual function (VF) interfaces to Pods in addition to other
+network interfaces.
+
 [id="ocp-4-1-web-console"]
 === Web console
 
@@ -758,15 +766,15 @@ features marked *GA* indicate _General Availability_.
 |TP
 |GA
 
-|OVN
-|
-|TP
-
 |HPA custom metrics adapter based on Prometheus
 |
 |TP
 
 |Machine health checks
+|
+|TP
+
+|SR-IOV
 |
 |TP
 |====


### PR DESCRIPTION
Received a note from multiple 4.1 users that Step 1 will not work in an Openshift 4.1 environment. The nodes are not externally exposed in a default AWS installation.

Because we discourage direct SSH access to the nodes, we may want to remove this article entirely and have users only use [openshift-docs/modules/registry-exposing-secure-registry-manually.adoc](https://github.com/openshift/openshift-docs/blob/enterprise-4.1/modules/registry-exposing-secure-registry-manually.adoc)