### PR TITLE
deploying cnv: fix button name

### DIFF
--- a/modules/cnv-deploying-cnv.adoc
+++ b/modules/cnv-deploying-cnv.adoc
@@ -21,7 +21,7 @@ in the `openshift-cnv` namespace
 . Click *KubeVirt HyperConverged Cluster Operator*.
 
 . Click the *KubeVirt HyperConverged Cluster Operator Deployment* tab and click
-*Create HyperConverged*.
+*Create HyperConverged Cluster*.
 
 . Click *Create* to launch {CNVProductName}.
 


### PR DESCRIPTION
The docs asked to click a button named "Create HyperConverged", but the
actual text on the button is "Create HyperConverged Cluster".

Signed-off-by: Dan Kenigsberg <danken@redhat.com>