### PR TITLE
BZ-1697799: Removed ipfailover command example and added link to admi…

### DIFF
--- a/dev_guide/expose_service/expose_internal_ip_service.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_service.adoc
@@ -464,35 +464,10 @@ your service is accessible outside the cluster.
 == Configure IP Failover using VIPs
 //from high_availability.html
 
-Optionally, an administrator can configure IP failover.
+Optionally, an administrator can xref:../../admin_guide/high_availability.adoc#configuring-ip-failover[configure IP failover].
 
 IP failover manages a pool of Virtual IP (VIP) addresses on a set of nodes. Every VIP in the set is serviced by a node selected from the set. As long as a single node is available, the VIPs will be served. There is no way to explicitly distribute the VIPs over the nodes. As such, there may be nodes with no VIPs and other nodes with multiple VIPs. If there is only one node, all VIPs will be on it.
 
-
 The VIPs must be routable from outside the cluster.
-
-To configure IP failover:
-
-. On the master, make sure the `ipfailover` service account has sufficient security privileges:
-+
-----
-$ oc adm policy add-scc-to-user privileged -z ipfailover
-----
-
-. Run the following command to create the IP failover:
-+
-----
-$ oc adm ipfailover --virtual-ips=<exposed_ip_address> --watch-port=<exposed_port> --replicas=<number_of_pods> --create
-----
-+
-For example:
-+
-----
-$ oc adm ipfailover --virtual-ips="172.30.233.169" --watch-port=32315 --replicas=4 --create
---> Creating IP failover ipfailover ...
-    serviceaccount "ipfailover" created
-    deploymentconfig "ipfailover" created
---> Success
-----
 
 // end::expose-svc-ip-fail[]


### PR DESCRIPTION
…n guide for ipfailover details

BZ-1697799 https://bugzilla.redhat.com/show_bug.cgi?id=1697799

@openshift/team-documentation PTAL. Add labels and milestone. Merge to enterprise-3.11.

Please let me know if I added the xref correctly. Thank you!