### PR TITLE
OSP: instruct users to uncompress the artifact

### DIFF
--- a/modules/installation-osp-creating-image.adoc
+++ b/modules/installation-osp-creating-image.adoc
@@ -19,7 +19,12 @@ The {product-title} installation program requires that a {op-system-first} image
 
 . Under *Version*, select version 4.2.0 for RHEL 8.
 
-. Download the _Red Hat Enterprise Linux CoreOS - OpenStack Image (QCOW)_.
+. Download the _Red Hat Enterprise Linux CoreOS - OpenStack Image (QCOW)_ and decompress the image.
++
+[NOTE]
+====
+You must decompress the OpenStack image before the cluster can use it.
+====
 
 . From the image that you downloaded, create an image that is named `rhcos` in your cluster by using the {rh-openstack} CLI:
 +


### PR DESCRIPTION
We've received multiple reports from users who did not uncompress the
OpenStack artifact before trying to use it in their cluster.  Let's
explicitly instruct them to uncompress the artifact before having them
try to use it in a cluster.