### PR TITLE
Updated Jaeger production configuration.

### DIFF
--- a/metering/metering-troubleshooting-debugging.adoc
+++ b/metering/metering-troubleshooting-debugging.adoc
@@ -1,7 +1,7 @@
 [id="metering-troubleshooting-debugging"]
 = Troubleshooting and debugging metering
 include::modules/common-attributes.adoc[]
-:context: metering-troubleshooting-debugging 
+:context: metering-troubleshooting-debugging
 
 toc::[]
 

--- a/modules/ossm-configuring-jaeger.adoc
+++ b/modules/ossm-configuring-jaeger.adoc
@@ -9,7 +9,7 @@ When the {ProductShortName} Operator creates the `ServiceMeshControlPlane` resou
 
 The default Jaeger parameters specified in the `ServiceMeshControlPlane` are as follows:
 
-.Default Jaeger parameters
+.Default `all-in-one` Jaeger parameters
 [source,yaml]
 ----
   apiVersion: maistra.io/v1
@@ -18,9 +18,8 @@ The default Jaeger parameters specified in the `ServiceMeshControlPlane` are as 
     istio:
       tracing:
         enabled: true
-        ingress:
-          enabled: true
-
+        jaeger:
+          template: all-in-one
 ----
 
 .Jaeger parameters
@@ -31,36 +30,34 @@ The default Jaeger parameters specified in the `ServiceMeshControlPlane` are as 
 
 |tracing
    enabled
-|This enables or disables tracing in {ProductShortName}. Jaeger is installed by default. If you do not want to install Jaeger, change the `enabled` value to `false`.
+|This parameter enables/disables tracing in {ProductShortName}. Jaeger is installed by default.
 |`true`/`false`
 |`true`
 
-|ingress
-   enabled
-|This enables/disables ingress.
-|`true`/`false`
-|`true`
+|jaeger
+   template
+|This parameter specifies which Jaeger deployment strategy to use.
+|* `all-in-one`- For development, testing, demonstrations, and proof of concept.
+* `production-elasticsearch` - For production use.
+|`all-in-one`
 |===
+
+[NOTE]
+====
+The default template in the `ServiceMeshControlPlane` resource is the `all-in-one` deployment strategy which uses in-memory storage. For production, the only supported storage option is Elasticsearch, therefore you must configure the `ServiceMeshControlPlane` to request the `production-elasticsearch` template when you deploy {ProductShortName} within a production environment.
+====
+
 
 [id="ossm-configuring-jaeger-elasticsearch_{context}"]
 == Configuring Elasticsearch
 
-Jaeger can be configured for different storage backends:
+The default Jaeger deployment strategy uses the `all-in-one` template so that the installation can be completed using minimal resources.  However, because the `all-in-one` template uses in-memory storage, it is only recommended for development, demo, or testing purposes and should NOT be used for production environments.
 
-* *Memory* - Simple in-memory storage, only recommended for development, demo, or testing purposes. This is the default option for the `AllInOne` deployment strategy. Do NOT use for production environments.
-* *Elasticsearch* - For production use. This is the default option for the `Production` deployment strategy.
+If you are deploying {ProductShortName} and Jaeger in a production environment you must change the template to the `production-elasticsearch` template, which uses Elasticsearch for Jaeger's storage needs.
 
-[NOTE]
-====
-The default template strategy in the `ServiceMeshControlPlane` resource is `AllInOne`. For production, the only supported storage option is Elasticsearch, therefore you must configure the `ServiceMeshControlPlane` to request the `production-elasticsearch` template strategy when you deploy {ProductShortName} within a production environment.
-====
+Elasticsearch is a memory intensive application. The initial set of nodes specified in the default {product-title} installation may not be large enough to support the Elasticsearch cluster.  You should modify the default Elasticsearch configuration to match your use case and the resources you have requested for your {product-title} installation. You can adjust both the CPU and memory limits for each component by modifying the resources block with valid CPU and memory values. Additional nodes must be added to the  cluster if you want to run with the recommended amount (or more) of memory. Ensure that you do not exceed the resources requested for your {product-title} installation.
 
