### PR TITLE
Removing managed state from configuring logging topic

### DIFF
--- a/modules/cluster-logging-deploying-about.adoc
+++ b/modules/cluster-logging-deploying-about.adoc
@@ -20,33 +20,7 @@ If you want to customize your deployment, make changes to the sample CR as neede
 You can configure your cluster logging environment by modifying the Cluster Logging Custom Resource deployed
 in the `openshift-logging` project.
 
-You can modify any of the following components upon install or after install
-
-Management state::
-The Cluster Logging Operator and Elasticsearch Operator can be in a _Managed_ or _Unmanaged_ state.
-
-In managed state, the Cluster Logging Operator (CLO) responds to changes in the Cluster Logging Custom Resource (CR) and attempts to update the cluster to match the CR.
-
-In order to modify certain components managed by the Cluster Logging Operator or the Elasticsearch Operator, you must set the operator to the _unmanaged_ state.
-
-In Unmanaged state, the operators do not respond to changes in the CRs. The administrator assumes full control of individual component configurations and upgrades when in unmanaged state.
-
-[NOTE]
-====
-The {product-title} documentation indicates in a prerequisite step when you must set the cluster to Unmanaged.
-====
-
-----
-  spec:
-    managementState: "Managed"
-----
-
-The {product-title} documentation indicates in a prerequisite step when you must set the cluster to Unmanaged.
-
-[IMPORTANT]
-====
-An unmanaged deployment will not receive updates until the `ClusterLogging` custom resource is placed back into a managed state.
-====
+You can modify any of the following components upon install or after install:
 
 Memory and CPU::
 You can adjust both the CPU and memory limits for each component by modifying the `resources`


### PR DESCRIPTION
Removing the Management State section from the Configuring and Tuning Cluster Logging topic. This caused confusion at a recent minimalism session and it seemed that managed/unmanaged were optional states that cluster logging could operate under.