### PR TITLE
BZ#1769243: Namespace of Velero pods in manual installation of CAM Operator

### DIFF
--- a/modules/migration-installing-migration-operator-manually.adoc
+++ b/modules/migration-installing-migration-operator-manually.adoc
@@ -59,4 +59,8 @@ Error from server (AlreadyExists): error when creating "./operator.yml": rolebin
 $ oc create -f controller-3.yml
 ----
 
-. Use the `oc get pods` command to verify that Velero is running.
+. Verify that the Velero Pod is running:
++
+----
+$ oc get pods -n openshift-migration
+----


### PR DESCRIPTION
[BZ1769243](https://bugzilla.redhat.com/show_bug.cgi?id=1769243)

Added example to clarify that `$ oc get pods` is run in `openshift-migration` namespace.