### PR TITLE
BZ1761524 remove callout 2

### DIFF
--- a/modules/dynamic-provisioning-aws-definition.adoc
+++ b/modules/dynamic-provisioning-aws-definition.adoc
@@ -15,34 +15,29 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: io1 <1>
-  zone: us-east-1d <2>
-  iopsPerGB: "10" <3>
-  encrypted: "true" <4>
-  kmsKeyId: keyvalue <5>
-  fsType: ext4 <6>
+  iopsPerGB: "10" <2>
+  encrypted: "true" <3>
+  kmsKeyId: keyvalue <4>
+  fsType: ext4 <5>
 ----
 <1> (required) Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`.
 See the
-link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] 
+link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for valid Amazon Resource Name (ARN) values.
-<2> (optional) The AWS zone. If no zone is specified, volumes are generally 
-round-robined across all active zones where the {product-title} cluster 
-has a node. The `zone` and `zones` parameters must not be used at the 
-same time.
-<3> (optional) Only for *io1* volumes. I/O operations per second per GiB. 
-The AWS volume plug-in multiplies this with the size of the requested 
-volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which 
-is the maximum supported by AWS. See the 
-link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] 
+<2> (optional) Only for *io1* volumes. I/O operations per second per GiB.
+The AWS volume plug-in multiplies this with the size of the requested
+volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which
+is the maximum supported by AWS. See the
+link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for further details.
-<4> (optional) Denotes whether to encrypt the EBS volume. Valid values 
+<3> (optional) Denotes whether to encrypt the EBS volume. Valid values
 are `true` or `false`.
-<5> (optional) The full ARN of the key to use when encrypting the volume. 
-If none is supplied, but `encypted` is set to `true`, then AWS generates a 
+<4> (optional) The full ARN of the key to use when encrypting the volume.
+If none is supplied, but `encypted` is set to `true`, then AWS generates a
 key. See the
-link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation] 
+link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for a valid ARN value.
-<6> (optional) File system that is created on dynamically provisioned 
-volumes. This value is copied to the `fsType` field of dynamically 
-provisioned persistent volumes and the file system is created when the 
+<5> (optional) File system that is created on dynamically provisioned
+volumes. This value is copied to the `fsType` field of dynamically
+provisioned persistent volumes and the file system is created when the
 volume is mounted for the first time. The default value is `ext4`.


### PR DESCRIPTION
[BZ 1761524](https://bugzilla.redhat.com/show_bug.cgi?id=1761524) - removed callout 2 for AWS zone, since zone is deprecated in 4.x.

@liangxia PTAL