### PR TITLE
Fix TP include expanding pvs

### DIFF
--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -1,14 +1,11 @@
 // Module included in the following assemblies:
 //
-// * monitoring/application-monitoring.adoc
+// * exposing-custom-application-metrics-for-autoscaling
 
 [id="exposing-custom-application-metrics-for-horizontal-pod-autoscaling_{context}"]
 = Exposing custom application metrics for horizontal pod autoscaling
 
 You can use the `prometheus-adapter` resource to expose custom application metrics for the horizontal pod autoscaler.
-
-:FeatureName: Prometheus Adapter
-include::modules/technology-preview.adoc[leveloffset=+0]
 
 .Prerequisites
 

--- a/modules/storage-expanding-csi-volumes.adoc
+++ b/modules/storage-expanding-csi-volumes.adoc
@@ -14,6 +14,3 @@ link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage ven
 
 {product-title} {product-version} supports version 1.1.0 of the
 link:https://github.com/container-storage-interface/spec[CSI specification].
-
-:FeatureName: Expanding CSI volumes
-include::modules/technology-preview.adoc[leveloffset=+0]

--- a/monitoring/application-monitoring.adoc
+++ b/monitoring/application-monitoring.adoc
@@ -17,4 +17,3 @@ include::modules/monitoring-exposing-custom-application-metrics-for-horizontal-p
 .Next steps
 
 * To automatically adjust the number of pods in which the application runs, xref:../monitoring/application-monitoring.adoc#application-monitoring[configure Horizontal Pod Autoscaling for the application.]
-

--- a/monitoring/exposing-custom-application-metrics-for-autoscaling.adoc
+++ b/monitoring/exposing-custom-application-metrics-for-autoscaling.adoc
@@ -7,10 +7,12 @@ toc::[]
 
 You can export custom application metrics for the horizontal pod autoscaler.
 
+:FeatureName: Prometheus Adapter
+include::modules/technology-preview.adoc[leveloffset=+0]
+
 include::modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc[leveloffset=+1]
 
 .Additional resources
 
 * See the xref:../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling[horizontal pod autoscaling documentation].
 * See the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale[Kubernetes documentation on horizontal pod autoscaler].
-

--- a/storage/expanding-persistent-volumes.adoc
+++ b/storage/expanding-persistent-volumes.adoc
@@ -8,6 +8,10 @@ include::modules/storage-expanding-add-volume-expansion.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-csi-volumes.adoc[leveloffset=+1]
 
+:FeatureName: Expanding CSI volumes
+
+include::modules/technology-preview.adoc[leveloffset=+1]
+
 include::modules/storage-expanding-filesystem-pvc.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-recovering-failure.adoc[leveloffset=+1]


### PR DESCRIPTION
Relates to [PR 18032](https://github.com/openshift/openshift-docs/pull/18032) (move TP module to expanding-persistent-volumes assembly)

@rh-max - I also moved the Tech Preview module to the assembly `monitoring/exposing-custom-application-metrics-for-autoscaling`. Both of us were having "Unresolved directive" build issues because we had the TP module within a module. It had to go either before or after the `exposing-custom-application-metrics-for-horizontal-pod-autoscaling` module, so I placed it before the include for that module. FYI in case you want to move it again.