### PR TITLE
Add dataSource field to CSI cloning example

### DIFF
--- a/modules/persistent-storage-csi-cloning-provisioning.adoc
+++ b/modules/persistent-storage-csi-cloning-provisioning.adoc
@@ -38,6 +38,9 @@ spec:
   resources:
     requests:
       storage: 5Gi
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: pvc-1
 ----
 +
 <1> Name of the storage class that provisions the storage back end. Default storage class can be used and `storageClassName` can be omitted in the spec.


### PR DESCRIPTION
As commented in [PR 19861](https://github.com/openshift/openshift-docs/pull/19861/files#r405519963), the cloning sample is missing `dataSource` field. This PR adds that, as described upstream here:  https://kubernetes.io/docs/concepts/storage/volume-pvc-datasource/#provisioning

For `master` and `enterprise-4.4` only.

@liangxia or @qinpingli PTAL to verify this works. Thanks.