### PR TITLE
[enterprise-3.10] Pod/Container can steal cpu/memory resources if cluster admin did not set minimum (not maximum) limitrange

### DIFF
--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -26,6 +26,10 @@ enumerated constraints, then the resource is rejected. If the resource does not
 set an explicit value, and if the constraint supports a default value, then the
 default value is applied to the resource.
 
+For CPU and Memory limits, if you specify a `max` value, but do not specify a
+`min` limit, the resource can consume CPU/memory resources greater than `max` value`.
+
+
 ifdef::openshift-origin,openshift-enterprise[]
 [NOTE]
 ====
@@ -93,13 +97,19 @@ containers.
 <3> The maximum amount of memory that a pod can request on a node across all
 containers.
 <4> The minimum amount of CPU that a pod can request on a node across all
-containers.
+containers. Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value.
 <5> The minimum amount of memory that a pod can request on a node across all
-containers.
+containers. Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value. 
 <6> The maximum amount of CPU that a single container in a pod can request.
 <7> The maximum amount of memory that a single container in a pod can request.
 <8> The minimum amount of CPU that a single container in a pod can request.
+Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value.
 <9> The minimum amount of memory that a single container in a pod can request.
+Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value.
 <10> The default amount of CPU that a container will be limited to use if not
 specified.
 <11> The default amount of memory that a container will be limited to use if not specified.
@@ -134,7 +144,9 @@ spec:
         cpu: "2" <4>
       	memory: "1Gi" <5>
       	ephemeral-storage: "1Gi" <6>
-
+     max:
+        cpu: "1" <7>
+      	memory: "1Gi" <8>
 ----
 <1> The maximum size of an image that can be pushed to an internal registry.
 <2> The maximum number of unique image tags per image stream's spec.
@@ -142,9 +154,13 @@ spec:
 <4> The maximum amount of CPU that a pod can request on a node across all containers.
 <5> The maximum amount of memory that a pod can request on a node across all containers.
 <6> The maximum amount of ephemeral storage that a pod can request on a node
-across all containers, if the ephemeral storage technology preview is enabled
-for {product-title} 3.10.
-
+across all containers, if the ephemeral storage technology preview is enabled.
+<7> The minimum amount of CPU that a pod can request on a node across all containers.
+Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value.
+<8> The minimum amount of memory that a pod can request on a node across all containers.
+Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value.
 // end::admin_limits_sample_definitions_2[]
 
 Both core and {product-title} resources can be specified in just one limit range
@@ -176,7 +192,8 @@ Per container, the following must hold true if specified:
 (optional)
 
 If the configuration defines a `min` CPU, then the request value must be greater
-than the CPU value. A limit value does not need to be specified.
+than the CPU value. Not setting a `min` value or setting `0` is unlimited 
+allowing the pod to consume more than the `max` value.
 
 |`*Max*`
 |`container.resources.limits[resource]` (required) less than or equal to
@@ -228,17 +245,18 @@ Across all containers in a pod, the following must hold true:
 
 |`*Min*`
 |`Min[resource]` less than or equal to `container.resources.requests[resource]`
-(required) less than or equal to `container.resources.limits[resource]`
-(optional)
+(required) less than or equal to `container.resources.limits[resource]`.
+Not setting a `min` value or setting `0` is unlimited allowing the 
+pod to consume more than the `max` value.
 
 |`*Max*`
 |`container.resources.limits[resource]` (required) less than or equal to
-`Max[resource]`
+`Max[resource]`.
 
 |`*MaxLimitRequestRatio*`
 |`MaxLimitRequestRatio[resource]` less than or equal to (
 `container.resources.limits[resource]` /
-`container.resources.requests[resource]`)
+`container.resources.requests[resource]`).
 
 |===
 // end::admin_limits_pod_limits[]

--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -16,10 +16,14 @@ ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicate
 
 A limit range provides a mechanism to enforce min/max limits placed on resources
 in a Kubernetes
-xref:../core_concepts/projects_and_users.adoc#namespaces[namespace].
+xref:../core_concepts/projects_and_users.adoc#namespaces[namespace]. 
 
 By adding a limit range to your namespace, you can enforce the minimum and
 maximum amount of CPU and Memory consumed by an individual pod or container.
+
+For CPU and Memory limits, if you specify a `max` value, but do not specify a
+`min` limit in the LimitRange object, the resource can consume CPU/memory 
+resources greater than `max` value`.
 
 == ResourceQuota
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/16312