### PR TITLE
Bug 1801385, pipeline strategy is dropped in 4.3

### DIFF
--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -39,11 +39,11 @@
 | 10,000
 | 10,000
 
-| Number of builds: Pipeline Strategy
-| 10,000 (Default pod RAM 512 Mi)
-| 10,000 (Default pod RAM 512 Mi)
-| 10,000 (Default pod RAM 512 Mi)
-| 10,000 (Default pod RAM 512 Mi)
+| Number of builds
+| 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
+| 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
+| 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
+| 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 
 | Number of pods per namespace footnoteref:[objectpernamespace,There are
 a number of control loops in the system that must iterate over all objects


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1801385

Preview build: http://file.rdu.redhat.com/~ahardin/Feb132020/BZ1801385-pipeline/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums_object-limits