### PR TITLE
CNV2525 - extended Telemetry metrics to include VMs and VMIs

### DIFF
--- a/cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
+++ b/cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
@@ -21,6 +21,7 @@ For more information on cluster logging, see the xref:../../logging/cluster-logg
 
 // Telemetry
 include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]
+include::modules/telemetry-what-information-is-collected.adoc[leveloffset=+1]
 
 == CLI troubleshooting and debugging commands
 

--- a/modules/telemetry-what-information-is-collected.adoc
+++ b/modules/telemetry-what-information-is-collected.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * telemetry/about-telemetry.adoc
+// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc 
+
+ifeval::["{context}" == "cnv-openshift-cluster-monitoring"]
+:cnv-cluster:
+endif::[]
 
 [id="what-information-is-collected_{context}"]
 = What information is collected
@@ -18,6 +23,9 @@ Primary information collected includes:
 * Number of members in the etcd cluster and number of objects currently stored in the etcd cluster
 * Number of CPU cores and RAM used per machine type - infra or master
 * Number of CPU cores and RAM used per cluster
+ifdef::cnv-cluster[]
+* Number of running virtual machine instances in the cluster
+endif::cnv-cluster[]
 * Use of {product-title} framework components per cluster
 * Version of the {product-title} cluster
 * Health, condition, and status for any {product-title} framework component that is installed on the cluster, for example Cluster Version Operator, Cluster Monitoring, Image Registry, and Elasticsearch for Logging


### PR DESCRIPTION
Added conditional information that includes VM and VMI count in the Telemetry 'what info is collected' list