### PR TITLE
Add qps burst

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -617,6 +617,10 @@ kubeletArguments:
     - "90"
   image-gc-low-threshold: <4>
     - "80"
+  kube-api-qps: <5>
+    - "20"
+  kube-api-burst: <6>
+    - "40"
 ----
 +
 <1> xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[Maximum number of pods that can run on this kubelet].
@@ -626,6 +630,8 @@ resolution configuration.
 Default: 90%
 <4> The percent of disk usage before which image garbage collection is never run.
 Lowest disk usage to garbage collect to. Default: 80%
+<5> The Queries per Second (QPS) to use while talking with the Kubernetes API server. 
+<6> The burst to use while talking with the Kubernetes API server. 
 +
 To view all available kubelet options:
 +


### PR DESCRIPTION
@gpei asked for a change in https://github.com/openshift/openshift-docs/pull/17320

_I noticed we have a specialized section https://docs.openshift.com/container-platform/3.11/admin_guide/manage_nodes.html#configuring-node-resources about how to add parameter to "kubeletArguments", can we add the expected kube-api-qps and kube-api-burst by following the above doc?_