### PR TITLE
Bug 1789657: Enhancement to Kuryr quota documentation

### DIFF
--- a/modules/installation-osp-default-kuryr-deployment.adoc
+++ b/modules/installation-osp-default-kuryr-deployment.adoc
@@ -16,21 +16,24 @@ Use the following quota to satisfy a default cluster's minimum requirements:
 
 [options="header"]
 |================================
-|Resource              | Value
-|Floating IP addresses | 3 - plus the expected number of Services of LoadBalancer type
-|Ports                 | 1500 - 1 needed per Pod
-|Routers               | 1
-|Subnets               | 250 - 1 needed per Namespace/Project
-|Networks              | 250 - 1 needed per Namespace/Project
-|RAM                   | 112 GB
-|vCPUs                 | 28
-|Volume storage        | 175 GB
-|Instances             | 7
-|Security groups       | 250 - 1 needed per Service and per NetworkPolicy
-|Security group rules  | 1000
-|Swift containers      | 2
-|Swift objects         | 1
-|Swift available space | 10 MB or more
+|Resource                | Value
+|Floating IP addresses   | 3 - plus the expected number of Services of LoadBalancer type
+|Ports                   | 1500 - 1 needed per Pod
+|Routers                 | 1
+|Subnets                 | 250 - 1 needed per Namespace/Project
+|Networks                | 250 - 1 needed per Namespace/Project
+|RAM                     | 112 GB
+|vCPUs                   | 28
+|Volume storage          | 175 GB
+|Instances               | 7
+|Security groups         | 250 - 1 needed per Service and per NetworkPolicy
+|Security group rules    | 1000
+|Swift containers        | 2
+|Swift objects           | 1
+|Swift available space   | 10 MB or more
+|Load balancers          | 100 - 1 needed per Service
+|Load balancer listeners | 500 - 1 needed per Service-exposed port
+|Load balancer pools     | 500 - 1 needed per Service-exposed port
 |================================
 
 A cluster might function with fewer than recommended resources, but its
@@ -53,8 +56,11 @@ account when estimating the number of security groups required for the quota.
 * Swift space requirements vary depending on the size of the bootstrap Ignition
 file and image registry.
 
-* Although the quota does not account for load balancer VM resources, they must be
-considered when deciding the OpenStack deployment size.
+* The quota does not account for load balancer resources (such as VM
+resources), but you must consider these resources when you decide the
+{rh-openstack} deployment's size. The default installation will have more than
+50 load balancers; the clusters must be able to accommodate them.
+
 
 An {product-title} deployment comprises control plane machines, compute
 machines, and a bootstrap machine.

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -17,7 +17,7 @@ protocols, like UDP and TCP, on the same port. Thus, Services exposing the same
 port for different protocols are not supported.
 * Due to the above UDP limitations of Octavia, Kuryr forces Pods to use TCP
 for DNS resolution. This is set with the `use-vc` option in `resolv.conf`. This
-might be a problem for Pods running Go applications compiled with the `CGO_DEBUG`
+might be a problem for Pods running Go applications compiled with the `CGO_ENABLED`
 flag disabled, as that uses the `go` resolver that only leverages UDP and is not
 considering the `use-vc` option added by Kuryr to the `resolv.conf`. This is a
 problem also for musl-based containers as its resolver does not support the


### PR DESCRIPTION
This adds information about the number of amphora VMs needed.
In addition it fixes a typo regarding the usage of CGO_ENABLED,
that is related to the amphora VMs.