### PR TITLE
SRVKS-409 Serverless metering updates for k8s 1.16 (>=OCP4.3) metrics

### DIFF
--- a/modules/serverless-metering-datasources.adoc
+++ b/modules/serverless-metering-datasources.adoc
@@ -24,7 +24,7 @@ spec:
              label_serving_knative_dev_service,
              label_serving_knative_dev_revision)
           (
-            label_replace(rate(container_cpu_usage_seconds_total{container_name!="POD",container_name!="",pod_name!=""}[1m]), "pod", "$1", "pod_name", "(.*)")
+            label_replace(rate(container_cpu_usage_seconds_total{container!="POD",container!="",pod!=""}[1m]), "pod", "$1", "pod", "(.*)")
             *
             on(pod, namespace)
             group_left(label_serving_knative_dev_service, label_serving_knative_dev_revision)
@@ -51,7 +51,7 @@ spec:
              label_serving_knative_dev_service,
              label_serving_knative_dev_revision)
           (
-            label_replace(container_memory_usage_bytes{container_name!="POD", container_name!="",pod_name!=""}, "pod", "$1", "pod_name", "(.*)")
+            label_replace(container_memory_usage_bytes{container!="POD", container!="",pod!=""}, "pod", "$1", "pod", "(.*)")
             *
             on(pod, namespace)
             group_left(label_serving_knative_dev_service, label_serving_knative_dev_revision)


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKS-409 

The pod_name and container_name metric labels have been renamed to pod and container, respectively in k8s 1.16 (since OCP 4.3)

see also https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#removed-metrics

(This needs to also be backported to OCP 4.3 and later)