### PR TITLE
Bug 1706991: Add examples for version inventory variables

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -326,10 +326,18 @@ If you alter this variable, ensure the host name is accessible via your router.
 (AWS) with multiple zones or multiple clusters. See xref:../install_config/configuring_aws.adoc#aws-cluster-labeling[Labeling Clusters for AWS] for details.
 
 |`openshift_image_tag`
-|Use this variable to specify a container image tag to install or configure.
+|Use this variable to specify a container image tag to install or configure. This
+allows user flexibility in specifying the exact resource desired by appending the
+string specified directly to the resource without modification.
+
+For example, `openshift_image_tag=v3.11.113-1`
 
 |`openshift_pkg_version`
-|Use this variable to specify an RPM version to install or configure.
+|Use this variable to specify an RPM version to install or configure. This
+allows user flexibility in specifying the exact resource desired by appending the
+string specified directly to the resource without modification.
+
+For example, `openshift_pkg_version=-3.11.113-1.git.0.1db441a.el7`
 
 |===
 
@@ -340,8 +348,8 @@ after the cluster is set up, then an upgrade can be triggered, resulting in
 downtime.
 
 * If `openshift_image_tag` is set, its value is used for all hosts in
-system container environments, even those that have another version installed. If
-* `openshift_pkg_version` is set, its value is used for all hosts in RPM-based
+system container environments, even those that have another version installed.
+* If `openshift_pkg_version` is set, its value is used for all hosts in RPM-based
 environments, even those that have another version installed.
 ====
 


### PR DESCRIPTION
Provides examples for:
openshift_image_tag
openshift_pkg_version

https://bugzilla.redhat.com/show_bug.cgi?id=1706991