### PR TITLE
Bug 1816773: add information about the possibility to remove UsingDeprecatedAPIExtensionsV1Beta1 alert

### DIFF
--- a/modules/monitoring-known-issues.adoc
+++ b/modules/monitoring-known-issues.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * monitoring/cluster_monitoring/managing-cluster-alerts.adoc
+
+[id="known-issues_{context}"]
+= Known Issues
+
+For short period of time `UsingDeprecatedAPIExtensionsV1Beta1` alert existed
+in {product-title} version 4.3. Starting from version 4.3.8 the alert is no
+more required, if you notice it is firing in your cluster and you are on a
+{product-title} version 4.3.8 or newer you can safely remove that `PrometheusRule`.
+
+
+.Procedure
+
+. Verify your cluster version:
++
+----
+$ oc get clusterversion
+----
+
+. If cluster version is 4.3.8 or newer proceed, otherwise upgrade your cluster.
+
+. Verify the contents of `kube-apiserv` `PrometheusRule` invoking:
++
+----
+$ oc get prometheusrules.monitoring.coreos.com/kube-apiserver -n openshift-kube-apiserver -oyaml
+----
+
+. Look for `UsingDeprecatedAPIExtensionsV1Beta1`, if this is the only rule you are safe to remove it invoking:
++
+----
+$ oc delete prometheusrules.monitoring.coreos.com/kube-apiserver -n openshift-kube-apiserver
+----
+
+. If there are more rules you should manually remove only the `UsingDeprecatedAPIExtensionsV1Beta1` rule from that resource.

--- a/monitoring/cluster_monitoring/managing-cluster-alerts.adoc
+++ b/monitoring/cluster_monitoring/managing-cluster-alerts.adoc
@@ -13,6 +13,7 @@ include::modules/monitoring-silencing-alerts.adoc[leveloffset=+1]
 include::modules/monitoring-getting-information-about-silences.adoc[leveloffset=+1]
 include::modules/monitoring-editing-silences.adoc[leveloffset=+1]
 include::modules/monitoring-expiring-silences.adoc[leveloffset=+1]
+include::modules/monitoring-known-issues.adoc[leveloffset=+1]
 
 .Next steps
 


### PR DESCRIPTION
We removed the alert `UsingDeprecatedAPIExtensionsV1Beta1` as part of https://bugzilla.redhat.com/show_bug.cgi?id=1795617 but after the upgrade the alert still persists as reported in https://bugzilla.redhat.com/show_bug.cgi?id=1816773. We figured out that we'll inform users they can safely remove that alert if they wish to.

This is ONLY for 4.3. 
/assign @bergerhoffer 