### PR TITLE
Fixing build errors and warnings

### DIFF
--- a/metering/configuring-metering/metering-configure-aws-billing-correlation.adoc
+++ b/metering/configuring-metering/metering-configure-aws-billing-correlation.adoc
@@ -20,27 +20,27 @@ spec:
         enabled: true
         # Replace these with where your AWS billing reports are
         # stored in S3.
-        bucket: "your-aws-cost-report-bucket" <1>
-        prefix: "path/to/report"
-        region: "your-buckets-region"
+        bucket: "<your-aws-cost-report-bucket>" <1>
+        prefix: "<path/to/report>"
+        region: "<your-buckets-region>"
 
   reporting-operator:
     spec:
       config:
         aws:
-          secretName: "your-aws-secret"
+          secretName: "<your-aws-secret>" <2>
 
   presto:
     spec:
       config:
         aws:
-          secretName: "your-aws-secret"
+          secretName: "<your-aws-secret>" <2>
 
   hive:
     spec:
       config:
         aws:
-          secretName: "your-aws-secret"
+          secretName: "<your-aws-secret>" <2>
 ----
 To enable AWS billing correlation, first ensure the AWS Cost and Usage Reports are enabled. For more information, see https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-gettingstarted-turnonreports.html[Turning on the AWS Cost and Usage Report] in the AWS documentation.
 
@@ -52,13 +52,13 @@ To enable AWS billing correlation, first ensure the AWS Cost and Usage Reports a
 apiVersion: v1
 kind: Secret
 metadata:
-  name: your-aws-secret
+  name: <your-aws-secret>
 data:
   aws-access-key-id: "dGVzdAo="
   aws-secret-access-key: "c2VjcmV0Cg=="
 ----
 
-To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket. For an example of an IAM policy granting the required permissions, see the `aws/read-write.json` file below. 
+To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket. For an example of an IAM policy granting the required permissions, see the `aws/read-write.json` file below.
 
 [source,json]
 ----
@@ -78,8 +78,8 @@ To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credent
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::operator-metering-data/*",
-                "arn:aws:s3:::operator-metering-data"
+                "arn:aws:s3:::operator-metering-data/*", <1>
+                "arn:aws:s3:::operator-metering-data" <1>
             ]
         }
     ]
@@ -100,8 +100,8 @@ To store data in S3, the `aws-access-key-id` and `aws-secret-access-key` credent
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::operator-metering-data/*",
-                "arn:aws:s3:::operator-metering-data"
+                "arn:aws:s3:::operator-metering-data/*", <1>
+                "arn:aws:s3:::operator-metering-data" <1>
             ]
         }
     ]

--- a/service_mesh/servicemesh-release-notes.adoc
+++ b/service_mesh/servicemesh-release-notes.adoc
@@ -5,8 +5,6 @@ include::modules/ossm-document-attributes.adoc[]
 
 toc::[]
 
-= {RN_BookName}
-
 // The following include statements pull in the module files that comprise the assembly.
 
 include::modules/ossm-servicemesh-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixing these build warnings/errors:

```
asciidoctor: WARNING: <stdin>: line 48: no callout found for <2>
asciidoctor: WARNING: <stdin>: line 110: no callout found for <1>
asciidoctor: ERROR: <stdin>: line 8: level 0 sections can only be used when doctype is book
```
