### PR TITLE
OSDOCS#936 - Migrate egress router for OpenShift SDN

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -676,6 +676,16 @@ Topics:
     File: editing-egress-firewall
   - Name: Removing an egress firewall from a project
     File: removing-egress-firewall
+  - Name: Considerations for the use of an egress router pod
+    File: using-an-egress-router
+  - Name: Deploying an egress router pod in redirect mode
+    File: deploying-egress-router-layer3-redirection
+  - Name: Deploying an egress router pod in HTTP proxy mode
+    File: deploying-egress-router-http-redirection
+  - Name: Deploying an egress router pod in DNS proxy mode
+    File: deploying-egress-router-dns-redirection
+  - Name: Configuring an egress router pod destination list from a config map
+    File: configuring-egress-router-configmap
   - Name: Enabling multicast for a project
     File: enabling-multicast
     Distros: openshift-origin,openshift-enterprise

--- a/modules/nw-egress-router-about.adoc
+++ b/modules/nw-egress-router-about.adoc
@@ -1,0 +1,103 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/using-an-egress-router.adoc
+
+[id="nw-egress-router-about_{context}"]
+= About an egress router pod
+
+The {product-title} egress router pod redirects traffic to a specified remote server, using a private source IP address that is not used for any other purpose.
+This allows you to send network traffic to servers that are set up to allow access only from specific IP addresses.
+
+[NOTE]
+====
+The egress router pod is not intended for every outgoing connection. Creating large numbers of egress router pods can exceed the limits of your network hardware. For example, creating an egress router pod for every project or application could exceed the number of local MAC addresses that the network interface can handle before reverting to filtering MAC addresses in software.
+====
+
+[IMPORTANT]
+====
+The egress router image is not compatible with Amazon AWS, Azure Cloud, or any other cloud platform that does not support layer 2 manipulations due to their incompatibility with macvlan traffic.
+====
+
+[id="nw-egress-router-about-modes_{context}"]
+== Egress router modes
+
+In _redirect mode_, an egress router pod sets up iptables rules to redirect traffic from its own IP address to one or more destination IP addresses. Client pods that need to use the reserved source IP address must be modified to connect to the egress router rather than connecting directly to the destination IP.
+
+In _HTTP proxy mode_, an egress router pod runs as an HTTP proxy on port `8080`. This mode only works for clients that are connecting to HTTP-based or HTTPS-based services, but usually requires fewer changes to the client pods to get them to work. Many programs can be told to use an HTTP proxy by setting an environment variable.
+
+In _DNS proxy mode_, an egress router pod runs as a DNS proxy for TCP-based services from its own IP address to one or more destination IP addresses. To make use of the reserved, source IP address, client pods must be modified to connect to the egress router pod rather than connecting directly to the destination IP address. This modification ensures that external destinations treat traffic as though it were coming from a known source.
+
+Redirect mode works for all services except for HTTP and HTTPS. For HTTP and HTTPS services, use HTTP proxy mode. For TCP-based services with IP addresses or domain names, use DNS proxy mode.
+
+[id="nw-egress-router-about-router-pod-implementation_{context}"]
+== Egress router pod implementation
+
+The egress router pod setup is performed by an initialization container. That container runs in a privileged context so that it can configure the macvlan interface and set up `iptables` rules.
+After the initialization container finishes setting up the `iptables` rules, it exits.
+Next the egress router pod executes the container to handles the egress router traffic. The image used varies depending on the egress router mode.
+
+The environment variables determine which addresses the egress-router image uses. The image configures the macvlan interface to use `EGRESS_SOURCE` as its IP address, with `EGRESS_GATEWAY` as the IP address for the gateway.
+
+Network Address Translation (NAT) rules are set up so that connections to the cluster IP address of the pod on any TCP or UDP port are redirected to the same port on IP address specified by the `EGRESS_DESTINATION` variable.
+
+If only some of the nodes in your cluster are capable of claiming the specified source IP address and using the specified gateway, you can specify a `nodeName` or `nodeSelector` indicating which nodes are acceptable.
+
+[id="nw-egress-router-about-deployments_{context}"]
+== Deployment considerations
+
+An egress router pod adds an additional IP address and MAC address to the primary network interface of the node. As a result, you might need to configure your hypervisor or cloud provider to allow the additional address.
+
+{rh-openstack-first}::
+
+If you are deploying {product-title} on {rh-openstack}, you must whitelist the IP and MAC addresses on your OpenStack environment, otherwise link:https://access.redhat.com/solutions/2803331[communication will fail]:
++
+[source,terminal]
+----
+$ openstack port set --allowed-address \
+  ip_address=<ip_address>,mac_address=<mac_address> <neutron_port_uuid>
+----
+
+{rh-virtualization-first}::
+
+If you are using link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/administration_guide/sect-virtual_network_interface_cards#Explanation_of_Settings_in_the_VM_Interface_Profile_Window[{rh-virtualization}], you must select *No Network Filter* for the Virtual Network Interface Card (vNIC).
+
+VMware vSphere::
+
+If you are using VMware vSphere, see the link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-3507432E-AFEA-4B6B-B404-17A020575358.html[VMWare documentation for securing vSphere standard switches]. View and change VMWare vSphere default settings by selecting the host virtual switch from the vSphere Web Client.
+
+Specifically, ensure that the following are enabled:
+
+* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-942BD3AA-731B-4A05-8196-66F2B4BF1ACB.html[MAC Address Changes]
+* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-7DC6486F-5400-44DF-8A62-6273798A2F80.html[Forged Transits]
+* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-92F3AB1F-B4C5-4F25-A010-8820D7250350.html[Promiscuous Mode Operation]
+
+[id="nw-egress-router-about-failover_{context}"]
+== Failover configuration
+
+To avoid downtime, you can deploy an egress router pod with a `Deployment` resource, as in the following example. To create a new `Service` object for the example deployment, use the `oc expose deployment/egress-demo-controller` command.
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: egress-demo-controller
+spec:
+  replicas: 1 <1>
+  selector:
+    name: egress-router
+  template:
+    metadata:
+      name: egress-router
+      labels:
+        name: egress-router
+      annotations:
+        pod.network.openshift.io/assign-macvlan: "true"
+    spec: <2>
+      initContainers:
+        ...
+      containers:
+        ...
+----
+<1> Ensure that replicas is set to `1`, because only one pod can use a given egress source IP address at any time. This means that only a single copy of the router runs on a node.
+<2> Specify the `Pod` object template for the egress router pod.

