### PR TITLE
CNV-OCP monitoring/telemetry modularization for associated products

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1009,7 +1009,7 @@ Topics:
     File: cnv-logs
   - Name: Viewing events
     File: cnv-events
-  - Name: OpenShift cluster monitoring
+  - Name: OpenShift cluster monitoring, logging, and Telemetry
     File: cnv-openshift-cluster-monitoring
 - Name: Container-native Virtualization 2.0 release notes
   Dir: cnv_release_notes

--- a/cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
+++ b/cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
@@ -1,19 +1,15 @@
 [id="cnv-openshift-cluster-monitoring"]
-= {product-title} cluster monitoring
+= {product-title} cluster monitoring, logging, and Telemetry
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-openshift-cluster-monitoring
 toc::[]
 
 {product-title} provides various resources for monitoring at the cluster level.
 
+// Cluster monitoring
+include::modules/monitoring-about-cluster-monitoring.adoc[leveloffset=+1]
 
-.Cluster monitoring
-
-{product-title} includes a pre-configured, pre-installed, and self-updating monitoring stack that is based on the link:https://prometheus.io/[Prometheus] open source project and its wider eco-system. It provides monitoring of cluster components and includes a set of alerts to immediately notify the cluster administrator about any occurring problems and a set of link:https://grafana.com/[Grafana] dashboards. The cluster monitoring stack is only supported for monitoring {product-title} clusters.
-
-For more information on cluster monitoring, see the xref:../../monitoring/cluster-monitoring/about-cluster-monitoring.adoc#about-cluster-monitoring[{product-title} cluster monitoring] documentation.
-
-.Cluster logging
+== Cluster logging
 
 The cluster logging components are based upon Elasticsearch, Fluentd, and Kibana (EFK).
 The collector, link:http://www.fluentd.org/architecture[Fluentd], is deployed to each node in the {product-title} cluster.
@@ -23,18 +19,10 @@ where users and administrators can create rich visualizations and dashboards wit
 
 For more information on cluster logging, see the xref:../../logging/efk-logging.adoc#efk-logging[{product-title} cluster logging] documentation.
 
-.Telemetry
+// Telemetry
+include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]
 
-Telemetry collects anonymized aggregated information about:
-
-* The size of an {product-title} cluster
-* The health and status of {product-title} components
-* Use of {product-title} components
-* The features in use
-
-For more information on Telemetry, see the xref:../../telemetry/about-telemetry.adoc#about-telemetry[{product-title} Telemetry] documentation.
-
-.CLI troubleshooting and debugging commands
+== CLI troubleshooting and debugging commands
 
 For a list of the `oc` client troubleshooting and debugging commands, see the xref:../../cli_reference/developer-cli-commands.adoc#cli-troubleshooting-commands_developer-cli-commands[{product-title} CLI reference] documentation.
 

--- a/modules/monitoring-about-cluster-monitoring.adoc
+++ b/modules/monitoring-about-cluster-monitoring.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * monitoring/cluster-monitoring/about-cluster-monitoring.adoc
+// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
+// 
+// This module uses a conditionalized title so that the module 
+// can be re-used in associated products but the title is not 
+// included in the existing OpenShift assembly.
+
+[id="monitoring-about-cluster-monitoring_{context}"]
+ifeval::["{context}" == "about-cluster-monitoring"]
+:ocp-monitoring:
+endif::[]
+
+ifndef::ocp-monitoring[]
+= About {product-title} cluster monitoring
+endif::ocp-monitoring[]
+:ocp-monitoring!:
+
+{product-title} includes a pre-configured, pre-installed, and self-updating monitoring stack that is based on the link:https://prometheus.io/[Prometheus] open source project and its wider eco-system. It provides monitoring of cluster components and includes a set of alerts to immediately notify the cluster administrator about any occurring problems and a set of link:https://grafana.com/[Grafana] dashboards. The cluster monitoring stack is only supported for monitoring {product-title} clusters.
+
+[IMPORTANT]
+====
+To ensure compatibility with future {product-title} updates, configuring only the specified monitoring stack options is supported.
+====
+

--- a/modules/telemetry-about-telemetry.adoc
+++ b/modules/telemetry-about-telemetry.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * telemetry/about-telemetry.adoc
+// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
+// 
+// This module uses a conditionalized title so that the module 
+// can be re-used in associated products but the title is not 
+// included in the existing OpenShift assembly.
+
+[id="telemetry-about-telemetry_{context}"]
+ifeval::["{context}" == "about-telemetry"]
+:ocp-telemetry:
+endif::[]
+
+ifndef::ocp-telemetry[]
+= About Telemetry
+endif::ocp-telemetry[]
+:ocp-telemetry!:
+
+Telemetry collects anonymized aggregated information about:
+
+* The size of an {product-title} cluster
+* The health and status of {product-title} components
+* Use of {product-title} components
+* The features in use
+
+This information is used by Red Hat to help make {product-title} better and more intuitive to use. None of the information is shared with third parties.
+

--- a/monitoring/cluster-monitoring/about-cluster-monitoring.adoc
+++ b/monitoring/cluster-monitoring/about-cluster-monitoring.adoc
@@ -1,17 +1,11 @@
 [id="about-cluster-monitoring"]
 = About cluster monitoring
 include::modules/common-attributes.adoc[]
-:context: about-monitoring
+:context: about-cluster-monitoring
 
 toc::[]
 
-{product-title} includes a pre-configured, pre-installed, and self-updating monitoring stack that is based on the link:https://prometheus.io/[Prometheus] open source project and its wider eco-system. It provides monitoring of cluster components and includes a set of alerts to immediately notify the cluster administrator about any occurring problems and a set of link:https://grafana.com/[Grafana] dashboards. The cluster monitoring stack is only supported for monitoring {product-title} clusters.
-
-[IMPORTANT]
-====
-To ensure compatibility with future {product-title} updates, configuring only the specified monitoring stack options is supported.
-====
-
+include::modules/monitoring-about-cluster-monitoring.adoc[leveloffset=+1]
 include::modules/monitoring-stack-components-and-monitored-targets.adoc[leveloffset=+1]
 
 .Next steps

--- a/telemetry/about-telemetry.adoc
+++ b/telemetry/about-telemetry.adoc
@@ -1,17 +1,9 @@
 [id="about-telemetry"]
 = About Telemetry
 include::modules/common-attributes.adoc[]
-:context: telemetry
+:context: about-telemetry
 
 toc::[]
 
-Telemetry collects anonymized aggregated information about:
-
-* The size of an {product-title} cluster
-* The health and status of {product-title} components
-* Use of {product-title} components
-* The features in use
-
-This information is used by Red Hat to help make {product-title} better and more intuitive to use. None of the information is shared with third parties.
-
+include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]
 include::modules/telemetry-what-information-is-collected.adoc[leveloffset=+1]


### PR DESCRIPTION
This was deferred from the CNV 2.0 release.
Separating introduction content from OCP into modules to allow for content re-use with associated products. Using conditionals so that the now-modules do not include the (otherwise redundant) titles for the original OpenShift assemblies.
