### PR TITLE
BZ-1754036: removed all instances of openshift_node_cert_expire_days …

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -213,9 +213,6 @@ See xref:../install_config/redeploying_certificates.adoc#redeploying-new-custom-
 |`openshift_ca_cert_expire_days`
 |Validity of the auto-generated CA certificate in days. Defaults to `1825` (5 years).
 
-|`openshift_node_cert_expire_days`
-|Validity of the auto-generated node certificate in days. Defaults to `730` (2 years).
-
 |`openshift_master_cert_expire_days`
 |Validity of the auto-generated master certificate in days. Defaults to `730` (2 years).
 
@@ -1600,7 +1597,6 @@ during installation using the following variables (default values shown):
 
 openshift_hosted_registry_cert_expire_days=730
 openshift_ca_cert_expire_days=1825
-openshift_node_cert_expire_days=730
 openshift_master_cert_expire_days=730
 etcd_ca_default_days=1825
 ----
@@ -1800,8 +1796,8 @@ openshift_logging_install_logging=true
 
 [NOTE]
 ====
-When installing cluster logging, you must also specify a node selector, 
-such as `openshift_logging_es_nodeselector={"node-role.kubernetes.io/infra": "true"}` 
+When installing cluster logging, you must also specify a node selector,
+such as `openshift_logging_es_nodeselector={"node-role.kubernetes.io/infra": "true"}`
 in the Ansible inventory file.
 ====
 


### PR DESCRIPTION
…and related information.

BZ-1754036 https://bugzilla.redhat.com/show_bug.cgi?id=1754036

@barleyer Please take a look for 3.11 and confirm that this is the only impacted version.