### PR TITLE
Update vmi ssh expose document

### DIFF
--- a/modules/cnv-accessing-vmi-ssh.adoc
+++ b/modules/cnv-accessing-vmi-ssh.adoc
@@ -14,6 +14,8 @@ the `fedora-vm-ssh` service that forwards port 22 of the `<fedora-vm>` virtual
 machine to a port on the node:
 
 .Prerequisites
+* The virtual machine instance you want to access must be connected
+to the default Pod network by using the `masquerade` binding method.
 * The virtual machine instance you want to access must be running.
 * Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
 


### PR DESCRIPTION
The PR add a prerequisites, the vm must be connected to the pod
network.

A multus networks only vm is not valid.