### PR TITLE
attach disk edits

### DIFF
--- a/modules/cnv-creating-vm.adoc
+++ b/modules/cnv-creating-vm.adoc
@@ -41,7 +41,7 @@ ReplicaSet is not currently supported in {CNVProductName}.
 |Memory
 |The amount of RAM that is allocated to the virtual machine by the node. Specify a value in *M* for Megabyte or *Gi* for Gigabyte.
 
-|Disks: name
+|Disks
 |The name of the volume that is referenced. Must match the name of a volume.
 |===
 

--- a/modules/cnv-storage-wizard-fields-web.adoc
+++ b/modules/cnv-storage-wizard-fields-web.adoc
@@ -11,11 +11,10 @@
 |Name | Description
 
 |Source
-|Select a blank disk for the virtual machine or choose from the options available: *PXE*, *Container*, *URL* or *Disk*. To select an existing disk and attach it to the virtual machine, choose *Attach Disk* from a list of available PersistentVolumeClaims (PVCs) or from a cloned disk.
+|Select a blank disk for the virtual machine or choose from the options available: *URL*,  *Container*, *Attach Cloned Disk*,  or *Attach Disk*. To select an existing disk and attach it to the virtual machine, choose *Attach Cloned Disk* or *Attach Disk* from a list of available PersistentVolumeClaims (PVCs).
 
 |Name
 |Name of the disk. The name can contain lowercase letters (`a-z`), numbers (`0-9`), hyphens (`-`), and periods (`.`), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters.
-
 
 |Size (GiB)
 |Size, in GiB, of the disk.

--- a/modules/cnv-vm-wizard-fields-web.adoc
+++ b/modules/cnv-vm-wizard-fields-web.adoc
@@ -37,10 +37,6 @@ endif::[]
 |Disk
 |Provision virtual machine from a disk.
 
-|Attach disk
-|
-|Attach an existing disk that was previously cloned or created and made available in the PersistentVolumeClaims. When this option is selected, you must manually complete the *Operating System*, *Flavor*, and *Workload Profile* fields.
-
 |Operating System
 |
 |The primary operating system that is selected for the virtual machine.
@@ -48,6 +44,14 @@ endif::[]
 |Flavor
 |small, medium, large, tiny, Custom
 |Presets that determine the amount of CPU and memory allocated to the virtual machine. The presets displayed for *Flavor* are determined by the operating system.
+
+|Memory
+|
+|Size in GiB of the memory allocated to the virtual machine.
+
+|CPUs
+|
+|The amount of CPU allocated to the virtual machine.
 
 .3+|Workload Profile
 |High Performance


### PR DESCRIPTION
This PR focuses on edits mentioned in the defect:
Doc update for cnv wizard disk terminology
https://bugzilla.redhat.com/show_bug.cgi?id=1798570 

As specified in the defect, the Attach Disk field and description were removed from the table which has fields and descriptions for the Virtual Machine Wizard.

In the Storage fields table, the description was modified for the "Source" field to reflect the minor update for Attach Disk and Attach Cloned Disk.

Remove "name" from "Disks: name" because it is not needed.