### PR TITLE
Added OCP on IBM System Z release notes

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1765,3 +1765,55 @@ link:https://access.redhat.com/solutions/4627461[{product-title} 4.2.9 container
 
 To upgrade an existing {product-title} 4.2 cluster to this latest release, see
 xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+
+[[ocp-4-2-10]]
+=== RHBA-2019:4092 - {product-title} 4.2.10 Bug Fix Update
+
+Issued: 2019-12-10
+
+{product-title} release 4.2.10 is now available. The list of packages included in
+the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2019:3952[RHBA-2019:4092] advisory.
+The container images and bug fixes included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2019:3953[RHBA-2019:4093] advisory.
+
+Space precluded documenting all of the container images for this release in the
+advisory. See the following article for notes on the container images in this
+release:
+
+link:https://access.redhat.com/solutions/4643781[{product-title} 4.2.10 container image list]
+
+[[ocp-4-2-10-features]]
+==== Features
+
+With this release, IBM System Z is now compatible with {product-title}
+{product-version}. See
+xref:../installing/installing_ibm_z/installing-ibm-z.adoc#[Installing a cluster
+on IBM Z] for installation instructions.
+
+*Restrictions*
+
+Note the following restrictions for {product-title} on IBM System Z:
+
+* {product-title} for IBM System Z does not include the Technology Preview for:
+** Container-native virtualization (CNV).
+** Knative - Serverless.
+* There is no support for:
+** Service Mesh, including Istion, Kiali, and Jaeger.
+** odo.
+** CodeReady Workspace.
+** Tekton - Pipelines.
+** OpenShift Metering, including Presto and Hive.
+** The Multus plug-in.
+* Worker nodes must run Red Hat Enterprise Linux CoreOS.
+* Persistent storage must be of type Filesystem: NFS.
+* These features are available for {product-title} on IBM System Z for
+{product-version}, but not for {product-title} {product-version} on x86:
+** HyperPAV enabled in IBM System Z or the virtual machine for FICON-attached ECKD storage.
+** HiperSockets.
+
+[[ocp-4-2-10-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.2 cluster to this latest release, see
+xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]


### PR DESCRIPTION
This content is scheduled to be released on December 10 and is related to the work in https://github.com/openshift/openshift-docs/pull/18469.

Preview Build: http://file.rdu.redhat.com/~ahardin/12052019/IBM-Z-restrictions/release_notes/ocp-4-2-release-notes.html#ocp-4-2-10

FYI @aheslin @sferich888 @zzoubkova

 @sheriff-rh We will still need to add a link to your Kbase per your new process once that's completed, but we can do that is a separate PR if necessary. 