### PR TITLE
ODP KIs, bug fixes, TP entries for Helm and Service Binding

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -138,9 +138,9 @@ xref:ocp-4-3-extend-user-workload-monitoring[extend user workload monitoring].
 
 ==== Cluster logging log forwarding
 
-The cluster logging log forwarding feature provides a way to ship container and node logs 
-to destinations that are not necessarily managed by the {product-title} cluster logging infrastructure. 
-Destination endpoints can be on or off your {product-title} cluster. Log forwarding provides an easier way to forward 
+The cluster logging log forwarding feature provides a way to ship container and node logs
+to destinations that are not necessarily managed by the {product-title} cluster logging infrastructure.
+Destination endpoints can be on or off your {product-title} cluster. Log forwarding provides an easier way to forward
 logs than the default log forwarding pipelines without requiring you to set the cluster to Unmanaged.
 
 [id="ocp-4-3-web-console"]
@@ -296,6 +296,14 @@ The following related APIs will be removed in a future release:
 
 [id="ocp-4-3-bug-fixes"]
 == Bug fixes
+
+*Web Console*
+
+* Previously, for admin users, non-serverless workloads showed resources for serverless workloads in the *Topology* resources panel and non-admin users would not be able to view any workloads. With this bug fix, the resources panel works as expected in the case of normal and Knative specific deployments and a non-admin user can now view the workloads.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1758628[*BZ#1758628*])
+* Previously, Pod status was depicted inconsistently in the *Topology* view, *Resources* side panel, and the *Deployment Config Details* page. With this bug fix, the *Topology* and *Resources* pages share the same logic, thus depicting the Pod status consistently.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1760827[*BZ#1760827*])
+* Previously, when an application was created using the *Add* page options, the deployed image ignored the selected target port and always used the first entry. With this bug fix, code in the `import-submit-utils` and `deployImage-submit-utils` files has been refactored to use shared code, enabling the deployed image to use the selected port.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1760836[*BZ#1760836*])
+* Previously, certain features, such as the name of the application and the build status, were not rendered in the *Topology* view on the Edge browser. With this bug fix, the Edge browser renders the application name and the build status as expected.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1760858[*BZ#1760858*])
+
 
 [id="ocp-4-3-technology-preview"]
 == Technology Preview features
@@ -621,6 +629,16 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 |GA
 
+|Helm CLI
+|
+|
+|TP
+
+|Service Binding
+|
+|
+|TP
+
 |====
 
 [id="ocp-4-3-known-issues"]
@@ -630,3 +648,5 @@ indicate that the feature is removed from the release or deprecated.
 {product-title}. For a workaround, see
 xref:../service_mesh/service_mesh_install/updating-ossm.adoc#updating-ossm[Updating OpenShift
 Service Mesh from version 1.0.1 to 1.0.2].
+* Determination of active Pods when a rollout fails can be incorrect in the *Topology* view. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1760828[*BZ#1760828*])
+* When a user with limited cluster-wide permissions creates an application using the *Container Image* option in the *Add* page, and chooses the *Image name from internal registry* option, no imagestreams are detected in the project, though an imagestream exists. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784264[*BZ#1784264*])


### PR DESCRIPTION
This PR has been raised on the Enterprise 4.3 branch for the 4.3 Release Notes. It adds the following:

- Known Issues for ODP
- Bug Fixes for ODP
- TP entries in the TP table for Helm and Service Binding

This has been validated by SMEs and QE

@ahardin-rh I see you have already added Pipelines Build Strategy to the Deprecated Features section. Thank You!