### PR TITLE
updating whitelist for quay.io changes

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -77,9 +77,6 @@ Before you install {product-title}, you must configure your firewall to grant ac
 |`mirror.openshift.com`
 |Required to access mirrored installation content and images
 
-|`*.cloudfront.net`
-|Required by the Quay CDN to deliver the Quay.io images that the cluster requires
-
 |`*.apps.<cluster_name>.<base_domain>`
 |Required to access the default cluster routes unless you set an ingress wildcard during installation
 


### PR DESCRIPTION
**Should go live on 4/25**

Per @cuppett, `*.cloudfront.net` will not need a separate entry based on a change that quay.io is rolling out on 4/25.