### PR TITLE
CNV - kubevirt-hyperconverged namespace changed to openshift-cnv

### DIFF
--- a/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
+++ b/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
@@ -19,7 +19,7 @@ include::modules/cnv-deleting-hco-subscription.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-You can now delete the `kubevirt-hyperconverged` namespace.
+You can now delete the `openshift-cnv` namespace.
 ====
 
 include::modules/deleting-a-project-using-the-web-console.adoc[leveloffset=+1]

--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -39,7 +39,7 @@ getting stuck in a `CrashLoopBackOff` state. The PVC is now deleted normally.
 
 * Some KubeVirt resources are improperly retained when removing {ProductName}.
 As a workaround, you must manually remove them by running the command
-`oc delete apiservices v1alpha3.subresources.kubevirt.io -n kubevirt-hyperconverged`.
+`oc delete apiservices v1alpha3.subresources.kubevirt.io -n openshift-cnv`.
 These resources will be removed automatically after
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1712429[*BZ#1712429*]) is
 resolved.

--- a/modules/cnv-configuring-live-migration-limits.adoc
+++ b/modules/cnv-configuring-live-migration-limits.adoc
@@ -8,7 +8,7 @@
 
 Configure live migration limits and timeouts for the cluster by adding updated 
 key:value fields to the `kubevirt-config` configuration file, which is located in the 
-`kubevirt-hyperconverged` namespace.
+`openshift-cnv` namespace.
 
 .Procedure
 
@@ -16,7 +16,7 @@ key:value fields to the `kubevirt-config` configuration file, which is located i
 live migration parameters. The following example shows the default values:
 +
 ----
-$ oc edit configmap kubevirt-config -n kubevirt-hyperconverged
+$ oc edit configmap kubevirt-config -n openshift-cnv
 ----
 +
 [source,yaml]

--- a/modules/cnv-deleting-custom-resource.adoc
+++ b/modules/cnv-deleting-custom-resource.adoc
@@ -14,7 +14,7 @@ during deployment.
 
 .Procedure
 
-. From the {product-title} web console, select `kubevirt-hyperconverged` from
+. From the {product-title} web console, select `openshift-cnv` from
 the *Projects* list.
 
 . Navigate to the *Catalog* -> *Installed Operators* page.
@@ -35,7 +35,7 @@ Pods are running.
 the following command:
 +
 ----
-$ oc delete apiservices v1alpha3.subresources.kubevirt.io -n kubevirt-hyperconverged
+$ oc delete apiservices v1alpha3.subresources.kubevirt.io -n openshift-cnv
 ----
 +
 [NOTE]

--- a/modules/cnv-deleting-hco-subscription.adoc
+++ b/modules/cnv-deleting-hco-subscription.adoc
@@ -14,7 +14,7 @@ Cluster Operator catalog subscription.
 
 .Procedure
 
-. From the {product-title} web console, select `kubevirt-hyperconverged` from
+. From the {product-title} web console, select `openshift-cnv` from
 the *Projects* list.
 
 . Navigate to the *Catalog* -> *Operator Management* page.

--- a/modules/cnv-deploying-cnv.adoc
+++ b/modules/cnv-deploying-cnv.adoc
@@ -12,7 +12,7 @@ to deploy {ProductName}.
 .Prerequisites
 
 * An active subscription to the *KubeVirt HyperConverged Cluster Operator* catalog
-in the `kubevirt-hyperconverged` namespace
+in the `openshift-cnv` namespace
 
 .Procedure
 

--- a/modules/cnv-preparing-to-install.adoc
+++ b/modules/cnv-preparing-to-install.adoc
@@ -7,9 +7,9 @@
 
 Before deploying {ProductName}:
 
-* Create a namespace called `kubevirt-hyperconverged`.
+* Create a namespace called `openshift-cnv`.
 * Create `OperatorGroup` and `CatalogSource` Custom Resource Definition objects
-(CRDs) in the `kubevirt-hyperconverged` namespace.
+(CRDs) in the `openshift-cnv` namespace.
 
 .Prerequisites
 
@@ -19,15 +19,15 @@ Before deploying {ProductName}:
 
 .Procedure
 
-. Create the `kubevirt-hyperconverged` namespace by running the following
+. Create the `openshift-cnv` namespace by running the following
 command:
 +
 ----
-$ oc new-project kubevirt-hyperconverged
+$ oc new-project openshift-cnv
 ----
 
 . Create the `OperatorGroup` and `CatalogSource` in the
-`kubevirt-hyperconverged` namespace by running the following command:
+`openshift-cnv` namespace by running the following command:
 +
 ----
 cat <<EOF | oc apply -f -
@@ -35,7 +35,7 @@ apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: hco-operatorgroup
-  namespace: kubevirt-hyperconverged
+  namespace: openshift-cnv
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource

--- a/modules/cnv-subscribing-to-hco-catalog.adoc
+++ b/modules/cnv-subscribing-to-hco-catalog.adoc
@@ -7,19 +7,19 @@
 
 Before you install {ProductName}, subscribe to the
 *KubeVirt HyperConverged Cluster Operator* catalog from
-the {product-title} web console. Subscribing gives the `kubevirt-hyperconverged`
+the {product-title} web console. Subscribing gives the `openshift-cnv`
 namespace access to the {ProductName} Operators.
 
 .Prerequisites
 
 * `OperatorGroup` and `CatalogSource` Custom Resource Definition objects (CRDs),
-both created in the `kubevirt-hyperconverged` namespace
+both created in the `openshift-cnv` namespace
 
 .Procedure
 
 . Open a browser window and navigate to the {product-title} web console.
 
-. Select the `kubevirt-hyperconverged` project from the *Projects* list.
+. Select the `openshift-cnv` project from the *Projects* list.
 
 . Navigate to the *Catalog* -> *Operator Management* page.
 


### PR DESCRIPTION
For [CNV-2474](https://jira.coreos.com/browse/CNV-2474)
`kubevirt-hyperconverged` namespace/project replaced with `openshift-cnv` in the CNV docs. 
This change does not impact the catalog, custom resource name, or the UI buttons for these objects.