### PR TITLE
BZ_174160 change to CSI 1.0.0

### DIFF
--- a/modules/persistent-storage-csi-example-deployment.adoc
+++ b/modules/persistent-storage-csi-example-deployment.adoc
@@ -37,7 +37,7 @@ attacher and provisioner and DaemonSet with the CSI driver.
 # In production, this needs to be in separate files, e.g. service account and
 # role and role binding needs to be created once.
 #
-# It server as an example how to use external attacher and external provisioner
+# It serves as an example how to use external attacher and external provisioner
 # images shipped with {product-title} with a community CSI driver.
 
 kind: ClusterRole
@@ -108,7 +108,7 @@ spec:
       serviceAccount: cinder-csi
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.4.1
+          image: quay.io/k8scsi/csi-attacher:v1.0.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -130,7 +130,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v0.4.1
+          image: quay.io/k8scsi/csi-provisioner:v1.0.0
           args:
             - "--v=5"
             - "--provisioner=csi-cinderplugin"

--- a/storage/persistent-storage/persistent-storage-csi.adoc
+++ b/storage/persistent-storage/persistent-storage-csi.adoc
@@ -19,7 +19,7 @@ include::modules/technology-preview.adoc[leveloffset=+0]
 use the CSI drivers provided by
 link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors].
 
-{product-title} {product-version} supports version 0.4.0 of the
+{product-title} {product-version} supports version 1.0.0 of the
 link:https://github.com/container-storage-interface/spec[CSI specification].
 ====
 


### PR DESCRIPTION
@liangxia Please review doc changes based on [Issue 16405](https://github.com/openshift/openshift-docs/issues/16405) 

Changed CSI version from 0.4.0 to 1.0.0. 

 **PR is for `enterprise-4.1` branch only.** (4.1 supports CSI 1.0.0, per @gnufied)

[BZ 174160](https://bugzilla.redhat.com/show_bug.cgi?id=1747160)

