### PR TITLE
updated api version

### DIFF
--- a/modules/ossm-automatic-sidecar-injection.adoc
+++ b/modules/ossm-automatic-sidecar-injection.adoc
@@ -21,7 +21,7 @@ When deploying an application into the {ProductName} you must opt in to injectio
 .Sleep test application example
 [source,yaml]
 ----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sleep


### PR DESCRIPTION
The apiVersion extension field in ossm-automatic-sidecar-injection.adoc was updated for OSSM 1.0.8.

https://issues.redhat.com/browse/OSSMDOC-47

It needs to be cherrypicked to 4.3 and 4.4 branch when 108 is released.