### PR TITLE
Cnv module metadata update 

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-collecting-cnv-data.adoc
 // * support/gathering-cluster-data.adoc
 
 [id="about-must-gather_{context}"]

--- a/modules/cluster-logging-about.adoc
+++ b/modules/cluster-logging-about.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
 //
+// * cnv/cnv_logging_events_monitoring/cnv-openshift-cluster-monitoring.adoc
 // * logging/cluster-logging.adoc
-// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
-//
+// * serverless/knative_serving/cluster-logging-serverless.adoc
+
 // This module uses conditionalized paragraphs so that the module
 // can be re-used in associated products.
 

--- a/modules/cnv-about-block-pvs.adoc
+++ b/modules/cnv-about-block-pvs.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes-block.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes-block.adoc
 
 [id="cnv-about-block-pvs_{context}"]
 = About block PersistentVolumes

--- a/modules/cnv-about-collecting-cnv-data.adoc
+++ b/modules/cnv-about-collecting-cnv-data.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-collecting-cnv-data.adoc
 
 [id="cnv-about-collecting-cnv-data_{context}"]
 = About collecting container-native virtualization data

--- a/modules/cnv-about-datavolumes.adoc
+++ b/modules/cnv-about-datavolumes.adoc
@@ -1,14 +1,14 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
-// * cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes-block.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
-// * cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-block.adoc
-// * cnv/cnv_users_guide/cnv-enabling-user-permissions-to-clone-datavolumes.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-preparing-cdi-scratch-space.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-enabling-user-permissions-to-clone-datavolumes.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes-block.adoc
 
 [id="cnv-about-datavolumes_{context}"]
 = About DataVolumes

--- a/modules/cnv-about-hostpath-provisioner.adoc
+++ b/modules/cnv-about-hostpath-provisioner.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-configuring-local-storage-for-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-configuring-local-storage-for-vms.adoc
 
 [id="cnv-about-hostpath-provisioner_{context}"]
 = About the hostpath provisioner

--- a/modules/cnv-about-liveness-readiness-probes.adoc
+++ b/modules/cnv-about-liveness-readiness-probes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-liveness-readiness-probe.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-monitoring-vm-health.adoc
 
 [id="cnv-about-liveness-readiness-probes_{context}"]
 

--- a/modules/cnv-about-red-hat-ansible-automation.adoc
+++ b/modules/cnv-about-red-hat-ansible-automation.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-automating-management-tasks.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-automating-management-tasks.adoc
 
 [id="cnv-about-red-hat-ansible-automation_{context}"]
 = About Red Hat Ansible Automation

--- a/modules/cnv-about-the-overview-dashboard.adoc
+++ b/modules/cnv-about-the-overview-dashboard.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
-// * cnv/cnv_users_guide/cnv-using-dashboard-to-get-cluster-info.adoc
+//
+// * cnv/cnv_logging_events_monitoring/cnv-using-dashboard-to-get-cluster-info.adoc
 // * web_console/using-dashboard-to-get-cluster-information.adoc
+
 ifeval::["{context}" == "cnv-using-dashboard-to-get-cluster-info"]
 :cnv-cluster:
 endif::[]

--- a/modules/cnv-about-the-vm-dashboard.adoc
+++ b/modules/cnv-about-the-vm-dashboard.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-viewing-information-about-vm-workloads.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-viewing-information-about-vm-workloads.adoc
 
 [id="cnv-about-the-vm-dashboard_{context}"]
 = About the Virtual Machines dashboard

--- a/modules/cnv-about-upgrading-cnv.adoc
+++ b/modules/cnv-about-upgrading-cnv.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_install/upgrading-container-native-virtualization.adoc
+// * cnv/upgrading-container-native-virtualization.adoc
 
 [id="cnv-about-upgrading-cnv_{context}"]
 = About upgrading container-native virtualization

--- a/modules/cnv-accessing-rdp-console.adoc
+++ b/modules/cnv-accessing-rdp-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-accessing-rdp-console_{context}"]
 = Connecting to a Windows virtual machine with an RDP console

--- a/modules/cnv-accessing-serial-console.adoc
+++ b/modules/cnv-accessing-serial-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-accessing-serial-console_{context}"]
 = Accessing the serial console of a virtual machine instance

--- a/modules/cnv-accessing-vmi-ssh.adoc
+++ b/modules/cnv-accessing-vmi-ssh.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-accessing-vmi-ssh_{context}"]
 = Accessing a virtual machine instance via SSH

--- a/modules/cnv-accessing-vmi-web.adoc
+++ b/modules/cnv-accessing-vmi-web.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-accessing-vmi-web_{context}"]
 = Connecting to a virtual machine with the web console

--- a/modules/cnv-accessing-vnc-console.adoc
+++ b/modules/cnv-accessing-vnc-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-accessing-vnc-console_{context}"]
 = Accessing the graphical console of a virtual machine instances with VNC

--- a/modules/cnv-add-disk-to-vm.adoc
+++ b/modules/cnv-add-disk-to-vm.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-edit-vms.adoc
-// * cnv/cnv_users_guide/cnv-editing-vm-template.adoc
+// * cnv/cnv_virtual_machines/cnv-edit-vms.adoc
+// * cnv/cnv_vm_templates/cnv-editing-vm-template.adoc
 
 // Establishing conditionals so content can be re-used for editing VMs
 // and VM templates.

