### PR TITLE
modules/installation-bootstrap-gather: --master for each machine

### DIFF
--- a/modules/installation-bootstrap-gather.adoc
+++ b/modules/installation-bootstrap-gather.adoc
@@ -49,15 +49,20 @@ command:
 ----
 $ ./openshift-install gather bootstrap --dir=<directory> \ <1>
     --bootstrap <bootstrap_address> \ <2>
-    --master "<master_address> <master_address> <master_address>" <3>
+    --master <master_1_address> \ <3>
+    --master <master_2_address> \ <3>
+    --master <master_3_address>" <3>
 ----
 <1> `installation_directory` is the directory you stored the {product-title}
 definition files that the installation program creates.
 <2> `<bootstrap_address>` is the fully-qualified domain name or IP address of
 the cluster's bootstrap machine.
-<3> `<master_address>` is the fully-qualified domain name or IP address of a
-control plane, or master, machine in your cluster. Specify a space-delimited
-list that contains all the control plane machines in your cluster.
+<3> For each control plane, or master, machine in your cluster, replace `<master_*_address>` with its fully-qualified domain name or IP address.
++
+[NOTE]
+====
+A default cluster contains three control plane machines. List all of your control plane machines as shown, no matter how many your cluster uses.
+====
 --
 +
 The command output resembles the following example:


### PR DESCRIPTION
This is what we do in CI since openshift/release@3013859bdc (openshift/release#4734), so we know it works.  Comma-delimited machines won't work, as described in that release commit.  I'd be surprised if space-delimited worked.