### PR TITLE
Updating Kuryr documentation to use OCP images

### DIFF
--- a/install_config/topics/ocp_osp_admin_tasks.adoc
+++ b/install_config/topics/ocp_osp_admin_tasks.adoc
@@ -42,14 +42,21 @@ $ openstack quota set --secgroups 30 --secgroup-rules 200 --ports 200 <project>
 [[osp_accounts_kuryr]]
 ==== Extra steps for Kuryr SDN
 
-If Kuryr SDN is enabled, and particularly if namespace isolation is used,
-increase the next quotas need to be raised: at least 100 security groups,
-500 security group rules, and 500 ports.
+If Kuryr SDN is enabled, especially if you are using namespace isolation,
+increase your project's quotas to:
+* 300 security groups (one for each namespace plus one for each load balancer)
+* 150 networks (one for each namespace)
+* 150 subnets (one for each namespace)
+* 500 security group rules
+* 500 ports (one port per pod and additional ports for pools to speed up pod
+  creation)
+
+If namespace isolation is enabled, each namespace is given a new network and
+subnet. Additionally, a security group is created to enable traffic between
+pods in the namespace.
+
 ----
-$ openstack quota set --secgroups 100 --secgroup-rules 500 --ports 500 <project>
-----
-----
-$ openstack quota set --secgroups 100 --secgroup-rules 500 --ports 500 <project>
+$ openstack quota set --networks 150 --subnets 150 --secgroups 300 --secgroup-rules 500 --ports 500 <project>
 <1>
 ----
 <1> For `<project>`, specify the name of the project to modify

--- a/install_config/topics/ocp_osp_enabling_octavia.adoc
+++ b/install_config/topics/ocp_osp_enabling_octavia.adoc
@@ -51,7 +51,7 @@ Hat OpenStack Platform release installed.
 ====
 
 The following step pulls the container images from registry.access.redhat.com
-to the undercloud node. This may take soem time depending on the speed of the
+to the undercloud node. This may take some time depending on the speed of the
 network and undercloud disk.
 
 ----

--- a/install_config/topics/ocp_osp_provisioning.adoc
+++ b/install_config/topics/ocp_osp_provisioning.adoc
@@ -158,13 +158,9 @@ openshift_kuryr_precreate_subports: 5
 
 kuryr_openstack_public_net_id: *<public_ID>*
 
-# To enable namespace isolation, uncomment
-#openshift_kuryr_subnet_driver: namespace
-#openshift_kuryr_sg_driver: namespace
-
-# Select kuryr image (always latest available)
-openshift_openstack_kuryr_controller_image: registry.access.redhat.com/rhosp14/openstack-kuryr-controller:latest
-openshift_openstack_kuryr_cni_image: registry.access.redhat.com/rhosp14/openstack-kuryr-cni:latest
+# To disable namespace isolation, comment the next 2 lines
+openshift_kuryr_subnet_driver: namespace
+openshift_kuryr_sg_driver: namespace
 
 openshift_master_open_ports:
 - service: dns tcp
@@ -204,20 +200,8 @@ openshift_openstack_user: openshift
 
 [NOTE]
 ====
-To enable namespace isolation, set 'openshift_kuryr_subnet_driver' to
-'namespace' so that a new Neutron subnet is created by Kuryr for each
-namespace. Also set 'openshift_kuryr_sg_driver' to 'namespace' to ensure that
-the proper security groups are created and used to enforce isolation between
-the different namespaces.
-====
-
-[NOTE]
-====
-Use the latest supported Kuryr images, regardless of the overcloud Red Hat
-OpenStack version. For instance, use Kuryr images from OSP 14, whether the
-overcloud is OSP 14 or OSP 13. Kuryr is just another workload on top of the
-overcloud, and it aligns better with new OpenShift features if you use the
-latest images.
+If namespace isolation is enabled, a new Neutron network and subnet are
+created by Kuryr-controller for each namespace.
 ====
 
 [NOTE]


### PR DESCRIPTION
This PR removes the information related to OSP Kuryr images
as the default ones are now consumed from OpenShift channels.
Besides that, this PR includes a couple of modifications to
clarify some of the steps needed to enable Kuryr SDN.