### PR TITLE
iSCSI fix in TP tracker table

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -820,9 +820,14 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 |GA
 
-|Raw Block and Persistent Storage with iSCSI
-|
+|Persistent Storage with iSCSI
 |TP
+|TP
+|GA
+
+|Raw Block with iSCSI
+|TP
+|GA
 |GA
 
 |Raw Block with Cinder


### PR DESCRIPTION
This comment isn't quite correct: https://github.com/openshift/openshift-docs/issues/17796#issuecomment-572644371

iSCSI raw block was GA in 4.2, while iSCSI persistent storage was TP. Both are GA in 4.3. So this PR creates separate rows in the Tech Preview Tracker table of 4.3 release notes.

