### PR TITLE
Update on "Updating and deleting SCCs"

### DIFF
--- a/modules/security-context-constraints-command-reference.adoc
+++ b/modules/security-context-constraints-command-reference.adoc
@@ -96,20 +96,26 @@ the default SCCs.
 [id="deleting-security-context-constraints_{context}"]
 == Deleting an SCC
 
+[WARNING]
+====
+Avoid updates and removals of the default SCCs. These are recreated on a
+cluster restart.
+====
+
 To delete an SCC:
 
 ----
 $ oc delete scc <scc_name>
 ----
 
-[NOTE]
-====
-If you delete a default SCC, it will regenerate when you restart the cluster.
-====
 
 [id="updating-security-context-constraints_{context}"]
-
 == Updating an SCC
+[WARNING]
+====
+Avoid updates and removals of the default SCCs. These are recreated on a
+cluster restart.
+====
 
 To update an existing SCC:
 
@@ -119,8 +125,8 @@ $ oc edit scc <scc_name>
 
 [NOTE]
 ====
-To preserve customized SCCs during upgrades, do not edit settings on
-the default SCCs.
-//other than priority, users, groups, labels, and annotations.
+To allow access to use an SCC, do not update any of its fields. Instead, refer to
+xref:../authentication/managing-security-context-constraints.html#role-based-access-to-ssc_configuring-internal-oauth[Role-based access to Security Context Constraints]
 ====
+
 endif::openshift-enterprise,openshift-origin[]


### PR DESCRIPTION
SCCs should not be edited with the intention to add access to
users/serviceaccounts. Instead, RBAC should be used.