### PR TITLE
Bug 1757866: Fixed documentation on fetching image-registry metrics.

### DIFF
--- a/modules/registry-accessing-metrics.adoc
+++ b/modules/registry-accessing-metrics.adoc
@@ -25,19 +25,28 @@ or using the cluster role.
 . Run a metrics query, for example:
 +
 ----
-$ curl -s -u <user>:<secret> \ <1>
-    http://172.30.30.30:5000/extensions/v2/metrics | grep openshift | head -n 10
-
-# HELP openshift_build_info A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift was built.
-# TYPE openshift_build_info gauge
-openshift_build_info{gitCommit="67275e1",gitVersion="v3.6.0-alpha.1+67275e1-803",major="3",minor="6+"} 1
-# HELP openshift_registry_request_duration_seconds Request latency summary in microseconds for each operation
-# TYPE openshift_registry_request_duration_seconds summary
-openshift_registry_request_duration_seconds{name="test/origin-pod",operation="blobstore.create",quantile="0.5"} 0
-openshift_registry_request_duration_seconds{name="test/origin-pod",operation="blobstore.create",quantile="0.9"} 0
-openshift_registry_request_duration_seconds{name="test/origin-pod",operation="blobstore.create",quantile="0.99"} 0
-openshift_registry_request_duration_seconds_sum{name="test/origin-pod",operation="blobstore.create"} 0
-openshift_registry_request_duration_seconds_count{name="test/origin-pod",operation="blobstore.create"} 5
+$ curl --insecure -s -u <user>:<secret> \ <1>
+    https://image-registry.openshift-image-registry.svc:5000/extensions/v2/metrics | grep imageregistry | head -n 20
+# HELP imageregistry_build_info A metric with a constant '1' value labeled by major, minor, git commit & git version from which the image registry was built.
+# TYPE imageregistry_build_info gauge
+imageregistry_build_info{gitCommit="9f72191",gitVersion="v3.11.0+9f72191-135-dirty",major="3",minor="11+"} 1
+# HELP imageregistry_digest_cache_requests_total Total number of requests without scope to the digest cache.
+# TYPE imageregistry_digest_cache_requests_total counter
+imageregistry_digest_cache_requests_total{type="Hit"} 5
+imageregistry_digest_cache_requests_total{type="Miss"} 24
+# HELP imageregistry_digest_cache_scoped_requests_total Total number of scoped requests to the digest cache.
+# TYPE imageregistry_digest_cache_scoped_requests_total counter
+imageregistry_digest_cache_scoped_requests_total{type="Hit"} 33
+imageregistry_digest_cache_scoped_requests_total{type="Miss"} 44
+# HELP imageregistry_http_in_flight_requests A gauge of requests currently being served by the registry.
+# TYPE imageregistry_http_in_flight_requests gauge
+imageregistry_http_in_flight_requests 1
+# HELP imageregistry_http_request_duration_seconds A histogram of latencies for requests to the registry.
+# TYPE imageregistry_http_request_duration_seconds summary
+imageregistry_http_request_duration_seconds{method="get",quantile="0.5"} 0.01296087
+imageregistry_http_request_duration_seconds{method="get",quantile="0.9"} 0.014847248
+imageregistry_http_request_duration_seconds{method="get",quantile="0.99"} 0.015981195
+imageregistry_http_request_duration_seconds_sum{method="get"} 12.260727916000022
 ----
 <1> `<user>` can be arbitrary, but `<secret>` must match the value specified in the
 registry configuration.


### PR DESCRIPTION
Old sample was wrong, showing metrics that do not exist  on version 4.1.