### PR TITLE
BZ1797036 Add optional step for configuring NFS PV in reg storage

### DIFF
--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -64,6 +64,77 @@ storage:
 Leave the `claim` field blank to allow the automatic creation of an
 `image-registry-storage` PVC.
 
+. Optional: Add a new storage class to a PV:
+.. Create the PV:
++
+----
+$ oc create -f -
+----
++
+[source,yaml]
+----
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: image-registry-pv
+spec:
+  accessModes:
+    ReadWriteMany
+    capacity:
+      storage: 100Gi
+  nfs:
+    path: /registry
+    server: 172.16.231.181
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs01
+----
++
+----
+$ oc get pv
+----
+
+.. Create the PVC:
++
+----
+$ oc create -n openshift-image-registry -f -
+----
++
+[source,yaml]
+----
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "image-registry-pvc"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: nfs01
+  volumeMode: Filesystem
+----
++
+----
+$ oc get pvc -n openshift-image-registry
+----
++
+Finally, add the name of your PVC:
++
+----
+$ oc edit configs.imageregistry.operator.openshift.io -o yaml
+----
++
+[source,yaml]
+----
+storage:
+  pvc:
+    claim: image-registry-pvc <1>
+----
+<1> Creating a custom PVC allows you to leave the `claim` field blank for default automatic creation of an `image-registry-storage` PVC.
+
++
 . Check the `clusteroperator` status:
 +
 ----


### PR DESCRIPTION
[BZ1797036](https://bugzilla.redhat.com/show_bug.cgi?id=1797036)
4.2+

[PREVIEW BUILD LINK](https://bz1797036--ocpdocs.netlify.com/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#registry-configuring-storage-vsphere_installing-restricted-networks-vsphere)

It really only makes sense to include this optional step after step 3 ("Check the registry configuration"). The customer request was: 

> We'd like to have kept the SC (`thin`) as the default class (storageclass.kubernetes.io/is-default-class=true) and are going to add a non-default SC (` nfs01`), and set it as new image-registry, .
> In this case, how do we edit PVC ?
> The reason why we would not like to change default SC, is that if the default class changes, and then the image registry should need to be rebuilt due to that. That meant changing the default SC after the service lanuched, and it will have negative impact to existing users