### PR TITLE
cnv-bz17931571 - remove IPAM from NAD examples

### DIFF
--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -38,7 +38,6 @@ spec:
       {
         "type": "cnv-bridge", <2>
         "bridge": "br0", <3>
-        "ipam": {}
       },
       {
         "type": "tuning" <4>

--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -37,7 +37,7 @@ spec:
     "plugins": [
       {
         "type": "cnv-bridge", <2>
-        "bridge": "br0", <3>
+        "bridge": "br0" <3>
       },
       {
         "type": "tuning" <4>

--- a/modules/cnv-pxe-booting-with-mac-address.adoc
+++ b/modules/cnv-pxe-booting-with-mac-address.adoc
@@ -37,7 +37,6 @@ spec:
         {
           "type": "cnv-bridge",
           "bridge": "br1",
-          "ipam": {}
         },
         {
           "type": "cnv-tuning" <1>

--- a/modules/cnv-pxe-booting-with-mac-address.adoc
+++ b/modules/cnv-pxe-booting-with-mac-address.adoc
@@ -36,7 +36,7 @@ spec:
       "plugins": [
         {
           "type": "cnv-bridge",
-          "bridge": "br1",
+          "bridge": "br1"
         },
         {
           "type": "cnv-tuning" <1>


### PR DESCRIPTION
The suggested fix in BZ#1793571 is to drop the 'ipam' line from the NAD examples.
Removed from two modules.

cherrypick to enterprise-4.3 