### PR TITLE
fixes/updates for CNV 2.0, inspired by recent feedback

### DIFF
--- a/cnv/cnv_install/installing-container-native-virtualization.adoc
+++ b/cnv/cnv_install/installing-container-native-virtualization.adoc
@@ -4,17 +4,23 @@ include::modules/cnv-document-attributes.adoc[]
 :context: installing-container-native-virtualization
 toc::[]
 
-Before you deploy {ProductName}, use the CLI to prepare the required namespace,
-`OperatorGroup`, and `CatalogSource`.
+Install {ProductName} to add virtualization functionality to your {product-title}
+cluster.
 
-You can install {ProductName} by using the {product-title} 4.1
-xref:../../web-console/web-console.adoc#web-console-overview_web-console[web console].
+Before you deploy {ProductName}, you must create two Custom Resource
+Definition (CRD) objects:
 
-.Prerequisites
+* `kind: OperatorGroup`
+* `kind: CatalogSource`
 
-* {product-title} 4.1
-* User with `cluster-admin` privileges
-* The {product-title} Command-line Interface (CLI), commonly known as `oc`
+You can create both objects by running a single command.
+
+To finish installing {ProductName}, use the {product-title} 4.1
+xref:../../web-console/web-console.adoc#web-console-overview_web-console[web console]
+to subscribe to and deploy the {ProductName} Operators.
+
+:FeatureName: {ProductName}
+include::modules/technology-preview.adoc[leveloffset=+1]
 
 include::modules/cnv-preparing-to-install.adoc[leveloffset=+1]
 

--- a/modules/cnv-editing-template-web.adoc
+++ b/modules/cnv-editing-template-web.adoc
@@ -5,8 +5,8 @@
 [id="cnv-editing-template-web_{context}"]
 = Editing a virtual machine template in the web console
 
-You can edit the YAML configuration of a virtual machine template from the 
-web console. 
+You can edit the YAML configuration of a virtual machine template from the
+web console.
 
 Not all parameters can be modified. If you click *Save* with an invalid configuration,
  an error message indicates the parameter that cannot be modified.
@@ -14,16 +14,16 @@ Not all parameters can be modified. If you click *Save* with an invalid configur
 [NOTE]
 ====
 Navigating away from the YAML screen while editing cancels any changes to the
- configuration that you made. 
+ configuration that you made.
 ====
 
 .Procedure
 
 . In the {ProductName} console, click *Workloads* -> *Virtual Machine Templates*.
 . Select a template.
-. Click the *YAML* tab to display the editable configuration. 
- state.
-. Edit the file and click *Save*. 
+. Click the *YAML* tab to display the editable configuration.
+. Edit the file and click *Save*.
 
-A confirmation message, which includes the updated version number for the object, shows the modification has been successful.
+A confirmation message, which includes the updated version number for the object,
+shows the modification has been successful.
 

--- a/modules/cnv-editing-vm-web.adoc
+++ b/modules/cnv-editing-vm-web.adoc
@@ -6,7 +6,9 @@
 
 = Using the web console to edit a virtual machine
 
-Edit select values of a virtual machine in the web console or from the *Virtual Machine Overview* screen. Other values can be edited using the CLI. Changes do not display until you reboot the virtual machine.
+Edit select values of a virtual machine in the *Virtual Machine Overview* screen
+of the web console. Other values can be edited using the CLI. Changes do not
+display until you reboot the virtual machine.
 
 .Prerequisites
 

--- a/modules/cnv-initiating-vm-migration-web.adoc
+++ b/modules/cnv-initiating-vm-migration-web.adoc
@@ -5,20 +5,23 @@
 [id="cnv-initiating-vm-migration-web_{context}"]
 = Initiating live migration of a virtual machine instance in the web console
 
-Migrate a running virtual machine instance to a different node in the cluster. 
+Migrate a running virtual machine instance to a different node in the cluster.
 
 [NOTE]
 ====
-The *Migrate Virtual Machine* action is visible to all users but only admin users 
-can initiate a virtual machine migration. 
+The *Migrate Virtual Machine* action is visible to all users but only admin users
+can initiate a virtual machine migration.
 ====
 
 .Procedure
 
 . In the {ProductName} console, click *Workloads* -> *Virtual Machines*.
