### PR TITLE
formatting change for ossm-26

### DIFF
--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -8,7 +8,7 @@
 You can deploy the {ProductShortName} control plane by using the {product-title} web console or the CLI.
 
 [id="ossm-control-plane-deploy-operatorhub_{context}"]
-= Deploying the control plane with the web console
+== Deploying the control plane with the web console
 
 Follow this procedure to deploy the {ProductName} control plane by using the web console.
 
@@ -52,7 +52,7 @@ Review xref:../service_mesh_install/customizing-installation-ossm.adoc#customize
 
 
 [id="ossm-control-plane-deploy-cli_{context}"]
-= Deploying the control plane from the CLI
+== Deploying the control plane from the CLI
 
 Follow this procedure to deploy the {ProductName} control plane by using the CLI.
 


### PR DESCRIPTION
Moving the deployment options under the deployment heading.