### PR TITLE
cisco_1749892: add Cisco ACI to SDN plug-ins

### DIFF
--- a/architecture/networking/network_plugins.adoc
+++ b/architecture/networking/network_plugins.adoc
@@ -28,6 +28,12 @@ for more information.
 
 == Third-Party SDN plug-ins
 
+ifdef::openshift-enterprise,openshift-origin[]
+[[cisco-sdn]]
+=== Cisco ACI SDN
+include::architecture/topics/cisco.adoc[]
+endif::[]
+
 ifndef::openshift-online[]
 [[flannel-sdn]]
 === Flannel SDN

--- a/architecture/topics/cisco.adoc
+++ b/architecture/topics/cisco.adoc
@@ -1,0 +1,18 @@
+////
+Module included in the following assembly:
+
+* architecture/networking/network_plugins.adoc
+////
+
+The Cisco ACI CNI plug-in for {product-title} provides integration between the Cisco Application Policy Infrastructure Controller (Cisco APIC) controller and one or more {product-title} clusters connected to a Cisco ACI fabric.
+
+This integration is implemented across two main functional areas:
+
+. The Cisco ACI CNI plug-in extends the ACI fabric capabilities to {product-title} clusters in order to provide IP address management, networking, load balancing, and security functions for {product-title} workloads. The Cisco ACI CNI plug-in connects all {product-title} Pods to the integrated VXLAN overlay provided by Cisco ACI.
+
+. The Cisco ACI CNI plug-in models the entire {product-title} cluster as a VMM domain on the Cisco APIC. This provides APIC with access to the inventory of resources of the {product-title} cluster, including the number of {product-title} nodes, {product-title} namespaces, services, deployments, Pods, their IP and MAC addresses, interfaces they are using, and so on. APIC uses this information to automatically correlate physical and virtual resources in order to simplify operations.
+
+The Cisco ACI CNI plug-in is designed to be transparent for {product-title} developers and administrators and to integrate seamlessly from an operational standpoint.
+
+For more information, see
+link:https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/white_papers/Cisco-ACI-CNI-Plugin-for-OpenShift-Architecture-and-Design-Guide.html[Cisco ACI CNI Plugin for Red Hat OpenShift Container Platform Architecture and Design Guide].

--- a/architecture/topics/nsxt.adoc
+++ b/architecture/topics/nsxt.adoc
@@ -6,6 +6,6 @@ The NSX-T components can be installed and configured as part of the Ansible inst
 into a data-center-wide NSX-T virtualised network connecting bare metal, virtual machines, and {product-title} pods.
 See the xref:../../install_config/configuring_nsxtsdn.adoc#install-config-configuring-nsxt-sdn[Installation] section for information on how to install and deploy {product-title} with VMware NSX-T.
 
-The NSX-T Container Plug-In (NCP) integrates {product-title} into an NSX-T Manager, which is typically configured for the entire data center. 
+The NSX-T Container Plug-In (NCP) integrates {product-title} into an NSX-T Manager, which is typically configured for the entire data center.
 
-For information on the NSX-T Data Cetner architecture and administration, see the link:https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.4/installation/GUID-10B1A61D-4DF2-481E-A93E-C694726393F9.html[VMware NSX-T Data Center v2.4 documentation] and the link:https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.4/com.vmware.nsxt.ncp_openshift.doc/GUID-1D75FE92-051C-4E30-8903-AF832E854AA7.html[NSX-T NCP configuration] guides.
+For information on the NSX-T Data Center architecture and administration, see the link:https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.4/installation/GUID-10B1A61D-4DF2-481E-A93E-C694726393F9.html[VMware NSX-T Data Center v2.4 documentation] and the link:https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.4/com.vmware.nsxt.ncp_openshift.doc/GUID-1D75FE92-051C-4E30-8903-AF832E854AA7.html[NSX-T NCP configuration] guides.


### PR DESCRIPTION
Added CISCO ACI integration to SDN plug-ins doc.
Related BZ [1749892](https://bugzilla.redhat.com/show_bug.cgi?id=1749892)

@sferich888 Can I please get an ack that this is OK using the external Cisco link at line 18? Request came from @mcurry-rh
