### PR TITLE
[enterprise-4.3] Fix error caused by left over merge conflict text

### DIFF
--- a/logging/cluster-logging.adoc
+++ b/logging/cluster-logging.adoc
@@ -6,10 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 
-<<<<<<< HEAD
 
-As an {product-title} cluster administrator, you can deploy cluster logging to aggregate logs for a range of {product-title} services.   
-=======
 ifdef::openshift-enterprise,openshift-origin[]
 As an {product-title} cluster administrator, you can deploy cluster logging to
 aggregate logs for a range of {product-title} services.
@@ -28,7 +25,6 @@ Logs in {product-title} are retained for two days before rotation. Logging
 storage is capped at 600GiB. This is independent of a cluster's allocated base
 storage.
 endif::[]
->>>>>>> 3c553ab51... dedicated logging corrections
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference


### PR DESCRIPTION
The asciibinder tool was throwing errors on `enterprise-4.3`, but not `master`. It appears this was caused by some leftover merge conflict text. This was removed and is now building correctly.