### PR TITLE
spelling out cnv in titles; fixing caps

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1039,24 +1039,24 @@ Topics:
 - Name: Service Mesh Release Notes
   File: servicemesh-release-notes
 ---
-Name: Container-native Virtualization
+Name: Container-native virtualization
 Dir: cnv
 Distros: openshift-enterprise
 Topics:
-- Name: Container-native Virtualization installation
+- Name: Container-native virtualization installation
   Dir: cnv_install
   Topics:
-  - Name: About Container-native Virtualization
+  - Name: About container-native virtualization
     File: cnv-about-cnv
-  - Name: Preparing your OpenShift cluster for Container-native Virtualization
+  - Name: Preparing your OpenShift cluster for container-native virtualization
     File: preparing-cluster-for-cnv
-  - Name: Installing Container-native Virtualization
+  - Name: Installing container-native virtualization
     File: installing-container-native-virtualization
   - Name: Installing the `virtctl` client
     File: cnv-installing-virtctl
-  - Name: Uninstalling Container-native Virtualization
+  - Name: Uninstalling container-native virtualization
     File: uninstalling-container-native-virtualization
-- Name: Container-native Virtualization user's guide
+- Name: Container-native virtualization user's guide
   Dir: cnv_users_guide
   Topics:
 ### VIRTUAL MACHINE CHESS SALAD (silly name to highlight that the commented out assemblies need to be checked against merged filenams)
@@ -1082,7 +1082,7 @@ Topics:
   - Name: Automating management tasks
     File: cnv-automating-management-tasks
 ### Virtual machine networking
-  - Name: Using the default Pod network with Container-native Virtualization
+  - Name: Using the default Pod network with container-native virtualization
     File: cnv-using-the-default-pod-network-with-cnv
   - Name: Attaching a virtual machine to multiple networks
     File: cnv-attaching-vm-multiple-networks
@@ -1150,10 +1150,10 @@ Topics:
     File: cnv-openshift-cluster-monitoring
   - Name: Collecting container-native virtualization data for Red Hat Support
     File: cnv-collecting-cnv-data
-- Name: Container-native Virtualization 2.0 release notes
+- Name: Container-native virtualization 2.0 release notes
   Dir: cnv_release_notes
   Topics:
-  - Name: Container-native Virtualization 2.0 release notes
+  - Name: Container-native virtualization 2.0 release notes
     File: cnv-release-notes
 ---
 Name: Serverless applications

--- a/cnv/cnv_install/cnv-about-cnv.adoc
+++ b/cnv/cnv_install/cnv-about-cnv.adoc
@@ -1,5 +1,5 @@
 [id="cnv-about-cnv"]
-= About Container-native Virtualization
+= About container-native virtualization
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-about-cnv
 toc::[]

--- a/cnv/cnv_install/installing-container-native-virtualization.adoc
+++ b/cnv/cnv_install/installing-container-native-virtualization.adoc
@@ -1,5 +1,5 @@
 [id="installing-container-native-virtualization"]
-= Installing {CNVProductName}
+= Installing container-native virtualization
 include::modules/cnv-document-attributes.adoc[]
 :context: installing-container-native-virtualization
 toc::[]

--- a/cnv/cnv_install/preparing-cluster-for-cnv.adoc
+++ b/cnv/cnv_install/preparing-cluster-for-cnv.adoc
@@ -1,15 +1,15 @@
 [id="preparing-cluster-for-cnv"]
-= Preparing your {product-title} cluster for {CNVProductName}
+= Preparing your cluster for container-native virtualization
 include::modules/cnv-document-attributes.adoc[]
 :context: preparing-cluster-for-cnv
 toc::[]
 
-{CNVProductNameStart} 2.0 works with {product-title} by default, however the following 
+{CNVProductNameStart} 2.0 works with {product-title} by default, however the following
 installation configurations are recommended:
 
-* The {product-title} cluster is installed on 
-xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal]. 
+* The {product-title} cluster is installed on
+xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal].
 Manage your Compute nodes in accordance with the number and size of the virtual machines to host in the cluster.
