### PR TITLE
metering: Add using-metering and metering-about-reports assemblies

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -813,6 +813,10 @@ Topics:
     File: metering-configure-reporting-operator
   - Name: Configuring AWS billing correlation
     File: metering-configure-aws-billing-correlation
+- Name: About reports
+  File: metering-about-reports
+- Name: Using metering
+  File: metering-using-metering
 ---
 Name: Telemetry
 Dir: telemetry

--- a/metering/metering-about-reports.adoc
+++ b/metering/metering-about-reports.adoc
@@ -1,0 +1,13 @@
+[id="metering-about-reports"]
+= About Reports
+include::modules/common-attributes.adoc[]
+:context: metering-about-reports
+
+toc::[]
+
+A Report is an API object that provides a method to manage periodic ETL (Extract Transform and Load) jobs using SQL queries.
+They are composed using other Metering resources such as `ReportQueries`, which provide the actual SQL query to run, and `ReportingDataSources`, which are what define the data available to the ReportQueries and Reports.
+
+Many use cases are addressed out-of-the-box with the predefined `ReportQueries` and `ReportingDataSources` that come installed with metering, so you do not need to define your own unless you have a use-case not covered by what is predefined.
+
+include::modules/metering-reports.adoc[leveloffset=+1]

--- a/metering/metering-using-metering.adoc
+++ b/metering/metering-using-metering.adoc
@@ -1,9 +1,15 @@
 [id="using-metering"]
 = Using Metering
 include::modules/common-attributes.adoc[]
-:context: metering 
+:context: using-metering
 
 toc::[]
 
-Using metering stub
+.Prerequisites
 
+* xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Install Metering]
+* Review the details about the available options that can be configured for a xref:../metering/metering-about-reports.adoc#metering-about-reports[Report] and how they function.
+
+include::modules/metering-writing-reports.adoc[leveloffset=+1]
+
+include::modules/metering-viewing-report-results.adoc[leveloffset=+1]

--- a/modules/metering-about-install.adoc
+++ b/modules/metering-about-install.adoc
@@ -6,5 +6,5 @@
 = About Installing Metering
 
 Metering leverages a SQL database called Presto.
-Presto itself doesn't actually store the data itself, instead it's storage is decoupled from it, often in the form of object storage.
-This means at a minimum, you need to configure persistent storage to hold reporting data, and the Hive metastore to hold metadata about database tables managed by Presto and Hive.
+Presto itself does not actually store the data itself; instead its storage is decoupled from it, often in the form of object storage.
+This means, at a minimum, you need to configure persistent storage to hold reporting data, and the Hive metastore to hold metadata about database tables managed by Presto and Hive.

--- a/modules/metering-overview.adoc
+++ b/modules/metering-overview.adoc
@@ -6,7 +6,7 @@
 [id="metering-overview_{context}"]
 = Metering overview
 
-Metering is general purpose data analysis tool that enables you to write Reports to process data from different data sources.
+Metering is a general purpose data analysis tool that enables you to write reports to process data from different data sources.
 As a cluster administrator, you can use Metering to analyze what is happening in your cluster.
 You can either write your own, or use predefined SQL queries to define how you want to process data from the different data sources you have available.
 
@@ -25,7 +25,7 @@ Metering is managed using the following `CustomResourceDefinitions` (CRDs):
 
 |*Reports* |Controls what query to use, when, and how often the query should be run, and where to store the results.
 
-|*ReportQueries* |Contains the SQL queries used to perform analysis on the data contained with in ReportDataSources.
+|*ReportQueries* |Contains the SQL queries used to perform analysis on the data contained within ReportDataSources.
 
 |*ReportDataSources* |Controls the data available to ReportQueries and Reports. Allows configuring access to different databases for use within Metering.
 

