### PR TITLE
No mcg noobaa

### DIFF
--- a/migration/migrating-3-4/migrating-openshift-3-to-4.adoc
+++ b/migration/migrating-3-4/migrating-openshift-3-to-4.adoc
@@ -1,14 +1,14 @@
 [id="migrating-openshift-3-to-4"]
-= Migrating {product-title} 3.7 to 4.2
+= Migrating {product-title} 3.7 to {product-version}
 include::modules/common-attributes.adoc[]
-:context: ocp-3-to-4_2
-:ocp-3-to-4_2:
+:context: migrating-3-4
+:migrating-3-4:
 
 toc::[]
 
-You can migrate application workloads from {product-title} 3.7 (and later) to {product-title} 4.2 with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
+You can migrate application workloads from {product-title} 3.7 (and later) to {product-title} {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
 
-The CAM tool's web console and API, based on Kubernetes custom resources, enable you to migrate stateful application workloads at the granularity of a namespace.
+The CAM tool's web console and API, based on Kubernetes custom resources (CRs), enable you to migrate stateful application workloads at the granularity of a namespace.
 
 Optionally, you can use the xref:migration-understanding-cpma_{context}[Control Plane Migration Assistant (CPMA)] to assist you in migrating control plane settings.
 
@@ -20,63 +20,55 @@ Before you begin your migration, be sure to review the information on xref:../..
 .Prerequisites
 
 * The source cluster must be {product-title} 3.7, 3.9, 3.10, or 3.11.
-* The target cluster must be {product-title} 4.2.
+* The target cluster must be {product-title} {product-version}.
 * You must have xref:../../cli_reference/openshift_cli/administrator-cli-commands.html#policy[`cluster-admin` privileges] on all clusters.
 * You must have `podman` installed.
-* You must configure a replication repository that supports the S3 API and is accessible to the source and target clusters.
-* If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster. If not, you must xref:../../openshift_images/image-streams-manage.html#images-imagestreams-update-tag_image-streams-managing[update the `imagestreamtags` references] to use an available version that is compatible with your application.
+* You must configure a replication repository that is accessible to the source and target clusters.
+* If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
 +
-[NOTE]
-====
-If the `imagestreamtags` cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to reference them.
+If the required images are not present, you must xref:../../openshift_images/image-streams-manage.html#images-imagestreams-update-tag_image-streams-managing[update the `imagestreamtags` references] to use an available version that is compatible with your application. If the `imagestreamtags` cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to reference them.
++
+The following `imagestreamtags` have been _removed_ from {product-title} {product-version}:
 
-The following `imagestreamtags` have been _removed_ from {product-title} 4.2:
-
-* `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
-* `dotnet-runtime:2.0`
-* `mariadb:10.1`
-* `mongodb:2.4`, `mongodb:2.6`
-* `mysql:5.5`, `mysql:5.6`
-* `nginx:1.8`
-* `nodejs:0.10`, `nodejs:4`, `nodejs:6`
-* `perl:5.16`, `perl:5.20`
-* `php:5.5`, `php:5.6`
-* `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
-* `python:3.3`, `python:3.4`
-* `ruby:2.0`, `ruby:2.2`
-====
+** `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
+** `dotnet-runtime:2.0`
+** `mariadb:10.1`
+** `mongodb:2.4`, `mongodb:2.6`
+** `mysql:5.5`, `mysql:5.6`
+** `nginx:1.8`
+** `nodejs:0.10`, `nodejs:4`, `nodejs:6`
+** `perl:5.16`, `perl:5.20`
+** `php:5.5`, `php:5.6`
+** `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
+** `python:3.3`, `python:3.4`
+** `ruby:2.0`, `ruby:2.2`
 
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
 
 [id='Configuring-replication-repository_{context}']
 == Configuring a replication repository
 
-You must configure an S3-compatible replication repository. The CAM tool uses the replication repository as a temporary intermediate storage space for copying data from the source cluster to the target cluster, using the xref:migration-understanding-data-copy-methods_{context}[filesystem or snapshot data copy methods].
+You must configure an object storage to use as a replication repository. The CAM tool copies data from the source cluster to the replication repository, and from there to the target cluster, using either the xref:file-system-copy-method_{context}[file system] or the xref:snapshot-copy-method_{context}[snapshot] data copy method.
 
 The following storage providers are supported:
 
-// * xref:migration-configuring-noobaa_{context}[NooBaa] or other generic S3 storage provider (does not support snapshot copy method)
-* Multi Cloud Gateway (MCG) or other generic S3 storage provider
-+
-MCG is installed by the CAM Operator and does not support the snapshot copy method.
-
+* Generic S3 object storage, for example, NooBaa, Minio, Ceph S3
 * xref:migration-configuring-aws-s3_{context}[AWS S3]
 * xref:migration-configuring-gcp_{context}[Google Cloud Provider]
 * xref:migration-configuring-azure_{context}[Microsoft Azure]
 
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+2]
-// include::modules/migration-configuring-noobaa.adoc[leveloffset=+2]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+2]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+2]
 include::modules/migration-configuring-azure.adoc[leveloffset=+2]
