### PR TITLE
Remove snapshots in 4.3

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -410,8 +410,6 @@ Topics:
 #    File: persistent-storage-manila
   - Name: Persistent storage using VMware vSphere
     File: persistent-storage-vsphere
-  - Name: Persistent storage using volume snapshots
-    File: persistent-storage-snapshots
 - Name: Expanding persistent volumes
   File: expanding-persistent-volumes
   Distros: openshift-enterprise,openshift-origin


### PR DESCRIPTION
@liangxia PTAL 
We added Snapshots to 4.1 & 4.2 docs, with a Deprecated note in 4.2. This PR removes Snapshots in master, CP to 4.3 only. SME (Jan) has approved.