### PR TITLE
[3.11] updating information related to customer-admin-cluster role in ARO

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -570,7 +570,7 @@ Topics:
   File: service_accounts
 - Name: Managing Role-based Access Control
   File: manage_rbac
-  Distros: openshift-origin,openshift-enterprise,openshift-dedicated
+  Distros: openshift-origin,openshift-enterprise,openshift-dedicated,openshift-aro
 - Name: Image Policy
   File: image_policy
   Distros: openshift-origin,openshift-enterprise,atomic-*
@@ -585,7 +585,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Managing Security Context Constraints
   File: manage_scc
-  Distros: openshift-origin,openshift-enterprise,openshift-dedicated
+  Distros: openshift-origin,openshift-enterprise,openshift-dedicated,openshift-aro
 - Name: Scheduling
   Dir: scheduling
   Distros: openshift-origin,openshift-enterprise

--- a/admin_guide/index.adoc
+++ b/admin_guide/index.adoc
@@ -85,7 +85,7 @@ xref:../admin_guide/limits.adoc#admin-guide-limits[limit ranges] for the
 project.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-aro[]
 [[admin-guide-index-cluster-level-permissions]]
 == Cluster-level Permissions
 
@@ -124,16 +124,4 @@ constraints].
 
 |===
 
-endif::[]
-
-ifdef::openshift-aro[]
-== Cluster-level Permissions
-
-View (`get`/`list`/`watch`) certain resources such as
-xref:../dev_guide/events.adoc#dev-guide-events[events],
-xref:../admin_guide/manage_rbac.adoc#managing-role-bindings[nodes],
-xref:../architecture/additional_concepts/storage.adoc#persistent-volumes[persistent
-volumes], and
-xref:../admin_guide/manage_scc.adoc#admin-guide-manage-scc[security context
-constraints].
 endif::[]

--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -30,7 +30,7 @@ xref:../architecture/additional_concepts/authorization.adoc#architecture-additio
 and bindings].
 
 ifdef::openshift-dedicated,openshift-aro[]
-{cluster-admin-name} can view but not manage cluster roles. They can manage cluster role bindings
+{cluster-admin-name}s can view but not manage cluster roles. They can manage cluster role bindings
 and manage local roles and bindings.
 endif::[]
 

--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -5,6 +5,16 @@
 :data-uri:
 :icons:
 :experimental:
+ifdef::openshift-dedicated[]
+:cluster-admin-name: Dedicated cluster administrator
+:cluster-admin-role: dedicated-cluster-admin
+:project-admin-role: dedicated-project-admin
+endif::[]
+ifdef::openshift-aro[]
+:cluster-admin-name: Customer cluster administrator
+:cluster-admin-role: customer-admin-cluster
+:project-admin-role: customer-admin-project
+endif::[]
 :toc: macro
 :toc-title:
 
@@ -19,11 +29,8 @@ resources] and the administrator CLI to manage the
 xref:../architecture/additional_concepts/authorization.adoc#architecture-additional-concepts-authorization[roles
 and bindings].
 
-ifdef::atomic-registry[]
-The web console also provides management of RBAC resources.
-endif::[]
-ifdef::openshift-dedicated[]
-Dedicated administrators can view but not manage cluster roles. They can manage cluster role bindings
+ifdef::openshift-dedicated,openshift-aro[]
+{cluster-admin-name} can view but not manage cluster roles. They can manage cluster role bindings
 and manage local roles and bindings.
 endif::[]
 
@@ -40,8 +47,8 @@ and groups] can be associated with, or _bound_ to, multiple roles at the same
 time. You can view details about the roles and their bindings using the `oc
 describe` command.
 
-ifdef::openshift-dedicated[]
-Users with the *dedicated-cluster-admin* role can view but not manage cluster roles. They can manage cluster
+ifdef::openshift-dedicated,openshift-aro[]
+Users with the *{cluster-admin-role}* role can view but not manage cluster roles. They can manage cluster
 role bindings and manage local roles and bindings. Users with the *admin*
 xref:../architecture/additional_concepts/authorization.adoc#roles[default cluster role]
 bound locally can manage roles and bindings in that project.
@@ -488,7 +495,7 @@ Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
 ...
 ----
 endif::[]
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-aro[]
 ----
 $ oc describe clusterrolebinding.rbac
 ----


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/15727 .

This should only be included in OS 3.11.