-Elasticsearch is a memory intensive application. The initial set of nodes created by the {product-title} installation may not be large enough to support the Elasticsearch cluster. Additional nodes must be added to the cluster if you want to run with the recommended amount (or more) memory. Each Elasticsearch node can operate with a lower memory setting though this is not recommended for production deployments.
-
-You should modify the default Elasticsearch configuration to match your use case. You can adjust both the CPU and memory limits for each component by modifying the resources block with valid memory and CPU values.
-
-
-.Default Jaeger parameters for Elasticsearch in production
+.Default "production" Jaeger parameters with Elasticsearch
 [source,yaml]
 ----
   apiVersion: maistra.io/v1
@@ -68,64 +65,113 @@ You should modify the default Elasticsearch configuration to match your use case
   spec:
     istio:
       tracing:
-        jaeger:
-          template: production-elasticsearch
-          elasticsearch:
-            nodeCount: 3
-            redundancyPolicy:
-            resources:
-              requests:
-                memory: "16Gi"
-                cpu: "1"
-              limits:
-                memory: "16Gi"
+      enabled: true
+      ingress:
+        enabled: true
+      jaeger:
+        template: production-elasticsearch
+        elasticsearch:
+          nodeCount: 3
+          redundancyPolicy:
+          resources:
+            requests:
+              cpu: "1"
+              memory: "16Gi"
+            limits:
+              cpu: "1"
+              memory: "16Gi"
+
 ----
 
 .Elasticsearch parameters
 [options="header"]
-[cols="l, a, a"]
+[cols="l, a, a, a, a"]
 |===
-|Parameter |Values |Description
-|nodeCount
-|integer value
-|Number of Elasticsearch nodes
+|Parameter |Description |Values |Default Value |Examples
 
-|cpu
-|Specified in units of cores (e.g., 200m, 0.5, 1)
-|Number of central processing units
+|tracing:
+  enabled
+|This parameter enables/disables tracing in {ProductShortName}. Jaeger is installed by default.
+|`true`/`false`
+|`true`
+|
 
-|memory
-|Specified in units of bytes (e.g., 200Ki, 50Mi, 5Gi)
-|Memory limit
-|===
+|ingress:
+  enabled
+|This parameter enables/disables ingress for Jaeger.
+|`true`/`false`
+|`true`
+|
 
-.Sample configurations
-[options="header"]
-[cols="l, a, a"]
-|===
-| Parameter |Proof of Concept | Minimal Deployment
+|jaeger
+   template
+|This parameter specifies which Jaeger deployment strategy to use.
+|`all-in-one`/`production-elasticsearch`
+|`all-in-one`
+|
 
-|Node count
+|elasticsearch:
+  nodeCount
+|Number of Elasticsearch nodes to create.
+|Integer value.
 |1
-|3
+|Proof of concept = 1,
+Minimum deployment =3
 
-|Requests CPU
-|500m
-|1
-
-|Requests memory
+|requests:
+  cpu
+|Number of central processing units for requests, based on your environment’s configuration.
+|Specified in cores or millicores (for example, 200m, 0.5, 1).
 |1Gi
-|16Gi
+|Proof of concept = 500m,
+Minimum deployment =1
 
-|Limits CPU
+|requests:
+  memory
+|Available memory for requests, based on your environment’s configuration.
+|Specified in bytes (for example, 200Ki, 50Mi, 5Gi).
 |500m
-|1
+|Proof of concept = 1Gi,
+Minimum deployment = 16Gi*
 
-|Limits memory
-|1Gi
-|16Gi
+|limits:
+  cpu
+|Limit on number of central processing units, based on your environment’s configuration.
+|Specified in cores or millicores (for example, 200m, 0.5, 1).
+|
+|Proof of concept = 500m,
+Minimum deployment =1
+
+|limits:
+  memory
+|Available memory limit based on your environment’s configuration.
+|Specified in bytes (for example, 200Ki, 50Mi, 5Gi).
+|
+|Proof of concept = 1Gi,
+Minimum deployment = 16Gi*
+
+|
+4+|{asterisk} Each Elasticsearch node can operate with a lower memory setting though this is *not* recommended for production deployments. For production use, you should have no less than 16Gi allocated to each Pod by default, but preferably allocate as much as you can, up to 64Gi per Pod.
 |===
 
