### PR TITLE
Kubernetes Feature Flag doc is confusing and incorrect

### DIFF
--- a/modules/feature-gate-features.adoc
+++ b/modules/feature-gate-features.adoc
@@ -5,25 +5,39 @@
 [id="feature-gate-features_{context}"]
 = Features that are affected by FeatureGates
 
-The following features are affected by FeatureGates:
+The following Technology Preview features included in {product-title}:
 
 [options="header"]
 |===
-| FeatureGate| Description
-
-|`CSIBlockVolume`
-|Enables external CSI drivers to implement raw block volume support.
+| FeatureGate| Description| Default
 
 |`ExperimentalCriticalPodAnnotation`
 |Enables annotating specific Pods as critical so that their scheduling is guaranteed.
-
-|`MachineHealthCheck`
-|Enables automatically repairing damaged machines in a machine pool.
+|True
 
 |`RotateKubeletServerCertificate`
 |Enables the rotation of the server TLS certificate on the cluster.
+|True
 
 |`SupportPodPidsLimit`
 |Enables support for limiting the number of processes (PIDs) running in a Pod.
+|True
+
+|`MachineHealthCheck`
+|Enables automatically repairing unhealthy machines in a machine pool.
+|False
+
+|`CSIBlockVolume`
+|Enables external CSI drivers to implement raw block volume support.
+|False
+
+|`LocalStorageCapacityIsolation`
+|Enable the consumption of local ephemeral storage and also the `sizeLimit` property of an `emptyDir` volume.
+|False
 
 |===
+
+You can enable the `MachineHealthCheck` and `CSIBlockVolume` features by editing the Feature Gate Custom Resource.
+Turning on these features cannot be undone and prevents the ability to upgrade your cluster.
+
+The `LocalStorageCapacityIsolation` cannot be enabled.

--- a/modules/nodes-cluster-enabling-features-cluster.adoc
+++ b/modules/nodes-cluster-enabling-features-cluster.adoc
@@ -3,34 +3,31 @@
 // * nodes/nodes-cluster-enabling-features.adoc
 
 [id="nodes-cluster-enabling-features-cluster_{context}"]
-= Enabling Technology Preview features using FeatureGates
+= Enabling Technology Preview features using feature gates
 
-You can turn Technology Preview features on for all nodes in the cluster by
-editing the FeatureGates Custom Resource, named `cluster`, in the
-`openshift-config` project.
+You can turn on the `MachineHealthCheck` and `CSIBlockVolume` Technology Preview features on for all nodes in the cluster by
+editing the Feature Gate Custom Resource, named `cluster`, in the `openshift-config` project.
+
+Turning 
 
 [IMPORTANT]
 ====
-Turning on Technology Preview features cannot be undone and prevents upgrades.
+Turning on Technology Preview features using the Feature Gate Custom Resource cannot be undone and prevents upgrades.
 ====
 
 .Procedure
 
 To turn on the Technology Preview features for the entire cluster:
 
-//The steps to create the instance are for Beta only
+. In the {product-title} web sonsole, switch to the the *Administration* -> *Custom Resource Definitions* page.
 
-. Create the FeatureGates instance:
+. On the *Custom Resource Definitions* page, click *FeatureGate*.
 
-.. Switch to the the *Administration* -> *Custom Resource Definitions* page.
+. On the *Custom Resource Definitions* page, click *Actions* -> *View Instances*.
 
-.. On the *Custom Resource Definitions* page, click *FeatureGate*.
+. On the *Feature Gates* page, click *Create Feature Gates*.
 
-.. On the *Custom Resource Definitions* page, click the *Actions Menu* and select *View Instances*.
-
-.. On the *Feature Gates* page, click *Create Feature Gates*.
-
-.. Replace the code with following sample:
+. Add the `featureSet` parameter:
 +
 [source,yaml]
 ----
@@ -38,21 +35,10 @@ apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
   name: cluster
-spec: {}
-----
-
-.. Click *Create*.
-
-. To turn on the Technology Preview features, change the `spec` parameter to:
-+
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
 spec:
-  featureSet: TechPreviewNoUpgrade <1>
+  featureSet: "TechPreviewNoUpgrade" <1>
 ----
-+
-<1> Add `featureSet: TechPreviewNoUpgrade` to enable the Technology Preview
-features that are affected by FeatureGates.
+<1> Add the `featureSet: "TechPreviewNoUpgrade"` parameter.
+
+. Click *Save*.
+

--- a/modules/nodes-cluster-features-about.adoc
+++ b/modules/nodes-cluster-features-about.adoc
@@ -3,16 +3,16 @@
 // * nodes/nodes-cluster-enabling-features.adoc
 
 [id="nodes-cluster-features-about_{context}"]
-= Understanding FeatureGates and Technology Preview features
+= Understanding feature gates and Technology Preview features
 
-You can use the FeatureGates Custom Resource to enable Technology Preview
+You can use the Feature Gate Custom Resource to enable Technology Preview
 features throughout your cluster. This allows you, for example, to enable
 Technology Preview features on test clusters where you can fully test them while
 ensuring they are disabled on production clusters.
 
 [IMPORTANT]
 ====
-After turning Technology Preview features on using FeatureGates, they cannot be
+After turning Technology Preview features on using feature gates, they cannot be
 turned off and cluster upgrades are prevented.
 
 ifndef::openshift-origin[]

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -1,6 +1,6 @@
 :context: nodes-cluster-enabling
 [id="nodes-cluster-enabling"]
-= Enabling {product-title} features using FeatureGates
+= Enabling features using feature gates
 include::modules/common-attributes.adoc[]
 
 toc::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1722240

This doc confuses me. It has 1 more feature listed than we manage (it lists MachineHealthCheck, which I believe we enable in 4.2, not 4.1.) It also doesn't really distinguish the nuances. By default we enable any Kubernetes feature gates which are beta. We disable any kubenretes feature gates which are for alpha features. By default we enable, by default a number of feature gates which are not beta/ga. Those include:
ExperimentalCriticalPodAnnotation
RotateKubeletServerCertificate
SupportPodPidsLimit

There is 1 feature gate which is enabled by default in kube but which we explicitly disable:
LocalStorageCapacityIsolation

If a user were to enable the 'tech preview no upgrade' features they will also get, but will likely lose the ability to upgrade that cluter:
CSIBlockVolume


I think the doc needs to be rewritten to explain those 3 categories of feature flags and to make it clear that setting tech preview no upgrade only affects the singe additional feature gate.