### PR TITLE
Revert "[enterprise-3.11] Edit suggested in file install_config/aggregate_logging.adoc"

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1605,7 +1605,7 @@ data:
     </label>
 ----
 
-This section writes error records to the link:https://www.elastic.co/guide/en/logstash/current/dead-letter-queues.html[Elasticsearch dead letter queue (DLQ) file].
+This section writes error records to the link:https://www.elastic.co/guide/en/logstash/current/dead-letter-queues.html[Elasticsearch dead letter queue (DLQ) file]. See link:https://docs.fluentd.org/v/0.12/output/file[the fluentd documentation] for more information about the file output.
 
 Then you can edit the file to clean up the records manually, edit the file to use with the Elasticsearch `/_bulk index` API and use cURL to add those records. For more information on Elasticsearch Bulk API, see link:https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-bulk.html[the Elasticsearch documentation].
 


### PR DESCRIPTION
Reverts openshift/openshift-docs#19973

Reverting as the link is good. There was an issue with the Fluentd docs that yielded a 404 when I made the change. The link works as expected now. 