### PR TITLE
Monitoring: fix storage config info, fix namespaces

### DIFF
--- a/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
@@ -50,7 +50,8 @@ data:
     *prometheusK8s*:
       *volumeClaimTemplate:
        spec:
-         storageClassName: gluster-block
+         storageClassName: fast
+         volumeMode: filesystem
          resources:
            requests:
              storage: 40Gi*

--- a/modules/monitoring-maintenance-and-support.adoc
+++ b/modules/monitoring-maintenance-and-support.adoc
@@ -9,7 +9,7 @@ The supported way of configuring {product-title} Monitoring is by configuring it
 
 Explicitly unsupported cases include:
 
-* *Creating additional `ServiceMonitor` objects in the `openshift-monitoring` namespace.* This extends the targets the cluster monitoring Prometheus instance scrapes, which can cause collisions and load differences that cannot be accounted for. These factors might make the Prometheus setup unstable.
+* *Creating additional `ServiceMonitor` objects in the `openshift-&#42;` namespaces.* This extends the targets the cluster monitoring Prometheus instance scrapes, which can cause collisions and load differences that cannot be accounted for. These factors might make the Prometheus setup unstable.
 * *Creating unexpected `ConfigMap` objects or `PrometheusRule` objects.* This causes the cluster monitoring Prometheus instance to include additional alerting and recording rules.
 * *Modifying resources of the stack.* The Prometheus Monitoring Stack ensures its resources are always in the state it expects them to be. If they are modified, the stack will reset them.
 * *Using resources of the stack for your purposes.* The resources created by the Prometheus Cluster Monitoring stack are not meant to be used by any other resources, as there are no guarantees about their backward compatibility.


### PR DESCRIPTION
Same fix as #19354, but for 4.2 and 4.1 (#19354 cannot be cherry-picked).