### PR TITLE
Fix example for ingress sharding by namespace

### DIFF
--- a/modules/nw-ingress-sharding-namespace-labels.adoc
+++ b/modules/nw-ingress-sharding-namespace-labels.adoc
@@ -34,7 +34,7 @@ items:
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/worker: ""
-    routeSelector:
+    namespaceSelector:
       matchLabels:
         type: sharded
   status: {}


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/16124.

* `modules/nw-ingress-sharding-namespace-labels.adoc`: Change `routeSelector` to `namespaceSelector`.