### PR TITLE
Added note to each assembly stating that Serverless is no longer supported on OCP 4.2

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -773,7 +773,7 @@ Topics:
 - Name: Modifying a MachineSet
   File: modifying-machineset
 - Name: Deleting a Machine
-  File: deleting-machine  
+  File: deleting-machine
 - Name: Applying autoscaling to a cluster
   File: applying-autoscaling
 - Name: Creating infrastructure MachineSets
@@ -1162,15 +1162,15 @@ Topics:
     File: odo-architecture
   - Name: Installing odo
     File: installing-odo
-  - Name: Using odo in a restricted environment  
+  - Name: Using odo in a restricted environment
     Dir: using_odo_in_a_restricted_environment
-    Topics: 
+    Topics:
     - Name: About odo in a restricted environment
-      File: about-odo-in-a-restricted-environment  
+      File: about-odo-in-a-restricted-environment
     - Name: Pushing the odo init image to the restricted cluster registry
       File: pushing-the-odo-init-image-to-the-restricted-cluster-registry
     - Name: Creating and deploying a component to the disconnected cluster
-      File: creating-and-deploying-a-component-to-the-disconnected-cluster        
+      File: creating-and-deploying-a-component-to-the-disconnected-cluster
   - Name: Creating a single-component application with odo
     File: creating-a-single-component-application-with-odo
   - Name: Creating a multicomponent application with odo

--- a/serverless/cluster-logging-serverless.adoc
+++ b/serverless/cluster-logging-serverless.adoc
@@ -6,6 +6,12 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 include::modules/cluster-logging-about.adoc[leveloffset=+1]
 include::modules/cluster-logging-deploying-about.adoc[leveloffset=+1]
 include::modules/serverless-using-cluster-logging-find-logs-knative-serving-components.adoc[leveloffset=+1]

--- a/serverless/configuring-knative-serving-autoscaling.adoc
+++ b/serverless/configuring-knative-serving-autoscaling.adoc
@@ -6,6 +6,12 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 {ServerlessProductName} provides capabilities for automatic Pod scaling, including scaling inactive Pods to zero, by enabling the Knative Serving autoscaling system in an {product-title} cluster.
 
 To enable autoscaling for Knative Serving, you must configure concurrency and scale bounds in the revision template.

--- a/serverless/getting-started-knative-services.adoc
+++ b/serverless/getting-started-knative-services.adoc
@@ -6,6 +6,12 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 Knative services are Kubernetes services that a user creates to deploy a serverless application. Each Knative service is defined by a route and a configuration, contained in a `.yaml` file.
 
 include::modules/creating-knative-services.adoc[leveloffset=+1]

--- a/serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing-openshift-serverless.adoc
@@ -8,6 +8,12 @@ toc::[]
 
 [IMPORTANT]
 ====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
+[IMPORTANT]
+====
 {ServerlessProductName} is not tested or supported for installation in a restricted network environment.
 ====
 

--- a/serverless/interacting-serverless-apps.adoc
+++ b/serverless/interacting-serverless-apps.adoc
@@ -6,6 +6,12 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 This section provides information about various tasks that can be performed once you have successfully created a serverless application.
 
 include::modules/verifying-serverless-app-deployment.adoc[leveloffset=+1]

--- a/serverless/knative-client.adoc
+++ b/serverless/knative-client.adoc
@@ -5,6 +5,12 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 Knative Client (`kn`) is the Knative command line interface (CLI).
 The CLI exposes commands for managing your applications, as well as lower level tools to interact with components of {product-title}.
 With `kn`, you can create applications and manage {product-title} projects from the terminal.

--- a/serverless/monitoring-serverless.adoc
+++ b/serverless/monitoring-serverless.adoc
@@ -4,6 +4,12 @@ include::modules/common-attributes.adoc[]
 include::modules/serverless-document-attributes.adoc[]
 :context: monitoring-serverless
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 As an {product-title} cluster administrator, you can deploy the {product-title} monitoring stack and monitor the metrics of {ServerlessProductName} components.
 
 When using the {ServerlessOperatorName}, the required ServiceMonitor objects are created automatically for monitoring the deployed components.

--- a/serverless/serverless-architecture.adoc
+++ b/serverless/serverless-architecture.adoc
@@ -4,6 +4,12 @@ include::modules/common-attributes.adoc[]
 include::modules/serverless-document-attributes.adoc[]
 :context: serverless-architecture
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 include::modules/knative-serving.adoc[leveloffset=+1]
 include::modules/knative-cli.adoc[leveloffset=+1]
 

--- a/serverless/serverless-getting-started.adoc
+++ b/serverless/serverless-getting-started.adoc
@@ -6,6 +6,12 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 :FeatureName: OpenShift Serverless
 include::modules/technology-preview.adoc[leveloffset=+1]
 

--- a/serverless/serverless-metering.adoc
+++ b/serverless/serverless-metering.adoc
@@ -4,6 +4,12 @@ include::modules/common-attributes.adoc[]
 include::modules/serverless-document-attributes.adoc[]
 :context: metering-serverless
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 As an {product-title} cluster administrator, you can use metering to analyze what is happening in your {ServerlessProductName} cluster.
 
 For more information about metering on {product-title}, see xref:../metering/metering-about-metering.adoc#about-metering[About metering].

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -6,6 +6,12 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+You are viewing documentation for a release of Red Hat OpenShift Serverless that is no longer supported.
+Red Hat OpenShift Serverless is currently supported on {product-title} 4.3 and newer.
+====
+
 For an overview of {ServerlessProductName} functionality, see xref:../serverless/serverless-getting-started.adoc#serverless-getting-started[Getting started with OpenShift Serverless].
 
 == Getting support


### PR DESCRIPTION
By request from @sferich888 until it is possible to add a deprecated banner to docs on the customer portal.