### PR TITLE
Adding an SCC when enabling unsafe sysctls

### DIFF
--- a/admin_guide/sysctls.adoc
+++ b/admin_guide/sysctls.adoc
@@ -114,7 +114,7 @@ The cluster administrator can allow certain unsafe sysctls for very special
 situations such as high-performance or real-time application tuning.
 
 If you want to use unsafe sysctls, cluster administrators must enable them
-individually on nodes. They can enable only namespaced sysctls.
+individually on nodes. They can enable only namespaced sysctls. As well, the `ServiceAccount` used to modify the node must be mapped to an SCC that lists the required sysctl parameter in the `allowedUnsafeSysctl` list. 
 
 [WARNING]
 ====
@@ -123,71 +123,34 @@ at-your-own-risk and can lead to severe problems like wrong behavior of
 containers, resource shortage, or complete breakage of a node.
 ====
 
-. Add the unsafe sysctls to the `kubeletArguments` parameter of the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] file, as described in xref:../admin_guide/manage_nodes.adoc#configuring-node-resources[Configuring Node Resources]:
-+
-For example:
-+
-----
-$ oc edit cm node-config-compute -n openshift-node
-
-....
-    kubeletArguments:
-      allowed-unsafe-sysctls: <1>
-      - "net.ipv4.tcp_keepalive_time"
-      - "net.ipv4.tcp_keepalive_intvl"
-      - "net.ipv4.tcp_keepalive_probes"
-----
-<1> Add the unsafe sysctls you want to use.
-
-. Create a new SCC that uses the contents of the *restricted* SCC and add the unsafe sysctls:
+. Use the `*kubeletArguments*` field in the *_/etc/origin/node/node-config.yaml_*
+file, as described in
+xref:../admin_guide/manage_nodes.adoc#configuring-node-resources[Configuring Node Resources], to set the desired unsafe sysctls:
 +
 ----
-....
-allowHostDirVolumePlugin: false
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: false
-allowHostPorts: false
-allowPrivilegeEscalation: true
-allowPrivilegedContainer: false
-allowedCapabilities: null
-allowedUnsafeSysctls: <1>
-- net.ipv4.tcp_keepalive_time
-- net.ipv4.tcp_keepalive_intvl
-- net.ipv4.tcp_keepalive_probes
-....
-metadata:
-  name: restricted-sysctls <2>
-....
----- 
-<1> Add the unsafe sysctls you want to use.
-<2> Specify a new name for the SCC.
+kubeletArguments:
+  allowed-unsafe-sysctls:
+    - "kernel.msg*,net.ipv4.route.min_pmtu"
+----
 
-. Grant the new SCC access to your pod ServiceAccount:
+. Add the required sysctl parameter to the `allowedUnsafeSysctls` list in a security context constraint (SCC) object. It is recommened to use a new SCC object:
++
+[source,yaml]
+----
+[...]
+allowedUnsafeSysctls:
+  - "kernel.msg*"
+  - "net.ipv4.route.min_pmtu"
+[...]
+----
+
+. Add the SCC to the `ServiceAccount` that is used for the `DeploymentConfig`:
 +
 ----
-$ oc adm policy add-scc-to-user restricted-sysctls -z default -n your_project_name
-----
-
-. Add the unsafe sysctls to the DeploymentConfig for your pods.
-+
-----
-kind: DeploymentConfig
-
-....
-  template:
-    ....
-    spec:
-      containers:
-      ....
-      securityContext:
-        sysctls:
-        - name: net.ipv4.tcp_keepalive_time
-          value: "300"
-        - name: net.ipv4.tcp_keepalive_intvl
-          value: "20"
-        - name: net.ipv4.tcp_keepalive_probes
-          value: "3"
+$ oc create -f restriced-sysctl.yaml
+$ oc create serviceaccount sysctls
+$ oc adm policy add-scc-to-user restricted-sysctls -z sysctls
+$ oc patch dc/nginx-example --patch '{"spec":{"template":{"spec":{"serviceAccountName": "sysctls"}}}}'
 ----
 
 . Restart the node service to apply the changes:


### PR DESCRIPTION
Updating this PR to go against the 3.11 branch. Original PR here - https://github.com/openshift/openshift-docs/pull/20914