### PR TITLE
updated 4.3 release notes

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -22,9 +22,10 @@ compliance, and governance requirements.
 
 Red Hat {product-title}
 (link:https://access.redhat.com/errata/RHBA-2019:1234[RHBA-2019:1234]) is now
-available. This release uses Kubernetes 1.16 with CRI-O runtime. New features,
-changes, and known issues that pertain to {product-title} {product-version} are
-included in this topic.
+available. This release uses Kubernetes 1.16 with CRI-O runtime. This is an
+increase of two versions of Kubernetes from {product-title} 4.2, which used
+Kubernetes 1.14. New features, changes, and known issues that pertain to
+{product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at
 https://cloud.redhat.com/openshift. The {cloud-redhat-com}


### PR DESCRIPTION
Added the following statement: 

`This is an increase of two versions of Kubernetes from {product-title} 4.2, which used Kubernetes 1.14.` 

Seeking approval from @bergerhoffer  and @ahardin-rh . 