### PR TITLE
CNV - Adding TLS certificate to ConfigMap

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1052,6 +1052,8 @@ Topics:
   - Name: Creating virtual machines
     File: cnv-create-vms
 ### Importing virtual machines
+  - Name: TLS certificates for DataVolume imports
+    File: cnv-tls-certificates-for-dv-imports
   - Name: Importing a VMware virtual machine or template with the virtual machine wizard
     File: cnv-importing-vmware-vm
   - Name: Importing virtual machine images with DataVolumes

--- a/cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
+++ b/cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
@@ -21,6 +21,10 @@ Refer to the operating system documentation for details.
 
 .Prerequisites 
 
+* If the endpoint requires a TLS certificate, the certificate must be 
+xref:../../cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc#cnv-adding-tls-certificates-for-authenticating-dv-imports_cnv-tls-certificates-for-dv-imports[included in a ConfigMap] 
+in the same namespace as the DataVolume and referenced in the DataVolume configuration. 
+
 * You may need to xref:../../cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc#cnv-defining-storageclass-in-cdi-configuration_cnv-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space] 
 for this operation to complete successfully.
 

--- a/cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc
+++ b/cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc
@@ -1,0 +1,11 @@
+[id="cnv-tls-certificates-for-dv-imports"]
+= TLS certificates for DataVolume imports
+include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: cnv-tls-certificates-for-dv-imports
+toc::[]
+
+include::modules/cnv-adding-tls-certificates-for-authenticating-dv-imports.adoc[leveloffset=+1]
+include::modules/cnv-example-configmap-tls-certificate.adoc[leveloffset=+1]
+
+

--- a/modules/cnv-adding-tls-certificates-for-authenticating-dv-imports.adoc
+++ b/modules/cnv-adding-tls-certificates-for-authenticating-dv-imports.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc
+
+[id="cnv-adding-tls-certificates-for-authenticating-dv-imports_{context}"]
+= Adding TLS certificates for authenticating DataVolume imports
+
+TLS certificates for registry or HTTPS endpoints must be added to a ConfigMap 
+in order to import data from these sources. This ConfigMap must be present 
+in the namespace of the destination DataVolume.
+
+Create the ConfigMap by referencing the relative file path for the TLS certificate.
+
+.Procedure
+
+. Ensure you are in the correct namespace. The ConfigMap can only be referenced by DataVolumes if it is in the same namespace.
++
+----
+$ oc get ns
+----
+
+. Create the ConfigMap:
++
+----
+$ oc create configmap <configmap-name> --from-file=</path/to/file/ca.pem>
+----
+

--- a/modules/cnv-example-configmap-tls-certificate.adoc
+++ b/modules/cnv-example-configmap-tls-certificate.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc
+
+[id="cnv-example-configmap-tls-certificate_{context}"]
+= Example: ConfigMap created from a TLS certificate
+
+The following example is of a ConfigMap created from `ca.pem` TLS certificate. 
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tls-certs
+data:
+  ca.pem: |
+    -----BEGIN CERTIFICATE-----
+    ... <base64 encoded cert> ...
+    -----END CERTIFICATE-----
+----

--- a/modules/cnv-importing-vm-datavolume.adoc
+++ b/modules/cnv-importing-vm-datavolume.adoc
@@ -76,6 +76,7 @@ spec:
         http:
           url: https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2 <1>
           secretRef: "" <2>
+          certConfigMap: "" <3> 
     status: {}
   running: false
   template:
@@ -104,6 +105,7 @@ status: {}
 ----
 <1> The `HTTP` source of the image you want to import.
 <2> The `secretRef` parameter is optional.
+<3> The `certConfigMap` is only required if the endpoint requires authentication. The referenced ConfigMap must be in the same namespace as the DataVolume.
 
 . Create the virtual machine:
 +


### PR DESCRIPTION
BZ#1715413 - Adding new content to cover the creation of a ConfigMap with TLS certificate for importing virtual machine images from endpoints requiring TLS certificates. The ConfigMap must be in the same namespace as the DataVolume used to import the VM image. 

Cherrypick to enterprise 4.1 and 4.2