### PR TITLE
Update securing_builds doc with warning on networking rule bypass

### DIFF
--- a/admin_guide/securing_builds.adoc
+++ b/admin_guide/securing_builds.adoc
@@ -27,6 +27,13 @@ xref:../architecture/core_concepts/builds_and_image_streams.adoc#docker-build[Do
 build] permission should also be granted with caution as a vulnerability in the Docker build
 logic could result in a privileges being granted on the host node.
 
+[WARNING]
+====
+During Docker and custom builds, actions performed by the Docker daemon are privileged and
+occur in the host network namespace. Such actions bypass configured networking rules
+including those defined by EgressNetworkPolicy objects and static egress IP addresses.
+====
+
 By default, all users that can create builds are granted permission to use the
 Docker and Source-to-Image build strategies. Users with xref:../architecture/additional_concepts/authorization.adoc#roles[*cluster-admin*]
 privileges can enable the Custom build strategy, as referenced in the xref:restricting-build-strategies-to-a-user-globally[Restricting Build Strategies to a User Globally]


### PR DESCRIPTION
Proposed warning only applies to OpenShift 3.x, not OpenShift 4.