### PR TITLE
Splitting out Jaeger release notes for reuse.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1418,8 +1418,8 @@ Name: Jaeger
 Dir: jaeger
 Distros: openshift-enterprise
 Topics:
-#- Name: Jaeger Release Notes
-#  File: rhbjaeger-release-notes
+- Name: Jaeger Release Notes
+  File: rhbjaeger-release-notes
 - Name: Jaeger Architecture
   Dir: jaeger_arch
   Topics:

--- a/modules/jaeger-document-attributes.adoc
+++ b/modules/jaeger-document-attributes.adoc
@@ -20,7 +20,7 @@
 // Note that the DocInfoProductName generates the URL for the product page.
 // Changing the value changes the generated URL.
 //
-:DocInfoProductName: Red Hat Build of Jaeger
+:DocInfoProductName: Red Hat OpenShift Jaeger
 :DocInfoProductNumber: 1.17.1
 //
 // Book Names:
@@ -30,7 +30,6 @@
 //     Using the pattern ending in 'BookName' makes it easy to grep for occurrences
 //     throughout the topics
 //
-:RN_BookName: Red Hat  Build of Jaeger Release Notes
-:Install_BookName: Installing the Red Hat Build of Jaeger
-:Using_BookName: Using the Red Hat  Build of Jaeger
-:Using_BookName: Using the Red Hat  Build of Jaeger
+:RN_BookName: Red Hat OpenShift Jaeger Release Notes
+:Install_BookName: Installing Red Hat OpenShift Jaeger
+:Using_BookName: Using Red Hat OpenShift Jaeger

--- a/modules/jaeger-product-overview.adoc
+++ b/modules/jaeger-product-overview.adoc
@@ -18,4 +18,4 @@ Using Jaeger lets you perform the following functions:
 
 * Perform root cause analysis
 
-Jaeger is based on the vendor-neutral OpenTracing APIs and instrumentation.
+Jaeger is based on the vendor-neutral link:https://opentracing.io/[OpenTracing] APIs and instrumentation.

--- a/modules/jaeger-rn-fixed-issues.adoc
+++ b/modules/jaeger-rn-fixed-issues.adoc
@@ -1,0 +1,22 @@
+////
+Module included in the following assemblies:
+- jaeger-release-notes.adoc
+////
+
+[id="jaeger-rn-fixed-issues_{context}"]
+= Jaeger Fixed issues
+////
+Provide the following info for each issue if possible:
+Consequence - What user action or situation would make this problem appear  (If you have the foo option enabled and did x)? What did the customer experience as a result of the issue? What was the symptom?
+Cause - Why did this happen?
+Fix - What did we change to fix the problem?
+Result - How has the behavior changed as a result?  Try to avoid “It is fixed” or “The issue is resolved” or “The error no longer presents”.
+////
+
+BZ# https://bugzilla.redhat.com/show_bug.cgi?id=000001[000001]
+
+There was a werewolf in the last release.  You would have only encountered this werewolf if it was a full moon and you were outside.  The werewolf has been shot with a silver bullet and no longer exists.
+
+BZ# https://bugzilla.redhat.com/show_bug.cgi?id=000005[000005]
+
+There was an unrecognized vampire in the last release.  As a result, the vampire bit a lot of people and sired multiple vampires.  But after the liberal application of sunlight, garlic, and holy water, all vampires have been removed from the current release and you no longer need to wear turtlenecks when going outside.

--- a/modules/jaeger-rn-known-issues.adoc
+++ b/modules/jaeger-rn-known-issues.adoc
@@ -1,10 +1,11 @@
 ////
 Module included in the following assemblies:
+- servicemesh-release-notes.adoc
 - rhbjaeger-release-notes.adoc
 ////
 
 [id="jaeger-rn-known-issues_{context}"]
-= Known issues
+= Jaeger known issues
 
 ////
 Consequence - What user action or situation would make this problem appear (Selecting the Foo option with the Bar version 1.3 plugin enabled results in an error message)?  What did the customer experience as a result of the issue? What was the symptom?
@@ -13,7 +14,12 @@ Workaround (If there is one)- What can you do to avoid or negate the effects of 
 Result - If the workaround does not completely address the problem.
 ////
 
+These limitations exist in Jaeger:
 
-These known issues exist in {ProductName}:
+* While Kafka publisher is included as part of Jaeger, it is not supported.
+* Apache Spark is not supported.
+* Only self-provisioned Elasticsearch instances are supported.  External Elasticsearch instances are not supported in this release.
 
