### PR TITLE
Bug 1686743: Formatting edits for Prometheus Cluster Monitoring assembly/modules

### DIFF
--- a/getting_started/dedicated_administrators.adoc
+++ b/getting_started/dedicated_administrators.adoc
@@ -246,7 +246,7 @@ ifndef::openshift-aro[]
 dashboards. The link:https://prometheus.io/[Prometheus] dashboard can be used to query cluster-wide
 metrics. The link:https://grafana.com/[Grafana] dashboard provides predefined graphs of many Prometheus
 metrics. The link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager] dashboard tracks alerting
-of link:https://docs.openshift.com/container-platform/3.11/install_config/prometheus_cluster_monitoring.html#alerting-rules[predefined rules]
+of link:https://docs.openshift.com/container-platform/3.11/install_config/prometheus_cluster_monitoring.html#alerting-rules_prometheus-cluster-monitoring[predefined rules]
 across the cluster.
 
 [IMPORTANT]

--- a/install_config/monitoring/accessing-prometheus-alertmanager-grafana.adoc
+++ b/install_config/monitoring/accessing-prometheus-alertmanager-grafana.adoc
@@ -1,16 +1,26 @@
+[id='accessing-prometheus-alertmanager-and-grafana_{context}']
 = Accessing Prometheus, Alertmanager, and Grafana
+:data-uri:
+:icons:
+:experimental:
+:prewrap!:
 
-{product-title} Monitoring ships with a Prometheus instance for cluster monitoring and a central Alertmanager cluster. In addition to Prometheus and Alertmanager, {product-title} Monitoring also includes a https://grafana.com/[Grafana] instance as well as pre-built dashboards for cluster monitoring troubleshooting.
+{product-title} Monitoring ships with a Prometheus instance for cluster monitoring and a central Alertmanager cluster. In addition to Prometheus and Alertmanager, {product-title} Monitoring also includes a link:https://grafana.com/[Grafana] instance as well as pre-built dashboards for cluster monitoring troubleshooting.
 
-You can get the addresses for accessing Prometheus, Alertmanager, and Grafana web UIs by running:
+To get the addresses for accessing Prometheus, Alertmanager, and Grafana web UIs:
 
-[subs="quotes"]
-  $ oc -n openshift-monitoring get routes
-  NAME                HOST/PORT                                                     ...
-  alertmanager-main   alertmanager-main-openshift-monitoring.apps._url_.openshift.com ...
-  grafana             grafana-openshift-monitoring.apps._url_.openshift.com           ...
-  prometheus-k8s      prometheus-k8s-openshift-monitoring.apps._url_.openshift.com    ...
+.Procedure
 
-Make sure to prepend `https://` to these addresses. You cannot access web UIs using unencrypted connection.
+. Run the following command:
++
+----
+$ oc -n openshift-monitoring get routes
+NAME                HOST/PORT
+alertmanager-main   alertmanager-main-openshift-monitoring.apps._url_.openshift.com
+grafana             grafana-openshift-monitoring.apps._url_.openshift.com
+prometheus-k8s      prometheus-k8s-openshift-monitoring.apps._url_.openshift.com
+----
++
+Make sure to prepend `https://` to these addresses. You cannot access web UIs using unencrypted connections.
 
-Authentication is performed against the {product-title} identity and uses the same credentials or means of authentication as is used elsewhere in {product-title}. You need to use a role that has read access to all namespaces, such as the `cluster-monitoring-view` cluster role.
+. Authentication is performed against the {product-title} identity and uses the same credentials or means of authentication as is used elsewhere in {product-title}. You must use a role that has read access to all namespaces, such as the `cluster-monitoring-view` cluster role.

--- a/install_config/monitoring/alerting-rules.adoc
+++ b/install_config/monitoring/alerting-rules.adoc
@@ -1,4 +1,4 @@
-[[alerting-rules]]
+[id='alerting-rules_{context}']
 = Alerting rules
 :data-uri:
 :icons:

--- a/install_config/monitoring/configuring-alertmanager.adoc
+++ b/install_config/monitoring/configuring-alertmanager.adoc
@@ -1,11 +1,11 @@
-[[configuring-alertmanager]]
-== Configuring Alertmanager
+[id='configuring-alertmanager_{context}']
+= Configuring Alertmanager
 :data-uri:
 :icons:
 :experimental:
 :prewrap!:
 
-The Alertmanager manages incoming alerts, including silencing, inhibition, aggregation, and sending out notifications through methods such as email, PagerDuty, and HipChat.
+The Alertmanager manages incoming alerts; this includes silencing, inhibition, aggregation, and sending out notifications through methods such as email, PagerDuty, and HipChat.
 
 The default configuration of the {product-title} Monitoring Alertmanager cluster is:
 
