### PR TITLE
QPS recommendation for OCP 3.11

### DIFF
--- a/scaling_performance/host_practices.adoc
+++ b/scaling_performance/host_practices.adoc
@@ -40,20 +40,40 @@ kubernetesMasterConfig:
     - "1000"
 ----
 
-For large and/or dense clusters, the API server might get overloaded because of the
-default QPS limits. Provided sufficient CPU and memory resources are available on the 
-API server system(s), this issue can be safely alleviated by doubling or quadrupling the 
-default API qps and burst values in the *_/etc/origin/master/master-config.yaml_* file:
+The number of client requests or API calls that are sent to the API server is determined
+by the Queries per second (QPS) value and the number of concurrent requests that can be processed 
+by the API server is determined by the maxRequestsInFlight setting. The number of requests the client
+can make in excess of the QPS rate depends on the burst value, this is helpful for applications that are 
+bursty in nature and can make irregular number of requests. The Response times for requests might have 
+high latencies when there are large numbers of concurrent requests being handled by the API server especially 
+for large and/or dense clusters. It is recommended to monitor the `apiserver_request_count` rate metric in 
+Prometheus and adjust the `maxRequestsInFlight` and `QPS` accordingly. 
+
+There needs to be a good balance when changing the default values as the CPU and memory consumption of 
+API server and etcd IOPS will increase when it is handling more requests in parallel. Also note that heavy 
+non-watch requests might overload the API server as they get cancelled after a fixed 60 second timeout and 
+the client starts retrying. 
+
+Provided sufficient CPU and memory resources are available on the API server system(s), the API server 
+requests overloading issue can be safely alleviated by taking into account the factors mentioned above and 
+bumping up the maxRequestsInFlight, API qps and burst values in the *_/etc/origin/master/master-config.yaml_* file:
 
 ----
 masterClients:
-  externalKubernetesClientConnectionOverrides:
-    burst: 1600
-    qps: 800
   openshiftLoopbackClientConnectionOverrides:
-    burst: 2400
-    qps: 1200
+    burst: 600
+    qps: 300
+servingInfo:
+  maxRequestsInFlight: 500
 ----
+
+[NOTE]
+====
+The maxRequestsInFlight, qps and burst values above are defaults for {product-title}.
+The qps can be higher than maxRequestsInFlight value if the requests take less than a second.
+If `maxRequestsInFlight' is set to zero, there is no limit on the number of concurrent requests that can be 
+processed by the server.
+====
 
 [[scaling-performance-capacity-host-practices-node]]
 == Recommended Practices for {product-title} Node Hosts
@@ -85,6 +105,24 @@ limits for an {product-title} cluster. The recommended sizing accounts for
 {product-title} and container engine coordination for container status updates. This
 coordination puts CPU pressure on the master and container engine processes, which can
 include writing a large amount of log data.
+
+The rate at which kubelet talks to API server depends on qps and burst values.
+The default values are good enough if there are limited pods running on each node.
+Provided there are enough CPU and memory resources on the node, the qps and burst
+values can be tweaked in the  *_/etc/origin/node/node-config.yaml_* file:
+
+----
+kubeletArguments:
+  kube-api-qps:
+  - "20"
+  kube-api-burst:
+  - "40"
+----
+
+[NOTE]
+====
+The qps and burst values above are defaults for {product-title}.
+====
 
 [[scaling-performance-capacity-host-practices-etcd]]
 == Recommended Practices for {product-title} etcd Hosts


### PR DESCRIPTION
This commit adds detailed explanation as to when we the default QPS
rate needs to be changed and the things to consider like etcd IOPS,
CPU and memory available on the API server systems before bumping it up.