### PR TITLE
modules/dr-recover-lost-control-plane-hosts: update setup-etcd-environment

### DIFF
--- a/modules/dr-recover-lost-control-plane-hosts.adoc
+++ b/modules/dr-recover-lost-control-plane-hosts.adoc
@@ -172,7 +172,7 @@ Login successful.
 ... Obtain the pull specification for the `kube-etcd-signer-server` image.
 +
 ----
-[core@ip-10-0-143-125 ~]$ export KUBE_ETCD_SIGNER_SERVER=$(oc adm release info --image-for kube-etcd-signer-server --registry-config=/var/lib/kubelet/config.json)
+[core@ip-10-0-143-125 ~]$ export KUBE_ETCD_SIGNER_SERVER=$(sudo oc adm release info --image-for kube-etcd-signer-server --registry-config=/var/lib/kubelet/config.json)
 ----
 
 ... Run the `tokenize-signer.sh` script.
@@ -216,11 +216,11 @@ Login successful.
 ... Export two environment variables that are required by the `etcd-member-recover.sh` script.
 +
 ----
-[core@ip-10-0-156-255 ~]$ export SETUP_ETCD_ENVIRONMENT=$(oc adm release info --image-for setup-etcd-environment --registry-config=/var/lib/kubelet/config.json)
+[core@ip-10-0-156-255 ~]$ export SETUP_ETCD_ENVIRONMENT=$(sudo oc adm release info --image-for machine-config-operator --registry-config=/var/lib/kubelet/config.json)
 ----
 +
 ----
-[core@ip-10-0-156-255 ~]$ export KUBE_CLIENT_AGENT=$(oc adm release info --image-for kube-client-agent --registry-config=/var/lib/kubelet/config.json)
+[core@ip-10-0-156-255 ~]$ export KUBE_CLIENT_AGENT=$(sudo oc adm release info --image-for kube-client-agent --registry-config=/var/lib/kubelet/config.json)
 ----
 
 ... Run the `etcd-member-recover.sh` script.


### PR DESCRIPTION
This PR updates the location of `setup-etcd-environment` image. This used to be its own image but is now part of the `machine-config-operator` [1]. I also prefixed all oc commands with`sudo` because core user does not have access to `/var/lib/kubelet/config.json`

```
$ ls -la /var/lib/kubelet/config.json
-rw-------. 1 root root 120 Aug 12 23:50 /var/lib/kubelet/config.json
```

[1] https://github.com/openshift/machine-config-operator/pull/1028

