### PR TITLE
BZ:1753311: Included BZ1751641.

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1356,3 +1356,10 @@ references if the mirror requires authentication.
 * If builds use a build secret, it is strongly recommended that layers are squashed
 using `imageOptimizationPolicy: SkipLayers`. Otherwise, secrets might leak in
 `source` and `docker` strategy builds.
+
+* AllowVolumeExpansion, and other StorageClass attributes, are not updated
+when upgrading {product-title}.
+It is recommended to delete the default StorageClass and allow the
+ClusterStorageOperator to recreate this with the correct attributes after
+the upgrade is completed.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1751641[*BZ#1751641*])


### PR DESCRIPTION
There's a known issue of the ClusterStorageOperator not updating the default SC during an upgrade. This is addressed in OCP 4.3, but should be documented in OCP 4.2.

This is for the OCP 4.2 release notes.