### PR TITLE
Bug BZ1725931 Certificate Background Info

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -1,5 +1,5 @@
 [[install-config-certificate-customization]]
-= Configuring Custom Certificates
+= Managing and Configuring Custom Certificates
 {product-author}
 {product-version}
 :data-uri:
@@ -11,12 +11,288 @@
 
 toc::[]
 
-== Overview
-Administrators can configure custom serving certificates for the public host
-names of the {product-title} API and
+[[pkis-to-manage-certificates]]
+== Using PKIs to Manage Certificates
+{product-name} includes several Public Key Infrastructures (PKIs) that
+can authenticate systems, typically on the server side of the communication.
+One way they perform system authentication is to manage certificates used
+for specific purposes. The PKIs perform different functions and must be
+configured in order to make informed security decisions.
+
+Among other things, a PKI is a hierarchy of certificate authorities and certificates.
+
+[NOTE]
+====
+PKIs include more components than certificates, but this discussion focuses on
+certificate hierarchy.
+====
+
+[[pki-structure]]
+=== PKI Structure
+A PKI has a structure similar to a tree, with a root, branches, and leaves.
+
+* The root is the Root CA, which is always a self-signed certificate.
+* The branches are subsidiary (sometimes also called intermediary) certificate
+authorities.
+* The leaves are the certificates that systems, users, and services can directly
+use to identify themselves.
+
+Leaf certificates, also known as end-entity certificates, are signed by the
+branches to which they are attached. Each branch is signed by a higher order
+branch until the path reaches back to the Root CA, which is self-signed.
+
+Processes and infrastructure of the complete PKI, together with this hierarchy,
+operate the entire authentication system. In certain cases, the Root CAs
+are stored in secure, disconnected locations, and a PKI only uses SubCAs to create
+certificates.
+
+A PKI also has processes to request and produce new certificates. At one time,
+the processes were mostly manual, and they were managed by a dedicated team.
+More recently, the PKI certificate process now also uses automation, such
+Ansible.
+
+If a system needed only an encrypted connection,  self-signed certificates 
+could suffice. However, since encryption alone is not enough
+to authenticate systems, CA-signed certificates are also necessary.
+
+[[pki-types]]
+=== Types of PKIs
+
+{product-name} can use various PKIs, including:
+
+* <<Platform PKIs>>
+* <<Etcd PKIs>>
+* <<Aggregator Proxy PKIs>>
+* <<Application-level PKIs>>
+
+[[pki-types-platform-pki]]
+==== Platform PKIs
+
+The platform PKI manages the platform components’ certificates,
+which include the master API, controllers, and nodes. Also, by default, most of
+the infrastructure components deployed at install time are signed by this CA,
+including metrics, logging, and the default router wildcard certificate. However,
+you can override these default certificates by using Ansible inventory parameters.
+
+At install time, it is also possible for the installer to create a new PKI, or
+to pass a SubCA and let {product-name} make use of it. In this case, {product-name}
+has full control of that SubCA, including access to its private keys. Supplying
+a SubCA at install time can be used, for example, when a company has
+an existing PKI, and a new SubCA is generated for use with {product-name}.
+
+By default, the PKI CA-related files are stored on all {product-name} masters in
+the `/etc/origin/master` directory as shown below:
+
+----
+[root@master-0 ~]# ls -la /etc/origin/master/ca*
+-rw-r--r--. 1 root root 1070 Nov 15 11:06 /etc/origin/master/ca-bundle.crt
+-rw-r--r--. 1 root root 1070 Nov 15 11:05 /etc/origin/master/ca.crt
+-rw-------. 1 root root 1679 Nov 15 11:05 /etc/origin/master/ca.key
+-rw-r--r--. 1 root root    3 Nov 15 11:20 /etc/origin/master/ca.serial.txt
+----
+
+[[pki-types-etcd-pki]]
+==== Etcd PKIs
+
+An Etcd cluster has its own PKI. The PKI Root CA files can be found in the 
+`/etc/etcd/ca` directory, as follows:
+
+----
+[root@master-0 ~]# ls -la /etc/etcd/ca
+total 48
+-rw-r--r--. 3 root root  1895 Nov 15 10:58 ca.crt
+-rw-r--r--. 1 root root  3272 Nov 15 10:58 ca.key
+----
+
+You cannot customize the Ectd PKI at install time. It is also very
+complicated to replace the Root CA and the associated certificates that have been
+generated with it at a later time. Therefore, it is recommended to use the Root CA
+for the Ectd PKI.
+
+It is possible to use the `redeploy-ca.yml` playbook to re-deploy a new CA if,
+for example, a system compromise is suspected.
+
+[[pkis-types-aggregator-proxy]]
+==== Aggregator Proxy PKIs
+
+This PKI is dedicated to managing certificates for extension API servers. This
+feature allows an extension of the control plane API by adding services dedicated
+to handling specific APIs. It is an alternative way of extending the API to 
+Custom Resource Definitions (CRDs) and controllers.
+
+Customizing the Aggregator Proxy PKI is not supported.
+
+The files of the Root CA are located in the {product-name} configuration directory,
+as follows:
+
+----
+[root@master-0 ~]# ls -la /etc/origin/master/frontproxy*
+-rw-r--r--. 1 root root 1078 Nov 15 11:06 /etc/origin/master/frontproxy-ca.crt
+-rw-------. 1 root root 1675 Nov 15 11:06 /etc/origin/master/frontproxy-ca.key
+-rw-r--r--. 1 root root    3 Nov 15 11:06 /etc/origin/master/frontproxy-ca.serial.txt
+encrypted routes.
+----
+
+[[pkis-types-application-level]]
+==== Application level PKIs
+￼
+{product-name} also includes an application level PKI. This PKI manages certificates
+generated with the service serving certificate secret feature. You can locate the
+Root CA files for this PKI as follows:
+
+----
+[root@master-0 ~]# ls -la /etc/origin/master/service-*
+-rw-r--r--. 1 root root 1115 Nov 15 11:06 /etc/origin/master/service-signer.crt
+-rw-------. 1 root root 1675 Nov 15 11:06 /etc/origin/master/service-signer.key
+----
+
+This feature enables {product-name} to generate certificates that can be used for
+pod-to-pod communications because they present the service name in the Subject
+Alternative Name field (SAN). You cannot initialize the application
+level PKI at install time with a SubCA. However, you can replace the Root CA
+with a SubCA after the installation completes.
+
+
+[[pki-security]]
+== Security Considerations of {product-name}-managed PKIs
+
+As described previously, the {product-name}-managed PKI can be
+installed with a RootCA or an externally supplied SubCA.
+
+[NOTE]
+====
+Some PKIs are more difficult to configure this way than others. For this reason,
+using the self-generated PKI for {product-name} instead of a SubCA PKI, is
+recommended. Doing so diminishes the impact of the CA private key being compromised.
+====
+
+
+[[pki-security-certificate-validation]]
+=== Certificate Validation
+
+Although there are several steps in the certificate validation algorithm,
+validation of the chain of trust is a significant part of PKI certificate validation.
+
+To validate that a certificate has been issued by a trusted Certificate, the
+validator must be able to retrace the steps up the chain from the presented
+certificate through all the intermediary CAs up to the Root CA.
+
+For validation to be successful, all of the CA's public keys, including the
+intermediary and root keys, must be available to the client. Normally a client,
+such as a browser, will only hold (and therefore trust) the Root CA of any trusted
+PKIs. However, during the TLS handshake, the server is allowed to send the
+entire CA certification path together with the certificate to be validated.
+For this reason, for a client to trust a certificate, it only needs
+to trust the Root CA, regardless of the depth of the chain of trust.
+
+[[pki-security-compromised-pki]]
+=== Consequences of a PKI being Compromised
+
+When a PKI is compromised, a hacker could possibly forge new certificates
+that pretend to be a legitimate server on any domain. If this were to occur, such
+certificates would be trusted by the rest of the system.
+
+If the self-generated PKI were used for {product-name}, the impact of it being
+compromised is contained to the {product-name} cluster. To remediate this
+situation, either run the `redeploy-openshift-ca` playbook to redeploy all
+certificates, or simply destroy and recreate the cluster.
+
+If you used a SubCA to install {product-name}, the impact extends
+to any system that trusts the RootCA from which that SubCA was generated, either
+directly or indirectly. In a company where the internal PKI was used to create
+a SubCA for {product-name}, this can impact the entire internal network, including
+both client and server machines. In fact, any client that trusts the company root
+CA would also trust a certificate forged with the stolen SubCA.
+
+[[pki-security-compromised-mitigation]]
+=== Mitigating PKI Compromise
+
+If a company’s SubCA was used to install {product-name}, you can use this
+procedure to mitigate the impact of a stolen SubCa:
+
+
+. Use the name constraint extension to scope down the domain of the certificates
+that can be generated by the SubCA. Ideally, the OCP cluster in question would be
+confined to its own domain, and everything else in the company would use different
+domains.
+
+. Use certificate transparency logging approaches to try to detect if rogue
+certificates are circulating in the company environments.
+
+. If you suspect that the OCP CA has been compromised, revoke it. This also
+implies that all certificates issued by that CA are no longer valid.
+
+. Use mechanisms such as certificate revocation list and OSCP stapling to ensure
+that clients on the company network do not trust revoked certificates.
+
+[NOTE]
+====
+Even when you use these mechanisms, the system may still trust revoked certificates.
+====
+
+Because the impact of a compromised SubCA propagates to the entire company’s
+network, it is recommended to keep the {product-name} PKIs separate from the
+company's main PKI. Using a Root CA for the {product-name} PKIs is a way to
+accomplish this. This explains why even with the Root CA, self-signed by definition, 
+there are no self-signed platform certificates in an {product-name} deployment.
+
+Because the services using the certificates generated with the {product-name}-managed
+PKIs form closed systems, there is no need to establish a level of trust with
+the rest of the company’s network. Therefore, using a Root CA for these PKIs does
+not introduce any limitations in the use of {product-name}. There is, however, a
+limited set of endpoints that need to be accessible and trusted from outside of
+{product-name}.
+
+[[External-endpoints]]
+== External Endpoints
+
+Some platform components, such the master API external endpoint, metrics, logging,
+and registry for instance, are exposed externally, and it is expected that users
+in the company network will connect to them. For these components, you should
+configure company-issued certificates so they can be trusted by external users.
+
+You can customize those components that are not customizable at install time
+after installation completes. Furthermore, those components that have
+the certificates defined in the route, if not customized, will use the default
+route certificate. Each of these components can be addressed by customizing this
+certificate.
+
+[[Wildcard-router-certificate]]
+== Wildcard Certificate for the Router
+
+By default, {product-name} uses a wildcard certificate in the router. When creating
+an encrypted route, you can choose whether to use the default wildcard certificate
+or use a router-specific certificate.
+
+Because a router’s certificates are externally facing, they should be company-signed.
+Also consider that wildcard certificates have been deprecated by the Internet
+Engineering Task Force (IETF, the organization overseeing the PKI/TLS standards).
+While it may be some time before wildcard certificates will stop functioning, it
+will most likely occur if this deprecation stands. For this reason, you should use
+a solution that does not rely on wildcard certificates.
+
+Development teams should be able to use self-provisioned certificates for their
+applications. This can be achieved by automating the certificate request process,
+such as by using the Automated Certificate Management Environment (ACME) protocol.
+
+If your organization does not allow that capability, it is recommended that you use
+wildcard certificates for non-production environments in which you expect a high
+number of new certificate requests.
+
+However, in production environments, where fewer requests for certificates would
+be expected to occur, it is recommended that you continue to use manually-provisioned
+certificates, because the overhead associated with the manual requests should be
+acceptable.
+
+[[custom-certificate-configuration]]
+== Configuring Custom Certificates
+
+In many cases, default certificates already in place are the best certificates
+to use; however, you can also configure custom certificates for specific purposes
+for the public host names of the {product-title} API and
 xref:../architecture/infrastructure_components/web_console.adoc#architecture-infrastructure-components-web-console[web console].
-This can be done during a
-xref:../install/configuring_inventory_file.adoc#advanced-install-custom-certificates[cluster installation] or configured after installation.
+This can be done during a xref:../install/configuring_inventory_file.adoc#advanced-install-custom-certificates[cluster installation]
+or configured after installation.
 
 [[using-certificate-chains]]
 == Configuring a Certificate Chain


### PR DESCRIPTION
For BUG BZ1725931: For Closed Loop Escalation Customer Support Case 02374412: Customer wants all information in the docs in one place. Initially, request was to modify https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html with additional, background information. 

However, to include everything from our docs in one place, we would have to redesign a number of books, which we are not going to do at this time, especially going back to release 3.11.

As a compromise, I'm suggesting adding the 292 new lines shown below as introductory/preparatory material to the certificate_customization.adoc file instead. 

Note: there are many cross-references in the BZ from Red Hat TAM Silvio Perez Torres to other files he sent the customer, and those could be added as links in the configuring_authentication.adoc file if it is determined to do so. I have not added all those references here.

silvio.perez@redhat.com, will you PTAL at this file, and see what you recommend for further information required, especially in the certificate_customization file mentioned above. 
