### PR TITLE
EgressNetworkPolicy only supports cidrSelector and dnsName

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -281,25 +281,21 @@ endif::openshift-enterprise,openshift-origin[]
 == Using an Egress Firewall to Limit Access to External Resources
 
 As an {product-title} cluster administrator, you can use egress firewall policy
-to limit the external addresses that some or all pods can access from within the
-cluster, so that:
+to limit the external IP addresses that some or all pods can access from within
+the cluster. Egress firewall policy supports the following scenarios:
 
-- A pod can only talk to internal hosts, and cannot initiate connections to the
-public Internet.
-+
-Or,
-- A pod can only talk to the public Internet, and cannot initiate connections to
-internal hosts (outside the cluster).
-+
-Or,
-- A pod cannot reach specified internal subnets/hosts that it should have no
-reason to contact.
+- A pod can only connect to internal hosts, and cannot initiate connections to
+the public Internet.
+- A pod can only connect to the public Internet, and cannot initiate connections
+to internal hosts that are outside the {product-title} cluster.
+- A pod cannot reach specified internal subnets or hosts that should be
+unreachable.
 
-Egress policies can be set at the pod selector-level and project-level. For
-example, you can allow `<project A>` access to a specified IP range but deny the
-same access to `<project B>`. Or, you can restrict application developers from
-updating from (Python) pip mirrors, and force updates to only come from approved
-sources.
+Egress policies can be set by specifying an IP address range in CIDR format or
+by specifying a DNS name. For example, you can allow `<project_A>` access to a
+specified IP range but deny the same access to `<project_B>`. Alternatively, you
+can restrict application developers from updating from (Python) pip mirrors, and
+force updates to only come from approved sources.
 
 [CAUTION]
 ====
@@ -342,7 +338,8 @@ To configure egress policy:
 
 . Navigate to the project you want to affect.
 
-. Create a JSON file with the desired policy details. For example:
+. Create a JSON file with the policy configuration you want to use, as in the
+following example:
 +
 [source, json]
 ----
@@ -699,17 +696,17 @@ hosts on the subnet.
 
 Each line of `EGRESS_DESTINATION` can be one of three types:
 
-- `<port> <protocol> <IP address>` - This says that incoming
+- `<port> <protocol> <IP_address>` - This says that incoming
 connections to the given `<port>` should be redirected to the same
-port on the given `<IP address>`. `<protocol>` is either `tcp` or
+port on the given `<IP_address>`. `<protocol>` is either `tcp` or
 `udp`. In the example above, the first line redirects traffic from
 local port 80 to port 80 on 203.0.113.25.
-- `<port> <protocol> <IP address> <remote port>` - As above, except
-that the connection is redirected to a different `<remote port>` on
-`<IP address>`. In the example above, the second and third lines
+- `<port> <protocol> <IP_address> <remote_port>` - As above, except
+that the connection is redirected to a different `<remote_port>` on
+`<IP_address>`. In the example above, the second and third lines
 redirect local ports 8080 and 8443 to remote ports 80 and 443 on
 203.0.113.26.
-- `<fallback IP address>` - If the last line of `EGRESS_DESTINATION`
+- `<fallback_IP_address>` - If the last line of `EGRESS_DESTINATION`
 is a single IP address, then any connections on any other port will be
 redirected to the corresponding port on that IP address (eg,
 203.0.113.27 in the example above). If there is no fallback IP address
@@ -1001,16 +998,16 @@ details.
 ====
 Each line of `EGRESS_DNS_PROXY_DESTINATION` can be set in one of two ways:
 
-- `<port> <remote address>` - This says that incoming connections to the given
- `<port>` should be proxied to the same TCP port on the given `<remote
- address>`. `<remote address>` can be an IP address or DNS name. In case of DNS
- name, DNS resolution is done at runtime. In the example above, the first line
- proxies TCP traffic from local port 80 to port 80 on 203.0.113.25. The second
- line proxies TCP traffic from local port 100 to port 100 on example.com.
+- `<port> <remote_address>` - This says that incoming connections to the given
+`<port>` should be proxied to the same TCP port on the given `<remote_address>`.
+`<remote_address>` can be an IP address or DNS name. In case of DNS name, DNS
+resolution is done at runtime. In the example above, the first line proxies TCP
+traffic from local port 80 to port 80 on 203.0.113.25. The second line proxies
+TCP traffic from local port 100 to port 100 on example.com.
 
-- `<port> <remote address> <remote port>` - As above, except
-that the connection is proxied to a different `<remote port>` on
-`<remote address>`. In the example above, the third line
+- `<port> <remote_address> <remote_port>` - As above, except
+that the connection is proxied to a different `<remote_port>` on
+`<remote_address>`. In the example above, the third line
 proxies local port 8080 to remote port 80 on 203.0.113.26 and the fourth line
 proxies local port 8443 to remote port 443 on foobar.com.
 ====


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1638714

`EgressNetworkPolicy` does not and has never supported selectors other than `cidrSelector` and `dnsName`. Update the docs to reflect this.