### PR TITLE
updates based on PR 17673 - applies to enterprise-3.10 only

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -150,7 +150,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defining htpasswd users
 #openshift_master_htpasswd_users={'user1': '<pre-hashed password>', 'user2': '<pre-hashed password>'}
 # or
-#openshift_master_htpasswd_file=<path to local pre-generated htpasswd file>
+#openshift_master_htpasswd_file=/etc/origin/master/htpasswd
 
 # Allow all auth
 #openshift_master_identity_providers=[{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
@@ -178,11 +178,11 @@ file. The
 identity provider name is the value of the `openshift_master_identity_providers`
 parameter, `ldap`, `openid`, or `request_header`. If you do not
 specify the CA text or the path to the local CA file, you must place the CA
-certificate in this location. If you specify multiple identity providers, you 
+certificate in this location. If you specify multiple identity providers, you
 must manually place the CA certificate for each provider in this location. You cannot change this location.
 
 You can specify multiple identity providers. If you do, you must place the
-CA certificate for each identity provider in the *_/etc/origin/master/_* directory. 
+CA certificate for each identity provider in the *_/etc/origin/master/_* directory.
 For example, you include the following providers in your
 `openshift_master_identity_providers` value:
 
@@ -374,6 +374,12 @@ other hash functions are not currently supported.
 The flat file is reread if its modification time changes, without requiring a
 server restart.
 
+[IMPORTANT]
+====
+Because the {product-title} master API now runs as a static pod, you must create the
+`HTPasswdPasswordIdentityProvider` htpasswd file in *_/etc/origin/master/_* so it can be read by the container.
+====
+
 To use the htpasswd command:
 
 // tag::htpasswd[]
@@ -381,7 +387,7 @@ To use the htpasswd command:
 * To create a flat file with a user name and hashed password, run:
 +
 ----
-$ htpasswd -c </path/to/users.htpasswd> <user_name>
+$ htpasswd -c /etc/origin/master/htpasswd <user_name>
 ----
 +
 Then, enter and confirm a clear-text password for the user. The command generates a hashed version of the password.
@@ -389,7 +395,7 @@ Then, enter and confirm a clear-text password for the user. The command generate
 For example:
 +
 ----
-htpasswd -c users.htpasswd user1
+htpasswd -c /etc/origin/master/htpasswd user1
 New password:
 Re-type new password:
 Adding password for user user1
@@ -415,13 +421,13 @@ Adding password for user user1
 * To add or update a login to the file, run:
 +
 ----
-$ htpasswd </path/to/users.htpasswd> <user_name>
+$ htpasswd /etc/origin/master/htpasswd <user_name>
 ----
 
 * To remove a login from the file, run:
 +
 ----
-$ htpasswd -D </path/to/users.htpasswd> <user_name>
+$ htpasswd -D /etc/origin/master/htpasswd <user_name>
 ----
 
 
@@ -439,7 +445,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: HTPasswdPasswordIdentityProvider
-      file: /path/to/users.htpasswd <5>
+      file: /etc/origin/master/htpasswd <5>
 ----
 <1> This provider name is prefixed to provider user names to form an identity
 name.
@@ -1196,7 +1202,7 @@ required settings and values:
 +
 [IMPORTANT]
 ====
-Carefully review the template and customize its contents to fit your 
+Carefully review the template and customize its contents to fit your
 environment.
 ====
 +
@@ -1257,7 +1263,7 @@ LoadModule auth_gssapi_module modules/mod_auth_gssapi.so
       # to password based authntication when they do not have a client
       # configured to perform kerberos authentication
       GssapiBasicAuth On
-      
+
       # For ldap:
       # AuthBasicProvider ldap
       # AuthLDAPURL "ldap://ldap.example.com:389/ou=People,dc=my-domain,dc=com?uid?sub?(objectClass=*)"
@@ -1370,7 +1376,7 @@ negotiate challenge, or both challenges:
 # oc login
 ----
 +
-Enter your Kerberos user name and password at the prompt. 
+Enter your Kerberos user name and password at the prompt.
 .. Log out of the `oc` command line:
 +
 ----
@@ -1382,7 +1388,7 @@ Enter your Kerberos user name and password at the prompt.
 # kinit
 ----
 +
