### PR TITLE
BZ#1807121 - NAD requires a 'name' for the configuration

### DIFF
--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -34,24 +34,26 @@ metadata:
 spec:
   config: '{
     "cniVersion": "0.3.1",
+    "name": "cnv-bridge-conf", <2> 
     "plugins": [
       {
-        "type": "cnv-bridge", <2>
-        "bridge": "br0" <3>
+        "type": "cnv-bridge", <3>
+        "bridge": "br0" <4>
       },
       {
-        "type": "tuning" <4>
+        "type": "tuning" <5>
       }
     ]
   }'
 ----
 <1> If you add this annotation to your NetworkAttachmentDefinition, your virtual machine instances
 will only run on nodes that have the `br0` bridge connected.
-<2> The actual name of the Container Network Interface (CNI) plug-in that provides
+<2> Required. A name for the configuration.
+<3> The actual name of the Container Network Interface (CNI) plug-in that provides
 the network for this NetworkAttachmentDefinition. Do not change this field unless
 you want to use a different CNI.
-<3> You must substitute the actual name of the bridge, if it is not `br0`.
-<4> Required. This allows the MAC pool manager to assign a unique MAC address to the connection.
+<4> You must substitute the actual name of the bridge, if it is not `br0`.
+<5> Required. This allows the MAC pool manager to assign a unique MAC address to the connection.
 +
 ----
 $ oc create -f <resource_spec.yaml>


### PR DESCRIPTION
Minor change to the NAD configuration to add a 'name' field and annotation (shuffling the others down).

I checked on our 2.2 environment and this also has an impact there.

cherrypick to enterprise-4.3 and enterprise-4.4
