### PR TITLE
modules/*logging*: Consistently 'oc edit ClusterLogging instance' before YAML

### DIFF
--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -17,8 +17,6 @@ $ oc edit ClusterLogging instance
 +
 [source,yaml]
 ----
-$ oc edit ClusterLogging instance
-
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
@@ -39,29 +37,3 @@ spec:
             memory: 1Gi
 ----
 <1> Specify the CPU and memory limits and requests as needed. The values shown are the default values.
-
-////
-[source,yaml]
-----
-$ oc edit ClusterLogging instance
-
-apiVersion: "logging.openshift.io/v1"
-kind: "ClusterLogging"
-metadata:
-  name: "instance"
-
-....
-
-spec:
-  collection:
-    logs:
-      rsyslog:
-        resources:
-          limits: <1>
-            memory: 358Mi
-          requests:
-            cpu: 100m
-            memory: 358Mi
-----
-<1> Specify the CPU and memory limits and requests as needed. The values shown are the default values.
-////

--- a/modules/cluster-logging-configuring-node-selector.adoc
+++ b/modules/cluster-logging-configuring-node-selector.adoc
@@ -9,12 +9,14 @@ Each component specification allows the component to target a specific node.
 
 .Procedure
 
-Edit the Cluster Logging Custom Resource (CR) in the `openshift-logging` project:
-
-[source,yaml]
+. Edit the Cluster Logging Custom Resource (CR) in the `openshift-logging` project:
++
 ----
 $ oc edit ClusterLogging instance
-
+----
++
+[source,yaml]
+----
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
@@ -56,10 +58,7 @@ spec:
         nodeSelector:  <4>
         logging: fluentd
 ----
-
 <1> Node selector for Elasticsearch.
 <2> Node selector for Kibana.
 <3> Node selector for Curator.
 <4> Node selector for Fluentd.
-
-

--- a/modules/cluster-logging-elasticsearch-limits.adoc
+++ b/modules/cluster-logging-elasticsearch-limits.adoc
@@ -59,5 +59,4 @@ For example:
 ----
 +
 Kubernetes generally adheres the node CPU configuration and DOES not allow Elasticsearch to use the specified limits. 
-Setting the same value for the `requests` and `limits` ensures that Elasticseach can use the CPU and memory you want, assuming the node has the CPU and memory available. 
-
+Setting the same value for the `requests` and `limits` ensures that Elasticseach can use the CPU and memory you want, assuming the node has the CPU and memory available.

--- a/modules/cluster-logging-kibana-scaling.adoc
+++ b/modules/cluster-logging-kibana-scaling.adoc
@@ -17,8 +17,6 @@ $ oc edit ClusterLogging instance
 +
 [source,yaml]
 ----
-$ oc edit ClusterLogging instance
-
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
@@ -33,4 +31,3 @@ spec:
         replicas: 1 <1>
 ---- 
 <1> Specify the number of Kibana nodes.
-

--- a/modules/cluster-logging-management-state-changing-es.adoc
+++ b/modules/cluster-logging-management-state-changing-es.adoc
@@ -30,12 +30,14 @@ elasticsearch   28h
 
 .Procedure
 
-Edit the Elasticsearch Custom Resource (CR) in the `openshift-logging` project:
-
-[source,yaml]
+. Edit the Elasticsearch Custom Resource (CR) in the `openshift-logging` project:
++
 ----
 $ oc edit Elasticsearch elasticsearch
-
+----
++
+[source,yaml]
+----
 apiVersion: logging.openshift.io/v1
 kind: Elasticsearch
 metadata:
@@ -47,7 +49,6 @@ metadata:
 spec:
   managementState: "Managed" <1>
 ----
-
 <1> Specify the management state as `Managed` or `Unmanaged`.
 
 [NOTE]

--- a/modules/cluster-logging-management-state-changing.adoc
+++ b/modules/cluster-logging-management-state-changing.adoc
@@ -35,8 +35,6 @@ $ oc edit ClusterLogging instance
 +
 [source,yaml]
 ----
-$ oc edit ClusterLogging instance
- 
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -30,6 +30,7 @@ You should set your MachineSet to use at least 6 replicas.
 $ oc edit ClusterLogging instance
 ----
 +
+[source,yaml]
 ----
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
@@ -78,5 +79,4 @@ spec:
 ....
 
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. 
-
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.


### PR DESCRIPTION
The edit command is not YAML itself, so consistently place it in its own block before the YAML block to get proper syntax highlighting (instead of highlighting the shell command as invalid YAML).  The command first appeared in the YAML blocks in 98e58b8c8a (#13877).  There was some subequent cleanup in aa33f74bc7 (#15682), with the command being moved out of YAML blocks in:

* `modules/efk-logging-elasticsearch-limits.adoc`
* `modules/efk-logging-fluentd-collector.adoc`
* `modules/efk-logging-kibana-limits.adoc`

aa33f74bc7 also copied out the `edit` command, but forgot to remove it from the YAML blocks in:

* `modules/efk-logging-fluentd-limits.adoc`
* `modules/efk-logging-kibana-scaling.adoc`
* `modules/efk-logging-management-state-changing.adoc`

Hopefully after this commit we're consistent in all of those locations ;).

CC @mburke5678