### PR TITLE
OKD: fix docs build and update OKD documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -61,7 +61,7 @@ Topics:
 ---
 Name: Release notes
 Dir: release_notes
-Distros: openshift-enterprise,openshift-webscale
+Distros: openshift-enterprise,openshift-webscale,openshift-origin
 Topics:
 - Name: OpenShift Container Platform 4.4 release notes
   File: ocp-4-4-release-notes
@@ -75,16 +75,19 @@ Topics:
 - Name: Product architecture
   File: architecture
 - Name: Installation and update
-  Distros: openshift-enterprise,openshift-webscale
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
   File: architecture-installation
 - Name: The control plane
   File: control-plane
   Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
 - Name: Understanding OpenShift development
   File: understanding-development
+- Name: Fedora CoreOS
+  File: architecture-rhcos
+  Distros: openshift-origin
 - Name: Red Hat Enterprise Linux CoreOS
   File: architecture-rhcos
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  Distros: openshift-enterprise,openshift-webscale
 ---
 Name: Administering a cluster
 Dir: administering_a_cluster
@@ -186,6 +189,7 @@ Topics:
     File: ipi-install-troubleshooting
 - Name: Installing on IBM Z
   Dir: installing_ibm_z
+  Distros: openshift-enterprise,openshift-webscale
   Topics:
   - Name: Installing a cluster on IBM Z
     File: installing-ibm-z
@@ -246,6 +250,7 @@ Topics:
   File: updating-cluster-cli
 - Name: Updating a cluster that includes RHEL compute machines
   File: updating-cluster-rhel-compute
+  Distros: openshift-enterprise,openshift-webscale
 #- Name: Updating a disconnected cluster
 #  File: updating-disconnected-cluster
 # - Name: Troubleshooting an update
@@ -882,8 +887,10 @@ Topics:
   File: creating-infrastructure-machinesets
 - Name: Adding a RHEL compute machine
   File: adding-rhel-compute
+  Distros: openshift-enterprise,openshift-webscale
 - Name: Adding more RHEL compute machines
   File: more-rhel-compute
+  Distros: openshift-enterprise,openshift-webscale
 - Name: Deploying machine health checks
   File: deploying-machine-health-checks
 ---
@@ -1088,7 +1095,7 @@ Topics:
 ---
 Name: Monitoring
 Dir: monitoring
-Distros: openshift-enterprise,openshift-webscale
+Distros: openshift-enterprise,openshift-webscale,openshift-origin
 Topics:
 - Name: Cluster monitoring
   Dir: cluster_monitoring
@@ -1271,7 +1278,7 @@ Topics:
     File: usage-oc-kubectl
 - Name: OpenShift Do developer CLI (odo)
   Dir: openshift_developer_cli
-  Distros: openshift-enterprise,openshift-webscale,openshift-online,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
   Topics:
   - Name: Understanding odo
     File: understanding-odo
@@ -1308,7 +1315,7 @@ Topics:
     File: odo-release-notes
 - Name: Helm CLI
   Dir: helm_cli
-  Distros: openshift-enterprise,openshift-webscale
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
   Topics:
   - Name: Getting started with Helm on OpenShift Container Platform
     File: getting-started-with-helm-on-openshift-container-platform

--- a/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc
@@ -16,7 +16,7 @@ image::odc_add_view.png[Add View]
 * *YAML*: Use the editor to add YAML or JSON definitions to create and modify resources.
 * *Database*: See the *Developer Catalog* to select the required database service and add it to your application.
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale[]
 [NOTE]
 ====
 The serverless sections in the above options are displayed only if the xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[*Serverless Operator*] is installed in your cluster.  OpenShift Serverless is a Technology Preview feature.
@@ -30,7 +30,7 @@ To create applications using the *Developer* perspective ensure that:
 * You are in the xref:../../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
 * You have the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create applications and other workloads in {product-title}.
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale[]
 
 To create serverless applications, in addition to the above, ensure that:
 

--- a/architecture/understanding-development.adoc
+++ b/architecture/understanding-development.adoc
@@ -72,11 +72,11 @@ The following diagram displays the process of building and pushing an image:
 .Create a simple containerized application and push it to a registry
 image::create-push-app.png[Creating and pushing a containerized application]
 