-:ocp-3-to-4_2!:
+:migrating-3-4!:
 
 == Deploying the Cluster Application Migration tool
 
 Deploying the CAM tool involves the following steps:
 
 . Installing the CAM Operator on the xref:installing-cam-operator-ocp-3_sourcecluster-3-4[source] and xref:installing-cam-operator-ocp-4_targetcluster-3-4[target] clusters
-. Configuring cross-origin resource sharing on the xref:migration-configuring-cors-3_ocp-3-to-4_2[source cluster]
+. Configuring cross-origin resource sharing on the xref:migration-configuring-cors-3_migrating-3-4[source cluster]
 
 :context: sourcecluster-3-4
 :sourcecluster-3-4:
@@ -88,8 +80,8 @@ include::modules/migration-installing-cam-operator-ocp-3.adoc[leveloffset=+2]
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
 :targetcluster-3-4!:
 
-:context: ocp-3-to-4_2
-:ocp-3-to-4_2:
+:context: migrating-3-4
+:migrating-3-4:
 include::modules/migration-configuring-cors-3.adoc[leveloffset=+2]
 
 == Migrating applications with the CAM web console
@@ -107,14 +99,13 @@ include::modules/migration-understanding-cpma.adoc[leveloffset=+2]
 include::modules/migration-installing-cpma.adoc[leveloffset=+2]
 include::modules/migration-using-cpma.adoc[leveloffset=+2]
 
-== Troubleshooting a failed migration
+== Troubleshooting
 
-You can view the migration custom resources (CRs) and download logs to troubleshoot a failed migration.
+You can view the migration CRs and download logs to troubleshoot a failed migration.
 
 include::modules/migration-custom-resources.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
 include::modules/migration-downloading-logs.adoc[leveloffset=+2]
 include::modules/migration-restic-timeout.adoc[leveloffset=+2]
-
-include::modules/migration-known-issues.adoc[leveloffset=+1]
-:ocp-3-to-4_2!:
+include::modules/migration-known-issues.adoc[leveloffset=+2]
+:migrating-3-4!:

--- a/migration/migrating-4-4/migrating-openshift-4_1-to-4.adoc
+++ b/migration/migrating-4-4/migrating-openshift-4_1-to-4.adoc
@@ -1,90 +1,82 @@
-[id="migrating-openshift-4_1-to-4"]
-= Migrating {product-title} 4.1 to 4.2
+[id="migrating-openshift-4_1-to-4_x"]
+= Migrating {product-title} 4.1 to {product-version}
 include::modules/common-attributes.adoc[]
-:context: ocp-4_1-4_2
-:ocp-4_1-4_2:
+:context: migrating-4_1-4_x
+:migrating-4_1-4_x:
 
 toc::[]
 
