### PR TITLE
WIP Add note regarding network policy and host network routers

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -6,10 +6,11 @@
 
 = About network policy
 
-In a cluster using a Kubernetes Container Network Interface (CNI) plug-in that
-supports NetworkPolicy, network isolation is controlled entirely by
-NetworkPolicy objects. In {product-title} {product-version}, OpenShift SDN
-supports using NetworkPolicy in its default network isolation mode.
+In a cluster using a Kubernetes Container Network Interface (CNI) Pod network
+provider plug-in that supports NetworkPolicy, network isolation is controlled
+entirely by NetworkPolicy objects. In {product-title} {product-version},
+OpenShift SDN supports using NetworkPolicy in its default network isolation
+mode.
 
 [NOTE]
 ====
@@ -48,6 +49,12 @@ spec:
 ----
 
 * Only allow connections from the {product-title} Ingress Controller:
++
+[IMPORTANT]
+====
+In {product-title} {product-version}, you can allow connections from the Ingress Controller only on public cloud providers.
+If your cluster is installed on a platform that uses the host network for the {product-title} router, enabling network policy for a project by defining at least one network policy object will block traffic from Pods in your project.
+====
 +
 To make a project allow only connections from the {product-title} Ingress
 Controller, add the following NetworkPolicy object: 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1768608
- https://bugzilla.redhat.com/show_bug.cgi?id=1764220

So, the cliff notes version is simply this:

If you enable network policy for a project, only traffic that is allowed by the policy can reach the Pod. However, this is not exactly the case for the ingress router. One some platforms (other than AWS, GCP, Azure), if you define a network policy in a project, traffic from the router _cannot_ reach any Pods in that project.

So the goal is to convey to a user that, if you are using a cluster installed on a platform other than AWS, GCP, and Azure, if you have a project with Pods that must be reachable from the ingress router, it is not possible to define network policy objects in that project.

(Specifically, if the router is installed on the _host network_, network policy cannot allow traffic from it.)