### PR TITLE
CNV-3136 - Create NAD gui

### DIFF
--- a/cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
+++ b/cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
@@ -4,20 +4,21 @@ include::modules/cnv-document-attributes.adoc[]
 :context: cnv-attaching-multiple-networks
 toc::[]
 
-{CNVProductNameStart} provides Layer-2 networking capabilities that allow you to connect
+{CNVProductNameStart} provides layer-2 networking capabilities that allow you to connect
 virtual machines to multiple networks. You can import virtual machines with
 existing workloads that depend on access to multiple interfaces. You can also
 configure a PXE network so that you can boot machines over the network.
 
-To get started, a network administrator configures a NetworkAttachmentDefinition
-of type `cnv-bridge`. Then, users can attach Pods, virtual machine instances,
-and virtual machines to the
-bridge network. From the {CNVProductName} web console, you can create a vNIC
-that refers to the bridge network.
+To get started, a network administrator configures a bridge NetworkAttachmentDefinition
+for a namespace in the web console or CLI. Users can then create a vNIC to attach Pods and virtual machines in that namespace to the bridge network. 
 
 include::modules/cnv-networking-glossary.adoc[leveloffset=+1]
 
-include::modules/cnv-connecting-resource-bridge-network.adoc[leveloffset=+1]
+== Creating a NetworkAttachmentDefinition
+
+include::modules/cnv-creating-bridge-nad-web.adoc[leveloffset=+2]
+
+include::modules/cnv-creating-bridge-nad-cli.adoc[leveloffset=+2]
 
 [NOTE]
 ====

--- a/cnv/cnv_users_guide/cnv-configuring-pxe-booting.adoc
+++ b/cnv/cnv_users_guide/cnv-configuring-pxe-booting.adoc
@@ -12,7 +12,7 @@ image from a PXE server when deploying a new host.
 
 .Prerequisites
 
-* A Linux bridge must be xref:../../cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc#connecting-resource-bridge-network_cnv-attaching-multiple-networks[connected].
+* A Linux bridge must be xref:../../cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc#attaching-to-multiple-networks[connected].
 * The PXE server must be connected to the same VLAN as the bridge.
 
 include::modules/cnv-networking-glossary.adoc[leveloffset=+1]

--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -2,8 +2,8 @@
 //
 // * cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
 
-[id="connecting-resource-bridge-network_{context}"]
-= Connecting a resource to a bridge-based network
+[id="cnv-creating-bridge-nad-cli_{context}"]
+= Creating a Linux bridge NetworkAttachmentDefinition in the CLI
 
 As a network administrator, you can configure a NetworkAttachmentDefinition
 of type `cnv-bridge` to provide Layer-2 networking to Pods and virtual machines.

--- a/modules/cnv-creating-bridge-nad-web.adoc
+++ b/modules/cnv-creating-bridge-nad-web.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * cnv-attaching-multiple-networks.adoc
+
+[id="cnv-creating-bridge-nad-web_{context}"]
+= Creating a Linux bridge NetworkAttachmentDefinition in the web console
+
+The NetworkAttachmentDefinition is a custom resource that exposes layer-2 devices
+to a specific namespace in your {CNVProductName} cluster. 
+
+Network administrators can create NetworkAttachmentDefinitions 
+to provide existing layer-2 networking to Pods and virtual machines. 
+
+.Prerequisites
+
+* Container-native virtualization 2.2 or above installed on your cluster.
+* A Linux bridge must be configured and attached to the correct
+Network Interface Card (NIC) on every node.
+* If you use VLANs, `vlan_filtering` must be enabled on the bridge.
+* The NIC must be tagged to all relevant VLANs.
+** For example: `bridge vlan add dev bond0 vid 1-4095 master`
+
+.Procedure
+
+. In the web console, click *Networking* -> *Network Attachment Definitions*.
+. Click *Create Network Attachment Definition* .
+. Enter a unique *Name* and optional *Description*.
+. Click the *Network Type* list and select *CNV Linux bridge*.
+. Enter the name of the bridge in the *Bridge Name* field.
+. (Optional) If the resource has VLAN IDs configured, enter the ID numbers in the *VLAN Tag Number* field.
+. Click *Create*. 
+
+

--- a/modules/cnv-networking-wizard-fields-web.adoc
+++ b/modules/cnv-networking-wizard-fields-web.adoc
@@ -12,24 +12,19 @@
 |===
 |Name | Description
 
-|Create NIC
-|Create a new NIC for the virtual machine.
-
-|NIC NAME
+|Name
 |Name for the NIC.
 
-|MAC ADDRESS
+|MAC Address
 |MAC address for the network interface. If a MAC address is not specified, an ephemeral address is generated for the session.
 
-|NETWORK CONFIGURATION
+|Network
 |List of available NetworkAttachmentDefinition objects.
 
-|BINDING METHOD
+|Type
 |List of available binding methods. For the default Pod network, `masquerade`
 is the only recommended binding method. For secondary networks, use the `bridge`
 binding method. The `masquerade` method is not supported for non-default
 networks.
 
-|PXE NIC
-|List of PXE-capable networks. Only visible if `PXE` has been selected as the `Provision Source`.
 |===

--- a/modules/cnv-vm-create-nic-web.adoc
+++ b/modules/cnv-vm-create-nic-web.adoc
@@ -10,8 +10,8 @@ Create and attach additional NICs to a virtual machine from the web console.
 .Procedure
 
 . In the correct project in the {CNVProductName} console, click *Workloads* -> *Virtual Machines*.
-. Select a virtual machine template.
+. Select a virtual machine.
 . Click *Network Interfaces* to display the NICs already attached to the virtual machine.
-. Click *Create NIC* to create a new slot in the list.
-. Fill in the *NAME*, *NETWORK*, *MAC ADDRESS*, and *BINDING METHOD* for the new NIC.
+. Click *Create Network Interface* to create a new slot in the list.
+. Fill in the *Name*, *Model*, *Network*, *Type*, and *MAC Address* for the new NIC.
 . Click the *&#10003;* button to save and attach the NIC to the virtual machine.

--- a/modules/cnv-vm-rdp-console-web.adoc
+++ b/modules/cnv-vm-rdp-console-web.adoc
@@ -17,7 +17,7 @@ preferred RDP client.
 
 * A running Windows virtual machine with the QEMU guest agent installed. The 
 `qemu-guest-agent` is included in the VirtIO drivers.
-* A layer 2 vNIC attached to the virtual machine. 
+* A layer-2 vNIC attached to the virtual machine. 
 * An RDP client installed on a machine on the same network as the 
 Windows virtual machine. 
 
@@ -27,7 +27,7 @@ Windows virtual machine.
 . Select a Windows virtual machine.
 . Click the *Consoles* tab. 
 . Click the *Consoles* list and select *Desktop Viewer*.
-. In the *Network Interface* list, select the layer 2 vNIC.
+. In the *Network Interface* list, select the layer-2 vNIC.
 . Click *Launch Remote Desktop* to download the `console.rdp` file.
 . Open an RDP client and reference the `console.rdp` file. For example, using 
 *remmina*:


### PR DESCRIPTION
You can now create NetworkAttachmentDefinitions for Linux bridge in the container-native virtualization web console   
- Added the Linux bridge NAD to the existing 'multiple networks' assembly
- changed all references to 'layer-2' to be consistent

cherry-pick to enterprise-4.3