### PR TITLE
Remove fluentd to external elasticsearch unsupported scenarios for 3.x

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -2125,14 +2125,8 @@ For an external Elasticsearch instance to contain both application and
 operations logs, you can set `ES_HOST` and `OPS_HOST` to the same destination,
 while ensuring that `ES_PORT` and `OPS_PORT` also have the same value.
 
-If your externally hosted Elasticsearch instance does not use TLS, update the
-`_CLIENT_CERT`, `_CLIENT_KEY`, and `_CA` variables to be empty. If it does
-use TLS, but not mutual TLS, update the `_CLIENT_CERT` and `_CLIENT_KEY`
-variables to be empty and patch or recreate the *logging-fluentd* secret with
-the appropriate `_CA` value for communicating with your Elasticsearch instance.
-If it uses Mutual TLS as the provided Elasticsearch instance does, patch or
-recreate the *logging-fluentd* secret with your client key, client cert, and CA.
-
+Only Mutual TLS configuration is supported, as the provided Elasticsearch instance does. 
+Patch or recreate the *logging-fluentd* secret with your client key, client cert, and CA.
 
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1739626
Need for change confirmed via https://coreos.slack.com/archives/GGUR75P60/p1566582530378100