### PR TITLE
Correcting typo referring to Web Console

### DIFF
--- a/modules/cnv-editing-vm-yaml-web.adoc
+++ b/modules/cnv-editing-vm-yaml-web.adoc
@@ -6,7 +6,7 @@
 
 = Editing the virtual machine YAML configuration
 
-Edit the YAML configuration of a virtual machine the web console.
+Edit the YAML configuration of a virtual machine.
 
 Not all parameters can be updated. If you edit values that cannot be changed and click *Save*, an error message indicates the parameter that was not able to be updated.
 


### PR DESCRIPTION
Correcting typo in this module referring to Web Console.

Test Build: http://file.bos.redhat.com/bgaydos/100719/cnv/cnv_users_guide/cnv-edit-vms.html

Open for Peer Review from @kalexand-rh @mburke5678 @huffmanca

Copying @alexxa

Thanks
Bob