### PR TITLE
BZ1794204 - Add OCS 4.2 to OCP 4.3+ persistent storage

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -37,6 +37,7 @@ The following table displays which volume plug-ins support block volumes.
 |iSCSI | ✅ | | ✅
 |Local volume | ✅ || ✅
 |NFS | | |
+|Red Hat OpenShift Container Storage | ✅ | ✅ | ✅
 |VMware vSphere  | ✅ | ✅ | ✅
 |===
 

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -145,6 +145,7 @@ the Pods that use these volumes are deleted.
 |iSCSI  | ✅ | ✅ |  -
 |Local volume | ✅ | - |  -
 |NFS  | ✅ | ✅ | ✅
+|Red Hat OpenShift Container Storage  | ✅ | - | ✅
 |VMware vSphere | ✅ | - |  -
 |===
 
@@ -264,6 +265,7 @@ The following PV types support mount options:
 - iSCSI
 - Local volume
 - NFS
+- Red Hat OpenShift Container Storage (Ceph RBD only)
 - VMware vSphere
 
 [NOTE]


### PR DESCRIPTION
[BZ1794204](https://bugzilla.redhat.com/show_bug.cgi?id=1794204) - Add OCS persistent storage support to 4.3+ (as we did in 4.2 with [PR 19193](https://github.com/openshift/openshift-docs/pull/19193)).

@RazTamir PTAL
@liangxia FYI