-* xref:../../monitoring/cluster-monitoring/about-cluster-monitoring.adoc#about-cluster-monitoring[Monitoring] 
-is configured in the cluster. 
+* xref:../../monitoring/cluster-monitoring/about-cluster-monitoring.adoc#about-cluster-monitoring[Monitoring]
+is configured in the cluster.
 

--- a/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
+++ b/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
@@ -1,5 +1,5 @@
 [id="uninstalling-container-native-virtualization"]
-= Uninstalling {CNVProductName}
+= Uninstalling container-native virtualization
 include::modules/cnv-document-attributes.adoc[]
 :context: uninstalling-container-native-virtualization
 toc::[]

--- a/cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
+++ b/cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
@@ -1,5 +1,5 @@
 [id="cnv-collecting-cnv-data"]
-= Collecting {CNVProductName} data for Red Hat Support
+= Collecting container-native virtualization data for Red Hat Support
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-collecting-cnv-data
 toc::[]

--- a/cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
+++ b/cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
@@ -1,5 +1,5 @@
 [id="cnv-using-the-default-pod-network-with-cnv"]
-= Using the default Pod network with {CNVProductName}
+= Using the default Pod network with container-native virtualization
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-using-the-default-pod-network-with-cnv
 toc::[]

--- a/modules/cnv-about-collecting-cnv-data.adoc
+++ b/modules/cnv-about-collecting-cnv-data.adoc
@@ -3,7 +3,7 @@
 // * cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
 
 [id="cnv-about-collecting-cnv-data_{context}"]
-= About collecting {CNVProductName} data
+= About collecting container-native virtualization data
 
 You can use the `oc adm must-gather` CLI command to collect information about your
 cluster, including features and objects associated with {CNVProductName}:

--- a/modules/cnv-deploying-cnv.adoc
+++ b/modules/cnv-deploying-cnv.adoc
@@ -3,7 +3,7 @@
 // * cnv/cnv_install/installing-container-native-virtualization.adoc
 
 [id="cnv-deploying-cnv_{context}"]
-= Deploying {CNVProductName}
+= Deploying container-native virtualization
 
 After subscribing to the *KubeVirt HyperConverged Cluster Operator* catalog,
 create the *KubeVirt HyperConverged Cluster Operator Deployment* custom resource
@@ -31,4 +31,4 @@ you can access {CNVProductName}.
 
 . You can verify the installation by navigating to the web console, as follows.
 .. Enter the command `oc get route -n openshift-console`.
-.. Log in using your {product-title} credentials. 
+.. Log in using your {product-title} credentials.

--- a/modules/cnv-document-attributes.adoc
+++ b/modules/cnv-document-attributes.adoc
@@ -17,13 +17,6 @@
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]
 //
-// Documentation publishing attributes used in the master-docinfo.xml file
-// Note that the DocInfoProductName generates the URL for the product page.
-// Changing the value changes the generated URL.
-//
-:DocInfoProductName: Container-native Virtualization
-:DocInfoProductNumber: 2.0
-//
 // Book Names:
 //     Defining the book names in document attributes instead of hard-coding them in
 //     the master.adoc files and in link references. This makes it easy to change the
@@ -31,6 +24,6 @@
 //     Using the pattern ending in 'BookName' makes it easy to grep for occurrences
 //     throughout the topics
 //
-:Install_BookName: Installing Container-native Virtualization
-:Using_BookName: Using Container-native Virtualization
-:RN_BookName: Container-native Virtualization 2.0 release notes
+:Install_BookName: Installing container-native virtualization
+:Using_BookName: Using container-native virtualization
+:RN_BookName: Container-native virtualization 2.0 release notes

--- a/modules/cnv-enabling-cnv-repos.adoc
+++ b/modules/cnv-enabling-cnv-repos.adoc
@@ -3,7 +3,7 @@
 // cnv_install/cnv-installing-virtctl.adoc
 
 [id="cnv-enabling-cnv-repos_{context}"]
-= Enabling {CNVProductName} repositories
+= Enabling container-native virtualization repositories
 
 Red Hat offers {CNVProductName} repositories for both Red Hat Enterprise Linux 8
 and Red Hat Enterprise Linux 7:
