### PR TITLE
Add Azure File and Cinder to block volume table

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -29,6 +29,7 @@ The following table displays which volume plug-ins support block volumes.
 |Volume Plug-in  |Manually provisioned  |Dynamically provisioned |Fully supported
 |AWS EBS  | ✅ | ✅ | ✅
 |Azure Disk | ✅ | ✅ | ✅
+|Azure File | | |
 |Cinder | ✅ | ✅ |
 |Fibre Channel | ✅ | |
 |GCP | ✅ | ✅ | ✅


### PR DESCRIPTION
[BZ1776239](https://bugzilla.redhat.com/show_bug.cgi?id=1776239) requests that we add Azure File and Cinder to the list of block volume plug-ins. This will be merged to master and CP to 4.2, 4.3. For Cinder, the support level changes with 4.3 (allows manual and dynamic provisioning).