### PR TITLE
[CNV] Fencing unhealthy nodes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1307,6 +1307,9 @@ Topics:
     File: cnv-setting-node-maintenance
   - Name: Resuming a node from maintenance mode
     File: cnv-resuming-node
+# Fencing
+  - Name: Fencing unhealthy nodes
+    File: cnv-fencing-unhealthy-nodes
 # Installing VirtIO drivers on Windows virtual machines
   - Name: Installing VirtIO driver on an existing Windows virtual machine
     File: cnv-installing-virtio-drivers-on-existing-windows-vm

--- a/cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
+++ b/cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
@@ -1,0 +1,14 @@
+[id="cnv-fencing-unhealthy-nodes"]
+= Fencing unhealthy nodes
+include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: cnv-fencing-unhealthy-nodes
+toc::[]
+
+include::modules/cnv-about-fencing.adoc[leveloffset=+1]
+
+include::modules/machine-health-checks-about.adoc[leveloffset=+1] 
+
+include::modules/machine-health-checks-resource.adoc[leveloffset=+1] 
+
+

--- a/modules/cnv-about-fencing.adoc
+++ b/modules/cnv-about-fencing.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
+
+[id="cnv-about-fencing_{context}"]
+= About Fencing
+
+Fencing is the process of isolating a failed node to protect a cluster and its resources.
+A node is considered _fenced_ when it can no longer access shared resources.
+Without fencing, a failed node can result in data corruption.
+
+In the case of an unhealthy node, Pods and virtual machines that depend on
+persistent storage cannot be replaced on another node until it can be confirmed
+that the original Pod or virtual machine is no longer accessing the storage.
+Fencing the node ensures that the workloads are no longer running on the
+unhealthy node, protecting the persistent storage. Once fencing is complete,
+workloads resume on other nodes.
+

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/deploying-machine-health-checks.adoc
+// * cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
 
 [id="machine-health-checks-about_{context}"]
 = About MachineHealthChecks

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * machine_management/deploying-machine-health-checks.adoc
+// * cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
+
 
 [id="machine-health-checks-resource_{context}"]
 = Sample MachineHealthCheck resource


### PR DESCRIPTION
Fencing was previously tracked in CNV-2593 (and in #16883, which I'm keeping open until this is merged) for 2.1 but was obsoleted. The MachineHealthCheck controller was then covered for OCP docs (in #18578) for 4.3. 

This assembly includes the modules from OCP with additional context for CNV users. 

Cherrypick to enterprise-4.3 only.