### PR TITLE
maximum number of pods per node when pods require PVCs

### DIFF
--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -25,7 +25,7 @@
 | 250
 | 250
 | 250
-| 500 footnoteref:[podspernode, This was tested on a cluster with 100 worker nodes with 500 pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `hostPrefix` of `22` in the `install-config.yaml` file and `maxPods` set to `500` using a custom KubeletConfig.]
+| 500 footnoteref:[podspernode, This was tested on a cluster with 100 worker nodes with 500 pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `hostPrefix` of `22` in the `install-config.yaml` file and `maxPods` set to `500` using a custom KubeletConfig. The maximum number of pods with attached Persistant Volume Claims (PVC) depends on storage backend from where PVC are allocated. In our tests, only OpenShift Container Storage v4 (OCS v4) was able to satisfy the number of pods per node discussed in this document.]
 
 | Number of pods per core
 | There is no default value.


### PR DESCRIPTION
- if pods require PVC to be attached to them then pods per node maximum value will
be limited by storage backend from Persistant Volume Claims are created.
