### PR TITLE
Fix bz1727861: use consistent indentation level for example yaml

### DIFF
--- a/install_config/persistent_storage/topics/glusterfs_dynamic_provisioning.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_dynamic_provisioning.adoc
@@ -33,14 +33,14 @@ storageclass "glusterfs" created
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
- name: gluster1
+  name: gluster1
 spec:
- accessModes:
+  accessModes:
   - ReadWriteMany
- resources:
-   requests:
-        storage: 30Gi
- storageClassName: glusterfs
+  resources:
+    requests:
+      storage: 30Gi
+  storageClassName: glusterfs
 ----
 
 . From the {product-title} master host, create the PVC:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1727861

@openshift/team-documentation 

Applies to enterprise-3.9 / 3.10 / 3.11