### PR TITLE
remove extra --role param and fix -role typo

### DIFF
--- a/modules/installation-azure-service-principal.adoc
+++ b/modules/installation-azure-service-principal.adoc
@@ -102,7 +102,7 @@ output. You need these values during {product-title} installation.
 . Create the service principal for your account:
 +
 ----
-$ az ad sp create-for-rbac --role "User Access Administrator" -role Contributor --name <service_principal> <1>
+$ az ad sp create-for-rbac --role Contributor --name <service_principal> <1>
 Changing "<service_principal>" to a valid URI of "http://<service_principal>", which is the required format used for service principal names
 Retrying role assignment creation: 1/36
 Retrying role assignment creation: 2/36


### PR DESCRIPTION
adding the "User Access Administrator" role is already handled by a future step, and you can only provide one '--role' param. So remove the extra param.

correct the typo of '-role'.