### PR TITLE
replace vnic with nic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1409,8 +1409,8 @@ Topics:
       File: cnv-attaching-vm-multiple-networks
     - Name: Installing the QEMU guest agent on virtual machines
       File: cnv-installing-qemu-guest-agent
-    - Name: Viewing the IP address of vNICs on a virtual machine
-      File: cnv-viewing-ip-of-vm-vnic
+    - Name: Viewing the IP address of NICs on a virtual machine
+      File: cnv-viewing-ip-of-vm-nic
 # A BETTER NAME THAN 'STORAGE 4 U'
   - Name: Virtual machine disks
     Dir: cnv_virtual_disks

--- a/cnv/cnv_virtual_machines/cnv_vm_networking/cnv-attaching-vm-multiple-networks.adoc
+++ b/cnv/cnv_virtual_machines/cnv_vm_networking/cnv-attaching-vm-multiple-networks.adoc
@@ -10,7 +10,7 @@ existing workloads that depend on access to multiple interfaces. You can also
 configure a PXE network so that you can boot machines over the network.
 
 To get started, a network administrator configures a bridge NetworkAttachmentDefinition
-for a namespace in the web console or CLI. Users can then create a vNIC to attach Pods and virtual machines in that namespace to the bridge network. 
+for a namespace in the web console or CLI. Users can then create a NIC to attach Pods and virtual machines in that namespace to the bridge network.
 
 include::modules/cnv-networking-glossary.adoc[leveloffset=+1]
 
@@ -22,7 +22,7 @@ include::modules/cnv-creating-bridge-nad-cli.adoc[leveloffset=+2]
 
 [NOTE]
 ====
-When defining the vNIC in the next section, ensure that the *NETWORK* value is
+When defining the NIC in the next section, ensure that the *NETWORK* value is
 the bridge network name from the NetworkAttachmentDefinition you created
 in the previous section.
 ====

--- a/cnv/cnv_virtual_machines/cnv_vm_networking/cnv-viewing-ip-of-vm-nic.adoc
+++ b/cnv/cnv_virtual_machines/cnv_vm_networking/cnv-viewing-ip-of-vm-nic.adoc
@@ -1,10 +1,10 @@
-[id="cnv-viewing-ip-of-vm-vnic"]
-= Viewing the IP address of vNICs on a virtual machine
+[id="cnv-viewing-ip-of-vm-nic"]
+= Viewing the IP address of NICs on a virtual machine
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-viewing-ip-of-vm-vnic
 toc::[]
 
-The QEMU guest agent runs on the virtual machine and passes the IP address of attached vNICs to the host, allowing you to view the IP address from both the web console and the `oc` client.
+The QEMU guest agent runs on the virtual machine and passes the IP address of attached NICs to the host, allowing you to view the IP address from both the web console and the `oc` client.
 
 .Prerequisites
 

--- a/modules/cnv-accessing-rdp-console.adoc
+++ b/modules/cnv-accessing-rdp-console.adoc
@@ -5,31 +5,31 @@
 [id="cnv-accessing-rdp-console_{context}"]
 = Connecting to a Windows virtual machine with an RDP console
 
-The Remote Desktop Protocol (RDP) provides a better console experience for 
-connecting to Windows virtual machines. 
+The Remote Desktop Protocol (RDP) provides a better console experience for
+connecting to Windows virtual machines.
 
-To connect to a Windows virtual machine with RDP, specify the IP address of the 
-attached L2 vNIC to your RDP client. 
+To connect to a Windows virtual machine with RDP, specify the IP address of the
+attached L2 NIC to your RDP client.
 
 .Prerequisites
 
-* A running Windows virtual machine with the QEMU guest agent installed. The 
+* A running Windows virtual machine with the QEMU guest agent installed. The
 `qemu-guest-agent` is included in the VirtIO drivers.
-* A layer 2 vNIC attached to the virtual machine. 
-* An RDP client installed on a machine on the same network as the 
-Windows virtual machine. 
+* A layer 2 NIC attached to the virtual machine. 
+* An RDP client installed on a machine on the same network as the
+Windows virtual machine.
 
 .Procedure
 
-. Log in to the {CNVProductName} cluster through the `oc` CLI tool as a user with 
-an access token. 
+. Log in to the {CNVProductName} cluster through the `oc` CLI tool as a user with
+an access token.
 +
 ----
 $ oc login -u <user> https://<cluster.example.com>:8443
 ----
 
-. Use `oc describe vmi` to display the configuration of the running 
-Windows virtual machine. 
+. Use `oc describe vmi` to display the configuration of the running
+Windows virtual machine.
 +
 ----
 $ oc describe vmi <windows-vmi-name>
@@ -49,26 +49,24 @@ spec:
 status:
   interfaces:
   - interfaceName: eth0
