### PR TITLE
BZ1649167 - Add gluster-block in Storage

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -166,7 +166,8 @@ ifdef::openshift-enterprise,openshift-origin[]
 
 - xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[NFS]
 - HostPath
-- xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#install-config-persistent-storage-persistent-storage-glusterfs[GlusterFS]
+- xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#overview-volumes[GlusterFS]
+- xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#overview-block-volumes[gluster-block]
 - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/html/operations_guide/chap-documentation-red_hat_gluster_storage_container_native_with_openshift_platform-openshift_creating_persistent_volumes#File_Storage[OpenShift Container Storage (OCS) File]
 - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/html/operations_guide/block_storage[OpenShift Container Storage (OCS) Block]
 - xref:../../install_config/persistent_storage/persistent_storage_ceph_rbd.adoc#install-config-persistent-storage-persistent-storage-ceph-rbd[Ceph
@@ -288,6 +289,7 @@ The following table lists the access modes supported by different PVs:
 |Fibre Channel  | ✅ | ✅ |  -
 |GCE Persistent Disk  | ✅ | - |  -
 |GlusterFS  | ✅ | ✅ | ✅
+|gluster-block  | ✅ | - | - 
 |HostPath  | ✅ | - |  -
 |iSCSI  | ✅ | ✅ |  -
 |NFS  | ✅ | ✅ | ✅


### PR DESCRIPTION
[BZ 1649167](https://bugzilla.redhat.com/show_bug.cgi?id=1649167) - Added `gluster-block` to "Types of PVs" storage list, and added as RWO in access modes table.
@nekop @jsafrane @liangxia PTAL and confirm if this looks correct to you. Thanks.