--- a/modules/nw-egress-router-configmap.adoc
+++ b/modules/nw-egress-router-configmap.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/configuring-egress-router-configmap.adoc
+
+[id="configuring-egress-router-configmap_{context}"]
+= Configuring an egress router destination mappings with a config map
+
+For a large or frequently-changing set of destination mappings, you can use a config map to externally maintain the list.
+An advantage of this approach is that permission to edit the config map can be delegated to users without `cluster-admin` privileges. Because the egress router pod requires a privileged container, it is not possible for users without `cluster-admin` privileges to edit the pod definition directly.
+
+[NOTE]
+====
+The egress router pod does not automatically update when the config map changes.
+You must restart the egress router pod to get updates.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a file containing the mapping data for the egress router pod, as in the following example:
++
+----
+# Egress routes for Project "Test", version 3
+
+80   tcp 203.0.113.25
+
+8080 tcp 203.0.113.26 80
+8443 tcp 203.0.113.26 443
+
+# Fallback
+203.0.113.27
+----
++
+You can put blank lines and comments into this file.
+
+. Create a `ConfigMap` object from the file:
++
+[source,terminal]
+----
+$ oc delete configmap egress-routes --ignore-not-found
+----
++
+[source,terminal]
+----
+$ oc create configmap egress-routes \
+  --from-file=destination=my-egress-destination.txt
+----
++
+In the previous command, the `egress-routes` value is the name of the `ConfigMap` object to create and `my-egress-destination.txt` is the name of the file that the data is read from.
+
+. Create an egress router pod definition and specify the `configMapKeyRef` stanza for the `EGRESS_DESTINATION` field in the environment stanza:
++
+[source,yaml]
+----
+...
+env:
+- name: EGRESS_DESTINATION
+  valueFrom:
+    configMapKeyRef:
+      name: egress-routes
+      key: destination
+...
+----

