### PR TITLE
Rm node_problem_detector & volumes from OSD, cleanup topicmap

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -32,17 +32,15 @@ Topics:
   Distros: openshift-enterprise
 - Name: Legal Notice
   File: legal_notice
-- Name: Full Revision History
-  File: revhistory_full
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
+  Distros: openshift-enterprise
 ---
 Name: Release Notes
 Dir: release_notes
-Distros: openshift-enterprise,openshift-dedicated,openshift-online
+Distros: openshift-enterprise
 Topics:
 - Name: Overview
   File: index
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
+  Distros: openshift-enterprise
 - Name: OpenShift Container Platform 3.11 Release Notes
   File: ocp_3_11_release_notes
   Distros: openshift-enterprise
@@ -61,9 +59,6 @@ Topics:
 - Name: Comparing with OpenShift Enterprise 2
   File: v2_vs_v3
   Distros: openshift-enterprise
-- Name: Revision History
-  File: revhistory_release_notes
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
 ---
 Name: What's New?
 Dir: whats_new
@@ -126,9 +121,6 @@ Topics:
 - Name: Comparing OpenShift 2 and 3
   File: online_v2_vs_v3
   Distros: openshift-online
-- Name: Revision History
-  File: revhistory_getting_started
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
 ---
 Name: Architecture
 Dir: architecture
@@ -234,9 +226,6 @@ Topics:
     File: ansible_service_broker
   - Name: AWS Service Broker
     File: aws_broker
-- Name: Revision History
-  File: revhistory_architecture
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
 ---
 Name: Container Security Guide
 Dir: security
@@ -262,9 +251,6 @@ Topics:
   File: storage
 - Name: Monitoring Events and Logs
   File: monitoring
-- Name: Revision History
-  File: revhistory_security
-  Distros: openshift-enterprise
 ---
 Name: Installing Clusters
 Dir: install
@@ -528,9 +514,6 @@ Topics:
 - Name: Installing the Operator Framework (Technology Preview)
   File: installing-operator-framework
   Distros: openshift-origin,openshift-enterprise
-- Name: Revision History
-  File: revhistory_install_config
-  Distros: openshift-enterprise
 ---
 Name: Day Two Operations Guide
 Dir: day_two_guide
@@ -655,7 +638,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Node Problem Detector
   File: node_problem_detector
-  Distros: openshift-origin,openshift-enterprise,openshift-dedicated
+  Distros: openshift-origin,openshift-enterprise
 - Name: Overcommitting
   File: overcommit
   Distros: openshift-origin,openshift-enterprise
@@ -713,28 +696,12 @@ Topics:
 - Name: Configuring the cluster auto-scaler in AWS
   File: cluster-autoscaler
   Distros: openshift-origin,openshift-enterprise
-- Name: Kuryr SDN Administration
-  File: kuryr
-  Distros: openshift-origin,openshift-enterprise
 - Name: Disabling Features using Feature Gates
   File: disabling_features
   Distros: openshift-origin,openshift-enterprise
-- Name: Revision History
-  File: revhistory_admin_guide
-  Distros: openshift-enterprise,openshift-dedicated
----
-Name: User Guide
-Dir: dev_guide
-Distros: atomic-*
-Topics:
-- Name: Overview
-  File: index
-- Name: Authentication
-  File: authentication
-- Name: Managing Images
-  File: managing_images
-- Name: Service Accounts
-  File: service_accounts
+- Name: Kuryr SDN Administration
+  File: kuryr
+  Distros: openshift-origin,openshift-enterprise
 ---
 Name: Scaling and Performance Guide
 Dir: scaling_performance
@@ -770,9 +737,6 @@ Topics:
   File: managing_hugepages
 - Name: Optimizing On GlusterFS Storage
   File: optimizing_on_glusterfs_storage
-- Name: Revision History
-  File: revhistory_scaling_performance
-  Distros: openshift-enterprise
 ---
 Name: Developer Guide
 Dir: dev_guide
@@ -910,6 +874,7 @@ Topics:
   File: downward_api
 - Name: Projected Volumes
   File: projected_volumes
+  Distros: openshift-enterprise,openshift-origin
 - Name: Using Daemonsets
   File: daemonsets
   Distros: openshift-enterprise,openshift-dedicated,openshift-aro,openshift-origin
@@ -917,6 +882,7 @@ Topics:
   File: pod_autoscaling
 - Name: Managing Volumes
   File: volumes
+  Distros: openshift-enterprise,openshift-origin
 - Name: Using Persistent Volumes
   File: persistent_volumes
 - Name: Expanding Persistent Volumes
@@ -962,9 +928,7 @@ Topics:
   File: application_memory_sizing
 - Name: Application ephemeral storage sizing
   File: application_ephemeral_storage_sizing
