### PR TITLE
Remove Greylock and Splunk from log forwarding

### DIFF
--- a/logging/config/cluster-logging-log-forwarding.adoc
+++ b/logging/config/cluster-logging-log-forwarding.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 
-The cluster logging *Log Forwarding* feature enables administrators to configure custom pipelines to send your container and node logs to specific endpoints within or outside of your cluster. You can send logs by type to the internal {product-title} Elasticsearch instance and/or remote destinations not managed by {product-title} cluster logging, such as your existing logging service, an external Elasticsearch cluster, external log aggregation solutions like Splunk and Graylog, or a Security Information and Event Management (SIEM) system.
+The cluster logging *Log Forwarding* feature enables administrators to configure custom pipelines to send your container and node logs to specific endpoints within or outside of your cluster. You can send logs by type to the internal {product-title} Elasticsearch instance and/or remote destinations not managed by {product-title} cluster logging, such as your existing logging service, an external Elasticsearch cluster, external log aggregation solutions, or a Security Information and Event Management (SIEM) system.
 
 :FeatureName: Log Forwarding
 include::modules/technology-preview.adoc[leveloffset=+1]


### PR DESCRIPTION
Removing Splunk and Graylog from into to log forwarding topic. These are future endpoints based on What New in OpenShift 4.3 presentation 1/13.