--- a/modules/nw-egress-router-dest-var.adoc
+++ b/modules/nw-egress-router-dest-var.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc
+// * networking/openshift_sdn/deploying-egress-router-http-redirection.adoc
+// * networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc
+
+// Every redirection mode supports an expanded environment variable
+
+// Conditional per flavor of Pod
+ifeval::["{context}" == "deploying-egress-router-layer3-redirection"]
+:redirect:
+endif::[]
+ifeval::["{context}" == "deploying-egress-router-http-redirection"]
+:http:
+endif::[]
+ifeval::["{context}" == "deploying-egress-router-dns-redirection"]
+:dns:
+endif::[]
+
+[id="nw-egress-router-dest-var_{context}"]
+= Egress destination configuration format
+
+ifdef::redirect[]
+When an egress router pod is deployed in redirect mode, you can specify redirection rules by using one or more of the following formats:
+
+- `<port> <protocol> <ip_address>` - Incoming connections to the given `<port>` should be redirected to the same port on the given `<ip_address>`. `<protocol>` is either `tcp` or `udp`.
+- `<port> <protocol> <ip_address> <remote_port>` - As above, except that the connection is redirected to a different `<remote_port>` on `<ip_address>`.
+- `<ip_address>` - If the last line is a single IP address, then any connections on any other port will be redirected to the corresponding port on that IP address. If there is no fallback IP address then connections on other ports are rejected.
+
+In the example that follows several rules are defined:
+
+- The first line redirects traffic from local port `80` to port `80` on `203.0.113.25`.
+- The second and third lines redirect local ports `8080` and `8443` to remote ports `80` and `443` on `203.0.113.26`.
+- The last line matches traffic for any ports not specified in the previous rules.
+
+.Example configuration
+[source,text]
+----
+80   tcp 203.0.113.25
+8080 tcp 203.0.113.26 80
+8443 tcp 203.0.113.26 443
+203.0.113.27
+----
+endif::redirect[]
+
+ifdef::http[]
+When an egress router pod is deployed in HTTP proxy mode, you can specify redirection rules by using one or more of the following formats. Each line in the configuration specifies one group of connections to allow or deny:
+
+- An IP address allows connections to that IP address, such as `192.168.1.1`.
+- A CIDR range allows connections to that CIDR range, such as `192.168.1.0/24`.
+- A host name allows proxying to that host, such as `www.example.com`.
+- A domain name preceded by `+*.+` allows proxying to that domain and all of its subdomains, such as `*.example.com`.
+- A `!` followed by any of the previous match expressions denies the connection instead.
+- If the last line is `*`, then anything that is not explicitly denied is allowed. Otherwise, anything that is not allowed is denied.
+
+You can also use `*` to allow connections to all remote destinations.
+
+.Example configuration
+[source,text]
+----
+!*.example.com
+!192.168.1.0/24
+192.168.2.1
+*
+----
+endif::http[]
+
+ifdef::dns[]
+When the router is deployed in DNS proxy mode, you specify a list of port and destination mappings. A destination may be either an IP address or a DNS name.
+
+An egress router pod supports the following formats for specifying port and destination mappings:
+
+Port and remote address::
+
+You can specify a source port and a destination host by using the two field format: `<port> <remote_address>`.
+
+The host can be an IP address or a DNS name. If a DNS name is provided, DNS resolution occurs at runtime. For a given host, the proxy connects to the specified source port on the destination host when connecting to the destination host IP address.
+
+.Port and remote address pair example
+[source,text]
+----
+80 172.16.12.11
+100 example.com
+----
+
+Port, remote address, and remote port::
+
+You can specify a source port, a destination host, and a destination port by using the three field format: `<port> <remote_address> <remote_port>`.
+
+The three field format behaves identically to the two field version, with the exception that the destination port can be different than the source port.
+
+.Port, remote address, and remote port example
+[source,text]
+----
+8080 192.168.60.252 80
+8443 web.example.com 443
+----
+endif::dns[]
+
+// unload flavors
+ifdef::redirect[]
+:!redirect:
+endif::[]
+ifdef::http[]
+:!http:
+endif::[]
+ifdef::dns[]
+:!dns:
+endif::[]

