### PR TITLE
Fixing typo in chown command

### DIFF
--- a/day_two_guide/topics/proc_scaling-etcd-manual.adoc
+++ b/day_two_guide/topics/proc_scaling-etcd-manual.adoc
@@ -258,8 +258,8 @@ Ensure version `etcd-2.3.7-4.el7.x86_64` or greater is installed,
 . Modify the file ownership permissions:
 +
 ----
-# chown -R etcd/etcd /etc/etcd/*
-# chown -R etcd/etcd /var/lib/etcd/
+# chown -R etcd:etcd /etc/etcd/*
+# chown -R etcd:etcd /var/lib/etcd/
 ----
 
 . Start etcd on the new host:


### PR DESCRIPTION
In progress. 

This is present in 3.7 to 3.11. 

https://bugzilla.redhat.com/show_bug.cgi?id=1694006