### PR TITLE
Example Apache HTTPD configuration for basic identity providers

### DIFF
--- a/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
@@ -20,4 +20,6 @@ include::modules/identity-provider-basic-authentication-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 
+include::modules/example-apache-httpd-configuration.adoc[leveloffset=+1]
+
 include::modules/identity-provider-basic-authentication-troubleshooting.adoc[leveloffset=+1]

--- a/modules/example-apache-httpd-configuration.adoc
+++ b/modules/example-apache-httpd-configuration.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * authentication/identity_providers/configuring-ldap-identity-provider.adoc
+
+[id="example-apache-httpd-configuration_{context}"]
+= Example Apache HTTPD configuration for basic identity providers
+
+The basic identify provider (IDP) configuration in {product-title} 4 requires
+that the IDP server respond with JSON for success and failures. You can use CGI
+scripting in Apache HTTPD to accomplish this. This section provides examples.
+
+.`/etc/httpd/conf.d/login.conf`
+----
+<VirtualHost *:443>
+  # CGI Scripts in here
+  DocumentRoot /var/www/cgi-bin
+
+  # SSL Directives
+  SSLEngine on
+  SSLCipherSuite PROFILE=SYSTEM
+  SSLProxyCipherSuite PROFILE=SYSTEM
+  SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+  SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+  # Configure HTTPD to execute scripts
+  ScriptAlias /basic /var/www/cgi-bin
+
+  # Handles a failed login attempt
+  ErrorDocument 401 /basic/fail.cgi
+
+  # Handles authentication
+  <Location /basic/login.cgi>
+    AuthType Basic
+    AuthName "Please Log In"
+    AuthBasicProvider file
+    AuthUserFile /etc/httpd/conf/passwords
+    Require valid-user
+  </Location>
+</VirtualHost>
+----
+
+.`/var/www/cgi-bin/login.cgi`
+----
+#!/bin/bash
+echo "Content-Type: application/json"
+echo ""
+echo '{"sub":"userid", "name":"'$REMOTE_USER'"}'
+exit 0
+----
+
+.`/var/www/cgi-bin/fail.cgi`
+----
+#!/bin/bash
+echo "Content-Type: application/json"
+echo ""
+echo '{"error": "Login failure"}'
+exit 0
+----
+
+== File requirements
+
+These are the requirements for the files you create on an Apache HTTPD web
+server:
+
+* `login.cgi` and `fail.cgi` must be executable (`chmod +x`).
+* `login.cgi` and `fail.cgi` must have proper SELinux contexts if SELinux is
+enabled: `restorecon -RFv /var/www/cgi-bin`, or ensure that the context is
+`httpd_sys_script_exec_t` using `ls -laZ`.
+* `login.cgi` is only executed if your user successfully logs in per `Require
+and Auth` directives.
+* `fail.cgi` is executed if the user fails to log in, resulting in an `HTTP 401`
+response.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-869

Preview build: http://file.rdu.redhat.com/~ahardin/12202019/example-appache-httpd-config/authentication/identity_providers/configuring-basic-authentication-identity-provider.html#example-apache-httpd-configuration_configuring-basic-authentication-identity-provider

@bostrt PTAL