### PR TITLE
*: Rename bastion -> mirror host

### DIFF
--- a/installing/install_config/installing-restricted-networks-preparations.adoc
+++ b/installing/install_config/installing-restricted-networks-preparations.adoc
@@ -5,23 +5,24 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Before you install a cluster on infrastructure that you provision in a restricted network, you must create a mirror registry. Installations on a restricted network are supported on only infrastructure that you provision, not infrastructure that the installer provisions.
+Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. Installations on a restricted network are supported on only infrastructure that you provision, not infrastructure that the installer provisions.
 
 [IMPORTANT]
 ====
-You must have access to the internet to obtain the data that populates the mirror
-repository. In this procedure, you place the mirror registry on a bastion host
+You must have access to the internet to obtain the necessary container images.
+In this procedure, you place the mirror registry on a mirror host
 that has access to both your network and the internet. If you do not have access
-to a bastion host, use the method that best fits your restrictions to bring the
+to a mirror host, use the method that best fits your restrictions to bring the
 contents of the mirror registry into your restricted network.
 ====
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
 [id="installing-preparing-bastion"]
-== Preparing the bastion host
+[id="installing-preparing-mirror"]
+== Preparing the mirror host
 
-Before you create the mirror registry, you must prepare the bastion host.
+Before you create the mirror registry, you must prepare the mirror host.
 
 include::modules/cli-installing-cli.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -27,7 +27,7 @@ according to your company's policies.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the mirror host, you may use that computer
+Because the installation media is on the mirror host, you can use that computer
 to complete all installation steps.
 ====
 * Review details about the
@@ -121,7 +121,7 @@ include::modules/installation-creating-aws-worker.adoc[leveloffset=+2]
 
 include::modules/installation-cloudformation-worker.adoc[leveloffset=+3]
 
-//You may install the CLI on the mirror host.
+//You can install the CLI on the mirror host.
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -22,12 +22,12 @@ according to your company's policies.
 
 .Prerequisites
 
-* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host]
+* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your mirror host]
  and obtain the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the bastion host, use that computer
+Because the installation media is on the mirror host, you may use that computer
 to complete all installation steps.
 ====
 * Review details about the
@@ -121,7 +121,7 @@ include::modules/installation-creating-aws-worker.adoc[leveloffset=+2]
 
 include::modules/installation-cloudformation-worker.adoc[leveloffset=+3]
 
-//You install the CLI on the bastion host.
+//You may install the CLI on the mirror host.
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -19,11 +19,11 @@ before you attempt to install an {product-title} cluster in such an environment.
 
 .Prerequisites
 
-* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host] and obtain the `imageContentSources` data for your version of {product-title}.
+* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the bastion host, use that computer
+Because the installation media is on the mirror host, you may use that computer
 to complete all installation steps.
 ====
 * Provision
@@ -57,7 +57,7 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 //You extract the installation program from the mirrored content.
 
-//You install the CLI on the bastion host.
+//You may install the CLI on the mirror host.
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -23,7 +23,7 @@ before you attempt to install an {product-title} cluster in such an environment.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the mirror host, you may use that computer
+Because the installation media is on the mirror host, you can use that computer
 to complete all installation steps.
 ====
 * Provision
@@ -57,7 +57,7 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 //You extract the installation program from the mirrored content.
 
-//You may install the CLI on the mirror host.
+//You can install the CLI on the mirror host.
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -14,7 +14,7 @@ VMware vSphere infrastructure that you provision in a restricted network.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the mirror host, you may use that computer
+Because the installation media is on the mirror host, you can use that computer
 to complete all installation steps.
 ====
 * Provision
@@ -50,7 +50,7 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 //You extract the installation program from the mirrored content.
 
-//You may install the CLI on the mirror host.
+//You can install the CLI on the mirror host.
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -10,11 +10,11 @@ VMware vSphere infrastructure that you provision in a restricted network.
 
 .Prerequisites
 
-* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host] and obtain the `imageContentSources` data for your version of {product-title}.
+* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the bastion host, use that computer
+Because the installation media is on the mirror host, you may use that computer
 to complete all installation steps.
 ====
 * Provision
@@ -50,7 +50,7 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 //You extract the installation program from the mirrored content.
 
-//You install the CLI on the bastion host.
+//You may install the CLI on the mirror host.
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -24,7 +24,7 @@ access for an installation on bare metal hardware or on VMware vSphere.
 
 To complete a restricted network installation, you must create a registry that
 mirrors the contents of the {product-title} registry and contains the
-installation media. You can create this mirror on a bastion host, which can
+installation media. You can create this registry on a mirror host, which can
 access both the internet and your closed network, or by using other methods
 that meet your restrictions.
 

--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -77,9 +77,9 @@ The contents of the file resemble the following example:
   },
 ...
 ----
