### PR TITLE
4.2 Kubernetes Feature Flag doc is confusing and incorrect

### DIFF
--- a/modules/feature-gate-features.adoc
+++ b/modules/feature-gate-features.adoc
@@ -25,11 +25,7 @@ The following Technology Preview features included in {product-title}:
 
 |`MachineHealthCheck`
 |Enables automatically repairing unhealthy machines in a machine pool.
-|False
-
-|`CSIBlockVolume`
-|Enables external CSI drivers to implement raw block volume support.
-|False
+|True
 
 |`LocalStorageCapacityIsolation`
 |Enable the consumption of local ephemeral storage and also the `sizeLimit` property of an `emptyDir` volume.
@@ -37,7 +33,7 @@ The following Technology Preview features included in {product-title}:
 
 |===
 
-You can enable the `MachineHealthCheck` and `CSIBlockVolume` features by editing the Feature Gate Custom Resource.
+You can enable these features by editing the Feature Gate Custom Resource.
 Turning on these features cannot be undone and prevents the ability to upgrade your cluster.
 
 The `LocalStorageCapacityIsolation` cannot be enabled.

--- a/modules/nodes-cluster-enabling-features-cluster.adoc
+++ b/modules/nodes-cluster-enabling-features-cluster.adoc
@@ -5,10 +5,19 @@
 [id="nodes-cluster-enabling-features-cluster_{context}"]
 = Enabling Technology Preview features using feature gates
 
-You can turn on the `MachineHealthCheck` and `CSIBlockVolume` Technology Preview features on for all nodes in the cluster by
+You can turn on Technology Preview features on for all nodes in the cluster by
 editing the Feature Gate Custom Resource, named `cluster`, in the `openshift-config` project.
 
-Turning 
+The following Technology Preview features are enabled by feature gates:
+
+* `ExperimentalCriticalPodAnnotation`
+
+* `RotateKubeletServerCertificate`
+
+* `SupportPodPidsLimit`
+
+* `MachineHealthCheck` 
+
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Updated Feature Gates features for 4,2. 

Original issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1722240

Slack thread, CSIBlockVolume is no longer Feature Gated. MachineHealthChecks is still Feature Gated:
https://coreos.slack.com/archives/CB48XQ4KZ/p1565193459358100

Feature Gates list in GitHub:
https://github.com/openshift/api/blob/release-4.2/config/v1/types_feature.go#L96-L118