### PR TITLE
modules/installation-bootstrap-gather: Gather SSHs for you

### DIFF
--- a/modules/installation-bootstrap-gather.adoc
+++ b/modules/installation-bootstrap-gather.adoc
@@ -63,40 +63,9 @@ list that contains all the control plane machines in your cluster.
 The command output resembles the following example:
 +
 ----
-INFO Use the following commands to gather logs from the cluster
-INFO ssh -A core@<bootstrap_address> '/usr/local/bin/installer-gather.sh <master_address> <master_address> <master_address>'
-INFO scp core@<bootstrap_address>:~/log-bundle.tar.gz .
+INFO Pulling debug logs from the bootstrap machine
+INFO Bootstrap gather logs captured here "<directory>/log-bundle-<timestamp>.tar.gz"
 ----
-+
-You use both commands that are displayed to gather and download the logs.
-
-. Gather logs from the bootstrap and master machines:
-+
-----
-$ ssh -A core@<bootstrap_address> '/usr/local/bin/installer-gather.sh <master_address> <master_address> <master_address>'
-----
-+
-You SSH into the bootstrap machine and run the gather tool, which is designed to
-collect as much data as possible from the bootstrap and control plane machines
-in your cluster and compress all of the gathered files.
-+
-[NOTE]
-====
-It is normal to see errors in the command output. If the command output
-displays the instructions to download the compressed log files,
-`log-bundle.tar.gz`, then the command succeeded.
-====
-
-. Download the compressed file that contains the logs:
-+
-----
-$ scp core@<bootstrap_address>:~/log-bundle.tar.gz . <1>
-----
-<1> `<bootstrap_address>` is the fully-qualified domain name or IP address of the bootstrap
-machine.
-+
-The command to download the log files is included at the end of the gather
-command output.
 +
 If you open a Red Hat support case about your installation failure, include
 the compressed logs in the case.


### PR DESCRIPTION
Since openshift/installer@cad7f02a8b (openshift/installer#1822).  This functionality is new in 4.2.z; you still need to SSH in 4.1.z.

Spun off from #17196.