-You can migrate application workloads from {product-title} 4.1 to 4.2 with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
+You can migrate application workloads from {product-title} 4.1 to {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
 
 The CAM tool's web console and API, based on Kubernetes custom resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
 
 .Prerequisites
 
 * You must have xref:../../cli_reference/openshift_cli/administrator-cli-commands.html#policy[`cluster-admin` privileges] on all clusters.
-* You must configure a replication repository that supports the S3 API and is accessible to the source and target clusters.
-* If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster. If not, you must xref:../../openshift_images/image-streams-manage.html#images-imagestreams-update-tag_image-streams-managing[update the `imagestreamtags` references] to use an available version that is compatible with your application.
+* You must configure a replication repository that is accessible to the source and target clusters.
+* If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
 +
-[NOTE]
-====
-If the `imagestreamtags` cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to reference them.
+If the required images are not present, you must xref:../../openshift_images/image-streams-manage.html#images-imagestreams-update-tag_image-streams-managing[update the `imagestreamtags` references] to use an available version that is compatible with your application. If the `imagestreamtags` cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to reference them.
++
+The following `imagestreamtags` have been _removed_ from {product-title} {product-version}:
 
-The following `imagestreamtags` have been _removed_ from {product-title} 4.2:
-
-* `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
-* `dotnet-runtime:2.0`
-* `mariadb:10.1`
-* `mongodb:2.4`, `mongodb:2.6`
-* `mysql:5.5`, `mysql:5.6`
-* `nginx:1.8`
-* `nodejs:0.10`, `nodejs:4`, `nodejs:6`
-* `perl:5.16`, `perl:5.20`
-* `php:5.5`, `php:5.6`
-* `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
-* `python:3.3`, `python:3.4`
-* `ruby:2.0`, `ruby:2.2`
-====
+** `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
+** `dotnet-runtime:2.0`
+** `mariadb:10.1`
+** `mongodb:2.4`, `mongodb:2.6`
+** `mysql:5.5`, `mysql:5.6`
+** `nginx:1.8`
+** `nodejs:0.10`, `nodejs:4`, `nodejs:6`
+** `perl:5.16`, `perl:5.20`
+** `php:5.5`, `php:5.6`
+** `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
+** `python:3.3`, `python:3.4`
+** `ruby:2.0`, `ruby:2.2`
 
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
 
 [id='Configuring-replication-repository_{context}']
 == Configuring a replication repository
 
-You must configure a replication repository. The CAM tool uses the replication repository as a temporary intermediate storage space for copying data from the source cluster to the target cluster, using the xref:migration-understanding-data-copy-methods_{context}[filesystem or snapshot copy method].
+You must configure an object storage to use as a replication repository. The CAM tool copies data from the source cluster to the replication repository, and from there to the target cluster, using either the xref:file-system-copy-method_{context}[file system] or the xref:snapshot-copy-method_{context}[snapshot] data copy method.
 
 The following storage providers are supported:
 
-// * xref:migration-configuring-noobaa_{context}[NooBaa] or other generic S3 storage provider (does not support snapshot copy method)
-* Multi Cloud Gateway (MCG) or other generic S3 storage provider
-+
-MCG is installed by the CAM Operator and does not support the snapshot copy method.
-
+* Generic S3 object storage, for example, NooBaa, Minio, Ceph S3
 * xref:migration-configuring-aws-s3_{context}[AWS S3]
 * xref:migration-configuring-gcp_{context}[Google Cloud Provider]
 * xref:migration-configuring-azure_{context}[Microsoft Azure]
 
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+2]
-// include::modules/migration-configuring-noobaa.adoc[leveloffset=+2]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+2]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+2]
 include::modules/migration-configuring-azure.adoc[leveloffset=+2]
-:ocp-4_1-4_2!:
+:migrating-4_1-4_x!:
 
 == Deploying the Cluster Application Migration tool
 
 Deploying the CAM tool involves the following steps:
 
-. Installing the CAM Operator on the xref:installing-cam-operator-ocp-4_sourcecluster-4_1-4_2[source] and xref:installing-cam-operator-ocp-4_sourcecluster-4_1-4_2[target] clusters
-. Configuring cross-origin resource sharing on the xref:migration-configuring-cors-4_sourcecluster-4_1-4_2[source cluster]
+. Installing the CAM Operator on the xref:installing-cam-operator-ocp-4_sourcecluster-4_1-4_x[source] and xref:installing-cam-operator-ocp-4_targetcluster-4_1-4_x[target] clusters
+. Configuring cross-origin resource sharing on the xref:migration-configuring-cors-4_sourcecluster-4_1-4_x[source cluster]
 
-:context: sourcecluster-4_1-4_2
-:sourcecluster-4_1-4_2:
+:context: sourcecluster-4_1-4_x
+:sourcecluster-4_1-4_x:
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
-:sourcecluster-4_1-4_2!:
+:sourcecluster-4_1-4_x!:
 
-:context: targetcluster-4_1-4_2
-:targetcluster-4_1-4_2:
+:context: targetcluster-4_1-4_x
+:targetcluster-4_1-4_x:
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
-:targetcluster-4_1-4_2!:
+:targetcluster-4_1-4_x!:
 
