### PR TITLE
OSDOCS-844: Create CSI volume snapshots assembly draft

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -510,6 +510,8 @@ Topics:
     File: persistent-storage-csi
   - Name: Persistent storage using CSI volume cloning
     File: persistent-storage-csi-cloning
+  - Name: Persistent storage using CSI volume snapshots
+    File: persistent-storage-csi-snapshots
   - Name: Persistent storage using Fibre Channel
     File: persistent-storage-fibre
   - Name: Persistent storage using FlexVolume

--- a/modules/persistent-storage-csi-snapshots-controller-sidecar.adoc
+++ b/modules/persistent-storage-csi-snapshots-controller-sidecar.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-controller-sidecar_{context}"]
+= CSI snapshot controller and sidecar
+
+{product-title} provides a snapshot controller that is deployed into the control plane. In addition, your CSI driver vendor provides the CSI snapshot sidecar as a helper container that is installed during the CSI driver installation.
+
+The CSI snapshot controller and sidecar provide volume snapshotting through the {product-title} API. These external components run in the cluster.
+
+The external controller is deployed by the CSI Snapshot Controller Operator.
+
+== External controller
+The CSI snapshot controller binds VolumeSnapshot and VolumeSnapshotContent objects. The controller manages dynamic provisioning by creating and deleting VolumeSnapshotContent objects.
+
+== External sidecar
+Your CSI driver vendor provides the `csi-external-snapshotter` sidecar. This is a separate helper container that is deployed with the CSI driver. The sidecar manages snapshots by triggering CreateSnapshot and DeleteSnapshot operations. Follow the installation instructions provided by your vendor.

--- a/modules/persistent-storage-csi-snapshots-create.adoc
+++ b/modules/persistent-storage-csi-snapshots-create.adoc
@@ -1,0 +1,141 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-csi-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-create_{context}"]
+= Creating a volume snapshot
+
+When you create a VolumeSnapshot object, {product-title} creates a volume snapshot.
+
+.Prerequisites
+* Logged in to a running {product-title} cluster.
+* A PVC created using a CSI driver that supports VolumeSnapshot objects.
+* A storage class to provision the storage backend.
+
+.Procedure
+
+To dynamically create a volume snapshot:
+
+. Create a file with the VolumeSnapshotClass object described by the following YAML:
+
++
+.volumesnapshotclass.yaml
+[source,yaml]
+----
+apiVersion: snapshot.storage.k8s.io
+kind: VolumeSnapshotClass <1>
+metadata:
+  name: csi-hostpath-snap
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true" <2>
+driver: hostpath.csi.k8s.io
+deletionPolicy: Delete
+----
+<1> Allows you to specify different attributes belonging to a VolumeSnapshot.
+<2> Optional. This annotation can be used to create a default VolumeSnapshotClass. This object will be used when VolumeSnapshot does not specify any explicit volumeSnapshotClassName.
+
++
+. Create the object you saved in the previous step by running the following command:
++
+----
+$ oc create -f volumesnapshotclass.yaml
+----
+
+. Create a VolumeSnapshot object:
+
++
+.volumesnapshot-dynamic.yaml
+[source,yaml]
+----
+apiVersion: snapshot.storage.k8s.io
+kind: VolumeSnapshot
+metadata:
+  name: mysnap
+spec:
+  volumeSnapshotClassName: csi-hostpath-snap <1>
+  source:
+    persistentVolumeClaimName: myclaim <2>
+----
+
+<1> The request for a particular class by the volume snapshot. If the parameter is not specified, the default class is used.
++
+[NOTE]
+====
+If no default class is set and `volumeSnapshotClassName` is empty, then no snapshot is created.
+====
++
+<2> The name of the PersistentVolumeClaim object bound to a persistent volume. This defines what you want to create a snapshot of. Required for dynamically provisioning a snapshot.
+
++
+. Create the object you saved in the previous step:
++
+----
+$ oc create -f volumesnapshot.yaml
+----
+
+
+To manually provision a snapshot:
+
+. Provide a value for the volumeSnapshotContentName parameter as the source for the snapshot, in addition to defining volume snapshot class as shown above.
++
+.volumesnapshot-manual.yaml
+[source,yaml]
+----
+apiVersion: snapshot.storage.k8s.io
+kind: VolumeSnapshot
+metadata:
+  name: snapshot-demo
+spec:
+  source:
+    volumeSnapshotContentName: mycontent <1>
+----
+<1> The volumeSnapshotContentName parameter is required for pre-provisioned snapshots.
+
+. Create the object you saved in the previous step:
++
+----
+$ oc create -f volumesnapshot.yaml
+----
+
+After the snapshot has been created in the cluster, additional details about the snapshot are available.
+
+. Display details about the volume snapshot that was created by running the following command:
++
+----
+$ oc describe volumesnapshot mysnap
+----
+
+The following example displays details about the `mysnap` volume snapshot:
+
+.volumesnapshot.yaml
+[source,yaml]
+----
+apiVersion: snapshot.storage.k8s.io
+kind: VolumeSnapshot
+metadata:
+  name: mysnap
+spec:
+  source:
+    persistentVolumeClaimName: myclaim
+  volumeSnapshotClassName: csi-hostpath-snap
+status:
+  boundVolumeSnapshotContentName: snapcontent-1af4989e-a365-4286-96f8-d5dcd65d78d6 <1>
+  creationTime: "2020-01-29T12:24:30Z" <2>
+  readyToUse: true <3>
+  restoreSize: 500Mi
+----
+<1> The pointer to the actual storage content that was created by the controller.
+<2> The time when the snapshot was created. The snapshot contains the volume content that was available at this indicated time.
+<3> If the value is set to `true`, the snapshot can be used to restore as a new PVC.
+  +
+If the value is set to `false`, the snapshot was created. However, the storage backend needs to perform additional tasks to make the snapshot usable so that it can be restored as a new volume. For example, Amazon Elastic Block Store data might be moved to a different, less expensive location, which can take several minutes.
+
+To verify that the volume snapshot was created automatically, run the following command:
+
+----
+$ oc get volumesnapshotcontent
+----
+
+The pointer to the actual content is displayed. When the `boundVolumeSnapshotContentName` field is populated, it means that there is a corresponding VolumeSnapshotContent.
+
+To verify that the snapshot is ready, confirm that the VolumeSnapshot has `readyToUse: true`.

