### PR TITLE
Fix NodePort markup

### DIFF
--- a/modules/nw-creating-project-and-service.adoc
+++ b/modules/nw-creating-project-and-service.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * ingress/getting-traffic-cluster.adoc
+// * networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-nodeport.adoc
 
 [id="nw-creating-project-and-service_{context}"]
 = Creating a project and service
@@ -8,10 +8,12 @@
 If the project and service that you want to expose do not exist, first create
 the project, then the service.
 
-If the project and service already exist, go to the next step:
-*Exposing the service to create a route*.
+If the project and service already exist, skip to the procedure on exposing the
+service to create a route.
 
-. Log in to  {product-title}.
+.Procedure
+
+. Log in to {product-title}.
 
 . Create a new project for your service:
 +
@@ -22,12 +24,10 @@ $ oc new-project <project_name>
 For example:
 +
 ----
-$ oc new-project <myproject>
+$ oc new-project myproject
 ----
 
-. Use the `oc new-app` command to create a service:
-+
-For example:
+. Use the `oc new-app` command to create a service. For example:
 +
 ----
 $ oc new-app \

--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -1,17 +1,19 @@
 // Module included in the following assemblies:
 //
-// * ingress/getting-traffic-cluster.adoc
+// * networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-nodeport.adoc
 
 [id="nw-exposing-service_{context}"]
 = Exposing the service by creating a route
 
 You can expose the service as a route using the `oc expose` command.
 
+.Procedure
+
 To expose the service:
 
-. Log in to  {product-title}.
+. Log in to {product-title}.
 
-. Log in to  the project where the service you want to expose is located.
+. Log in to the project where the service you want to expose is located:
 +
 ----
 $ oc project project1
@@ -20,32 +22,32 @@ $ oc project project1
 . Run the following command to expose the route:
 +
 ----
-oc expose service <service-name>
+$ oc expose service <service_name>
 ----
 +
 For example:
 +
 ----
-oc expose service mysql-55-rhel7
+$ oc expose service mysql-55-rhel7
 route "mysql-55-rhel7" exposed
 ----
 
-. Use a tool, such as cURL, to make sure you can reach the
-service using the cluster IP address for the service:
+. Use a tool, such as cURL, to make sure you can reach the service using the
+cluster IP address for the service:
 +
 ----
-curl <pod-ip>:<port>
+$ curl <pod_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 172.30.131.89:3306
+$ curl 172.30.131.89:3306
 ----
 +
 The examples in this section use a MySQL service, which requires a client
 application. If you get a string of characters with the `Got packets out of order`
-message,you are connected to the service.
+message, you are connected to the service.
 +
 If you have a MySQL client, log in with the standard CLI command:
 +

--- a/modules/nw-using-nodeport.adoc
+++ b/modules/nw-using-nodeport.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * ingress/getting-traffic-cluster.adoc
+// * networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-nodeport.adoc
 
 [id="nw-using-nodeport_{context}"]
 = Using a NodePort to get traffic into the cluster
@@ -9,17 +9,16 @@ Use a `NodePort`-type `Service` resource to expose a service on a specific port
 on all nodes in the cluster. The port is specified in the `Service` resource's
 `.spec.ports[*].nodePort` field.
 
-[NOTE]
+[IMPORTANT]
 ====
-Using `NodePort`s requires additional port resources.
+Using ``NodePort``s requires additional port resources.
 ====
 
-A node port exposes the service on a static port on the node IP address.
-
-`NodePort`s are in the `30000-32767` range by default, which means a `NodePort` is
-unlikely to match a service’s intended port. For example, `8080` may be exposed
-as `31020`.
+A `NodePort` exposes the service on a static port on the node IP address.
+``NodePort``s are in the `30000` to `32767` range by default, which means a
+`NodePort` is unlikely to match a service’s intended port. For example, `8080`
+may be exposed as `31020`.
 
 The administrator must ensure the external IPs are routed to the nodes.
 
-`NodePort`s and external IPs are independent and both can be used concurrently.
+``NodePort``s and external IPs are independent and both can be used concurrently.

--- a/networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-nodeport.adoc
+++ b/networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-nodeport.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-
 {product-title} provides methods for communicating from
 outside the cluster with services running in the cluster. This method uses a
 `NodePort`.
@@ -29,7 +28,7 @@ can reach the cluster.
 to a user, run the following command:
 +
 ----
-oc adm policy add-cluster-role-to-user cluster-admin username
+$ oc adm policy add-cluster-role-to-user cluster-admin <user_name>
 ----
 
 * Have an {product-title} cluster with at least one master and at least one node


### PR DESCRIPTION
Fixing backticks that have a trailing plural "s", as suggested by known AsciiDoctor issue. Also other minor fixes per style guidelines.

Preview: https://nodeport_markup--ocpdocs.netlify.com/openshift-enterprise/latest/networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-nodeport.html