-:context: sourcecluster-4_1-4_2
-:sourcecluster-4_1-4_2:
+:context: sourcecluster-4_1-4_x
+:sourcecluster-4_1-4_x:
 include::modules/migration-configuring-cors-4.adoc[leveloffset=+2]
-:sourcecluster-4_1-4_2!:
+:sourcecluster-4_1-4_x!:
 
-:context: ocp-4_1-4_2
-:ocp-4_1-4_2:
+:context: migrating-4_1-4_x
+:migrating-4_1-4_x:
 == Migrating applications with the CAM web console
 
 include::modules/migration-launching-cam.adoc[leveloffset=+2]
@@ -94,7 +86,7 @@ include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+2]
 include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+2]
 
-== Troubleshooting a failed migration
+== Troubleshooting
 
 You can view the migration custom resources (CRs) and download logs to troubleshoot a failed migration.
 
@@ -102,6 +94,5 @@ include::modules/migration-custom-resources.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
 include::modules/migration-downloading-logs.adoc[leveloffset=+2]
 include::modules/migration-restic-timeout.adoc[leveloffset=+2]
-
-include::modules/migration-known-issues.adoc[leveloffset=+1]
-:ocp-4_1-4_2!:
+include::modules/migration-known-issues.adoc[leveloffset=+2]
+:migrating-4_1-4_x!:

--- a/migration/migrating-4-4/migrating-openshift-4_2-to-4.adoc
+++ b/migration/migrating-4-4/migrating-openshift-4_2-to-4.adoc
@@ -1,8 +1,8 @@
 [id="migrating-openshift-4_2-to-4"]
 = Migrating between {product-title} 4.2 clusters
 include::modules/common-attributes.adoc[]
-:context: ocp-4_2-4_2
-:ocp-4_2-4_2:
+:context: migrating-4_2-4_x
+:migrating-4_2-4_x:
 
 toc::[]
 
@@ -13,56 +13,53 @@ The CAM tool's web console and API, based on Kubernetes custom resources, enable
 .Prerequisites
 
 * You must have xref:../../cli_reference/openshift_cli/administrator-cli-commands.html#policy[`cluster-admin` privileges] on all clusters.
-* You must have a replication repository that supports the S3 API and is accessible to the source and target clusters.
+* You must configure a replication repository that is accessible to the source and target clusters.
 
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
 
 [id='Configuring-replication-repository_{context}']
 == Configuring a replication repository
 
-You must configure a replication repository. The CAM tool uses the replication repository as a temporary intermediate storage space for copying data from the source cluster to the target cluster, using the xref:migration-understanding-data-copy-methods_{context}[file system or snapshot copy method].
+You must configure an object storage to use as a replication repository. The CAM tool copies data from the source cluster to the replication repository, and from there to the target cluster, using either the xref:file-system-copy-method_{context}[file system] or the xref:snapshot-copy-method_{context}[snapshot] data copy method.
 
-// * xref:migration-configuring-noobaa_{context}[NooBaa] or other generic S3 storage provider (does not support the snapshot copy method)
-* Multi Cloud Gateway (MCG) or other generic S3 storage provider
-+
-MCG is installed by the CAM Operator and does not support the snapshot copy method.
+The following storage providers are supported:
 
+* Generic S3 storage, with an S3 bucket for migration
 * xref:migration-configuring-aws-s3_{context}[AWS S3]
 * xref:migration-configuring-gcp_{context}[Google Cloud Provider]
 * xref:migration-configuring-azure_{context}[Microsoft Azure]
 
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+2]
-// include::modules/migration-configuring-noobaa.adoc[leveloffset=+2]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+2]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+2]
 include::modules/migration-configuring-azure.adoc[leveloffset=+2]
-:ocp-4_2-4_2!:
+:ocp-4_2-4_x!:
 
 == Deploying the Cluster Application Migration tool
 
 Deploying the CAM tool involves the following steps:
 
