### PR TITLE
Readd assembly for configuring custom PKI

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -426,6 +426,9 @@ Topics:
 - Name: Configuring the cluster-wide proxy
   File: enable-cluster-wide-proxy
   Distros: openshift-enterprise,openshift-origin
+- Name: Configuring a custom PKI
+  File: configuring-a-custom-pki
+  Distros: openshift-enterprise,openshift-origin
 ---
 Name: Storage
 Dir: storage
@@ -770,7 +773,7 @@ Topics:
 - Name: Modifying a MachineSet
   File: modifying-machineset
 - Name: Deleting a Machine
-  File: deleting-machine
+  File: deleting-machine  
 - Name: Applying autoscaling to a cluster
   File: applying-autoscaling
 - Name: Creating infrastructure MachineSets

--- a/builds/setting-up-trusted-ca.adoc
+++ b/builds/setting-up-trusted-ca.adoc
@@ -22,3 +22,4 @@ include::modules/configmap-adding-ca.adoc[leveloffset=+1]
 
 * link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#create-a-configmap[Create a ConfigMap]
 * link:https://kubectl.docs.kubernetes.io/pages/app_management/secrets_and_configmaps.html[Secrets and ConfigMaps]
+* xref:../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]

--- a/modules/certificate-injection-using-operators.adoc
+++ b/modules/certificate-injection-using-operators.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-a-custom-pki.adoc
+
+[id="certificate-injection-using-operators_{context}"]
+= Certificate injection using Operators
+
+Once your custom CA certificate is added to the cluster via ConfigMap, the
+Cluster Network Operator merges the user-provided and system CA certificates
+into a single bundle and injects the merged bundle into the Operator requesting
+the trust bundle injection.
+
+Operators request this injection by creating an empty ConfigMap with the
+following label:
+
+[source,yaml]
+----
+config.openshift.io/inject-trusted-cabundle="true"
+----
+
+The Operator mounts this ConfigMap into the container's local trust store.
+
+[NOTE]
+====
+Adding a trusted CA certificate is only needed if the certificate is not
+included in the {op-system-first} trust bundle.
+====
+
+Certificate injection is not limited to Operators. The Cluster Network Operator
+injects certificates across any namespace when an empty ConfigMap is created with the
+`config.openshift.io/inject-trusted-cabundle=true` label.
+
+The ConfigMap can reside in any namespace, but the ConfigMap must be mounted as
+a volume to each container within a Pod that requires a custom CA. For example:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-example-custom-ca-deployment
+  namespace: my-example-custom-ca-ns
+spec:
+  . . .
+    spec:
+      . . .
+      containers:
+        - name: my-container-that-needs-custom-ca
+          volumeMounts:
+          - name: trusted-ca
+            mountPath: /etc/pki/ca-trust/extracted/pem
+            readOnly: true
+      volumes:
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          items:
+            - key: ca-bundle.crt <1>
+              path: tls-ca-bundle.pem <2>
+----
+<1> `ca-bundle.crt` is required as the ConfigMap key.
+<2> `tls-ca-bundle.pem` is required as the ConfigMap path.

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -9,6 +9,7 @@
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
+// * networking/configuring-a-custom-pki.adoc
 
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:

--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -12,15 +12,10 @@ custom resource (CR).
 .Prerequisites
 
 * You must have a certificate/key pair in PEM-encoded files, where the
-certificate is signed by a trusted certificate authority and valid for the
-Ingress domain.
-+
-[WARNING]
-====
-If you replace the default certificate, it *must* be signed by a public
-certificate authority already included in the CA bundle as provided by the
-container userspace.
-====
+certificate is signed by a trusted certificate authority or by a private trusted
+certificate authority that you configured in a custom PKI.
+
+* Your certificate is valid for the Ingress domain.
 
 * You must have an `IngressController` CR. You may use the default one:
 +

--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// * networking/configuring-a-custom-pki.adoc
 // * networking/enable-cluster-wide-proxy.adoc
 
 [id="nw-proxy-configure-object_{context}"]

--- a/networking/configuring-a-custom-pki.adoc
+++ b/networking/configuring-a-custom-pki.adoc
@@ -1,0 +1,53 @@
+[id="configuring-a-custom-pki"]
+= Configuring a custom PKI
+include::modules/common-attributes.adoc[]
+:context: configuring-a-custom-pki
+
+toc::[]
+
+Some platform components, such as the web console, use Routes for communication and
+must trust other components' certificates to interact with them. If
+you are using a custom public key infrastructure (PKI), you must configure it so
+its privately signed CA certificates are recognized across the cluster.
+
+You can leverage the Proxy API to add cluster-wide trusted CA certificates. You
+must do this either during installation or at runtime.
+
+[NOTE]
+====
+Using the Proxy API to add cluster-wide trusted CA certificates is supported for
+{product-title} 4.2.23 and later.
+====
+
+* During _installation_, xref:installation-configure-proxy_{context}[configure the cluster-wide proxy]. You must define your
+privately signed CA certificates in the `install-config.yaml` file's
+`additionalTrustBundle` setting.
++
+The installation program generates a ConfigMap that is named `user-ca-bundle`
+that contains the additional CA certificates you defined. The Cluster Network
+Operator then creates a `trusted-ca-bundle` ConfigMap that merges these CA
+certificates with the {op-system-first} trust bundle; this ConfigMap is
+referenced in the Proxy object's `trustedCA` field.
+
+* At _runtime_, xref:nw-proxy-configure-object_{context}[modify the default Proxy object to include your privately signed
+CA certificates] (part of cluster's proxy enablement workflow). This involves
+creating a ConfigMap that contains the privately signed CA certificates that
+should be trusted by the cluster, and then modifying the proxy resource with the
+`trustedCA` referencing the privately signed certificates' ConfigMap.
+
+[NOTE]
+====
+The installer configuration's `additionalTrustBundle` field and the proxy
+resource's `trustedCA` field are used to manage the cluster-wide trust bundle;
+`additionalTrustBundle` is used at install time and the proxy's `trustedCA` is
+used at runtime.
+
+The `trustedCA` field is a reference to a `ConfigMap` containing the custom
+certificate and key pair used by the cluster component.
+====
+
+include::modules/installation-configure-proxy.adoc[leveloffset=+1]
+
+include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]
+
+include::modules/certificate-injection-using-operators.adoc[leveloffset=+1]

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -40,3 +40,7 @@ include::modules/nw-ingress-setting-internal-lb.adoc[leveloffset=+1]
 include::modules/nw-ingress-default-internal.adoc[leveloffset=+1]
 
 //include::modules/nw-ingress-select-route.adoc[leveloffset=+1]
+
+== Additional resources
+
+* xref:../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]


### PR DESCRIPTION
This content was removed in #19483 due to issues discovered later in 4.2.x testing. We've been waiting for the official [backport](https://issues.redhat.com/browse/MON-884) to release before adding this back for 4.2 (already available in 4.3 docs [here](https://docs.openshift.com/container-platform/4.3/networking/configuring-a-custom-pki.html)).

This is planned to be available once OCP `4.2.23` ships (2020-03-17).