### PR TITLE
Remove  from iSCSI raw block row

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -34,7 +34,7 @@ The following table displays which volume plug-ins support block volumes.
 |Fibre Channel | ✅ | |
 |GCP | ✅ | ✅ | ✅
 |HostPath | | |
-|iSCSI | ✅ | | ✅
+|iSCSI | ✅ | |
 |Local volume | ✅ || ✅
 |NFS | | |
 |VMware vSphere  | ✅ | ✅ | ✅


### PR DESCRIPTION
As discussed in [BZ1782116](https://bugzilla.redhat.com/show_bug.cgi?id=1782116), there is confusion about iSCSI persistent storage and iSCSI raw block volume support in 4.2. This PR removes "Fully supported" from the iSCSI row in the raw block table because iSCSI raw block support is available in Tech Preview only.