### PR TITLE
Remove CRC from 4.1 RN

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -354,14 +354,6 @@ install a separate metrics server.
 [id="ocp-4-1-developer-experience"]
 === Developer experience
 
-[id="ocp-4-1-code-ready-containers"]
-==== Code ready containers
-
-A local desktop instance of {product-title} 4.1 replaces the functions of `oc
-cluster` commands, Minishift, and CDK. {product-title} 4.1 focuses on ease of
-access and native experience, with a native installation program on macOS and Microsoft
-Windows, native hypervisor support, and tray icon integration.
-
 [id="ocp-4-1-multistage-builds"]
 ==== Multi-stage Dockerfile Builds Generally Available
 


### PR DESCRIPTION
This PR removes the mention of CRC from the 4.1 release notes since it was not yet released at that point. I/Kevin will raise a separate PR for adding a RN entry for CRC in 4.2