### PR TITLE
updates for BZ1746768

### DIFF
--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -31,6 +31,11 @@ users can authenticate.
 ----
 $ oc apply -f </path/to/CR>
 ----
++
+[NOTE]
+====
+If a CR does not exist, `oc apply` creates a new CR and might trigger the following warning: `Warning: oc apply should be used on resources created by either oc create --save-config or oc apply`. In this case you can safely ignore this warning.
+====
 
 . Log in to the cluster as a user from your identity provider, entering the
 password when prompted.


### PR DESCRIPTION
Replacing `oc-apply` with `oc-replace` when adding an identity provider.