### PR TITLE
removing prereq for unmanaged state per slack

### DIFF
--- a/modules/efk-logging-fluentd-external.adoc
+++ b/modules/efk-logging-fluentd-external.adoc
@@ -25,10 +25,6 @@ For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log fo
 The logging deployment provides a `secure-forward.conf` section in the Fluentd configmap
 for configuring the external aggregator:
 
-. Prerequisite
-
-Set cluster logging to the unmanaged state.
-
 .Procedure
 
 To send a copy of Fluentd logs to an external log aggregator:


### PR DESCRIPTION
Using `secure_forward` in managed state is supported per Slack conversation: https://coreos.slack.com/archives/CB3HXM2QK/p1567096883068200