### PR TITLE
When deploying logging, storage config is stripped out of the imported ClusterLogging instance

### DIFF
--- a/modules/efk-logging-deploying-about.adoc
+++ b/modules/efk-logging-deploying-about.adoc
@@ -104,11 +104,9 @@ You can configure a persistent storage class and size for the Elasticsearch clus
     logStore:
       type: "elasticsearch"
       elasticsearch:
-        nodeCount: 3
         storage:
-          storageClass:
-            name: "gp2"
-            size: "200G"
+          storageClassName: "gp2"
+          size: "200G"
 ----
 
 This example specifies each data node in the cluster will be bound to a `PersistentVolumeClaim` that
@@ -123,7 +121,6 @@ Omitting the `storage` block results in a deployment that includes ephemeral sto
     logStore:
       type: "elasticsearch"
       elasticsearch:
-        nodeCount: 3
         storage: {}
 ----
 ====

--- a/modules/efk-logging-elasticsearch-storage.adoc
+++ b/modules/efk-logging-elasticsearch-storage.adoc
@@ -30,9 +30,8 @@ metadata:
       elasticsearch:
         nodeCount: 3
         storage:
-          storageClass: 
-            name: "gp2"
-            size: "200G"
+          storageClassName: "gp2"
+          size: "200G"
 ----
 
 This example specifies each data node in the cluster is bound to a Persistent Volume Claim that requests "200G" of AWS General Purpose SSD (gp2) storage.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1734107