### PR TITLE
[enterprise-4.2]Removed duplicated intro sentence

### DIFF
--- a/modules/cluster-logging-about.adoc
+++ b/modules/cluster-logging-about.adoc
@@ -12,19 +12,17 @@ endif::[]
 
 [id="cluster-logging-about_{context}"]
 = About cluster logging
-
-As an {product-title} cluster administrator, you can deploy cluster logging to
-aggregate logs for a range of {product-title} services. 
+ 
 ifdef::openshift-enterprise,openshift-origin[]
 ifndef::cnv-logging[]
 As an {product-title} cluster administrator, you can deploy cluster logging to
 aggregate logs for a range of {product-title} services.
 endif::cnv-logging[]
 
-The cluster logging components are based upon Elasticsearch, Fluentd or Rsyslog, and Kibana.  
-The collector, link:http://www.fluentd.org/architecture[Fluentd], is deployed to each node in the {product-title} cluster.  
-It collects all node and container logs and writes them to link:https://www.elastic.co/products/elasticsearch[Elasticsearch] (ES).   
-link:https://www.elastic.co/guide/en/kibana/current/introduction.html[Kibana] is the centralized, web UI 
+The cluster logging components are based upon Elasticsearch, Fluentd or Rsyslog, and Kibana.
+The collector, link:http://www.fluentd.org/architecture[Fluentd], is deployed to each node in the {product-title} cluster.
+It collects all node and container logs and writes them to link:https://www.elastic.co/products/elasticsearch[Elasticsearch] (ES).
+link:https://www.elastic.co/guide/en/kibana/current/introduction.html[Kibana] is the centralized, web UI
 where users and administrators can create rich visualizations and dashboards with the aggregated data.
 
 ifndef::cnv-logging[]
@@ -60,7 +58,7 @@ endif::openshift-dedicated[]
 
 You can configure cluster logging by modifying the Cluster Logging Custom Resource (CR), named `instance`.
 The CR defines a complete cluster logging deployment that includes all the components
-of the logging stack to collect, store and visualize logs.  The Cluster Logging Operator watches the `ClusterLogging` 
+of the logging stack to collect, store and visualize logs.  The Cluster Logging Operator watches the `ClusterLogging`
 Custom Resource and adjusts the logging deployment accordingly.
 
 Administrators and application developers can view the logs of the projects for which they have view access.
@@ -68,4 +66,3 @@ endif::cnv-logging[]
 ifdef::cnv-logging[]
 :cnv-logging!:
 endif::cnv-logging[]
-


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-docs/issues/17908

This is 4.2 only; no issue in master
Opening a separate PR against 4.3