### PR TITLE
Moving node selector logging topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -757,6 +757,8 @@ Topics:
 - Name: Viewing cluster logging status
   File: efk-logging-cluster-status
   Distros: openshift-enterprise,openshift-origin
+- Name: Moving the cluster logging resources with node selectors
+  File: efk-logging-moving-nodes
 - Name: Manually rolling out Elasticsearch
   File: efk-logging-manual-rollout
   Distros: openshift-enterprise,openshift-origin

--- a/logging/config/efk-logging-configuring.adoc
+++ b/logging/config/efk-logging-configuring.adoc
@@ -82,4 +82,3 @@ The Rsyslog log collector is currently a Technology Preview feature.
 // assemblies.
 
 include::modules/efk-logging-configuring-image-about.adoc[leveloffset=+1]
-include::modules/efk-logging-configuring-node-selector.adoc[leveloffset=+1]

--- a/logging/efk-logging-moving-nodes.adoc
+++ b/logging/efk-logging-moving-nodes.adoc
@@ -1,0 +1,21 @@
+:context: efk-logging-moving
+[id="efk-logging-moving"]
+= Moving the cluster logging resources with node selectors
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+
+
+
+
+You use node selectors to deploy the Elasticsearch, Kibana, and Curator pods to different nodes. 
+
+// The following include statements pull in the module files that comprise
+// the assembly. Include any combination of concept, procedure, or reference
+// modules required to cover the user story. You can also include other
+// assemblies.
+
+include::modules/infrastructure-moving-logging.adoc[leveloffset=+1]
+
+

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
+// * logging/efk-logging-moving.adoc
 
 [id="infrastructure-moving-logging_{context}"]
 = Moving the cluster logging resources


### PR DESCRIPTION
There are two different modules in the logging docs that provide steps to use node selectors for cluster logging components. Both modules are in the wrong place . Creating a new assembly for one of the modules. 