### PR TITLE
cnv: point to the product, not the community operator

### DIFF
--- a/modules/cnv-deleting-custom-resource.adoc
+++ b/modules/cnv-deleting-custom-resource.adoc
@@ -6,11 +6,11 @@
 = Deleting the KubeVirt HyperConverged custom resource
 
 To uninstall {CNVProductName}, you must first delete the
-*KubeVirt HyperConverged Cluster Operator Deployment* custom resource.
+*Container-native virtualization Operator Deployment* custom resource.
 
 .Prerequisites
 
-* An active *KubeVirt HyperConverged Cluster Operator Deployment* custom resource
+* An active *Container-native virtualization Operator Deployment* custom resource
 
 .Procedure
 
@@ -19,9 +19,9 @@ the *Projects* list.
 
 . Navigate to the *Operators* -> *Installed Operators* page.
 
-. Click *KubeVirt HyperConverged Cluster Operator*.
+. Click *Container-native virtualization Operator*.
 
-. Click the *KubeVirt HyperConverged Cluster Operator Deployment* tab.
+. Click the *Container-native virtualization Operator Deployment* tab.
 
 . Click the Options menu {kebab} in the row containing the *hyperconverged-cluster*
 custom resource. In the expanded menu, click *Delete HyperConverged*.

--- a/modules/cnv-deleting-hco-subscription.adoc
+++ b/modules/cnv-deleting-hco-subscription.adoc
@@ -3,19 +3,19 @@
 // * cnv/cnv_install/uninstalling-container-native-virtualization.adoc
 
 [id="cnv-deleting-hco-subscription_{context}"]
-= Deleting the KubeVirt HyperConverged Cluster Operator catalog subscription
+= Deleting the Container-native virtualization Operator catalog subscription
 
 To finish uninstalling {CNVProductName}, uninstall the
-*KubeVirt HyperConverged Cluster Operator subscription*.
+*Container-native virtualization Operator subscription*.
 
 .Prerequisites
 
-* An active *KubeVirt HyperConverged Cluster Operator* catalog subscription
+* An active *Container-native virtualization Operator* catalog subscription
 
 .Procedure
 
 . Navigate to the *Catalog -> OperatorHub* page.
 
-. Locate the *KubeVirt HyperConverged Cluster Operator* and then select it.
+. Locate the *Container-native virtualization Operator* and then select it.
 
 . Click *Uninstall*.

--- a/modules/cnv-deploying-cnv.adoc
+++ b/modules/cnv-deploying-cnv.adoc
@@ -5,22 +5,22 @@
 [id="cnv-deploying-cnv_{context}"]
 = Deploying container-native virtualization
 
-After subscribing to the *KubeVirt HyperConverged Cluster Operator* catalog,
-create the *KubeVirt HyperConverged Cluster Operator Deployment* custom resource
+After subscribing to the *Container-native virtualization Operator* catalog,
+create the *Container-native virtualization Operator Deployment* custom resource
 to deploy {CNVProductName}.
 
 .Prerequisites
 
-* An active subscription to the *KubeVirt HyperConverged Cluster Operator* catalog
+* An active subscription to the *Container-native virtualization Operator* catalog
 in the `openshift-cnv` namespace
 
 .Procedure
 
 . Navigate to the *Operators* -> *Installed Operators* page.
 
-. Click *KubeVirt HyperConverged Cluster Operator*.
+. Click *Container-native virtualization Operator*.
 
-. Click the *KubeVirt HyperConverged Cluster Operator Deployment* tab and click
+. Click the *Container-native virtualization Operator Deployment* tab and click
 *Create HyperConverged*.
 
 . Click *Create* to launch {CNVProductName}.

--- a/modules/cnv-subscribing-to-hco-catalog.adoc
+++ b/modules/cnv-subscribing-to-hco-catalog.adoc
@@ -3,10 +3,10 @@
 // * cnv/cnv_install/installing-container-native-virtualization.adoc
 
 [id="cnv-subscribing-to-hco-catalog_{context}"]
-= Subscribing to the KubeVirt HyperConverged Cluster Operator catalog
+= Subscribing to the Container-native virtualization Operator catalog
 
 Before you install {CNVProductName}, subscribe to the
-*KubeVirt HyperConverged Cluster Operator* catalog from
+*Container-native virtualization Operator* catalog from
 the {product-title} web console. Subscribing gives the `openshift-cnv`
 namespace access to the {CNVProductName} Operators.
 
@@ -20,7 +20,7 @@ namespace access to the {CNVProductName} Operators.
 
 . Navigate to the *Operators* → *OperatorHub* page.
 
-. Locate the *KubeVirt HyperConverged Cluster Operator* and then select it.
+. Locate the *Container-native virtualization Operator* and then select it.
 
 . Read the information about the Operator and click *Install*.
 


### PR DESCRIPTION
UNTESTED - this autogenerated change requires manual verification.

Searching for "KubeVirt HyperConverged Cluster Operator" leads to an old
unsupportable community operator. "Container-native virtualization
Operator" is the name we should direct customers to use.

Related to https://issues.redhat.com/browse/CNV-3740

Signed-off-by: Dan Kenigsberg <danken@redhat.com>