### PR TITLE
Clarify SAML support

### DIFF
--- a/modules/identity-provider-about-request-header.adoc
+++ b/modules/identity-provider-about-request-header.adoc
@@ -13,7 +13,7 @@ an authenticating proxy, which sets the request header value.
 ====
 You can also use the request header identity provider for advanced configurations
 such as the community-supported link:https://github.com/openshift/request-header-saml-service-provider[SAML authentication].
-Note that SAML authentication is not supported by Red Hat.
+Note that this solution is not supported by Red Hat.
 ====
 
 For users to authenticate using this identity provider, they must access


### PR DESCRIPTION
The current wording may be interpreted as if there was no support
for SAML-providing identity providers, which is not true as in
such cases, the RequestHeader IdP can be used if a login proxy
is properly configured.