### PR TITLE
Bug 1661562: Rm <node2> from oc adm drain cmds

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -87,7 +87,7 @@ $ oc describe node <node>
 For example:
 
 ----
-# oc describe node node1.example.com 
+# oc describe node node1.example.com
 
 Name:               node1.example.com <1>
 Roles:              master <2>
@@ -153,7 +153,7 @@ Events:         <none>
 <4> The annotations applied to the node.
 <5> The xref:../admin_guide/scheduling/taints_tolerations.adoc#admin-guide-taints[taints] applied to the node.
 <6> xref:../admin_guide/manage_nodes.adoc#node-conditions[Node conditions].
-<7> The IP address and host name of the node. 
+<7> The IP address and host name of the node.
 <8> The xref:../admin_guide/allocating_node_resources.adoc#admin-guide-allocating-node-resources[pod resources and allocatable resources].
 <9> Information about the node host.
 <10> The pods on the node.
@@ -169,12 +169,12 @@ To view the usage statistics:
 
 ----
 $ oc adm top nodes
-NAME       CPU(cores)   CPU%      MEMORY(bytes)   MEMORY%   
-node-1     297m         29%       4263Mi          55%       
-node-0     55m          5%        1201Mi          15%       
-infra-1    85m          8%        1319Mi          17%       
-infra-0    182m         18%       2524Mi          32%       
-master-0   178m         8%        2584Mi          16%  
+NAME       CPU(cores)   CPU%      MEMORY(bytes)   MEMORY%
+node-1     297m         29%       4263Mi          55%
+node-0     55m          5%        1201Mi          15%
+infra-1    85m          8%        1319Mi          17%
+infra-0    182m         18%       2524Mi          32%
+master-0   178m         8%        2584Mi          16%
 ----
 
 To view the usage statistics for nodes with labels:
@@ -309,23 +309,22 @@ nodes as schedulable or unschedulable.
 [[evacuating-pods-on-nodes]]
 == Evacuating pods on nodes
 
-Evacuating pods allows you to migrate all or selected pods from a given node or
-nodes. Nodes must first be
-xref:marking-nodes-as-unschedulable-or-schedulable[marked unschedulable] to
-perform pod evacuation.
+Evacuating pods allows you to migrate all or selected pods from a given node.
+Nodes must first be xref:marking-nodes-as-unschedulable-or-schedulable[marked unschedulable]
+to perform pod evacuation.
 
 Only pods backed by a
-xref:../architecture/core_concepts/deployments.adoc#replication-controllers[replication
-controller] can be evacuated; the replication controllers create new pods on
-other nodes and remove the existing pods from the specified node(s). Bare pods,
-meaning those not backed by a replication controller, are unaffected by default.
-You can evacuate a subset of pods by specifying a pod-selector. Pod selector is                                                                                             
+xref:../architecture/core_concepts/deployments.adoc#replication-controllers[replication controller]
+can be evacuated; the replication controllers create new pods on other nodes and
+remove the existing pods from the specified node(s). Bare pods, meaning those
+not backed by a replication controller, are unaffected by default. You can
+evacuate a subset of pods by specifying a pod-selector. Pod selector is
 based on labels, so all the pods with the specified label will be evacuated.
 
-To evacuate all or selected pods on one or more nodes:
+To evacuate all or selected pods on a node:
 
 ----
-$ oc adm drain <node1> <node2> [--pod-selector=<pod_selector>]
+$ oc adm drain <node> [--pod-selector=<pod_selector>]
 ----
 
 You can force deletion of bare pods by using the `--force` option. When set to
@@ -333,49 +332,49 @@ You can force deletion of bare pods by using the `--force` option. When set to
 controller, ReplicaSet, job, daemonset, or StatefulSet:
 
 ----
-$ oc adm drain <node1> <node2> --force=true
+$ oc adm drain <node> --force=true
 ----
 
 You can use `--grace-period` to set a period of time in seconds for each pod to
-terminate gracefully. If negative, the default value specified in the pod will
-be used:
+terminate gracefully. If negative, the default value specified in the pod is
+used:
 
 ----
-$ oc adm drain <node1> <node2> --grace-period=-1
+$ oc adm drain <node> --grace-period=-1
 ----
 
 You can use `--ignore-daemonsets` and set it to `true` to ignore
 daemonset-managed pods:
 
 ----
-$ oc adm drain <node1> <node2> --ignore-daemonsets=true
+$ oc adm drain <node> --ignore-daemonsets=true
 ----
 
 You can use `--timeout` to set the length of time to wait before giving up. A
 value of `0` sets an infinite length of time:
 
 ----
