### PR TITLE
modules/rhcos-about.adoc: fix links related to RHCOS upgrades

### DIFF
--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -65,10 +65,8 @@ images. You can use the crictl CLI tool to work with containers and pods from t
 CRI-O container engine. While direct use of these tools in {op-system} is
 discouraged, you can use them for debugging purposes.
 
-{op-system} features transactional upgrades and rollbacks using the
-http://www.projectatomic.io/docs/os-updates/[rpm]
-http://www.projectatomic.io/docs/os-updates/[-ostree]
-upgrade system. Updates are delivered via container images and are part of the
+{op-system} features transactional upgrades using the `rpm-ostree` system.
+ Updates are delivered via container images and are part of the
  OpenShift update process. When deployed, the container image is pulled,
  extracted, and written to disk, then the bootloader is modified to boot into
  the new version. The machine will reboot into the update in a rolling manner to
@@ -84,12 +82,13 @@ For {op-system} systems, the layout of the `rpm-ostree` file system has the
 * `/var/lib/containers` is the graph storage location for storing container
  images.
 
-In {product-title}, the Machine Config Operator handles operating
-system upgrades. Instead of upgrading individual packages, as is done with yum
-upgrades, rpm-ostree delivers upgrades as an atomic unit. The downloaded tree goes
-into effect on the next reboot. If something goes wrong with the upgrade, a
-single rollback and reboot returns the system to the previous state. {op-system}
-upgrades in {product-title} are performed during cluster updates.
+In {product-title}, the Machine Config Operator handles operating system upgrades.
+Instead of upgrading individual packages, as is done with `yum`
+upgrades, `rpm-ostree` delivers upgrades of the OS as an atomic unit. The
+new OS deployment is staged during upgrades and goes into effect on the next reboot.
+If something goes wrong with the upgrade, a single rollback and reboot returns the
+system to the previous state. {op-system} upgrades in {product-title} are performed
+during cluster updates.
 
 [id="rhcos-configuring_{context}"]
 == Configuring {op-system} in {product-title}


### PR DESCRIPTION
We don't want users going to projectatomic.io, so just link directly
to the `rpm-ostree` GitHub page instead.

Add link to MCO docs about how OS upgrades are handled.