### PR TITLE
Add content for EgressNetworkPolicy

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -400,6 +400,12 @@ Topics:
   - Name: Enabling egress IPs for a project
     File: assigning-egress-ips
     Distros: openshift-origin,openshift-enterprise
+  - Name: Configuring an egress firewall for a project
+    File: configuring-egress-firewall
+  - Name: Editing an egress firewall for a project
+    File: editing-egress-firewall
+  - Name: Removing an egress firewall from a project
+    File: removing-egress-firewall
   - Name: Using multicast
     File: using-multicast
     Distros: openshift-origin,openshift-enterprise

--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift-sdn/configuring-egress-firewall.adoc
+
+[id="nw-egressnetworkpolicy-about_{context}"]
+= How an egress firewall works in a project
+
+As an {product-title} cluster administrator, you can use an _egress firewall_ to
+limit the external hosts that some or all Pods can access from within the
+cluster. An egress firewall supports the following scenarios:
+
+- A Pod can only connect to internal hosts and cannot initiate connections to
+the public Internet.
+- A Pod can only connect to the public Internet and cannot initiate connections
+to internal hosts that are outside the {product-title} cluster.
+- A Pod cannot reach specified internal subnets or hosts outside the {product-title} cluster.
+- A Pod can connect to only specific external hosts.
+
+You configure an egress firewall policy by creating an EgressNetworkPolicy Custom Resource (CR) object and specifying an IP address range in CIDR format or by specifying a DNS name.
+For example, you can allow one project access to a specified IP range but deny the same access to a different project. Or you can restrict application developers from updating from Python pip mirrors, and force updates to come only from approved sources.
+
+[IMPORTANT]
+====
+You must have OpenShift SDN configured to use either the network policy or multitenant modes to configure egress firewall policy.
+
+If you use network policy mode, egress policy is compatible with only one policy per namespace and will not work with projects that share a network, such as global projects.
+====
+
+[CAUTION]
+====
+Egress firewall rules do not apply to traffic that goes through routers. Any user with permission to create a Route CR object can bypass egress network policy rules by creating a route that points to a forbidden destination.
+====
+
+[id="limitations-of-an-egress-firewall_{context}"]
+== Limitations of an egress firewall
+
+An egress firewall has the following limitations:
+
+* No project can have more than one EgressNetworkPolicy object.
+
+* The `default` project cannot use egress network policy.
+
+* When using the OpenShift SDN network provider in multitenant mode, the following limitations apply:
+
+  - Global projects cannot use an egress firewall. You can make a project global by using the `oc adm pod-network make-projects-global` command.
+
+  - Projects merged by using the `oc adm pod-network join-projects` command cannot use an egress firewall in any of the joined projects.
+
+Violating any of these restrictions results in broken egress network policy for the project, and may cause all external network traffic to be dropped.
+
+[id="policy-rule-order_{context}"]
+== Matching order for egress network policy rules
+
+The egress network policy rules are evaluated in the order that they are defined, from first to last. The first rule that matches an egress connection from a Pod applies. Any subsequent rules are ignored for that connection.
+
+[id="domain-name-server-resolution_{context}"]
+== How Domain Name Server (DNS) resolution works
+
+If you use DNS names in any of your egress firewall policy rules, proper resolution of the domain names is subject to the following restrictions:
+
+* Domain name updates are polled based on the TTL (time to live) value of the domain returned by the local non-authoritative servers.
+
+* The Pod must resolve the domain from the same local name servers when necessary. Otherwise the IP addresses for the domain known by the egress firewall controller and the Pod can be different. If the IP addresses for a host name differ, the egress firewall might not be enforced consistently.
+
+* Because the egress firewall controller and Pods asynchronously poll the same local name server, the Pod might obtain the updated IP address before the egress controller does, which causes a race condition. Due to this current limitation, domain name usage in EgressNetworkPolicy objects is only recommended for domains with infrequent IP address changes.
+
+[NOTE]
+====
+The egress firewall always allows Pods access to the external interface of the node that the Pod is on for DNS resolution.
+
+If you use domain names in your egress firewall policy and your DNS resolution is not handled by a DNS server on the local node, then you must add egress firewall rules that allow access to your DNS server’s IP addresses. if you are using domain names in your Pods.
+====

