### PR TITLE
metering: Add about-metering and about-installing-metering assemblies

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -785,10 +785,14 @@ Topics:
 - Name: Exposing custom application metrics for autoscaling
   File: exposing-custom-application-metrics-for-autoscaling
 ---
-Name: Metering 
+Name: Metering
 Dir: metering
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: About metering
+  File: metering-about-metering
+- Name: About installing metering
+  File: metering-about-installing-metering
 - Name: Installing metering
   File: metering-installing-metering
 ---

--- a/metering/metering-about-installing-metering.adoc
+++ b/metering/metering-about-installing-metering.adoc
@@ -1,0 +1,12 @@
+[id="about-installing-metering"]
+= About installing Metering
+include::modules/common-attributes.adoc[]
+:context: about-installing-metering
+
+toc::[]
+
+Before installing Metering into your cluster, review the following sections.
+
+include::modules/metering-about-install.adoc[leveloffset=+1]
+
+include::modules/metering-install-prerequisites.adoc[leveloffset=+1]

--- a/metering/metering-about-metering.adoc
+++ b/metering/metering-about-metering.adoc
@@ -1,0 +1,8 @@
+[id="about-metering"]
+= About Metering
+include::modules/common-attributes.adoc[]
+:context: about-metering
+
+toc::[]
+
+include::modules/metering-overview.adoc[leveloffset=+1]

--- a/metering/metering-installing-metering.adoc
+++ b/metering/metering-installing-metering.adoc
@@ -1,23 +1,23 @@
 [id="installing-metering"]
 = Installing Metering
 include::modules/common-attributes.adoc[]
-:context: metering 
+:context: installing-metering
 
 toc::[]
 
 On {product-title} 4 clusters the Metering Operator can be installed through the OperatorHub. If you are using an earlier version of OpenShift or a Kubernetes cluster without OpenShift, use the link:https://github.com/operator-framework/operator-metering/tree/master/Documentation[upstream documentation] to install, configure, and use the Metering Operator.
 
-include::modules/metering-install-prerequisites.adoc[leveloffset=+1]
-
 include::modules/metering-install-operator.adoc[leveloffset=+1]
 
 // This content is included directly in the assembly and NOT in a module because the workflow for installing metering requires linking off to the config docs, and xrefs are not allowed in modules. [klamenzo]
 [id="metering-install-metering-stack_{context}"]
-== Installing the Metering stack 
+== Installing the Metering stack
 
-To install the metering stack, create a MeteringConfig resource and add your configuration details. Review
-//xref:metering-configuring-metering.adoc[configuring metering]
-configure metering for more details about all available configuration options. At a minimum you need to configure persistent storage to hold reporting data, and the Hive metastore to hold metadata about database tables managed by Presto and Hive.
+To install the metering stack, create a `MeteringConfig` resource and add your configuration details.
+
+Before creating your `MeteringConfig`:
+
+* Review the installation options in xref:../metering/metering-about-installing-metering.adoc#metering-about-install_about-installing-metering[About installing metering]
 
 After entering you configuration details, the MeteringConfig resource installs all the necessary metering components inside the openshift-metering namespace.
 
@@ -34,7 +34,7 @@ There can only be one MeteringConfig resource in the `openshift-metering` namesp
 +
 [NOTE]
 ====
-You can review example configuration files and all supported configuration options in the configuing metering documentation. 
+You can review example configuration files and all supported configuration options in the configuing metering documentation.
 //xref:metering-configuring-metering.adoc[configuring metering].
 ====
 
@@ -42,8 +42,8 @@ You can review example configuration files and all supported configuration optio
 
 The MeteringConfig resource will beging to create the necessary resources for your metering stack. You can now move on to verifying your installation.
 
-[id="metering-install-verify_{context}"] 
-== Verify Installation 
+[id="metering-install-verify_{context}"]
+== Verify Installation
 
 To verify your installation you can check that all the required Pods have been activated, and check that your report data sources are beginning to import data.
 

--- a/modules/metering-about-install.adoc
+++ b/modules/metering-about-install.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-installing-metering.adoc
+
+[id="metering-about-install_{context}"]
+= About Installing Metering
+
+Metering leverages a SQL database called Presto.
+Presto itself doesn't actually store the data itself, instead it's storage is decoupled from it, often in the form of object storage.
+This means at a minimum, you need to configure persistent storage to hold reporting data, and the Hive metastore to hold metadata about database tables managed by Presto and Hive.

--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -11,14 +11,14 @@ To install the Metering Operator first create an `openshift-metering` namespace,
 
 . In the {product-title} web console, click *Administration* -> *Namespaces* ->  *Create Namespace*.
 
-. Set the name to `openshift-metering`. No other namespace is supported. Label the namespace with `openshift.io/cluster-monitoring=true`, and click *Create*. 
+. Set the name to `openshift-metering`. No other namespace is supported. Label the namespace with `openshift.io/cluster-monitoring=true`, and click *Create*.
 
 . Next, click *Operators* -> *OperatorHub*, and filter for `metering` to find the
 Metering Operator.
 
 . Click the Metering card, review the package description, and then click *Install*.
 
-. On the *Create Operator Subscription* screen, select the `openshift-metering` namespace you created above. Specify your update channel and approval strategy, then click *Subscribe* to install metering. 
+. On the *Create Operator Subscription* screen, select the `openshift-metering` namespace you created above. Specify your update channel and approval strategy, then click *Subscribe* to install metering.
 
 . On the *Installed Operators* screen the *Status* displays *InstallSucceeded* when metering has finished installing. Click the name of the operator in the first column to view the *Operator Details* page.
 

--- a/modules/metering-install-prerequisites.adoc
+++ b/modules/metering-install-prerequisites.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * metering/metering-installing-metering.adc
+// * metering/metering-installing-metering.adoc
 
 [id="metering-install-prerequisites_{context}"]
 = Prerequisites

--- a/modules/metering-overview.adoc
+++ b/modules/metering-overview.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-installing-metering.adoc
+// * metering/metering-using-metering.adoc
+
+[id="metering-overview_{context}"]
+= Metering overview
+
+Metering is general purpose data analysis tool that enables you to write Reports to process data from different data sources.
+As a cluster administrator, you can use Metering to analyze what is happening in your cluster.
+You can either write your own, or use predefined SQL queries to define how you want to process data from the different data sources you have available.
+
+Metering focuses primarily on in-cluster metric data using Prometheus as a default data source, enabling users of Metering to do reporting on pods, namespaces, and most other Kubernetes resources.
+
+== Metering resources
+
+Metering has many resources which can be used to manage the deployment and installation of Metering, as well as the reporting functionality Metering provides.
+
+Metering is managed using the following `CustomResourceDefinitions` (CRDs):
+
+[cols="1,7"]
+|===
+
+|*MeteringConfig* |Configures the Metering stack for deployment. Contains customizations and configuration options to control each component that makes up the Metering stack.
+
+|*Reports* |Controls what query to use, when, and how often the query should be run, and where to store the results.
+
+|*ReportQueries* |Contains the SQL queries used to perform analysis on the data contained with in ReportDataSources.
+
+|*ReportDataSources* |Controls the data available to ReportQueries and Reports. Allows configuring access to different databases for use within Metering.
+
+|===


### PR DESCRIPTION
Created 2 assemblies:
- about-metering to cover an overview of what Metering is and does.
- about-installing-metering which covers pre-installation concepts like storage and resource management.
Currently this is a bit bare, but this is will be updated to contain all of the information about the supported storage providers (S3, GCS, Azure, S3Compatible, Shared PVC). Other considerations such as resource requests/limits sizing that users may want to do prior to install will also go here.