### PR TITLE
bug 1801528 correction machine deletion command

### DIFF
--- a/modules/machine-delete.adoc
+++ b/modules/machine-delete.adoc
@@ -26,7 +26,7 @@ The command output contains a list of Machines in the `<clusterid>-worker-<cloud
 . Delete the Machine:
 +
 ----
-$ oc delete <machine> -n openshift-machine-api
+$ oc delete machine <machine> -n openshift-machine-api
 ----
 
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1801528

@shellyyang1989, will you please confirm? Also, this bug was filed against 4.2, so I assume that it's valid for 4.3 and 4.4 as well. Is it also valid in 4.1?