### PR TITLE
modules/*proxy*: httpsProxy supports https:// too

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -50,7 +50,7 @@ apiVersion: v1
 baseDomain: my.domain.com
 proxy:
   httpProxy: http://<username>:<pswd>@<ip>:<port> <1>
-  httpsProxy: http://<username>:<pswd>@<ip>:<port> <2>
+  httpsProxy: https://<username>:<pswd>@<ip>:<port> <2>
   noProxy: example.com <3>
 additionalTrustBundle: | <4>
     -----BEGIN CERTIFICATE-----
@@ -62,8 +62,7 @@ additionalTrustBundle: | <4>
 URL scheme must be `http`.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster. If
 this field is not specified, then `httpProxy` is used for both HTTP and HTTPS
-connections. The URL scheme must be `http`; `https` is currently not
-supported.
+connections.
 <3> A comma-separated list of destination domain names, domains, IP addresses, or
 other network CIDRs to exclude proxying. Preface a domain with `.` to include
 all subdomains of that domain. Use `*` to bypass proxy for all destinations.

--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -81,7 +81,7 @@ metadata:
   name: cluster
 spec:
   httpProxy: http://<username>:<pswd>@<ip>:<port> <1>
-  httpsProxy: http://<username>:<pswd>@<ip>:<port> <2>
+  httpsProxy: https://<username>:<pswd>@<ip>:<port> <2>
   noProxy: example.com <3>
   readinessEndpoints:
   - http://www.google.com <4>
@@ -93,8 +93,7 @@ spec:
 URL scheme must be `http`.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster. If
 this is not specified, then `httpProxy` is used for both HTTP and HTTPS
-connections. The URL scheme must be `http`; `https` is currently not
-supported.
+connections.
 <3> A comma-separated list of destination domain names, domains, IP addresses or
 other network CIDRs to exclude proxying. Preface a domain with `.` to include
 all subdomains of that domain. Use `*` to bypass proxy for all destinations.


### PR DESCRIPTION
Drop the wording from aa39bf33b4 (#16635), because the network operator [explicitly supports both][1] the `http` and `https` schemes since openshift/cluster-network-operator@42dbcf8955 (openshift/cluster-network-operator#245), which landed before release-4.2 split off from the network operator's master.  This should be backported to 4.2 as well.

CC @bergerhoffer, @danehans

[1]: https://github.com/openshift/cluster-network-operator/blob/42dbcf89559c543b656c3f3eb72e46a4e954b16d/pkg/controller/proxyconfig/validation.go#L37-L38