### PR TITLE
Fixing one more build error

### DIFF
--- a/networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
+++ b/networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 {product-title} provides methods for communicating from outside the cluster with
 services running in the cluster. This method uses an Ingress Controller.
+
 ifdef::openshift-enterprise,openshift-origin[]
 include::modules/nw-using-ingress-and-routes.adoc[leveloffset=+1]
 
@@ -37,6 +38,7 @@ procedure assumes that the external system is on the same subnet as the cluster.
 The additional networking required for external systems on a different subnet is
 out-of-scope for this topic.
 endif::[]
+
 include::modules/nw-creating-project-and-service.adoc[leveloffset=+1]
 
 include::modules/nw-exposing-service.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixing build error and rendering `:leveloffset: +1` in the docs [1].

[1] https://docs.openshift.com/container-platform/4.2/networking/configuring-ingress-cluster-traffic/configuring-ingress-cluster-traffic-ingress-controller.html