### PR TITLE
BZ1817548 - Add Pod teardown note and other minor updates

### DIFF
--- a/modules/persistent-storage-csi-snapshots-create.adoc
+++ b/modules/persistent-storage-csi-snapshots-create.adoc
@@ -7,10 +7,17 @@
 
 When you create a VolumeSnapshot object, {product-title} creates a volume snapshot.
 
+
 .Prerequisites
 * Logged in to a running {product-title} cluster.
 * A PVC created using a CSI driver that supports VolumeSnapshot objects.
 * A storage class to provision the storage backend.
+* No Pods are using the persistent volume claim (PVC) that you want to take a snapshot of.
++
+[NOTE]
+====
+Do not create a volume snapshot of a PVC if a Pod is using it. Doing so might cause data corruption because the PVC is not quiesced (paused). Be sure to first tear down a running Pod to ensure consistent snapshots.
+====
 
 .Procedure
 
@@ -35,7 +42,7 @@ deletionPolicy: Delete
 <2> Optional. This annotation can be used to create a default VolumeSnapshotClass. This object will be used when VolumeSnapshot does not specify any explicit volumeSnapshotClassName.
 
 +
-. Create the object you saved in the previous step by running the following command:
+. Create the object you saved in the previous step by entering the following command:
 +
 ----
 $ oc create -f volumesnapshotclass.yaml
@@ -67,10 +74,10 @@ If no default class is set and `volumeSnapshotClassName` is empty, then no snaps
 <2> The name of the PersistentVolumeClaim object bound to a persistent volume. This defines what you want to create a snapshot of. Required for dynamically provisioning a snapshot.
 
 +
-. Create the object you saved in the previous step:
+* Create the object you saved in the previous step by entering the following command:
 +
 ----
-$ oc create -f volumesnapshot.yaml
+$ oc create -f volumesnapshot-dynamic.yaml
 ----
 
 
@@ -91,22 +98,23 @@ spec:
 ----
 <1> The volumeSnapshotContentName parameter is required for pre-provisioned snapshots.
 
-. Create the object you saved in the previous step:
+. Create the object you saved in the previous step by entering the following command:
 +
 ----
-$ oc create -f volumesnapshot.yaml
+$ oc create -f volumesnapshot-manual.yaml
 ----
 
+.Verification steps
 After the snapshot has been created in the cluster, additional details about the snapshot are available.
 
-. Display details about the volume snapshot that was created by running the following command:
+. To display details about the volume snapshot that was created, enter the following command:
 +
 ----
 $ oc describe volumesnapshot mysnap
 ----
-
++
 The following example displays details about the `mysnap` volume snapshot:
-
++
 .volumesnapshot.yaml
 [source,yaml]
 ----
@@ -130,12 +138,12 @@ status:
   +
 If the value is set to `false`, the snapshot was created. However, the storage backend needs to perform additional tasks to make the snapshot usable so that it can be restored as a new volume. For example, Amazon Elastic Block Store data might be moved to a different, less expensive location, which can take several minutes.
 
-To verify that the volume snapshot was created automatically, run the following command:
-
+. To verify that the volume snapshot was created, enter the following command:
++
 ----
 $ oc get volumesnapshotcontent
 ----
++
+The pointer to the actual content is displayed. If the `boundVolumeSnapshotContentName` field is populated, a VolumeSnapshotContent object exists and the snapshot was created.
 
-The pointer to the actual content is displayed. When the `boundVolumeSnapshotContentName` field is populated, it means that there is a corresponding VolumeSnapshotContent.
-
-To verify that the snapshot is ready, confirm that the VolumeSnapshot has `readyToUse: true`.
+. To verify that the snapshot is ready, confirm that the VolumeSnapshot has `readyToUse: true`.

--- a/modules/persistent-storage-csi-snapshots-operator.adoc
+++ b/modules/persistent-storage-csi-snapshots-operator.adoc
@@ -5,7 +5,7 @@
 [id="persistent-storage-csi-snapshots-operator_{context}"]
 = About the CSI Snapshot Controller Operator
 
