### PR TITLE
Enhance KuryrSDN configuration details

### DIFF
--- a/install_config/configuring_kuryrsdn.adoc
+++ b/install_config/configuring_kuryrsdn.adoc
@@ -24,104 +24,28 @@ machines (VMs).
 
 Kuryr-Kubernetes and {product-title} integration is primarily designed for
 {product-title} clusters running on OpenStack VMs. Kuryr-Kubernetes components
-are installed as pods on {product-title} in the `openshift-infra` namespace:
+are installed as pods on {product-title} in the `kuryr` namespace:
 
-* kuryr-controller - a single service instance, installed on any node. Modeled
-  in {product-title} as a `Deployment`.
+* kuryr-controller - a single service instance, installed on an `infra` node.
+Modeled in {product-title} as a `Deployment`.
 * kuryr-cni - container installing and configuring Kuryr as CNI driver on each
   {product-title} node. Modeled in {product-title} as a `DaemonSet`.
 
+
+The Kuryr controller watches the OpenShift API server for pod, service, and
+namespace create, update, and delete events. It maps the {product-title} API calls to
+corresponding objects in Neutron and Octavia. This means that every network
+solution that implements the Neutron trunk port functionality can be used to
+back {product-title} via Kuryr. This includes open source solutions such as OVS and
+OVN as well as Neutron-compatible commercial SDNs.
+
+
 [[kuryr-sdn-installation]]
-== Installation
+== Installing Kuryr SDN
 
-The system running openshift-ansible must be subscribed to the OSP as well as
-OCP repositories. The OpenStack integration requires a few extra packages. To
-install the dependencies, run:
-
-----
-$ sudo yum install -y ansible openshift-ansible python2-shade python-dns \
-    python2-heatclient python2-octaviaclient python-openstackclient bind-utils
-----
-
-In the Ansible nodes file, specify the following parameters in order to set up
-Kuryr-Kubernetes as the network plug-in:
-
-----
- # Enable Kuryr.
- openshift_use_openshift_sdn=False
- openshift_use_kuryr=True
- os_sdn_network_plugin_name=cni
-
- # Set userspace so that there are no iptables remains.
- openshift_node_proxy_mode='userspace'
-
- # Keystone URL.
- kuryr_openstack_auth_url=http://127.0.0.1/identity
-
- # OpenStack domain name of user owning Kuryr resources.
- kuryr_openstack_user_domain_name=default
-
- # OpenStack project name of user owning Kuryr resources.
- kuryr_openstack_user_project_name=admin
-
- # OpenStack project id for Kuryr resources.
- kuryr_openstack_project_id=ec0b31802fd043c08bc15b74d2f9a3d3
-
- # OpenStack username that will own kuryr resources.
- kuryr_openstack_username=admin
-
- # Password for that user.
- kuryr_openstack_password=password
-
- # Default Neutron security groups' IDs for Kubernetes pods
- kuryr_openstack_pod_sg_id=f74c83a8-a520-421a-930e-21b6cd098c6a,01f85594-9950-4ded-a92c-5ad546a41188
-
- # Default Neutron subnet ID for Kubernetes pods.
- kuryr_openstack_pod_subnet_id=c85cdee6-0ed1-4d8f-ae61-7afa4674b311
-
- # Default OpenStack project ID for Kubernetes resources.
- kuryr_openstack_pod_project_id=ec0b31802fd043c08bc15b74d2f9a3d3
-
- # Neutron subnet ID for Kubernetes worker node VMs.
- kuryr_openstack_worker_nodes_subnet_id=477cfa49-e641-4d31-a7b5-5bc834743f61
-
- # Default Neutron subnet ID for Kubernetes services.
- kuryr_openstack_service_subnet_id=3b31a106-4084-4db9-bc0c-00b97afe186e
-----
-
-You must also specify an OpenStack cloud provider as described in the
+For the Kuryr SDN installation on an OpenStack cloud, you must follow the steps
+described in the
 xref:configuring_openstack.adoc#install-config-configuring-openstack[OpenStack configuration documentation].
-
-Prior to the installation, you must also provide a DNS server the
-{product-title} nodes will be using for internal name resolution. OpenStack does
-not provide a node name resolution out of the box. In the following example,
-`10.20.30.40` is  the IP address of the DNS server:
-
-----
-openshift_openstack_dns_nameservers=[10.20.30.40]
-----
-
-If the DNS server supports remote updates via `nsupdate` (RFC 2136), the
-playbooks can populate it automatically, if you add the following configuration:
-
-----
-openshift_openstack_external_nsupdate_keys={private: {"key_secret": "<nsupdate key>", "key_algorithm": "<nsupdate key algorithm>", "key_name": "<nsupdate key name>", "server": 10.20.30.40}}
-----
-
-Finally, install {product-title} by changing to the playbook directory and running the *_provision_install.yml_*
-playbook. You must specify the dynamic inventory file, *_inventory.py_*, and the
-the path to the Ansible nodes file that you created:
-
-----
-$ cd /usr/share/ansible/openshift-ansible
-$ ansible-playbook --user openshift -i playbooks/openstack/inventory.py -i ansible-nodes.txt playbooks/openstack/openshift-cluster/provision_install.yml
-----
-
-If you want to do any custom setup on the created nodes before the
-{product-title} installation, you can run the *_provision.yml_* and
-*_install.yml_* playbooks separately. *_provision.yml_* will create the
-OpenStack resources (nodes, networks, and so on) and *_install.yml_* will
-install {product-title}.
 
 [[kuryr-sdn-verification]]
 == Verification
