### PR TITLE
BZ1726493 - fixed 2 typos in release notes/images

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -1049,8 +1049,8 @@ openshift4/postgresql-apb
 openshift4/ose-haproxy-router-base
 openshift4/ose-azure-machine-controllers
 openshift4/ose-baremetal-machine-controllers
-openshift4/ose-cluster-update-keyso
-penshift4/ose-multus-admission-controller
+openshift4/ose-cluster-update-keys
+openshift4/ose-multus-admission-controller
 openshift4/ose-openstack-machine-controllers
 openshift4/ose-sriov-dp-admission-controller
 ----


### PR DESCRIPTION
Fixed 2 typo issues for 4.1 as described in bug; typos are located here:
https://access.redhat.com/solutions/4262071 (linked from "Release Notes RHBA-2019:0758 - OpenShift Container Platform 4.1 Image Release advisory" https://docs.openshift.com/container-platform/4.1/release_notes/ocp-4-1-release-notes.html#ocp-4-1)

PR ID mislabeled w/incorrect BZ #. BZ is #https://bugzilla.redhat.com/show_bug.cgi?id=1726493, located here:
https://bugzilla.redhat.com/show_bug.cgi?id=1726493

@openshift/team-documentation 