### PR TITLE
BZ-1792907 Fixed broken link to Red Hat Single Sign-On

### DIFF
--- a/authentication/identity_providers/configuring-oidc-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-oidc-identity-provider.adoc
@@ -15,7 +15,7 @@ endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale[]
 You can
-link:https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_single_sign-on_for_openshift/tutorials[configure Red Hat Single Sign-On]
+link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/[configure Red Hat Single Sign-On]
 as an OpenID Connect identity provider for {product-title}.
 endif::[]
 


### PR DESCRIPTION
BZ-1792907 https://bugzilla.redhat.com/show_bug.cgi?id=1792907

@openshift/team-documentation PTAL. Merge to master, CP to 4.2-4.4. Add labels and milestone.

The link suggested in the BZ is "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/".  I am suggesting a link that will automatically redirect to the latest version and not the specific 7.3 version, i.e., "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/".