### PR TITLE
BZ1725848 Release Notes

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -65,12 +65,17 @@ mode and use a `cloud-init` disk, the virtual machine will lose its network
 connectivity after being restarted. As a workaround, remove the `HWADDR` line
 in the file `/etc/sysconfig/network-scripts/ifcfg-eth0`.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1708680[*BZ#1708680*])
-+
-[NOTE]
-====
-Avoid this issue by using the recommended `masquerade` binding method for
-the default Pod network.
-====
+
+* Masquerade does not currently work with CNV. Due to an upstream issue,
+you cannot connect a virtual machine to the default Pod network while in Masquerade mode.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1725848[*BZ#1725848*])
+
+* Creating a NIC with Masquerade in the wizard does not allow you to specify the `port` option.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1725848[*BZ#1725848*])
+
+* RWX (Read, Write, Execute) file systems are the only supported storage for
+Live Migration, UI, and importing VMWare virtual machines.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1719134[*BZ#1719134*])
 
 * If a virtual machine uses guaranteed CPUs, it will not be scheduled, because
 the label `cpumanager=true` is not automatically set on nodes. As a
@@ -82,4 +87,8 @@ machines with guaranteed CPUs on your cluster.
 * If you use the web console to create a virtual machine template that has the same name as an existing
 virtual machine, the operation fails and the message `Name is already used by another virtual machine` is displayed.
 As a workaround, create the template from the command line.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1717802[*BZ#1717802*])
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1717930[*BZ#1717930*])
+
+* When you create your virtual machine using the wizard, your virtual machine’s
+storage medium must support Read-Write-Many (RWM) PVCs.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1724654[*BZ#1724654*])


### PR DESCRIPTION
For these release notes, we need a good SME/Dev review, tagging the following people who are mentioned in the bug:
@rhrazdil @nellyc @dankenigsberg @aburdenthehand 

- In particular check the wording of this note: RWX (Read, Write, Execute) file systems are the only supported storage for Live Migration, UI, and importing VMWare virtual machines. 

- Should the above note have a BZ number to associate with it? it originated from QE feedback in this doc: https://docs.google.com/document/d/16LPmRvY8cV9EaIFuAi3HH11xzwKj1kBMvCHAYzUVvW0/edit# [last row]

This is for CNV 2.0.

Thanks,
Bob