### PR TITLE
Update to include Certificate Chain info

### DIFF
--- a/migration/migrating-3-4/planning-migration-3-to-4.adoc
+++ b/migration/migrating-3-4/planning-migration-3-to-4.adoc
@@ -89,17 +89,12 @@ Local storage is only supported by using the Local Storage Operator in {product-
 
 For more information, see xref:../../storage/persistent-storage/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
 
-////
-// TODO: Removing until Support confirms
-
 [discrete]
 ==== FlexVolume persistent storage
 
 The FlexVolume plug-in location changed from {product-title} 3.11. The new location in {product-title} 4.3 is `/etc/kubernetes/kubelet-plugins/volume/exec`. Attachable FlexVolume plug-ins are no longer supported.
 
-// TODO: No FlexVolume docs in 4.3 to link to right now.
-
-////
+For more information, see xref:../../storage/persistent-storage/persistent-storage-flexvolume.adoc#persistent-storage-using-flexvolume[Persistent storage using FlexVolume].
 
 [discrete]
 ==== Container Storage Interface (CSI) persistent storage

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -18,16 +18,7 @@ client's URL.
 reach the API server.
 * The certificate must have the `subjectAltName` extension for the URL.
 
-
-[WARNING]
-====
-Do not provide a named certificate for the internal load balancer (host
-name `api-int.<cluster_name>.<base_domain>`). Doing so will leave your
-cluster in a degraded state.
-
-If a certificate chain is used, all certificates must be manually concatenated into a single named certificate file.
-
-Ex: (cat first_cert.pem second_cert.pem third_cert.pem >combined_cert.pem) 
+If a certificate chain is used, all certificates must be manually concatenated into a single named certificate file. This can be achieved with the following example: cat first_cert.pem second_cert.pem third_cert.pem >combined_cert.pem 
 
 The order of the chain should be:
 
@@ -36,6 +27,13 @@ The order of the chain should be:
 * Intermediate CA certificate.
 
 * Root CA certificate.
+
+
+[WARNING]
+====
+Do not provide a named certificate for the internal load balancer (host
+name `api-int.<cluster_name>.<base_domain>`). Doing so will leave your
+cluster in a degraded state.
 ====
 
 .Procedure

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -18,11 +18,24 @@ client's URL.
 reach the API server.
 * The certificate must have the `subjectAltName` extension for the URL.
 
+
 [WARNING]
 ====
 Do not provide a named certificate for the internal load balancer (host
 name `api-int.<cluster_name>.<base_domain>`). Doing so will leave your
 cluster in a degraded state.
+
+If a certificate chain is used, all certificates must be manually concatenated into a single named certificate file.
+
+Ex: (cat first_cert.pem second_cert.pem third_cert.pem >combined_cert.pem) 
+
+The order of the chain should be:
+
+* OpenShift Container Platform master host certificate.
+
+* Intermediate CA certificate.
+
+* Root CA certificate.
 ====
 
 .Procedure

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -18,11 +18,11 @@ client's URL.
 reach the API server.
 * The certificate must have the `subjectAltName` extension for the URL.
 
-If a certificate chain is used, all certificates must be manually concatenated into a single named certificate file. This can be achieved with the following example: cat first_cert.pem second_cert.pem third_cert.pem >combined_cert.pem 
+If a certificate chain is used, all certificates must be manually concatenated into a single named certificate file. This can be achieved with the following example: `cat first_cert.pem second_cert.pem third_cert.pem >combined_cert.pem`. 
 
 The order of the chain should be:
 
-* OpenShift Container Platform master host certificate.
+* {product-title} master host certificate.
 
 * Intermediate CA certificate.
 

--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -18,6 +18,17 @@ client's URL.
 reach the API server.
 * The certificate must have the `subjectAltName` extension for the URL.
 
+If a certificate chain is used, all certificates must be manually concatenated into a single named certificate file. This can be achieved with the following example: `cat first_cert.pem second_cert.pem third_cert.pem >combined_cert.pem`. 
+
+The order of the chain should be:
+
+* {product-title} master host certificate.
+
+* Intermediate CA certificate.
+
+* Root CA certificate.
+
+
 [WARNING]
 ====
 Do not provide a named certificate for the internal load balancer (host


### PR DESCRIPTION
Added chain certificate information in WARNING section. If a public cert is used, without chain, an x509 error will be present, based on recent experience.