### PR TITLE
Fix release notes table for TP features

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -659,7 +659,6 @@ features marked *GA* indicate _General Availability_.
 |-
 
 |ImageStreams with Kubernetes Resources
-|
 |GA
 |GA
 


### PR DESCRIPTION
The data in the table appears in incorrect columns due to an extraneous | in the adoc