### PR TITLE
removing and updating hard-coded versions for 2.2 upgrade docs

### DIFF
--- a/modules/cnv-about-upgrading-cnv.adoc
+++ b/modules/cnv-about-upgrading-cnv.adoc
@@ -8,14 +8,18 @@
 If you enabled automatic updates when you installed {CNVProductName}, you
 receive updates as they become available.
 
-.Additional information
+=== How {CNVProductName} upgrades work
 
-* In {CNVProductName} version 2.1, only _z-stream_ updates are available.
-For example, {CNVProductName} 2.1.0 -> {CNVProductName} 2.1.1
+* Only _z-stream_ updates are available. For example, you can upgrade from {CNVVersion}.0 to {CNVVersion}.1.
 
 * Updates are delivered via the _Marketplace Operator_, which is deployed
 during {product-title} installation. The Marketplace Operator makes
 external Operators available to your cluster.
+
+* The amount of time an update takes to complete depends on your network
+connection. Most automatic updates complete within fifteen minutes.
+
+=== How {CNVProductName} upgrades affect your cluster
 
 * Upgrading does not interrupt virtual machine workloads.
 ** Virtual machine Pods are not restarted or migrated during an upgrade. If you
@@ -33,6 +37,3 @@ used to manage the virtual machine process.
 
 * DataVolumes and their associated PersistentVolumeClaims are preserved during
 upgrade.
-
-* The amount of time an update takes to complete depends on your network
-connection. Most automatic updates complete within fifteen minutes.

--- a/modules/cnv-document-attributes.adoc
+++ b/modules/cnv-document-attributes.adoc
@@ -13,6 +13,7 @@
 :ProductShortName: CNV
 :ProductRelease:
 :ProductVersion:
+:CNVVersion: 2.2
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/cnv-monitoring-upgrade-status.adoc
+++ b/modules/cnv-monitoring-upgrade-status.adoc
@@ -32,8 +32,8 @@ $ oc get csv
 +
 ----
 VERSION  REPLACES                                        PHASE
-2.1.1    kubevirt-hyperconverged-operator.v2.1.0         Installing
-2.1.0                                                    Replacing
+2.2.1    kubevirt-hyperconverged-operator.v2.2.0         Installing
+2.2.0                                                    Replacing
 ----
 
 . Optional: Monitor the aggregated status of all {CNVProductName} component


### PR DESCRIPTION
- No BZ.
- For enterprise-4.3 and enterprise-4.4 only.
- Preview build: http://file.bos.redhat.com/pousley/012520/hard-coded-versions/cnv/cnv_install/upgrading-container-native-virtualization.html

@aburdenthehand Please review and merge if you can. Thanks!