### PR TITLE
[enterprise-3.10] document AlwaysPullImages admission plugin as protection against imagePullPolicy: Never

### DIFF
--- a/admin_guide/image_policy.adoc
+++ b/admin_guide/image_policy.adoc
@@ -233,6 +233,36 @@ endif::[]
 value in your `master-config.yaml` file.
 ====
 
+[[image-policy-always-pull-images]]
+== Using an Admission Controller to Always Pull Images
+
+After an image is pulled to a node, any Pod on that node from any user can use the image without an authorization check against the image. 
+To ensure that Pods do not use images for which they do not have credentials, use the *AlwaysPullImages* admission controller. 
+
+This xref:../architecture/additional_concepts/admission_controllers.adoc#architecture-additional-concepts-admission-controllers[admission controller] modifies every new Pod to force the image pull policy to `Always`, ensuring that private images can only be used by those who have the credentials to pull them, even if the Pod specification uses an xref:../dev_guide/managing_images.adoc#image-pull-policy[image pull policy] of `Never`. 
+
+To enable the *AlwaysPullImages* admission controller:
+
+. Add the following to the `master-config.yaml`:
++
+----
+admissionConfig:
+  pluginConfig:
+    AlwaysPullImages: <1> 
+      configuration:
+        kind: DefaultAdmissionConfig
+        apiVersion: v1
+        disable: false <2>
+----
+<1> Admission plug-in name.
+<2> Specify `false` to indicate that the plug-in should be enabled.
+
+. Restart master services running in control plane static Pods using the `master-restart` command:
++
+----
+$ master-restart api
+$ master-restart controllers
+----
 
 [[image-policy-testing-image-policy-admission-plug-in]]
 == Testing the ImagePolicy Admission Plug-in

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -490,6 +490,12 @@ parameter is not specified, {product-title} sets it based on the image's tag:
 . Otherwise, {product-title} defaults `*imagePullPolicy*` to `*IfNotPresent*`.
 endif::[]
 
+[NOTE]
+====
+When using the `*Never*` Image Pull Policy, you can ensure that private images can only be used by pods with credentials to pull those images
+using the `AlwaysPullImages` admission controller. If this admission controller is not enabled, any pod from any user on a node can use the image without any authorization check against the image.  
+====
+
 [[accessing-the-internal-registry]]
 == Accessing the Internal Registry
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/17289/