### PR TITLE
[enterprise-4.1] Moving node selector logging topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -727,6 +727,9 @@ Topics:
 - Name: Viewing Elasticsearch status
   File: efk-logging-elasticsearch-status
   Distros: openshift-enterprise,openshift-origin
+- Name: Moving the cluster logging resources with node selectors
+  File: efk-logging-moving-nodes
+  Distros: openshift-enterprise,openshift-origin
 - Name: Manually rolling out Elasticsearch
   File: efk-logging-manual-rollout
   Distros: openshift-enterprise,openshift-origin

--- a/logging/config/efk-logging-configuring.adoc
+++ b/logging/config/efk-logging-configuring.adoc
@@ -86,4 +86,3 @@ The Rsyslog log collector is currently a Technology Preview feature.
 
 include::modules/efk-logging-configuring-image-about.adoc[leveloffset=+1]
 
-include::modules/efk-logging-configuring-node-selector.adoc[leveloffset=+1]

--- a/logging/efk-logging-moving-nodes.adoc
+++ b/logging/efk-logging-moving-nodes.adoc
@@ -1,0 +1,27 @@
+:context: efk-logging-moving-ndes
+[id="efk-logging-moving-nodes"]
+= Moving the cluster logging resources with node selectors
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+
+
+
+
+You can use node selectors to deploy the Elasticsearch, Kibana, and Curator pods to different nodes. 
+
+// The following include statements pull in the module files that comprise
+// the assembly. Include any combination of concept, procedure, or reference
+// modules required to cover the user story. You can also include other
+// assemblies.
+
+include::modules/efk-logging-configuring-node-selector.adoc[leveloffset=+1]
+
+
+= Additional resources
+
+* For more information on node selectors, see: xref:../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors].
+
+
+

--- a/modules/efk-logging-configuring-node-selector.adoc
+++ b/modules/efk-logging-configuring-node-selector.adoc
@@ -1,16 +1,32 @@
 // Module included in the following assemblies:
 //
-// * logging/efk-logging-elasticsearch.adoc
+// * logging/efk-logging-moving-nodes.adoc
 
 [id="efk-logging-configuring-node-selector_{context}"]
 = Specifying a node for cluster logging components using node selectors
 
 Each component specification allows the component to target a specific node. 
 
+.Prerequisites
+
+* Cluster logging and Elasticsearch must be installed. These features are not installed by default.
+
 .Procedure
 
-Edit the Cluster Logging Custom Resource (CR) in the `openshift-logging` project:
+. Add the desired label to your nodes:
++
+----
+$ oc label <resource> <name> <key>=<value>
+----
++
+For example, to label a node:
++
+----
+$ oc label nodes ip-10-0-142-25.ec2.internal type=elasticsearch
+----
 
+. Edit the Cluster Logging Custom Resource in the `openshift-logging` project:
++
 [source,yaml]
 ----
 $ oc edit ClusterLogging instance

--- a/modules/efk-logging-deploy-subscription.adoc
+++ b/modules/efk-logging-deploy-subscription.adoc
@@ -82,12 +82,14 @@ metadata:
   name: openshift-logging
   annotations:
     openshift.io/node-selector: "" <1>
-  labels:
+  labels:  <2>
     openshift.io/cluster-logging: "true"
     openshift.io/cluster-monitoring: "true"
 ----
-<1> Optionally specify an empty node selector in order for the logging pods to spread
-evenly across your cluster. If you want the logging pods to run on specific nodes, you can specify a node selector value here.
+<1> Specify an empty node selector to spread the logging pods evenly across your cluster. 
+If you want the logging pods to run on specific nodes, leave this parameter empty 
+and specify node selectors in the Cluster Logging Custom Resource after installation.
+<2> Specify these labels as shown.
 
 .. Run the following command to create the namespace:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1756847

Per Slack convo, moving the node selector topic in 4.1 to match 4.2 

Slack: https://coreos.slack.com/archives/CB3HXM2QK/p1569940357403000
4.2 PR https://github.com/openshift/openshift-docs/pull/16667