### PR TITLE
CNV-3061 Release Note

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -24,6 +24,8 @@ method. It is not supported for non-default networks.
 * For secondary networks, use the `bridge` binding method.
 
 === Web console improvements
+* The {product-title} dashboard captures high-level information about clusters.
+From the OpenShift web console, access the dashboard by clicking *Home > Dashboards > Overview*. Note that virtual machines are no longer listed in the web console project overview. Virtual machines are now listed within the *Cluster Inventory* card of the dashboard.
 * You can now view all services associated with a virtual machine in the
 *Virtual Machine Details* screen.
 
@@ -89,3 +91,9 @@ As a workaround, create the template from the command line.
 importing VMware virtual machines, and creating virtual machines by using the
 wizard.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1724654[*BZ#1724654*])
+
+* When you install {CNVProductName}, kubemacpool automatically
+starts. If you define a secondary vNIC without specifying the MAC address,
+the MAC pool allocates a unique address to the vNIC. However, if you do not
+define a secondary vNIC and specify the MAC address, the secondary vNIC may
+collide with another vNIC in the cluster.


### PR DESCRIPTION
Adding release note for story https://jira.coreos.com/browse/CNV-3061

See **Known Issues**. Here is a test build: http://file.bos.redhat.com/bgaydos/092619/cnv/cnv_release_notes/cnv-release-notes.html

The note is as follows:

_When you install container-native virtualization, kubemacpool automatically starts. If you define a secondary vNIC without specifying the MAC address, the MAC pool allocates a unique address to the vNIC. However, if you do not define a secondary vNIC and specify the MAC address, the secondary vNIC may collide with another vNIC in the cluster._

Please label for Enterprise 4.2._

Peer Review requested @kalexand-rh @mburke5678 @huffmanca

Tagging @phoracek for code review.

Thanks!
Bob