-https://issues.redhat.com/browse/TRACING-809[TRACING-809] Jaeger Ingester is incompatible with Kafka 2.3. When there are two or more instances of the Jaeger Ingester and enough traffic it will continuously generate rebalancing messages in the logs.  This is due to a regression in Kafka 2.3 that was fixed in Kafka 2.3.1.  For more information, see https://github.com/jaegertracing/jaeger/issues/1819[Jaegertracing-1819].
+These are the known issues in Jaeger:
+
+* link:https://issues.redhat.com/browse/TRACING-809[TRACING-809] Jaeger Ingester is incompatible with Kafka 2.3. When there are two or more instances of the Jaeger Ingester and enough traffic it will continuously generate rebalancing messages in the logs.  This is due to a regression in Kafka 2.3 that was fixed in Kafka 2.3.1.  For more information, see https://github.com/jaegertracing/jaeger/issues/1819[Jaegertracing-1819].

--- a/modules/jaeger-rn-new-features.adoc
+++ b/modules/jaeger-rn-new-features.adoc
@@ -4,7 +4,7 @@ Module included in the following assemblies:
 ////
 
 [id="jaeger-rn-new-features_{context}"]
-== New features {ProductName} 1.16
+= New features {ProductName} 1.16
 
 ////
 Feature – Describe the new functionality available to the customer.  For enhancements, try to describe as specifically as possible where the customer will see changes.

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -17,7 +17,7 @@ Result - How has the behavior changed as a result?  Try to avoid â€œIt is fixedâ
 The following issues been resolved in the current release:
 
 [id="ossm-rn-fixed-issues-ossm_{context}"]
-== {ProductName} fixed issues
+== {ProductShortName} fixed issues
 * link:https://issues.jboss.org/browse/OSSM-99[OSSM-99] Workloads generated from direct Pod without labels may crash Kiali.
 
 * link:https://issues.jboss.org/browse/OSSM-93[OSSM-93] IstioConfigList can't filter by two or more names.

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -21,17 +21,12 @@ These limitations exist in {ProductName}:
 
 * {ProductName} does not support installation on a restricted network.
 
-[NOTE]
-====
-While Kafka publisher is included in the release as part of Jaeger, it is not supported.
-====
-
 [id="ossm-rn-known-issues-ossm_{context}"]
-== {ProductName} known issues
+== {ProductShortName} known issues
 
 These are the known issues in {ProductName}:
 
-* link:https://bugzilla.redhat.com/show_bug.cgi?id=1821432[Bug 1821432] Toggle controls in {product-title} Control Resource details page do not update the CR correctly. UI Toggle controls in the Service Mesh Control Plane (SMCP) Overview page in the {product-title} web console sometimes update the wrong field in the resource. To update a SMCP, edit the YAML content directly or update the resource from the command line instead of clicking the toggle controls. 
+* link:https://bugzilla.redhat.com/show_bug.cgi?id=1821432[Bug 1821432] Toggle controls in {product-title} Control Resource details page do not update the CR correctly. UI Toggle controls in the Service Mesh Control Plane (SMCP) Overview page in the {product-title} web console sometimes update the wrong field in the resource. To update a SMCP, edit the YAML content directly or update the resource from the command line instead of clicking the toggle controls.
 
 * link:https://access.redhat.com/solutions/4970771[Jaeger/Kiali Operator upgrade blocked with operator pending] When upgrading the Jaeger or Kiali Operators with Service Mesh 1.0.x installed, the operator status shows as Pending. There is a solution in progress and a workaround. See the linked Knowledge Base article for more information.
 
@@ -58,6 +53,8 @@ If the `istio-operator` pod is evicted while deploying the control pane, delete 
 
 [id="ossm-rn-known-issues-kiali_{context}"]
 == Kiali known issues
+
+These are the known issues in Kiali:
 
 * link:https://issues.jboss.org/browse/KIALI-3262[KIALI-3262] In the Kiali console, when you click on Distributed Tracing in the navigation or on a Traces tab, you are asked to accept the certificate, and then asked to provide your OpenShift login credentials. This happens due to an issue with how the framework displays the Trace pages in the Console. The Workaround is to open the URL for the Jaeger console in another browser window and log in. Then you can view the embedded tracing pages in the Kiali console.
 

--- a/service_mesh/servicemesh-release-notes.adoc
+++ b/service_mesh/servicemesh-release-notes.adoc
@@ -17,4 +17,8 @@ include::modules/ossm-rn-new-features.adoc[leveloffset=+1]
 
 include::modules/ossm-rn-known-issues.adoc[leveloffset=+1]
 
+include::modules/jaeger-rn-known-issues.adoc[leveloffset=+2]
+
 include::modules/ossm-rn-fixed-issues.adoc[leveloffset=+1]
+
+//include::modules/jaeger-rn-fixed-issues.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR pulls out the Jaeger release notes into separate topics for reuse in both Service Mesh and OpenShift Jaeger release notes.
This PR also publishes the Jaeger release notes.