### PR TITLE
[enterprise-4.4] Added Serverless 1.5.0 relnotes and updates to docs for 4.3

### DIFF
--- a/modules/deploying-serverless-apps.adoc
+++ b/modules/deploying-serverless-apps.adoc
@@ -19,10 +19,3 @@ $ oc apply --filename service.yaml
 Now that service has been created and the application has been deployed, Knative will create a new immutable revision for this version of the application.
 
 Knative will also perform network programming to create a route, ingress, service, and load balancer for your application, and will automatically scale your pods up and down based on traffic, including inactive pods.
-
-[NOTE]
-====
-The first time that a Knative service is created in a namespace, that namespace will automatically receive a new networking configuration. This might cause the initial service to take longer than is usually required for a service to become ready.
-
-If the namespace has no existing NetworkPolicy configuration, an "allow all" type policy will be applied automatically. This policy will be removed automatically if all Knative Services are removed from that namespace and no other NetworkPolicy configurations have been applied.
-====

--- a/modules/serverless-rn-1-5-0.adoc
+++ b/modules/serverless-rn-1-5-0.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * serverless/release-notes.adoc
+
+[id="serverless-rn-1-5-0_{context}"]
+
+= Release Notes for Red Hat {ServerlessProductName} Technology Preview 1.5.0
+
+[id="new-features-1-5-0_{context}"]
+== New features
+* {ServerlessProductName} 1.5.0 is available on {product-title} 4.3 and newer versions.
+* {ServerlessProductName} has been updated to use Knative Serving 0.12.1.
+* {ServerlessProductName} has been updated to use Knative Client (`kn` CLI) 0.12.0.
+* {ServerlessProductName} has been updated to use Knative Serving Operator 0.12.1.
+* {ServerlessProductName} ingress implementation has been updated to use Kourier in place of Service Mesh. No user intervention is necessary, as this change is automatic when the {ServerlessOperatorName} is upgraded to 1.5.0.
+
+[id="fixed-issues-1-5-0_{context}"]
+== Fixed issues
+* In previous releases, {product-title} scale from zero latency caused a delay of approximately 10 seconds when creating pods. This issue has been fixed in the {product-title} 4.3.5 bug fix update.
+
+[id="known-issues-1-5-0_{context}"]
+== Known issues
+* Deleting `KnativeServing.operator.knative.dev` from the `knative-serving` namespace may cause the deletion process to hang. This is due to a race condition between deletion of the CRD and `knative-openshift-ingress` removing finalizers.

--- a/serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing-openshift-serverless.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [IMPORTANT]
 ====
-{ServerlessProductName} is not tested or supported for installation in a restricted network environment.
+{ServerlessProductName} is supported for installation in a restricted network environment. For more information, see xref:../operators/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
 ====
 
 // Cluster sizing requirements
@@ -29,18 +29,7 @@ The {ServerlessOperatorName} can be installed using the {product-title} instruct
 
 You can install the {ServerlessOperatorName} in the host cluster by following the {product-title} instructions on installing an Operator.
 
-[NOTE]
-====
-The {ServerlessOperatorName} only works for {product-title} versions 4.1.13 and later.
-====
-
 For details, see the {product-title} documentation on xref:../operators/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[adding Operators to a cluster].
-
-[IMPORTANT]
-====
-The {ServerlessOperatorName} automatically installs the Service Mesh Operator. If you already have a community version of Maistra installed, this will cause a conflict with the {ServerlessOperatorName} Service Mesh auto-install. In this case, the already existing community version of Maistra will be used instead.
-====
-
 
 // Installing Knative Serving
 include::modules/serverless-installing-knative-serving.adoc[leveloffset=+1]

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -15,6 +15,7 @@ If you experience difficulty with a procedure described in this documentation,
 visit the link:https://access.redhat.com/support/offerings/techpreview/[Customer Portal] to learn more about support for Technology Preview features.
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-5-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-4-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-3-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-2-0.adoc[leveloffset=+1]


### PR DESCRIPTION
cp for https://github.com/openshift/openshift-docs/pull/19688

cc @abrennan89 