### PR TITLE
Add director and dnsmasq param in network prereqs

### DIFF
--- a/modules/installation-osp-verifying-external-network.adoc
+++ b/modules/installation-osp-verifying-external-network.adoc
@@ -18,7 +18,23 @@ endif::[]
 The {product-title} installer requires external network access. You must provide an external network value to it, or deployment fails. Before you run the installer, verify that a network with the External router type exists in {rh-openstack-first}.
 
 .Prerequisites
-* https://docs.openstack.org/neutron/rocky/admin/config-dns-res.html#case-2-dhcp-agents-forward-dns-queries-from-instances[Configure OpenStack's networking service to have DHCP agents forward instances' DNS queries]
+
+* On {rh-openstack}, the `NeutronDhcpAgentDnsmasqDnsServers` parameter must be configured to allow DHCP agents to forward instances' DNS queries. One way to set this parameter is to:
+.. link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/advanced_overcloud_customization/sect-understanding_heat_templates#sect-Environment_Files[Create a new environment file] in the template directory.
+.. Provide link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html-single/overcloud_parameters/index#networking-neutron-parameters[parameter values] in the file. For example:
++
+.Sample `neutron-dhcp-agent-dnsmasq-dns-servers.yaml` file
+
+[source,yaml]
+----
+parameter_defaults:
+  NeutronDhcpAgentDnsmasqDnsServers: ['<DNS_server_address_1>','<DNS_server_address_2']
+----
+.. link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/advanced_overcloud_customization/sect-understanding_heat_templates#sect-Including_Environment_Files_in_Overcloud_Creation[Include the environment file] in your Overcloud deploy command. For example:
++
+----
+$ openstack overcloud deploy --templates -e neutron-dhcp-agent-dnsmasq-dns-servers.yaml ...
+----
 
 .Procedure
 


### PR DESCRIPTION
Context: https://bugzilla.redhat.com/show_bug.cgi?id=1765108

This change updates a prerequisite in the external network module. Previous commit described an unsupported method. 08c2691 doesn't. 

4.2+. 