### PR TITLE
BZ#1794683 Remove warning for required public CA signing of certs

### DIFF
--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -13,7 +13,7 @@ custom resource (CR).
 
 * You must have a certificate/key pair in PEM-encoded files, where the
 certificate is signed by a trusted certificate authority or by a private trusted
-certificate authority that you have configured.
+certificate authority that you configured in a custom PKI.
 
 * Your certificate is valid for the Ingress domain.
 
@@ -24,13 +24,6 @@ $ oc --namespace openshift-ingress-operator get ingresscontrollers
 NAME      AGE
 default   10m
 ----
-
-[WARNING]
-====
-If the default certificate is replaced, it *must* be signed by a public
-certificate authority already included in the CA bundle as provided by the
-container userspace.
-====
 
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1794683