### PR TITLE
BZ1783419 - Differences between oc and kubectl in 4.x

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1091,6 +1091,8 @@ Topics:
   - Name: Administrator CLI commands
     File: administrator-cli-commands
     Distros: openshift-enterprise,openshift-origin
+  - Name: Usage of oc and kubectl commands
+    File: usage-oc-kubectl
 - Name: OpenShift Do developer CLI (odo)
   Dir: openshift_developer_cli
   Distros: openshift-enterprise,openshift-online,openshift-dedicated,openshift-online

--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -1,0 +1,28 @@
+[id="usage-oc-kubectl"]
+= Usage of oc and kubectl commands
+include::modules/common-attributes.adoc[]
+:context: usage-oc-kubectl
+
+Kubernetes' command line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because OpenShift Container Platform is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with {product-title}, or you can gain extended functionality by using the `oc` binary.
+
+== The oc binary
+
+The `oc` binary offers the same capabilities as the `kubectl` binary, but it extends to natively support additional {product-title} features, including:
+
+* **Full support for {product-title} resources**
++
+Resources such as DeploymentConfigs, BuildConfigs, Routes, ImageStreams, and ImageStreamTags are specific to {product-title} distributions, and build upon standard Kubernetes primitives.
++
+* **Authentication**
++
+The `oc` binary offers a built-in `login` command that allows authentication and enables you to work with {product-title} projects, which map Kubernetes namespaces to authenticated users. See xref:../../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication] for more information.
++
+* **Additional commands**
++
+The additional command `oc new-app`, for example, makes it easier to get new applications started using existing source code or pre-built images. Similarly, the additional command `oc new-project` makes it easier to start a project that you can switch to as your default.
+
+== The kubectl binary
+
+The `kubectl` binary is provided as a means to support existing workflows and scripts for new {product-title} users coming from a standard Kubernetes environment, or for those who prefer to use the `kubectl` CLI. Existing users of `kubectl` can continue to use the binary to interact with Kubernetes primitives, with no changes required to the {product-title} cluster.
+
+For more information, see the link:https://www.google.com/url?q=https://kubernetes.io/docs/reference/kubectl/overview/&sa=D&ust=1576620297762000&usg=AFQjCNGBR2LsVeM-JuLDz1rA5U9n-WwcPw[kubectl docs].


### PR DESCRIPTION
@soltysh PTAL and verify that content is still valid in 4.x. Thank you!

xref: [BZ1783419](https://bugzilla.redhat.com/show_bug.cgi?id=1783419)

This PR ports content from 3.11 (https://docs.openshift.com/container-platform/3.11/cli_reference/differences_oc_kubectl.html) to 4.x.

Once approved, content will be merged to `master` and CP to 4.1, 4.2, 4.3.

