### PR TITLE
Add Cinder to block volume table

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -29,7 +29,7 @@ The following table displays which volume plug-ins support block volumes.
 |Volume Plug-in  |Manually provisioned  |Dynamically provisioned |Fully supported
 |AWS EBS  | ✅ | ✅ | ✅
 |Azure Disk | ✅ | ✅ | ✅
-
+|Cinder | | |
 |Fibre Channel | ✅ | |
 
 |GCP | ✅ | ✅ | ✅


### PR DESCRIPTION
[BZ1776239](https://bugzilla.redhat.com/show_bug.cgi?id=1776239) requests that we add Cinder to the list of block volume plug-ins. This PR will be merged to 4.2 and CP to only 4.1. (In 4.3, Cinder allows Manual & Dynamic Provisioning.)
[PR 18410](https://github.com/openshift/openshift-docs/pull/18410) adds Azure File, which doesn't change from 4.2->4.3 the way Cinder does. 