### PR TITLE
Added note about community versions of Maistra to Serverless docs

### DIFF
--- a/serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing-openshift-serverless.adoc
@@ -6,7 +6,7 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
-[NOTE]
+[IMPORTANT]
 ====
 {ServerlessProductName} is not tested or supported for installation in a restricted network environment.
 ====
@@ -55,6 +55,11 @@ The {ServerlessOperatorName} only works for {product-title} versions 4.1.13 and 
 ====
 
 For details, see the {product-title} documentation on xref:../operators/olm-adding-operators-to-cluster.adoc[adding Operators to a cluster].
+
+[IMPORTANT]
+====
+The {ServerlessOperatorName} automatically installs the Service Mesh Operator. If you already have a community version of Maistra installed, this will cause a conflict with the {ServerlessOperatorName} Service Mesh auto-install. In this case, the already existing community version of Maistra will be used instead.
+====
 
 
 // Installing Knative Serving


### PR DESCRIPTION
Note requested by QE. Valid for OCP 4.2 docs.