--- a/modules/metering-reports.adoc
+++ b/modules/metering-reports.adoc
@@ -1,0 +1,333 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-about-reports.adoc
+[id="metering-reports_{context}"]
+= Reports
+
+The `Report` custom resource is used to manage the execution and status of reports.
+Metering produces reports derived from usage data sources, which can be used in further analysis and filtering.
+
+A single `Report` resource represents a job manages a database table and updates it with new information according to a schedule, and exposes the data in that table via the reporting-operator HTTP API.
+Reports with a `spec.schedule` field set are always running, and will track what time periods it has collected data for, ensuring that if Metering is shutdown or unavailable for an extended period of time, it will backfill the data starting where it left off.
+If the schedule is unset, then the Report will run once for the time specified by the `reportingStart` and `reportingEnd`.
+By default, reports will wait for `ReportDataSources` to have the progressed in their import process to cover the report period being processed.
+If the Report has a schedule, it will wait until the period currently being processed has been covered by the import process.
+
+== Example Report with a Schedule
+
+The following example Report will contain information on every Pod's CPU requests, and will run every hour, adding the last hours worth of data each time it runs.
+
+----
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: pod-cpu-request-hourly
+spec:
+  query: "pod-cpu-request"
+  reportingStart: "2019-07-01T00:00:00Z"
+  schedule:
+    period: "hourly"
+    hourly:
+      minute: 0
+      second: 0
+----
+
+== Example Report without a Schedule (Run-Once)
+
+The following example Report will contain information on every Pod's CPU requests for all of July.
+After completion, it does not run again.
+
+----
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: pod-cpu-request-hourly
+spec:
+  query: "pod-cpu-request"
+  reportingStart: "2019-07-01T00:00:00Z"
+  reportingEnd: "2019-07-31T00:00:00Z"
+----
+
+== query
+
+Names the `ReportQuery` used to generate the report.
+The report query controls the schema of the report as well how the results are processed.
+
+*`query` is a required field.*
+
+Use `kubectl` to obtain a list of available `ReportQuery` objects:
+
+----
+$ kubectl -n $METERING_NAMESPACE get reportqueries
+NAME                                         AGE
+cluster-cpu-capacity                         23m
+cluster-cpu-capacity-raw                     23m
+cluster-cpu-usage                            23m
+cluster-cpu-usage-raw                        23m
+cluster-cpu-utilization                      23m
+cluster-memory-capacity                      23m
+cluster-memory-capacity-raw                  23m
+cluster-memory-usage                         23m
+cluster-memory-usage-raw                     23m
+cluster-memory-utilization                   23m
+cluster-persistentvolumeclaim-request        23m
+namespace-cpu-request                        23m
+namespace-cpu-usage                          23m
+namespace-cpu-utilization                    23m
+namespace-memory-request                     23m
+namespace-memory-usage                       23m
+namespace-memory-utilization                 23m
+namespace-persistentvolumeclaim-request      23m
+namespace-persistentvolumeclaim-usage        23m
+node-cpu-allocatable                         23m
+node-cpu-allocatable-raw                     23m
+node-cpu-capacity                            23m
+node-cpu-capacity-raw                        23m
+node-cpu-utilization                         23m
+node-memory-allocatable                      23m
+node-memory-allocatable-raw                  23m
+node-memory-capacity                         23m
+node-memory-capacity-raw                     23m
+node-memory-utilization                      23m
+persistentvolumeclaim-capacity               23m
+persistentvolumeclaim-capacity-raw           23m
+persistentvolumeclaim-phase-raw              23m
+persistentvolumeclaim-request                23m
+persistentvolumeclaim-request-raw            23m
+persistentvolumeclaim-usage                  23m
+persistentvolumeclaim-usage-raw              23m
+persistentvolumeclaim-usage-with-phase-raw   23m
+pod-cpu-request                              23m
+pod-cpu-request-raw                          23m
+pod-cpu-usage                                23m
+pod-cpu-usage-raw                            23m
+pod-memory-request                           23m
+pod-memory-request-raw                       23m
+pod-memory-usage                             23m
+pod-memory-usage-raw                         23m
+----
+
+ReportQueries with the `-raw` suffix are used by other ReportQueries to build more complex queries, and should not be used directly for reports.
+
+`namespace-` prefixed queries aggregate Pod CPU/memory requests by namespace, providing a list of namespaces and their overall usage based on resource requests.
+
+`pod-` prefixed queries are similar to 'namespace-' prefixed, but aggregate information by Pod, rather than namespace. These queries include the Pod's namespace and node.
+
+`node-` prefixed queries return information about each node's total available resources.
+
+`aws-` prefixed queries are specific to AWS. Queries suffixed with `-aws` return the same data as queries of the same name without the suffix, and correlate usage with the EC2 billing data.
+
+The `aws-ec2-billing-data` report is used by other queries, and should not be used as a standalone report. The `aws-ec2-cluster-cost` report provides a total cost based on the nodes included in the cluster, and the sum of their costs for the time period being reported on.
+
+For a complete list of fields, use `kubectl` to get the ReportQuery as YAML, and check the `spec.columns` field:
+
+For example, run:
+
+----
+$ kubectl -n $METERING_NAMESPACE get reportqueries namespace-memory-request -o yaml
+----
+
+You should see output like:
+
+----
+apiVersion: metering.openshift.io/v1
+kind: ReportQuery
+metadata:
+  name: namespace-memory-request
+  labels:
+    operator-metering: "true"
+spec:
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: namespace
+    type: varchar
+    unit: kubernetes_namespace
+  - name: pod_request_memory_byte_seconds
+    type: double
+    unit: byte_seconds
+----
+
+== schedule
+
+The `spec.schedule` configuration block defines when the report runs.
+The main fields in the `schedule` section are `period`, and then depending on the value of `period`, the fields `hourly`, `daily`, `weekly`, and `monthly` allow you to fine-tune when the report runs.
+
+For example, if `period` is set to `weekly`, you can add a `weekly` field to the `spec.schedule` block.
+The following example will run once a week on Wednesday, at 1 PM (hour 13 in the day).
+
+----
+...
+  schedule:
+    period: "weekly"
+    weekly:
+      dayOfWeek: "wednesday"
+      hour: 13
+...
+----
+
+=== period
+
+Valid values of `schedule.period` are listed below, and the options available to set for a given period are also listed.
+
+* `hourly`
+** `minute`
+** `second`
+* `daily`
+** `hour`
+** `minute`
+** `second`
+* `weekly`
+** `dayOfWeek`
+** `hour`
+** `minute`
+** `second`
+* `monthly`
+** `dayOfMonth`
+** `hour`
+** `minute`
+** `second`
+* `cron`
+** `expression`
+
+Generally, the `hour`, `minute`, `second` fields control when in the day the report runs, and `dayOfWeek`/`dayOfMonth` control what day of the week, or day of month the report runs on, if it is a weekly or monthly report period.
+
+For each of these fields, there is a range of valid values:
+
+* `hour` is an integer value between 0-23.
+* `minute` is an integer value between 0-59.
+* `second` is an integer value between 0-59.
+* `dayOfWeek` is a string value that expects the day of the week (spelled out).
+* `dayOfMonth` is an integer value between 1-31.
+
+For cron periods, normal cron expressions are valid:
+
+* `expression: "*/5 * * * *"`
+
+== reportingStart
+
+To support running a Report against existing data, you can set the `spec.reportingStart` field to a link:https://tools.ietf.org/html/rfc3339#section-5.8[RFC3339 timestamp] to tell the Report to run according to its `schedule` starting from `reportingStart` rather than the current time.
+One important thing to understand is that this will result in the reporting-operator running many queries in succession for each interval in the schedule that is between the `reportingStart` time and the current time.
+This could be thousands of queries if the period is less than daily and the `reportingStart` is more than a few months back.
+If `reportingStart` is left unset, the Report will run at the next full reportingPeriod after the time the report is created.
+
+As an example of how to use this field, if you had data already collected dating back to January 1st, 2019, which you wanted to be included in your Report, you could create a report with the following values:
+
+----
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: pod-cpu-request-hourly
+spec:
+  query: "pod-cpu-request"
+  schedule:
+    period: "hourly"
+  reportingStart: "2019-01-01T00:00:00Z"
+----
+
+
+== reportingEnd
+
+To configure a Report to only run until a specified time, you can set the `spec.reportingEnd` field to an link:https://tools.ietf.org/html/rfc3339#section-5.8[RFC3339 timestamp].
+The value of this field will cause the Report to stop running on its schedule after it has finished generating reporting data for the period covered from its start time until `reportingEnd`.
+Because a schedule will most likely not align with reportingEnd, the last period in the schedule will be shortened to end at the specified reportingEnd time.
+If left unset, then the Report will run forever, or until a `reportingEnd` is set on the Report.
+
+For example, if you wanted to create a report that runs once a week for the month of July:
+
+----
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: pod-cpu-request-hourly
+spec:
+  query: "pod-cpu-request"
+  schedule:
+    period: "weekly"
+  reportingStart: "2019-07-01T00:00:00Z"
+  reportingEnd: "2019-07-31T00:00:00Z"
+----
+
+== runImmediately
+
+Set `spec.runImmediately` to `true` to run the report immediately with all available data, regardless of the `reportingStart` or `reportingEnd` values, and without checking if there is any data for the report period.
+For reports with a schedule set, it will not wait for each period's reportingEnd to elapse before processing and all reportPeriods between `reportingStart` and `reportingEnd`.
+
+== inputs
+
+The `spec.inputs` field of a Report can be used to override or set values defined in a `ReportQuery`'s `spec.inputs` field.
+
+It is a list of name-value pairs:
+
+----
+spec:
+  inputs:
+  - name: "NamespaceCPUUsageReportName"
+    value: "namespace-cpu-usage-hourly"
+----
+
+The `name` of an input must exist in the ReportQuery's `inputs` list.
+The `value` of the input must be the correct type for the input's `type`.
+
+// TODO(chance): include modules/metering-reportquery-inputs.adoc module
+
+== Roll-up Reports
+
+Report data is stored in the database much like metrics themselves, and therefore, can be used in aggregated or roll-up reports.
+A simple use case for a roll-up report is to spread the time required to produce a report over a longer period of time; instead of: requiring a monthly report to query and add all data over an entire month, the task can be split into daily reports that each run over a thirtieth of the data.
+
+A custom roll-up report requires a custom report query.
+The ReportQuery template processor provides a function: `reportTableName` that can get the necessary table name from a `Report`'s `metadata.name`.
+
+Below is an snippet taken from a built-in query:
+
+----
+# Taken from pod-cpu.yaml
+spec:
+...
+  inputs:
+  - name: ReportingStart
+    type: time
+  - name: ReportingEnd
+    type: time
+  - name: NamespaceCPUUsageReportName
+    type: Report
+  - name: PodCpuUsageRawDataSourceName
+    type: ReportDataSource
+    default: pod-cpu-usage-raw
+...
+
+  query: |
+...
+    {|- if .Report.Inputs.NamespaceCPUUsageReportName |}
+      namespace,
+      sum(pod_usage_cpu_core_seconds) as pod_usage_cpu_core_seconds
+    FROM {| .Report.Inputs.NamespaceCPUUsageReportName | reportTableName |}
+...
+----
+
+----
+# aggregated-report.yaml
+spec:
+  query: "namespace-cpu-usage"
+  inputs:
+  - name: "NamespaceCPUUsageReportName"
+    value: "namespace-cpu-usage-hourly"
+----
+
+// TODO(chance): replace the comment below with an include on the modules/metering-rollup-report.adoc
+// For more information on setting up a roll-up report, see the [roll-up report guide](rollup-reports.md).
+
+=== Report Status
+
+The execution of a scheduled report can be tracked using its status field. Any errors occurring during the preparation of a report will be recorded here.
+
+The `status` field of a `Report` currently has two fields:
+
+* `conditions`: Conditions is a list of conditions, each of which have a `type`, `status`, `reason`, and `message` field. Possible values of a condition's `type` field are `Running` and `Failure`, indicating the current state of the scheduled report. The `reason` indicates why its `condition` is in its current state with the `status` being either `true`, `false` or, `unknown`. The `message` provides a human readable indicating why the condition is in the current state. For detailed information on the `reason` values see link:https://github.com/operator-framework/operator-metering/blob/master/pkg/apis/metering/v1/util/report_util.go#L10[`pkg/apis/metering/v1/util/report_util.go`].
+* `lastReportTime`: Indicates the time Metering has collected data up to.
+

