### PR TITLE
Add static IP to 4.3 installs (OSDOCS-727)

### DIFF
--- a/modules/installation-infrastructure-user-infra.adoc
+++ b/modules/installation-infrastructure-user-infra.adoc
@@ -28,7 +28,7 @@ ifdef::ibm-z[]
 . Set up an FTP server.
 endif::ibm-z[]
 ifndef::ibm-z[]
-. Configure DHCP.
+. Configure DHCP or set static IP addresses on each node.
 endif::ibm-z[]
 
 . Provision the required load balancers.

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -24,7 +24,8 @@ Ensure that the machines have persistent IP
 addresses and host names.
 endif::ibm-z[]
 ifndef::ibm-z[]
-During the initial boot, the machines require a DHCP server in order to
+During the initial boot, the machines require either a DHCP server
+or that static IP addresses be set on each host in the cluster in order to
 establish a network connection, which allows them to download their Ignition config files.
 
 It is recommended to use the DHCP server to manage the machines for the cluster

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -59,7 +59,8 @@ ifdef::ibm-z[]
 The machines are configured with static IP addresses. No DHCP server is required.
 endif::ibm-z[]
 ifndef::ibm-z[]
-During the initial boot, the machines require a DHCP server in order to establish a network
+During the initial boot, the machines require either a DHCP server 
+or that static IP addresses be set in order to establish a network
 connection to download their Ignition config files.
 endif::ibm-z[]
 

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -59,10 +59,19 @@ coreos.inst=yes
 coreos.inst.install_dev=sda <1>
 coreos.inst.image_url=<bare_metal_image_URL> <2>
 coreos.inst.ignition_url=http://example.com/config.ign <3>
+ip=<dhcp or static IP address> <4>
 ----
 <1> Specify the block device of the system to install to.
 <2> Specify the URL of the RAW image that you uploaded to your server.
 <3> Specify the URL of the Ignition config file for this machine type.
+<4> Set `ip=dhcp` or set an individual static IP address (ip=) and DNS server (nameserver=) on each node.
+For example, setting
+`ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none nameserver=4.4.4.41` sets:
+* Node's IP address to 10.10.10.2
+* Gateway address to 10.10.10.254
+* Netmask to 255.255.255.0
+* Hostname to core0.example.com
+* The DNS server address to 4.4.4.41
 
 . Press Enter to complete the installation. After {op-system} installs, the system
 reboots. After the system reboots, it applies the Ignition config file that you


### PR DESCRIPTION
This PR is meant to resolve [OSDOCS-727](https://issues.redhat.com/browse/OSDOCS-727). It describes how to do ISO installs in environments without access to DHCP, so IP address information needs to be set statically.  I was going to add a section on setting static IP addresses from a PXE server. But since that would require DHCP, that wouldn't fly.