### PR TITLE
CNV-1547 Support matrix added to relevant CDI procedures

### DIFF
--- a/cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
+++ b/cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
@@ -8,8 +8,18 @@ You can clone the PersistentVolumeClaim (PVC) of a virtual machine disk into
 a new DataVolume by referencing the source PVC in your DataVolume configuration
 file.
 
+.Prerequisites 
+
+* You may need to xref:../../cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc#cnv-defining-storageclass-in-cdi-configuration_cnv-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space] 
+for this operation to complete successfully. The 
+xref:#cnv-cdi-supported-operations-matrix_cnv-cloning-vm-disk-into-new-datavolume[CDI supported operations matrix] 
+shows the conditions that require scratch space.
+
 include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/cnv-cloning-pvc-of-vm-disk-into-new-datavolume.adoc[leveloffset=+1]
 
 include::modules/cnv-template-datavolume-clone.adoc[leveloffset=+1]
+
+include::modules/cnv-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+

--- a/cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
+++ b/cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
@@ -8,8 +8,18 @@ You can create a new virtual machine by cloning the PersistentVolumeClaim (PVC) 
 an existing VM. By including a `dataVolumeTemplate` in your virtual machine
 configuration file, you create a new DataVolume from the original PVC.
 
+.Prerequisites 
+
+* You may need to xref:../../cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc#cnv-defining-storageclass-in-cdi-configuration_cnv-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space] 
+for this operation to complete successfully. The 
+xref:#cnv-cdi-supported-operations-matrix_cnv-cloning-vm-using-datavolumetemplate[CDI supported operations matrix] 
+shows the conditions that require scratch space.
+ 
 include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/cnv-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc[leveloffset=+1]
 
 include::modules/cnv-template-datavolume-vm.adoc[leveloffset=+1]
+
+include::modules/cnv-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+

--- a/cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
+++ b/cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
@@ -19,6 +19,13 @@ The resizing procedure varies based on the operating system installed on the VM.
 Refer to the operating system documentation for details.
 ====
 
+.Prerequisites 
+
+* You may need to xref:../../cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc#cnv-defining-storageclass-in-cdi-configuration_cnv-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space] 
+for this operation to complete successfully.
+
+include::modules/cnv-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+
 include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/cnv-importing-vm-datavolume.adoc[leveloffset=+1]

--- a/cnv/cnv_users_guide/cnv-uploading-local-disk-images-virtctl.adoc
+++ b/cnv/cnv_users_guide/cnv-uploading-local-disk-images-virtctl.adoc
@@ -12,4 +12,10 @@ command-line utility.
 * xref:../../cnv/cnv_install/cnv-installing-virtctl.adoc#cnv-installing-virtctl[Install]
 the `kubevirt-virtctl` package
 
+* You may need to xref:../../cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc#cnv-defining-storageclass-in-cdi-configuration_cnv-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space] 
+for this operation to complete successfully.  
+
+include::modules/cnv-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+
 include::modules/cnv-uploading-local-disk-image-pvc.adoc[leveloffset=+1]
+

--- a/modules/cnv-cdi-supported-operations-matrix.adoc
+++ b/modules/cnv-cdi-supported-operations-matrix.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cdi-supported-operations.adoc
+// * cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc
+// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
+// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-virtctl.adoc
+// * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
+
 
 [id="cnv-cdi-supported-operations-matrix_{context}"]
 = CDI supported operations matrix


### PR DESCRIPTION
Added the CDI supported op matrix and related scratch space prerequisite to relevant CDI assemblies. This module was added to the end of the 'cloning' assemblies, because it only relates to scratch space for them, but at the top of the importing and uploading assemblies because the supported/unsupported operations in the matrix comes into play.

The support matrix was merged as a part of #16153. 