### PR TITLE
Added note about disconnected installations for Serverless

### DIFF
--- a/serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing-openshift-serverless.adoc
@@ -6,6 +6,11 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+[NOTE]
+====
+{ServerlessProductName} is not tested or supported for installation in a restricted network environment.
+====
+
 // Cluster sizing requirements
 include::modules/serverless-cluster-sizing-requirements.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This note clarifies that restricted network installations are not supported for Serverless