### PR TITLE
Updated version numbers for 4.3

### DIFF
--- a/cnv/cnv_install/installing-container-native-virtualization.adoc
+++ b/cnv/cnv_install/installing-container-native-virtualization.adoc
@@ -7,12 +7,12 @@ toc::[]
 Install {CNVProductName} to add virtualization functionality to your {product-title}
 cluster.
 
-You can use the {product-title} 4.2
+You can use the {product-title} {product-version}
 xref:../../web-console/web-console.adoc#web-console-overview_web-console[web console]
 to subscribe to and deploy the {CNVProductName} Operators.
 
 .Prerequisites
-* {product-title} 4.2
+* {product-title} {product-version}
 
 :FeatureName: {CNVProductNameStart}
 include::modules/technology-preview.adoc[leveloffset=+1]

--- a/modules/cli-administrator-other.adoc
+++ b/modules/cli-administrator-other.adoc
@@ -45,8 +45,8 @@ Manage various aspects of the {product-title} release process, such as viewing i
 .Example: Generate a changelog between two releases and save to `changelog.md`
 ----
 $ oc adm release info --changelog=/tmp/git \
-    quay.io/openshift-release-dev/ocp-release:4.2.0-rc.7 \
-    quay.io/openshift-release-dev/ocp-release:4.2.0 \
+    quay.io/openshift-release-dev/ocp-release:4.3.0-rc.7 \
+    quay.io/openshift-release-dev/ocp-release:4.3.0 \
     > changelog.md
 ----
 

--- a/modules/cluster-logging-configuring-image-about.adoc
+++ b/modules/cluster-logging-configuring-image-about.adoc
@@ -16,11 +16,11 @@ $ oc -n openshift-logging set env deployment/cluster-logging-operator --list | g
 ----
 
 ----
-ELASTICSEARCH_IMAGE=registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2 <1>
-FLUENTD_IMAGE=registry.redhat.io/openshift4/ose-logging-fluentd:v4.2 <2>
-KIBANA_IMAGE=registry.redhat.io/openshift4/ose-logging-kibana5:v4.2 <3>
-CURATOR_IMAGE=registry.redhat.io/openshift4/ose-logging-curator5:v4.2 <4>
-OAUTH_PROXY_IMAGE=registry.redhat.io/openshift4/ose-oauth-proxy:v4.2 <5>
+ELASTICSEARCH_IMAGE=registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3 <1>
+FLUENTD_IMAGE=registry.redhat.io/openshift4/ose-logging-fluentd:v4.3 <2>
+KIBANA_IMAGE=registry.redhat.io/openshift4/ose-logging-kibana5:v4.3 <3>
+CURATOR_IMAGE=registry.redhat.io/openshift4/ose-logging-curator5:v4.3 <4>
+OAUTH_PROXY_IMAGE=registry.redhat.io/openshift4/ose-oauth-proxy:v4.3 <5>
 ----
 <1> *ELASTICSEARCH_IMAGE* deploys Elasticsearch.
 <2> *FLUENTD_IMAGE* deploys Fluentd.
@@ -29,7 +29,7 @@ OAUTH_PROXY_IMAGE=registry.redhat.io/openshift4/ose-oauth-proxy:v4.2 <5>
 <5> *OAUTH_PROXY_IMAGE* defines OAUTH for {product-title}.
 
 ////
-RSYSLOG_IMAGE=registry.redhat.io/openshift4/ose-logging-rsyslog:v4.2 <6>
+RSYSLOG_IMAGE=registry.redhat.io/openshift4/ose-logging-rsyslog:v4.3 <6>
 <6> *RSYSLOG_IMAGE* deploys Rsyslog.
 
 

--- a/modules/cluster-logging-deploy-subscription.adoc
+++ b/modules/cluster-logging-deploy-subscription.adoc
@@ -132,7 +132,7 @@ $ oc create -f eo-og.yaml
 ----
 $ oc get packagemanifest elasticsearch-operator -n openshift-marketplace -o jsonpath='{.status.channels[].name}'
 
-4.2
+4.3
 ----
 
 .. Create a Subscription object YAML file (for example, `eo-sub.yaml`) to
@@ -147,7 +147,7 @@ metadata:
   generateName: "elasticsearch-"
   namespace: "openshift-operators-redhat" <1>
 spec:
-  channel: "4.2" <2>
+  channel: "4.3" <2>
   installPlanApproval: "Automatic"
   source: "redhat-operators"
   sourceNamespace: "openshift-marketplace"

