### PR TITLE
CNV 2.1 upgrade + install docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1057,6 +1057,8 @@ Topics:
     File: installing-container-native-virtualization
   - Name: Installing the `virtctl` client
     File: cnv-installing-virtctl
+  - Name: Upgrading container-native virtualization
+    File: upgrading-container-native-virtualization
   - Name: Uninstalling container-native virtualization
     File: uninstalling-container-native-virtualization
 - Name: Container-native virtualization user's guide

--- a/cnv/cnv_install/installing-container-native-virtualization.adoc
+++ b/cnv/cnv_install/installing-container-native-virtualization.adoc
@@ -7,19 +7,14 @@ toc::[]
 Install {CNVProductName} to add virtualization functionality to your {product-title}
 cluster.
 
-Before you deploy {CNVProductName}, you must create two Custom Resource
-Definition (CRD) objects:
-
-* `kind: OperatorGroup`
-* `kind: CatalogSource`
-
-You can create both objects by running a single command.
-
-To finish installing {CNVProductName}, use the {product-title} 4.1
+You can use the {product-title} 4.2
 xref:../../web-console/web-console.adoc#web-console-overview_web-console[web console]
 to subscribe to and deploy the {CNVProductName} Operators.
 
-:FeatureName: {CNVProductName}
+.Prerequisites
+* {product-title} 4.2
+
+:FeatureName: {CNVProductNameStart}
 include::modules/technology-preview.adoc[leveloffset=+1]
 
 include::modules/cnv-preparing-to-install.adoc[leveloffset=+1]

--- a/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
+++ b/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
@@ -4,14 +4,12 @@ include::modules/cnv-document-attributes.adoc[]
 :context: uninstalling-container-native-virtualization
 toc::[]
 
-You can uninstall {CNVProductName} by using the {product-title} 4.1
+You can uninstall {CNVProductName} by using the {product-title}
 xref:../../web-console/web-console.adoc#web-console-overview_web-console[web console].
-First, delete the custom resource you created during deployment. Then, delete
-the *KubeVirt HyperConverged Cluster Operator* catalog subscription.
 
 .Prerequisites
 
-* {CNVProductNameStart} 2.0
+* {CNVProductNameStart} 2.1
 
 include::modules/cnv-deleting-custom-resource.adoc[leveloffset=+1]
 

--- a/cnv/cnv_install/upgrading-container-native-virtualization.adoc
+++ b/cnv/cnv_install/upgrading-container-native-virtualization.adoc
@@ -1,0 +1,19 @@
+[id="upgrading-container-native-virtualization"]
+= Upgrading container-native virtualization
+include::modules/cnv-document-attributes.adoc[]
+:context: upgrading-container-native-virtualization
+toc::[]
+
+You enable automatic updates during {CNVProductName} xref:../../cnv/cnv_install/installing-container-native-virtualization.adoc#cnv-subscribing-to-hco-catalog_installing-container-native-virtualization[installation].
+Learn what to expect and how you can check the status of an update in progress.
+
+:FeatureName: {CNVProductNameStart}
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+include::modules/cnv-about-upgrading-cnv.adoc[leveloffset=+1]
+
+include::modules/cnv-monitoring-upgrade-status.adoc[leveloffset=+1]
+
+.Additional information
+
+* xref:../../applications/operators/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[ClusterServiceVersions (CSVs)]

--- a/modules/cnv-about-upgrading-cnv.adoc
+++ b/modules/cnv-about-upgrading-cnv.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_install/upgrading-container-native-virtualization.adoc
+
+[id="cnv-about-upgrading-cnv_{context}"]
+= About upgrading container-native virtualization
+
+If you enabled automatic updates when you installed {CNVProductName}, you
+receive updates as they become available.
+
+.Additional information
+
+* In {CNVProductName} version 2.1, only _z-stream_ updates are available.
+For example, {CNVProductName} 2.1.0 -> {CNVProductName} 2.1.1
+
+* Updates are delivered via the _Marketplace Operator_, which is deployed
+during {product-title} installation. The Marketplace Operator makes
+external Operators available to your cluster.
+
+* Upgrading does not interrupt virtual machine workloads.
+** Virtual machine Pods are not restarted or migrated during an upgrade. If you
+need to update the `virt-launcher` Pod, you must restart or live migrate the
+virtual machine.
++
+[NOTE]
+====
+Each virtual machine has a `virt-launcher` Pod that runs the virtual machine
+instance. The `virt-launcher` Pod runs an instance of `libvirt`, which is
+used to manage the virtual machine process.
+====
+
+* Upgrading does not interrupt network connections.
+
+* DataVolumes and their associated PersistentVolumeClaims are preserved during
+upgrade.
+
+* The amount of time an update takes to complete depends on your network
+connection. Most automatic updates complete within fifteen minutes.

