### PR TITLE
Add OCP 4.2 scale run environment details

### DIFF
--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+
+[id="cluster-maximums-environment_{context}"]
+= {product-title} environment and configuration on which the cluster maximums are tested
+
+Google Cloud Platform:
+
+[options="header",cols="8*"]
+|===
+| Node |Flavor |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOPS |Count |Region
+
+| Master/Etcd
+| n1-highmem-16
+| 16
+| 104
+| Regional/Zonal SSD 
+| 220
+| 3
+| us-east4
+
+| Infra footnoteref:[infranodesgcp,Infra nodes are used to host Monitoring, Ingress and Registry components to make sure they have enough resources to run at large scale.]
+| n1-standard-64
+| 64
+| 240
+| Regional/Zonal SSD 
+| 100 
+| 3
+| us-east4
+
+| Workload footnoteref:[workloadnodegcp, Workload node is dedicated to run performance and scalability workload generators.]
+| n1-standard-16 
+| 16
+| 60
+| Regional/Zonal SSD
+| 500 footnoteref:[disksizegcp, Larger disk size is used to have enough space to store large amounts of data collected during the performance and scalability test run.]
+| 1
+| us-east4
+
+| Worker
+| n1-standard-8 
+| 8
+| 30
+| Regional/Zonal SSD
+| 100
+| 3/25/250 footnoteref:[nodescalegcp, Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
+| us-east4
+
+|===
+
+
+AWS cloud platform:
+
+[options="header",cols="8*"]
+|===
+| Node |Flavor |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOPS |Count |Region
+
+| Master/Etcd footnoteref:[masteretcdnodeaws, io1 disk with 3000 IOPS is used for master/etcd nodes as etcd is I/O intensive and latency sensitive.]
+| r5.4xlarge
+| 16
+| 128
+| io1 
+| 220 / 3000
+| 3
+| us-west-2
+
+| Infra footnoteref:[infranodesaws,Infra nodes are used to host Monitoring, Ingress and Registry components to make sure they have enough resources to run at large scale.]
+| m5.12xlarge
+| 48
+| 192
+| gp2 
+| 100 
+| 3
+| us-west-2
+
+| Workload footnoteref:[workloadnodeaws, Workload node is dedicated to run performance and scalability workload generators.]
+| m5.4xlarge
+| 16
+| 64
+| gp2 
+| 500 footnoteref:[disksizeaws, Larger disk size is used to have enough space to store large amounts of data collected during the performance and scalability test run.]
+| 1
+| us-west-2
+
+| Worker
+| m5.large 
+| 2
+| 8
+| gp2 
+| 100 
+| 2000
+| us-west-2
+
+|===

--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -17,6 +17,8 @@ does not necessarily mean that the cluster will fail.
 
 include::modules/openshift-cluster-maximums.adoc[leveloffset=+1]
 
+include::modules/openshift-cluster-maximums-environment.adoc[leveloffset=+1]
+
 include::modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc[leveloffset=+1]
 
 include::modules/how-to-plan-your-environment-according-to-application-requirements.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit:
- Adds details about the environment including cloud platform used
  for running the performance and scale tests on OCP 4.2 as well as
  info about the cluster configuration like instance types, CPU,
  memory, disk, node count e.t.c.
- Adds info on why we went with particular configuration as well as
  pointers to the docs wherever required.

Fixes #20868