### PR TITLE
OSDOCS-909: Updating migration planning content for 4.4

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1158,11 +1158,10 @@ Topics:
 - Name: Migrating OpenShift Container Platform 3 to 4
   Dir: migrating_3_4
   Topics:
-  # TODO: Commenting out until planning content has been updated for 4.4  
-  # - Name: About migrating OpenShift Container Platform 3 to 4
-  #   File: about-migration
-  # - Name: Planning your OpenShift Container Platform 3 to 4 migration
-  #   File: planning-migration-3-to-4
+  - Name: About migrating OpenShift Container Platform 3 to 4
+    File: about-migration
+  - Name: Planning your OpenShift Container Platform 3 to 4 migration
+    File: planning-migration-3-to-4
   - Name: Migrating application workloads from OpenShift Container Platform 3.7 to 4.3
     File: migrating-application-workloads-3-to-4
   - Name: Configuring a replication repository

--- a/migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
+++ b/migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
@@ -12,13 +12,10 @@ The CAM tool's web console and API, based on Kubernetes Custom Resources, enable
 
 Optionally, you can use the xref:../../migration/migrating_3_4/migrating-with-cpma.adoc#migration-understanding-cpma_{context}[Control Plane Migration Assistant (CPMA)] to assist you in migrating control plane settings.
 
-////
-// TODO: Add back in once 4.4 planning content has been added
 [IMPORTANT]
 ====
 Before you begin your migration, be sure to review the information on xref:../../migration/migrating_3_4/planning-migration-3-to-4.adoc#planning-migration-3-to-4[planning your migration].
 ====
-////
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]

--- a/migration/migrating_3_4/planning-migration-3-to-4.adoc
+++ b/migration/migrating_3_4/planning-migration-3-to-4.adoc
@@ -5,11 +5,11 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Before performing your migration to {product-title} 4.3, it is important to take the time to properly plan for the transition. {product-title} 4 introduces architectural changes and enhancements, so the procedures that you used to manage your {product-title} 3 cluster might not apply for {product-title} 4.
+Before performing your migration to {product-title} 4.4, it is important to take the time to properly plan for the transition. {product-title} 4 introduces architectural changes and enhancements, so the procedures that you used to manage your {product-title} 3 cluster might not apply for {product-title} 4.
 
 [NOTE]
 ====
-This planning document assumes that you are transitioning from {product-title} 3.11 to {product-title} 4.3.
+This planning document assumes that you are transitioning from {product-title} 3.11 to {product-title} 4.4.
 ====
 
 This document provides high-level information on the most important xref:../../migration/migrating_3_4/planning-migration-3-to-4.adoc#migration-comparing-ocp-3-4[differences between {product-title} 3 and {product-title} 4] and the most noteworthy xref:../../migration/migrating_3_4/planning-migration-3-to-4.adoc#migration-considerations[migration considerations]. For detailed information on configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For detailed information on new features and other notable technical changes, review the xref:../../release_notes/ocp-4-4-release-notes.adoc#ocp-4-4-release-notes[OpenShift Container Platform 4.4 release notes].
@@ -52,11 +52,11 @@ For more information, see xref:../../operators/olm-what-operators-are.adoc#olm-w
 
 To install {product-title} 3.11, you prepared your Red Hat Enterprise Linux (RHEL) hosts, set all of the configuration values your cluster needed, and then ran an Ansible playbook to install and set up your cluster.
 
-In {product-title} 4.3, you use the OpenShift installation program to create a minimum set of resources required for a cluster. Once the cluster is running, you use Operators to further configure your cluster and to install new services. After first boot, {op-system-first} systems are managed by the Machine Config Operator (MCO) that runs in the {product-title} cluster.
+In {product-title} 4.4, you use the OpenShift installation program to create a minimum set of resources required for a cluster. Once the cluster is running, you use Operators to further configure your cluster and to install new services. After first boot, {op-system-first} systems are managed by the Machine Config Operator (MCO) that runs in the {product-title} cluster.
 
 For more information, see xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process].
 
-If you want to add RHEL worker machines to your {product-title} 4.3 cluster, you use an Ansible playbook to join the RHEL worker machines after the cluster is running. For more information, see xref:../../machine_management/adding-rhel-compute.adoc#adding-rhel-compute[Adding RHEL compute machines to an {product-title} cluster].
+If you want to add RHEL worker machines to your {product-title} 4.4 cluster, you use an Ansible playbook to join the RHEL worker machines after the cluster is running. For more information, see xref:../../machine_management/adding-rhel-compute.adoc#adding-rhel-compute[Adding RHEL compute machines to an {product-title} cluster].
 
 [discrete]
 ==== Infrastructure options
