### PR TITLE
Bug 1809431: "illegal base64 data at input byte 76 ..." error message is shown due to incorrect base64 command

### DIFF
--- a/modules/cluster-logging-collector-external.adoc
+++ b/modules/cluster-logging-collector-external.adoc
@@ -142,9 +142,9 @@ in `configmap/fluentd`:
 +
 ----
 $ oc patch secrets/fluentd --type=json \
-  --patch "[{'op':'add','path':'/data/your_ca_cert','value':'$(base64 /path/to/your_ca_cert.pem)'}]"
+  --patch "[{'op':'add','path':'/data/your_ca_cert','value':'$(base64 -w0 /path/to/your_ca_cert.pem)'}]"
 $ oc patch secrets/fluentd --type=json \
-  --patch "[{'op':'add','path':'/data/your_private_key','value':'$(base64 /path/to/your_private_key.pem)'}]"
+  --patch "[{'op':'add','path':'/data/your_private_key','value':'$(base64 -w0 /path/to/your_private_key.pem)'}]"
 ----
 +
 [NOTE]
@@ -157,9 +157,9 @@ For example:
 +
 ----
 $ oc patch secrets/fluentd --type=json \
-  --patch "[{'op':'add','path':'/data/ca.crt','value':'$(base64 /etc/fluent/keys/ca.crt)'}]"
+  --patch "[{'op':'add','path':'/data/ca.crt','value':'$(base64 -w0 /etc/fluent/keys/ca.crt)'}]"
 $ oc patch secrets/fluentd --type=json \
-  --patch "[{'op':'add','path':'/data/ext-agg','value':'$(base64 /etc/fluent/keys/ext-agg.pem)'}]"
+  --patch "[{'op':'add','path':'/data/ext-agg','value':'$(base64 -w0 /etc/fluent/keys/ext-agg.pem)'}]"
 ----
 
 . Configure the `secure-forward.conf` file on the external aggregator to accept messages securely from Fluentd.


### PR DESCRIPTION
* Version: OCP4.2
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1809431
* Description: 
  "base64" is not encoded as one line, it causes error to patch secret certificates. So it should replace   "base64" with "base64 -w0".

e.g.
~~~
$ base64 ca.crt 
LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM2akNDQWRLZ0F3SUJBZ0lCQVRBTkJna3Fo
a2lHOXcwQkFRc0ZBREFtTVNRd0lnWURWUVFEREJ0dmNHVnUKYzJocFpuUXRjMmxuYm1WeVFERTFO
emswTXpZMk1qTXdIaGNOTWpBd01URTVNVEl5TXpReVdoY05NalV3TVRFMwpNVEl5TXpReldqQW1N
U1F3SWdZRFZRUUREQnR2Y0dWdWMyaHBablF0YzJsbmJtVnlRREUxTnprME16WTJNak13CmdnRWlN
:
$ base64 -w0 ca.crt
LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM2akNDQWRLZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFtTVNRd0lnWURWUVFEREJ0dmNHVnUKYzJocFpuUXRjMmxuYm1WeVFERTFOemswTXpZMk1qTXdIaGNOTWpBd01URTVNVEl5TXpReVdoY05NalV3TVRFMwpNVEl5TXpReldqQW1NU1F3SWdZRFZRUUREQnR2Y0dWdWMyaHBablF0Y ...
~~~



Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1809431