### PR TITLE
TP note for service binding

### DIFF
--- a/applications/deployments/deployment-strategies.adoc
+++ b/applications/deployments/deployment-strategies.adoc
@@ -52,7 +52,15 @@ include::modules/deployments-rolling-strategy.adoc[leveloffset=+1]
 include::modules/deployments-canary-deployments.adoc[leveloffset=+2]
 include::modules/deployments-creating-rolling-deployment.adoc[leveloffset=+2]
 include::modules/odc-starting-rolling-deployment.adoc[leveloffset=+2]
+.Additional resources
+- xref:../../applications/application-life-cycle-management/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
+- xref:../../applications/application-life-cycle-management/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
+
 include::modules/deployments-recreate-strategy.adoc[leveloffset=+1]
 include::modules/odc-starting-recreate-deployment.adoc[leveloffset=+1]
+.Additional resources
+- xref:../../applications/application-life-cycle-management/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
+- xref:../../applications/application-life-cycle-management/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
+
 include::modules/deployments-custom-strategy.adoc[leveloffset=+1]
 include::modules/deployments-lifecycle-hooks.adoc[leveloffset=+1]

--- a/modules/odc-connecting-components.adoc
+++ b/modules/odc-connecting-components.adoc
@@ -37,6 +37,21 @@ image::odc_connecting_multiple_applications.png[Connecting Multiple Applications
 
 == Creating a binding connection between components
 
+[IMPORTANT]
+====
+Service Binding is a Technology Preview feature only. Technology Preview features
+are not supported with Red Hat production service level agreements (SLAs) and
+might not be functionally complete. Red Hat does not recommend using them
+in production. These features provide early access to upcoming product
+features, enabling customers to test functionality and provide feedback during
+the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
+
+
 [NOTE]
 ====
 Currently, only a few specific Operators like the *etcd* and the *PostgresSQL Database* Operator's service instances are bindable.


### PR DESCRIPTION
This PR adds a TP note to the service binding workflow and adds links as additional resources to the rolling and recreate update flows.
This is relevant to the 4.3 branch and has been validated by the QE and SMEs