### PR TITLE
CNV - BZ#1761501 - VM count added to telemetry

### DIFF
--- a/modules/telemetry-what-information-is-collected.adoc
+++ b/modules/telemetry-what-information-is-collected.adoc
@@ -21,9 +21,9 @@ Primary information collected by Telemetry includes:
 * The number of members in the etcd cluster and number of objects currently stored in the etcd cluster
 * The number of CPU cores and RAM used per machine type - infra or master
 * The number of CPU cores and RAM used per cluster
-// ifdef::cnv-cluster[]
-// * The number of running virtual machine instances in the cluster
-// endif::cnv-cluster[]
+ifdef::cnv-cluster[]
+* The number of running virtual machine instances in the cluster
+endif::cnv-cluster[]
 * Use of {product-title} framework components per cluster
 * The version of the {product-title} cluster
 * Health, condition, and status for any {product-title} framework component that is installed on the cluster, for example Cluster Version Operator, Cluster Monitoring, Image Registry, and Elasticsearch for Logging


### PR DESCRIPTION
Uncommenting telemetry VM count line now that it's been acked for 2.2
This is conditionalised for CNV use only. 

Cherrypick to enterprise-4.3