### PR TITLE
Improve visibility of support tools

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -203,6 +203,26 @@ Topics:
 # - Name: Troubleshooting an update
 #  File: updating-troubleshooting
 ---
+Name: Support
+Dir: support
+Distros: openshift-enterprise,openshift-online,openshift-dedicated
+Topics:
+- Name: Getting support
+  File: getting-support
+- Name: Gathering data about your cluster
+  File: gathering-cluster-data
+  Distros: openshift-enterprise,openshift-dedicated
+- Name: Remote health monitoring with connected clusters
+  Dir: remote_health_monitoring
+  Distros: openshift-enterprise,openshift-dedicated
+  Topics:
+  - Name: About remote health monitoring
+    File: about-remote-health-monitoring
+  - Name: Showing data collected by remote health monitoring
+    File: showing-data-collected-by-remote-health-monitoring
+  - Name: Opting out of remote health reporting
+    File: opting-out-of-remote-health-reporting
+---
 Name: Web console
 Dir: web-console
 Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
@@ -1307,23 +1327,3 @@ Topics:
 ### Release Notes
 - Name: Release Notes
   File: serverless-release-notes
----
-Name: Support
-Dir: support
-Distros: openshift-enterprise,openshift-online,openshift-dedicated
-Topics:
-- Name: Getting support
-  File: getting-support
-- Name: Gathering data about your cluster
-  File: gathering-cluster-data
-  Distros: openshift-enterprise,openshift-dedicated
-- Name: Remote health monitoring with connected clusters
-  Dir: remote_health_monitoring
-  Distros: openshift-enterprise,openshift-dedicated
-  Topics:
-  - Name: About remote health monitoring
-    File: about-remote-health-monitoring
-  - Name: Showing data collected by remote health monitoring
-    File: showing-data-collected-by-remote-health-monitoring
-  - Name: Opting out of remote health reporting
-    File: opting-out-of-remote-health-reporting


### PR DESCRIPTION
Move Support topic to be below the Updating topics.

Hanging or failing upgrades is the most frequent scenario where running `oc adm must-gather` is useful. Moving "Support" to be below this section makes it easier for customers and the community to get help by running the must-gather tool by placing this info in a more prominent location.

This section is currently at the very bottom of our topic links, which makes it easy for individuals to miss it. There have been instances where developers who work on OpenShift have not been aware of this tool.