### PR TITLE
search: add ARO search support

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -25,7 +25,7 @@ function hcSearchCategory(label, version) {
         si: 0,
         q: query.val(),
         label: label,
-        urlFilter: (typeof version === "undefined" || version == "Branch Build") ? "" : (" url:*\\/" + version + "\\/*")
+        urlFilter: (typeof version === "undefined" || version == "Branch Build") ? "" : (" url:*\\/" + version.toLowerCase() + "\\/*")
       };
       modalSearch.show();
       hcsearch(searchParams);
@@ -65,7 +65,7 @@ function hcsearch(searchParams) {
       $("#hc-search-result").append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
       hcSearchIndicator.hide();
     }
-    if (hcsearchresults.response.result) {
+    if (!$.isEmptyObject(hcsearchresults.response.result)) { 
       // if there are any results
       $(hcsearchresults.response.result).each(function () {
         var row = '<div class="search-result-item"><a href="' + this.url +

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -155,7 +155,8 @@
     'openshift-origin': ['docs_origin', version],
     'openshift-dedicated': ['docs_dedicated', version],
     'openshift-online': ['docs_online', version],
-    'openshift-enterprise': ['docs_cp', version]
+    'openshift-enterprise': ['docs_cp', version],
+    'openshift-aro' : ['docs_aro']
   };
 
   distros[dk] ? hcSearchCategory.apply(null, distros[dk]) : hcSearchCategory("docs");


### PR DESCRIPTION
- Adds Azure Red Hat OpenShift docs search support (preview available [here](http://commercial-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/aro/welcome/index.html))
- Fixes search filtering for mixed case version strings used as filters, by simply lower-casing the `version` string, which appears to be a safe assumption atm. The OKD 'Latest' currently excluding results with lower-case `latest` in the URL, thus returning no results. The OKD Latest community searching can be previewed [here](http://community-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/latest/welcome/index.html).
- Fixes the incorrect message (*"No more results"*) when no search results are returned. This can be previewed [here](http://community-docs-pro.b9ad.pro-us-east-1.openshiftapps.com/latest/welcome/index.html).

@vikram-redhat, PTAL. I tried cherry-picking into enterprise 3.11 through to 4.3 branches which produced the above preview environments. The commercial docs preview is still fetching the `hc-search.js` from production, so the filter lower-casing and proper result array test are not visible there; it's intended for the ARO search check only. 