### PR TITLE
modules/installation-mirror-repository: Less-specific imageContentSources example

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -71,10 +71,7 @@ To use the new mirrored repository to install, add the following section to the 
 imageContentSources:
 - mirrors:
   - <local_registry_host_name>:<local_registry_host_port>/<repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-release
-- mirrors:
-  - <local_registry_host_name>:<local_registry_host_port>/<repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  source: <upstream_repository>
 ...
 ----
 


### PR DESCRIPTION
We want folks to copy/paste from the `mirror` command's output, not from these docs.  Make the doc copy less specific to encourage that; it just needs to be big enough so users know which part of the `mirror` output they are looking for.