### PR TITLE
Adding Kibana index mode to 4.x

### DIFF
--- a/modules/cluster-logging-elasticsearch-index-policy.adoc
+++ b/modules/cluster-logging-elasticsearch-index-policy.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-elasticsearch.adoc
+
+[id="cluster-logging-elasticsearch-index-policy_{context}"]
+= Configuring Elasticsearch index policy
+
+
+
+.Prerequisites
+
+* Cluster logging and Elasticsearch must be installed.
+
+* Set cluster logging to the unmanaged state.
+
+.Procedure
+
+. Edit the Elasticsearch ConfigMap in the `openshift-logging` project:
++
+----
+oc edit clusterlogging instance
+----
++
+[source,yaml]
+----
+data:
+  elasticsearch.yaml
+
+....
+
+    openshift.kibana.index.mode: shared_ops <1>
+
+----
+<1> Specify an index policy:
++
+


### PR DESCRIPTION
After discovering that the section on Kibana index mode configuration did not convert from 3.11 to 4.x, I created this section to add the missing info.  

https://github.com/openshift/openshift-docs/pull/17772#discussion_r346873590