--- a/modules/cnv-add-nic-to-vm.adoc
+++ b/modules/cnv-add-nic-to-vm.adoc
@@ -1,10 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-edit-vms.adoc
-// * cnv/cnv_users_guide/cnv-editing-vm-template
-//
-// Establishing conditionals so content can be re-used for editing VMs
-// and VM templates.
+// * cnv/cnv_virtual_machines/cnv-edit-vms.adoc
+// * cnv/cnv_vm_templates/cnv-editing-vm-template.adoc
 
 ifeval::["{context}" == "cnv-edit-vms"]
 :object: virtual machine

--- a/modules/cnv-adding-tls-certificates-for-authenticating-dv-imports.adoc
+++ b/modules/cnv-adding-tls-certificates-for-authenticating-dv-imports.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-tls-certificates-for-dv-imports.adoc
 
 [id="cnv-adding-tls-certificates-for-authenticating-dv-imports_{context}"]
 = Adding TLS certificates for authenticating DataVolume imports

--- a/modules/cnv-adding-virtio-drivers-vm-yaml.adoc
+++ b/modules/cnv-adding-virtio-drivers-vm-yaml.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
 
 [id="cnv-adding-virtio-drivers-vm-yaml_{context}"]
 = Adding VirtIO drivers container disk to a virtual machine

--- a/modules/cnv-automating-virtual-machine-creation-with-ansible.adoc
+++ b/modules/cnv-automating-virtual-machine-creation-with-ansible.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-automating-management-tasks.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-automating-management-tasks.adoc
 
 [id="cnv-automating-virtual-machine-creation-with-ansible_{context}"]
 = Automating virtual machine creation

--- a/modules/cnv-cancelling-vm-migration-cli.adoc
+++ b/modules/cnv-cancelling-vm-migration-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-cancel-vmi-migration.adoc
+// * cnv/cnv_live_migration/cnv-cancel-vmi-migration.adoc
 
 [id="cnv-cancelling-vm-migration-cli_{context}"]
 = Cancelling live migration of a virtual machine instance in the CLI

--- a/modules/cnv-cancelling-vm-migration-web.adoc
+++ b/modules/cnv-cancelling-vm-migration-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-cancel-vmi-migration.adoc
+// * cnv/cnv_live_migration/cnv-cancel-vmi-migration.adoc
 
 [id="cnv-cancelling-vm-migration-web_{context}"]
 = Cancelling live migration of a virtual machine instance in the web console

--- a/modules/cnv-cdi-supported-operations-matrix.adoc
+++ b/modules/cnv-cdi-supported-operations-matrix.adoc
@@ -1,10 +1,13 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-preparing-cdi-scratch-space.adoc
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-virtctl.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-virtctl.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-preparing-cdi-scratch-space.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes-block.adoc
 
 
 [id="cnv-cdi-supported-operations-matrix_{context}"]

--- a/modules/cnv-cli-reference-controlling-vms.adoc
+++ b/modules/cnv-cli-reference-controlling-vms.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-controlling-vm-states.adoc
+// * cnv/cnv_virtual_machines/cnv-controlling-vm-states.adoc
 
 [id="cnv-cli-reference-controlling-vms_{context}"]
 = CLI reference for controlling virtual machines

--- a/modules/cnv-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
+++ b/modules/cnv-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
-//
-// `blockstorage` conditionals are used (declared in the "*-block" assembly) to separate content
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
+
+// `blockstorage` conditionals are used (declared in the "*-block" assembly) to separate content 
 
 [id="cnv-cloning-pvc-of-vm-disk-into-new-datavolume_{context}"]
 = Cloning the PersistentVolumeClaim of a virtual machine disk into a new DataVolume

--- a/modules/cnv-cloud-init-fields-web.adoc
+++ b/modules/cnv-cloud-init-fields-web.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_vm_templates/cnv-creating-vm-template.adoc
 
 [id="cnv-cloud-init-fields-web_{context}"]
 = Cloud-init fields

--- a/modules/cnv-configuring-guest-memory-overcommitment.adoc
+++ b/modules/cnv-configuring-guest-memory-overcommitment.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-managing-guest-memory.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-managing-guest-memory.adoc
 
 [id="cnv-configuring-guest-memory-overcommitment_{context}"]
 = Configuring guest memory overcommitment

--- a/modules/cnv-configuring-live-migration-limits.adoc
+++ b/modules/cnv-configuring-live-migration-limits.adoc
@@ -1,7 +1,7 @@
 
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-live-migration-limits.adoc
+// * cnv/cnv_live_migration/cnv-live-migration-limits.adoc
 
 [id="cnv-configuring-live-migration-limits_{context}"]
 = Configuring live migration limits and timeouts

--- a/modules/cnv-configuring-masquerade-mode-cli.adoc
+++ b/modules/cnv-configuring-masquerade-mode-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-using-the-default-pod-network-with-cnv.adoc
 
 [id="cnv-configuring-masquerade-mode-cli_{context}"]
 = Configuring masquerade mode from the command line

