### PR TITLE
Ensure product name is capitalized

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -44,10 +44,10 @@ openshift-online:
   site_url: https://docs.openshift.com/
   branches:
     enterprise-3.11:
-      name: 'pro'
+      name: 'Pro'
       dir: online/pro
     enterprise-4.2:
-      name: 'starter'
+      name: 'Starter'
       dir: online/starter
 openshift-enterprise:
   name: OpenShift Container Platform


### PR DESCRIPTION
@vikram-redhat, I notice the name for these shows up as _OpenShift Online <lowercase>_ in the docs but on the product page, the entire name is capitalized.

https://www.openshift.com/products/online/