### PR TITLE
Rename OLM topic 'Disconnected' -> 'Restricted network'

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -544,8 +544,8 @@ Topics:
   - Name: Creating policy for Operator installations and upgrades
     File: olm-creating-policy
     Distros: openshift-origin,openshift-enterprise
-  - Name: Configuring OLM in disconnected mode
-    File: olm-disconnected
+  - Name: Configuring OLM for restricted networks
+    File: olm-restricted-networks
     Distros: openshift-origin,openshift-enterprise
 - Name:  Application life cycle management
   Dir: application-life-cycle-management

--- a/applications/operators/olm-restricted-networks.adoc
+++ b/applications/operators/olm-restricted-networks.adoc
@@ -1,15 +1,15 @@
-[id="olm-disconnected"]
-= Using Operator Lifecycle Manager on disconnected clusters
+[id="olm-restricted-networks"]
+= Using Operator Lifecycle Manager on restricted networks
 include::modules/common-attributes.adoc[]
-:context: olm-disconnected
+:context: olm-restricted-networks
 
 toc::[]
 
-When {product-title} is installed as a disconnected cluster, Operator Lifecycle
+When {product-title} is installed on restricted networks, Operator Lifecycle
 Manager (OLM) can no longer use the default OperatorHub sources as they require
-Internet connectivity. Cluster administrators can disable those default sources
-and create local mirrors so that OLM can install and manage Operators from the
-local sources instead.
+full Internet connectivity. Cluster administrators can disable those default
+sources and create local mirrors so that OLM can install and manage Operators
+from the local sources instead.
 
 ////
 .Additional resources
@@ -17,7 +17,7 @@ local sources instead.
 * Link to section about disconnected cluster installations.
 ////
 
-include::modules/olm-disconnected-operatorhub-disconnected-mode.adoc[leveloffset=+1]
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
 .Additional resources
 
 * For details on exposing your {product-title} cluster's internal registry to

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -1,17 +1,17 @@
 // Module included in the following assemblies:
 //
-// * applications/operators/olm-disconnected.adoc
+// * applications/operators/olm-restricted-networks.adoc
 
-[id="olm-disconnected-operatohub-disconnected-mode_{context}"]
-= Configuring OperatorHub in disconnected mode
+[id="olm-restricted-networks-operatorhub_{context}"]
+= Configuring OperatorHub for restricted networks
 
 Cluster administrators can configure OLM and OperatorHub to use local content in
-a disconnected mode.
+restricted network environments.
 
 .Prerequisites
 
-* Cluster administrator access to a connected or disconnected {product-title} cluster and its internal registry.
-* Separate workstation with full Internet access.
+* Cluster administrator access to a {product-title} cluster and its internal registry.
+* Separate workstation without network restrictions.
 * If pushing images to the {product-title} cluster's internal registry, the registry must be exposed with a route.
 * `podman` version 1.5.1+
 
@@ -32,7 +32,8 @@ a {product-title} installation.
 . **Retrieve package lists.**
 +
 To get the list of packages that are available for the default OperatorSources,
-run the following `curl` commands from your workstation with Internet access:
+run the following `curl` commands from your workstation without network
+restrictions:
 +
 ----
 $ curl https://quay.io/cnr/api/v1/packages?namespace=redhat-operators > packages.txt
@@ -41,8 +42,8 @@ $ curl https://quay.io/cnr/api/v1/packages?namespace=certified-operators >> pack
 ----
 +
 Each package in the new `packages.txt` is an Operator that you could add to your
-disconnected catalog. From this list, you could either pull every Operator or a
-subset that you would like to expose to users.
+restricted network catalog. From this list, you could either pull every Operator
+or a subset that you would like to expose to users.
 
 . **Pull Operator content.**
 +
@@ -161,6 +162,36 @@ defaultChannel: singlenamespace-alpha
 packageName: etcd
 ----
 
+. **Identify images required by the Operators you want to use.**
++
+Inspect the CSV files of each Operator for `image:` fields to identify the pull
+specs for any images required by the Operator, and note them for use in a later
+step.
++
+For example, in the following `deployments` spec of an etcd Operator CSV:
++
+[source,yaml]
+----
+  spec:
+   serviceAccountName: etcd-operator
+   containers:
+   - name: etcd-operator
+     command:
+     - etcd-operator
+     - --create-crd=false
+     image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943 <1>
+     env:
+     - name: MY_POD_NAMESPACE
+       valueFrom:
+         fieldRef:
+           fieldPath: metadata.namespace
+     - name: MY_POD_NAME
+       valueFrom:
+         fieldRef:
+           fieldPath: metadata.name
+----
+<1> Image required by Operator.
+
 . **Create an Operator catalog image.**
 
 .. Save the following to a Dockerfile, for example named