@@ -68,7 +68,7 @@ For more information, see xref:../../architecture/architecture-installation.adoc
 [discrete]
 ==== Upgrading your cluster
 
-In {product-title} 3.11, you upgraded your cluster by running Ansible playbooks. In {product-title} 4.3, the cluster manages its own updates, including updates to {op-system-first} on cluster nodes. You can easily upgrade your cluster by using the web console or by using the `oc adm upgrade` command from the OpenShift CLI and the Operators will automatically upgrade themselves. If your {product-title} 4.3 cluster has Red Hat Enterprise Linux worker machines, then you will still need to run an Ansible playbook to upgrade those worker machines.
+In {product-title} 3.11, you upgraded your cluster by running Ansible playbooks. In {product-title} 4.4, the cluster manages its own updates, including updates to {op-system-first} on cluster nodes. You can easily upgrade your cluster by using the web console or by using the `oc adm upgrade` command from the OpenShift CLI and the Operators will automatically upgrade themselves. If your {product-title} 4.4 cluster has Red Hat Enterprise Linux worker machines, then you will still need to run an Ansible playbook to upgrade those worker machines.
 
 For more information, see xref:../../updating/updating-cluster-between-minor.adoc#updating-cluster-between-minor[Updating clusters].
 
@@ -80,39 +80,39 @@ Review the changes and other considerations that might affect your transition fr
 [id="migration-preparing-storage"]
 === Storage considerations
 
-Review the following storage changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.3.
+Review the following storage changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.4.
 
 [discrete]
 ==== Local volume persistent storage
 
-Local storage is only supported by using the Local Storage Operator in {product-title} 4.3. It is not supported to use the local provisioner method from {product-title} 3.11.
+Local storage is only supported by using the Local Storage Operator in {product-title} 4.4. It is not supported to use the local provisioner method from {product-title} 3.11.
 
 For more information, see xref:../../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
 
 [discrete]
 ==== FlexVolume persistent storage
 
-The FlexVolume plug-in location changed from {product-title} 3.11. The new location in {product-title} 4.3 is `/etc/kubernetes/kubelet-plugins/volume/exec`. Attachable FlexVolume plug-ins are no longer supported.
+The FlexVolume plug-in location changed from {product-title} 3.11. The new location in {product-title} 4.4 is `/etc/kubernetes/kubelet-plugins/volume/exec`. Attachable FlexVolume plug-ins are no longer supported.
 
 For more information, see xref:../../storage/persistent_storage/persistent-storage-flexvolume.adoc#persistent-storage-using-flexvolume[Persistent storage using FlexVolume].
 
 [discrete]
 ==== Container Storage Interface (CSI) persistent storage
 
-Persistent storage using the Container Storage Interface (CSI) was link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] in {product-title} 3.11. CSI version 1.1.0 is fully supported in {product-title} 4.3, but does not ship with any CSI drivers. You must install your own driver.
+Persistent storage using the Container Storage Interface (CSI) was link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] in {product-title} 3.11. CSI version 1.1.0 is fully supported in {product-title} 4.4, but does not ship with any CSI drivers. You must install your own driver.
 
 For more information, see xref:../../storage/persistent_storage/persistent-storage-csi.adoc#persistent-storage-using-csi[Persistent storage using the Container Storage Interface (CSI)].
 
 [discrete]
 ==== Unsupported persistent storage options
 
-Support for the following persistent storage options from {product-title} 3.11 has changed in {product-title} 4.3:
+Support for the following persistent storage options from {product-title} 3.11 has changed in {product-title} 4.4:
 
 * GlusterFS is no longer supported.
 * CephFS is no longer supported.
 * Ceph RBD is no longer supported.
 
-If you used of one these in {product-title} 3.11, you must choose a different persistent storage option for full support in {product-title} 4.3.
+If you used of one these in {product-title} 3.11, you must choose a different persistent storage option for full support in {product-title} 4.4.
 
 For more information, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
 
@@ -121,28 +121,28 @@ For more information, see xref:../../storage/understanding-persistent-storage.ad
 [id="migration-preparing-networking"]
 === Networking considerations
 
-Review the following networking changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.3.
+Review the following networking changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.4.
 
 [discrete]
 ==== Network isolation mode
 
-The default network isolation mode for {product-title} 3.11 was `ovs-subnet`, though users frequently switched to use `ovn-multitenant`. The default network isolation mode for {product-title} 4.3 is now NetworkPolicy.
+The default network isolation mode for {product-title} 3.11 was `ovs-subnet`, though users frequently switched to use `ovn-multitenant`. The default network isolation mode for {product-title} 4.4 is now NetworkPolicy.
 
