### PR TITLE
Added 1.7.0 GA release notes for Serverless

### DIFF
--- a/modules/serverless-rn-1-6-0.adoc
+++ b/modules/serverless-rn-1-6-0.adoc
@@ -49,8 +49,6 @@ This `HTTP_PROXY` support does not include using custom certificates.
 * In previous versions, the `oc explain` command did not work correctly. The structural schema of the `KnativeServing` CRD was updated in {ServerlessProductName} 1.6.0 so that the `oc explain` command now works correctly.
 * In previous versions, it was possible to create more than one `KnativeServing` CR. Multiple `KnativeServing` CRs are now prevented synchronously in {ServerlessProductName} 1.6.0. Attempting to create more than one `KnativeServing` CR now results in an error.
 * In previous versions, {ServerlessProductName} was not compatible with {product-title} deployments on GCP. This issue was fixed in {ServerlessProductName} 1.6.0.
-// * In previous versions,  requesting `KnativeServing` CRs without specifying an API group, for example, `oc get knativeserving -n knative-serving`, occasionally caused errors. This issue was fixed in {ServerlessProductName} 1.6.0.
-// Move this fixed issue to 1.7.0 release notes once these are created and it's confirmed as fixed
 * In previous releases, the Knative Serving webhook crashed with an out of memory error if the cluster had more than 170 namespaces. This issue was fixed in {ServerlessProductName} 1.6.0.
 * In previous releases, {ServerlessProductName} did not automatically fix an {product-title} route that it created if the route was changed by another component. This issue was fixed in {ServerlessProductName} 1.6.0.
 * In previous versions, deleting a `KnativeServing` CR occasionally caused the system to hang. This issue was fixed in {ServerlessProductName} 1.6.0.

--- a/modules/serverless-rn-1-7-0.adoc
+++ b/modules/serverless-rn-1-7-0.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * serverless/release-notes.adoc
+
+[id="serverless-rn-1-7-0_{context}"]
+
+= Release Notes for Red Hat {ServerlessProductName} 1.7.0
+
+[id="new-features-1-7-0_{context}"]
+== New features
+* {ServerlessProductName} 1.7.0 is now Generally Available (GA) on {product-title} 4.3 and newer versions. In previous versions, {ServerlessProductName} was a Technology Preview.
+* {ServerlessProductName} now uses Knative Serving 0.13.2.
+* {ServerlessProductName} now uses Knative Serving Operator 0.13.2.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.13.2.
+* Knative `kn` CLI downloads now support disconnected, or restricted network installations.
+* Knative `kn` CLI libraries are now signed by Red Hat.
+* Knative Eventing is now available as a Technology Preview with {ServerlessProductName}. {ServerlessProductName} uses Knative Eventing 0.13.2.
+
+[IMPORTANT]
+====
+Before upgrading to the latest Serverless release, you must remove the community Knative Eventing Operator if you have previously installed it. Having the Knative Eventing Operator installed will prevent you from being able to install the latest Technology Preview version of Knative Eventing that is included with {ServerlessProductName} 1.7.0.
+====
+
+* High availability (HA) is now enabled by default for the `autoscaler-hpa`, `controller`, `activator` , `kourier-control`, and `kourier-gateway` components.
++
+If you have installed a previous version of {ServerlessProductName}, after the KnativeServing custom resource (CR) is updated, the deployment will default to a HA configuration with `KnativeServing.spec.high-availability.replicas = 2`.
++
+You can disable HA for these components by completing the procedure in the _Configuring high availability components_ documentation.
+* {ServerlessProductName} now supports the `trustedCA` setting in {product-title}'s cluster-wide proxy, and is now fully compatible with {product-title}'s proxy settings.
+* {ServerlessProductName} now supports HTTPS using the wildcard certificate that is registered for {product-title} routes. For more information on `http` and `https` on Knative Serving, see the documentation on _Verifying your serverless application deployment_.
+
+[id="fixed-issues-1-7-0_{context}"]
+== Fixed issues
+* In previous versions, requesting KnativeServing custom resources (CRs) without specifying an API group, for example, `oc get knativeserving -n knative-serving`, occasionally caused errors. This issue is fixed in {ServerlessProductName} 1.7.0.
+* In previous versions, the Knative Serving controller was not notified when a new service CA certificate was generated due to service CA certificate rotation. New revisions created after a service CA certificate rotation were failing with the error:
++
+----
+Revision "foo-1" failed with message: Unable to fetch image "image-registry.openshift-image-registry.svc:5000/eap/eap-app": failed to resolve image to digest: failed to fetch image information: Get https://image-registry.openshift-image-registry.svc:5000/v2/: x509: certificate signed by unknown authority.
+----
++
+The {ServerlessOperatorName} now restarts the Knative Serving controller whenever a new service CA certificate is generated, which ensures that the controller is always configured to use the current service CA certificate. For more information, see the {product-title} documentation on _Securing service traffic using service serving certificate secrets_ under _Authentication_.
+
+[id="known-issues-1-7-0_{context}"]
+== Known issues
+* When upgrading from {ServerlessProductName} 1.6.0 to 1.7.0, support for HTTPS requires a change to the format of routes. Knative services created on {ServerlessProductName} 1.6.0 are no longer reachable at the old format URLs. You must retrieve the new URL for each service after upgrading {ServerlessProductName}. For more information, see the documentation on _Upgrading OpenShift Serverless_.
+* If you are using Knative Eventing on an Azure cluster, it is possible that the `imc-dispatcher` pod may not start. This is due to the pod's default `resources` settings. As a work-around, you can remove the `resources` settings.
+* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there will be a delay when you create the first new service after KnativeServing becomes Ready.
++
+`3scale-kourier-control` reconciles all previous Knative services before processing the creation of a new service, which causes the new service to spend approximately 800 seconds in an `IngressNotConfigured` or `Unknown` state before the state will update to `Ready`.

