### PR TITLE
CronJob: fix English of leading sentence

### DIFF
--- a/modules/nodes-nodes-jobs-about.adoc
+++ b/modules/nodes-nodes-jobs-about.adoc
@@ -37,7 +37,7 @@ For more information about how to make use of the different types of Job, see li
 
 CronJob::
 
-A CronJob can be scheduled to run multiple times, use a CronJob.
+A Job can be scheduled to run multiple times, using a CronJob.
 
 A _CronJob_ builds on a regular Job by allowing you to specify
 how the Job should be run. CronJobs are part of the


### PR DESCRIPTION
I think that the existing syntax is incorrect, and try to explain CronJob by itself.