### PR TITLE
Add new bundle format / opm info to deprecation msg in 4.4 relnotes

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -217,6 +217,86 @@ The `OS_EDITOR` is deprecated. Users should start using `KUBE_EDITOR` or
 The `machineCIDR` network parameter used in the `install-config.yaml` file is
 now deprecated. You should use `machineNetwork.cidr` instead.
 
+[id="ocp-4-4-deprecation-of-operatorsources"]
+==== Deprecation of OperatorSources, CatalogSourceConfigs, and packaging format
+
+OperatorSources and CatalogSourceConfigs are deprecated from OperatorHub. The
+following related APIs will be removed in a future release:
+
+* `operatorsources.operators.coreos.com/v1`
+* `catalogsourceconfigs.operators.coreos.com/v2`
+* `catalogsourceconfigs.operators.coreos.com/v1`
+
+The Operator Framework's current packaging format is also being deprecated, to
+be replaced by a new bundle format in a future release.
+
+*Upcoming new Operator bundle format and `opm` CLI*
+
+[IMPORTANT]
+====
+The following features are not currently supported on {product-title} 4.4 or
+intended for production use. They are highlighted here to notify users of an
+important upcoming change to the Operator Framework. Limited documentation is
+available at this time.
+====
+
+Related to the removal of OperatorSources and CatalogSourceConfigs, Operator
+Lifecycle Manager (OLM) will be introducing a new _Operator bundle_ format in a
+future release of {product-title}. A bundle is a container image that stores
+Kubernetes manifests and metadata associated with an Operator and is meant to
+present a specific version of an Operator.
+
+When writing an Operator, the new bundle format requires two directories named
+`manifests` and `metadata`:
+
+----
+/
+├── manifests
+│   ├── etcdcluster.crd.yaml
+│   └── etcdoperator.clusterserviceversion.yaml
+└── metadata
+    └── annotations.yaml
+----
+
+In addition, the new Operator Package Manager (`opm`) is introduced alongside
+the new Operator bundle format. The `opm` CLI tool can:
+
+- generate bundle annotations,
+- build bundle images, and
+- validate bundle images available in a registry.
+
+See the upstream `operator-framework/operator-registry` project repository for
+documentation on these upcoming features:
+
+- link:https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md[Operator Bundle Overview]
+- link:https://github.com/operator-framework/operator-registry/blob/master/README.md[Operator Registry README]
+
+See the project's *Releases* page for `opm` downloads:
+
+- link:https://github.com/operator-framework/operator-registry/releases[Releases]
+
+[id="ocp-4-4-service-catalog-deprecated"]
+==== Service Catalog, Template Service Broker, Ansible Service Broker, and their Operators
+
+Service Catalog, Template Service Broker, Ansible Service Broker, and their
+associated Operators were deprecated in {product-title} 4.2 and will be removed
+in a future {product-title} release. If they are enabled in 4.3, the web console
+now warns the user that these features are still enabled.
+
+The following alerts can be viewed from the *Monitoring* -> *Alerts* page and
+have a *Warning* severity:
+
+* `ServiceCatalogAPIServerEnabled`
+* `ServiceCatalogControllerManagerEnabled`
+* `TemplateServiceBrokerEnabled`
+* `AnsibleServiceBrokerEnabled`
+
+The following related APIs will be removed in a future release:
+
+* `.servicecatalog.k8s.io/v1beta1`
+* `.automationbroker.io/v1alpha1`
+* `.osb.openshift.io/v1`
+
 [id="ocp-4-4-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
Preview (internal): http://file.rdu.redhat.com/~adellape/031620/44rn_deprecate_newbundle/release_notes/ocp-4-4-release-notes.html#ocp-4-4-deprecation-of-operatorsources

FYI @codyhoag 