### PR TITLE
BZ1784530 - Add storageClassName note

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -5,9 +5,9 @@
 [id="local-volume-cr_{context}"]
 = Provision the local volumes
 
-Local volumes can not be created by dynamic provisioning. Instead,
+Local volumes cannot be created by dynamic provisioning. Instead,
 PersistentVolumes must be created by the Local Storage Operator. This
-provisioner will look for any devices, both Filesystem and Block volumes,
+provisioner will look for any devices, both filesystem and block volumes,
 at the paths specified in defined resource.
 
 .Prerequisites
@@ -19,6 +19,13 @@ at the paths specified in defined resource.
 
 . Create the local volume resource. This must define the nodes
 and paths to the local volumes.
+
++
+[NOTE]
+====
+Do not use different StorageClass names for the same device. Doing so will create multiple PVs.
+====
+
 +
 .Example: Filesystem
 [source,yaml]

--- a/modules/persistent-storage-local-pvc.adoc
+++ b/modules/persistent-storage-local-pvc.adoc
@@ -10,7 +10,7 @@ to be accessed by the Pod.
 
 .Prerequisite
 
-* PersistentVolumes have been created the local volume provisioner.
+* PersistentVolumes have been created using the local volume provisioner.
 
 .Procedure
 

--- a/storage/persistent-storage/persistent-storage-local.adoc
+++ b/storage/persistent-storage/persistent-storage-local.adoc
@@ -10,7 +10,7 @@ local volumes. Local persistent volumes allow you to access local storage
 devices, such as a disk or partition, by using the standard
 PVC interface.
 
-Local volumes can be used without manually scheduling pods to nodes,
+Local volumes can be used without manually scheduling Pods to nodes,
 because the system is aware of the volume node's constraints. However,
 local volumes are still subject to the availability of the underlying node
 and are not suitable for all applications.


### PR DESCRIPTION
In `modules/persistent-storage-local-create-cr.adoc `, adds note to LSO creation of PV that warns against using different sc names for the same device. Also a couple of minor typo fixes.
[BZ1784530](https://bugzilla.redhat.com/show_bug.cgi?id=1784530) (and [BZ1744385](https://bugzilla.redhat.com/show_bug.cgi?id=1744385)).
@huffmanca and @liangxia -  PTAL and let me know if you agree with where this note is placed?

`master`, `enterprise-4.2`, `enterprise-4.3`