### PR TITLE
cnv-must-gather: request customers to supply OCP and CNV collections

### DIFF
--- a/cnv/cnv_logging_events_monitoring/cnv-collecting-cnv-data.adoc
+++ b/cnv/cnv_logging_events_monitoring/cnv-collecting-cnv-data.adoc
@@ -4,12 +4,15 @@ include::modules/cnv-document-attributes.adoc[]
 :context: cnv-collecting-cnv-data
 toc::[]
 
-When opening a support case, it is often helpful to provide debugging
+When opening a support case, it is helpful to provide debugging
 information about your cluster to Red Hat Support.
 
 The `must-gather` tool enables you to collect diagnostic information about your
 {product-title} cluster, including virtual machines and other data related to
 {CNVProductName}.
+
+For prompt support, supply diagnostic information for both {product-title}
+and {CNVProductName}.
 
 :FeatureName: {CNVProductNameStart}
 


### PR DESCRIPTION
Since CNV's must gather requires creating new pods, it sometimes fails.
Thus we should be explicit in asking to provide both OpenShift *and* CNV's must-gather collections.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>