--- a/modules/nw-egress-router-dns-mode.adoc
+++ b/modules/nw-egress-router-dns-mode.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc
+
+[id="nw-egress-router-dns-mode_{context}"]
+= Deploying an egress router pod in DNS proxy mode
+
+In _DNS proxy mode_, an egress router pod acts as a DNS proxy for TCP-based services from its own IP address to one or more destination IP addresses.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an egress router pod.
+
+. Create a service for the egress router pod:
+
+.. Create a file named `egress-router-service.yaml` that contains the following YAML. Set `spec.ports` to the list of ports that you defined previously for the `EGRESS_DNS_PROXY_DESTINATION` environment variable.
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: egress-dns-svc
+spec:
+  ports:
+    ...
+  type: ClusterIP
+  selector:
+    name: egress-dns-proxy
+----
++
+For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: egress-dns-svc
+spec:
+  ports:
+  - name: con1
+    protocol: TCP
+    port: 80
+    targetPort: 80
+  - name: con2
+    protocol: TCP
+    port: 100
+    targetPort: 100
+  type: ClusterIP
+  selector:
+    name: egress-dns-proxy
+----
+
+.. To create the service, enter the following command:
++
+[source,terminal]
+----
+$ oc create -f egress-router-service.yaml
+----
++
+Pods can now connect to this service. The connections are proxied to the corresponding ports on the external server, using the reserved egress IP address.

--- a/modules/nw-egress-router-http-proxy-mode.adoc
+++ b/modules/nw-egress-router-http-proxy-mode.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/deploying-egress-router-http-redirection.adoc
+
+[id="nw-egress-router-http-proxy-mode_{context}"]
+= Deploying an egress router pod in HTTP proxy mode
+
+In _HTTP proxy mode_, an egress router pod runs as an HTTP proxy on port `8080`. This mode only works for clients that are connecting to HTTP-based or HTTPS-based services, but usually requires fewer changes to the client pods to get them to work. Many programs can be told to use an HTTP proxy by setting an environment variable.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an egress router pod.
+
+. To ensure that other pods can find the IP address of the egress router pod, create a service to point to the egress router pod, as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: egress-1
+spec:
+  ports:
+  - name: http-proxy
+    port: 8080 <1>
+  type: ClusterIP
+  selector:
+    name: egress-1
+----
+<1> Ensure the `http` port is set to `8080`.
+
+. To configure the client pod (not the egress proxy pod) to use the HTTP proxy, set the `http_proxy` or `https_proxy` variables:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-1
+  labels:
+    name: app-1
+spec:
+  containers:
+    env:
+    - name: http_proxy
+      value: http://egress-1:8080/ <1>
+    - name: https_proxy
+      value: http://egress-1:8080/
+    ...
+----
+<1> The service created in the previous step.
++
+[NOTE]
+====
+Using the `http_proxy` and `https_proxy` environment variables is not necessary for all setups. If the above does not create a working setup, then consult the documentation for the tool or software you are running in the pod.
+====

