### PR TITLE
Bug 1813277, added clarification about 3.11 maximum

### DIFF
--- a/scaling_performance/cluster_maximums.adoc
+++ b/scaling_performance/cluster_maximums.adoc
@@ -39,7 +39,7 @@ It does not necessarily mean that the cluster will fail.
 | 150,000
 | 150,000
 
-| Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per node]
+| Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per node] footnoteref:[podspernode, The actual limit is the lower of the limits imposed by `max-pods` and `pods-per-core` multiplied by the number of cores.]
 | 250
 | 250
 | 250


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1813277

Preview builds of footnote and footnote placement:
http://file.rdu.redhat.com/~ahardin/April-7-2020/3-11-tested-maximums-note/scaling_performance/cluster_maximums.html#_footnotedef_2

http://file.rdu.redhat.com/~ahardin/April-7-2020/3-11-tested-maximums-note/scaling_performance/cluster_maximums.html#scaling-performance-current-cluster-maximums

@RobertKrawitz PTAL

