### PR TITLE
added alertmanager module for dedicated-admin role

### DIFF
--- a/administering_a_cluster/dedicated-admin-role.adoc
+++ b/administering_a_cluster/dedicated-admin-role.adoc
@@ -30,6 +30,7 @@ include::modules/dedicated-managing-service-accounts.adoc[leveloffset=+1]
 
 include::modules/dedicated-managing-quotas-and-limit-ranges.adoc[leveloffset=+1]
 
+
 [id="osd-installing-operators-from-operatorhub_{context}"]
 == Installing Operators from the OperatorHub
 

--- a/modules/dedicated-accessing-alertmanager.adoc
+++ b/modules/dedicated-accessing-alertmanager.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// administering_a_cluster/dedicated-admin-role.adoc
+
+[id="dedicated-accessing-alertmanager{context}"]
+= Accessing Alertmanager
+
+You can access the Alertmanager web UI using a Web browser through the
+{product-title} Web console.
+
+[NOTE]
+====
+The Alertmanager UI accessed in this procedure is the old interface for Alertmanager.
+====
+
+Navigate to the {product-title} Web console and run:
+
+----
+$ oc -n openshift-monitoring get routes
+NAME                HOST/PORT                                                     ...
+alertmanager-main   alertmanager-main-openshift-monitoring.apps.url.openshift.com ...
+grafana             grafana-openshift-monitoring.apps.url.openshift.com           ...
+prometheus-k8s      prometheus-k8s-openshift-monitoring.apps.url.openshift.com    ...
+----
+
+Prepend `https://` to the address. You cannot access web UIs using an
+unencrypted connection. Navigate to the address using a web browser and
+authenticate. 


### PR DESCRIPTION
Alertmanager usage has been added to the dedicated-admin role page.

Preview build: http://file.rdu.redhat.com/~antaylor/071219/osd_v4_monitoring/administering_a_cluster/dedicated-admin-role.html