### PR TITLE
CNV 2.3 Release notes 

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -10,54 +10,24 @@ include::modules/cnv-what-you-can-do-with-cnv.adoc[leveloffset=+2]
 
 === {CNVProductNameStart} support
 
-:FeatureName: {CNVProductName}
+:FeatureName: {CNVProductNameStart}
 include::modules/technology-preview.adoc[leveloffset=+2]
 
 == New and changed features
 
-* Managing virtual machines is simpler and more efficient due to improvements 
-in design and workflow. You can now:
-** Run the virtual machine wizard with less navigation. The wizard now uses
-a comprehensive in-page style and includes a review page for confirming
-configuration details before submission.
-** Import a single VMware virtual machine with less navigation.
-** Edit virtual machine templates as well as virtual machine configurations.
-** Monitor health of virtual machine-backed services as you would for
-Pod-based services.
-** Enable persistent local storage for virtual machine images.
-** Add, edit, and view virtual CD-ROM devices attached to a virtual machine.
-** Add and view network attachment definitions with a graphical editor.
+
 
 == Resolved issues
 
-* Previously, when you added a disk to a virtual machine via the *Disks* tab in
-the web console, the added disk had a `Filesystem` volumeMode regardless of the
-volumeMode set in the `kubevirt-storage-class-default` ConfigMap. This issue has been fixed.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1753688[*BZ#1753688*])
-
-* Previously, when navigating to the *Virtual Machines Console* tab,
-sometimes no content was displayed. This issue has been fixed.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1753606[*BZ#1753606*])
-
-* Previously, attempting to list all instances of the {CNVProductName} operator
-from a browser resulted in a 404 (page not found) error.
-This issue has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1757526[*BZ#1757526*])
-
-* Previously, if a virtual machine used guaranteed CPUs, it was not scheduled
-because the label `cpumanager=true` was not automatically set on nodes.
-This issue has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1718944[*BZ#1718944*])
 
 == Known issues
 
-* If you have {CNVProductName} 2.1.0 deployed, you must first upgrade {CNVProductName}
-to 2.2.0 before upgrading {product-title}. Upgrading {product-title} before upgrading
-{CNVProductName} might trigger virtual machine deletion.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1785661[*BZ#1785661*])
-
+// For 2.3: Add new Known Issues above this line (so that we don't mix the new with the old/possibly no longer irrelevant ones)
 // Don't remove: this BZ is probably true for all 2.x releases
 * The `masquerade` binding method for virtual machines cannot be used in clusters with RHEL 7 compute nodes.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1741626[*BZ#1741626*])
 
+// The following 7 bugs are from the 2.2 release notes but from their bugs they still seem to be relevant for 2.3:
 * After migration, a virtual machine is assigned a new IP address. However, the
 commands `oc get vmi` and `oc describe vmi` still generate output containing the
 obsolete IP address. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1686208[*BZ#1686208*])
@@ -67,10 +37,6 @@ obsolete IP address. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1686208[*
 ----
 $ oc get pod -o wide
 ----
-
-* Some resources are improperly retained when removing {CNVProductName}. You
-must manually remove these resources in order to reinstall {CNVProductName}.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1712429[*BZ#1712429*])
 
 * Users without administrator privileges cannot add a network interface
 to a project in an L2 network using the virtual machine wizard.
@@ -155,17 +121,6 @@ value by running `oc describe node <node>` for all nodes and looking at the
 `cpu-model-<name>` labels. Select the CPU model that is present on all of your
 nodes.
 
-* When running `virtctl image-upload` to upload large VM disk images in `qcow2`
-format, an end-of-file (EOF) error may be reported after the data is
-transmitted, even though the upload is either progressing normally or completed.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1789093[*BZ#1789093*])
-+
-Run the following command to check the status of an upload on a given PVC:
-+
-----
-$ oc describe pvc <pvc-name> | grep cdi.kubevirt.io/storage.pod.phase
-----
-
 * When attempting to create and launch a virtual machine using a Haswell CPU,
 the launch of the virtual machine can fail due to incorrectly labeled nodes.
 This is a change in behavior from previous versions of container-native
@@ -173,13 +128,6 @@ virtualization, where virtual machines could be successfully launched on Haswell
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1781497[*BZ#1781497*])
 +
 As a workaround, select a different CPU model, if possible.
-
-* If you select a directory that shares space with your operating system,
-you can potentially exhaust the space on the partition, causing the node to
-be non-functional. Instead, create a separate partition
-and point the hostpath provisioner to that partition so it will not
-interfere with your operating system.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1793132[*BZ#1793132*])
 
 * The {CNVProductName} upgrade process occasionally fails due to an interruption
 from the Operator Lifecycle Manager (OLM). This issue is caused by the limitations
@@ -196,6 +144,7 @@ drain if there are virtual machines running on top of them.
 The current solution is to put nodes into maintenance.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1707427[*BZ#1707427*])
 
+// Temporary comment: BZ1819700 PR (#20823) likely to conflict here because of updated version change.
 * If you navigate to the *Subscription* tab on the *Operators* -> *Installed Operators*
 page and click the current upgrade channel to edit it, there might be no visible results.
 If this occurs, there are no visible errors.
@@ -205,7 +154,7 @@ If this occurs, there are no visible errors.
 from the CLI by running the following `oc` patch command:
 +
 ----
-$ TARGET_NAMESPACE=openshift-cnv HCO_CHANNEL=2.2 oc patch -n "${TARGET_NAMESPACE}" $(oc get subscription -n ${TARGET_NAMESPACE} --no-headers -o name) --type='json' -p='[{"op": "replace", "path": "/spec/channel", "value":"${HCO_CHANNEL}"}, {"op": "replace", "path": "/spec/installPlanApproval", "value":"Automatic"}]'
+$ export TARGET_NAMESPACE=openshift-cnv CNV_CHANNEL=2.3 && oc patch -n "${TARGET_NAMESPACE}" $(oc get subscription -n ${TARGET_NAMESPACE} --no-headers -o name) --type='json' -p='[{"op": "replace", "path": "/spec/channel", "value":"'${CNV_CHANNEL}'"}, {"op": "replace", "path": "/spec/installPlanApproval", "value":"Automatic"}]'
 ----
 +
-This command points your subscription to upgrade channel `2.2` and enables automatic updates.
+This command points your subscription to upgrade channel `2.3` and enables automatic updates.

--- a/modules/cnv-document-attributes.adoc
+++ b/modules/cnv-document-attributes.adoc
@@ -13,7 +13,7 @@
 :ProductShortName: CNV
 :ProductRelease:
 :ProductVersion:
-:CNVVersion: 2.2
+:CNVVersion: 2.3
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]


### PR DESCRIPTION
Manual cherrypick*: Went through the 2.2 known issues and removed all the ones that have been resolved. It looks as though there are still eight bugs that are still relevant for 2.3.

* Original CP (#20824) failed due to trailing whitespace in comment line. 