### PR TITLE
Remove Tenant Driven Snapshotting from TP Tracker Table

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1204,11 +1204,6 @@ indicate that the feature is removed from the release or deprecated.
 |GA
 |GA
 
-|Tenant Driven Snapshotting
-|TP
-|TP
-|TP
-
 |`oc` CLI Plug-ins
 |TP
 |TP


### PR DESCRIPTION
[BZ1813156](https://bugzilla.redhat.com/show_bug.cgi?id=1813156)
This was a holdover from 3.x docs and is not accurate. It is also being removed from newer 4.x Release Notes versions.

@liangxia PTAL

@openshift/team-documentation PTAL