### PR TITLE
bug 1731441 must keep cluster running for 24 hours

### DIFF
--- a/modules/installation-aws-user-infra-installation.adoc
+++ b/modules/installation-aws-user-infra-installation.adoc
@@ -38,6 +38,11 @@ INFO Waiting up to 30m0s for the cluster to initialize...
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you
 stored the installation files in.
++
+[IMPORTANT]
+====
+The Ignition config files that the installation program generates contain certificates that expire after 24 hours. You must keep the cluster running for 24 hours in a non-degraded state to ensure that the first certificate rotation has finished.
+====
 
 ifdef::restricted[]
 . Register your cluster on the link:https://cloud.redhat.com/openshift/register[Cluster registration] page.

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -71,6 +71,11 @@ stored the installation files in.
 +
 The command succeeds when the Cluster Version Operator finishes deploying the
 {product-title} cluster from Kubernetes API server.
++
+[IMPORTANT]
+====
+The Ignition config files that the installation program generates contain certificates that expire after 24 hours. You must keep the cluster running for 24 hours in a non-degraded state to ensure that the first certificate rotation has finished.
+====
 
 . Confirm that the Kubernetes API server is communicating with the Pods.
 .. To view a list of all Pods, use the following command:

--- a/modules/installation-gcp-user-infra-completing.adoc
+++ b/modules/installation-gcp-user-infra-completing.adoc
@@ -25,6 +25,11 @@ INFO Waiting up to 30m0s for the cluster to initialize...
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you
 stored the installation files in.
++
+[IMPORTANT]
+====
+The Ignition config files that the installation program generates contain certificates that expire after 24 hours. You must keep the cluster running for 24 hours in a non-degraded state to ensure that the first certificate rotation has finished.
+====
 
 . Observe the running state of your cluster.
 +

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -197,6 +197,11 @@ display in your terminal.
 +
 [IMPORTANT]
 ====
+The Ignition config files that the installation program generates contain certificates that expire after 24 hours. You must keep the cluster running for 24 hours in a non-degraded state to ensure that the first certificate rotation has finished.
+====
++
+[IMPORTANT]
+====
 You must not delete the installation program or the files that the installation
 program creates. Both are required to delete the cluster.
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1731441

This note should appear in all of the installation assemblies after the installation program finishes or you run the `wait-for install-complete` command.

@gpei, will you PTAL?