-. Installing the CAM Operator  on the xref:installing-cam-operator-ocp-4_sourcecluster-4_2-4_2[source] and xref:installing-cam-operator-ocp-4_targetcluster-4_2-4_2[target] clusters
-. Configuring cross-origin resource sharing on the xref:migration-configuring-cors-4_sourcecluster-4_2-4_2[source cluster]
+. Installing the CAM Operator  on the xref:installing-cam-operator-ocp-4_sourcecluster-4_2-4_x[source] and xref:installing-cam-operator-ocp-4_targetcluster-4_2-4_x[target] clusters
+. Configuring cross-origin resource sharing on the xref:migration-configuring-cors-4_sourcecluster-4_2-4_x[source cluster]
 
-:context: sourcecluster-4_2-4_2
-:sourcecluster-4_2-4_2:
+:context: sourcecluster-4_2-4_x
+:sourcecluster-4_2-4_x:
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
-:sourcecluster-4_2-4_2!:
+:sourcecluster-4_2-4_x!:
 
-:context: targetcluster-4_2-4_2
-:targetcluster-4_2-4_2:
+:context: targetcluster-4_2-4_x
+:targetcluster-4_2-4_x:
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
-:targetcluster-4_2-4_2!:
+:targetcluster-4_2-4_x!:
 
-:context: sourcecluster-4_2-4_2
-:sourcecluster-4_2-4_2:
+:context: sourcecluster-4_2-4_x
+:sourcecluster-4_2-4_x:
 include::modules/migration-configuring-cors-4.adoc[leveloffset=+2]
-:sourcecluster-4_2-4_2!:
+:sourcecluster-4_2-4_x!:
 
 
-:context: ocp-4_2-4_2
-:ocp-4_2-4_2:
+:context: migrating-4_2-4_x
+:migrating-4_2-4_x:
 == Migrating applications with the CAM web console
 
 include::modules/migration-launching-cam.adoc[leveloffset=+2]
@@ -72,7 +69,7 @@ include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+2]
 include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+2]
 
-== Troubleshooting a failed migration
+== Troubleshooting
 
 You can view the migration custom resources (CRs) and download logs to troubleshoot a failed migration.
 
@@ -80,6 +77,5 @@ include::modules/migration-custom-resources.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
 include::modules/migration-downloading-logs.adoc[leveloffset=+2]
 include::modules/migration-restic-timeout.adoc[leveloffset=+2]
-
-include::modules/migration-known-issues.adoc[leveloffset=+1]
-:ocp-4_2-4_2!:
+include::modules/migration-known-issues.adoc[leveloffset=+2]
+:migrating-4_2-4_x!:

--- a/modules/migration-adding-replication-repository-to-cam.adoc
+++ b/modules/migration-adding-replication-repository-to-cam.adoc
@@ -4,14 +4,18 @@
 // migration/migrating-4-4/migrating-openshift-4_1-to-4.adoc
 // migration/migrating-4-4/migrating-openshift-4_2-to-4.adoc
 [id='migration-adding-replication-repository-to-cam_{context}']
-= Adding a Repository to the CAM web console
+= Adding a replication repository to the CAM web console
 
-You can add an S3 repository to the CAM web console.
+You can add an object storage bucket as a replication repository to the CAM web console.
+
+.Prerequisites
+
+* You must configure an object storage bucket for migrating the data.
 
 .Procedure
 
 . Log in to the CAM web console.
-. In the *Repositories* section, click *Add repository*.
+. In the *Replication repositories* section, click *Add repository*.
 . Select a *Storage provider type* and fill in the following fields:
 
 * *AWS* for AWS S3 and generic S3 providers:
