### PR TITLE
CNV Updating Network Attachment Definition

### DIFF
--- a/modules/cnv-connecting-resource-bridge-network.adoc
+++ b/modules/cnv-connecting-resource-bridge-network.adoc
@@ -33,21 +33,26 @@ metadata:
     k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/br0 <1>
 spec:
   config: '{
-    "cniVersion": "0.3.0",
-    "name": "a-bridge-network", <2>
-    "type": "cnv-bridge", <3>
-    "bridge": "br0", <4>
-    "isGateway": true,
-    "ipam": {}
-}'
+    "cniVersion": "0.3.1",
+    "plugins": [
+      {
+        "type": "cnv-bridge", <2>
+        "bridge": "br0", <3>
+        "ipam": {}
+      },
+      {
+        "type": "tuning" <4>
+      }
+    ]
+  }'
 ----
 <1> If you add this annotation to your NetworkAttachmentDefinition, your virtual machine instances
 will only run on nodes that have the `br0` bridge connected.
-<2> The `name` value is part of the annotation you will use in the next step.
-<3> The actual name of the Container Network Interface (CNI) plug-in that provides
+<2> The actual name of the Container Network Interface (CNI) plug-in that provides
 the network for this NetworkAttachmentDefinition. Do not change this field unless
 you want to use a different CNI.
-<4> You must substitute the actual name of the bridge, if it is not `br0`.
+<3> You must substitute the actual name of the bridge, if it is not `br0`.
+<4> Required. This allows the MAC pool manager to assign a unique MAC address to the connection.
 +
 ----
 $ oc create -f <resource_spec.yaml>


### PR DESCRIPTION
The current NAD was flagged as incorrect by networking cnv dev. This PR provides the suggested fix.

@phoracek can you please review. Also, is this just for upcoming 2.1 release, or should it also be applied to 2.0 docs?