### PR TITLE
Fixing build warnings/errors

### DIFF
--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -66,14 +66,14 @@ objects:
 .. Create a new project:
 +
 ----
-oc new-project <project>
+$ oc new-project <project> <1>
 ----
 <1> Replace `<project>` with the name for the project you are creating.
 
 .. Confirm that the network policy objects in the new project template exist in the new project:
 +
 ----
-oc get networkpolicy
+$ oc get networkpolicy
 NAME                           POD-SELECTOR   AGE
 allow-from-openshift-ingress   <none>         7s
 allow-from-same-namespace      <none>         7s

--- a/networking/configuring-networkpolicy.adoc
+++ b/networking/configuring-networkpolicy.adoc
@@ -18,7 +18,7 @@ include::modules/nw-networkpolicy-view.adoc[leveloffset=+1]
 include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+1]
 
 [id="nw-networkpolicy-creating-default-networkpolicy-objects-for-a-new-project"]
-= Creating default network policies for a new project
+== Creating default network policies for a new project
 
 As a cluster administrator, you can modify the new project template to
 automatically include NetworkPolicy objects when you create a new project.


### PR DESCRIPTION
This is to fix these errors and warnings:

```
asciidoctor: ERROR: <stdin>: line 21: level 0 sections can only be used when doctype is book
asciidoctor: WARNING: modules/modifying-template-for-new-projects.adoc: line 6: section title out of sequence: expected level 1, got level 2
asciidoctor: WARNING: modules/nw-networkpolicy-project-defaults.adoc: line 6: section title out of sequence: expected level 1, got level 2
asciidoctor: WARNING: modules/nw-networkpolicy-project-defaults.adoc: line 71: no callout found for <1>
```

@jboxman Would you mind reviewing this please since the fixes are in networking? 