### PR TITLE
Add Authentication troubleshooting, and how to set authentication log level

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -318,6 +318,9 @@ Topics:
 - Name: Removing the kubeadmin user
   File: remove-kubeadmin
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
+- Name: Troubleshooting Authentication
+  File: troubleshooting-authentication
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
 #- Name: Configuring LDAP failover
 #  File: configuring-ldap-failover
 - Name: Configuring the user agent

--- a/authentication/troubleshooting-authentication.adoc
+++ b/authentication/troubleshooting-authentication.adoc
@@ -1,0 +1,7 @@
+[id="troubleshooting-identity-providers"]
+= Troubleshooting Identity Providers
+include::modules/common-attributes.adoc[]
+:context: troubleshooting-identity-providers
+toc::[]
+
+include::modules/authentication-set-log-level.adoc[leveloffset=+1]

--- a/modules/authentication-set-log-level.adoc
+++ b/modules/authentication-set-log-level.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * authentication/troubleshooting-authentication.adoc
+
+[id="set_authentication_log_level_{context}"]
+= Setting the Authentication log level
+
+When troubleshooting authentication providers on {product-title}, it
+can be useful to to increase the verbosity of the logs to better understand
+what is going on.
+
+.Prerequisites
+
+* You must be logged in as an administrator.
+
+.Procedure
+
+* Edit the cluster-wide settings for authentication:
++
+----
+$ oc edit authentications.operator.openshift.io cluster
+----
+
+* Set `spec.logLevel`
++
+----
+spec:
+  logLevel: Debug
+----
+
+`spec.logLevel` can be set to `Normal`, `Debug`, `Trace`, and `TraceAll`. These values are listed in ascending verbosity.


### PR DESCRIPTION
Context: Operators often face issues configuring identity providers, and standard logging don't give sufficient information to find the source of problems with authentication. 

I think this topic its own article, as I'm sure more can be added to it, and it doesn't really fit into any other articles under the Authentication tree.