### PR TITLE
CNV_1020 Live and Readiness Probes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -137,7 +137,7 @@ Topics:
   - Name: Installing a cluster on GCP into an existing VPC
     File: installing-gcp-vpc
   - Name: Installing a private cluster on GCP
-    File: installing-gcp-private    
+    File: installing-gcp-private
   - Name: Installing a cluster on GCP using Deployment Manager templates
     File: installing-gcp-user-infra
   - Name: Uninstalling a cluster on GCP
@@ -770,7 +770,7 @@ Topics:
 - Name: Modifying a MachineSet
   File: modifying-machineset
 - Name: Deleting a Machine
-  File: deleting-machine  
+  File: deleting-machine
 - Name: Applying autoscaling to a cluster
   File: applying-autoscaling
 - Name: Creating infrastructure MachineSets
@@ -1359,10 +1359,10 @@ Topics:
     File: cnv-logs
   - Name: Viewing events
     File: cnv-events
-    Name: Viewing cluster information
+  - Name: Monitoring virtual machine health
+    File: cnv-monitoring-vm-health
+  - Name: Viewing cluster information
     File: cnv-using-dashboard-to-get-cluster-info
-  - Name: Viewing information about virtual machine workloads
-    File: cnv-viewing-information-about-vm-workloads
   - Name: OpenShift cluster monitoring, logging, and Telemetry
     File: cnv-openshift-cluster-monitoring
   - Name: Collecting container-native virtualization data for Red Hat Support

--- a/cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+++ b/cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
@@ -1,0 +1,13 @@
+[id="cnv-monitoring-vm-health"]
+= Monitoring virtual machine health
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-monitoring-vm-health
+toc::[]
+
+Use this procedure to create liveness and readiness probes
+to monitor virtual machine health.
+
+include::modules/cnv-about-liveness-readiness-probes.adoc[leveloffset=+1]
+include::modules/cnv-define-http-liveness-probe.adoc[leveloffset=+1]
+include::modules/cnv-define-tcp-liveness-probe.adoc[leveloffset=+1]
+include::modules/cnv-define-readiness-probe.adoc[leveloffset=+1]

--- a/modules/cnv-about-liveness-readiness-probes.adoc
+++ b/modules/cnv-about-liveness-readiness-probes.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-liveness-readiness-probe.adoc
+
+[id="cnv-about-liveness-readiness-probes_{context}"]
+
+= About liveness and readiness probes
+
+When a VirtualMachineInstance (VMI) fails, _liveness probes_ stop the VMI.
+Controllers such as VirtualMachine then spawn other VMIs, restoring virtual
+machine responsiveness.
+
+_Readiness probes_ are indicators for services and endpoints that
+the VirtualMachineInstance is ready to receive traffic from services.
+If readiness probes fail, the VirtualMachineInstance is removed from
+applicable endpoints until the probe recovers.

--- a/modules/cnv-define-http-liveness-probe.adoc
+++ b/modules/cnv-define-http-liveness-probe.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+
+[id="cnv-define-http-liveness-probe_{context}"]
+
+= Define a HTTP liveness probe
+
+This procedure provides an example configuration file for defining HTTP
+liveness probes.
+
+.Procedure
+
+. Customize a YAML configuration file to create an HTTP liveness probe, using
+the following code block as an example. In this example:
+* You configure a probe using `spec.livenessProbe.httpGet`, which queries port `1500` of the
+VirtualMachineInstance, after an initial delay of `120` seconds.
+* The VirtualMachineInstance installs and runs a minimal HTTP server
+on port `1500` using `cloud-init`.
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  labels:
+    special: vmi-fedora
+  name: vmi-fedora
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+    resources:
+      requests:
+        memory: 1024M
+  livenessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 20
+    httpGet:
+      port: 1500
+    timeoutSeconds: 10
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - name: containerdisk
+    registryDisk:
+      image: kubevirt/fedora-cloud-registry-disk-demo
+  - cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+        bootcmd:
+          - setenforce 0
+          - dnf install -y nmap-ncat
+          - systemd-run --unit=httpserver nc -klp 1500 -e '/usr/bin/echo -e HTTP/1.1 200 OK\\n\\nHello World!'
+    name: cloudinitdisk
+----
++
+. Create the VirtualMachineInstance by running the following command:
++
+----
+$ oc create -f <file name>.yaml
+----

