### PR TITLE
Include the Local Storage Operator.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -372,6 +372,8 @@ Topics:
     File: persistent-storage-fibre
   - Name: Persistent storage using GCE Persistent Disk
     File: persistent-storage-gce
+  - Name: Persistent storage using local volumes
+    File: persistent-storage-local
   - Name: Persistent storage using NFS
     File: persistent-storage-nfs
   - Name: Persistent Storage using iSCSI

--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -1,0 +1,142 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-local.adoc
+
+[id="local-volume-cr_{context}"]
+= Provision the local volumes
+
+Local volumes can not be created by dynamic provisioning. Instead,
+PersistentVolumes must be created by the Local Storage Operator. This
+provisioner will look for any devices, both Filesystem and Block volumes,
+at the paths specified in defined resource.
+
+.Prerequisites
+
+* The Local Storage Operator is installed.
+* Local disks are attached to the {product-title} nodes.
+
+.Procedure
+
+. Create the local volume resource. This must define the nodes
+and paths to the local volumes.
++
+.Example: Filesystem
+[source,yaml]
+----
+apiVersion: "local.storage.openshift.io/v1"
+kind: "LocalVolume"
+metadata:
+  name: "local-disks"
+  namespace: "local-storage" <1>
+spec:
+  nodeSelector: <2>
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ip-10-0-140-183
+          - ip-10-0-158-139
+          - ip-10-0-164-33
+  storageClassDevices:
+    - storageClassName: "local-sc"
+      volumeMode: Filesystem <3>
+      fsType: xfs <4>
+      devicePaths: <5>
+        - /path/to/device
+----
+<1> The namespace where the Local Storage Operator is installed.
+<2> Optional: A node selector containing a list of nodes where the local storage volumes are attached. This
+example uses the node host names, obtained from `oc get node`. If a value is not
+defined, then the Local Storage Operator will attempt to find matching disks
+on all available nodes.
+<3> The volume mode, either `Filesystem` or `Block`, defining the type of the
+local volumes.
+<4> The file system that is created when the local volume is mounted for the
+first time.
+<5> The path to where the local volumes have been attached to the node.
++
+.Example: Block
+[source,yaml]
+----
+apiVersion: "local.storage.openshift.io/v1"
+kind: "LocalVolume"
+metadata:
+  name: "local-disks"
+  namespace: "local-storage" <1>
+spec:
+  nodeSelector: <2>
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ip-10-0-136-143
+          - ip-10-0-140-255
+          - ip-10-0-144-180
+  storageClassDevices:
+    - storageClassName: "localblock-sc"
+      volumeMode: Block  <3>
+      devicePaths: <4>
+        - /dev/xvdg
+----
+<1> The namespace where the Local Storage Operator is installed.
+<2> Optional: A node selector containing a list of nodes where the local storage volumes are attached. This
+example uses the node host names, obtained from `oc get node`. If a value is not
+defined, then the Local Storage Operator will attempt to find matching disks
+on all available nodes.
+<3> The volume mode, either `Filesystem` or `Block`, defining the type of the
+local volumes.
+<4> The path to where the local volumes have been attached to the node.
+
+. Create the local volume resource in your {product-title} cluster, specifying
+the file you just created:
++
+----
+$ oc create -f <local-volume>.yaml
+----
+
+. Verify the provisioner was created, and the corresponding DaemonSets were
+created:
++
+----
+$ oc get all -n local-storage
+
+NAME                                          READY   STATUS    RESTARTS   AGE
+pod/local-disks-local-provisioner-h97hj       1/1     Running   0          46m
+pod/local-disks-local-provisioner-j4mnn       1/1     Running   0          46m
+pod/local-disks-local-provisioner-kbdnx       1/1     Running   0          46m
+pod/local-diskslocal-diskmaker-ldldw          1/1     Running   0          46m
+pod/local-diskslocal-diskmaker-lvrv4          1/1     Running   0          46m
+pod/local-diskslocal-diskmaker-phxdq          1/1     Running   0          46m
+pod/local-storage-manifests-f8zc9             1/1     Running   0          48m
+pod/local-storage-operator-54564d9988-vxvhx   1/1     Running   0          47m
+
+NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
+service/local-storage-manifests   ClusterIP   172.30.183.114   <none>        50051/TCP   48m
+service/local-storage-operator    ClusterIP   172.30.49.90     <none>        60000/TCP   47m
+
+NAME                                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/local-disks-local-provisioner   3         3         3       3            3           <none>          46m
+daemonset.apps/local-diskslocal-diskmaker      3         3         3       3            3           <none>          46m
+
+NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/local-storage-operator   1/1     1            1           47m
+
+NAME                                                DESIRED   CURRENT   READY   AGE
+replicaset.apps/local-storage-operator-54564d9988   1         1         1       47m
+----
++
+Note the desired and current number of DaemonSet processes. If the desired
+count is `0`, it indicates the label selectors were invalid.
+
+. Verify that the PersistentVolumes were created:
++
+----
+$ oc get pv
+
+NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
+local-pv-1cec77cf   100Gi      RWO            Delete           Available           local-sc                88m
+local-pv-2ef7cd2a   100Gi      RWO            Delete           Available           local-sc                82m
+local-pv-3fa1c73    100Gi      RWO            Delete           Available           local-sc                48m
+----

