### PR TITLE
templates: pass OSO version when searching

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -51,7 +51,7 @@ function hcsearch(searchParams) {
   var hcSearchResult = $("#hc-search-results");
 
   // the "searchprovider" is to return a JSON response in the expected format
-  var searchprovider = "https://help.openshift.com/search/search_custom.php";
+  var searchprovider = "https://search.help.openshift.com/json";
   var searchReq = { "q" : searchParams.q + searchParams.urlFilter,
                     "l" : searchParams.label,
                     "si" : searchParams.si }  // q = query, l = label

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -139,7 +139,7 @@
   var distros = {
     'openshift-origin': ['docs_origin', version],
     'openshift-dedicated': ['docs_dedicated', version],
-    'openshift-online': ['docs_online'],
+    'openshift-online': ['docs_online', version],
     'openshift-enterprise': ['docs_cp', version]
   };
 

--- a/_templates/_search_online.html.erb
+++ b/_templates/_search_online.html.erb
@@ -17,5 +17,5 @@
 </div>
 
 <script>
-  hcSearchCategory("docs_online");
+  hcSearchCategory("docs_online", "<%= version %>");
 </script>

--- a/search-commercial.html
+++ b/search-commercial.html
@@ -206,7 +206,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     var hcSearchResult = $("#hc-search-results");
 
     // the "searchprovider" is to return a JSON response in the expected format
-    var searchprovider = "https://help.openshift.com/search/search_custom.php";
+    var searchprovider = "https://search,help.openshift.com/json";
     var searchReq = { "q" : searchParams.q + searchParams.urlFilter,
                       "l" : searchParams.label,
                       "si" : searchParams.si }  // q = query, l = label


### PR DESCRIPTION
This small change includes the version filter for OSO docs searching (similarly as it's already in place with the other docs), so only relevant Starter or Pro results are to be displayed.
Also, it updates the search endpoint.

The search functionality can be previewed here:
[OSO Starter](http://commercial-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/online/starter/welcome/index.html)
[OSO Pro](http://commercial-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/online/pro/welcome/index.html)