### PR TITLE
Adding link admission controller

### DIFF
--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -493,7 +493,7 @@ endif::[]
 [NOTE]
 ====
 When using the `*Never*` Image Pull Policy, you can ensure that private images can only be used by pods with credentials to pull those images
-using the `AlwaysPullImages` admission controller. If this admission controller is not enabled, any pod from any user on a node can use the image without any authorization check against the image.  
+using the `AlwaysPullImages` xref:../architecture/additional_concepts/admission_controllers.adoc#architecture-additional-concepts-admission-controllers[admission controller]. If this admission controller is not enabled, any pod from any user on a node can use the image without any authorization check against the image.  
 ====
 
 [[accessing-the-internal-registry]]


### PR DESCRIPTION
Adding  a link that was causing https://github.com/openshift/openshift-docs/pull/17601 to fail Travis.