### PR TITLE
removed xref from dedicated module

### DIFF
--- a/modules/dedicated-creating-your-cluster.adoc
+++ b/modules/dedicated-creating-your-cluster.adoc
@@ -26,7 +26,6 @@ following are the default ranges available to use:
 .. Pod CIDR: 10.128.0.0/14
 
 . Add your Identity provider by clicking the *Add OAuth Configuration* link.
-Further configuration details may be found xref:../authentication/dedicated-understanding-authentication.adoc[here].
 
 . Add a user by clicking the *Users* tab, then *Add User*. Input the user's name, then click *Add*.
 


### PR DESCRIPTION
Swapped an `xref` for a `link`. Preview build here: 
http://file.rdu.redhat.com/~antaylor/xrefremoval/xrefremoval/getting_started/accessing-your-services.html

@vikram-redhat  PTAL. 