### PR TITLE
OCP 4.1 cluster limits changes

### DIFF
--- a/modules/openshift-cluster-limits.adoc
+++ b/modules/openshift-cluster-limits.adoc
@@ -13,13 +13,13 @@
 | 2,000
 | 2,000
 | 2,000
-| 250
+| 2,000
 
 | Number of pods footnoteref:[numberofpods,The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.]
 | 120,000
 | 150,000
 | 150,000
-| 62,500
+| 150,000
 
 | Number of pods per node
 | 250
@@ -37,7 +37,7 @@
 | 10,000
 | 10,000
 | 10,000
-| 8,000
+| 10,000
 
 | Number of builds: Pipeline Strategy
 | 10,000 (Default pod RAM 512 Mi)


### PR DESCRIPTION
This commit bumps up the number of nodes, namespaces per cluster and
total number of pods limit for OpenShift 4.1.