### PR TITLE
Configuring MCG as replication repo for migration

### DIFF
--- a/migration/migrating_3_4/configuring-replication-repository.adoc
+++ b/migration/migrating_3_4/configuring-replication-repository.adoc
@@ -10,12 +10,20 @@ You must configure an object storage to use as a replication repository. The Clu
 
 The following storage providers are supported:
 
-* Generic S3 object storage, for example, NooBaa, Minio, Ceph S3
-* xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#migration-configuring-aws-s3_{context}[AWS S3]
-* xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#migration-configuring-gcp_{context}[Google Cloud Provider]
-* xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#migration-configuring-azure_{context}[Microsoft Azure]
+* Generic S3 object storage, for example, Minio or Ceph S3
+* Multi-Cloud Object Gateway (MCG)
+* Amazon Web Services (AWS) S3
+* Google Cloud Provider (GCP)
+* Microsoft Azure
 
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
+
+ifeval::["{product-version}" == "4.2"]
+:FeatureName: Configuring Multi-Cloud Object Gateway as a replication repository for migration
+include::modules/technology-preview.adoc[leveloffset=+1]
+endif::[]
+
+include::modules/migration-configuring-mcg.adoc[leveloffset=+1]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+1]
 include::modules/migration-configuring-azure.adoc[leveloffset=+1]

--- a/migration/migrating_4_1_4/configuring-replication-repository.adoc
+++ b/migration/migrating_4_1_4/configuring-replication-repository.adoc
@@ -10,12 +10,20 @@ You must configure an object storage to use as a replication repository. The Clu
 
 The following storage providers are supported:
 
-* Generic S3 object storage, for example, NooBaa, Minio, Ceph S3
-* xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#migration-configuring-aws-s3_{context}[AWS S3]
-* xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#migration-configuring-gcp_{context}[Google Cloud Provider]
-* xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#migration-configuring-azure_{context}[Microsoft Azure]
+* Generic S3 object storage, for example, Minio or Ceph S3
+* Multi-Cloud Object Gateway (MCG)
+* Amazon Web Services (AWS) S3
+* Google Cloud Provider (GCP)
+* Microsoft Azure
 
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
+
+ifeval::["{product-version}" == "4.2"]
+:FeatureName: Configuring Multi-Cloud Object Gateway as a replication repository for migration
+include::modules/technology-preview.adoc[leveloffset=+1]
+endif::[]
+
+include::modules/migration-configuring-mcg.adoc[leveloffset=+1]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+1]
 include::modules/migration-configuring-azure.adoc[leveloffset=+1]

--- a/migration/migrating_4_2_4/configuring-replication-repository.adoc
+++ b/migration/migrating_4_2_4/configuring-replication-repository.adoc
@@ -10,12 +10,20 @@ You must configure an object storage to use as a replication repository. The Clu
 
 The following storage providers are supported:
 
-* Generic S3 object storage, for example, NooBaa, Minio, Ceph S3
-* xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#migration-configuring-aws-s3_{context}[AWS S3]
-* xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#migration-configuring-gcp_{context}[Google Cloud Provider]
-* xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#migration-configuring-azure_{context}[Microsoft Azure]
+* Generic S3 object storage, for example, Minio or Ceph S3
+* Multi-Cloud Object Gateway (MCG)
+* Amazon Web Services (AWS) S3
+* Google Cloud Provider (GCP)
+* Microsoft Azure
 
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
+
+ifeval::["{product-version}" == "4.2"]
+:FeatureName: Configuring Multi-Cloud Object Gateway as a replication repository for migration
+include::modules/technology-preview.adoc[leveloffset=+1]
+endif::[]
+
+include::modules/migration-configuring-mcg.adoc[leveloffset=+1]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+1]
 include::modules/migration-configuring-azure.adoc[leveloffset=+1]

--- a/modules/migration-adding-replication-repository-to-cam.adoc
+++ b/modules/migration-adding-replication-repository-to-cam.adoc
@@ -18,28 +18,28 @@ You can add an object storage bucket as a replication repository to the CAM web 
 . In the *Replication repositories* section, click *Add repository*.
 . Select a *Storage provider type* and fill in the following fields:
 
-* *AWS* for AWS S3 and generic S3 providers:
+* *AWS* for AWS S3, MCG, and generic S3 providers:
 