--- a/modules/cluster-logging-elasticsearch-status-comp.adoc
+++ b/modules/cluster-logging-elasticsearch-status-comp.adoc
@@ -121,7 +121,7 @@ The output includes the following status information:
 ....
   Containers:
    elasticsearch:
-    Image:      registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2
+    Image:      registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3
     Readiness:  exec [/usr/share/elasticsearch/probe/readiness.sh] delay=10s timeout=30s period=5s #success=1 #failure=3
 
 ....
@@ -162,7 +162,7 @@ The output includes the following status information:
 ....
   Containers:
    elasticsearch:
-    Image:      registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2
+    Image:      registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3
     Readiness:  exec [/usr/share/elasticsearch/probe/readiness.sh] delay=10s timeout=30s period=5s #success=1 #failure=3
 
 ....

--- a/modules/cluster-logging-external-syslog.adoc
+++ b/modules/cluster-logging-external-syslog.adoc
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: fluentd
-          image: 'registry.redhat.io/openshift4/ose-logging-fluentd:v4.2'
+          image: 'registry.redhat.io/openshift4/ose-logging-fluentd:v4.3'
           env:
             - name: REMOTE_SYSLOG_HOST <1>
               value: host1

--- a/modules/cluster-logging-upgrading-logging.adoc
+++ b/modules/cluster-logging-upgrading-logging.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-about_{context}"]
 = Upgrading cluster logging
 
-After upgrading the {product-title} cluster, you can upgrade cluster logging from 4.1 to 4.2 by updating the subscription for the Elasticsearch Operator and the Cluster Logging Operator.
+After upgrading the {product-title} cluster, you can upgrade cluster logging from 4.2 to 4.3 by updating the subscription for the Elasticsearch Operator and the Cluster Logging Operator.
 
 .Prerequisites
 
@@ -15,72 +15,72 @@ After upgrading the {product-title} cluster, you can upgrade cluster logging fro
 +
 ** All Pods are `ready`.
 ** Elasticsearch cluster is healthy.
- 
+
 .Procedure
 
 . Upgrade the Elasticsearch Operator:
 
-.. From the web console, click *Operators* -> *Installed Operators*. 
+.. From the web console, click *Operators* -> *Installed Operators*.
 
 .. Select the `openshift-logging` project.
 
 .. Click the *Elasticsearch Operator*.
 
-.. Click *Subscription* -> *Channel*. 
+.. Click *Subscription* -> *Channel*.
 
-.. In the *Change Subscription Update Channel* window, select *4.2* and click *Save*.
+.. In the *Change Subscription Update Channel* window, select *4.3* and click *Save*.
 
-.. Wait for a few seconds, then click *Operators* -> *Installed Operators*. 
+.. Wait for a few seconds, then click *Operators* -> *Installed Operators*.
 +
-The Elasticsearch Operator is shown as 4.2. For example:
+The Elasticsearch Operator is shown as 4.3. For example:
 +
 ----
 Elasticsearch Operator
-4.2.0-201909201915 provided 
+4.3.0-201909201915 provided
 by Red Hat, Inc
 ----
 
 . Upgrade the Cluster Logging Operator:
 
-.. From the web console, click *Operators* -> *Installed Operators*. 
+.. From the web console, click *Operators* -> *Installed Operators*.
 
 .. Select the `openshift-logging` Project.
 
 .. Click the *Cluster Logging Operator*.
 
-.. Click *Subscription* -> *Channel*. 
+.. Click *Subscription* -> *Channel*.
 
-.. In the *Change Subscription Update Channel* window, select *4.2* and click *Save*.
+.. In the *Change Subscription Update Channel* window, select *4.3* and click *Save*.
 
-.. Wait for a few seconds, then click *Operators* -> *Installed Operators*. 
+.. Wait for a few seconds, then click *Operators* -> *Installed Operators*.
 +
-The Cluster Logging Operator is shown as 4.2. For example:
+The Cluster Logging Operator is shown as 4.3. For example:
 +
 ----
 Cluster Logging
-4.2.0-201909201915 provided 
+4.3.0-201909201915 provided
 by Red Hat, Inc
 ----
 
 . Check the logging components:
 
-.. Ensure that the Elasticsearch Pods are using a 4.2 image:
+.. Ensure that the Elasticsearch Pods are using a 4.3 image:
 +
 ----
 $ oc get pod -o yaml -n openshift-logging --selector component=elasticsearch |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
 ----
 +
 .. Ensure that all Elasticsearch Pods are in the *Ready* status:
@@ -108,41 +108,40 @@ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b75
 ----
 
 
