### PR TITLE
BZ1756296: Added information about default uid and gid.

### DIFF
--- a/modules/dynamic-provisioning-azure-file-considerations.adoc
+++ b/modules/dynamic-provisioning-azure-file-considerations.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// storage/persistent-storage/persistent-storage-azure-file.adoc
+
+[id="azure-file-considerations_{context}"]
+= Considerations when using Azure File
+
+The following file system features are not supported by the default Azure File StorageClass:
+
+* Symlinks
+* Hard links
+* Extended attributes
+* Sparse files
+* Named pipes
+
+Additionally, the owner user identifier (UID) of the Azure File mounted directory is different from the process UID of the container. The `uid` mount option can be specified in the StorageClass to define
+a specific user identifier to use for the mounted directory.
+
+The following StorageClass demonstrates modifying the user and group identifier, along with enabling symlinks for the mounted directory.
+
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: azure-file
+mountOptions:
+  - uid=1500 <1>
+  - gid=1500 <2>
+  - myfsymlinks <3>
+provisioner: kubernetes.io/azure-file
+parameters:
+  location: eastus
+  skuName: Standard_LRS
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+----
+<1> Specifies the user identifier to use for the mounted directory.
+<2> Specifies the group identifier to use for the mounted directory.
+<3> Enables symlinks.

--- a/storage/dynamic-provisioning.adoc
+++ b/storage/dynamic-provisioning.adoc
@@ -22,6 +22,8 @@ include::modules/dynamic-provisioning-azure-disk-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-azure-file-definition.adoc[leveloffset=+2]
 
+include::modules/dynamic-provisioning-azure-file-considerations.adoc[leveloffset=+3]
+
 include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
 
 // include::modules/dynamic-provisioning-gluster-definition.adoc[leveloffset=+2]


### PR DESCRIPTION
Included information about the considerations of Azure File, specifically that the uid will not necessarily match the Pod's.

This is for OCP 4.2.