### PR TITLE
fixed tags

### DIFF
--- a/migration/migrating-3-4/migrating-openshift-3-to-4.adoc
+++ b/migration/migrating-3-4/migrating-openshift-3-to-4.adoc
@@ -69,10 +69,10 @@ The CAM Operator installs the following:
 include::modules/migration-installing-cam-operator-ocp-3.adoc[leveloffset=+2]
 :ocp-3-to-4!:
 
-:context: targetcluster_4.2
-:targetcluster_4.2:
+:context: targetcluster_3-4
+:targetcluster_3-4:
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
-:targetcluster_4.2!:
+:targetcluster_3-4!:
 
 :context: ocp-3-to-4
 :ocp-3-to-4:

--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -18,7 +18,7 @@ You can install the CAM Operator on an {product-title} 4.2 source cluster with O
 
 The CAM Operator installs Velero and Restic.
 endif::[]
-ifdef::targetcluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster_3-4,targetcluster-4_2-4_2,targetcluster-4_1-4_2[]
 = Installing the CAM Operator on an {product-title} 4.2 target cluster
 
 You can install the CAM Operator on an {product-title} 4.2 target cluster with OLM.
@@ -33,7 +33,7 @@ endif::[]
 .. Click *Create Namespace*.
 .. Enter `openshift-migration` in the *Name* field and click *Create*.
 
-ifdef::targetcluster-4_2-4_2,sourcecluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster_3-4,targetcluster-4_2-4_2,sourcecluster-4_2-4_2,targetcluster-4_1-4_2[]
 . Click *Operators* -> *OperatorHub*.
 endif::[]
 ifdef::sourcecluster-4_1-4_2[]
@@ -47,7 +47,7 @@ endif::[]
 .. Select the *openshift-migration* namespace if it is not already selected.
 .. Select an *Automatic* or *Manual* approval strategy.
 .. Click *Subscribe*.
-ifdef::targetcluster-4_2-4_2,sourcecluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster_3-4,targetcluster-4_2-4_2,sourcecluster-4_2-4_2,targetcluster-4_1-4_2[]
 . Click *Operators* -> *Installed Operators*.
 endif::[]
 ifdef::sourcecluster-4_1-4_2[]
@@ -91,6 +91,6 @@ endif::[]
 ifdef::sourcecluster-4_1-4_2,sourcecluster-4_2-4_2[]
 . Click *Workloads* -> *Pods* to verify that the Restic and Velero Pods are running.
 endif::[]
-ifdef::targetcluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster_3-4,targetcluster-4_2-4_2,targetcluster-4_1-4_2[]
 . Click *Workloads* -> *Pods* to verify that the Controller Manager, Migration UI, Restic, and Velero Pods are running.
 endif::[]


### PR DESCRIPTION
Urgent. Missing tag caused parts of CAM operator installation on target cluster to be omitted for OCP 3-4 migration.

Doc preview: http://file.tlv.redhat.com/~apinnick/3-to-4-migration-fix/migration/migrating-3-4/migrating-openshift-3-to-4.html