### PR TITLE
The ES pod went to Error state and after few hours -follow up

### DIFF
--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -59,10 +59,10 @@ spec:
       resources:
         limits:
           cpu: 500m
-          memory: 4Gi
+          memory: 16Gi
         requests:
           cpu: 500m
-          memory: 4Gi
+          memory: 16Gi
       storage: {}
     type: elasticsearch
   managementState: Managed


### PR DESCRIPTION
 https://docs.openshift.com/container-platform/4.2/logging/cluster-logging-moving-nodes.html I see 4Gi memory is mentioned here as well, It would be good to change that as it is very misleading

https://bugzilla.redhat.com/show_bug.cgi?id=1752815#c18