### PR TITLE
removing rogue plus sign from CNV upgrade docs

### DIFF
--- a/modules/cnv-monitoring-upgrade-status.adoc
+++ b/modules/cnv-monitoring-upgrade-status.adoc
@@ -8,7 +8,7 @@
 The best way to monitor {CNVProductName} upgrade status is to watch the
 ClusterServiceVersion (CSV) `PHASE`. You can also monitor the CSV conditions
 in the web console or by running the command provided here.
-+
+
 [NOTE]
 ====
 The `PHASE` and conditions values are approximations that are based on


### PR DESCRIPTION
No BZ, just noticed this typo [here](https://docs.openshift.com/container-platform/4.2/cnv/cnv_install/upgrading-container-native-virtualization.html#cnv-monitoring-upgrade-status_upgrading-container-native-virtualization) and wanted to fix it.

CP to enterprise-4.2 and enterprise-4.3, please.

[Preview build](http://file.bos.redhat.com/pousley/110619/extra-plus-sign/cnv/cnv_install/upgrading-container-native-virtualization.html#cnv-monitoring-upgrade-status_upgrading-container-native-virtualization)