-For production use, you should have no less than 16Gi allocated to each Pod by default, but preferably allocate as much as you can, up to 64Gi per Pod.
 
+.Procedure
 
+. Log in to the {product-title} web console as a user with the `cluster-admin` role.
+
+. Navigate to *Catalogs* -> *Installed Operators*.
+
+. Click the {ProductName} Operator.
+
+. Click the *Istio Service Mesh Control Plane* tab.
+
+. Click the name of your control plane file, for example, `basic-install`.
+
+. Click the *YAML* tab.
+
+. Edit the Jaeger parameters, replacing the default `all-in-one` template with parameters for the `production-elasticsearch` template, modified for your use case.  Ensure that the indentation is correct.
+
+. Click *Save*.
+
+. Click *Reload*.
+{product-title} redeploys Jaeger and creates the Elasticsearch resources based on the specified parameters.

--- a/modules/ossm-configuring-kiali.adoc
+++ b/modules/ossm-configuring-kiali.adoc
@@ -9,7 +9,7 @@ When the {ProductShortName} Operator creates the `ServiceMeshControlPlane` it al
 
 The default Kiali parameters specified in the `ServiceMeshControlPlane` are as follows:
 
-.Default Kiali parameters
+.Example Kiali parameters
 [source,yaml]
 ----
 apiVersion: maistra.io/v1
@@ -30,19 +30,19 @@ spec:
 |Parameter |Description |Values |Default value
 
 |enabled
-|This enables or disables Kiali in {ProductShortName}. Kiali is installed by default. If you do not want to install Kiali, change the `enabled` value to `false`.
+|This parameter enables/disables Kiali. Kiali is enabled by default.
 |`true`/`false`
 |`true`
 
 |dashboard
    viewOnlyMode
-|Whether the Kiali console should be in a view-only mode, not allowing the user to make changes to the Service Mesh.
+|This parameter enables/disables view-only mode for the Kiali console.  When view-only mode is enabled, users cannot use the console to make changes to the {ProductShortname}.
 |`true`/`false`
 |`false`
 
 |ingress
    enabled
-|This enables/disables ingress.
+|This parameter enables/disables ingress for Kiali.
 |`true`/`false`
 |`true`
 |===

--- a/modules/ossm-cr-example.adoc
+++ b/modules/ossm-cr-example.adoc
@@ -64,9 +64,12 @@ The 3scale Istio Adapter is deployed and configured in the custom resource file.
 
       pilot:
         autoscaleEnabled: false
-        traceSampling: 100.0
+        traceSampling: 100
 
       kiali:
+        enabled: true
+
+      grafana:
         enabled: true
 
       tracing:

--- a/modules/ossm-cr-gateway.adoc
+++ b/modules/ossm-cr-gateway.adoc
@@ -7,6 +7,7 @@
 
 Here is an example that illustrates the Istio gateway parameters for the `ServiceMeshControlPlane` and a description of the available parameters with appropriate values.
 
+.Example gateway parameters
 [source,yaml]
 ----
   gateways:
