### PR TITLE
Removing CNV variable from headings

### DIFF
--- a/cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
+++ b/cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
@@ -1,5 +1,5 @@
 [id="cnv-collecting-cnv-data"]
-= Collecting {CNVProductName} data for Red Hat Support
+= Collecting container-native virtualization data for Red Hat Support
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-collecting-cnv-data
 toc::[]

--- a/modules/cnv-about-collecting-cnv-data.adoc
+++ b/modules/cnv-about-collecting-cnv-data.adoc
@@ -3,7 +3,7 @@
 // * cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
 
 [id="cnv-about-collecting-cnv-data_{context}"]
-= About collecting {CNVProductName} data
+= About collecting container-native virtualization data
 
 You can use the `oc adm must-gather` CLI command to collect information about your
 cluster, including features and objects associated with {CNVProductName}:


### PR DESCRIPTION
I'd forgotten that the Portal doesn't play well with variables in headings/titles when I did my last PR, so I'm fixing that now.