### PR TITLE
BZ 1791599: Fix typos and formatting issues in expose_service docs

### DIFF
--- a/dev_guide/expose_service/expose_internal_ip_load_balancer.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_load_balancer.adoc
@@ -64,7 +64,7 @@ $ oc project project1
 . Open a text file on the master node and paste the following text, editing the file as needed:
 +
 .Sample load balancer configuration file
-====
+[source,yaml]
 ----
 apiVersion: v1
 kind: Service
@@ -79,43 +79,41 @@ spec:
   selector:
     name: mysql <4>
 ----
-
 <1> Enter a descriptive name for the load balancer service.
 <2> Enter the same port that the service you want to expose is listening on.
 <3> Enter `loadbalancer` as the type.
 <4> Enter the name of the service.
-====
 
 . Save and exit the file.
 
 . Run the following command to create the service:
 +
 ----
-oc create -f <file-name>
+$ oc create -f <file_name>
 ----
 +
 For example:
 +
 ----
-oc create -f mysql-lb.yaml
+$ oc create -f mysql-lb.yaml
 ----
 
 . Execute the following command to view the new service:
 +
 ----
-oc get svc
+$ oc get svc
 NAME              CLUSTER-IP       EXTERNAL-IP                   PORT(S)                   AGE
-egress-2          172.30.236.167   172.29.121.74,172.29.121.74   3306/TCP                  6s
+egress-2          172.30.236.167   172.29.121.74,172.29.121.74   3306:30036/TCP            6s
 ----
 +
-Note that the service has an external IP address automatically assigned. 
+Note that the service has an external IP address automatically assigned.
 
 . On the master, use a tool, such as cURL, to make sure you can reach the service using the public IP address:
 +
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
-++
++
 For example:
 +
 ----
@@ -134,7 +132,6 @@ Welcome to the MariaDB monitor.  Commands end with ; or \g.
 
 MySQL [(none)]>
 ----
-
 
 [[load-balancer-ips-network]]
 == Configuring Networking
@@ -164,13 +161,13 @@ $ route add -net 172.29.121.74 netmask 255.255.0.0 gw 10.16.41.22 dev eth0
 . Use a tool, such as cURL, to make sure you can reach the service using the public IP address:
 +
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 172.29.121.74:3306
+$ curl 172.29.121.74:3306
 ----
 +
 If you get a string of characters with the `Got packets out of order` message, your service is accessible from the node.
@@ -195,19 +192,16 @@ $ route add -net 172.29.121.74 netmask 255.255.0.0 gw 10.16.41.22 dev eth0
 . Make sure you can reach the service using the public IP address:
 +
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 172.29.121.74:3306
+$ curl 172.29.121.74:3306
 ----
 +
 If you get a string of characters with the `Got packets out of order` message, your service is accessible outside the cluster.
 
 [[expose-lb-fail]]
 include::dev_guide/expose_service/expose_internal_ip_service.adoc[tag=expose-svc-ip-fail]
-
-
-

--- a/dev_guide/expose_service/expose_internal_ip_nodeport.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_nodeport.adoc
@@ -16,7 +16,7 @@ toc::[]
 
 Use NodePorts xref:index.adoc#getting-traffic-into-cluster-index[to expose the service] nodePort on all nodes in the cluster.
 
-[[NOTE]]
+[NOTE]
 ====
 Using NodePorts requires additional port resources.
 ====
@@ -58,8 +58,9 @@ For example:
 $ oc new-project external-ip
 ----
 
-. Edit the service definition to specify `spec.type:NodePort` and optionally specify a port in the in the 30000-32767 range.
+. Edit the service definition to specify `spec.type:NodePort` and optionally specify a port in the 30000-32767 range.
 +
+[source,yaml]
 ----
 apiVersion: v1
 kind: Service
@@ -70,7 +71,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 3036
+    - port: 3306
       nodePort: 30036
       name: http
   selector:
@@ -80,22 +81,22 @@ spec:
 . Execute the following command to xref:../../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create the service]:
 +
 ----
-$ oc new-app <file-name>
+$ oc new-app <file_name>
 ----
 +
 For example:
 +
 ----
-oc new-app mysql.yaml
+$ oc new-app mysql.yaml
 ----
 
 . Execute the following command to see that the new service is created:
 +
 ----
