### PR TITLE
Modified Tech Preview Table

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1412,7 +1412,7 @@ indicate that the feature is removed from the release or deprecated.
 |GA
 |GA
 
-|Cluster Autoscaling (AWS Only)
+|Cluster Autoscaling
 |GA
 |GA
 |GA


### PR DESCRIPTION
Changed `Cluster Autoscaling` in the Tech preview table - removed the `(AWS Only0` clause. 