### PR TITLE
Fix prune groups sync config option name

### DIFF
--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -76,13 +76,13 @@ for the structure of this file.
 To see the groups that the prune command deletes:
 
 ----
-$ oc adm prune groups --sync-file=ldap-sync-config.yaml
+$ oc adm prune groups --sync-config=ldap-sync-config.yaml
 ----
 
 To perform the prune operation:
 
 ----
-$ oc adm prune groups --sync-file=ldap-sync-config.yaml --confirm
+$ oc adm prune groups --sync-config=ldap-sync-config.yaml --confirm
 ----
 
 [[pruning-deployments]]


### PR DESCRIPTION
Two examples of group pruning is using not existing pruner option:
--sync-file
From oc cli and other examples it should be:
--sync-config

Verified on oc v3.11.154