### PR TITLE
Bug 1813848: [4.1] Fix invalid command "oc clusterversion"

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -877,7 +877,7 @@ secrets after several days of uptime.
 memory-based autoscaling is failing while looking for resources.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1707785[*BZ#1707785*])
 
-* After successfully performing updates, `oc clusterversion` may report that the
+* After successfully performing updates, `oc get clusterversion` may report that the
 update could not be applied.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1711964[*BZ#1711964*])
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1813848

Apply to enterprise-4.1 only.