-- Name: Revision History
-  File: revhistory_dev_guide
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
+  Distros: openshift-enterprise,openshift-dedicated
 ---
 Name: Security
 Dir: product_security
@@ -1025,9 +989,6 @@ Topics:
 - Name: Custom Builder
   File: custom
   Distros: openshift-enterprise,openshift-dedicated,openshift-aro,openshift-origin
-- Name: Revision History
-  File: revhistory_creating_images
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
 ---
 Name: Using Images
 Dir: using_images
@@ -1085,9 +1046,6 @@ Topics:
     File: jenkins_slaves
   - Name: Other Container Images
     File: other_container_images
-- Name: Revision History
-  File: revhistory_using_images
-  Distros: openshift-enterprise,openshift-dedicated,openshift-aro
 ---
 Name: CLI Reference
 Dir: cli_reference
@@ -1111,9 +1069,6 @@ Topics:
 - Name: Extending the CLI
   File: extend_cli
   Distros: openshift-enterprise,openshift-origin
-- Name: Revision History
-  File: revhistory_cli_reference
-  Distros: openshift-enterprise,openshift-dedicated
 ---
 Name: Ansible Playbook Bundle Development Guide
 Dir: apb_devel
@@ -1130,9 +1085,6 @@ Topics:
     File: getting_started
   - Name: Reference
     File: reference
-- Name: Revision History
-  File: revhistory_apb_devel
-  Distros: openshift-enterprise
 ---
 Name: Go Client Library Reference
 Dir: go_client
@@ -1618,7 +1570,6 @@ Topics:
     File: v1.User
   - Name: v1.UserIdentityMapping
     File: v1.UserIdentityMapping
-
 ---
 Name: CRI-O Runtime
 Dir: crio
@@ -1626,7 +1577,6 @@ Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Using the CRI-O Container Engine
   File: crio_runtime
-
 ---
 Name: Service Mesh Install
 Dir: servicemesh-install

--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -221,11 +221,15 @@ $ oc edit <object_type>/<object_name> \
     -o <object_type_format>
 ----
 
+ifdef::openshift-enterprise,openshift-origin[]
 === volume
+
 Modify a xref:../dev_guide/volumes.adoc#dev-guide-volumes[volume]:
+
 ----
 $ oc set volume <object_type>/<object_name> [--option]
 ----
+endif::[]
 
 [[oc-label]]
 === label

--- a/dev_guide/application_lifecycle/new_app.adoc
+++ b/dev_guide/application_lifecycle/new_app.adoc
@@ -373,9 +373,9 @@ as input to `new-app`, then an image stream is created for that image as well.
 
 a|`DeploymentConfig`
 a|A `DeploymentConfig` is created either to deploy the output of a build, or a
-specified image. The `new-app` command creates xref:../volumes.adoc#dev-guide-volumes[*emptyDir*
-volumes] for all Docker volumes that are specified in containers included in the
-resulting `DeploymentConfig`.
+specified image. The `new-app` command creates `emptyDir` volumes for all Docker
+volumes that are specified in containers included in the resulting
+`DeploymentConfig`.
 
 a|`Service`
 a|The `new-app` command attempts to detect exposed ports in input images. It

--- a/dev_guide/dev_tutorials/maven_tutorial.adoc
+++ b/dev_guide/dev_tutorials/maven_tutorial.adoc
@@ -175,6 +175,9 @@ using the Nexus mirror. If successful, you should see output referencing the URL
 
 [[nexus-additional-resources]]
 == Additional Resources
+
+ifdef::openshift-enterprise,openshift-origin[]
 * xref:../../dev_guide/volumes.adoc#dev-guide-volumes[Managing Volumes in {product-title}]
+endif::[]
 * link:https://blog.openshift.com/improving-build-time-java-builds-openshift/[Improving Build Time of Java Builds on {product-title}]
 * link:https://books.sonatype.com/nexus-book/reference/index.html[Nexus Repository Documentation]


### PR DESCRIPTION
Removing `admin_guide/node_problem_detector` and `dev_guide/volumes` topics that don't apply to OSD per @spurtell.

Also cleaning up the `master-3` branch version of the `topic_map` to get it in better sync w/ the `enterprise-3.11` branch's. Mainly:

- Removing `revhistory` entries (not in use anymore).
- Removing `atomic` distro entries (not in use anymore).

Manual cherry-pick to `enterprise-3.11` branch done via https://github.com/openshift/openshift-docs/pull/15922.

Preview (internal):

http://file.rdu.redhat.com/~adellape/071619/osd_v3_nodefix/dev_guide/

cc @sheriff-rh 	