### PR TITLE
openshift/origin-metrics#393

### DIFF
--- a/modules/nodes-pods-viewing-usage.adoc
+++ b/modules/nodes-pods-viewing-usage.adoc
@@ -11,7 +11,7 @@ storage consumption.
 
 .Prerequisites
 
-* You must have `cluster-reader` permission to view the usage statistics.
+* You must have `cluster-admin` permission to view the usage statistics.
 
 * Metrics must be installed to view the usage statistics.
 


### PR DESCRIPTION
According to openshift/origin-metrics#393
And confirmed with a customer today (OCP 3.11.161).

`cluster-reader` is not enough, to use `oc adm top pods`
`cluster-admin` may be used.

As an alternative to `cluster-admin`, I managed to get those command to work, using the following ClusterRole:

```
apiVersion: authorization.openshift.io/v1
kind: ClusterRole
metadata:
  annotations:
    openshift.io/description: Nagios Monitoring ClusterRole
    openshift.io/reconcile-protect: "false"
  name: monit-reader
rules:
- apiGroups:
  - ""
  attributeRestrictions: null
  resources:
  - configmaps
  - endpoints
  - limitranges
  - namespaces
  - namespaces/status
  - nodes
  - nodes/status
  - persistentvolumeclaims
  - persistentvolumeclaims/status
  - persistentvolumes
  - persistentvolumes/status
  - pods
  - pods/eviction
  - pods/status
  - resourcequotas
  - resourcequotas/status
  - resourcequotausages
  - services
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  - project.openshift.io
  attributeRestrictions: null
  resources:
  - projects
  verbs:
  - list
  - watch
  - get
- apiGroups:
  - ""
  attributeRestrictions: null
  resources:
  - nodes/metrics
  - nodes/spec
  verbs:
  - get
- apiGroups:
  - ""
  attributeRestrictions: null
  resources:
  - nodes/proxy
  - nodes/stats
  - services/proxy
  verbs:
  - create
  - get

```

Note: the above includes all the permissions I need to run some Nagios checks against OpenShift API: it goes beyond querying Hawkular metrics. While more restrictive than `cluster-reader` or `cluster-admin`.