--- a/modules/cnv-configuring-selinux-hpp-on-rhcos8.adoc
+++ b/modules/cnv-configuring-selinux-hpp-on-rhcos8.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-configuring-local-storage-for-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-configuring-local-storage-for-vms.adoc
 
 [id="cnv-configuring-selinux-hpp-on-rhcos8_{context}"]
 = Configuring SELinux for the hostpath provisioner on Red Hat Enterprise Linux CoreOS 8

--- a/modules/cnv-configuring-vm-live-migration-cli.adoc
+++ b/modules/cnv-configuring-vm-live-migration-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-configuring-vmi-eviction-strategy.adoc
+// * cnv/cnv_live_migration/cnv-configuring-vmi-eviction-strategy.adoc
 
 [id="cnv-configuring-vm-live-migration-cli_{context}"]
 = Configuring custom virtual machines with the `LiveMigration` eviction strategy 

--- a/modules/cnv-connecting-to-the-terminal.adoc
+++ b/modules/cnv-connecting-to-the-terminal.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-connecting-to-the-terminal_{context}"]
 

--- a/modules/cnv-connecting-vnc-console.adoc
+++ b/modules/cnv-connecting-vnc-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-connecting-vnc-console_{context}"]
 = Connecting to the VNC console

--- a/modules/cnv-creating-an-upload-dv.adoc
+++ b/modules/cnv-creating-an-upload-dv.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-block.adoc
 
 [id="cnv-creating-an-upload-dv_{context}"]
 = Creating an upload DataVolume

--- a/modules/cnv-creating-blank-disk-datavolumes.adoc
+++ b/modules/cnv-creating-blank-disk-datavolumes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
 
 [id="cnv-creating-blank-disk-datavolumes_{context}"]
 = Creating a blank disk image with DataVolumes

--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-attaching-vm-multiple-networks.adoc
 
 [id="cnv-creating-bridge-nad-cli_{context}"]
 = Creating a Linux bridge NetworkAttachmentDefinition in the CLI

--- a/modules/cnv-creating-local-block-pv.adoc
+++ b/modules/cnv-creating-local-block-pv.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes-block.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume-block.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes-block.adoc
 
 [id="cnv-creating-local-block-pv_{context}"]
 = Creating a local block PersistentVolume

--- a/modules/cnv-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc
+++ b/modules/cnv-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-using-datavolumetemplate.adoc
 
 [id="cnv-creating-new-vm-from-cloned-pvc-using-datavolumetemplate_{context}"]
 = Creating a new virtual machine from a cloned PersistentVolumeClaim by using a DataVolumeTemplate

--- a/modules/cnv-creating-storage-class.adoc
+++ b/modules/cnv-creating-storage-class.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-configuring-local-storage-for-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-configuring-local-storage-for-vms.adoc
 
 [id="cnv-creating-storage-class_{context}"]
 = Creating a StorageClass object

--- a/modules/cnv-creating-template-wizard-web.adoc
+++ b/modules/cnv-creating-template-wizard-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-creating-vm-template.adoc
+// * cnv/cnv_vm_templates/cnv-creating-vm-template.adoc
 
 [id="cnv-creating-template-wizard-web_{context}"]
 = Creating a virtual machine template with the interactive wizard in the web console

--- a/modules/cnv-creating-vddk-image.adoc
+++ b/modules/cnv-creating-vddk-image.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
 
 [id="cnv-creating-vddk-image_{context}"]
 = Creating a VDDK image

--- a/modules/cnv-creating-vm-wizard-web.adoc
+++ b/modules/cnv-creating-vm-wizard-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
 
 [id="cnv-creating-vm-wizard-web_{context}"]
 = Running the virtual machine wizard to create a virtual machine

--- a/modules/cnv-creating-vm-yaml-web.adoc
+++ b/modules/cnv-creating-vm-yaml-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
 
 [id="cnv-creating-vm-yaml-web_{context}"]
 = Pasting in a pre-configured YAML file to create a virtual machine

--- a/modules/cnv-creating-vm.adoc
+++ b/modules/cnv-creating-vm.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
 
 [id="cnv-creating-vm_{context}"]
 = Using the CLI to create a virtual machine

--- a/modules/cnv-define-http-liveness-probe.adoc
+++ b/modules/cnv-define-http-liveness-probe.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-monitoring-vm-health.adoc
 
 [id="cnv-define-http-liveness-probe_{context}"]
 

--- a/modules/cnv-define-readiness-probe.adoc
+++ b/modules/cnv-define-readiness-probe.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-monitoring-vm-health.adoc
 
 [id="cnv-define-readiness-probe_{context}"]
 

--- a/modules/cnv-define-tcp-liveness-probe.adoc
+++ b/modules/cnv-define-tcp-liveness-probe.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-monitoring-vm-health.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-monitoring-vm-health.adoc
 
 [id="cnv-define-tcp-liveness-probe_{context}"]
 

--- a/modules/cnv-defining-storageclass-in-cdi-configuration.adoc
+++ b/modules/cnv-defining-storageclass-in-cdi-configuration.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cdi-scratch-space.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-preparing-cdi-scratch-space.adoc
 
 [id="cnv-defining-storageclass-in-cdi-configuration_{context}"]
 = Defining a StorageClass in the CDI configuration

--- a/modules/cnv-delete-vm-web.adoc
+++ b/modules/cnv-delete-vm-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-delete-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-delete-vms.adoc
 
 [id="cnv-delete-vm-web_{context}"]
 

