### PR TITLE
Add info about machine delete policies

### DIFF
--- a/modules/machineset-manually-scaling.adoc
+++ b/modules/machineset-manually-scaling.adoc
@@ -36,7 +36,26 @@ $ oc edit machineset <machineset> -n openshift-machine-api
 You can scale the MachineSet up or down. It takes several minutes for the new
 machines to be available.
 +
+
+= The MachineSet delete policy
+`Random`, `Newest`, and `Oldest` are the three supported options. The default is `Random`, meaning  that random machines are chosen and deleted when scaling MachineSets down. The delete policy can be set according to the use case by modifying the particular MachineSet:
+
+----
+
+spec:
+  deletePolicy: <delete policy>
+  replicas: <desired replica count>
+
+----
+
+Specific machines can also be priortized for deletion by adding the annotation `machine.openshift.io/cluster-api-delete-machine` to the machine of interest, regardless of the delete policy.
+
 [IMPORTANT]
 ====
 By default, the {product-title} router pods are deployed on workers. Because the router is required to access some cluster resources, including the web console, do not scale the worker MachineSet to `0` unless you first relocate the router pods.
+====
+
+[NOTE]
+====
+Custom MachineSets can be used for use cases requiring that services run on specific nodes and that those services are ignored by the controller when the worker MachineSets are scaling down. This prevents service disruption.
 ====


### PR DESCRIPTION
This commit:
- Adds information about the available machineset delete
policies which are Random, Newest and Oldest as well the default
policy used i.e Random. The priority of the machines to be deleted
can also be set by adding the machine.openshift.io/cluster-api-delete-machine
annotation to the machines.
- Adds information about using custom/pet machinesets for use cases which
needs the services to run on particular nodes and would want the controller
to ignore them during scale down.
