### PR TITLE
Bug 1784532: Clarify FROM behavior in builds.

### DIFF
--- a/modules/builds-strategy-docker-from-image.adoc
+++ b/modules/builds-strategy-docker-from-image.adoc
@@ -5,7 +5,8 @@
 = Replacing Dockerfile FROM image
 
 You can replace the `FROM` instruction of the *_Dockerfile_* with the `from` of
-the `BuildConfig`.
+the `BuildConfig`. If the *_Dockerfile_* uses multi-stage builds, the image in
+the last `FROM` instruction will be replaced.
 
 .Procedure
 


### PR DESCRIPTION
In Docker strategy builds, the `from` field will replace the last FROM
directive in a multi-stage Dockerfile build.

Companion to https://github.com/openshift/api/pull/583