### PR TITLE
[master-3] Edit suggested in file architecture/networking/routes.adoc

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -152,7 +152,7 @@ See the link:https://wiki.mozilla.org/Security/Server_Side_TLS[Security/Server
 Side TLS] reference guide for more information.
 
 The router defaults to the `intermediate` profile. You can select a different
-profile using the `--ciphers` option when creating a route, or by changing
+profile using the `--ciphers` option when creating a router, or by changing
 the `ROUTER_CIPHERS` environment variable with the values `modern`,
 `intermediate`, or `old` for an existing router. Alternatively, a set of ":"
 separated ciphers can be provided. The ciphers must be from the set displayed


### PR DESCRIPTION
<!--
Please submit only documentation-related issues with this form, or follow the
Contribute to OpenShift guidelines (https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/contributing.adoc) to submit a PR.
-->

### Which section(s) is the issue in?

## Router Cipher Suite

The line 155 mention route and not router, this may cause confusion for someone who are looking to change the cipher of only one route. This option need to be clear that it will only work on the router config.

### What needs fixing?

```diff
The router defaults to the `intermediate` profile. You can select a different
- profile using the `--ciphers` option when creating a route, or by changing
the `ROUTER_CIPHERS` environment variable with the values `modern`,
`intermediate`, or `old` for an existing router. Alternatively, a set of ":"
separated ciphers can be provided. The ciphers must be from the set displayed
by:

The router defaults to the `intermediate` profile. You can select a different
+ profile using the `--ciphers` option when creating a router, or by changing
the `ROUTER_CIPHERS` environment variable with the values `modern`,
`intermediate`, or `old` for an existing router. Alternatively, a set of ":"
separated ciphers can be provided. The ciphers must be from the set displayed
by:
```