### PR TITLE
command no longer exists in 'oc' cli

### DIFF
--- a/modules/cli-administrator-configuration.adoc
+++ b/modules/cli-administrator-configuration.adoc
@@ -23,15 +23,6 @@ $ oc adm create-api-client-config \
   --user='system:proxy'
 ----
 
-== create-bootstrap-policy-file
-
-Create the default bootstrap policy.
-
-.Example: Create a file called `policy.json` with the default bootstrap policy
-----
-$ oc adm create-bootstrap-policy-file --filename=policy.json
-----
-
 == create-bootstrap-project-template
 
 Create a bootstrap project template.


### PR DESCRIPTION
"create-bootstrap-policy-file" was removed from 'oc' back in May 2019 and does not exist in the official 'oc' client version 4.3.1.  It 'might' exist in 4.1.

Reference to the removal of the command:
https://github.com/openshift/openshift-apiserver/commit/363299faddd680b41dea2c23885358eeaa618493