--- a/modules/persistent-storage-csi-snapshots-delete.adoc
+++ b/modules/persistent-storage-csi-snapshots-delete.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-csi-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-delete_{context}"]
+= Deleting a volume snapshot
+
+You can configure how {product-title} deletes volume snapshots.
+
+.Procedure
+
+To enable deletion of a volume snapshot in a cluster:
+
+. Specify the deletion policy that you require in the VolumeSnapshotClass object, as shown in the following example:
+
++
+.volumesnapshot.yaml
+[source,yaml]
+----
+apiVersion: snapshot.storage.k8s.io
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-hostpath-snap
+driver: hostpath.csi.k8s.io
+deletionPolicy: Delete <1>
+----
+<1> If the `Delete` value is set, the underlying snapshot will be deleted, along with the VolumeSnapshotContent object. If the `Retain` value is set, both the underlying snapshot and VolumeSnapshotContent remain.
+  +
+If the `Retain` value is set, and the VolumeSnapshot object is deleted without deleting the corresponding VolumeSnapshotContent, then the content will remain. The snapshot itself is also retained in the storage backend.

--- a/modules/persistent-storage-csi-snapshots-operator.adoc
+++ b/modules/persistent-storage-csi-snapshots-operator.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent-storage/persistent-storage-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-operator_{context}"]
+= About the CSI Snapshot Controller Operator
+
+The CSI Snapshot Controller Operator runs in the `cluster-csi-snapshot-controller-operator` namespace. It is installed by the Cluster Version Operator (CVO) in all clusters by default.
+
+The CSI Snapshot Controller Operator installs the CSI snapshot controller, which runs in the `csi-snapshot-controller` namespace.
+
+== VolumeSnapshot CRDs
+
+During {product-title} installation, the CSI Snapshot Controller Operator creates the following snapshot Custom Resource Definitions (CRDs) in the `snapshot.storage.k8s.io/` API group:
+
+VolumeSnapshotContent::
+A snapshot taken of a volume in the cluster that has been provisioned by a cluster administrator.
++
+Similar to the PersistentVolume CRD, the VolumeSnapshotContent CRD is a cluster resource that points to a real snapshot in the storage backend.
++
+For manually pre-provisioned snapshots, a cluster administrator creates a number of VolumeSnapshotContent objects. These carry the details of the real volume snapshot in the storage system.
++
+The VolumeSnapshotContent CRD is not namespaced and is for use by a cluster administrator.
+
+VolumeSnapshot::
+
+Similar to the PersistentVolumeClaim CRD, the VolumeSnapshot CRD defines a developer request for a snapshot. The CSI snapshot controller handles the binding of a VolumeSnapshot object with an appropriate VolumeSnapshotContent object. The binding is a one-to-one mapping.
++
+The VolumeSnapshot CRD is namespaced. A developer uses the CRD as a distinct request for a snapshot.
+
+VolumeSnapshotClass::
+
+Allows a cluster administrator to specify different attributes belonging to a VolumeSnapshot object. These attributes may differ among snapshots taken of the same volume on the storage system, in which case they would not be expressed by using the same StorageClass of a PersistentVolumeClaim.
++
+The VolumeSnapshotClass CRD defines the parameters for the `csi-external-snapshotter` sidecar to use when creating a snapshot. This allows the storage backend to know what kind of snapshot to dynamically create if multiple options are supported.
++
+Dynamically provisioned snapshots use the VolumeSnapshotClass to specify storage-provider-specific parameters to use when creating a snapshot.
++
+The VolumeSnapshotContentClass CRD is not namespaced and is for use by a cluster administrator to enable global configuration options for their storage backend.

