### PR TITLE
CNV - callout fixes

### DIFF
--- a/modules/cnv-creating-local-block-pv.adoc
+++ b/modules/cnv-creating-local-block-pv.adoc
@@ -27,7 +27,7 @@ $ dd if=/dev/zero of=<loop10> bs=100M count=20
 . Mount the `loop10` file as a loop device.
 +
 ----
-$ losetup </dev/loop10><1> <loop10><2>
+$ losetup </dev/loop10>d3 <loop10> <1> <2>
 ----
 <1> File path where the loop device is mounted.
 <2> The file created in the previous step to be mounted as the loop device.

--- a/modules/cnv-uploading-local-disk-image-dv.adoc
+++ b/modules/cnv-uploading-local-disk-image-dv.adoc
@@ -28,7 +28,7 @@ certificate.
 You must specify the DV name and file location. For example:
 +
 ----
-$ virtctl image-upload --dv-name=<upload-datavolume><1> --image-path=</images/fedora.qcow2><2>
+$ virtctl image-upload --dv-name=<upload-datavolume> --image-path=</images/fedora.qcow2> <1> <2>
 ----
 <1> The name of the DataVolume that you are creating.
 <2> The filepath of the virtual machine disk image you are uploading.


### PR DESCRIPTION
Minor fix to merged content.
Turns out callouts can only work at the end of a line. This is a known issue in asciidoc and the fix has not yet been decided on.