### PR TITLE
CNV - Temporarily commenting out VM count in telemetry

### DIFF
--- a/modules/telemetry-what-information-is-collected.adoc
+++ b/modules/telemetry-what-information-is-collected.adoc
@@ -23,9 +23,9 @@ Primary information collected includes:
 * Number of members in the etcd cluster and number of objects currently stored in the etcd cluster
 * Number of CPU cores and RAM used per machine type - infra or master
 * Number of CPU cores and RAM used per cluster
-ifdef::cnv-cluster[]
-* Number of running virtual machine instances in the cluster
-endif::cnv-cluster[]
+//ifdef::cnv-cluster[]
+//* Number of running virtual machine instances in the cluster
+//endif::cnv-cluster[]
 * Use of {product-title} framework components per cluster
 * Version of the {product-title} cluster
 * Health, condition, and status for any {product-title} framework component that is installed on the cluster, for example Cluster Version Operator, Cluster Monitoring, Image Registry, and Elasticsearch for Logging


### PR DESCRIPTION
BZ#1755915 (VM count is missing at the prometheus) is targetted for 2.1.1 z-stream. Commenting out the VM count in telemetry until it's fixed.

cherrypick to enterprise-4.2