### PR TITLE
CNV - scratchspace

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -965,6 +965,8 @@ Topics:
     File: cnv-uploading-local-disk-images-virtctl
   - Name: Expanding virtual storage by adding blank disk images
     File: cnv-expanding-virtual-storage-with-blank-disk-images
+  - Name: Preparing CDI scratch space
+    File: cnv-preparing-cdi-scratch-space
 ### Virtual machine live migration
   - Name: Virtual machine live migration
     File: cnv-live-migration

--- a/cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc
+++ b/cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc
@@ -1,0 +1,21 @@
+[id="cnv-preparing-cdi-scratch-space"]
+= Preparing CDI scratch space
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-preparing-cdi-scratch-space
+toc::[]
+
+include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
+
+include::modules/cnv-understanding-scratch-space.adoc[leveloffset=+1]
+
+include::modules/cnv-defining-storageclass-in-cdi-configuration.adoc[leveloffset=+1]
+
+include::modules/cnv-operations-requiring-scratch-space.adoc[leveloffset=+1]
+
+include::modules/cnv-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See the xref:../../storage/dynamic-provisioning.adoc#about_dynamic-provisioning[Dynamic provisioning] section for more information on StorageClasses and how these are defined in the cluster.
+
+

--- a/modules/cnv-cdi-supported-operations-matrix.adoc
+++ b/modules/cnv-cdi-supported-operations-matrix.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-cdi-supported-operations.adoc
+
+[id="cnv-cdi-supported-operations-matrix_{context}"]
+= CDI supported operations matrix
+
+This matrix shows the supported CDI operations for content types against endpoints, and which of these operations requires scratch space.
+
+|===
+|Content types | HTTP | HTTPS | HTTP basic auth | Registry | S3 Bucket | Upload
+
+| KubeVirt(QCOW2)        
+|&#10003; QCOW2 +
+&#10003; GZ* +
+&#10003; XZ*
+
+|&#10003; QCOW2** +
+&#10003; GZ* +
+&#10003; XZ*
+
+|&#10003; QCOW2 +
+&#10003; GZ* +
+&#10003; XZ*
+
+| &#10003; QCOW2* +
+&#9633; GZ +
+&#9633; XZ 
+
+| &#10003; QCOW2* +
+&#10003; GZ* +
+&#10003; XZ*
+| &#10003; QCOW2* +
+&#10003; GZ* +
+&#10003; XZ*
+
+| KubeVirt (RAW)          
+|&#10003; RAW +
+&#10003; GZ +
+&#10003; XZ
+
+|&#10003; RAW +
+&#10003; GZ +
+&#10003; XZ
+
+| &#10003; RAW +
+&#10003; GZ +
+&#10003; XZ
+
+| &#10003; RAW* +
+&#9633; GZ +
+&#9633; XZ
+
+| &#10003; RAW +
+&#10003; GZ +
+&#10003; XZ
+
+| &#10003; RAW* +
+&#10003; GZ* +
+&#10003; XZ*
+
+| Archive+ 
+| &#10003; TAR
+| &#10003; TAR
+| &#10003; TAR
+| &#9633; TAR
+| &#9633; TAR
+| &#9633; TAR
+|===
+
+&#10003; Supported operation
+
+&#9633; Unsupported operation
+
+$$*$$ Requires scratch space
+
+$$**$$ Requires scratch space if a custom certificate authority is required
+
++ Archive does not support block mode DVs
+
+
+
+

--- a/modules/cnv-defining-storageclass-in-cdi-configuration.adoc
+++ b/modules/cnv-defining-storageclass-in-cdi-configuration.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-cdi-scratch-space.adoc
+
+[id="cnv-defining-storageclass-in-cdi-configuration_{context}"]
+= Defining a StorageClass in the CDI configuration
+
+Define a StorageClass in the CDI configuration to dynamically provision scratch 
+space for CDI operations. 
+
+.Procedure
+
+* Use the `oc` client to edit the `cdiconfig/config` and add or edit the 
+`spec: scratchSpaceStorageClass` to match a StorageClass in the cluster.
++
+----
+$ oc edit cdiconfig/config
+----
++
+[source,yaml]
+----
+API Version:  cdi.kubevirt.io/v1alpha1
+kind: CDIConfig
+metadata:
+  name: config
+...
+spec:
+  scratchSpaceStorageClass: "<storage_class>"
+...
+----
+

