### PR TITLE
Reorganize service mesh docs for better flow.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -886,6 +886,8 @@ Topics:
     File: ossm-kiali
   - Name: Understanding Jaeger
     File: ossm-jaeger
+  - Name: Comparing service mesh and Istio
+    File: ossm-vs-community
 - Name: Service Mesh Installation
   Dir: service_mesh_install
   Topics:
@@ -895,14 +897,6 @@ Topics:
     File: installing-ossm
   - Name: Customizing the installation
     File: customizing-installation-ossm
-#  - Name: Kiali tutorial
-#    File: ossm-tutorial-kiali
-#  - Name: Distributed tracing tutorial
-#    File: ossm-tutorial-jaeger-tracing
-#  - Name: Grafana tutorial
-#    File: ossm-tutorial-grafana
-#  - Name: Prometheus tutorial
-#    File: ossm-tutorial-prometheus
   - Name: Removing service mesh
     File: removing-ossm
 - Name: Day Two
@@ -912,10 +906,16 @@ Topics:
     File: prepare-to-deploy-applications-ossm
   - Name: Configuring Jaeger
     File: configuring-jaeger
-#  - Name: Configuring Tracing
-#    File: ossm-configuring-jaeger
   - Name: Example application
     File: ossm-example-bookinfo
+#  - Name: Kiali tutorial
+#    File: ossm-tutorial-kiali
+#  - Name: Distributed tracing tutorial
+#    File: ossm-tutorial-jaeger-tracing
+#  - Name: Grafana tutorial
+#    File: ossm-tutorial-grafana
+#  - Name: Prometheus tutorial
+#    File: ossm-tutorial-prometheus
 - Name: 3scale adapter
   Dir: threescale_adapter
   Topics:

--- a/modules/ossm-jaeger-service-mesh.adoc
+++ b/modules/ossm-jaeger-service-mesh.adoc
@@ -1,12 +1,12 @@
 ////
 This CONCEPT module included in the following assemblies:
--assembly.adoc
+-ossm-vs-community.adoc
 ////
 
 [id="ossm-jaeger-service-mesh_{context}"]
 = Jaeger and service mesh
 
-Installing Jaeger with the Service Mesh on OpenShift differs from community Jaeger installations in multiple ways. These modifications are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on OpenShift or OKD.
+Installing Jaeger with the Service Mesh on {product-title} differs from community Jaeger installations in multiple ways. These modifications are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on {product-title}.
 
 * Jaeger has been enabled by default for {ProductShortName}.
 * Ingress has been enabled by default for {ProductShortName}.

--- a/modules/ossm-kiali-service-mesh.adoc
+++ b/modules/ossm-kiali-service-mesh.adoc
@@ -1,6 +1,6 @@
 ////
 This CONCEPT module included in the following assemblies:
--ossm-kiali.adoc
+-ossm-vs-community.adoc
 ////
 
 [id="ossm-kiali-service-mesh_{context}"]

--- a/modules/ossm-mixer-policy.adoc
+++ b/modules/ossm-mixer-policy.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service_mesh/service_mesh_install/installing-ossm.adoc
+// * service_mesh/service_mesh_install/prepare-to-deploy-applications-ossm.adoc
 
 [id="ossm-mixer-policy_{context}"]
 = Updating Mixer policy enforcement