-If your {product-title} 3.11 cluster used the `ovs-subnet` or `ovs-multitenant` mode, it is recommended to switch to the NetworkPolicy mode for your {product-title} 4.3 cluster. NetworkPolicy is supported upstream, is more flexible, and also provides the functionality that `ovs-multitenant` does. If you want to maintain the `ovs-multitenant` behavior while using NetworkPolicy in {product-title} 4.3, follow the steps to xref:../../networking/configuring-networkpolicy.adoc#nw-networkpolicy-multitenant-isolation_configuring-networkpolicy-plugin[configure multitenant isolation using NetworkPolicy].
+If your {product-title} 3.11 cluster used the `ovs-subnet` or `ovs-multitenant` mode, it is recommended to switch to the NetworkPolicy mode for your {product-title} 4.4 cluster. NetworkPolicy is supported upstream, is more flexible, and also provides the functionality that `ovs-multitenant` does. If you want to maintain the `ovs-multitenant` behavior while using NetworkPolicy in {product-title} 4.4, follow the steps to xref:../../networking/configuring-networkpolicy.adoc#nw-networkpolicy-multitenant-isolation_configuring-networkpolicy-plugin[configure multitenant isolation using NetworkPolicy].
 
 For more information, see xref:../../networking/configuring-networkpolicy.adoc#nw-networkpolicy-about_configuring-networkpolicy-plugin[About network policy].
 
 [discrete]
 ==== Encrypting traffic between hosts
 
-In {product-title} 3.11, you could use IPsec to encrypt traffic between hosts. {product-title} 4.3 does not support IPsec. It is recommended to use Red Hat OpenShift Service Mesh to enable mutual TLS between services.
+In {product-title} 3.11, you could use IPsec to encrypt traffic between hosts. {product-title} 4.4 does not support IPsec. It is recommended to use Red Hat OpenShift Service Mesh to enable mutual TLS between services.
 
 For more information, see xref:../../service_mesh/service_mesh_arch/understanding-ossm.adoc#understanding-ossm[Understanding Red Hat OpenShift Service Mesh].
 
 [id="migration-preparing-logging"]
 === Logging considerations
 
-Review the following logging changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.3.
+Review the following logging changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.4.
 
 [discrete]
 ==== Deploying cluster logging
@@ -161,12 +161,12 @@ For more information, see xref:../../logging/cluster-logging.adoc#cluster-loggin
 [id="migration-preparing-security"]
 === Security considerations
 
-Review the following security changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.3.
+Review the following security changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.4.
 
 [discrete]
 ==== Unauthenticated access to discovery endpoints
 
-In {product-title} 3.11, an unauthenticated user could access the discovery endpoints (for example, [x-]`/api/*` and [x-]`/apis/*`). For security reasons, unauthenticated access to the discovery endpoints is no longer allowed in {product-title} 4.3. If you do need to allow unauthenticated access, you can configure the RBAC settings as necessary; however, be sure to consider the security implications as this can expose internal cluster components to the external network.
+In {product-title} 3.11, an unauthenticated user could access the discovery endpoints (for example, [x-]`/api/*` and [x-]`/apis/*`). For security reasons, unauthenticated access to the discovery endpoints is no longer allowed in {product-title} 4.4. If you do need to allow unauthenticated access, you can configure the RBAC settings as necessary; however, be sure to consider the security implications as this can expose internal cluster components to the external network.
 
 // TODO: Anything to xref to, or additional details?
 
@@ -175,15 +175,15 @@ In {product-title} 3.11, an unauthenticated user could access the discovery endp
 
 Configuration for identity providers has changed for {product-title} 4, including the following notable changes:
 
-* The request header identity provider in {product-title} 4.3 requires mutual TLS, where in {product-title} 3.11 it did not.
-* The configuration of the OpenID Connect identity provider was simplified in {product-title} 4.3. It now obtains data, which previously had to specified in {product-title} 3.11, from the provider's `/.well-known/openid-configuration` endpoint.
+* The request header identity provider in {product-title} 4.4 requires mutual TLS, where in {product-title} 3.11 it did not.
+* The configuration of the OpenID Connect identity provider was simplified in {product-title} 4.4. It now obtains data, which previously had to specified in {product-title} 3.11, from the provider's `/.well-known/openid-configuration` endpoint.
 
 For more information, see xref:../../authentication/understanding-identity-provider.adoc#understanding-identity-provider[Understanding identity provider configuration].
 
 [id="migration-preparing-monitoring"]
 === Monitoring considerations
 
-Review the following monitoring changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.3.
+Review the following monitoring changes to consider when transitioning from {product-title} 3.11 to {product-title} 4.4.
 
 [discrete]
 ==== Alert for monitoring infrastructure availability


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-909

So far, no differences to note from 4.3 have been identified.