### PR TITLE
SRVCOM-490 documentation for Knative services

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -961,3 +961,7 @@ Topics:
 #  File: understanding-serverless
 #- Name: Serverless product architecture
 #  File: serverless-architecture
+#- Name: Getting started with Knative services
+#  File: getting-started-knative-services
+#- Name: Configuring Knative services
+#  File: configuring-knative-services

--- a/modules/configuring-knative-services-domains.adoc
+++ b/modules/configuring-knative-services-domains.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * serverless/getting-started-knative-services.adoc
+
+[id="configuring-knative-services-domains_{context}"]
+= Configuring domains for Knative services
+
+The Red Hat OpenShift Serverless Operator will attempt to find the public domain that is used by the cluster and use that same domain for Knative Services. Having a domain configured makes it possible to reach services in your cluster via HTTP over the internet directly, for example, using the `curl` command.
+
+Alternatively, you can configure a different domain for Knative services or even configure a different domain for different Knative services based on labels. Once you have completed this configuration, you can create a template for the domain configuration.
+
+.Procedure
+. To change the configuration for Knative services, you must edit the `config-domain` ConfigMap in the `knative-serving` namespace using `oc edit`.
+
+   # oc edit cm config-domain -n knative-serving
+
+. Copy the sample ConfigMap and modify the relevant fields.
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  example.com: |
+----
++
+Here is an example of the configuration for the domain `example.com`, which will be used for routes with the label `app` set to `example`.
++
+[source,yaml]
+----
+data:
+  example.com: |
+    selector:
+      app: example
+----

--- a/modules/creating-knative-services.adoc
+++ b/modules/creating-knative-services.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * serverless/getting-started-knative-services.adoc
+
+[id="creating-knative-services_{context}"]
+= Creating a Knative service
+
+To create a service, you must create the `service.yaml` file.
+
+You can copy the sample below. This sample will create a sample golang application called `helloworld-go` and allows you to specify the image for that application.
+
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1alpha1 # Current version of Knative
+kind: Service
+metadata:
+  name: helloworld-go # The name of the app
+  namespace: default # The namespace the app will use
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go # The URL to the image of the app
+          env:
+            - name: TARGET # The environment variable printed out by the sample app
+              value: "Go Sample v1"
+----

--- a/modules/deploying-serverless-apps.adoc
+++ b/modules/deploying-serverless-apps.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * serverless/getting-started-knative-services.adoc
+
+[id="deploying-serverless-apps_{context}"]
+= Deploying a serverless application
+
+To deploy a serverless application, you must apply the `service.yaml` file.
+
+.Procedure
+
+. Navigate to the directory where the `service.yaml` file is contained.
+. Deploy the application by applying the `service.yaml` file.
++
+----
+$ oc apply --filename service.yaml
+----
+
+Now that service has been created and the application has been deployed, Knative will create a new immutable revision for this version of the application.
+
+Knative will also perform network programming to create a route, ingress, service, and load balancer for your application, and will automatically scale your pods up and down based on traffic, including inactive pods.

--- a/modules/domain-templates-knative-services.adoc
+++ b/modules/domain-templates-knative-services.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * serverless/knative-services.adoc
+
+[id="domain-templates-knative-services_{context}"]
+= Defining a template for the configured domain
+
+.Procedure
+. Define a `domainTemplate`.
++
+`domainTemplate` specifies the golang text template string to use when constructing the Knative service's DNS name.
++
+The default value is `{{.Name}}.{{.Namespace}}.{{.Domain}}`.
++
+An example of this DNS name would look like `myapp.mynamespace.example.com` for an application called `myapp` with a namespace called `mynamespace`, and `example.com` as the domain.
++
+- You will need to change this value if extra levels in the domain name cause issues. For example, if the wildcard certificate’s domain only supports a single level domain name.
+
+- To resolve these types of issues, use the format `{{.Name}}-{{.Namespace}}.{{.Domain}}` or remove the Namespace entirely from the template.
+
+- When choosing a new value, remember that using characters such as dashes in service or namespace names can cause conflicts and should be avoided.
++
+NOTE: It is strongly recommended to keep the namespace part of the template to avoid domain name clashes.
++
+
+. Define a `tagTemplate`.
++
+`tagTemplate` specifies the golang text template string to use when constructing the DNS name for tags within traffic blocks.
++
+Tags are similar to subroutes that enable traffic blocks to specific revisions.
+Tags are used along with the `domainTemplate` to determine the full URL for the tag in the format `{{.Name}}-{{.Tag}}`.
++
+For example, if your service is called `myapp`, the namespace is `mynamespace`, the domain is `example.com` and the tag you want is `latest`, the generated host will be `myapp-latest.mynamespace.example.com`.
+
+.Additional resources
+For more information about golang templates, see the https://www.google.com/url?q=https://golang.org/pkg/text/template/&sa=D&ust=1564657248236000&usg=AFQjCNHYHtGgv1m-F2bBMJaGyOBRBCl_rg[Go package template documentation].

