### PR TITLE
Remove aws-only for autoscaling GA OCP 4.2 release notes

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1397,7 +1397,7 @@ indicate that the feature is removed from the release or deprecated.
 |GA
 |GA
 
-|Cluster Autoscaling (AWS Only)
+|Cluster Autoscaling
 |GA
 |GA
 |GA


### PR DESCRIPTION
Remove aws-only for autoscaling GA OCP 4.2 release notes