### PR TITLE
Added an example of the allowVolumeExpansion attribute in a StorageClass

### DIFF
--- a/dev_guide/expanding_persistent_volumes.adoc
+++ b/dev_guide/expanding_persistent_volumes.adoc
@@ -15,8 +15,23 @@ toc::[]
 
 To allow expansion of persistent volume claims (PVC) by {product-title} users,
 {product-title} administrators must create or update a StorageClass with
-`allowVolumeExpansion` set to `true`. Only PVCs created from that class are
-allowed to expand.
+`allowVolumeExpansion` set to `true`. Only PVCs created from that class are allowed to expand.
+
+For example, {product-title} administrators can add the `allowVolumeExpansion` attribute to the StorageClass’s configuration:
+
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gluster-container
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "http://heketi-storage-project.cloudapps.mystorage.com"
+  restuser: "admin"
+  secretNamespace: "default"
+  secretName: "heketi-secret"
+allowVolumeExpansion: true
+----
 
 [[expanding_glusterfs_pvc]]
 == Expanding GlusterFS-Based Persistent Volume Claims


### PR DESCRIPTION
BZ-1658863 https://bugzilla.redhat.com/show_bug.cgi?id=1658863

@jsafrane Please take a look for 3.11. I used sample data from https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/html-single/operations_guide/index#sect_file_reg_storageclass.