### PR TITLE
Clarify which CSR gets automatically approved.

### DIFF
--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -63,9 +63,9 @@ Because the CSRs rotate automatically, approve your CSRs within an hour
 of adding the machines to the cluster. If you do not approve them within an
 hour, the certificates will rotate, and more than two certificates will be
 present for each node. You must approve all of these certificates. After you
-approve the initial CSRs, the subsequent CSRs are automatically approved by the
-cluster `kube-controller-manager`. You must implement a method of automatically
-approving the kubelet serving certificate requests.
+approve the initial CSRs, the subsequent node client CSRs are automatically
+approved by the cluster `kube-controller-manager`. You must implement a method
+of automatically approving the kubelet serving certificate requests.
 ====
 
 ** To approve them individually, run the following command for each valid


### PR DESCRIPTION
commit 6912507d69af22bfb8bd49ac920ec84221b97afb added a clarifying
note that the server certificate requests must still be manually
approved somehow.  Adjust the prior text to clarify that only the node
client CSRs will be automatically approved after the first one is
approved.

Related to bug 1712268