### PR TITLE
Resolving BZ1758152

### DIFF
--- a/modules/cnv-cdi-supported-operations-matrix.adoc
+++ b/modules/cnv-cdi-supported-operations-matrix.adoc
@@ -13,9 +13,9 @@
 This matrix shows the supported CDI operations for content types against endpoints, and which of these operations requires scratch space.
 
 |===
-|Content types | HTTP | HTTPS | HTTP basic auth | Registry | S3 Bucket | Upload
+|Content types | HTTP | HTTPS | HTTP basic auth | Registry | Upload
 
-| KubeVirt(QCOW2)        
+| KubeVirt(QCOW2)
 |&#10003; QCOW2 +
 &#10003; GZ* +
 &#10003; XZ*
@@ -30,16 +30,13 @@ This matrix shows the supported CDI operations for content types against endpoin
 
 | &#10003; QCOW2* +
 &#9633; GZ +
-&#9633; XZ 
+&#9633; XZ
 
 | &#10003; QCOW2* +
 &#10003; GZ* +
 &#10003; XZ*
-| &#10003; QCOW2* +
-&#10003; GZ* +
-&#10003; XZ*
 
-| KubeVirt (RAW)          
+| KubeVirt (RAW)
 |&#10003; RAW +
 &#10003; GZ +
 &#10003; XZ
@@ -56,19 +53,14 @@ This matrix shows the supported CDI operations for content types against endpoin
 &#9633; GZ +
 &#9633; XZ
 
-| &#10003; RAW +
-&#10003; GZ +
-&#10003; XZ
-
 | &#10003; RAW* +
 &#10003; GZ* +
 &#10003; XZ*
 
-| Archive+ 
+| Archive+
 | &#10003; TAR
 | &#10003; TAR
 | &#10003; TAR
-| &#9633; TAR
 | &#9633; TAR
 | &#9633; TAR
 |===
@@ -82,7 +74,3 @@ $$*$$ Requires scratch space
 $$**$$ Requires scratch space if a custom certificate authority is required
 
 + Archive does not support block mode DVs
-
-
-
-


### PR DESCRIPTION
In CDI Supported Operations matrix, the S3 column should not be present per bug 
https://bugzilla.redhat.com/show_bug.cgi?id=1758152

Test Build is here:
http://file.bos.redhat.com/bgaydos/100919/cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.html

Please label for Enterprise-4.2.

Peer review needed from either @mburke5678 @huffmanca or @kalexand-rh
Will wait on QE ack and then this is ready for merge and pick.

Thanks,

Bob