### PR TITLE
Minimize words for procedure steps

### DIFF
--- a/modules/nw-cluster-network-operator.adoc
+++ b/modules/nw-cluster-network-operator.adoc
@@ -14,7 +14,7 @@ using a DaemonSet.
 The Cluster Network Operator is deployed during installation as a Kubernetes
 `Deployment`.
 
-. Run the following command to view the Deployment status:
+. View the Deployment status:
 +
 ----
 $ oc get -n openshift-network-operator deployment/network-operator
@@ -23,7 +23,7 @@ NAME               READY   UP-TO-DATE   AVAILABLE   AGE
 network-operator   1/1     1            1           56m
 ----
 
-. Run the following command to view the state of the Cluster Network Operator:
+. View the state of the Cluster Network Operator:
 +
 ----
 $ oc get clusteroperator/network

--- a/modules/nw-cno-logs.adoc
+++ b/modules/nw-cno-logs.adoc
@@ -9,7 +9,7 @@ You can view Cluster Network Operator logs by using the `oc logs` command.
 
 .Procedure
 
-* Run the following command to view the logs of the Cluster Network Operator:
+* View the logs of the Cluster Network Operator:
 +
 ----
 $ oc logs --namespace=openshift-network-operator deployment/network-operator

--- a/modules/nw-multitenant-joining.adoc
+++ b/modules/nw-multitenant-joining.adoc
@@ -14,7 +14,7 @@ services in different projects.
 
 .Procedure
 
-. Use the following command to join projects to an existing project network:
+. Join projects to an existing project network:
 +
 ----
 $ oc adm pod-network join-projects --to=<project1> <project2> <project3>
@@ -24,8 +24,7 @@ Alternatively, instead of specifying specific project names, you can use the
 `--selector=<project_selector>` option to specify projects based upon an
 associated label.
 
-. Optional: Run the following command to view the pod networks that you have
-joined together:
+. Optional: View the pod networks that you have joined together:
 +
 ----
 $ oc get netnamespaces


### PR DESCRIPTION
- Clean up 'the following command'

@openshift/team-documentation, so this came up in a recent minimalism session. I have many other files like this, but don't want to proceed unless it actually seems logical to omit instances of this. The consensus was this text is unnecessary when introducing a command to execute.