### PR TITLE
Bug 1754521: Fixing example yaml typo for crontab clusterrole

### DIFF
--- a/modules/proc_creating-aggregated-cluster-role.adoc
+++ b/modules/proc_creating-aggregated-cluster-role.adoc
@@ -45,7 +45,7 @@ roles.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1 <1>
 metadata:
-  name: name: aggregate-cron-tabs-admin-edit <2>
+  name: aggregate-cron-tabs-admin-edit <2>
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true" <3>
     rbac.authorization.k8s.io/aggregate-to-edit: "true" <4>


### PR DESCRIPTION
Fixing small typo error example yaml in doc link [1]

[1] - https://docs.openshift.com/container-platform/3.11/admin_guide/custom_resource_definitions.html#creating-aggregated-cluster-role-crd_admin-guide-custom-resources