### PR TITLE
Add network customization for vSphere, GCP, bare-metal installs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -110,6 +110,8 @@ Topics:
     File: installing-gcp-default
   - Name: Installing a cluster on GCP with customizations
     File: installing-gcp-customizations
+  - Name: Installing a cluster on GCP with network customizations
+    File: installing-gcp-network-customizations
   - Name: Uninstalling a cluster on GCP
     File: uninstalling-cluster-gcp
 - Name: Installing on user-provisioned AWS
@@ -127,6 +129,8 @@ Topics:
   Topics:
   - Name: Installing a cluster on bare metal
     File: installing-bare-metal
+  - Name: Installing a cluster on bare metal with network customizations
+    File: installing-bare-metal-network-customizations
 - Name: Installing on OpenStack
   Dir: installing_openstack
   Topics:
@@ -145,6 +149,8 @@ Topics:
   Topics:
   - Name: Installing a cluster on vSphere
     File: installing-vsphere
+  - Name: Installing a cluster on vSphere with network customizations
+    File: installing-vsphere-network-customizations
 - Name: Installing in restricted networks
   Dir: installing_restricted_networks
   Topics:

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -1,0 +1,90 @@
+[id="installing-bare-metal-network-customizations"]
+= Installing a cluster on bare metal with network customizations
+include::modules/common-attributes.adoc[]
+:context: installing-bare-metal-network-customizations
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster on bare
+metal infrastructure that you provision with customized network configuration
+options. By customizing your network configuration, your cluster can coexist
+with existing IP address allocations in your environment and integrate with
+existing MTU and VXLAN configurations.
+
+You must set most of the network configuration parameters during installation,
+and you can modify only `kubeProxy` configuration parameters in a running
+cluster.
+
+.Prerequisites
+
+* Provision
+xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
+for your cluster. To deploy a private image registry, your storage must provide
+ReadWriteMany access modes.
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+
+include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
+
+include::modules/installation-network-user-infra.adoc[leveloffset=+2]
+
+include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/installation-initializing-manual.adoc[leveloffset=+1]
+
+include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
+
+include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
+
+include::modules/installation-generate-ignition-configs.adoc[leveloffset=+1]
+
+// Network Operator specific configuration
+
+include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
+
+[id="creating-machines-bare-metal-network-customization"]
+== Creating {op-system-first} machines
+
+Before you install a cluster on bare metal infrastructure that you provision,
+you must create {op-system} machines for it to use. Follow either the steps
+to use an ISO image or network PXE booting to create the machines.
+
+include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
+
+include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
+
+include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/installation-approve-csrs.adoc[leveloffset=+1]
+
+include::modules/installation-operators-config.adoc[leveloffset=+1]
+
+include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+3]
+
+include::modules/installation-registry-storage-non-production.adoc[leveloffset=+3]
+
+include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -1,0 +1,61 @@
+[id="installing-gcp-network-customizations"]
+= Installing a cluster on GCP with network customizations
+include::modules/common-attributes.adoc[]
+:context: installing-gcp-network-customizations
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster with a
+customized network configuration on infrastructure that the installation program
+provisions on Google Cloud Platform (GCP). By customizing your network
+configuration, your cluster can coexist with existing IP address allocations in
+your environment and integrate with existing MTU and VXLAN configurations. To
+customize the installation, you modify parameters in the `install-config.yaml`
+file before you install the cluster.
+
+You must set most of the network configuration parameters during installation,
+and you can modify only `kubeProxy` configuration parameters in a running
+cluster.
+
+.Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
+to host the cluster.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+1]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
+
+include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
+
+// Removing; Proxy not supported for GCP IPI for 4.2
+// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+// Network Operator specific configuration
+include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -1,0 +1,85 @@
+[id="installing-vsphere-network-customizations"]
+= Installing a cluster on vSphere with network customizations
+include::modules/common-attributes.adoc[]
+:context: installing-vsphere-network-customizations
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster on
+VMware vSphere infrastructure that you provision with customized network
+configuration options.  By customizing your network configuration, your cluster
+can coexist with existing IP address allocations in your environment and
+integrate with existing MTU and VXLAN configurations.
+
+You must set most of the network configuration parameters during installation,
+and you can modify only `kubeProxy` configuration parameters in a running
+cluster.
+
+
+.Prerequisites
+
+* Provision
+xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
+for your cluster. To deploy a private image registry, your storage must provide
+ReadWriteMany access modes.
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
+
+include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+
+include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
+
+include::modules/installation-network-user-infra.adoc[leveloffset=+2]
+
+include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing-manual.adoc[leveloffset=+1]
+
+include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
+
+include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
+
+include::modules/installation-generate-ignition-configs.adoc[leveloffset=+1]
+
+// Network Operator specific configuration
+
+include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
+
+include::modules/installation-vsphere-machines.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/installation-approve-csrs.adoc[leveloffset=+1]
+
+include::modules/installation-operators-config.adoc[leveloffset=+1]
+
+include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
+
+include::modules/installation-registry-storage-non-production.adoc[leveloffset=+3]
+
+include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
+
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/modules/nw-install-config-parameters.adoc
+++ b/modules/nw-install-config-parameters.adoc
@@ -2,6 +2,16 @@
 //
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:ovn-preview:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:ovn-preview:
+endif::[]
 
 [id="network-customization-config-yaml_{context}"]
 = Network configuration parameters
@@ -20,11 +30,19 @@ You cannot modify these parameters in the `install-config.yaml` file after insta
 |====
 |Parameter|Description|Value
 