-$ oc adm drain <node1> <node2> --timeout=5s
+$ oc adm drain <node> --timeout=5s
 ----
 
 You can use `--delete-local-data` and set it to `true` to continue deletion even
-if there are pods using emptyDir (local data that will be deleted when the node
-is drained):
+if there are pods using emptyDir (local data that is deleted when the node is
+drained):
 
 ----
-$ oc adm drain <node1> <node2> --delete-local-data=true
+$ oc adm drain <node> --delete-local-data=true
 ----
 
 To list objects that will be migrated without actually performing the evacuation,
 use the `--dry-run` option and set it to `true`:
 
 ----
-$ oc adm drain <node1> <node2>  --dry-run=true
+$ oc adm drain <node> --dry-run=true
 ----
 
-Instead of specifying specific node names (for example, `<node1> <node2>`), you
-can use the `--selector=<node_selector>` option to evacuate pods on selected
-nodes.
+Instead of specifying a specific node name, you can use the
+`--selector=<node_selector>` option to evacuate pods on nodes that match the
+selector.
 
 [[rebooting-nodes]]
 == Rebooting nodes
@@ -442,7 +441,7 @@ spec:
             matchExpressions:
             - key: docker-registry <4>
               operator: In <5>
-              values: 
+              values:
               - default
           topologyKey: kubernetes.io/hostname
 ----
@@ -485,7 +484,7 @@ process] for infrastructure nodes.
 == Modifying Nodes
 
 // tag::node-configmap[]
-During installation, {product-title} creates a configmap in the *openshift-node* project for each type of node group: 
+During installation, {product-title} creates a configmap in the *openshift-node* project for each type of node group:
 
 * node-config-master
 
@@ -498,7 +497,7 @@ During installation, {product-title} creates a configmap in the *openshift-node*
 * node-config-master-infra
 
 To make configuration changes to an existing node, edit the appropriate configuration map. A _sync pod_ on each node
-watches for changes in the configuration maps. During installation, the sync pods are created by using _sync Daemonsets_, 
+watches for changes in the configuration maps. During installation, the sync pods are created by using _sync Daemonsets_,
 and a *_/etc/origin/node/node-config.yaml_* file, where the node configuration parameters reside, is added to each node. When a sync pod
 detects configuration map change, it updates the *_node-config.yaml_* on all nodes in that node group and restarts the appropriate nodes.
 // end::node-configmap[]
@@ -572,27 +571,27 @@ volumeConfig:
   localQuota:
     perFSGroup: null    <8>
 volumeDirectory: /var/lib/origin/openshift.local.volumes
- 
+
 Events:  <none>
 ----
 
 <1> Authentication and authorization configuration options.
 <2> IP address prepended to a pod’s *_/etc/resolv.conf_*.
 <3> Key value pairs that are passed directly to the Kubelet that match the link:https://kubernetes.io/docs/admin/kubelet/[Kubelet's command line arguments].
-<4> The path to the pod manifest file or directory. A directory must contain one or more manifest files. 
+<4> The path to the pod manifest file or directory. A directory must contain one or more manifest files.
 {product-title} uses the manifest files to create pods on the node.
 <5> The pod network settings on the node.
 <6> Software defined network (SDN) plug-in. Set to `redhat/openshift-ovs-subnet` for the *ovs-subnet* plug-in;
 `redhat/openshift-ovs-multitenant` for the *ovs-multitenant* plug-in; or
 `redhat/openshift-ovs-networkpolicy` for the *ovs-networkpolicy* plug-in.
-<7> Certificate information for the node. 
+<7> Certificate information for the node.
 <8> Optional: PEM-encoded certificate bundle. If set, a valid client certificate
 must be presented and validated against the certificate authorities in the
 specified file before the request headers are checked for user names.
 
 [NOTE]
 ====
-Do not manually modify the *_/etc/origin/node/node-config.yaml_* file. 
+Do not manually modify the *_/etc/origin/node/node-config.yaml_* file.
 ====
 
 // For more information, see architecture/infrastructure_components/kubernetes_infrastructure.html#node-bootstrapping[Node Bootstrapping].
@@ -778,7 +777,7 @@ $ mkdir /var/lib/docker
 . Run the following command to restart Docker and the *atomic-openshift-node* service:
 +
 ----
-$ systemctl start docker atomic-openshift-node 
+$ systemctl start docker atomic-openshift-node
 ----
 
 . Restart the node service by rebooting the host:


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1661562

Command only supports specifying one node. Removing suggestion that you can pass mulitple.

Preview (internal): http://file.rdu.redhat.com/~adellape/071019/drain/admin_guide/manage_nodes.html#evacuating-pods-on-nodes