### PR TITLE
BZ-1738703: Updated supported storage types.

### DIFF
--- a/modules/available-persistent-storage-options.adoc
+++ b/modules/available-persistent-storage-options.adoc
@@ -19,19 +19,23 @@ a|* Presented to the operating system (OS) as a block device
 bypassing the file system
 * Also referred to as a Storage Area Network (SAN)
 * Non-shareable, which means that only one client at a time can mount an endpoint of this type
-| Ceph RBD, OpenStack Cinder, AWS EBS, Azure Disk, GCE persistent disk, and VMware vSphere support dynamic persistent volume (PV) provisioning natively in {product-title}.
+| AWS EBS and VMware vSphere support dynamic persistent volume (PV) provisioning natively in {product-title}.
+// Ceph RBD, OpenStack Cinder, Azure Disk, GCE persistent disk
 
 |File
 a| * Presented to the OS as a file system export to be mounted
 * Also referred to as Network Attached Storage (NAS)
 * Concurrency, latency, file locking mechanisms, and other capabilities vary widely between protocols, implementations, vendors, and scales.
-|RHEL NFS, NetApp NFS footnoteref:[netappnfs,NetApp NFS supports dynamic PV provisioning when using the Trident plug-in.], Azure File, Vendor NFS, AWS EFS
+|RHEL NFS, NetApp NFS footnoteref:[netappnfs,NetApp NFS supports dynamic PV provisioning when using the Trident plug-in.], and Vendor NFS
+// Azure File, AWS EFS
 
 | Object
 a| * Accessible through a REST API endpoint
 * Configurable for use in the {product-title} Registry
 * Applications must build their drivers into the application and/or container.
-| Ceph Object Storage (RADOS Gateway), OpenStack Swift, Aliyun OSS, AWS S3, Google Cloud Storage, Azure Blob Storage
+| AWS S3
+// Aliyun OSS, Ceph Object Storage (RADOS Gateway)
+// Google Cloud Storage, Azure Blob Storage, OpenStack Swift
 |===
 
 [IMPORTANT]


### PR DESCRIPTION
I've updated the list of supported storage types in the "Scalability and performance" section. This includes removing entrances in the `Object` storage type for unsupported platforms in 4.1, such as GCE and Azure.

These files should be updated for 4.2 to include Azure, GCE, and EFS.

This is for OS 4.x.