### PR TITLE
CNV-2692

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1133,6 +1133,8 @@ Topics:
     File: cnv-logs
   - Name: Viewing events
     File: cnv-events
+    Name: Viewing cluster information
+    File: cnv-using-dashboard-to-get-cluster-info
   - Name: OpenShift cluster monitoring, logging, and Telemetry
     File: cnv-openshift-cluster-monitoring
   - Name: Collecting container-native virtualization data for Red Hat Support

--- a/cnv/cnv_install/installing-container-native-virtualization.adoc
+++ b/cnv/cnv_install/installing-container-native-virtualization.adoc
@@ -27,10 +27,3 @@ include::modules/cnv-preparing-to-install.adoc[leveloffset=+1]
 include::modules/cnv-subscribing-to-hco-catalog.adoc[leveloffset=+1]
 
 include::modules/cnv-deploying-cnv.adoc[leveloffset=+1]
-
-[NOTE]
-====
-You can verify the installation by navigating to the web console at
-`kubevirt-web-ui.your.app.subdomain.host.com`. Log in by using your
-{product-title} credentials.
-====

--- a/cnv/cnv_users_guide/cnv-edit-vms.adoc
+++ b/cnv/cnv_users_guide/cnv-edit-vms.adoc
@@ -6,10 +6,12 @@ toc::[]
 
 Edit a virtual machine by completing one of the following tasks:
 
-* Using the web console
+// Temporarily commenting out this module. This will be revisited for 2.2:
+// * Using the web console
 * Editing the virtual machine YAML configuration
 * Using the CLI
 
-include::modules/cnv-editing-vm-web.adoc[leveloffset=+1]
+// Temporarily commenting out this module. This will be revisited for 2.2:
+// include::modules/cnv-editing-vm-web.adoc[leveloffset=+1]
 include::modules/cnv-editing-vm-yaml-web.adoc[leveloffset=+1]
 include::modules/cnv-editing-vm-cli.adoc[leveloffset=+1]

--- a/cnv/cnv_users_guide/cnv-using-dashboard-to-get-cluster-info.adoc
+++ b/cnv/cnv_users_guide/cnv-using-dashboard-to-get-cluster-info.adoc
@@ -1,0 +1,11 @@
+[id="cnv-using-dashboard-to-get-cluster-info"]
+= Using the {product-title} dashboard to get cluster information
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-using-dashboard-to-get-cluster-info
+toc::[]
+
+Access the {product-title} dashboard, which captures high-level information about the cluster, by clicking *Home > Dashboards > Overview* from the {product-title} web console.
+
+The {product-title} dashboard provides various cluster information, captured in individual dashboard _cards_.
+
+include::modules/cnv-about-the-overview-dashboard.adoc[leveloffset=+1]

--- a/modules/cnv-about-the-overview-dashboard.adoc
+++ b/modules/cnv-about-the-overview-dashboard.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+// * cnv/cnv_users_guide/cnv-using-dashboard-to-get-cluster-info.adoc
+
+[id="cnv-about-the-overview-dashboard_{context}"]
+= About the {product-title} dashboards page
+
+The {product-title} dashboard consists of the following cards:
+
+* *Details* provides a brief overview of informational cluster details.
++
+Status include *ok*, *error*, *warning*, *in progress*, and *unknown*. Resources can add custom status names.
++
+** Cluster ID
+** Provider
+** Version
+* *Cluster Inventory* details number of resources and associated statuses. It is helpful when intervention is required to resolve problems, including information about:
+** Number of nodes
+** Number of Pods
+** Persistent storage volume claims
+** Virtual machines (available if {CNVProductName} is installed)
+** Bare metal hosts in the cluster, listed according to their state (only available in *metal3* environment).
+* *Cluster Health* summarizes the current health of the cluster as a whole, including relevant alerts and descriptions. If {CNVProductName} is installed, the overall health of {CNVProductName} is diagnosed as well. If more than one subsystem is present, click *See All* to view the status of each subsystem.
+* *Cluster Capacity* charts help administrators understand when additional resources are required in the cluster. The charts contain an inner ring that displays current consumption, while an outer ring displays thresholds configured for the resource, including information about:
+** CPU time
+** Memory allocation
+** Storage consumed
+** Network resources consumed
+* *Cluster Utilization* shows the capacity of various resources over a specified period of time, to help administrators understand the scale and frequency of high resource consumption.
+* *Events* lists messages related to recent activity in the cluster, such as Pod creation or virtual machine migration to another host.
+* *Top Consumers* helps administrators understand how cluster resources are consumed. Click on a resource to jump to a detailed page listing Pods and nodes that consume the largest amount of the specified cluster resource (CPU, memory, or storage).

--- a/modules/cnv-accessing-vmi-web.adoc
+++ b/modules/cnv-accessing-vmi-web.adoc
@@ -11,7 +11,7 @@ You can connect to a virtual machine by using the web console.
 
 .  Ensure you are in the correct project. If not, click the *Project*
 list and select the appropriate project.
-.  Click *Applications* -> *Virtual Machines* to display the virtual
+.  Click *Workloads* -> *Virtual Machines* to display the virtual
 machines in the project.
 .  Select a virtual machine.
 .  In the *Overview* tab, click the `virt-launcher-<vm-name>` pod.

--- a/modules/cnv-deploying-cnv.adoc
+++ b/modules/cnv-deploying-cnv.adoc
@@ -28,3 +28,7 @@ in the `openshift-cnv` namespace
 . Navigate to the *Workloads* -> *Pods* page and monitor the {CNVProductName} Pods
 until they are all *Running*. After all the Pods display the *Running* state,
 you can access {CNVProductName}.
+
+. You can verify the installation by navigating to the web console, as follows.
+.. Enter the command `oc get route -n openshift-console`.
+.. Log in using your {product-title} credentials. 

--- a/modules/cnv-editing-vm-web.adoc
+++ b/modules/cnv-editing-vm-web.adoc
@@ -19,7 +19,6 @@ display until you reboot the virtual machine.
 . Click *Workloads* -> *Virtual Machines* from the side menu.
 . Select a Virtual Machine.
 . Click *Edit* to make editable fields available.
-. You can change the *Flavor* but only to *Custom*, which provides additional fields for *CPU* and *Memory*.
 . Click *Save*.
 +
 The values and virtual machine are updated after the operation is processed.


### PR DESCRIPTION
This PR contains a new assembly and one new module that instructs the user how to access the Overview Dashboard displaying various information about CNV clusters.

Previously this dashboard was accessed by a URL. It can now be accessed directly through the Open Source Web Console.

See story https://jira.coreos.com/browse/CNV-2692 for details.

Need Peer Review from any of the following: @ahardin-rh @jboxman @sheriff-rh 

Please label Needs Peer Review, OpenShift-Enterprise-4.2

Thanks,
Bob

