### PR TITLE
bug 1531449 add note on master about restart with cloud outage

### DIFF
--- a/modules/nodes-pods-configuring-restart.adoc
+++ b/modules/nodes-pods-configuring-restart.adoc
@@ -43,6 +43,12 @@ restart, use a restart policy of `Never`.
 If an entire pod fails, {product-title} starts a new pod. Developers must address the possibility that applications might be restarted in a new pod. In particular,
 applications must handle temporary files, locks, incomplete output, and so forth caused by previous runs.
 
+[NOTE]
+====
+Kubernetes architecture expects reliable endpoints from cloud providers. When a cloud provider is down, the kubelet prevents {product-title} from restarting.
+
+If the underlying cloud provider endpoints are not reliable, do not install a cluster using cloud provider integration. Install the cluster as if it was in a no-cloud environment. It is not recommended to toggle cloud provider integration on or off in an installed cluster.
+====
+
 For details on how {product-title} uses restart policy with failed Containers, see
 the link:https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#example-states[Example States] in the Kubernetes documentation.
-


### PR DESCRIPTION
Approved by SME, change made on master for CP to 4.1, 4.2. Relates to [PR 16068 ](https://github.com/openshift/openshift-docs/pull/16068/), where note was added to master-3 for 3.9, 3.10, 3.11. 
Content location changed from 3.x (architecture/core_concepts/pods_and_services.adoc)
/to 4.x (modules/nodes-pods-configuring-restart.adoc), so placed note in same text location.

[BZ 1531449](https://bugzilla.redhat.com/show_bug.cgi?id=1531449)

@openshift/team-documentation Peer Review Needed