### PR TITLE
[enterprise-4.1] Kuryr was not TP for 4.1

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -718,10 +718,6 @@ features marked *GA* indicate _General Availability_.
 |TP
 |TP
 
-|Kuryr CNI Plug-in
-|TP
-|TP
-
 |Sharing Control of the PID Namespace
 |TP
 |TP


### PR DESCRIPTION
Change based on https://github.com/openshift/openshift-docs/issues/17796#issuecomment-573303220