### PR TITLE
Bug 1813819: [4.2] Remove known issue for pod sysctls in 4.2 as it exist in 4.1 only

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1297,7 +1297,7 @@ indicate that the feature is removed from the release or deprecated.
 |Pod sysctls
 |GA
 |GA
-|GA. See xref:ocp-4-2-known-issues[Known issues] for current limitations.
+|GA
 
 |Central Audit
 |GA


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1813819

Known issue for pod sysctls is in OCP 4.1, which is wrongly applied to OCP 4.2 in 4.2 release note.

Apply to enterprise-4.2 only. @openshift/team-documentation 