### PR TITLE
Add recommendation for installing large clusters

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1049,6 +1049,8 @@ Name: Scalability and performance
 Dir: scalability_and_performance
 Distros: openshift-origin,openshift-enterprise
 Topics:
+- Name: Recommended installation practices
+  File: recommended-install-practices
 - Name: Recommended host practices
   File: recommended-host-practices
 - Name: Using the Node Tuning Operator

--- a/modules/recommended-install-practices.adoc
+++ b/modules/recommended-install-practices.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-install-practices.adoc
+
+[id="recommended-install-practices_{context}"]
+= Recommended practices for installing large scale clusters
+
+When installing large clusters or scaling the cluster to larger node counts,
+set the cluster network `cidr` accordingly in your `install-config.yaml`
+file before you install the cluster:
+
+----
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+----
+
+The default clusterNetwork cidr 10.128.0.0/14 cannot be used if the cluster size is more
+than 500 nodes. It must be set to 10.128.0.0/12 or 10.128.0.0/10 to get to larger node
+counts beyond 500 nodes. 

--- a/scalability_and_performance/recommended-install-practices.adoc
+++ b/scalability_and_performance/recommended-install-practices.adoc
@@ -1,0 +1,11 @@
+[id="recommended-cluster-install-practices"]
+= Recommended practices for installing large clusters
+include::modules/common-attributes.adoc[]
+:context: cluster-install
+
+toc::[]
+
+Apply the following practices when installing large clusters or scaling clusters
+to larger node counts.
+
+include::modules/recommended-install-practices.adoc[leveloffset=+1]


### PR DESCRIPTION
The default cluster network cidr will just allow us to get to 500 nodes,
it needs to be set accordingly in the install-config.yaml before installing
the cluster in case we want to get to larger node counts.