### PR TITLE
Added hypercc to run cluster-capacity command

### DIFF
--- a/admin_guide/cluster_capacity.adoc
+++ b/admin_guide/cluster_capacity.adoc
@@ -12,13 +12,13 @@ toc::[]
 
 == Overview
 
-As a cluster administrator, you can use the cluster capacity tool to view the
+As a cluster administrator, you can use the `hypercc cluster-capacity` tool to view the
 number of pods that can be scheduled to increase the current resources before
 they become exhausted, and to ensure any future pods can be scheduled. This
 capacity comes from an individual node host in a cluster, and includes CPU,
 memory, disk space, and others.
 
-The cluster capacity tool simulates a sequence of scheduling decisions to
+The `hypercc cluster-capacity` tool simulates a sequence of scheduling decisions to
 determine how many instances of an input pod can be scheduled on the cluster
 before it is exhausted of resources to provide a more accurate estimation.
 
@@ -35,22 +35,23 @@ on its selection and affinity criteria. As a result, the estimation of which
 remaining pods a cluster can schedule can be difficult.
 ====
 
-You can run the cluster capacity analysis tool as a stand-alone utility from the command line, or xref:admin-guide-running-cluster-capacity-inside-pod[as a job] in a pod inside an {product-title} cluster. Running it as job inside of a pod enables you to run it multiple times without intervention.
+You can run the `hypercc cluster-capacity` analysis tool as a stand-alone utility from the command line, or xref:admin-guide-running-cluster-capacity-inside-pod[as a job] in a pod inside an {product-title} cluster. Running it as job inside of a pod enables you to run it multiple times without intervention.
 
 [[cluster-capacity-running-analysis]]
 == Running Cluster Capacity Analysis on the Command Line
 
+Install the openshift-enterprise-cluster-capacity RPM package to get the tool.
 To run the tool on the command line:
 
 ----
-$ cluster-capacity --kubeconfig <path-to-kubeconfig> \
+$ hypercc cluster-capacity --kubeconfig <path-to-kubeconfig> \
     --podspec <path-to-pod-spec>
 ----
 
 The `--kubeconfig` option indicates your Kubernetes configuration file, and the
 `--podspec` option indicates a sample pod specification file, which the tool
 uses for estimating resource usage. The `podspec` specifies its resource
-requirements as `limits` or `requests`. The cluster capacity tool takes the
+requirements as `limits` or `requests`. The `hypercc cluster-capacity` tool takes the
 pod's resource requirements into account for its estimation analysis.
 
 An example of the pod specification input is:
@@ -82,7 +83,7 @@ You can also add the `--verbose` option to output a detailed description of how
 many pods can be scheduled on each node in the cluster:
 
 ----
-$ cluster-capacity --kubeconfig <path-to-kubeconfig> \
+$ hypercc cluster-capacity --kubeconfig <path-to-kubeconfig> \
     --podspec <path-to-pod-spec> --verbose
 ----
 


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1695027.

Described how the "hypercc" command is now needed to run "cluster-capacity" as a subcommand. Also described the need to install the openshift-enterprise-cluster-capacity package to get that tool.