### PR TITLE
BZ1794757 - Move OCS and add description on 4.3 Welcome page

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -28,8 +28,6 @@ ifdef::openshift-enterprise,openshift-origin[]
 == Cluster installer activities
 As someone setting out to install an {product-title} {product-version} cluster, this documentation will help you:
 
-- **xref:../storage/red-hat-openshift-container-storage.adoc#red-hat-openshift-container-storage[Use Red Hat OpenShift Container Storage]**
-
 - **xref:../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Install a cluster on AWS]**: You have the most installation options when you deploy a cluster on Amazon Web Services (AWS). You can deploy clusters with xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[default settings] or xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[custom AWS settings].
 You can also deploy a cluster on AWS infrastructure that you provisioned yourself. You can modify the provided xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[AWS CloudFormation templates] to meet your needs.
 
@@ -79,6 +77,8 @@ Internet access is still required to access the cloud APIs and installation medi
 - **xref:../installing/installing-gather-logs.adoc#installing-gather-logs[Check installation logs]**: Access installation logs to evaluate issues that occur during {product-title} {product-version} installation.
 
 - **xref:../web-console/web-console.adoc#web-console[Access {product-title}]**: Use credentials output at the end of the installation process to log in to the {product-title} cluster from the command line or web console.
+
+- **xref:../storage/red-hat-openshift-container-storage.adoc#red-hat-openshift-container-storage[Install Red Hat OpenShift Container Storage]**: Install Red Hat OpenShift Container Storage on existing worker nodes to provide agnostic persistent storage for {product-title}.
 endif::[]
 
 == Developer activities


### PR DESCRIPTION
[BZ 1794757](https://bugzilla.redhat.com/show_bug.cgi?id=1794757) - Moves xref to OCS docs to a more logical entry point, and adds brief description to make it consistent with other entries on the page. `enterprise-4.3` only.