### PR TITLE
Update logging secure forward

### DIFF
--- a/modules/efk-logging-fluentd-external.adoc
+++ b/modules/efk-logging-fluentd-external.adoc
@@ -25,16 +25,41 @@ For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log fo
 The logging deployment provides a `secure-forward.conf` section in the Fluentd configmap
 for configuring the external aggregator:
 
+.Sample `secure-forward.conf` section
+[source,yaml]
+----
+ secure-forward.conf: |
+    # <store>
+    # @type secure_forward
+
+    # self_hostname ${hostname}
+    # shared_key <SECRET_STRING>
+
+    # secure yes
+    # enable_strict_verification yes
+
+    # ca_cert_path /etc/fluent/keys/your_ca_cert
+    # ca_private_key_path /etc/fluent/keys/your_private_key
+      # for private CA secret key
+    # ca_private_key_passphrase passphrase
+
+    # <server>
+      # or IP
+    #   host server.fqdn.example.com
+----
+
 .Procedure
 
 To send a copy of Fluentd logs to an external log aggregator:
 
 . Edit the `secure-forward.conf` section of the Fluentd configuration map:
 +
-.Sample `secure-forward.conf` section
 ----
 $ oc edit configmap/fluentd -n openshift-logging
-
+----
++
+[source,yaml]
+----
 <store>
   @type forward
   <server> <1>
@@ -51,10 +76,45 @@ $ oc edit configmap/fluentd -n openshift-logging
 ----
 <1> Enter the name, host, and port for your external Fluentd server.
 
+. Add the path to your certificate and private key to the `secure-forward.conf` section:
++
+[source,yaml]
+----
+  secure-forward.conf: |
+    # <store>
+    # @type secure_forward
+
+    # self_hostname ${hostname}
+    # shared_key <SECRET_STRING>
+
+    secure yes
+    # enable_strict_verification yes
+
+    ca_cert_path /etc/fluent/keys/ca.crt <1>
+    ca_private_key_path /etc/fluent/keys/privkey.pem <2>
+      # for private CA secret key
+    # ca_private_key_passphrase passphrase
+
+    # <server>
+      # or IP
+    #   host server.fqdn.example.com
+    #   port 24284
+    # </server>
+    # <server>
+      # ip address to connect
+    #   host 203.0.113.8
+      # specify hostlabel for FQDN verification if ipaddress is used for host
+    #   hostlabel server.fqdn.example.com
+    # </server>
+    # </store>
+----
+<1> Add the path to your certificate.
+<2> Add the path to your private key.
+ 
 . Add certificates to be used in `secure-forward.conf` to the existing
 secret that is mounted on the Fluentd pods. The `your_ca_cert` and
 `your_private_key` values must match what is specified in `secure-forward.conf`
-in `configmap/logging-fluentd`:
+in `configmap/fluentd`:
 +
 ----
 $ oc patch secrets/fluentd --type=json \
@@ -69,6 +129,15 @@ Replace `your_private_key` with a generic name. This is a link to the JSON path,
 not a path on your host system.
 ====
 +
+For example:
++
+----
+$ oc patch secrets/fluentd --type=json \
+  --patch "[{'op':'add','path':'/data/ca.crt','value':'$(base64 /etc/fluent/keys/ca.crt)'}]"
+$ oc patch secrets/fluentd --type=json \
+  --patch "[{'op':'add','path':'/data/privkey.pem','value':'$(base64 /etc/fluent/keys/privkey.pem)'}]"
+----
+
 When configuring the external aggregator, it must be able to accept messages
 securely from Fluentd.
 +

--- a/modules/efk-logging-fluentd-external.adoc
+++ b/modules/efk-logging-fluentd-external.adoc
@@ -23,7 +23,7 @@ For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log fo
 ====
 
 The logging deployment provides a `secure-forward.conf` section in the Fluentd configmap
-for configuring the external aggregator:
+in the `openshift-logging` project for configuring the external aggregator:
 
 .Sample `secure-forward.conf` section
 [source,yaml]
@@ -87,11 +87,11 @@ $ oc edit configmap/fluentd -n openshift-logging
     # self_hostname ${hostname}
     # shared_key <SECRET_STRING>
 
-    secure yes
-    # enable_strict_verification yes
+    secure yes <1>
+    enable_strict_verification yes <1>
 
-    ca_cert_path /etc/fluent/keys/ca.crt <1>
-    ca_private_key_path /etc/fluent/keys/privkey.pem <2>
+    ca_cert_path /etc/fluent/keys/ca.crt <2>
+    ca_private_key_path /etc/fluent/keys/privkey.pem <3>
       # for private CA secret key
     # ca_private_key_passphrase passphrase
 
@@ -108,7 +108,8 @@ $ oc edit configmap/fluentd -n openshift-logging
     # </server>
     # </store>
 ----
-<1> Add the path to your certificate.
+<1> Clear the comment to use certificates and private keys.
+<2> Add the path to your certificate.
 <2> Add the path to your private key.
  
 . Add certificates to be used in `secure-forward.conf` to the existing

--- a/modules/efk-logging-fluentd-external.adoc
+++ b/modules/efk-logging-fluentd-external.adoc
@@ -17,11 +17,6 @@ ifdef::openshift-enterprise[]
 The `secure-forward` plug-in is supported by Fluentd only.
 endif::openshift-enterprise[]
 
-[NOTE]
-====
-For Rsyslog, you can edit the Rsyslog configmap to add support for Syslog log forwarding using the *omfwd* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html[omfwd: syslog Forwarding Output Module]. To send logs to a different Rsyslog instance, you can the *omrelp* module, see link:https://www.rsyslog.com/doc/v8-stable/configuration/modules/omrelp.html[omrelp: RELP Output Module].
-====
-
 The logging deployment provides a `secure-forward.conf` section in the Fluentd configmap
 in the `openshift-logging` project for configuring the external aggregator:
 
@@ -110,7 +105,7 @@ $ oc edit configmap/fluentd -n openshift-logging
 ----
 <1> Clear the comment to use certificates and private keys.
 <2> Add the path to your certificate.
-<2> Add the path to your private key.
+<3> Add the path to your private key.
  
 . Add certificates to be used in `secure-forward.conf` to the existing
 secret that is mounted on the Fluentd pods. The `your_ca_cert` and


### PR DESCRIPTION
Per slack convo with @richm 
https://coreos.slack.com/archives/CB3HXM2QK/p1571171589181800?thread_ts=1571167864.174500&cid=CB3HXM2QK

* Added a full `secure_forward` section from the `fluentd` configmap
* Added a step to update the `secure_forward` with the cert file and private key
* Added an example of the secret patch command with the same cert file and private key in new step.