-.. Ensure that the logging collector Pods are using a 4.2 image:
+.. Ensure that the logging collector Pods are using a 4.3 image:
 +
 ----
 $ oc get pod -n openshift-logging --selector logging-infra=fluentd -o yaml |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.2.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
 ----
 
-.. Ensure that the Kibana Pods are using a 4.2 image:
+.. Ensure that the Kibana Pods are using a 4.3 image:
 +
 ----
 $ oc get pod -n openshift-logging --selector logging-infra=kibana -o yaml |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.2.0-201909210748
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.2.0-201909210748
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.3.0-201909210748
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.3.0-201909210748
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
 ----
 
-.. Ensure that the Curator CronJob is using a 4.2 image:
+.. Ensure that the Curator CronJob is using a 4.3 image:
 +
 ----
 $ $ oc get CronJob curator -n openshift-logging -o yaml |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-curator5:v4.2.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-curator5:v4.3.0-201909201915
 ----
-

--- a/modules/dr-recover-expired-control-plane-certs.adoc
+++ b/modules/dr-recover-expired-control-plane-certs.adoc
@@ -20,7 +20,7 @@ Follow this procedure to recover from a situation where your control plane certi
 ----
 # RELEASE_IMAGE=<release_image> <1>
 ----
-<1> An example value for `<release_image>` is `quay.io/openshift-release-dev/ocp-release:4.2.0`.
+<1> An example value for `<release_image>` is `quay.io/openshift-release-dev/ocp-release:4.3.0`.
 +
 ----
 # KAO_IMAGE=$( oc adm release info --registry-config='/var/lib/kubelet/config.json' "${RELEASE_IMAGE}" --image-for=cluster-kube-apiserver-operator )

--- a/modules/dr-recover-lost-control-plane-hosts.adoc
+++ b/modules/dr-recover-lost-control-plane-hosts.adoc
@@ -266,13 +266,13 @@ Starting etcd..
 .... In the etcd container, export variables needed for connecting to etcd.
 +
 ----
-sh-4.2# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
+sh-4.3# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
 ----
 +
 .... In the etcd container, execute `etcdctl member list` and verify that the new member is listed.
 +
 ----
-sh-4.2#  etcdctl member list -w table
+sh-4.3#  etcdctl member list -w table
 
 +------------------+---------+------------------------------------------+----------------------------------------------------------------+---------------------------+
 |        ID        | STATUS  |                   NAME                   |                           PEER ADDRS                           |       CLIENT ADDRS        |

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -103,13 +103,13 @@ When the snapshot has been applied, the `currentConfig` of the master will match
 .. In the etcd container, export variables needed for connecting to etcd.
 +
 ----
-sh-4.2# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
+sh-4.3# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
 ----
 +
 .. In the etcd container, execute `etcdctl member list` and verify that the three members show as started.
 +
 ----
-sh-4.2#  etcdctl member list -w table
+sh-4.3#  etcdctl member list -w table
 
 +------------------+---------+------------------------------------------+------------------------------------------------------------------+---------------------------+
 |        ID        | STATUS  |                   NAME                   |                            PEER ADDRS                            |       CLIENT ADDRS        |

--- a/modules/exploring-cvo.adoc
+++ b/modules/exploring-cvo.adoc
@@ -11,7 +11,7 @@ To see the current version that your cluster is on, type:
 $ oc get clusterversion
 
 NAME    VERSION   AVAILABLE PROGRESSING SINCE STATUS
-version 4.2.0-0.0 True      False       10h   Cluster version is 4.2.0-0.0
+version 4.3.0-0.0 True      False       10h   Cluster version is 4.3.0-0.0
 ----
 
 Each release version is represented by a set of images. To see basic release information and a list of those images, type:

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -38,7 +38,7 @@ firewall, you can install {product-title} into a
 datacenter that is in a restricted network. See
 Mirroring the {product-title} image repository for details.
 
-* After {product-title} installation time: Even if you don't configure mirroring during {product-title} 
+* After {product-title} installation time: Even if you don't configure mirroring during {product-title}
 installation, you can do so later using the `ImageContentSourcePolicy` object.
 
 The following procedure provides a post-installation mirror configuration, where you create an `ImageContentSourcePolicy` object that identifies:
@@ -101,7 +101,7 @@ spec:
   - mirrors:
     - example.com/example/ubi-minimal
     source: registry.access.redhat.com/ubi8/ubi-minimal
-~                                                 
+~
 ----
 <1> Indicates the name of the image registry and repository
 <2> Indicates the registry and repository containing the content that is mirrored
