### PR TITLE
BZ1767460: Removing the step to add the cluster-admin role.

### DIFF
--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -36,9 +36,3 @@ $ oc new-project local-storage
 .. Click *Subscribe*.
 
 . Once finished, the Local Storage Operator will be listed in the *Installed Operators* section of the web console.
-
-. Add the `cluster-admin` role to the ServiceAccount created by the Local Storage Operator, so that this Operator can manage the necessary resources:
-+
-----
-$ oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:local-storage:local-storage-operator
-----


### PR DESCRIPTION
Removing the instruction to add the cluster-admin role to the LocalStorage Operator. This was needed for 4.3 clusters due to https://bugzilla.redhat.com/show_bug.cgi?id=1766856 ; however, I've confirmed that this step is not required for 4.2 clusters.

This is for OCP 4.2 and 4.3.