### PR TITLE
[enterprise-4.4] Add --from to catalog build cmds

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -52,18 +52,20 @@ link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
-    --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<2>
-    [-a <path_to_registry_credentials>] \//<3>
-    [--insecure] <4>
+    --from=quay.io/openshift/origin-operator-registry:4.4 \//<2>
+    --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<3>
+    [-a <path_to_registry_credentials>] \//<4>
+    [--insecure] <5>
 
 INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
 ...
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v1
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Name your catalog image and include a tag, for example, `v1`.
-<3> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
-<4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<2> Set `--from` to the `quay.io/openshift/origin-operator-registry:<tag>` base image where `<tag>` matches the target {product-title} cluster major and minor version.
+<3> Name your catalog image and include a tag, for example, `v1`.
+<4> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
+<5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 +
 Sometimes invalid manifests are accidentally introduced into Red Hat's catalogs;
 when this happens, you might see some errors:

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -42,18 +42,20 @@ link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
-    --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<2>
-    [-a <path_to_registry_credentials>] \//<3>
-    [--insecure] <4>
+    --from=quay.io/openshift/origin-operator-registry:4.4 \//<2>
+    --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<3>
+    [-a <path_to_registry_credentials>] \//<4>
+    [--insecure] <5>
 
 INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
 ...
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v2
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Name your catalog image and include a tag, for example, `v2` because it is the updated catalog.
-<3> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
-<4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<2> Set `--from` to the `quay.io/openshift/origin-operator-registry:<tag>` base image where `<tag>` matches the target {product-title} cluster major and minor version.
+<3> Name your catalog image and include a tag, for example, `v2` because it is the updated catalog.
+<4> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
+<5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 
 . Mirror the contents of your catalog to your target registry. The following
 `oc adm catalog mirror` command extracts the contents of your custom Operator


### PR DESCRIPTION
Cherrypick to enterprise-4.4 from https://github.com/openshift/openshift-docs/pull/21025: Bump tag version to 4.4