-<1> For `<local_registry_host_name>`, specify the registry domain name
-that you specified in your certificate, and for `<local_registry_host_port>`,
-specify the port that your mirror registry uses to serve content.
+<1> For `<mirror_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example,
+`registry.example.com` or `registry.example.com:5000`
 <2> For `<credentials>`, specify the base64-encoded user name and password for
 the mirror registry.
 +

--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -15,7 +15,7 @@ restricted network.
 
 .Procedure
 
-Complete the following steps on the bastion host:
+Complete the following steps on the mirror host:
 
 ifndef::openshift-origin[]
 . Download your `registry.redhat.io` pull secret from the
@@ -71,7 +71,7 @@ The contents of the file resemble the following example:
 ----
   "auths": {
 ...
-    "<local_registry_host_name>:<local_registry_host_port>": { <1>
+    "<mirror_registry>": { <1>
       "auth": "<credentials>", <2>
       "email": "you@example.com"
   },
@@ -81,7 +81,7 @@ The contents of the file resemble the following example:
 that you specified in your certificate, and for `<local_registry_host_port>`,
 specify the port that your mirror registry uses to serve content.
 <2> For `<credentials>`, specify the base64-encoded user name and password for
-the mirror registry that you generated.
+the mirror registry.
 +
 The file resembles the following example:
 +
@@ -100,7 +100,7 @@ The file resembles the following example:
       "auth": "NTE3Njg5Nj...",
       "email": "you@example.com"
     },
-    "<local_registry_host_name>:<local_registry_host_port>": {
+    "<mirror_registry>": {
       "auth": "<credentials>",
       "email": "you@example.com"
     },

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -43,7 +43,7 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}' <12>
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<bastion_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
+pullSecret: '{"auths":{"<mirror_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...' <13>
 ifdef::restricted[]
@@ -53,10 +53,10 @@ additionalTrustBundle: | <14>
   -----END CERTIFICATE-----
 imageContentSources: <15>
 - mirrors:
-  - <bastion_host_name>:5000/<repo_name>/release
+  - <mirror_registry>/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
-  - <bastion_host_name>:5000/<repo_name>/release
+  - <mirror_registry>/<repo_name>/release
   source: registry.svc.ci.openshift.org/ocp/release
 endif::restricted[]
 ----
@@ -112,10 +112,10 @@ provided by the included authorities, including Quay.io, which serves the
 container images for {product-title} components.
 endif::restricted[]
 ifdef::restricted[]
-<12> For `bastion_host_name`, specify the registry domain name
-that you specified in the certificate for your mirror registry, and for
-`<credentials>`, specify the base64-encoded user name and password for
-your mirror registry.
+<12> For `<mirror_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
 endif::restricted[]
 <13> The public portion of the default SSH key for the `core` user in
 {op-system-first}.

--- a/modules/installation-creating-mirror-registry.adoc
+++ b/modules/installation-creating-mirror-registry.adoc
@@ -12,9 +12,13 @@ endif::[]
 
 Create a registry to host the mirrored content that you require for installing
 {product-title}.
+
 ifdef::restricted[]
-For installation in a restricted network, you must place the mirror on your
-bastion host.
+For installation in a restricted network, you may place the mirror
+registry on a host that can be accessed from both the your network and
+the internet. If you do not have access to such a host, use the
+method that best fits your restrictions to bring the contents of the
+mirror registry into your restricted network.
 endif::restricted[]
 
 [NOTE]
@@ -36,7 +40,7 @@ as the registry host.
 .Procedure
 
 ifdef::restricted[]
-On the bastion host, take the following actions:
+On the mirror host, take the following actions:
 endif::restricted[]
 
 . Install the required packages:

--- a/modules/installation-creating-mirror-registry.adoc
+++ b/modules/installation-creating-mirror-registry.adoc
@@ -14,7 +14,7 @@ Create a registry to host the mirrored content that you require for installing
 {product-title}.
 
 ifdef::restricted[]
-For installation in a restricted network, you may place the mirror
+For installation in a restricted network, you can place the mirror
 registry on a host that can be accessed from both the your network and
 the internet. If you do not have access to such a host, use the
 method that best fits your restrictions to bring the contents of the

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -18,7 +18,7 @@ installation program needs to deploy your cluster.
 * Obtain the {product-title} installation program and the pull secret for your
 cluster.
 ifdef::restricted[]
-For a restricted network installation, these files are on your bastion host.
+For a restricted network installation, these files are on your mirror host.
 endif::restricted[]
 
 .Procedure
@@ -80,13 +80,13 @@ is required for an installation in a restricted network.
 your registry:
 +
 ----
-pullSecret: '{"auths":{"<bastion_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}'
+pullSecret: '{"auths":{"<mirror_registry>": {"auth": "<credentials>","email": "you@example.com"}}}'
 ----
 +
