### PR TITLE
Add CRD custom validation to OSDK GS

### DIFF
--- a/modules/building-memcached-operator-using-osdk.adoc
+++ b/modules/building-memcached-operator-using-osdk.adoc
@@ -51,6 +51,7 @@ This scaffolds the Memcached resource API under `pkg/apis/cache/v1alpha1/`.
 .. Modify the spec and status of the `Memcached` Custom Resource (CR) at the
 `pkg/apis/cache/v1alpha1/memcached_types.go` file:
 +
+[source,go]
 ----
 type MemcachedSpec struct {
 	// Size is the size of the memcached deployment
@@ -67,6 +68,60 @@ update the generated code for that resource type:
 +
 ----
 $ operator-sdk generate k8s
+----
+
+. *Optional: Add custom validation to your CRD.*
++
+OpenAPI v3.0 schemas are added to CRD manifests in the `spec.validation` block when
+the manifests are generated. This validation block allows Kubernetes to validate
+the properties in a Memcached CR when it is created or updated.
++
+Additionally, a `pkg/apis/<group>/<version>/zz_generated.openapi.go` file is
+generated. This file contains the Go representation of this validation block if
+the `+k8s:openapi-gen=true annotation` is present above the `Kind` type
+declaration, which is present by default. This auto-generated code is your Go
+`Kind` type's OpenAPI model, from which you can create a full OpenAPI
+Specification and generate a client.
++
+As an Operator author, you can use Kubebuilder markers (annotations) to
+configure custom validations for your API. These markers must always have a
+`+kubebuilder:validation` prefix. For example, adding an enum-type specification
+can be done by adding the following marker:
++
+[source,go]
+----
+// +kubebuilder:validation:Enum=Lion;Wolf;Dragon
+type Alias string
+----
++
+Usage of markers in API code is discussed in the Kubebuilder
+link:https://book.kubebuilder.io/reference/generating-crd.html[Generating CRDs]
+and link:https://book.kubebuilder.io/reference/markers.html[Markers for Config/Code Generation]
+documentation. A full list of OpenAPIv3 validation markers is also available in
+the Kubebuilder
+link:https://book.kubebuilder.io/reference/markers/crd-validation.html[CRD Validation]
+documentation.
++
+If you add any custom validations, run the following command to update the
+OpenAPI validation section in the CRD's
+`deploy/crds/cache.example.com_memcacheds_crd.yaml` file:
++
+----
+$ operator-sdk generate openapi
+----
++
+.Example generated YAML
+[source,yaml]
+----
+spec:
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            size:
+              format: int32
+              type: integer
 ----
 
 . *Add a new Controller.*
@@ -326,3 +381,8 @@ $ oc delete -f deploy/role.yaml
 $ oc delete -f deploy/role_binding.yaml
 $ oc delete -f deploy/service_account.yaml
 ----
+
+.Additional resources
+
+* For more information about OpenAPI v3.0 validation schemas in CRDs, refer to the
+link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema[Kubernetes documentation].


### PR DESCRIPTION
More from https://issues.redhat.com/browse/OSDOCS-451 via https://issues.redhat.com/browse/OSDK-304.

* Adds "Step 3. Optional: Add custom validation to your CRD."

Preview build (internal): http://file.rdu.redhat.com/~adellape/121919/crd_validation/operators/operator_sdk/osdk-getting-started.html#building-memcached-operator-using-osdk_osdk-getting-started