### PR TITLE
TP12 Release Notes Update (Add MAISTRA-684)

### DIFF
--- a/modules/ossm-cr-tracing-jaeger.adoc
+++ b/modules/ossm-cr-tracing-jaeger.adoc
@@ -14,6 +14,7 @@ This example illustrates tracing parameters for the {ProductName} custom resourc
   tracing:
       enabled: false
       jaeger:
+        tag: 1.13.1
         template: all-in-one
         agentStrategy: DaemonSet
 ----

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -34,9 +34,89 @@ to set the *enabled* field in the *istio_cni* section to `true`.
 While Kafka publisher is included in the release as part of Jaeger, it is not supported.
 ====
 
+[id="ossm-rn-known-issues-sm_{context}"]
+== {ProductName} Issues
+
 These are the known issues in {ProductName} at this time:
 
-* https://issues.jboss.org/browse/MAISTRA-62[MAISTRA-62] After a successful Istio installation, when upgrading an OCP cluster from 3.10 to 3.11, the storage upgrade task fails causing the entire upgrade process to fail.
+* https://issues.jboss.org/browse/MAISTRA-684[MAISTRA-684] The default Jaeger version in the `istio-operator` is 1.12.0, which does not match Jaeger version 1.13.1 that shipped in {ProductName} {ProductVersion}.
++
+If you install {ProductName} {ProductVersion} without changing the Jaeger version to 1.13.1, this is what you see when you check the pods in `istio-system`:
++
+----
+$ oc get pods -n istio-system
+
+NAME                                      READY   STATUS             RESTARTS   AGE
+elasticsearch-0                           1/1     Running            0          16m
+grafana-694d54c786-m6dfc                  2/2     Running            0          18m
+istio-citadel-7658c96954-r8p46            1/1     Running            0          18m
+istio-egressgateway-d759556b8-hwc7n       1/1     Running            0          18m
+istio-galley-7cf565999f-b729t             1/1     Running            0          18m
+istio-ingressgateway-bc97545d5-5mpw4      1/1     Running            0          18m
+istio-pilot-dd7c67fb5-r8nbt               2/2     Running            0          29m
+istio-policy-b5df8c557-5xbbl              2/2     Running            0          18m
+istio-sidecar-injector-5bccb75987-xl6t6   1/1     Running            0          18m
+istio-telemetry-7f86b4f6d9-kgl5p          2/2     Running            0          30m
+jaeger-collector-85c597698c-54b2c         0/1     ImagePullBackOff   0          18m
+jaeger-query-59b877c9d9-92vmj             1/3     ImagePullBackOff   0          18m
+kiali-54ff784b57-8clh2                    1/1     Running            0          18m
+prometheus-7b89468cf6-pbnqh               2/2     Running            0          18m
+----
++
+Run this command to see `istio-system` events:
++
+----
+$ oc get events -n istio-system
+----
++
+You will see this error:
++
+----
+...
+8m50s       Warning   Failed                         pod/jaeger-query-59b877c9d9-92vmj              Failed to pull image "registry.redhat.io/distributed-tracing-tech-preview/jaeger-agent:1.12.0": rpc error: code = Unknown desc = Error reading manifest 1.12.0 in registry.redhat.io/distributed-tracing-tech-preview/jaeger-agent: error parsing HTTP 404 response body: invalid character 'F' looking for beginning of value: "File not found.\""
+...
+----
++
+The workaround is to make the following change to your custom resource to ensure you install Jaeger 1.13.1:
++
+[source,yaml]
+----
+  tracing:
+        enabled: true
+        jaeger:
+          tag: 1.13.1
+----
+
+* https://issues.jboss.org/browse/MAISTRA-622[MAISTRA-622] In Maistra 0.12.0/TP12, permissive mode does not work. The user has the option to use Plain text mode or Mutual TLS mode, but not permissive.
+
+* https://issues.jboss.org/browse/MAISTRA-572[MAISTRA-572] Jaeger cannot be used with Kiali. In this release Jaeger is configured to use the OAuth proxy, but is also only configured to work through a browser and doesn't allow service access.  Kiali cannot properly communicate with the Jaeger endpoint and it considers Jaeger to be disabled.  See also https://issues.jboss.org/browse/TRACING-591[TRACING-591].
+
+* https://issues.jboss.org/browse/MAISTRA-465[MAISTRA-465] The Maistra operator fails to create a service for operator metrics.
+
+* https://issues.jboss.org/browse/MAISTRA-453[MAISTRA-453] If you create a new project and deploy pods immediately, sidecar injection does not occur. The operator fails to add the `maistra.io/member-of` before the pods are created, therefore the pods must be deleted and recreated for sidecar injection to occur.
+
+* https://issues.jboss.org/browse/MAISTRA-357[MAISTRA-357] In OpenShift 4 Beta on AWS, it is not possible, out of the box, to access a TCP or HTTPS service through the ingress gateway on a port other than port 80. The AWS load balancer has a health check that verifies if port 80 on the service endpoint is active.
++
+The load balancer health check only checks the first port defined in the Istio ingress gateway ports list. This port is configured as 80/HTTP:31380/TCP. Without a service running on this port, the load balancer health check fails.
++
+To check HTTPS or TCP traffic by using an ingress gateway, you must have an existing HTTP service, for example, the Bookinfo sample application product page running on the ingress gateway port 80. Alternatively, using the AWS EC2 console, you can change the port that the load balancer uses to perform the health check, and replace 80 with the port your service actually uses.
+
+* https://issues.jboss.org/browse/MAISTRA-348[MAISTRA-348] To access a TCP service by using the ingress gateway on a port other than 80 or 443, use the service hostname provided by the AWS load balancer rather than the OpenShift router.
++
+The istio-ingressgateway route hostname (for example, `istio-ingressgateway-istio-system.apps.[cluster name].openshift.com`) works with port 80 or port 443 traffic. However, that route hostname does not support other port traffic.
++
+To access service(s) running on the ingress gateway TCP port(s), you can retrieve the istio-ingressgateway external hostname (for example,
+`[uuid].[aws region].elb.amazonaws.com`) and then check traffic by using that external hostname value.
++
+To retrieve the external IP hostname value, issue this command:
++
+----
+$ oc -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+----
+
+* https://issues.jboss.org/browse/MAISTRA-193[MAISTRA-193] Unexpected console info messages are visible when health checking is enabled for citadel.
+
+* https://issues.jboss.org/browse/MAISTRA-158[MAISTRA-158] Applying multiple gateways referencing the same hostname will cause all gateways to stop functioning.
 
 * https://issues.jboss.org/browse/MAISTRA-108[MAISTRA-108] Part of the process to install Operator Lifecycle Manager (OLM) in an {product-title} cluster is to run the https://docs.openshift.com/container-platform/3.11/install_config/installing-operator-framework.html#installing-olm-using-ansible_installing-operator-framework[registry authorization playbook], but an error prevents the process from completing successfully.
 +
