### PR TITLE
cnv: maintenance: fix capitalization of LiveMigration

### DIFF
--- a/modules/virt-setting-node-maintenance-cli.adoc
+++ b/modules/virt-setting-node-maintenance-cli.adoc
@@ -33,6 +33,6 @@ $ oc apply -f <node02-maintenance.yaml>
 ----
 
 The node live migrates virtual machine instances that have the
-`liveMigration` eviction strategy, and taint the node so that it is no longer
+`LiveMigration` eviction strategy, and taint the node so that it is no longer
 schedulable. All other pods and virtual machines on the node are deleted and
 recreated on another node.

--- a/modules/virt-setting-node-maintenance-web.adoc
+++ b/modules/virt-setting-node-maintenance-web.adoc
@@ -21,5 +21,5 @@ where you can view comprehensive details of the selected node:
 . Click *Start Maintenance* in the confirmation window. 
 
 The node will live migrate virtual machine instances that have the 
-`liveMigration` eviction strategy, and the node is no longer schedulable. All 
+`LiveMigration` eviction strategy, and the node is no longer schedulable. All
 other pods and virtual machines on the node are deleted and recreated on another node. 


### PR DESCRIPTION
The source code and most of the doc use uppercase L. The remaining two
occurrences should conform.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>