-oc get svc
+$ oc get svc
 
 NAME             CLUSTER_IP       EXTERNAL_IP   PORT(S)                      AGE
-mysql            172.30.89.219    <nodes>       3036:30036/TCP               2m
+mysql            172.30.89.219    <nodes>       3306:30036/TCP               2m
 ----
 +
 Note that the external IP is listed as `<nodes>` and the node ports are listed.

--- a/dev_guide/expose_service/expose_internal_ip_service.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_service.adoc
@@ -61,10 +61,10 @@ request to reach the IP address.
 
 * Configure the {product-title} cluster to xref:../../install_config/configuring_authentication.adoc#install-config-configuring-authentication[use an identity provider] that allows appropriate user access.
 
-* Make sure there is at least one user with cluster admin role. To add this role to a user, run the following command:
+* Make sure there is at least one user with `cluster-admin` role. To add this role to a user, run the following command:
 +
 ----
-oadm policy add-cluster-role-to-user cluster-admin username
+$ oadm policy add-cluster-role-to-user cluster-admin <username>
 ----
 
 * Have an  {product-title} cluster with at least one master and at least one node and a system outside the cluster that has network access to the cluster. This procedure assumes that the external system is on the same subnet as the cluster. The additional networking required for external systems on a different subnet is out-of-scope for this topic.
@@ -94,6 +94,7 @@ Using project "default".
 
 . Configure the `externalIPNetworkCIDRs` parameter in the *_/etc/origin/master/master-config.yaml_* file as shown:
 +
+[source,yaml]
 ----
 networkConfig:
   externalIPNetworkCIDRs:
@@ -102,6 +103,7 @@ networkConfig:
 +
 For example:
 +
+[source,yaml]
 ----
 networkConfig:
   externalIPNetworkCIDRs:
@@ -158,7 +160,7 @@ $ oc new-app \
 . Run the following command to see that the new service is created:
 +
 ----
-oc get svc
+$ oc get svc
 NAME               CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
 mysql-55-rhel7     172.30.131.89   <none>        3306/TCP   13m
 ----
@@ -186,26 +188,26 @@ $ oc project project1
 . Run the following command to expose the route:
 +
 ----
-oc expose service <service-name>
+$ oc expose service <service_name>
 ----
 +
 For example:
 +
 ----
-oc expose service mysql-55-rhel7
+$ oc expose service mysql-55-rhel7
 route "mysql-55-rhel7" exposed
 ----
 
 . On the master, use a tool, such as cURL, to make sure you can reach the service using the cluster IP address for the service:
 +
 ----
-curl <pod-ip>:<port>
+$ curl <pod_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 172.30.131.89:3306
+$ curl 172.30.131.89:3306
 ----
 +
 The examples in this section use a MySQL service, which requires a client application. If you get a string of characters with the `Got packets out of order` message,
@@ -241,7 +243,7 @@ To assign an external IP address to a service:
 . Run the following command to assign an external IP address to the service you want to access. Use an IP address from the xref:defining_ip_range[external IP address range]:
 +
 ----
-oc patch svc <name> -p '{"spec":{"externalIPs":["<ip_address>"]}}'
+$ oc patch svc <name> -p '{"spec":{"externalIPs":["<ip_address>"]}}'
 ----
 +
 The `<name>` is the name of the service and `-p` indicates a patch to be applied to the service JSON file. The expression in the brackets will assign the specified IP address to the specified service.
@@ -249,7 +251,7 @@ The `<name>` is the name of the service and `-p` indicates a patch to be applied
 For example:
 +
 ----
-oc patch svc mysql-55-rhel7 -p '{"spec":{"externalIPs":["192.174.120.10"]}}'
+$ oc patch svc mysql-55-rhel7 -p '{"spec":{"externalIPs":["192.174.120.10"]}}'
 
 "mysql-55-rhel7" patched
 ----
@@ -257,7 +259,7 @@ oc patch svc mysql-55-rhel7 -p '{"spec":{"externalIPs":["192.174.120.10"]}}'
 . Run the following command to see that the service has a public IP:
 +
 ----
-oc get svc
+$ oc get svc
 NAME               CLUSTER-IP      EXTERNAL-IP     PORT(S)    AGE
 mysql-55-rhel7     172.30.131.89   192.174.120.10  3306/TCP   13m
 ----
