### PR TITLE
Privileged pods not required for hostpath PV[C]s

### DIFF
--- a/modules/persistent-storage-hostpath-pod.adoc
+++ b/modules/persistent-storage-hostpath-pod.adoc
@@ -3,7 +3,7 @@
 // * storage/persistent-storage/persistent-storage-hostpath.adoc
 
 [id="persistent-storage-hostpath-pod_{context}"]
-= Mounting the hostPath share in a privileged Pod
+= Mounting the hostPath share in a Pod
 
 After the PersistentVolumeClaim has been created, it can be used inside by an application. The following example demonstrates mounting this share inside of a Pod.
 
@@ -12,7 +12,7 @@ After the PersistentVolumeClaim has been created, it can be used inside by an ap
 
 .Procedure
 
-* Create a privileged Pod that mounts the existing PersistentVolumeClaim:
+* Create a Pod that mounts the existing PersistentVolumeClaim:
 +
 [source,yaml]
 ----
@@ -23,19 +23,16 @@ metadata:
 spec:
   containers:
     ...
-    securityContext:
-      privileged: true <2>
     volumeMounts:
-    - mountPath: /data <3>
-      name: hostpath-privileged
+    - mountPath: /data <2>
+      name: hostpath-volume
   ...
   securityContext: {}
   volumes:
-    - name: hostpath-privileged
+    - name: hostpath-volume
       persistentVolumeClaim:
-        claimName: task-pvc-volume <4>
+        claimName: task-pvc-volume <3>
 ----
 <1> The name of the Pod.
-<2> The Pod must run as privileged to access the node's storage.
-<3> The path to mount the hostPath share inside the privileged Pod.
-<4> The name of the PersistentVolumeClaim that has been previously created.
+<2> The path to mount the hostPath share inside the privileged Pod.
+<3> The name of the PersistentVolumeClaim that has been previously created.

--- a/storage/persistent-storage/persistent-storage-hostpath.adoc
+++ b/storage/persistent-storage/persistent-storage-hostpath.adoc
@@ -7,11 +7,6 @@ toc::[]
 
 A hostPath volume in an {product-title} cluster mounts a file or directory from the host node’s filesystem into your Pod. Most Pods will not need a hostPath volume, but it does offer a quick option for testing should an application require it.
 
-[IMPORTANT]
-====
-The cluster administrator must configure Pods to run as privileged. This grants access to Pods in the same node.
-====
-
 include::modules/persistent-storage-hostpath-about.adoc[leveloffset=+1]
 include::modules/persistent-storage-hostpath-static-provisioning.adoc[leveloffset=+1]
 include::modules/persistent-storage-hostpath-pod.adoc[leveloffset=+1]


### PR DESCRIPTION
When reviewing the documentation about hostpath volumes I noticed that
the section claims that Pods must be privileged in order to run with
PVCs that are bound to statically provisioned hostpath PVs.  This is not
correct.  Unprivileged pods can use these volumes as well.

I suspect there was some confusion between this usage model and the
deprecated inline volume specification for pods.  In that model the path
on the host could be specified in the Pod spec and this would obviously
create a security risk so this was restricted to privileged pods only.
In the case of a statically provisioned hostpath PV that is bound to a
PVC, only a cluster admin may create such a PV so there is no danger in
exposing a sensitive host path to an unprivileged user.

Signed-off-by: Adam Litke <alitke@redhat.com>