### PR TITLE
[enterprise-3.10] masterClientConnectionOverrides set in node-config.yaml is ignored

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1051,6 +1051,8 @@ dnsConfig:
 
 |`*MasterClientConnectionOverrides*`
 |Provides overrides to the client connection used to connect to the master.
+This parameter is not supported. To set QPS and burst values, see 
+xref:#master-node-configuration-node-qps-burst[Setting Node QPS and Burst Values].
 
 |`*MaxRequestsInFlight*`
 |The number of concurrent requests allowed to the server. If zero, no limit.
@@ -1513,6 +1515,29 @@ application is skipped.
 ====
 Do not edit the *_/etc/origin/node/volume-config.yaml_* file directly. The file is created from the *_node-config-compute_* configuration map.
 Use the *_node-config-compute_* configuration map to create or edit the paramaters in the *_volume-config.yaml_* file.
+====
+
+[[master-node-configuration-node-qps-burst]]
+=== Setting Node Queries per Second (QPS) Limits and Burst Values
+
+The rate at which Kubelet talks to API server depends on Queries per Second (QPS) and burst values.
+The default values are good enough if there are limited pods running on each node.
+Provided there are enough CPU and memory resources on the node, the QPS and burst
+values can be tweaked in the  *_/etc/origin/node/node-config.yaml_* file:
+
+----
+kubeletArguments:
+  kube-api-qps:
+  - "20"
+  kube-api-burst:
+  - "40"
+----
+
+Then xref:master-node-config-restart-services[restart {product-title} node services].
+
+[NOTE]
+====
+The QPS and burst values above are defaults for {product-title}.
 ====
 
 [[master-node-configuration-parallel-image-pulls-with-docker]]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/17320

https://bugzilla.redhat.com/show_bug.cgi?id=1691046

Text on QPS and burst taken from 3.11: 
https://docs.openshift.com/container-platform/3.11/scaling_performance/host_practices.html#scaling-performance-capacity-host-practices-node