### PR TITLE
Fix logging documentation for eventrouter

### DIFF
--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -32,18 +32,18 @@ metadata:
   name: eventrouter-template
   annotations:
     description: "A pod forwarding kubernetes events to cluster logging stack."
-    tags: "events,EFK,logging, cluster-logging"
+    tags: "events,EFK,logging,cluster-logging"
 objects:
   - kind: ServiceAccount <1>
     apiVersion: v1
     metadata:
-      name: cluster-logging-eventrouter
+      name: eventrouter
       namespace: ${NAMESPACE}
   - kind: ClusterRole <2>
     apiVersion: v1
     metadata:
       name: event-reader
-    rules:             <3>
+    rules:   <3>
     - apiGroups: [""]
       resources: ["events"]
       verbs: ["get", "watch", "list"]
@@ -53,7 +53,7 @@ objects:
       name: event-reader-binding
     subjects:
     - kind: ServiceAccount
-      name: cluster-logging-eventrouter
+      name: eventrouter
       namespace: ${NAMESPACE}
     roleRef:
       kind: ClusterRole
@@ -61,7 +61,7 @@ objects:
   - kind: ConfigMap
     apiVersion: v1
     metadata:
-      name: cluster-logging-eventrouter
+      name: eventrouter
       namespace: ${NAMESPACE}
     data:
       config.json: |-
@@ -71,7 +71,7 @@ objects:
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
-      name: cluster-logging-eventrouter
+      name: eventrouter
       namespace: ${NAMESPACE}
       labels:
         component: eventrouter
@@ -90,9 +90,9 @@ objects:
             component: eventrouter
             logging-infra: eventrouter
             provider: openshift
-          name: cluster-logging-eventrouter
+          name: eventrouter
         spec:
-          serviceAccount: cluster-logging-eventrouter
+          serviceAccount: eventrouter
           containers:
             - name: kube-eventrouter
               image: ${IMAGE}
@@ -109,9 +109,9 @@ objects:
           volumes:
             - name: config-volume
               configMap:
-                name: cluster-logging-eventrouter
+                name: eventrouter
 parameters:
-  - name: IMAGE  <5>
+  - name: IMAGE <5>
     displayName: Image
     value: "registry.redhat.io/openshift4/ose-logging-eventrouter:latest"
   - name: MEMORY <6>
@@ -147,11 +147,11 @@ For example:
 ----
 $ oc process -f eventrouter.yaml | oc apply -f -
 
-serviceaccount/cluster-logging-eventrouter created
+serviceaccount/logging-eventrouter created
 clusterrole.authorization.openshift.io/event-reader created
 clusterrolebinding.authorization.openshift.io/event-reader-binding created
-configmap/cluster-logging-eventrouter created
-deployment.apps/cluster-logging-eventrouter created
+configmap/logging-eventrouter created
+deployment.apps/logging-eventrouter created
 ----
 
 . Validate that the Event Router installed:
@@ -159,11 +159,11 @@ deployment.apps/cluster-logging-eventrouter created
 ----
 $ oc get pods --selector  component=eventrouter -o name
 
-pod/cluster-logging-eventrouter-d649f97c8-qvv8r
+pod/logging-eventrouter-d649f97c8-qvv8r
 ----
 +
 ----
-$ oc logs cluster-logging-eventrouter-d649f97c8-qvv8r
+$ oc logs logging-eventrouter-d649f97c8-qvv8r
 
 {"verb":"ADDED","event":{"metadata":{"name":"elasticsearch-operator.v0.0.1.158f402e25397146","namespace":"openshift-operators","selfLink":"/api/v1/namespaces/openshift-operators/events/elasticsearch-operator.v0.0.1.158f402e25397146","uid":"37b7ff11-4f1a-11e9-a7ad-0271b2ca69f0","resourceVersion":"523264","creationTimestamp":"2019-03-25T16:22:43Z"},"involvedObject":{"kind":"ClusterServiceVersion","namespace":"openshift-operators","name":"elasticsearch-operator.v0.0.1","uid":"27b2ca6d-4f1a-11e9-8fba-0ea949ad61f6","apiVersion":"operators.coreos.com/v1alpha1","resourceVersion":"523096"},"reason":"InstallSucceeded","message":"waiting for install components to report healthy","source":{"component":"operator-lifecycle-manager"},"firstTimestamp":"2019-03-25T16:22:43Z","lastTimestamp":"2019-03-25T16:22:43Z","count":1,"type":"Normal"}}
 ----


### PR DESCRIPTION
Item #2 in https://bugzilla.redhat.com/show_bug.cgi?id=1758222#c0

2) The Deployment name should be "logging-eventrouter" instead of "cluster-logging-eventrouter" - the fluentd config expects the pod name to begin with "logging-eventrouter" - otherwise, the log records will not be assigned a UID matching the source UID of the event, they will be assigned a random UID