### PR TITLE
Fixed topic map for Serverless

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1401,6 +1401,8 @@ Topics:
   File: getting-started-knative-services
 - Name: Creating serverless applications
   File: creating-serverless-applications
+- Name: Interacting wtih serverless applications
+  File: interacting-serverless-apps
 - Name: Splitting traffic between revisions
   File: splitting-traffic-between-revisions
 ### Monitoring


### PR DESCRIPTION
Interacting w/ serverless apps was missing so I re-added it.
Valid for OCP 4.2+