### PR TITLE
making stylesheets same

### DIFF
--- a/_stylesheets/commercial-home.css
+++ b/_stylesheets/commercial-home.css
@@ -1,5 +1,5 @@
 .masthead-docs{
-    background:url(../_images/commercial-masthead.png) repeat-x scroll 50% 0 / cover #60605b;
+    background:url(../_images/commercial-masthead.jpg) repeat-x scroll 50% 0 / cover #60605b;
     margin-top: -20px;
     padding: 20px 0 80px;
  }

--- a/_stylesheets/foundation.css
+++ b/_stylesheets/foundation.css
@@ -1,6 +1,6 @@
 @import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 
-/* Adapted for OpenShift Origin from the 'foundation' style sheet at */
+/* Adapted for OKD from the 'foundation' style sheet at */
 /* https://github.com/asciidoctor/asciidoctor-stylesheet-factory/blob/master/sass/foundation.scss */
 
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */

--- a/_stylesheets/sass/settings/_origin.scss
+++ b/_stylesheets/sass/settings/_origin.scss
@@ -46,7 +46,7 @@ $pre-padding: .8em .8em .6em .8em;
 $list-side-margin: emCalc(24px);
 $definition-list-header-margin-bottom: emCalc(5px);
 $definition-list-margin-bottom: emCalc(20px);
-// FIXME must account for nested definition list
+// FIXME need to account for nested definition list
 //$definition-list-content-margin-left: 0;
 
 // Blockquotes

--- a/_stylesheets/search.css
+++ b/_stylesheets/search.css
@@ -11,26 +11,45 @@
 }
 
 #hc-search-modal {
+    background-color: rgb(0,0,0);
+    background-color: rgba(0,0,0,0.4);
     display: none;
     position: fixed;
-    z-index: 1;
-    padding-top: 5%;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
     overflow: auto;
-    background-color: rgb(0,0,0);
-    background-color: rgba(0,0,0,0.4);
+    z-index: 10000;
+}
+@media screen and (max-width: 767px) {
+    #hc-search-modal {
+        padding-top: 80px;
+    }
+}
+@media screen and (min-width: 768px) {
+    #hc-search-modal {
+        padding-top: 5%;
+    }
 }
 
 #hc-modal-content {
     background-color: #fefefe;
-    margin: auto;
-    padding: 20px;
     border: 1px solid #888;
-    width: 80%;
-    height: 80vh;
+    padding: 20px;
+}
+@media screen and (max-width: 767px) {
+    #hc-modal-content {
+        height: 100%;
+        width: 100%;
+    }
+}
+@media screen and (min-width: 768px) {
+    #hc-modal-content {
+        height: 80vh;
+        margin: auto;
+        width: 80%;
+    }
 }
 
 #hc-modal-close {
@@ -38,6 +57,8 @@
     float: right;
     font-size: 28px;
     font-weight: bold;
+    position: relative;
+    z-index: 10001;
 }
 
 #hc-modal-close:hover,
@@ -45,4 +66,16 @@
     color: #000;
     text-decoration: none;
     cursor: pointer;
+}
+
+#hc-search-results-wrapper {
+    height: 75vh;
+    padding-bottom: 15px;
+    overflow: auto;
+}
+
+@media screen and (max-width: 767px) {
+    #hc-search-more-btn, #hc-search-progress-indicator {
+        margin-bottom: 2em;
+    }
 }


### PR DESCRIPTION
All docs (including okd) are now using a hard coded link to the 4.1 stylesheets. This PR makes that stylesheet the same as with the master/master-3 and doesn't need CPing to other branches.