### PR TITLE
BZ1739420 - Clarify selector-label volume binding

### DIFF
--- a/install_config/persistent_storage/selector_label_binding.adoc
+++ b/install_config/persistent_storage/selector_label_binding.adoc
@@ -21,14 +21,14 @@ storage] by identifiers defined by a cluster administrator.
 [[selector-label-volume-motivation]]
 == Motivation
 In cases of statically provisioned storage, developers seeking persistent
-storage are required to know a handful identifying attributes of a PV in order
+storage are required to know a handful of identifying attributes of a PV in order
 to deploy and bind a PVC. This creates several problematic situations. Regular
 users might have to contact a cluster administrator to either deploy the PVC or
 provide the PV values. PV attributes alone do not convey the intended use of the
 storage volumes, nor do they provide methods by which volumes can be grouped.
 
 Selector and label attributes can be used to abstract away PV details from the
-user while providing cluster administrators a way of identifying volumes by a
+user while providing cluster administrators with a way of identifying volumes by a
 descriptive and customizable tag. Through the selector-label method of binding,
 users are only required to know which labels are defined by the administrator.
 
@@ -53,7 +53,7 @@ xref:./index.adoc#install-config-persistent-storage-index[storage provider]
 [[selector-label-volume-define]]
 === Define the Persistent Volume and Claim
 
-. As the *cluser-admin* user, define the PV. For this example, we will
+. As the *cluster-admin* user, define the PV. For this example, we will
 be using a
 xref:./persistent_storage_glusterfs.adoc#install-config-persistent-storage-persistent-storage-glusterfs[GlusterFS]
 volume.
@@ -109,6 +109,69 @@ spec:
 <1> Begin *selectors* section.
 <2> List all labels by which the user is requesting storage. Must match _all_
 labels of targeted PV.
+====
+
+[[selector-label-volume-bind]]
+=== Optional: Bind a PVC to a specific PV
+
+A PVC that does not specify a PV name or selector will match any PV.
+
+To bind a PVC to a specific PV as a cluster administrator:
+
+* Use `pvc.spec.volumeName` if you know the PV name.
+* Use `pvc.spec.selector` if you know the PV labels.
++
+By specifying a selector, the PVC requires the PV to have specific labels.
+
+
+[[selector-label-volume-reserve]]
+=== Optional: Reserve a PV to a specific PVC or namespace
+
+To reserve a PV for specific tasks, you have two options: create a specific storage class, or pre-bind the PV to your PVC.
+
+. Request a specific storage class for the PV by specifying the storage class’s name.
++
+The following resource shows the required values that you use to configure a StorageClass. This example uses the AWS ElasticBlockStore (EBS) object definition.
+
++
+.StorageClass definition for EBS
+====
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kafka
+provisioner: kubernetes.io/aws-ebs
+...
+----
+====
++
+[IMPORTANT]
+====
+If necessary in a multi-tenant environment, use a quota definition to reserve the storage class and PV(s) only to a specific namespace.
+====
+
+. Pre-bind the PV to your PVC using the PVC namespace and name. A PV defined as such will bind only to the specified PVC and to nothing else, as shown in the following example:
++
+.claimRef in PV definition
+====
+----
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mktg-ops--kafka--kafka-broker01
+spec:
+  capacity:
+    storage: 15Gi
+  accessModes:
+    - ReadWriteOnce
+  claimRef:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: kafka-broker01
+      namespace: default
+...
+----
 ====
 
 [[selector-label-volume-deploy]]

--- a/install_config/persistent_storage/selector_label_binding.adoc
+++ b/install_config/persistent_storage/selector_label_binding.adoc
@@ -125,7 +125,7 @@ By specifying a selector, the PVC requires the PV to have specific labels.
 
 
 [[selector-label-volume-reserve]]
-=== Optional: Reserve a PV to a specific PVC or namespace
+=== Optional: Reserve a PV to a specific PVC
 
 To reserve a PV for specific tasks, you have two options: create a specific storage class, or pre-bind the PV to your PVC.
 


### PR DESCRIPTION
[BZ1739420](https://bugzilla.redhat.com/show_bug.cgi?id=1739420)
Doc bug asks to include optional steps for how to reserve a PV for specific tasks, as described in [BZ1717746](https://bugzilla.redhat.com/show_bug.cgi?id=1717746).
Applies to `enterprise-3.11` only.