-If you use a computer that runs Red Hat Enterprise Linux (RHEL) as the operating
+If you use a computer that runs {op-system-base-full} as the operating
 system, the process of creating a containerized application requires the
 following steps:
 
-. Install container build tools: RHEL contains a set of tools that includes
+. Install container build tools: {op-system-base} contains a set of tools that includes
 podman, buildah, and skopeo that you use to build and manage containers.
 . Create a Dockerfile to combine base image and software: Information about
 building your container goes into a file that is named `Dockerfile`. In that
@@ -84,7 +84,7 @@ file, you identify the base image you build from, the software packages you
 install, and the software you copy into the container. You also identify
 parameter values like network ports that you expose outside the container and
 volumes that you mount inside the container. Put your Dockerfile and the
-software you want to containerized in a directory on your RHEL system.
+software you want to containerized in a directory on your {op-system-base} system.
 . Run buildah or docker build: Run the `buildah build-using-dockerfile` or
 the `docker build` command to pull you chosen base image to the local system and
 creates a container image that is stored locally. You can also build container
@@ -110,7 +110,7 @@ endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 === Container build tool options
 
 While the Docker Container Engine and `docker` command are popular tools
-to work with containers, with RHEL and many other Linux systems, you can
+to work with containers, with {op-system-base} and many other Linux systems, you can
 instead choose a different set of container tools that includes podman, skopeo,
 and buildah. You can still use Docker Container Engine tools to create
 containers that will run in {product-title} and any other container platform.

--- a/cli_reference/openshift_cli/getting-started-cli.adoc
+++ b/cli_reference/openshift_cli/getting-started-cli.adoc
@@ -15,8 +15,10 @@ You can install the OpenShift CLI (`oc`) either by downloading the binary or by 
 // Installing the CLI by downloading the binary
 include::modules/cli-installing-cli.adoc[leveloffset=+2]
 
+ifndef::openshift-origin[]
 // Installing the CLI by using an RPM
 include::modules/cli-installing-cli-rpm.adoc[leveloffset=+2]
+endif::[]
 
 // Logging in to the CLI
 include::modules/cli-logging-in.adoc[leveloffset=+1]

