### PR TITLE
Release notes for Service Mesh 1.0.4 release

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1184,6 +1184,8 @@ Name: Service Mesh
 Dir: service_mesh
 Distros: openshift-enterprise
 Topics:
+- Name: Service Mesh Release Notes
+  File: servicemesh-release-notes
 - Name: Service Mesh Architecture
   Dir: service_mesh_arch
   Topics:
@@ -1208,7 +1210,6 @@ Topics:
     File: updating-ossm
   - Name: Removing service mesh
     File: removing-ossm
-
 - Name: Day Two
   Dir: service_mesh_day_two
   Topics:
@@ -1231,8 +1232,6 @@ Topics:
   Topics:
   - Name: Using the 3scale Istio adapter
     File: threescale-adapter
-- Name: Service Mesh Release Notes
-  File: servicemesh-release-notes
 ---
 Name: Container-native virtualization
 Dir: cnv

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -11,7 +11,7 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 1.0.2
+:ProductVersion: 1.0.4
 :product-build:
 :DownloadURL: registry.redhat.io
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -16,39 +16,38 @@ Result - How has the behavior changed as a result?  Try to avoid â€œIt is fixedâ
 
 The following issues been resolved in the current release:
 
-[id="ossm-rn-fixed-issues-sm_{context}"]
+[id="ossm-rn-fixed-issues-ossm_{context}"]
 == {ProductName} fixed issues
+* link:https://issues.jboss.org/browse/OSSM-99[OSSM-99] Workloads generated from direct Pod without labels may crash Kiali.
+
+* link:https://issues.jboss.org/browse/OSSM-93[OSSM-93] IstioConfigList can't filter by two or more names.
+
+* link:https://issues.jboss.org/browse/OSSM-92[OSSM-92] Cancelling unsaved changes on the VS/DR YAML edit page does not cancel the changes.
+
+* link:https://issues.jboss.org/browse/OSSM-90[OSSM-90] Traces not available on the service details page.
+
+[id="ossm-rn-fixed-issues-maistra_{context}"]
+* link:https://issues.jboss.org/browse/MAISTRA-1001[MAISTRA-1001] Closing HTTP/2 connections could lead to segmentation faults in `istio-proxy`.
+
+* link:https://issues.jboss.org/browse/MAISTRA-932[MAISTRA-932] Added the `requires` metadata to add dependency relationship between Jaeger operator and Elasticsearch operator. Ensures that when the Jaeger operator is installed, it automatically deploys the Elasticsearch operator if it is not available.
+
+* link:https://issues.jboss.org/browse/MAISTRA-862[MAISTRA-862] Galley dropped watches and stopped providing configuration to other components after many namespace deletions and re-creations.
+
+* link:https://issues.jboss.org/browse/MAISTRA-833[MAISTRA-833] Pilot stopped delivering configuration after many namespace deletions and re-creations.
 
 * link:https://issues.jboss.org/browse/MAISTRA-684[MAISTRA-684] The default Jaeger version in the `istio-operator` is 1.12.0, which does not match Jaeger version 1.13.1 that shipped in {ProductName} 0.12.TechPreview.
 
+* link:https://issues.jboss.org/browse/MAISTRA-622[MAISTRA-622] In Maistra 0.12.0/TP12, permissive mode does not work. The user has the option to use Plain text mode or Mutual TLS mode, but not permissive.
+
 * link:https://issues.jboss.org/browse/MAISTRA-572[MAISTRA-572] Jaeger cannot be used with Kiali. In this release Jaeger is configured to use the OAuth proxy, but is also only configured to work through a browser and does not allow service access. Kiali cannot properly communicate with the Jaeger endpoint and it considers Jaeger to be disabled. See also link:https://issues.jboss.org/browse/TRACING-591[TRACING-591].
 
