### PR TITLE
BZ-1724563: Removed RBD examples.

### DIFF
--- a/modules/storage-persistent-storage-nfs-group-ids.adoc
+++ b/modules/storage-persistent-storage-nfs-group-ids.adoc
@@ -4,17 +4,17 @@
 
 = Group IDs
 
-The recommended way to handle NFS access, assuming it is not an option to 
-change permissions on the NFS export, is to use supplemental groups. 
-Supplemental groups in {product-title} are used for shared storage, of 
-which NFS is an example. In contrast block storage, such as Ceph RBD or 
-iSCSI, use the `fsGroup` SCC strategy and  the `fsGroup` value in the 
+The recommended way to handle NFS access, assuming it is not an option to
+change permissions on the NFS export, is to use supplemental groups.
+Supplemental groups in {product-title} are used for shared storage, of
+which NFS is an example. In contrast block storage, such as
+iSCSI, use the `fsGroup` SCC strategy and  the `fsGroup` value in the
 Pod's `securityContext`.
 
 [NOTE]
 ====
 It is generally preferable to use supplemental group IDs to gain access to
-persistent storage versus using user IDs. 
+persistent storage versus using user IDs.
 ====
 
 Because the group ID on the example target NFS directory
@@ -30,25 +30,25 @@ spec:
   securityContext: <1>
     supplementalGroups: [5555] <2>
 ----
-<1> `securityContext` must be defined at the Pod level, not under a 
+<1> `securityContext` must be defined at the Pod level, not under a
 specific container.
-<2> An array of GIDs defined for the Pod. In this case, there is 
+<2> An array of GIDs defined for the Pod. In this case, there is
 one element in the array. Additional GIDs would be comma-separated.
 
-Assuming there are no custom SCCs that might satisfy the Pod's 
-requirements, the Pod likely matches the `restricted` SCC. This SCC has 
-the `supplementalGroups` strategy set to `RunAsAny`, meaning that any 
+Assuming there are no custom SCCs that might satisfy the Pod's
+requirements, the Pod likely matches the `restricted` SCC. This SCC has
+the `supplementalGroups` strategy set to `RunAsAny`, meaning that any
 supplied group ID is accepted without range checking.
 
 As a result, the above Pod passes admissions and is launched. However,
-if group ID range checking is desired, a custom SCC is the preferred 
+if group ID range checking is desired, a custom SCC is the preferred
 solution. A custom SCC can be created such that minimum
-and maximum group IDs are defined, group ID range checking is enforced, 
+and maximum group IDs are defined, group ID range checking is enforced,
 and a group ID of `5555` is allowed.
 
 [NOTE]
 ====
 To use a custom SCC, you must first add it to the appropriate service
 account. For example, use the `default` service account in the given project
-unless another has been specified on the Pod specification. 
+unless another has been specified on the Pod specification.
 ====


### PR DESCRIPTION
Removed the reference to Ceph RBD.

This is for OS 4.x.