@@ -27,37 +28,37 @@ Here is an example that illustrates the Istio gateway parameters for the `Servic
 
 |`istio-egressgateway`
 |`autoscaleEnabled`
-|This parameter enables autoscaling.
+|This parameter enables/disables autoscaling.
 |`true`/`false`
 |`true`
 
 |
 |`autoscaleMin`
-|The minimum number of pods to deploy for the egress gateway based on the autoscaleEnabled setting
-|A valid number of allocatable pods based on your environment's configuration
+|The minimum number of pods to deploy for the egress gateway based on the `autoscaleEnabled` setting.
+|A valid number of allocatable pods based on your environment's configuration.
 |`1`
 
 |
 |`autoscaleMax`
-|The maximum number of pods to deploy for the egress gateway based on the autoscaleEnabled setting
-|A valid number of allocatable pods based on your environment's configuration
+|The maximum number of pods to deploy for the egress gateway based on the `autoscaleEnabled` setting.
+|A valid number of allocatable pods based on your environment's configuration.
 |`5`
 
 |`istio-ingressgateway`
 |`autoscaleEnabled`
-|This parameter enables autoscaling.
+|This parameter enables/disables autoscaling.
 |`true`/`false`
 |`true`
 
 |
 |`autoscaleMin`
-|The minimum number of pods to deploy for the ingress gateway based on the autoscaleEnabled setting
-|A valid number of allocatable pods based on your environment's configuration
+|The minimum number of pods to deploy for the ingress gateway based on the `autoscaleEnabled` setting.
+|A valid number of allocatable pods based on your environment's configuration.
 |`1`
 
 |
 |`autoscaleMax`
-|The maximum number of pods to deploy for the ingress gateway based on the autoscaleEnabled setting
-|A valid number of allocatable pods based on your environment's configuration
+|The maximum number of pods to deploy for the ingress gateway based on the `autoscaleEnabled` setting.
+|A valid number of allocatable pods based on your environment's configuration.
 |`5`
 |===

--- a/modules/ossm-cr-istio-global.adoc
+++ b/modules/ossm-cr-istio-global.adoc
@@ -12,6 +12,7 @@ Here is an example that illustrates the Istio global parameters for the `Service
 In order for the 3scale Istio Adapter to work, `disablePolicyChecks` must be `false`.
 ====
 
+.Example global parameters
 [source,yaml]
 ----
   istio:
@@ -34,42 +35,37 @@ In order for the 3scale Istio Adapter to work, `disablePolicyChecks` must be `fa
         - MyPullSecret
 ----
 
-[NOTE]
-====
-See the OpenShift documentation on xref:../../scalability_and_performance/recommended-host-practices.adoc#recommended-node-host-practices_[Scalability and performance] for additional details on CPU and memory resources for the containers in your pod.
-====
-
 .Global parameters
 |===
 |Parameter |Description |Values |Default value
 
 |`disablePolicyChecks`
-|This boolean indicates whether to enable policy checks
+|This parameter enables/disables policy checks.
 |`true`/`false`
 |`true`
 
 |`policyCheckFailOpen`
-|This boolean indicates whether traffic is allowed to pass through to the Envoy sidecar when the Mixer policy service cannot be reached
+|This parameter indicates whether traffic is allowed to pass through to the Envoy sidecar when the Mixer policy service cannot be reached.
 |`true`/`false`
 |`false`
 
 |`tag`
-|The tag that the Operator uses to pull the Istio images
-|A valid container image tag
+|The tag that the Operator uses to pull the Istio images.
+|A valid container image tag.
 |`1.0.0`
 
 |`hub`
-|The hub that the Operator uses to pull Istio images
-|A valid image repo
+|The hub that the Operator uses to pull Istio images.
+|A valid image repository.
 |`maistra/` or `registry.redhat.io/openshift-service-mesh/`
 
 |`mtls`
-|This controls whether to enable Mutual Transport Layer Security (mTLS) between services by default
+|This parameter controls whether to enable/disable Mutual Transport Layer Security (mTLS) between services by default.
 |`true`/`false`
 |`false`
 
 |`imagePullSecrets`
-|If access to the registry providing the Istio images is secure, list an link:https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod[imagePullSecret] here
+|If access to the registry providing the Istio images is secure, list an link:https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod[imagePullSecret] here.
 |redhat-registry-pullsecret OR quay-pullsecret
 |None
 |===
@@ -82,25 +78,25 @@ These parameters are specific to the proxy subset of global parameters.
 
 |Resources
 |`cpu`
-|The amount of CPU resources requested for Envoy proxy
-|CPU resources in cores or millicores based on your environment's configuration
+|The amount of CPU resources requested for Envoy proxy.
+|CPU resources, specified in cores or millicores (for example, 200m, 0.5, 1) based on your environment’s configuration.
 |`100m`
 
 |
 |`memory`
 |The amount of memory requested for Envoy proxy
-|Available memory in bytes based on your environment's configuration
+|Available memory in bytes(for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
 |`128Mi`
 
 |Limits
 |`cpu`
-|The maximum amount of CPU resources requested for Envoy proxy
-|CPU resources in cores or millicores based on your environment's configuration
+|The maximum amount of CPU resources requested for Envoy proxy.
+|CPU resources, specified in cores or millicores (for example, 200m, 0.5, 1) based on your environment’s configuration.
 |`2000m`
 
 |
 |`memory`
-|The maximum amount of memory Envoy proxy is permitted to use
-|Available memory in bytes based on your environment's configuration
+|The maximum amount of memory Envoy proxy is permitted to use.
+|Available memory in bytes (for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
 |`128Mi`
 |===

--- a/modules/ossm-cr-mixer.adoc
+++ b/modules/ossm-cr-mixer.adoc
@@ -7,21 +7,22 @@
 
 Here is an example that illustrates the Mixer parameters for the `ServiceMeshControlPlane` and a description of the available parameters with appropriate values.
 
+.Example mixer parameters
 [source,yaml]
 ----
-  mixer:
-    enabled: true
-    policy:
-      autoscaleEnabled: false
-    telemetry:
-      autoscaleEnabled: false
-        resources:
-          requests:
-            cpu: 100m
-            memory: 1G
-          limits:
-            cpu: 500m
-            memory: 4G
+mixer:
+  enabled: true
+  policy:
+    autoscaleEnabled: false
+  telemetry:
+    autoscaleEnabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 4G
+      requests:
+        cpu: 100m
+        memory: 1G
 ----
 
 
@@ -30,23 +31,23 @@ Here is an example that illustrates the Mixer parameters for the `ServiceMeshCon
 |Parameter |Description |Values |Default value
 
 |`enabled`