--- a/modules/nw-egress-router-pod.adoc
+++ b/modules/nw-egress-router-pod.adoc
@@ -1,0 +1,234 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc
+// * networking/openshift_sdn/deploying-egress-router-http-redirection.adoc
+// * networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc
+
+// Conditional per flavor of Pod
+ifeval::["{context}" == "deploying-egress-router-layer3-redirection"]
+:redirect:
+:router-type: redirect
+endif::[]
+ifeval::["{context}" == "deploying-egress-router-http-redirection"]
+:http:
+:router-type: HTTP
+endif::[]
+ifeval::["{context}" == "deploying-egress-router-dns-redirection"]
+:dns:
+:router-type: DNS
+endif::[]
+
+:egress-router-image-name: openshift4/ose-egress-router
+:egress-router-image-url: registry.redhat.io/{egress-router-image-name}
+
+ifdef::http[]
+:egress-http-proxy-image-name: ose-egress-http-proxy
+:egress-http-proxy-image-url: registry.redhat.io/{egress-http-proxy-image-name}
+endif::[]
+ifdef::dns[]
+:egress-dns-proxy-image-name: openshift4/ose-egress-dns-proxy
+:egress-dns-proxy-image-url: registry.redhat.io/{egress-dns-proxy-image-name}
+endif::[]
+// After bz-1896170 switch to: openshift4/ose-pod
+ifdef::redirect[]
+:egress-pod-image-name: openshift3/ose-pod
+:egress-pod-image-url: registry.redhat.io/{egress-pod-image-name}
+endif::[]
+
+// All the images are different for OKD
+ifdef::openshift-origin[]
+
+:egress-router-image-name: openshift/origin-egress-router
+:egress-router-image-url: {egress-router-image-name}
+
+ifdef::http[]
+:egress-http-proxy-image-name: openshift/origin-egress-http-proxy
+:egress-http-proxy-image-url: {egress-http-proxy-image-name}
+endif::[]
+ifdef::dns[]
+:egress-dns-proxy-image-name: openshift/origin-egress-dns-proxy
+:egress-dns-proxy-image-url: {egress-dns-proxy-image-name}
+endif::[]
+ifdef::redirect[]
+:egress-pod-image-name: openshift/origin-pod
+:egress-pod-image-url: {egress-pod-image-name}
+endif::[]
+
+endif::openshift-origin[]
+
+[id="nw-egress-router-pod_{context}"]
+= Egress router pod specification for {router-type} mode
+
+Define the configuration for an egress router pod in the `Pod` object. The following YAML describes the fields for the configuration of an egress router pod in {router-type} mode:
+
+// Because redirect needs privileged access to setup `EGRESS_DESTINATION`
+// and the other modes do not, this ends up needing its own almost
+// identical Pod. It's not possible to use conditionals for an unequal
+// number of callouts.
+
+ifdef::redirect[]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egress-1
+  labels:
+    name: egress-1
+  annotations:
+    pod.network.openshift.io/assign-macvlan: "true" <1>
+spec:
+  initContainers:
+  - name: egress-router
+    image: {egress-router-image-url}
+    securityContext:
+      privileged: true
+    env:
+    - name: EGRESS_SOURCE <2>
+      value: <egress_router>
+    - name: EGRESS_GATEWAY <3>
+      value: <egress_gateway>
+    - name: EGRESS_DESTINATION <4>
+      value: <egress_destination>
+    - name: EGRESS_ROUTER_MODE
+      value: init
+  containers:
+  - name: egress-router-wait
+    image: {egress-pod-image-url}
+----
+<1> Before starting the `egress-router` container, create a macvlan network interface on the primary network interface and move that interface into the pod network namespace. You must include the quotation marks around the `"true"` value. To create the macvlan interface on a network interface other than the primary one, set the annotation value to the name of that interface. For example, `eth1`.
+<2> IP address from the physical network that the node is on that is reserved for use by the egress router pod. Optional: You can include the subnet length, the `/24` suffix, so that a proper route to the local subnet is set. If you do not specify a subnet length, then the egress router can access only the host specified with the `EGRESS_GATEWAY` variable and no other hosts on the subnet.
+<3> Same value as the default gateway used by the node.
+<4> External server to direct traffic to. Using this example, connections to the pod are redirected to `203.0.113.25`, with a source IP address of `192.168.12.99`.
+
+.Example egress router Pod specification
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egress-multi
+  labels:
+    name: egress-multi
+  annotations:
+    pod.network.openshift.io/assign-macvlan: "true"
+spec:
+  initContainers:
+  - name: egress-router
+    image: {egress-router-image-url}
+    securityContext:
+      privileged: true
+    env:
+    - name: EGRESS_SOURCE
+      value: 192.168.12.99/24
+    - name: EGRESS_GATEWAY
+      value: 192.168.12.1
+    - name: EGRESS_DESTINATION
+      value: |
+        80   tcp 203.0.113.25
+        8080 tcp 203.0.113.26 80
+        8443 tcp 203.0.113.26 443
+        203.0.113.27
+    - name: EGRESS_ROUTER_MODE
+      value: init
+  containers:
+  - name: egress-router-wait
+    image: {egress-pod-image-url}
+----
+endif::redirect[]
+
+// Many conditionals because DNS offers one additional env variable.
+
+ifdef::dns,http[]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egress-1
+  labels:
+    name: egress-1
+  annotations:
+    pod.network.openshift.io/assign-macvlan: "true" <1>
+spec:
+  initContainers:
+  - name: egress-router
+    image: {egress-router-image-url}
+    securityContext:
+      privileged: true
+    env:
+    - name: EGRESS_SOURCE <2>
+      value: <egress-router>
+    - name: EGRESS_GATEWAY <3>
+      value: <egress-gateway>
+    - name: EGRESS_ROUTER_MODE
+ifdef::dns[]
+      value: dns-proxy
+endif::dns[]
+ifdef::http[]
+      value: http-proxy
+endif::http[]
+  containers:
+  - name: egress-router-pod
+ifdef::dns[]
+    image: {egress-dns-proxy-image-url}
+    securityContext:
+      privileged: true
+endif::dns[]
+ifdef::http[]
+    image: {egress-http-proxy-image-url}
+endif::http[]
+    env:
+ifdef::http[]
+    - name: EGRESS_HTTP_PROXY_DESTINATION <4>
+      value: |-
+        ...
+endif::http[]
+ifdef::dns[]
+    - name: EGRESS_DNS_PROXY_DESTINATION <4>
+      value: |-
+        ...
+    - name: EGRESS_DNS_PROXY_DEBUG <5>
+      value: "1"
+endif::dns[]
+    ...
+----
+<1> Before starting the `egress-router` container, create a macvlan network interface on the primary network interface and move that interface into the pod network namespace. You must include the quotation marks around the `"true"` value. To create the macvlan interface on a network interface other than the primary one, set the annotation value to the name of that interface. For example, `eth1`.
+<2> IP address from the physical network that the node is on that is reserved for use by the egress router pod. Optional: You can include the subnet length, the `/24` suffix, so that a proper route to the local subnet is set. If you do not specify a subnet length, then the egress router can access only the host specified with the `EGRESS_GATEWAY` variable and no other hosts on the subnet.
+<3> Same value as the default gateway used by the node.
+ifdef::http[]
+<4> A string or YAML multi-line string specifying how to configure the proxy. Note that this is specified as an environment variable in the HTTP proxy container, not with the other environment variables in the init container.
+endif::http[]
+ifdef::dns[]
+<4> Specify a list of one or more proxy destinations.
+<5> Optional: Specify to output the DNS proxy log output to `stdout`.
+endif::dns[]
+endif::[]
+
+// unload flavors
+ifdef::redirect[]
+:!redirect:
+endif::[]
+ifdef::http[]
+:!http:
+endif::[]
+ifdef::dns[]
+:!dns:
+endif::[]
+ifdef::router-type[]
+:!router-type:
+endif::[]
+
+// unload images
+ifdef::egress-router-image-name[]
+:!egress-router-image-name:
+endif::[]
+ifdef::egress-router-image-url[]
+:!egress-router-image-url:
+endif::[]
+ifdef::egress-pod-image-name[]
+:!egress-pod-image-name:
+endif::[]
+ifdef::egress-pod-image-url[]
+:!egress-pod-image-url:
+endif::[]

