### PR TITLE
Publish OpenShift Jaeger Docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1393,29 +1393,29 @@ Topics:
   - Name: Using the 3scale Istio adapter
     File: threescale-adapter
 
-#---
-#Name: Jaeger
-#Dir: jaeger
-#Distros: openshift-enterprise
-#Topics:
+---
+Name: Jaeger
+Dir: jaeger
+Distros: openshift-enterprise
+Topics:
 #- Name: Jaeger Release Notes
 #  File: rhbjaeger-release-notes
-#- Name: Jaeger Architecture
-#  Dir: jaeger_arch
-#  Topics:
-#  - Name: Jaeger architecture
-#    File: rhbjaeger-architecture
-#- Name: Jaeger Installation
-#  Dir: jaeger_install
-#  Topics:
-#  - Name: Installing Jaeger
-#    File: rhbjaeger-installation
+- Name: Jaeger Architecture
+  Dir: jaeger_arch
+  Topics:
+  - Name: Jaeger architecture
+    File: rhbjaeger-architecture
+- Name: Jaeger Installation
+  Dir: jaeger_install
+  Topics:
+  - Name: Installing Jaeger
+    File: rhbjaeger-installation
 #  - Name: Deploying Jaeger
 #    File: rhbjaeger-deploying
-#  - Name: Upgrading Jaeger
-#    File: rhbjaeger-updating
-#  - Name: Removing Jaeger
-#    File: rhbjaeger-removing
+  - Name: Upgrading Jaeger
+    File: rhbjaeger-updating
+  - Name: Removing Jaeger
+    File: rhbjaeger-removing
 
 ---
 Name: Container-native virtualization


### PR DESCRIPTION
Un-commenting the Topic Map to publish the OpenShift Jaeger (stand-alone) documentation.

I'm going to modularlize the Release Notes and split Jaeger out from Service Mesh after we publish so that I can publish the Jaeger Release Notes separately.

I will publish Deploying when https://github.com/openshift/openshift-docs/pull/20643 is merged.

