### PR TITLE
WIP: OKD is now in Preview mode

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -6,9 +6,11 @@ openshift-origin:
   site_name: Documentation
   site_url: https://docs.okd.io/
   branches:
-    master-3:
-      name: Latest
+    master:
+      name: Preview
       dir: latest
+      distro-overrides:
+        name: OKD4
     enterprise-3.2:
       name: '1.2'
       dir: '1.2'

--- a/contributing_to_docs/contributing.adoc
+++ b/contributing_to_docs/contributing.adoc
@@ -130,8 +130,7 @@ are released, the `master` branch is merged down to new or existing release
 branches. Here is the general naming scheme used in the branches:
 
 * `master` - This is our *working* branch.
-* `master-3` - OKD latest code; essentially, this is our *working*
-branch for the 3.x stream.
+* `master-3` - *working* branch for the 3.x stream.
 * `enterprise-N.N` - OpenShift Container Platform support releases. The docs
 for OpenShift Online and OpenShift Dedicated are based on the appropriate
 `enterprise-N.N` branch.

--- a/index-community.html
+++ b/index-community.html
@@ -49,7 +49,7 @@
            <div class="btn-group">
              <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
              <ul class="dropdown-menu" role="menu">
-               <li><a href="latest/"><i class="fa fa-arrow-circle-o-right"></i> OKD Latest</a></li>
+               <li><a href="latest/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4 Preview</a></li>
                <li><a href="3.11/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.11</a></li>
                <li><a href="3.10/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.10</a></li>
                <li><a href="3.9/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.9</a></li>


### PR DESCRIPTION

This updates OKD docs link to point to latest master.

OKD4 in Preview mode thus distro-override is set to indicate the difference and release name is set to "Preview". Once all changes are merged the override and release name would be removed