### PR TITLE
Bump RHCOS image mirror path to 4.3

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -26,7 +26,7 @@ installation program created to your HTTP server. Note the URLs of these files.
 of installing operating system instances from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
 Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.3/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -25,7 +25,7 @@ installation program created to your HTTP server. Note the URLs of these files.
 and `initramfs` files from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
 Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.3/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]


### PR DESCRIPTION
Bump RHCOS image mirror path to 4.3 for installation of infra machines via iso and pxe.