### PR TITLE
Closing BZ1777555

### DIFF
--- a/cnv/cnv_install/preparing-cluster-for-cnv.adoc
+++ b/cnv/cnv_install/preparing-cluster-for-cnv.adoc
@@ -4,6 +4,9 @@ include::modules/cnv-document-attributes.adoc[]
 :context: preparing-cluster-for-cnv
 toc::[]
 
+To obtain an evaluation version of {product-title}, download a trial
+from the {product-title} home page.
+
 {CNVProductNameStart} works with {product-title} by default, however the following
 installation configurations are recommended:
 


### PR DESCRIPTION
This is a brief amendment to the opening page on installing CNV.

The new content is: "To obtain an evaluation version of OpenShift Container Platform, download a trial from the OpenShift Container Platform home page." I wanted to avoid an URL and make this as generic as possible.

Test Build: http://file.bos.redhat.com/bgaydos/121019/cnv/cnv_install/preparing-cluster-for-cnv.html

Please label **Peer Review Needed** and then if all is OK, merge and pick to both **enterprise-4.2** and **enterprise-4.3**.

Thanks,
Bob