@@ -64,41 +144,15 @@ pass:quotes[*kubeConfigFile: /dev/null*]
 +
 Create a soft link from `/var/lib/origin/null` to `/dev/null` and replace the two kubeConfigFile variables to `/var/lib/origin/null`. This makes the task think /var/lib/origin/null is an asset in the origin "perimeter" and continue running.
 
-* https://issues.jboss.org/browse/MAISTRA-158[MAISTRA-158] Applying multiple gateways referencing the same hostname will cause all gateways to stop functioning.
+* https://issues.jboss.org/browse/MAISTRA-62[MAISTRA-62] After a successful Istio installation, when upgrading an OCP cluster from 3.10 to 3.11, the storage upgrade task fails causing the entire upgrade process to fail.
 
-* https://issues.jboss.org/browse/MAISTRA-193[MAISTRA-193] Unexpected console info messages are visible when health checking is enabled for citadel.
+[id="ossm-rn-known-issues-kiali_{context}"]
+== Kiali Issues
 
-* https://issues.jboss.org/browse/MAISTRA-348[MAISTRA-348] To access a TCP service by using the ingress gateway on a port other than 80 or 443, use the service hostname provided by the AWS load balancer rather than the OpenShift router.
-+
-The istio-ingressgateway route hostname (for example, `istio-ingressgateway-istio-system.apps.[cluster name].openshift.com`) works with port 80 or port 443 traffic. However, that route hostname does not support other port traffic.
-+
-To access service(s) running on the ingress gateway TCP port(s), you can retrieve the istio-ingressgateway external hostname (for example,
-`[uuid].[aws region].elb.amazonaws.com`) and then check traffic by using that external hostname value.
-+
-To retrieve the external IP hostname value, issue this command:
-+
-----
-$ oc -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
-----
-* https://issues.jboss.org/browse/MAISTRA-357[MAISTRA-357] In OpenShift 4 Beta on AWS, it is not possible, out of the box, to access a TCP or HTTPS service through the ingress gateway on a port other than port 80. The AWS load balancer has a health check that verifies if port 80 on the service endpoint is active.
-+
-The load balancer health check only checks the first port defined in the Istio ingress gateway ports list. This port is configured as 80/HTTP:31380/TCP. Without a service running on this port, the load balancer health check fails.
-+
-To check HTTPS or TCP traffic by using an ingress gateway, you must have an existing HTTP service, for example, the Bookinfo sample application product page running on the ingress gateway port 80. Alternatively, using the AWS EC2 console, you can change the port that the load balancer uses to perform the health check, and replace 80 with the port your service actually uses.
-
-* https://issues.jboss.org/browse/MAISTRA-453[MAISTRA-453] If you create a new project and deploy pods immediately, sidecar injection does not occur. The operator fails to add the `maistra.io/member-of` before the pods are created, therefore the pods must be deleted and recreated for sidecar injection to occur.
-
-* https://issues.jboss.org/browse/MAISTRA-465[MAISTRA-465] The Maistra operator fails to create a service for operator metrics.
-
-* https://issues.jboss.org/browse/MAISTRA-572[MAISTRA-572] Jaeger cannot be used with Kiali. In this release Jaeger is configured to use the OAuth proxy, but is also only configured to work through a browser and doesn't allow service access.  Kiali cannot properly communicate with the Jaeger endpoint and it considers Jaeger to be disabled.  See also https://issues.jboss.org/browse/TRACING-591[TRACING-591].
-
-* https://issues.jboss.org/browse/MAISTRA-622[MAISTRA-622]
-In Maistra 0.12.0/TP12, permissive mode does not work. The user has the option to use Plain text mode or Mutual TLS mode, but not permissive.
-
-* https://github.com/kiali/kiali/issues/507[KIALI-507] Kiali does not support Internet Explorer 11. This is because the underlying frameworks do not support Internet Explorer. To access the Kiali console, use one of the two most recent versions of the Chrome, Edge, Firefox or Safari browser.
-
-* https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.
+* https://issues.jboss.org/browse/KIALI-3118[KIALI-3118] After changes to the ServiceMeshMemberRoll, for example adding or removing namespaces, the Kiali pod restarts and then displays errors on the Graph page while the Kiali pod is restarting.
 
 * https://issues.jboss.org/browse/KIALI-3096[KIALI-3096] Runtime metrics fail in {ProductShortName}. There is an oauth filter between the {ProductShortname} and Prometheus, requiring a bearer token to be passed to Prometheus before access will be granted.  Kiali has been updated to use this token when communicating to the Prometheus server, but the application metrics are currently failing with 403 errors.
 
