### PR TITLE
Revoke "RHOSP" initialism treatment

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -120,7 +120,7 @@ ifdef::osp[]
 .. Select *openstack* as the platform to target.
 .. Specify the {rh-openstack-first} external network name to use for installing the cluster.
 .. Specify the Floating IP address to use for external access to the OpenShift API.
-.. Specify an {rh-openstack} flavor with at least 16 GB RAM to use for control plane
+.. Specify a {rh-openstack} flavor with at least 16 GB RAM to use for control plane
 and compute nodes.
 .. Select the base domain to deploy the cluster to. All DNS records will be
 sub-domains of this base and will also include the cluster name.

--- a/modules/installation-osp-about-kuryr.adoc
+++ b/modules/installation-osp-about-kuryr.adoc
@@ -11,7 +11,7 @@ Kuryr improves network performance by connecting Pods to the OpenStack SDN. It a
 
 [IMPORTANT]
 ====
-Kuryr is recommended for deployments on encapsulated {rh-openstack}-tenant networks to avoid double encapsulation. For example, on a deployment of an encapsulated OpenShift SDN over an {rh-openstack} network.
+Kuryr is recommended for deployments on encapsulated {rh-openstack}-tenant networks to avoid double encapsulation. For example, on a deployment of an encapsulated OpenShift SDN over a {rh-openstack} network.
 
 The default OpenShift SDN is recommended if:
 

--- a/modules/installation-osp-balancing-external-loads.adoc
+++ b/modules/installation-osp-balancing-external-loads.adoc
@@ -11,7 +11,7 @@ The load balancer serves ports 6443, 443, and 80 to any users of the system. Por
 
 .Prerequisites
 
-* Access to an {rh-openstack} administrator's account
+* Access to a {rh-openstack} administrator's account
 * The https://docs.openstack.org/python-openstackclient/latest/[{rh-openstack} client] installed on the target environment
 
 .Procedure

--- a/modules/installation-osp-enabling-swift.adoc
+++ b/modules/installation-osp-enabling-swift.adoc
@@ -13,7 +13,7 @@ Swift is operated by a user account with the `swiftoperator` role and `temp-url`
 
 .Prerequisites
 
-* An {rh-openstack} administrator account on the target environment
+* A {rh-openstack} administrator account on the target environment
 * On Ceph RGW, https://docs.ceph.com/docs/master/radosgw/config-ref/#swift-settings[the `account in url` option must be enabled]
 
 .Procedure


### PR DESCRIPTION
4.2+

Context: 

* https://github.com/openshift/openshift-docs/pull/17304
* https://github.com/openshift/openshift-docs/pull/17323

From the OSP DPM today:

> We had a larger conversation around RHOSP this morning, with overwhelming support for "a RHOSP...".
> 
> I'll send a note to the writer team to ensure we are consistent when we write RHOSP. We do use the full name a lot...

@bergerhoffer Would you like to take this, since you're pretty familiar with the issue at this point? :)