--- a/modules/cnv-deleting-template-web.adoc
+++ b/modules/cnv-deleting-template-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-deleting-vm-template.adoc
+// * cnv/cnv_vm_templates/cnv-deleting-vm-template.adoc
 
 [id="cnv-deleting-template-wizard-web_{context}"]
 = Deleting a virtual machine template in the web console

--- a/modules/cnv-deleting-vms.adoc
+++ b/modules/cnv-deleting-vms.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-delete-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-delete-vms.adoc
 
 [id="cnv-deleting-vms_{context}"]
 

--- a/modules/cnv-disabling-guest-memory-overhead-accounting.adoc
+++ b/modules/cnv-disabling-guest-memory-overhead-accounting.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-managing-guest-memory.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-managing-guest-memory.adoc
 
 [id="cnv-disabling-guest-memory-overhead-accounting_{context}"]
 = Disabling guest memory overhead accounting

--- a/modules/cnv-edit-cdrom-vm.adoc
+++ b/modules/cnv-edit-cdrom-vm.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-edit-vms.adoc
-// * cnv/cnv_users_guide/cnv-editing-vm-template.adoc
+// * cnv/cnv_virtual_machines/cnv-edit-vms.adoc
+// * cnv/cnv_vm_templates/cnv-editing-vm-template.adoc
 
 // Establishing conditionals so content can be re-used for editing VMs
 // and VM templates.

--- a/modules/cnv-editing-template-yaml-web.adoc
+++ b/modules/cnv-editing-template-yaml-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-editing-vm-template.adoc
+// * cnv/cnv_vm_templates/cnv-editing-vm-template.adoc
 
 [id="cnv-editing-template-yaml-web_{context}"]
 = Editing virtual machine template YAML configuration in the web console

--- a/modules/cnv-editing-vm-cli.adoc
+++ b/modules/cnv-editing-vm-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-edit-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-edit-vms.adoc
 
 [id="cnv-editing-vm-cli_{context}"]
 = Editing a virtual machine YAML configuration using the CLI

--- a/modules/cnv-editing-vm-web.adoc
+++ b/modules/cnv-editing-vm-web.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-edit-vms.adoc
-// * cnv/cnv_users_guide/cnv-editing-vm-template.adoc
+// * cnv/cnv_virtual_machines/cnv-edit-vms.adoc
+// * cnv/cnv_vm_templates/cnv-editing-vm-template.adoc
 
 // Establishing conditionals so content can be re-used for editing VMs
 // and VM templates. 

--- a/modules/cnv-editing-vm-yaml-web.adoc
+++ b/modules/cnv-editing-vm-yaml-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-edit-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-edit-vms.adoc
 
 [id="cnv-editing-vm-yaml-web_{context}"]
 

--- a/modules/cnv-example-ansible-playbook-creating-vms.adoc
+++ b/modules/cnv-example-ansible-playbook-creating-vms.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-automating-management-tasks.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-automating-management-tasks.adoc
 
 [id="cnv-example-ansible-playbook-creating-vms_{context}"]
 = Example: Ansible Playbook for creating virtual machines

--- a/modules/cnv-example-configmap-tls-certificate.adoc
+++ b/modules/cnv-example-configmap-tls-certificate.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-tls-certificates-for-dv-imports.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-tls-certificates-for-dv-imports.adoc
 
 [id="cnv-example-configmap-tls-certificate_{context}"]
 = Example: ConfigMap created from a TLS certificate

--- a/modules/cnv-importing-vm-datavolume.adoc
+++ b/modules/cnv-importing-vm-datavolume.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes.adoc
 
 [id="cnv-importing-vm-datavolume_{context}"]
 = Importing a virtual machine image into an object with DataVolumes

--- a/modules/cnv-importing-vm-to-block-pv.adoc
+++ b/modules/cnv-importing-vm-to-block-pv.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes-block.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes-block.adoc
 
 [id="cnv-importing-vm-to-block-pv_{context}"]
 = Importing a virtual machine image to a block PersistentVolume using DataVolumes

--- a/modules/cnv-importing-vmware-vm.adoc
+++ b/modules/cnv-importing-vmware-vm.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
+
 [id='Importing_vmware_vm_or_template_{context}']
 = Importing a VMware virtual machine or template
 

--- a/modules/cnv-initiating-vm-migration-cli.adoc
+++ b/modules/cnv-initiating-vm-migration-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-migrate-vmi.adoc
+// * cnv/cnv_live_migration/cnv-migrate-vmi.adoc
 
 [id="cnv-initiating-vm-migration-cli_{context}"]
 = Initiating live migration of a virtual machine instance in the CLI

--- a/modules/cnv-initiating-vm-migration-web.adoc
+++ b/modules/cnv-initiating-vm-migration-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-migrate-vmi.adoc
+// * cnv/cnv_live_migration/cnv-migrate-vmi.adoc
 
 [id="cnv-initiating-vm-migration-web_{context}"]
 = Initiating live migration of a virtual machine instance in the web console

--- a/modules/cnv-installing-qemu-guest-agent-on-linux-vm.adoc
+++ b/modules/cnv-installing-qemu-guest-agent-on-linux-vm.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-qemu-guest-agent.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-installing-qemu-guest-agent.adoc
 
 [id="cnv-installing-qemu-guest-agent-on-linux-vm_{context}"]
 = Installing QEMU guest agent on a Linux virtual machine