--- a/modules/nw-egress-router-redirect-mode.adoc
+++ b/modules/nw-egress-router-redirect-mode.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc
+
+[id="nw-egress-router-redirect-mode_{context}"]
+= Deploying an egress router pod in redirect mode
+
+In _redirect mode_, an egress router pod sets up iptables rules to redirect traffic from its own IP address to one or more destination IP addresses. Client pods that need to use the reserved source IP address must be modified to connect to the egress router rather than connecting directly to the destination IP.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an egress router pod.
+
+. To ensure that other pods can find the IP address of the egress router pod, create a service to point to the egress router pod, as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: egress-1
+spec:
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443
+  type: ClusterIP
+  selector:
+    name: egress-1
+----
++
+Your pods can now connect to this service. Their connections are redirected to
+the corresponding ports on the external server, using the reserved egress IP
+address.

--- a/networking/openshift_sdn/configuring-egress-router-configmap.adoc
+++ b/networking/openshift_sdn/configuring-egress-router-configmap.adoc
@@ -1,0 +1,17 @@
+[id="configuring-egress-router-configmap"]
+= Configuring an egress router pod destination list from a config map
+include::modules/common-attributes.adoc[]
+:context: configuring-egress-router-configmap
+
+toc::[]
+
+As a cluster administrator, you can define a `ConfigMap` object that specifies destination mappings for an egress router pod. The specific format of the configuration depends on the type of egress router pod. For details on the format, refer to the documentation for the specific egress router pod.
+
+include::modules/nw-egress-router-configmap.adoc[leveloffset=+1]
+
+[id="configuring-egress-router-configmap-additional-resources"]
+== Additional resources
+
+- xref:../../networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc#nw-egress-router-dest-var_deploying-egress-router-layer3-redirection[Redirect mode]
+- xref:../../networking/openshift_sdn/deploying-egress-router-http-redirection.adoc#nw-egress-router-dest-var_deploying-egress-router-http-redirection[HTTP proxy mode]
+- xref:../../networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc#nw-egress-router-dest-var_deploying-egress-router-dns-redirection[DNS proxy mode]

