### PR TITLE
Tweaks for RHOSP vs. others. BZ 17617109.

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -60,7 +60,7 @@ endif::[]
 [id="installation-launching-installer_{context}"]
 = Deploy the cluster
 
-You can install {product-title} on a compatible cloud.
+You can install {product-title} on a compatible cloud platform.
 
 [IMPORTANT]
 ====
@@ -69,7 +69,10 @@ You can run the `create cluster` command of the installation program only once, 
 
 .Prerequisites
 
-* Configure an account with the cloud platform that hosts your cluster.
+ifndef::osp[* Configure an account with the cloud platform that hosts your cluster.]
+
+ifdef::osp[* Have an administrator account on the target environment.]
+
 * Obtain the {product-title} installation program and the pull secret for your
 cluster.
 


### PR DESCRIPTION
Context: https://bugzilla.redhat.com/show_bug.cgi?id=1767109

This PR:
* Adds a conditional statement so that 'Configuring a cloud platform account' isn't a prereq in RHOSP assemblies
* Changes the first line of the run installer module to be more platform-agnostic.
