### PR TITLE
[enterprise-4.4] Use downstream base image for catalog build

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -45,6 +45,13 @@ target mirror registry:
 ----
 $ podman login <registry_host_name>
 ----
++
+Also authenticate with `registry.redhat.io` so that the base image can be pulled
+during the build:
++
+----
+$ podman login registry.redhat.io
+----
 
 . Build a catalog image based on the `redhat-operators` catalog from
 link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
@@ -52,7 +59,7 @@ link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
-    --from=quay.io/openshift/origin-operator-registry:4.4 \//<2>
+    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.4 \//<2>
     --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<3>
     [-a <path_to_registry_credentials>] \//<4>
     [--insecure] <5>
@@ -62,7 +69,7 @@ INFO[0013] loading Bundles                               dir=/var/folders/st/9cs
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v1
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Set `--from` to the `quay.io/openshift/origin-operator-registry:<tag>` base image where `<tag>` matches the target {product-title} cluster major and minor version.
+<2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
 <3> Name your catalog image and include a tag, for example, `v1`.
 <4> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
 <5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -35,6 +35,13 @@ target mirror registry:
 ----
 $ podman login <registry_host_name>
 ----
++
+Also authenticate with `registry.redhat.io` so that the base image can be pulled
+during the build:
++
+----
+$ podman login registry.redhat.io
+----
 
 . Build a new catalog image based on the `redhat-operators` catalog from
 link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
@@ -42,7 +49,7 @@ link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
-    --from=quay.io/openshift/origin-operator-registry:4.4 \//<2>
+    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.4 \//<2>
     --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<3>
     [-a <path_to_registry_credentials>] \//<4>
     [--insecure] <5>
@@ -52,7 +59,7 @@ INFO[0013] loading Bundles                               dir=/var/folders/st/9cs
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v2
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Set `--from` to the `quay.io/openshift/origin-operator-registry:<tag>` base image where `<tag>` matches the target {product-title} cluster major and minor version.
+<2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
 <3> Name your catalog image and include a tag, for example, `v2` because it is the updated catalog.
 <4> Optional: If required, specify the location of your registry credentials file for `podman` or `docker`.
 <5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.


### PR DESCRIPTION
Cherry-pick to enterprise-4.4 from https://github.com/openshift/openshift-docs/pull/21032: Bump tag version to v4.4