--- a/networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc
+++ b/networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc
@@ -1,0 +1,19 @@
+[id="deploying-egress-router-dns-redirection"]
+= Deploying an egress router pod in DNS proxy mode
+include::modules/common-attributes.adoc[]
+:context: deploying-egress-router-dns-redirection
+
+toc::[]
+
+As a cluster administrator, you can deploy an egress router pod configured to proxy traffic to specified DNS names and IP addresses.
+
+include::modules/nw-egress-router-pod.adoc[leveloffset=+1]
+
+include::modules/nw-egress-router-dest-var.adoc[leveloffset=+1]
+
+include::modules/nw-egress-router-dns-mode.adoc[leveloffset=+1]
+
+[id="deploying-egress-router-dns-redirection-additional-resources"]
+== Additional resources
+
+* xref:../../networking/openshift_sdn/configuring-egress-router-configmap.adoc#configuring-egress-router-configmap[Configuring an egress router destination mappings with a ConfigMap]

--- a/networking/openshift_sdn/deploying-egress-router-http-redirection.adoc
+++ b/networking/openshift_sdn/deploying-egress-router-http-redirection.adoc
@@ -1,0 +1,19 @@
+[id="deploying-egress-router-http-redirection"]
+= Deploying an egress router pod in HTTP proxy mode
+include::modules/common-attributes.adoc[]
+:context: deploying-egress-router-http-redirection
+
+toc::[]
+
+As a cluster administrator, you can deploy an egress router pod configured to proxy traffic to specified HTTP and HTTPS-based services.
+
+include::modules/nw-egress-router-pod.adoc[leveloffset=+1]
+
+include::modules/nw-egress-router-dest-var.adoc[leveloffset=+1]
+
+include::modules/nw-egress-router-http-proxy-mode.adoc[leveloffset=+1]
+
+[id="deploying-egress-router-http-redirection-additional-resources"]
+== Additional resources
+
+* xref:../../networking/openshift_sdn/configuring-egress-router-configmap.adoc#configuring-egress-router-configmap[Configuring an egress router destination mappings with a ConfigMap]

