### PR TITLE
removing bash,source

### DIFF
--- a/modules/metering-debugging.adoc
+++ b/modules/metering-debugging.adoc
@@ -16,7 +16,7 @@ All of the commands in this section assume you have installed metering through O
 == Get reporting operator logs
 The command below will follow the logs of the `reporting-operator`.
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering logs -f "$(oc -n openshift-metering get pods -l app=reporting-operator -o name | cut -c 5-)" -c reporting-operator
 ----
@@ -27,19 +27,19 @@ The following command opens an interactive presto-cli session where you can quer
 
 By default, Presto is configured to communicate using TLS. You must to run the following command to run Presto queries:
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering exec -it "$(oc -n openshift-metering get pods -l app=presto,presto=coordinator -o name | cut -d/ -f2)"  -- /usr/local/bin/presto-cli --server https://presto:8080 --catalog hive --schema default --user root --keystore-path /opt/presto/tls/keystore.pem
 ----
 
 Once you run this command, a prompt appears where you can run queries. Use the `show tables from metering;` query to view the list of tables:
 
-[source,bash]
+[source]
 ----
 $ presto:default> show tables from metering;
 
                                  Table
- 
+
  datasource_your_namespace_cluster_cpu_capacity_raw
  datasource_your_namespace_cluster_cpu_usage_raw
  datasource_your_namespace_cluster_memory_capacity_raw
@@ -83,16 +83,16 @@ presto:default>
 
 [id="metering-query-hive-using-beeline_{context}"]
 == Query Hive using beeline
-The following opens an interactive beeline session where you can query Hive. This session runs in the same container as Hive and launches an additional Java instance, which can create memory limits for the Pod. If this occurs, you should increase the memory request and limits of the Hive Pod. 
+The following opens an interactive beeline session where you can query Hive. This session runs in the same container as Hive and launches an additional Java instance, which can create memory limits for the Pod. If this occurs, you should increase the memory request and limits of the Hive Pod.
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering exec -it $(oc -n openshift-metering get pods -l app=hive,hive=server -o name | cut -d/ -f2) -c hiveserver2 -- beeline -u 'jdbc:hive2://127.0.0.1:10000/default;auth=noSasl'
 ----
 
 Once you run this command, a prompt appears where you can run queries. Use the `show tables;` query to view the list of tables:
 
-[source,bash]
+[source]
 ----
 $ 0: jdbc:hive2://127.0.0.1:10000/default> show tables from metering;
 +----------------------------------------------------+
@@ -139,7 +139,7 @@ $ 0: jdbc:hive2://127.0.0.1:10000/default> show tables from metering;
 == Port-forward to the Hive web UI
 Run the following command:
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering port-forward hive-server-0 10002
 ----
@@ -149,7 +149,7 @@ You can now open http://127.0.0.1:10002 in your browser window to view the Hive 
 == Port-forward to hdfs
 To the namenode:
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering port-forward hdfs-namenode-0 9870
 ----
@@ -158,7 +158,7 @@ You can now open http://127.0.0.1:9870 in your browser window to view the HDFS w
 
 To the first datanode:
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering port-forward hdfs-datanode-0 9864
 ----
@@ -173,7 +173,7 @@ Metering uses the Ansible Operator to watch and reconcile resources in a cluster
 === Accessing ansible logs
 In the default installation, the metering Operator is deployed as a Pod. In this case, we can check the logs of the ansible container within this Pod:
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering logs $(oc -n openshift-metering get pods -l app=metering-operator -o name | cut -d/ -f2) -c ansible
 ----
@@ -184,7 +184,7 @@ Alternatively, you can view the logs of the Operator container (replace `-c ansi
 === Checking the MeteringConfig Status
 It can be helpful to view the `.status` field of your MeteringConfig custom resource to debug any recent failures. You can do this with the following command:
 
-[source,bash]
+[source]
 ----
 $ oc -n openshift-metering get meteringconfig operator-metering -o json | jq '.status'
 ----

--- a/modules/metering-exposing-the-reporting-api.adoc
+++ b/modules/metering-exposing-the-reporting-api.adoc
@@ -18,7 +18,7 @@ By default, the reporting API is secured with TLS and authentication. This is do
 
 In order to access the reporting API, the metering operator exposes a route. Once that route has been installed, you can run the following command to get the route's hostname.
 
-[source,bash]
+[source]
 ----
 METERING_ROUTE_HOSTNAME=$(oc -n openshift-metering get routes metering -o json | jq -r '.status.ingress[].host')
 ----
@@ -29,7 +29,7 @@ Next, set up authentication using either a service account token or basic authen
 === Authenticate using a service account token
 With this method, you use the token in the reporting Operator's service account, and pass that bearer token to the Authorization header in the following command:
 
-[source,bash]
+[source]
 ----
 TOKEN=$(oc -n openshift-metering serviceaccounts get-token reporting-operator)
 curl -H "Authorization: Bearer $TOKEN" -k "https://$METERING_ROUTE_HOSTNAME/api/v1/reports/get?name=[Report Name]&namespace=openshift-metering&format=[Format]"
@@ -43,7 +43,7 @@ We are able to do basic authentication using a username and password combination
 
 Once you have specified the above in your MeteringConfig, you can run the following command:
 
-[source,bash]
+[source]
 ----
 curl -u testuser:password123 -k "https://$METERING_ROUTE_HOSTNAME/api/v1/reports/get?name=[Report Name]&namespace=openshift-metering&format=[Format]"
 ----
@@ -69,7 +69,7 @@ You need to set `reporting-operator.spec.authProxy.enabled` and `reporting-opera
 
 You can generate a 32-character random string using the following command.
 
-[source, bash]
+[source]
 ----
 $ openssl rand -base64 32 | head -c32; echo.
 ----

--- a/modules/metering-store-data-in-azure.adoc
+++ b/modules/metering-store-data-in-azure.adoc
@@ -42,7 +42,7 @@ data:
 
 You can use the following command to create the secret.
 
-[source,bash]
+[source]
 ----
 oc create secret -n openshift-metering generic your-azure-secret --from-literal=azure-storage-account-name=your-storage-account-name --from-literal=azure-secret-access-key-your-secret-key
 ----

--- a/modules/metering-store-data-in-gcp.adoc
+++ b/modules/metering-store-data-in-gcp.adoc
@@ -39,7 +39,7 @@ data:
 
 You can use the following command to create the secret.
 
-[source,bash]
+[source]
 ----
 oc create secret -n openshift-metering generic your-gcs-secret --from-file gcs-service-account.json=/path/to/your/service-account-key.json
 ----

--- a/modules/metering-store-data-in-s3.adoc
+++ b/modules/metering-store-data-in-s3.adoc
@@ -53,11 +53,11 @@ You can use the following command to create the secret.
 
 [NOTE]
 ====
-This command automatically base64 encodes your `aws-access-key-id` and `aws-secret-access-key` values. 
+This command automatically base64 encodes your `aws-access-key-id` and `aws-secret-access-key` values.
 
 ====
 
-[source,bash]
+[source]
 ----
 oc create secret -n openshift-metering generic your-aws-secret --from-literal=aws-access-key-id=your-access-key  --from-literal=aws-secret-access-key=your-secret-key
 ----


### PR DESCRIPTION
Removing the usage of [source,bash] in codeblocks per our style guide.