### PR TITLE
bug 1777206 Fix the process how to add interfaces

### DIFF
--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -30,17 +30,9 @@ endif::sriov[]
 
 .Procedure
 
-To add a Pod to an additional network, complete the following steps:
+To add a Pod with additional networks, complete the following steps:
 
-. Edit the Pod resource definition. If you are editing an existing Pod, run the
-following command to edit its definition in the default editor. Replace `<name>`
-with the name of the Pod to edit.
-+
-----
-$ oc edit pod <name>
-----
-
-. In the Pod resource definition, add the `k8s.v1.cni.cncf.io/networks`
+. Create the Pod resource definition and add the `k8s.v1.cni.cncf.io/networks`
 parameter to the Pod `metadata` mapping. The `k8s.v1.cni.cncf.io/networks`
 accepts a comma separated string of one or more NetworkAttachmentDefinition Custom Resource (CR) names:
 +
@@ -71,6 +63,12 @@ spec:
   - name: example-pod
     command: ["/bin/bash", "-c", "sleep 2000000000000"]
     image: centos/tools
+----
+
+. Create the Pod by running the following command:
++
+----
+$ oc create -f pod.yaml
 ----
 
 . Optional: Confirm that the annotation exists in the Pod CR by running the


### PR DESCRIPTION
Currently multus-cni only supports to add interface to pod at creation.
Once created pod, multus-cni does not modify interfaces.
This change fix the document to align it, i.e. use 'oc create -f' command,
not 'oc edit'.