### PR TITLE
New, add kernel args to nodes per OSDOCS-479 Jira

### DIFF
--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -1,0 +1,146 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-nodes-working.adoc
+
+[id="nodes-nodes-kernel-arguments_{context}"]
+= Adding kernel arguments to Nodes
+
+In some special cases, you might want to add kernel arguments
+to a set of nodes in your cluster.
+This should only be done with caution and clear understanding
+of the implications of the arguments you set.
+
+[WARNING]
+====
+Improper use of kernel arguments can result in your systems becoming unbootable.
+====
+
+Examples of kernel arguments you could set include:
+
+* **selinux=0**: Disables Security Enhanced Linux (SELinux).
+While not recommended for production, disabling SELinux can
+improve performance by 2% - 3%.
+
+* **nosmt**: Disables symmetric multithreading (SMT) in the kernel.
+Multithreading allows multiple logical threads for each CPU.
+You could consider `nosmt` in multi-tenant environments to reduce
+risks from potential cross-thread attacks. By disabling SMT, you essentially choose security over performance.
+
+See link:https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt[Kernel.org kernel parameters]
+for a list and descriptions of kernel arguments.
+
+In the following procedure, you create a MachineConfig that identifies:
+
+* A set of machines to which you want to add the kernel argument.
+In this case, machines with a worker role.
+* Kernel arguments that are appended to the end of the existing kernel arguments.
+* A label that indicates where in the list of MachineConfigs the change is appplied.
+
+.Prerequisites
+* Have administrative privilege to a working {product-title} cluster.
+
+.Procedure
+
+. List existing MachineConfigs for your {product-title} cluster to determine how to
+label your MachineConfig:
++
+----
+$ oc get MachineConfig
+NAME                                                        GENERATEDBYCONTROLLER                      IGNITIONVERSION   CREATED
+00-master                                                   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+00-worker                                                   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+01-master-container-runtime                                 577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+01-master-kubelet                                           577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+01-worker-container-runtime                                 577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+01-worker-kubelet                                           577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+99-master-1131169f-dae9-11e9-b5dd-12a845e8ffd8-registries   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+99-master-ssh                                                                                          2.2.0             30m
+99-worker-114e8ac7-dae9-11e9-b5dd-12a845e8ffd8-registries   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+99-worker-ssh                                                                                          2.2.0             30m
+rendered-master-b3729e5f6124ca3678188071343115d0            577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+rendered-worker-18ff9506c718be1e8bd0a066850065b7            577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             30m
+----
+
+. Create a MachineConfig file that identifies the kernel argument (for example, `05-worker-kernelarg-selinuxoff.yaml`)
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker<1>
+  name: 05-worker-kernelarg-selinuxoff<2>
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+  kernelArguments:
+    - selinux=0<3>
+----
++
+<1> Applies the new kernel argument only to worker nodes.
+<2> Named to identify where it fits among the MachineConfigs (05) and what it does (adds
+a kernel argument to turn off SELinux).
+<3> Identifies the exact kernel argument as `selinux=0`.
+
+. Create the new MachineConfig:
++
+----
+$ oc create -f 05-worker-kernelarg-selinuxoff.yaml
+----
+
+. Check the MachineConfigs to see that the new one was added:
++
+----
+$ oc get MachineConfig
+NAME                                                        GENERATEDBYCONTROLLER                      IGNITIONVERSION   CREATED
+00-master                                                   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+00-worker                                                   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+01-master-container-runtime                                 577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+01-master-kubelet                                           577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+01-worker-container-runtime                                 577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+01-worker-kubelet                                           577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+
+05-worker-kernelarg-selinuxoff                                                                         2.2.0             105s
+
+99-master-1131169f-dae9-11e9-b5dd-12a845e8ffd8-registries   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+99-master-ssh                                                                                          2.2.0             30m
+99-worker-114e8ac7-dae9-11e9-b5dd-12a845e8ffd8-registries   577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+99-worker-ssh                                                                                          2.2.0             31m
+rendered-master-b3729e5f6124ca3678188071343115d0            577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+rendered-worker-18ff9506c718be1e8bd0a066850065b7            577c2d527b09cd7a481a162c50592139caa15e20   2.2.0             31m
+----
+
+. Check the nodes:
++
+----
+$ oc get node
+NAME                           STATUS                     ROLES    AGE   VERSION
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.14.6+90fadebfa
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.14.6+90fadebfa
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.14.6+90fadebfa
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.14.6+90fadebfa
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.14.6+90fadebfa
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.14.6+90fadebfa
+----
++
+You can see that scheduling on each worker node is disabled as the change is being applied.
+
+. Check that the kernel argument worked by going to one of the worker nodes and listing
+the kernel command line arguments (in `/proc/cmdline` on the host):
++
+----
+$ oc debug node/ip-10-0-141-105.ec2.internal
+Starting pod/ip-10-0-141-105ec2internal-debug ...
+To use host binaries, run `chroot /host`
+
+sh-4.2# cat /host/proc/cmdline
+BOOT_IMAGE=/ostree/rhcos-... console=tty0 console=ttyS0,115200n8
+rootflags=defaults,prjquota rw root=UUID=fd0... ostree=/ostree/boot.0/rhcos/16...
+coreos.oem.id=qemu coreos.oem.id=ec2 ignition.platform.id=ec2 selinux=0
+
+sh-4.2# exit
+----
++
+You should see the `selinux=0` argument added to the other kernel arguments.

--- a/nodes/nodes/nodes-nodes-working.adoc
+++ b/nodes/nodes/nodes-nodes-working.adoc
@@ -25,6 +25,8 @@ include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-working-deleting.adoc[leveloffset=+1]
 
+include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
+
 == Additional resources
 
 For more information on scaling your cluster using a MachineSet,


### PR DESCRIPTION
This is a new procedure for adding kernel arguments to OpenShift 4.2 nodes using machineconfigs.