### PR TITLE
OSDOCS-468-DEVEXP-401 Add Builds - Mount trusted CA for cluster proxies warning

### DIFF
--- a/modules/builds-source-code.adoc
+++ b/modules/builds-source-code.adoc
@@ -1,8 +1,5 @@
 // Module included in the following assemblies:
-//* assembly/builds
-
-// This module can be included from assemblies using the following include statement:
-// include::<path>/builds-source-code.adoc[leveloffset=+1]
+//* builds/creating-build-inputs.adoc
 
 [id="source-code_{context}"]
 = Git source
@@ -49,3 +46,10 @@ commit on the default branch (typically `master`) are downloaded.  This results
 in repositories downloading faster, but without the full commit history.  To
 perform a full `git clone` of the default branch of a specified repository, set
 `ref` to the name of the default branch (for example `master`).
+
+
+[WARNING]
+====
+Git clone operations that go through a proxy that is performing man in the middle
+(MITM) TLS hijacking or reencrypting of the proxied connection will not work.
+====


### PR DESCRIPTION
https://jira.coreos.com/browse/DEVEXP-401

Adding warning based on discussion from: https://github.com/openshift/openshift-docs/issues/16327#issuecomment-533255545