### PR TITLE
removing Hipersockets from the release notes

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1815,7 +1815,6 @@ Note the following restrictions for {product-title} on IBM System Z:
 * These features are available for {product-title} on IBM System Z for
 {product-version}, but not for {product-title} {product-version} on x86:
 ** HyperPAV enabled in IBM System Z or the virtual machine for FICON-attached ECKD storage.
-** HiperSockets.
 
 [[ocp-4-2-10-upgrading]]
 ==== Upgrading


### PR DESCRIPTION
Per request from @zzoubkova.