### PR TITLE
bug 172535 removed startingCSV and callout 3 in example subscription 2f

### DIFF
--- a/modules/efk-logging-deploy-subscription.adoc
+++ b/modules/efk-logging-deploy-subscription.adoc
@@ -15,7 +15,7 @@ creates and manages the Elasticsearch cluster used by cluster logging.
 The {product-title} cluster logging solution requires that you install both the
 Cluster Logging Operator and Elasticsearch Operator. There is no use case
 in {product-title} for installing the operators individually.
-You *must* install the Elasticsearch Operator using the CLI following the directions below. 
+You *must* install the Elasticsearch Operator using the CLI following the directions below.
 You can install the Cluster Logging Operator using the web console or CLI.
 ====
 
@@ -31,7 +31,7 @@ memory setting though this is not recommended for production deployments.
 
 [NOTE]
 ====
-You *must* install the Elasticsearch Operator using the CLI following the directions below. 
+You *must* install the Elasticsearch Operator using the CLI following the directions below.
 You can install the Cluster Logging Operator using the web console or CLI.
 ====
 
@@ -67,7 +67,7 @@ $ oc create -f eo-project.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-operators-redhat 
+  name: openshift-operators-redhat
   namespace: openshift-operators-redhat <1>
 spec: {}
 ----
@@ -79,7 +79,7 @@ spec: {}
 $ oc create -f eo-og.yaml
 ----
 
-.. Create a CatalogSourceConfig object YAML file (for example, `eo-csc.yaml`) to enable the Elasticsearch Operator on the cluster. 
+.. Create a CatalogSourceConfig object YAML file (for example, `eo-csc.yaml`) to enable the Elasticsearch Operator on the cluster.
 +
 .Example CatalogSourceConfig
 [source,yaml]
@@ -104,20 +104,20 @@ namespace specified in `targetNamespace`.
 $ oc create -f eo-csc.yaml
 ----
 
-.. Use the following commands to get the `channel` and `currentCSV` values required for the next step. 
+.. Use the following commands to get the `channel` and `currentCSV` values required for the next step.
 +
 ----
 $ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath='{.status.channels[].name}'
 
 preview
 
-$ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath='{.status.channels[].currentCSV}'  
+$ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath='{.status.channels[].currentCSV}'
 
 elasticsearch-operator.v4.1.0
 ----
 
 .. Create a Subscription object YAML file (for example, `eo-sub.yaml`) to
-subscribe a Namespace to an Operator. 
+subscribe a Namespace to an Operator.
 +
 .Example Subscription
 [source,yaml]
@@ -133,11 +133,9 @@ spec:
   source: "elasticsearch"
   sourceNamespace: "openshift-operators-redhat" <1>
   name: "elasticsearch-operator"
-  startingCSV: "elasticsearch-operator.v4.1.0" <3>
 ----
 <1> You must specify the `openshift-operators-redhat` namespace for `namespace` and `sourceNameSpace`.
 <2> Specify the `.status.channels[].name` value from the previous step.
-<3> Specify the `.status.channels[].currentCSV` value from the previous step.
 
 .. Create the Subscription object:
 +
@@ -197,7 +195,7 @@ $ oc create -f eo-rbac.yaml
 The Elasticsearch operator is installed to each project in the cluster.
 
 
-. You can install the Cluster Logging Operator using the {product-title} web console for best results: 
+. You can install the Cluster Logging Operator using the {product-title} web console for best results:
 
 .. In the CLI, create a project for cluster logging. You must create the project with the CLI:
 +
@@ -315,7 +313,7 @@ However, an unmanaged deployment does not receive updates until the cluster logg
 [NOTE]
 +
 ====
-The maximum number of Elasticsearch master nodes is three. If you specify a `nodeCount` greater than `3`, {product-title} creates three Elasticsearch nodes that are Master-eligible nodes, with the master, client, and data roles. The additional Elasticsearch nodes are created as Data-only nodes, using client and data roles. Master nodes perform cluster-wide actions such as creating or deleting an index, shard allocation, and tracking nodes. Data nodes hold the shards and perform data-related operations such as CRUD, search, and aggregations. Data-related operations are I/O-, memory-, and CPU-intensive. It is important to monitor these resources and to add more Data nodes if the current nodes are overloaded. 
+The maximum number of Elasticsearch master nodes is three. If you specify a `nodeCount` greater than `3`, {product-title} creates three Elasticsearch nodes that are Master-eligible nodes, with the master, client, and data roles. The additional Elasticsearch nodes are created as Data-only nodes, using client and data roles. Master nodes perform cluster-wide actions such as creating or deleting an index, shard allocation, and tracking nodes. Data nodes hold the shards and perform data-related operations such as CRUD, search, and aggregations. Data-related operations are I/O-, memory-, and CPU-intensive. It is important to monitor these resources and to add more Data nodes if the current nodes are overloaded.
 
 For example, if `nodeCount=4`, the following nodes are created:
 


### PR DESCRIPTION
In 2f, removed "startingCSV: "elasticsearch-operator.v4.1.0" in subscription example and also removed callout 3, which referred to this value.
https://bugzilla.redhat.com/show_bug.cgi?id=1724028
@openshift/team-documentation