### PR TITLE
cnv: avoid documenting cnv-bridge-cni

### DIFF
--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -6,7 +6,7 @@
 = Creating a Linux bridge NetworkAttachmentDefinition in the CLI
 
 As a network administrator, you can configure a NetworkAttachmentDefinition
-of type `cnv-bridge` to provide Layer-2 networking to Pods and virtual machines.
+of type `bridge` to provide Layer-2 networking to Pods and virtual machines.
 
 .Procedure
 
@@ -28,7 +28,7 @@ spec:
     "name": "cnv-bridge-conf", <2> 
     "plugins": [
       {
-        "type": "cnv-bridge", <3>
+        "type": "bridge", <3>
         "bridge": "br0" <4>
       },
       {

--- a/modules/cnv-pxe-booting-with-mac-address.adoc
+++ b/modules/cnv-pxe-booting-with-mac-address.adoc
@@ -35,16 +35,16 @@ spec:
       "name": "pxe-net-conf",
       "plugins": [
         {
-          "type": "cnv-bridge",
+          "type": "bridge",
           "bridge": "br1"
         },
         {
-          "type": "cnv-tuning" <1>
+          "type": "tuning" <1>
         }
       ]
     }'
 ----
-<1> The `cnv-tuning` plug-in provides support for custom MAC addresses.
+<1> The `tuning` plug-in provides support for custom MAC addresses.
 +
 [NOTE]
 ====


### PR DESCRIPTION
As of OpenShift 4.3, the standard bridge-cni and tuning-cni are support
vlan filtering and static mac address, respectfully. We should direct
user to use these standard CNIs and not the CNV-crafted ones.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>