### PR TITLE
OSDOCS-687: Included FibreChannel details.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -324,6 +324,8 @@ Topics:
   Topics:
   - Name: Persistent storage using AWS Elastic Block Store
     File: persistent-storage-aws
+  - Name: Persistent storage using Fibre Channel
+    File: persistent-storage-fibre
   - Name: Persistent storage using NFS
     File: persistent-storage-nfs
   - Name: Persistent Storage using iSCSI

--- a/modules/persistent-storage-fibre-disk-quotas.adoc
+++ b/modules/persistent-storage-fibre-disk-quotas.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * storage/persitent-storage/persistent-storage-fibre.adoc
+
+[id="enforcing-disk-quota_{context}"]
+= Enforcing disk quotas
+Use LUN partitions to enforce disk quotas and size constraints.
+Each LUN is mapped to a single PersistentVolume, and unique
+names must be used for PersistentVolumes.
+
+Enforcing quotas in this way allows the end user to request persistent storage
+by a specific amount, such as 10Gi, and be matched with a corresponding volume
+of equal or greater capacity.

--- a/modules/persistent-storage-fibre-provisioning.adoc
+++ b/modules/persistent-storage-fibre-provisioning.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-fibre.adoc
+
+[id="provisioning-fibre_{context}"]
+= Provisioning
+To provision Fibre Channel volumes using the PersistentVolume API
+the following must be available:
+
+* The `targetWWNs` (array of Fibre Channel target's World Wide
+Names).
+* A valid LUN number.
+* The filesystem type.
+
+A PersistentVolume and a LUN have a one-to-one mapping between them.
+
+.Prerequisites
+
+* Fibre Channel LUNs must exist in the underlying infrastructure.
+
+.PersistentVolume Object Definition
+
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0001
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  fc:
+    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <1>
+    lun: 2
+    fsType: ext4
+----
+<1> Fibre Channel WWNs are identified as
+`/dev/disk/by-path/pci-<IDENTIFIER>-fc-0x<WWN>-lun-<LUN#>`,
+but you do not need to provide any part of the path leading up to the `WWN`,
+including the `0x`, and anything after, including the `-` (hyphen).
+
+[IMPORTANT]
+====
+Changing the value of the `fstype` parameter after the volume has been
+formatted and provisioned can result in data loss and pod failure.
+====

--- a/modules/persistent-storage-fibre-volume-security.adoc
+++ b/modules/persistent-storage-fibre-volume-security.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-fibre.adoc
+
+[id="fibre-volume-security_{context}"]
+= Fibre Channel volume security
+Users request storage with a PersistentVolumeClaim. This claim only lives in
+the user's namespace, and can only be referenced by a pod within that same
+namespace. Any attempt to access a PersistentVolume across a namespace causes
+the pod to fail.
+
+Each Fibre Channel LUN must be accessible by all nodes in the cluster.

--- a/storage/persistent-storage/persistent-storage-fibre.adoc
+++ b/storage/persistent-storage/persistent-storage-fibre.adoc
@@ -1,0 +1,34 @@
+[id="persistent-storage-using-fibre"]
+= Persistent storage using Fibre Channel
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-fibre
+
+toc::[]
+
+{product-title} supports Fibre Channel, allowing you to provision your
+{product-title} cluster with persistent storage using Fibre channel volumes.
+Some familiarity with Kubernetes and Fibre Channel is assumed.
+
+The Kubernetes persistent volume framework allows administrators to provision a
+cluster with persistent storage and gives users a way to request those
+resources without having any knowledge of the underlying infrastructure.
+PersistentVolumes are not bound to a single project or namespace; they can be
+shared across the {product-title} cluster.
+PersistentVolumeClaims are specific to a project or namespace and can be
+requested by users.
+
+[IMPORTANT]
+====
+High availability of storage in the infrastructure is left to the underlying
+storage provider.
+====
+
+.Additional references
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-fibrechanel[Fibre Channel]
+
+include::modules/persistent-storage-fibre-provisioning.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-fibre-disk-quotas.adoc[leveloffset=+2]
+
+include::modules/persistent-storage-fibre-volume-security.adoc[leveloffset=+2]


### PR DESCRIPTION
Included FibreChannel details. This is for OCP 4.1 and 4.2, and is a port of the 3.x documentation.