### PR TITLE
Fix missing callout 3 (Relates to PR 16917)

### DIFF
--- a/modules/storage-persistent-storage-azure-file-pod.adoc
+++ b/modules/storage-persistent-storage-azure-file-pod.adoc
@@ -30,7 +30,7 @@ spec:
   volumes:
     - name: azure-file-share
       persistentVolumeClaim:
-        claimName: claim1 <4>
+        claimName: claim1 <3>
 ----
 <1> The name of the Pod.
 <2> The path to mount the Azure File share inside the Pod.


### PR DESCRIPTION
This small fix relates to [PR 16917](https://github.com/openshift/openshift-docs/pull/16917/).
Warning on build was showing: 
`>>> Working on storage book in openshift-enterprise <<<
Transforming the AsciiDoc content to DocBook XML...
asciidoctor: WARNING: includes/storage-persistent-storage-azure-file-pod.adoc: line 37: no callout found for <3>`
Found that line 33 in file had `<4>` as callout, changed to `<3>` to match callout ref on line 37.
@vikram-redhat Please review. If possible, you could also merge to master, CP to 4.2. Thanks!