### PR TITLE
Add instructions to isolate compute workload

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -21,14 +21,21 @@ new MachineSet.
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
 [id="creating-infrastructure-machinesets-production"]
-== Creating infrastructure MachineSets for production environments
+== Creating infrastructure and compute MachineSets for production environments
 
 In a production deployment, deploy at least three MachineSets to hold
 infrastructure components. Both the logging aggregation solution and
 the service mesh deploy Elasticsearch, and Elasticsearch requires three
 instances that are installed on different nodes. For high availability, install
 deploy these nodes to different availability zones. Since you need different
-MachineSets for each availability zone, create at least three MachineSets.
+MachineSets for each availability zone, create at least three MachineSets with
+role "infra".
+
+Compute nodes are required to isolate workload that should not use the
+infrastructure nodes becaus the default worker machinesets do not produce node
+labels required to select the default worker nodes. Create compute MachineSets
+for each availability zone and then disable the default worker machinesets by
+scaling them to zero.
 
 [id="creating-infrastructure-machinesets-clouds"]
 === Creating MachineSets for different clouds
@@ -43,6 +50,8 @@ include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 
+include::modules/machineset-disabling-default.adoc[leveloffset=+2]
+
 [id="moving-resources-to-infrastructure-machinesets"]
 == Moving resources to infrastructure MachineSets
 
@@ -56,3 +65,14 @@ include::modules/infrastructure-moving-registry.adoc[leveloffset=+2]
 include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+2]
 
 include::modules/infrastructure-moving-logging.adoc[leveloffset=+2]
+
+[id="isolating-compute-workload"]
+== Isolating Compute Workload
+
+OpenShift MachineSets will produce nodes that are labeled as
+`node-role.kubernetes.io/worker` even if this is not configured on within
+the MachineSet. In order to separate infrastructure workload from compute
+workload additional MachineSets are required and the default node selector
+must be configured for the scheduler.
+
+include::modules/infrastructure-isolating-compute.adoc[leveloffset=+2]

--- a/modules/infrastructure-isolating-compute.adoc
+++ b/modules/infrastructure-isolating-compute.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+
+[id="infrastructure-isolating-compute_{context}"]
+= Configuring Cluster Default Node Selector
+
+Set the default node selector to select nodes for compute workload.
+
+.Prerequisites
+
+* Nodes running in your cluster with appropriate labels and sufficient capacity
+to handle the compute workload.
+
+.Procedure
+
+. Set the default node selector in the cluster scheduler:
++
+----
+$ oc patch schedulers.config.openshift.io cluster --type=merge \
+     -p '{"spec":{"defaultNodeSelector":"node-role.kubernetes.io/compute="}}'
+----
+
+. Add `openshift.io/node-selector` annotations for specific namespaces to
+allow them to run on other nodes:
++
+----
+$ oc annotate namespace <namespace> openshift.io/node-selector=''
+----
+
+[NOTE]
+====
+Application pods previously scheduled on cluster nodes will not be deleted
+and removed automatically.
+====

--- a/modules/machineset-disabling-default.adoc
+++ b/modules/machineset-disabling-default.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+
+[id="machineset-disabling-default_{context}"]
+= Disabling Default Worker Machinesets
+
+You must disable the default worker MachineSets in order to isolate workload
+to specific worker node roles.
+
+.Prerequisites
+
+* Deploy an {product-title} cluster.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`
+* Log in to `oc` as a user with `cluster-admin` permission.
+* Create and scale up custom MachineSets.
+
+.Procedure
+
+. View current MachineSet status.
++
+Ensure that custom machinesets are ready before disabling the default workers.
+
+.. View the current MachineSets.
++
+----
+$ oc get machinesets -n openshift-machine-api
+
+NAME                               DESIRED   CURRENT   READY   AVAILABLE   AGE
+cluster-2jcwr-compute-us-east-2a   1         1         1       1           5m20s
+cluster-2jcwr-compute-us-east-2b   1         1         1       1           5m32s
+cluster-2jcwr-compute-us-east-2c   1         1         1       1           5m41s
+cluster-2jcwr-infra-us-east-2a     1         1         1       1           4m11s
+cluster-2jcwr-infra-us-east-2b     0         0                             2m11s
+cluster-2jcwr-infra-us-east-2c     0         0                             2m11s
+cluster-2jcwr-worker-us-east-2a    1         1         1       1           2d
+cluster-2jcwr-worker-us-east-2b    1         1         1       1           2d
+cluster-2jcwr-worker-us-east-2c    1         1         1       1           2d
+----
+
+.. Scale down the default worker machinesets:
++
+----
+$ oc scale machineset <machineset_name> -n openshift-machine-api --replicas=0
+----
+
+.. Confirm machineset scale-down:
++
+----
+$ oc get machineset -n openshift-machine-api
+NAME                               DESIRED   CURRENT   READY   AVAILABLE   AGE
+cluster-2jcwr-compute-us-east-2a   1         1         1       1           17m
+cluster-2jcwr-compute-us-east-2b   1         1         1       1           17m
+cluster-2jcwr-compute-us-east-2c   1         1         1       1           17m
+cluster-2jcwr-infra-us-east-2a     1         1         1       1           19m
+cluster-2jcwr-infra-us-east-2b     0         0                             19m
+cluster-2jcwr-infra-us-east-2c     0         0                             19m
+cluster-2jcwr-worker-us-east-2a    0         0                             2d
+cluster-2jcwr-worker-us-east-2b    0         0                             2d
+cluster-2jcwr-worker-us-east-2c    0         0                             2d
+----

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -14,6 +14,9 @@ In this sample, `<infrastructureID>` is the infrastructure ID label that is
 based on the cluster ID that you set when you provisioned
 the cluster, and `<role>` is the node label to add.
 
+Nodes will appear with label `node-role.kubernetes.io/worker` in addition to
+labels explicitly defined in the MachineSet spec template spec metadata.
+
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -21,6 +24,8 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+    machine.openshift.io/cluster-api-machine-role: <role> <3>
+    machine.openshift.io/cluster-api-machine-type: <role> <3>
   name: <infrastructureID>-<role>-<zone> <2>
   namespace: openshift-machine-api
 spec:


### PR DESCRIPTION
The current instructions to add infra nodes is not complete without also having instructions describing how to isolate other compute workload to prevent it from running on the new infra nodes.

This PR adds documentation describing how to implement compute nodes with workload isolation using node selectors. While similar functionality could be achieved with taints and tolerations, it is significantly easier to implement in a secure manner with node-selectors. Current OpenShift administrators are also likely to be familiar and comfortable with how to manage node selectors.