### PR TITLE
Replace Elasticsearch Operator install

### DIFF
--- a/modules/efk-logging-deploy-subscription.adoc
+++ b/modules/efk-logging-deploy-subscription.adoc
@@ -37,42 +37,9 @@ You can install the Cluster Logging Operator using the web console or CLI.
 
 .Procedure
 
-. Create Namespaces for the Elasticsearch Operator and Cluster Logging Operator.
-+
-[NOTE]
-====
-You can also create the Namespaces in the web console using the *Administration* -> *Namespaces* page.
-You must apply the `cluster-logging` and `cluster-monitoring` labels listed in the sample YAML to the namespaces you create.
-====
+. Create a Namespace for the Cluster Logging Operator (for example, `clo-namespace.yaml`):
 
-.. Create a Namespace for the Elasticsearch Operator (for example, `eo-namespace.yaml`):
-+
-----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-operators-redhat <1>
-  annotations:
-    openshift.io/node-selector: ""
-  labels:
-    openshift.io/cluster-logging: "true"
-    openshift.io/cluster-monitoring: "true"
-----
-<1> You must specify the `openshift-operators-redhat` namespace.
-
-.. Run the following command to create the namespace:
-+
-----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-----
-$ oc create -f eo-namespace.yaml
-----
-
-.. Create a Namespace for the Cluster Logging Operator (for example, `clo-namespace.yaml`):
+.. Create a text file in the CLI that contains the following:
 +
 [source,yaml]
 ----
@@ -101,142 +68,16 @@ For example:
 $ oc create -f clo-namespace.yaml
 ----
 
-. Install the Elasticsearch Operator by creating the following objects:
+. Install the Elasticsearch Operator:
 
-.. Create an Operator Group object YAML file (for example, `eo-og.yaml`) for the Elasticsearch operator:
-+
-----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: openshift-operators-redhat
-  namespace: openshift-operators-redhat <1>
-spec: {}
-----
-<1> You must specify the `openshift-operators-redhat` namespace.
+.. In the {product-title} console, click *Catalog* -> *OperatorHub*.
 
-.. Create an Operator Group object:
-+
-----
-$ oc create -f eo-og.yaml
-----
+.. Choose  *Elasticsearch Operator* from the list of available Operators, and click *Install*.
 
-.. Create a CatalogSourceConfig object YAML file (for example, `eo-csc.yaml`) to enable the Elasticsearch Operator on the cluster.
-+
-.Example CatalogSourceConfig
-[source,yaml]
-----
-apiVersion: "operators.coreos.com/v1"
-kind: "CatalogSourceConfig"
-metadata:
-  name: "elasticsearch"
-  namespace: "openshift-marketplace"
-spec:
-  targetNamespace: "openshift-operators-redhat" <1>
-  packages: "elasticsearch-operator"
-----
-<1> You must specify the `openshift-operators-redhat` namespace.
-+
-The Operator generates a CatalogSource from your CatalogSourceConfig in the
-namespace specified in `targetNamespace`.
-
-.. Create a CatalogSourceConfig object:
-+
-----
-$ oc create -f eo-csc.yaml
-----
-
-.. Use the following commands to get the `channel` and `currentCSV` values required for the next step.
-+
-----
-$ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath='{.status.channels[].name}'
-
-preview
-
-$ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath='{.status.channels[].currentCSV}'
-
-elasticsearch-operator.v4.1.0
-----
-
-.. Create a Subscription object YAML file (for example, `eo-sub.yaml`) to
-subscribe a Namespace to an Operator.
-+
-.Example Subscription
-[source,yaml]
-----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  generateName: "elasticsearch-"
-  namespace: "openshift-operators-redhat" <1>
-spec:
-  channel: "preview" <2>
-  installPlanApproval: "Automatic"
-  source: "elasticsearch"
-  sourceNamespace: "openshift-operators-redhat" <1>
-  name: "elasticsearch-operator"
-----
-<1> You must specify the `openshift-operators-redhat` namespace for `namespace` and `sourceNameSpace`.
-<2> Specify the `.status.channels[].name` value from the previous step.
-
-.. Create the Subscription object:
-+
-----
-$ oc create -f eo-sub.yaml
-----
-
-.. Change to the `openshift-operators-redhat` project:
-+
-----
-$ oc project openshift-operators-redhat
-
-Now using project "openshift-operators-redhat"
-----
-
-.. Create a Role-based Access Control (RBAC) object file (for example, `eo-rbac.yaml`) to grant Prometheus permission to access the `openshift-operators-redhat` namespace:
-+
-[source,yaml]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: prometheus-k8s
-  namespace: openshift-operators-redhat
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: prometheus-k8s
-  namespace: openshift-operators-redhat
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-subjects:
-- kind: ServiceAccount
-  name: prometheus-k8s
-namespace: openshift-operators-redhat
-----
-
-.. Create the RBAC object:
-+
-----
-$ oc create -f eo-rbac.yaml
-----
+.. On the *Create Operator Subscription* page, select *All namespaces on the cluster* under *Installation Mode*.
+Then, click *Subscribe*.
 +
 The Elasticsearch operator is installed to each project in the cluster.
-
 
 . Install the Cluster Logging Operator using the {product-title} web console for best results:
 


### PR DESCRIPTION
In 4.1, the Elasticsearch Operator could not be installed via the web console. In 4.2 that functionality has returned and the user can use the web console to install the EO. 