### PR TITLE
Changing wording per Christian H in slack

### DIFF
--- a/modules/cluster-logging-log-forwarding-about.adoc
+++ b/modules/cluster-logging-log-forwarding-about.adoc
@@ -27,7 +27,7 @@ A pipeline associates the type of data to an output. A type of data you can forw
 
 Note the following:
 
-* Log forwarding does not provide secure storage for audit logs. You are responsible to ensure the endpoint is compliant with your organizational and governmental regulations and is properly secured. {product-title} cluster logging does not comply with those regulations.
+* The internal {product-title} Elasticsearch instance does not provide secure storage for audit logs. We recommend you ensure that the system to which you forward audit logs is compliant with your organizational and governmental regulations and is properly secured. {product-title} cluster logging does not comply with those regulations.
 
 * An output supports TLS communication using a secret. Secrets must have keys of: *tls.crt*, *tls.key*, and *ca-bundler.crt* which point to the respective certificates for which they represent. Secrets must have the key *shared_key* for use when using forward in a secure manner.
 


### PR DESCRIPTION
one note on the following:
Log forwarding does not provide secure storage for audit logs. You are responsible to ensure the endpoint is compliant with your organizational and governmental regulations and is properly secured. OpenShift Container Platform cluster logging does not comply with those regulations.
Can we replace “Log forwarding” with “OpenShift Logging”. We don’t provide any security mechanisms with the Elasticsearch solution shipped as a storage for OpenShift Logging and that’s why we would recommend using an appropriate storage as you said, and why we don’t support collecting audit logs by default but only through the Log Forwarding feature.

https://coreos.slack.com/archives/GGUR75P60/p1579860545100800