### PR TITLE
BZ-1743397: Included block detailing not to use vSphere storage for registry storage.

### DIFF
--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -15,6 +15,12 @@ registry to use storage.
 * A cluster on VMware vSphere.
 * A provisioned persistent volume (PV) with `ReadWriteMany` access mode, such as
 `NFS`.
++
+[IMPORTANT]
+====
+vSphere volumes do not support the `ReadWriteMany` access mode. You must use
+a different storage backend, such as `NFS`, to configure the registry storage.
+====
 * Must have "100Gi" capacity.
 
 .Procedure


### PR DESCRIPTION
Included block detailing not to use vSphere storage for registry storage. vSphere storage does not support ReadWriteMany, which is a requirement for the image registry storage.

This is for OCP 4.x.