### PR TITLE
Update EO channel version to 4.3

### DIFF
--- a/modules/cluster-logging-deploy-subscription.adoc
+++ b/modules/cluster-logging-deploy-subscription.adoc
@@ -139,14 +139,14 @@ metadata:
   generateName: "elasticsearch-"
   namespace: "openshift-operators-redhat" <1>
 spec:
-  channel: "4.2" <2>
+  channel: "4.3" <2>
   installPlanApproval: "Automatic"
   source: "redhat-operators"
   sourceNamespace: "openshift-marketplace"
   name: "elasticsearch-operator"
 ----
 <1> You must specify the `openshift-operators-redhat` namespace.
-<2> Specify `4.2` as the channel.
+<2> Specify `4.3` as the channel.
 
 .. Create the Subscription object:
 +


### PR DESCRIPTION
Change channel version in Elasticsearch Operator object file due to https://github.com/openshift/openshift-docs/pull/18924 changes.