### PR TITLE
reworking if statements in the installation modules

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -4,6 +4,13 @@
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // Consider also adding the installation-configuration-parameters.adoc module.
 
+ifeval::["{context}" == "install-customizations-cloud"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:aws:
+endif::[]
+
 [id="installation-initializing_{context}"]
 = Creating the installation configuration file
 
@@ -42,12 +49,14 @@ For production {product-title} clusters on which you want to perform installatio
 debugging or disaster recovery, you must provide an SSH key that your `ssh-agent`
 process uses to the installation program.
 ====
-... Select AWS as the platform to target.
-... If you do not have an AWS profile stored on your computer, enter the AWS
+ifdef::aws[]
+... Select *AWS* as the platform to target.
+... If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS
 access key ID and secret access key for the user that you configured to run the
 installation program.
 ... Select the AWS region to deploy the cluster to.
 ... Select the base domain for the Route53 service that you configured for your cluster.
+endif::aws[]
 ... Enter a descriptive name for your cluster.
 ... Paste the pull secret that you obtained from the
 link:https://cloud.redhat.com/openshift/install[OpenShift Infrastructure Providers] page.

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -6,6 +6,19 @@
 // If you use this module in any other assembly, you must update the ifeval
 // statements.
 
+ifeval::["{context}" == "install-customizations-cloud"]
+:custom-config:
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:custom-config:
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-default"]
+:no-config:
+:aws:
+endif::[]
+
 [id="installation-launching-installer_{context}"]
 = Deploy the cluster
 
@@ -18,7 +31,7 @@ You can run the installation program only once, during initial installation.
 
 .Prerequisites
 
-* Configure an Amazon Web Services (AWS) account to host your cluster.
+* Configure an account with the cloud platform that hosts your cluster.
 * Obtain the {product-title} installation program and the pull secret for your
 cluster.
 
@@ -30,18 +43,16 @@ cluster.
 $ ./openshift-install create cluster --dir=<installation_directory> \ <1>
     --log-level debug <2>
 ----
-ifeval::["{context}" == "install-customizations-cloud"]
+ifdef::custom-config[]
 <1> For `<installation_directory>`, specify the location of your customized
 `./install-config.yaml` file.
-endif::[]
-ifeval::["{context}" == "installing-aws-network-customizations"]
-<1> For `<installation_directory>`, specify the location of your
-customized `./install-config.yaml` file.
-endif::[]
-ifeval::["{context}" == "installing-aws-default"]
+endif::custom-config[]
+ifdef::no-config[]
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.
+endif::no-config[]
 <2> Optionally, include the `--log-level debug` option to view installation details.
+ifdef::no-config[]
 +
 [IMPORTANT]
 ====
@@ -64,21 +75,23 @@ For production {product-title} clusters on which you want to perform installatio
 debugging or disaster recovery, you must provide an SSH key that your `ssh-agent`
 process uses to the installation program.
 ====
+ifdef::aws[]
 .. Select AWS as the platform to target.
-.. If you do not have an AWS profile stored on your computer, enter the AWS
+.. If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS
 access key ID and secret access key for the user that you configured to run the
 installation program.
 .. Select the AWS region to deploy the cluster to.
 .. Select the base domain for the Route53 service that you configured for your cluster.
 .. Enter a descriptive name for your cluster.
+endif::aws[]
 .. Paste the pull secret that you obtained from the
 link:https://cloud.redhat.com/openshift/install[OpenShift Infrastructure Providers] page.
 --
-endif::[]
+endif::no-config[]
 +
 [NOTE]
 ====
-If the AWS account that you configured on your host does not have sufficient
+If the cloud provider account that you configured on your host does not have sufficient
 permissions to deploy the cluster, the installation process stops, and the
 missing permissions are displayed.
 ====
@@ -92,6 +105,7 @@ display in your terminal.
 You must not delete the installation program or the files that the installation
 program creates. Both are required to delete the cluster.
 ====
-
+ifdef::aws[]
 . Optional: Remove or disable the `AdministratorAccess` policy from the IAM
 account that you used to install the cluster.
+endif::aws[]


### PR DESCRIPTION
@jboxman, will you PTAL? The `installation-launching-installer.adoc` module was becoming unworkable with the new GCP and Azure content, so I think that implementing the combination of ifeval and ifdef statements that you mentioned will be necessary.

I'd like to apply this change as a separate PR so I can tidy up my installation PRs.