### PR TITLE
OSASINFRA-1352: OpenStack: remove pin on Ansible 2.5

### DIFF
--- a/install_config/topics/ocp_osp_prerequisites.adoc
+++ b/install_config/topics/ocp_osp_prerequisites.adoc
@@ -6,23 +6,25 @@ installation of {product-title} using Ansible. In the following subsequent secti
 regarding the prerequisites and configuration changes required for an {product-title} on a
 OpenStack environment are discussed in detail.
 
-NOTE: All the OpenStack CLI commands in this reference environment are executed
-using the CLI `openstack` commands within the OpenStack director node. If using a
-workstation or laptop to execute these commands instead of the OpenStack
-director node, please ensure to install the following packages found
-within the specified repositories.
+[NOTE]
+All of the OpenStack CLI commands in this reference environment are executed
+using the CLI `openstack` commands within a different node from the director
+node. The commands are executed in the other node to avoid package conflicts
+with Ansible version 2.6 and above. Be sure to install the following packages
+in the specified repositories.
 
 Example:
 
-Enable the rhel-7-server-openstack-{rhosp_version}-rpms and the required
+Enable the rhel-7-server-openstack-{rhosp_version}-tools-rpms and the required
 {product-title} repositories from
 xref:../getting_started/install_openshift.adoc#set-up-repositories[Set Up
 Repositories].
 
 ----
 $ sudo subscription-manager repos \
---enable rhel-7-server-openstack-13-rpms \
---enable rhel-7-server-ansible-2.6-rpms
+--enable rhel-7-server-openstack-{rhosp_version}-tools-rpms \
+--enable rhel-7-server-openstack-14-tools-rpms
+$ sudo subscription-manager repo-override --repo=rhel-7-server-openstack-14-tools-rpms --add=includepkgs:"python2-openstacksdk.* python2-keystoneauth1.* python2-os-service-types.*"
 $ sudo yum install -y python2-openstackclient python2-heatclient python2-octaviaclient ansible
 ----
 
@@ -31,7 +33,4 @@ Verify the packages are of at least the following versions (use `rpm -q <package
 * `python2-openstackclient` - `3.14.1.-1`
 * `python2-heatclient` `1.14.0-1`
 * `python2-octaviaclient` `1.4.0-1`
-* Requires Ansible 2.6
-
-//NOTE: Ansible 2.6 requires `python2-openstacksdk` > 0.12.0 that is not part of
-//the {rhel} {rhel_version} distribution.
+* `python2-openstacksdk` `0.17.2`


### PR DESCRIPTION
The openstacksdk version shipped in OSP 13 is limited to version
0.11.x, while Ansible 2.6+ has a hard requirement on openstacksdk >=
  0.12.0 and therefore will not work with the OSP 13 repos.

Install openstack clients from rhel-7-server-openstack-14-rpms
repository instead in order to remove the pin on EOL Ansible 2.5.