### PR TITLE
CNV-3061 Release Note for Macpool

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -89,3 +89,8 @@ As a workaround, create the template from the command line.
 importing VMware virtual machines, and creating virtual machines by using the
 wizard.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1724654[*BZ#1724654*])
+
+* When you install {CNVProductName}, kubemacpool automatically starts. 
+If you define a secondary vNIC without specifying the MAC address, the MAC pool allocates
+a unique address to the vNIC. However, if you do not define a secondary vNIC and
+specify the MAC address, the secondary vNIC may collide with another vNIC in the cluster.


### PR DESCRIPTION
Here is a test build: http://file.bos.redhat.com/bgaydos/092619/cnv/cnv_release_notes/cnv-release-notes.html#known-issues

See **Known Issues**. The note reads as follows:

_When you install container-native virtualization, kubemacpool automatically starts. If you define a secondary vNIC without specifying the MAC address, the MAC pool allocates a unique address to the vNIC. However, if you do not define a secondary vNIC and specify the MAC address, the secondary vNIC may collide with another vNIC in the cluster._

Please label for Enterprise 4.2.

Peer Review requested @kalexand-rh @mburke5678 @huffmanca

Tagging @phoracek for code review.

Thanks,
Bob