### PR TITLE
modules/configuring-firewall: Document release signature sources

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -75,23 +75,26 @@ Before you install {product-title}, you must configure your firewall to grant ac
 |URL | Function
 
 |`mirror.openshift.com`
-|Required to access mirrored installation content and images
+|Required to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
+
+|`storage.googleapis.com/openshift-release`
+|A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
 
 |`*.apps.<cluster_name>.<base_domain>`
-|Required to access the default cluster routes unless you set an ingress wildcard during installation
+|Required to access the default cluster routes unless you set an ingress wildcard during installation.
 
 |`quay-registry.s3.amazonaws.com`
-|Required to access Quay image content in AWS
+|Required to access Quay image content in AWS.
 
 |`api.openshift.com`
-|Required to check if updates are available for the cluster
+|Required to check if updates are available for the cluster.
 
 |`art-rhcos-ci.s3.amazonaws.com`
-|Required to download {op-system-first} images
+|Required to download {op-system-first} images.
 
 |`api.openshift.com`
-|Required for your cluster token
+|Required for your cluster token.
 
 |`cloud.redhat.com/openshift`
-|Required for your cluster token
+|Required for your cluster token.
 |===


### PR DESCRIPTION
Reflecting [this configuration][1], which tells the cluster-version operator to pull signatures from Google Storage and/or Red Hat's mirrors ([the search order is an internal detail][2]).

[1]: https://github.com/openshift/cluster-update-keys/blob/cca4ce696383e70ae669e770bd63265a9540b721/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml#L4-L5
[2]: https://github.com/openshift/cluster-version-operator/blob/54faf6fad0d4dfa7c2a7953076f608d018577fd1/pkg/verify/configmap.go#L33-L48