### PR TITLE
fix for BZ#1762038 - wrong iptables table in the command, should be O…

### DIFF
--- a/install_config/router/default_haproxy_router.adoc
+++ b/install_config/router/default_haproxy_router.adoc
@@ -456,8 +456,8 @@ The following is an example using `iptables` to open the custom router service
 ports.
 
 ----
-$ iptables -A INPUT -p tcp --dport 10080 -j ACCEPT
-$ iptables -A INPUT -p tcp --dport 10443 -j ACCEPT
+$ iptables -A OS_FIREWALL_ALLOW -p tcp --dport 10080 -j ACCEPT
+$ iptables -A OS_FIREWALL_ALLOW -p tcp --dport 10443 -j ACCEPT
 ----
 [[working-with-multiple-routers]]
 == Working With Multiple Routers


### PR DESCRIPTION
fix for BZ#1762038 - wrong iptables table in the command, should be OS_FIREWALL_ALLOW

https://bugzilla.redhat.com/show_bug.cgi?id=1762038