### PR TITLE
Rollback  Service Mesh docs (temporarility) from 4.2 branch

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1034,8 +1034,8 @@ Topics:
 #Distros: openshift-enterprise
 #Topics:
 #- Name: Service Mesh Architecture
-#  Dir: service_mesh_arch
 #  Topics:
+#  Dir: service_mesh_arch
 #  - Name: Understanding service mesh
 #    File: understanding-ossm
 #  - Name: Understanding Kiali

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1028,58 +1028,58 @@ Topics:
     File: odo-cli-reference
   - Name: odo release notes
     File: odo-release-notes
----
-Name: Service Mesh
-Dir: service_mesh
-Distros: openshift-enterprise
-Topics:
-- Name: Service Mesh Architecture
-  Dir: service_mesh_arch
-  Topics:
-  - Name: Understanding service mesh
-    File: understanding-ossm
-  - Name: Understanding Kiali
-    File: ossm-kiali
-  - Name: Understanding Jaeger
-    File: ossm-jaeger
-  - Name: Comparing service mesh and Istio
-    File: ossm-vs-community
-- Name: Service Mesh Installation
-  Dir: service_mesh_install
-  Topics:
-  - Name: Preparing to install service mesh
-    File: preparing-ossm-installation
-  - Name: Installing service mesh
-    File: installing-ossm
-  - Name: Customizing the installation
-    File: customizing-installation-ossm
-  - Name: Removing service mesh
-    File: removing-ossm
-
-- Name: Day Two
-  Dir: service_mesh_day_two
-  Topics:
-  - Name: Deploying applications on service mesh
-    File: prepare-to-deploy-applications-ossm
-  - Name: Configuring Jaeger
-    File: configuring-jaeger
-  - Name: Example application
-    File: ossm-example-bookinfo
-  - Name: Kiali tutorial
-    File: ossm-tutorial-kiali
-  - Name: Distributed tracing tutorial
-    File: ossm-tutorial-jaeger-tracing
+#---
+#Name: Service Mesh
+#Dir: service_mesh
+#Distros: openshift-enterprise
+#Topics:
+#- Name: Service Mesh Architecture
+#  Dir: service_mesh_arch
+#  Topics:
+#  - Name: Understanding service mesh
+#    File: understanding-ossm
+#  - Name: Understanding Kiali
+#    File: ossm-kiali
+#  - Name: Understanding Jaeger
+#    File: ossm-jaeger
+#  - Name: Comparing service mesh and Istio
+#    File: ossm-vs-community
+#- Name: Service Mesh Installation
+#  Dir: service_mesh_install
+#  Topics:
+#  - Name: Preparing to install service mesh
+#    File: preparing-ossm-installation
+#  - Name: Installing service mesh
+#    File: installing-ossm
+#  - Name: Customizing the installation
+#    File: customizing-installation-ossm
+#  - Name: Removing service mesh
+#    File: removing-ossm
+#
+#- Name: Day Two
+#  Dir: service_mesh_day_two
+#  Topics:
+#  - Name: Deploying applications on service mesh
+#    File: prepare-to-deploy-applications-ossm
+#  - Name: Configuring Jaeger
+#    File: configuring-jaeger
+#  - Name: Example application
+#    File: ossm-example-bookinfo
+#  - Name: Kiali tutorial
+#    File: ossm-tutorial-kiali
+#  - Name: Distributed tracing tutorial
+#    File: ossm-tutorial-jaeger-tracing
 #  - Name: Grafana tutorial
 #    File: ossm-tutorial-grafana
 #  - Name: Prometheus tutorial
 #    File: ossm-tutorial-prometheus
-- Name: 3scale adapter
-  Dir: threescale_adapter
-  Topics:
-  - Name: Using the 3scale Istio adapter
-    File: threescale-adapter
-- Name: Service Mesh Release Notes
-  File: servicemesh-release-notes
+#- Name: 3scale adapter
+#  Dir: threescale_adapter
+#  Topics:
+#  - Name: Using the 3scale Istio adapter
+#    File: threescale-adapter
+#- Name: Service Mesh Release Notes
+#  File: servicemesh-release-notes
 #---
 #Name: Container-native virtualization
 #Dir: cnv

--- a/serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing-openshift-serverless.adoc
@@ -26,7 +26,10 @@ include::modules/machineset-manually-scaling.adoc[leveloffset=+2]
 [id="installing-service-mesh_{context}"]
 == Installing Service Mesh
 
-An installed version of Service Mesh is required for the installation of {ServerlessProductName}. For details, see the {product-title} documentation on xref:../service_mesh/service_mesh_install/installing-ossm.adoc[Installing Service Mesh].
+An installed version of Service Mesh is required for the installation of {ServerlessProductName}.
+////
+For details, see the {product-title} documentation on xref:../service_mesh/service_mesh_install/installing-ossm.adoc[Installing Service Mesh].
+////
 
 [NOTE]
 ====


### PR DESCRIPTION
Backing out Service Mesh docs until 1.0.2 (which includes support for 4.2) releases.

@vikram-redhat