-|This enables Mixer
+|This parameter enables/disables Mixer.
 |`true`/`false`
 |`true`
 
 |`autoscaleEnabled`
-|This controls whether to enable autoscaling. Disable this for small environments.
+|This parameter enables/disables autoscaling. Disable this for small environments.
 |`true`/`false`
 |`true`
 
 |`autoscaleMin`
-|The minimum number of pods to deploy based on the autoscaleEnabled setting
-|A valid number of allocatable pods based on your environment's configuration
+|The minimum number of pods to deploy based on the `autoscaleEnabled` setting.
+|A valid number of allocatable pods based on your environment's configuration.
 |`1`
 
 |`autoscaleMax`
-|The maximum number of pods to deploy based on the autoscaleEnabled setting
-|A valid number of allocatable pods based on your environment's configuration
+|The maximum number of pods to deploy based on the `autoscaleEnabled` setting.
+|A valid number of allocatable pods based on your environment's configuration.
 |`5`
 |===
 
@@ -57,25 +58,25 @@ Here is an example that illustrates the Mixer parameters for the `ServiceMeshCon
 
 |Resources
 |`cpu`
-|The percentage of CPU resources requested for Mixer telemetry
-|CPU resources in millicores based on your environment's configuration
-|`1000m`
+|The percentage of CPU resources requested for Mixer telemetry.
+|CPU resources in millicores based on your environment's configuration.
+|`100m`
 
 |
 |`memory`
-|The amount of memory requested for Mixer telemetry
-|Available memory in bytes based on your environment's configuration
+|The amount of memory requested for Mixer telemetry.
+|Available memory in bytes (for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
 |`1G`
 
 |Limits
 |`cpu`
-|The maximum percentage of CPU resources Mixer telemetry is permitted to use
-|CPU resources in millicores based on your environment's configuration
-|`4800m`
+|The maximum percentage of CPU resources Mixer telemetry is permitted to use.
+|CPU resources in millicores based on your environment's configuration.
+|`500m`
 
 |
 |`memory`
-|The maximum amount of memory Mixer telemetry is permitted to use
-|Available memory in bytes based on your environment's configuration
+|The maximum amount of memory Mixer telemetry is permitted to use.
+|Available memory in bytes (for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
 |`4G`
 |===

--- a/modules/ossm-cr-pilot.adoc
+++ b/modules/ossm-cr-pilot.adoc
@@ -7,14 +7,16 @@
 
 Here is an example that illustrates the Istio Pilot parameters for the `ServiceMeshControlPlane` and a description of the available parameters with appropriate values.
 
+.Example pilot parameters
 [source,yaml]
 ----
   pilot:
     resources:
       requests:
         cpu: 100m
+        memory: 128Mi
     autoscaleEnabled: false
-    traceSampling: 100.0
+    traceSampling: 100
 ----
 
 .Istio Pilot parameters
@@ -22,17 +24,23 @@ Here is an example that illustrates the Istio Pilot parameters for the `ServiceM
 |Parameter |Description |Values |Default value
 
 |`cpu`
