### PR TITLE
Bring back Azure UPI registry storage

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -509,8 +509,8 @@ Topics:
     File: configuring-registry-storage-gcp-user-infrastructure
 #  - Name: Configuring the registry for OpenStack user-provisioned infrastructure
 #    File: configuring-registry-storage-openstack-user-infrastructure
-#  - Name: Configuring the registry for Azure user-provisioned infrastructure
-#    File: configuring-registry-storage-azure-user-infrastructure
+  - Name: Configuring the registry for Azure user-provisioned infrastructure
+    File: configuring-registry-storage-azure-user-infrastructure
   - Name: Configuring the registry for bare metal
     File: configuring-registry-storage-baremetal
   - Name: Configuring the registry for vSphere

--- a/modules/registry-configuring-storage-azure-user-infra.adoc
+++ b/modules/registry-configuring-storage-azure-user-infra.adoc
@@ -18,6 +18,15 @@ cloud credentials.
 
 .Procedure
 
- link:https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal[Create an Azure storage container] and provide the `accountName` and
- `container` parameters for `ImageRegistryConfigStorageAzure` on the
- configuration image registry resource, `configs.imageregistry.operator.openshift.io`, `spec.storage.azure` file.
+. Create an link:https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal[Azure storage container].
+
+. Fill in the storage configuration in `configs.imageregistry.operator.openshift.io/cluster`:
++
+----
+$ oc edit configs.imageregistry.operator.openshift.io/cluster
+
+storage:
+  azure:
+    accountName: <account-name>
+    container: <container-name>
+----

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -47,5 +47,6 @@ include::modules/registry-operator-config-resources-storage-credentials.adoc[lev
 
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.adoc#configuring-registry-storage-aws-user-infrastructure[Configuring the registry for AWS user-provisioned infrastructure]
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-gcp-user-infrastructure.adoc#configuring-registry-storage-gcp-user-infrastructure[Configuring the registry for GCP user-provisioned infrastructure]
+* xref:../registry/configuring_registry_storage/configuring-registry-storage-azure-user-infrastructure.adoc#configuring-registry-storage-azure-user-infrastructure[Configuring the registry for Azure user-provisioned infrastructure]
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc#configuring-registry-storage-baremetal[Configuring the registry for bare metal]
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere]

--- a/registry/configuring_registry_storage/configuring-registry-storage-azure-user-infrastructure.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-azure-user-infrastructure.adoc
@@ -8,7 +8,3 @@ toc::[]
 include::modules/registry-operator-config-resources-secret-azure.adoc[leveloffset=+1]
 
 include::modules/registry-configuring-storage-azure-user-infra.adoc[leveloffset=+1]
-
-////
-This assembly is commented out for 4.2. When Azure UPI GAs, we can updated the associated modules and allow this assembly to build.
-////


### PR DESCRIPTION
This resurrects the Azure registry storage information that was originally completed in #16593 for OCP 4.2. Now that Azure UPI deployment support is planned for OCP 4.4, this content should complement the incoming Azure UPI installer docs.

cc @bmcelvee 
