### PR TITLE
CNV - PVC must be RWX for live migration

### DIFF
--- a/modules/cnv-understanding-live-migration.adoc
+++ b/modules/cnv-understanding-live-migration.adoc
@@ -12,6 +12,12 @@ to migrate to another node, or an automatic process, if the
 virtual machine instance has a `LiveMigrate` eviction strategy and the node on 
 which it is running is placed into maintenance. 
 
+[IMPORTANT]
+====
+Virtual machines must have a PersistentVolumeClaim (PVC) with a 
+ReadWriteMany (RWX) access mode to be live migrated.
+====
+
 [NOTE]
 ====
 NFS shared volumes, CephFS volumes, and Ceph RADOS Block Devices (RBDs) are the 

--- a/modules/cnv-understanding-node-maintenance.adoc
+++ b/modules/cnv-understanding-node-maintenance.adoc
@@ -15,6 +15,12 @@ virtual machines.
 Virtual machine instances without an eviction strategy will be deleted on the 
 node and recreated on another node. 
 
+[IMPORTANT]
+====
+Virtual machines must have a PersistentVolumeClaim (PVC) with a 
+ReadWriteMany (RWX) access mode to be live migrated.
+====
+
 [NOTE]
 ====
 NFS shared volumes, CephFS volumes, and Ceph RADOS Block Devices (RBDs) are the


### PR DESCRIPTION
Adding what was a release note to the CNV User Guide for live migration.

CP to enterprise-4.2