### PR TITLE
CNV - Importing VMs structural change

### DIFF
--- a/cnv/cnv_users_guide/cnv-create-vms.adoc
+++ b/cnv/cnv_users_guide/cnv-create-vms.adoc
@@ -29,22 +29,3 @@ API Reference] for a definitive list of virtual machine settings.
 
 include::modules/cnv-vm-storage-volume-types.adoc[leveloffset=+1]
 
-[id="cnv-importing-vmware-vm_{context}"]
-== Importing a VMware virtual machine or template with the virtual machine wizard
-
-You can import a VMware virtual machine or template. If you import a template, a virtual machine based on the template is created.
-
-:FeatureName: Importing a VMware virtual machine or template
-include::modules/technology-preview.adoc[leveloffset=+1]
-:!FeatureName:
-
-.Prerequisites
-
-* The VMware virtual machine is powered off.
-* The VMware Virtual Disk Development Kit (VDDK) has been uploaded to the namespace in which you are importing the virtual machine.
-* The target storage supports a minimum transfer speed of 100 MB per second.
-* The target storage supports ReadWriteMany access.
-
-include::modules/cnv-uploading-vddk.adoc[leveloffset=+2]
-include::modules/cnv-importing-vmware-vm.adoc[leveloffset=+2]
-include::modules/cnv-updating-imported-vm-network-name.adoc[leveloffset=+2]

--- a/cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
+++ b/cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
@@ -1,0 +1,30 @@
+[id="cnv-importing-vmware-vm"]
+= Importing a VMware virtual machine or template with the virtual machine wizard
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-importing-vmware-vm
+toc::[]
+
+You can import a VMware virtual machine or template. If you import a template, a virtual machine based on the template is created.
+
+:FeatureName: Importing a VMware virtual machine or template
+include::modules/technology-preview.adoc[leveloffset=+1]
+:!FeatureName:
+
+.Prerequisites
+
+* The VMware virtual machine is powered off.
+* The VMware Virtual Disk Development Kit (VDDK) has been uploaded to the namespace in which you are importing the virtual machine.
+
+include::modules/cnv-uploading-vddk.adoc[leveloffset=+1]
+include::modules/cnv-importing-vmware-vm.adoc[leveloffset=+1]
+
+Refer to the xref:cnv-importing-vmware-vm-wizard-fields_cnv-importing-vmware-vm[virtual machine wizard fields] section for more information on the  wizard fields.
+
+include::modules/cnv-updating-imported-vm-network-name.adoc[leveloffset=+1]
+
+[id="cnv-importing-vmware-vm-wizard-fields_{context}"]
+== Virtual machine wizard fields
+include::modules/cnv-vm-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/cnv-cloud-init-fields-web.adoc[leveloffset=+2]
+include::modules/cnv-networking-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/cnv-storage-wizard-fields-web.adoc[leveloffset=+2]


### PR DESCRIPTION
Moving the importing procedures to their own assemblies for consistency. 
I've included the wizard fields reference tables at the end of the assembly, even though they are relevant specifically for the *Importing the VMware virtual machine or template* procedure. The concern was that the reference material then overshadowed the next procedure. To overcome this I've included an xref that points to the reference tables. 
It is an imperfect solution, however it is only temporary since this procedure will become more user-friendly.

Not a part of this PR but the importing procedures should be moved so they follow 'Creating VM'.
@vikram-redhat - this will involve a change to the_topic_map WIP

Build link: http://file.bne.redhat.com/aburden/CNV-docs-preview/cnv-importing-vmware-assembly/cnv/cnv_users_guide/cnv-importing-vmware-vm.html