### PR TITLE
Add OCP 3.11 scale run environment details

### DIFF
--- a/scaling_performance/cluster_maximums.adoc
+++ b/scaling_performance/cluster_maximums.adoc
@@ -102,6 +102,66 @@ application requirements.]
 
 |===
 
+[[scaling-performance-tested-maximums-environment]]
+== Environment and configuration on which {product-title} cluster maximums are tested
+
+Infrastructure as a service provider: OpenStack
+
+[options="header",cols="6*"]
+|===
+|Node |vCPU |RAM(MiB) |Disk size(GiB) |pass-through disk |Count
+
+| Master/Etcd footnoteref:[masteretcdnvme, The master/etcd nodes are backed by NVMe disks as etcd is I/O intensive and latency sensitive.]
+| 16
+| 124672
+| 128
+| Yes, NVMe
+| 3
+
+| Infra footnoteref:[infranodes, Infra nodes host the Router, Registry, Logging and Monitoring and are backed by NVMe disks.]
+| 40
+| 163584
+| 256
+| Yes, NVMe
+| 3
+
+| Cluster DNS
+| 1
+| 1740
+| 71
+| No
+| 1
+
+| Load Balancer
+| 4
+| 16128
+| 96
+| No
+| 1
+
+| Container Native Storage footnoteref:[cns, Container Native Storage or Ceph storage nodes are backed by NVMe disks.]
+| 16
+| 65280
+| 200
+| Yes, NVMe
+| 3
+
+| Bastion footnoteref:[bastionnode, The Bastion node is part of the OCP network and is used to orchestrate the performance and scale tests.]
+| 16
+| 65280
+| 200
+| No
+| 1
+
+| Worker
+| 2
+| 7936
+| 96
+| No
+| 2000
+
+|===
+
 [[scaling-performance-planning-your-environment-according-to-cluster-maximums]]
 == Planning Your Environment According to Cluster Maximums
 


### PR DESCRIPTION
This commit:
- Adds details about the environment including cloud platform used
  for running the performance and scale tests on OCP 3.11 as well as
  info about the cluster configuration like instance types, CPU,
  memory, disk, node count e.t.c.
- Adds info on why we went with particular configuration as well as
  pointers to the docs wherever required.

Fixes #20868