### PR TITLE
CNV - BZ1741626 Release Note

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -53,6 +53,10 @@ connectivity after being restarted. This issue is fixed in {CNVProductName} 2.1.
 
 == Known issues
 
+// Don't remove: this BZ is probably true for all 2.x releases
+* The `masquerade` binding method for virtual machines cannot be used in clusters with RHEL 7 compute nodes. 
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1741626[*BZ#1741626*])
+
 * When adding a disk to a virtual machine via the *Disks* tab in the web console,
 the added disk always has a `Filesystem` volumeMode, regardless of the volumeMode
 set in the `kubevirt-storage-class-default` ConfigMap.


### PR DESCRIPTION
Known Issue: `masquerade` binding method is not supported on el7 nodes

Cherrypick to enterprise-4.2 and enterprise-4.3