### PR TITLE
Add persistent storage iSCSI to TP tracker table

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -700,7 +700,7 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 |GA
 
-|Raw Block with iSCSI
+|Raw Block and Persistent Storage with iSCSI
 |
 |TP
 |GA


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/17796#issuecomment-572644371
This PR adds Persistent Storage with iSCSI in Table 1 - TP Tracker table. `enterprise-4.3` branch only.
@openshift/team-documentation PTAL