### PR TITLE
Removed OCS and updated raw block storage.

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -244,16 +244,6 @@ based on node or pod labels and profile priorities.
 Persistent volumes using the Local Storage Operator is now available in
 {product-title} {product-version}.
 
-[id="ocp-4-2-OCS"]
-==== OpenShift Container Storage {product-version}
-
-With {product-title} {product-version}, OpenShift Container Storage (OCS)
-{product-version} is available, providing persistent storage for applications
-and {product-title} infrastructure services. OCS {product-version} will provide
-complete data services for {product-title}, including dynamic provisioning of
-object buckets. This S3 capability is new in OCS {product-version}. A consistent
-S3 interface is now added across public and on-premise infrastructure.
-
 [id="ocp-4-2-CSI"]
 ==== OpenShift Container Storage Interface (CSI)
 
@@ -267,17 +257,14 @@ For now, only the API is available. CSI drivers contained in operators will be
 available in future releases.
 
 [id="ocp-4-2-storage-devices"]
-==== Storage devices
+==== Raw block volume support
 
-The Cluster Storage Operator sets up the default storage class. It looks through
-the cloud provider and sets up the correct storage class.
+The following raw block volumes are now fully supported with {product-title} {product-version}:
 
-Raw Block with iSCSI is now in xref:ocp-4-2-technology-preview[Technology Preview].
+* Local volumes
+* Cloud providers (AWS, GCP, Azure, and vSphere)
 
-New storage devices are supported in {product-title} {product-version}:
-
-* Raw block with local Volumes
-* Raw block with cloud providers (AWS, GCP, Azure, and vSphere)
+Raw block volumes using iSCSI are now in xref:ocp-4-2-technology-preview[Technology Preview].
 
 [id="ocp-4-2-scale"]
 === Scale


### PR DESCRIPTION
Removes OCS from the OCP 4.2 release notes, and rewords the details surrounding raw block volume support.

Note the ClusterStorageOperator has been present since 4.1, so this has also been removed.

This is for OCS 4.2.