### PR TITLE
Reorganize cluster logging per F2F

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -623,6 +623,8 @@ Topics:
     File: persistent-storage-csi-manila
   - Name: AWS Elastic Block Store CSI Driver Operator
     File: persistent-storage-csi-ebs
+  - Name: OpenStack Manila CSI Driver Operator
+    File: persistent-storage-csi-manila
 - Name: Expanding persistent volumes
   File: expanding-persistent-volumes
   Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated

--- a/modules/cluster-logging-elasticsearch-rules.adoc
+++ b/modules/cluster-logging-elasticsearch-rules.adoc
@@ -48,3 +48,4 @@ nodes if possible. Make sure more disk space is added to the node or drop old in
 |ES process CPU usage on the node in cluster is <value>
 |alert
 |===
+

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -5,7 +5,7 @@
 [id="serverless-sinkbinding-yaml_{context}"]
 = Using SinkBinding with the YAML method
 
- This guide describes the steps required to create, manage, and delete a SinkBinding instance using YAML files.
+This guide describes the steps required to create, manage, and delete a SinkBinding instance using YAML files.
 
 .Prerequisites
 


### PR DESCRIPTION
Multiple discussions around reorganizing the cluster logging docs arose at the cluster logging F2F in March 2020. 
Make the docs less EFK-centric
Better flow needed
Isolate or remove procedures that require unmanaged state as unsupported
Etc.

Version to be determined if/when we decide to proceed. Labeling as 4.5 for now.

Christian review doc: https://docs.google.com/document/d/1Ca04KEUW8-J1z_LuesiD_QivDSFMGTAqiJuft2aI_jw/edit?usp=sharing