### PR TITLE
cnv subscribing: only openshift-cnv must be used

### DIFF
--- a/modules/cnv-subscribing-to-hco-catalog.adoc
+++ b/modules/cnv-subscribing-to-hco-catalog.adoc
@@ -34,9 +34,9 @@ list and choose the `openshift-cnv` namespace.
 `openshift-operators` namespace to watch and be made available to all namespaces
 in the cluster. This option is not supported for use with {CNVProductName}.
 You must only install the Operator in the `openshift-cnv` namespace.
-* *A specific namespace on the cluster* allows you to choose a specific, single
-namespace in which to install the Operator. The Operator will only watch and be
-made available for use in this single namespace.
+* *A specific namespace on the cluster* is what you must select.
+The Operator will only watch and be
+made available for use in the `openshift-cnv` namespace.
 ====
 .. Select *2.1* from the list of available *Update Channel* options.
 .. For *Approval Strategy*, ensure that *Automatic*, which is the default value,


### PR DESCRIPTION
The warning text seemed to suggest that any namespace may be chosen for
cnv. This is not the case; openshift-cnv must be typed in.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>