### PR TITLE
Rectifying certificate expiry warning default values for BZ 1687770.

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -225,8 +225,7 @@ validity for etcd CA, peer, server and client certificates. Defaults to `1825`
 (5 years).
 
 |`openshift_certificate_expiry_warning_days`
-|The amount of time the auto-generated certificates must be valid for an upgrade
-to proceed. Defaults to `365` (1 year).
+|Halt upgrades to clusters that have certificates expiring in this many days or fewer. Defaults to `365` (1 year).
 
 |`openshift_certificate_expiry_fail_on_warn`
 |Whether upgrade fails if the auto-generated certificates are not valid for the

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -63,7 +63,7 @@ The `openshift_certificate_expiry` role uses the following variables:
 |Base {product-title} configuration directory.
 
 |`openshift_certificate_expiry_warning_days`
-|`30`
+|`365`
 |Flag certificates that will expire in this many days from now.
 
 |`openshift_certificate_expiry_show_all`


### PR DESCRIPTION
Aligning the default OpenShift certificate expiry warning values in two documents for https://bugzilla.redhat.com/show_bug.cgi?id=1687770.

Awaiting QE verification. 