### PR TITLE
BZ1735755/BZ1735759 correcting and adding more detail about user agents

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -2081,13 +2081,13 @@ characters long, to select AES-128, AES-192, or AES-256.
 == Preventing CLI version mismatch with user agent
 
 {product-title} implements a user agent that can be used to prevent an
-application developer's CLI accessing the {product-title} API.
+application developer's CLI from accessing the {product-title} API.
 
 User agents for the {product-title} CLI are constructed from a set of values
 within {product-title}:
 
 ----
-<command>/<version> (<platform>/<architecture>) <client>/<git_commit>
+<command>/<version>+<git_commit> (<platform>/<architecture>) <client>/<git_commit>
 ----
 
 So, for example, when:
@@ -2105,7 +2105,15 @@ by `oc version`)
 the user agent will be:
 
 ----
-oc/v3.3.0 (linux/amd64) openshift/f034127
+oc/v3.3.0+f034127 (linux/amd64) openshift/f034127
+----
+
+You must configure the user agent in the master configuration file,
+*_/etc/origin/master/master-config.yaml_*. To apply the configuration, restart
+the API server:
+
+----
+$ /usr/local/bin/master-restart api
 ----
 
 As an {product-title} administrator, you can prevent clients from accessing the
@@ -2150,6 +2158,24 @@ policyConfig:
       httpVerbs:
       - POST
       - PUT
+----
+====
+
+To deny a client that would otherwise be included in a set of allowed clients,
+use `deniedClients` and `requiredClients` values together. The following example
+allows all 1.X client binaries except for 1.13:
+
+====
+----
+policyConfig:
+  userAgentMatchingConfig:
+    defaultRejectionMessage: "Your client is too old.  Go to https://example.org to update it."
+    deniedClients:
+    - regex: '\w+/v1\.13.0\+\w{7} \(.+/.+\) openshift/\w{7}'
+    - regex: '\w+/v1\.13.0\+\w{7} \(.+/.+\) kubernetes/\w{7}'
+    requiredClients:
+    - regex: '\w+/v1\.[1-9][1-9].[0-9]\+\w{7} \(.+/.+\) openshift/\w{7}'
+    - regex: '\w+/v1\.[1-9][1-9].[0-9]\+\w{7} \(.+/.+\) kubernetes/\w{7}'
 ----
 ====
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1735755
BZ1735755: Updates user agent format for OCP 3.11, adds example of denying a specific binary that is within a subset of allowed binaries.

https://bugzilla.redhat.com/show_bug.cgi?id=1735759
BZ1735759: Adds information about where to configure the user agent and that an API server restart is required.