@@ -265,13 +267,13 @@ mysql-55-rhel7     172.30.131.89   192.174.120.10  3306/TCP   13m
 . On the master, use a tool, such as cURL, to make sure you can reach the service using the public IP address:
 +
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 192.168.120.10:3306
+$ curl 192.168.120.10:3306
 ----
 +
 If you get a string of characters with the `Got packets out of order` message,
@@ -305,7 +307,7 @@ These steps assume that all of the systems are on the same subnet.
 . Restart the network to make sure the network is up.
 +
 ----
-$ service network restart
+# service network restart
 Restarting network (via systemctl):  [  OK  ]
 ----
 +
@@ -314,7 +316,7 @@ If the network is not up, you will receive error messages such as *Network is un
 . Run the following command with the external IP address of the service you want to expose and device name associated with the host IP from the `ifconfig` command output:
 +
 ----
-$ ip address add <external-ip> dev <device>
+$ ip address add <external_ip> dev <device>
 ----
 +
 For example:
@@ -369,7 +371,7 @@ $ route add -net 192.174.120.0/24 gw 10.16.41.22 eth0
 . Restart the network to make sure the network is up.
 +
 ----
-$ service network restart
+# service network restart
 Restarting network (via systemctl):  [  OK  ]
 ----
 +
@@ -384,7 +386,7 @@ $ route add -net 10.16.40.0 netmask 255.255.248.0 gw 10.16.47.254 eth0
 The `ifconfig` command displays the host IP:
 +
 ----
-ifconfig
+$ ifconfig
 eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         inet 10.16.41.71  netmask 255.255.248.0  broadcast 10.19.41.255
 ----
@@ -392,7 +394,7 @@ eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
 The `netstat -nr` command displays the gateway IP:
 +
 ----
-netstat -nr
+$ netstat -nr
 Kernel IP routing table
 Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
 0.0.0.0         10.16.41.254    0.0.0.0         UG        0 0          0 eth0
@@ -407,13 +409,13 @@ $ route add -net 192.174.120.0 netmask 255.255.255.0 gw 10.16.41.22 dev eth0
 . Use a tool, such as cURL, to make sure you can reach the service using the public IP address:
 +
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 192.168.120.10:3306
+$ curl 192.168.120.10:3306
 ----
 +
 If you get a string of characters with the `Got packets out of order` message,
@@ -445,13 +447,13 @@ $ route add -net 192.174.120.0 netmask 255.255.248.0 gw 10.16.41.22
 . Use a tool, such as cURL, to make sure you can reach the service using the public IP address:
 +
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
 +
 For example:
 +
 ----
-curl 192.168.120.10:3306
+$ curl 192.168.120.10:3306
 ----
 +
 If you get a string of characters with the `Got packets out of order` message,
@@ -474,19 +476,19 @@ To configure IP failover:
 . On the master, make sure the `ipfailover` service account has sufficient security privileges:
 +
 ----
-oadm policy add-scc-to-user privileged -z ipfailover
+$ oadm policy add-scc-to-user privileged -z ipfailover
 ----
 
 . Run the following command to create the IP failover:
 +
 ----
-oadm ipfailover --virtual-ips=<exposed-ip-address> --watch-port=<exposed-port> --replicas=<number-of-pods> --create
+$ oadm ipfailover --virtual-ips=<exposed_ip_address> --watch-port=<exposed_port> --replicas=<number_of_pods> --create
 ----
 +
 For example:
 +
 ----
-oadm ipfailover --virtual-ips="172.30.233.169" --watch-port=32315 --replicas=4 --create
+$ oadm ipfailover --virtual-ips="172.30.233.169" --watch-port=32315 --replicas=4 --create
 --> Creating IP failover ipfailover ...
     serviceaccount "ipfailover" created
     deploymentconfig "ipfailover" created


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1791599

Addresses some incorrect port numbers as well as minor typos and formatting fixes to the surrounding areas.

Preview (internal): 

* http://file.rdu.redhat.com/~adellape/030220/311networking/dev_guide/expose_service/expose_internal_ip_load_balancer.html#automatically-assign-create-lb
* http://file.rdu.redhat.com/~adellape/030220/311networking/dev_guide/expose_service/expose_internal_ip_nodeport.html#configuring-the-service