@@ -130,9 +54,8 @@ Once the installation of {product-title} is finished, you can check if Kuryr
 pods are deployed successfully:
 
 ----
-$ oc -n openshift-infra get pods -o wide
+$ oc -n kuryr get pods -o wide
 NAME                                READY     STATUS    RESTARTS   AGE       IP              NODE
-bootstrap-autoapprover-0            1/1       Running   0          3d        10.11.0.7       master-0.openshift.example.com
 kuryr-cni-ds-66kt2                  2/2       Running   0          3d        192.168.99.14   infra-node-0.openshift.example.com
 kuryr-cni-ds-ggcpz                  2/2       Running   0          3d        192.168.99.16   master-0.openshift.example.com
 kuryr-cni-ds-mhzjt                  2/2       Running   0          3d        192.168.99.6    app-node-1.openshift.example.com
@@ -141,8 +64,8 @@ kuryr-cni-ds-v8hp8                  2/2       Running   0          3d        192
 kuryr-controller-59fc7f478b-qwk4k   1/1       Running   0          3d        192.168.99.5    infra-node-1.openshift.example.com
 ----
 
-kuryr-cni pods should run on every {product-title} node. Single
-kuryr-controller instances should run on any of the nodes.
+kuryr-cni pods run on every {product-title} node. Single
+kuryr-controller instances run on any of the `infra` nodes.
 
 [NOTE]
 ====

--- a/install_config/configuring_openstack.adoc
+++ b/install_config/configuring_openstack.adoc
@@ -21,6 +21,7 @@ xref:../install_config/persistent_storage/persistent_storage_cinder.adoc#install
 
 == Before you Begin
 
+include::install_config/topics/ocp_osp_sdn.adoc[leveloffset=+2]
 include::install_config/topics/ocp_osp_prerequisites.adoc[leveloffset=+2]
 include::install_config/topics/ocp_osp_enabling_octavia.adoc[leveloffset=+2]
 include::install_config/topics/ocp_osp_admin_tasks.adoc[leveloffset=+2]

--- a/install_config/topics/ocp_osp_admin_tasks.adoc
+++ b/install_config/topics/ocp_osp_admin_tasks.adoc
@@ -32,18 +32,32 @@ $ openstack role add --user <username> --project <project> _member_
 
 The default quotas assigned to new RH OSP projects are not high enough for
 {product-title} installations. Increase the quotas to at least 30 security
-groups, 200 security group rules, and 200 ports. If kuryr SDN is enabled, and
-particularly if namespace isolation is used, increase the quotas to at least
-100 security groups, 500 security group rules, and 500 ports.
+groups, 200 security group rules, and 200 ports.
 ----
-$ openstack quota set --secgroups 30 --secgroup-rules 200 --ports 200 *<project>*
+$ openstack quota set --secgroups 30 --secgroup-rules 200 --ports 200 <project>
+<1>
 ----
+<1> For `<project>`, specify the name of the project to modify
 
-If Kuryr-SDN is used, with the namespace isolation feature enabled, there is
-an extra step to make once the project is created. It needs to be added to
-octavia.conf configuration to ensure LoadBalancer security groups belong to
-that project and can be updated to enforce services isolation across
-namespaces.
+[[osp_accounts_kuryr]]
+==== Extra steps for Kuryr SDN
+
+If Kuryr SDN is enabled, and particularly if namespace isolation is used,
+increase the next quotas need to be raised: at least 100 security groups,
+500 security group rules, and 500 ports.
+----
+$ openstack quota set --secgroups 100 --secgroup-rules 500 --ports 500 <project>
+----
+----
+$ openstack quota set --secgroups 100 --secgroup-rules 500 --ports 500 <project>
+<1>
+----
+<1> For `<project>`, specify the name of the project to modify
+
+If you enabled namespace isolation, you must add the project ID to the
+`octavia.conf` configuration file after you create the project. This step
+ensures that required LoadBalancer security groups belong to that project
+and that they can be updated to enforce services isolation across namespaces.
 
 . Get the project ID
 +
@@ -96,9 +110,12 @@ controller-0$ sudo docker restart octavia_worker
 ----
 
 
-Once the above is complete, an OpenStack administrator can create an RC file
-with all the required information to the user(s) implementing the {product-title}
-environment.
+[[env_file]]
+==== Configuring the RC file
+
+After you configure the project, an OpenStack administrator can create an RC
+file with all the required information to the user(s) implementing the
+{product-title} environment.
 
 An example RC file:
 

--- a/install_config/topics/ocp_osp_provisioning.adoc
+++ b/install_config/topics/ocp_osp_provisioning.adoc
@@ -19,9 +19,9 @@ the _all.yml_ file and all the available {product-title} cluster parameters
 that you can customize.
 
 [[all-yaml-file]]
