### PR TITLE
Fix wrong elasticsearch labels

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -993,9 +993,9 @@ label, in this case `logging-es-node=1`.
 For example, if your deployment has three infrastructure nodes, you could add labels for those
 nodes as follows:
 ----
-$ oc label node <nodename1> logging-es-node=1
-$ oc label node <nodename2> logging-es-node=2
-$ oc label node <nodename3> logging-es-node=3
+$ oc label node <nodename1> logging-es-node=0
+$ oc label node <nodename2> logging-es-node=1
+$ oc label node <nodename3> logging-es-node=2
 ----
 
 For information about adding a label to a node, see
@@ -1108,9 +1108,9 @@ For example, if your deployment has three infrastructure nodes, you could add
 labels for those nodes as follows:
 +
 ----
-  $ oc label node <nodename1> logging-es-node=1
-  $ oc label node <nodename2> logging-es-node=2
-  $ oc label node <nodename3> logging-es-node=3
+  $ oc label node <nodename1> logging-es-node=0
+  $ oc label node <nodename2> logging-es-node=1
+  $ oc label node <nodename3> logging-es-node=2
 ----
 +
 To automate application of the node selector, use the `oc patch` command


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1760471

The counter of the playbook starts at 0, so the labels should be logging-es-{0,1,2}.
If the customer set logging-es-{1,2,3} the install/upgrade playbooks will fail.