--- a/modules/interacting-serverless-apps.adoc
+++ b/modules/interacting-serverless-apps.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * serverless/getting-started-knative-services.adoc
+
+[id="interacting-serverless-apps_{context}"]
+= Interacting with your serverless application
+
+To verify that your serverless application has been deployed successfully, you must get the host URL created by Knative, and then send a request to that URL and observe the output.
+
+NOTE: If you changed the application name from `helloworld-go` to a new name when creating the `service.yaml` file, replace `helloworld-go` in the commands with the new name you created.
+
+.Procedure
+
+. Find the host URL.
++
+----
+oc get ksvc helloworld-go
+NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
+helloworld-go   http://helloworld-go.default.example.com   helloworld-go-4wsd2   helloworld-go-4wsd2   True
+----
+. Make a request to your cluster and observe the output.
++
+----
+$ curl http://helloworld-go.default.example.com
+Hello World: Go Sample v1!
+----

--- a/modules/knative-serving.adoc
+++ b/modules/knative-serving.adoc
@@ -5,11 +5,11 @@
 [id="knative-serving_{context}"]
 = Knative Serving
 
-Knative Serving on {product-title} builds on Kubernetes and Maistra to support deploying and serving serverless applications.
+Knative Serving on {product-title} builds on Kubernetes and Istio to support deploying and serving serverless applications.
 
 It creates a set of Kubernetes Custom Resource Definitions (CRDs) that are used to define and control the behavior of serverless workloads on an {product-title} cluster.
 
-These CRDs can be used as building blocks to address complex use cases, such as rapid deployment of serverless containers, automatic scaling of pods, routing and network programming for Maistra components, or viewing point-in-time snapshots of deployed code and configurations.
+These CRDs can be used as building blocks to address complex use cases, such as rapid deployment of serverless containers, automatic scaling of pods, routing and network programming for Istio components, or viewing point-in-time snapshots of deployed code and configurations.
 
 [id="knative-serving-components_{context}"]
 == Knative Serving components

--- a/serverless/configuring-knative-services.adoc
+++ b/serverless/configuring-knative-services.adoc
@@ -1,0 +1,11 @@
+[id="configuring-knative-services"]
+= Configuring Knative services
+include::modules/common-attributes.adoc[]
+:context: getting-started-knative-services
+
+You must configure the 'yaml' file for each Knative service before you can deploy an application.
+
+This section provides information on basic Knative service `yaml` configuration tasks, such as configuring a domain for the service.
+
+include::modules/configuring-knative-services-domains.adoc[leveloffset=+1]
+include::modules/domain-templates-knative-services.adoc[leveloffset=+1]

--- a/serverless/getting-started-knative-services.adoc
+++ b/serverless/getting-started-knative-services.adoc
@@ -1,0 +1,10 @@
+[id="getting-started-knative-services"]
+= Getting started with Knative services
+include::modules/common-attributes.adoc[]
+:context: getting-started-knative-services
+
+Knative services are Kubernetes services that a user creates to deploy a serverless application. Each Knative service is defined by a route and a configuration, contained in a `.yaml` file.
+
+include::modules/creating-knative-services.adoc[leveloffset=+1]
+include::modules/deploying-serverless-apps.adoc[leveloffset=+1]
+include::modules/interacting-serverless-apps.adoc[leveloffset=+1]

--- a/serverless/understanding-serverless.adoc
+++ b/serverless/understanding-serverless.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 :FeatureName: Red Hat OpenShift Serverless
 include::modules/technology-preview.adoc[leveloffset=+1]
 
-Red Hat OpenShift Serverless is based on the open source Knative project, which provides portability and consistency across hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform. It implements the building blocks for developers to create modern, source-centric, container-based applcations through a series of Custom Resource Definitions (CRDs) and associated controllers in Kubernetes.
+Red Hat OpenShift Serverless is based on the open source Knative project, which provides portability and consistency across hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform. It implements the building blocks for developers to create modern, source-centric, container-based applications through a series of Custom Resource Definitions (CRDs) and associated controllers in Kubernetes.
 
 Red Hat OpenShift Serverless simplifies the process of getting code from development into production by reducing the requirement for developer input in infrastructure set up or back-end development.
 Developers on Red Hat OpenShift Serverless can use the provided Kubernetes-native APIs, as well as familiar languages and frameworks to deploy applications and container workloads.


### PR DESCRIPTION
Adding documentation for getting started with Knative services, configuring domains and deploying serverless applications.