### PR TITLE
Hide daemon set section for OpenShift 3.11 ARO

### DIFF
--- a/admin_guide/index.adoc
+++ b/admin_guide/index.adoc
@@ -119,8 +119,12 @@ volumes], and
 xref:../admin_guide/manage_scc.adoc#admin-guide-manage-scc[security context
 constraints].
 
+endif::[]
+ifdef::openshift-dedicated[]
 |Create Daemon Sets
 |Create link:http://kubernetes.io/docs/admin/daemons/[daemon sets], which ensure that all (or some) nodes run a copy of a pod.
+endif::[]
+ifdef::openshift-dedicated,openshift-aro[]
 
 |===
 


### PR DESCRIPTION
Hide the daemon set section in the OpenShift 3.11 ARO docs. It is not possible in OpenShift 3.11 ARO for a user with the `osa-customer-admin` role to patch a namespace to disable the default project-wide node selector as described on https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/developer_guide/dev-guide-daemonsets

