### PR TITLE
Bug 1752602: OpenShift config which controls imageregistry is not namespace dependent

### DIFF
--- a/modules/infrastructure-moving-registry.adoc
+++ b/modules/infrastructure-moving-registry.adoc
@@ -16,7 +16,7 @@ You configure the registry Operator to deploy its pods to different nodes.
 . View the `config/instance` object:
 +
 ----
-$ oc get config/cluster -n openshift-ingress -o yaml
+$ oc get config/cluster -o yaml
 ----
 +
 The output resembles the following text:
@@ -54,7 +54,7 @@ status:
 . Edit the `config/instance` object:
 +
 ----
-$ oc edit config/cluster -n openshift-ingress
+$ oc edit config/cluster
 ----
 
 . Add the following lines of text the `spec` section of the object:


### PR DESCRIPTION
* Version: 4.1

* Description: 
  `Config` CR of `imageregistry.operator.openshift.io/v1` is `cluster-scoped`, so it's singleton across cluster. It's not required to specify a namespace for configuring like PV.
  You can compare the `Config` CR of `cluster-image-registry-operator` with `IngressController` 
 CR of `cluster-ingress-operator` as follows. Watch out both `scope:` section on each yaml. The `cluster-image-operator` is `cluster-scoped`, conversely the `cluster-ingress-operator` is `namspace-scoped`.

- [CRD of cluster-image-registry-operator](https://github.com/openshift/cluster-image-registry-operator/blob/release-4.1/manifests/00-crd.yaml#L6-L8)
```yaml
spec:
  group: imageregistry.operator.openshift.io
  scope: Cluster
```

- Conversely, [CRD of cluster-ingress-operator](https://github.com/openshift/cluster-ingress-operator/blob/release-4.1/manifests/00-custom-resource-definition.yaml#L5-L12)
```yaml
spec:
  group: operator.openshift.io
  names:
    kind: IngressController
    listKind: IngressControllerList
    plural: ingresscontrollers
    singular: ingresscontroller
  scope: Namespaced
```

* Reference: 
  - [OpenShift config which controls imageregistry is not namespace dependent](https://bugzilla.redhat.com/show_bug.cgi?id=1752602)