### PR TITLE
4.2 installation stubs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -91,6 +91,35 @@ Topics:
   Topics:
   - Name: Installing a cluster on AWS using CloudFormation templates
     File: installing-aws-user-infra
+#- Name: Installing on Azure
+#  Dir: installing_azure
+#  Topics:
+#  - Name: Configuring an Azure account
+#    File: installing-azure-account
+#  - Name: Installing a cluster quickly on Azure
+#    File: installing-azure-default
+#  - Name: Installing a cluster on Azure with customizations
+#    File: installing-azure-customizations
+#  - Name: Uninstalling a cluster on Azure
+#    File: uninstalling-cluster-azure
+#- Name: Installing on GCP
+#  Dir: installing_gcp
+#  Topics:
+#  - Name: Configuring an GCP account
+#    File: installing-gcp-account
+#  - Name: Installing a cluster quickly on GCP
+#    File: installing-gcp-default
+#  - Name: Installing a cluster on GCP with customizations
+#    File: installing-gcp-customizations
+#  - Name: Uninstalling a cluster on GCP
+#    File: uninstalling-cluster-gcp
+#- Name: Installing in a disconnected environment
+#  Dir: installing_disconnected
+#  Topics:
+#  - Name: Preparing for a disconnected installation
+#    File: installing-disconnected-preparations
+#  - Name: Installing in a disconnected environment
+#    File: installing-disconnected
 - Name: Installing on bare metal
   Dir: installing_bare_metal
   Topics:
@@ -111,6 +140,8 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Configuring your firewall
     File: configuring-firewall
+#  - Name: Configuring a custom certificate authority
+#    File: configuring-custom-ca
 ---
 Name: Updating clusters
 Dir: updating
@@ -122,6 +153,8 @@ Topics:
   File: updating-cluster-cli
 - Name: Updating a cluster that includes RHEL compute machines
   File: updating-cluster-rhel-compute
+#- Name: Updating a disconnected cluster
+#  File: updating-disconnected-cluster
 # - Name: Troubleshooting an update
 #  File: updating-troubleshooting
 ---

--- a/installing/install_config/configuring-custom-ca.adoc
+++ b/installing/install_config/configuring-custom-ca.adoc
@@ -1,0 +1,11 @@
+[id="configuring-custom-ca"]
+= Configuring a custom certificate authority
+include::modules/common-attributes.adoc[]
+:context: configuring-custom-ca
+
+toc::[]
+
+If you install {product-title} with a proxy or in a disconnected environment,
+you might need to configure a custom certificate authority (CA).
+
+//include::modules/configuring-firewall.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-account.adoc
+++ b/installing/installing_azure/installing-azure-account.adoc
@@ -1,0 +1,26 @@
+[id="installing-azure-account"]
+= Configuring an Azure account
+include::modules/common-attributes.adoc[]
+:context: installing-azure-account
+
+toc::[]
+
+Before you can install {product-title}, you must configure a Microsoft Azure
+ account.
+
+include::modules/installation-aws-route53.adoc[leveloffset=+1]
+
+include::modules/installation-aws-limits.adoc[leveloffset=+1]
+
+include::modules/installation-aws-permissions.adoc[leveloffset=+1]
+
+include::modules/installation-aws-iam-user.adoc[leveloffset=+1]
+
+include::modules/installation-aws-regions.adoc[leveloffset=+1]
+
+.Next steps
+
+* Install an {product-title} cluster. You can
+xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[install a customized cluster]
+or xref:../../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[quickly install a cluster]
+with default options.

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -1,0 +1,47 @@
+[id="installing-azure-customizations"]
+= Installing a cluster on Azjre with customizations
+include::modules/common-attributes.adoc[]
+:context: installing-azure-customizations
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a customized
+cluster on infrastructure that the installation program provisions on
+Microsoft Azure. To customize the installation, you modify
+some parameters in the `install-config.yaml` file before you install the cluster.
+
+.Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account]
+to host the cluster.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+1]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+//include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+//include::modules/installing-aws-customizations.adoc[leveloffset=+1]
+
+include::modules/cli-install.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../telemetry/opting-out-of-telemetry.adoc#opting-out-of-telemetry[opt out of telemetry].

--- a/installing/installing_azure/installing-azure-default.adoc
+++ b/installing/installing_azure/installing-azure-default.adoc
@@ -1,0 +1,37 @@
+[id="installing-azure-default"]
+= Installing a cluster quickly on Azure
+include::modules/common-attributes.adoc[]
+:context: installing-azure-default
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster on
+Microsoft Azure that uses the default configuration options.
+
+.Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account]
+to host the cluster.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-install.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../telemetry/opting-out-of-telemetry.adoc#opting-out-of-telemetry[opt out of telemetry].

--- a/installing/installing_azure/uninstalling-cluster-azure.adoc
+++ b/installing/installing_azure/uninstalling-cluster-azure.adoc
@@ -1,0 +1,10 @@
+[id="uninstalling-cluster-azure"]
+= Uninstalling a cluster on Azure
+include::modules/common-attributes.adoc[]
+:context: uninstall-cluster-azure
+
+toc::[]
+
+You can remove a cluster that you deployed to Microsoft Azure.
+
+//include::modules/installation-uninstall-aws.adoc[leveloffset=+1]

