### PR TITLE
Remove cluster-api-cluster label on MHC

### DIFF
--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -20,24 +20,21 @@ metadata:
 spec:
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructureID> <2>
-      machine.openshift.io/cluster-api-machine-role: <role> <3>
-      machine.openshift.io/cluster-api-machine-type: <role> <3>
-      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone> <4>
+      machine.openshift.io/cluster-api-machine-role: <role> <2>
+      machine.openshift.io/cluster-api-machine-type: <role> <2>
+      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone> <3>
   unhealthyConditions:
   - type:    "Ready"
     timeout: "300s"
   - type:    "Ready"
     timeout: "300s"
-  maxUnhealthy: "40%" <5>
+  maxUnhealthy: "40%" <4>
 ----
 <1> Specify the name of the MachineHealthCheck to deploy.
-<2> Specify the infrastructure ID that is based on the cluster ID that you set
-when you provisioned the cluster.
-<3> Specify a label for the machine pool that you want to check.
-<4> Specify the MachineSet to track in `<cluster_name>-<label>-<zone>`
+<2> Specify a label for the machine pool that you want to check.
+<3> Specify the MachineSet to track in `<cluster_name>-<label>-<zone>`
 format. For example, `prod-node-us-east-1a`.
-<5> Specify the amount of unhealthy machines allowed in the targeted pool of
+<4> Specify the amount of unhealthy machines allowed in the targeted pool of
 machines. This can be set as a percentage or an integer.
 
 [NOTE]


### PR DESCRIPTION
There's no reason to include this label on a MHC to filter machines, dropping it to avoid confusion.