### PR TITLE
Reuse Using the OCP dashboard to get cluster information content in Web Console section

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -185,6 +185,8 @@ Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Accessing the web console
   File: web-console
+- Name: Viewing cluster information
+  File: using-dashboard-to-get-cluster-information
 - Name: Configuring the web console
   File: configuring-web-console
 - Name: Customizing the web console

--- a/modules/cnv-about-the-overview-dashboard.adoc
+++ b/modules/cnv-about-the-overview-dashboard.adoc
@@ -1,5 +1,9 @@
 // Module included in the following assemblies:
 // * cnv/cnv_users_guide/cnv-using-dashboard-to-get-cluster-info.adoc
+// * web-console/using-dashboard-to-get-cluster-information.adoc
+ifeval::["{context}" == "cnv-using-dashboard-to-get-cluster-info"]
+:cnv-cluster:
+endif::[]
 
 [id="cnv-about-the-overview-dashboard_{context}"]
 = About the {product-title} dashboards page
@@ -17,9 +21,13 @@ Status include *ok*, *error*, *warning*, *in progress*, and *unknown*. Resources
 ** Number of nodes
 ** Number of Pods
 ** Persistent storage volume claims
+ifdef::cnv-cluster[]
 ** Virtual machines (available if {CNVProductName} is installed)
+endif::cnv-cluster[]
 ** Bare metal hosts in the cluster, listed according to their state (only available in *metal3* environment).
+ifdef::cnv-cluster[]
 * *Cluster Health* summarizes the current health of the cluster as a whole, including relevant alerts and descriptions. If {CNVProductName} is installed, the overall health of {CNVProductName} is diagnosed as well. If more than one subsystem is present, click *See All* to view the status of each subsystem.
+endif::cnv-cluster[]
 * *Cluster Capacity* charts help administrators understand when additional resources are required in the cluster. The charts contain an inner ring that displays current consumption, while an outer ring displays thresholds configured for the resource, including information about:
 ** CPU time
 ** Memory allocation

--- a/web-console/using-dashboard-to-get-cluster-information.adoc
+++ b/web-console/using-dashboard-to-get-cluster-information.adoc
@@ -1,0 +1,14 @@
+[id="using-dashboard-to-get-cluster-info"]
+= Using the {product-title} dashboard to get cluster information
+include::modules/common-attributes.adoc[]
+:context: using-dashboard-to-get-cluster-info
+toc::[]
+
+Access the {product-title} dashboard, which captures high-level information
+about the cluster, by navigating to *Home* -> *Dashboards* -> *Overview* from
+the {product-title} web console.
+
+The {product-title} dashboard provides various cluster information, captured in
+individual dashboard cards.
+
+include::modules/cnv-about-the-overview-dashboard.adoc[leveloffset=+1]


### PR DESCRIPTION
Adding topic from https://github.com/openshift/openshift-docs/pull/16751 to Web Console section per discussion with @bgaydosrh 