### PR TITLE
Bug 1780519: [DOCS] Unclear "node" term for restarting "atomic-openshift-node.service"

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -523,7 +523,7 @@ During installation, {product-title} creates a configmap in the *openshift-node*
 To make configuration changes to an existing node, edit the appropriate configuration map. A _sync pod_ on each node
 watches for changes in the configuration maps. During installation, the sync pods are created by using _sync Daemonsets_,
 and a *_/etc/origin/node/node-config.yaml_* file, where the node configuration parameters reside, is added to each node. When a sync pod
-detects configuration map change, it updates the *_node-config.yaml_* on all nodes in that node group and restarts the appropriate nodes.
+detects configuration map change, it updates the *_node-config.yaml_* on all nodes in that node group and restarts the appropriate nodes `atomic-openshift-node.service`.
 
 ----
 $ oc get cm -n openshift-node


### PR DESCRIPTION
* Version: v3.11

* Bugzilla: [[DOCS] Unclear "node" term for restarting "atomic-openshift-node.service"](Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1780519)

* Description:
  "restarts the appropriate nodes" can misunderstand as "restart node hosts", so added "atomic-openshift-node.service" for suppressing confused.