@@ -46,4 +50,4 @@ Currently, `https://` is supported only for AWS. For other providers, use `http:
 
 . Click *Close*.
 +
-The repository appears in the *Repositories* section.
+The new repository appears in the *Replication repositories* section.

--- a/modules/migration-configuring-cors-4.adoc
+++ b/modules/migration-configuring-cors-4.adoc
@@ -4,12 +4,12 @@
 // migration/migrating-4-4/migrating-openshift-4_1-to-4.adoc
 // migration/migrating-4-4/migrating-openshift-4_2-to-4.adoc
 [id='migration-configuring-cors-4_{context}']
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 = Configuring cross-origin resource sharing on an {product-title} 4.1 source cluster
 
 You must configure cross-origin resource sharing on an {product-title} 4.1 source cluster to enable communication between the source cluster's API server and the CAM tool.
 endif::[]
-ifdef::sourcecluster-4_2-4_2[]
+ifdef::sourcecluster-4_2-4_x[]
 = Configuring cross-origin resource sharing on an {product-title} 4.2 source cluster
 
 You must configure cross-origin resource sharing on an {product-title} 4.2 source cluster to enable communication between the source cluster's API server and the CAM tool.
@@ -25,7 +25,7 @@ $ oc get -n openshift-migration route/migration -o go-template='(?i)//{{ .spec.h
 ----
 
 . Log in to the source cluster.
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 . Edit the OAuth server CR:
 +
 ----
@@ -48,18 +48,18 @@ endif::[]
 
 . Edit the Kubernetes API server CR:
 +
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 ----
 $ oc edit kubeapiserver.operator cluster
 ----
 endif::[]
-ifdef::sourcecluster-4_2-4_2[]
+ifdef::sourcecluster-4_2-4_x[]
 ----
 $ oc edit apiserver.config.openshift.io cluster
 ----
 endif::[]
 
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 . Add the CORS configuration value to `corsAllowedOrigins` under `unsupportedConfigOverrides` in the `spec` stanza:
 +
 [source,yaml]
@@ -71,7 +71,7 @@ spec:
 ----
 <1> Specify your CORS configuration value.
 endif::[]
-ifdef::sourcecluster-4_2-4_2[]
+ifdef::sourcecluster-4_2-4_x[]
 . Add the CORS configuration value to `additionalCORSAllowedOrigins` in the `spec` stanza:
 +
 [source,yaml]

--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -36,7 +36,7 @@ The *Plan name* can contain up to 253 lower-case alphanumeric characters (`a-z, 
 
 . Select a *Copy method* for the PVs:
 
-* *Snapshot* backs up and restores the disk using the cloud provider's snapshot functionality. It is significantly faster than the *Filesystem* copy method.
+* *Snapshot* backs up and restores the disk using the cloud provider's snapshot functionality. It is significantly faster than *Filesystem*.
 +
 [NOTE]
 ====

--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -1,17 +1,17 @@
 // Module included in the following assemblies:
 //
-// migration/migrating-3-4/migrating-openshift-3-to-4.adoc
+// migration/migrating-3-4/migrating-openshift-3-4.adoc
 // migration/migrating-4-4/migrating-openshift-4_1-to-4.adoc
 // migration/migrating-4-4/migrating-openshift-4_2-to-4.adoc
 [id="installing-cam-operator-ocp-4_{context}"]
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 = Installing the CAM Operator on an {product-title} 4.1 source cluster
 
 You can install the CAM Operator on an {product-title} 4.1 source cluster with OLM.
 
 The CAM Operator installs Velero and Restic.
 endif::[]
-ifdef::sourcecluster-4_2-4_2[]
+ifdef::sourcecluster-4_2-4_x[]
 = Installing the CAM Operator on an {product-title} 4.2 source cluster
 
 You can install the CAM Operator on an {product-title} 4.2 source cluster with OLM.
@@ -19,16 +19,16 @@ You can install the CAM Operator on an {product-title} 4.2 source cluster with O
 The CAM Operator installs Restic and Velero.
 endif::[]
 
-ifdef::targetcluster-3-4,targetcluster-4_2-4_2,targetcluster-4_1-4_2[]
-= Installing the CAM Operator on an {product-title} 4.2 target cluster
+ifdef::targetcluster-3-4,targetcluster-4_2-4_x,targetcluster-4_1-4_x[]
+= Installing the CAM Operator on an {product-title} {product-version} target cluster
 
-You can install the CAM Operator on an {product-title} 4.2 target cluster with OLM.
+You can install the CAM Operator on an {product-title} {product-version} target cluster with OLM.
 
 The CAM Operator installs the following on the target cluster:
 
-* OpenShift Container Storage Operator
-+
-The OpenShift Container Storage Operator installs Multi Cloud Gateway and creates an S3 storage bucket as a replication repository
+// * OpenShift Container Storage Operator
+// +
+// The OpenShift Container Storage Operator installs Multi Cloud Gateway and creates an S3 storage bucket as a replication repository
 * Migration controller CR
 * CAM web console
 * Restic
@@ -42,10 +42,10 @@ endif::[]
 .. Click *Create Namespace*.
 .. Enter `openshift-migration` in the *Name* field and click *Create*.
 
