### PR TITLE
bug 1755300 updating RHCOS mirror link

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -24,7 +24,7 @@ installation program created to your HTTP server. Note the URLs of these files.
 of installing operating system instances from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
 Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -24,7 +24,7 @@ installation program created to your HTTP server. Note the URLs of these files.
 and `initramfs` files from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
 Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -68,7 +68,7 @@ $ base64 -w0 <installation_directory>/append-bootstrap.ign > <installation_direc
 . Obtain the {op-system} OVA image from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
 Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1755300

All of the `https://mirror.openshift.com/` links now point to 4.2.