### PR TITLE
bz1724028 remove callout ref

### DIFF
--- a/modules/efk-logging-deploy-subscription.adoc
+++ b/modules/efk-logging-deploy-subscription.adoc
@@ -178,7 +178,6 @@ spec:
 ----
 <1> You must specify the `openshift-operators-redhat` namespace for `namespace` and `sourceNameSpace`.
 <2> Specify the `.status.channels[].name` value from the previous step.
-<3> Specify the `.status.channels[].currentCSV` value from the previous step.
 
 .. Create the Subscription object:
 +
@@ -254,7 +253,7 @@ Then, click *Subscribe*.
 
 .. Ensure that *Cluster Logging* is listed in the *openshift-logging* project with a *Status* of *InstallSucceeded*.
 
-.. Ensure that *Elasticsearch Operator* is listed in the *openshift-operator-redhat* project with a *Status* of *InstallSucceeded*. 
+.. Ensure that *Elasticsearch Operator* is listed in the *openshift-operator-redhat* project with a *Status* of *InstallSucceeded*.
 The Elasticsearch Operator is copied to all other projects.
 +
 [NOTE]
@@ -370,4 +369,3 @@ You should see several pods for cluster logging, Elasticsearch, Fluentd, and Kib
 * fluentd-pb2f8
 * fluentd-zqgqx
 * kibana-7fb4fd4cc9-bvt4p
-


### PR DESCRIPTION
Removed startingCSV callout 3 listing. (Previous PR removed callout 3 and marker, but not ref listing. Also note that this issue was fixed in previous PR for 4.2 but not 4.1, which is why this PR is being submitted.)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1724028

@openshift/team-documentation