--- a/serverless/installing_serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing_serverless/installing-openshift-serverless.adoc
@@ -48,6 +48,11 @@ For more advanced use-cases such as logging or metering on {product-title}, you 
 // If you have high availability (HA) enabled on your cluster, this requires between 0.5 - 1.5 cores and between 200m - 2GB of memory for each replica of the Knative Serving control plane.
 // HA is enabled for some Knative Serving components by default. You can disable HA by following the documentation on xref:../../serverless-config-HA.adoc#serverless-config-HA[Configuring High Availability components].
 
+[IMPORTANT]
+====
+Before upgrading to the latest Serverless release, you must remove the community Knative Eventing operator if you have previously installed it. Having the Knative Eventing operator installed will prevent you from being able to install the latest Technology Preview version of Knative Eventing that is included with {ServerlessProductName} 1.7.0.
+====
+
 include::modules/serverless-install-web-console.adoc[leveloffset=+1]
 
 == Next steps

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -11,6 +11,7 @@ For an overview of {ServerlessProductName} functionality, see xref:../serverless
 include::modules/serverless-getting-support.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-7-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-6-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-5-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-4-0.adoc[leveloffset=+1]
@@ -24,9 +25,3 @@ include::modules/serverless-rn-1-4-0.adoc[leveloffset=+1]
 * For details about the latest Knative Serving Operator release, see the link:https://github.com/knative/serving-operator/releases[Knative Serving Operator releases page].
 * For details about the latest Knative CLI release, see the link:https://github.com/knative/client/releases[Knative client releases page].
 * For details about the latest Knative Eventing release, see the link:https://github.com/knative/eventing/releases[Knative Eventing releases page].
-
-[NOTE]
-====
-Knative Eventing is currently available as a Developer Preview on {product-title}.
-See the upstream link:https://openshift-knative.github.io/docs/docs/index.html[Knative Eventing on {product-title} documentation].
-====


### PR DESCRIPTION
- Applies for OCP 4.3 and 4.4.
- Please do not merge until requested.
