### PR TITLE
Updates for OCS 4.2 

### DIFF
--- a/modules/dynamic-provisioning-ocs-object-definition.adoc
+++ b/modules/dynamic-provisioning-ocs-object-definition.adoc
@@ -1,0 +1,11 @@
+// Module included in the following definitions:
+//
+// * storage/dynamic-provisioning.adoc
+
+[id="ocs-object-definition_{context}"]
+= Red Hat OpenShift Container Storage object definition
+
+When using Red Hat OpenShift Container Storage, the storage classes for dynamic
+volume provisioning are created when Red Hat OpenShift Container Storage 4.2 is
+deployed from the Operator Hub as described in
+link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html-single/deploying_openshift_container_storage/index#verify_that_the_storage_classes_are_created_and_listed[Verify that the storage classes are created and listed].

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -145,7 +145,10 @@ the Pods that use these volumes are deleted.
 |iSCSI  | ✅ | ✅ |  -
 |Local volume | ✅ | - |  -
 |NFS  | ✅ | ✅ | ✅
-|Red Hat OpenShift Container Storage | ✅ | - | ✅
+|Red Hat OpenShift Container Storage
+
+See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.2/html-single/managing_openshift_container_storage/index#available-plug-ins_rhocs[Available dynamic provisioning plug-ins] for more information.
+| `ceph-rbd` | - | `ceph-fs`
 |VMware vSphere | ✅ | - |  -
 |===
 

--- a/storage/dynamic-provisioning.adoc
+++ b/storage/dynamic-provisioning.adoc
@@ -32,5 +32,7 @@ include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-vsphere-definition.adoc[leveloffset=+2]
 
+include::modules/dynamic-provisioning-ocs-object-definition.adoc[leveloffset=+2]
+
 
 include::modules/dynamic-provisioning-change-default-class.adoc[leveloffset=+1]


### PR DESCRIPTION
Updates for OCS 4.2 in "Table 2. Supported access modes for PVs", and addition of section "Red Hat OpenShift Container Storage object definition"