### PR TITLE
BZ1744497: Updated instructions for removing the LSO

### DIFF
--- a/modules/persistent-storage-local-uninstall-operator.adoc
+++ b/modules/persistent-storage-local-uninstall-operator.adoc
@@ -7,11 +7,23 @@
 
 To uninstall the Local Storage Operator, you must remove the Operator and all created resources in the `local-storage` project.
 
+[WARNING]
+====
+Uninstalling the Local Storage Operator while local storage PVs are still in use is not recommended. While the PVs will remain after the Operator's removal,
+there might be indeterminate behavior if the Operator is uninstalled and reinstalled without removing the PVs and local storage resources.
+====
+
 .Prerequisites
 
 * Access to the {product-title} web console.
 
 .Procedure
+
+. Delete any local volume resources in the project:
++
+----
+$ oc delete localvolume --all --all-namespaces
+----
 
 . Uninstall the Local Storage Operator from the web console.
 
@@ -27,13 +39,7 @@ To uninstall the Local Storage Operator, you must remove the Operator and all cr
 
 .. Click *Remove* in the window that appears.
 
-. Delete the Pods created by the Local Storage Operator:
-+
-----
-$ oc delete pods --all -n local-storage
-----
-
-. Delete the PersistentVolumes (PV) created by the Local Storage Operator. All of these PVs begin with `local-pv`.
+. The PVs created by the Local Storage Operator will remain in the cluster until deleted. Once these volumes are no longer in use, delete them by running the following command:
 +
 ----
 $ oc delete pv <pv-name>


### PR DESCRIPTION
BZ-1744497 is being addressed through updating the documentation instead of the code for the operator itself. I've updated the instructions for uninstalling the Local Storage Operator to more clearly indicate this concern.

This is for OCP 4.2 onward.