### PR TITLE
Added host-device config for using ipam CNI plug-in

### DIFF
--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -53,7 +53,10 @@ plug-in:
   "device": "<device>", <2>
   "hwaddr": "<hwaddr>", <3>
   "kernelpath": "<kernelpath>", <4>
-  "pciBusID": "<pciBusID>" <5>
+  "pciBusID": "<pciBusID>", <5>
+    "ipam": { <6>
+    ...
+  }
 }
 ----
 <1> Specify the value for the `name` parameter you provided previously for
@@ -67,6 +70,9 @@ the CNO configuration.
 `/sys/devices/pci0000:00/0000:00:1f.6`.
 
 <5> Specify the PCI address of the network device, such as `0000:00:1f.6`.
+
+<6> Specify a configuration object for the ipam CNI plug-in. The plug-in
+manages IP address assignment for the attachment definition.
 
 [id="nw-multus-hostdev-config-example_{context}"]
 == host-device configuration example

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -3,6 +3,7 @@
 // * networking/multiple-networks/configuring-macvlan.adoc
 // * networking/multiple-networks/configuring-ipvlan.adoc
 // * networking/multiple-networks/configuring-bridge.adoc
+// * networking/multiple-networks/configuring-host-device.adoc
 
 // Because the Cluster Network Operator abstracts the configuration for
 // Macvlan, including IPAM configuration, this must be provided as YAML
@@ -28,7 +29,7 @@ specify must be reachable from the additional network.
 ====
 In {product-title} 4.2.0, if you attach a Pod to an additional network that uses
 DHCP for IP address management, the Pod will fail to start.
-This will be fixed in a future release.
+This is fixed in {product-title} 4.2.1.
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1754686[BZ#1754686].
 ====
 

--- a/networking/multiple-networks/configuring-host-device.adoc
+++ b/networking/multiple-networks/configuring-host-device.adoc
@@ -12,6 +12,7 @@ namespace into the Pod's network namespace.
 
 include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
 .Next steps
 


### PR DESCRIPTION
This adds the missing ipam CNI configuration for `host-device`.