### PR TITLE
Could not forward logs to rsyslog server

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1034,9 +1034,9 @@ Topics:
     File: cluster-logging-collector
   - Name: Using tolerations to control cluster logging pod placement
     File: cluster-logging-tolerations
-  - Name: Forwarding cluster logs to specific endpoints
+  - Name: Forwarding cluster logs using Log Forwarding
     File: cluster-logging-log-forwarding
-  - Name: Sending logs to external devices using Fluentd plug-ins
+  - Name: Fowarding cluster logs using Fluentd plug-ins
     File: cluster-logging-external
   - Name: Configuring systemd-journald for cluster logging
     File: cluster-logging-systemd

--- a/logging/config/cluster-logging-external.adoc
+++ b/logging/config/cluster-logging-external.adoc
@@ -1,19 +1,21 @@
 :context: cluster-logging-external
 [id="cluster-logging-external"]
-= Sending logs to external devices using Fluentd Forward plug-ins
+= Fowarding cluster logs using Fluentd plug-ins
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} cluster logging allows you to configure the Fluentd *out_forward* plug-in to send logs to external devices. 
+{product-title} cluster logging allows you to send logs to destinations outside of your {product-title} cluster instead of the default Elasticsearch instance.
 
-You can use the xref:../../logging/config/cluster-logging-log-forwarding.adoc#cluster-logging-log-forwarding[log forwarding feature], which can be easier to configure than the plugins. Note that the log forwarding feature is currently in Technology Preview.
+* *Sending logs using Fluentd*. You can use the Fluentd *out_forward* plug-in to securely send logs to another logging collector using the Fluent forward protocol. 
+
+* *Sending logs using syslog*. You can use the Fluentd *syslog* plug-in to send logs to another logging collector using the syslog protocol (RFC 3164). Many logging collectors such as Fluentd, Rsyslog, and others support this protocol.
+
+You can use the xref:../../logging/config/cluster-logging-log-forwarding.adoc#cluster-logging-log-forwarding[log forwarding feature], which can be easier to configure than the plug-ins. The log forwarding feature is currently in Technology Preview.
 
 [IMPORTANT]
 ====
-Changes introduced by the new log forward feature modified the support for *out_forward* starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap to configure *out_forward*, as described below, instead of editing the `secure-forward.conf` section in the `fluentd` ConfigMap. You can add any certificates required by your external devices to a secret, called `secure-forward`, which is mounted to the Fluentd Pods.
-
-When you update to {product-title} 4.3, any existing modifications to the `secure-forward.conf` section of the `fluentd` ConfigMap are removed. You can copy your current `secure-forward.conf` section before updating to use when creating the `secure-forward` ConfigMap. 
+Changes that are introduced by the new log forwarding feature modified the support for the Fluentd *syslog* plug-in starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap, as described below, to configure a Fluentd plug-in. 
 ==== 
 
 // The following include statements pull in the module files that comprise
