### PR TITLE
rhel compute: simplify user action

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -28,8 +28,7 @@ your RHEL machines and the `upgrade` playbook.
 . Stop and disable firewalld on the host:
 +
 ----
-# systemctl disable firewalld.service
-# systemctl stop firewalld.service
+# systemctl disable --now firewalld.service
 ----
 +
 [NOTE]

--- a/modules/rhel-preparing-node.adoc
+++ b/modules/rhel-preparing-node.adoc
@@ -74,8 +74,7 @@ Note that this might take a few minutes if you have a large number of available 
 . Stop and disable firewalld on the host:
 +
 ----
-# systemctl disable firewalld.service
-# systemctl stop firewalld.service
+# systemctl disable --now firewalld.service
 ----
 +
 [NOTE]


### PR DESCRIPTION
 # systemctl disable --now firewalld.service

has the same effect as

 # systemctl disable firewalld.service
 # systemctl stop firewalld.service

but is simpler to read and to type.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>