### PR TITLE
Revert dash additions added in 4.3 RNs

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -1363,8 +1363,8 @@ indicate that the feature is removed from the release or deprecated.
 |GA
 
 |Raw Block with Cinder
-|-
-|-
+|
+|
 |TP
 
 |OperatorHub
@@ -1373,33 +1373,33 @@ indicate that the feature is removed from the release or deprecated.
 |GA
 
 |Three-node bare metal deployments
-|-
+|
 |TP
 |TP
 
 |SR-IOV Network Operator
-|-
+|
 |TP
 |GA
 
 |Helm CLI
-|-
-|-
+|
+|
 |TP
 
 |Service Binding
-|-
-|-
+|
+|
 |TP
 
 |Log forwarding
-|-
-|-
+|
+|
 |TP
 
 |User workload monitoring
-|-
-|-
+|
+|
 |TP
 
 |OpenShift Serverless
@@ -1408,8 +1408,8 @@ indicate that the feature is removed from the release or deprecated.
 |TP
 
 |Compute Node Topology Manager
-|-
-|-
+|
+|
 |TP
 
 |====


### PR DESCRIPTION
The dashes were added for several features in the 4.3 TP table for consistency purposes (#19093), to show when a feature was not in TP or GA. After a discussion in #20996, several should be removed since the dash (`-`) is strictly used for deprecated/removed features.