### PR TITLE
[master-3] bug 1725235 fix typos

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -234,9 +234,9 @@ overwritten by default values during the upgrade, which could cause pods to not
 run properly or other cluster stability issues.
 .. By default, the installer checks to see if your certificates will expire
 within a year and fails if they will expire within that time. To change the
-number of days that your certificate must valid, specify a new value for the
+number of days that your certificate is valid, specify a new value for the
 `openshift_certificate_expiry_warning_days` parameter. For example, to ensure
-that your certificates are valid for a 180 days, specify
+that your certificates are valid for 180 days, specify
 `openshift_certificate_expiry_warning_days=180`.
 .. To skip checking if your certificates will expire, set
 `openshift_certificate_expiry_fail_on_warn=False`.


### PR DESCRIPTION
I noticed that the error fixed in https://github.com/openshift/openshift-docs/pull/15929 appears in master-3 also. My cherrypick resulted in a merge conflict, https://github.com/openshift/openshift-docs/pull/15929#issuecomment-512968298. I manually made the change.
@vikram-redhat Is this the best method to correct this? Or, should we revert https://github.com/openshift/openshift-docs/pull/15929 and create a new PR against master-3 and cherrypick to 3.11?