### PR TITLE
BZ1688089 - Standalone Heketi not supported in 3.11

### DIFF
--- a/install_config/persistent_storage/topics/glusterfs_overview_external.adoc
+++ b/install_config/persistent_storage/topics/glusterfs_overview_external.adoc
@@ -1,6 +1,5 @@
 With {gluster-external}, {gluster} runs on its own dedicated nodes and is
 managed by an instance of link:https://github.com/heketi/heketi[heketi], the
-GlusterFS volume management REST service. This heketi service can run either
-standalone or containerized. Containerization allows for an easy mechanism to
-provide high-availability to the service. This documentation will focus on the
-configuration where heketi is containerized.
+GlusterFS volume management REST service. This heketi service must run as
+containerized, and not as standalone. Containerization allows for an easy mechanism to
+provide high-availability to the service. This documentation focuses on the containerized heketi configuration.


### PR DESCRIPTION
[BZ 1688089](https://bugzilla.redhat.com/show_bug.cgi?id=1688089) - Removing statement that standalone Heketi config is supported. OCP 3.11 only supports containerized Heketi config.

Because we are changing existing documented functionality, I need acks from the following before merging:
@jsafrane, @gnufied,  or @jarrpa 
@sferich888 
@reestr 
@xltian 

