### PR TITLE
improved docs for openshift 3.11

### DIFF
--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -47,7 +47,7 @@ $ oc whoami --token
 dIAo76N-W-GXK3S_w_KsC6DmH3MzP79zq7jbMQvCOUo
 ----
 
-For openshift version: 3.11 the command: $ oc whoami --token is not recognised, you should use:
+For openshift version: 3.11 the command: $ oc whoami --token could not be recognised, you should use:
 ---
 $ oc whoami -t 
 ---

--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -47,6 +47,11 @@ $ oc whoami --token
 dIAo76N-W-GXK3S_w_KsC6DmH3MzP79zq7jbMQvCOUo
 ----
 
+For openshift version: 3.11 the command: $ oc whoami --token is not recognised, you should use:
+---
+$ oc whoami -t 
+---
+
 [[rest-api-serviceaccount-tokens]]
 === Service Account Tokens
 


### PR DESCRIPTION
on some distribution of oc 3.11 there is no oc whoami --token command, you had to use -t