### PR TITLE
Changed to version 4.2

### DIFF
--- a/modules/cluster-logging-deploy-clo-cli.adoc
+++ b/modules/cluster-logging-deploy-clo-cli.adoc
@@ -81,13 +81,13 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging <1> 
 spec:
-  channel: "4.3" <2>
+  channel: "4.2" <2>
   name: cluster-logging 
   source: redhat-operators 
   sourceNamespace: openshift-marketplace
 ----
 <1> You must specify the `openshift-logging` Namespace.
-<2> Specify `4.3` as the channel.
+<2> Specify `4.2` as the channel.
 
 .. Create the Subscription object:
 +
@@ -112,7 +112,7 @@ oc get csv --all-namespaces
 
 NAMESPACE                                               NAME                                         DISPLAY                  VERSION               REPLACES   PHASE
 ...
-openshift-logging                                       clusterlogging.4.3.1-202002032140            Cluster Logging          4.3.1-202002032140               Succeeded
+openshift-logging                                       clusterlogging.4.2.1-202002032140            Cluster Logging          4.2.1-202002032140               Succeeded
 ...
 ----
 

--- a/modules/cluster-logging-deploy-eo-cli.adoc
+++ b/modules/cluster-logging-deploy-eo-cli.adoc
@@ -97,14 +97,14 @@ metadata:
   generateName: "elasticsearch-"
   namespace: "openshift-operators-redhat" <1>
 spec:
-  channel: "4.3" <2>
+  channel: "4.2" <2>
   installPlanApproval: "Automatic"
   source: "redhat-operators"
   sourceNamespace: "openshift-marketplace"
   name: "elasticsearch-operator"
 ----
 <1> You must specify the `openshift-operators-redhat` Namespace.
-<2> Specify `4.3` as the channel.
+<2> Specify `4.2` as the channel.
 
 .. Create the Subscription object:
 +
@@ -182,14 +182,14 @@ The Elasticsearch Operator is installed to the `openshift-operators-redhat` Name
 oc get csv --all-namespaces
 
 NAMESPACE                                               NAME                                         DISPLAY                  VERSION               REPLACES   PHASE
-default                                                 elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-kube-node-lease                                         elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-kube-public                                             elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-kube-system                                             elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-openshift-apiserver-operator                            elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-openshift-apiserver                                     elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-openshift-authentication-operator                       elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
-openshift-authentication                                elasticsearch-operator.4.3.1-202002032140    Elasticsearch Operator   4.3.1-202002032140               Succeeded
+default                                                 elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+kube-node-lease                                         elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+kube-public                                             elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+kube-system                                             elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+openshift-apiserver-operator                            elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+openshift-apiserver                                     elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+openshift-authentication-operator                       elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
+openshift-authentication                                elasticsearch-operator.4.2.1-202002032140    Elasticsearch Operator   4.2.1-202002032140               Succeeded
 ...
 ----
 +


### PR DESCRIPTION
The changes in https://github.com/openshift/openshift-docs/pull/19955 introduced `4.3` versions in several places. This PR changes them back to `4.2`.