### PR TITLE
BZ1661949 - Fix command for disabling ID mapping on NFSv4

### DIFF
--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -446,9 +446,16 @@ a|- Could be attributed to the ID mapping settings (/etc/idmapd.conf) on your NF
 - See https://access.redhat.com/solutions/33455[this Red Hat Solution].
 
 |Disabling ID mapping on NFSv4
-a|- On both the NFS client and server, run:
+a|- On the NFS server, run:
 +
 ----
 # echo 'Y' > /sys/module/nfsd/parameters/nfs4_disable_idmapping
 ----
++
+- On the NFS client, run:
++
+----
+# echo 'Y' > /sys/module/nfs/parameters/nfs4_disable_idmapping
+----
++
 |===


### PR DESCRIPTION
[BZ1661949](https://bugzilla.redhat.com/show_bug.cgi?id=1661949)
merge to `master-3` and CP to `enterprise-3.11`

Additional command added to show methods for both client and server, as described in bug.

@jrosenta - We are only supporting OCP 3.11 branch, so this was not backported to versions prior. PTAL to confirm this is correct.