### PR TITLE
Changes to updating logging for 4.3

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -928,7 +928,7 @@ Topics:
 - Name: Deploying cluster logging
   File: dedicated-cluster-deploying
   Distros: openshift-dedicated
-- Name: Upgrading cluster logging
+- Name: Updating cluster logging
   File: cluster-logging-upgrading
 - Name: Deploying and Configuring the Event Router
   File: cluster-logging-eventrouter

--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -1,13 +1,13 @@
 :context: cluster-logging-upgrading
 [id="cluster-logging-upgrading"]
-= Upgrading cluster logging
+= Updating cluster logging
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
 
 
-After upgrading the {product-title} cluster from 4.1 to 4.2, you must then upgrade cluster logging from 4.1 to 4.2.
+After updating the {product-title} cluster from 4.2 to 4.3, you must then upgrade cluster logging from 4.2 to 4.3.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference

--- a/modules/cluster-logging-upgrading-logging.adoc
+++ b/modules/cluster-logging-upgrading-logging.adoc
@@ -3,22 +3,31 @@
 // * logging/cluster-logging.adoc
 
 [id="cluster-logging-about_{context}"]
-= Upgrading cluster logging
+= Updating cluster logging
 
-After upgrading the {product-title} cluster, you can upgrade cluster logging from 4.2 to 4.3 by updating the subscription for the Elasticsearch Operator and the Cluster Logging Operator.
+After updating the {product-title} cluster, you can update cluster logging from 4.2 to 4.3 by updating the subscription for the Elasticsearch Operator and the Cluster Logging Operator.
+
+[IMPORTANT]
+====
+Changes introduced by the new log forward feature modified the support for *out_forward* starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap to configure *out_forward*. Any updates to the `secure-forward.conf` section of the Fluentd ConfigMap are removed. 
+
+If you use the the *out_forward* plug-in, before updating, you can copy your current `secure-forward.conf` section from the Fluentd ConfigMap and use the copied data when you create the `secure-forward` ConfigMap. 
+====
 
 .Prerequisites
 
-* Upgrade cluster from 4.1 to 4.2.
+* Update the cluster from 4.2 to 4.3.
 
-* Make sure the clusterlogging status is healthy:
+* Make sure the cluster logging status is healthy:
 +
 ** All Pods are `ready`.
 ** Elasticsearch cluster is healthy.
 
+* Optionally, copy your current `secure-forward.conf` section from the Fluentd ConfigMap for use if you want to create the `secure-forward` ConfigMap. See the note above. 
+
 .Procedure
 
-. Upgrade the Elasticsearch Operator:
+. Update the Elasticsearch Operator:
 
 .. From the web console, click *Operators* -> *Installed Operators*.
 
@@ -40,7 +49,7 @@ Elasticsearch Operator
 by Red Hat, Inc
 ----
 
-. Upgrade the Cluster Logging Operator:
+. Update the Cluster Logging Operator:
 
 .. From the web console, click *Operators* -> *Installed Operators*.
 
@@ -69,18 +78,18 @@ by Red Hat, Inc
 ----
 $ oc get pod -o yaml -n openshift-logging --selector component=elasticsearch |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
 ----
 +
 .. Ensure that all Elasticsearch Pods are in the *Ready* status:
@@ -107,24 +116,23 @@ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b75
 
 ----
 
-
 .. Ensure that the logging collector Pods are using a 4.3 image:
 +
 ----
 $ oc get pod -n openshift-logging --selector logging-infra=fluentd -o yaml |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-202001081344
 ----
 
 .. Ensure that the Kibana Pods are using a 4.3 image:
@@ -132,10 +140,10 @@ image: registry.redhat.io/openshift4/ose-logging-fluentd:v4.3.0-201909201915
 ----
 $ oc get pod -n openshift-logging --selector logging-infra=kibana -o yaml |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.3.0-201909210748
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
-image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.3.0-201909210748
-image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-logging-kibana5:v4.3.0-202001081344
+image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-202001081344
 ----
 
 .. Ensure that the Curator CronJob is using a 4.3 image:
@@ -143,5 +151,5 @@ image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3.0-201909201915
 ----
 $ $ oc get CronJob curator -n openshift-logging -o yaml |grep 'image:'
 
-image: registry.redhat.io/openshift4/ose-logging-curator5:v4.3.0-201909201915
+image: registry.redhat.io/openshift4/ose-logging-curator5:v4.3.0-202001081344
 ----


### PR DESCRIPTION
I added the _Changes introduced by the new log forward feature_ note to the updating docs for anyone who used the forward plugin to copy their current configuration for use in the new config map. 
Also caught a few instances where the version numbers needed updating and updated the image names to 4.3.