### PR TITLE
Bug 1720351 Remove broken link

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -919,7 +919,7 @@ $ ansible-playbook -vvv -i ${INVENTORY_FILE} playbooks/openshift-prometheus/conf
 ====
 Make sure you have nodes labeled with `node-role.kubernetes.io/infra=true`, which
 is the default value for `openshift_prometheus_node_selector`. If you want to
-use other node selectors, please see xref:#openshift-prometheus-additional-deploy[Deploy Using Node-Selector]. 
+use other node selectors, please see xref:#openshift-prometheus-additional-deploy[Deploy Using Node-Selector].
 ====
 
 [[openshift-prometheus-additional-deploy]]
@@ -1076,10 +1076,6 @@ by setting the corresponding role variable, for example:
 openshift_prometheus_alertmanager_limits_memory: 1Gi
 openshift_prometheus_oauth_proxy_cpu_requests: 100m
 ----
-
-For more detailed information, see
-link:https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_prometheus#openshift-prometheus[OpenShift
-Prometheus].
 
 [NOTE]
 ====


### PR DESCRIPTION
In 3.9 and 3.10 only, Chapter 34.12.2.3 references a broken link to a GH page. This text does not appear after 3.10. 

This PR is for `enterprise-3.9'. If it CP's to 'enterprise-3.10' then no separate PR required. 

https://bugzilla.redhat.com/show_bug.cgi?id=1720351

@openshift/team-documentation 