-The CSI Snapshot Controller Operator runs in the `cluster-csi-snapshot-controller-operator` namespace. It is installed by the Cluster Version Operator (CVO) in all clusters by default.
+The CSI Snapshot Controller Operator runs in the `openshift-cluster-storage-operator` namespace. It is installed by the Cluster Version Operator (CVO) in all clusters by default.
 
 The CSI Snapshot Controller Operator installs the CSI snapshot controller, which runs in the `csi-snapshot-controller` namespace.
 
@@ -24,7 +24,7 @@ The VolumeSnapshotContent CRD is not namespaced and is for use by a cluster admi
 
 VolumeSnapshot::
 
-Similar to the PersistentVolumeClaim CRD, the VolumeSnapshot CRD defines a developer request for a snapshot. The CSI snapshot controller handles the binding of a VolumeSnapshot object with an appropriate VolumeSnapshotContent object. The binding is a one-to-one mapping.
+Similar to PersistentVolumeClaim, the VolumeSnapshot CRD defines a developer request for a snapshot. The CSI Snapshot Controller Operator runs the CSI snapshot controller, which handles the binding of a VolumeSnapshot object with an appropriate VolumeSnapshotContent object. The binding is a one-to-one mapping.
 +
 The VolumeSnapshot CRD is namespaced. A developer uses the CRD as a distinct request for a snapshot.
 

--- a/modules/persistent-storage-csi-snapshots-provision.adoc
+++ b/modules/persistent-storage-csi-snapshots-provision.adoc
@@ -3,16 +3,16 @@
 // * storage/persistent_storage/persistent-storage-csi-snapshots.adoc
 
 [id="persistent-storage-csi-snapshots-provision_{context}"]
-= Provisioning a volume snapshot
+= Volume snapshot provisioning
 
-There are two ways to provision snapshots: xref:#snapshots-manual-provisioning[manually] and xref:#snapshots-dynamic-provisioning[dynamically].
+There are two ways to provision snapshots: dynamically and manually.
 
-[id="snapshots-manual-provisioning"]
-== Manual provisioning
-
-As a cluster administrator, you can manually pre-provision a number of VolumeSnapshotContent objects. These carry the real volume snapshot details available to cluster users.
-
-[id="snapshots-dynamic-provisioning"]
+[id="snapshots-dynamic-provisioning_{context}"]
 == Dynamic provisioning
 
 Instead of using a preexisting snapshot, you can request that a snapshot be taken dynamically from a PersistentVolumeClaim. Parameters are specified using VolumeSnapshotClass.
+
+[id="snapshots-manual-provisioning_{context}"]
+== Manual provisioning
+
+As a cluster administrator, you can manually pre-provision a number of VolumeSnapshotContent objects. These carry the real volume snapshot details available to cluster users.

--- a/modules/persistent-storage-csi-snapshots-restore.adoc
+++ b/modules/persistent-storage-csi-snapshots-restore.adoc
@@ -41,14 +41,14 @@ spec:
 <2> Must be set to the `VolumeSnapshot` value.
 <3> Must be set to the `snapshot.storage.k8s.io` value.
 
-. Create a PVC by running the following command:
+. Create a PVC by entering the following command:
 
 +
 ----
 $ oc create -f pvc-restore.yaml
 ----
 
-. Verify that the restored PVC has been created by running the following command:
+. Verify that the restored PVC has been created by entering the following command:
 
 +
 ----


### PR DESCRIPTION
[BZ 1817548](https://bugzilla.redhat.com/show_bug.cgi?id=1817548) - Adds additional prerequisite and admonishment to not use snapshots when a Pod is running. 

Other minor updates in this PR: 

- Change order of dynamic and manual provisioning refs to match procedure order
- Standardize usage of "the following command"
- Add `.Verification steps` header to breakup content as shown in `mod-docs` template