### PR TITLE
Add recommendation to enable machine health checks

### DIFF
--- a/modules/recommended-scale-practices.adoc
+++ b/modules/recommended-scale-practices.adoc
@@ -26,3 +26,6 @@ handle impacts the process. The controller will start to query more while trying
 to create, check, and update the machines with the status. The cloud platform on
 which {product-title} is deployed has API request limits and excessive queries
 might lead to machine creation failures due to cloud platform limitations.
+
+Enable machine health checks when scaling to large node counts. In case of failures, 
+the health checks monitor the condition and automatically repair unhealthy machines.

--- a/scalability_and_performance/recommended-cluster-scaling-practices.adoc
+++ b/scalability_and_performance/recommended-cluster-scaling-practices.adoc
@@ -10,4 +10,11 @@ your {product-title} cluster. You scale the worker machines by increasing or
 decreasing the number of replicas that are defined in the worker MachineSet.
 
 include::modules/recommended-scale-practices.adoc[leveloffset=+1]
+
 include::modules/machineset-modifying.adoc[leveloffset=+1]
+
+include::modules/machine-health-checks-about.adoc[leveloffset=+1]
+
+include::modules/machine-health-checks-resource.adoc[leveloffset=+1]
+
+include::modules/machine-health-checks-creating.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit adds a recommendation in scalability and performance
guide to enable machine health checks at large node counts to repair
the unhealthy machines automatically instead of manually deleting
them in case of failures.