### PR TITLE
Add a note to clarify master certs redeployment.

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -413,6 +413,11 @@ $ ansible-playbook -i <inventory_file> \
     playbooks/openshift-master/redeploy-certificates.yml
 ----
 
+[NOTE]
+====
+If you use named certificates, you must update xref:../install_config/certificate_customization.adoc#configuring-custom-certificates[named certificate parameters] in the *_master-config.yaml_* file on each master node. Then, restart the {product-title} master services to apply the changes.
+====
+
 [IMPORTANT]
 ====
 After running this playbook, you must regenerate any xref:../dev_guide/secrets.adoc#service-serving-certificate-secrets[service signing certificate or key pairs]


### PR DESCRIPTION
Redeploying master certs docs [1] is not clear, as it seems the only step neeeded is to run the playbook, but changing master-config.yaml manually is required.

[1] https://docs.openshift.com/container-platform/3.11/install_config/redeploying_certificates.html#redeploying-master-certificates