@@ -142,8 +142,8 @@ $ oc debug node/ip-10-0-147-35.ec2.internal
 Starting pod/ip-10-0-147-35ec2internal-debug ...
 To use host binaries, run `chroot /host`
 
-sh-4.2# chroot /host
-sh-4.2# cat /etc/containers/registries
+sh-4.3# chroot /host
+sh-4.3# cat /etc/containers/registries
 unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
 [[registry]]
   location = "registry.access.redhat.com/ubi8/"
@@ -165,7 +165,7 @@ unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
 resolved by the mirror.
 +
 ----
-sh-4.2# podman pull --log-level=debug registry.access.redhat.com/ubi8/ubi-minimal
+sh-4.3# podman pull --log-level=debug registry.access.redhat.com/ubi8/ubi-minimal
 ----
 
 .Troubleshooting repository mirroring
@@ -179,4 +179,4 @@ troubleshoot the problem.
 * From the system context, the `Insecure` flags are used as fallback.
 * The format of the `/etc/containers/registries` file has
 changed recently. It is now version 2 and in TOML format.
-* 
+*

--- a/modules/images-other-jenkins-agent-images.adoc
+++ b/modules/images-other-jenkins-agent-images.adoc
@@ -11,10 +11,10 @@ The {product-title} Jenkins agent images are available on `quay.io` or
 Jenkins images are available through the Red Hat Registry:
 
 ----
-$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.2.0>
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-nodejs:<v4.2.0>
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-maven:<v4.2.0>
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-base:<v4.2.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.3.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-nodejs:<v4.3.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-maven:<v4.3.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-base:<v4.3.0>
 ----
 
 To use these images, you can either access them directly from `quay.io` or

--- a/modules/installation-azure-regions.adoc
+++ b/modules/installation-azure-regions.adoc
@@ -5,7 +5,7 @@
 [id="installation-azure-regions_{context}"]
 = Supported Azure regions
 
-The installation program dynamically generates the list of available Microsoft Azure regions based on your subscription. The following Azure regions were tested and validated in {product-title} version 4.2.0:
+The installation program dynamically generates the list of available Microsoft Azure regions based on your subscription. The following Azure regions were tested and validated in {product-title} version 4.3.0:
 
 * centralus (Central US)
 * eastus (East US)

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -32,31 +32,31 @@ cluster on infrastructure that you provide.
 $ watch -n5 oc get clusteroperators
 
 NAME                                 VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-authentication                       4.2.0     True        False         False      10m
-cloud-credential                     4.2.0     True        False         False      22m
-cluster-autoscaler                   4.2.0     True        False         False      21m
-console                              4.2.0     True        False         False      10m
-dns                                  4.2.0     True        False         False      21m
-image-registry                       4.2.0     True        False         False      16m
-ingress                              4.2.0     True        False         False      16m
-kube-apiserver                       4.2.0     True        False         False      19m
-kube-controller-manager              4.2.0     True        False         False      18m
-kube-scheduler                       4.2.0     True        False         False      22m
-machine-api                          4.2.0     True        False         False      22m
-machine-config                       4.2.0     True        False         False      18m
-marketplace                          4.2.0     True        False         False      18m
-monitoring                           4.2.0     True        False         False      18m
-network                              4.2.0     True        False         False      16m
-node-tuning                          4.2.0     True        False         False      21m
-openshift-apiserver                  4.2.0     True        False         False      21m
-openshift-controller-manager         4.2.0     True        False         False      17m
-openshift-samples                    4.2.0     True        False         False      14m
-operator-lifecycle-manager           4.2.0     True        False         False      21m
-operator-lifecycle-manager-catalog   4.2.0     True        False         False      21m
-service-ca                           4.2.0     True        False         False      21m
-service-catalog-apiserver            4.2.0     True        False         False      16m
-service-catalog-controller-manager   4.2.0     True        False         False      16m
-storage                              4.2.0     True        False         False      16m
+authentication                       4.3.0     True        False         False      10m
+cloud-credential                     4.3.0     True        False         False      22m
+cluster-autoscaler                   4.3.0     True        False         False      21m
+console                              4.3.0     True        False         False      10m
+dns                                  4.3.0     True        False         False      21m
+image-registry                       4.3.0     True        False         False      16m
+ingress                              4.3.0     True        False         False      16m
+kube-apiserver                       4.3.0     True        False         False      19m
+kube-controller-manager              4.3.0     True        False         False      18m
+kube-scheduler                       4.3.0     True        False         False      22m
+machine-api                          4.3.0     True        False         False      22m
+machine-config                       4.3.0     True        False         False      18m
+marketplace                          4.3.0     True        False         False      18m
+monitoring                           4.3.0     True        False         False      18m
+network                              4.3.0     True        False         False      16m
+node-tuning                          4.3.0     True        False         False      21m
+openshift-apiserver                  4.3.0     True        False         False      21m
+openshift-controller-manager         4.3.0     True        False         False      17m
+openshift-samples                    4.3.0     True        False         False      14m
+operator-lifecycle-manager           4.3.0     True        False         False      21m
+operator-lifecycle-manager-catalog   4.3.0     True        False         False      21m
+service-ca                           4.3.0     True        False         False      21m
+service-catalog-apiserver            4.3.0     True        False         False      16m
+service-catalog-controller-manager   4.3.0     True        False         False      16m
+storage                              4.3.0     True        False         False      16m
 ----
 +
 When all of the cluster Operators are `AVAILABLE`, you can complete the installation.

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -34,7 +34,7 @@ $ export LOCAL_SECRET_JSON='<path_to_pull_secret>' <5>
 $ export RELEASE_NAME="ocp-release" <6>
 ----
 <1> For `<release_version>`, specify the version number of {product-title} to
