### PR TITLE
Added TP 1.2.0 release notes for Serverless

### DIFF
--- a/modules/serverless-rn-1-2-0.adoc
+++ b/modules/serverless-rn-1-2-0.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * serverless/release-notes.adoc
+
+[id="serverless-rn-1-2-0_{context}"]
+//update the <version> to match the filename
+
+= Release Notes for Red Hat {ServerlessProductName} Technology Preview 1.2.0
+// add a version, e.g. Technology Preview 1.0.0
+
+[id="new-features-1-2-0_{context}"]
+== New features
+* {ServerlessProductName} has been updated to use Knative Serving 0.9.0.
+* {ServerlessProductName} has been updated to use Knative Client (`kn` CLI) 0.9.0.
+* {ServerlessProductName} on {product-title} 4.2 now uses the Operator Lifecycle Manager (OLM) dependency resolution mechanism to install the ServiceMesh Operator automatically. The required ServiceMeshControlPlane and ServiceMeshMemberRoll are also installed and managed for the user.
+* Access to the KnativeServing resource is now restricted to `cluster-admin` roles to prevent any user from blocking the resource. Only `cluster-admin` roles can create KnativeServing CRs.
+* The {ServerlessProductName} Operator can now be found in the OperatorHub by searching for "knative".
+* The {product-title} web console now shows status conditions for the KnativeServing resource.
+* In version 1.2.0, the {ServerlessProductName} Operator inspects network policies for namespaces.
++
+If no network policy exists, the Operator automatically creates a wide open policy, to ensure that traffic can flow in and out of the namespace and OpenShift routes can be used.
++
+If there is an existing network policy, {ServerlessProductName} will not create a new policy. The Operator expects the user to continue managing their own network policies as needed for their applications. For example, the user must set policies that allow traffic to flow in and out of the namespace, and allow OpenShift routes to still be used after the namespace is added to a ServiceMeshMemberRoll.
+
+
+[id="fixed-issues-1-2-0_{context}"]
+== Fixed issues
+* In previous releases, using the same services or routes in different namespaces caused services to not work properly and caused {product-title} routes to be overriden. This issue has been fixed.
+* In previous releases, different traffic split targets required a mandatory tag. A single traffic split can now be defined with `untagged` traffic targets.
+* Existing Knative Services and Routes which had been created with public visibility in {ServerlessProductName} Operator version 1.1.0 were not able to be updated to cluster-local visibility. This issue is now fixed.
+* The `Unknown Uninitialized : Waiting for VirtualService` error has been fixed.
+* Knative service no longer returns a 503 status code when the cluster is running for a
+long time.
+
+[id="known-issues-1-2-0_{context}"]
+== Known issues
+* Installing the {ServerlessProductName} Operator on {product-title} versions older than 4.2.4 using OLM may incorrectly use community versions of the required dependencies. As a workaround, on  {product-title} versions older than 4.2.4, explicitly install the Red Hat provided versions of the Elastic Search, Jaeger, Kiali and ServiceMesh Operators before installing the {ServerlessProductName} Operator.
+* If you are upgrading the {ServerlessProductName} from version 1.1.0 to version 1.2.0 and you have set up a ServiceMeshControlPlane and ServiceMeshMemberRoll to work with your Knative Serving instance, you must remove the `knative-serving` namespace and any other namespaces that contain Knative Services from the ServiceMeshMemberRoll in `istio-system`.
++
+You can also delete the ServiceMeshControlPlane from the namespace entirely if it is not required for other applications.
++
+Once the upgrade starts, existing services will continue to work as before, but new Services will never become ready. Once you unblock the release by removing the `knative-serving` and any other relevant namespaces from the ServiceMeshMemberRoll, there will be a brief outage to all active Services. This will fix itself. Make sure that you remove all namespaces containing Knative Services from the original ServiceMeshMemberRoll.
+
+* gRPC and HTTP2 do not work against routes. This is a known limitation of
+OpenShift routes.

--- a/modules/serverless-rn-template-module.adoc
+++ b/modules/serverless-rn-template-module.adoc
@@ -8,11 +8,11 @@
 = Release Notes for Red Hat {ServerlessProductName} <VERSION>
 // add a version, e.g. Technology Preview 1.0.0
 
-[id="new-features_<VERSION>{context}"]
+[id="new-features-<VERSION>_{context}"]
 == New features
 
-[id="fixed-issues_<VERSION>{context}"]
+[id="fixed-issues-<VERSION>_{context}"]
 == Fixed issues
 
-[id="known-issues_<VERSION>{context}"]
+[id="known-issues-<VERSION>_{context}"]
 == Known issues

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -14,5 +14,6 @@ If you experience difficulty with a procedure described in this documentation,
 visit the link:https://access.redhat.com/support/offerings/techpreview/[Customer Portal] to learn more about support for Technology Preview features.
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-2-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-1-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-0-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Change is valid for both OCP 4.1 and OCP 4.2.