+ifdef::ovn-preview[]
 |`networking.networkType`
 |The network plug-in to deploy. The `OpenShiftSDN` plug-in is the only plug-in
 supported in {product-title} {product-version}. The `OVNKubernetes` plug-in is
 available as Technology Preview in {product-title} 4.2.
 |Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OpenShiftSDN`.
+endif::ovn-preview[]
+ifndef::ovn-preview[]
+|`networking.networkType`
+|The network plug-in to deploy. The `OpenShiftSDN` plug-in is the only plug-in
+supported in {product-title} {product-version}.
+|The default value is `OpenShiftSDN`.
+endif::[]
 
 |`networking.clusterNetwork.cidr`
 |A block of IP addresses from which Pod IP addresses are allocated. The
@@ -52,3 +70,10 @@ network block.
 |An IP address allocation in CIDR format. The default value is `10.0.0.0/16`.
 
 |====
+
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!ovn-preview:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:!ovn-preview:
+endif::[]

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -2,6 +2,16 @@
 //
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+
+ifeval::["{context}" == "installing-bare-metal-network-customizations"]
+:ignition-config:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:ignition-config:
+endif::[]
 
 [id="modifying-nwoperator-config-startup_{context}"]
 = Modifying advanced network configuration parameters
@@ -21,7 +31,10 @@ Modifying the {product-title} manifest files directly is not supported.
 
 .Prerequisites
 
-* Generate the `install-config.yaml` file and complete any modifications to it.
+* Create the `install-config.yaml` file and complete any modifications to it.
+ifdef::ignition-config[]
+* Create the Ignition config files for your cluster.
+endif::ignition-config[]
 
 .Procedure
 
@@ -79,3 +92,10 @@ specify only the parameters that you want to change.
 . Optional: Back up the `manifests/cluster-network-03-config.yml` file. The
 installation program deletes the `manifests/` directory when creating the
 cluster.
+
+ifeval::["{context}" == "installing-bare-metal-network-customizations"]
+:!ignition-config:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!ignition-config:
+endif::[]

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -3,12 +3,22 @@
 // * networking/cluster-network-operator.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
 
-ifeval::["{context}" == "installing-aws-network-customizations"]
-:install:
+// Installation assemblies need different details than the CNO operator does
+ifeval::["{context}" == "cluster-network-operator"]
+:operator:
 endif::[]
+
+// Remove for OCP 4.3
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:ovn-preview:
+endif::[]
+// Remove for OCP 4.3
 ifeval::["{context}" == "installing-azure-network-customizations"]
-:install:
+:ovn-preview:
 endif::[]
 
 // Extract parameter descriptions that may have a different ordinal
@@ -43,7 +53,7 @@ both the parameters you can configure and valid parameter values:
 
 .Cluster Network Operator CR
 [source,yaml]
-ifdef::install[]
+ifndef::operator[]
 ----
 apiVersion: operator.openshift.io/v1
 kind: Network
@@ -73,9 +83,9 @@ displayed default parameter values.
 
 <4> {kube-proxy-refresh}
 <5> {iptables-min-sync-period}
-endif::install[]
+endif::operator[]
 
-ifndef::install[]
+ifdef::operator[]
 ----
 apiVersion: operator.openshift.io/v1
 kind: Network
@@ -109,15 +119,16 @@ network.
 
 <5> {kube-proxy-refresh}
 <6> {iptables-min-sync-period}
-endif::install[]
+endif::operator[]
 
+[id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
 == Configuration parameters for OpenShift SDN
 
 The following YAML object describes the configuration parameters for
 OpenShift SDN:
 
 [source,yaml]
-ifdef::install[]
+ifndef::operator[]
 ----
 defaultNetwork:
   type: OpenShiftSDN <1>
@@ -145,9 +156,9 @@ another VXLAN network, then you might be required to change this.
 +
 On Amazon Web Services (AWS), you can select an alternate port for the VXLAN
 between port `9000` and port `9999`.
-endif::install[]
+endif::operator[]
 
-ifndef::install[]
+ifdef::operator[]
 ----
 defaultNetwork:
   type: OpenShiftSDN <1>
@@ -167,16 +178,18 @@ the only plug-in supported in {product-title} {product-version}.
 automatically.
 
 <5> The port to use for all VXLAN packets. The default value is `4789`.
-endif::install[]
+endif::operator[]
 
-ifdef::install[]
+ifdef::ovn-preview[]
+[id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
 == Configuration parameters for Open Virtual Network (OVN) SDN
 
 The OVN SDN does not have any configuration parameters in {product-title}
 {product-version}.
 
-endif::install[]
+endif::ovn-preview[]
 
+[id="nw-operator-example-cr_{context}"]
 == Cluster Network Operator example CR
 
 A complete CR for the CNO is displayed in the following example:
@@ -207,9 +220,15 @@ spec:
       - 30s
 ----
 
-ifeval::["{context}" == "installing-aws-network-customizations"]
-:!install:
+ifeval::["{context}" == "cluster-network-operator"]
+:!operator:
 endif::[]
+
+// Remove for OCP 4.3
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!ovn-preview:
+endif::[]
+// Remove for OCP 4.3
 ifeval::["{context}" == "installing-azure-network-customizations"]
-:!install:
+:!ovn-preview:
 endif::[]


### PR DESCRIPTION
So, it's possible to configure the CNO for all installation types, not just AWS.

@kalexand-rh, what are you thoughts on placement for this content? Ignition configuration happens prior to creating manifests, so I placed the modules for configuring the CNO by editing manifests after. Unlike the AWS install, I notice for vSphere the example file doesn't include any networking parameters; Is that not configurable for vSphere?

This probably needs deeper investigation but I wanted to start this.

Thanks!