-install, such as `4.2.0`.
+install, such as `4.3.0`.
 <2> For `<local_registry_host_name>`, specify the registry domain name for your mirror
 repository, and for `<local_registry_host_port>`, specify the port that it
 serves content on.

--- a/modules/installing-cluster-loader.adoc
+++ b/modules/installing-cluster-loader.adoc
@@ -11,5 +11,5 @@ Cluster Loader is included in the `origin-tests` container image.
 . To pull the `origin-tests` container image, run:
 +
 ----
-$ sudo podman pull quay.io/openshift/origin-tests:4.2
+$ sudo podman pull quay.io/openshift/origin-tests:4.3
 ----

--- a/modules/looking-inside-nodes.adoc
+++ b/modules/looking-inside-nodes.adoc
@@ -18,7 +18,7 @@ ip-10-0-0-1.us-east-2.compute.internal   Ready   worker 3h19m  v1.16.2
 
 ip-10-0-0-39.us-east-2.compute.internal  Ready   master 3h37m  v1.16.2
 
-…  
+…
 
 $ oc debug nodes/ip-10-0-138-39.us-east-2.compute.internal
 
@@ -34,7 +34,7 @@ To use host binaries, run chroot /host
 
 If you don’t see a command prompt, try pressing enter.
 
-sh-4.2#
+sh-4.3#
 ----
 
 As noted, you can change to the root of the node’s filesystem by typing chroot /host and running commands from the host on that filesystem as though you were logged in directly from the host. Here are some examples of commands you can run to see what is happening on the node:

--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -178,7 +178,7 @@ spec:
 +
 ----
 $ kubectl get -n openshift-monitoring deploy/prometheus-adapter -o jsonpath="{..image}"
-quay.io/openshift-release-dev/ocp-v4.2-art-dev@sha256:76db3c86554ad7f581ba33844d6a6ebc891236f7db64f2d290c3135ba81c264c
+quay.io/openshift-release-dev/ocp-v4.3-art-dev@sha256:76db3c86554ad7f581ba33844d6a6ebc891236f7db64f2d290c3135ba81c264c
 ----
 
 . Add configuration for deploying `prometheus-adapter`:
@@ -206,7 +206,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: prometheus-adapter
-        image: openshift-release-dev/ocp-v4.2-art-dev <1>
+        image: openshift-release-dev/ocp-v4.3-art-dev <1>
         args:
         - --secure-port=6443
         - --tls-cert-file=/var/run/serving-cert/tls.crt
@@ -237,7 +237,7 @@ spec:
       - name: tmp-vol
         emptyDir: {}
 ----
-<1> `image: openshift-release-dev/ocp-v4.2-art-dev` specifies the Prometheus Adapter image found in the previous step.
+<1> `image: openshift-release-dev/ocp-v4.3-art-dev` specifies the Prometheus Adapter image found in the previous step.
 
 . Apply the configuration file to the cluster:
 +

--- a/modules/nodes-containers-volumes-subpath.adoc
+++ b/modules/nodes-containers-volumes-subpath.adoc
@@ -15,7 +15,7 @@ instead of the volume's root.
 +
 ----
 $ oc rsh <pod>
