### PR TITLE
Add proc for using tolerations on local-storage-operator Pods

### DIFF
--- a/modules/persistent-storage-local-tolerations.adoc
+++ b/modules/persistent-storage-local-tolerations.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// storage/persistent-storage/persistent-storage-local.adoc
+
+[id="local-tolerations_{context}"]
+= Using tolerations with Local Storage Operator Pods
+
+Taints can be applied to nodes to prevent them from running general workloads. To allow the Local Storage Operator to use tainted nodes, you must add tolerations to the Pod or DaemonSet definition. This allows the created resources to run on these tainted nodes.
+
+You apply tolerations to the Local Storage Operator Pod through the LocalVolume resource
+and apply taints to a node through the node specification. A taint on a node instructs the node to repel all Pods that do not tolerate the taint. Using a specific taint that is not on other Pods ensures that the Local Storage Operator Pod can also run on that node.
+
+[IMPORTANT]
+====
+Taints and tolerations consist of a key, value, and effect. As an argument, it is expressed as `key=value:effect`. An operator allows you to leave one of these parameters empty.
+====
+
+.Prerequisites
+
+* The Local Storage Operator is installed.
+
+* Local disks are attached to {product-title} nodes with a taint.
+
+* Tainted nodes are expected to provision local storage.
+
+.Procedure
+To configure local volumes for scheduling on tainted nodes:
+
+. Modify the YAML file that defines the Pod and add the `LocalVolume` spec, as shown in the following example:
++
+[source, yaml]
+----
+  apiVersion: "local.storage.openshift.io/v1"
+  kind: "LocalVolume"
+  metadata:
+    name: "local-disks"
+    namespace: "local-storage"
+  spec:
+    tolerations:
+      - key: localstorage <1>
+        operator: Equal <2>
+        value: "localstorage" <3>
+----
+<1> Specify the key that you added to the node.
+<2> Specify the `Equal` operator to require the `key`/`value` parameters to match. If operator is 'Exists`, the system checks that the key exists and ignores the value. If operator is `Equal`, then the key and value must match.
+<3> Specify the value `local` of the tainted node.
+
+The defined tolerations will be passed to the resulting DaemonSets, allowing the diskmaker and provisioner Pods to be created for nodes that contain the specified taints.

--- a/storage/persistent-storage/persistent-storage-local.adoc
+++ b/storage/persistent-storage/persistent-storage-local.adoc
@@ -28,6 +28,8 @@ include::modules/persistent-storage-local-pvc.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-local-pod.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-local-tolerations.adoc[leveloffset=+1]
+
 == Deleting the Local Storage Operator's resources
 
 include::modules/persistent-storage-local-removing-devices.adoc[leveloffset=+2]


### PR DESCRIPTION
[BZ 1781233](https://bugzilla.redhat.com/show_bug.cgi?id=1781233)
Borrowing some content from https://docs.openshift.com/container-platform/4.2/logging/config/cluster-logging-kibana.html#cluster-logging-kibana-tolerations_cluster-logging-kibana to explain taint terminology and usage. 

Doc update to be merged to master and CP to enterprise-4.3.