### PR TITLE
BZ1761067: Corrected local storage output example.

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -106,19 +106,17 @@ NAME                                          READY   STATUS    RESTARTS   AGE
 pod/local-disks-local-provisioner-h97hj       1/1     Running   0          46m
 pod/local-disks-local-provisioner-j4mnn       1/1     Running   0          46m
 pod/local-disks-local-provisioner-kbdnx       1/1     Running   0          46m
-pod/local-diskslocal-diskmaker-ldldw          1/1     Running   0          46m
-pod/local-diskslocal-diskmaker-lvrv4          1/1     Running   0          46m
-pod/local-diskslocal-diskmaker-phxdq          1/1     Running   0          46m
-pod/local-storage-manifests-f8zc9             1/1     Running   0          48m
+pod/local-disks-local-diskmaker-ldldw         1/1     Running   0          46m
+pod/local-disks-local-diskmaker-lvrv4         1/1     Running   0          46m
+pod/local-disks-local-diskmaker-phxdq         1/1     Running   0          46m
 pod/local-storage-operator-54564d9988-vxvhx   1/1     Running   0          47m
 
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
-service/local-storage-manifests   ClusterIP   172.30.183.114   <none>        50051/TCP   48m
 service/local-storage-operator    ClusterIP   172.30.49.90     <none>        60000/TCP   47m
 
 NAME                                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
 daemonset.apps/local-disks-local-provisioner   3         3         3       3            3           <none>          46m
-daemonset.apps/local-diskslocal-diskmaker      3         3         3       3            3           <none>          46m
+daemonset.apps/local-disks-local-diskmaker     3         3         3       3            3           <none>          46m
 
 NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/local-storage-operator   1/1     1            1           47m


### PR DESCRIPTION
This corrects the output of the `local-storage` namespace.

This is for OCP 4.2.