-sh-4.2$ ls /path/to/volume/subpath/mount
+sh-4.3$ ls /path/to/volume/subpath/mount
 example_file1 example_file2 example_file3
 ----
 

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -135,12 +135,12 @@ $ oc debug node/ip-10-0-141-105.ec2.internal
 Starting pod/ip-10-0-141-105ec2internal-debug ...
 To use host binaries, run `chroot /host`
 
-sh-4.2# cat /host/proc/cmdline
+sh-4.3# cat /host/proc/cmdline
 BOOT_IMAGE=/ostree/rhcos-... console=tty0 console=ttyS0,115200n8
 rootflags=defaults,prjquota rw root=UUID=fd0... ostree=/ostree/boot.0/rhcos/16...
 coreos.oem.id=qemu coreos.oem.id=ec2 ignition.platform.id=ec2 selinux=0
 
-sh-4.2# exit
+sh-4.3# exit
 ----
 +
 You should see the `selinux=0` argument added to the other kernel arguments.

--- a/modules/nodes-nodes-working-master-schedulable.adoc
+++ b/modules/nodes-nodes-working-master-schedulable.adoc
@@ -13,7 +13,7 @@ default.
 
 [IMPORTANT]
 ====
-In version 4.2, the ability to create a cluster that does not have worker nodes is available to only clusters that are deployed on bare metal as a technology preview. For all other cluster types, you can set the masters to be schedulable but must retain worker nodes.
+In version {product-version}, the ability to create a cluster that does not have worker nodes is available to only clusters that are deployed on bare metal as a technology preview. For all other cluster types, you can set the masters to be schedulable but must retain worker nodes.
 ====
 
 You can allow or disallow master nodes to be schedulable by configuring the

--- a/modules/nodes-pods-using-example.adoc
+++ b/modules/nodes-pods-using-example.adoc
@@ -62,7 +62,7 @@ spec:
           readOnly: true
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       terminationMessagePolicy: File
-      image: registry.redhat.io/openshift4/ose-ogging-eventrouter:v4.2 <6>
+      image: registry.redhat.io/openshift4/ose-ogging-eventrouter:v4.3 <6>
   serviceAccount: default     <7>
   volumes:                    <8>
     - name: default-token-wbqsl

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -79,7 +79,7 @@ metadata:
   labels:
     kubernetes.io/os: linux
     failure-domain.beta.kubernetes.io/zone: us-east-1a
-    node.openshift.io/os_version: '4.2'
+    node.openshift.io/os_version: '4.3'
     node-role.kubernetes.io/worker: ''
     failure-domain.beta.kubernetes.io/region: us-east-1
     node.openshift.io/os_id: rhcos

--- a/modules/nw-cluster-network-operator.adoc
+++ b/modules/nw-cluster-network-operator.adoc
@@ -29,7 +29,7 @@ network-operator   1/1     1            1           56m
 $ oc get clusteroperator/network
 
 NAME      VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-network   4.2.0     True        False         False      50m
+network   4.3.0     True        False         False      50m
 ----
 The following fields provide information about the status of the operator:
 `AVAILABLE`, `PROGRESSING`, and `DEGRADED`. The `AVAILABLE` field is `True` when

--- a/modules/nw-multus-delete-network.adoc
+++ b/modules/nw-multus-delete-network.adoc
@@ -11,7 +11,7 @@ is attached to.
 
 [IMPORTANT]
 ====
