### PR TITLE
Use UBI in Operator registry Dockerfile

### DIFF
--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -205,7 +205,7 @@ COPY manifests manifests
 
 RUN /bin/initializer -o ./bundles.db
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi7/ubi
 
 COPY --from=builder /registry/bundles.db /bundles.db
 COPY --from=builder /usr/bin/registry-server /registry-server


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1790376

Downstream UBI image is newer than upstream `origin-base`.