### PR TITLE
Removing logging systemd topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -706,8 +706,6 @@ Topics:
     File: efk-logging-curator
   - Name: Configuring Fluentd
     File: efk-logging-fluentd
-  - Name: Configuring systemd-journald
-    File: efk-logging-systemd
   - Name: Sending logs to external devices
     File: efk-logging-external
 - Name: Viewing Elasticsearch status


### PR DESCRIPTION
According to @richm _there are a few problems with that doc_, including a step to restart Rsyslog, which is not in 4.x.
https://github.com/openshift/openshift-docs/pull/16597#discussion_r323850430

Removing the topic from 4.1 and created [PR is to fix the topic and place it back](https://github.com/openshift/openshift-docs/pull/16662).