-ifdef::targetcluster-3-4,targetcluster-4_2-4_2,sourcecluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster-3-4,targetcluster-4_2-4_x,sourcecluster-4_2-4_x,targetcluster-4_1-4_x[]
 . Click *Operators* -> *OperatorHub*.
 endif::[]
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 . Click *Catalog* -> *OperatorHub*.
 endif::[]
 . On the *OperatorHub* page:
@@ -56,10 +56,10 @@ endif::[]
 .. Select the *openshift-migration* namespace if it is not already selected.
 .. Select an *Automatic* or *Manual* approval strategy.
 .. Click *Subscribe*.
-ifdef::targetcluster-3-4,targetcluster-4_2-4_2,sourcecluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster-3-4,targetcluster-4_2-4_x,sourcecluster-4_2-4_x,targetcluster-4_1-4_x[]
 . Click *Operators* -> *Installed Operators*.
 endif::[]
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 . Click *Catalog* -> *Installed Operators*.
 endif::[]
 +
@@ -69,7 +69,7 @@ The *Cluster Application Migration Operator* is listed in the *openshift-migrati
 .. Under *Provided APIs*, click *View 12 more...*.
 .. Click *Create New* -> *MigrationController*.
 
-ifdef::sourcecluster-4_1-4_2[]
+ifdef::sourcecluster-4_1-4_x[]
 .. Update the `migration_controller` and `migration_ui` parameters and add the `deprecated_cors_configuration` parameter to the `spec` stanza:
 +
 [source,yaml]
@@ -82,7 +82,7 @@ spec:
   deprecated_cors_configuration: true
 ----
 endif::[]
-ifdef::sourcecluster-4_2-4_2[]
+ifdef::sourcecluster-4_2-4_x[]
 .. Update the `migration_controller` and `migration_ui` parameters in the `spec` stanza:
 +
 [source,yaml]
@@ -97,9 +97,9 @@ endif::[]
 
 .. Click *Create*.
 
-ifdef::ocp-3-to-4_2,sourcecluster-4_1-4_2,sourcecluster-4_2-4_2[]
+ifdef::migrating-3-4,sourcecluster-4_1-4_x,sourcecluster-4_2-4_x[]
 . Click *Workloads* -> *Pods* to verify that the Restic and Velero Pods are running.
 endif::[]
-ifdef::targetcluster-3-4,targetcluster-4_2-4_2,targetcluster-4_1-4_2[]
+ifdef::targetcluster-3-4,targetcluster-4_2-4_x,targetcluster-4_1-4_x[]
 . Click *Workloads* -> *Pods* to verify that the Controller Manager, Migration UI, Restic, and Velero Pods are running.
 endif::[]

--- a/modules/migration-understanding-data-copy-methods.adoc
+++ b/modules/migration-understanding-data-copy-methods.adoc
@@ -3,23 +3,25 @@
 // migration/migrating-3-4/migrating-openshift-3-to-4.adoc
 // migration/migrating-4-4/migrating-openshift-4-to-4.adoc
 [id='migration-understanding-data-copy-methods_{context}']
-= Understanding the file system and snapshot data copy methods
+= Understanding the data copy methods for migration
 
-The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster.
+The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
 
+[id='file-system-copy-method_{context}']
 == File system copy method
 
 The CAM tool copies data files from the source cluster to the replication repository, and from there to the target cluster.
 
 [cols="1,1", options="header"]
-.File system copy method
+.File system copy method summary
 |===
 |Benefits |Limitations
 a|* Clusters can have different storage classes
-* Suitable for all S3 storage providers
+* Supported for all S3 storage providers
 a|* Slower than the snapshot copy method
 |===
 
+[id='snapshot-copy-method_{context}']
 == Snapshot copy method
 
 The CAM tool copies a snapshot of the source cluster's data to a cloud provider's object storage, configured as a replication repository. The data is restored on the target cluster.
@@ -27,7 +29,7 @@ The CAM tool copies a snapshot of the source cluster's data to a cloud provider'
 AWS, Google Cloud Provider, and Microsoft Azure support the snapshot copy method.
 
 [cols="1,1", options="header"]
-.Snapshot copy method
+.Snapshot copy method summary
 |===
 |Benefits |Limitations
 a|* Faster than the file system copy method


### PR DESCRIPTION
Removing MCG, Noobaa, and OSP Operator support for CAM 1.0.1. 
Requires cherry-picking for 4.2+