### PR TITLE
Added information on Operator-defined Installation Namespace

### DIFF
--- a/modules/cluster-logging-deploy-clo.adoc
+++ b/modules/cluster-logging-deploy-clo.adoc
@@ -5,66 +5,29 @@
 [id="cluster-logging-deploy-clo_{context}"]
 = Install the Cluster Logging Operator using the web console
 
-You can use the {product-title} web console to install the Cluster Logging Operator.  
-
-[NOTE]
-====
-You cannot create a Project starting with `openshift-` using the web console or 
-by using the `oc new-project` command. You must create a Namespace using a YAML 
-object file and run the `oc create -f <file-name>.yaml` command, as shown.
-==== 
+You can use the {product-title} web console to install the Cluster Logging Operator.
 
 .Procedure
 
 To install the Cluster Logging Operator using the {product-title} web console:
 
-. Create a Namespace for the Cluster Logging Operator. You must use the CLI to create the Namespace.
+. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
-.. Create a Namespace object YAML file (for example, `clo-namespace.yaml`) for the Cluster Logging Operator:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-logging <1>
-  annotations:
-    openshift.io/node-selector: "" <1>
-  labels:
-    openshift.io/cluster-monitoring: "true" <1>
-----
-<1> Specify these values as shown.
+. Choose  *Cluster Logging* from the list of available Operators, and click *Install*.
 
-.. Create the Namespace:
-+
-----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-----
-$ oc create -f clo-namespace.yaml
-----
+. Select an *Update Channel* and *Approval Strategy*.
 
-. Install the Cluster Logging Operator:
-
-.. In the {product-title} web console, click *Operators* -> *OperatorHub*.
-
-.. Choose  *Cluster Logging* from the list of available Operators, and click *Install*.
-
-.. On the *Create Operator Subscription* page, under *A specific Namespace on the cluster* select *openshift-logging*.
-Then, click *Subscribe*.
+. Click *Subscribe*.
 
 . Verify that the Cluster Logging Operator installed:
 
 .. Switch to the *Operators* → *Installed Operators* page.
 
-.. Ensure that *Cluster Logging* is listed in the *openshift-logging* project with a *Status* of *InstallSucceeded*.
+.. Ensure that *Cluster Logging* is listed in the *openshift-logging* project with a *Status* of *Succeeded*.
 +
 [NOTE]
 ====
-During installation an Operator might display a *Failed* status. If the Operator then installs with an *InstallSucceeded* message,
+During installation an Operator might display a *Failed* status. If the Operator then installs with an *Succeeded* message,
 you can safely ignore the *Failed* message.
 ====
 +
@@ -73,7 +36,7 @@ If the Operator does not appear as installed, to troubleshoot further:
 * Switch to the *Operators* → *Installed Operators* page and inspect
 the *Status* column for any errors or failures.
 * Switch to the *Workloads* → *Pods* page and check the logs in any Pods in the
-`openshift-logging` and `openshift-operators-redhat` projects that are reporting issues.
+`openshift-logging` project that are reporting issues.
 
 . Create a cluster logging instance:
 

--- a/modules/cnv-subscribing-to-the-catalog.adoc
+++ b/modules/cnv-subscribing-to-the-catalog.adoc
@@ -21,6 +21,7 @@ Operators.
 . Read the information about the Operator and click *Install*.
 
 . On the *Create Operator Subscription* page:
+
 .. For *Installed Namespace*, ensure that the *Operator recommended namespace* option
 is selected. This installs the Operator in the mandatory `openshift-cnv` namespace, which
 is automatically created if it does not exist.
@@ -37,3 +38,6 @@ is selected.
 available.
 
 . Click *Subscribe* to make the Operator available to the `openshift-cnv` namespace.
++
+On the *Installed Operators* screen, the *Status* displays *Succeeded* when
+{CNVProductName} finishes installation.

--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -5,26 +5,21 @@
 [id="metering-install-operator_{context}"]
 = Installing the Metering Operator
 
-To install the Metering Operator first create an `openshift-metering` namespace, and then install the Metering Operator from OperatorHub.
 
 .Procedure
 
-. In the {product-title} web console, click *Administration* -> *Namespaces* ->  *Create Namespace*.
-
-. Set the name to `openshift-metering`. No other namespace is supported. Label the namespace with `openshift.io/cluster-monitoring=true`, and click *Create*.
-
-. Next, click *Operators* -> *OperatorHub*, and filter for `metering` to find the
+. In the {product-title} web console,  click *Operators* -> *OperatorHub*, and filter for `metering` to find the
 Metering Operator.
 
 . Click the Metering card, review the package description, and then click *Install*.
+. Select an *Update Channel*, *Installation Mode*, and *Approval Strategy*.
+. Click *Subscribe*.
 
-. On the *Create Operator Subscription* screen, select the `openshift-metering` namespace you created above. Specify your update channel and approval strategy, then click *Subscribe* to install metering.
-
-. On the *Installed Operators* screen the *Status* displays *InstallSucceeded* when metering has finished installing. Click the name of the operator in the first column to view the *Operator Details* page.
+. On the *Installed Operators* screen, the *Status* displays *Succeeded* when the Metering Operator finishes installation. Click the name of the Operator in the first column to view the *Operator Details* page.
 
 [NOTE]
 ====
-It may take a few minutes for the metering operator to appear.
+It might take a few minutes for the Metering Operator to appear.
 ====
 
 From the *Operator Details* page you can create different resources related to metering. To complete your installation create a MeteringConfig resource to configure metering and install the components of the metering stack.

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -15,14 +15,10 @@ You can install the OpenShift Container Storage Operator from OperatorHub on the
 
 .Procedure
 
-. In the {product-title} web console, click *Administration* -> *Namespaces*.
-. Click *Create Namespace*.
-. Enter `openshift-storage` in the *Name* field and click *Create*.
-. Click *Operators* -> *OperatorHub*.
+. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 . Use *Filter by keyword* (in this case, *OCS*) to find the *OpenShift Container Storage Operator*.
 . Select the *OpenShift Container Storage Operator* and click *Install*.
-. On the *Create Operator Subscription* page, select the `openshift-storage` namespace.
-. Specify your update channel and approval strategy.
+. Select an *Update Channel*, *Installation Mode*, and *Approval Strategy*.
 . Click *Subscribe*.
 +
 On the *Installed Operators* page, the *OpenShift Container Storage Operator* appears in the *openshift-storage* project with the status *Succeeded*.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-732

Preview Builds:
http://file.rdu.redhat.com/~ahardin/March27-2020/web-console-operator-namespaces/operators/understanding_olm/olm-understanding-operatorgroups.html#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups

http://file.rdu.redhat.com/~ahardin/March27-2020/web-console-operator-namespaces/logging/cluster-logging-deploying.html#cluster-logging-deploy-clo_cluster-logging-deploying

http://file.rdu.redhat.com/~ahardin/March27-2020/web-console-operator-namespaces/cnv/cnv_install/installing-container-native-virtualization.html#cnv-subscribing-to-the-catalog_installing-container-native-virtualization

http://file.rdu.redhat.com/~ahardin/March27-2020/web-console-operator-namespaces/metering/metering-installing-metering.html#metering-install-operator_installing-metering

http://file.rdu.redhat.com/~ahardin/March27-2020/web-console-operator-namespaces/migration/migrating_4_2_4/configuring-replication-repository.html#installing-the-ocs-operator_migrating-4_2-4_x