### PR TITLE
Fix file ID changed by PR 17558

### DIFF
--- a/modules/cluster-logging-collector-external.adoc
+++ b/modules/cluster-logging-collector-external.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * logging/efk-logging-external.adoc
+// * logging/cluster-logging-external.adoc
 
-[id="efk-logging-fluentd-external_{context}"]
+[id="cluster-logging-fluentd-external_{context}"]
 = Configuring Fluentd to send logs to an external log aggregator
 
 You can configure Fluentd to send a copy of its logs to an external log


### PR DESCRIPTION
For some reason, https://github.com/openshift/openshift-docs/pull/17558 changed the ID of the file from `cluster-` to `efk-`. 