### PR TITLE
CNV 2.2 - BZ#1793132 - warning for hostpath-provisioner backing partition

### DIFF
--- a/modules/cnv-configuring-selinux-hpp-on-rhcos8.adoc
+++ b/modules/cnv-configuring-selinux-hpp-on-rhcos8.adoc
@@ -19,6 +19,12 @@ If you do not use Red Hat Enterprise Linux CoreOS workers, skip this procedure.
 * Create a backing directory on each node for the PersistentVolumes (PVs)
 that the hostpath provisioner creates.
 
+[WARNING]
+====
+If you select a directory that shares space with your operating system, you can
+exhaust the space on that partition, causing the node to stop functioning. To avoid
+this issue, create a separate partition and point the hostpath provisioner to that directory.
+====
 
 .Procedure
 

--- a/modules/cnv-using-hostpath-provisioner.adoc
+++ b/modules/cnv-using-hostpath-provisioner.adoc
@@ -13,6 +13,13 @@ storage, first create a HostPathProvisioner custom resource.
 * Create a backing directory on each node for the PersistentVolumes (PVs)
 that the hostpath provisioner creates.
 
+[WARNING]
+====
+If you select a directory that shares space with your operating system, you can
+exhaust the space on that partition, causing the node to stop functioning. To avoid
+this issue, create a separate partition and point the hostpath provisioner to that directory.
+====
+
 * Apply the SELinux context `container_file_t` to the PV
 backing directory on each node. For example:
 +


### PR DESCRIPTION
Adding a warning admonition (taken from upstream) to hostpath-provisioner config: backing partitions shouldn't share with OS

Targeted to enterprise-4.3 only as this is being fixed for 2.3 (bz#1794050)