### PR TITLE
OVN-Kubernetes MTU support and minor cleanup

### DIFF
--- a/modules/nw-cluster-network-operator.adoc
+++ b/modules/nw-cluster-network-operator.adoc
@@ -4,10 +4,8 @@
 [id="nw-cluster-network-operator_{context}"]
 = Cluster Network Operator
 
-The Cluster Network Operator implements the `network` API from the
-`operator.openshift.io` API group. The Operator deploys the OpenShift SDN
-plug-in, or a different SDN plug-in if selected during cluster installation,
-using a DaemonSet.
+The Cluster Network Operator implements the `network` API from the `operator.openshift.io` API group.
+The Operator deploys the OpenShift SDN Pod network provider plug-in, or the Pod network provider plug-in that you selected during cluster installation, by using a DaemonSet.
 
 .Procedure
 

--- a/modules/nw-install-config-parameters.adoc
+++ b/modules/nw-install-config-parameters.adoc
@@ -32,15 +32,17 @@ You cannot modify these parameters in the `install-config.yaml` file after insta
 
 ifdef::ovn-preview[]
 |`networking.networkType`
-|The network plug-in to deploy. The `OpenShiftSDN` plug-in is the only plug-in
-supported in {product-title} {product-version}. The `OVNKubernetes` plug-in is
-available as Technology Preview in {product-title} 4.2.
+|The Pod network provider plug-in to deploy. The `OpenShiftSDN` plug-in is the
+only plug-in supported in {product-title} {product-version}. The `OVNKubernetes`
+plug-in is available as a Technology Preview in {product-title}
+{product-version}.
 |Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OpenShiftSDN`.
 endif::ovn-preview[]
+
 ifndef::ovn-preview[]
 |`networking.networkType`
-|The network plug-in to deploy. The `OpenShiftSDN` plug-in is the only plug-in
-supported in {product-title} {product-version}.
+|The Pod network provider plug-in to deploy. The `OpenShiftSDN` plug-in is the
+only plug-in supported in {product-title} {product-version}.
 |The default value is `OpenShiftSDN`.
 endif::[]
 

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -10,46 +10,23 @@
 // Installation assemblies need different details than the CNO operator does
 ifeval::["{context}" == "cluster-network-operator"]
 :operator:
+:ovn-preview:
 endif::[]
-
-// Remove for OCP 4.3
+// Remove for OCP 4.5
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :ovn-preview:
 endif::[]
-// Remove for OCP 4.3
+// Remove for OCP 4.5
 ifeval::["{context}" == "installing-azure-network-customizations"]
 :ovn-preview:
 endif::[]
 
-// Extract parameter descriptions that may have a different ordinal
-// position depending on the module context.
-
-:default-network: pass:q[Configures the software-defined networking (SDN) \
-for the cluster network.]
-
-:kube-proxy-refresh: pass:q[The refresh period for `iptables` rules. The default \
-value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in \
-the link:https://golang.org/pkg/time/#ParseDuration[Go time package] \
-documentation.]
-
-:iptables-min-sync-period: pass:q[The minimum duration before refreshing `iptables` \
-rules. This parameter ensures that the refresh does not happen too frequently. \
-Valid suffixes include `s`, `m`, and `h` and are described in the \
-link:https://golang.org/pkg/time/#ParseDuration[Go time package]]
-
-// Begin module
-
 [id="nw-operator-cr_{context}"]
-= Cluster Network Operator custom resource (CR)
+= Cluster Network Operator configuration
 
-The cluster network configuration in the `Network.operator.openshift.io` custom
-resource (CR) stores the configuration settings for the Cluster Network
-Operator (CNO). The Operator manages the cluster network.
+The configuration for the cluster network is specified as part of the Cluster Network Operator (CNO) configuration and stored in a CR object that is named `cluster`. The CR specifies the parameters for the `Network` API in the `operator.openshift.io` API group.
 
-You can specify the cluster network configuration for your {product-title}
-cluster by setting the parameters for the `defaultNetwork` parameter in the CNO
-CR. The following CR displays the default configuration for the CNO and explains
-both the parameters you can configure and valid parameter values:
+You can specify the cluster network configuration for your {product-title} cluster by setting the parameter values for the `defaultNetwork` parameter in the CNO CR. The following CR displays the default configuration for the CNO and explains both the parameters you can configure and the valid parameter values:
 
 .Cluster Network Operator CR
 [source,yaml]
@@ -75,14 +52,15 @@ spec:
 ----
 <1> Specified in the `install-config.yaml` file.
 
-<2> {default-network}
+<2> Configures the Pod network provider for the cluster network.
 
 <3> The parameters for this object specify the `kube-proxy` configuration. If
 you do not specify the parameter values, the Network Operator applies the
 displayed default parameter values.
 
-<4> {kube-proxy-refresh}
-<5> {iptables-min-sync-period}
+<4> The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
+
+<5> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
 endif::operator[]
 
 ifdef::operator[]
@@ -112,20 +90,26 @@ allocated and the subnet prefix length assigned to each individual node.
 Interface (CNI) plug-in supports only a single IP address block for the service
 network.
 
-<3> {default-network}
+<3> Configures the Pod network provider for the cluster network.
 
 <4> The parameters for this object specify the Kubernetes network proxy
-(kube-proxy) configuration.
+(kube-proxy) configuration. If you are using the OVN-Kubernetes network
+provider, the kube-proxy configuration has no effect.
 
-<5> {kube-proxy-refresh}
-<6> {iptables-min-sync-period}
+<5> The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
+
+<6> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
 endif::operator[]
 
 [id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
-== Configuration parameters for OpenShift SDN
+== Configuration parameters for the OpenShift SDN network provider
 
 The following YAML object describes the configuration parameters for
-OpenShift SDN:
+the OpenShift SDN Pod network provider.
+
+ifdef::operator[]
+NOTE: You can only change the configuration for your Pod network provider during cluster installation.
+endif::operator[]
 
 [source,yaml]
 ifndef::operator[]
@@ -142,13 +126,14 @@ defaultNetwork:
 <2> Specify only if you want to override part of the OpenShift SDN
 configuration.
 
-<3> Configures the network isolation mode for `OpenShiftSDN`. The allowed values
+<3> Configures the network isolation mode for OpenShift SDN. The allowed values
 are `Multitenant`, `Subnet`, or `NetworkPolicy`. The default value is
 `NetworkPolicy`.
 
-<4> MTU for the VXLAN overlay network. This value is normally configured
-automatically, but if the nodes in your cluster do not all use the same MTU,
-then you must set this explicitly to 50 less than the smallest node MTU value.
+<4> The maximum transmission unit (MTU) for the VXLAN overlay network. This
+value is normally configured automatically, but if the nodes in your cluster do
+not all use the same MTU, then you must set this explicitly to 50 less than the
+smallest node MTU value.
 
 <5> The port to use for all VXLAN packets. The default value is `4789`. If you
 are running in a virtualized environment with existing nodes that are part of
@@ -170,32 +155,69 @@ defaultNetwork:
     mtu: 1450 <4>
     vxlanPort: 4789 <5>
 ----
-<1> The Software Defined Networking (SDN) plug-in being used. OpenShift SDN is
-the only plug-in supported in {product-title} {product-version}.
+<1> The Pod network provider plug-in that is used.
 
 <2> OpenShift SDN specific configuration parameters.
 
-<3> The network isolation mode for the OpenShift SDN CNI plug-in.
+<3> The network isolation mode for OpenShift SDN.
 
-<4> MTU for the VXLAN overlay network. This value is normally configured
-automatically.
+<4> The maximum transmission unit (MTU) for the VXLAN overlay network. This
+value is normally configured automatically.
 
 <5> The port to use for all VXLAN packets. The default value is `4789`.
 endif::operator[]
 
 ifdef::ovn-preview[]
 [id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
-== Configuration parameters for Open Virtual Network (OVN) SDN
+== Configuration parameters for the OVN-Kubernetes network provider
 
-The OVN SDN does not have any configuration parameters in {product-title}
-{product-version}.
+The following YAML object describes the configuration parameters for the OVN-Kubernetes Pod network provider.
+
+ifdef::operator[]
+NOTE: You can only change the configuration for your Pod network provider during cluster installation.
+endif::operator[]
+
+[source,yaml]
+----
+defaultNetwork:
+  type: OVNKubernetes <1>
+  ovnKubernetesConfig: <2>
+    mtu: 1450 <3>
+----
+ifndef::operator[]
+<1> Specified in the `install-config.yaml` file.
+endif::operator[]
+
+ifdef::operator[]
+<1> The Pod network provider plug-in that is used.
+endif::operator[]
+
+ifndef::operator[]
+<2> Specify only if you want to override part of the OVN-Kubernetes configuration.
+endif::operator[]
+
+ifdef::operator[]
+<2> OVN-Kubernetes specific configuration parameters.
+endif::operator[]
+
+ifndef::operator[]
+<3> The MTU for the Generic Network Virtualization Encapsulation (GENEVE)
+overlay network. This value is normally configured automatically, but if the
+nodes in your cluster do not all use the same MTU, then you must set this
+explicitly to 100 less than the smallest node MTU value.
+endif::operator[]
+
+ifdef::operator[]
+<3> The MTU for the Generic Network Virtualization Encapsulation (GENEVE)
+overlay network. This value is normally configured automatically.
+endif::operator[]
 
 endif::ovn-preview[]
 
 [id="nw-operator-example-cr_{context}"]
-== Cluster Network Operator example CR
+== Cluster Network Operator example configuration
 
-A complete CR for the CNO is displayed in the following example:
+A complete CR object for the CNO is displayed in the following example:
 
 .Cluster Network Operator example CR
 [source,yaml]
@@ -225,13 +247,14 @@ spec:
 
 ifeval::["{context}" == "cluster-network-operator"]
 :!operator:
+:!ovn-preview:
 endif::[]
 
-// Remove for OCP 4.3
+// Remove for OCP 4.5
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :!ovn-preview:
 endif::[]
-// Remove for OCP 4.3
+// Remove for OCP 4.5
 ifeval::["{context}" == "installing-azure-network-customizations"]
 :!ovn-preview:
 endif::[]

--- a/networking/cluster-network-operator.adoc
+++ b/networking/cluster-network-operator.adoc
@@ -5,10 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The Cluster Network Operator (CNO) deploys and manages the cluster network
-components on an {product-title} cluster, including the Container Network
-Interface (CNI) Software Defined Networking (SDN) plug-in selected for the
-cluster during installation.
+The Cluster Network Operator (CNO) deploys and manages the cluster network components on an {product-title} cluster, including the Container Network Interface (CNI) Pod network provider plug-in selected for the cluster during installation.
 
 include::modules/nw-cluster-network-operator.adoc[leveloffset=+1]
 
@@ -17,5 +14,7 @@ include::modules/nw-cno-view.adoc[leveloffset=+1]
 include::modules/nw-cno-status.adoc[leveloffset=+1]
 
 include::modules/nw-cno-logs.adoc[leveloffset=+1]
+
+include::modules/nw-ovn-technology-preview.adoc[leveloffset=+1]
 
 include::modules/nw-operator-cr.adoc[leveloffset=+1]


### PR DESCRIPTION
~This is currently based on https://github.com/openshift/openshift-docs/pull/15999, but will be rebased against master once that merges.~

This PR will:

- Adds back `mtu` for OVN SDN
~- Remove any OVN TP conditionals~
~- Remove the includes for OVN TP module~

This content further exposes OVN-Kubernetes TP and tidies up some files.

Was previously changes for OVN-Kubernetes GA, but no longer.