### PR TITLE
Deprecation note for jenkins pipeline builds

### DIFF
--- a/modules/builds-strategy-pipeline-build.adoc
+++ b/modules/builds-strategy-pipeline-build.adoc
@@ -7,8 +7,15 @@
 [id="builds-strategy-pipeline-build_{context}"]
 = Pipeline build
 
+[IMPORTANT]
+====
+The Pipeline build strategy is deprecated in {product-title} 4. Equivalent and improved functionality is present in the OpenShift Pipelines based on Tekton.
+
+Jenkins images on OpenShift are fully supported and users should follow Jenkins user documentation for defining their Jenkinsfile in a job or store it in a Source Control Management system.
+====
+
 The Pipeline build strategy allows developers to define a _Jenkins pipeline_ for
-execution by the Jenkins pipeline plugin. The build can be started, monitored,
+execution by the Jenkins pipeline plug-in. The build can be started, monitored,
 and managed by {product-title} in the same way as any other build type.
 
 Pipeline workflows are defined in a Jenkinsfile, either embedded directly in the


### PR DESCRIPTION
- This PR adds a note of deprecation for the Jenkins pipeline builds in the two instances it surfaces in the OCP docs.
- This is relevant to the 4.3 branch
- This has been reviewed by the SME.