### PR TITLE
OSP: add note about compressed image format

### DIFF
--- a/modules/installation-osp-creating-image.adoc
+++ b/modules/installation-osp-creating-image.adoc
@@ -16,7 +16,10 @@ The {product-title} installation program requires that a {op-system-first} image
 .Procedure
 //Links not valid--release images aren't posted yet.
 . Download the latest {op-system} image from the https://access.redhat.com/downloads/content/290[Product Downloads] page of the Red Hat customer portal or the https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/[{op-system} image mirror page].
-
++
+[NOTE]
+The OpenStack QCOW2 images are delivered in compressed format, so you must specify additional options to download them.  With `curl`, specify `curl --compressed -J -L -O <image_url>`.  With `wget`, specify `wget --compression=auto <image_url>`.
++
 . From the image that you downloaded, create an image that is named `rhcos` to your cluster by using the OpenStack CLI:
 +
 ----


### PR DESCRIPTION
The OpenStack QCOW2 images will be delivered in compressed format.
Users that try to download these images without the proper options
will end up with an image that looks corrupted.

See https://bugzilla.redhat.com/show_bug.cgi?id=1755506 for additional
details.