### PR TITLE
Registering GutHub OAuth - Add oauth apps section to procedure

### DIFF
--- a/modules/identity-provider-registering-github.adoc
+++ b/modules/identity-provider-registering-github.adoc
@@ -12,7 +12,8 @@ an application to use.
 
 . Register an application on GitHub:
 ** For GitHub, click https://github.com/settings/profile[Settings] ->
-https://github.com/settings/developers[Developer settings] ->
+https://github.com/settings/apps[Developer settings] ->
+https://github.com/settings/developers[OAuth Apps] ->
 https://github.com/settings/applications/new[Register a new OAuth application].
 ** For GitHub Enterprise, go to your GitHub Enterprise home page and then click
 *Settings -> Developer settings -> Register a new application*.


### PR DESCRIPTION
Add oauth apps section to path, in case users are reading the text and not clicking the links.

Choosing the Developer settings option on GitHub brings users to the GitHub Apps
section (settings/apps) and not the OAuth Apps section (/settings/developers)