### PR TITLE
Adding the registry name for openshift/origin-base image

### DIFF
--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -205,7 +205,7 @@ COPY manifests manifests
 
 RUN /bin/initializer -o ./bundles.db
 
-FROM openshift/origin-base
+FROM quay.io/openshift/origin-base:4.2
 
 COPY --from=builder /registry/bundles.db /bundles.db
 COPY --from=builder /usr/bin/registry-server /registry-server


### PR DESCRIPTION
Resolves [Bug 1789767](https://bugzilla.redhat.com/show_bug.cgi?id=1789767)

https://docs.openshift.com/container-platform/4.2/operators/olm-restricted-networks.html#olm-restricted-networks-operatorhub_olm-restricted-networks

In the 6th point on the above page, it's necessary to add the registry name as well:

<snip>

FROM registry.redhat.io/openshift4/ose-operator-registry:v4.2.8 AS builder

COPY manifests manifests

RUN /bin/initializer -o ./bundles.db

FROM openshift/origin-base

COPY --from=builder /registry/bundles.db /bundles.db

</snip>

As we have the registry name mentioned for the first image, add the registry and version for the below line as well:

FROM openshift/origin-base

The reason is, these steps will be performed on the host which is outside openshift. We might have other registries like docker.io configured and we may end up pulling the wrong images which are unsupported one.