-Enter your Kerberos user name and password at the prompt. 
+Enter your Kerberos user name and password at the prompt.
 .. Confirm that you can log in to the `oc` command line:
 +
 ----

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -124,7 +124,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defining htpasswd users
 #openshift_master_htpasswd_users={'<name>': '<hashed-password>', '<name>': '<hashed-password>'}
 # or
-#openshift_master_htpasswd_file=<path/to/local/pre-generated/htpasswdfile>
+#openshift_master_htpasswd_file=/etc/origin/master/htpasswd
 ----
 +
 --
@@ -147,7 +147,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defining htpasswd users
 openshift_master_htpasswd_users={'jsmith': '$apr1$wIwXkFLI$bAygtKGmPOqaJftB', 'bloblaw': '7IRJ$2ODmeLoxf4I6sUEKfiA$2aDJqLJe'}
 # or
-#openshift_master_htpasswd_file=<path/to/local/pre-generated/htpasswdfile>
+#openshift_master_htpasswd_file=/etc/origin/master/htpasswd
 ----
 
 . Re-run the ansible playbook for these modifications to take effect:
@@ -217,7 +217,7 @@ To create a flat file with a user name and hashed password:
 . Execute the following command:
 +
 ----
-$ htpasswd -c </path/to/users.htpasswd> <user_name>
+$ htpasswd -c /etc/origin/master/htpasswd <user_name>
 ----
 +
 [NOTE]
@@ -234,7 +234,7 @@ $ htpasswd -c -b <user_name> <password>
 For example:
 +
 ----
-htpasswd -c users.htpasswd user1
+htpasswd -c /etc/origin/master/htpasswd user1
 New password:
 Re-type new password:
 Adding password for user user1
@@ -271,7 +271,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: HTPasswdPasswordIdentityProvider
-      file: /path/to/users.htpasswd
+      file: /etc/origin/master/htpasswd
 ----
 . Save your changes and close the file.
 . Restart the master for the changes to take effect:
@@ -1051,7 +1051,7 @@ dnsConfig:
 
 |`*MasterClientConnectionOverrides*`
 |Provides overrides to the client connection used to connect to the master.
-This parameter is not supported. To set QPS and burst values, see 
+This parameter is not supported. To set QPS and burst values, see
 xref:#master-node-configuration-node-qps-burst[Setting Node QPS and Burst Values].
 
 |`*MaxRequestsInFlight*`
@@ -1713,7 +1713,7 @@ $ openshift start node --config=/openshift.local.config/node-<node_hostname>/nod
 
 [NOTE]
 ====
-The number of lines displayed in the web console is hard-coded at 5000 and cannot be changed. 
+The number of lines displayed in the web console is hard-coded at 5000 and cannot be changed.
 To see the entire log, use the CLI.
 ====
 

--- a/install_config/registry/accessing_registry.adoc
+++ b/install_config/registry/accessing_registry.adoc
@@ -143,7 +143,7 @@ For example, if you are using `HTPASSWD` authentication, you can create one
 using the following command:
 +
 ----
-# htpasswd /etc/origin/openshift-htpasswd <user_name>
+# htpasswd /etc/origin/master/htpasswd <user_name>
 ----
 
 - For pulling images, for example when using the `docker pull` command,


### PR DESCRIPTION
Original [BZ 1766167](https://bugzilla.redhat.com/show_bug.cgi?id=1766167)
Relates to [PR 17673](https://github.com/openshift/openshift-docs/pull/17673). In that PR, the merge was successful for 3.11 but failed for master-3 and enterprise-3.10 branches. This PR is to merge to **`enterprise-3.10 only`**. 

[PR 17692](https://github.com/openshift/openshift-docs/pull/17692) makes same fix for master-3 branch only.

Note: [PR 17673](https://github.com/openshift/openshift-docs/pull/17673) references a change in file `modules/cnv_creating_cluster_admin_user.adoc` but that file does not exist in master-3 or enterprise-3.10 branches. (It does appear in 3.11.) Will check with CNV team to investigate how/when this file was added to 3.11. See [this file](https://github.com/mrobson/openshift-docs/commits/b1e0ab49384eda920c05e3c4b691e774bbafe1c5/modules/cnv_creating_cluster_admin_user.adoc) for history.