### PR TITLE
Show HPA info in ARO docs (except Ansible section)

### DIFF
--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -42,6 +42,8 @@ For additional information on these commands, see
 xref:../admin_guide/manage_nodes.html#viewing-nodes[Viewing Nodes] and
 xref:../admin_guide/managing_pods.adoc#viewing-pods[Viewing Pods].
 
+endif::openshift-origin,openshift-enterprise[]
+ifdef::openshift-origin,openshift-enterprise,openshift-aro[]
 [[hpa-supported-metrics]]
 == Supported Metrics
 
@@ -392,4 +394,4 @@ Conditions:
   ScalingLimited    False     DesiredWithinRange  the desired replica count is within the acceptable range
 Events:
 ----
-endif::openshift-origin,openshift-enterprise[]
+endif::openshift-origin,openshift-enterprise,openshift-aro[]


### PR DESCRIPTION
ARO docs should show HPA info, except the section regarding Ansible. Adjust the conditional blocks so that this info is shown.