### PR TITLE
Fix context variable connector

### DIFF
--- a/modules/applications-create-using-cli-image.adoc
+++ b/modules/applications-create-using-cli-image.adoc
@@ -2,7 +2,7 @@
 //
 // * applications/application-life-cycle-management/creating-applications-using-the-cli.adoc
 
-[id="applications-create-using-cli-image-{context}"]
+[id="applications-create-using-cli-image_{context}"]
 = Creating an application from an image
 
 You can deploy an application from an existing image. Images can come from

--- a/modules/applications-create-using-cli-modify.adoc
+++ b/modules/applications-create-using-cli-modify.adoc
@@ -2,7 +2,7 @@
 //
 // * applications/application-life-cycle-management/creating-applications-using-the-cli.adoc
 
-[id="applications-create-using-cli-modify-{context}"]
+[id="applications-create-using-cli-modify_{context}"]
 = Modifying application creation
 
 The `new-app` command generates {product-title} objects that build, deploy, and

--- a/modules/applications-create-using-cli-source-code.adoc
+++ b/modules/applications-create-using-cli-source-code.adoc
@@ -2,7 +2,7 @@
 //
 // * applications/application-life-cycle-management/creating-applications-using-the-cli.adoc
 
-[id="applications-create-using-cli-source-code-{context}"]
+[id="applications-create-using-cli-source-code_{context}"]
 = Creating an application from source code
 
 With the `new-app` command you can create applications from source code in a

--- a/modules/cluster-logging-clo-status-comp.adoc
+++ b/modules/cluster-logging-clo-status-comp.adoc
@@ -2,7 +2,7 @@
 //
 // * logging/cluster-logging-cluster-status.adoc
 
-[id="cluster-logging-clo-status-example-{context}"]
+[id="cluster-logging-clo-status-example_{context}"]
 = Viewing the status of cluster logging components
 
 You can view the status for a number of cluster logging components.


### PR DESCRIPTION
Checked both `enterprise-4.2` and `enterprise-4.3` branches. They also only contain the four fixes in this PR, so the cherry-pick for them should suffice.

The `enterprise-4.1` branch contained a few more, so its changes were made in a separate PR: #18435