### PR TITLE
Bump OSDK ver for OCP 4.3

### DIFF
--- a/modules/building-memcached-operator-using-osdk.adoc
+++ b/modules/building-memcached-operator-using-osdk.adoc
@@ -31,7 +31,7 @@ Use the CLI to create a new `memcached-operator` project:
 ----
 $ mkdir -p $GOPATH/src/github.com/example-inc/
 $ cd $GOPATH/src/github.com/example-inc/
-$ operator-sdk new memcached-operator --dep-manager dep
+$ operator-sdk new memcached-operator
 $ cd memcached-operator
 ----
 
@@ -194,7 +194,7 @@ link:https://quay.io/new/[create a new public image] repository named
 .... Push the image to the registry:
 +
 ----
-$ docker push quay.io/example/memcached-operator:v0.0.1
+$ podman push quay.io/example/memcached-operator:v0.0.1
 ----
 
 .... Setup RBAC and deploy `memcached-operator`:

--- a/modules/osdk-building-helm-operator.adoc
+++ b/modules/osdk-building-helm-operator.adoc
@@ -185,7 +185,7 @@ method for production use.
 +
 ----
 $ operator-sdk build quay.io/example/nginx-operator:v0.0.1
-$ docker push quay.io/example/nginx-operator:v0.0.1
+$ podman push quay.io/example/nginx-operator:v0.0.1
 ----
 
 ... Deployment manifests are generated in the `deploy/operator.yaml` file. The

--- a/modules/osdk-cli-reference-new.adoc
+++ b/modules/osdk-cli-reference-new.adoc
@@ -22,9 +22,6 @@ The `operator-sdk new` command creates a new Operator application and generates
 |`--api-version`
 |CRD `APIVersion` in the format `$GROUP_NAME/$VERSION`, for example `app.example.com/v1alpha1`. Used with `ansible` or `helm` types.
 
-|`--dep-manager [dep\|modules]`
-|Dependency manager the new project will use. Used with `go` type. (Default: `modules`)
-
 |`--generate-playbook`
 |Generate an Ansible playbook skeleton. Used with `ansible` type.
 
@@ -53,6 +50,13 @@ The `operator-sdk new` command creates a new Operator application and generates
 |Type of Operator to initialize: `go`, `ansible` or `helm`. (Default: `go`)
 
 |===
+
+[NOTE]
+====
+Starting with Operator SDK v0.12.0, the `--dep-manager` flag and support for
+`dep`-based projects have been removed. Go projects are now scaffolded to use Go
+modules.
+====
 
 .Example usage for Go project
 ----

--- a/modules/osdk-installing-cli.adoc
+++ b/modules/osdk-installing-cli.adoc
@@ -27,9 +27,15 @@ project on GitHub.
 
 .Prerequisites
 
-- link:https://docs.docker.com/install/[`docker`] v17.03+
-- OpenShift CLI (`oc`) v4.1+ installed
-- Access to a cluster based on Kubernetes v1.11.3+
+- link:https://golang.org/dl/[Go] v1.13+
+ifdef::openshift-origin[]
+- link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
+endif::[]
+ifndef::openshift-origin[]
+- `docker` v17.03+, `podman` v1.2.0+, or `buildah` v1.7+
+endif::[]
+- OpenShift CLI (`oc`) v4.3+ installed
+- Access to a cluster based on Kubernetes v1.12.0+
 - Access to a container registry
 
 .Procedure
@@ -37,7 +43,7 @@ project on GitHub.
 . Set the release version variable:
 +
 ----
-RELEASE_VERSION=v0.8.0
+RELEASE_VERSION=v0.12.0
 ----
 
 . Download the release binary.
@@ -146,9 +152,14 @@ You can install the SDK CLI using Homebrew.
 .Prerequisites
 
 - link:https://brew.sh/[Homebrew]
-- link:https://docs.docker.com/install/[`docker`] v17.03+
-- OpenShift CLI (`oc`) v4.1+ installed
-- Access to a cluster based on Kubernetes v1.11.3+
+ifdef::openshift-origin[]
+- link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
+endif::[]
+ifndef::openshift-origin[]
+- `docker` v17.03+, `podman` v1.2.0+, or `buildah` v1.7+
+endif::[]
+- OpenShift CLI (`oc`) v4.3+ installed
+- Access to a cluster based on Kubernetes v1.12.0+
 - Access to a container registry
 
 .Procedure
@@ -172,12 +183,16 @@ You can obtain the Operator SDK source code to compile and install the SDK CLI.
 
 .Prerequisites
 
-- link:https://golang.github.io/dep/docs/installation.html[dep] v0.5.0+
 - link:https://git-scm.com/downloads[Git]
-- link:https://golang.org/dl/[Go] v1.10+
-- link:https://docs.docker.com/install/[`docker`] v17.03+
-- OpenShift CLI (`oc`) v4.1+ installed
-- Access to a cluster based on Kubernetes v1.11.3+
+- link:https://golang.org/dl/[Go] v1.13+
+ifdef::openshift-origin[]
+- link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
+endif::[]
+ifndef::openshift-origin[]
+- `docker` v17.03+, `podman` v1.2.0+, or `buildah` v1.7+
+endif::[]
+- OpenShift CLI (`oc`) v4.3+ installed
+- Access to a cluster based on Kubernetes v1.12.0+
 - Access to a container registry
 
 .Procedure

--- a/operators/operator_sdk/osdk-getting-started.adoc
+++ b/operators/operator_sdk/osdk-getting-started.adoc
@@ -16,7 +16,7 @@ and the Operator Lifecycle Manager (OLM).
 
 [NOTE]
 ====
-{product-title} 4 supports Operator SDK v0.7.0 or later.
+{product-title} 4.3 supports Operator SDK v0.12.0 or later.
 ====
 
 include::modules/osdk-architecture.adoc[leveloffset=+1]


### PR DESCRIPTION
xref: https://jira.coreos.com/browse/OSDOCS-451

- Updates SDK version support to v0.12.0
- Removes use of `--dep-manager`
- Updates example commands to use `podman`
- Updates Prerequisites versions/links

Preview (internal):

http://file.rdu.redhat.com/~adellape/120419/bump_osdk_ver_43/operators/operator_sdk/osdk-getting-started.html

http://file.rdu.redhat.com/~adellape/120419/bump_osdk_ver_43/operators/operator_sdk/osdk-cli-reference.html#osdk-cli-reference-new_osdk-cli-reference

See also related OCP 4.3 Release Notes: https://github.com/openshift/openshift-docs/pull/18451