### PR TITLE
Clarify phrasing for choosing a region

### DIFF
--- a/modules/installation-aws-limits.adoc
+++ b/modules/installation-aws-limits.adoc
@@ -52,10 +52,10 @@ and each NAT gateway requires a separate
 link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[elastic IP].
 Review the
 link:https://aws.amazon.com/about-aws/global-infrastructure/[AWS region map] to
-determine how many availability zones are in each region. You can install a
-single cluster in many regions without increasing your EIP limit, but to take
-advantage of the default high availability, install the cluster in a region with
-at least three availability zones.
+determine how many availability zones are in each region. To take advantage of
+the default high availability, install the cluster in a region with at least
+three availability zones. To install a cluster in a region with more than five
+availability zones, you must increase the EIP limit.
 [IMPORTANT]
 ====
 To use the `us-east-1` region, you must increase the EIP limit for your account.


### PR DESCRIPTION
Clarify phrasing for criteria to pick an AWS region.

`You can install a single cluster in many regions` sounds like creating a stretched cluster across multiple regions, which is not the intent here.

Applies to 4.1, 4.2, and 4.3 docs.