--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -27,8 +27,9 @@ include::modules/installation-special-config-encrypt-disk-tpm2.adoc[leveloffset=
 include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
 include::modules/installation-special-config-crony.adoc[leveloffset=+1]
 
-
+ifndef::openshift-origin[]
 == Additional resources
 
 See xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
 for information on FIPS support.
+endif::[]

--- a/migration/migrating_3_4/planning-migration-3-to-4.adoc
+++ b/migration/migrating_3_4/planning-migration-3-to-4.adoc
@@ -18,8 +18,8 @@ It is not possible to upgrade your existing {product-title} 3 cluster to {produc
 
 [id="migration-comparing-ocp-3-4"]
 == Comparing {product-title} 3 and {product-title} 4
+With {product-title} 3, administrators individually deployed {op-system-base-full} hosts, and then installed {product-title} on top of these hosts to form a cluster. Administrators were responsible for properly configuring these hosts and performing updates.
 
-With {product-title} 3, administrators individually deployed Red Hat Enterprise Linux (RHEL) hosts, and then installed {product-title} on top of these hosts to form a cluster. Administrators were responsible for properly configuring these hosts and performing updates.
 
 {product-title} 4 represents a significant change in the way that {product-title} clusters are deployed and managed. {product-title} 4 includes new technologies and functionality, such as Operators, MachineSets, and {op-system-first}, which are core to the operation of the cluster. This technology shift enables clusters to self-manage some functions previously performed by administrators. This also ensures platform stability and consistency, and simplifies installation and scaling.
 
@@ -31,7 +31,7 @@ For more information, see xref:../../architecture/architecture.adoc#architecture
 [discrete]
 ==== Immutable infrastructure
 
-{product-title} 4 uses {op-system-first}, which is designed to run containerized applications, and provides efficient installation, Operator-based management, and simplified upgrades. {op-system} is an immutable container host, rather than a customizable operating system like RHEL. {op-system} enables {product-title} 4 to manage and automate the deployment of the underlying container host. {op-system} is a part of {product-title}, which means that everything runs inside a container and is deployed using {product-title}.
+{product-title} 4 uses {op-system-first}, which is designed to run containerized applications, and provides efficient installation, Operator-based management, and simplified upgrades. {op-system} is an immutable container host, rather than a customizable operating system like {op-system-base}. {op-system} enables {product-title} 4 to manage and automate the deployment of the underlying container host. {op-system} is a part of {product-title}, which means that everything runs inside a container and is deployed using {product-title}.
 
 In {product-title} 4, control plane nodes must run {op-system}, ensuring that full-stack automation is maintained for the control plane. This makes rolling out updates and upgrades a much easier process than in {product-title} 3.
 
@@ -50,13 +50,15 @@ For more information, see xref:../../operators/olm-what-operators-are.adoc#olm-w
 [discrete]
 ==== Installation process
 
-To install {product-title} 3.11, you prepared your Red Hat Enterprise Linux (RHEL) hosts, set all of the configuration values your cluster needed, and then ran an Ansible playbook to install and set up your cluster.
+To install {product-title} 3.11, you prepared your {op-system-base-full} hosts, set all of the configuration values your cluster needed, and then ran an Ansible playbook to install and set up your cluster.
 
 In {product-title} 4.4, you use the OpenShift installation program to create a minimum set of resources required for a cluster. Once the cluster is running, you use Operators to further configure your cluster and to install new services. After first boot, {op-system-first} systems are managed by the Machine Config Operator (MCO) that runs in the {product-title} cluster.
 
 For more information, see xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process].
 
+ifndef::openshift-origin[]
 If you want to add RHEL worker machines to your {product-title} 4.4 cluster, you use an Ansible playbook to join the RHEL worker machines after the cluster is running. For more information, see xref:../../machine_management/adding-rhel-compute.adoc#adding-rhel-compute[Adding RHEL compute machines to an {product-title} cluster].
+endif::[]
 
 [discrete]
 ==== Infrastructure options
@@ -144,7 +146,9 @@ For more information, see xref:../../networking/configuring-networkpolicy.adoc#n
 
 In {product-title} 3.11, you could use IPsec to encrypt traffic between hosts. {product-title} 4.4 does not support IPsec. It is recommended to use Red Hat OpenShift Service Mesh to enable mutual TLS between services.
 
+ifndef::openshift-origin[]
 For more information, see xref:../../service_mesh/service_mesh_arch/understanding-ossm.adoc#understanding-ossm[Understanding Red Hat OpenShift Service Mesh].
+endif::[]
 
 [id="migration-preparing-logging"]
 === Logging considerations

--- a/modules/cli-installing-cli-rpm.adoc
+++ b/modules/cli-installing-cli-rpm.adoc
@@ -5,7 +5,7 @@
 [id="cli-installing-cli-rpm_{context}"]
 = Installing the CLI by using an RPM
 
-For Red Hat Enterprise Linux (RHEL), you can install the OpenShift CLI (`oc`) as an RPM if you have an active {product-title} subscription on your Red Hat account.
+For {op-system-base-full}, you can install the OpenShift CLI (`oc`) as an RPM if you have an active {product-title} subscription on your Red Hat account.
 
 .Prerequisites
 

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -39,9 +39,14 @@ install the new version of `oc`.
 ====
 
 .Procedure
-
+ifdef::openshift-origin[]
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system
+. Download `oc.tar.gz`
+endif::[]
+ifndef::openshift-origin[]
 . From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type and
 click *Download Command-line Tools*.
+endif::[]
 . Click the folder for your operating system and architecture and click the
 compressed file.
 +

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -9,6 +9,14 @@
 :prewrap!:
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :op-system: RHCOS
+:op-system-base: RHEL
+:op-system-base-full: Red Hat Enterprise Linux (RHEL)
+ifdef::openshift-origin[]
+:op-system-first: Fedora CoreOS (FCOS)
+:op-system: FCOS
+:op-system-base: Fedora
+:op-system-base-full: Fedora
+endif::[]
 :asb-name: OpenShift Ansible Broker
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -26,7 +26,7 @@ The following diagram shows a subset of the installation targets and dependencie
 .{product-title} installation targets and dependencies
 image::targets-and-dependencies.png[{product-title} installation targets and dependencies]
 
-After installation, each cluster machine uses {op-system-first} as the operating system. {op-system} is the immutable container host version of Red Hat Enterprise Linux (RHEL) and features a RHEL kernel with SELinux enabled by default. It includes the `kubelet`, which is the Kubernetes node agent, and the CRI-O container runtime, which is optimized for Kubernetes.
+After installation, each cluster machine uses {op-system-first} as the operating system. {op-system} is the immutable container host version of {op-system-base-full} and features a {op-system-base} kernel with SELinux enabled by default. It includes the `kubelet`, which is the Kubernetes node agent, and the CRI-O container runtime, which is optimized for Kubernetes.
 
 Every control plane machine in an {product-title} {product-version} cluster must
 use {op-system}, which includes a critical first-boot provisioning tool called

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -8,14 +8,14 @@
 {op-system-first} represents the next generation of single-purpose
 container operating system technology. Created by the same development teams
 that created Red Hat Enterprise Linux Atomic Host and CoreOS Container Linux,
-{op-system} combines the quality standards of Red Hat Enterprise Linux (RHEL)
+{op-system} combines the quality standards of {op-system-base-full}
 with the automated, remote upgrade features from Container Linux.
 
 {op-system} is supported only as a component of {product-title}
 {product-version} for all {product-title} machines. {op-system} is the only
 supported operating system for {product-title} control plane, or master,
 machines. While {op-system} is the default operating system for all cluster
-machines, you can create compute machines, which are also known as worker machines, that use RHEL as their
+machines, you can create compute machines, which are also known as worker machines, that use {op-system-base} as their
 operating system. There are two general ways {op-system} is deployed in
 {product-title} {product-version}:
 
@@ -34,15 +34,15 @@ files to provision your machines.
 
 The following list describes key features of the {op-system} operating system:
 
-* **Based on RHEL**: The underlying operating system consists primarily of RHEL components.
-The same quality, security, and control measures that support RHEL also support
+* **Based on {op-system-base}**: The underlying operating system consists primarily of {op-system-base} components.
+The same quality, security, and control measures that support {op-system-base} also support
 {op-system}. For example, {op-system} software is in
-RPM packages, and each {op-system} system starts up with a RHEL kernel and a set
+RPM packages, and each {op-system} system starts up with a {op-system-base} kernel and a set
 of services that are managed by the systemd init system.
 
-* **Controlled immutability**: Although it contains RHEL components, {op-system}
+* **Controlled immutability**: Although it contains {op-system-base} components, {op-system}
 is designed to be managed
-more tightly than a default RHEL installation. Management is
+more tightly than a default {op-system-base} installation. Management is
 performed remotely from the {product-title} cluster. When you set up your
 {op-system} machines, you can modify only a few system settings. This controlled
 immutability allows {product-title} to

--- a/modules/whats-new-features.adoc
+++ b/modules/whats-new-features.adoc
@@ -13,7 +13,7 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-operators"]
 == Operators
 
-xref:../applications/operators/olm-what-operators-are.adoc#olm-what-operators-are[Operators]
+xref:../operators/olm-what-operators-are.adoc#olm-what-operators-are[Operators]
 are pieces of software that ease the operational complexity of running another
 piece of software. They act like an extension of the software vendor’s
 engineering team, watching over a Kubernetes environment (such as
@@ -35,7 +35,7 @@ access to Operators running on their cluster:
 * Supports role-based access control (RBAC) for certain teams to use certain Operators
 
 See
-xref:../applications/operators/olm-understanding-olm.adoc#olm-understanding-olm[Understanding the Operator Lifecycle Manager (OLM)] for more information.
+xref:../operators/understanding_olm/olm-understanding-olm.adoc#olm-understanding-olm[Understanding the Operator Lifecycle Manager (OLM)] for more information.
 
 [id="ocp-installation-and-upgrade"]
 == Installation and upgrade
@@ -113,7 +113,7 @@ from Red Hat products, Red Hat partners, and the community.
 |===
 
 See
-xref:../applications/operators/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Understanding the OperatorHub] for more information.
+xref:../operators/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Understanding the OperatorHub] for more information.
 
 [id="ocp-storage"]
 == Storage


### PR DESCRIPTION
This fixes docs build using:
```
python3 build.py --distro openshift-origin --product "OKD" --version 4.4 --no-upstream-fetch && python3 makeBuild.py && asciibinder build -t 0
```

and updates OKD docs.

Fixes https://github.com/openshift/okd/issues/44
Fixes https://github.com/openshift/okd/issues/100
Fixes https://github.com/openshift/okd/issues/115
Fixes https://github.com/openshift/okd/issues/108

