### PR TITLE
Fixing instances of {ProductName}; adding the word Platform

### DIFF
--- a/cnv/cnv_users_guide/cnv-automating-management-tasks.adoc
+++ b/cnv/cnv_users_guide/cnv-automating-management-tasks.adoc
@@ -4,8 +4,8 @@ include::modules/cnv-document-attributes.adoc[]
 :context: cnv-automating-management-tasks
 toc::[]
 
-You can automate {ProductName} management tasks by using Red Hat Ansible
-Automation. Learn the basics by using an Ansible Playbook to create a new
+You can automate {CNVProductName} management tasks by using Red Hat Ansible
+Automation Platform. Learn the basics by using an Ansible Playbook to create a new
 virtual machine.
 
 include::modules/cnv-about-red-hat-ansible-automation.adoc[leveloffset=+1]

--- a/modules/cnv-about-red-hat-ansible-automation.adoc
+++ b/modules/cnv-about-red-hat-ansible-automation.adoc
@@ -7,11 +7,11 @@
 
 link:https://docs.ansible.com/ansible/latest/index.html[Ansible] is an automation
 tool used to configure systems, deploy software, and perform rolling updates.
-Ansible includes support for {ProductName}, and Ansible modules enable you to
+Ansible includes support for {CNVProductName}, and Ansible modules enable you to
 automate cluster management tasks such as template, persistent volume claim, and
 virtual machine operations.
 
-Ansible provides a way to automate {ProductName} management, which you can also
+Ansible provides a way to automate {CNVProductName} management, which you can also
 accomplish by using the `oc` CLI tool or APIs. Ansible is unique because it
 allows you to integrate
 link:https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html#kubevirt[KubeVirt modules] with other Ansible modules.

--- a/modules/cnv-automating-virtual-machine-creation-with-ansible.adoc
+++ b/modules/cnv-automating-virtual-machine-creation-with-ansible.adoc
@@ -6,7 +6,7 @@
 = Automating virtual machine creation
 
 You can use the `kubevirt_vm` Ansible Playbook to create virtual machines in
-your {product-title} cluster using Red Hat Ansible Automation.
+your {product-title} cluster using Red Hat Ansible Automation Platform.
 
 .Prerequisites
 


### PR DESCRIPTION
- There were a few instances where `{ProductName}` was still used instead of `{CNVProductName}`; Aiko pointed these out in the localization review
- Red Hat Ansible Automation is now called Red Hat Ansible Automation Platform

There is no BZ associated with these changes.
They should be cherrypicked to enterprise-4.2 and enterprise-4.3.