### PR TITLE
Structure changes for Event Sources

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1585,7 +1585,9 @@ Topics:
 ###  Topics:
 ###  - Name: How Knative Eventing works
 ###    File: serverless-knative-eventing
-###  - Name: Using Knative Eventing sources
+###  - Name: Event source types
+###    File: serverless-event-source-types
+###  - Name: Using kn to interact with event sources and event types
 ###    File: serverless-kn-source
 ###  - Name: Using triggers with Knative Eventing
 ###    File: serverless-kn-trigger

--- a/serverless/knative_eventing/serverless-event-source-types.adoc
+++ b/serverless/knative_eventing/serverless-event-source-types.adoc
@@ -1,0 +1,17 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="serverless-event-source-types"]
+= Event source types
+include::modules/common-attributes.adoc[]
+:context: serverless-event-source-types
+
+toc::[]
+
+Currently, `kn` supports management of the following event source types:
+
+`ApiServerSource`:: Connects a sink to the Kubernetes API server.
+`PingSource`:: Periodically sends ping events with a constant payload. It can be used as a timer.
+`SinkBinding`:: Connects core Kubernetes resources like `Deployment`, `Job`, or `StatefulSet` with a sink.
+
+// include::modules/serverless-pingsource.adoc[leveloffset=+1]
+// include::modules/serverless-apiserversource.adoc[leveloffset=+1]
+// include::modules/serverless-sinkbinding.adoc[leveloffset=+1]

--- a/serverless/knative_eventing/serverless-kn-source.adoc
+++ b/serverless/knative_eventing/serverless-kn-source.adoc
@@ -1,24 +1,19 @@
-[id="serverless-kn-source"]
-= Using Knative Eventing sources
-include::modules/common-attributes.adoc[]
 include::modules/serverless-document-attributes.adoc[]
+[id="serverless-kn-source"]
+= Using `kn` to interact with event sources and event types
+include::modules/common-attributes.adoc[]
 :context: serverless-kn-source
 
 toc::[]
 
-You can use `kn` to list available event sources or event source types for use with Knative Eventing.
-For information about installing `kn`, see xref:../installing_serverless/installing-kn.adoc#installing-kn[Installing Knative client].
+ You can use `kn` to list and manage available event sources or event source types for use with Knative Eventing.
+ For information about installing `kn`, see xref:../installing_serverless/installing-kn.adoc#installing-kn[Installing Knative client].
 
-Currently, Knative Eventing supports the following event source types:
+For more information about supported event source types, see xref:../knative_eventing/serverless-event-source-types.adoc#serverless-event-source-types[Event source types].
 
-`ApiServerSource`:: Connects a sink to the Kubernetes API server.
-`PingSource`:: Periodically sends ping events with a constant payload. It can be used as a timer.
-`SinkBinding`:: Connects core Kubernetes resources like `Deployment`, `Job`, or `StatefulSet` with a sink.
-// additional modules TBA for creating and managing these sources
-
-Additional sources can be added by the cluster administrator. For example, {ServerlessProductName} can be used with Kafka and Camel K event sources, which are installed using the Operator Hub in the {product-title} web console.
-
-// For more information about adding event source types as a cluster administrator, see...(add modules later)
+// Additional sources can be added by the cluster administrator. For example, {ServerlessProductName} can be used with Kafka and Camel K event sources, which are installed using the Operator Hub in the {product-title} web console.
+// For more information about adding event source types as a cluster administrator, see
+// xref:../knative-client.adoc#knative-client[Installing Knative Client].
 
 include::modules/serverless-list-source-types.adoc[leveloffset=+1]
 include::modules/serverless-list-source.adoc[leveloffset=+1]

--- a/serverless/serverless-metering.adoc
+++ b/serverless/serverless-metering.adoc
@@ -1,8 +1,8 @@
-include::modules/common-attributes.adoc[]
+include::modules/serverless-document-attributes.adoc[]
 [id="metering-serverless"]
 = Using metering with {ServerlessProductName}
 :context: metering-serverless
-include::modules/serverless-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
 
 toc::[]
 


### PR DESCRIPTION
Changes to docs structure for event sources. This is now split into types and use of `kn` with event sources (there will be separate docs for dev console event source use).