### PR TITLE
fix link

### DIFF
--- a/storage/persistent-storage/persistent-storage-flexvolume.adoc
+++ b/storage/persistent-storage/persistent-storage-flexvolume.adoc
@@ -13,7 +13,7 @@ Pods interact with FlexVolume drivers through the `flexvolume` in-tree plugin.
 
 .Additional References
 
-* xref:../expanding-persistent-volumes.adoc#expanding-persistent-volumes[Expanding persistent volumes]
+* xref:../../storage/expanding-persistent-volumes.adoc#expanding-persistent-volumes[Expanding persistent volumes]
 
 include::modules/persistent-storage-flexvolume-drivers.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/19295

@bobfuru I apologise. This is the correct path. It should traverse up twice and then back down using the actual folder names. I confused it by incorrectly fixing it the first time.