### PR TITLE
Remove Temp-URL step from Swift procedure - BZ 1805176

### DIFF
--- a/modules/installation-osp-enabling-swift.adoc
+++ b/modules/installation-osp-enabling-swift.adoc
@@ -9,7 +9,7 @@
 
 {product-title} on {rh-openstack-first} uses https://docs.openstack.org/security-guide/object-storage.html[OpenStack Object Storage (Swift)] to store and serve user configuration files.
 
-Swift is operated by a user account with the `swiftoperator` role and `temp-url` support.
+Swift is operated by a user account with the `swiftoperator` role.
 
 .Prerequisites
 
@@ -24,11 +24,6 @@ To enable Swift on {rh-openstack}:
 +
 ----
 $ openstack role add --user <user> --project <project> swiftoperator
-----
-. As the account with the `swiftoperator` role, set a temporary URL property for the account:
-+
-----
-$ openstack object store account set --property Temp-URL-Key=superkey
 ----
 
 Your {rh-openstack} deployment can now use Swift to store and serve files.


### PR DESCRIPTION
Remove superfluous step from the Swift enablement procedure in the ShiftStack IPI docs. 

https://bugzilla.redhat.com/show_bug.cgi?id=1805176