-==== All YAML file
+==== OpenShiftSDN All YAML file
 
-The All YAML file has many options that can be modified to meet your specific needs.
+The _all.yml_ file has many options that can be modified to meet your specific needs.
 The information gathered in this file is for the provisioning portion of the instances
 required for a successful deployment of {product-title}. It
 is important to review these carefully. This document will provide a condensed
@@ -109,8 +109,11 @@ key "update-key" {
 NOTE: The key name may vary and the above is only an example.
 
 
-The following [filename]all.yaml file enables Kuryr SDN instead of the default
-openshift-sdn. Note that the example below is a condensed version and it is
+[[kuryr-all-yaml-file]]
+==== KuryrSDN All YAML file
+
+The following _all.yml_ file enables Kuryr SDN instead of the default
+OpenShiftSDN. Note that the example below is a condensed version and it is
 important to review the default template carefully.
 
 ----
@@ -303,7 +306,7 @@ openshift_master_default_subdomain: "apps.{{ (openshift_openstack_clusterid|trim
 
 openshift_master_cluster_public_hostname: "console.{{ (openshift_openstack_clusterid|trim == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_clusterid + '.' + openshift_openstack_public_dns_domain) }}"
 
-*##OpenStack Credentials:*
+*#OpenStack Credentials:*
 openshift_cloudprovider_kind: openstack
 openshift_cloudprovider_openstack_auth_url: "{{ lookup('env','OS_AUTH_URL') }}"
 openshift_cloudprovider_openstack_username: "{{ lookup('env','OS_USERNAME') }}"
@@ -312,7 +315,7 @@ openshift_cloudprovider_openstack_tenant_name: "{{ lookup('env','OS_PROJECT_NAME
 openshift_cloudprovider_openstack_blockstorage_version: v2
 openshift_cloudprovider_openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 
-*## Use Cinder volume for Openshift registry:*
+*#Use Cinder volume for Openshift registry:*
 openshift_hosted_registry_storage_kind: openstack
 openshift_hosted_registry_storage_access_modes: ['ReadWriteOnce']
 openshift_hosted_registry_storage_openstack_filesystem: xfs
@@ -419,3 +422,20 @@ see what caused the errors:
 $ openstack stack failures list openshift-cluster
 ----
 ====
+
+
+[[stack-name]]
+=== Stack Name Configuration
+
+By default, the Heat stack that is created by OpenStack for the {product-title}
+cluster is named `openshift-cluster`. If you want to use a different
+name then you must set the `OPENSHIFT_CLUSTER` environment variable before
+running the playbooks:
+
+----
+$ export OPENSHIFT_CLUSTER=openshift.example.com
+----
+
+If you use a non-default stack name and run the openshift-ansible playbooks to
+update your deployment, you must set `OPENSHIFT_CLUSTER` to your stack name to
+avoid errors.

--- a/install_config/topics/ocp_osp_sdn.adoc
+++ b/install_config/topics/ocp_osp_sdn.adoc
@@ -1,0 +1,38 @@
+[[osp-sdns]]
+=== {product-title} SDN
+
+The default {product-title} SDN is
+xref:../architecture/networking/sdn.adoc#architecture-additional-concepts-sdn[OpenShiftSDN].
+There is another option: use xref:../install_config/configure_kuryrsdn.adoc#kuryr-sdn-and-openshift[Kuryr SDN].
+
+
+[[kuryr-sdn]]
+=== Kuryr SDN
+
+Kuryr is a CNI plug-in that uses Neutron and Octavia to provide networking for pods
+and services. It is primarily designed for {product-title} clusters that run on
+OpenStack virtual machines. Kuryr improves the network performance by plugging
+{product-title} pods into OpenStack SDN. In addition it provides
+interconnectivity between {product-title} pods and OpenStack virtual instances.
+
+Kuryr is recommended for {product-title} deployments on encapsulated OpenStack
+tenant networks in order to avoid double encapsulation, such as running an
+encapsulated OpenShift SDN over an OpenStack network. Kuryr is recommended
+whenever VXLAN, GRE, or GENEVE are required.
+
+Conversely, implementing Kuryr does not make sense in the following cases:
+
+* You use provider networks, tenant VLANs, or a third party commercial SDN such as
+Cisco ACI or Juniper Contrail.
+* The deployment will use many services on a few hypervisors,
+or {product-title} virtual machine nodes. Each {product-title} service
+creates an Octavia Amphora virtual machine in OpenStack that hosts a
+required load balancer.
+
+To enable Kuryr SDN, your environment must meet the following requirements:
+
+* Running OpenStack 13 or later
+* Overcloud with Octavia
+* Neutron Trunk ports extension enabled
+* If ML2/OVS Neutron driver is used the OpenvSwitch firewall driver must be
+used, instead of the ovs-hybrid one.


### PR DESCRIPTION
This PR ensures a better differentiation between OpenShiftSDN and
the extra requirements by KuryrSDN is made. It also adds information
about why to choose or not KuryrSDN. In addition it adds missing
information about changing stack name.