### PR TITLE
Fixing typo in bare metal installation

### DIFF
--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -33,7 +33,7 @@ names for the installation assets might change between releases. Use caution
 when copying installation files from an earlier {product-title} version.
 ====
 
-. Customize the following `install-config.yaml` file template and save the
+. Customize the following `install-config.yaml` file template and save 
 it in the `<installation_directory>`.
 +
 [NOTE]


### PR DESCRIPTION
Removing redundant word from installation guide.