--- a/modules/metering-resources.adoc
+++ b/modules/metering-resources.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-install-metering.adoc
+
+[id="metering-resources_{context}"]
+= Metering resources
+
+Metering has many resources, which can be used to manage the deployment and installation of Metering, as well as the reporting functionality Metering provides.
+
+Metering is managed using the following `CustomResourceDefinitions` (CRDs):
+
+[cols="1,7"]
+|===
+
+|*MeteringConfig* |Configures the Metering stack for deployment. Contains customizations and configuration options to control each component that makes up the Metering stack.
+
+|*Reports* |Controls what query to use, when, and how often the query should be run, and where to store the results.
+
+|*ReportQueries* |Contains the SQL queries used to perform analysis on the data contained with in `ReportDataSources`.
+
+|*ReportDataSources* |Controls the data available to ReportQueries and Reports. Allows configuring access to different databases for use within Metering.
+
+|===

--- a/modules/metering-viewing-report-results.adoc
+++ b/modules/metering-viewing-report-results.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-using-metering.adoc
+[id="metering-viewing-report-results"]
+= Viewing Report results
+
+Viewing a Report's results involves querying the reporting-api `Route` and authenticating to the API using your {product-tile} credentials.
+Reports can be retrieved as `JSON`, `CSV`, or `Tabular` formats.
+
+.Prerequisites
+
+* Metering is installed.
+* To access Report results, you must either be a cluster administrator, or you need to be granted access using the `report-exporter` role in the `openshift-metering` namespace.
+
+.Procedure
+
+. Change to the `openshift-metering` project:
++
+----
+$ oc project openshift-metering
+----
+
+. Query the reporting API for results:
+
+.. Get the route to the `reporting-api`:
++
+----
+$ meteringRoute="$(oc get routes metering -o jsonpath='{.spec.host}')"
+$ echo "$meteringRoute"
+----
+
+.. Get the token of your current user to be used in the request:
++
+----
+$ token="$(oc whoami -t)"
+----
+
+
+.. To get the results, use `curl` to make a request to the reporting API for your report:
++
+----
+$ reportName=namespace-cpu-request-2019 <1>
+$ reportFormat=csv <2>
+$ curl --insecure -H "Authorization: Bearer ${token}" "https://${meteringRoute}/api/v1/reports/get?name=${reportName}&namespace=openshift-metering&format=$reportFormat"
+----
+<1> Set `reportName` to the name of the `Report` you created.
+<2> Set `reportFormat` to one of `csv`, `json`, or `tabular` to specify the output format of the API response.
++
+The response should look similar to the following (example output is with `reportName=namespace-cpu-request-2019` and `reportFormat=csv`):
++
+----
+period_start,period_end,namespace,pod_request_cpu_core_seconds
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-apiserver,11745.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-apiserver-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-authentication,522.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-authentication-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cloud-credential-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-machine-approver,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-node-tuning-operator,3385.800000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-samples-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-version,522.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-console,522.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-console-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-controller-manager,7830.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-controller-manager-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-dns,34372.800000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-dns-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-etcd,23490.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-image-registry,5993.400000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-ingress,5220.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-ingress-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-apiserver,12528.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-apiserver-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-controller-manager,8613.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-controller-manager-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-machine-api,1305.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-machine-config-operator,9637.800000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-metering,19575.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-monitoring,6256.800000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-network-operator,261.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-sdn,94503.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-service-ca,783.000000
+2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-service-ca-operator,261.000000
+----

