### PR TITLE
Add uninstall OSP assembly - BZ 1764297

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -138,6 +138,8 @@ Topics:
   #   File: installing-openstack-installer-kuryr
   # - Name: Load balancing deployments on OpenStack
   #   File: installing-openstack-load-balancing
+  - Name: Uninstalling a cluster on OpenStack
+    File: uninstalling-cluster-openstack
 - Name: Installing on vSphere
   Dir: installing_vsphere
   Topics:

--- a/installing/installing_openstack/uninstalling-cluster-openstack.adoc
+++ b/installing/installing_openstack/uninstalling-cluster-openstack.adoc
@@ -1,0 +1,10 @@
+[id="uninstalling-cluster-osp"]
+= Uninstalling a cluster on OpenStack
+include::modules/common-attributes.adoc[]
+:context: uninstall-cluster-openstack
+
+toc::[]
+
+You can remove a cluster that you deployed to {rh-openstack-first}.
+
+include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_aws/uninstalling-cluster-aws.adoc
 // * installing/installing_azure/uninstalling-cluster-azure.adoc
 // * installing/installing_gcp/uninstalling-cluster-gcp.adoc
+// * installing/installing_osp/uninstalling-cluster-openstack.adoc
 
 [id="installation-uninstall-clouds_{context}"]
 = Removing a cluster that uses installer-provisioned infrastructure


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1764297

4.2+.

PR adds instructions for uninstalling clusters created via ShiftStack IPI flow to docs.

@iamemilio Any objections to using the generic instructions from modules/installation-uninstall-clouds.adoc for this?