### PR TITLE
[enterprise-4.1] Remove cluster-api-cluster label on MHC

### DIFF
--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -18,16 +18,15 @@ metadata:
 Spec:
   Selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <cluster_name> <2>
-      machine.openshift.io/cluster-api-machine-role: <label> <3>
-      machine.openshift.io/cluster-api-machine-type: <label> <3>
-      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<AWS-zone> <4>
+
+      machine.openshift.io/cluster-api-machine-role: <label> <2>
+      machine.openshift.io/cluster-api-machine-type: <label> <2>
+      machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<AWS-zone> <3>
 ----
 <1> Specify the name of the MachineHealthCheck to deploy. Include the name of the
 MachinePool to track.
-<2> Specify the name of your cluster.
-<3> Specify a label for the MachinePool that you want to check.
-<4> Specify the MachineSet to track in `<cluster_name>-<label>-<AWS-zone>`
+<2> Specify a label for the MachinePool that you want to check.
+<3> Specify the MachineSet to track in `<cluster_name>-<label>-<zone>`
 format. For example, `prod-node-us-east-1a`.
 
 ////


### PR DESCRIPTION
There's no reason to include this label on a MHC to filter machines, dropping it to avoid confusion.

From https://github.com/openshift/openshift-docs/pull/19160