--- a/modules/metering-writing-reports.adoc
+++ b/modules/metering-writing-reports.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-using-metering.adoc
+[id="metering-writing-reports"]
+= Writing Reports
+
+Writing a Report is the way to process and analyze data using Metering.
+
+To write a report, you must define a `Report` resource in a yaml file, and specify the required parameters, and create it in the `openshift-metering` namespace using `oc`.
+
+.Prerequisites
+
+* Metering is installed.
+
+.Procedure
+
+. Change to the `openshift-metering` project:
++
+----
+$ oc project openshift-metering
+----
+
+. Create a report resources as a YAML file:
++
+.. Create a YAML file with the following:
++
+----
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: namespace-cpu-request-2019 <2>
+  namespace: openshift-metering
+spec:
+  reportingStart: '2019-01-01T00:00:00Z'
+  reportingEnd: '2019-12-30T23:59:59Z'
+  query: namespace-cpu-request <1>
+  runImmediately: true <3>
+----
+<1> The `query` specifies `ReportQuery` used to generate the report. Change this based on what you want to report on. For a list of options, run `oc get reportqueries | grep -v raw`.
+<2> The `metadata.name` of the report should be something descriptive about what the report does. A good name is the query, and the schedule or period you used.
+<3> Set `runImmediately`  to `true` for it to run what whatever data is available, or set it to `false` if you want it to wait for `reportingEnd` to pass.
+
+.. Run the following command to create the report:
++
+----
+$ oc create -f <file-name>.yaml
+
+report.metering.openshift.io/namespace-cpu-request-2019 created
+----
++
+
+. You can list reports and their `Running` status with the following command:
++
+----
+$ oc get reports
+
+NAME                         QUERY                   SCHEDULE   RUNNING    FAILED   LAST REPORT TIME       AGE
+namespace-cpu-request-2019   namespace-cpu-request              Finished            2019-12-30T23:59:59Z   26s
+----


### PR DESCRIPTION
Covers basic reporting usage and goes into more depth about Report
resources. Currently about-reports and the reports module could use more
information about ReportQueries and ReportDataSources.