### PR TITLE
group sync needs to indicate that userNameAttributes needs to match LDAP configuration

### DIFF
--- a/install_config/syncing_groups_with_ldap.adoc
+++ b/install_config/syncing_groups_with_ldap.adoc
@@ -326,7 +326,7 @@ rfc2307:
         derefAliases: never
         pageSize: 0
     userUIDAttribute: dn <6>
-    userNameAttributes: [ mail ] <7>
+    userNameAttributes: [ uid ] <7>
     tolerateMemberNotFoundErrors: false
     tolerateMemberOutOfScopeErrors: false
 ----
@@ -410,7 +410,7 @@ rfc2307:
         derefAliases: never
         pageSize: 0
     userUIDAttribute: dn <4>
-    userNameAttributes: [ mail ]
+    userNameAttributes: [ uid ]
     tolerateMemberNotFoundErrors: false
     tolerateMemberOutOfScopeErrors: false
 ----
@@ -554,7 +554,7 @@ rfc2307:
         scope: sub
         derefAliases: never
     userUIDAttribute: dn <3>
-    userNameAttributes: [ mail ]
+    userNameAttributes: [ uid ]
     tolerateMemberNotFoundErrors: true <1>
     tolerateMemberOutOfScopeErrors: true <2>
 ----
@@ -665,7 +665,7 @@ activeDirectory:
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
         pageSize: 0
-    userNameAttributes: [ mail ] <1>
+    userNameAttributes: [ uid ] <1>
     groupMembershipAttributes: [ memberOf ] <2>
 ----
 <1> The attribute to use as the name of the user in the {product-title} group record.
@@ -788,7 +788,7 @@ augmentedActiveDirectory:
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
         pageSize: 0
-    userNameAttributes: [ mail ] <3>
+    userNameAttributes: [ uid ] <3>
     groupMembershipAttributes: [ memberOf ] <4>
 ----
 <1> The attribute that uniquely identifies a group on the LDAP server. You
@@ -953,7 +953,7 @@ augmentedActiveDirectory:
         derefAliases: never
         filter: (objectclass=inetOrgPerson)
         pageSize: 0
-    userNameAttributes: [ mail ] <4>
+    userNameAttributes: [ uid ] <4>
     groupMembershipAttributes: [ "memberOf:1.2.840.113556.1.4.1941:" ] <5>
 ----
 <1> `groupsQuery` filters cannot be specified. The `groupsQuery` base DN and scope
@@ -961,7 +961,7 @@ values are ignored. `groupsQuery` must set a valid `derefAliases`.
 <2> The attribute that uniquely identifies a group on the LDAP server. It must be set to `dn`.
 <3> The attribute to use as the name of the group.
 <4> The attribute to use as the name of the user in the {product-title} group
-record. `mail` or `sAMAccountName` are preferred choices in most installations.
+record. `uid` or `sAMAccountName` are preferred choices in most installations.
 <5> The attribute on the user that stores the membership information. Note the use
 of https://msdn.microsoft.com/en-us/library/aa746475(v=vs.85).aspx[`LDAP_MATCHING_RULE_IN_CHAIN`].
 


### PR DESCRIPTION
The example LDAP configuration in the documentation uses "uid" as the preferredUsername, but then the sync examples (https://docs.openshift.org/latest/install_config/syncing_groups_with_ldap.html) use "mail" as the userNameAttributes.

...there was a mismatch between the two examples....the two examples need to match
https://github.com/openshift/openshift-docs/issues/1424