### PR TITLE
Clarify podman auth.json for OLM disconnected

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -36,6 +36,13 @@ endif::[]
 * `podman` version 1.5.1+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* If you are working with private registries, set the `REG_CREDS` environment
+variable to the file path of your registry credentials for use in later steps.
+For example, for the `podman` CLI:
++
+----
+$ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
+----
 
 .Procedure
 
@@ -61,7 +68,7 @@ $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
     --from=registry.redhat.io/openshift4/ose-operator-registry:v4.3 \//<2>
     --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<3>
-    [-a <path_to_registry_credentials>] \//<4>
+    [-a ${REG_CREDS}] \//<4>
     [--insecure] <5>
 
 INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
@@ -71,7 +78,7 @@ Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 t
 <1> Organization (namespace) to pull from an App Registry instance.
 <2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
 <3> Name your catalog image and include a tag, for example, `v1`.
-<4> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
+<4> Optional: If required, specify the location of your registry credentials file.
 <5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 +
 Sometimes invalid manifests are accidentally introduced into Red Hat's catalogs;

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -21,6 +21,13 @@ endif::[]
 * `podman` version 1.5.1+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* If you are working with private registries, set the `REG_CREDS` environment
+variable to the file path of your registry credentials for use in later steps.
+For example, for the `podman` CLI:
++
+----
+$ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
+----
 
 .Procedure
 
@@ -43,13 +50,13 @@ the manifests required for mirroring and mirrors the images to your registry:
 $ oc adm catalog mirror \
     <registry_host_name>:<port>/olm/redhat-operators:v1 \//<1>
     <registry_host_name>:<port> \
-    [-a <path_to_registry_credentials>] \//<2>
+    [-a ${REG_CREDS}] \//<2>
     [--insecure] <3>
 
 mirroring ...
 ----
 <1> Specify your Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
+<2> Optional: If required, specify the location of your registry credentials file.
 <3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 +
 This command also creates a `<image_name>-manifests/` directory in the current

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -26,6 +26,13 @@ endif::[]
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * OperatorHub configured to use custom catalog images
+* If you are working with private registries, set the `REG_CREDS` environment
+variable to the file path of your registry credentials for use in later steps.
+For example, for the `podman` CLI:
++
+----
+$ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
+----
 
 .Procedure
 
@@ -51,7 +58,7 @@ $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
     --from=registry.redhat.io/openshift4/ose-operator-registry:v4.3 \//<2>
     --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<3>
-    [-a <path_to_registry_credentials>] \//<4>
+    [-a ${REG_CREDS}] \//<4>
     [--insecure] <5>
 
 INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
@@ -61,7 +68,7 @@ Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 t
 <1> Organization (namespace) to pull from an App Registry instance.
 <2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
 <3> Name your catalog image and include a tag, for example, `v2` because it is the updated catalog.
-<4> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
+<4> Optional: If required, specify the location of your registry credentials file.
 <5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 
 . Mirror the contents of your catalog to your target registry. The following
@@ -73,13 +80,13 @@ images to your registry:
 $ oc adm catalog mirror \
     <registry_host_name>:<port>/olm/redhat-operators:v2 \//<1>
     <registry_host_name>:<port> \
-    [-a <path_to_registry_credentials>] \//<2>
+    [-a ${REG_CREDS}] \//<2>
     [--insecure] <3>
 
 mirroring ...
 ----
 <1> Specify your new Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
+<2> Optional: If required, specify the location of your registry credentials file.
 <3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 
 . Apply the newly generated manifests:


### PR DESCRIPTION
Be more clear about the path for podman's auth file.

Preview: https://dc_private_reg--ocpdocs.netlify.com/openshift-enterprise/latest/operators/olm-restricted-networks.html