--- a/modules/cnv-installing-qemu-guest-agent-on-windows-vm.adoc
+++ b/modules/cnv-installing-qemu-guest-agent-on-windows-vm.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-qemu-guest-agent.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-installing-qemu-guest-agent.adoc
+
 [id="installing-qemu-guest-agent-on-a-windows-virtual-machine"]
 = Installing QEMU guest agent on a Windows virtual machine
 

--- a/modules/cnv-installing-virtio-drivers-existing-windows.adoc
+++ b/modules/cnv-installing-virtio-drivers-existing-windows.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-installing-qemu-guest-agent.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
 
 [id="cnv-installing-virtio-drivers-existing-windows_{context}"]
 = Installing VirtIO drivers on an existing Windows virtual machine

--- a/modules/cnv-installing-virtio-drivers-installing-windows.adoc
+++ b/modules/cnv-installing-virtio-drivers-installing-windows.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-installing-qemu-guest-agent.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
 
 [id="cnv-installing-virtio-drivers-installing-windows_{context}"]
 = Installing VirtIO drivers during Windows installation

--- a/modules/cnv-live-migration-limits-reftable.adoc
+++ b/modules/cnv-live-migration-limits-reftable.adoc
@@ -1,7 +1,7 @@
 
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-live-migration-limits.adoc
+// * cnv/cnv_live_migration/cnv-live-migration-limits.adoc
 
 [id="cnv-live-migration-limits-ref_{context}"]
 = Cluster-wide live migration limits and timeouts

--- a/modules/cnv-monitoring-upgrade-status.adoc
+++ b/modules/cnv-monitoring-upgrade-status.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_install/upgrading-container-native-virtualization.adoc
+// * cnv/upgrading-container-native-virtualization.adoc
 
 [id="cnv-monitoring-upgrade-status_{context}"]
 = Monitoring upgrade status

--- a/modules/cnv-monitoring-vm-migration-cli.adoc
+++ b/modules/cnv-monitoring-vm-migration-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-monitor-vmi-migration.adoc
+// * cnv/cnv_live_migration/cnv-monitor-vmi-migration.adoc
 
 [id="cnv-monitoring-vm-migration-cli_{context}"]
 = Monitoring live migration of a virtual machine instance in the CLI

--- a/modules/cnv-monitoring-vm-migration-web.adoc
+++ b/modules/cnv-monitoring-vm-migration-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-monitor-vmi-migration.adoc
+// * cnv/cnv_live_migration/cnv-monitor-vmi-migration.adoc
 
 [id="cnv-monitoring-vm-migration-web_{context}"]
 = Monitoring live migration of a virtual machine instance in the web console

--- a/modules/cnv-networking-glossary.adoc
+++ b/modules/cnv-networking-glossary.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
-// * cnv/cnv_users_guide/cnv-configuring-pxe-booting.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-configuring-pxe-booting.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-attaching-vm-multiple-networks.adoc
 
 [id="cnv-networking-glossary_{context}"]
 = Container-native virtualization networking glossary

--- a/modules/cnv-networking-wizard-fields-web.adoc
+++ b/modules/cnv-networking-wizard-fields-web.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
-// * cnv/cnv_users_guide/cnv-creating-vm-template.adoc
-// * cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
-// * cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
-// * cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-using-the-default-pod-network-with-cnv.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-attaching-vm-multiple-networks.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_vm_templates/cnv-creating-vm-template.adoc
 
 [id="cnv-networking-wizard-fields-web_{context}"]
 = Networking fields

--- a/modules/cnv-openshift-client-commands.adoc
+++ b/modules/cnv-openshift-client-commands.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-using-the-cli-tools.adoc
+// * cnv/cnv-using-the-cli-tools.adoc
 
 [id="cnv-openshift-client-commands_{context}"]
 = {product-title} client commands

--- a/modules/cnv-operations-requiring-scratch-space.adoc
+++ b/modules/cnv-operations-requiring-scratch-space.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cdi-scratch-space.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-preparing-cdi-scratch-space.adoc
 
 [id="cnv-operations-requiring-scratch-space_{context}"]
 = CDI operations that require scratch space 

--- a/modules/cnv-pxe-booting-with-mac-address.adoc
+++ b/modules/cnv-pxe-booting-with-mac-address.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-configuring-pxe-booting.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-configuring-pxe-booting.adoc
 
 [id="cnv-pxe-booting-with-mac-address_{context}"]
 = PXE booting with a specified MAC address

--- a/modules/cnv-refreshing-certificates.adoc
+++ b/modules/cnv-refreshing-certificates.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-refresh-certificates.adoc
+// * cnv/cnv_node_maintenance/cnv-refresh-certificates.adoc
 
 [id="cnv-refreshing-certificates_{context}"]
 = Refreshing TLS certificates

--- a/modules/cnv-removing-virtio-disk-from-vm.adoc
+++ b/modules/cnv-removing-virtio-disk-from-vm.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
 
 [id="cnv-removing-virtio-disk-from-vm_{context}"]
 = Removing the VirtIO container disk from a virtual machine

