### PR TITLE
CNV - closing context 

### DIFF
--- a/cnv/cnv_users_guide/cnv-create-vms.adoc
+++ b/cnv/cnv_users_guide/cnv-create-vms.adoc
@@ -24,6 +24,8 @@ include::modules/cnv-storage-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-creating-vm-yaml-web.adoc[leveloffset=+1]
 include::modules/cnv-creating-vm.adoc[leveloffset=+1]
 
+:virtualmachine!:
+
 Virtual machine storage volume types are listed here, as well as domain and volume settings. See the
 https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinespec[kubevirt
 API Reference] for a definitive list of virtual machine settings.

--- a/cnv/cnv_users_guide/cnv-creating-vm-template.adoc
+++ b/cnv/cnv_users_guide/cnv-creating-vm-template.adoc
@@ -21,4 +21,4 @@ include::modules/cnv-vm-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-cloud-init-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-networking-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-storage-wizard-fields-web.adoc[leveloffset=+2]
-
+:vmtemplate!:

--- a/cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
+++ b/cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
@@ -26,3 +26,4 @@ include::modules/cnv-vm-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-cloud-init-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-networking-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/cnv-storage-wizard-fields-web.adoc[leveloffset=+2]
+:virtualmachine!:


### PR DESCRIPTION
When the VM/VM template content was merged with conditionals, I didn't close the context tags in the assemblies. This fixes that error in three assemblies. 

Cherrypick to enterprise-4.1 and enterprise-4.2