### PR TITLE
Correct oreg_url syntax typos that cause installation failures

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -982,7 +982,7 @@ If you use the default registry at `registry.redhat.io`, you must set the follow
 variables:
 
 ----
-oreg_url=registry.redhat.io/openshift3/ose-$<component>:$<version>
+oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user="<user>"
 oreg_auth_password="<password>"
 ----


### PR DESCRIPTION
Using the following variable:

oreg_url=registry.redhat.io/openshift3/ose-$\<component\>:$\<version\>

will result in the following error during installation:

  1. Hosts:    openshift.example.com
     Play:     OpenShift Health Checks
     Task:     Run health checks (install) - EL
     Message:  One or more checks failed
     Details:  check "docker_image_availability":
              One or more required container images are not available:
                   registry.redhat.io/openshift3/ose-$\<component\>:$\<version\>
               Checked with: skopeo inspect [--tls-verify=false] [--creds=\<user\>:\<pass\>] docker://\<registry\>/\<image\>
              
Should be this instead:

oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}