### PR TITLE
Serverless metering compatible with metering-ocp

### DIFF
--- a/modules/serverless-metering-datasources.adoc
+++ b/modules/serverless-metering-datasources.adoc
@@ -12,7 +12,7 @@ This datasource provides the accumulated CPU seconds used per Knative service ov
 .YAML file
 [source, yaml]
 ----
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportDataSource
 metadata:
   name: knative-service-cpu-usage
@@ -39,7 +39,7 @@ This datasource provides the average memory consumption per Knative service over
 .YAML file
 [source, yaml]
 ----
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportDataSource
 metadata:
   name: knative-service-memory-usage

--- a/modules/serverless-metering-queries.adoc
+++ b/modules/serverless-metering-queries.adoc
@@ -11,7 +11,7 @@ The following `ReportQuery` resources reference the example `DataSources` provid
 .YAML file
 [source, yaml]
 ----
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportQuery
 metadata:
   name: knative-service-cpu-usage
@@ -20,7 +20,7 @@ spec:
   - name: ReportingStart
     type: time
   - name: ReportingEnd
-    type: timeq
+    type: time
   - default: knative-service-cpu-usage
     name: KnativeServiceCpuUsageDataSource
     type: ReportDataSource
@@ -66,7 +66,7 @@ spec:
 .YAML file
 [source, yaml]
 ----
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportQuery
 metadata:
   name: knative-service-memory-usage
@@ -75,7 +75,7 @@ spec:
   - name: ReportingStart
     type: time
   - name: ReportingEnd
-    type: timeq
+    type: time
   - default: knative-service-memory-usage
     name: KnativeServiceMemoryUsageDataSource
     type: ReportDataSource
@@ -99,7 +99,7 @@ spec:
     unit: date
   - name: service_usage_memory_byte_seconds
     type: double
-    unit: bytes_seconds
+    unit: byte_seconds
   query: |
     SELECT
       timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,

--- a/modules/serverless-metering-reports.adoc
+++ b/modules/serverless-metering-reports.adoc
@@ -10,7 +10,7 @@ Before you run a report, you must modify the input parameter within the `Report`
 .YAML file
 [source, yaml]
 ----
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: Report
 metadata:
   name: knative-service-cpu-usage


### PR DESCRIPTION
This is to make our docs compatible with the RedHat-provided Metering operator from operatorhub. The docs are currently only compatible with the "community" version of Metering and this PR aims to fix that.

JIRA: https://jira.coreos.com/browse/SRVCOM-613