### PR TITLE
Remove mention of Kuryr from IPI on OpenStack section of Release Notes

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -330,11 +330,6 @@ OpenStack Platform.
 {product-title} {product-version} can be deployed on Red Hat OpenStack version
 13.
 
-Kuryr exists to improve the network performance of pods when running workloads
-on Red Hat OpenStack. Kuryr is an SDN solution combining a Kubernetes CNI plug-in
-(kuryr-kubernetes) and OpenStack Neutron to provide interconnectivity between
-Kubernetes pods and OpenStack virtual instances.
-
 [id="ocp-4-2-OVN"]
 ==== OVN (Technology Preview)
 


### PR DESCRIPTION
cc @vikram-redhat @aheslin @maxwelldb Removing per recent announcement and discussion in today's program meeting