### PR TITLE
Added release notes for Serverless 1.6.0

### DIFF
--- a/modules/serverless-rn-1-6-0.adoc
+++ b/modules/serverless-rn-1-6-0.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * serverless/release-notes.adoc
+
+[id="serverless-rn-1-6-0_{context}"]
+
+= Release Notes for Red Hat {ServerlessProductName} Technology Preview 1.6.0
+
+[id="new-features-1-6-0_{context}"]
+== New features
+* {ServerlessProductName} 1.6.0 is available on {product-title} 4.3 and newer versions.
+* {ServerlessProductName} now uses Knative Serving 0.13.1.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.13.1.
+* {ServerlessProductName} now uses Knative Serving Operator 0.13.1.
+* The `serving.knative.dev` API group has now been fully deprecated and is replaced by the `operator.knative.dev` API group.
++
+You must complete the steps that are described in the {ServerlessProductName} 1.4.0 release notes, that replace the `serving.knative.dev` API group with the `operator.knative.dev` API group, before you can upgrade to the latest version of {ServerlessProductName}.
++
+[IMPORTANT]
+====
+This change causes commands without a fully qualified APIGroup and kind, such as `oc get knativeserving`, to become unreliable and not always work correctly.
+
+After upgrading to {ServerlessProductName} 1.6.0, you must remove the old CRD to fix this issue.
+You can remove the old CRD by entering the following command:
+----
+$ oc delete crd knativeservings.serving.knative.dev
+----
+====
+* The *Subscription Update Channel* for new {ServerlessProductName} releases was updated from `techpreview` to `preview-4.3`.
++
+[IMPORTANT]
+====
+You must update your channel by following the upgrade documentation to use the latest {ServerlessProductName} version.
+====
+* {ServerlessProductName} now supports the use of `HTTP_PROXY`.
+* {ServerlessProductName} now supports `HTTPS_PROXY` cluster-proxy settings.
++
+[NOTE]
+====
+This `HTTP_PROXY` support does not include using custom certificates.
+====
+* The `KnativeServing` CRD is now hidden from the Developer Catalog by default so that only users with cluster administrator permissions can view it.
+* Parts of the `KnativeServing` control plane and data plane are now deployed as highly available (HA) by default.
+* Kourier is now actively watched and reconciles changes automatically.
+* {ServerlessProductName} now supports use on {product-title} nightly builds.
+
+[id="fixed-issues-1-6-0_{context}"]
+== Fixed issues
+* In previous versions, the `oc explain` command did not work correctly. The structural schema of the `KnativeServing` CRD was updated in {ServerlessProductName} 1.6.0 so that the `oc explain` command now works correctly.
+* In previous versions, it was possible to create more than one `KnativeServing` CR. Multiple `KnativeServing` CRs are now prevented synchronously in {ServerlessProductName} 1.6.0. Attempting to create more than one `KnativeServing` CR now results in an error.
+* In previous versions, {ServerlessProductName} was not compatible with {product-title} deployments on GCP. This issue was fixed in {ServerlessProductName} 1.6.0.
+// * In previous versions,  requesting `KnativeServing` CRs without specifying an API group, for example, `oc get knativeserving -n knative-serving`, occasionally caused errors. This issue was fixed in {ServerlessProductName} 1.6.0.
+// Move this fixed issue to 1.7.0 release notes once these are created and it's confirmed as fixed
+* In previous releases, the Knative Serving webhook crashed with an out of memory error if the cluster had more than 170 namespaces. This issue was fixed in {ServerlessProductName} 1.6.0.
+* In previous releases, {ServerlessProductName} did not automatically fix an {product-title} route that it created if the route was changed by another component. This issue was fixed in {ServerlessProductName} 1.6.0.
+* In previous versions, deleting a `KnativeServing` CR occasionally caused the system to hang. This issue was fixed in {ServerlessProductName} 1.6.0.
+* Due to the ingress migration from Service Mesh to Kourier that occured in {ServerlessProductName} 1.5.0, orphaned VirtualServices sometimes remained on the system. In {ServerlessProductName} 1.6.0, orphaned VirtualServices are automatically removed.
+
+[id="known-issues-1-6-0_{context}"]
+== Known issues
+* In {ServerlessProductName} 1.6.0, if a cluster administrator uninstalls {ServerlessProductName} by following the uninstall procedure provided in the documentation, the *Serverless* dropdown is still be visible in the *Administrator* perspective of the {product-title} web console, and the *Knative Service* resource is still be visible in the *Developer* perspective of the {product-title} web console.
+Although you can create Knative services by using this option, these Knative services do not work.
++
+To prevent {ServerlessProductName} from being visible in the {product-title} web console, the cluster administrator must delete additional CRDs from the deployment after removing the Knative Serving CR.
++
+Cluster administrators can remove these CRDs by entering the following command:
++
+----
+$ oc get crd -oname | grep -E '(serving|internal).knative.dev' | xargs oc delete
+----

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -15,6 +15,7 @@ If you experience difficulty with a procedure described in this documentation,
 visit the link:https://access.redhat.com/support/offerings/techpreview/[Customer Portal] to learn more about support for Technology Preview features.
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-6-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-5-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-4-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Release notes for 1.6.0 - applies for OCP 4.3+