### PR TITLE
[enterprise-4.2] unset variables

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -323,3 +323,27 @@ endif::azure[]
 ifdef::gcp[]
 .Additional Google Cloud Platform (GCP) parameters
 ////
+
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-customizations"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-custom"]
+:!osp:
+:!osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:!osp:
+:!osp-kuryr:
+endif::[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -172,3 +172,25 @@ it to install multiple clusters.
 The `install-config.yaml` file is consumed during the installation process. If
 you want to reuse the file, you must back it up now.
 ====
+
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-customizations"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-user-infra"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-custom"]
+:!osp:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:!osp:
+endif::[]

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -205,3 +205,43 @@ ifdef::aws[]
 . Optional: Remove or disable the `AdministratorAccess` policy from the IAM
 account that you used to install the cluster.
 endif::aws[]
+
+ifeval::["{context}" == "installing-aws-customizations"]
+:custom-config:
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:custom-config:
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-default"]
+:no-config:
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-default"]
+:!no-config:
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!custom-config:
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-default"]
+:!no-config:
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-azure-customizations"]
+:!custom-config:
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-custom"]
+:!osp:
+:!custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:!osp:
+:!custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer"]
+:!osp:
+endif::[]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -138,3 +138,13 @@ The following files are generated in the directory:
 ├── metadata.json
 └── worker.ign
 ----
+
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-gcp-user-infra"]
+:!gcp:
+endif::[]


### PR DESCRIPTION
@openshift/team-documentation if you set a variable, unset it at the end of its life (typically, at the end of the module/assembly), otherwise it continues to propagate through the rest of the content. I will need to update our guidelines to put this in.