### PR TITLE
Correcting VM YAML for cloud-init

### DIFF
--- a/modules/cnv-importing-vmware-vm.adoc
+++ b/modules/cnv-importing-vmware-vm.adoc
@@ -60,6 +60,25 @@ If you do not select a storage class, {CNVProductName} uses the default storage 
 .. Click *Save* and then click *Next*.
 
 . In the *Advanced* screen, enter the *Hostname* and *Authorized SSH Keys* if you are using `cloud-init`.
++
+You must xref:../../cnv/cnv_users_guide/cnv-edit-vms.adoc#cnv-editing-vm-yaml-web_cnv-edit-vms[edit the virtual machine's YAML configuration] after importing it:
+
+.. In the `cloudInitNoCloud` stanza, under `userData`, change `ssh-authorized-keys` to `ssh_authorized_keys`:
++
+[source,yaml]
+----
+- cloudInitNoCloud:
+    userData: |
+      #cloud-config
+      name: default
+      hostname: myhostname
+      ssh-authorized-keys:
+----
+
+.. Restart the virtual machine.
++
+See link:https://bugzilla.redhat.com/show_bug.cgi?id=1786350[BZ#1786350] for details.
+
 . Click *Next*.
 
 . Review your settings and click *Create Virtual Machine*.


### PR DESCRIPTION
For CNV 2.1.1 (OpenShift 4.2 and 4.3)

[BZ1786350](https://bugzilla.redhat.com/show_bug.cgi?id=1786350)

YAML of imported VM has to be fixed if using cloud-init (`ssh_authorized_keys`). This is a temporary workaround. That is why the procedure is in a note instead of a module.