### PR TITLE
Increment copyright year 2020 on master-3

### DIFF
--- a/404-commercial.html
+++ b/404-commercial.html
@@ -177,7 +177,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/_templates/_footer_other.html.erb
+++ b/_templates/_footer_other.html.erb
@@ -6,7 +6,7 @@
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -252,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/search-commercial.html
+++ b/search-commercial.html
@@ -172,7 +172,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2019 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2020 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">


### PR DESCRIPTION
This PR updates the copyright year to 2020 for `master-3` branch of docs.openshift.com. (Relates to [PR 20193](https://github.com/openshift/openshift-docs/pull/20193).)

Merge to `master-3`. CP to `enterprise-3.11` in this PR: https://github.com/openshift/openshift-docs/pull/20219

@openshift/team-documentation PTAL