### PR TITLE
Fix how to create new alertmanager.yaml secret

### DIFF
--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -23,31 +23,29 @@ $ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .
 +
 [source,yaml]
 ----
-data:
- config.yaml: |
-  global:
-    resolve_timeout: 5m
-  route:
-    group_wait: 30s
-    group_interval: 5m
-    repeat_interval: 12h
-    receiver: default
+global:
+  resolve_timeout: 5m
+route:
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: default
+  routes:
+  - match:
+      alertname: Watchdog
+    repeat_interval: 5m
+    receiver: watchdog
+  - match:
+      service: <your_service> <1>
     routes:
     - match:
-        alertname: Watchdog
-      repeat_interval: 5m
-      receiver: watchdog
-    - match:
-        service: <your_service> <1>
-      routes:
-      - match:
-          <your_matching_rules> <2>
-        receiver: <receiver> <3>
-  receivers:
-  - name: default
-  - name: watchdog
-  - name: <receiver>
-    <receiver_configuration>
+        <your_matching_rules> <2>
+      receiver: <receiver> <3>
+receivers:
+- name: default
+- name: watchdog
+- name: <receiver>
+  <receiver_configuration>
 ----
 <1> `service` specifies the service that fires the alerts.
 <2> `<your_matching_rules>` specify the target alerts.
@@ -57,32 +55,30 @@ For example, this listing configures PagerDuty for notifications:
 +
 [source,yaml,subs=quotes]
 ----
-data:
- config.yaml: |
-  global:
-    resolve_timeout: 5m
-  route:
-    group_wait: 30s
-    group_interval: 5m
-    repeat_interval: 12h
-    receiver: default
+global:
+  resolve_timeout: 5m
+route:
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: default
+  routes:
+  - match:
+      alertname: Watchdog
+    repeat_interval: 5m
+    receiver: watchdog
+  *- match:
+      service: example-app
     routes:
     - match:
-        alertname: Watchdog
-      repeat_interval: 5m
-      receiver: watchdog
-    *- match:
-        service: example-app
-      routes:
-      - match:
-          severity: critical
-        receiver: team-frontend-page*
-  receivers:
-  - name: default
-  - name: watchdog
-  *- name: team-frontend-page
-    pagerduty_configs:
-    - service_key: "_your-key_"*
+        severity: critical
+      receiver: team-frontend-page*
+receivers:
+- name: default
+- name: watchdog
+*- name: team-frontend-page
+  pagerduty_configs:
+  - service_key: "_your-key_"*
 ----
 +
 With this configuration, alerts of `critical` severity fired by the `example-app` service are sent using the `team-frontend-page` receiver, which means that these alerts are paged to a chosen person.


### PR DESCRIPTION
The way how it was described didn't work. A) There is no file config.yaml in the game here
and B) if you do create secret --from-file it will automatically add the base64 encoded content
of the file to data with the filename it read from.

This is broken in 4.2 configs as well, should be backported there.