### PR TITLE
Corrected example for in_forward for external logger

### DIFF
--- a/modules/efk-logging-fluentd-external.adoc
+++ b/modules/efk-logging-fluentd-external.adoc
@@ -95,11 +95,10 @@ secure-forward.conf: |
     # for private CA secret key
   # ca_private_key_passphrase passphrase
 
-  # <server>
-    # or IP
-  #   host server.fqdn.example.com
-  #   port 24284
-  # </server>
+  <server>
+    host server.fqdn.example.com  # or IP
+    # port 24284
+  </server>
   # <server>
     # ip address to connect
   #   host 203.0.113.8


### PR DESCRIPTION
@richm Tiny change. I think I was missing the Host address in the configuration sample for sending Fluentd logs to an external aggregator using `in_forward` for Fluentd 0.12