### PR TITLE
CNV3398 - manually refreshing certificates via script

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1342,6 +1342,9 @@ Topics:
 # Fencing
   - Name: Fencing unhealthy nodes
     File: cnv-fencing-unhealthy-nodes
+# Node care
+  - Name: Manually refreshing TLS certificates
+    File: cnv-refresh-certificates
 # Installing VirtIO drivers on Windows virtual machines
   - Name: Installing VirtIO driver on an existing Windows virtual machine
     File: cnv-installing-virtio-drivers-on-existing-windows-vm

--- a/cnv/cnv_users_guide/cnv-refresh-certificates.adoc
+++ b/cnv/cnv_users_guide/cnv-refresh-certificates.adoc
@@ -1,0 +1,13 @@
+[id="cnv-refresh-certificates"]
+= Manually refreshing TLS certificates
+include::modules/cnv-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: cnv-refresh-certificates
+toc::[]
+
+The TLS certificates for {CNVProductName} components are created at the time
+of installation and are valid for one year. You must manually refresh
+these certificates before they expire. 
+
+include::modules/cnv-refreshing-certificates.adoc[leveloffset=+1]
+

--- a/modules/cnv-refreshing-certificates.adoc
+++ b/modules/cnv-refreshing-certificates.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv-refresh-certificates.adoc
+
+[id="cnv-refreshing-certificates_{context}"]
+= Refreshing TLS certificates
+
+To refresh the TLS certificates for {CNVProductName}, download and run the `rotate-certs` script. This script is available from the `kubevirt/hyperconverged-cluster-operator` repository on GitHub. 
+
+[IMPORTANT]
+====
+When refreshing the certificates, the following operations are impacted:
+
+* Migrations are canceled
+* Image uploads are canceled
+* VNC and console connections are closed
+====
+
+.Prerequisites
+
+* Ensure that you are logged in to the cluster as a user with `cluster-admin` privileges. 
+The script uses your active session to the cluster to refresh certificates in the `openshift-cnv` namespace.
+
+.Procedure
+
+. Download the `rotate-certs.sh` script from GitHub:
++
+----
+$ curl -O https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/tools/rotate-certs.sh
+----
+
+. Ensure the script is executable:
++
+----
+$ chmod +x rotate-certs.sh
+----
+
+. Run the script:
++
+----
+$ ./rotate-certs.sh -n openshift-cnv
+----
+
+The TLS certificates are refreshed and valid for one year.
+


### PR DESCRIPTION
New assembly with one module to cover manually refreshing TLS certificates for CNV

Cherrypick to enterprise-4.2 and enterprise-4.3