### PR TITLE
Added web console port in example and note on defaults - BZ1770664

### DIFF
--- a/day_two_guide/topics/api_service_status.adoc
+++ b/day_two_guide/topics/api_service_status.adoc
@@ -17,13 +17,14 @@ NAME                             READY     STATUS    RESTARTS   AGE
 master-api-myserver.com          1/1       Running   0          56d
 ----
 
-The API service exposes a health check, which can be queried externally using the API host name:
+The API service exposes a health check, which can be queried externally using the API host name. Both the API service and web console share the same port, usually TCP 8443 or 443, depending on the setup. This port needs to be available within the cluster and to everyone who needs to work with the deployed environment:
 
 ----
 oc get pod -n kube-system -o wide
 NAME                                               READY     STATUS    RESTARTS   AGE       IP            NODE
-master-api-myserver.com                            1/1       Running   0          7h        10.240.0.16   myserver.com/healthz
+master-api-myserver.com                            1/1       Running   0          7h        10.240.0.16   myserver.com
 
-$ curl -k https://myserver.com/healthz
+$ curl -k https://myserver.com:443/healthz <1>
 ok
 ----
+<1> This must be reachable from the client's network. The web console port in this example is `443`. Specify the value set for `openshift_master_console_port` in the host inventory file prior to {product-title} deployment. If `openshift_master_console_port` is not included in the inventory file, port `8443` is set by default.


### PR DESCRIPTION
Applies to branch/enterprise-3.11. Relates to https://bugzilla.redhat.com/show_bug.cgi?id=1770664.

Preview available at http://file.fab.redhat.com/~pneedle/environment_health_checks.html.

