### PR TITLE
Replacing oc get nodes output with updated version

### DIFF
--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -123,13 +123,13 @@ go to one of your nodes. For example:
 +
 ----
 $ oc get node
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-128-213.ec2.internal   Ready    worker   59m   v1.16.2
-ip-10-0-130-162.ec2.internal   Ready    worker   60m   v1.16.2
-ip-10-0-136-29.ec2.internal    Ready    master   66m   v1.16.2
-ip-10-0-142-198.ec2.internal   Ready    master   66m   v1.16.2
-ip-10-0-149-229.ec2.internal   Ready    master   66m   v1.16.2
-ip-10-0-149-52.ec2.internal    Ready    worker   60m   v1.16.2
+NAME                           STATUS                     ROLES    AGE  VERSION
+ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.16.2
+ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.16.2
+ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.16.2
+ip-10-0-147-35.ec2.internal    Ready,SchedulingDisabled   worker   7m   v1.16.2
+ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.16.2
+ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.16.2
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -86,8 +86,8 @@ In this example, the running pod is on the `ip-10-0-217-226.ec2.internal` node.
 ----
 $ oc get node <node_name> <1>
 
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-129-189.ec2.internal   Ready    worker   70m   v1.16.2
+NAME                          STATUS  ROLES         AGE   VERSION
+ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.16.2
 ----
 <1> Specify the `<node_name>` that you obtained from the pod list.
 +

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -29,13 +29,12 @@ these CSRs are approved or, if necessary, approve them yourself.
 ----
 $ oc get nodes
 
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-129-189.ec2.internal   Ready    worker   65m   v1.16.2
-ip-10-0-133-88.ec2.internal    Ready    worker   65m   v1.16.2
-ip-10-0-141-129.ec2.internal   Ready    master   72m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready    master   72m   v1.16.2
-ip-10-0-146-242.ec2.internal   Ready    worker   65m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready    master   72m   v1.16.2
+NAME      STATUS    ROLES   AGE  VERSION
+master-0  Ready     master  63m  v1.16.2
+master-1  Ready     master  63m  v1.16.2
+master-2  Ready     master  64m  v1.16.2
+worker-0  NotReady  worker  76s  v1.16.2
+worker-1  NotReady  worker  70s  v1.16.2
 ----
 +
 The output lists all of the machines that you created.

--- a/modules/looking-inside-nodes.adoc
+++ b/modules/looking-inside-nodes.adoc
@@ -12,22 +12,29 @@ For debugging purposes, the oc debug command lets you go inside any pod and look
 ----
 $ oc get nodes
 
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-129-189.ec2.internal   Ready    worker   69m   v1.16.2
-ip-10-0-133-88.ec2.internal    Ready    worker   69m   v1.16.2
-ip-10-0-141-129.ec2.internal   Ready    master   76m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready    master   76m   v1.16.2
-ip-10-0-146-242.ec2.internal   Ready    worker   69m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready    master   76m   v1.16.2
+NAME                                     STATUS  ROLES  AGE    VERSION
+
+ip-10-0-0-1.us-east-2.compute.internal   Ready   worker 3h19m  v1.16.2
+
+ip-10-0-0-39.us-east-2.compute.internal  Ready   master 3h37m  v1.16.2
+
+…  
+
+$ oc debug nodes/ip-10-0-138-39.us-east-2.compute.internal
+
+Starting pod/ip-10-0-138-39us-east-2computeinternal-debug …​
 ----
 
 ----
