### PR TITLE
bz-1780401 ETCD restore using upstream binary with incorrect version

### DIFF
--- a/day_two_guide/topics/proc_restoring-etcd.adoc
+++ b/day_two_guide/topics/proc_restoring-etcd.adoc
@@ -273,14 +273,18 @@ Before restoring etcd on a static pod:
 * `etcdctl` binaries must be available or, in containerized installations,
 the `rhel7/etcd` container must be available.
 +
-You can obtain etcd by running the following commands:
+You can install the `etcdctl` binary with the etcd package by running the following commands:
 +
 ----
-$ git clone https://github.com/coreos/etcd.git
-$ cd etcd
-$ ./build
+# yum install etcd
 ----
 
++ The package also installs the systemd service. Disable and mask the service so that it does not run as a systemd service when etcd runs in static pod. By disabling and masking the service, you ensure that you do not accidentally start it and prevent it from automatically restarting when you reboot the system.
+
+----
+# systemctl disable etcd.service 
+# systemctl mask etcd.service
+----
 
 To restore etcd on a static pod:
 


### PR DESCRIPTION
originally opened here - https://github.com/openshift/openshift-docs/pull/18470

due mistake I deleted the branch before merge.

Please check again and comment.