### PR TITLE
clarifying a note and removing a GitHub link

### DIFF
--- a/install_config/oab_broker_configuration.adoc
+++ b/install_config/oab_broker_configuration.adoc
@@ -569,8 +569,8 @@ registry:
       - ".*"
 ----
 
-NOTE: A heavy percentage of helm charts from the stable repository are not well suited for OpenShift.
-See the link:https://github.com/ansibleplaybookbundle/helm2bundle/wiki/Known-Issues[Known Issues] for more information.
+NOTE: Many Helm charts in the stable repository are not suitable for use with
+{product-title} and will fail with errors if you use them.
 
 [[oab-config-api-v2-registry]]
 === API V2 Docker Registry


### PR DESCRIPTION
Our translator had questions about this section, so I think we should clarify the text. One of the questions involved the suitability of the GitHub link. I don't think that it's vital enough to get an exemption to include it.

@nccurry, @bergerhoffer, will you PTAL?