--- a/modules/cnv-deleting-custom-resource.adoc
+++ b/modules/cnv-deleting-custom-resource.adoc
@@ -5,8 +5,8 @@
 [id="cnv-deleting-kubevirt-hyperconverged-custom-resource_{context}"]
 = Deleting the KubeVirt HyperConverged custom resource
 
-To uninstall {CNVProductName}, you must delete the custom resource that you created
-during deployment.
+To uninstall {CNVProductName}, you must first delete the
+*KubeVirt HyperConverged Cluster Operator Deployment* custom resource.
 
 .Prerequisites
 

--- a/modules/cnv-deleting-hco-subscription.adoc
+++ b/modules/cnv-deleting-hco-subscription.adoc
@@ -5,8 +5,8 @@
 [id="cnv-deleting-hco-subscription_{context}"]
 = Deleting the KubeVirt HyperConverged Cluster Operator catalog subscription
 
-To finish uninstalling {CNVProductName}, delete your KubeVirt HyperConverged
-Cluster Operator catalog subscription.
+To finish uninstalling {CNVProductName}, uninstall the
+*KubeVirt HyperConverged Cluster Operator subscription*.
 
 .Prerequisites
 
@@ -14,15 +14,8 @@ Cluster Operator catalog subscription.
 
 .Procedure
 
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the KubeVirt HyperConverged Cluster Operator. Then,
-click on it.
+. Navigate to the *Catalog -> OperatorHub* page.
 
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
+. Locate the *KubeVirt HyperConverged Cluster Operator* and then select it.
 
-. When prompted by the *Remove Operator Subscription* window, optionally select the
-*Also completely remove the Operator from the selected namespace*
-check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the Pods, Deployments, CRDs, and CRs
-associated with the Operator.
+. Click *Uninstall*.

--- a/modules/cnv-monitoring-upgrade-status.adoc
+++ b/modules/cnv-monitoring-upgrade-status.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_install/upgrading-container-native-virtualization.adoc
+
+[id="cnv-monitoring-upgrade-status_{context}"]
+= Monitoring upgrade status
+
+The best way to monitor {CNVProductName} upgrade status is to watch the
+ClusterServiceVersion (CSV) `PHASE`.
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+
+.Procedure
+
+. Run the following command:
++
+----
+$ oc get csv
+----
+
+. Review the output, checking the `PHASE` field. For example:
++
+----
+VERSION  REPLACES                                        PHASE
+2.1.1    kubevirt-hyperconverged-operator.v2.1.0         Installing
+2.1.0                                                    Replacing
+----
+
+. Optional: Monitor the aggregated status of all {CNVProductName} component
+`Conditions` by running the following command:
++
+----
+$ oc get hco -n openshift-cnv hyperconverged-cluster \
+-o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
+----
++
+A successful upgrade results in the following output:
++
+----
+ReconcileComplete  True  Reconcile completed successfully
+Available          True  Reconcile completed successfully
+Progressing        False Reconcile completed successfully
+Degraded           False Reconcile completed successfully
+Upgradeable        True  Reconcile completed successfully
+----

--- a/modules/cnv-preparing-to-install.adoc
+++ b/modules/cnv-preparing-to-install.adoc
@@ -5,48 +5,18 @@
 [id="cnv-preparing-to-install_{context}"]
 = Preparing to install container-native virtualization
 
-Before deploying {CNVProductName}:
-
-* Create a namespace called `openshift-cnv`.
-* Create `OperatorGroup` and `CatalogSource` Custom Resource Definition objects
-(CRDs) in the `openshift-cnv` namespace.
+Before deploying {CNVProductName}, create a namespace that is named
+`openshift-cnv`.
 
 .Prerequisites
 
