### PR TITLE
BZ1752212: Marking iSCSI as tech preview.

### DIFF
--- a/storage/persistent-storage/persistent-storage-iscsi.adoc
+++ b/storage/persistent-storage/persistent-storage-iscsi.adoc
@@ -15,6 +15,9 @@ provision a cluster with persistent storage and gives users a way to
 request those resources without having any knowledge of the 
 underlying infrastructure.
 
+:FeatureName: Persistent storage using iSCSI
+include::modules/technology-preview.adoc[leveloffset=+0]
+
 [IMPORTANT]
 ====
 High-availability of storage in the infrastructure is left to the underlying


### PR DESCRIPTION
In a storage standup it was mentioned that iSCSI should be marked as Technology Preview in OCP 4.x. This PR marks the assembly as TP.

This is for OCP 4.x.