### PR TITLE
BZ1799065

### DIFF
--- a/cnv/cnv_virtual_machines/cnv-create-vms.adoc
+++ b/cnv/cnv_virtual_machines/cnv-create-vms.adoc
@@ -4,12 +4,20 @@ include::modules/cnv-document-attributes.adoc[]
 :context: cnv-create-vms
 toc::[]
 
+
 Use one of these procedures to create a virtual machine:
 
 * Running the virtual machine wizard
 * Pasting a pre-configured YAML file with the virtual machine wizard
 * Using the CLI
 * Importing a VMware virtual machine or template with the virtual machine wizard
+
+[WARNING]
+====
+Do not create virtual machines in `openshift-*` namespaces.
+Instead, create a new namespace or use an existing namespace without the
+`openshift` prefix.
+====
 
 include::modules/cnv-creating-vm-wizard-web.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Resolving bug by adding the following as a prerequisite to the Create VMs assembly:

_Before creating your virtual machine, ensure your namespace is not `openshift-cnv`.
Create a new namespace or use another preexisting namespace that is not named
 `openshift-cnv`._

Label **Peer Review Needed** and **Enterprise-4.3** and **Enterprise-4.4**

See https://bz1799065--ocpdocs.netlify.com/openshift-enterprise/latest/cnv/cnv_virtual_machines/cnv-create-vms.html for Preview Build. Topic is Create Virtual Machines.

Bob