-    ipAddress: 198.51.100.0/24 
+    ipAddress: 198.51.100.0/24
     ipAddresses:
-      198.51.100.0/24 
+      198.51.100.0/24
     mac: a0:36:9f:0f:b1:70
     name: default
   - interfaceName: eth1
-    ipAddress: 192.0.2.0/24 
+    ipAddress: 192.0.2.0/24
     ipAddresses:
-      192.0.2.0/24 
+      192.0.2.0/24
       2001:db8::/32
     mac: 00:17:a4:77:77:25
     name: bridge-net
 ...
 ----
 
-. Identify and copy the IP address of the layer 2 network interface. This is 
-`192.0.2.0` in the above example, or `2001:db8::` if you prefer IPv6. 
-. Open an RDP client and use the IP address copied in the previous step for the 
-connection. 
-. Enter the *Administrator* user name and password to connect to the 
+. Identify and copy the IP address of the layer 2 network interface. This is
+`192.0.2.0` in the above example, or `2001:db8::` if you prefer IPv6.
+. Open an RDP client and use the IP address copied in the previous step for the
+connection.
+. Enter the *Administrator* user name and password to connect to the
 Windows virtual machine.
-
-

--- a/modules/cnv-viewing-vmi-ip-web.adoc
+++ b/modules/cnv-viewing-vmi-ip-web.adoc
@@ -1,15 +1,15 @@
 // Module included in the following assemblies:
 //
-// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-viewing-ip-of-vm-vnic.adoc
+// * cnv/cnv_virtual_machines/cnv_vm_networking/cnv-viewing-ip-of-vm-nic.adoc
 
 [id="cnv-viewing-vmi-ip-web_{context}"]
 = Viewing the IP address of a virtual machine interface in the web console
 
-The IP information displays in the *Virtual Machine Overview* screen for the virtual machine. 
+The IP information displays in the *Virtual Machine Overview* screen for the virtual machine.
 
 .Procedure
 
 . In the {CNVProductName} console, click *Workloads* -> *Virtual Machines*.
 . Click the virtual machine name to open the *Virtual Machine Overview* screen.
 
-The information for each attached vNIC is displayed under *IP ADDRESSES*.
+The information for each attached NIC is displayed under *IP ADDRESSES*.

--- a/modules/cnv-vm-rdp-console-web.adoc
+++ b/modules/cnv-vm-rdp-console-web.adoc
@@ -5,29 +5,29 @@
 [id="cnv-vm-rdp-console-web_{context}"]
 = Connecting to the RDP console
 
-The desktop viewer console, which utilizes the Remote Desktop Protocol (RDP), 
+The desktop viewer console, which utilizes the Remote Desktop Protocol (RDP),
 provides a better console experience for connecting to Windows virtual machines.
 
-To connect to a Windows virtual machine with RDP, download the `console.rdp` 
-file for the virtual machine from the *Consoles* tab in the 
-*Virtual Machine Details* screen of the web console and supply it to your 
-preferred RDP client. 
+To connect to a Windows virtual machine with RDP, download the `console.rdp`
+file for the virtual machine from the *Consoles* tab in the
+*Virtual Machine Details* screen of the web console and supply it to your
+preferred RDP client.
 
 .Prerequisites
 
-* A running Windows virtual machine with the QEMU guest agent installed. The 
+* A running Windows virtual machine with the QEMU guest agent installed. The
 `qemu-guest-agent` is included in the VirtIO drivers.
-* A layer-2 vNIC attached to the virtual machine. 
-* An RDP client installed on a machine on the same network as the 
-Windows virtual machine. 
+* A layer-2 NIC attached to the virtual machine.
+* An RDP client installed on a machine on the same network as the
+Windows virtual machine.
 
 .Procedure
 
 . In the {CNVProductName} console, click *Workloads* -> *Virtual Machines*.
 . Select a Windows virtual machine.
-. Click the *Consoles* tab. 
+. Click the *Consoles* tab.
 . Click the *Consoles* list and select *Desktop Viewer*.
-. In the *Network Interface* list, select the layer-2 vNIC.
+. In the *Network Interface* list, select the layer-2 NIC.
 . Click *Launch Remote Desktop* to download the `console.rdp` file.
 . Open an RDP client and reference the `console.rdp` file. For example, using 
 *remmina*:
@@ -36,6 +36,5 @@ Windows virtual machine.
 $ remmina --connect /path/to/console.rdp
 ----
 
-. Enter the *Administrator* user name and password to connect to the 
+. Enter the *Administrator* user name and password to connect to the
 Windows virtual machine.
-


### PR DESCRIPTION
It was agreed that the term "vNIC" be replaced with the term "NIC.' The CNV user guide doc was updated to reflect this change.