### PR TITLE
FIXME: modules/customize-certificates-replace-default-router: Include egress CAs

### DIFF
--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -19,7 +19,7 @@ both in the PEM format, for use.
 
 .Procedure
 
-. Create a ConfigMap that includes the certificate authority used to signed the new certificate:
+. Create a ConfigMap that includes the certificate authority used to sign the new certificate:
 +
 ----
 $ oc create configmap custom-ca \
@@ -27,6 +27,8 @@ $ oc create configmap custom-ca \
      -n openshift-config
 ----
 <1> `</path/to/example-ca.crt>` is the path to the certificate authority file on your local file system.
++
+Including the ingress certificate authority supports cluster components like OAuth reaching other cluster components via public routes. If you are also using a proxy for egress (FIXME: link to https://docs.openshift.com/container-platform/4.3/networking/enable-cluster-wide-proxy.html ), the `ca-bundle.crt` value should include both the ingress and egress CAs.
 
 . Update the cluster-wide proxy configuration with the newly created ConfigMap:
 +


### PR DESCRIPTION
Explain that you may not be able to use *just* the ingress CA(s) for the proxy's trusted CAs.

CC @Miciah