### PR TITLE
CNV - closing conditional in telemetry module

### DIFF
--- a/modules/telemetry-what-information-is-collected.adoc
+++ b/modules/telemetry-what-information-is-collected.adoc
@@ -31,3 +31,8 @@ Primary information collected by Telemetry includes:
 * The name of the platform that {product-title} is deployed on, such as Amazon Web Services
 
 Telemetry does not collect identifying information such as user names, passwords, or the names or addresses of user resources.
+
+ifeval::["{context}" == "cnv-openshift-cluster-monitoring"]
+:!cnv-cluster:
+endif::[]
+


### PR DESCRIPTION
Closing the cnv-cluster condition at the end of the module. I should have done this when I added the conditional in the first place. Sorry @vikram-redhat. 