### PR TITLE
use a working example as node selectors

### DIFF
--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -82,22 +82,22 @@ spec:
   reporting-operator:
     spec:
       nodeSelector:
-        "node-role.kubernetes.io/infra": "true"
+        "node-role.kubernetes.io/infra": ""
 
   presto:
     spec:
       coordinator:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": ""
       worker:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": ""
   hive:
     spec:
       metastore:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": ""
       server:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": ""
 ----


### PR DESCRIPTION
In the section how to create infra nodes, we set the node label
to the following: node-role.kubernetes.io/infra: ""

Please backbort this to other versions