### PR TITLE
Remove VM provisioning vars from official docs

### DIFF
--- a/install_config/topics/configuring_for_vsphere.adoc
+++ b/install_config/topics/configuring_for_vsphere.adoc
@@ -73,13 +73,6 @@ openshift_deployment_type=openshift-enterprise
 oreg_url=registry.access.redhat.com/openshift3/ose-${component}:${version}
 openshift_examples_modify_imagestreams=true
 
-VM deployment
-openshift_cloudprovider_vsphere_template="rhel75-template"
-openshift_cloudprovider_vsphere_vm_network="VM Network"
-openshift_cloudprovider_vsphere_vm_netmask="255.255.254.0"
-openshift_cloudprovider_vsphere_vm_gateway="10.x.y.254"
-openshift_cloudprovider_vsphere_vm_dns="10.x.y.5"
-
 # vSphere Cloud provider
 openshift_cloudprovider_kind=vsphere
 openshift_cloudprovider_vsphere_username="administrator@vsphere.local"


### PR DESCRIPTION
This removes the mention of the provisioning Ansible variables for vSphere. Provisioning is covered under an unsupport appendix section of the vsphere reference architecture for OCP 3.10 and 3.11.

As per BZ# https://bugzilla.redhat.com/show_bug.cgi?id=1730003

