### PR TITLE
Document Issues with swapping log collectors after deployment

### DIFF
--- a/logging/cluster-logging-deploying.adoc
+++ b/logging/cluster-logging-deploying.adoc
@@ -8,9 +8,9 @@ toc::[]
 The process for deploying cluster Logging to {product-title} involves:
 
 
-* Review the installation options in xref:../logging/efk-logging-deploying-about.adoc#cluster-logging-deploying-about[About deploying cluster logging].
+* Review the installation options in xref:../logging/cluster-logging-deploying-about.adoc#cluster-logging-deploying-about[About deploying cluster logging].
 
-* Review the xref:../logging/efk-logging-deploying-about.adoc#cluster-logging-deploy-storage-considerations_cluster-logging-deploying-about[cluster logging storage considerations].
+* Review the xref:../logging/cluster-logging-deploying-about.adoc#cluster-logging-deploy-storage-considerations_cluster-logging-deploying-about[cluster logging storage considerations].
 
 * Install the Cluster Logging subscription using the web console.
 

--- a/logging/config/cluster-logging-fluentd.adoc
+++ b/logging/config/cluster-logging-fluentd.adoc
@@ -31,6 +31,8 @@ modules/cluster-logging-fluentd-log-rotation.adoc[leveloffset=+1]
 include::modules/cluster-logging-fluentd-collector.adoc[leveloffset=+1]
 ////
 
+include::modules/cluster-logging-collector-fluentd-v-rsyslog.adoc[leveloffset=+1]
+
 include::modules/cluster-logging-fluentd-log-location.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-fluentd-external.adoc[leveloffset=+1]

--- a/modules/cluster-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/cluster-logging-collector-fluentd-v-rsyslog.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * logging/efk-logging-fluentd.adoc
+// * logging/cluster-logging-fluentd.adoc
 
-[id="efk-logging-collector-fluentd-v-rsyslog_{context}"]
+[id="cluster-logging-collector-fluentd-v-rsyslog_{context}"]
 = About Fluentd and Rsyslog
 
 In {product-title} {product-version}, you can choose between Fluentd and Rsyslog as the logging collector. 

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -19,4 +19,8 @@ Some of the noteable differences between the two collectors are:
 
 * remote syslog
 
+When switching between the two collectors can result in:
 
+* A gap in messages between scale down of one collector and scale up of the other when reading from the tail.
+
+* Duplicate messages between scale down of one collector and scale up of the other when reading from the head.

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -24,3 +24,13 @@ When switching between the two collectors can result in:
 * A gap in messages between scale down of one collector and scale up of the other when reading from the tail.
 
 * Duplicate messages between scale down of one collector and scale up of the other when reading from the head.
++
+By default, Rsyslog reads from the head of the container log files, and from the start of the journal. Switching to Rsyslog 
+will lead to many duplicated messages, as well as Rsyslog taking a long time to record the most current log entries.
++
+You can configure Rsyslog to skip older entries in the journal and start reading from the end by setting the `RSYSLOG_JOURNAL_READ_FROM_TAIL`
+parameter in the Rsyslog daemonset:
++
+----
+oc set env ds/rsyslog RSYSLOG_JOURNAL_READ_FROM_TAIL=true
+----

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -5,7 +5,12 @@
 [id="efk-logging-collector-fluentd-v-rsyslog_{context}"]
 = About Fluentd and Rsyslog
 
-You can choose between Fluentd and Rsyslog as the logging collector. 
+In {product-title} {product-version}, you can choose between Fluentd and Rsyslog as the logging collector. 
+
+[NOTE]
+====
+We are currently evaluating alternative log collectors in order to offer the best collection tool for cluster logging.  
+====
 
 Some of the noteable differences between the two collectors are:
 
@@ -27,7 +32,7 @@ You can work around this issue using one of the following methods:
 ----
 oc set env ds/rsyslog RSYSLOG_K8S_CACHE_ENTRY_TTL=60
 ----
-
+go
 When switching between the two collectors can result in:
 
 * A gap in messages between scale down of one collector and scale up of the other when reading from the tail.

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -17,7 +17,16 @@ For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log fo
 
 * The Event Router is not supported for the Rsyslog log collector.
 
-* remote syslog
+* Due to a known Rsyslog issue, if you delete a project and create a new project using the same name before Rsyslog removes the cache entry, Rsyslog sends logs to the exsiting index. 
++
+You can work around this issue using one of the following methods:
++
+** Restart Rsyslog after deleting the namespace and before creating another namespace with the same name.
+** Adjust the cache settings for link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/mmkubernetes.html#cacheexpireinterval[cache expiration] and link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/mmkubernetes.html#cacheentryttl[cache entry TTL] so that cache entries are deleted more frequently.  By default, TTL is 1 hour. For example, use the following command to set the TTL to 1 minute: 
++
+----
+oc set env ds/rsyslog RSYSLOG_K8S_CACHE_ENTRY_TTL=60
+----
 
 When switching between the two collectors can result in:
 

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -9,9 +9,9 @@ You can choose between Fluentd and Rsyslog as the logging collector.
 
 Some of the noteable differences between the two collectors are:
 
-* No throttling in Rsyslog. With Fluentd, an administrator can reduce the rate at which the logs are read in by Fluentd before being processed. This feature is not currently available with Rsyslog.
+* No throttling in Rsyslog. With Fluentd, an administrator can reduce the rate at which the logs are read in by Fluentd before being processed. Log throttling is not currently available with Rsyslog.
 
