### PR TITLE
Fix style for options that are not compulsory

### DIFF
--- a/modules/cluster-logging-collector-fluentd.adoc
+++ b/modules/cluster-logging-collector-fluentd.adoc
@@ -191,7 +191,7 @@ For example:
 $ oc create configmap secure-forward --from-file=secure-forward.conf -n openshift-logging
 ----
 
-. Optionally, import any secrets required for the receiver:
+. Optional: Import any secrets required for the receiver:
 +
 ----
 $ oc create secret generic secure-forward --from-file=<arbitrary-name-of-key1>=cert_file_from_fluentd_receiver --from-literal=shared_key=value_from_fluentd_receiver

--- a/modules/migration-running-migration-plan-cam.adoc
+++ b/modules/migration-running-migration-plan-cam.adoc
@@ -29,7 +29,7 @@ You can run *Stage* multiple times to reduce the actual migration time.
 +
 *Migrate* stops the application workload on the source cluster and recreates its resources on the target cluster.
 
-. Optionally, in the *Migrate* window, you can select *Do not stop applications on the source cluster during migration*.
+. Optional: In the *Migrate* window, you can select *Do not stop applications on the source cluster during migration*.
 . Click *Migrate*.
 . When the migration is complete, verify that the application migrated successfully in the {product-title} web console:
 

--- a/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
+++ b/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
@@ -35,7 +35,7 @@ data:
 
 . Save the file to apply the changes. Monitoring your own services is enabled automatically.
 
-. Optionally, you can check that the `prometheus-user-workload` pods were created:
+. Optional: You can check that the `prometheus-user-workload` pods were created:
 +
 ----
 $ oc -n openshift-user-workload-monitoring get pod

--- a/modules/nw-egressnetworkpolicy-edit.adoc
+++ b/modules/nw-egressnetworkpolicy-edit.adoc
@@ -24,7 +24,7 @@ To edit an existing egress network policy object for a project, complete the fol
 $ oc get -n <project> egressnetworkpolicy
 ----
 
-. Optionally, if you did not save a copy of the EgressNetworkPolicy object when you created the egress network firewall, enter the following command to create a copy.
+. Optional: If you did not save a copy of the EgressNetworkPolicy object when you created the egress network firewall, enter the following command to create a copy.
 +
 ----
 $ oc get -n <project> \ <1>

--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -54,32 +54,32 @@ spec:
 ----
 <1> Replace `<name>` with a name for the CR. The Operator will create a NetworkAttachmentDefinition CR with same name.
 <2> Specify the namespace where the SR-IOV Operator is installed.
-<3> Optional. Replace `<target_namespace>` with the namespace where the NetworkAttachmentDefinition CR will be created. The default value is `openshift-sriov-network-operator`.
-<4> Optional. Replace `<ipam>` a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
-<5> Optional. Replace `<vlan>` with a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
+<3> Optional: Replace `<target_namespace>` with the namespace where the NetworkAttachmentDefinition CR will be created. The default value is `openshift-sriov-network-operator`.
+<4> Optional: Replace `<ipam>` a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
+<5> Optional: Replace `<vlan>` with a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
 <6> Replace `<sriov_resource_name>` with the value for the `.spec.resourceName` parameter from the SriovNetworkNodePolicy CR that defines the SR-IOV hardware for this additional network.
-<7> Optional. Replace `<link_state>` with the link state of Virtual Function (VF). Allowed value are `enable`, `disable` and `auto`.
-<8> Optional. Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
-<9> Optional. Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.
+<7> Optional: Replace `<link_state>` with the link state of Virtual Function (VF). Allowed value are `enable`, `disable` and `auto`.
+<8> Optional: Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
+<9> Optional: Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.
 +
 [NOTE]
 ====
 Intel NICs do not support the `minTxRate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1772847].
 ====
-<10> Optional. Replace `<vlan_qos>` with an IEEE 802.1p priority level for the VF. The default value is `0`.
-<11> Optional. Replace `<spoof_check>` with the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
+<10> Optional: Replace `<vlan_qos>` with an IEEE 802.1p priority level for the VF. The default value is `0`.
+<11> Optional: Replace `<spoof_check>` with the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value you specify in quotes or the CR will be rejected by the SR-IOV Network Operator.
 ====
-<12> Optional. Replace `<trust_vf>` with the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
+<12> Optional: Replace `<trust_vf>` with the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value you specify in quotes or the CR will be rejected by the SR-IOV Network Operator.
 ====
-<13> Optional. Replace `<capabilities>` with the capabilities to configure for this network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+<13> Optional: Replace `<capabilities>` with the capabilities to configure for this network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
 
 [start=2]
 . Create the CR by running the following command:

--- a/modules/odc-creating-projects-using-developer-perspective.adoc
+++ b/modules/odc-creating-projects-using-developer-perspective.adoc
@@ -24,7 +24,7 @@ You can create a project using the *Developer* perspective, as follows:
 image::odc_create_project.png[Create Project]
 
 . In the *Create Project* dialog box, enter a unique name for the *Name* field. For example, enter `myproject` as the name of the project in the *Name* field.
-. Optionally, add the *Display Name* and *Description* details for the Project.
+. Optional: Add the *Display Name* and *Description* details for the Project.
 . Click *Create*.
 . Navigate to the *Advanced → Project Details* page to see the dashboard for your project.
 . In the *Project* drop-down menu at the top of the screen, select *all projects* to list all of the projects in your cluster. If you have adequate permissions for a project, you can use the  *Options* menu {kebab} to edit or delete the project.

--- a/modules/odc-importing-codebase-from-git-to-create-application.adoc
+++ b/modules/odc-importing-codebase-from-git-to-create-application.adoc
@@ -16,7 +16,7 @@ Create, build, and deploy an application on {product-title} using an existing co
 image::odc_import_from_git.png[Import from Git]
 
 . In the *Git* section, enter the Git repository URL for the codebase you want to use to create an application. For example, enter the URL of this sample Node.js application `\https://github.com/sclorg/nodejs-ex`. The URL is then validated.
-. Optionally, you can click *Show Advanced Git Options*  to add details such as:
+. Optional: You can click *Show Advanced Git Options*  to add details such as:
 
 * *Git Reference* to point to code in a specific branch, tag, or commit to be used to build the application.
 * *Context Dir* to specify the subdirectory for the application source code you want to use to build the application.
@@ -45,7 +45,7 @@ The *Knative Service* option is displayed in the *Import from git* form only if 
 ====
 
 . In the *Advanced Options* section, the *Create a route to the application* is selected by default so that you can access your application using a publicly available URL. You can clear the check box if you do not want to expose your application on a public route.
-. Optionally, you can use the following advanced options to further customize your application:
+. Optional: You can use the following advanced options to further customize your application:
 
 Routing::
 Click the *Routing* link to:


### PR DESCRIPTION
So IBM says:

> Indicating optional and conditional steps
If a step is optional, begin the step with the word Optional. If your authoring tool provides a semantic element to generate the word Optional, use that element.

> Example
> 1. Optional: Click Set password. In the Password field, type a password.

Do we care about a period versus a colon for this? Do we care about _optional_ versus _optionally_?

And do we want to offset this semantically, with italics or bold? (We do no, currently.)