### PR TITLE
3scaleIstioAdapter: Edits based on adding backend-url and removing x-

### DIFF
--- a/modules/ossm-threescale-authentication.adoc
+++ b/modules/ossm-threescale-authentication.adoc
@@ -21,14 +21,14 @@ Modify the `instance` custom resource, as illustrated in the following authentic
 
 [NOTE]
 ====
-When specifying values from headers they must be lower case. For example, if you want to send a header as `X-User-Key`, this must be referenced in the configuration as `request.headers["x-user-key"]`.
+When specifying values from headers, they must be lower case. For example, if you want to send a header as `User-Key`, this must be referenced in the configuration as `request.headers["user-key"]`.
 ====
 
 [id="ossm-threescale-apikey-authentication_{context}"]
 === API key authentication method
 {ProductShortName} looks for the API key in query parameters and request headers as specified in the `user` option in the `subject` custom resource parameter. It checks the values in the order given in the custom resource file. You can restrict the search for the API key to either query parameters or request headers by omitting the unwanted option.
 
-In this example {ProductShortName} looks for the API key in the `user_key` query parameter. If the API key is not in the query parameter, {ProductShortName} then checks the `x-user-key` header.
+In this example, {ProductShortName} looks for the API key in the `user_key` query parameter. If the API key is not in the query parameter, {ProductShortName} then checks the `user-key` header.
 
 .API key authentication method example
 
@@ -43,7 +43,7 @@ spec:
   template: authorization
   params:
     subject:
-      user: request.query_params["user_key"] | request.headers["x-user-key"] | ""
+      user: request.query_params["user_key"] | request.headers["user-key"] | ""
     action:
       path: request.url_path
       method: request.method | "get"
@@ -70,8 +70,8 @@ spec:
   template: authorization
   params:
     subject:
-        app_id: request.query_params["app_id"] | request.headers["x-app-id"] | ""
-        app_key: request.query_params["app_key"] | request.headers["x-app-key"] | ""
+        app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
     action:
       path: request.url_path
       method: request.method | "get"
@@ -98,7 +98,7 @@ You can manipulate this object using the methods described previously. In the ex
     params:
       Subject:
   properties:
-          app_key: request.query_params["app_key"] | request.headers["x-app-key"] | ""
+          app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
           client_id: request.auth.claims["azp"] | ""
       action:
         path: request.url_path
@@ -149,10 +149,10 @@ spec:
   template: authorization
   params:
     subject:
-      user: request.query_params["user_key"] | request.headers["x-user-key"] |
+      user: request.query_params["user_key"] | request.headers["user-key"] |
       properties:
-        app_id: request.query_params["app_id"] | request.headers["x-app-id"] | ""
-        app_key: request.query_params["app_key"] | request.headers["x-app-key"] | ""
+        app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
         client_id: request.auth.claims["azp"] | ""
     action:
       path: request.url_path

--- a/modules/ossm-threescale-cr.adoc
+++ b/modules/ossm-threescale-cr.adoc
@@ -36,6 +36,11 @@ The adapter includes a tool that allows you to generate the `handler`, `instance
 |Yes
 |
 
+|`--backend-url`
+|3scale backend URL. If set, it overrides the value that is read from system configuration
+|No
+|
+
 |`-s, --service`
 |3scale API/Service ID
 |No

--- a/modules/ossm-threescale-integrate.adoc
+++ b/modules/ossm-threescale-integrate.adoc
@@ -45,6 +45,8 @@ Pay particular attention to the `kind: handler` resource. You must update this w
      address: "threescale-istio-adapter:3333"
 ----
 
+Optionally, you can provide a `backend_url` field within the _params_ section to override the URL provided by the 3scale configuration. This may be useful if the adapter runs on the same cluster as the 3scale on-premise instance, and you wish to leverage the internal cluster DNS.
+
 . Modify the rule configuration with your 3scale configuration to dispatch the rule to the threescale handler.
 +
 .Rule configuration example


### PR DESCRIPTION
This PR is for the Service Mesh docs in the 4.x stream prior to GA. It adds the `backend-url` flag
 from the CLI and removes `x-` from `x-user-key`, `x-app-id`, and `x-app-key`.

This PR includes the following changes:
3scale docs update for GA.

This is a WIP and further updates will be added according to feedback.

@kalexand-rh and @vikram-redhat can you review to ensure these docs are accurate for GA?

@JStickler can you double-check to make sure I have everything in here?

Thanks to @geekspertise for your help and advice.

If I've tagged you and you feel you should not have been tagged, please let me know and I can remove you.

Adding @seanhuck as watcher.

This is my first PR for OpenShift docs. Be gentle. :smile: 

PS: It appears I cannot add reviewers.