@@ -59,50 +59,54 @@ openshift_cluster_monitoring_operator_alertmanager_config: |+
     - service_key: "<key>"
 ----
 
-The sub-route matches only on alerts that have a severity of `critical`, and sends them via the receiver called `team-frontend-page`. As the name indicates, someone should be paged for alerts that are critical. See https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
+The sub-route matches only on alerts that have a severity of `critical` and sends them using the receiver called `team-frontend-page`. As the name indicates, someone should be paged for alerts that are critical. See https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 
-[[dead-mans-switch]]
+[id='dead-mans-switch_{context}']
 == Dead man's switch
 
-{product-title} Monitoring ships with a "Dead man's switch" to ensure the availability of the monitoring infrastructure.
+{product-title} Monitoring ships with a _dead man's switch_ to ensure the availability of the monitoring infrastructure.
 
-The "Dead man's switch" is a simple Prometheus alerting rule that always triggers. The Alertmanager continuously sends notifications for the dead man's switch to the notification provider that supports this functionality. This also ensures that communication between the Alertmanager and the notification provider is working.
+The dead man's switch is a simple Prometheus alerting rule that always triggers. The Alertmanager continuously sends notifications for the dead man's switch to the notification provider that supports this functionality. This also ensures that communication between the Alertmanager and the notification provider is working.
 
