### PR TITLE
Split multicast content for OpenShift SDN

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -406,8 +406,11 @@ Topics:
     File: editing-egress-firewall
   - Name: Removing an egress firewall from a project
     File: removing-egress-firewall
-  - Name: Using multicast
-    File: using-multicast
+  - Name: Enabling multicast for a project
+    File: enabling-multicast
+    Distros: openshift-origin,openshift-enterprise
+  - Name: Disabling multicast for a project
+    File: disabling-multicast
     Distros: openshift-origin,openshift-enterprise
   - Name: Configuring multitenant isolation
     File: multitenant-isolation

--- a/modules/nw-about-multicast.adoc
+++ b/modules/nw-about-multicast.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * networking/openshift-sdn/using-multicast.adoc
-// * networking/ovn-kubernetes-network-provider/enabling-multicast.adoc
+// * networking/openshift_sdn/enabling-multicast.adoc
+// * networking/ovn_kubernetes_network_provider/enabling-multicast.adoc
 
-ifeval::["{context}" == "using-multicast"]
+ifeval::["{context}" == "openshift-sdn-enabling-multicast"]
 :openshift-sdn:
 :sdn: OpenShift SDN
 endif::[]
@@ -46,7 +46,7 @@ other projects only if each project is joined together and multicast is enabled
 in each joined project.
 endif::openshift-sdn[]
 
-ifeval::["{context}" == "using-multicast"]
+ifeval::["{context}" == "openshift-sdn-enabling-multicast"]
 :!openshift-sdn:
 endif::[]
 ifeval::["{context}" == "ovn-kubernetes-enabling-multicast"]

--- a/modules/nw-disabling-multicast.adoc
+++ b/modules/nw-disabling-multicast.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * networking/using-multicast.adoc
-// * networking/ovn-kubernetes-network-provider/disabling-multicast.adoc
+// * networking/openshift_sdn/disabling-multicast.adoc
+// * networking/ovn_kubernetes_network_provider/disabling-multicast.adoc
 
-ifeval::["{context}" == "using-multicast"]
+ifeval::["{context}" == "openshift-sdn-disabling-multicast"]
 :namespace: netnamespace
 :annotation: netnamespace.network.openshift.io/multicast-enabled-
 endif::[]
@@ -34,7 +34,7 @@ $ oc annotate {namespace} <namespace> \ <1>
 +
 <1> The `namespace` for the project you want to disable multicast for.
 
-ifeval::["{context}" == "using-multicast"]
+ifeval::["{context}" == "openshift-sdn-disabling-multicast"]
 :!annotation:
 :!namespace:
 endif::[]

--- a/modules/nw-enabling-multicast.adoc
+++ b/modules/nw-enabling-multicast.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * networking/using-multicast.adoc
-// * networking/ovn-kubernetes-network-provider/enabling-multicast.adoc
+// * networking/openshift_sdn/enabling-multicast.adoc
+// * networking/ovn_kubernetes_network_provider/enabling-multicast.adoc
 
-ifeval::["{context}" == "using-multicast"]
+ifeval::["{context}" == "openshift-sdn-enabling-multicast"]
 :namespace: netnamespace
 :annotation: netnamespace.network.openshift.io/multicast-enabled=true
 endif::[]
@@ -34,7 +34,7 @@ $ oc annotate {namespace} <namespace> \ <1>
 +
 <1> The `namespace` for the project you want to enable multicast for.
 
-ifeval::["{context}" == "using-multicast"]
+ifeval::["{context}" == "openshift-sdn-enabling-multicast"]
 :!annotation:
 :!namespace:
 endif::[]

--- a/networking/openshift_sdn/disabling-multicast.adoc
+++ b/networking/openshift_sdn/disabling-multicast.adoc
@@ -1,0 +1,9 @@
+[id="disabling-multicast"]
+= Disabling multicast for a project
+include::modules/common-attributes.adoc[]
+:context: openshift-sdn-disabling-multicast
+
+toc::[]
+
+include::modules/nw-disabling-multicast.adoc[leveloffset=+1]
+

--- a/networking/openshift_sdn/enabling-multicast.adoc
+++ b/networking/openshift_sdn/enabling-multicast.adoc
@@ -1,11 +1,9 @@
-[id="networking-using-multicast"]
-= Using multicast
+[id="enabling-multicast"]
+= Enabling multicast for a project
 include::modules/common-attributes.adoc[]
-:context: using-multicast
+:context: openshift-sdn-enabling-multicast
 
 toc::[]
 
 include::modules/nw-about-multicast.adoc[leveloffset=+1]
 include::modules/nw-enabling-multicast.adoc[leveloffset=+1]
-include::modules/nw-disabling-multicast.adoc[leveloffset=+1]
-


### PR DESCRIPTION
This duplicates the topic layout used for ovn-kube multicast for consistency.