### PR TITLE
Remove dash for CSI features in TP Tracker

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -662,13 +662,13 @@ indicate that the feature is removed from the release or deprecated.
 |
 
 |CSI volume snapshots
-|-
-|-
+|
+|
 |TP
 
 |CSI volume cloning
-|-
-|-
+|
+|
 |TP
 
 |====


### PR DESCRIPTION
Removing dashes in TP tracker table for CSI snapshots/cloning because, as explained above the table, "features marked as *-* indicate that the feature is removed from the release or deprecated" (which is not the case for CSI snapshots and CSI cloning).