### PR TITLE
Fix pruning groups example code block

### DIFF
--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -44,9 +44,9 @@ This specifies:
 To prune groups records from an external provider, administrators can
 run the following command:
 
----
+----
 $ oc adm prune groups --sync-config=path/to/sync/config [<options>]
----
+----
 
 .Prune groups CLI configuration options
 [cols="4,8",options="header"]


### PR DESCRIPTION
Code block was missing additional dash in beginning and in the end of block.