### PR TITLE
CNV - logging module re-use

### DIFF
--- a/cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
+++ b/cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
@@ -9,19 +9,14 @@ toc::[]
 // Cluster monitoring
 include::modules/monitoring-about-cluster-monitoring.adoc[leveloffset=+1]
 
-== Cluster logging
-
-The cluster logging components are based upon Elasticsearch, Fluentd, and Kibana (EFK).
-The collector, link:http://www.fluentd.org/architecture[Fluentd], is deployed to each node in the {product-title} cluster.
-It collects all node and container logs and writes them to link:https://www.elastic.co/products/elasticsearch[Elasticsearch] (ES).
-link:https://www.elastic.co/guide/en/kibana/current/introduction.html[Kibana] is the centralized, web UI
-where users and administrators can create rich visualizations and dashboards with the aggregated data.
+// Cluster logging
+include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
 For more information on cluster logging, see the xref:../../logging/cluster-logging.adoc#cluster-logging[{product-title} cluster logging] documentation.
 
 // Telemetry
 include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]
-include::modules/telemetry-what-information-is-collected.adoc[leveloffset=+1]
+include::modules/telemetry-what-information-is-collected.adoc[leveloffset=+2]
 
 == CLI troubleshooting and debugging commands
 

--- a/modules/cluster-logging-about.adoc
+++ b/modules/cluster-logging-about.adoc
@@ -1,13 +1,23 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging.adoc
+// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
+//
+// This module uses conditionalized paragraphs so that the module
+// can be re-used in associated products.
+
+ifeval::["{context}" == "cnv-openshift-cluster-monitoring"]
+:cnv-logging:
+endif::[]
 
 [id="cluster-logging-about_{context}"]
 = About cluster logging
 
 ifdef::openshift-enterprise,openshift-origin[]
+ifndef::cnv-logging[]
 As an {product-title} cluster administrator, you can deploy cluster logging to
 aggregate logs for a range of {product-title} services.
+endif::cnv-logging[]
 
 The cluster logging components are based upon Elasticsearch, Fluentd, and Kibana
 (EFK). The collector, link:http://www.fluentd.org/architecture[Fluentd], is
@@ -18,14 +28,17 @@ link:https://www.elastic.co/guide/en/kibana/current/introduction.html[Kibana] is
 the centralized, web UI where users and administrators can create rich
 visualizations and dashboards with the aggregated data.
 
+ifndef::cnv-logging[]
 {product-title} cluster administrators can deploy cluster logging using a few
 CLI commands and the {product-title}  web console to install the Elasticsearch
 Operator and Cluster Logging Operator. When the operators are installed, create
 a Cluster Logging Custom Resource (CR) to schedule cluster logging pods and
 other resources necessary to support cluster logging. The operators are
 responsible for deploying, upgrading, and maintaining cluster logging.
-endif::[]
+endif::cnv-logging[]
+endif::openshift-enterprise,openshift-origin[]
 
+ifndef::cnv-logging[]
 ifdef::openshift-dedicated[]
 As an {product-title} cluster administrator, you can deploy cluster logging to
 aggregate logs for your applications.
@@ -44,7 +57,7 @@ Elasticsearch operators via OperatorHub and configure logging in the
 `openshift-logging` namespace. Configuring logging will deploy Elasticsearch,
 Fluentd, and Kibana in the `openshift-logging` namespace. The operators are
 responsible for deploying, upgrading, and maintaining cluster logging.
-endif::[]
+endif::openshift-dedicated[]
 
 You can configure cluster logging by modifying the Cluster Logging Custom Resource (CR), named `instance`.
 The CR defines a complete cluster logging deployment that includes all the components
@@ -52,3 +65,8 @@ of the logging stack to collect, store and visualize logs.  The Cluster Logging 
 Custom Resource and adjusts the logging deployment accordingly.
 
 Administrators and application developers can view the logs of the projects for which they have view access.
+endif::cnv-logging[]
+ifdef::cnv-logging[]
+:cnv-logging!:
+endif::cnv-logging[]
+


### PR DESCRIPTION
Adding conditionalized paras so that OCP logging module can be re-used in CNV.
