### PR TITLE
Removed SM docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1588,20 +1588,6 @@ Topics:
 - Name: Using the CRI-O Container Engine
   File: crio_runtime
 ---
-Name: Service Mesh Install
-Dir: servicemesh-install
-Distros: openshift-enterprise
-Topics:
-- Name: Service Mesh Installation
-  File: servicemesh-install
----
-Name: Service Mesh Release Notes
-Dir: servicemesh-release-notes
-Distros: openshift-enterprise
-Topics:
-- Name: Release Notes
-  File: servicemesh-release-notes
----
 Name: Container-native Virtualization Install
 Dir: cnv_install
 Distros: openshift-enterprise

--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -962,10 +962,6 @@ Based on the open source link:https://istio.io/[Istio] project, Red Hat
 OpenShift Service Mesh layers transparently onto existing distributed
 applications, without requiring any changes in the service code.
 
-See
-xref:../servicemesh-install/servicemesh-install.adoc#product-overview[Installing
-Red Hat OpenShift Service Mesh] for more information.
-
 [[ocp-311-notable-technical-changes]]
 == Notable Technical Changes
 


### PR DESCRIPTION
This removes the SM docs from the 3.11 branch.

@JStickler @neal-timpe 

The archived docs are available here in PDF format: https://access.redhat.com/articles/4399691