### PR TITLE
Fix incorrect default value for iptablesSyncPeriod

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1449,7 +1449,7 @@ dockerConfig:
 imageConfig:
   format: openshift/origin-${component}:${version}
   latest: false
-iptablesSyncPeriod: 5s
+iptablesSyncPeriod: 30s
 kind: NodeConfig
 masterKubeConfig: node.kubeconfig
 networkConfig:


### PR DESCRIPTION
I know 3.9 is EOL soon, but we still have some clusters that use it and this now bit me repeatedly 🙈 

Relates: #12227