### PR TITLE
Verify 3.x authentication with registry.redhat.io

### DIFF
--- a/modules/migration-installing-cam-operator-ocp-3.adoc
+++ b/modules/migration-installing-cam-operator-ocp-3.adoc
@@ -43,6 +43,12 @@ $ sudo podman cp $(sudo podman create registry.redhat.io/rhcam-1-1/openshift-mig
 $ sudo podman cp $(sudo podman create registry.redhat.io/rhcam-1-1/openshift-migration-rhel7-operator:v1.1 ):/controller-3.yml ./
 ----
 
+. Verify that your {product-title} 3 cluster is correctly configured to authenticate with `registry.redhat.io`:
++
+----
+$ oc run test --image registry.redhat.io/ubi8 --command sleep infinity
+----
+
 . Create the Cluster Application Migration Operator CR object:
 +
 ----


### PR DESCRIPTION
When deploying CAM on OCP 3.x cluster, user must create secret for registry.redhat.io authentication and verify authentication.

Cherrypick 4.2 and 4.3.