### PR TITLE
improved docs for openshift 3.11

### DIFF
--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -48,6 +48,12 @@ $ oc whoami --token
 dIAo76N-W-GXK3S_w_KsC6DmH3MzP79zq7jbMQvCOUo
 ----
 
+For openshift version: 3.11 the command: $ oc whoami --token is not recognised, you should use:
+
+---
+$ oc whoami -t 
+---
+
 [[rest-api-serviceaccount-tokens]]
 === Service Account Tokens
 


### PR DESCRIPTION
on oc 3.11 there is no oc whoami --token command, you had to use -t