--- a/installing/installing_disconnected/installing-disconnected-preparations.adoc
+++ b/installing/installing_disconnected/installing-disconnected-preparations.adoc
@@ -1,0 +1,19 @@
+[id="installing-disconnected-preparations"]
+= Preparing to install a disconnected cluster
+include::modules/common-attributes.adoc[]
+:context: installing-disconnected-preparations
+
+toc::[]
+
+Before you install a cluster on infrastructure that you provision in a
+disconnected environment, you must prepare the environment.
+
+//include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+
+.Next steps
+
+* Install a cluster on infrastructure that you provision, such as
+xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[VMware vSphere]
+or
+xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal].

--- a/installing/installing_disconnected/installing-disconnected.adoc
+++ b/installing/installing_disconnected/installing-disconnected.adoc
@@ -1,0 +1,45 @@
+[id="installing-disconnected"]
+= Installing a disconnected cluster
+include::modules/common-attributes.adoc[]
+:context: installing-disconnected
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster on
+infrastructure that you provision in a disconnected environment.
+
+.Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* xref:../../installing/installing_disconnected/installing-disconnected-preparations.adoc#installing-disconnected-preparations[Prepare your environment]
+to host the cluster.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+1]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+//include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
+
+//include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-install.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../telemetry/opting-out-of-telemetry.adoc#opting-out-of-telemetry[opt out of telemetry].

--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -1,0 +1,26 @@
+[id="installing-gcp-account"]
+= Configuring a GCP account
+include::modules/common-attributes.adoc[]
+:context: installing-gcp-account
+
+toc::[]
+
+Before you can install {product-title}, you must configure an
+Google Cloud Platform (GCP) account.
+
+//include::modules/installation-aws-route53.adoc[leveloffset=+1]
+
+//include::modules/installation-aws-limits.adoc[leveloffset=+1]
+
+//include::modules/installation-aws-permissions.adoc[leveloffset=+1]
+
+//include::modules/installation-aws-iam-user.adoc[leveloffset=+1]
+
+//include::modules/installation-aws-regions.adoc[leveloffset=+1]
+
+.Next steps
+
+* Install an {product-title} cluster. You can
+xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[install a customized cluster]
+or xref:../../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[quickly install a cluster]
+with default options.

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -1,0 +1,47 @@
+[id="installing-gcp-customizations"]
+= Installing a cluster on GCP with customizations
+include::modules/common-attributes.adoc[]
+:context: install-customizations-cloud
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a customized
+cluster on infrastructure that the installation program provisions on
+Google Cloud Platform (GCP). To customize the installation, you modify
+some parameters in the `install-config.yaml` file before you install the cluster.
+
+.Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
+to host the cluster.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+1]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+//include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+//include::modules/installing-aws-customizations.adoc[leveloffset=+1]
+
+//include::modules/cli-install.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../telemetry/opting-out-of-telemetry.adoc#opting-out-of-telemetry[opt out of telemetry].

--- a/installing/installing_gcp/installing-gcp-default.adoc
+++ b/installing/installing_gcp/installing-gcp-default.adoc
@@ -1,0 +1,37 @@
+[id="installing-gcp-default"]
+= Installing a cluster quickly on GCP
+include::modules/common-attributes.adoc[]
+:context: installing-gcp-default
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster on
+Google Cloud Platform (GCP) that uses the default configuration options.
+
+.Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
+to host the cluster.
+* If you use a firewall, you must
+xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+//include::modules/cli-install.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../telemetry/opting-out-of-telemetry.adoc#opting-out-of-telemetry[opt out of telemetry].

--- a/installing/installing_gcp/uninstalling-cluster-gcp.adoc
+++ b/installing/installing_gcp/uninstalling-cluster-gcp.adoc
@@ -1,0 +1,10 @@
+[id="uninstalling-cluster-gcp"]
+= Uninstalling a cluster on GCP
+include::modules/common-attributes.adoc[]
+:context: uninstalling-cluster-gcp
+
+toc::[]
+
+You can remove a cluster that you deployed to Google Cloud Platform (GCP).
+
+// include::modules/installation-uninstall-aws.adoc[leveloffset=+1]

--- a/updating/updating-disconnected-cluster.adoc
+++ b/updating/updating-disconnected-cluster.adoc
@@ -1,0 +1,20 @@
+[id="updating-disconnected-cluster"]
+= Updating a disconnected cluster to a minor version
+include::modules/common-attributes.adoc[]
+:context: updating-disconnected-cluster
+
+toc::[]
+
+You can update, or upgrade, an {product-title} cluster that you installed in a
+disconnected environment to a minor version by using the web console.
+
+.Prerequisites
+
+* Access to the cluster as a user with `admin` privileges.
+See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].
+
+//mirror module
+
+include::modules/update-service-overview.adoc[leveloffset=+1]
+
+include::modules/update-upgrading-web.adoc[leveloffset=+1]


### PR DESCRIPTION
I don't want to fight merge conflicts in the installation TOC, so I created stubs for the stories that are associated with the Azure, GCP, and disconnected epics and added them to the TOC. I'll uncomment them as I complete drafts of the assemblies.

@openshift/team-documentation, any objections?