### PR TITLE
Re-use olm-creating-etcd-cluster-from-operator module in Applications

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -596,10 +596,12 @@ Topics:
 - Name:  Application life cycle management
   Dir: application-life-cycle-management
   Topics:
-  - Name: Creating applications using the CLI
-    File: creating-applications-using-cli
   - Name: Creating an application using the Developer perspective
     File: odc-creating-applications-using-developer-perspective
+  - Name: Creating applications from installed Operators
+    File: creating-apps-from-installed-operators
+  - Name: Creating applications using the CLI
+    File: creating-applications-using-cli
   - Name: Viewing application composition using the Topology view
     File: odc-viewing-application-composition-using-topology-view
 - Name: Service brokers

--- a/applications/application-life-cycle-management/creating-apps-from-installed-operators.adoc
+++ b/applications/application-life-cycle-management/creating-apps-from-installed-operators.adoc
@@ -1,0 +1,22 @@
+[id="creating-apps-from-installed-operators"]
+= Creating applications from installed Operators
+include::modules/common-attributes.adoc[]
+:context: creating-apps-from-installed-operators
+
+toc::[]
+
+_Operators_ are a method of packaging, deploying, and managing a Kubernetes
+application. You can create applications on {product-title} using Operators that
+have been installed by a cluster administrator.
+
+This guide walks developers through an example of creating applications from an
+installed Operator using the {product-title} web console.
+
+.Additional resources
+
+* See the
+xref:../../operators/olm-what-operators-are.adoc#olm-what-operators-are[Operators]
+guide for more on how Operators work and how the Operator Lifecycle Manager is
+integrated in {product-title}.
+
+include::modules/olm-creating-etcd-cluster-from-operator.adoc[leveloffset=+1]

--- a/operators/olm-creating-apps-from-installed-operators.adoc
+++ b/operators/olm-creating-apps-from-installed-operators.adoc
@@ -6,6 +6,6 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 This guide walks developers through an example of creating applications from an
-installed Operator using the {product-title} {product-version} web console.
+installed Operator using the {product-title} web console.
 
 include::modules/olm-creating-etcd-cluster-from-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
Adds an Operator-focused topic under **Applications** -> **Application life cycle management** that re-uses the module from the **Operators** guide.

Also re-orders this subdir:

```
Application life cycle management
- Creating an application using the Developer perspective
- Creating applications from installed Operators
- Creating applications using the CLI
- Viewing application composition using the Topology view
```

Preview (internal): http://file.rdu.redhat.com/~adellape/101419/reuse_operator_app/applications/application-life-cycle-management/creating-apps-from-installed-operators.html