### PR TITLE
BZ 1622018 - storageclass default note added to master

### DIFF
--- a/modules/storage-persistent-storage-pvc.adoc
+++ b/modules/storage-persistent-storage-pvc.adoc
@@ -56,6 +56,11 @@ When a default storage class is configured, the PVC must explicitly ask for
 `StorageClass` or `storageClassName` annotations set to `""` to be bound
 to a PV without a storage class.
 
+[NOTE]
+====
+If more than one StorageClass is marked as default, a PVC can only be created if the `storageClassName` is explicitly specified. Therefore, only one StorageClass should be set as the default.
+====
+
 [id="pvc-access-modes_{context}"]
 == Access modes
 


### PR DESCRIPTION
[BZ 1622018](https://bugzilla.redhat.com/show_bug.cgi?id=1622018)
This PR is related to [PR 17641](https://github.com/openshift/openshift-docs/pull/17641), which applies the note to 3.10, 3.11. 
This PR is for master, CP to 4.1, 4.2, 4.3.
@liangxia PTAL