### PR TITLE
BZ-1752553: Indicated that the default SC is Operator-owned.

### DIFF
--- a/modules/dynamic-provisioning-defining-storage-class.adoc
+++ b/modules/dynamic-provisioning-defining-storage-class.adoc
@@ -8,11 +8,13 @@
 StorageClass objects are currently a globally scoped object and must be
 created by `cluster-admin` or `storage-admin` users.
 
-[NOTE]
+[IMPORTANT]
 ====
-For AWS, a default StorageClass is created during {product-title} 
-installation. You can change the default StorageClass after installation,
-but the created StorageClass cannot be deleted.
+The ClusterStorageOperator may install a default StorageClass depending
+on the platform in use. This StorageClass is owned and controlled by the
+operator. It cannot be deleted or modified beyond defining annotations
+and labels. If different behavior is desired, you must define a custom
+StorageClass.
 ====
 
 The following sections describe the basic object definition for a

--- a/modules/storage-persistent-storage-pvc.adoc
+++ b/modules/storage-persistent-storage-pvc.adoc
@@ -41,6 +41,16 @@ provisioners to service one or more storage classes. The cluster
 administrator can create a PV on demand  that matches the specifications
 in the PVC.
 
+
+[IMPORTANT]
+====
+The ClusterStorageOperator may install a default StorageClass depending
+on the platform in use. This StorageClass is owned and controlled by the
+operator. It cannot be deleted or modified beyond defining annotations
+and labels. If different behavior is desired, you must define a custom
+StorageClass.
+====
+
 The cluster administrator can also set a default storage class for all PVCs.
 When a default storage class is configured, the PVC must explicitly ask for
 `StorageClass` or `storageClassName` annotations set to `""` to be bound


### PR DESCRIPTION
Added notes to indicate that the default StorageClass is owned by the ClusterStorageOperator, and changes, beyond adjusting the annotations or labels, should not be made.

This is for OCP 4.x.