### PR TITLE
added supports networkpolicy

### DIFF
--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -17,7 +17,6 @@ OpenShift Online and OpenShift Dedicated are not supported for {ProductName} {Pr
 
 * The deployment must be contained to a single {product-title} cluster that is not federated.
 * This release of {ProductName} is only available on {product-title} x86_64.
-* {ProductName} is only suited for {product-title} Software Defined Networking (SDN) configured as a flat network with no external providers.
 * This release only supports configurations where all {ProductShortName} components are contained in the OpenShift cluster in which it operates. It does not support management of microservices that reside outside of the cluster, or in a multi-cluster scenario.
 * This release only supports configurations that do not integrate external services such as virtual machines.
 


### PR DESCRIPTION
Please cherry pick this PR to the 4.2 and 4.3 branch.

https://bugzilla.redhat.com/show_bug.cgi?id=1770538
https://issues.jboss.org/projects/OSSMDOC/issues/OSSMDOC-13?filter=allissues

The BZ says that the current 4.2 docs say, "Red Hat OpenShift Service Mesh is only suited for OpenShift Container Platform Software Defined Networking (SDN) configured as a flat network with no external providers." And that's no longer true.

I've changed that to say Red Hat OpenShift Service Mesh supports NetworkPolicy. 