### PR TITLE
Fix ingress controller sharding example when using namespace labels

### DIFF
--- a/modules/nw-ingress-sharding-namespace-labels.adoc
+++ b/modules/nw-ingress-sharding-namespace-labels.adoc
@@ -34,7 +34,7 @@ items:
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/worker: ""
-    routeSelector:
+    namespaceSelector:
       matchLabels:
         type: sharded
   status: {}


### PR DESCRIPTION
The ingress controller sharding example is using the wrong selector.
Instead of using namespaceSelector for selecting based on namespace labels, the example is using routeSelector.