-* link:https://issues.jboss.org/browse/MAISTRA-357[MAISTRA-357] In OpenShift 4 Beta on AWS, it is not possible, by default, to access a TCP or HTTPS service through the ingress gateway on a port other than port 80. The AWS load balancer has a health check that verifies if port 80 on the service endpoint is active.
-+
-The load balancer health check only checks the first port defined in the Istio ingress gateway ports list. This port is configured as 80/HTTP:31380/TCP. Without a service running on this port, the load balancer health check fails.
-+
-To check HTTPS or TCP traffic by using an ingress gateway, you must have an existing HTTP service, for example, the Bookinfo sample application product page running on the ingress gateway port 80. Alternatively, using the AWS EC2 console, you can change the port that the load balancer uses to perform the health check, and replace 80 with the port your service actually uses.
+* link:https://issues.jboss.org/browse/MAISTRA-357[MAISTRA-357] In OpenShift 4 Beta on AWS, it is not possible, by default, to access a TCP or HTTPS service through the ingress gateway on a port other than port 80. The AWS load balancer has a health check that verifies if port 80 on the service endpoint is active. Without a service running on port 80, the load balancer health check fails.
+
+* link:https://issues.jboss.org/browse/MAISTRA-348[MAISTRA-348] OpenShift 4 Beta on AWS does not support ingress gateway traffic on ports other than 80 or 443.  If you configure your ingress gateway to handle TCP traffic with a port number other than 80 or 443, you have to use the service hostname provided by the AWS load balancer rather than the OpenShift router as a workaround.
 
 [id="ossm-rn-fixed-issues-kiali_{context}"]
 == Kiali fixed issues
 
-* link:https://issues.jboss.org/browse/KIALI-3096[KIALI-3096] Runtime metrics fail in {ProductShortName}. There is an oauth filter between the {ProductShortname} and Prometheus, requiring a bearer token to be passed to Prometheus before access will be granted. Kiali has been updated to use this token when communicating to the Prometheus server, but the application metrics are currently failing with 403 errors.
-+
-* link:https://issues.jboss.org/browse/OSSM-90[OSSM-90] Traces not available on the service details page.
-+
-* link:https://issues.jboss.org/browse/OSSM-92[OSSM-92] Cancelling unsaved changes on the VS/DR YAML edit page does not cancel the changes.
-+
-* link:https://issues.jboss.org/browse/OSSM-93[OSSM-93] IstioConfigList can't filter by two or more names.
-+
-* link:https://issues.jboss.org/browse/OSSM-99[OSSM-99] Workloads generated from direct Pod without labels may crash Kiali.
+* link:https://issues.jboss.org/browse/KIALI-3096[KIALI-3096] Runtime metrics fail in {ProductShortName}. There is an OAuth filter between the {ProductShortname} and Prometheus, requiring a bearer token to be passed to Prometheus before access will be granted. Kiali has been updated to use this token when communicating to the Prometheus server, but the application metrics are currently failing with 403 errors.
 
-[id="ossm-rn-fixed-issues-maistra_{context}"]
-== Maistra fixed issues
-
-* link:https://issues.jboss.org/browse/MAISTRA-932[MAISTRA-932] Added the `requires` metadata to add dependency relationship between Jaeger operator and Elasticsearch operator. Ensures that when the Jaeger operator is installed, it automatically deploys the Elasticsearch operator if it is not available.
-
-* link:https://issues.jboss.org/browse/MAISTRA-1001[MAISTRA-1001] Closing HTTP/2 connections could lead to segmentation faults in `istio-proxy`.
-
-* link:https://issues.jboss.org/browse/MAISTRA-833[MAISTRA-833] Pilot stopped delivering configuration after many namespace deletions and re-creations. 
-
-* link:https://issues.jboss.org/browse/MAISTRA-862[MAISTRA-862] Galley dropped watches and stopped providing configuration to other components after many namespace deletions and re-creations.
+* link:https://issues.jboss.org/browse/KIALI-3070[KIALI-3070] This bug only affects custom dashboards, not the default dashboards. When you select labels in metrics settings and refresh the page, your selections are retained in the menu but your selections are not displayed on the charts.

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -26,7 +26,7 @@ These limitations exist in {ProductName} at this time:
 While Kafka publisher is included in the release as part of Jaeger, it is not supported.
 ====
 
-[id="ossm-rn-known-issues-sm_{context}"]
+[id="ossm-rn-known-issues-ossm_{context}"]
 == {ProductName} known issues
 
 These are the known issues in {ProductName} at this time:
