### PR TITLE
install: fixes for bare metal artifacts + architecture usage

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -36,14 +36,13 @@ to the {product-title} version that you install. Use the image versions
 that match your {product-title} version if they are available.
 ====
 +
-You must download the ISO file and either the BIOS or UEFI file.
+You must download the ISO file and the RAW disk file.
 Those file names resemble the following examples:
 
-** ISO: `rhcos-<version>-<architecture>-installer.iso`
-** Compressed metal BIOS: `rhcos-<version>-<architecture>-metal-bios.raw.gz`
-** Compressed metal UEFI: `rhcos-<version>-<architecture>-metal-uefi.raw.gz`
+** ISO: `rhcos-<version>-installer.<architecture>.iso`
+** Compressed metal RAW: `rhcos-<version>-metal.<architecture>.raw.gz`
 
-. Upload either the BIOS or UEFI {op-system} image file to your HTTP server and
+. Upload either the RAW {op-system} image file to your HTTP server and
 note its URL.
 
 . Use the ISO to start the {op-system} installation. Use one of the following
@@ -61,7 +60,7 @@ coreos.inst.image_url=<bare_metal_image_URL> <2>
 coreos.inst.ignition_url=http://example.com/config.ign <3>
 ----
 <1> Specify the block device of the system to install to.
-<2> Specify the URL of the UEFI or BIOS image that you uploaded to your server.
+<2> Specify the URL of the RAW image that you uploaded to your server.
 <3> Specify the URL of the Ignition config file for this machine type.
 
 . Press Enter to complete the installation. After {op-system} installs, the system

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -21,7 +21,7 @@ booting to create the machines.
 . Upload the master, worker, and bootstrap Ignition config files that the
 installation program created to your HTTP server. Note the URLs of these files.
 
-. Obtain the {op-system} ISO image, compressed metal BIOS, `kernel`
+. Obtain the {op-system} ISO image, compressed metal RAW image, `kernel`
 and `initramfs` files from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
 Hat customer portal or the
@@ -39,12 +39,12 @@ that match your {product-title} version if they are available.
 The file names contain the {product-title} version number.
 They resemble the following examples:
 
-** ISO: `rhcos-<version>-<architecture>-installer.iso`
-** Compressed metal BIOS: `rhcos-<version>-<architecture>-metal-bios.raw.gz`
-** `kernel`: `rhcos-<version>-<architecture>-installer-kernel`
-** `initframs`: `rhcos-<version>-<architecture>-installer-initramfs.img`
+** ISO: `rhcos-<version>-installer.<architecture>.iso`
+** Compressed metal RAW image: `rhcos-<version>metal.<architecture>.raw.gz`
+** `kernel`: `rhcos-<version>-installer-kernel-<architecture>`
+** `initframs`: `rhcos-<version>-installer-initramfs.<architecture>.img`
 
-. Upload the compressed metal BIOS file and the `kernel` and `initramfs` files
+. Upload the compressed metal RAW image and the `kernel` and `initramfs` files
 to your HTTP server.
 
 . Configure the network boot infrastructure so that the machines boot from their
@@ -62,8 +62,8 @@ DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
-    KERNEL http://<HTTP_server>/rhcos-<version>-<architecture>-installer-kernel <1>
-    APPEND ip=dhcp rd.neednet=1 initrd=rhcos-<version>-<architecture>-installer-initramfs.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-<architecture>-metal-bios.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <2> <3>
+    KERNEL http://<HTTP_server>/rhcos-<version>-installer-kernel-<architecture> <1>
+    APPEND ip=dhcp rd.neednet=1 initrd=http://<HTTP_server>/rhcos-<version>-installer-initramfs.<architecture>.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-metal.<architecture>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <2> <3>
 ----
 <1> Specify the location of the `kernel` file that you uploaded to your HTTP
 server.
@@ -72,41 +72,25 @@ For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 <3> Specify locations of the {op-system} files that you uploaded to your
 HTTP server. The `initrd` parameter value is the location of the `initramfs` file,
 the `coreos.inst.image_url` parameter value is the location of the compressed
-metal BIOS file, and the `coreos.inst.ignition_url` parameter value is the
+metal RAW image, and the `coreos.inst.ignition_url` parameter value is the
 location of the bootstrap Ignition config file.
 
 ** For iPXE:
 +
 ----
-kernel  http://<HTTP_server>/rhcos-<version>-<architecture>-installer-kernel ip=dhcp rd.neednet=1 initrd=http://<HTTP_server>/rhcos-<version>-<architecture>-installer-initramfs.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-<architecture>-metal-bios.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
-initrd http://<HTTP_server>/rhcos-<version>-<architecture>-installer-initramfs.img <3>
+kernel  http://<HTTP_server>/rhcos-<version>-installer-kernel-<architecture> ip=dhcp rd.neednet=1 initrd=http://<HTTP_server>/rhcos-<version>-installer-initramfs.<architecture>.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-metal.<arhcitectutre>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
+initrd http://<HTTP_server>/rhcos-<version>-installer-initramfs.<architecture>.img <3>
 boot
 ----
 <1> Specify locations of the {op-system} files that you uploaded to your
 HTTP server. The `kernel` parameter value is the location of the `kernel` file,
 the `initrd` parameter value is the location of the `initramfs` file,
 the `coreos.inst.image_url` parameter value is the location of the compressed
-metal BIOS file, and the `coreos.inst.ignition_url` parameter value is the
+metal RAW image, and the `coreos.inst.ignition_url` parameter value is the
 location of the bootstrap Ignition config file.
 <2> If you use multiple NICs, specify a single interface in the `ip` option.
 For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 <3> Specify the location of the `initramfs` file that you uploaded to your HTTP
-server.
-
-. If you use UEFI, edit the included `grub.conf` file that is included in the
-ISO that you downloaded to include the following installation options:
-+
-----
-menuentry 'Install Red Hat Enterprise Linux CoreOS' --class fedora --class gnu-linux --class gnu --class os {
-	linux /images/vmlinuz nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-<architecture>-metal-uefi.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1>
-	initrd http://<HTTP_server>/rhcos-<version>-<architecture>-installer-initramfs.img <2>
-}
-----
-<1> For the `coreos.inst.image_url` parameter value, specify the location of
-the compressed metal UEFI file that you uploaded to your HTTP server. For the
-`coreos.inst.ignition_url`, specify the location of the bootstrap Ignition
-config file that you uploaded to your HTTP server.
-<2> Specify the location of the `initramfs` file that you uploaded to your HTTP
 server.
 
 . Continue to create the machines for your cluster.

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -81,7 +81,7 @@ that matches your {product-title} version if it is available.
 ====
 +
 The file name contains the {product-title} version number in the format
-`rhcos-<version>-<architecture>-vmware.ova`.
+`rhcos-<version>-vmware.<architecture>.ova`.
 
 . In the vSphere Client, create a folder in your datacenter to store your VMs.
 .. Click the *VMs and Templates* view.


### PR DESCRIPTION
- There is a single bare metal RHCOS artifact for both BIOS/UEFI installs
- The architecture information for RHCOS artifacts appears right before the filetype in the artifact name.

This change should be used for 4.3 docs and onward

cc: @chrisnegus 