### PR TITLE
BZ1755357 remove Reclaim policy header

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -186,30 +186,6 @@ of *emptyDir* storage.
    ** *emptyDir* volumes are deleted when the Pod is deleted.
 endif::[]
 
-ifdef::openshift-enterprise,openshift-origin[]
-[id="pv-reclaim-policy_{context}"]
-== Reclaim policy
-
-The following table lists the current reclaim policy:
-
-.Current reclaim policy
-[cols="1,2",options="header"]
-|===
-
-|Reclaim policy
-|Description
-
-|Retain
-|Manual reclamation
-
-|===
-
-[WARNING]
-====
-If you do not want to retain all Pods, use dynamic provisioning.
-====
-endif::[]
-
 [id="pv-phase_{context}"]
 == Phase
 


### PR DESCRIPTION
As noted in [BZ 1755357](https://bugzilla.redhat.com/show_bug.cgi?id=1755357), it's confusing to have Reclaim policy listed in two headers. This PR removes the second instance of Reclaim policy because "Reclaim Policy in use is going to be determined by the StorageClass that's defined. It defaults to Delete in most cases as well" (per Dev).

@duanwei33 Please ack if this is lgtm