### PR TITLE
Changing API for ES CR

### DIFF
--- a/modules/cluster-logging-management-state-changing-es.adoc
+++ b/modules/cluster-logging-management-state-changing-es.adoc
@@ -36,7 +36,7 @@ Edit the Elasticsearch Custom Resource (CR) in the `openshift-logging` project:
 ----
 $ oc edit Elasticsearch elasticsearch
 
-apiVersion: logging.openshift.io/v1alpha1
+apiVersion: logging.openshift.io/v1
 kind: Elasticsearch
 metadata:
   name: elasticsearch


### PR DESCRIPTION
Missed one instance of `logging.openshift.io/v1alpha1` in the docs.