--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-local.adoc
+
+[id="local-storage-install_{context}"]
+= Installing the Local Storage Operator
+
+The Local Storage Operator is not installed in {product-title} by default. Use the following procedure to install and configure this Operator to enable local volumes in your cluster.
+
+.Prerequisites
+
+* Access to the {product-title} web console.
+
+.Procedure
+
+. Create the `local-storage` project:
++
+----
+$ oc new-project local-storage
+----
+
+. Install the Local Storage Operator from the web console.
+
+.. Log in to the {product-title} web console.
+
+.. Navigate to *Operators* -> *OperatorHub*.
+
+.. Type *Local Storage* into the filter box to locate the Local Storage Operator.
+
+.. Click *Install*.
+
+.. On the *Create Operator Subscription* page, select *A specific namespace on the cluster*. Select *local-storage* from the drop-down menu.
+
+.. Adjust the values for the *Update Channel* and *Approval Strategy* to the desired values.
+
+.. Click *Subscribe*.
+
+. Once finished, the Local Storage Operator will be listed in the *Installed Operators* section of the web console.
+
+. Add the `cluster-admin` role to the ServiceAccount created by the Local Storage Operator, so that this Operator can manage the necessary resources:
++
+----
+$ oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:local-storage:local-storage-operator
+----

--- a/modules/persistent-storage-local-pod.adoc
+++ b/modules/persistent-storage-local-pod.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// storage/persistent-storage/persistent-storage-local.adoc
+
+[id="local-pod_{context}"]
+= Attach the local claim
+
+After a local volume has been mapped to a PersistentVolumeClaim (PVC)
+it can be specified inside of a resource.
+
+.Prerequisites
+
+* A PVC exists in the same namespace.
+
+.Procedure
+
+. Include the defined claim in the resource's Spec. The following example
+declares the PVC inside a Pod:
++
+----
+apiVersion: v1
+kind: Pod
+spec:
+  ...
+  containers:
+    volumeMounts:
+    - name: localpvc <1>
+      mountPath: "/data" <2>
+  volumes:
+  - name: localpvc
+    persistentVolumeClaim:
+      claimName: localpvc <3>
+----
+<1> Name of the volume to mount.
+<2> Path inside the Pod where the volume is mounted.
+<3> Name of the existing PVC to use.
+
+. Create the resource in the {product-title} cluster, specifying the file
+you just created:
++
+----
+$ oc create -f <local-pod>.yaml
+----

--- a/modules/persistent-storage-local-pvc.adoc
+++ b/modules/persistent-storage-local-pvc.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-local.adoc
+
+[id="create-local-pvc_{context}"]
+= Create the local volume PersistentVolumeClaim
+
+Local volumes must be statically created as a PersistentVolumeClaim (PVC)
+to be accessed by the Pod.
+
+.Prerequisite
+
+* PersistentVolumes have been created the local volume provisioner.
+
+.Procedure
+
+. Create the PVC using the corresponding StorageClass:
++
+[source,yaml]
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: local-pvc-name <1>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  volumeMode: Filesystem <2>
+  resources:
+    requests:
+      storage: 100Gi <3>
+  storageClassName: local-sc <4>
+----
+<1> Name of the PVC.
+<2> The type of the PVC. Defaults to `Filesystem`.
+<3> The amount of storage available to the PVC.
+<4> Name of the StorageClass required by the claim.
+
+. Create the PVC in the {product-title} cluster, specifying the file
+you just created:
++
+----
+$ oc create -f <local-pvc>.yaml
+----

