### PR TITLE
Fix bz1727760: use consistent storage class name

### DIFF
--- a/install_config/persistent_storage/topics/glusterfs_dynamic_provisioning.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_dynamic_provisioning.adoc
@@ -54,6 +54,6 @@ persistentvolumeclaim "gluster1" created
 +
 ----
 # oc get pvc
-NAME          	STATUS	VOLUME                                 		CAPACITY   	ACCESSMODES   	STORAGECLASS   	AGE
-gluster1        Bound	pvc-78852230-d8e2-11e6-a3fa-0800279cf26f   	30Gi   		RWX       	gluster-dyn	42s
+NAME       STATUS   VOLUME                                     CAPACITY   ACCESSMODES   STORAGECLASS   AGE
+gluster1   Bound    pvc-78852230-d8e2-11e6-a3fa-0800279cf26f   30Gi       RWX           glusterfs      42s
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1727760

@openshift/team-documentation 

Applies to enter-prise-3.9/3.10/3.11