### PR TITLE
Monitoring 'TP include' fix

### DIFF
--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -1,14 +1,11 @@
 // Module included in the following assemblies:
 //
-// * monitoring/application-monitoring.adoc
+// * monitoring/exposing-custom-application-metrics-for-autoscaling.adoc
 
 [id="exposing-custom-application-metrics-for-horizontal-pod-autoscaling_{context}"]
 = Exposing custom application metrics for horizontal pod autoscaling
 
 You can use the `prometheus-adapter` resource to expose custom application metrics for the horizontal pod autoscaler.
-
-:FeatureName: Prometheus Adapter
-include::modules/technology-preview.adoc[leveloffset=+0]
 
 .Prerequisites
 

--- a/monitoring/exposing-custom-application-metrics-for-autoscaling.adoc
+++ b/monitoring/exposing-custom-application-metrics-for-autoscaling.adoc
@@ -7,6 +7,9 @@ toc::[]
 
 You can export custom application metrics for the horizontal pod autoscaler.
 
+:FeatureName: Prometheus Adapter
+include::modules/technology-preview.adoc[leveloffset=+0]
+
 include::modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc[leveloffset=+1]
 
 .Additional resources


### PR DESCRIPTION
Moving the Tech Preview attribute and include from the module to the assembly. Also updated the metadata in the module, which was stale.

@bergerhoffer 