-** *Repository name*: Specify the repository name in the CAM web console.
-** *S3 bucket name*: Specify the name of the S3 bucket.
-** *S3 bucket region*: Specify the S3 bucket region. *Required* for AWS S3. *Optional* for a generic S3 provider.
-** *S3 endpoint*:  Specify the URL of the S3 service, not the bucket, for example, `\https://<s3-storage.apps.cluster.com>`. *Required* for a generic S3 provider.
+** *Replication repository name*: Specify the replication repository name in the CAM web console.
+** *S3 bucket name*: Specify the name of the S3 bucket you created.
+** *S3 bucket region*: Specify the S3 bucket region. *Required* for AWS S3. *Optional* for other S3 providers.
+** *S3 endpoint*: Specify the URL of the S3 service, not the bucket, for example, `\https://<s3-storage.apps.cluster.com>`. *Required* for a generic S3 provider. You must use the `https://` prefix.
 
-** *S3 provider access key*: Specify the `<AWS_SECRET_ACCESS_KEY>`.
-** *S3 provider secret access key*: Specify the `<AWS_ACCESS_KEY_ID>`.
+** *S3 provider access key*: Specify the `<AWS_SECRET_ACCESS_KEY>` for AWS or the S3 provider access key for MCG.
+** *S3 provider secret access key*: Specify the `<AWS_ACCESS_KEY_ID>` for AWS or the S3 provider secret access key for MCG.
 ** *Require SSL verification*: Clear this check box if you are using a generic S3 provider.
 
 * *GCP*:
 
-** *Repository name*: Specify the repository name in the CAM web console.
+** *Replication repository name*: Specify the replication repository name in the CAM web console.
 ** *GCP bucket name*: Specify the name of the GCP bucket.
 ** *GCP credential JSON blob*: Specify the string in the `credentials-velero` file.
 
 * *Azure*:
 
-** *Repository name*: Specify the repository name in the CAM web console.
+** *Replication repository name*: Specify the replication repository name in the CAM web console.
 ** *Azure resource group*: Specify the resource group of the Azure Blob storage.
-** *Azure storage account name*: Specify the Azure Blob storage account name
+** *Azure storage account name*: Specify the Azure Blob storage account name.
 ** *Azure credentials - INI file contents*: Specify the string in the `credentials-velero` file.
 
 . Click *Add repository* and wait for connection validation.

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -1,0 +1,171 @@
+// Module included in the following assemblies:
+//
+// migration/migrating_3_4/configuring-replication-repository.adoc
+// migration/migrating_4_1_4/configuring-replication-repository.adoc
+// migration/migrating_4_2_4/configuring-replication-repository.adoc
+[id='migration-configuring-mcg_{context}']
+= Configuring a Multi-Cloud Object Gateway storage bucket as a replication repository
+
+You can install the OpenShift Container Storage Operator and configure a Multi-Cloud Object Gateway (MCG) storage bucket as a replication repository on the CAM tool cluster.
+
+[id='installing-the-ocs-operator_{context}']
+== Installing the OpenShift Container Storage Operator
+
+You can install the OpenShift Container Storage Operator from OperatorHub on the CAM tool cluster.
+
+.Procedure
+
+. In the {product-title} web console, click *Administration* -> *Namespaces*.
+. Click *Create Namespace*.
+. Enter `openshift-storage` in the *Name* field and click *Create*.
+. Click *Operators* -> *OperatorHub*.
+. Use *Filter by keyword* (in this case, *OCS*) to find the *OpenShift Container Storage Operator*.
+. Select the *OpenShift Container Storage Operator* and click *Install*.
+. On the *Create Operator Subscription* page, select the `openshift-storage` namespace.
+. Specify your update channel and approval strategy.
+. Click *Subscribe*.
++
+On the *Installed Operators* page, the *OpenShift Container Storage Operator* appears in the *openshift-storage* project with the status *Succeeded*.
+
+[id='configuring-mcg-storage-bucket_{context}']
+== Creating the Multi-Cloud Object Gateway storage bucket
+
+You can create the Multi-Cloud Object Gateway (MCG) storage bucket's Custom Resources (CRs) on the CAM tool cluster.
+
+.Procedure
+
+. Log in to the CAM tool cluster.
+. Create the `NooBaa` CR configuration file, `noobaa.yml`, with the following content:
++
+[source,yaml]
+----
+apiVersion: noobaa.io/v1alpha1
+kind: NooBaa
+metadata:
+  name: noobaa
+  namespace: openshift-storage
+spec:
+ dbResources:
+   requests:
+     cpu: 0.5 <1>
+     memory: 1Gi
+ coreResources:
+   requests:
+     cpu: 0.5 <1>
+     memory: 1Gi
+----
+<1> For a very small cluster, you can change the `cpu` value to `0.1`.
+
+. Create the `NooBaa` object:
++
+----
+$ oc create -f noobaa.yml
+----
+
+. Create the `BackingStore` CR configuration file, `bs.yml`, with the following content:
++
+[source,yaml]
+----
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  labels:
+    app: noobaa
+  name: mcg-pv-pool-bs
+  namespace: openshift-storage
+spec:
+  pvPool:
+    numVolumes: 3 <1>
+    resources:
+      requests:
+        storage: 50Gi <2>
+    storageClass: gp2 <3>
+  type: pv-pool
+----
+<1> Specify the number of volumes in the PV pool.
+<2> Specify the size of the volumes.
+<3> Specify the storage class.
+
+. Create the `BackingStore` object:
++
+----
+$ oc create -f bs.yml
+----
+
+. Create the `BucketClass` CR configuration file, `bc.yml`, with the following content:
++
+[source,yaml]
+----
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  labels:
+    app: noobaa
+  name: mcg-pv-pool-bc
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - mcg-pv-pool-bs
+      placement: Spread
+----
+
+. Create the `BucketClass` object:
++
+----
+$ oc create -f bc.yml
+----
+
+. Create the `ObjectBucketClaim` CR configuration file, `obc.yml`, with the following content:
++
+[source,yaml]
+----
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: migstorage
+  namespace: openshift-storage
+spec:
+  bucketName: migstorage <1>
+  storageClassName: openshift-storage.noobaa.io
+  additionalConfig:
+    bucketclass: mcg-pv-pool-bc
+----
+<1> Record the bucket name for adding the replication repository to the CAM web console.
+
+. Create the `ObjectBucketClaim` object:
++
+----
+$ oc create -f obc.yml
+----
+
+. Watch the resource creation process to verify that the `ObjectBucketClaim` status is `Bound`:
++
+----
+$ watch -n 30 'oc get -n openshift-storage objectbucketclaim migstorage -o yaml'
+----
++
+This process can take five to ten minutes.
+
+. Obtain and record the following values, which are required when you add the replication repository to the CAM web console:
+
+* S3 endpoint:
++
+----
+$ oc get route -n openshift-storage s3
+----
+
+* S3 provider access key:
++
+----
+$ oc get secret -n openshift-storage migstorage -o go-template='{{ .data.AWS_ACCESS_KEY_ID }}' | base64 -d
+----
+
+* S3 provider secret access key:
++
+----
+$ oc get secret -n openshift-storage migstorage -o go-template='{{ .data.AWS_SECRET_ACCESS_KEY }}' | base64 -d
+----