-. You can initiate the migration from this screen, which makes it easier to perform actions on multiple virtual machines in the one screen, or from the *Virtual Machine Details* screen where you can view comprehensive details of the selected virtual machine:
+. You can initiate the migration from this screen, which makes it easier to
+perform actions on multiple virtual machines in the one screen, or from the
+*Virtual Machine Details* screen where you can view comprehensive details of the
+selected virtual machine:
 ** Click the Options menu {kebab} at the end of virtual machine and select
-*Migrate Virtual Machine Migration*.
+*Migrate Virtual Machine*.
 ** Click the virtual machine name to open the *Virtual Machine Details*
-screen and click *Actions* -> *Migrate Virtual Machine Migration*.
+screen and click *Actions* -> *Migrate Virtual Machine*.
 . Click *Migrate* to migrate the virtual machine to another node.

--- a/modules/cnv-preparing-to-install.adoc
+++ b/modules/cnv-preparing-to-install.adoc
@@ -5,14 +5,17 @@
 [id="cnv-preparing-to-install_{context}"]
 = Preparing to install {ProductName}
 
-Before deploying {ProductName}, you must create the `kubevirt-hyperconverged`
-namespace. After the namespace is created, create a supporting `OperatorGroup`
-and `CatalogSource`.
+Before deploying {ProductName}:
+
+* Create a namespace called `kubevirt-hyperconverged`.
+* Create `OperatorGroup` and `CatalogSource` Custom Resource Definition objects
+(CRDs) in the `kubevirt-hyperconverged` namespace.
 
 .Prerequisites
 
 * {product-title} 4.1
 * User with `cluster-admin` privileges
+* The {product-title} Command-line Interface (CLI), commonly known as `oc`
 
 .Procedure
 
@@ -23,7 +26,7 @@ command:
 $ oc new-project kubevirt-hyperconverged
 ----
 
-. Create the `OperatorGroup` and `CatalogSource` for the
+. Create the `OperatorGroup` and `CatalogSource` in the
 `kubevirt-hyperconverged` namespace by running the following command:
 +
 ----

--- a/modules/cnv-subscribing-to-hco-catalog.adoc
+++ b/modules/cnv-subscribing-to-hco-catalog.adoc
@@ -7,18 +7,17 @@
 
 Before you install {ProductName}, subscribe to the
 *KubeVirt HyperConverged Cluster Operator* catalog from
-the {product-title} {product-version} web console. Subscribing gives the
-`kubevirt-hyperconverged` namespace access to the {ProductName} Operators.
+the {product-title} web console. Subscribing gives the `kubevirt-hyperconverged`
+namespace access to the {ProductName} Operators.
 
 .Prerequisites
 
-* The `kubevirt-hyperconverged` namespace, with a supporting `OperatorGroup`
-and `CatalogSource`
+* `OperatorGroup` and `CatalogSource` Custom Resource Definition objects (CRDs),
+both created in the `kubevirt-hyperconverged` namespace
 
 .Procedure
 
-. Open a browser window and navigate to the {product-title} {product-version}
-web console.
+. Open a browser window and navigate to the {product-title} web console.
 
 . Select the `kubevirt-hyperconverged` project from the *Projects* list.
 


### PR DESCRIPTION
This PR fixes a few issues raised by the translation team and a few assorted issues that I found in the process.

Fixes include:

- Clearly specified that `OperatorGroup` and `CatalogSource` are CRD objects
- Fixed error that made it seem like the *Virtual Machine Overview* screen might not be in the web console
- Typo: removed `state.` from cnv-editing-template-web.adoc
- Typo: *Migrate Virtual Machine Migration* -> *Migrate Virtual Machine* in two places in cnv-initiating-vm-migration-web.adoc
- Added a few newlines to cap line length
- Assorted installation assembly improvements (introductory sentence, added tech preview module, moved prerequisites to module, rephrased a couple of things for clarity)
- Removed {product-version} because it does not exist in cnv-document-attributes.adoc

These changes are for enterprise-4.1 and enterprise-4.2.
