### PR TITLE
Bug 1746768: "oc apply -f <yaml>" example is always showing warning messages

### DIFF
--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -29,7 +29,7 @@ users can authenticate.
 . Apply the defined CR:
 +
 ----
-$ oc apply -f </path/to/CR>
+$ oc replace -f </path/to/CR>
 ----
 
 . Log in to the cluster as a user from your identity provider, entering the


### PR DESCRIPTION
* Fix: [Bug 1746768 - "oc apply -f <yaml>" example is always showing warning messages](https://bugzilla.redhat.com/show_bug.cgi?id=1746768)

* Version: v4.x

* Description:
  Always `oc apply` is shown the following message at first time, it's confusing to users whether the command is successful. And it might be unexpected result, such as unmatched fields with the live CR config. Refer [Merging changes to primitive fields](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#merging-changes-to-primitive-fields) for more details.
~~~
# oc apply -f <CR>
Warning: oc apply should be used on resource created by either oc create --save-config or oc apply.
~~~