--- a/modules/migration-understanding-cam.adoc
+++ b/modules/migration-understanding-cam.adoc
@@ -10,19 +10,19 @@ The Cluster Application Migration (CAM) tool enables you to migrate Kubernetes r
 
 Migrating an application with the CAM web console involves the following steps:
 
-. Installing the Cluster Application Migration Operator on all clusters
+. Install the Cluster Application Migration Operator on all clusters.
 +
 [NOTE]
 ====
-The Cluster Application Migration Operator installs the CAM tool (CAM web console and Migration controller) on the target cluster by default. You can change this configuration in order to install the CAM tool on another cluster.
+The Cluster Application Migration Operator installs the CAM tool (CAM web console and Migration controller) on the target cluster by default. You can configure the Migration controller to install the CAM tool on another cluster. The cluster on which the CAM tool is installed is referred to as the CAM tool cluster.
 ====
 
-. Configuring the replication repository, an intermediate object storage that the CAM tool uses to migrate data
-. Adding the source cluster to the CAM web console
-. Adding the replication repository to the CAM web console
-. Creating a migration plan, with one of the following data migration options:
+. Configure the replication repository, an intermediate object storage that the CAM tool uses to migrate data.
+. Add the source cluster to the CAM web console.
+. Add the replication repository to the CAM web console.
+. Create a migration plan, with one of the following data migration options:
 
-* *Copy*: The CAM tool copies the data from the source cluster to the replication repository, and from there to the target cluster.
+* *Copy*: The CAM tool copies the data from the source cluster to the replication repository, and from the replication repository to the target cluster.
 +
 image::migration-PV-copy.png[]
 
@@ -35,12 +35,12 @@ Although the replication repository does not appear in this diagram, it is requi
 +
 image::migration-PV-move.png[]
 
-. Running the migration plan, with one of the following options:
+. Run the migration plan, with one of the following options:
 
 * *Stage* (optional) copies data to the target cluster without stopping the application.
 +
 Staging can be run multiple times so that most of the data is copied to the target before migration. This minimizes the actual migration time and application downtime.
 
-* *Migrate* stops the application on the source cluster and recreates its resources on the target cluster. You have the option of migrating the workload without stopping the application.
+* *Migrate* stops the application on the source cluster and recreates its resources on the target cluster. Optionally, you can migrate the workload without stopping the application.
 
 image::OCP_3_to_4_App_migration.png[]


### PR DESCRIPTION
CP for 4.2, 4.3, and 4.4.
This is a tech preview for 4.2, so it has an "ifeval" tag around the tech preview note.