### PR TITLE
Fixing Deploying Logging in topic_map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -711,7 +711,7 @@ Topics:
 - Name: Deploying cluster logging
   File: efk-logging-deploying
   Distros: openshift-enterprise,openshift-origin
-  Name: Deploying cluster Logging
+- Name: Deploying cluster logging
   File: dedicated-efk-deploying
   Distros: openshift-dedicated
 - Name: Configuring cluster logging


### PR DESCRIPTION
Fixing the topic map to get https://docs.openshift.com/container-platform/4.1/logging/efk-logging-deploying.html to appear. Per https://coreos.slack.com/archives/CB3HXM2QK/p1565588260404000