--- a/modules/cnv-restarting-vm-web.adoc
+++ b/modules/cnv-restarting-vm-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-controlling-vm-states.adoc
+// * cnv/cnv_virtual_machines/cnv-controlling-vm-states.adoc
 
 [id="cnv-restarting-vm-web_{context}"]
 = Restarting a virtual machine

--- a/modules/cnv-resuming-node-maintenance-cli.adoc
+++ b/modules/cnv-resuming-node-maintenance-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-maintenance-mode.adoc
+// * cnv/cnv_node_maintenance/cnv-resuming-node.adoc
 
 [id="cnv-resuming-node-maintenance-cli_{context}"]
 = Resuming a node from maintenance mode in the CLI

--- a/modules/cnv-resuming-node-maintenance-web.adoc
+++ b/modules/cnv-resuming-node-maintenance-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-maintenance-mode.adoc
+// * cnv/cnv_node_maintenance/cnv-resuming-node.adoc
 
 [id="cnv-resuming-node-maintenance-web_{context}"]
 = Resuming a node from maintenance mode in the web console

--- a/modules/cnv-setting-node-maintenance-cli.adoc
+++ b/modules/cnv-setting-node-maintenance-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-setting-node-maintenance.adoc
+// * cnv/cnv_node_maintenance/cnv-setting-node-maintenance.adoc
 
 [id="cnv-setting-node-maintenance-cli_{context}"]
 = Setting a node to maintenance mode in the CLI

--- a/modules/cnv-setting-node-maintenance-web.adoc
+++ b/modules/cnv-setting-node-maintenance-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-setting-node-maintenance.adoc
+// * cnv/cnv_node_maintenance/cnv-setting-node-maintenance.adoc
 
 [id="cnv-setting-node-maintenance-web_{context}"]
 = Setting a node to maintenance mode in the web console

--- a/modules/cnv-starting-vm-web.adoc
+++ b/modules/cnv-starting-vm-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-controlling-vm-states.adoc
+// * cnv/cnv_virtual_machines/cnv-controlling-vm-states.adoc
 
 [id="cnv-starting-vm-web_{context}"]
 = Starting a virtual machine

--- a/modules/cnv-stopping-vm-web.adoc
+++ b/modules/cnv-stopping-vm-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-controlling-vm-states.adoc
+// * cnv/cnv_virtual_machines/cnv-controlling-vm-states.adoc
 
 [id="cnv-stopping-vm-web_{context}"]
 = Stopping a virtual machine

--- a/modules/cnv-storage-wizard-fields-web.adoc
+++ b/modules/cnv-storage-wizard-fields-web.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
-// * cnv/cnv_users_guide/cnv-creating-vm-template.adoc
-// * cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_vm_templates/cnv-creating-vm-template.adoc
 
 [id="cnv-storage-wizard-fields-web_{context}"]
 = Storage fields

--- a/modules/cnv-supported-virtio-drivers.adoc
+++ b/modules/cnv-supported-virtio-drivers.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
 
 [id="cnv-supported-virtio-drivers_{context}"]
 = Supported VirtIO drivers for Microsoft Windows virtual machines

--- a/modules/cnv-template-blank-disk-datavolume.adoc
+++ b/modules/cnv-template-blank-disk-datavolume.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-expanding-virtual-storage-with-blank-disk-images.adoc
 
 [id="cnv-template-blank-disk-datavolume_{context}"]
 = Template: DataVolume configuration file for blank disk images

--- a/modules/cnv-template-datavolume-clone.adoc
+++ b/modules/cnv-template-datavolume-clone.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-disk-into-new-datavolume.adoc
 
 [id="cnv-template-datavolume-clone_{context}"]
 = Template: DataVolume clone configuration file

--- a/modules/cnv-template-datavolume-import.adoc
+++ b/modules/cnv-template-datavolume-import.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes.adoc
 
 [id="cnv-template-datavolume-import_{context}"]
 = Template: DataVolume import configuration file

--- a/modules/cnv-template-datavolume-vm.adoc
+++ b/modules/cnv-template-datavolume-vm.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-virtual-machine-images-datavolumes.adoc
-// * cnv/cnv_users_guide/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-cloning-vm-using-datavolumetemplate.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-virtual-machine-images-datavolumes.adoc
 
 [id="cnv-template-datavolume-vm_{context}"]
 = Template: DataVolume virtual machine configuration file

--- a/modules/cnv-template-vm-config.adoc
+++ b/modules/cnv-template-vm-config.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-using-the-default-pod-network-with-cnv.adoc
 
 [id="cnv-template-vm-config_{context}"]
 = Template: virtual machine configuration file

--- a/modules/cnv-template-vmi-pxe-config.adoc
+++ b/modules/cnv-template-vmi-pxe-config.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-configuring-pxe-booting.adoc
-// * cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-configuring-pxe-booting.adoc
 
 [id="cnv-pxe-vmi-template_{context}"]
 = Template: virtual machine instance configuration file for PXE booting

--- a/modules/cnv-template-windows-vmi.adoc
+++ b/modules/cnv-template-windows-vmi.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-using-the-default-pod-network-with-cnv.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-using-the-default-pod-network-with-cnv.adoc
 
 [id="cnv-template-windows-vmi_{context}"]
 = Template: Windows virtual machine instance configuration file

--- a/modules/cnv-understanding-events.adoc
+++ b/modules/cnv-understanding-events.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-events.adoc
 
 [id="cnv-understanding-events_{context}"]
 = Understanding virtual machine events