-In {product-title} 4.2.0 you must manually delete the additional network CR after removing it from the Cluster Network Operator configuration.
+In {product-title} {product-version}, you must manually delete the additional network CR after removing it from the Cluster Network Operator configuration.
 This will be fixed in a future release.
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1755908[BZ#1755908].
 ====

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -25,15 +25,6 @@ other CNI plug-ins. You can configure ipam for either static IP address
 assignment or dynamic IP address assignment by using DHCP. The DHCP server you
 specify must be reachable from the additional network.
 
-[IMPORTANT]
-====
-In {product-title} 4.2.0, if you attach a Pod to an additional network that uses
-DHCP for IP address management, the Pod will fail to start.
-This is fixed in {product-title} 4.2.1.
-For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1754686[BZ#1754686].
-====
-
-
 ifdef::json[]
 The following JSON configuration object describes the parameters that you can set.
 endif::json[]

--- a/modules/openshift-developer-cli-connecting-the-database.adoc
+++ b/modules/openshift-developer-cli-connecting-the-database.adoc
@@ -29,13 +29,13 @@ mongodb-1-gsznc                     1/1       Running   0          28m
 nodejs-nodejs-ex-mhbb-app-4-vkn9l   1/1       Running   0          1m
 
 $ oc rsh nodejs-nodejs-ex-mhbb-app-4-vkn9l
-sh-4.2$ env
+sh-4.3$ env
 uri=mongodb://172.30.126.3:27017
 password=dHIOpYneSkX3rTLn
 database_name=sampledb
 username=user43U
 admin_password=NCn41tqmx7RIqmfv
-sh-4.2$
+sh-4.3$
 ----
 
 . Open the URL in the browser and notice the database configuration in the bottom right:

--- a/modules/registry-operator-config-resources-configmap.adoc
+++ b/modules/registry-operator-config-resources-configmap.adoc
@@ -84,7 +84,7 @@ spec:
 +
 ----
 $ oc rsh image-registry-xxxxx
-sh-4.2
+sh-4.3
 $ ls /etc/pki/ca-trust/source/anchors
 <external_registry_address> image-registry.openshift-image-registry.svc..5000 image-registry.openshift-image-registry.svc.cluster.local..5000
 ----
@@ -107,4 +107,4 @@ data:
     -----END CERTIFICATE-----
 ----
 <1>  If the registry has the port, such as `registry-with-port.example.com:5000`,
-`:` should be replaced with `..`. 
+`:` should be replaced with `..`.

--- a/modules/restore-add-master.adoc
+++ b/modules/restore-add-master.adoc
@@ -70,13 +70,13 @@ etcd-member-ip-10-0-171-108.us-east-2.compute.internal   2/2     Running   0    
 .. In the etcd container, export the variables needed for connecting to etcd:
 +
 ----
-sh-4.2# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
+sh-4.3# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
 ----
 
 .. In the etcd container, execute `etcdctl member list` and verify that the new member is listed:
 +
 ----
-sh-4.2#  etcdctl member list -w table
+sh-4.3#  etcdctl member list -w table
 
 +------------------+---------+------------------------------------------+------------------------------------------------------------------+---------------------------+
 |        ID        | STATUS  |                   NAME                   |                            PEER ADDRS                            |       CLIENT ADDRS        |
@@ -92,7 +92,7 @@ It may take up to 10 minutes for the new member to start.
 .. In the etcd container, execute `etcdctl endpoint health` and verify that the new member is healthy:
 +
 ----
-sh-4.2# etcdctl endpoint health --cluster
+sh-4.3# etcdctl endpoint health --cluster
 https://10.0.128.73:2379 is healthy: successfully committed proposal: took = 4.5576ms
 https://10.0.147.172:2379 is healthy: successfully committed proposal: took = 5.1521ms
 https://10.0.171.108:2379 is healthy: successfully committed proposal: took = 4.2631ms

--- a/modules/restore-remove-failed-master.adoc
+++ b/modules/restore-remove-failed-master.adoc
@@ -49,13 +49,13 @@ etcd member etcd-member-ip-10-0-147-172.us-east-2.compute.internal with 23e4736d
 .. In the etcd container, export the variables needed for connecting to etcd:
 +
 ----
-sh-4.2# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
+sh-4.3# export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)
 ----
 
 .. In the etcd container, execute `etcdctl member list` and verify that the removed member is no longer listed:
 +
 ----
-sh-4.2#  etcdctl member list -w table
+sh-4.3#  etcdctl member list -w table
 
 +------------------+---------+------------------------------------------+------------------------------------------------------------------+---------------------------+
 |        ID        | STATUS  |                   NAME                   |                            PEER ADDRS                            |       CLIENT ADDRS        |

--- a/modules/rhel-preparing-node.adoc
+++ b/modules/rhel-preparing-node.adoc
@@ -68,7 +68,7 @@ Note that this might take a few minutes if you have a large number of available 
 # subscription-manager repos \
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
-    --enable="rhel-7-server-ose-4.2-rpms"
+    --enable="rhel-7-server-ose-4.3-rpms"
 ----
 
 . Stop and disable firewalld on the host:

--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -69,7 +69,7 @@ a pool with an `OpenShift` subscription to it:
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ansible-2.8-rpms" \
-    --enable="rhel-7-server-ose-4.2-rpms"
+    --enable="rhel-7-server-ose-4.3-rpms"
 ----
 
 . Install the required packages, including `Openshift-Ansible`:

--- a/modules/running-cluster-loader.adoc
+++ b/modules/running-cluster-loader.adoc
@@ -12,7 +12,7 @@ template builds and waits for them to complete:
 +
 ----
 $ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z -i \
-quay.io/openshift/origin-tests:4.2 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
+quay.io/openshift/origin-tests:4.3 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
 openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the \
 cluster [Suite:openshift]"'
 ----
@@ -23,7 +23,7 @@ setting the environment variable for `VIPERCONFIG`:
 ----
 $ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z \
 -v ${LOCAL_CONFIG_FILE_PATH}:/root/configs/:z \
--i quay.io/openshift/origin-tests:4.2 \
+-i quay.io/openshift/origin-tests:4.3 \
 /bin/bash -c 'KUBECONFIG=/root/.kube/config VIPERCONFIG=/root/configs/test.yaml \
 openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should \
 load the cluster [Suite:openshift]"'

--- a/modules/templates-rails-writing-application.adoc
+++ b/modules/templates-rails-writing-application.adoc
@@ -13,7 +13,7 @@ Rails gem first. Then you can proceed with writing your application.
 +
 ----
 $ gem install rails
-Successfully installed rails-4.2.0
+Successfully installed rails-4.3.0
 1 gem installed
 ----
 

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -28,17 +28,17 @@ known as `oc`, that matches the version for your updated version.
 $ oc get clusterversion
 
 NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
-version   4.2.0     True        False         158m    Cluster version is 4.2.0
+version   4.3.0     True        False         158m    Cluster version is 4.3.0
 ----
 
 . Review the current update channel information and confirm that your channel
-is set to `stable-4.2`:
+is set to `stable-4.3`:
 +
 ----
 $ oc get clusterversion -o json|jq ".items[0].spec"
 
 {
-  "channel": "stable-4.2",
+  "channel": "stable-4.3",
   "clusterID": "990f7ab8-109b-4c95-8480-2bd1deec55ff",
   "upstream": "https://api.openshift.com/api/upgrades_info/v1/graph"
 }
@@ -84,12 +84,12 @@ previous command.
 $ oc get clusterversion -o json|jq ".items[0].spec"
 
 {
-  "channel": "stable-4.2",
+  "channel": "stable-4.3",
   "clusterID": "990f7ab8-109b-4c95-8480-2bd1deec55ff",
   "desiredUpdate": {
     "force": false,
     "image": "quay.io/openshift-release-dev/ocp-release@sha256:9c5f0df8b192a0d7b46cd5f6a4da2289c155fd5302dec7954f8f06c878160b8b",
-    "version": "4.2.1" <1>
+    "version": "4.3.1" <1>
   },
   "upstream": "https://api.openshift.com/api/upgrades_info/v1/graph"
 }

--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -18,6 +18,9 @@ If updates are available, you can update your cluster from the web console.
 You can find information about available {product-title} advisories and updates
 link:https://access.redhat.com/downloads/content/290/ver=4.2/rhel---7/4.2.0/x86_64/product-errata[in the errata section]
 of the Customer Portal.
+////
+update link to 4.3 when available
+////
 
 .Prerequisites
 

--- a/modules/upgrade-cluster-version-definition.adoc
+++ b/modules/upgrade-cluster-version-definition.adoc
@@ -21,7 +21,7 @@ metadata:
   selfLink: /apis/config.openshift.io/v1/clusterversions/version
   uid: 82f9f2c4-4cae-11e9-90b7-06dc0f62ad38
 spec:
-  channel: stable-4.2 <1>
+  channel: stable-4.3 <1>
   overrides: "" <2>
   clusterID: 0b1cf91f-c3fb-4f9e-aa02-e0d70c71f6e6
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph

--- a/modules/user-agent-overview.adoc
+++ b/modules/user-agent-overview.adoc
@@ -20,7 +20,7 @@ within {product-title}:
 For example, when:
 
 * <command> = `oc`
-* <version> = The client version. For example, `v4.2.0`. Requests made against the Kubernetes
+* <version> = The client version. For example, `v4.3.0`. Requests made against the Kubernetes
 API at `/api` receive the Kubernetes version, while requests made against the
 {product-title} API at `/oapi` receive the {product-title} version (as specified
 by `oc version`)

--- a/openshift_images/using_images/images-other-jenkins.adoc
+++ b/openshift_images/using_images/images-other-jenkins.adoc
@@ -21,7 +21,7 @@ The {product-title} Jenkins images are available on `quay.io` or
 For example:
 
 ----
-$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.2.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.3.0>
 ----
 
 To use these images, you can either access them directly from these registries


### PR DESCRIPTION
https://jira.coreos.com/browse/OSDOCS-766

cc @vikram-redhat 

There are still many instances of 4.2 in the migration content that I did not touch yet. I will coordinate with @bergerhoffer 

There are also several external URLs with 4.2 paths that I assume will be updated post-release to point to the latest content.