-This mechanism is supported by PagerDuty to issue alerts when the monitoring system itself is down. For more information, see xref:#dead-mans-switch-pagerduty[Dead man's switch PagerDuty] below.
+This mechanism is supported by PagerDuty to issue alerts when the monitoring system itself is down. For more information, see xref:dead-mans-switch-pagerduty_{context}[Dead man's switch PagerDuty] below.
 
 == Grouping alerts
 
-Once alerts are firing against the Alertmanager, it must be configured to know how to logically group them.
+After alerts are firing against the Alertmanager, it must be configured to know how to logically group them.
 
-For this example a new route will be added to reflect alert routing of the "frontend" team.
+For this example, a new route is added to reflect alert routing of the `frontend` team.
 
-First, add new routes. Multiple routes may be added beneath the original route, typically to define the receiver for the notification. The following example uses a matcher to ensure that only alerts coming from the service `example-app` are used.
+.Procedure
 
-  global:
-    resolve_timeout: 5m
-  route:
-    group_wait: 30s
-    group_interval: 5m
-    repeat_interval: 12h
-    receiver: default
+. Add new routes. Multiple routes may be added beneath the original route, typically to define the receiver for the notification. The following example uses a matcher to ensure that only alerts coming from the service `example-app` are used:
++
+----
+global:
+  resolve_timeout: 5m
+route:
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: default
+  routes:
+  - match:
+      alertname: DeadMansSwitch
+    repeat_interval: 5m
+    receiver: deadmansswitch
+  - match:
+      service: example-app
     routes:
     - match:
-        alertname: DeadMansSwitch
-      repeat_interval: 5m
-      receiver: deadmansswitch
-    - match:
-        service: example-app
-      routes:
-      - match:
-          severity: critical
-        receiver: team-frontend-page
-  receivers:
-  - name: default
-  - name: deadmansswitch
+        severity: critical
+      receiver: team-frontend-page
+receivers:
+- name: default
+- name: deadmansswitch
+----
++
+The sub-route matches only on alerts that have a severity of `critical`, and sends them using the receiver called `team-frontend-page`. As the name indicates, someone should be paged for alerts that are critical.
 
-The sub-route matches only on alerts that have a severity of `critical`, and sends them via the receiver called `team-frontend-page`. As the name indicates, someone should be paged for alerts that are critical.
-
-[[dead-mans-switch-pagerduty]]
+[id='dead-mans-switch-pagerduty_{context}']
 == Dead man's switch PagerDuty
 
 https://www.pagerduty.com/[PagerDuty] supports this mechanism through an integration called https://deadmanssnitch.com/[Dead Man's Snitch]. Simply add a `PagerDuty` configuration to the default `deadmansswitch` receiver. Use the process described above to add this configuration.

--- a/install_config/monitoring/configuring-etcd-monitoring.adoc
+++ b/install_config/monitoring/configuring-etcd-monitoring.adoc
@@ -1,4 +1,4 @@
-[[configuring-etcd-monitoring]]
+[id='configuring-etcd-monitoring_{context}']
 = Configuring etcd monitoring
 :data-uri:
 :icons:
@@ -9,9 +9,10 @@ If the `etcd` service does not run correctly, successful operation of the whole 
 
 Follow these steps to configure `etcd` monitoring:
 
+.Procedure
+
 . Verify that the monitoring stack is running:
 +
-[subs="quotes"]
 ----
 $ oc -n openshift-monitoring get pods
 NAME                                           READY     STATUS              RESTARTS   AGE
@@ -32,54 +33,50 @@ prometheus-operator-6c9fddd47f-9jfgk           1/1       Running             0  
 
 . Open the configuration file for the cluster monitoring stack:
 +
-[subs="quotes"]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
 
 . Under `config.yaml: |+`, add the `etcd` section.
-+
+
 .. If you run `etcd` in static pods on your master nodes, you can specify the `etcd` nodes using the selector:
 +
-[subs="quotes"]
 ----
 ...
 data:
   config.yaml: |+
     ...
-    *etcd:
+    etcd:
       targets:
         selector:
           openshift.io/component: etcd
-          openshift.io/control-plane: "true"*
+          openshift.io/control-plane: "true"
 ----
-+
+
 .. If you run `etcd` on separate hosts, you need to specify the nodes using IP addresses:
 +
-[subs="quotes"]
 ----
 ...
 data:
   config.yaml: |+
     ...
-    *etcd:
+    etcd:
       targets:
        ips:
        - "127.0.0.1"
        - "127.0.0.2"
-       - "127.0.0.3"*
+       - "127.0.0.3"
 ----
 +
-If `etcd` nodes IP addresses change, you need to update this list.
+If the IP addresses for `etcd` nodes change, you must update this list.
 
 . Verify that the `etcd` service monitor is now running:
 +
-[subs="quotes"]
 ----
 $ oc -n openshift-monitoring get servicemonitor
 NAME                  AGE
 alertmanager          35m
-*etcd                  1m*
+etcd                  1m <1>
 kube-apiserver        36m
 kube-controllers      36m
 kube-state-metrics    34m
@@ -88,45 +85,48 @@ node-exporter         34m
 prometheus            36m
 prometheus-operator   37m
 ----
+<1> The `etcd` service monitor.
 +
 It might take up to a minute for the `etcd` service monitor to start.
 
-. Now you can navigate to the Web interface to see more information about status of `etcd` monitoring:
-+
+. Now you can navigate to the web interface to see more information about the status of `etcd` monitoring.
+
 .. To get the URL, run:
 +
-[subs="quotes"]
 ----
 $ oc -n openshift-monitoring get routes
 NAME                HOST/PORT                                                                           PATH      SERVICES            PORT      TERMINATION   WILDCARD
 ...
 prometheus-k8s      prometheus-k8s-openshift-monitoring.apps.msvistun.origin-gce.dev.openshift.com                prometheus-k8s      web       reencrypt     None
 ----
-+
+
 .. Using `https`, navigate to the URL listed for `prometheus-k8s`. Log in.
 
-. Ensure the user belongs to the `cluster-monitoring-view` role. This role provides access to viewing cluster monitoring UIs. For example, to add user `developer` to `cluster-monitoring-view`, run:
-
-  $ oc adm policy add-cluster-role-to-user cluster-monitoring-view developer
+. Ensure the user belongs to the `cluster-monitoring-view` role. This role provides access to viewing cluster monitoring UIs.
 +
+For example, to add user `developer` to the `cluster-monitoring-view` role, run:
++
+----
+$ oc adm policy add-cluster-role-to-user cluster-monitoring-view developer
+----
 
-. In the Web interface, log in as the user belonging to the `cluster-monitoring-view` role.
+. In the web interface, log in as the user belonging to the `cluster-monitoring-view` role.
 
 . Click *Status*, then *Targets*. If you see an `etcd` entry, `etcd` is being monitored.
 +
 image::etcd-no-certificate.png[]
 
-While `etcd` is being monitored, Prometheus is not yet able to authenticate against `etcd`, and so cannot gather metrics. To configure Prometheus authentication against `etcd`:
-
-. Copy the `/etc/etcd/ca/ca.crt` and `/etc/etcd/ca/ca.key` credentials files from the master node to the local machine:
+. While `etcd` is now being monitored, Prometheus is not yet able to authenticate against `etcd`, and so cannot gather metrics.
 +
-[subs="quotes"]
+To configure Prometheus authentication against `etcd`:
+
+.. Copy the `/etc/etcd/ca/ca.crt` and `/etc/etcd/ca/ca.key` credentials files from the master node to the local machine:
++
 ----
 $ ssh -i gcp-dev/ssh-privatekey cloud-user@35.237.54.213
-...
 ----
 
-. Create the `openssl.cnf` file with these contents:
+.. Create the `openssl.cnf` file with these contents:
 +
 ----
 [ req ]
@@ -139,31 +139,28 @@ keyUsage = nonRepudiation, keyEncipherment, digitalSignature
 extendedKeyUsage=serverAuth, clientAuth
 ----
 
-. Generate the `etcd.key` private key file:
+.. Generate the `etcd.key` private key file:
 +
-[subs="quotes"]
 ----
 $ openssl genrsa -out etcd.key 2048
 ----
 
-. Generate the `etcd.csr` certificate signing request file:
+.. Generate the `etcd.csr` certificate signing request file:
 +
-[subs="quotes"]
 ----
 $ openssl req -new -key etcd.key -out etcd.csr -subj "/CN=etcd" -config openssl.cnf
 ----
 
-. Generate the `etcd.crt` certificate file:
+.. Generate the `etcd.crt` certificate file:
 +
-[subs="quotes"]
 ----
 $ openssl x509 -req -in etcd.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out etcd.crt -days 365 -extensions v3_req -extfile openssl.cnf
 ----
 
-. Put the credentials into format used by {product-title}:
+.. Put the credentials into format used by {product-title}:
 +
 ----
-cat <<-EOF > etcd-cert-secret.yaml
+$ cat <<-EOF > etcd-cert-secret.yaml
 apiVersion: v1
 data:
   etcd-client-ca.crt: "$(cat ca.crt | base64 --wrap=0)"
@@ -179,12 +176,12 @@ EOF
 +
 This creates the *_etcd-cert-secret.yaml_* file
 
-. Apply the credentials file to the cluster:
-
+.. Apply the credentials file to the cluster:
++
 ----
 $ oc apply -f etcd-cert-secret.yaml
 ----
 
-. Visit the "Targets" page of the Web interface again. Verify that `etcd` is now being correctly monitored. It might take several minutes for changes to take effect.
+. Now that you have configured authentication, visit the *Targets* page of the web interface again. Verify that `etcd` is now being correctly monitored. It might take several minutes for changes to take effect.
 +
 image::etcd-monitoring-working.png[]

--- a/install_config/monitoring/configuring-openshift-cluster-monitoring.adoc
+++ b/install_config/monitoring/configuring-openshift-cluster-monitoring.adoc
@@ -1,4 +1,4 @@
-[[configuring-openshift-cluster-monitoring]]
+[id='configuring-openshift-cluster-monitoring_{context}']
 = Configuring {product-title} cluster monitoring
 :data-uri:
 :icons:
@@ -109,9 +109,9 @@ After you enable dynamic storage, you can also set the `storageclass` for the pe
 Each of these variables applies only if its corresponding `storage_enabled` variable is set to `true`.
 
 [[supported-configuration]]
-=== Supported configuration
+== Supported configuration
 
-The supported way of configuring {product-title} Monitoring is by configuring it using the options described in xref:#configuring-openshift-cluster-monitoring[Configuring OpenShift cluster monitoring]. Beyond those explicit configuration options, it is possible to inject additional configuration into the stack. However this is unsupported, as configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled.
+The supported way of configuring {product-title} Monitoring is by configuring it using the options described in this guide. Beyond those explicit configuration options, it is possible to inject additional configuration into the stack. However this is unsupported, as configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled.
 
 Explicitly unsupported cases include:
 

--- a/install_config/monitoring/overview.adoc
+++ b/install_config/monitoring/overview.adoc
@@ -1,3 +1,4 @@
+[id='overview_{context}']
 = Overview
 :data-uri:
 :icons:

--- a/install_config/monitoring/update-and-compatibility-guarantees.adoc
+++ b/install_config/monitoring/update-and-compatibility-guarantees.adoc
@@ -1,21 +1,24 @@
-[[update-and-compatibility-guarantees]]
+[id='update-and-compatibility-guarantees_{context}']
 = Update and compatibility guarantees
 :data-uri:
 :icons:
 :experimental:
 :prewrap!:
 
-In order to be able to deliver updates with guaranteed compatibility, configurability of the {product-title} Monitoring stack is limited to the explicitly available options. This document describes known pitfalls of which types of configuration and customization are unsupported, as well as misuse of resources provided by {product-title} Monitoring. All configuration options described in in this topic
- are explicitly supported.
+In order to be able to deliver updates with guaranteed compatibility, configurability of the {product-title} Monitoring stack is limited to the explicitly available options. This document describes known pitfalls of which types of configuration and customization are unsupported, as well as misuse of resources provided by {product-title} Monitoring. All configuration options described in in this topic are explicitly supported.
 
 == Modifying {product-title} monitoring resources
 
-The {product-title} Monitoring stack ensures its resources are _always_ in the state it expects them to be. If they are modified, {product-title} Monitoring will ensure that this will be reset. Nonetheless it is possible to pause this behavior, by setting the `paused` field in the `AppVersion` called `openshift-monitoring`. Setting the {product-title} Monitoring stack to be paused, stops all future updates and will cause modification of the otherwise managed resources. If resources are modified in an uncontrolled manner, this will cause undefined behavior during updates.
+The {product-title} Monitoring stack ensures its resources are _always_ in the state it expects them to be. If they are modified, {product-title} Monitoring ensures that this is reset. Nonetheless, it is possible to pause this behavior, by setting the `paused` field in the `AppVersion` called `openshift-monitoring`.
+
+Setting the {product-title} Monitoring stack to be paused stops all future updates and causes modification of the otherwise managed resources. If resources are modified in an uncontrolled manner, this causes undefined behavior during updates.
 
 In order to ensure compatible and functioning updates, the `paused` field must be set to `false` on upgrades.
 
 == Using resources created by {product-title} monitoring
 
-{product-title} Monitoring creates a number of resources. These resources are not meant to be used by any other resources, as there are no guarantees about their backward compatibility. For example, a `ClusterRole` called `prometheus-k8s` is created, and has very specific roles that exist solely for the cluster monitoring Prometheus pods to be able to access the resources it requires access to. All of these resources have no compatibility guarantees going forward. While some of these resources may incidentally have the necessary information for RBAC purposes for example, they can be subject to change in any upcoming release, with no backward compatibility.
+{product-title} Monitoring creates a number of resources. These resources are not meant to be used by any other resources, as there are no guarantees about their backward compatibility. For example, a `ClusterRole` called `prometheus-k8s` is created and has very specific roles that exist solely for the cluster monitoring Prometheus pods to be able to access the resources it requires access to.
 
-If the `Role` or `ClusterRole` objects that are similar are needed, we recommend creating a new object that has exactly the permissions required for the case at hand, rather than using the resources created and maintained by {product-title} Monitoring.
+All of these resources have no compatibility guarantees going forward. While some of these resources may incidentally have the necessary information for RBAC purposes, for example, they can be subject to change in any upcoming release, with no backward compatibility.
+
+If the `Role` or `ClusterRole` objects that are similar are needed, create a new object that has exactly the permissions required for the case at hand, rather than using the resources created and maintained by {product-title} Monitoring.

--- a/install_config/prometheus_cluster_monitoring.adoc
+++ b/install_config/prometheus_cluster_monitoring.adoc
@@ -1,10 +1,16 @@
+[id='prometheus-cluster-monitoring']
+= Prometheus Cluster Monitoring
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
 :toc: macro
 :toc-title:
+:prewrap!:
+:context: prometheus-cluster-monitoring
 
 toc::[]
-
-[[prometheus-cluster-monitoring]]
-= Prometheus Cluster Monitoring
 
 include::install_config/monitoring/overview.adoc[leveloffset=+1]
 include::install_config/monitoring/configuring-openshift-cluster-monitoring.adoc[leveloffset=+1]


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1686743

@rh-max Could you PTAL? Internal preview: http://file.rdu.redhat.com/~adellape/070219/fix_format_prom/install_config/prometheus_cluster_monitoring.html

Changes include:

- The `[subs="quotes"]` works well on docs.openshift for marking up portions of a code block, but it doesn't work on the Customer Portal builds (the original complaint in the linked BZ), so I've removed them.

- Noticed that some of the modularization seemed a little off, so I made some adjustments that seemed to be the intended TOC arrangement. Here's some a rendered diff of the TOC:

   Old TOC:

   ![image](https://user-images.githubusercontent.com/3442316/60542376-cb116400-9ce1-11e9-93d4-576dd50731ad.png)

   New TOC:

   ![image](https://user-images.githubusercontent.com/3442316/60542338-b0d78600-9ce1-11e9-9baa-54e46972ce2c.png)

   Does that seem right to you? Particularly bringing the "Supported configuration" subsection up one level under "Configuration OCP cluster monitoring", and bringing all of "Configuring Alertmanager" up a level as well.

- Added a `context` to the assembly, and unique IDs using `{context}` to each module. This also required a few anchor modifications to some `xref`s.

- Minor editing to the content itself, including fixing or adding some Procedure steps.