### PR TITLE
Bug 1712525, Ingress Controller requires CA to communicate with web console

### DIFF
--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -71,5 +71,24 @@ map[name:custom-certs-default]
 +
 The certificate secret name should match the value used to update the CR.
 
+Your Ingress Controller now uses the custom certificate, but it is not trusted
+by the web console. You must expose your CA certificate so the Ingress
+Controller can communicate with all routes.
+
+. Configure the CA certificate as the cluster proxy certificate:
++
+----
+$ oc -n openshift-config create configmap custom-ca --from-file=ca-bundle.crt=example-ca.crt
+$ oc patch proxy/cluster --type=merge --patch='{"spec":{"trustedCA":{"name":"custom-ca"}}}'
+----
++
+. Configure the certificate as the Ingress Controller's default certificate:
++
+----
+$ oc -n openshift-ingress create secret tls custom-default-cert --cert=example.crt --key=example.key
+$ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=merge \
+  --patch='{"spec":{"defaultCertificate":{"name":"custom-default-cert"}}}'
+----
+
 Once the `IngressController` CR has been modified, the Ingress Operator
-will update the Ingress Controller's deployment to use the custom certificate.
+updates the Ingress Controller's deployment to use both certificates.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1712525

@bergerhoffer Can you take a look at these changes and let me know what you think? Mostly, I want to make sure I got the language right. Please let me know SME/QE resources I should run this through.

Just recently, a PR that may fix this issue for 4.3 was merged: openshift/console-operator#328. If it does (still waiting for confirmation), this will only be necessary for 4.2.

Thanks!