### PR TITLE
Correct typo in article preceding "RHOSP"

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -14,7 +14,7 @@ In {product-title} version {product-version}, you can install a customized clust
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
 processes.
 
-* Have access to an {rh-openstack} administrator's account
+* Have access to a {rh-openstack} administrator's account
 
 include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]


### PR DESCRIPTION
Context: https://github.com/openshift/openshift-docs/pull/17388

"RHOSP" is not an initialism. "an" -> "a" as per IBM Style and OSP naming guidelines.

4.2+.