### PR TITLE
Update steps on odo multi component documentation

### DIFF
--- a/modules/openshift-developer-cli-deploying-the-back-end-component.adoc
+++ b/modules/openshift-developer-cli-deploying-the-back-end-component.adoc
@@ -13,7 +13,6 @@
 ----
 $ oc import-image openjdk18 \
 --from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift --confirm
-oc annotate istag/openjdk18:latest tags=builder
 ----
 
 . Tag the image as `builder` to make it accesible for {odo-title}:
@@ -35,7 +34,7 @@ openjdk18     myproject     latest
 . Change directory to the back-end source directory and check that you have the correct files in the directory:
 +
 ----
-$ cd ~/backend
+$ cd <directory-name>
 $ ls
 debug.sh  pom.xml  src
 ----


### PR DESCRIPTION
- Removes an extra step that was added accidently to the odo documentation.
- Changes a `cd` step to `<directory-name>` instead of specifying the
folder