### PR TITLE
Updating CNV uninstall assembly with new namespace module

### DIFF
--- a/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
+++ b/cnv/cnv_install/uninstalling-container-native-virtualization.adoc
@@ -20,4 +20,4 @@ include::modules/cnv-deleting-catalog-subscription.adoc[leveloffset=+1]
 You can now delete the `openshift-cnv` namespace.
 ====
 
-include::modules/deleting-a-project-using-the-web-console.adoc[leveloffset=+1]
+include::modules/deleting-a-namespace-using-the-web-console.adoc[leveloffset=+1]

--- a/modules/deleting-a-namespace-using-the-web-console.adoc
+++ b/modules/deleting-a-namespace-using-the-web-console.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_install/uninstalling-container-native-virtualization.adoc
+
+[id="deleting-a-namespace-using-the-web-console_{context}"]
+= Deleting a namespace using the web console
+
+You can delete a namespace by using the {product-title} web console.
+
+[NOTE]
+====
+If you do not have permissions to delete the namespace, the *Delete Namespace*
+option is not available.
+====
+
+.Procedure
+
+. Navigate to *Administration* -> *Namespaces*.
+
+. Locate the namespace that you want to delete in the list of namespaces.
+
+. On the far right side of the namespace listing, select *Delete Namespace* from the
+Options menu {kebab}.
+
+. When the *Delete Namespace* pane opens, enter the name of the namespace that
+you want to delete in the field.
+
+. Click *Delete*.

--- a/modules/deleting-a-project-using-the-web-console.adoc
+++ b/modules/deleting-a-project-using-the-web-console.adoc
@@ -1,10 +1,17 @@
 // Module included in the following assemblies:
 //
 // * applications/projects/working-with-projects.adoc
-// * cnv/cnv_install/uninstalling-container-native-virtualization.adoc
 
-[id="deleting-a-project-using-the-web-console{context}"]
+[id="deleting-a-project-using-the-web-console_{context}"]
 = Deleting a project using the web console
+
+You can delete a project by using the {product-title} web console.
+
+[NOTE]
+====
+If you do not have permissions to delete the project, the *Delete Project*
+option is not available.
+====
 
 .Procedure
 
@@ -13,5 +20,9 @@
 . Locate the project that you want to delete from the list of projects.
 
 . On the far right side of the project listing, select *Delete Project* from the
-menu. If you do not have permissions to delete the project, the *Delete Project*
-option is grayed out and the option is not clickable.
+Options menu {kebab}.
+
+. When the *Delete Project* pane opens, enter the name of the project that
+you want to delete in the field.
+
+. Click *Delete*.


### PR DESCRIPTION
@alexxa noted that the uninstall assembly incorrectly includes a module about how to delete projects instead of namespaces. No BZ. This PR adds a new module for core OCP and updates the CNV assembly.

enterprise-4.2, 4.3, and 4.4.