--- a/modules/persistent-storage-local-removing-devices.adoc
+++ b/modules/persistent-storage-local-removing-devices.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// storage/persistent-storage/persistent-storage-local.adoc
+
+[id="local-removing-device_{context}"]
+= Removing a local volume
+
+Occasionally, local volumes must be deleted. While removing the entry in the LocalVolume resource and deleting the PersistentVolume is typically enough, if you want to re-use the same device path or have it managed by a different StorageClass, then additional steps are needed.
+
+[WARNING]
+====
+The following procedure involves accessing a node as the root user. Modifying the state of the node beyond the steps in this procedure could result in cluster instability.
+====
+
+.Prerequisite
+
+* The PersistentVolume must be in a `Released` or `Available` state.
++
+[WARNING]
+====
+Deleting a PersistentVolume that is still in use can result in data loss or corruption.
+====
+
+.Procedure
+
+. Edit the previously created LocalVolume to remove any unwanted disks.
+
+.. Edit the cluster resource:
++
+----
+$ oc edit localvolume <name> -n local-storage
+----
+
+.. Navigate to the lines under `devicePaths`, and delete any representing unwanted disks.
+
+. Delete any PersistentVolumes created.
++
+----
+$ oc delete pv <pv-name>
+----
+
+. Delete any symlinks on the node.
+.. Create a debug pod on the node:
++
+----
+$ oc debug node/<node-name>
+----
+
+.. Change your root directory to the host:
++
+----
+$ chroot /host
+----
+
+.. Navigate to the directory containing the local volume symlinks.
++
+----
+$ cd /mnt/local-storage/<sc-name> <1>
+----
+<1> The name of the StorageClass used to create the local volumes.
+
+.. Delete the symlink belonging to the removed device.
++
+----
+$ rm <symlink>
+----

--- a/modules/persistent-storage-local-uninstall-operator.adoc
+++ b/modules/persistent-storage-local-uninstall-operator.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-local.adoc
+
+[id="local-storage-uninstall_{context}"]
+= Uninstalling the Local Storage Operator
+
+To uninstall the Local Storage Operator, you must remove the Operator and all created resources in the `local-storage` project.
+
+.Prerequisites
+
+* Access to the {product-title} web console.
+
+.Procedure
+
+. Uninstall the Local Storage Operator from the web console.
+
+.. Log in to the {product-title} web console.
+
+.. Navigate to *Operators* -> *Installed Operators*.
+
+.. Type *Local Storage* into the filter box to locate the Local Storage Operator.
+
+.. Click the Options menu {kebab} at the end of the Local Storage Operator.
+
+.. Click *Uninstall Operator*.
+
+.. Click *Remove* in the window that appears.
+
+. Delete the Pods created by the Local Storage Operator:
++
+----
+$ oc delete pods --all -n local-storage
+----
+
+. Delete the PersistentVolumes (PV) created by the Local Storage Operator. All of these PVs begin with `local-pv`.
++
+----
+$ oc delete pv <pv-name>
+----
+
+. Delete the `local-storage` project:
++
+----
+$ oc delete project local-storage
+----

--- a/storage/persistent-storage/persistent-storage-local.adoc
+++ b/storage/persistent-storage/persistent-storage-local.adoc
@@ -1,0 +1,35 @@
+[id="persistent-storage-using-local-volume"]
+= Persistent storage using local volumes
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-local
+
+toc::[]
+
+{product-title} can be provisioned with persistent storage by using
+local volumes. Local persistent volumes allow you to access local storage
+devices, such as a disk or partition, by using the standard
+PVC interface.
+
+Local volumes can be used without manually scheduling pods to nodes,
+because the system is aware of the volume node's constraints. However,
+local volumes are still subject to the availability of the underlying node
+and are not suitable for all applications.
+
+[NOTE]
+====
+Local volumes can only be used as a statically created Persistent Volume.
+====
+
+include::modules/persistent-storage-local-install.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-local-create-cr.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-local-pvc.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-local-pod.adoc[leveloffset=+1]
+
+== Deleting the Local Storage Operator's resources
+
+include::modules/persistent-storage-local-removing-devices.adoc[leveloffset=+2]
+
+include::modules/persistent-storage-local-uninstall-operator.adoc[leveloffset=+2]


### PR DESCRIPTION
This includes the instructions for using the Local Storage Operator in OCP 4.2.

This PR is listed as a WIP, because the operator is not yet available through OperatorHub, and the catalog must be manually added. Installation instructions will be updated once it's available.