### PR TITLE
Indicate that labels updates must include a value

### DIFF
--- a/admin_guide/manage_users.adoc
+++ b/admin_guide/manage_users.adoc
@@ -166,7 +166,7 @@ Next steps:
 To add a label to a user or group:
 
 ----
-$ oc label user/<user_name> <label_name>
+$ oc label user/<user_name> <label_name>=<label_value>
 ----
 
 For example, if the user name is *theuser* and the label is *level=gold*:


### PR DESCRIPTION
The current `oc label` command formatting example does not imply that a key-value pair must be passed.