@@ -21,5 +23,6 @@ When you update to {product-title} 4.3, any existing modifications to the `secur
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/cluster-logging-collector-external.adoc[leveloffset=+1]
+include::modules/cluster-logging-collector-fluentd.adoc[leveloffset=+1]
+include::modules/cluster-logging-collector-syslog.adoc[leveloffset=+1]
 

--- a/logging/config/cluster-logging-log-forwarding.adoc
+++ b/logging/config/cluster-logging-log-forwarding.adoc
@@ -1,6 +1,6 @@
 :context: cluster-logging-log-forwarding
 [id="cluster-logging-log-forwarding"]
-= Forwarding cluster logs to specific endpoints
+= Forwarding cluster logs using Log Forwarding
 include::modules/common-attributes.adoc[]
 
 toc::[]

--- a/modules/cluster-logging-collector-fluentd.adoc
+++ b/modules/cluster-logging-collector-fluentd.adoc
@@ -2,13 +2,10 @@
 //
 // * logging/cluster-logging-external.adoc
 
-[id="cluster-logging-collector-external_{context}"]
-= Configuring the Fluentd out_forward plug-in to send logs to an external log aggregator
+[id="cluster-logging-collector-fluentd_{context}"]
+= Configuring the Fluentd forward plug-ins to send logs to an external log aggregator
 
-You can configure Fluentd to send a copy of its logs to an external log
-aggregator instead of the default Elasticsearch instance using the Fluentd *forward*
-plug-in. From there, you can further process log records after the locally
-hosted Fluentd has processed them. 
+You can use the Fluentd *forward* plug-ins to send a copy of your logs to an external log aggregator, instead of the default Elasticsearch.
 
 [NOTE]
 ====
@@ -19,26 +16,25 @@ In this documentation, the {product-title} cluster is called the _sender_ and th
 
 [NOTE]
 ====
-This legacy *out_forward* method is deprecated and will be removed in a future release.
+This legacy out_forward method is deprecated and will be removed in a future release.
 ====
 
 ifdef::openshift-origin[]
-The *forward* plug-ins are provided with the Fluentd image as of v1.4.0.
-The *out_forward* plug-in implements the client side (sender) and the *in_forward* plug-in implements the server side (receiver).
+The forward plug-ins are provided with the Fluentd image as of v1.4.0.
+The in_forward plug-in implements the server side (receiver), and out_forward implements the client side (sender).
 endif::openshift-origin[]
 
 ifdef::openshift-enterprise,openshift-webscale[]
-The *forward* plug-ins are supported by Fluentd only.
-The *out_forward* plug-in implements the client side (sender) and the *in_forward* plug-in implements the server side (receiver)
+The forward plug-ins are supported by Fluentd only.
+The in_forward plug-in implements the server side (receiver), and out_forward implements the client side (sender).
 endif::openshift-enterprise,openshift-webscale[]
 
-To configure {product-title} to send logs using *out_forward*, create a ConfigMap called `secure-forward` in the `openshift-logging` namespace that points to a receiver. 
-On the receiver, configure the *in_forward* plug-in to receive the logs from {product-title}. For more information on using the *in_forward* plug-in, see the link:https://docs.fluentd.org/input/forward[Fluentd documentation].
-
+To configure {product-title} to send logs using out_forward, create a ConfigMap called `secure-forward` in the `openshift-logging` namespace that points to a receiver. 
+On the receiver, configure the in_forward plug-in to receive the logs from {product-title}. For more information on using the in_forward plug-in, see the link:https://docs.fluentd.org/input/forward[Fluentd documentation].
 
 [IMPORTANT]
 ====
-Changes introduced by the new log forward feature modified the support for *out_forward* starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap, as described below, to configure out_forward. Any updates to the `secure-forward.conf` section of the Fluentd ConfigMap are removed. Before upgrading cluster logging, you can copy your current `secure-forward.conf` section and use the copied data when you create the `secure-forward` ConfigMap. 
+Changes introduced by the new log forward feature modified the support for out_forward starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap, as described below, to configure out_forward. 
 
 Additionally, you can add any certificates required by your configuration to a secret named `secure-forward` that will be mounted to the Fluentd Pods.
 ====
@@ -125,9 +121,9 @@ metadata:
 
 .Procedure
 
-To configure the *out_forward* plug-in:
+To configure the out_forward plug-in:
 
-. Create a configuration file named `secure-forward.conf` for the *out_forward* parameters: 
+. Create a configuration file named `secure-forward.conf` for the out_forward parameters: 
 +
 .. Configure the secrets and TLS information:
 +
@@ -220,8 +216,8 @@ $ oc delete pod --selector logging-infra=fluentd
 
 . Configure the `secure-forward.conf` file on the receiver to accept messages securely from {product-title}.
 +
-When configuring the recevier, it must be able to accept messages securely from {product-title}.
+When configuring the receiver, it must be able to accept messages securely from {product-title}.
 
-You can find further explanation of link:https://docs.fluentd.org/v1.0/articles/in_forward[how to set up the *in_forward* plug-in] and link:https://docs.fluentd.org/v1.0/articles/out_forward[the *out_forward* plug-in].
+You can find further explanation of link:https://docs.fluentd.org/v1.0/articles/in_forward[how to set up the in_forward plug-in] and link:https://docs.fluentd.org/v1.0/articles/out_forward[the out_forward plug-in].
 
 

--- a/modules/cluster-logging-collector-syslog.adoc
+++ b/modules/cluster-logging-collector-syslog.adoc
@@ -1,0 +1,179 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-external.adoc
+
+[id="cluster-logging-collector-syslog_{context}"]
+= Sending logs using the Fluentd syslog plug-in (RFC 3164)
+
+You can use the Fluentd *syslog* plug-in to send a copy of your logs to an external syslog server, 
+not the default Elasticsearch. Note the following about the syslog plug-in:
+
+* uses syslog protocol (RFC 3164), not RFC 5424
+* does not support TLS and thus, is not secure
+* does not provide Kubernetes metadata, systemd data, or other metadata
+
+[NOTE]
+====
+The Fluentd syslog plug-in method is deprecated and will be removed in a future release.
+====
+
+There are two versions of the Fluentd syslog plug-in:
+
+* *out_syslog*: The non-buffered implementation, which communicates through UDP, does not buffer data and writes out results immediately. 
+* *out_syslog_buffered*: The buffered implementation, which communicates through TCP, link:https://docs.fluentd.org/buffer[buffers data into chunks]. 
+
+To configure the Fluentd syslog plug-in, create a configuration file, called `sysconfig.conf`, with the information needed to forward the logs. Then use that file to create a ConfigMap called `syslog` in the `openshift-logging` namespace, which {product-title} uses when forwarding the logs. On the receiver, configure the *in_syslog* plug-in to receive the logs from {product-title}. For more information on using the *in_forward* plug-in, see the link:https://docs.fluentd.org/input/syslog[Fluentd documentation].
+
+[IMPORTANT]
+====
+Changes introduced by the new log forward feature modified the support for Fluentd syslog plug-in starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap, as described below, to configure the Fluentd syslog plug-in. 
+====
+
+You can use multiple syslog servers by specifying separate `<store>` stanzas in the configuration file.
+
+.Sample `sysconfig.conf`
+----
+<store>
+@type syslog_buffered <1>
+remote_syslog rsyslogserver.openshift-logging.svc.cluster.local <2>
+port 514 <3>
+hostname fluentd-4nzfz <4>
+remove_tag_prefix tag <5>
+tag_key ident,systemd.u.SYSLOG_IDENTIFIER <6>
+facility local0 <7>
+severity info <8>
+use_record true <9>
+payload_key message <10>
+</store>
+----
+
+<1> The Fluentd syslog plug-in.
+<2> The fully qualified domain name (FQDN) or IP address of the syslog server.
+<3> The port number to connect on. Defaults to `514`.
+<4> The name of the syslog server.
+<5> Removes the prefix from the tag. Defaults to `''` (empty).
+<6> The field to set the syslog key.
+<7> The syslog log facility or source.
+<8> The syslog log severity.
+<9> Determines whether to use the severity and facility from the record if available.
+<10> The key to set the payload of the syslog message. Defaults to `message`.
+
+
+// Above definitions from https://github.com/docebo/fluent-plugin-remote-syslog
+
+
+.Sample `syslog` ConfigMap based on the sample `sysconfig.conf`
+
+[source,yaml]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: syslog
+  namespace: openshift-logging
+data:
+  sysconfig.conf: |
+    <store>
+     @type syslog_buffered
+     remote_syslog syslogserver.openshift-logging.svc.cluster.local
+     port 514
+     hostname fluentd-4nzfz
+     remove_tag_prefix tag
+     tag_key ident,systemd.u.SYSLOG_IDENTIFIER
+     facility local0
+     severity info
+     use_record true
+     payload_key message
+    </store> 
+----
+
+.Procedure
+
+To configure the Fluentd syslog plug-in:
+
+. Create a configuration file named `sysconfig.conf` that contains the following
+parameters within the `<store>` stanza: 
+
+.. Specify the Fluentd syslog plug-in type:
++
+----
+@type syslog_buffered <1>
+----
++
+<1> Specify the plug-in to use, either: `syslog` or `syslog_buffered`. 
+
+.. Configure the name, host, and port for your external syslog server:
++
+----
+remote_syslog <remote> <1>
+port <number> <2>
+hostname <name> <3>
+----
++
+<1> Specify the FQDN or IP address of the syslog server.
+<2> Specify the port of the syslog server.
+<3> Specify a name for this syslog server.
++
+For example:
++
+----
+remote_syslog syslogserver.openshift-logging.svc.cluster.local
+port 514
+hostname fluentd-server	
+----
++
+If you specify two or more receivers, the Fluentd syslog plug-in uses these servers in a round-robin order.
+
+.. Configure the other syslog variables as needed:
++
+----
+remove_tag_prefix <1>
+tag_key <key> <2>
+facility <value>  <3>
+severity <value>  <4>
+use_record <value> <5>
+payload_key message <6>
+----
++
+<1> Add this parameter to remove the `tag` field from the syslog prefix.
+<2> Specify the field to set the syslog key.
+<3> Specify the syslog log facility or source. For values, see link:https://tools.ietf.org/html/rfc3164#section-4.1.1[RTF 3164].
+<4> Specify the syslog log severity. For values, see link:link:https://tools.ietf.org/html/rfc3164#section-4.1.1[RTF 3164]. 
+<5> Specify `true` to use the severity and facility from the record if available. If `true`, the `container_name`, `namespace_name`, and `pod_name` are included in the output content.
+<6> Specify the key to set the payload of the syslog message. Defaults to `message`.
++
+For example:
++
+----
+facility local0
+severity info
+----
++
+The configuration file appears similar to the following:
++
+----
+<store>
+@type syslog_buffered
+remote_syslog syslogserver.openshift-logging.svc.cluster.local
+port 514
+hostname fluentd-4nzfz
+tag_key ident,systemd.u.SYSLOG_IDENTIFIER
+facility local0
+severity info
+use_record false
+</store>
+----
+
+. Create a ConfigMap named `syslog` in the `openshift-logging` namespace from the configuration file:
++
+----
+$ oc create configmap syslog --from-file=sysconfig.conf -n openshift-logging
+----
++
+The Cluster Logging Operator redeploys the Fluentd Pods. If the Pods do not redeploy, you can delete the Fluentd 
+Pods to force them to redeploy.
++
+----
+$ oc delete pod --selector logging-infra=fluentd
+----
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-915

Depends on https://github.com/openshift/cluster-logging-operator/pull/359 merging and https://bugzilla.redhat.com/show_bug.cgi?id=1799024 being fixed. 
Also, 1799024 cloned to https://bugzilla.redhat.com/show_bug.cgi?id=1812918

Will be back-ported to 4.3