### PR TITLE
Prefer short flag for whoami -t

### DIFF
--- a/rest_api/index.adoc
+++ b/rest_api/index.adoc
@@ -43,7 +43,7 @@ command:
 ----
 $ oc login -u test_user
 Using project "test".
-$ oc whoami --token
+$ oc whoami -t
 dIAo76N-W-GXK3S_w_KsC6DmH3MzP79zq7jbMQvCOUo
 ----
 


### PR DESCRIPTION
@vikram-redhat, probably oldest cherry-pick in the entire repo. This was fixed by a commit in 2016, but apparently never made it into _enterprise-3.11_.