@@ -12,8 +12,8 @@ and Red Hat Enterprise Linux 7:
 
 * Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.0-rpms`
 
-The process for enabling the repository in `subscription-manager` is the same 
-in both platforms. 
+The process for enabling the repository in `subscription-manager` is the same
+in both platforms.
 
 .Procedure
 

--- a/modules/cnv-importing-vm-datavolume.adoc
+++ b/modules/cnv-importing-vm-datavolume.adoc
@@ -3,7 +3,7 @@
 // * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
 
 [id="cnv-importing-vm-datavolume_{context}"]
-= Importing a virtual machine image into a {CNVProductName} object with DataVolumes
+= Importing a virtual machine image into a container-native virtualization object with DataVolumes
 
 To create a virtual machine from an imported image, specify the image location
 in the `VirtualMachine` configuration file before you create the virtual machine.

--- a/modules/cnv-networking-glossary.adoc
+++ b/modules/cnv-networking-glossary.adoc
@@ -4,7 +4,7 @@
 // * cnv/cnv_users_guide/cnv-configuring-pxe-booting.adoc
 
 [id="cnv-networking-glossary_{context}"]
-= {CNVProductNameStart} networking glossary
+= Container-native virtualization networking glossary
 
 {CNVProductNameStart} provides advanced networking functionality by using custom
 resources and plug-ins.

--- a/modules/cnv-preparing-to-install.adoc
+++ b/modules/cnv-preparing-to-install.adoc
@@ -3,7 +3,7 @@
 // * cnv/cnv_install/installing-container-native-virtualization.adoc
 
 [id="cnv-preparing-to-install_{context}"]
-= Preparing to install {CNVProductName}
+= Preparing to install container-native virtualization
 
 Before deploying {CNVProductName}:
 

--- a/modules/cnv-supported-virtio-drivers.adoc
+++ b/modules/cnv-supported-virtio-drivers.adoc
@@ -4,7 +4,7 @@
 // * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
 
 [id="cnv-supported-virtio-drivers_{context}"]
-= Supported VirtIO drivers for Microsoft Windows virtual machines in {CNVProductName}
+= Supported VirtIO drivers for Microsoft Windows virtual machines
 
 .Supported drivers
 |===
@@ -13,19 +13,19 @@
 |*viostor*
 |VEN_1AF4&DEV_1001 +
 VEN_1AF4&DEV_1042
-|The block driver. Sometimes displays as an *SCSI Controller* in the *Other devices* 
+|The block driver. Sometimes displays as an *SCSI Controller* in the *Other devices*
 group.
 
 |*viorng*
 |VEN_1AF4&DEV_1005 +
 VEN_1AF4&DEV_1044
-|The entropy source driver. Sometimes displays as a *PCI Device* in the 
+|The entropy source driver. Sometimes displays as a *PCI Device* in the
 *Other devices* group.
 
 |*NetKVM*
 |VEN_1AF4&DEV_1000 +
 VEN_1AF4&DEV_1041
-|The network driver. Sometimes displays as an *Ethernet Controller* in the 
+|The network driver. Sometimes displays as an *Ethernet Controller* in the
 *Other devices* group. Available only if a VirtIO NIC is configured.
 |===
 

--- a/modules/cnv-what-you-can-do-with-cnv.adoc
+++ b/modules/cnv-what-you-can-do-with-cnv.adoc
@@ -4,7 +4,7 @@
 // * cnv/cnv_release_notes/cnv-release-notes.adoc
 
 [id="cnv-what-you-can-do-with-cnv_{context}"]
-= What you can do with {CNVProductName}
+= What you can do with container-native virtualization
 
 {CNVProductNameStart} is an add-on to {product-title} that allows you to run and manage
  virtual machine workloads alongside container workloads.


### PR DESCRIPTION
Due to a mysterious issue, variables don't always work in titles. This PR changes instances of `{CNVProductName}` and `{CNVProductNameStart}` in module/assembly titles to `container-native virtualization` and `Container-native virtualization` while also fixing incorrect capitalization in the _topic_map.yml. There were a couple of cases where I removed the name entirely because it seemed superfluous.

attn: @vikram-redhat 