### PR TITLE
OSDOCS-728: Add CSI volume expansion module

### DIFF
--- a/modules/storage-expanding-csi-volumes.adoc
+++ b/modules/storage-expanding-csi-volumes.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies
+//
+// * storage/expanding-persistent-volumes.adoc
+
+[id="expanding-csi-volumes_{context}"]
+= Expanding CSI volumes
+
+You can use the Container Storage Interface (CSI) to expand storage volumes after they have already been created.
+
+{product-title} supports CSI volume expansion by default. However, a specific CSI driver is required.
+
+{product-title} does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by
+link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
+
+{product-title} {product-version} supports version 1.1.0 of the
+link:https://github.com/container-storage-interface/spec[CSI specification].
+
+:FeatureName: Expanding CSI volumes
+include::modules/technology-preview.adoc[leveloffset=+0]

--- a/storage/expanding-persistent-volumes.adoc
+++ b/storage/expanding-persistent-volumes.adoc
@@ -6,6 +6,8 @@ toc::[]
 
 include::modules/storage-expanding-add-volume-expansion.adoc[leveloffset=+1]
 
+include::modules/storage-expanding-csi-volumes.adoc[leveloffset=+1]
+
 include::modules/storage-expanding-filesystem-pvc.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-recovering-failure.adoc[leveloffset=+1]


### PR DESCRIPTION
@gnufied @liangxia PTAL and note comment about whether OCP 4.3 supports 1.2.0 CSI spec. Thanks!

As tracked in [OSDOCS-728](https://jira.coreos.com/browse/OSDOCS-728), we are adding CSI volume expansion support to OCP 4.3 in Tech Preview. Once approved, this will merge to master and CP to 4.3 only.