### PR TITLE
PR based on "cnv subscribing: only openshift-cnv must be used"

### DIFF
--- a/modules/cnv-subscribing-to-hco-catalog.adoc
+++ b/modules/cnv-subscribing-to-hco-catalog.adoc
@@ -32,11 +32,8 @@ list and choose the `openshift-cnv` namespace.
 ====
 * *All namespaces on the cluster (default)* installs the Operator in the default
 `openshift-operators` namespace to watch and be made available to all namespaces
-in the cluster. This option is not supported for use with {CNVProductName}.
+in the cluster. This option is *not* supported for use with {CNVProductName}.
 You must only install the Operator in the `openshift-cnv` namespace.
-* *A specific namespace on the cluster* allows you to choose a specific, single
-namespace in which to install the Operator. The Operator will only watch and be
-made available for use in this single namespace.
 ====
 .. Select *2.1* from the list of available *Update Channel* options.
 .. For *Approval Strategy*, ensure that *Automatic*, which is the default value,


### PR DESCRIPTION
* See discussion in https://github.com/openshift/openshift-docs/pull/18974
* Cherrypick to enterprise-4.2 and enterprise-4.3