@@ -40,25 +40,9 @@ These are the known issues in {ProductName} at this time:
 
 * link:https://issues.jboss.org/browse/MAISTRA-681[MAISTRA-681] and link:https://issues.jboss.org/browse/KIALI-2686[KIALI-2686] When the control plane has many namespaces, it can lead to performance issues.
 
-* link:https://issues.jboss.org/browse/MAISTRA-622[MAISTRA-622] In Maistra 0.12.0/TP12, permissive mode does not work. The user has the option to use Plain text mode or Mutual TLS mode, but not permissive.
-
 * link:https://issues.jboss.org/browse/MAISTRA-465[MAISTRA-465] The Maistra operator fails to create a service for operator metrics.
 
 * link:https://issues.jboss.org/browse/MAISTRA-453[MAISTRA-453] If you create a new project and deploy pods immediately, sidecar injection does not occur. The operator fails to add the `maistra.io/member-of` before the pods are created, therefore the pods must be deleted and recreated for sidecar injection to occur.
-
-
-* link:https://issues.jboss.org/browse/MAISTRA-348[MAISTRA-348] To access a TCP service by using the ingress gateway on a port other than 80 or 443, use the service hostname provided by the AWS load balancer rather than the OpenShift router.
-+
-The istio-ingressgateway route hostname (for example, `istio-ingressgateway-istio-system.apps.[cluster name].openshift.com`) works with port 80 or port 443 traffic. However, that route hostname does not support other port traffic.
-+
-To access service(s) running on the ingress gateway TCP port(s), you can retrieve the istio-ingressgateway external hostname (for example,
-`[uuid].[aws region].elb.amazonaws.com`) and then check traffic by using that external hostname value.
-+
-To retrieve the external IP hostname value, issue this command:
-+
-----
-$ oc -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
-----
 
 * link:https://issues.jboss.org/browse/MAISTRA-193[MAISTRA-193] Unexpected console info messages are visible when health checking is enabled for citadel.
 
@@ -76,8 +60,6 @@ If the `istio-operator` pod is evicted while deploying the control pane, delete 
 * link:https://issues.jboss.org/browse/KIALI-3239[KIALI-3239] If a Kiali Operator pod has failed with a status of “Evicted” it blocks the Kiali operator from deploying. The workaround is to delete the Evicted pod and redeploy the Kiali operator.
 
 * link:https://issues.jboss.org/browse/KIALI-3118[KIALI-3118] After changes to the ServiceMeshMemberRoll, for example adding or removing projects, the Kiali pod restarts and then displays errors on the Graph page while the Kiali pod is restarting.
-
-* link:https://issues.jboss.org/browse/KIALI-3070[KIALI-3070] This bug only affects custom dashboards, not the default dashboards. When you select labels in metrics settings and refresh the page, your selections are retained in the menu but your selections are not displayed on the charts.
 
 * link:https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.
 

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -10,6 +10,21 @@ Feature – Describe the new functionality available to the customer.  For enhan
 Reason – If known, include why has the enhancement been implemented (use case, performance, technology, etc.).   For example, showcases integration of X with Y, demonstrates Z API feature, includes latest framework bug fixes.  There may not have been a 'problem' previously, but system behaviour may have changed.
 Result – If changed, describe the current user experience
 ////