-|The percentage of CPU resources requested for Pilot
-|CPU resources in millicores based on your environment's configuration
+|The percentage of CPU resources requested for Pilot.
+|CPU resources in millicores based on your environment's configuration.
 |`500m`
 
 |`memory`
-|The amount of memory requested for Pilot
-|Available memory in bytes based on your environment's configuration
+|The amount of memory requested for Pilot.
+|Available memory in bytes (for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
 |`2048Mi`
 
+|`autoscaleEnabled`
+|This parameter enables/disables autoscaling. Disable this for small environments.
+|`true`/`false`
+|`true`
+
+
 |`traceSampling`
-|This value controls how often random sampling occurs. Note: increase for development or testing.
-|A valid percentage
-|`1.0`
+|This value controls how often random sampling occurs. *Note:* Increase for development or testing.
+|A valid percentage.
+|`100`
 |===

--- a/modules/ossm-cr-threescale.adoc
+++ b/modules/ossm-cr-threescale.adoc
@@ -8,6 +8,7 @@
 
 Here is an example that illustrates the 3scale Istio Adapter parameters for the {ProductName} custom resource and a description of the available parameters with appropriate values.
 
+.Example 3scale parameters
 [source,yaml]
 ----
   threeScale:

--- a/service_mesh/service_mesh_install/customizing-installation-ossm.adoc
+++ b/service_mesh/service_mesh_install/customizing-installation-ossm.adoc
@@ -7,8 +7,10 @@ toc::[]
 You can customize your {ProductName} by modifying the default {ProductShortName} custom resource or by creating a new custom resource.
 
 .Prerequisites
-* Follow the xref:../service_mesh_install/preparing-ossm-installation.adoc#preparing-ossm-installation[Preparing to install {ProductName}] process.
-* An account with cluster administration access.
+* An account with the `cluster-admin` role.
+* Completed the xref:../service_mesh_install/preparing-ossm-installation.adoc#preparing-ossm-installation[Preparing to install {ProductName}] process.
+* Have installed the operators.
+
 
 include::modules/ossm-cr-example.adoc[leveloffset=+1]
 
@@ -25,6 +27,8 @@ include::modules/ossm-cr-pilot.adoc[leveloffset=+2]
 include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
 
 include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
+
+For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-elasticsearch.adoc[Configuring Elasticsearch].
 
 include::modules/ossm-cr-threescale.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR
    • Updates all the configuration topics under https://docs.openshift.com/container-platform/4.1/service_mesh/service_mesh_install/customizing-installation-ossm.html 
    • Validates all default values against the installer.
    • Adds titles to the example YAML snippets.
    • Standardizes headings and text across the parameter tables.
    • Updates the default Jaeger installation to “all-in-one”
    • Documents how to change the Jaeger deployment strategy from “all-in-one” to “Production”.  (I checked this against a test deployment, but didn't have the resources to deploy Elasticsearch, will need QE to verify).
    
@brianredbeard, @knrc, @objectiser, @kevinearls, @jkandasa, @tvieira, @yxun