### PR TITLE
Cnv3398 TLS certificate refresh for 1.4

### DIFF
--- a/cnv_users_guide/cnv_users_guide.adoc
+++ b/cnv_users_guide/cnv_users_guide.adoc
@@ -107,6 +107,10 @@ include::modules/cnv_pxebooting.adoc[leveloffset=+2]
 include::modules/cnv_configuring_guest_memory_overcommit.adoc[leveloffset=+2]
 include::modules/cnv_disabling_guest_memory_overhead_accounting.adoc[leveloffset=+2]
 
+[[cnv_cluster_maintenance_tasks]]
+== Cluster maintenance tasks
+include::modules/cnv_refreshing_certificates.adoc[leveloffset=+2]
+
 [[cnv_userguide_reference]]
 == Reference
 include::modules/cnv_vm_wizard_fields_web.adoc[leveloffset=+2]

--- a/modules/cnv_refreshing_certificates.adoc
+++ b/modules/cnv_refreshing_certificates.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * cnv_users_guide/cnv_users_guide.adoc
+
+[[cnv-refreshing-certificates]]
+= Manually refreshing TLS certificates
+
+The TLS certificates for {ProductName} components are created at the time
+of installation and are valid for one year. You must manually refresh
+these certificates before they expire.
+
+To refresh the TLS certificates for {ProductName}, download and run the `rotate-certs` script. This script is available from the `kubevirt/hyperconverged-cluster-operator` repository on GitHub.
+
+[IMPORTANT]
+====
+When refreshing the certificates, the following operations are impacted:
+
+* Migrations are canceled
+* Image uploads are canceled
+* VNC and console connections are closed
+====
+
+.Prerequisites
+
+* Ensure that you are logged in to the cluster as a user with `cluster-admin` privileges.
+The script uses your active session to the cluster to refresh certificates in the `kubevirt-hyperconverged` namespace.
+
+.Procedure
+
+. Download the `rotate-certs.sh` script from GitHub:
++
+----
+$ curl -O https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/tools/rotate-certs.sh
+----
+
+. Ensure the script is executable:
++
+----
+$ chmod +x rotate-certs.sh
+----
+
+. Run the script:
++
+----
+$ ./rotate-certs.sh -n kubevirt-hyperconverged
+----
+
+The TLS certificates are refreshed and valid for one year.
+


### PR DESCRIPTION
Same content as #18844 but with altered namespace for 1.4
(one module + addition to master.adoc)

Cherrypick to enterprise-3.11