### PR TITLE
modules/installation-aws-user-infra-rhcos-ami: Bump to RHCOS 43.81.201912131630.0

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -18,51 +18,51 @@ You must use a valid {op-system-first} AMI for your Amazon Web Services
 |AWS AMI
 
 |`ap-northeast-1`
-|`ami-0e4526517ac524c64`
+|`ami-0afb10d03bbb5c2d7`
 
 |`ap-northeast-2`
-|`ami-0e616119366bf59c8`
+|`ami-0626ca9496be1943e`
 
 |`ap-south-1`
-|`ami-0bb5479b43b5b9a6a`
+|`ami-09f86e87cf87f0baa`
 
 |`ap-southeast-1`
-|`ami-0733dbf3f7daa30f0`
+|`ami-0c2f29b4bfd323414`
 
 |`ap-southeast-2`
-|`ami-01f88c7b2ffc45137`
+|`ami-0884cbd9cdb58fc05`
 
 |`ca-central-1`
-|`ami-075cf25ace0174b41`
+|`ami-099f45b9016d2381c`
 
 |`eu-central-1`
-|`ami-0d27c613cd5307caf`
+|`ami-0cce1b0da1ada8687`
 
 |`eu-north-1`
-|`ami-0a7db400b3ccc5400`
+|`ami-02a635301838351d9`
 
 |`eu-west-1`
-|`ami-0e173367c56629034`
+|`ami-0f3219cc77034c608`
 
 |`eu-west-2`
-|`ami-08e7d384fb6f0be97`
+|`ami-023549dc17b3e913b`
 
 |`eu-west-3`
-|`ami-0b765b4670474aaf2`
+|`ami-03a57cd3ac282874a`
 
 |`sa-east-1`
-|`ami-05acc0e0f3fa4633c`
+|`ami-0575a4791e03f4d25`
 
 |`us-east-1`
-|`ami-014ce8846db8b463d`
+|`ami-0aea6a5be0fc2b3fc`
 
 |`us-east-2`
-|`ami-0c83319db4b3b3602`
+|`ami-02b88883d49c41e94`
 
 |`us-west-1`
-|`ami-050658e468dd3db4b`
+|`ami-0fd33deb765c27822`
 
 |`us-west-2`
-|`ami-04051ef4316373b52`
+|`ami-0dd66dd9f4c0155b5`
 
 |===


### PR DESCRIPTION
Following up on #18396 and catching up with openshift/installer@3544350cc (openshift/installer#2777).

Generated with:

```console
$ date --iso=m --utc
2020-01-09T00:57+0000
$ git fetch origin
$ git --no-pager log -1 --oneline origin/release-4.3 -- data/data/rhcos.json
3544350cc (origin/pr/2777) BZ 1775388: rhcos: Bump to 43.81.201912131630.0
$ git cat-file -p 3544350cc:data/data/rhcos.json | jq -r '.amis | to_entries | sort_by(.key)[] | "\n|`" + .key + "`\n|`" + .value.hvm + "`"'
```

and pasting the output into the module doc.