### PR TITLE
follow up Clean up node config documentation

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -500,7 +500,6 @@ To make configuration changes to an existing node, edit the appropriate configur
 watches for changes in the configuration maps. During installation, the sync pods are created by using _sync Daemonsets_,
 and a *_/etc/origin/node/node-config.yaml_* file, where the node configuration parameters reside, is added to each node. When a sync pod
 detects configuration map change, it updates the *_node-config.yaml_* on all nodes in that node group and restarts the appropriate nodes.
-// end::node-configmap[]
 
 ----
 $ oc get cm -n openshift-node
@@ -513,6 +512,7 @@ node-config-master-infra   1         1d
 ----
 
 .Sample configuration map for the *node-config-compute* group
+[source,yaml]
 ----
 apiVersion: v1
 authConfig:      <1>
@@ -571,8 +571,6 @@ volumeConfig:
   localQuota:
     perFSGroup: null    <8>
 volumeDirectory: /var/lib/origin/openshift.local.volumes
-
-Events:  <none>
 ----
 
 <1> Authentication and authorization configuration options.
@@ -593,6 +591,7 @@ specified file before the request headers are checked for user names.
 ====
 Do not manually modify the *_/etc/origin/node/node-config.yaml_* file.
 ====
+// end::node-configmap[]
 
 // For more information, see architecture/infrastructure_components/kubernetes_infrastructure.html#node-bootstrapping[Node Bootstrapping].
 

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1431,78 +1431,7 @@ SSL-Session:
 [[node-configuration-files]]
 == Node Configuration Files
 
-The following *_node-config.yaml_* file is a sample node configuration file that
-was generated with the default values as of writing.
-
-// include::admin_guide/manage_nodes.adoc[tag=node-configmap]
-
-[NOTE]
-====
-To modify a node in your cluster, update the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps] as needed.
-Do not manually edit the `node-config.yaml` file.
-====
-
-////
-Do we need this in 3.10 with mew node-config?
-You can
-xref:creating-new-configuration-files[create a new node configuration file] to
-see the valid options for your installed version of {product-title}.
-////
-
-.Sample Node Configuration File
-====
-[source,yaml]
-----
-allowDisabledDocker: false
-apiVersion: v1
-authConfig:
-  authenticationCacheSize: 1000
-  authenticationCacheTTL: 5m
-  authorizationCacheSize: 1000
-  authorizationCacheTTL: 5m
-dnsDomain: cluster.local
-dnsIP: 0.0.0.0 <1>
-dockerConfig:
-  execHandlerName: native
-imageConfig:
-  format: openshift/origin-${component}:${version}
-  latest: false
-iptablesSyncPeriod: 5s
-kind: NodeConfig
-masterKubeConfig: node.kubeconfig
-networkConfig:
-  mtu: 1450
-  networkPluginName: ""
-nodeIP: ""
-nodeName: node1.example.com
-podManifestConfig: <2>
-  path: "/path/to/pod-manifest-file" <3>
-  fileCheckIntervalSeconds: 30 <4>
-proxyArguments:
-  proxy-mode:
-  - iptables <5>
-servingInfo:
-  bindAddress: 0.0.0.0:10250
-  bindNetwork: tcp4
-  certFile: server.crt
-  clientCA: node-client-ca.crt
-  keyFile: server.key
-  namedCertificates: null
-volumeDirectory: /root/openshift.local.volumes
-----
-<1> Configures an IP address to be prepended to a pod's *_/etc/resolv.conf_* by adding the address here.
-<2> Allows pods to be placed directly on certain set of nodes, or on all nodes
-without going through the scheduler. You can then use pods to perform the same
-administrative tasks and support the same services on each node.
-<3> Specifies the path for the
-xref:../architecture/core_concepts/pods_and_services.adoc#pods[pod manifest file]
-or directory. If it is a directory, then it is expected to contain one or more
-manifest files. This is used by the Kubelet to create pods on the node.
-<4> This is the interval (in seconds) for checking the manifest file for new
-data. The interval must be a positive value.
-<5> The xref:../architecture/core_concepts/pods_and_services.adoc#service-proxy-mode[service
-proxy implementation] to use.
-====
+include::admin_guide/manage_nodes.adoc[tag=node-configmap]
 
 The node configuration file determines the resources of a node. See the
 xref:../admin_guide/allocating_node_resources.adoc#admin-guide-allocating-node-resources[Allocating


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/17094

Changed base branch to `master-3`
included section from `manage_nodes.adoc[tag=node-configmap]` to replace the sample `node-config.yaml` file 