### PR TITLE
Resolves #17893: Disconnected install refrences 3.10 repos

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -124,7 +124,7 @@ $ subscription-manager attach --pool=<pool_id>
 $ subscription-manager repos --disable="*"
 ----
 
-. Enable only the repositories required by {product-title} 3.10.
+. Enable only the repositories required by {product-title} 3.11.
 ** For cloud installations and on-premise installations on x86_64 servers,
 run the following command:
 +
@@ -216,7 +216,7 @@ rhel-7-for-power-le-extras-rpms \
 rhel-7-for-power-le-optional-rpms \
 rhel-7-server-ansible-2.6-for-power-le-rpms \
 rhel-7-server-for-power-le-rhscl-rpms \
-rhel-7-for-power-le-ose-3.10-rpms
+rhel-7-for-power-le-ose-3.11-rpms
 do
   reposync --gpgcheck -lm --repoid=${repo} --download_path=</path/to/repos> <1>
   createrepo -v </path/to/repos/>${repo} -o </path/to/repos/>${repo} <1>
@@ -234,7 +234,7 @@ rhel-7-for-power-9-extras-rpms \
 rhel-7-for-power-9-optional-rpms \
 rhel-7-server-ansible-2.6-for-power-9-rpms \
 rhel-7-server-for-power-9-rhscl-rpms \
-rhel-7-for-power-le-ose-3.10-rpms
+rhel-7-for-power-le-ose-3.11-rpms
 do
   reposync --gpgcheck -lm --repoid=${repo} --download_path=/<path/to/repos> <1>
   createrepo -v </path/to/repos/>${repo} -o </path/to/repos/>${repo} <1>


### PR DESCRIPTION
This PR resolves #17893 and updates the repos to align with the [prepare your hosts](https://github.com/openshift/openshift-docs/blob/a3008833195c76d9281cd681f62c183f75a1665b/install/host_preparation.adoc) section.

This PR only applies to the enterprise-3.11 branch.