### PR TITLE
Add optional annotation step to block default node selector in LSO

### DIFF
--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -19,6 +19,19 @@ The Local Storage Operator is not installed in {product-title} by default. Use t
 $ oc new-project local-storage
 ----
 
+. Optional: Allow local storage creation on infrastructure nodes.
++
+You might want to use the Local Storage Operator to create volumes on infrastructure nodes in support of components such as logging and monitoring.
++
+You must adjust the default node selector so that the Local Storage Operator includes the infrastructure nodes, and not just worker nodes.
++
+To block the Local Storage Operator from inheriting the cluster-wide default selector, enter the following command:
++
+----
+$ oc annotate project local-storage openshift.io/node-selector=''
+----
+
+
 . Install the Local Storage Operator from the web console.
 
 .. Log in to the {product-title} web console.


### PR DESCRIPTION
Adds an optional step to LSO Install procedure for blocking cluster-wide default node selector, as described in [ISSUE-20181](https://github.com/openshift/openshift-docs/issues/20181). 

@huffmanca or @gnufied PTAL - does this addition look accurate and make sense to you?

@liangxia PTAL

Preview link here: https://issue-20181--ocpdocs.netlify.com/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-storage-install_persistent-storage-local