-$ oc debug nodes/ip-10-0-129-189.ec2.internal
-Starting pod/ip-10-0-129-189ec2internal-debug ...
-To use host binaries, run `chroot /host`
-Pod IP: 10.0.129.189
-If you don't see a command prompt, try pressing enter.
-sh-4.2# 
+$ oc debug nodes/ip-10-0-138-39.us-east-2.compute.internal
+
+Starting pod/ip-10-0-138-39us-east-2computeinternal-debug …​
+
+To use host binaries, run chroot /host
+
+If you don’t see a command prompt, try pressing enter.
+
+sh-4.2#
 ----
 
 As noted, you can change to the root of the node’s filesystem by typing chroot /host and running commands from the host on that filesystem as though you were logged in directly from the host. Here are some examples of commands you can run to see what is happening on the node:

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -116,13 +116,13 @@ rendered-worker-18ff9506c718be1e8bd0a066850065b7            577c2d527b09cd7a481a
 +
 ----
 $ oc get nodes
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-129-189.ec2.internal   Ready    worker   69m   v1.16.2
-ip-10-0-133-88.ec2.internal    Ready    worker   69m   v1.16.2
-ip-10-0-141-129.ec2.internal   Ready    master   76m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready    master   76m   v1.16.2
-ip-10-0-146-242.ec2.internal   Ready    worker   69m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready    master   76m   v1.16.2
+NAME                           STATUS                     ROLES    AGE   VERSION
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.16.2
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.16.2
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.16.2
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.16.2
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.16.2
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.16.2
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -12,13 +12,10 @@ You can get detailed information on the nodes in the cluster.
 ----
 $ oc get nodes
 
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-129-189.ec2.internal   Ready    worker   69m   v1.16.2
-ip-10-0-133-88.ec2.internal    Ready    worker   69m   v1.16.2
-ip-10-0-141-129.ec2.internal   Ready    master   76m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready    master   76m   v1.16.2
-ip-10-0-146-242.ec2.internal   Ready    worker   69m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready    master   76m   v1.16.2
+NAME                   STATUS    ROLES     AGE       VERSION
+master.example.com     Ready     master    7h        v1.16.2
+node1.example.com      Ready     worker    7h        v1.16.2
+node2.example.com      Ready     worker    7h        v1.16.2
 ----
 
 * The `-wide` option provides additional information on all nodes.

--- a/modules/understanding-workers-masters.adoc
+++ b/modules/understanding-workers-masters.adoc
@@ -12,13 +12,13 @@ To see which workers and masters are running on your cluster, type:
 ----
 $ oc get nodes
 
-NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-129-189.ec2.internal   Ready,SchedulingDisabled   worker   81m   v1.16.2
-ip-10-0-133-88.ec2.internal    Ready                      worker   81m   v1.16.2
-ip-10-0-141-129.ec2.internal   Ready                      master   88m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready                      master   88m   v1.16.2
-ip-10-0-146-242.ec2.internal   Ready                      worker   80m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready                      master   88m   v1.16.2
+NAME                                   STATUS ROLES  AGE    VERSION
+ip-10-0-0-1.us-east-2.compute.internal Ready  worker 4h20m  v1.16.2
+ip-10-0-0-2.us-east-2.compute.internal Ready  master 4h39m  v1.16.2
+ip-10-0-0.3.us-east-2.compute.internal Ready  worker 4h20m  v1.16.2
+ip-10-0-0-4.us-east-2.compute.internal Ready  master 4h39m  v1.16.2
+ip-10-0-0-5.us-east-2.compute.internal Ready  master 4h39m  v1.16.2
+ip-10-0-0-6.us-east-2.compute.internal Ready  worker 4h20m  v1.16.2
 ----
 
 To see more information about internal and external IP addresses, the type of operating system ({op-system}), kernel version, and container runtime (CRI-O), add the `-o wide` option.
@@ -26,13 +26,8 @@ To see more information about internal and external IP addresses, the type of op
 ----
 $ oc get nodes -o wide
 
-NAME                                       STATUS ROLES  AGE  VERSION                       +
- INTERNAL-IP   EXTERNAL-IP  
-
-      OS-IMAGE             KERNEL-VERSION            CONTAINER-RUNTIME
-
-NAME                           STATUS                     ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                     KERNEL-VERSION          CONTAINER-RUNTIME
-ip-10-0-129-189.ec2.internal   Ready,SchedulingDisabled   worker   81m   v1.16.2   10.0.129.189   <none>        Red Hat Enterprise Linux CoreOS 43.81.201911071053.0 (Ootpa)   4.18.0-147.el8.x86_64   cri-o://1.16.0-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
+NAME                                       STATUS  ROLES  AGE  VERSION  INTERNAL-IP   EXTERNAL-IP  OS-IMAGE             KERNEL-VERSION             CONTAINER-RUNTIME
+ip-10-0-134-252.us-east-2.compute.internal Ready   worker 17h  v1.16.2  10.0.134.252  <none>       Red Hat CoreOS 4.0   3.10.0-957.5.1.el7.x86_64  cri-o://1.13.6-1.rhaos4.0.git2f0cb0d.el7
 
 ....
 ----


### PR DESCRIPTION
In https://github.com/openshift/openshift-docs/pull/17685 I replaced the output for `oc get nodes` throughout the docs to update the kubernetes version to 1.16.2. 
In one case, I removed necessary information. As such, I am replacing the original output and updating the version column only. 