### PR TITLE
Cnv bz1771927 rbac+cloning VM disks

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1228,6 +1228,8 @@ Topics:
   - Name: Deleting a virtual machine template
     File: cnv-deleting-vm-template
 # Cloning virtual machines
+  - Name: Enabling user permissions to clone datavolumes across namespaces
+    File: cnv-enabling-user-permissions-to-clone-datavolumes
   - Name: Cloning a virtual machine disk into a new DataVolume
     File: cnv-cloning-vm-disk-into-new-datavolume
   - Name: Cloning a virtual machine by using a DataVolumeTemplate

--- a/cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
+++ b/cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
@@ -15,6 +15,8 @@ xref:#cnv-cdi-supported-operations-matrix_cnv-cloning-vm-disk-into-new-datavolum
 xref:../../cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc#cnv-defining-storageclass-in-cdi-configuration_cnv-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space]
 for this operation to complete successfully.
 
+* Users need xref:../../cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc#cnv-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
+
 :blockstorage:
 include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
 

--- a/cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
+++ b/cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
@@ -15,6 +15,8 @@ for this operation to complete successfully. The
 xref:#cnv-cdi-supported-operations-matrix_cnv-cloning-vm-disk-into-new-datavolume[CDI supported operations matrix] 
 shows the conditions that require scratch space.
 
+* Users need xref:../../cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc#cnv-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
+
 include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/cnv-cloning-pvc-of-vm-disk-into-new-datavolume.adoc[leveloffset=+1]

--- a/cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
+++ b/cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
@@ -14,6 +14,8 @@ configuration file, you create a new DataVolume from the original PVC.
 for this operation to complete successfully. The 
 xref:#cnv-cdi-supported-operations-matrix_cnv-cloning-vm-using-datavolumetemplate[CDI supported operations matrix] 
 shows the conditions that require scratch space.
+
+* Users need xref:../../cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc#cnv-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
  
 include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
 

--- a/cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc
+++ b/cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc
@@ -1,0 +1,24 @@
+[id="cnv-enabling-user-permissions-to-clone-datavolumes"]
+= Enabling user permissions to clone DataVolumes across namespaces
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-enabling-user-permissions-to-clone-datavolumes
+toc::[]
+
+The isolating nature of namespaces means that users cannot by default 
+clone resources between namespaces. 
+
+To enable a user to clone a virtual machine to another namespace, a 
+user with the `cluster-admin` role must create a new ClusterRole. Bind 
+this ClusterRole to a user to enable them to clone virtual machines
+to the destination namespace. 
+
+.Prerequisites
+
+* Only a user with the xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[`cluster-admin`]
+role can create ClusterRoles.
+
+include::modules/cnv-about-datavolumes.adoc[leveloffset=+1]
+
+include::modules/cnv-creating-rbac-cloning-dvs.adoc[leveloffset=+1]
+
+

--- a/modules/cnv-about-datavolumes.adoc
+++ b/modules/cnv-about-datavolumes.adoc
@@ -8,6 +8,7 @@
 // * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
 // * cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc
 // * cnv/cnv_users_guide/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc
 
 [id="cnv-about-datavolumes_{context}"]
 = About DataVolumes

--- a/modules/cnv-creating-rbac-cloning-dvs.adoc
+++ b/modules/cnv-creating-rbac-cloning-dvs.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv-virtual-machines/cnv-cloning-vms/cnv-enabling-user-permissions-to-clone-datavolumes.adoc
+
+[id="cnv-creating-rbac-cloning-dvs_{context}"]
+= Creating RBAC resources for cloning DataVolumes
+
+Create a new ClusterRole that enables permissions for all actions for the `datavolumes` resource. 
+
+.Procedure
+
+. Create a ClusterRole manifest:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: <datavolume-cloner> <1>
+rules:
+- apiGroups: ["cdi.kubevirt.io"]
+  resources: ["datavolumes/source"]
+  verbs: ["*"]
+----
+<1> Unique name for the ClusterRole.
+
+. Create the ClusterRole in the cluster:
++
+----
+$ oc create -f <datavolume-cloner.yaml> <1>
+----
+<1> The file name of the ClusterRole manifest created in the previous step.
+
+. Create a RoleBinding manifest that applies to both the source and destination namespaces and references
+the ClusterRole created in the previous step. 
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: <allow-clone-to-user> <1>
+  namespace: <Source namespace> <2>
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: <Destination namespace> <3>
+roleRef:
+  kind: ClusterRole
+  name: datavolume-cloner <4>
+  apiGroup: rbac.authorization.k8s.io
+----
+<1> Unique name for the RoleBinding.
+<2> The namespace for the source DataVolume.
+<3> The namespace to which the DataVolume is cloned.
+<4> The name of the ClusterRole created in the previous step.
+
+. Create the RoleBinding in the cluster:
++
+----
+$ oc create -f <datavolume-cloner.yaml> <1>
+----
+<1> The file name of the RoleBinding manifest created in the previous step.


### PR DESCRIPTION
Users need additional permissions (new ClusterRole and RoleBinding required) to clone VM disk (PVC or DV) to another namespace. This PR adds an assembly with one module; Prerequisite xrefs added to the three cloning assemblies.

Cherrypick to enterprise-4.3