### PR TITLE
Note that elasticsearch CPU request should be set appropriately for heavy log loads

### DIFF
--- a/modules/cluster-logging-elasticsearch-limits.adoc
+++ b/modules/cluster-logging-elasticsearch-limits.adoc
@@ -37,8 +37,27 @@ spec:
             cpu: "4000m"
             memory: "4Gi"
           requests:
-            cpu: "100m"
+            cpu: "4000m"
             memory: "1Gi"
 ----
 <1> Specify the CPU and memory limits as needed. If you leave these values blank,
 the Elasticsearch Operator sets default values that should be sufficient for most deployments.
++
+If you adjust the amount of Elasticsearch CPU and memory, you must change both the request value and the limit value. 
++
+For example:
++
+[source,yaml]
+----
+      resources:
+        limits:
+          cpu: "8"
+          memory: "32Gi"
+        requests:
+          cpu: "8"
+          memory: "32Gi"
+----
++
+Kubernetes generally adheres the node CPU configuration and DOES not allow Elasticsearch to use the specified limits. 
+Setting the same value for the `requests` and `limits` ensures that Elasticseach can use the CPU and memory you want, assuming the node has the CPU and memory available. 
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1759318

Describe the issue: 
It should be noted in the CPU/memory limit section that ElasticSearch uses the number of availalbe processors to determine thread pool size at initialization, so you will need to set the CPU request to something that makes sense if you require more logging performance.
This means setting the elasticsearch pod CPU request low but the limit high will not give expected results.
Ex. set CPU request to 1 but limit to 32, the cpu usage on those pods will never get that high because Elasticsearch only created threads for 1 CPU and performance will be essentially the same as 1 cpu request and limit.

Suggestions for improvement:
Make a note of this for anyone that requires more performant logging.