### PR TITLE
Fixing release note regarding Read-Write-Many

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -73,10 +73,6 @@ you cannot connect a virtual machine to the default Pod network while in Masquer
 * Creating a NIC with Masquerade in the wizard does not allow you to specify the `port` option.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1725848[*BZ#1725848*])
 
-* RWX (Read, Write, Execute) file systems are the only supported storage for
-Live Migration, UI, and importing VMWare virtual machines.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1719134[*BZ#1719134*])
-
 * If a virtual machine uses guaranteed CPUs, it will not be scheduled, because
 the label `cpumanager=true` is not automatically set on nodes. As a
 workaround, remove the `CPUManager` entry from the `kubevirt-config` ConfigMap.
@@ -89,6 +85,7 @@ virtual machine, the operation fails and the message `Name is already used by an
 As a workaround, create the template from the command line.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1717930[*BZ#1717930*])
 
-* When you create your virtual machine using the wizard, your virtual machine’s
-storage medium must support Read-Write-Many (RWM) PVCs.
+* ReadWriteMany (RWX) is the only supported storage access mode for live migration,
+importing VMware virtual machines, and creating virtual machines by using the
+wizard.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1724654[*BZ#1724654*])


### PR DESCRIPTION
For CNV 2.0, to be released today. 

enterprise-4.1 and 4.2

This is based on direct QE feedback and has no associated BZ.