### PR TITLE
CNV-4285 not all bond modes supported

### DIFF
--- a/modules/cnv-example-bond-nncp.adoc
+++ b/modules/cnv-example-bond-nncp.adoc
@@ -8,6 +8,15 @@
 Create a bond interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest
 to the cluster. 
 
+[NOTE]
+====
+{CNVProductNameStart} only supports the following bond modes:
+
+* mode=1 active-backup +
+* mode=5 balance-tlb +
+* mode=6 balance-alb
+====
+
 The following YAML file is an example of a manifest for a bond interface.
 It includes samples values that you must replace with your own information.
 
@@ -30,7 +39,7 @@ spec:
         dhcp: true <8>
         enabled: true <9>
       link-aggregation:
-        mode: balance-rr <10>
+        mode: active-backup <10>
         options:
           miimon: '140' <11>
         slaves: <12>
@@ -47,7 +56,7 @@ spec:
 <7> The requested state for the interface after creation.
 <8> Optional. If you do not use `dhcp` you must specify static IP address for the interface.
 <9> Enables `ipv4` in this example.
-<10> The driver mode for the bond. This example uses a round-robin mode.
+<10> The driver mode for the bond. This example uses an active backup mode.
 <11> Optional. This example uses miimon to inspect the bond link every 140ms.
 <12> The subordinate node NICs in the bond. 
 <13> Optional. The maximum transmission unit (MTU) for the bond. If not specified, this value is set to `1500` by default. 


### PR DESCRIPTION
Adding note that only bond modes 1,5,6 are supported for CNV 2.3. Also changed the mode used in the example.

enterprise-4.4 only 