--- a/modules/cnv-operations-requiring-scratch-space.adoc
+++ b/modules/cnv-operations-requiring-scratch-space.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-cdi-scratch-space.adoc
+
+[id="cnv-operations-requiring-scratch-space_{context}"]
+= CDI operations that require scratch space 
+
+[options="header"]
+|===
+| Type | Reason
+
+| Registry imports 
+| The CDI must download the image to a scratch space and extract the layers to find the image file. The image file is then passed to QEMU-IMG for conversion to a raw disk.
+
+| Upload image 
+| QEMU-IMG does not accept input from STDIN. Instead, the image to upload is saved in scratch space before it can be passed to QEMU-IMG for conversion. 
+
+| HTTP imports of archived images 
+| QEMU-IMG does not know how to handle the archive formats CDI supports. Instead, the image is unarchived and saved into scratch space before it is passed to QEMU-IMG.
+
+| HTTP imports of authenticated images 
+| QEMU-IMG inadequately handles authentication. Instead, the image is saved to scratch space and authenticated before it is passed to QEMU-IMG.
+
+| HTTP imports of custom certificates 
+| QEMU-IMG inadequately handles custom certificates of HTTPS endpoints. Instead, the CDI downloads the image to scratch space before passing the file to QEMU-IMG.
+|===

--- a/modules/cnv-understanding-scratch-space.adoc
+++ b/modules/cnv-understanding-scratch-space.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-cdi-scratch-space.adoc
+
+[id="cnv-understanding-scratch-space_{context}"]
+= Understanding scratch space 
+
+The Containerized Data Importer (CDI) requires scratch space (temporary storage) 
+to complete some operations, such as importing and uploading virtual machine images.
+During this process, the CDI provisions a scratch space PVC equal to the size of 
+the PVC backing the destination DataVolume (DV). The scratch space PVC is deleted 
+after the operation completes or aborts.
+
+The CDIConfig object allows you to define which StorageClass to use to bind the 
+scratch space PVC by setting the `scratchSpaceStorageClass` in the `spec:` 
+section of the CDIConfig object. 
+
+If the defined StorageClass does not match a StorageClass in the cluster, then 
+the default StorageClass defined for the cluster is used. If there is no 
+default StorageClass defined in the cluster, the StorageClass used to provision 
+the original DV or PVC is used. 
+
+[NOTE]
+====
+The CDI requires requesting scratch space with a `file` volume mode, regardless 
+of the PVC backing the origin DataVolume. If the origin PVC is backed by 
+`block` volume mode, you must define a StorageClass capable of provisioning 
+`file` volume mode PVCs.
+====
+
+[discrete]
+== Manual provisioning 
+
+If there are no storage classes, the CDI will use any PVCs in the project that 
+match the size requirements for the image. If there are no PVCs that match these 
+requirements, the CDI import Pod will remain in a *Pending* state until an 
+appropriate PVC is made available or until a timeout function kills the Pod. 
+


### PR DESCRIPTION
This PR covers two related stories ([CNV-1523](https://jira.coreos.com/browse/CNV-1523) and [CNV-1547](https://jira.coreos.com/browse/CNV-1547))
1. defining a storageclass in the CDI config allows scratch space to be provisioned for CDI operations that require it. This includes description of scratch space and the logic of which storageclass is used depending on the cluster. 
2. supported CDI operations matrix: content type vs endpoint, and which of these operations require scratch space.

This content is for CNV 2.0 (enterprise-4.1) and can be published immediately. 
It can also be CP'd to enterprise-4.2.