### PR TITLE
Added note for OCP 4.1 Serverless docs

### DIFF
--- a/serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing-openshift-serverless.adoc
@@ -17,9 +17,14 @@ include::modules/serverless-cluster-sizing-requirements.adoc[leveloffset=+1]
 .Additional resources
 For more information on using the MachineSet API, see xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[Creating MachineSets].
 
-
 // Add or remove an instance of a machine in a MachineSet
 include::modules/machineset-manually-scaling.adoc[leveloffset=+2]
+
+// Installing Service Mesh
+[id="installing-service-mesh_{context}"]
+== Installing Service Mesh
+
+An installed version of the Service Mesh Operator only is required for the installation of {ServerlessProductName}. For details, see the {product-title} documentation on xref:../service_mesh/service_mesh_install/installing-ossm.adoc#installing-ossm[Installing the Service Mesh Operator].
 
 // Installing Serverless Operator
 [id="installing-serverless-operator_{context}"]


### PR DESCRIPTION
Service Mesh is installed automatically by the Serverless Operator from tech preview version 1.2.0+
This does not apply for OCP 4.1, so I am adding a note to just these docs to point to the service mesh docs.