### PR TITLE
Add multitenant isolation using NetworkPolicy objects

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// networking/configuring-networkpolicy.adoc
+
+[id="nw-networkpolicy-multitenant-isolation_{context}"]
+= Configuring multitenant isolation using NetworkPolicy
+
+You can configure your project to isolate it from Pods and Services in other
+projects.
+
+.Prerequisites
+
+* A cluster using the OpenShift SDN network plug-in with `mode: NetworkPolicy`
+set. This mode is the default for OpenShift SDN.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* You must log in to the cluster.
+
+.Procedure
+
+. Create the following files containing NetworkPolicy object definitions:
+.. A file named `allow-from-openshift-ingress.yaml` containing the following:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----
+
+.. A file named `allow-from-openshift-monitoring.yaml` containing the
+following:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----
+
+. For each policy file, run the following command to create the NetworkPolicy
+object:
++
+----
+$ oc apply -f <policy-name>.yaml \ <1>
+  -n <project> <2>
+----
+<1> Replace `<policy-name>` with the filename of the file containing the policy.
+<2> Replace `<project>` with the name of the project to apply the NetworkPolicy
+object to.
+
+. Optional: Confirm that the NetworkPolicy object exists in your current project
+by running the following command:
++
+----
+$ oc get networkpolicy <policy-name> -o yaml
+----
++
+In the following example, the `allow-from-openshift-ingress` NetworkPolicy
+object is displayed:
++
+----
+$ oc get networkpolicy allow-from-openshift-ingress -o yaml
+
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: project1
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----

--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-networkpolicy.adoc
+
+[id="networkpolicy-adding-network-policy-objects-to-the-new-project-template_{context}"]
+= Adding network policy objects to the new project template
+
+As a cluster administrator, you can add network policy objects to the default template for new projects.
+{product-title} will automatically create all the NetworkPolicy CRs specified in the template in the project.
+
+.Prerequisites
+
+* A cluster using the OpenShift SDN network plug-in with `mode: NetworkPolicy`
+set. This mode is the default for OpenShift SDN.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* You must log in to the cluster with a user with `cluster-admin` privileges.
+* You must have created a custom default project template for new projects.
+
+.Procedure
+
+. Edit the default template for a new project by running the following command:
++
+----
+$ oc edit template <project_template> -n openshift-config
+----
++
+Replace `<project_template>` with the name of the default template that you
+configured for your cluster. The default template name is `project-request`.
+
+. In the template, add each NetworkPolicy object as an element to the `objects`
+parameter. The `objects` parameter accepts a collection of one or more objects.
++
+In the following example, the `objects` parameter collection includes several
+NetworkPolicy objects:
++
+[source,yaml]
+----
+objects:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-same-namespace
+  spec:
+    podSelector:
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+...
+----
+
+. Optional: Create a new project to confirm that your network policy objects are created successfully by running the following commands:
+
+.. Create a new project:
++
+----
+oc new-project <project>
+----
+<1> Replace `<project>` with the name for the project you are creating.
+
+.. Confirm that the network policy objects in the new project template exist in the new project:
++
+----
+oc get networkpolicy
+NAME                           POD-SELECTOR   AGE
+allow-from-openshift-ingress   <none>         7s
+allow-from-same-namespace      <none>         7s
+----

--- a/networking/configuring-networkpolicy.adoc
+++ b/networking/configuring-networkpolicy.adoc
@@ -14,3 +14,15 @@ include::modules/nw-networkpolicy-create.adoc[leveloffset=+1]
 include::modules/nw-networkpolicy-delete.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-view.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+1]
+
+[id="nw-networkpolicy-creating-default-networkpolicy-objects-for-a-new-project"]
+= Creating default network policies for a new project
+
+As a cluster administrator, you can modify the new project template to
+automatically include NetworkPolicy objects when you create a new project.
+
+include::modules/modifying-template-for-new-projects.adoc[leveloffset=+2]
+
+include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+2]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1719936

Updated to include new project template module directly.

~This is awkward, because we already have a module that explains how to create a default new project template for the cluster, but that needs to be done so that NetworkPolicy objects can be added to it. But as I understand it, I can't link to that from a module, so I put the entire contents in the assembly.~

~I'm open to suggestions on alternate approaches for this.~