### PR TITLE
Bug 1774377: [DOCS] No mention for how to upgrade RHEL compute node from v4.1 to v4.2

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -37,6 +37,29 @@ your RHEL machines and the `upgrade` playbook.
 You must not enable firewalld later. If you do, you cannot access {product-title} logs on the worker.
 ====
 
+. Enable the repositories that are required for {product-title} {product-version}:
+.. On the machine that you run the Ansible playbooks, update the required repositories:
++
+----
+# subscription-manager repos --disable=rhel-7-server-ansible-2.7-rpms  \
+                             --disable=rhel-7-server-ose-4.1-rpms \
+                             --enable=rhel-7-server-ansible-2.8-rpms \
+                             --enable=rhel-7-server-ose-4.2-rpms
+----
+
+.. On the machine that you run the Ansible playbooks, update the required packages, including `openshift-ansible`:
++
+----
+# yum update openshift-ansible openshift-clients
+----
+
+.. On each RHEL compute node, update the required repositories:
++
+----
+# subscription-manager repos --disable=rhel-7-server-ose-4.1-rpms \
+                             --enable=rhel-7-server-ose-4.2-rpms
+----
+
 . Review your Ansible inventory file at `/<path>/inventory/hosts`
 and ensure that all of your compute, or worker, machines are listed in the
 `[workers]` section, as shown in the following example:


### PR DESCRIPTION
- Reference: [[DOCS] No mention for how to upgrade RHEL compute node from v4.1 to v4.2](https://bugzilla.redhat.com/show_bug.cgi?id=1774377)
- Version: 4.2
- Description: If a RHEL compute node upgrade from 4.1 to 4.2, you should switch the required repositories as new version.
