### PR TITLE
Simplify AWS cluster deletion instuctions - BZ 1747306

### DIFF
--- a/modules/installation-uninstall-aws.adoc
+++ b/modules/installation-uninstall-aws.adoc
@@ -10,18 +10,10 @@ You can remove a cluster that you installed on Amazon Web Services (AWS).
 .Prerequisites
 
 * Have a copy of the installation program that you used to deploy the cluster.
+* Have the files that the installation program generated when you created your
+cluster.
 
 .Procedure
-
-. Optional: From the computer that you used to install the cluster, run the
-following command and record the UUID that it outputs:
-+
-----
-$ oc get clusterversion -o jsonpath='{.spec.clusterID}{"\n"}' version
-----
-+
-If not all of the cluster resources are removed from AWS, you can use this UUID
-to locate them and remove them.
 
 . From the computer that you used to install the cluster, run the following command:
 +


### PR DESCRIPTION
Ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1747306

This change aligns the 4.1 AWS cluster deletion instructions with those in [4.2](https://docs.openshift.com/container-platform/4.2/installing/installing_aws/uninstalling-cluster-aws.html), as well as the [training docs](https://github.com/openshift/training/tree/master/docs).

The prerequisites include having `metadata.json`, which eliminates the need to keep the optional, UUID-searching material in the topic. 

This PR applies only to 4.1.