### PR TITLE
Add note on restriction on openshift- project name

### DIFF
--- a/applications/projects/working-with-projects.adoc
+++ b/applications/projects/working-with-projects.adoc
@@ -8,6 +8,11 @@ toc::[]
 A _project_ allows a community of users to organize and manage their content in
 isolation from other communities.
 
+[NOTE]
+====
+Projects starting with `openshift-` and `kube-` are  xref:../../authentication/using-rbac.adoc#rbac-default-projects_using-rbac[default projects]. These projects host cluster components that run as Pods and other infrastructure components. As such, {product-title} does not allow you to create Projects starting with `openshift-` or `kube-` using the `oc new-project` command. Cluster administrators can create these Projects using the xref:../../cli_reference/openshift_cli/administrator-cli-commands.adoc#new-project[`oc adm new-project` command].
+====
+
 include::modules/creating-a-project-using-the-web-console.adoc[leveloffset=+1]
 
 include::modules/odc-creating-projects-using-developer-perspective.adoc[leveloffset=+1]

--- a/modules/creating-a-project-using-the-CLI.adoc
+++ b/modules/creating-a-project-using-the-CLI.adoc
@@ -7,6 +7,11 @@
 
 If allowed by your cluster administrator, you can create a new project.
 
+[NOTE]
+====
+Projects starting with `openshift-` and `kube-` are considered critical by {product-title}. As such, {product-title} does not allow you to create Projects starting with `openshift-` or `kube-` using the `oc new-project` command. Cluster administrators can create these Projects using the xref:../../cli_reference/openshift_cli/administrator-cli-commands.adoc#new-project[`oc adm new-project` command].
+====
+
 .Procedure
 
 . Run:

--- a/modules/creating-a-project-using-the-web-console.adoc
+++ b/modules/creating-a-project-using-the-web-console.adoc
@@ -7,6 +7,11 @@
 
 If allowed by your cluster administrator, you can create a new project.
 
+[NOTE]
+====
+Projects starting with `openshift-` and `kube-` are considered critical by {product-title}. As such, {product-title} does not allow you to create Projects starting with `openshift-` using the web console.
+====
+
 .Procedure
 
 . Navigate to *Home* -> *Projects*.

--- a/modules/odc-creating-projects-using-developer-perspective.adoc
+++ b/modules/odc-creating-projects-using-developer-perspective.adoc
@@ -7,6 +7,11 @@
 
 You can use the *Developer* perspective in the {product-title} web console to create a project in your namespace.
 
+[NOTE]
+====
+Projects starting with `openshift-` and `kube` host cluster components that run as Pods and other infrastructure components. As such, {product-title} does not allow you to create Projects starting with `openshift-` or `kube-` using the CLI. Cluster administrators can create these Projects using the xref:../../cli_reference/openshift_cli/administrator-cli-commands.adoc#new-project[`oc adm new-project` command].
+====
+
 .Prerequisites
 
 * Ensure that you have the appropriate link:https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html#default-roles_using-rbac[roles and permissions] to create projects, applications, and other workloads in {product-title}.


### PR DESCRIPTION
When investigating https://github.com/openshift/openshift-docs/pull/20318 we found a restriction against creating projects named `openshift-`. 
This PR adds notes to the Projects assembly and creating projects modules. 
20318 addresses this issue specific to Cluster Logging where the user *must* create the `openshift-logging` Namespace using a YAML. I didn't want to add that work around in the Projects docs.  