--- a/modules/cnv-understanding-live-migration.adoc
+++ b/modules/cnv-understanding-live-migration.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-live-migration.adoc
+// * cnv/cnv_live_migration/cnv-live-migration.adoc
 
 [id="cnv-understanding-live-migration_{context}"]
 = Understanding live migration

--- a/modules/cnv-understanding-logs.adoc
+++ b/modules/cnv-understanding-logs.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-logs.adoc
 
 [id="cnv-understanding-logs_{context}"]
 = Understanding virtual machine logs

--- a/modules/cnv-understanding-node-maintenance.adoc
+++ b/modules/cnv-understanding-node-maintenance.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-node-maintenance.adoc
+// * cnv/cnv_node_maintenance/cnv-node-maintenance.adoc
+// * cnv/cnv_node_maintenance/cnv-setting-node-maintenance.adoc
 
 [id="cnv-understanding-node-maintenance{context}"]
 = Understanding node maintenance mode

--- a/modules/cnv-understanding-scratch-space.adoc
+++ b/modules/cnv-understanding-scratch-space.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-cdi-scratch-space.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-preparing-cdi-scratch-space.adoc
 
 [id="cnv-understanding-scratch-space_{context}"]
 = Understanding scratch space 

--- a/modules/cnv-understanding-virtio-drivers.adoc
+++ b/modules/cnv-understanding-virtio-drivers.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
-// * cnv_users_guide/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-new-windows-vm.adoc
+// * cnv/cnv_virtual_machines/cnv-installing-virtio-drivers-on-existing-windows-vm.adoc
 
 [id="cnv-understanding-virtio-drivers_{context}"]
 = Understanding VirtIO drivers

--- a/modules/cnv-updating-imported-vm-network-name.adoc
+++ b/modules/cnv-updating-imported-vm-network-name.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
+
 [id="cnv-updating-imported-vmware-vm-network-name_{context}"]
 = Updating the imported VMware virtual machine's NIC name
 

--- a/modules/cnv-uploading-local-disk-image-dv.adoc
+++ b/modules/cnv-uploading-local-disk-image-dv.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-block.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-block.adoc
 
 [id="cnv-uploading-local-disk-image-dv_{context}"]
 = Uploading a local disk image to a new DataVolume

--- a/modules/cnv-uploading-local-disk-image-pvc.adoc
+++ b/modules/cnv-uploading-local-disk-image-pvc.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-uploading-local-disk-images-virtctl.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-virtctl.adoc
 
 [id="cnv-uploading-local-disk-image-pvc_{context}"]
 = Uploading a local disk image to a new PersistentVolumeClaim

--- a/modules/cnv-using-hostpath-provisioner.adoc
+++ b/modules/cnv-using-hostpath-provisioner.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-configuring-local-storage-for-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-configuring-local-storage-for-vms.adoc
 
 [id="cnv-using-hostpath-provisioner_{context}"]
 = Using the hostpath provisioner to enable local storage

--- a/modules/cnv-viewing-namespace-events-cli.adoc
+++ b/modules/cnv-viewing-namespace-events-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-events.adoc
 
 [id="cnv-viewing-namespace-events-cli_{context}"]
 = Viewing namespace events in the CLI

--- a/modules/cnv-viewing-resource-events-cli.adoc
+++ b/modules/cnv-viewing-resource-events-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-events.adoc
 
 [id="cnv-viewing-resource-events-cli_{context}"]
 = Viewing resource events in the CLI

--- a/modules/cnv-viewing-virtual-machine-logs-cli.adoc
+++ b/modules/cnv-viewing-virtual-machine-logs-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-logs.adoc
 
 [id="cnv-viewing-virtual-machine-logs-cli_{context}"]
 = Viewing virtual machine logs in the CLI

--- a/modules/cnv-viewing-virtual-machine-logs-web.adoc
+++ b/modules/cnv-viewing-virtual-machine-logs-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-logs.adoc
 
 [id="cnv-viewing-virtual-machine-logs-web_{context}"]
 = Viewing virtual machine logs in the web console

--- a/modules/cnv-viewing-vm-events-web.adoc
+++ b/modules/cnv-viewing-vm-events-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-logs-events.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-events.adoc
 
 [id="cnv-viewing-vm-events-web_{context}"]
 = Viewing the events for a virtual machine in the web console

--- a/modules/cnv-viewing-vmi-ip-cli.adoc
+++ b/modules/cnv-viewing-vmi-ip-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-viewing-ip-of-vm-vnic.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-viewing-ip-of-vm-vnic.adoc
 
 [id="cnv-viewing-vmi-ip-cli_{context}"]
 = Viewing the IP address of a virtual machine interface in the CLI

--- a/modules/cnv-viewing-vmi-ip-web.adoc
+++ b/modules/cnv-viewing-vmi-ip-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv_users_guide/cnv-viewing-ip-of-vm-vnic.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-viewing-ip-of-vm-vnic.adoc
 
 [id="cnv-viewing-vmi-ip-web_{context}"]
 = Viewing the IP address of a virtual machine interface in the web console

--- a/modules/cnv-virtctl-commands.adoc
+++ b/modules/cnv-virtctl-commands.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv_users_guide/cnv-using-the-cli-tools.adoc
+// * cnv/cnv-using-the-cli-tools.adoc
 
 [id="cnv-virtctl-commands_{context}"]
 = Virtctl client commands

