### PR TITLE
BZ-1729195: Indicated pods must be privileged for block volumes.

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -11,6 +11,11 @@
 You can statically provision raw block volumes by including API fields
 in your PV and PVC specifications.
 
+[IMPORTANT]
+====
+Pods using raw block volumes must be configured to allow privileged containers.
+====
+
 The following table displays which volume plug-ins support block volumes.
 
 .Block volume support


### PR DESCRIPTION
Indicated pods must be privileged for block volumes.

This is for OCP 4.x.