### PR TITLE
Reintroduce GA'd features in TP table

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -73,10 +73,20 @@ indicate that the feature is removed from the release or deprecated.
 |====
 |Feature |OCP 4.2 |OCP 4.3 |OCP 4.4
 
+|Prometheus Cluster Monitoring
+|GA
+|GA
+|GA
+
 |Precision Time Protocol (PTP)
 |-
 |TP
 |
+
+|CRI-O for runtime Pods
+|GA
+|GA
+|GA
 
 |Tenant Driven Snapshotting
 |TP
@@ -103,6 +113,51 @@ indicate that the feature is removed from the release or deprecated.
 |-
 |
 
+|Network Policy
+|GA
+|GA
+|GA
+
+|Multus
+|GA
+|GA
+|GA
+
+|New Add Project Flow
+|GA
+|GA
+|GA
+
+|Search Catalog
+|GA
+|GA
+|GA
+
+|Cron Jobs
+|GA
+|GA
+|GA
+
+|Kubernetes Deployments
+|GA
+|GA
+|GA
+
+|StatefulSets
+|GA
+|GA
+|GA
+
+|Explicit Quota
+|GA
+|GA
+|GA
+
+|Mount Options
+|GA
+|GA
+|GA
+
 |System Containers for Docker, CRI-O
 |-
 |-
@@ -123,10 +178,30 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 |
 
+|Pod sysctls
+|GA
+|GA
+|GA
+
 |Central Audit
 |-
 |-
 |
+
+|Static IPs for External Project Traffic
+|GA
+|GA
+|GA
+
+|Template Completion Detection
+|GA
+|GA
+|GA
+
+|`replicaSet`
+|GA
+|GA
+|GA
 
 |Clustered MongoDB Template
 |-
@@ -137,6 +212,36 @@ indicate that the feature is removed from the release or deprecated.
 |-
 |-
 |
+
+|ImageStreams with Kubernetes Resources
+|GA
+|GA
+|GA
+
+|Device Manager
+|GA
+|GA
+|GA
+
+|Persistent Volume Resize
+|GA
+|GA
+|GA
+
+|Huge Pages
+|GA
+|GA
+|GA
+
+|CPU Pinning
+|GA
+|GA
+|GA
+
+|Admission Webhooks
+|GA
+|GA
+|GA
 
 |External provisioner for AWS EFS
 |TP
@@ -188,6 +293,46 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 |
 
+|Cluster Administrator console
+|GA
+|GA
+|GA
+
+|Cluster Autoscaling
+|GA
+|GA
+|GA
+
+|Container Storage Interface (CSI)
+|GA
+|GA
+|GA
+
+|Operator Lifecycle Manager
+|GA
+|GA
+|GA
+
+|Red Hat OpenShift Service Mesh
+|GA
+|GA
+|GA
+
+|"Fully Automatic" Egress IPs
+|GA
+|GA
+|GA
+
+|Pod Priority and Preemption
+|GA
+|GA
+|GA
+
+|Multi-stage builds in Dockerfiles
+|GA
+|GA
+|GA
+
 |OVN-Kubernetes Pod network provider
 |TP
 |TP
@@ -217,6 +362,11 @@ indicate that the feature is removed from the release or deprecated.
 |-
 |TP
 |
+
+|OperatorHub
+|GA
+|GA
+|GA
 
 |Three-node bare metal deployments
 |TP


### PR DESCRIPTION
@vikram-redhat based on our discussion, I've re-added the long standing GA features to the TP table I had initially removed for the 4.4 release notes.

@sheriff-rh FYI: for precautionary reasons, we're going to keep the long standing GA features in the TP table for now.