### PR TITLE
Bug 1792325: No mention about "openshift_node_group_node_data_dir" for volumeDirectory config

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1104,7 +1104,7 @@ At present this is only implemented for emptyDir volumes, and if the underlying
 - `*DynamicProvisioningEnabled*` (boolean): Default value is `true`, and toggles dynamic provisioning off when `false`.
 
 |`*VolumeDirectory*`
-|The directory that volumes are stored under.
+|The directory that volumes are stored under. `openshift_node_group_data_dir` can specify a same `volumeDirectory` to all node groups during installation.
 
 |===
 


### PR DESCRIPTION
* Version: v3.11

* Reference: [No mention about "openshift_node_group_node_data_dir" for volumeDirectory config](https://bugzilla.redhat.com/show_bug.cgi?id=1792325)

* Description:
  Add description for `openshift_node_group_data_dir`, because it is a valid parameter to specify "volumeDirectory".
