### PR TITLE
Adding back Support

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1081,13 +1081,13 @@ Topics:
 #  File: understanding-kubefed
 #- Name: Installing OpenShift KubeFed
 #  File: installing-kubefed
-#---
-#Name: Support
-#Dir: support
-#Distros: openshift-enterprise,openshift-online,openshift-dedicated
-#Topics:
-#- Name: Getting support
-#  File: getting-support
-#- Name: Gathering data about your cluster
-#  File: gathering-cluster-data
-#  Distros: openshift-enterprise,openshift-dedicated
+---
+Name: Support
+Dir: support
+Distros: openshift-enterprise,openshift-online,openshift-dedicated
+Topics:
+- Name: Getting support
+  File: getting-support
+- Name: Gathering data about your cluster
+  File: gathering-cluster-data
+  Distros: openshift-enterprise,openshift-dedicated


### PR DESCRIPTION
@bergerhoffer for some reason, https://github.com/openshift/openshift-docs/pull/16587 overwrote your changes to add the Support section in master and 4.2. I am adding it back here for master, and  will CP to 4.2.  I have already fixed it in 4.1 (https://github.com/openshift/openshift-docs/pull/16600) due to a conflict resolution for 16587.

I *think* what happened was that x16587 hadn't rebased against master before doing the final push.

Let me know if you see something amiss.