### PR TITLE
removed images attribute from SM

### DIFF
--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -3,7 +3,6 @@
 // The following are shared by all RHOSSM documents:
 :toc:
 :toclevels: 4
-:imagesdir: service_mesh/images
 :experimental:
 //
 // Product content attributes, that is, substitution variables in the files.


### PR DESCRIPTION
@JStickler @geekspertise removed this attribute as it was overriding it for the customer portal docs. It could also have been contributing to the missing images.