### PR TITLE
Remove mentions of trunkSupport and octaviaSupport

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -262,14 +262,6 @@ ifdef::osp[]
 |An existing floating IP address to associate with the load balancer API.
 |An IP address, for example `128.0.0.1`.
 
-|`machines.platform.openstack.trunkSupport`
-|Whether {rh-openstack} ports can be trunked.
-|`true` or `false`
-
-|`machines.platform.openstack.octaviaSupport`
-|Whether {rh-openstack} supports Octavia.
-|`true` or `false`
-
 |`machines.platform.openstack.defaultMachinePlatform`
 | _Optional_. The default machine pool platform configuration.
 |

--- a/modules/installation-osp-config-yaml.adoc
+++ b/modules/installation-osp-config-yaml.adoc
@@ -45,8 +45,6 @@ platform:
     externalNetwork: external
     computeFlavor: m1.xlarge
     lbFloatingIP: 128.0.0.1
-    trunkSupport: false
-    octaviaSupport: false
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ----

--- a/modules/installation-osp-enabling-kuryr.adoc
+++ b/modules/installation-osp-enabling-kuryr.adoc
@@ -36,15 +36,8 @@ apiVersion: v1
 ...
 networking:
   networkType: Kuryr
-  ...
-platform:
-  openstack:
-    ...
-    trunkSupport: true <1>
-    octaviaSupport: true <1>
-    ...
+...
 ----
-<1> The installation program automatically discovers both `trunkSupport` and `octaviaSupport`, so you are not required to provide values for these parameters.
 
 +
 At deployment, the Kuryr SDN is used in place of the OpenShift SDN.


### PR DESCRIPTION
The aforementioned options are autodetected by the installer and are not
supposed to be set by the user. Their presence in the example of
OpenStack's `install-config.yaml` sparks confusion as setting them does
not change how the installer behaves, especially setting `trunkSupport`
to `0` or `false` does not disable adding trunk ports to OpenShift VMs.