### PR TITLE
release notes catchup

### DIFF
--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -11,7 +11,7 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 1.0.7
+:ProductVersion: 1.0.9
 :product-build:
 :DownloadURL: registry.redhat.io
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -17,10 +17,29 @@ Result – If changed, describe the current user experience
 * *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
 * *Telemetry* -  Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.
 
+== New features {ProductName} 1.0.9
+
+This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs).
+
+== New features {ProductName} 1.0.8
+
+This release of {ProductName} addresses compatibility issues with {product-title} 4.4. You must upgrade {ProductName} to 1.0.8 before you upgrade from {product-title} 4.3 to {product-title} 4.4.
+
+== New features {ProductName} 1.0.7
+
+This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs).
+
+== New features {ProductName} 1.0.6
+
+This release contains internal improvements.
+
+== New features {ProductName} 1.0.5
+
+This release contains internal improvements.
+
 == New features {ProductName} 1.0.4
 
 This release of {ProductName} adds support for Kiali 1.0.9, and addresses Common Vulnerabilities and Exposures (CVEs).
-
 
 == New features {ProductName} 1.0.3
 


### PR DESCRIPTION
Added notes for the CVE-only releases and one item for 1.0.8. 

@tvieira Can you Check the notes I made for the 1.0.8 issue? Our plan is to have a note about this in the OCP release notes and the OSSM release notes. Is the note I wrote accurate and adequate?