### PR TITLE
modules/installation-aws-user-infra-rhcos-ami: Bump to RHCOS 43.81.201911221453.0

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -18,51 +18,51 @@ You must use a valid {op-system-first} AMI for your Amazon Web Services
 |AWS AMI
 
 |`ap-northeast-1`
-|`ami-0426ca3481a088c7b`
+|`ami-0e4526517ac524c64`
 
 |`ap-northeast-2`
-|`ami-014514ae47679721b`
+|`ami-0e616119366bf59c8`
 
 |`ap-south-1`
-|`ami-0bd772ba746948d9a`
+|`ami-0bb5479b43b5b9a6a`
 
 |`ap-southeast-1`
-|`ami-0d76ac0ebaac29e40`
+|`ami-0733dbf3f7daa30f0`
 
 |`ap-southeast-2`
-|`ami-0391e92574fb09e08`
+|`ami-01f88c7b2ffc45137`
 
 |`ca-central-1`
-|`ami-04419691da69850cf`
+|`ami-075cf25ace0174b41`
 
 |`eu-central-1`
-|`ami-092b69120ecf915ed`
+|`ami-0d27c613cd5307caf`
 
 |`eu-north-1`
-|`ami-0175e9c9d258cc11d`
+|`ami-0a7db400b3ccc5400`
 
 |`eu-west-1`
-|`ami-04370efd78434697b`
+|`ami-0e173367c56629034`
 
 |`eu-west-2`
-|`ami-00c74e593125e0096`
+|`ami-08e7d384fb6f0be97`
 
 |`eu-west-3`
-|`ami-058ad17da14ff4d0d`
+|`ami-0b765b4670474aaf2`
 
 |`sa-east-1`
-|`ami-03f6b71e93e630dab`
+|`ami-05acc0e0f3fa4633c`
 
 |`us-east-1`
-|`ami-01e7fdcb66157b224`
+|`ami-014ce8846db8b463d`
 
 |`us-east-2`
-|`ami-0bc59aaa7363b805d`
+|`ami-0c83319db4b3b3602`
 
 |`us-west-1`
-|`ami-0ba912f53c1fdcdf0`
+|`ami-050658e468dd3db4b`
 
 |`us-west-2`
-|`ami-08e10b201e19fd5e7`
+|`ami-04051ef4316373b52`
 
 |===


### PR DESCRIPTION
Catching up with openshift/installer@3c056215376 (openshift/installer#2666).  Generated with:

```console
$ git --no-pager log -1 --oneline origin/release-4.3 -- data/data/rhcos.json
3c0562153 (origin/pr/2666) RHCOS: Bump to 43.81.201911192044.0 for CRI-O bug fix
$ git cat-file -p 3c056215376:data/data/rhcos.json | jq -r '.amis | to_entries | sort_by(.key)[] | "\n|`" + .key + "`\n|`" + .value.hvm + "`"'
```

and pasting the output into the module doc.