### PR TITLE
107 cleanup items

### DIFF
--- a/modules/ossm-configuring-jaeger.adoc
+++ b/modules/ossm-configuring-jaeger.adoc
@@ -159,7 +159,7 @@ Minimum deployment = 16Gi*
 
 . Log in to the {product-title} web console as a user with the `cluster-admin` role.
 
-. Navigate to *Catalogs* -> *Installed Operators*.
+. Navigate to *Operators* -> *Installed Operators*.
 
 . Click the {ProductName} Operator.
 

--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -38,7 +38,7 @@ Follow this procedure to deploy the {ProductName} control plane by using the web
 
 .. Click *Create*.
 
-. Navigate to *Catalogs* -> *Installed Operators*.
+. Navigate to *Operators* -> *Installed Operators*.
 
 . If necessary, select `istio-system` from the Project menu.  You may have to wait a few moments for the Operators to be copied to the new project.
 

--- a/modules/ossm-control-plane-remove.adoc
+++ b/modules/ossm-control-plane-remove.adoc
@@ -23,7 +23,7 @@ Follow this procedure to remove the {ProductName} control plane by using the web
 
 . Click the *Project* menu and choose the `istio-system` project from the list.
 
-. Navigate to *Catalogs* -> *Installed Operators*.
+. Navigate to *Operators* -> *Installed Operators*.
 
 . Click on *Service Mesh Control Plane* under *Provided APIs*.
 

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -11,7 +11,7 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 1.0.5
+:ProductVersion: 1.0.7
 :product-build:
 :DownloadURL: registry.redhat.io
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/ossm-member-roll-create.adoc
+++ b/modules/ossm-member-roll-create.adoc
@@ -29,7 +29,7 @@ Follow this procedure to add one or more projects to the {ProductShortName} memb
 
 . Log in to the {product-title} web console.
 
-. Navigate to *Catalogs* -> *Installed Operators*.
+. Navigate to *Operators* -> *Installed Operators*.
 
 . Click the *Project* menu and choose the project where your `ServiceMeshControlPlane` is deployed from the list, for example `istio-system`.
 

--- a/modules/ossm-member-roll-modify.adoc
+++ b/modules/ossm-member-roll-modify.adoc
@@ -24,7 +24,7 @@ Follow this procedure to modify an existing {ProductShortName} `ServiceMeshMembe
 
 . Log in to the {product-title} web console.
 
-. Navigate to *Catalogs* -> *Installed Operators*.
+. Navigate to *Operators* -> *Installed Operators*.
 
 . Click the *Project* menu and choose the project where your `ServiceMeshControlPlane` is deployed from the list, for example `istio-system`.
 

--- a/service_mesh/service_mesh_install/updating-ossm.adoc
+++ b/service_mesh/service_mesh_install/updating-ossm.adoc
@@ -1,45 +1,12 @@
 [id="updating-ossm"]
-= Updating {ProductName} from version 1.0.1 to 1.0.2
+= Upgrading {ProductName}
 include::modules/ossm-document-attributes.adoc[]
 :context: installing-ossm
 toc::[]
 
-Updating {ProductName} requires extra steps before you update {product-title} to version 4.2. 
-You must upgrade {ProductName} to 1.0.2 before upgrading {product-title} 4.1.x to 4.2.
+If you selected the automatic update stream, updating {ProductName} doesn't require any extra steps. 
 
-.Prerequisites
+If you choose to update manually, the Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. OLM runs by default in {product-title}.
+OLM uses CatalogSources, which use the Operator Registry API, to query for available Operators as well as upgrades for installed Operators.
 
-* {ProductName} version 1.0.1
-* {product-title} version 4.1
-
-.Procedure
-
-. Configure existing SMCP resource requests by running the following `oc patch` command. Replace
-the <smcp_namespace> and <smcp_name> with your specific names:
-+
-----
-$ oc patch -n <smcp_namespace> smcp <smcp_name> \// <1>
-    --type=merge -p \
-    '{"spec": {"istio": {"global": {"defaultResources": {"requests": {"cpu": "10m","memory": "128Mi"},"limits":{}},"proxy": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"},"limits":{}}},"defaultPodDisruptionBudget": {"enabled": false}},"security": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}},"galley": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}},"pilot": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}},"mixer": {"telemetry": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}}},"gateways": {"istio-egressgateway": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}},"istio-ingressgateway": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}}},"prometheus": {"resources": {"requests": {"cpu": "10m","memory": "128Mi"}}}}}}'
-----
-<1> For example, `basic-install`.
-+
-After running this command, wait until all SMCP Pods are replaced in the SMCP namespace.
-+
-. After the Pods are running in the SMCP namespace, redeploy your Data Plane applications, such as `bookinfo`.  
-+
-. Log in as a `cluster-admin` user such as `kubeadmin`, and then run the following command to delete the CNI `istio-node` DaemonSet.  
-Replace `openshift-operators` if your {ProductName} Operator was not installed in the default `openshift-operators` namespace:
-+
-----
-$ oc delete -n openshift-operators daemonset istio-node
-----
-+
-. Upgrade {ProductName} Operator and SMCP to 1.0.2. After all Pods are running in the SMCP namespace, patch Data Plane applications by running the following command for each deployment:
-+
-----
-$ oc patch -n <data_plane_namespace> deployment/<deployment_name> -p \
-    '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt": "'`date -Iseconds`'"}}}}}'
-----
-+
-. Upgrade {product-title} using the {product-title} web console.
+* For more information about how {product-title} handled upgrades, refer to the xref:../../operators/understanding-olm/olm-understanding-olm.adoc#olm-overview_olm-understanding-olm[Operator Lifecycle Manager] documentation.


### PR DESCRIPTION
This PR addresses several 4.3 only issues. It should only be cherrypicked to the enterprise-4.3. 

It addresses three issues:
1. Updates OSSM version variable to 107
2. Removes a topic that was written for a specific OCP 4.1 to 4.2 and earlier version OSSM update scenario that is no longer relevant.
3. Updates some UI text for OCP 4.3.

Made an issue to track this work.
https://issues.redhat.com/projects/OSSMDOC/issues/OSSMDOC-45