### PR TITLE
BZ1704090 - Add registry encryption variables for configuring S3

### DIFF
--- a/install_config/topics/configuring_for_aws_registry-proc.adoc
+++ b/install_config/topics/configuring_for_aws_registry-proc.adoc
@@ -76,16 +76,19 @@ openshift_hosted_registry_storage_s3_bucket=openshift-registry-storage <3>
 openshift_hosted_registry_storage_s3_region=us-east-1 <4>
 openshift_hosted_registry_storage_s3_chunksize=26214400
 openshift_hosted_registry_storage_s3_rootdirectory=/registry
+openshift_hosted_registry_storage_s3_encrypt=false
+openshift_hosted_registry_storage_s3_kmskeyid=aws_kms_key_id <5>
 openshift_hosted_registry_pullthrough=true
 openshift_hosted_registry_acceptschema2=true
 openshift_hosted_registry_enforcequota=true
 openshift_hosted_registry_replicas=3
+
 ----
 <1> The access key for the IAM user. (Not required with IAM Roles in place)
 <2> The secret key for the IAM user. (Not required with IAM Roles in place)
 <3> The S3 storage bucket name.
 <4> The region in which the bucket exists.
-
+<5> The AWS Key Management Service (AWS KMS) key ID of the encryption key used to encrypt data in the cluster.
 
 === Manually configuring {product-title} registry to use S3
 


### PR DESCRIPTION
[BZ 1704090](https://bugzilla.redhat.com/show_bug.cgi?id=1704090) - adds the four encryption variables to set initial registry to encryption configuration, as  noted in the BZ.
@wzheng1 PTAL