### PR TITLE
migration: 3.7 APIs not supported by 4.4

### DIFF
--- a/modules/migration-known-issues.adoc
+++ b/modules/migration-known-issues.adoc
@@ -17,8 +17,9 @@ This release has the following known issues:
 These annotations preserve the UID range, ensuring that the containers retain their file system permissions on the target cluster. There is a risk that the migrated UIDs could duplicate UIDs within an existing or future namespace on the target cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1748440[*BZ#1748440*])
 
 * If an AWS bucket is added to the CAM web console and then deleted, its status remains `True` because the MigStorage CR is not updated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1738564[*BZ#1738564*])
-* Migration fails if the Migration controller is running on a cluster other than the target cluster. The `EnsureCloudSecretPropagated` phase is skipped with a logged warning. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1757571[*BZ#1757571*])
 * Most cluster-scoped resources are not yet handled by the CAM tool. If your applications require cluster-scoped resources, you may have to create them manually on the target cluster.
-* Incorrect source cluster storage class is displayed when creating the migration plan. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1777869[*BZ#1777869*])
-* If a cluster in the CAM web console becomes inaccessible, it blocks attempts to close open migration plans. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1758269[*BZ#1758269*])
 * If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
+
+ifdef::migrating-3-4[]
+* In the current release (CAM 1.1.2), you cannot migrate from {product-title} 3.7 to 4.4 because certain APIs, for example, `apps.v1beta1.Deployment`, that are used by the source cluster are deprecated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1817251[*BZ#1817251*])
+endif::[]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1817251

ONLY for 4.4. Do not CP for 4.2 or 4.3