### PR TITLE
commenting out CNV 2.1 docs to prevent early release

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1047,131 +1047,131 @@ Topics:
     File: threescale-adapter
 - Name: Service Mesh Release Notes
   File: servicemesh-release-notes
----
-Name: Container-native virtualization
-Dir: cnv
-Distros: openshift-enterprise
-Topics:
-- Name: Container-native virtualization installation
-  Dir: cnv_install
-  Topics:
-  - Name: About container-native virtualization
-    File: cnv-about-cnv
-  - Name: Preparing your OpenShift cluster for container-native virtualization
-    File: preparing-cluster-for-cnv
-  - Name: Installing container-native virtualization
-    File: installing-container-native-virtualization
-  - Name: Installing the `virtctl` client
-    File: cnv-installing-virtctl
-  - Name: Upgrading container-native virtualization
-    File: upgrading-container-native-virtualization
-  - Name: Uninstalling container-native virtualization
-    File: uninstalling-container-native-virtualization
-- Name: Container-native virtualization user's guide
-  Dir: cnv_users_guide
-  Topics:
-### VIRTUAL MACHINE CHESS SALAD (silly name to highlight that the commented out assemblies need to be checked against merged filenams)
-  - Name: Creating virtual machines
-    File: cnv-create-vms
-### Importing virtual machines
-  - Name: TLS certificates for DataVolume imports
-    File: cnv-tls-certificates-for-dv-imports
-  - Name: Importing virtual machine images with DataVolumes
-    File: cnv-importing-virtual-machine-images-datavolumes
-### VM CHESS SALAD cont'd
-  - Name: Editing virtual machines
-    File: cnv-edit-vms
-  - Name: Deleting virtual machines
-    File: cnv-delete-vms
-  - Name: Controlling virtual machines states
-    File: cnv-controlling-vm-states
-  - Name: Accessing virtual machine consoles
-    File: cnv-accessing-vm-consoles
-  - Name: Using the CLI tools
-    File: cnv-using-the-cli-tools
-### Automating management tasks
-  - Name: Automating management tasks
-    File: cnv-automating-management-tasks
-### Virtual machine networking
-  - Name: Using the default Pod network with container-native virtualization
-    File: cnv-using-the-default-pod-network-with-cnv
-  - Name: Attaching a virtual machine to multiple networks
-    File: cnv-attaching-vm-multiple-networks
-  - Name: Installing the QEMU guest agent on virtual machines
-    File: cnv-installing-qemu-guest-agent
-  - Name: Viewing the IP address of vNICs on a virtual machine
-    File: cnv-viewing-ip-of-vm-vnic
-### Advanced virtual machine configuration
-  - Name: Configuring PXE booting for virtual machines
-    File: cnv-configuring-pxe-booting
-  - Name: Managing guest memory
-    File: cnv-managing-guest-memory
-### Templates
-  - Name: Creating virtual machine templates
-    File: cnv-creating-vm-template
-  - Name: Editing a virtual machine template
-    File: cnv-editing-vm-template
-  - Name: Deleting a virtual machine template
-    File: cnv-deleting-vm-template
-### Cloning virtual machines
-  - Name: Cloning a virtual machine disk into a new DataVolume
-    File: cnv-cloning-vm-disk-into-new-datavolume
-  - Name: Cloning a virtual machine by using a DataVolumeTemplate
-    File: cnv-cloning-vm-using-datavolumetemplate
-### A BETTER NAME THAN 'STORAGE 4 U'
-  - Name: Uploading local disk images by using the virtctl tool
-    File: cnv-uploading-local-disk-images-virtctl
-  - Name: Uploading a local disk image to a block storage DataVolume
-    File: cnv-uploading-local-disk-images-block
-  - Name: Expanding virtual storage by adding blank disk images
-    File: cnv-expanding-virtual-storage-with-blank-disk-images
-  - Name: Preparing CDI scratch space
-    File: cnv-preparing-cdi-scratch-space
-  - Name: Importing virtual machine images to block storage with DataVolumes
-    File: cnv-importing-virtual-machine-images-datavolumes-block
-  - Name: Cloning a virtual machine disk into a new block storage DataVolume
-    File: cnv-cloning-vm-disk-into-new-datavolume-block
-### Virtual machine live migration
-  - Name: Virtual machine live migration
-    File: cnv-live-migration
-  - Name: Live migration limits and timeouts
-    File: cnv-live-migration-limits
-  - Name: Migrating a virtual machine instance to another node
-    File: cnv-migrate-vmi
-  - Name: Monitoring live migration of a virtual machine instance
-    File: cnv-monitor-vmi-migration
-  - Name: Cancelling the live migration of a virtual machine instance
-    File: cnv-cancel-vmi-migration
-### Node maintenance mode
-  - Name: Node maintenance mode
-    File: cnv-node-maintenance
-  - Name: Configuring virtual machine eviction strategy
-    File: cnv-configuring-vmi-eviction-strategy
-  - Name: Setting a node to maintenance mode
-    File: cnv-setting-node-maintenance
-  - Name: Resuming a node from maintenance mode
-    File: cnv-resuming-node
-### Installing VirtIO drivers on Windows virtual machines
-  - Name: Installing VirtIO driver on an existing Windows virtual machine
-    File: cnv-installing-virtio-drivers-on-existing-windows-vm
-  - Name: Installing VirtIO driver on a new Windows virtual machine
-    File: cnv-installing-virtio-drivers-on-new-windows-vm
-### Logging, events, and monitoring
-  - Name: Viewing logs
-    File: cnv-logs
-  - Name: Viewing events
-    File: cnv-events
-    Name: Viewing cluster information
-    File: cnv-using-dashboard-to-get-cluster-info
-  - Name: OpenShift cluster monitoring, logging, and Telemetry
-    File: cnv-openshift-cluster-monitoring
-  - Name: Collecting container-native virtualization data for Red Hat Support
-    File: cnv-collecting-cnv-data
-- Name: Container-native virtualization 2.0 release notes
-  Dir: cnv_release_notes
-  Topics:
-  - Name: Container-native virtualization 2.0 release notes
-    File: cnv-release-notes
+#---
+#Name: Container-native virtualization
+#Dir: cnv
+#Distros: openshift-enterprise
+#Topics:
+#- Name: Container-native virtualization installation
+#  Dir: cnv_install
+#  Topics:
+#  - Name: About container-native virtualization
+#    File: cnv-about-cnv
+#  - Name: Preparing your OpenShift cluster for container-native virtualization
+#    File: preparing-cluster-for-cnv
+#  - Name: Installing container-native virtualization
+#    File: installing-container-native-virtualization
+#  - Name: Installing the `virtctl` client
+#    File: cnv-installing-virtctl
+#  - Name: Upgrading container-native virtualization
+#    File: upgrading-container-native-virtualization
+#  - Name: Uninstalling container-native virtualization
+#    File: uninstalling-container-native-virtualization
+#- Name: Container-native virtualization user's guide
+#  Dir: cnv_users_guide
+#  Topics:
+#### VIRTUAL MACHINE CHESS SALAD (silly name to highlight that the commented out assemblies need to be checked against merged filenams)
+#  - Name: Creating virtual machines
+#    File: cnv-create-vms
+#### Importing virtual machines
+#  - Name: TLS certificates for DataVolume imports
+#    File: cnv-tls-certificates-for-dv-imports
+#  - Name: Importing virtual machine images with DataVolumes
+#    File: cnv-importing-virtual-machine-images-datavolumes
+#### VM CHESS SALAD cont'd
+#  - Name: Editing virtual machines
+#    File: cnv-edit-vms
+#  - Name: Deleting virtual machines
+#    File: cnv-delete-vms
+#  - Name: Controlling virtual machines states
+#    File: cnv-controlling-vm-states
+#  - Name: Accessing virtual machine consoles
+#    File: cnv-accessing-vm-consoles
+#  - Name: Using the CLI tools
+#    File: cnv-using-the-cli-tools
+#### Automating management tasks
+#  - Name: Automating management tasks
+#    File: cnv-automating-management-tasks
+#### Virtual machine networking
+#  - Name: Using the default Pod network with container-native virtualization
+#    File: cnv-using-the-default-pod-network-with-cnv
+#  - Name: Attaching a virtual machine to multiple networks
+#    File: cnv-attaching-vm-multiple-networks
+#  - Name: Installing the QEMU guest agent on virtual machines
+#    File: cnv-installing-qemu-guest-agent
+#  - Name: Viewing the IP address of vNICs on a virtual machine
+#    File: cnv-viewing-ip-of-vm-vnic
+#### Advanced virtual machine configuration
+#  - Name: Configuring PXE booting for virtual machines
+#    File: cnv-configuring-pxe-booting
+#  - Name: Managing guest memory
+#    File: cnv-managing-guest-memory
+#### Templates
+#  - Name: Creating virtual machine templates
+#    File: cnv-creating-vm-template
+#  - Name: Editing a virtual machine template
+#    File: cnv-editing-vm-template
+#  - Name: Deleting a virtual machine template
+#    File: cnv-deleting-vm-template
+#### Cloning virtual machines
+#  - Name: Cloning a virtual machine disk into a new DataVolume
+#    File: cnv-cloning-vm-disk-into-new-datavolume
+#  - Name: Cloning a virtual machine by using a DataVolumeTemplate
+#    File: cnv-cloning-vm-using-datavolumetemplate
+#### A BETTER NAME THAN 'STORAGE 4 U'
+#  - Name: Uploading local disk images by using the virtctl tool
+#    File: cnv-uploading-local-disk-images-virtctl
+#  - Name: Uploading a local disk image to a block storage DataVolume
+#    File: cnv-uploading-local-disk-images-block
+#  - Name: Expanding virtual storage by adding blank disk images
+#    File: cnv-expanding-virtual-storage-with-blank-disk-images
+#  - Name: Preparing CDI scratch space
+#    File: cnv-preparing-cdi-scratch-space
+#  - Name: Importing virtual machine images to block storage with DataVolumes
+#    File: cnv-importing-virtual-machine-images-datavolumes-block
+#  - Name: Cloning a virtual machine disk into a new block storage DataVolume
+#    File: cnv-cloning-vm-disk-into-new-datavolume-block
+#### Virtual machine live migration
+#  - Name: Virtual machine live migration
+#    File: cnv-live-migration
+#  - Name: Live migration limits and timeouts
+#    File: cnv-live-migration-limits
+#  - Name: Migrating a virtual machine instance to another node
+#    File: cnv-migrate-vmi
+#  - Name: Monitoring live migration of a virtual machine instance
+#    File: cnv-monitor-vmi-migration
+#  - Name: Cancelling the live migration of a virtual machine instance
+#    File: cnv-cancel-vmi-migration
+#### Node maintenance mode
+#  - Name: Node maintenance mode
+#    File: cnv-node-maintenance
+#  - Name: Configuring virtual machine eviction strategy
+#    File: cnv-configuring-vmi-eviction-strategy
+#  - Name: Setting a node to maintenance mode
+#    File: cnv-setting-node-maintenance
+#  - Name: Resuming a node from maintenance mode
+#    File: cnv-resuming-node
+#### Installing VirtIO drivers on Windows virtual machines
+#  - Name: Installing VirtIO driver on an existing Windows virtual machine
+#    File: cnv-installing-virtio-drivers-on-existing-windows-vm
+#  - Name: Installing VirtIO driver on a new Windows virtual machine
+#    File: cnv-installing-virtio-drivers-on-new-windows-vm
+#### Logging, events, and monitoring
+#  - Name: Viewing logs
+#    File: cnv-logs
+#  - Name: Viewing events
+#    File: cnv-events
+#    Name: Viewing cluster information
+#    File: cnv-using-dashboard-to-get-cluster-info
+#  - Name: OpenShift cluster monitoring, logging, and Telemetry
+#    File: cnv-openshift-cluster-monitoring
+#  - Name: Collecting container-native virtualization data for Red Hat Support
+#    File: cnv-collecting-cnv-data
+#- Name: Container-native virtualization 2.0 release notes
+#  Dir: cnv_release_notes
+#  Topics:
+#  - Name: Container-native virtualization 2.0 release notes
+#    File: cnv-release-notes
 ---
 Name: Serverless applications
 Dir: serverless


### PR DESCRIPTION
attn: @vikram-redhat 

As discussed in the CNV docs meeting, I commented out all CNV sections in the topic map. This is  intended to prevent early release in case CNV 2.1 goes out after OCP 4.2.

10/14: Removed the WIP tag after hearing that CNV 2.1 is going out on Oct. 23.