-* https://issues.jboss.org/browse/KIALI-3118[KIALI-3118] After changes to the ServiceMeshMemberRoll, for example adding or removing namespaces, the Kiali pod restarts and then displays errors on the Graph page while the Kiali pod is restarting.
+* https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.
+
+* https://github.com/kiali/kiali/issues/507[KIALI-507] Kiali does not support Internet Explorer 11. This is because the underlying frameworks do not support Internet Explorer. To access the Kiali console, use one of the two most recent versions of the Chrome, Edge, Firefox or Safari browser.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -13,7 +13,7 @@ Result – If changed, describe the current user experience
 
 == New features Technology Preview 12
 
-This release of {ProductName} adds support for Istio 1.1.8, Jaeger 1.13.1, Kiali 1.0.0, the 3scale Istio Adapter 0.7.1.
+This release of {ProductName} adds support for Istio 1.1.8, Jaeger 1.13.1, Kiali 1.0.0, and the 3scale Istio Adapter 0.7.1.
 
 Other notable changes in this release include the following:
 
@@ -21,11 +21,11 @@ Other notable changes in this release include the following:
 * Adds support for Kubernetes Container Network Interface (CNI).
 * Adds support for Operator Lifecycle Management (OLM).
 * Updates the Istio OpenShift Router for multitenancy.
-* Defaults to a newer approach to configuring the control planes which includes support for multitenancy.  For this release, the user can still use the previous approach for configuring a single tenant.
+* Defaults to configuring the control planes for multitenancy. You can still configure a single tenant control plane in {ProductName} {ProductVersion}.
 
 [NOTE]
 ====
-To reduce the permissions required for installation and to simplify installation and support, future releases will remove the older approach to single tenancy and support only the newer approach for one or more tenants.
+To simplify installation and support, future releases will only support the a multi-tenant control plane for one or more tenants.
 ====
 
 == New features Technology Preview 11

--- a/modules/ossm-support.adoc
+++ b/modules/ossm-support.adoc
@@ -13,4 +13,4 @@ If you experience difficulty with a procedure described in this documentation, v
 * Submit a support case to Red Hat Global Support Services (GSS)
 * Access other product documentation
 
-If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at http://bugzilla.redhat.com against *Product* for the *Documentation* component. Please provide specific details, such as the section number, guide name, and {product-title_short} version so we can easily locate the content.
+If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at http://bugzilla.redhat.com against *Product* for the *Documentation* component. Please provide specific details, such as the section number, guide name, and {ProductShortName} version so we can easily locate the content.

--- a/service_mesh/servicemesh-release-notes.adoc
+++ b/service_mesh/servicemesh-release-notes.adoc
@@ -15,6 +15,6 @@ include::modules/ossm-support.adoc[leveloffset=+1]
 
 include::modules/ossm-rn-new-features.adoc[leveloffset=+1]
 
-include::modules/ossm-rn-fixed-issues.adoc[leveloffset=+1]
-
 include::modules/ossm-rn-known-issues.adoc[leveloffset=+1]
+
+include::modules/ossm-rn-fixed-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
I've added MAISTRA-684 (Jaeger version in istio-operator does not match the shipped version) with the workaround prescribed in JIRA. I also cleaned up the release notes a bit and updated the Jaeger/Tracing yaml example in the install process to reflect the changes in MAISTRA-684). 

@rcernich @brian-avery and @tvieira can you take a look at this for technical accuracy. 

@JStickler can you provide a peer review?