### PR TITLE
CNV - l10n minor fix

### DIFF
--- a/modules/cnv_openshift_commands.adoc
+++ b/modules/cnv_openshift_commands.adoc
@@ -24,7 +24,7 @@ specific resource.
 stdin.
 
 |`oc process -f <config>` |Process a template into a configuration file.
-Templates have ``parameters'', which are either generated on creation
+Templates have "parameters", which are either generated on creation
 or set by the user, as well as metadata describing the template.
 
 |`oc apply -f <file>` |Apply a configuration to a resource by filename


### PR DESCRIPTION
Localization flagged an inconsistent markup on "parameter" in the CNV 1.4 (OCP 3.11) docs. This PR fixes that to make it consistent with the `oc --help` text.