### PR TITLE
CNV-2284 Live migration now includes VMs with CephFS and RBD volumes

### DIFF
--- a/modules/cnv-understanding-live-migration.adoc
+++ b/modules/cnv-understanding-live-migration.adoc
@@ -14,8 +14,8 @@ which it is running is placed into maintenance.
 
 [NOTE]
 ====
-NFS shared volumes are the only shared data volume type supported for 
-live migration in {CNVProductName} 2.0.
+NFS shared volumes, CephFS volumes, and Ceph RADOS Block Devices (RBDs) are the 
+only shared data volume type that are supported for live migration in {CNVProductName} 2.1. 
 ====
 
 

--- a/modules/cnv-understanding-node-maintenance.adoc
+++ b/modules/cnv-understanding-node-maintenance.adoc
@@ -17,9 +17,7 @@ node and recreated on another node.
 
 [NOTE]
 ====
-NFS shared volumes are the only shared data volume type supported for
-live migration in {CNVProductName} 2.0.
+NFS shared volumes, CephFS volumes, and Ceph RADOS Block Devices (RBDs) are the
+only shared data volume type that are supported for live migration in {CNVProductName} 2.1.
 ====
-
-
 


### PR DESCRIPTION
Changing live migration note to reflect 2.1 addition of CephFS and RBD for VM live migration, made available through OCS 4.2

cherrypick to enterprise-4.2