### PR TITLE
templates: pass OSD version when searching

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -130,7 +130,7 @@
 
   var distros = {
     'openshift-origin': ['docs_origin', version],
-    'openshift-dedicated': ['docs_dedicated'],
+    'openshift-dedicated': ['docs_dedicated', version],
     'openshift-online': ['docs_online'],
     'openshift-enterprise': ['docs_cp', version]
   };

--- a/_templates/_search_dedicated.html.erb
+++ b/_templates/_search_dedicated.html.erb
@@ -17,5 +17,5 @@
 </div>
 
 <script>
-  hcSearchCategory("docs_dedicated");
+  hcSearchCategory("docs_dedicated", "<%= version %>");
 </script>


### PR DESCRIPTION
This simply adds passing the version parameter for OpenShift Dedicated search, so that only relevant results are displayed (currently the v3 and v4 results are mixed when searching in either OSD docs). The functionality can be previewed here:
[OSD v3](http://commercial-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/dedicated/3/welcome/index.html)
[OSD v4](http://commercial-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/dedicated/4/welcome/index.html)

@vikram-redhat PTAL