+{ProductName} provides a number of key capabilities uniformly across a network of services:
+
+* *Traffic Management* - Control the flow of traffic and API calls between services, make calls more reliable, and make the network more robust in the face of adverse conditions.
+* *Service Identity and Security* - Provide services in the mesh with a verifiable identity and provide the ability to protect service traffic as it flows over networks of varying degrees of trustworthiness.
+* *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
+* *Telemetry* -  Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.
+
+== New features {ProductName} 1.0.4
+
+This release of {ProductName} adds support for Kiali 1.0.9, and addresses Common Vulnerabilities and Exposures (CVEs).
+
+
+== New features {ProductName} 1.0.3
+
+This release of {ProductName} adds support for Kiali 1.0.8, and addresses Common Vulnerabilities and Exposures (link:https://access.redhat.com/errata/RHSA-2019:4222[CVEs]).
 
 == New features {ProductName} 1.0.2
 
@@ -30,70 +45,3 @@ Other notable changes in this release include the following:
 * The Elasticsearch, Jaeger, Kiali, and {ProductShortName} Operators are installed from OperatorHub.
 * You can create and specify control plane templates.
 * Automatic route creation was removed from this release.
-
-
-== New features Technology Preview 12
-
-This release of {ProductName} adds support for Istio 1.1.8, Jaeger 1.13.1, Kiali 1.0.0, and the 3scale Istio Adapter 0.7.1.
-
-Other notable changes in this release include the following:
-
-* Integrates the Kiali and Jaeger operators into the installation.
-* Adds support for Kubernetes Container Network Interface (CNI) plug-in.
-* Adds support for Operator Lifecycle Management (OLM).
-* Updates the Istio OpenShift Router for multitenancy.
-* Defaults to configuring the control planes for multitenancy. You can still configure a single tenant control plane in {ProductName} 0.12.TechPreview.
-
-[NOTE]
-====
-To simplify installation and support, this release only supports a multi-tenant control plane for one or more tenants.
-====
-
-== New features Technology Preview 11
-
-The release of {ProductName} adds support for multi-tenant installations, Red Hat Enterprise Linux (RHEL) Universal Base Images (UBI8), OpenSSL 1.1.1, Kiali 0.20.x, the 3scale Istio Adapter 0.6.0, and Istio 1.1.5.
-
-== New features Technology Preview 10
-
-The release of {ProductName} adds support for Kiali 0.16.x, the 3scale Istio Adapter 0.5.0, and Istio 1.1.
-
-== New features Technology Preview 9
-
-The release of {ProductName} adds support for Kiali 0.15.x, Jaeger 1.11, the 3scale Istio Adapter 0.4.1, and Istio 1.1.0-rc.2.
-
-== New features Technology Preview 8
-
-The release of {ProductName} adds support for Kiali 0.14.x and the 3scale Istio Adapter 0.3.
-
-== New features Technology Preview 7
-
-The release of {ProductName} adds the 3scale Istio Adapter and support for Kiali 0.13.x, Jaeger 1.9.0, and Istio 1.1.
-
-== New features Technology Preview 6
-
-The release of {ProductName} adds support for Kiali 0.11.x and Istio 1.0.5.
-
-== New features Technology Preview 5
-
-The release of {ProductName} adds support for Kiali 0.10.x, Jaeger 1.8.1, and Istio 1.0.4.
-
-== New features Technology Preview 4
-
-The release of {ProductName} adds support for Kiali 0.9.x and Istio 1.0.3.
-
-== New features Technology Preview 3
-
-The release of {ProductName} adds support for OpenShift 3.11, support for Kiali 0.8.x, and an updated base Ansible installer (3.11.16-3).
-
-== New features Technology Preview 2
-
-The release adds the Kiali observability console to {ProductName}. Kiali provides a number of graphs that you can use to view the topography and health of the microservices that make up your service mesh. You can view predefined dashboards that provide detailed request and response metrics (volume, duration, size, TCP traffic) per inbound and outbound traffic. You can also browse your service mesh by application, workloads, and services to view the health of each element.
-
-== New features Technology Preview 1
-
-{ProductName} provides a number of key capabilities uniformly across a network of services:
-
-* *Traffic Management* - Control the flow of traffic and API calls between services, make calls more reliable, and make the network more robust in the face of adverse conditions.
-* *Service Identity and Security* - Provide services in the mesh with a verifiable identity and provide the ability to protect service traffic as it flows over networks of varying degrees of trustworthiness.
-* *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
-* *Telemetry* -  Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.


### PR DESCRIPTION
This PR includes the following changes for the 1.0.4 release:
Moves the Release Notes to first position in the doc set (this will make the Release Notes easier to find on the Customer Portal, where the Service Mesh docs are a single "manual")
Removes Tech Preview content from New Features file
Updates Known issues
Updates Fixed issues
Updates the version in the attributes file