### PR TITLE
Add documentation for multiple indetity providers order

### DIFF
--- a/authentication/understanding-identity-provider.adoc
+++ b/authentication/understanding-identity-provider.adoc
@@ -76,3 +76,5 @@ include::modules/authentication-remove-kubeadmin.adoc[leveloffset=+1]
 include::modules/identity-provider-parameters.adoc[leveloffset=+1]
 
 include::modules/identity-provider-default-CR.adoc[leveloffset=+1]
+
+include::modules/multiple-identity-providers.adoc[leveloffset=+1]

--- a/modules/multiple-identity-providers.adoc
+++ b/modules/multiple-identity-providers.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * authentication/understanding-identity-provider.adoc
+
+[id="multiple-identity-providers_{context}"]
+= Multiple Identity providers
+
+There could be scenarios in which multiple identity providers
+are configured with OAuth server. The order in which identity
+providers are configured also determines the precedence. OAuth
+server checks against Identity providers sequentially in the
+order they are configured.


### PR DESCRIPTION
Add documentation to clear things on the order in which IDPs are checked if more than one of them is configured.