### PR TITLE
Add storageclassDevices to Pod spec

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -61,7 +61,7 @@ on all available nodes.
 local volumes.
 <4> The file system that is created when the local volume is mounted for the
 first time.
-<5> The path to where the local volumes have been attached to the node.
+<5> The path containing a list of local storage devices to choose from.
 +
 .Example: Block
 [source,yaml]
@@ -94,7 +94,7 @@ defined, then the Local Storage Operator will attempt to find matching disks
 on all available nodes.
 <3> The volume mode, either `Filesystem` or `Block`, defining the type of the
 local volumes.
-<4> The path to where the local volumes have been attached to the node.
+<4> The path containing a list of local storage devices to choose from.
 
 . Create the local volume resource in your {product-title} cluster, specifying
 the file you just created:

--- a/modules/persistent-storage-local-tolerations.adoc
+++ b/modules/persistent-storage-local-tolerations.adoc
@@ -40,9 +40,17 @@ To configure local volumes for scheduling on tainted nodes:
       - key: localstorage <1>
         operator: Equal <2>
         value: "localstorage" <3>
+    storageClassDevices:
+        - storageClassName: "localblock-sc"
+          volumeMode: Block <4>
+          devicePaths: <5>
+            - /dev/xvdg
+
 ----
 <1> Specify the key that you added to the node.
 <2> Specify the `Equal` operator to require the `key`/`value` parameters to match. If operator is 'Exists`, the system checks that the key exists and ignores the value. If operator is `Equal`, then the key and value must match.
 <3> Specify the value `local` of the tainted node.
+<4> The volume mode, either `Filesystem` or `Block`, defining the type of the local volumes.
+<5> The path containing a list of local storage devices to choose from.
 
 The defined tolerations will be passed to the resulting DaemonSets, allowing the diskmaker and provisioner Pods to be created for nodes that contain the specified taints.


### PR DESCRIPTION
Relates to https://github.com/openshift/openshift-docs/issues/20482
The sample YAML definition file is missing `storageClassDevices` and CR cannot be created. This PR adds the necessary parameters to avoid error (`The LocalVolume "local-disks" is invalid: spec.storageClassDevices: Required value`) that occurs from `oc create` command.