-* {product-title} 4.1
 * User with `cluster-admin` privileges
-* The {product-title} Command-line Interface (CLI), commonly known as `oc`
 
 .Procedure
 
-. Create the `openshift-cnv` namespace by running the following
+* Create the `openshift-cnv` namespace by running the following
 command:
 +
 ----
-$ oc new-project openshift-cnv
-----
-
-. Create the `OperatorGroup` and `CatalogSource` in the
-`openshift-cnv` namespace by running the following command:
-+
-----
-cat <<EOF | oc apply -f -
-apiVersion: operators.coreos.com/v1alpha2
-kind: OperatorGroup
-metadata:
-  name: hco-operatorgroup
-  namespace: openshift-cnv
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: hco-catalogsource
-  namespace: openshift-operator-lifecycle-manager
-  imagePullPolicy: Always
-spec:
-  sourceType: grpc
-  image: registry.redhat.io/container-native-virtualization/hco-bundle-registry:v2.0.0
-  displayName: KubeVirt HyperConverged
-  publisher: Red Hat
-EOF
+$ oc create ns openshift-cnv
 ----

--- a/modules/cnv-subscribing-to-hco-catalog.adoc
+++ b/modules/cnv-subscribing-to-hco-catalog.adoc
@@ -12,28 +12,37 @@ namespace access to the {CNVProductName} Operators.
 
 .Prerequisites
 
-* `OperatorGroup` and `CatalogSource` Custom Resource Definition objects (CRDs),
-both created in the `openshift-cnv` namespace
+* Create a namespace that is named `openshift-cnv`.
 
 .Procedure
 
-. Open a browser window and navigate to the {product-title} web console.
+. Open a browser window and log in to the {product-title} web console.
 
-. Navigate in the web console to the *Operators → OperatorHub* page.
+. Navigate to the *Operators* → *OperatorHub* page.
 
-. Scroll or type a keyword into the *Filter by keyword* box to find the KubeVirt
-HyperConverged Cluster Operator, then click on it.
+. Locate the *KubeVirt HyperConverged Cluster Operator* and then select it.
 
 . Read the information about the Operator and click *Install*.
 
 . On the *Create Operator Subscription* page:
-.. Select one of the following:
-*** *All namespaces on the cluster (default)* installs the Operator in the default
+.. Select *A specific namespace on the cluster* from the *Installation Mode*
+list and choose the `openshift-cnv` namespace.
++
+[WARNING]
+====
+* *All namespaces on the cluster (default)* installs the Operator in the default
 `openshift-operators` namespace to watch and be made available to all namespaces
-in the cluster. This option is not always available.
-*** *A specific namespace on the cluster* allows you to choose a specific, single
+in the cluster. This option is not supported for use with {CNVProductName}.
+You must only install the Operator in the `openshift-cnv` namespace.
+* *A specific namespace on the cluster* allows you to choose a specific, single
 namespace in which to install the Operator. The Operator will only watch and be
 made available for use in this single namespace.
+====
+.. Select *2.1* from the list of available *Update Channel* options.
+.. For *Approval Strategy*, ensure that *Automatic*, which is the default value,
+is selected.
+{CNVProductNameStart} automatically updates when a new z-stream release is
+available.
 
 . Click *Subscribe* to make the Operator available to the selected namespaces on
 this {product-title} cluster.


### PR DESCRIPTION
Note: The upgrade docs depend on/overlap with the installation guide updates for 2.1. For now, I'm bundling all the updates in this one PR, but if that turns out to be counterproductive, I'll split them up.

Relevant Jiras: CNV-2278, CNV-2473, CNV-2581

**Preview builds**

Upgrade: http://file.bos.redhat.com/pousley/100319/cnv-2.1-upgrade/cnv/cnv_install/upgrading-container-native-virtualization.html

Install: http://file.bos.redhat.com/pousley/100319/cnv-2.1-upgrade/cnv/cnv_install/installing-container-native-virtualization.html

Uninstall: http://file.bos.redhat.com/pousley/100319/cnv-2.1-upgrade/cnv/cnv_install/uninstalling-container-native-virtualization.html

PTAL, @openshift/team-documentation - thanks!

Please cherrypick to enterprise-4.2 only.