### PR TITLE
Update Kuryr known limitations

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -5,20 +5,57 @@
 [id="installation-osp-kuryr-known-limitations_{context}"]
 = Known limitations of installing with Kuryr
 
-There are known limitations when using Kuryr SDN:
+Using {product-title} with Kuryr SDN has several known limitations.
 
-* An Amphora load balancer VM is deployed per OpenShift Service with
-the default Octavia load balancer driver (Amphora driver). If the environment is
-resource constrained, creating a large amount of Services could be a problem.
-* Depending on the Octavia version, UDP listeners are not supported. This means
-that OpenShift UDP Services are not supported.
-* There is a known limitation of Octavia not supporting listeners on different
-protocols, like UDP and TCP, on the same port. Thus, Services exposing the same
-port for different protocols are not supported.
-* Due to the above UDP limitations of Octavia, Kuryr forces Pods to use TCP
-for DNS resolution. This is set with the `use-vc` option in `resolv.conf`. This
-might be a problem for Pods running Go applications compiled with the `CGO_ENABLED`
-flag disabled, as that uses the `go` resolver that only leverages UDP and is not
-considering the `use-vc` option added by Kuryr to the `resolv.conf`. This is a
-problem also for musl-based containers as its resolver does not support the
-`use-vc` option. This includes images built from `alpine`.
+[discrete]
+[id="openstack-resource-limitations_{context}"]
+== {rh-openstack} resource limitations
+
+* An Amphora load balancer VM is deployed per OpenShift Service that uses the
+default Octavia load balancer driver (Amphora driver). Creating too many Services
+can cause you to run out of resources.
+
+[discrete]
+[id="openstack-version-limitations_{context}"]
+== {rh-openstack} version limitations
+
+Using {product-title} with Kuryr SDN has several limitations that depend on the {rh-openstack} version.
+
+* Octavia {rh-openstack} versions before 16 do not support UDP listeners. Therefore,
+OpenShift UDP services are not supported.
+
+* Octavia {rh-openstack} versions before 16 cannot listen to multiple protocols on the
+same port. Services that expose the same port to different protocols, like TCP
+and UDP, are not supported.
+
+[IMPORTANT]
+====
+The OVN Octavia driver does not support listeners that use different protocols on
+any {rh-openstack} version.
+====
+
+[discrete]
+[id="openstack-go-limitations_{context}"]
+== {rh-openstack} environment limitations
+
+There are limitations when using Kuryr SDN that depend on your deployment environment.
+
+Because of Octavia's lack of support for the UDP protocol and multiple listeners, Kuryr forces Pods to use TCP
+for DNS resolution if:
+
+* The {rh-openstack} version is earlier than 16
+* The OVN Octavia driver is used
+
+In Go versions 1.12 and earlier, applications that are compiled with CGO support disabled use UDP only. In this case,
+the native Go resolver does not recognize the `use-vc` option in `resolv.conf`, which controls whether TCP is forced for DNS resolution.
+As a result, UDP is still used for DNS resolution, which fails.
+
+To ensure that TCP forcing is allowed, compile applications either with the environment variable `CGO_ENABLED` set to `1`, i.e. `CGO_ENABLED=1`, or ensure that the variable is absent.
+
+In Go versions 1.13 and later, TCP is used automatically if DNS resolution using UDP fails.
+
+[INFO]
+====
+musl-based containers, including Alpine-based containers, do not support the `use-vc` option.
+====
+

--- a/modules/installation-osp-kuryr-octavia-configuration.adoc
+++ b/modules/installation-osp-kuryr-octavia-configuration.adoc
@@ -116,13 +116,23 @@ backend is ML2/OVS. There is no need for modifications if the backend is
 ML2/OVN.
 ====
 
-. To enforce network policies across Services, like when traffic goes through
-the Octavia load balancer, you must ensure Octavia creates the Amphora VM
-security groups on the user project. To do that, you must add the project ID
+. In {rh-openstack} versions 13 and 15, add the project ID
 to the `octavia.conf` configuration file after you create the project.
+* To enforce
+network policies across Services, like when traffic goes through
+the Octavia load balancer, you must ensure Octavia creates the Amphora VM
+security groups on the user project.
 +
-This ensures that required LoadBalancer security groups belong to that project
+This change ensures that required LoadBalancer security groups belong to that project,
 and that they can be updated to enforce Services isolation.
++
+[NOTE]
+====
+This task is unnecessary in {rh-openstack} version 16 or later.
+
+Octavia implements a new ACL API that restricts access to the Load
+Balancers VIP.
+====
 
 .. Get the project ID
 +


### PR DESCRIPTION
Some of the limitations has been fixed when using OpenStack 16
version of Octavia. This patch adds that information