--- a/modules/cnv-define-readiness-probe.adoc
+++ b/modules/cnv-define-readiness-probe.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+
+[id="cnv-define-readiness-probe_{context}"]
+
+= Define a readiness probe
+
+This procedure provides an example configuration file for defining
+readiness probes.
+
+.Procedure
+
+. Customize a YAML configuration file to create a readiness probe. Readiness
+probes are configured in a similar manner to liveness probes. However, note the
+following differences in this example:
+* Readiness probes are saved using a different spec name. For example, you
+create a readiness probe as `spec.readinessProbe` instead of as
+`spec.livenessProbe.<type-of-probe>`.
+* When creating a readiness probe, you optionally set a `failureThreshold` and a
+`successThreshold` to switch between `ready` and `non-ready` states, should the probe
+succeed or fail multiple times.
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  labels:
+    special: vmi-fedora
+  name: vmi-fedora
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+    resources:
+      requests:
+        memory: 1024M
+  readinessProbe:
+    httpGet:
+      port: 1500
+    initialDelaySeconds: 120
+    periodSeconds: 20
+    timeoutSeconds: 10
+    failureThreshold: 3
+    successThreshold: 3
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - name: containerdisk
+    registryDisk:
+      image: kubevirt/fedora-cloud-registry-disk-demo
+  - cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+        bootcmd:
+          - setenforce 0
+          - dnf install -y nmap-ncat
+          - systemd-run --unit=httpserver nc -klp 1500 -e '/usr/bin/echo -e HTTP/1.1 200 OK\\n\\nHello World!'
+    name: cloudinitdisk
+----
++
+. Create the VirtualMachineInstance by running the following command:
++
+----
+$ oc create -f <file name>.yaml
+----

--- a/modules/cnv-define-tcp-liveness-probe.adoc
+++ b/modules/cnv-define-tcp-liveness-probe.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+
+[id="cnv-define-tcp-liveness-probe_{context}"]
+
+= Define a TCP liveness probe
+
+This procedure provides an example configuration file for defining
+TCP liveness probes.
+
+.Procedure
+
+. Customize a YAML configuration file to create an TCP liveness probe, using
+this code block as an example. In this example:
+* You configure a probe using `spec.livenessProbe.tcpSocket`, which queries port `1500` of the
+VirtualMachineInstance, after an initial delay of `120` seconds.
+* The VirtualMachineInstance installs and runs a minimal HTTP server
+on port `1500` using `cloud-init`.
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  labels:
+    special: vmi-fedora
+  name: vmi-fedora
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+    resources:
+      requests:
+        memory: 1024M
+  livenessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 20
+    tcpSocket:
+      port: 1500
+    timeoutSeconds: 10
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - name: containerdisk
+    registryDisk:
+      image: kubevirt/fedora-cloud-registry-disk-demo
+  - cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+        bootcmd:
+          - setenforce 0
+          - dnf install -y nmap-ncat
+          - systemd-run --unit=httpserver nc -klp 1500 -e '/usr/bin/echo -e HTTP/1.1 200 OK\\n\\nHello World!'
+    name: cloudinitdisk
+----
++
+. Create the VirtualMachineInstance by running the following command:
++
+----
+$ oc create -f <file name>.yaml
+----


### PR DESCRIPTION
See Jira story: https://jira.coreos.com/browse/CNV-1020

Created new assembly titled **cnv-monitoring-vm-health**. 
Created module titled **cnv-configure-liveness-readiness-probes**.
Updated Topic Map to add **Monitoring virtual machine health** topic.

Test Build: http://file.bos.redhat.com/bgaydos/111219/cnv/cnv_users_guide/cnv-monitoring-vm-health.html 

Peer review requested from @sheriff-rh @ahardin-rh or @adellape 

Code review requested from Mark Sluiter via Jira and email.

Label **Peer Review Needed** and **enterprise-4.3**.

Many thanks!

Bob