### PR TITLE
BZ1772649: Add OCS 4.2 Info to OCP 4.2+ Docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -411,6 +411,9 @@ Name: Storage
 Dir: storage
 Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
 Topics:
+- Name: Red Hat OpenShift Container Storage
+  File: red-hat-openshift-container-storage
+  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
 - Name: Understanding persistent storage
   File: understanding-persistent-storage
   Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -52,6 +52,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 - iSCSI
 - Local volume
 - NFS
+- Red Hat OpenShift Container Storage
 - VMware vSphere
 // - Local
 endif::[]

--- a/storage/red-hat-openshift-container-storage.adoc
+++ b/storage/red-hat-openshift-container-storage.adoc
@@ -1,0 +1,35 @@
+[id="red-hat-openshift-container-storage"]
+= Red Hat OpenShift Container Storage
+include::modules/common-attributes.adoc[]
+:context: red-hat-openshift-container-storage
+toc::[]
+
+Red Hat OpenShift Container Storage is a provider of agnostic persistent storage for {product-title} supporting file, block, and object storage, either in-house or in hybrid clouds. As a Red Hat storage solution, Red Hat OpenShift Container Storage is completely integrated with {product-title} for deployment, management, and monitoring.
+
+Red Hat OpenShift Container Storage provides its own documentation library. The complete set of Red Hat OpenShift Container Storage documentation identified below is available at https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/
+
+[options="header",cols="1,1"]
+|===
+
+|If you are looking for Red Hat OpenShift Container Storage information about...
+|See the following Red Hat OpenShift Container Storage documentation:
+
+|What’s new, known issues, notable bug fixes, and Technology Previews
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html/4.2_release_notes/[Red Hat OpenShift Container Storage 4.2 Release Notes]
+
+|Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html/planning_your_deployment/index[Planning your Red Hat OpenShift Container Storage 4.2 deployment]
+
+|Deploying Red Hat OpenShift Container Storage 4.2 on an existing {product-title} cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html/deploying_openshift_container_storage/index[Deploying Red Hat OpenShift Container Storage 4.2]
+
+|Managing a Red Hat OpenShift Container Storage 4.2 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html/managing_openshift_container_storage/index[Managing Red Hat OpenShift Container Storage 4.2]
+
+|Monitoring a Red Hat OpenShift Container Storage 4.2 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html/monitoring_openshift_container_storage/index[Monitoring Red Hat OpenShift Container Storage 4.2]
+
+|Migrating your {product-title} cluster from version 3 to version 4
+|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/migration/index[Migration]
+
+|===

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -28,6 +28,8 @@ ifdef::openshift-enterprise,openshift-origin[]
 == Cluster installer activities
 As someone setting out to install an {product-title} {product-version} cluster, this documentation will help you:
 
+- **xref:../storage/red-hat-openshift-container-storage.adoc#red-hat-openshift-container-storage[Use Red Hat OpenShift Container Storage]**
+
 - **xref:../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Install a cluster on AWS]**: You have the most installation options when you deploy a cluster on Amazon Web Services (AWS). You can deploy clusters with xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[default settings] or xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[custom AWS settings].
 You can also deploy a cluster on AWS infrastructure that you provisioned yourself. You can modify the provided xref:../installing/installing_aws_user_infra/installing-aws-user-infra.adoc#installing-aws-user-infra[AWS CloudFormation templates] to meet your needs.
 


### PR DESCRIPTION
[BZ 1772649](https://bugzilla.redhat.com/show_bug.cgi?id=1772649) Adds OCS 4.2 assembly to OCP 4.2+ documentation (pending 12/19/19 GA of OCS 4.2). Also mentioned here: https://github.com/openshift/openshift-docs/issues/17796#issuecomment-566194565