### PR TITLE
CephFS and Manila provisioners were removed for 4.x

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -538,10 +538,10 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
-|CephFS
-|TP
-|TP
-|
+|CephFS Provisioner
+|-
+|-
+|-
 
 |Podman
 |TP
@@ -559,9 +559,9 @@ In the table below, features are marked with the following statuses:
 |
 
 |Manila Provisioner
-|TP
-|TP
-|
+|-
+|-
+|-
 
 |Cluster Administrator console
 |GA


### PR DESCRIPTION
This was manually cherry-picked to 4.1-4.3 RNs too:
#21109 (4.1)
#21110 (4.2)
#21111 (4.3)