### PR TITLE
Edits for OLM 4.3 disconnected

### DIFF
--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -12,6 +12,22 @@ for your Operator to run properly in a restricted network environment:
 require to perform their functions.
 * Reference all specified images by a digest (SHA) and not by a tag.
 
+When processed by the Operator Lifecycle Manager (OLM), the related image
+references are then passed down and populated as annotations on the Operator's
+Deployment objects:
+
+[source,yaml]
+----
+kind: Deployment
+metadata:
+  name: etcd-operator
+  annotations:
+    default: quay.io/coreos/etcd@sha256:12345
+    olm.relatedImage.etcd-2.1.5: quay.io/coreos/etcd@sha256:12345
+    olm.relatedImage.etcd-3.1.1: quay.io/coreos/etcd@sha256:12345
+[...]
+----
+
 .Prerequisites
 
 * An Operator project with a CSV

--- a/operators/olm-restricted-networks.adoc
+++ b/operators/olm-restricted-networks.adoc
@@ -27,8 +27,8 @@ include::modules/olm-building-operator-catalog-image.adoc[leveloffset=+1]
 
 * xref:../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Creating a mirror registry for installation in a restricted network]
 
-include::modules/olm-testing-operator-catalog-image.adoc[leveloffset=+1]
 include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+include::modules/olm-testing-operator-catalog-image.adoc[leveloffset=+1]
 
 .Additional resources
 

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -19,11 +19,11 @@ information contained in manually-defined YAML manifests and Operator source
 files.
 
 A CSV-generating command removes the responsibility of Operator authors having
-in-depth Operator Lifecycle Manager (OLM) knowledge in order for their Operator
-to interact with OLM or publish metadata to the Catalog Registry. Further,
-because the CSV spec will likely change over time as new Kubernetes and OLM
-features are implemented, the Operator SDK is equipped to easily extend its
-update system to handle new CSV features going forward.
+in-depth OLM knowledge in order for their Operator to interact with OLM or
+publish metadata to the Catalog Registry. Further, because the CSV spec will
+likely change over time as new Kubernetes and OLM features are implemented, the
+Operator SDK is equipped to easily extend its update system to handle new CSV
+features going forward.
 
 The CSV version is the same as the Operator's, and a new CSV is generated when
 upgrading Operator versions. Operator authors can use the `--csv-version` flag


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/18424.

* Move "Testing" procedure to end of assembly: http://file.rdu.redhat.com/~adellape/012220/olm_dis_edit/operators/olm-restricted-networks.html#olm-testing-operator-catalog-image_olm-restricted-networks
* Add info on Deployment annotations for related images: http://file.rdu.redhat.com/~adellape/012220/olm_dis_edit/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs