### PR TITLE
Fix iscsi raw block in 4.2 table

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1470,8 +1470,8 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 
 |Raw Block with iSCSI
-|GA
-|TP
+|-
+|-
 |TP
 
 |OperatorHub


### PR DESCRIPTION
[BZ1797876](https://bugzilla.redhat.com/show_bug.cgi?id=1797876)
Confirmed with Storage team that there was no support for `iSCSI raw block` until 4.2, when it was introduced as tech preview. In 4.3, it went GA.
This PR updates the tracker table in `4.2 Release Notes` to remove ref to raw block support in 3.11 and 4.1 releases.

@liangxia PTAL