### PR TITLE
Changes in Node Tuning Operator 4.2 functionality.

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -14,3 +14,9 @@ Use this process to access an example Node Tuning Operator specification.
 ----
 $ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
+
+Note the default CR is meant for delivering standard node-level tuning for
+the OpenShift platform and any custom changes to the the default CR will be
+overwritten by the Operator. For custom tuning, create your own tuned CRs.
+Newly created CRs will be combined with the default CR and custom tuning
+applied to OpenShift nodes based on node/pod labels and profile priorities.

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/using-node-tuning-operator.adoc
+
+[id="custom-tuning-example_{context}"]
+= Custom tuning example
+
+Assume you want to apply custom node-level tuning for
+OpenShift nodes that run an ingress pod with label
+`tuned.openshift.io/ingress-pod-label=ingress-pod-label-value`.
+As an OpenShift admin, use the following command to create a custom tuned CR.
+
+.Example
+
+----
+oc create -f- <<_EOF_
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: ingress
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=A custom OpenShift ingress profile
+      include=openshift-control-plane
+      [sysctl]
+      net.ipv4.ip_local_port_range="1024 65535"
+      net.ipv4.tcp_tw_reuse=1
+    name: openshift-ingress
+  recommend:
+  - match:
+    - label: tuned.openshift.io/ingress-pod-label
+      value: "ingress-pod-label-value"
+      type: pod
+    priority: 10
+    profile: openshift-ingress
+_EOF_
+----

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -8,12 +8,17 @@
 The Node Tuning Operator helps you manage node-level tuning by orchestrating the
 tuned daemon. The majority of high-performance applications require some level of
 kernel tuning. The Node Tuning Operator provides a unified management interface
-to users of node-level sysctls and more flexibility to add custom tuning, which
-is currently a Technology Preview feature, specified by user needs. The Operator
+to users of node-level sysctls and more flexibility to add custom tuning
+specified by user needs. The Operator
 manages the containerized tuned daemon for {product-title} as a Kubernetes
 DaemonSet. It ensures the custom tuning specification is passed to all
 containerized tuned daemons running in the cluster in the format that the
 daemons understand. The daemons run on all nodes in the cluster, one per node.
+
+Node-level settings applied by the containerized tuned are rolled back on
+an event that triggers a profile change or when the containerized tuned
+daemon is terminated gracefully by receiving and handling a termination
+signal.
 
 The Node Tuning Operator is part of a standard {product-title} installation in
 version 4.1 and later.

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -14,9 +14,10 @@ include::modules/accessing-an-example-cluster-node-tuning-operator-specification
 
 include::modules/cluster-node-tuning-operator-default-profiles-set.adoc[leveloffset=+1]
 
-:FeatureName: Custom profiles for custom tuning specification
 include::modules/technology-preview.adoc[leveloffset=+1]
 
 include::modules/custom-tuning-specification.adoc[leveloffset=+1]
+
+include::modules/custom-tuning-example.adoc[leveloffset=+1]
 
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+1]


### PR DESCRIPTION
  - profile settings rollback on profile changes
  - the default operator's CR being overwritten
  - custom profiles are no longer a Technology Preview
  - a complete example of using custom profiles