### PR TITLE
Cluster name length limit and OL fix - BZ 1763879

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -116,15 +116,20 @@ specified by the service account that you configured.
 to the public DNS zone that you created for your cluster.
 endif::gcp[]
 ifdef::osp[]
-.. Select *openstack* as the platform to target.
-.. Specify the {rh-openstack-first} external network name to use for installing the cluster.
-.. Specify the Floating IP address to use for external access to the OpenShift API.
-.. Specify a {rh-openstack} flavor with at least 16 GB RAM to use for control plane
+... Select *openstack* as the platform to target.
+... Specify the {rh-openstack-first} external network name to use for installing the cluster.
+... Specify the Floating IP address to use for external access to the OpenShift API.
+... Specify a {rh-openstack} flavor with at least 16 GB RAM to use for control plane
 and compute nodes.
-.. Select the base domain to deploy the cluster to. All DNS records will be
+... Select the base domain to deploy the cluster to. All DNS records will be
 sub-domains of this base and will also include the cluster name.
 endif::osp[]
+ifndef::osp[]
 ... Enter a descriptive name for your cluster.
+endif::osp[]
+ifdef::osp[]
+... Enter a name for your cluster. The name must be 14 or fewer characters long.
+endif::osp[]
 ifdef::azure[]
 +
 [IMPORTANT]


### PR DESCRIPTION
This PR resolves [this DDF-generated ticket](https://bugzilla.redhat.com/show_bug.cgi?id=1763879).

It specifies a cluster name restriction at an appropriate point in the ShiftStack IPI flow, and also fixes a problem with OL nesting.

4.2+.

Change in action: http://file.rdu.redhat.com/mbridges/102519/cluster-name-len-1763879/installing/installing_openstack/installing-openstack-installer-custom.html#installation-initializing_installing-openstack-installer-custom