### PR TITLE
Remove Kuryr flow from ShiftStack IPI docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -129,8 +129,8 @@ Topics:
 #    File: installing-openstack-installer
   - Name: Installing a cluster on OpenStack with customizations
     File: installing-openstack-installer-custom
-  - Name: Installing a cluster on OpenStack with Kuryr
-    File: installing-openstack-installer-kuryr
+  # - Name: Installing a cluster on OpenStack with Kuryr
+  #   File: installing-openstack-installer-kuryr
   # - Name: Load balancing deployments on OpenStack
   #   File: installing-openstack-load-balancing
 - Name: Installing on vSphere


### PR DESCRIPTION
This escaped from [last PR's](https://github.com/openshift/openshift-docs/pull/17113) comment out. 

OpenShift on OpenStack w/Kuryr is not available in 4.2. 