--- a/modules/persistent-storage-csi-snapshots-overview.adoc
+++ b/modules/persistent-storage-csi-snapshots-overview.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-overview_{context}"]
+= Overview of CSI volume snapshots
+
+A _snapshot_ represents the state of the storage volume in a cluster at a particular point in time. VolumeSnapshots can be used to provision a new volume.
+
+{product-title} supports CSI volume snapshots by default. However, a specific CSI driver is required.
+
+With CSI volume snapshots, a cluster administrator can:
+
+* Deploy a third-party CSI driver that supports snapshots.
+* Create a new persistent volume claim (PVC) from an existing volume snapshot.
+* Take a snapshot of an existing PVC.
+* Restore a snapshot as a different PVC.
+* Delete an existing volume snapshot.
+
+With CSI volume snapshots, an app developer can:
+
+* Use volume snapshots as building blocks for developing application- or cluster-level storage backup solutions.
+* Rapidly rollback to a previous development version.
+* Use storage more efficiently by not having to make a full copy each time.
+
+Be aware of the following when using VolumeSnapshot:
+
+* Support is only available for CSI drivers. In-tree and FlexVolumes are not supported.
+* {product-title} does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by
+link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
+* CSI drivers may or may not have implemented the volume snapshot functionality. CSI drivers that have provided support for VolumeSnapshots will likely use the `csi-external-snapshotter` sidecar. See documentation provided by the CSI driver for details.
+* {product-title} {product-version} supports version 1.1.0 of the link:https://github.com/container-storage-interface/spec[CSI specification].

--- a/modules/persistent-storage-csi-snapshots-provision.adoc
+++ b/modules/persistent-storage-csi-snapshots-provision.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-csi-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-provision_{context}"]
+= Provisioning a volume snapshot
+
+There are two ways to provision snapshots: xref:#snapshots-manual-provisioning[manually] and xref:#snapshots-dynamic-provisioning[dynamically].
+
+[id="snapshots-manual-provisioning"]
+== Manual provisioning
+
+As a cluster administrator, you can manually pre-provision a number of VolumeSnapshotContent objects. These carry the real volume snapshot details available to cluster users.
+
+[id="snapshots-dynamic-provisioning"]
+== Dynamic provisioning
+
+Instead of using a preexisting snapshot, you can request that a snapshot be taken dynamically from a PersistentVolumeClaim. Parameters are specified using VolumeSnapshotClass.

--- a/modules/persistent-storage-csi-snapshots-restore.adoc
+++ b/modules/persistent-storage-csi-snapshots-restore.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-csi-snapshots.adoc
+
+[id="persistent-storage-csi-snapshots-restore_{context}"]
+= Restoring a volume snapshot
+
+After your VolumeSnapshot object is bound, you can use that object to provision a new volume that is pre-populated with data from the snapshot.
+
+The volume snapshot content object is used to restore the existing volume to a previous state.
+
+.Prerequisites
+* Logged in to a running {product-title} cluster.
+* A persistent volume claim (PVC) created using a Container Storage Interface (CSI) driver that supports VolumeSnapshots.
+* A storage class to provision the storage backend.
+
+.Procedure
+
+. Specify a VolumeSnapshot data source on a PVC as shown in the following:
++
+.pvc-restore.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: myclaim-restore
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    name: mysnap <1>
+    kind: VolumeSnapshot <2>
+    apiGroup: snapshot.storage.k8s.io <3>
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+----
+<1> Name of the VolumeSnapshot object representing the snapshot to use as source.
+<2> Must be set to the `VolumeSnapshot` value.
+<3> Must be set to the `snapshot.storage.k8s.io` value.
+
+. Create a PVC by running the following command:
+
++
+----
+$ oc create -f pvc-restore.yaml
+----
+
+. Verify that the restored PVC has been created by running the following command:
+
++
+----
+$ oc get pvc
+----
++
+Two different PVCs are displayed.

--- a/storage/persistent_storage/persistent-storage-csi-snapshots.adoc
+++ b/storage/persistent_storage/persistent-storage-csi-snapshots.adoc
@@ -1,0 +1,26 @@
+[id="persistent-storage-csi-snapshots"]
+= Persistent storage using CSI volume snapshots
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-csi-snapshots
+
+toc::[]
+
+This document describes how to use VolumeSnapshots with supported Container Storage Interface (CSI) drivers to protect against data loss in {product-title}. Familiarity with xref:../../storage/understanding-persistent-storage.adoc#persistent-volumes_understanding-persistent-storage[persistent volumes] is suggested.
+
+:FeatureName: CSI VolumeSnapshot
+
+include::modules/technology-preview.adoc[leveloffset=+0]
+
+include::modules/persistent-storage-csi-snapshots-overview.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-snapshots-controller-sidecar.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-snapshots-operator.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-snapshots-provision.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-snapshots-create.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-snapshots-delete.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-snapshots-restore.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-844](https://issues.redhat.com/browse/OSDOCS-844), [OSDOCS-857](https://issues.redhat.com/browse/OSDOCS-857), [OSDOCS-920](https://issues.redhat.com/browse/OSDOCS-920), and [OSDOCS-949](https://issues.redhat.com/browse/OSDOCS-949).
Documents create/delete/restore methods for snapshot with supported CSI drivers. 