-* No _built-in_ support for remote syslog forwarding in rsyslog. With Fluentd, you can use the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. This feature is not currently available with Rsyslog.
+* No _built-in_ support for remote syslog forwarding in rsyslog. With Fluentd, you can use the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. Remote syslog forwarding is not currently available with Rsyslog.
 +
 For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log forwarding using the *omfwd* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html[]. To send logs to a different Rsyslog instance, you can the *omrelp* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omrelp.html[]
 

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * logging/efk-logging-fluentd.adoc
+
+[id="efk-logging-collector-fluentd-v-rsyslog_{context}"]
+= About Fluentd and Rsyslog
+
+You can choose between Fluentd and Rsyslog as the logging collector. 
+
+Some of the noteable differences between the two collectors are:
+
+* Daching differences.
+
+* Deleted namespace
+
+* No throttling in Rsyslog. With Fluentd, an administrator can reduce the rate at which the logs are read in by Fluentd before being processed. This feature is not currently available with Rsyslog.
+
+* No secure forward in Rsyslog. With Fluentd, you can use the Fluentd the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. This feature is not currently available with Rsyslog.
+
+* remote syslog
+
+

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -11,7 +11,7 @@ Some of the noteable differences between the two collectors are:
 
 * No throttling in Rsyslog. With Fluentd, an administrator can reduce the rate at which the logs are read in by Fluentd before being processed. This feature is not currently available with Rsyslog.
 
-* No _built-in_ support for remote syslog forwarding in rsyslog. With Fluentd, you can use the Fluentd the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. This feature is not currently available with Rsyslog.
+* No _built-in_ support for remote syslog forwarding in rsyslog. With Fluentd, you can use the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. This feature is not currently available with Rsyslog.
 +
 For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log forwarding using the *omfwd* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html[]. To send logs to a different Rsyslog instance, you can the *omrelp* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omrelp.html[]
 

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -25,12 +25,22 @@ When switching between the two collectors can result in:
 
 * Duplicate messages between scale down of one collector and scale up of the other when reading from the head.
 +
-By default, Rsyslog reads from the head of the container log files, and from the start of the journal. Switching to Rsyslog 
-will lead to many duplicated messages, as well as Rsyslog taking a long time to record the most current log entries.
+By default, Rsyslog reads from the head of the container log files, and from the start of the journal. Fluentd
+reads from the end of the log files.
+
+Switching from Fluentd to Rsyslog will lead to many duplicated messages and Rsyslog taking a long time to record the most current log entries.
 +
 You can configure Rsyslog to skip older entries in the journal and start reading from the end by setting the `RSYSLOG_JOURNAL_READ_FROM_TAIL`
 parameter in the Rsyslog daemonset:
 +
 ----
-oc set env ds/rsyslog RSYSLOG_JOURNAL_READ_FROM_TAIL=true
+$ oc set env ds/rsyslog RSYSLOG_JOURNAL_READ_FROM_TAIL=true
+----
++
+Switching from Rsyslog to Fluentd presents the same problems. You can configure Fluentd to read from the beginning of the log files, which results duplicate records, or you can configure Fluentd to read from the tail of the log files, which results in missing records. Set the `JOURNAL_READ_FROM_TAIL`
+parameter in the Fluentd daemonset:
++
+----
+$ oc set env ds/fluentd JOURNAL_READ_FROM_TAIL=true
+$ oc set env ds/fluentd JOURNAL_READ_FROM_TAIL=false
 ----

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -26,7 +26,7 @@ When switching between the two collectors can result in:
 * Duplicate messages between scale down of one collector and scale up of the other when reading from the head.
 +
 By default, Rsyslog reads from the head of the container log files, and from the start of the journal. Fluentd
-reads from the end of the log files.
+reads container logs from the head and the journal log files from the end.
 
 Switching from Fluentd to Rsyslog will lead to many duplicated messages and Rsyslog taking a long time to record the most current log entries.
 +
@@ -41,6 +41,6 @@ Switching from Rsyslog to Fluentd presents the same problems. You can configure 
 parameter in the Fluentd daemonset:
 +
 ----
-$ oc set env ds/fluentd JOURNAL_READ_FROM_TAIL=true
-$ oc set env ds/fluentd JOURNAL_READ_FROM_TAIL=false
+$ oc set env ds/fluentd JOURNAL_READ_FROM_HEAD=true
+$ oc set env ds/fluentd CONTAINER_READ_FROM_TAIL=false
 ----

--- a/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
+++ b/modules/efk-logging-collector-fluentd-v-rsyslog.adoc
@@ -9,13 +9,13 @@ You can choose between Fluentd and Rsyslog as the logging collector.
 
 Some of the noteable differences between the two collectors are:
 
-* Daching differences.
-
-* Deleted namespace
-
 * No throttling in Rsyslog. With Fluentd, an administrator can reduce the rate at which the logs are read in by Fluentd before being processed. This feature is not currently available with Rsyslog.
 
-* No secure forward in Rsyslog. With Fluentd, you can use the Fluentd the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. This feature is not currently available with Rsyslog.
+* No _built-in_ support for remote syslog forwarding in rsyslog. With Fluentd, you can use the Fluentd the `secure-forward` plug-in to send a copy of its logs to an external log aggregator. This feature is not currently available with Rsyslog.
++
+For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log forwarding using the *omfwd* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html[]. To send logs to a different Rsyslog instance, you can the *omrelp* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omrelp.html[]
+
+* The Event Router is not supported for the Rsyslog log collector.
 
 * remote syslog
 


### PR DESCRIPTION
We are assembling a list of differences between Fluentd and Rsyslog as log collectors and the ramifications of switching between the two.

https://jira.coreos.com/browse/OSDOCS-624
https://jira.coreos.com/browse/LOG-20