### PR TITLE
[enterprise-4.3] Remove version admonitions from ShiftStack docs

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -18,17 +18,6 @@ processes.
 
 * Have metadata service enabled in {rh-openstack}
 
-[IMPORTANT]
-====
-{product-title} 4.3 is supported for use with {rh-openstack} 13 and
-{rh-openstack} 16.
-
-The latest {product-title} release supports both the latest {rh-openstack} long
-life release and intermediate release. The release cycles of {product-title} and
-{rh-openstack} are different and versions tested may vary in the future
-depending on the release dates of both products.
-====
-
 include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]
 include::modules/installation-osp-control-compute-machines.adoc[leveloffset=+2]
 include::modules/installation-osp-bootstrap-machine.adoc[leveloffset=+2]

--- a/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
@@ -16,17 +16,6 @@ processes.
 
 * Have access to an {rh-openstack} administrator's account
 
-[IMPORTANT]
-====
-{product-title} 4.3 is supported for use with {rh-openstack} 13 and
-{rh-openstack} 16.
-
-The latest {product-title} release supports both the latest {rh-openstack} long
-life release and intermediate release. The release cycles of {product-title} and
-{rh-openstack} are different and versions tested may vary in the future
-depending on the release dates of both products.
-====
-
 include::modules/installation-osp-about-kuryr.adoc[leveloffset=+1]
 include::modules/installation-osp-default-kuryr-deployment.adoc[leveloffset=+1]
 include::modules/installation-osp-kuryr-increase-quota.adoc[leveloffset=+2]

--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -70,7 +70,9 @@ installer-provisioned infrastructure on the following platforms:
 * Amazon Web Services (AWS)
 * Google Cloud Platform (GCP)
 * Microsoft Azure
-* Red Hat OpenStack Platform version 13, 15 and 16
+* {rh-openstack-first} version 13, 15, and 16
+** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release
+* Red Hat Virtualization (RHV)
 
 For these clusters, all machines, including the computer that you run the installation process on, must have direct internet access to pull images for platform containers and provide telemetry data to Red Hat.
 


### PR DESCRIPTION
Move OCP release note to arch docs

Manual CP of https://github.com/openshift/openshift-docs/pull/20787