### PR TITLE
Reverting node output changes and just keeping version bump

### DIFF
--- a/modules/dr-recover-lost-control-plane-hosts.adoc
+++ b/modules/dr-recover-lost-control-plane-hosts.adoc
@@ -74,11 +74,8 @@ In a terminal that has access to the cluster, run the following command to verif
 +
 ----
 $ oc get nodes -l node-role.kubernetes.io/master
-
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-141-129.ec2.internal   Ready    master   72m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready    master   72m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready    master   72m   v1.16.2
+NAME                                         STATUS   ROLES    AGE   VERSION
+ip-10-0-143-125.us-east-2.compute.internal   Ready    master   46m   v1.16.2
 ----
 +
 [NOTE]
@@ -125,11 +122,10 @@ Be sure to approve both the pending client and server CSR for each master that w
 +
 ----
 $ oc get nodes -l node-role.kubernetes.io/master
-
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-141-129.ec2.internal   Ready    master   72m   v1.16.2
-ip-10-0-141-69.ec2.internal    Ready    master   72m   v1.16.2
-ip-10-0-148-252.ec2.internal   Ready    master   72m   v1.16.2
+NAME                                         STATUS   ROLES    AGE   VERSION
+ip-10-0-143-125.us-east-2.compute.internal   Ready    master   50m   v1.16.2
+ip-10-0-156-255.us-east-2.compute.internal   Ready    master   92s   v1.16.2
+ip-10-0-162-178.us-east-2.compute.internal   Ready    master   70s   v1.16.2
 ----
 
 . Correct the DNS entries.


### PR DESCRIPTION
Reverting update to this file from #17685 and just keeping the version bump change in the output.