-For `bastion_host_name`, specify the registry domain name
-that you specified in the certificate for your mirror registry, and for
-`<credentials>`, specify the base64-encoded user name and password for
-your mirror registry.
+For `<mirror_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
 .. Add the `additionalTrustBundle` parameter and value. The value must be the contents of the certificate file that you used for your mirror registry, which can be an exiting, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
 +
 ----
@@ -100,10 +100,10 @@ additionalTrustBundle: |
 ----
 imageContentSources:
 - mirrors:
-  - <bastion_host_name>:5000/<repo_name>/release
+  - <mirror_registry>/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
-  - <bastion_host_name>:5000/<repo_name>/release
+  - <mirror_registry>/<repo_name>/release
   source: registry.svc.ci.openshift.org/ocp/release
 ----
 +

--- a/modules/installation-generate-ignition-configs.adoc
+++ b/modules/installation-generate-ignition-configs.adoc
@@ -27,7 +27,7 @@ to ensure that the first certificate rotation has finished.
 
 * Obtain the {product-title} installation program and the pull secret for your cluster.
 ifdef::restricted[]
-For a restricted network installation, these files are on your bastion host.
+For a restricted network installation, these files are on your mirror host.
 endif::restricted[]
 
 .Procedure

--- a/modules/installation-local-registry-pull-secret.adoc
+++ b/modules/installation-local-registry-pull-secret.adoc
@@ -15,7 +15,7 @@ the information for your registry.
 
 .Procedure
 
-. On the bastion host, generate the pull secret for your registry:
+. On the mirror host, generate the pull secret for your registry:
 +
 ----
 $ podman login --authfile ~/pullsecret_config.json <local_registry_host_name>:<local_registry_host_port> <1>

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 .Procedure
 
-Complete the following steps on the bastion host:
+Complete the following steps on a host that can access both quay.io and your mirror registry:
 
 . Review the
 link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -33,7 +33,7 @@ endif::[]
 
 Before you install {product-title}, download the installation file on
 ifdef::restricted[]
- the bastion host.
+the mirror host.
 endif::restricted[]
 ifndef::restricted[]
 ifdef::ibm-z[ your provisioning machine.]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -64,7 +64,7 @@ to ensure that the first certificate rotation has finished.
 
 * Obtain the {product-title} installation program.
 ifdef::restricted,baremetal-restricted[]
-For a restricted network installation, these files are on your bastion host.
+For a restricted network installation, these files are on your mirror host.
 endif::restricted,baremetal-restricted[]
 * Create the `install-config.yaml` installation configuration file.
 

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -41,7 +41,7 @@ pullSecret: '{"auths": ...}' <13>
 endif::restricted[]
 ifdef::restricted[]
 fips: false <12>
-pullSecret: '{"auths":{"<bastion_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
+pullSecret: '{"auths":{"<mirror_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...' <14>
 ifdef::restricted[]
@@ -51,10 +51,10 @@ additionalTrustBundle: | <15>
   -----END CERTIFICATE-----
 imageContentSources: <16>
 - mirrors:
-  - <bastion_host_name>:5000/<repo_name>/release
+  - <mirror_registry>/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
-  - <bastion_host_name>:5000/<repo_name>/release
+  - <mirror_registry>/<repo_name>/release
   source: registry.svc.ci.openshift.org/ocp/release
 endif::restricted[]
 ----
@@ -106,10 +106,10 @@ provided by the included authorities, including Quay.io, which serves the
 container images for {product-title} components.
 endif::restricted[]
 ifdef::restricted[]
-<13> For `bastion_host_name`, specify the registry domain name
-that you specified in the certificate for your mirror registry, and for
-`<credentials>`, specify the base64-encoded user name and password for
-your mirror registry.
+<13> For `<mirror_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
 endif::restricted[]
 <14> The public portion of the default SSH key for the `core` user in
 {op-system-first}.

--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -23,8 +23,8 @@ registry because it does not support pushing without a tag, which is required
 during the mirroring process.
 ====
 
-For this example, the procedure assumes use of the mirror registry created on
-the bastion host during a restricted network cluster installation.
+For this example, the procedure assumes use of the mirror registry
+that has access to both your network and the internet.
 
 .Prerequisites
 


### PR DESCRIPTION
This is part of decoupling our docs from the assumption that a bastion will exist.  For installation, we just care that there is a registry with the mirrored content that the cluster can pull from.  Having that
registry on a bastion makes creating the mirrored images easier, but as our existing docs hint, there are other ways you can get the mirrored images in to your mirror repository.  This commit borrows its motivation and some of its wording from @smarterclayton's [here][1].

Also push the port information into `<mirror_registry>`, because we want to make it clear that we don't require a port for these entries.  The previous content was not consistent about whether placeholder were
referenced with or without their wrapping `<>`.  In my new text, I've included the `<>` to make it more clear that they are part of the placeholder, and not literal characters that should remain after placeholder substitution.

CC @kalexand-rh.  There's a lot of duplicate-ish content in here.  Any ideas for DRYing it up?

[1]: https://github.com/openshift/openshift-docs/pull/17896#discussion_r342723419