### PR TITLE
CNV-2307 - kubevirt-storage-class-defaults ConfigMap

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1546,6 +1546,8 @@ Topics:
       File: cnv-uploading-local-disk-images-block
     - Name: Expanding virtual storage by adding blank disk images
       File: cnv-expanding-virtual-storage-with-blank-disk-images
+    - Name: Storage defaults for DataVolumes
+      File: cnv-storage-defaults-for-datavolumes
     - Name: Preparing CDI scratch space
       File: cnv-preparing-cdi-scratch-space
     - Name: Deleting DataVolumes

--- a/cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc
+++ b/cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc
@@ -1,0 +1,16 @@
+[id="cnv-storage-defaults-for-datavolumes"]
+= Storage defaults for DataVolumes
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-storage-defaults-for-datavolumes
+toc::[]
+
+The `kubevirt-storage-class-defaults` ConfigMap provides _access mode_ and _volume mode_ defaults for DataVolumes. You can edit or add storage class defaults to the ConfigMap in order to create DataVolumes in the web console that better match the underlying storage.
+
+include::modules/cnv-about-storage-setting-for-datavolumes.adoc[leveloffset=+1]
+
+include::modules/cnv-editing-kubevirtstorageclassdefaults-web.adoc[leveloffset=+1]
+
+include::modules/cnv-editing-kubevirtstorageclassdefaults-cli.adoc[leveloffset=+1]
+
+include::modules/cnv-example-kubevirtstorageclassdefaults.adoc[leveloffset=+1]
+

--- a/modules/cnv-about-storage-setting-for-datavolumes.adoc
+++ b/modules/cnv-about-storage-setting-for-datavolumes.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc
+
+[id="cnv-about-kubevirtstorageclassdefaults_{context}"]
+= About storage settings for DataVolumes
+
+DataVolumes require a defined _access mode_ and _volume mode_ to be created in the web console. 
+These storage settings are configured by default with a `ReadWriteOnce` access mode and `Filesystem` volume mode.
+
+You can modify these settings by editing the `kubevirt-storage-class-defaults` ConfigMap in the `openshift-cnv` namespace.
+You can also add settings for other storage classes in order to create DataVolumes in the web console for different storage types. 
+
+[NOTE]
+====
+You must configure storage settings that are supported by the underlying storage.
+====
+
+All DataVolumes that you create in the web console use the default storage settings unless you specifya storage class that is also defined in the ConfigMap.
+
+[id="cnv-datavolumes-access-modes_{context}"]
+== Access modes
+
+DataVolumes support the following access modes:
+
+* `ReadWriteOnce`: The volume can be mounted as read-write by a single node. `ReadWriteOnce` has greater versatility and is the default setting.
+* `ReadWriteMany`: The volume can be mounted as read-write by many nodes. `ReadWriteMany` is required for some features, such as live migration of virtual machines between nodes.
+
+`ReadWriteMany` is recommended if the underlying storage supports it.
+
+[id="cnv-datavolumes-volume-modes_{context}"]
+== Volume modes
+
+The volume mode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. DataVolumes support the following volume modes:
+
+* `Filesystem`: Creates a filesystem on the DataVolume. This is the default setting.
+* `Block`: Creates a block DataVolume. Only use `Block` if the underlying storage supports it.
+

--- a/modules/cnv-editing-kubevirtstorageclassdefaults-cli.adoc
+++ b/modules/cnv-editing-kubevirtstorageclassdefaults-cli.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc
+
+[id="cnv-editing-kubevirtstorageclassdefaults-cli_{context}"]
+= Editing the `kubevirt-storage-class-defaults` ConfigMap in the CLI
+
+Modify the storage settings for DataVolumes by editing the `kubevirt-storage-class-defaults` ConfigMap in the `openshift-cnv` namespace.
+You can also add settings for other storage classes in order to create DataVolumes in the web console for different storage types.
+
+[NOTE]
+====
+You must configure storage settings that are supported by the underlying storage.
+====
+
+.Procedure
+
+. Use `oc edit` to edit the ConfigMap:
++
+----
+$ oc edit configmap kubevirt-storage-class-defaults -n openshift-cnv
+----
+
+. Update the `data` values of the ConfigMap:
++
+[source,yaml]
+----
+...
+data:
+  accessMode: ReadWriteOnce <1>
+  volumeMode: Filesystem <2>
+  <new>.accessMode: ReadWriteMany <3>
+  <new>.volumeMode: Block <4>
+----
+<1> The default accessMode is `ReadWriteOnce`.
+<2> The default volumeMode is `Filesystem`. 
+<3> If you add an access mode for  storage class, replace the `<new>` part of the parameter with the storage class name.
+<4> If you add a volume mode for a storage class, replace the `<new>` part of the parameter with the storage class name.
+
+. Save and exit the editor to update the ConfigMap.
+

--- a/modules/cnv-editing-kubevirtstorageclassdefaults-web.adoc
+++ b/modules/cnv-editing-kubevirtstorageclassdefaults-web.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc
+
+[id="cnv-editing-kubevirtstorageclassdefaults-web_{context}"]
+= Editing the `kubevirt-storage-class-defaults` ConfigMap in the web console
+
+Modify the storage settings for DataVolumes by editing the `kubevirt-storage-class-defaults` ConfigMap in the `openshift-cnv` namespace.
+You can also add settings for other storage classes in order to create DataVolumes in the web console for different storage types.
+
+[NOTE]
+====
+You must configure storage settings that are supported by the underlying storage.
+====
+
+.Procedure
+
+. Click *Workloads* -> *Config Maps* from the side menu. 
+. In the *Project* list, select *openshift-cnv*.
+. Click *kubevirt-storage-class-defaults* to open the *Config Map Overview*.
+. Click the *YAML* tab to display the editable configuration.
+. Update the `data` values with the storage configuration that is appropriate for your underlying storage:
++
+[source,yaml]
+----
+...
+data:
+  accessMode: ReadWriteOnce <1>
+  volumeMode: Filesystem <2>
+  <new>.accessMode: ReadWriteMany <3>
+  <new>.volumeMode: Block <4>
+----
+<1> The default accessMode is `ReadWriteOnce`.
+<2> The default volumeMode is `Filesystem`. 
+<3> If you add an access mode for a storage class, replace the `<new>` part of the parameter with the storage class name.
+<4> If you add a volume mode for a storage class, replace the `<new>` part of the parameter with the storage class name.
+
+. Click *Save* to update the ConfigMap. 
+
+
+

--- a/modules/cnv-example-kubevirtstorageclassdefaults.adoc
+++ b/modules/cnv-example-kubevirtstorageclassdefaults.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc
+
+[id="cnv-example-kubevirtstorageclassdefaults_{context}"]
+= Example of multiple storage class defaults
+
+The following YAML file is an example of a `kubevirt-storage-class-defaults` ConfigMap that has storage settings configured for two storage classes, `migration` and `block`.
+ 
+Ensure that all settings are supported by your underlying storage before you update the ConfigMap.
+
+[source,yaml]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubevirt-storage-class-defaults
+  namespace: openshift-cnv
+...
+data:
+  accessMode: ReadWriteOnce
+  volumeMode: Filesystem
+  nfs-sc.accessMode: ReadWriteMany 
+  nfs-sc.volumeMode: Filesystem
+  block-sc.accessMode: ReadWriteMany
+  block-sc.volumeMode: Block
+----
+


### PR DESCRIPTION
Default storage settings are required for users to create DataVolumes in the web console. These settings can be modified, and you can also add settings for storage classes to be used (if they are different from the default).