--- a/networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc
+++ b/networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc
@@ -1,0 +1,19 @@
+[id="deploying-egress-router-layer3-redirection"]
+= Deploying an egress router pod in redirect mode
+include::modules/common-attributes.adoc[]
+:context: deploying-egress-router-layer3-redirection
+
+toc::[]
+
+As a cluster administrator, you can deploy an egress router pod that is configured to redirect traffic to specified destination IP addresses.
+
+include::modules/nw-egress-router-pod.adoc[leveloffset=+1]
+
+include::modules/nw-egress-router-dest-var.adoc[leveloffset=+1]
+
+include::modules/nw-egress-router-redirect-mode.adoc[leveloffset=+1]
+
+[id="deploying-egress-router-layer3-redirection-additional-resources"]
+== Additional resources
+
+* xref:../../networking/openshift_sdn/configuring-egress-router-configmap.adoc#configuring-egress-router-configmap[Configuring an egress router destination mappings with a ConfigMap]

--- a/networking/openshift_sdn/using-an-egress-router.adoc
+++ b/networking/openshift_sdn/using-an-egress-router.adoc
@@ -1,0 +1,15 @@
+[id="using-an-egress-router"]
+= Considerations for the use of an egress router pod
+include::modules/common-attributes.adoc[]
+:context: using-an-egress-router
+
+toc::[]
+
+include::modules/nw-egress-router-about.adoc[leveloffset=+1]
+
+[id="using-an-egress-router-additional-resources"]
+== Additional resources
+
+- xref:../../networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc#deploying-egress-router-layer3-redirection[Deploying an egress router in redirection mode]
+- xref:../../networking/openshift_sdn/deploying-egress-router-http-redirection.adoc#deploying-egress-router-http-redirection[Deploying an egress router in HTTP proxy mode]
+- xref:../../networking/openshift_sdn/deploying-egress-router-dns-redirection.adoc#deploying-egress-router-dns-redirection[Deploying an egress router in DNS proxy mode]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-936

So this pulls forward ancient egress router documentation; This might be superseded by a new CNI plug-in, but not until 4.7 and will continue to work regardless.

What follows is an early draft of the egress router documentation from OCP 3.11, updated to conform to our OCP 4.x style. 

- [Considerations for the use of an egress router](https://osdocs-936--ocpdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/using-an-egress-router.html)
- [Deploying an egress router in redirection mode](https://osdocs-936--ocpdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-layer3-redirection.html)
- [Deploying an egress router in HTTP proxy mode](https://osdocs-936--ocpdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-http-redirection.html)
- [Deploying an egress router in DNS proxy mode](https://osdocs-936--ocpdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-dns-redirection.html)
- [Configuring an egress router destination mappings with a ConfigMap](https://osdocs-936--ocpdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-egress-router-configmap.html)
