### PR TITLE
Include missing steps for using a service nodeport

### DIFF
--- a/modules/nw-create-load-balancer-service.adoc
+++ b/modules/nw-create-load-balancer-service.adoc
@@ -27,7 +27,6 @@ $ oc project project1
 file as needed:
 +
 .Sample load balancer configuration file
-====
 ----
 apiVersion: v1
 kind: Service
@@ -42,12 +41,10 @@ spec:
   selector:
     name: mysql <4>
 ----
-
 <1> Enter a descriptive name for the load balancer service.
 <2> Enter the same port that the service you want to expose is listening on.
 <3> Enter `loadbalancer` as the type.
 <4> Enter the name of the service.
-====
 
 . Save and exit the file.
 
@@ -80,7 +77,7 @@ using the public IP address:
 ----
 $ curl <public-ip>:<port>
 ----
-++
++
 For example:
 +
 ----

--- a/modules/nw-creating-project-and-service.adoc
+++ b/modules/nw-creating-project-and-service.adoc
@@ -11,9 +11,11 @@ the project, then the service.
 If the project and service already exist, skip to the procedure on exposing the
 service to create a route.
 
-.Procedure
+.Prerequisites
 
-. Log in to {product-title}.
+* Install the `oc` CLI and log in as a cluster administrator.
+
+.Procedure
 
 . Create a new project for your service:
 +
@@ -34,16 +36,15 @@ $ oc new-app \
     -e MYSQL_USER=admin \
     -e MYSQL_PASSWORD=redhat \
     -e MYSQL_DATABASE=mysqldb \
-    registry.redhat.io/openshift3/mysql-55-rhel7
+    registry.redhat.io/rhscl/mysql-80-rhel7
 ----
 
 . Run the following command to see that the new service is created:
 +
 ----
-$ oc get svc -n openshift-ingress
-NAME                      TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                      AGE
-router-default            LoadBalancer   172.30.16.119   52.230.228.163   80:30745/TCP,443:32561/TCP   2d6h
-router-internal-default   ClusterIP      172.30.101.15   <none>           80/TCP,443/TCP,1936/TCP      2d6h
+$ oc get svc -n myproject
+NAME             TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+mysql-80-rhel7   ClusterIP   172.30.63.31   <none>        3306/TCP   4m55s
 ----
 +
 By default, the new service does not have an external IP address.

--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -2,10 +2,14 @@
 //
 // * networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
 
+ifeval::["{context}" == "configuring-ingress-cluster-traffic-nodeport"]
+:nodeport:
+endif::[]
+
 [id="nw-exposing-service_{context}"]
 = Exposing the service by creating a route
 
-You can expose the service as a route using the `oc expose` command.
+You can expose the service as a route by using the `oc expose` command.
 
 .Procedure
 
@@ -19,6 +23,7 @@ To expose the service:
 $ oc project project1
 ----
 
+ifndef::nodeport[]
 . Run the following command to expose the route:
 +
 ----
@@ -28,8 +33,8 @@ $ oc expose service <service_name>
 For example:
 +
 ----
-$ oc expose service mysql-55-rhel7
-route "mysql-55-rhel7" exposed
+$ oc expose service mysql-80-rhel7
+route "mysql-80-rhel7" exposed
 ----
 
 . Use a tool, such as cURL, to make sure you can reach the service using the
@@ -58,7 +63,34 @@ Welcome to the MariaDB monitor.  Commands end with ; or \g.
 
 MySQL [(none)]>
 ----
+endif::nodeport[]
+ifdef::nodeport[]
+. To expose a node port for the application, enter the following command. {product-title} automatically selects an available port in the `30000-32767` range.
++
+----
+$ oc expose dc mysql-80-rhel7 --type=NodePort --name=mysql-ingress
+----
+
+. Optional: To confirm the service is available with a node port exposed, enter the following command:
++
+----
+$ oc get svc -n myproject
+NAME             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
+mysql-80-rhel7   ClusterIP   172.30.217.127   <none>        3306/TCP         9m44s
+mysql-ingress    NodePort    172.30.107.72    <none>        3306:31345/TCP   39s
+----
+
+. Optional: To remove the service created automatically by the `oc new-app` command, enter the following command:
++
+----
+$ oc delete svc mysql-80-rhel7
+----
+endif::nodeport[]
 
 //Potentially add verification step, "If a verification step is needed, it would
 //look something like oc get route mysql-55-rhel7 and curl with the host from the
 //output of the oc get route command."
+
+ifdef::nodeport[]
+:!nodeport:
+endif::[]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1774213

This is more of a patch so that documentation is accurate; it can probably use a stylistic clean up as well, but that's beyond the scope of the immediate fire.

~As of yet, I am uncertain what the steps will be, exactly. I'll need access to host network pods to usefully test it.~