### PR TITLE
[OCDOCS-470] dot to slash in CIDR guidance note

### DIFF
--- a/modules/installation-osp-verifying-external-network.adoc
+++ b/modules/installation-osp-verifying-external-network.adoc
@@ -53,7 +53,7 @@ The default network ranges are:
 |172.30.0.0/16
 
 |clusterNetwork
-|10.128.0.0.14
+|10.128.0.0/14
 |====
 ====
 endif::osp-custom,osp-kuryr[]


### PR DESCRIPTION
Correcting a typo. 
https://jira.coreos.com/browse/OSDOCS-470
4.2. 