--- a/modules/nw-egressnetworkpolicy-create.adoc
+++ b/modules/nw-egressnetworkpolicy-create.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift-sdn/configuring-egress-firewall.adoc
+
+[id="nw-networkpolicy-create_{context}"]
+= Creating an egress firewall policy object
+
+As a {product-title} cluster administrator, you can create an egress firewall policy object for a project.
+
+[IMPORTANT]
+====
+If the project already has an EgressNetworkPolicy object defined, you must edit the existing policy to make changes to the egress firewall rules.
+====
+
+.Prerequisites
+
+* A cluster that uses the OpenShift SDN network provider plug-in.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* You must log in to the cluster as a cluster administrator.
+
+.Procedure
+
+. Create a policy rule:
+.. Create a `<policy-name>.yaml` file where `<policy-name>` describes the egress
+policy rules.
+.. In the file you created, define an egress policy object.
+
+. Enter the following command to create the policy object:
++
+----
+$ oc create -f <policy-name>.yaml -n <project>
+----
++
+In the following example, a new EgressNetworkPolicy object is created in a
+project named `project1`:
++
+----
+$ oc create -f default-rules.yaml -n project1
+egressnetworkpolicy.network.openshift.io/default-rules created
+----
++
+. Optional: Save the `<policy-name>.yaml` so that you can make changes later.

--- a/modules/nw-egressnetworkpolicy-delete.adoc
+++ b/modules/nw-egressnetworkpolicy-delete.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift-sdn/removing-egress-firewall.adoc
+
+[id="nw-egressnetworkpolicy-delete_{context}"]
+
+= Removing an EgressNetworkPolicy object
+
+As a {product-title} cluster administrator, you can remove an egress firewall from a project.
+
+.Prerequisites
+
+* A cluster using the OpenShift SDN network plug-in.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* You must log in to the cluster as a cluster administrator.
+
+.Procedure
+
+To remove an egress network policy object for a project, complete the following steps:
+
+. Find the name of the EgressNetworkPolicy object for the project. Replace `<project>` with the name of the project.
++
+----
+$ oc get -n <project> egressnetworkpolicy
+----
+
+. Enter the following command to delete the EgressNetworkPolicy object. Replace `<project>` with the name of the project and `<name>` with the name of the object.
++
+----
+$ oc delete -n <project> egressnetworkpolicy <name>
+----

--- a/modules/nw-egressnetworkpolicy-edit.adoc
+++ b/modules/nw-egressnetworkpolicy-edit.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift-sdn/editing-egress-firewall.adoc
+
+[id="nw-egressnetworkpolicy-edit_{context}"]
+
+= Editing an EgressNetworkPolicy object
+
+As a {product-title} cluster administrator, you can update the egress firewall for a project.
+
+.Prerequisites
+
+* A cluster using the OpenShift SDN network plug-in.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* You must log in to the cluster as a cluster administrator.
+
+.Procedure
+
+To edit an existing egress network policy object for a project, complete the following steps:
+
+. Find the name of the EgressNetworkPolicy object for the project. Replace `<project>` with the name of the project.
++
+----
+$ oc get -n <project> egressnetworkpolicy
+----
+
+. Optionally, if you did not save a copy of the EgressNetworkPolicy object when you created the egress network firewall, enter the following command to create a copy.
++
+----
+$ oc get -n <project> \ <1>
+  egressnetworkpolicy <name> \ <2>
+  -o yaml > <filename>.yaml <3>
+----
+<1> Replace `<project>` with the name of the project
+<2> Replace `<name>` with the name of the object.
+<3> Replace `<filename>` with the name of the file to save the YAML.
+
+. Enter the following command to replace the EgressNetworkPolicy object. Replace `<filename>` with the name of the file containing the updated EgressNetworkPolicy object.
++
+----
+$ oc replace -f <filename>.yaml
+----

