### PR TITLE
BZ-1766167 Cleanup htpasswd documentation to reflect the new requirem…

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -150,7 +150,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defining htpasswd users
 #openshift_master_htpasswd_users={'user1': '<pre-hashed password>', 'user2': '<pre-hashed password>'}
 # or
-#openshift_master_htpasswd_file=<path to local pre-generated htpasswd file>
+#openshift_master_htpasswd_file=/etc/origin/master/htpasswd
 
 # Allow all auth
 #openshift_master_identity_providers=[{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
@@ -374,6 +374,12 @@ other hash functions are not currently supported.
 The flat file is reread if its modification time changes, without requiring a
 server restart.
 
+[IMPORTANT]
+====
+Because the {product-title} master API now runs as a static pod, you must create the 
+`HTPasswdPasswordIdentityProvider` htpasswd file in *_/etc/origin/master/_* so it can be read by the container.
+====
+
 To use the htpasswd command:
 
 // tag::htpasswd[]
@@ -381,7 +387,7 @@ To use the htpasswd command:
 * To create a flat file with a user name and hashed password, run:
 +
 ----
-$ htpasswd -c </path/to/users.htpasswd> <user_name>
+$ htpasswd -c /etc/origin/master/htpasswd <user_name>
 ----
 +
 Then, enter and confirm a clear-text password for the user. The command generates a hashed version of the password.
@@ -389,7 +395,7 @@ Then, enter and confirm a clear-text password for the user. The command generate
 For example:
 +
 ----
-htpasswd -c users.htpasswd user1
+htpasswd -c /etc/origin/master/htpasswd user1
 New password:
 Re-type new password:
 Adding password for user user1
@@ -415,13 +421,13 @@ Adding password for user user1
 * To add or update a login to the file, run:
 +
 ----
-$ htpasswd </path/to/users.htpasswd> <user_name>
+$ htpasswd /etc/origin/master/htpasswd <user_name>
 ----
 
 * To remove a login from the file, run:
 +
 ----
-$ htpasswd -D </path/to/users.htpasswd> <user_name>
+$ htpasswd -D /etc/origin/master/htpasswd <user_name>
 ----
 
 
@@ -439,7 +445,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: HTPasswdPasswordIdentityProvider
-      file: /path/to/users.htpasswd <5>
+      file: /etc/origin/master/htpasswd <5>
 ----
 <1> This provider name is prefixed to provider user names to form an identity
 name.

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -124,7 +124,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defining htpasswd users
 #openshift_master_htpasswd_users={'<name>': '<hashed-password>', '<name>': '<hashed-password>'}
 # or
-#openshift_master_htpasswd_file=<path/to/local/pre-generated/htpasswdfile>
+#openshift_master_htpasswd_file=/etc/origin/master/htpasswd
 ----
 +
 --
@@ -147,7 +147,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defining htpasswd users
 openshift_master_htpasswd_users={'jsmith': '$apr1$wIwXkFLI$bAygtKGmPOqaJftB', 'bloblaw': '7IRJ$2ODmeLoxf4I6sUEKfiA$2aDJqLJe'}
 # or
-#openshift_master_htpasswd_file=<path/to/local/pre-generated/htpasswdfile>
+#openshift_master_htpasswd_file=/etc/origin/master/htpasswd
 ----
 
 . Re-run the ansible playbook for these modifications to take effect:
@@ -217,7 +217,7 @@ To create a flat file with a user name and hashed password:
 . Execute the following command:
 +
 ----
-$ htpasswd -c </path/to/users.htpasswd> <user_name>
+$ htpasswd -c /etc/origin/master/htpasswd <user_name>
 ----
 +
 [NOTE]
@@ -234,7 +234,7 @@ $ htpasswd -c -b <user_name> <password>
 For example:
 +
 ----
-htpasswd -c users.htpasswd user1
+htpasswd -c /etc/origin/master/htpasswd user1
 New password:
 Re-type new password:
 Adding password for user user1
@@ -271,7 +271,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: HTPasswdPasswordIdentityProvider
-      file: /path/to/users.htpasswd
+      file: /etc/origin/master/htpasswd
 ----
 . Save your changes and close the file.
 . Restart the master for the changes to take effect:

--- a/install_config/registry/accessing_registry.adoc
+++ b/install_config/registry/accessing_registry.adoc
@@ -143,7 +143,7 @@ For example, if you are using `HTPASSWD` authentication, you can create one
 using the following command:
 +
 ----
-# htpasswd /etc/origin/openshift-htpasswd <user_name>
+# htpasswd /etc/origin/master/htpasswd <user_name>
 ----
 
 - For pulling images, for example when using the `docker pull` command,

--- a/modules/cnv_creating_cluster_admin_user.adoc
+++ b/modules/cnv_creating_cluster_admin_user.adoc
@@ -20,7 +20,7 @@ $ oc login -u system:admin
 . Create a new user as per the xref:../install_config/configuring_authentication.adoc#identity-providers-configuring[configured identity provider]. The following example uses the command for the xref:../install_config/configuring_authentication.adoc#HTPasswdPasswordIdentityProvider[`HTPasswd`] identity provider to create a *cnv-admin* user.
 +
 ----
-$ htpasswd -c </path/to/users.htpasswd> cnv-admin
+$ htpasswd -c /etc/origin/master/htpasswd cnv-admin
 ----
 
 . Add the *cluster-admin* cluster role to the new user:


### PR DESCRIPTION
…ent of placing the htpasswd file in /etc/origin/master/ for static master pods