### PR TITLE
CNV - Unsetting variable cleanup (4.2)

### DIFF
--- a/modules/cnv-add-disk-to-vm.adoc
+++ b/modules/cnv-add-disk-to-vm.adoc
@@ -31,7 +31,15 @@ Add a disk to a virtual machine.
 . Edit the disk configuration by using the drop-down lists and check boxes.
 . Click *OK*.
 
-// Scrubbing all conditionals used in module
+// Unsetting all conditionals used in module
 
+ifeval::["{context}" == "cnv-edit-vms"]
 :object!:
 :object-gui!:
+endif::[]
+
+ifeval::["{context}" == "cnv-editing-vm-template"]
+:object!:
+:object-gui!:
+endif::[]
+

--- a/modules/cnv-add-nic-to-vm.adoc
+++ b/modules/cnv-add-nic-to-vm.adoc
@@ -45,7 +45,15 @@ detailed information.
 The *Link State* is set to *Up* by default when the network interface card
 is defined on the virtual machine and connected to the network.
 
-// Scrubbing all conditionals used in module
+// Unsetting all conditionals used in module
 
+ifeval::["{context}" == "cnv-edit-vms"]
 :object!:
 :object-gui!:
+endif::[]
+
+ifeval::["{context}" == "cnv-editing-vm-template"]
+:object!:
+:object-gui!:
+endif::[]
+


### PR DESCRIPTION
Wrapping the unsetting of variables in the conditionals that they were set in.

This is for 4.2 repo only because these assemblies include a module that has an identical file name but different content in the master branch. 