### PR TITLE
Changes to clarify managed vs unmanaged logging

### DIFF
--- a/logging/config/cluster-logging-management.adoc
+++ b/logging/config/cluster-logging-management.adoc
@@ -6,13 +6,11 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 
-The Cluster Logging Operator and Elasticsearch Operator can be in a _Managed_ or _Unmanaged_ state.
-
-In managed state, the Cluster Logging Operator (CLO) responds to changes in the Cluster Logging Custom Resource (CR) and attempts to update the cluster to match the CR.
-
 In order to modify certain components managed by the Cluster Logging Operator or the Elasticsearch Operator, you must set the operator to the _unmanaged_ state.
 
-In Unmanaged state, the operators do not respond to changes in the CRs. The administrator assumes full control of individual component configurations and upgrades when in unmanaged state.
+In unmanaged state, the operators do not respond to changes in the CRs. The administrator assumes full control of individual component configurations and upgrades when in unmanaged state.
+
+In managed state, the Cluster Logging Operator (CLO) responds to changes in the Cluster Logging Custom Resource (CR) and attempts to update the cluster to match the CR.
 
 The {product-title} documentation indicates in a prerequisite step when you must set the cluster to Unmanaged.
 

--- a/modules/cluster-logging-management-state-changing-es.adoc
+++ b/modules/cluster-logging-management-state-changing-es.adoc
@@ -5,8 +5,6 @@
 [id="cluster-logging-management-state-changing-es_{context}"]
 = Changing the Elasticsearch management state
 
-The Elasticsearch Operator can be in a _Managed_ or _Unmanaged_ state.
-
 You must set the operator to the _unmanaged_ state in order to modify the Elasticsearch deployment files, which are managed by the Elasticsearch Operator. 
 
 If you make changes to these components in managed state, the Elsticsearch Operator reverts those changes. 

--- a/modules/cluster-logging-management-state-changing.adoc
+++ b/modules/cluster-logging-management-state-changing.adoc
@@ -5,8 +5,6 @@
 [id="cluster-logging-management-state-changing_{context}"]
 = Changing the cluster logging management state
 
-The Cluster Logging Operator can be in a _Managed_ or _Unmanaged_ state.
-
 You must set the operator to the _unmanaged_ state in order to modify the components managed by the Cluster Logging Operator:
 
 * the Curator CronJob, 


### PR DESCRIPTION
During a minimalism session, there was confusion over managed/unmanged in cluster logging. I removed the _The Cluster Logging Operator can be in a Managed or Unmanaged state._ wording to clarify that managed vs unmanaged is not an operational choice but a requirement when configuring certain aspects of cluster logging. 