### PR TITLE
[DDF] Addresses BZ1789244, BZ1789250, and BZ1789251.

### DIFF
--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -90,7 +90,7 @@ $ oc login https://{HOSTNAME}:6443
 $ oc new-project istio-system
 ----
 
-. Create a `ServiceMeshControlPlane` file named `istio-installation.yaml` using the full example found in "Customize the {ProductName} installation". You can customize the values as needed to match your use case. For production, you _must_ change the default Jaeger template.
+. Create a `ServiceMeshControlPlane` file named `istio-installation.yaml` using the example found in "Customize the {ProductName} installation". You can customize the values as needed to match your use case.  For production deployments you _must_ change the default Jaeger template.
 
 . Run the following command to deploy the control plane:
 +
@@ -131,6 +131,6 @@ istio-policy-77fd498655-7pvjw            2/2     Running            0          2
 istio-sidecar-injector-df45bd899-ctxdt   1/1     Running            0          28h
 istio-telemetry-66f697d6d5-cj28l         2/2     Running            0          28h
 jaeger-896945cbc-7lqrr                   2/2     Running            0          11h
-kiali-78d9c5b87c-snjzh                   0/1     Running            0          22h
+kiali-78d9c5b87c-snjzh                   1/1     Running            0          22h
 prometheus-6dff867c97-gr2n5              2/2     Running            0          28h
 ----

--- a/modules/ossm-cr-example.adoc
+++ b/modules/ossm-cr-example.adoc
@@ -21,59 +21,60 @@ This example `ServiceMeshControlPlane` definition contains all of the supported 
 The 3scale Istio Adapter is deployed and configured in the custom resource file. It also requires a working 3scale account (link:https://www.3scale.net/signup/[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html/infrastructure/onpremises-installation[On-Premises]).
 ====
 
-.Full example istio-installation.yaml
+.Example istio-installation.yaml
 
 [source,yaml]
 ----
-  apiVersion: maistra.io/v1
-  kind: ServiceMeshControlPlane
-  metadata:
-    name: full-install
-  spec:
+apiVersion: maistra.io/v1
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic-install
+spec:
 
-    istio:
-      global:
-        proxy:
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
+  istio:
+    global:
+      proxy:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 128Mi
 
-      gateways:
-        istio-egressgateway:
-          autoscaleEnabled: false
-        istio-ingressgateway:
-          autoscaleEnabled: false
-
-      mixer:
-        policy:
-          autoscaleEnabled: false
-
-        telemetry:
-          autoscaleEnabled: false
-          resources:
-            requests:
-              cpu: 100m
-              memory: 1G
-            limits:
-              cpu: 500m
-              memory: 4G
-
-      pilot:
+    gateways:
+      istio-egressgateway:
         autoscaleEnabled: false
-        traceSampling: 100
+      istio-ingressgateway:
+        autoscaleEnabled: false
+        ior_enabled: false
 
-      kiali:
-        enabled: true
+    mixer:
+      policy:
+        autoscaleEnabled: false
 
-      grafana:
-        enabled: true
+      telemetry:
+        autoscaleEnabled: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1G
+          limits:
+            cpu: 500m
+            memory: 4G
 
-      tracing:
-        enabled: true
-        jaeger:
-          template: all-in-one
+    pilot:
+      autoscaleEnabled: false
+      traceSampling: 100
+
+    kiali:
+      enabled: true
+
+    grafana:
+      enabled: true
+
+    tracing:
+      enabled: true
+      jaeger:
+        template: all-in-one
 ----


### PR DESCRIPTION
This PR addresses the following Bugzillas from Direct Documentation Feedback:
- 1789244 Move the text in the istio.installation YAML example to the left
- 1789250 Change the name of the istio-installation match the CLI instructions for consistency.
- 1789251 Update the sample output to indicate that the Kiali pod has started.