### PR TITLE
Fixed typo related to API port referenced in oc login

### DIFF
--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -81,7 +81,7 @@ Follow this procedure to deploy the {ProductName} control plane the command line
 . Log in to the {product-title} CLI as a user with the `cluster-admin` role.
 +
 ----
-$ oc login https://{HOSTNAME}:8443
+$ oc login https://{HOSTNAME}:6443
 ----
 
 . Create a project named `istio-system`.


### PR DESCRIPTION
This PR applies to version 4.2 and later.