### PR TITLE
modules/installation-aws-user-infra-rhcos-ami: Bump to RHCOS 44.81.202001030903.0

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -18,51 +18,54 @@ You must use a valid {op-system-first} AMI for your Amazon Web Services
 |AWS AMI
 
 |`ap-northeast-1`
-|`ami-0426ca3481a088c7b`
+|`ami-02bb6c599c86663bd`
 
 |`ap-northeast-2`
-|`ami-014514ae47679721b`
+|`ami-03dd9e368f20dbc76`
 
 |`ap-south-1`
-|`ami-0bd772ba746948d9a`
+|`ami-0192efd438962e43a`
 
 |`ap-southeast-1`
-|`ami-0d76ac0ebaac29e40`
+|`ami-0fc688622e368c765`
 
 |`ap-southeast-2`
-|`ami-0391e92574fb09e08`
+|`ami-083ae473d8d6b7771`
 
 |`ca-central-1`
-|`ami-04419691da69850cf`
+|`ami-0e3eba4d065f52d54`
 
 |`eu-central-1`
-|`ami-092b69120ecf915ed`
+|`ami-03c14a5bb0eadf4e3`
 
 |`eu-north-1`
-|`ami-0175e9c9d258cc11d`
+|`ami-027eb49da627f8899`
 
 |`eu-west-1`
-|`ami-04370efd78434697b`
+|`ami-0fda05c1fd2f78f3d`
 
 |`eu-west-2`
-|`ami-00c74e593125e0096`
+|`ami-0fd3f4561265de484`
 
 |`eu-west-3`
-|`ami-058ad17da14ff4d0d`
+|`ami-05ee3993a0d19102e`
+
+|`me-south-1`
+|`ami-013932b8aad1e340f`
 
 |`sa-east-1`
-|`ami-03f6b71e93e630dab`
+|`ami-000abe9467b83a7db`
 
 |`us-east-1`
-|`ami-01e7fdcb66157b224`
+|`ami-07b760584db62cbb2`
 
 |`us-east-2`
-|`ami-0bc59aaa7363b805d`
+|`ami-005141ec3f197b7be`
 
 |`us-west-1`
-|`ami-0ba912f53c1fdcdf0`
+|`ami-05bd75163809cc646`
 
 |`us-west-2`
-|`ami-08e10b201e19fd5e7`
+|`ami-0a2ce8ff0118b47a7`
 
 |===


### PR DESCRIPTION
Catching up with openshift/installer@a8e9991876 (openshift/installer#2714) and its encryption fixes.  Generated with:

```console
$ git cat-file -p a8e9991876:data/data/rhcos.json | jq -r '.amis | to_entries | sort_by(.key)[] | "\n|`" + .key + "`\n|`" + .value.hvm + "`"'
```

and pasting the output into the module doc.