### PR TITLE
BZ-1728315: Clarified usage of CA inside ConfigMap.

### DIFF
--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -12,10 +12,11 @@
 
 Identity providers use {product-title} ConfigMaps in the `openshift-config`
 namespace to contain the certificate authority bundle. These are primarily
-used to contain certificate bundles needed by the identity provider. 
+used to contain certificate bundles needed by the identity provider.
 
 * Define an {product-title} ConfigMap containing the
-certificate authority by using the following command.
+certificate authority by using the following command. The certificate
+authority must be stored in the `ca.crt` key of the ConfigMap.
 +
 ----
 $ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config


### PR DESCRIPTION
Adjusted the text of the ConfigMap declaration to indicate that the key must be `ca.crt`.

This is for OS 4.x.