### PR TITLE
Increment copyright year 2020

### DIFF
--- a/404-commercial.html
+++ b/404-commercial.html
@@ -186,7 +186,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/_templates/_footer_other.html.erb
+++ b/_templates/_footer_other.html.erb
@@ -6,7 +6,7 @@
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -286,7 +286,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/search-commercial.html
+++ b/search-commercial.html
@@ -172,7 +172,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">


### PR DESCRIPTION
This PR updates the copyright year to 2020 for docs.openshift.com. ([PR 13383](https://github.com/openshift/openshift-docs/pull/13383) was used as reference.)

Merge to `master` only and CP to branches.

@openshift/team-documentation PTAL