### PR TITLE
CNV-3535 Dedicated Resources Module and Assembly Links

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1498,6 +1498,8 @@ Topics:
       File: cnv-configuring-pxe-booting
     - Name: Managing guest memory
       File: cnv-managing-guest-memory
+    - Name: Enabling dedicated resources for a virtual machine
+      File: cnv-dedicated-resources-vm
 # Importing virtual machines
   - Name: Importing virtual machines
     Dir: cnv_importing_vms
@@ -1562,6 +1564,8 @@ Topics:
     File: cnv-creating-vm-template
   - Name: Editing a virtual machine template
     File: cnv-editing-vm-template
+  - Name: Enabling dedicated resources for a virtual machine template
+    File: cnv-dedicated-resources-vm-template
   - Name: Deleting a virtual machine template
     File: cnv-deleting-vm-template
 # Virtual machine live migration

--- a/cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-dedicated-resources-vm.adoc
+++ b/cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-dedicated-resources-vm.adoc
@@ -1,0 +1,19 @@
+[id="cnv-dedicated-resources-vm"]
+= Enabling dedicated resources for virtual machines
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-dedicated-resources-vm
+toc::[]
+
+Virtual machines can have resources of a node, such as CPU,
+dedicated to them in order to improve performance.
+
+include::modules/cnv-about-dedicated-resources.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* The
+xref:../../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must
+be configured on the node. Verify that the node has the `cpumanager` = `true`
+label before scheduling virtual machine workloads.
+
+include::modules/cnv-enabling-dedicated-resources.adoc[leveloffset=+1]

--- a/cnv/cnv_vm_templates/cnv-dedicated-resources-vm-template.adoc
+++ b/cnv/cnv_vm_templates/cnv-dedicated-resources-vm-template.adoc
@@ -1,0 +1,19 @@
+[id="cnv-dedicated-resources-vm-template"]
+= Enabling dedicated resources for virtual machine templates
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-dedicated-resources-vm-template
+toc::[]
+
+Virtual machines can have resources of a node, such as CPU,
+dedicated to them in order to improve performance.
+
+include::modules/cnv-about-dedicated-resources.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* The
+xref:../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must
+be configured on the node. Verify that the node has the `cpumanager` = `true`
+label before scheduling virtual machine workloads.
+
+include::modules/cnv-enabling-dedicated-resources.adoc[leveloffset=+1]

--- a/modules/cnv-about-dedicated-resources.adoc
+++ b/modules/cnv-about-dedicated-resources.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-dedicated-resources-vm.adoc
+// * cnv/cnv_vm_templates/cnv-dedicated-resources-vm-template.adoc
+
+[id="cnv-about-dedicated-resources_{context}"]
+
+= About dedicated resources
+
+When you enable dedicated resources for your virtual machine, your virtual
+machine's workload is scheduled on CPUs that will not be used by other
+processes. By using dedicated resources, you can improve the performance of the
+virtual machine and the accuracy of latency predictions.

--- a/modules/cnv-enabling-dedicated-resources.adoc
+++ b/modules/cnv-enabling-dedicated-resources.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-dedicated-resources-vm.adoc
+// * cnv/cnv_vm_templates/cnv-dedicated-resources-vm-template.adoc
+
+// Establishing conditionals so content can be re-used for editing VMs
+// and VM templates.
+
+ifeval::["{context}" == "cnv-dedicated-resources-vm-template"]
+:cnv-vm-template:
+:object: virtual machine template
+:object-gui: Virtual Machine Template
+endif::[]
+
+ifeval::["{context}" == "cnv-dedicated-resources-vm"]
+:cnv-vm:
+:object: virtual machine
+:object-gui: Virtual Machine
+endif::[]
+
+[id="cnv-enabling-dedicated-resources_{context}"]
+= Enabling dedicated resources for a {object}
+
+You can enable dedicated resources for a {object} in the
+*{object-gui} Overview* page of the web console.
+
+.Procedure
+
+. Click *Workloads* -> *{object-gui}s* from the side menu.
+. Select a {object} to open the *{object-gui} Overview* page.
+. Click the *Details* tab.
+. Click the pencil icon to the right of the *Dedicated Resources* field to open
+the *Dedicated Resources* window.
+. Select *Schedule this workload with dedicated resources (guaranteed policy)*.
+. Click *Save*.
+
+// Unsetting all conditionals used in module
+
+ifeval::["{context}" == "cnv-dedicated-resources-vm"]
+:cnv-vm!:
+:object!:
+:object-gui!:
+endif::[]
+
+ifeval::["{context}" == "cnv-dedicated-resources-vm-template"]
+:cnv-vm-template!:
+:object!:
+:object-gui!:
+endif::[]


### PR DESCRIPTION
This PR has been extensively revised to include detailed preparation procedures from peer review feedback..

@jelkosz and @rhrazdil please code and QE review this as soon as possible.

@aburdenthehand can do peer review following final code and QE review.

I asked if there was any need to set a custom policy from Simone in Installer via Pan Ousley. He said: "https://github.com/kubevirt/user-guide/blob/master/creation/dedicated-cpu.md#identifying-nodes-with-a-running-cpu-manager" --- 
this is what we say upstream about configuring the feature gate for CPUManager" "and HCO is setting it by default: 
https://github.com/kubevirt/hyperconverged-cluster-operator/blob/release-2.3/pkg/controller/hyperconverged/hyperconverged_controller.go#L434" 
"Honestly I'm not aware of the need to set custom policy, but maybe it's not really up to me to tell the opposite"

Latest Test Builds:For VMs and templates 
http://file.bos.redhat.com/bgaydos/042820_2/cnv/cnv_virtual_machines/cnv_advanced_vm_management/cnv-dedicated-resources-vm.html

http://file.bos.redhat.com/bgaydos/042820_2/cnv/cnv_vm_templates/cnv-dedicated-resources-vm-template.html