### PR TITLE
updating RHEL packages for 4.3

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -42,9 +42,9 @@ You must not enable firewalld later. If you do, you cannot access {product-title
 +
 ----
 # subscription-manager repos --disable=rhel-7-server-ansible-2.7-rpms  \
-                             --disable=rhel-7-server-ose-4.1-rpms \
+                             --disable=rhel-7-server-ose-4.2-rpms \
                              --enable=rhel-7-server-ansible-2.8-rpms \
-                             --enable=rhel-7-server-ose-4.2-rpms
+                             --enable=rhel-7-server-ose-4.3-rpms
 ----
 
 .. On the machine that you run the Ansible playbooks, update the required packages, including `openshift-ansible`:
@@ -56,8 +56,8 @@ You must not enable firewalld later. If you do, you cannot access {product-title
 .. On each RHEL compute node, update the required repositories:
 +
 ----
-# subscription-manager repos --disable=rhel-7-server-ose-4.1-rpms \
-                             --enable=rhel-7-server-ose-4.2-rpms
+# subscription-manager repos --disable=rhel-7-server-ose-4.2-rpms \
+                             --enable=rhel-7-server-ose-4.3-rpms
 ----
 
 . Review your Ansible inventory file at `/<path>/inventory/hosts`


### PR DESCRIPTION
4.3 follow-up to https://github.com/openshift/openshift-docs/pull/18328

@gpei, is this enough for the RHEL packages for 4.3, or does the Ansible version need to change, too?