### PR TITLE
OSDOCS-729_731: Update block volume support table for Cinder, iSCSI

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -29,14 +29,11 @@ The following table displays which volume plug-ins support block volumes.
 |Volume Plug-in  |Manually provisioned  |Dynamically provisioned |Fully supported
 |AWS EBS  | ✅ | ✅ | ✅
 |Azure Disk | ✅ | ✅ | ✅
-
+|Cinder | ✅ | ✅ |
 |Fibre Channel | ✅ | |
-
 |GCP | ✅ | ✅ | ✅
 |HostPath | | |
-
-|iSCSI | ✅ | |
-
+|iSCSI | ✅ | | ✅
 |Local Volumes | ✅ | ✅ | ✅
 |NFS | | |
 |VMware vSphere  | ✅ | ✅ | ✅


### PR DESCRIPTION
In OCP 4.3, Cinder is moving to tech preview ([OSDOCS-729](https://jira.coreos.com/browse/OSDOCS-729)) and iSCSI is moving to GA ([OSDOCS-731](https://jira.coreos.com/browse/OSDOCS-731)). 

This PR modifies the [Block volume support](https://docs.openshift.com/container-platform/4.2/storage/understanding-persistent-storage.html#block-volume-support_understanding-persistent-storage) table accordingly. (Cinder - manual/dynamic provisioning, not fully supported; iSCSI - manual provisioning only, full support.)