### PR TITLE
Ensure procedure steps are sequential

### DIFF
--- a/modules/nw-sriov-dpdk-example-intel.adoc
+++ b/modules/nw-sriov-dpdk-example-intel.adoc
@@ -29,17 +29,16 @@ spec:
     rootDevices: ["<pci_bus_id>", "..."]
   deviceType: vfio-pci <1>
 ----
-
 <1> Specify the driver type for the virtual functions to `vfio-pci`.
-
++
 [NOTE]
 =====
 Please refer to the `Configuring SR-IOV network devices` section for a detailed explanation on each option in `SriovNetworkNodePolicy`.
-
++
 When applying the configuration specified in a SriovNetworkNodePolicy CR, the SR-IOV Operator may drain the nodes, and in some cases, reboot nodes.
 It may take several minutes for a configuration change to apply.
 Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
-
++
 After the configuration update is applied, all the Pods in `openshift-sriov-network-operator` namespace will change to a `Running` status.
 =====
 
@@ -64,14 +63,13 @@ spec:
   vlan: <vlan>
   resourceName: intelnics
 ----
-
 <1> Specify an empty object `"{}"` for the ipam CNI plug-in. DPDK works in userspace mode and does not require an IP address.
-
++
 [NOTE]
 =====
 Please refer to the `Configuring SR-IOV additional network` section for a detailed explanation on each option in `SriovNetwork`.
 =====
-
++
 . Create the SriovNetworkNodePolicy CR by running the following command:
 +
 ----
@@ -116,7 +114,6 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-
 <1> Specify the same `target_namespace` where the SriovNetwork CR `intel-dpdk-network` is created. If you would like to create the Pod in a different namespace, change `target_namespace` in both the Pod spec and the SriovNetowrk CR.
 <2> Specify the DPDK image which includes your application and the DPDK library used by application.
 <3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside container.

--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -30,19 +30,18 @@ spec:
   deviceType: netdevice <2>
   isRdma: true <3>
 ----
-
 <1> Specify the device hex code of the SR-IOV network device. The only allowed values for Mellanox cards are `1015`, `1017`.
 <2> Specify the driver type for the virtual functions to `netdevice`. Mellanox SR-IOV VF can work in DPDK mode without using the `vfio-pci` device type. VF device appears as a kernel network interface inside a container.
 <3> Enable RDMA mode. This is required by Mellanox cards to work in DPDK mode.
-
++
 [NOTE]
 =====
 Please refer to `Configuring SR-IOV network devices` section for detailed explanation on each option in `SriovNetworkNodePolicy`.
-
++
 When applying the configuration specified in a SriovNetworkNodePolicy CR, the SR-IOV Operator may drain the nodes, and in some cases, reboot nodes.
 It may take several minutes for a configuration change to apply.
 Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
-
++
 After the configuration update is applied, all the Pods in the `openshift-sriov-network-operator` namespace will change to a `Running` status.
 =====
 
@@ -68,9 +67,8 @@ spec:
   vlan: <vlan>
   resourceName: mlxnics
 ----
-
 <1> Specify a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
-
++
 [NOTE]
 =====
 Please refer to `Configuring SR-IOV additional network` section for detailed explanation on each option in `SriovNetwork`.
@@ -120,7 +118,6 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-
 <1> Specify the same `target_namespace` where SriovNetwork CR `mlx-dpdk-network` is created. If you would like to create the Pod in a different namespace, change `target_namespace` in both Pod spec and SriovNetowrk CR.
 <2> Specify the DPDK image which includes your application and the DPDK library used by application.
 <3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside the container.

--- a/modules/nw-sriov-rdma-example-mellanox.adoc
+++ b/modules/nw-sriov-rdma-example-mellanox.adoc
@@ -33,19 +33,18 @@ spec:
   deviceType: netdevice <2>
   isRdma: true <3>
 ----
-
 <1> Specify the device hex code of SR-IOV network device. The only allowed values for Mellanox cards are `1015`, `1017`.
 <2> Specify the driver type for the virtual functions to `netdevice`.
 <3> Enable RDMA mode.
-
++
 [NOTE]
 =====
 Please refer to the `Configuring SR-IOV network devices` section for a detailed explanation on each option in `SriovNetworkNodePolicy`.
-
++
 When applying the configuration specified in a SriovNetworkNodePolicy CR, the SR-IOV Operator may drain the nodes, and in some cases, reboot nodes.
 It may take several minutes for a configuration change to apply.
 Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
-
++
 After the configuration update is applied, all the Pods in the `openshift-sriov-network-operator` namespace will change to a `Running` status.
 =====
 
@@ -71,9 +70,8 @@ spec:
   vlan: <vlan>
   resourceName: mlxnics
 ----
-
 <1> Specify a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
-
++
 [NOTE]
 =====
 Please refer to `Configuring SR-IOV additional network` section for detailed explanation on each option in `SriovNetwork`.
@@ -121,7 +119,6 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-
 <1> Specify the same `target_namespace` where SriovNetwork CR `mlx-rdma-network` is created. If you would like to create the Pod in a different namespace, change `target_namespace` in both Pod spec and SriovNetowrk CR.
 <2> Specify the RDMA image which includes your application and RDMA library used by application.
 <3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside the container.


### PR DESCRIPTION
The procedures were missing some `+` in critical places.