### PR TITLE
Added note about Knative Eventing to Serverless arch section

### DIFF
--- a/serverless/serverless-architecture.adoc
+++ b/serverless/serverless-architecture.adoc
@@ -6,3 +6,6 @@ include::modules/serverless-document-attributes.adoc[]
 
 include::modules/knative-serving.adoc[leveloffset=+1]
 include::modules/knative-cli.adoc[leveloffset=+1]
+
+== Knative Eventing
+A developer preview version of Knative Eventing is available for use with {ServerlessProductName}. However, this is not included in the {ServerlessOperatorName} and is not currently supported as part of this Technology Preview. For more information about Knative Eventing, including installation instructions and samples, see the link:https://openshift-knative.github.io/docs/docs/index.html[Knative Eventing on {product-title}] documentation.


### PR DESCRIPTION
- Note was previously only in release notes
- folks were overlooking this and we had a support case for someone who used incorrect Eventing tutorials to install Knative; making the external link for the dev preview more visible will hopefully help prevent this in future