### PR TITLE
Updates to Storage, edits to notable tech changes

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -160,7 +160,7 @@ the web console] for more information.
 [id="ocp-4-3-open-a-support-case"]
 ==== Open a Support case from the web console
 
-You can now open a Red Hat Support case from the web console.
+You can now open a Red Hat Support case from the help menu in the web console.
 
 [id="ocp-4-3-scale"]
 === Scale
@@ -178,17 +178,32 @@ Limit Calculator] to estimate cluster limits for your environment.
 [id="ocp-4-3-storage"]
 === Storage
 
-[id="ocp-4-3-iscsi"]
-==== iSCSI
+[id="ocp-4-3-ocs-4-2"]
+==== OpenShift Container Storage 4.2
 
-Persistent volumes and raw block volumes using iSCSI, previously in Technology
-Preview, are now fully supported in {product-title} 4.3.
+You can now deploy, manage, monitor, and migrate a Red Hat OpenShift Container Storage 4.2 cluster. See the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html/4.2_release_notes/[Red Hat OpenShift Container Storage 4.2 Release Notes] for more information.
+
+[id="ocp-4-3-iscsi-persistent-storage"]
+==== Persistent storage Using iSCSI
+
+Persistent volumes using iSCSI, previously in Technology Preview, is now fully supported in {product-title} 4.3.
+
+[id="ocp-4-3-raw-block-volume"]
+==== Raw block volume support
+
+iSCSI raw block volumes are now fully supported with OpenShift Container Platform 4.3.
+
+Raw block volumes using Cinder are now in Technology Preview.
 
 [id="ocp-4-3-csi-volume-expansion"]
-==== Container Storage Interface
+==== CSI volume expansion
 
-Using the Container Storage Interface (CSI) to expand storage volumes after they
-have already been created is now enabled by default in Technology Preview.
+You can now use the Container Storage Interface (CSI) to expand storage volumes after they have already been created. This feature is enabled by default in Technology Preview.
+
+[id="ocp-4-3-lso-tolerations"]
+==== Use tolerations in Local Storage Operator
+
+The Local Storage Operator now tolerates node taints, allowing you to provision local volumes from tainted nodes.
 
 [id="ocp-4-3-operators"]
 === Operators
@@ -219,23 +234,36 @@ v1.13.
 scaffolded to use Go modules. The `operator-sdk new` command's `--dep-manager`
 flag has likewise been removed.
 
+[id="ocp-4-3-unsupported-features"]
+=== Unsupported features
+
+[id="ocp-4-3-local-provisioner"]
+==== Local storage provisioner
+
+The previously deprecated Technical Preview of the `ose-local-storage-provisioner` container has been removed. It is recommended to use the OLM-based Local Storage Operator (`ose-local-storage-operator`).
+
+[id="ocp-4-3-pv-snapshots"]
+==== Persistent volume snapshots
+
+Persistent volume snapshots were deprecated in {product-title} 4.2 and have been removed in {product-title} 4.3.
+
 [id="ocp-4-3-deprecated-features"]
 === Deprecated features
 
 [id="ocp-4-3-pipelines-now-deprecated"]
-==== Deprecation of pipelines build strategy
+==== Pipelines build strategy
 
-The pipelines build strategy is now depreciated. Use OpenShift Pipelines
+The pipelines build strategy is now deprecated. Use OpenShift Pipelines
 instead.
 
 [id="ocp-4-3-beta-workload-alerts-deprecated"]
-==== Deprecation of beta workload alerts
+==== Beta workload alerts
 
 The `apps/v1beta1`, `apps/v1beta2`, `extensions/v1beta1` workload alerts are now
 deprecated with the introduction of Kubernetes 1.16.
 
 [id="ocp-4-3-service-catalog-deprecated"]
-==== Deprecation of Service Catalog, Template Service Broker, Ansible Service Broker, and their Operators
+==== Service Catalog, Template Service Broker, Ansible Service Broker, and their Operators
 
 Service Catalog, Template Service Broker, Ansible Service Broker, and their
 associated Operators were deprecated in {product-title} 4.2 and will be removed
@@ -287,6 +315,11 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 |TP
 |TP
+
+|iSCSI Persistent Volumes
+|-
+|TP
+|GA
 
 |CRI-O for runtime Pods
 |GA


### PR DESCRIPTION
@jsafrane Can you PTAL at Storage-related to be sure we sufficiently cover what's in 4.3?

Incorporates RN Tracker notes ([PR 17796](https://github.com/openshift/openshift-docs/issues/17796)) and [BZ 1781233](https://bugzilla.redhat.com/show_bug.cgi?id=1784279). 

Note: Link to OCS release notes (referenced in `[id="ocp-4-3-ocs-4-2"]`) will be live at OCS 4.2 GA (Dec. 19). (This relates to [PR 18679](https://github.com/openshift/openshift-docs/pull/18679), as required by OCS Docs team.)

Will merge to 4.3 branch only upon approval.