### PR TITLE
Remove Tenant Driven Snapshotting from TP Tracker Table

### DIFF
--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -267,9 +267,7 @@ xref:../applications/operators/olm-understanding-operatorhub.adoc#olm-understand
 [id="ocp-4-1-storage"]
 === Storage
 
-Storage support in {product-title} 4.1 is the same as {product-title} 3.11 with
-the exception of the following available in Technology Preview: EFS (CSI Driver
-handled via Amazon), Manila provisioner/operator, and Snapshot.
+Storage support in {product-title} 4.1 is the same as {product-title} 3.11.
 
 [id="ocp-4-1-scale"]
 === Scale
@@ -558,10 +556,6 @@ features marked *GA* indicate _General Availability_.
 |GA* footnoteref:[disclaimer, Features marked with `*` indicate delivery in a z-stream patch.]
 |GA
 
-|Tenant Driven Snapshotting
-|TP
-|TP
-
 |`oc` CLI Plug-ins
 |TP
 |TP
@@ -690,7 +684,7 @@ features marked *GA* indicate _General Availability_.
 |TP
 |GA
 
-|External provisoner for AWS EFS
+|External provisioner for AWS EFS
 |TP
 |TP
 


### PR DESCRIPTION
[BZ1813156](https://bugzilla.redhat.com/show_bug.cgi?id=1813156)
This was a holdover from 3.x docs and is not accurate. It is also being removed from newer 4.x Release Notes versions.

@liangxia PTAL

@openshift/team-documentation PTAL