### PR TITLE
y-stream CNV upgrades for 2.2 and 2.3

### DIFF
--- a/cnv/upgrading-container-native-virtualization.adoc
+++ b/cnv/upgrading-container-native-virtualization.adoc
@@ -4,13 +4,15 @@ include::modules/cnv-document-attributes.adoc[]
 :context: upgrading-container-native-virtualization
 toc::[]
 
-You enable automatic updates during {CNVProductName} xref:../cnv/cnv_install/installing-container-native-virtualization.adoc#cnv-subscribing-to-the-catalog_installing-container-native-virtualization[installation].
-Learn what to expect and how you can check the status of an update in progress.
+You can manually upgrade to the next minor version of {CNVProductName} and
+monitor the status of an update by using the web console.
 
 :FeatureName: {CNVProductNameStart}
 include::modules/technology-preview.adoc[leveloffset=+1]
 
 include::modules/cnv-about-upgrading-cnv.adoc[leveloffset=+1]
+
+include::modules/cnv-upgrading-cnv.adoc[leveloffset=+1]
 
 include::modules/cnv-monitoring-upgrade-status.adoc[leveloffset=+1]
 

--- a/modules/cnv-about-upgrading-cnv.adoc
+++ b/modules/cnv-about-upgrading-cnv.adoc
@@ -5,12 +5,12 @@
 [id="cnv-about-upgrading-cnv_{context}"]
 = About upgrading container-native virtualization
 
-If you enabled automatic updates when you installed {CNVProductName}, you
-receive updates as they become available.
-
 == How {CNVProductName} upgrades work
 
-* Only _z-stream_ updates are available. For example, you can upgrade from {CNVVersion}.0 to {CNVVersion}.1.
+* You can upgrade to the next minor version of {CNVProductName} by using the
+{product-title} web console to change the channel of your Operator subscription.
+
+* You can enable automatic _z-stream_ updates during {CNVProductName} installation.
 
 * Updates are delivered via the _Marketplace Operator_, which is deployed
 during {product-title} installation. The Marketplace Operator makes

--- a/modules/cnv-upgrading-cnv.adoc
+++ b/modules/cnv-upgrading-cnv.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * cnv/upgrading-container-native-virtualization.adoc
+
+[id="cnv-upgrading-cnv_{context}"]
+= Upgrading {CNVProductName} to the next minor version
+
+You can manually upgrade {CNVProductName} to the next minor version by using the
+{product-title} web console to change the channel of your Operator subscription.
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Access the {product-title} web console and navigate to *Operators* -> *Installed Operators*.
+
+. Click *{CNVProductNameStart}* to open the *Operator Details* page.
+
+. Click the *Subscription* tab to open the *Subscription Overview* page.
+
+. In the *Channel* pane, click the pencil icon on the right side of the
+version number to open the *Change Subscription Update Channel* window.
+
+. Select the next minor version. For example, if you want to upgrade to {CNVProductName}
+{CNVVersion}, select *{CNVVersion}*.
+
+. Click *Save*.
+
+. Check the status of the upgrade by navigating to *Operators* -> *Installed Operators*.
+You can also check the status by running the following `oc` command:
++
+----
+$ oc get csv -n openshift-cnv
+----


### PR DESCRIPTION
Removing inaccurate information about which upgrade types are available and adding a procedure for triggering a y-stream upgrade.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1796657
For enterprise-4.3 and 4.4 (CNV 2.2 and 2.3)

Preview build: http://file.bos.redhat.com/pousley/021920/y-upgrades-2.2/cnv/upgrading-container-native-virtualization.html
