### PR TITLE
Fix url to odo linux binary

### DIFF
--- a/modules/openshift-developer-cli-installing-odo-on-linux.adoc
+++ b/modules/openshift-developer-cli-installing-odo-on-linux.adoc
@@ -9,7 +9,7 @@
 == Binary installation
 
 ----
-# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o /usr/local/bin/odo
+# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o /usr/local/bin/odo
 # chmod +x /usr/local/bin/odo
 ----
 


### PR DESCRIPTION
link incorrectly pointed to darwin (MacOS binary).

/cc @bergerhoffer @boczkowska 

