### PR TITLE
Add note about setting PW in clouds.yaml - BZ 1763866

### DIFF
--- a/modules/installation-osp-describing-cloud-parameters.adoc
+++ b/modules/installation-osp-describing-cloud-parameters.adoc
@@ -14,6 +14,11 @@ The {product-title} installation program relies on a file called `clouds.yaml`. 
 . Create the `clouds.yaml` file:
 
 ** If your OpenStack distribution includes the Horizon web UI, generate a `clouds.yaml` file in it.
++
+[IMPORTANT]
+====
+Remember to add a password to the `auth` field. You can also keep secrets in link:https://docs.openstack.org/os-client-config/latest/user/configuration.html#splitting-secrets[a separate file] from `clouds.yaml`.
+====
 
 ** If your OpenStack distribution does not include the Horizon web UI, or you do not want to use Horizon, create the file yourself. For detailed information about `clouds.yaml`, see https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#config-files[Config files] in the {rh-openstack} documentation.
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1763866

Adds a note reminding reader to include a password in their clouds.yaml file as part of OSP installation flows.