### PR TITLE
Add warning when using NetworkPolicy with hostNetwork

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -17,6 +17,11 @@ The Kubernetes `v1` NetworkPolicy features are available in {product-title}
 except for egress policy types and IPBlock.
 ====
 
+[WARNING]
+====
+`NetworkPolicy` rules do not apply to the host network namespace. Pods with host networking enabled are unaffected by `NetworkPolicy` rules.
+====
+
 By default, all Pods in a project are accessible from other Pods and network
 endpoints. To isolate one or more Pods in a project, you can create
 NetworkPolicy objects in that project to indicate the allowed incoming


### PR DESCRIPTION
This warning applies to all OpenShift versions, I'll make a separate PR for 3.x.