### PR TITLE
osdocs-634 and osdocs-639 deleting gcp and azure clusters

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -93,28 +93,28 @@ Topics:
   Topics:
   - Name: Installing a cluster on AWS using CloudFormation templates
     File: installing-aws-user-infra
-#- Name: Installing on Azure
-#  Dir: installing_azure
-#  Topics:
+- Name: Installing on Azure
+  Dir: installing_azure
+  Topics:
 #  - Name: Configuring an Azure account
 #    File: installing-azure-account
 #  - Name: Installing a cluster quickly on Azure
 #    File: installing-azure-default
 #  - Name: Installing a cluster on Azure with customizations
 #    File: installing-azure-customizations
-#  - Name: Uninstalling a cluster on Azure
-#    File: uninstalling-cluster-azure
-#- Name: Installing on GCP
-#  Dir: installing_gcp
-#  Topics:
+  - Name: Uninstalling a cluster on Azure
+    File: uninstalling-cluster-azure
+- Name: Installing on GCP
+  Dir: installing_gcp
+  Topics:
 #  - Name: Configuring an GCP account
 #    File: installing-gcp-account
 #  - Name: Installing a cluster quickly on GCP
 #    File: installing-gcp-default
 #  - Name: Installing a cluster on GCP with customizations
 #    File: installing-gcp-customizations
-#  - Name: Uninstalling a cluster on GCP
-#    File: uninstalling-cluster-gcp
+  - Name: Uninstalling a cluster on GCP
+    File: uninstalling-cluster-gcp
 #- Name: Installing in a disconnected environment
 #  Dir: installing_disconnected
 #  Topics:

--- a/installing/installing_aws/uninstalling-cluster-aws.adoc
+++ b/installing/installing_aws/uninstalling-cluster-aws.adoc
@@ -7,4 +7,4 @@ toc::[]
 
 You can remove a cluster that you deployed to Amazon Web Services (AWS).
 
-include::modules/installation-uninstall-aws.adoc[leveloffset=+1]
+include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/installing/installing_azure/uninstalling-cluster-azure.adoc
+++ b/installing/installing_azure/uninstalling-cluster-azure.adoc
@@ -7,4 +7,4 @@ toc::[]
 
 You can remove a cluster that you deployed to Microsoft Azure.
 
-//include::modules/installation-uninstall-aws.adoc[leveloffset=+1]
+include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/installing/installing_gcp/uninstalling-cluster-gcp.adoc
+++ b/installing/installing_gcp/uninstalling-cluster-gcp.adoc
@@ -7,4 +7,4 @@ toc::[]
 
 You can remove a cluster that you deployed to Google Cloud Platform (GCP).
 
-// include::modules/installation-uninstall-aws.adoc[leveloffset=+1]
+include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -1,27 +1,22 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/uninstalling-cluster-aws.adoc
+// * installing/installing_azure/uninstalling-cluster-azure.adoc
+// * installing/installing_gcp/uninstalling-cluster-gcp.adoc
 
-[id="installation-uninstall-aws_{context}"]
-= Removing a cluster from AWS
+[id="installation-uninstall-clouds_{context}"]
+= Removing a cluster that uses installer-provisioned infrastructure
 
-You can remove a cluster that you installed on Amazon Web Services (AWS).
+You can remove a cluster that uses installer-provisioned infrastructure from
+your cloud.
 
 .Prerequisites
 
 * Have a copy of the installation program that you used to deploy the cluster.
+* Have the files that the installation program generated when you created your
+cluster.
 
 .Procedure
-
-. Optional: From the computer that you used to install the cluster, run the
-following command and record the UUID that it outputs:
-+
-----
-$ oc get clusterversion -o jsonpath='{.spec.clusterID}{"\n"}' version
-----
-+
-If not all of the cluster resources are removed from AWS, you can use this UUID
-to locate them and remove them.
 
 . From the computer that you used to install the cluster, run the following command:
 +


### PR DESCRIPTION
https://jira.coreos.com/browse/OSDOCS-634
https://jira.coreos.com/browse/OSDOCS-639

@abhinavdahiya  says that there's no difference in procedure between uninstalling for AWS, Azure, and GCP IPI. I had a chat with @aheslin about the structure for the uninstalling processes and made a generic module and an assembly for each cloud platform.

@e-tienne, @wmengRH, as you test out Azure and GCP, let me know if you see anything different in the cluster deletion process or if these methods are fine.