### PR TITLE
[enterprise-4.3] templates: pass OSO version when searching

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -51,7 +51,7 @@ function hcsearch(searchParams) {
   var hcSearchResult = $("#hc-search-results");
 
   // the "searchprovider" is to return a JSON response in the expected format
-  var searchprovider = "https://help.openshift.com/search/search_custom.php";
+  var searchprovider = "https://search.help.openshift.com/json";
   var searchReq = { "q" : searchParams.q + searchParams.urlFilter,
                     "l" : searchParams.label,
                     "si" : searchParams.si }  // q = query, l = label

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -139,7 +139,7 @@
   var distros = {
     'openshift-origin': ['docs_origin', version],
     'openshift-dedicated': ['docs_dedicated', version],
-    'openshift-online': ['docs_online'],
+    'openshift-online': ['docs_online', version],
     'openshift-enterprise': ['docs_cp', version]
   };
 

--- a/_templates/_search_online.html.erb
+++ b/_templates/_search_online.html.erb
@@ -11,5 +11,5 @@
 </div>
 
 <script>
-  hcSearchCategory("docs_online");
+  hcSearchCategory("docs_online", "<%= version %>");
 </script>

--- a/search-commercial.html
+++ b/search-commercial.html
@@ -181,14 +181,68 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </footer>
 
 <script type="text/javascript">
-// custom help.openshift.com search
-function parseParamsFromUrl() {
-        var params = {};
-        var parts = window.location.search.substr(1).split('&');
-        for (var i = 0; i < parts.length; i++) {
-            var keyValuePair = parts[i].split('=');
-            var key = keyValuePair[0];
-            params[key] = keyValuePair[1];
+  // custom help.openshift.com search
+  function parseParamsFromUrl() {
+          var params = {};
+          var parts = window.location.search.substr(1).split('&');
+          for (var i = 0; i < parts.length; i++) {
+              var keyValuePair = parts[i].split('=');
+              var key = keyValuePair[0];
+              params[key] = keyValuePair[1];
+          }
+          return params;
+  }  // function parseParamsFromUrl()
+
+  function hcsearch(searchParams) {
+    // elements used repeatedly
+    var hcMoreBtn = $("#hc-search-more-btn");
+    var hcSearchIndicator = $("#hc-search-progress-indicator");
+    var hcSearchResult = $("#hc-search-results");
+
+    // the "searchprovider" is to return a JSON response in the expected format
+    var searchprovider = "https://search,help.openshift.com/json";
+    var searchReq = { "q" : searchParams.q + searchParams.urlFilter,
+                      "l" : searchParams.label,
+                      "si" : searchParams.si }  // q = query, l = label
+
+    hcMoreBtn.hide();
+    hcSearchIndicator.show();
+    $.get(searchprovider, searchReq).done(function (hcsearchresults) {
+      // GET success
+      if (hcsearchresults == "") {
+        // success, but no response (response code mismatch)
+        $("#hc-search-result").append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+        hcSearchIndicator.hide();
+      }
+      if (hcsearchresults.response.result) {
+        // if there are any results
+        $(hcsearchresults.response.result).each(function () {
+          var row = '<div class="search-result-item"><a href="' + this.url +
+            '" target="_blank">' + this.title + '</a>';
+          row += '<p class="excerpt">' + this.content_description.replace(/\<br\>/g, ' ') + '</p></div>';
+          hcSearchResult.append(row);
+        });
+        if (hcsearchresults.response.page_number < hcsearchresults.response.page_count) {
+          // if there are more results beyond the retrieved ones
+          // index of the first item on the next page (first item = 0, first page = 1)
+          searchParams.si = hcsearchresults.response.page_number * hcsearchresults.response.page_size;
+          // replace any existing click handler with one to fetch the next set of results
+          hcMoreBtn.off('click');
+          hcMoreBtn.click(function() {
+            hcsearch(searchParams);
+          });
+          hcMoreBtn.show();
+        } else {
+          // no more results beyond the retrieved ones
+          hcSearchResult.append("<p><strong>No more results.</strong></p>");
+        }
+      } else {
+        if (searchParams.si > 0) {
+            // no results reurned, but some already displayed
+            hcSearchResult.append("<p><strong>No more results.</strong></p>");
+        } else {
+          // no results on initial search
+          hcSearchResult.append("<p><strong>No results found. Try rewording your search.</strong></p>");
         }
         return params;
   }


### PR DESCRIPTION
* Passes OSO version [starter|pro] to the URL filter to get relevant
  (v3/v4) results
* Updates the search endpoint

Signed-off-by: Jiri Fiala <jfiala@redhat.com>

xref: https://github.com/openshift/openshift-docs/pull/18130