### PR TITLE
Update podman command for CAM 1.1 (OSP 3.x)

### DIFF
--- a/modules/migration-installing-cam-operator-ocp-3.adoc
+++ b/modules/migration-installing-cam-operator-ocp-3.adoc
@@ -34,13 +34,13 @@ $ sudo podman login registry.redhat.io
 . Download the `operator.yml` file:
 +
 ----
-$ sudo podman cp $(podman create registry.redhat.io/rhcam-1-0/openshift-migration-rhel7-operator:v1.0 ):/operator.yml ./
+$ sudo podman cp $(sudo podman create registry.redhat.io/rhcam-1-1/openshift-migration-rhel7-operator:v1.1):/operator.yml ./
 ----
 
 . Download the `controller-3.yml` file:
 +
 ----
-$ sudo podman cp $(podman create registry.redhat.io/rhcam-1-0/openshift-migration-rhel7-operator:v1.0 ):/controller-3.yml ./
+$ sudo podman cp $(sudo podman create registry.redhat.io/rhcam-1-1/openshift-migration-rhel7-operator:v1.1 ):/controller-3.yml ./
 ----
 
 . Create the CAM Operator CR object:


### PR DESCRIPTION
Updated Podman command for CAM 1.1. To be cherrypicked for 4.2 and 4.3.