### PR TITLE
deduplicate fluentd config sections

### DIFF
--- a/logging/config/cluster-logging-collector.adoc
+++ b/logging/config/cluster-logging-collector.adoc
@@ -33,8 +33,6 @@ include::modules/cluster-logging-collector-collector.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-log-location.adoc[leveloffset=+1]
 
-include::modules/cluster-logging-collector-external.adoc[leveloffset=+1]
-
 include::modules/cluster-logging-collector-throttling.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-json.adoc[leveloffset=+1]


### PR DESCRIPTION
We do not need this section in two different places, it just creates user 
confusion. 

The configuring fluentd section is primarily about supported configuration
changes our operator manages, so i'm removing this content from that section.

removes it from here:
https://docs.openshift.com/container-platform/4.1/logging/config/efk-logging-fluentd.html#efk-logging-fluentd-external_efk-logging-fluentd

leaves it here:
https://docs.openshift.com/container-platform/4.1/logging/config/efk-logging-external.html#efk-logging-fluentd-external_efk-logging-external