--- a/modules/cnv-vm-console-web.adoc
+++ b/modules/cnv-vm-console-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-vm-console-web_{context}"]
 = Virtual machine console sessions

--- a/modules/cnv-vm-create-nic-web.adoc
+++ b/modules/cnv-vm-create-nic-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-attaching-vm-multiple-networks.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-attaching-vm-multiple-networks.adoc
 
 [id="cnv-vm-create-nic-web_{context}"]
 = Creating a NIC for a virtual machine

--- a/modules/cnv-vm-rdp-console-web.adoc
+++ b/modules/cnv-vm-rdp-console-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-vm-rdp-console-web_{context}"]
 = Connecting to the RDP console

--- a/modules/cnv-vm-serial-console-web.adoc
+++ b/modules/cnv-vm-serial-console-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-accessing-vm-consoles.adoc
+// * cnv/cnv_virtual_machines/cnv-accessing-vm-consoles.adoc
 
 [id="cnv-vm-serial-console-web_{context}"]
 = Connecting to the serial console

--- a/modules/cnv-vm-storage-volume-types.adoc
+++ b/modules/cnv-vm-storage-volume-types.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
 
 [id="cnv-vm-storage-volume-types_{context}"]
 = Virtual machine storage volume types

--- a/modules/cnv-vm-wizard-fields-web.adoc
+++ b/modules/cnv-vm-wizard-fields-web.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-create-vms.adoc
-// * cnv/cnv_users_guide/cnv-importing-vmware-vm.adoc
-// * cnv/cnv_users_guide/cnv-creating-vm-template.adoc
+// * cnv/cnv_virtual_machines/cnv-create-vms.adoc
+// * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
+// * cnv/cnv_vm_templates/cnv-creating-vm-template.adoc
 
 // VM wizard includes additional options to VM template wizard
 // Call appropriate attribute in the assembly

--- a/modules/cnv-what-you-can-do-with-cnv.adoc
+++ b/modules/cnv-what-you-can-do-with-cnv.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_users_guide/cnv-about-cnv.adoc
+// * cnv/cnv-about-cnv.adoc
 // * cnv/cnv_release_notes/cnv-release-notes.adoc
 
 [id="cnv-what-you-can-do-with-cnv_{context}"]

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * support/gathering-cluster-data.adoc
-// * cnv/cnv_users_guide/cnv-collecting-cnv-data.adoc
-// Dependency: modules/cnv-document-attributes.adoc
+// * cnv/cnv_logging_events_monitoring/cnv-collecting-cnv-data.adoc
+
+// Dependency: modules/cnv-document-attributes.adoc 
 
 [id="gathering-data-specific-features_{context}"]
 = Gathering data about specific features

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * machine_management/deploying-machine-health-checks.adoc
-// * cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
 
 [id="machine-health-checks-about_{context}"]
 = About MachineHealthChecks

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * machine_management/deploying-machine-health-checks.adoc
-// * cnv/cnv_users_guide/cnv-fencing-unhealthy-nodes.adoc
 
 
 [id="machine-health-checks-resource_{context}"]

--- a/modules/monitoring-about-cluster-monitoring.adoc
+++ b/modules/monitoring-about-cluster-monitoring.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
+// * cnv/cnv_logging_events_monitoring/cnv-openshift-cluster-monitoring.adoc
 // * monitoring/cluster_monitoring/about-cluster-monitoring.adoc
-// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
-//
+
 // This module uses a conditionalized title so that the module
 // can be re-used in associated products but the title is not
 // included in the existing OpenShift assembly.

--- a/modules/telemetry-about-telemetry.adoc
+++ b/modules/telemetry-about-telemetry.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
+// * cnv/cnv_logging_events_monitoring/cnv-openshift-cluster-monitoring.adoc
 // * support/remote_health_monitoring/about-remote-health-monitoring.adoc
-// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
 
 [id="telemetry-about-telemetry_{context}"]
 = About Telemetry

--- a/modules/telemetry-what-information-is-collected.adoc
+++ b/modules/telemetry-what-information-is-collected.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
+// * cnv/cnv_logging_events_monitoring/cnv-openshift-cluster-monitoring.adoc
 // * support/remote_health_monitoring/about-remote-health-monitoring.adoc
-// * cnv/cnv_users_guide/cnv-openshift-cluster-monitoring.adoc
 
 ifeval::["{context}" == "cnv-openshift-cluster-monitoring"]
 :cnv-cluster:


### PR DESCRIPTION
Restructuring the repo means a lot of changes to module metadata. This PR updates all that precious metadata, as well as correcting a few additional things along the way:
- all cnv metadata now employs `// * <assembly_name> (previously an inconsistent inclusion of asterix)
- all metadata now has an empty line immediately following the metadata (important for running scripts like this)
- all modules used in CNV now have completely up-to-date metadata (some had been neglected)

In addition, two modules jumped out:
* modules/cnv-accessing-vmi-web.adoc 
(Not used in any assembly)

* modules/gathering-data-specific-features.adoc
(seems to be cnv-specific but no cnv prefix? Also, declares dependency for something that we use regardless? maybe hangover for when it was used in ocp docs?)