@@ -192,23 +223,23 @@ Dockerfile:
 +
 ----
 $ podman build -f custom-registry.Dockerfile \
-    -t <internal_registry_route>/<namespace>/custom-registry <1>
+    -t <local_registry_host_name>:<local_registry_host_port>/<namespace>/custom-registry <1>
 ----
-<1> Tag the image for the internal registry of the disconnected {product-title}
-cluster and any namespace.
+<1> Tag the image for the internal registry of the restricted network
+{product-title} cluster and any namespace.
 
 . **Push the Operator catalog image to a registry.**
 +
-Your new Operator catalog image must be pushed to a registry that the
-{product-title} can access. This can be the internal registry of the cluster
-itself or another registry that the disconnected cluster has network access to,
+Your new Operator catalog image must be pushed to a registry that the restricted
+network {product-title} cluster can access. This can be the internal registry of
+the cluster itself or another registry that the cluster has network access to,
 such as an on-premise Quay Enterprise registry.
 +
-For this example, login and push the image to the internal registry of the
-disconnected {product-title} cluster
+For this example, login and push the image to the internal registry
+{product-title} cluster:
 +
 ----
-$ podman push <internal_registry_route>/<namespace>/custom-registry
+$ podman push <local_registry_host_name>:<local_registry_host_port>/<namespace>/custom-registry
 ----
 
 . **Create a CatalogSource pointing to the new Operator catalog image.**
@@ -225,7 +256,7 @@ metadata:
 spec:
   displayName: My Operator Catalog
   sourceType: grpc
-  image: <internal_registry_route>/<namespace>/custom-registry:latest
+  image: <local_registry_host_name>:<local_registry_host_port>/<namespace>/custom-registry:latest
 ----
 
 .. Create the CatalogSource resource:
@@ -256,9 +287,9 @@ console.
 
 . **Mirror the images required by the Operators you want to use.**
 
-.. Determine the images defined by the Operator that you are expecting. This
- example uses the etcd Operator, requiring the `quay.io/coreos/etcd-operator`
- image.
+.. Determine the images defined by the Operator(s) that you are expecting. This
+example uses the etcd Operator, requiring the `quay.io/coreos/etcd-operator`
+image.
 
 .. To use mirrored images, you must first create an ImageContentSourcePolicy for
 each image to change the source location of the Operator catalog image. For
@@ -273,17 +304,18 @@ metadata:
 spec:
   repositoryDigestMirrors:
   - mirrors:
-    - <internal_registry_route>:5000/coreos/etcd-operator
+    - <local_registry_host_name>:<local_registry_host_port>/coreos/etcd-operator
     source: quay.io/coreos/etcd-operator
 ----
 
-.. Use the `oc image mirror` command from your workstation with Internet access to
-pull the image from the source registry and push to the internal registry
-without being stored locally:
+.. Use the `oc image mirror` command from your workstation without network
+restrictions to pull the image from the source registry and push to the internal
+registry without being stored locally:
 +
 ----
 $ oc image mirror quay.io/coreos/etcd-operator \
-    <internal_registry_route>:5000/coreos/etcd-operator
+    <local_registry_host_name>:<local_registry_host_port>/coreos/etcd-operator
 ----
 
-You can now install the Operator from the OperatorHub in disconnected mode.
+You can now install the Operator from the OperatorHub on your restricted network
+{product-title} cluster.

--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -97,7 +97,7 @@ future release.
 
 See
 xref:../installing/installing_restricted_networks/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Installing in restricted networks]
-and xref:../applications/operators/olm-disconnected.adoc#olm-disconnected[Using Operator Lifecycle Manager on restricted networks]
+and xref:../applications/operators/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
 for details.
 
 [id="ocp-4-2-cluster-wide-egresss-proxy"]


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/16458 per feedback.

Rename usage of "disconnected" to "restricted networks", and other minor edits.

Preview (internal): http://file.rdu.redhat.com/~adellape/092619/olm_restricted_network_edits/applications/operators/olm-restricted-networks.html