### PR TITLE
updating bare metal network parameter

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -24,7 +24,7 @@ controlPlane:
 metadata:
   name: test <6>
 networking:
-  clusterNetworks:
+  clusterNetwork:
   - cidr: 10.128.0.0/14 <7>
     hostPrefix: 23 <8>
   networkType: OpenShiftSDN


### PR DESCRIPTION
Per https://github.com/openshift/installer/pull/2227/files, `clusterNetworks` should be `clusterNetwork` in the `install-config.yaml` files. This is the only instance that has not been updated.

@morenod, will you PTAL? I think this change is valid for 4.1 and 4.2.