### PR TITLE
Fix versions in 4.2 release note

### DIFF
--- a/release_notes/dedicated-4-2-release-notes.adoc
+++ b/release_notes/dedicated-4-2-release-notes.adoc
@@ -198,7 +198,7 @@ To workaround such upgrade failures:
 . Move the CatalogSource object from the previous global catalog namespace to
 the `openshift-marketplace` namespace.
 
-[id="ocp-41-deprecated-features"]
+[id="ocp-4-2-deprecated-features"]
 === Deprecated features
 
 [discrete]

--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -636,7 +636,7 @@ To workaround such upgrade failures:
 . Move the CatalogSource object from the previous global catalog namespace to
 the `openshift-marketplace` namespace.
 
-[id="ocp-41-deprecated-features"]
+[id="ocp-4-2-deprecated-features"]
 === Deprecated features
 
 [discrete]


### PR DESCRIPTION
For 4.1,
https://docs.openshift.com/container-platform/4.1/release_notes/ocp-4-1-release-notes.html#ocp-41-deprecated-features
For 4.2,
https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-41-deprecated-features
For 4.3,
https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-deprecated-features

Apply to enterprise-4.2 only.
@openshift/team-documentation 