--- a/modules/ossm-threescale-integrate.adoc
+++ b/modules/ossm-threescale-integrate.adoc
@@ -13,7 +13,7 @@ You can use these examples to configure requests to your services using the 3sca
 * {ProductName} 0.12.0+
 * A working 3scale account (link:https://www.3scale.net/signup/[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.5/html/installing_3scale/onpremises-installation[3scale 2.5 On-Premises])
 * xref:../service_mesh_install/preparing-ossm-installation.adoc#preparing-ossm-installation[{ProductName} prerequisites]
-* Ensure Mixer policy enforcement is enabled. xref:../service_mesh_install/installing-ossm.adoc#ossm-mixer-policy_installing-ossm[Update Mixer policy enforcement] provides instructions to check the current Mixer policy enforcement status and enable policy enforcement.
+* Ensure Mixer policy enforcement is enabled. xref:../service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc#ossm-mixer-policy_deploying-applications-ossm[Update Mixer policy enforcement] provides instructions to check the current Mixer policy enforcement status and enable policy enforcement.
 
 [NOTE]
 ====

--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -1,21 +1,15 @@
-// Module included in the following assemblies:
-//
-// * service_mesh/service_mesh_install/understanding-ossm.adoc
-
-[id="ossm-vs-istio_{context}"]
-= Comparing {ProductName} and upstream Istio community installations
-
-An installation of {ProductName} differs from upstream Istio community installations in multiple ways. The modifications to {ProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on OpenShift.
-
-The current release of {ProductName} differs from the current upstream Istio community release in the following ways:
+////
+Module included in the following assemblies:
+-ossm-vs-community.adoc
+////
 
 [id="ossm-multi-tenant-install_{context}"]
-== {ProductName} control plane
+= {ProductName} control plane
 
 {ProductName} installs a multi-tenant control plane by default. You specify the projects that can access the {ProductShortName}, and isolate the {ProductShortName} from other control plane instances.
 
 [id="ossm-mt-vs-clusterwide_{context}"]
-=== Multi-tenancy in {ProductName} versus cluster-wide installations
+= Multi-tenancy in {ProductName} versus cluster-wide installations
 
 The main difference between a multi-tenant installation and a cluster-wide installation is the scope of privileges used by the control plane deployments, for example, Galley and Pilot. The components no longer use cluster-scoped Role Based Access Control (RBAC) resource `ClusterRoleBinding`, but rely on project-scoped `RoleBinding`.
 
@@ -37,14 +31,14 @@ This also restricts ingress to only member projects. If ingress from non-member 
 * *Subnet*: No additional configuration is performed.
 
 [id="ossm-automatic-injection_{context}"]
-== Automatic injection
+= Automatic injection
 
 The upstream Istio community installation automatically injects the sidecar into pods within the projects you have labeled.
 
 {ProductName} does not automatically inject the sidecar to any pods, but requires you to specify the `sidecar.istio.io/inject` annotation as illustrated in the xref:../service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc#ossm-automatic-sidecar-injection_deploying-applications-ossm[Automatic sidecar injection] section.
 
 [id="ossm-rbac_{context}"]
-== Istio Role Based Access Control features
+= Istio Role Based Access Control features
 
 Istio Role Based Access Control (RBAC) provides a mechanism you can use to control access to a service. You can identify subjects by user name or by specifying a set of properties and apply access controls accordingly.
 
@@ -86,12 +80,12 @@ spec:
 
 
 [id="ossm-openssl_{context}"]
-== OpenSSL
+= OpenSSL
 
 {ProductName} replaces BoringSSL with OpenSSL. OpenSSL is a software library that contains an open source implementation of the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols. The {ProductName} Proxy binary dynamically links the OpenSSL libraries (libssl and libcrypto) from the underlying Red Hat Enterprise Linux operating system.
 
 
 [id="ossm-cni_{context}"]
-== The Istio Container Network Interface (CNI) plug-in
+= The Istio Container Network Interface (CNI) plug-in
 
 {ProductName} includes CNI plug-in, which provides you with an alternate way to configure application pod networking. The CNI plug-in replaces the `init-container` network configuration eliminating the need to grant service accounts and projects access to Security Context Constraints (SCCs) with elevated privileges.

--- a/service_mesh/service_mesh_arch/ossm-jaeger.adoc
+++ b/service_mesh/service_mesh_arch/ossm-jaeger.adoc
@@ -24,5 +24,3 @@ include::modules/ossm-jaeger-overview.adoc[leveloffset=+1]
 include::modules/ossm-jaeger-architecture.adoc[leveloffset=+1]
 
 include::modules/ossm-jaeger-features.adoc[leveloffset=+1]
-
-include::modules/ossm-jaeger-config-elasticsearch.adoc[leveloffset=+1]

--- a/service_mesh/service_mesh_arch/ossm-kiali.adoc
+++ b/service_mesh/service_mesh_arch/ossm-kiali.adoc
@@ -15,5 +15,3 @@ include::modules/ossm-kiali-overview.adoc[leveloffset=+1]
 include::modules/ossm-kiali-architecture.adoc[leveloffset=+1]
 
 include::modules/ossm-kiali-features.adoc[leveloffset=+1]
-
-include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]

--- a/service_mesh/service_mesh_arch/ossm-vs-community.adoc
+++ b/service_mesh/service_mesh_arch/ossm-vs-community.adoc
@@ -1,0 +1,18 @@
+[id="ossm-vs-community"]
+= Comparing Service Mesh and Istio
+include::modules/ossm-document-attributes.adoc[]
+:context: ossm-vs-istio
+
+toc::[]
+
+An installation of {ProductName} differs from upstream Istio community installations in multiple ways. The modifications to {ProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on {product-title}.
+
+The current release of {ProductName} differs from the current upstream Istio community release in the following ways:
+
+// The following include statements pull in the module files that comprise the assembly.
+
+include::modules/ossm-vs-istio.adoc[leveloffset=+1]
+
+include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]
+
+include::modules/ossm-jaeger-service-mesh.adoc[leveloffset=+1]

--- a/service_mesh/service_mesh_day_two/ossm-example-bookinfo.adoc
+++ b/service_mesh/service_mesh_day_two/ossm-example-bookinfo.adoc
@@ -16,10 +16,10 @@ include::modules/ossm-tutorial-bookinfo-overview.adoc[leveloffset=+1]
 
 include::modules/ossm-tutorial-bookinfo-install.adoc[leveloffset=+1]
 
-include::modules/ossm-tutorial-bookinfo-verify-install.adoc[leveloffset=+1]
-
 include::modules/ossm-tutorial-bookinfo-adding-destination-rules.adoc[leveloffset=+1]
 
+include::modules/ossm-tutorial-bookinfo-verify-install.adoc[leveloffset=+1]
+////
 Now that you have a sample application, you can use the other tutorials in this guide to examine your service mesh.
-
+////
 include::modules/ossm-tutorial-bookinfo-removing.adoc[leveloffset=+1]

--- a/service_mesh/service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc
+++ b/service_mesh/service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc
@@ -1,3 +1,4 @@
+
 [id="deploying-applications-ossm"]
 = Deploying applications on {ProductName}
 include::modules/ossm-document-attributes.adoc[]
@@ -9,7 +10,7 @@ When you deploy an application into the {ProductShortName}, there are several di
 
 .Prerequisites
 
-* Review xref:../service_mesh_arch/understanding-ossm.adoc#ossm-vs-istio_understanding-ossm[Comparing {ProductName} and upstream Istio community installations]
+* Review xref:../service_mesh_arch/ossm-vs-community.adoc#ossm-vs-community[Comparing {ProductName} and upstream Istio community installations]
 
 * Review xref:../service_mesh_install/installing-ossm.adoc#installing-ossm[Installing {ProductName}]
 
@@ -18,6 +19,8 @@ include::modules/ossm-control-plane-templates.adoc[leveloffset=+1]
 include::modules/ossm-sidecar-injection.adoc[leveloffset=+1]
 
 include::modules/ossm-automatic-sidecar-injection.adoc[leveloffset=+2]
+
+include::modules/ossm-mixer-policy.adoc[leveloffset=+1]
 
 .Next steps
 

--- a/service_mesh/service_mesh_install/customizing-installation-ossm.adoc
+++ b/service_mesh/service_mesh_install/customizing-installation-ossm.adoc
@@ -22,11 +22,12 @@ include::modules/ossm-cr-mixer.adoc[leveloffset=+2]
 
 include::modules/ossm-cr-pilot.adoc[leveloffset=+2]
 
-include::modules/ossm-cr-threescale.adoc[leveloffset=+2]
-
 include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
 
 include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
+
+include::modules/ossm-cr-threescale.adoc[leveloffset=+1]
+
 
 .Next steps
 

--- a/service_mesh/service_mesh_install/installing-ossm.adoc
+++ b/service_mesh/service_mesh_install/installing-ossm.adoc
@@ -8,7 +8,7 @@ Installing the {ProductShortName} involves installing the Elasticsearch, Jaeger,
 
 [NOTE]
 ====
-Mixer’s policy enforcement is disabled by default. You must enable it to run policy tasks. See xref:../service_mesh_install/installing-ossm.adoc#ossm-mixer-policy_installing-ossm[Update Mixer policy enforcement] for instructions on enabling Mixer policy enforcement.
+Mixer’s policy enforcement is disabled by default. You must enable it to run policy tasks. See xref:../service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc#ossm-mixer-policy_deploying-applications-ossm[Update Mixer policy enforcement] for instructions on enabling Mixer policy enforcement.
 ====
 
 [NOTE]
@@ -21,10 +21,6 @@ Multi-tenant control plane installations are the default configuration starting 
 * An account with cluster administration access.
 
 include::modules/ossm-operatorhub-install.adoc[leveloffset=+1]
-
-include::modules/ossm-mixer-policy.adoc[leveloffset=+1]
-
-include::modules/ossm-control-plane-templates.adoc[leveloffset=+1]
 
 include::modules/ossm-control-plane-deploy.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR has virtually zero content changes, the majority of the changes are to reorganize content for better flow and to correct some duplication of topics.

Deletes duplicate topic - Configuring the Elasticsearch index job (was in Architecture - Jaeger overview and Day Two-Configuring Jaeger)
Deletes duplicate topic - Creating control plane templates (was in Installation and Day Two) (Addresses https://issues.jboss.org/browse/OSSM-41)
Moves Updating Mixer Policy to Day Two (addresses https://issues.jboss.org/browse/OSSM-40)
Moves Default destination rules topic (addresses https://issues.jboss.org/browse/OSSM-46)
Created a new assembly for all of the "community vs product" comparison topics.
