### PR TITLE
The clusterNetwork install-config parameter must be singular

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -24,7 +24,7 @@ controlPlane:
 metadata:
   name: test <6>
 networking:
-  clusterNetworks:
+  clusterNetwork:
   - cidr: 10.128.0.0/14 <7>
     hostPrefix: 23 <8>
   networkType: OpenShiftSDN


### PR DESCRIPTION
@kalexand-rh, at some point the parameter name changed before 4.1 GA. Not sure who to tag from QE. Thanks!