--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift-sdn/configuring-egress-firewall.adoc
+
+[id="nw-egressnetworkpolicy-object_{context}"]
+= EgressNetworkPolicy custom resource (CR) object
+
+The following YAML describes an EgressNetworkPolicy CR object:
+
+[source,yaml]
+----
+kind: EgressNetworkPolicy
+apiVersion: v1
+metadata:
+  name: <name> <1>
+spec:
+  egress: <2>
+    ...
+----
+<1> Specify a `name` for your egress firewall policy.
+
+<2> Specify a collection of one or more egress network policy rules as described in the following section.
+
+[id="egressnetworkpolicy-rules_{context}"]
+== EgressNetworkPolicy rules
+
+The following YAML describes an egress firewall rule object. The `egress` key expects an array of one or more objects.
+
+[source,yaml]
+----
+egress:
+- type: <type> <1>
+  to: <2>
+    cidrSelector: <cidr> <3>
+    dnsName: <dns-name> <4>
+----
+<1> Specify the type of rule. The value must be either `Allow` or `Deny`.
+
+<2> Specify a value for either the `cidrSelector` key or the `dnsName` key for the rule. You cannot use both keys in a rule.
+
+<3> Specify an IP address range in CIDR format.
+
+<4> Specify a domain name.
+
+[id="egressnetworkpolicy-example_{context}"]
+== Example EgressNetworkPolicy CR object
+
+The following example defines several egress firewall policy rules:
+
+[source,yaml]
+----
+kind: EgressNetworkPolicy
+apiVersion: v1
+metadata:
+  name: default-rules <1>
+spec:
+  egress: <2>
+  - type: Allow
+    to:
+      cidrSelector: 1.2.3.0/24
+  - type: Allow
+    to:
+      dnsName: www.example.com
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0
+----
+<1> The name for the policy object.
+
+<2> A collection of egress firewall policy rule objects.

--- a/modules/nw-egressnetworkpolicy-view.adoc
+++ b/modules/nw-egressnetworkpolicy-view.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// networking/openshift-sdn/configuring-egressnetworkpolicy.adoc
+
+[id="nw-egressnetworkpolicy-view_{context}"]
+
+= Viewing NetworkPolicy objects
+
+You can list the EgressNetworkPolicy objects in your cluster.
+
+.Prerequisites
+
+* A cluster using the OpenShift SDN network plug-in.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* You must log in to the cluster.
+
+.Procedure
+
+* To view the names of the EgressNetworkPolicy objects defined in your cluster,
+enter the following command:
++
+----
+$ oc get egressnetworkpolicy -o go-template='{{range .items}}{{.metadata.name}}{{end}}'
+----
+
+* Optional: You can inspect a specific policy object by entering the following
+command:
++
+----
+$ oc get egressnetworkpolicy <policy-name> -o yaml
+----
++
+Replace `<policy-name>` with the name of the policy to inspect.

--- a/networking/openshift_sdn/configuring-egress-firewall.adoc
+++ b/networking/openshift_sdn/configuring-egress-firewall.adoc
@@ -1,0 +1,14 @@
+[id="configuring-egress-firewall"]
+= Configuring an egress firewall to control access to external IP addresses
+include::modules/common-attributes.adoc[]
+:context: configuring-an-egress-firewall
+
+toc::[]
+
+As a cluster administrator, you can create an egress firewall for a project that will restrict egress traffic leaving your {product-title} cluster.
+
+include::modules/nw-egressnetworkpolicy-about.adoc[leveloffset=+1]
+
+include::modules/nw-egressnetworkpolicy-object.adoc[leveloffset=+1]
+
+include::modules/nw-egressnetworkpolicy-create.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/editing-egress-firewall.adoc
+++ b/networking/openshift_sdn/editing-egress-firewall.adoc
@@ -1,0 +1,12 @@
+[id="editing-egress-firewall"]
+= Editing an egress firewall for a project
+include::modules/common-attributes.adoc[]
+:context: editing-egress-network-policy
+
+toc::[]
+
+As a cluster administrator, you can modify network traffic rules for an existing egress firewall.
+
+include::modules/nw-egressnetworkpolicy-edit.adoc[leveloffset=+1]
+
+include::modules/nw-egressnetworkpolicy-object.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/removing-egress-firewall.adoc
+++ b/networking/openshift_sdn/removing-egress-firewall.adoc
@@ -1,0 +1,11 @@
+[id="removing-egress-firewall"]
+= Removing an egress firewall from a project
+include::modules/common-attributes.adoc[]
+:context: removing-egress-network-policy
+
+toc::[]
+
+As a cluster administrator, you can remove an egress firewall from a project to remove all restrictions on network traffic from the project that leaves the {product-title} cluster.
+
+include::modules/nw-egressnetworkpolicy-delete.adoc[leveloffset=+1]
+


### PR DESCRIPTION
- OSDOCS-648

Bring content forward from 3.11 for `EgressNetworkPolicy`. This applies only to OpenShift SDN ~as OVN uses the `NetworkPolicy` CR instead for this functionality~.