### PR TITLE
Remove ipi/upi dichotomy for machine management capabilities

### DIFF
--- a/modules/machine-user-provisioned-limitations.adoc
+++ b/modules/machine-user-provisioned-limitations.adoc
@@ -8,8 +8,6 @@
 
 [IMPORTANT]
 ====
-This process is not applicable to clusters that use user-provisioned
-infrastructure. Because you manually provisioned your machines yourself, you
-cannot use the advanced machine management and scaling capabilities
-that an installer-provisioned infrastructure cluster offers.
+This process is not applicable to clusters where you manually provisioned the machines yourself. You
+can use the advanced machine management and scaling capabilities only in clusters where the machine API is operational.
 ====


### PR DESCRIPTION
Usage of the machine API does NOT mandate that the customer used IPI. The only requirement is that the customer delegates the ability to create lifecycle machines to the product.