### PR TITLE
ARO: Add link to Azure Monitor documentation

### DIFF
--- a/architecture/azure/resources.adoc
+++ b/architecture/azure/resources.adoc
@@ -186,9 +186,9 @@ Directory group to the cluster's RBAC customer-admin group. It also ensures
 that required RBAC roles are granted in customer-created namespaces.
 
 | Monitoring related
-| A cluster monitoring Prometheus instance gathers monitoring data for Azure Red Hat
-OpenShift site reliability engineering teams. Customers cannot access this
-instance directly, but the data it gathers is exposed via Azure Monitoring
-Workspaces.
+| A cluster monitoring Prometheus instance gathers monitoring data for {product-title}
+site reliability engineering teams. Customers cannot access this instance.
+Customers can link:https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-azure-redhat-setup[configure clusters with Azure Monitor for containers]
+to get extensive telemetry and container logs.
 
 |===


### PR DESCRIPTION
Microsoft already has documentation on Azure Monitor for containers including on ARO clusters. We do not wan't to duplicate it, but we need to make our customers aware that this feature is available to them and provide links to that documentation.