### PR TITLE
Remove iSCSI Tech Preview note

### DIFF
--- a/storage/persistent-storage/persistent-storage-iscsi.adoc
+++ b/storage/persistent-storage/persistent-storage-iscsi.adoc
@@ -10,13 +10,10 @@ persistent storage using
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-iscsi.html[iSCSI].
 Some familiarity with Kubernetes and iSCSI is assumed.
 
-The Kubernetes persistent volume framework allows administrators to 
-provision a cluster with persistent storage and gives users a way to 
-request those resources without having any knowledge of the 
+The Kubernetes persistent volume framework allows administrators to
+provision a cluster with persistent storage and gives users a way to
+request those resources without having any knowledge of the
 underlying infrastructure.
-
-:FeatureName: Persistent storage using iSCSI
-include::modules/technology-preview.adoc[leveloffset=+0]
 
 [IMPORTANT]
 ====
@@ -26,8 +23,8 @@ storage provider.
 
 [IMPORTANT]
 ====
-When you use iSCSI on Amazon Web Services, you must update the default 
-security policy to include TCP traffic between nodes on the iSCSI ports. 
+When you use iSCSI on Amazon Web Services, you must update the default
+security policy to include TCP traffic between nodes on the iSCSI ports.
 By default, they are ports `860` and `3260`.
 ====
 


### PR DESCRIPTION
@openshift/team-documentation PTAL

Merge to master, CP to 4.3.

Background:
Note was added in 4.x ([PR 16650](https://github.com/openshift/openshift-docs/pull/16650#issuecomment-534008812)). 

Now, based on work related to [17887](https://github.com/openshift/openshift-docs/pull/17887), this note can be removed in 4.3.