### PR TITLE
Make the OS support accurate in 4.2 release note

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -35,12 +35,12 @@ either on-premise or cloud environments.
 later, as well as Red Hat Enterprise Linux CoreOS 4.2.
 
 You must use {op-system-first} for the control plane, or master, machines and
-can use either {op-system} or Red Hat Enterprise Linux 7.6 for compute, or worker,
-machines.
+can use either {op-system} or Red Hat Enterprise Linux 7.6 or later for compute,
+or worker, machines.
 
 [IMPORTANT]
 ====
-Because only Red Hat Enterprise Linux version 7.6 is supported for compute
+Because only Red Hat Enterprise Linux version 7.6 or later is supported for compute
 machines, you must not upgrade the Red Hat Enterprise Linux compute machines to
 version 8.
 ====


### PR DESCRIPTION
https://access.redhat.com/articles/4763741
In OCP 4.1, we support Red Hat Enterprise Linux 7.6
While in OCP 4.2, we support Red Hat Enterprise Linux 7.6 and 7.7

Apply to enterprise-4.2 only, as we already contains the accurate info for [OCP 4.3](https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-about-this-release)