### PR TITLE
Fix some incorrect or unclear wording

### DIFF
--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -604,7 +604,7 @@ not specified, then the current project is used.
 |Removes a given role from specified users in the current project.
 
 |`$ oc adm policy remove-user _<username>_`
-|Removes specified users and all of their roles in the current project.
+|Removes customer-admin-cluster role from specified users in the current project.
 
 |`$ oc adm policy add-role-to-group _<role>_ _<groupname>_`
 |Binds a given role to specified groups in the current project.
@@ -613,10 +613,10 @@ not specified, then the current project is used.
 |Removes a given role from specified groups in the current project.
 
 |`$ oc adm policy remove-group _<groupname>_`
-|Removes specified groups and all of their roles in the current project.
+|Removes customer-admin-cluster role from specified groups in the current project.
 
 |`--rolebinding-name=`
-|Can be used with `oc adm policy` commands to retain the rolebinding name assigned to a user or group.
+|Can be used with `oc adm policy` commands to assign a custom rolebinding name to a user or group.
 
 |===
 
@@ -645,7 +645,7 @@ cluster role bindings use non-namespaced resources.
 |Removes a given role from specified groups for all projects in the cluster.
 
 |`--rolebinding-name=`
-|Can be used with `oc adm policy` commands to retain the rolebinding name assigned to a user or group.
+|Can be used with `oc adm policy` commands to assign a custom rolebinding name to a user or group.
 
 |===
 endif::[]


### PR DESCRIPTION
Clarify a few things in the docs.

- `oc adm policy remove-user` does not remove users; it removes roles from users
- `oc adm policy remove-group` does not remove groups; it removes roles from groups.
- The use of the word "retain" when talking about `--rolebinding-name=` is confusing. "Retain" implies that a name that already existed will be preserved and carried forward, but the name being assigned is new (being currently created by the user).
