### PR TITLE
moving 3.x contrib guide to 3.11 branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,49 @@
 = OpenShift Documentation
+Welcome to the OpenShift documentation GitHub repository that contains the source files for the technical documentation for the following products:
 
-Welcome to the OpenShift documentation GitHub repository. To contribute to OpenShift docs, see https://github.com/openshift/openshift-docs/blob/master/README.adoc
+*IMPORTANT*
+The information in this README file and the associated contribution guide applies to only OpenShift Container Platform version 3.
+
+* https://www.okd.io/[OKD]
+* https://www.openshift.com/products/online/[OpenShift Online]
+* https://www.openshift.com/products/container-platform/[OpenShift Container Platform]
+* https://www.openshift.com/products/dedicated/[OpenShift Dedicated]
+
+All OpenShift documentation is sourced in http://www.methods.co.nz/asciidoc/[AsciiDoc] and transformed into HTML/CSS and other formats through automation that is based on http://asciidoctor.org/[AsciiDoctor].
+
+The documentation published from these source files can be viewed at http://docs.openshift.com.
+
+== Contributing to OpenShift documentation
+If you are interested in contributing to OpenShift technical documentation, you can view all our link:./contributing_to_docs[resources] that will help you get set up and provide more information.
+
+
+The following table provides quick links to help you get started.
+
+[options="header"]
+|===
+
+|Question |Link
+
+|I'm interested, how do I contribute?
+|See the link:/contributing_to_docs/contributing.adoc[contributing] topic to learn more about this repository and how you can contribute.
+
+|Are there any basic guidelines to help me?
+|The link:/contributing_to_docs/doc_guidelines.adoc[documentation guidelines] topic provides some basic guidelines to help us keep our content consistent, and includes other style information.
+
+|How do I set up my workstation?
+|See the link:/contributing_to_docs/tools_and_setup.adoc[tools and setup] topic to set up your workstation.
+
+|How do I edit an existing topic, or create new content?
+|See the link:/contributing_to_docs/create_or_edit_content.adoc[create or edit content] topic to get started.
+
+|What do I need to know about contributing content for 4.x?
+|See the link:/contributing_to_docs/contributing_user_stories.adoc[contributing user stories] topic to learn how the docs and contributing to the docs are changing in 4.0.
+|===
+
+== Contacts
+
+For questions or comments about OpenShift documentation:
+
+* OpenShift team members can be found on the http://webchat.freenode.net/?randomnick=1&channels=openshift&uio=d4[#openshift] and http://webchat.freenode.net/?randomnick=1&channels=openshift-dev&uio=d4[#openshift-dev] channels on http://www.freenode.net/[FreeNode].
+* You can also join the http://lists.openshift.redhat.com/openshiftmm/listinfo/users[Users] or http://lists.openshift.redhat.com/openshiftmm/listinfo/dev[Developers] mailing list.
+* Send an email to the OpenShift documentation team at openshift-docs@redhat.com.

--- a/contributing_to_docs/contributing.adoc
+++ b/contributing_to_docs/contributing.adoc
@@ -1,0 +1,217 @@
+[[contributing-to-docs-contributing]]
+= Contribute to OpenShift documentation
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+:description: Basic information about the OpenShift GitHub repository
+
+toc::[]
+
+[NOTE]
+====
+Are you contributing content for 4.x? If yes, please read how to https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/contributing_user_stories.adoc[contribute user stories].
+====
+
+== Different ways to contribute
+There are a few different ways you can contribute to OpenShift documentation:
+
+* Email the OpenShift documentation team openshift-docs@redhat.com
+* https://github.com/openshift/openshift-docs/issues/new[Create an issue in
+GitHub]
+* If you would like to do the work yourself, or if it is a substantial change,
+then you should clone the repository, make your changes, and submit a PR.
+Each PR should have closely-related changes.
+In particular, it is a good idea to use separate PRs
+for bugfix changes (for an old or current release)
+vs enhancement changes (for an upcoming new release). If you are submitting content for
+OCP 4.x, please read how to https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/contributing_user_stories.adoc[contribute user stories].
+
+*What happens when you submit a PR?*
+
+If you make a substantial change and submit a PR in GitHub, your PR will be
+reviewed by our
+documentation team. Tag the team using @openshift/team-documentation as a comment to get their attention.
+If there are any further changes, updates, or corrections required, we will
+inform you in the PR. When the PR has been reviewed and all changes have been
+accepted by our documentation team, your PR will be merged.
+
+== Repository organization
+Each top directory in the OpenShift documentation repository can include a
+collection of top-level topics, and/or subdirectories that further contain a
+second level of topics. The exceptions to this rule are directories whose names
+start with an underscore (like `_builder_lib` and `_javascripts`), which contain
+the assets used to generate the finished documentation.
+
+Each top-level `<topic>` directory contains the topics as AsciiDoc files, any
+`<subtopic>` subdirectories, and an `images` directory where all images for that
+topic are stored.
+
+----
+/
+/topic_dir1
+/subtopic_dir1
+/subtopic_dirN
+/topic_dir/topic1.adoc
+/topic_dir/topicN.adoc
+/topic_dir/subtopic_dir1/topic1.adoc
+/topic_dir/subtopic_dirN/topicN.adoc
+/topic_dir/images
+/topic_dir/images/img1.png
+/topic_dir/images/imgN.png
+...
+/topic_dir2
+----
+
+== Version management
+Most of the content applies to all four OpenShift products: OKD, Online, Dedicated and
+Enterprise (some versions of Enterprise), so approximately 80% of the content is reused. In many cases, this
+means that individual topics may need to include or exclude individual
+paragraphs with respect to a specific OpenShift product. While it is _possible_
+to accomplish this solely with Git branches to maintain slightly different
+versions of a given topic, doing so would make the task of maintaining internal
+consistency extremely difficult for content contributors.
+
+Git branching is still extremely valuable and serves the important role of
+tracking the release versions of documentation for the various OpenShift
+products.
+
+=== Conditional text between products
+OpenShift documentation uses AsciiDoc's `ifdef/endif` macro to conditionalize
+and reuse content across the different OpenShift products, down to the
+single-line level.
+
+The supported distribution attributes used with the OpenShift build mechanism
+are:
+
+* _openshift-origin_
+* _openshift-online_
+* _openshift-enterprise_
+* _openshift-dedicated_
+
+These attributes can be used by themselves, or in conjunction to conditionalize
+text within a topic document.
+
+Here is an example of this concept in use:
+
+----
+This first line is unconditionalized, and will appear for all versions.
+
+\ifdef::openshift-online[]
+This line will only appear for OpenShift Online.
+endif::[]
+
+\ifdef::openshift-enterprise[]
+This line will only appear for OpenShift Enterprise.
+endif::[]
+
+\ifdef::openshift-origin,openshift-enterprise[]
+This line will appear for OKD and Enterprise, but not for OpenShift Online or OpenShift Dedicated.
+endif::[]
+----
+
+Note that the following limitations exist when conditionalizing text:
+
+1. The `ifdef/endif` blocks have no size limit, however, they should not be used
+to conditionalize an entire topic. If an entire topic file is specific to a
+given OpenShift distribution, see the xref:how-it-all-comes-together[How it all
+comes together] section for information on how to conditionalize whole topics
+with the metadata `yaml` file.
+
+2. Avoid using `ifndef/endif`. As of writing, it's use is broken and buggy.
+
+== Release branches
+With the combination of conditionalizing content within topics with
+`ifdef/endif` and conditionalizing whole topics with the
+xref:how-it-all-comes-together[metadata `yaml` file], the `master` branch of
+this repository always contains a complete set of documentation for all five
+OpenShift products. However, when and as new versions of an OpenShift product
+are released, the `master` branch is merged down to new or existing release
+branches. Here is the general naming scheme used in the branches:
+
+* `master` - OKD latest code; essentially, this is our *working*
+branch
+* `enterprise-N.N` - OpenShift Enterprise support releases
+* The `dedicated` and `online` branches are built using the enterprise version that they correspond to.
+
+On a 6 hourly basis, the documentation websites are rebuilt for each of these
+branches. This way the published content for each released version of an
+OpenShift product will remain the same while development continues on the
+`master` branch. Additionally, any corrections or additions that are
+"cherry-picked" into the release branches will show up in the published
+documentation after 6 hours.
+
+[NOTE]
+====
+All OpenShift content development occurs on the `master`, or *working* branch.
+Therefore, when submitting your work the PR must be created against the `master`
+branch. Once it is reviewed that content will then migrate to the corresponding
+release branches.
+====
+
+[[how-it-all-comes-together]]
+== How it all comes together
+The documentation build system reads the `&#95;distro&#95;map.yml` to figure out which branches to build and then the `&#95;topic&#95;map.yml` metadata file for each of the branches
+to construct the content from the source files and publish to the relevant
+product site at https://docs.openshift.com. The build system _only_ reads this
+file to determine which topic files to include. Therefore, all new topics that
+are created must be included in the `&#95;topic&#95;map.yml` metadata file in
+order to be processed by the build system.
+
+=== Metadata file format
+The format of this file is as indicated:
+
+----
+--- //<1>
+Name: Origin of the Species <2>
+Dir:  origin_of_the_species <3>
+Distros: all <4>
+Topics:
+  - Name: The Majestic Marmoset <5>
+    File: the_majestic_marmoset <6>
+    Distros: all
+  - Name: The Curious Crocodile
+    File: the_curious_crocodile
+    Distros: openshift-online,openshift-enterprise <7>
+  - Name: The Numerous Nematodes
+    Dir: the_numerous_nematodes <8>
+    Topics:
+      - Name: The Wily Worm <9>
+        File: the_wily_worm
+      - Name: The Acrobatic Ascarid  <= Sub-topic 2 name
+        File: the_acrobatic_ascarid  <= Sub-topic 2 file under <group dir>/<subtopic dir>
+----
+<1> Record separator at the top of each topic group
+<2> Display name of topic group
+<3> Directory name of topic group
+<4> Which OpenShift versions this topic group is part of
+<5> Topic name
+<6> Topic file under the topic group dir without `.adoc`
+<7> Which OpenShift versions this topic is part of
+<8> This topic is actually a subtopic group. Instead of a `File` path it has a
+`Dir` path and `Topics`, just like a top-level topic group.
+<9> Topics belonging to a subtopic group are listed just like regular topics
+with a `Name` and `File`.
+
+****
+Notes on *Distros* metadata attribute
+
+* The *Distros* setting is optional for topic groups and topic items. By
+default, if the *Distros* setting is not used, it is processed as if it was set
+to *Distros: all* for that particular topic or topic group. This means that the
+topic or topic group will appear in all five product documentation.
+* The *all* value for *Distros* is a synonym for
+_openshift-origin,openshift-enterprise,openshift-online,openshift-dedicated,openshift-aro_.
+* The *all* value overrides other values, so _openshift-online,all_ is processed
+as *all*.
+****
+
+== Next steps
+* First, you should link:tools_and_setup.adoc[Install and set up the tools and
+software] on your workstation so that you can contribute.
+* Next, we recommend that you link:doc_guidelines.adoc[review the documentation
+guidelines] to understand some basic guidelines to keep things consistent
+across our content.
+* If you are ready to create new content or want to edit existing content, the
+link:create_or_edit_content.adoc[create or edit content] topic describes how
+you can do this by creating a working branch.

--- a/contributing_to_docs/contributing_user_stories.adoc
+++ b/contributing_to_docs/contributing_user_stories.adoc
@@ -1,0 +1,124 @@
+[[contributing-user-stories]]
+= Contribute user stories to OpenShift documentation
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+:description: Basic information about how to create user stories for OpenShift GitHub repository
+
+toc::[]
+
+== Modularization backstory
+OpenShift docs are getting modularized, starting from OpenShift 4.1.
+All existing content will be completely replaced with content that is based on user stories and
+complies with the modularization guidelines. All future content must both
+support a user story and be modular.
+
+== How do I contribute modularized content?
+To contribute modularized content, you need to write a user story, create
+documentation modules to support the user story, and create an assembly for the
+story.
+
+== What if I don't want to write in modules?
+If you don't want to write the modules yourself but have a content change,
+write a user story, provide details to support the story, and reach out to the
+OpenShift docs team.
+
+== Where do I contribute modularized content?
+If you have new content for OCP 4.1, it must be modularized before it is merged
+to the collection.
+Here is an overview of the active branches:
+
+* link:https://github.com/openshift/openshift-docs/tree/enterprise-4.1[enterprise-4.1]
++
+This builds both OCP 4.1 and OKD/Upstream content. Just like today, OKD content will be separated using
+ifdef statements in content and distro statements in the _topic_map.yml.
++
+Only CCS submits and merges their PRs here until OCP 4.1 is released unless others are keen to submit
+content in modularized format.
+
+* https://github.com/openshift/openshift-docs/tree/master[master]
+This builds legacy (existing), mostly non-user story based content. This branch will continue to update
+docs.okd.io (upstream) until we switch to 4.1 with the enterprise-4.1 branch.
++
+Please continue to submit your PRs to this branch and specify if it is for 3.11 and/or 4.1.
+If the submitted PR is for the 3.11 branch, CCS merges with follow up edits in 3.11.
+CCS then creates user stories for its inclusion in enterprise-4.1 branch.
+
+* https://github.com/openshift/openshift-docs/tree/enterprise-3.11[enterprise-3.11]
+This branch contains content for the 3.11 branch and the last branch that contains content that is not completely
+modularized.
++
+This may contain modularized content based on user stories for content for completely new features.
+
+== How do I write a user story? Is there a template?
+Instead of a template, we have a series of questions for you to answer to
+create the user story. Follow the same steps if you are writing the modules
+yourself or if you plan to work with the docs team.
+
+The basic format of a user story is:
+
+----
+As a <type of user>, I want to <goal state> because <reason behind the goal>.
+----
+
+For example, "As a cluster administrator, I want to enable an Auto Scaling group to manage my OpenShift Enterprise
+cluster deployed on AWS because I want my node count to scale based on application demand."
+
+Use the following questions to guide you in providing the context for your user story and the necessary technical details to start a draft.
+You don't have to answer all of these questions, only the ones that make sense to your particular user story.
+
+=== Feature info
+* What is the feature being developed? What does it do?
+* How does it work?
+* Are there any configuration files/settings/parameters being added or modified? Are any new commands being added or modified?
+* What tools or software does the docs team need to test how this feature works? Does the docs team need to update any installed software?
+* Are there any existing blogs, Wiki posts, Kbase articles, or Bzs involving this feature? Or any other existing information that may help to understand this feature?
+
+=== Customer impact
+* Who is the intended audience for this feature? If it's for Enterprise, does it apply to developers, admins, or both?
+* Why is it important for our users? Why would they want to use this feature? How does it benefit them?
+* How will the customer use it? Is there a use case?
+* How will the customer interact with this feature? Client tools? Web console? REST API?
+
+=== Product info
+* Is this feature being developed for Online? Enterprise? Dedicated? OKD? All?
+* Will this feature be rolled back to previous versions?
+* If it's for Online, what type of plan do users need to use this feature?
+* Is it user-facing, or more behind-the-scenes admin stuff?
+* What tools or software does the docs team need to test how this feature works?
+
+== How do I write in modules?
+The full guidelines for writing modules are in the Customer Content Services (CCS)
+link:https://redhat-documentation.github.io/modular-docs/[modularization guide].
+
+The main concepts of writing in modules are:
+
+* Each assembly contains the information required for a user to achieve a single
+goal.
+* Assemblies contain primarily `include` statements, which are references to
+smaller, targeted module files.
+* Modules can contain conceptual information, reference information, or steps,
+but not a combination of the types.
+
+For example, a simple assembly might contain the following three modules:
+
+* A concept module that contains background information about the feature
+that the user will configure
+* A reference module that contains an annotated sample yaml file that the user
+needs to modify
+* A procedure module that contains the prerequisites that the user needs to
+complete before they start configuring and steps that the user takes to
+complete the configuration.
+
+The `enterprise-4.1` branch contains sample assemblies that explain how to
+get started with modular documentation for OpenShift and that serve as
+references for including modules in assemblies. The
+link:https://raw.githubusercontent.com/openshift/openshift-docs/enterprise-4.1/mod_docs_guide/mod-docs-conventions-ocp.adoc[Modular Docs OpenShift conventions]
+assembly contains the
+link:https://raw.githubusercontent.com/openshift/openshift-docs/enterprise-4.1/modules/mod-docs-ocp-conventions.adoc[Modular docs OpenShift conventions]
+reference module, and the
+link:https://github.com/openshift/openshift-docs/blob/enterprise-4.1/mod_docs_guide/getting-started-modular-docs-ocp.adoc[Getting started with modular docs on OpenShift]
+assembly contains the
+link:https://raw.githubusercontent.com/openshift/openshift-docs/enterprise-4.1/modules/creating-your-first-content.adoc[Creating your first content]
+procedure module.

--- a/contributing_to_docs/create_or_edit_content.adoc
+++ b/contributing_to_docs/create_or_edit_content.adoc
@@ -1,0 +1,235 @@
+[[contributing-to-docs-create-or-edit-content]]
+= Create new content or edit existing content
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+:description: Create working branch to contribute new content or updates
+
+toc::[]
+
+== Before you begin
+Before you proceed, we recommend that you have completed the following:
+
+* Read and reviewed the link:contributing.adoc[Contribute to OpenShift
+documentation] topic to understand some basics
+* link:tools_and_setup.adoc[Installed and set up the tools and software]
+required to contribute
+* Read and reviewed the link:doc_guidelines.adoc[Documentation guidelines] topic
+to understand the basic guidelines for consistency
+
+== Ensure your local repository is in sync with the remote
+Before you create a local working branch, it is good practice to ensure that
+your local `master` branch is in sync with the remote and that you have all the
+latest changes. You must also ensure that your forked repository is also in sync
+with the remote repository.
+
+1. From your local repository, make sure you have the `master` branch checked
+out:
++
+----
+$ git checkout master
+----
+
+2. Fetch the current state of the OpenShift documentation repository:
++
+----
+$ git fetch upstream
+----
+
+3. Incorporate the commits from the remote repository, in this case
+`openshift/openshift-docs`, into your local repository:
++
+----
+$ git rebase upstream/master
+----
+
+4. Push the latest updates to your forked repository so that it is also in sync
+with the remote:
++
+----
+$ git push origin master
+----
+
+== Add new topics or update existing content on the local branch
+With your local and forked repositories in sync with the remote, you can now
+create a local working branch where you will make all your updates, or create
+any new content.
+
+*Step 1:* Create a local branch
+
+The following command creates a new local branch from the branch that you are currently on and checks it out
+automatically. Be sure to replace `<working_branch>` with a suitable name.
+Also, be sure that the changes made on this branch are closely related and
+do indeed reflect that name.
+In particular, it is a good idea to use separate PRs
+for bugfix changes (for an old or current release)
+vs enhancement changes (for an upcoming new release).
+
+----
+$ git checkout -b <working_branch>
+----
+
+[NOTE]
+====
+This command creates a new specified branch and also checks it out, so you will
+automatically switch to the new branch.
+====
+
+*Step 2:* Create new content or update existing content as required
+
+With the local branch created and checked out, you can now edit any content, or
+start adding new content.
+
+If you are creating a new topic, it is best to use the topic templates so that
+all of the required metadata is included:
+
+* For an Overview topic, use the
+https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/templates/overview_topic_template.adoc[Overview
+topic template].
+* For all other topics, use the
+https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/templates/topic_template.adoc[normal
+topic template].
+
+Otherwise, ensure that any new topic contains the required metadata as described
+in the link:doc_guidelines.adoc[documentation guidelines] topic, including
+naming and title conventions.
+
+*Step 3:* Add all of your changes to a pending commit
+
+When you are finished making all of your changes and have tested the updated or
+new content, the following command adds those changes to a pending commit:
+
+----
+$ git add .
+----
+
+*Step 4:* Commit your changes
+
+After adding your changes to a pending commit, the following command commits
+those changes locally:
+
+----
+$ git commit -am "Detailed comments about what changes were made; for example, fixed typo"
+----
+
+*Step 5:* Rebase updates from `master` into your working branch
+
+If you fetched the latest changes from `master` before you created your local
+branch, this step may not be necessary. However, it is good practice to fetch
+the latest changes from `master` and rebase those onto your working branch.
+
+Remember, that you should rebase against the branch that you created this working branch from. In most cases, it will be the master branch.
+
+----
+$ git rebase upstream/master
+----
+
+[NOTE]
+====
+If you find any conflicts you must fix those, and repeat steps 3 and 4.
+====
+
+*Step 6:* Push all changes to your GitHub account
+
+After you have rebased, fixed any conflicts, and committed your changes, you can
+push them to your GitHub account. This command adds your local working branch to
+your GitHub repository:
+
+----
+$ git push origin <working_branch>
+----
+
+== Submit PR to merge your work
+When you have pushed your changes to your GitHub account, you can submit a PR to
+have your work from your GitHub fork to the `master` branch of the OpenShift
+documentation repository. The documentation team will review the work, advise of
+any further changes that may or may not be required, and finally merge your
+work.
+
+1. Go to your forked GitHub repository on the GitHub website, and you should see
+your local branch that includes all of your work.
+2. Click on *Pull Request* to submit the PR against the `master` branch of the
+`openshift-docs` repository.
+3. Attach labels to your *Pull Request* to indicate to the DOCS team which branches your PR might apply to. Some requests may only apply to the origin distro (origin-only), and some may only apply to a specific version of the enterprise (branch/enterprise-3.4, branch/enterprise-3.5, branch/enterprise-3.6) or dedicated (branch/dedicated) or online (branch/online) docs. If a request applies to multiple versions of a distro, then specify the minimum version (branch/enterprise-3.5 and above, for example). The docs team maintains these branches for all active and future distros and your PR will be applied to one or more these.
+4. *Tag the documentation team* with @openshift/team-documentation by leaving this as a comment. You must do this to get a timely response.
+
+*If you don't have permissions to apply labels, make sure to leave that information as a comment.*
+
+== Confirm your changes have been merged
+When your PR has been merged into the `master` branch, you should confirm and
+then sync your local and GitHub repositories with the `master` branch.
+
+1. On your workstation, switch to the `master` branch:
++
+----
+$ git checkout master
+----
+
+2. Pull the latest changes from `master`:
++
+----
+$ git fetch upstream
+----
+
+3. Incorporate the commits from the remote repository, in this case
+`openshift/openshift-docs`, into your local repository:
++
+----
+$ git rebase upstream/master
+----
+
+4. After confirming in your rebased local repository that your changes have been
+merged, push the latest changes, including your work, to your GitHub account:
++
+----
+$ git push origin master
+----
+
+== Add changes to an existing PR, if required
+In some cases, you might have to make changes to a PR that you have already
+submitted. A PR can contain multiple commits, and we strive to preserve the
+review history and all discussions that occur around those commits. The
+following instructions describe how to make changes to an existing PR you have
+already submitted.
+
+1. Commit whatever updates you have made to the working branch by creating a new
+commit:
++
+----
+$ git commit -am "Detailed message as noted earlier"
+----
+
+2. To keep the Git history clean, you may be asked to rebase your PR and squash
+multiple commits into one commit. Before you push your changes in the next step,
+follow the instructions here to rebase:
+https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request
+
+3. After you have rebased, push the latest updates to the local working branch
+to your GitHub account.
++
+----
+$ git push origin <working_branch> --force
+----
+
+The `--force` flag ignores whatever is on the remote server and replaces
+everything with the local copy. You should now see the new commits in the
+existing PR. Sometimes a refresh of your browser may be required.
+
+== Delete the local working branch
+When you have confirmed that all of your changes have been accepted and merged,
+and you have pulled the latest changes on `master` and pushed them to your
+GitHub account, you can delete the local working branch. Ensure you are in your
+local repository before proceeding.
+
+1. Delete the local working branch from your workstation.
++
+----
+$ git branch -D <working_branch>
+----
+
+2. Delete the working branch from your GitHub account:
++
+----
+$ git push origin :<working_branch>
+----

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1,0 +1,757 @@
+[[contributing-to-docs-doc-guidelines]]
+= Documentation Guidelines
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+:description: These are basic guidelines for creating technical documentation for OpenShift 3.x.
+
+NOTE: The guidelines in this branch are specific for OpenShift / OKD 3.x
+documentation. See the
+link:https://github.com/openshift/openshift-docs/tree/enterprise-4.1/contributing_to_docs[`enterprise-4.1` branch]
+for guidelines for OpenShift / OKD 4.x documentation.
+
+toc::[]
+
+== Topic Metadata
+Every topic file should contain the following metadata at the top, with no line spacing in between, except where noted:
+
+----
+= Document/Topic Title                                          <1>
+:data-uri:                                                      <2>
+:icons:                                                         <3>
+:toc: macro                                                     <4>
+:toc-title:                                                     <5>
+-----------intentional blank line--------------
+toc::[]                                                         <6>
+----
+
+<1> Human readable title of document/topic title line (notice the '=' top-level header)
+<2> AsciiDoctor attribute to embed all images directly in the HTML
+<3> AsciiDoctor attribute for icons used in admonitions and such (TIP, NOTE, WARNING, etc.)
+<4> Adds a table of contents (TOC) with manual placement.
+<5> Overrides the default title of TOC and removes the title.
+<6> Placement of the TOC.
+
+After the heading block and a single whitespace line, you can include any content for the topic.
+
+[NOTE]
+====
+Please set your editor to strip trailing whitespace.
+====
+
+[NOTE]
+====
+The topic title, which is the first line of the document, is the only level 1 ( = ) title. Section headers within the topic must be level 2 ( == ) or lower.
+====
+
+*All titles must have a unique (within the OpenShift docs suite) section anchor*, and this anchor must be all lowercase letters, with no line spaces between the anchor and the section title:
+
+----
+[[section-anchor-name]]
+=== Section Title
+----
+
+== Topic File Names
+
+Try to shorten the topic file name as much as possible _without_ abbreviating
+important terms that may cause confusion. For example, the
+`managing_authorization_policies.adoc` file name would be appropriate for a
+topic titled "Managing Authorization Policies".
+
+== Topic Titles and Section Headings
+
+Use sentence case in all topic titles and section headings. See http://www.titlecase.com/ or
+https://convertcase.net/ for a conversion tool.
+
+Try to be as descriptive as possible with the topic title or section headings
+without making them unnecessarily too long. Use a verb form in headings. Some
+suggestions:
+
+* Creating
+* Managing
+* Using
+* Understanding
+
+Use "Overview" as a heading sparingly. Choose a more descriptive heading
+instead.
+
+=== Unique IDs
+
+The content in this repo is used to build docs that publish to multiple
+locations (e.g., docs.openshift.com, docs.okd.io, and the Red Hat
+Customer Portal). While heading IDs will be created automatically from any
+section titles (e.g., "Managing Authorization Policies" would generate an ID of
+`managing-authorization-policies`, which would act as an anchor reference), we
+should not rely on this automatic generation because the IDs need to be unique
+across all topics in the repo. This is mainly to avoid build failures for the
+Customer Portal docs, due to ID collision.
+
+Therefore, always add a unique ID manually, and check the repo to make sure that
+it is unique and not already in use (for example, check with `CTRL+F` to search
+the repo if using Atom).
+
+Manual IDs use the following syntax:
+
+----
+[[managing-authorization-policies]]
+== Managing Authorization Policies
+----
+
+=== Discrete Headings
+
+If you have a section heading that you do not want to appear in the TOC (like if you think that some section is not worth showing up or if there are already too many nested levels), you can use a discrete (or floating) heading:
+
+http://asciidoctor.org/docs/user-manual/#discrete-or-floating-section-titles
+
+A discrete heading also will not get a section number in the Customer Portal
+build of the doc. Previously, we would use plain bold markup around a heading
+like this, but discrete headings also allow you to ignore section nesting rules
+(like jumping from a `==` section level to a `====` level if you wanted for some
+style reason).
+
+To use a discrete heading, just add `[discrete]` to the line before your unique
+ID. For example:
+
+----
+[discrete]
+[[managing-authorization-policies]]
+== Managing Authorization Policies
+----
+
+== Product Name & Version Attributes
+
+When possible, generalize references to the product name and/or version using
+the `{product-title}` and/or `{product-version}` attributes. These attributes
+are pulled from distro mapping definitions in the
+https://github.com/openshift/openshift-docs/blob/master/_distro_map.yml[distro_map.yml]
+file.
+
+The `{product-title}` comes from the first `name:` field in a distro mapping,
+while the associated `{product-version}` comes from the `name:` fields on any
+`branches:` defined.
+
+How these attributes render is dependent on which distro and branch build you
+are viewing. The following table shows the current slate of distros and the
+possible values for `{product-title}` and `{product-version}`.
+
+[options="header"]
+|===
+|Distro |`{product-title}` |`{product-version}`
+
+|`openshift-origin`
+|OKD
+|Latest
+
+|`openshift-enterprise`
+|OpenShift Enterprise
+|3.1, 3.0
+
+|`openshift-dedicated`
+|OpenShift Dedicated
+|3.1, 3.0
+
+|`openshift-online`
+|OpenShift Online
+|Latest
+|===
+
+For example:
+
+----
+You can deploy applications on {product-title}.
+----
+
+This is a safe statement that could appear in probably any of the builds, so an
+https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/contributing.adoc#conditional-text-between-products[ifdef/endif
+statement] is not necessary. For example, if you were viewing a build for the
+`openshift-enterprise` distro (for any of the distro-defined branches), this
+would render as:
+
+"You can deploy applications on OpenShift Enterprise."
+
+And for the `openshift-origin` distro:
+
+"You can deploy applications on OKD."
+
+Considering that we use distinct branches to keep content for product versions
+separated, global use of `{product-version}` across all branches is probably
+less useful, but it is available if you come across a need for it. Just consider
+how it will render across any branches that the content appears in.
+
+Do not use markup in headings.
+
+*Do not use internal company server names in command or example output*. See suggested host name examples https://docs.openshift.com/container-platform/latest/install_config/install/planning.html#multi-masters-using-native-ha-colocated[here].
+
+== Links, Hyperlinks, and Cross References
+Links can be used to cross-reference internal topics or send customers to external information resources for further reading.
+
+In OpenShift docs:
+
+* all links to internal topics are created using `xref` and **must have an anchor ID**.
+* all links to external websites are created using `link`.
+
+[IMPORTANT]
+====
+Do not split link paths across lines when wrapping text. This will cause issues with the doc builds.
+====
+
+=== Example URLs
+To provide an example URL path that you do not want to render as a hyperlink, use this format:
+
+....
+`\https://www.example.com`
+....
+
+=== Internal Cross-References
+Whenever possible the link to another topic should be part of the actual sentence. Avoid creating links as a separate sentence that begins with "See [this topic] for more information on x".
+
+[NOTE]
+====
+Use the relative file path (from the file you are editing, to the file you are linking to), even if you are linking to the same directory that you are writing in. This makes search and replace operations to fix broken links much easier.
+
+For example, if you are writing in *_architecture/core_concepts/deployments.adoc_* and you want to link to *_architecture/core_concepts/routes.adoc_* then you would need to include the path back to the first level of the topic directory:
+
+----
+xref:../../architecture/networking/routes.adoc#architecture-core-concepts-routes
+----
+====
+
+.Markup example of cross-referencing to internal topics
+----
+Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or
+the xref:../cli_reference/get_started_cli.adoc#installing-the-cli[OpenShift CLI].
+
+Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
+----
+
+.Rendered output of cross-referencing to internal topics:
+====
+Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the xref:../cli_reference/get_started_cli.adoc#installing-the-cli[OpenShift CLI].
+
+Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
+====
+
+=== Links to External Websites
+
+If you want to link to a different website, use:
+
+----
+link:http://othersite.com/otherpath[friendly reference text]
+----
+
+IMPORTANT: You must use `link:` before the start of the URL.
+
+IMPORTANT: You cannot link to a repository that is hosted on www.github.com.
+
+TIP: If you want to build a link from a URL _without_ changing the text from the actual URL, just print the URL without adding a `[friendly text]` block at the end; it will automatically be rendered as a link.
+
+=== Links to Internal Topics
+There probably are three scenarios for linking to other content:
+
+1. Link to another topic file that exists in the same topic group, or directory.
+2. Link to another topic file that exists in a separate topic group, or directory.
+
+The following examples use the example directory structure shown here:
+....
+/
+/foo
+/foo/bar.adoc
+/baz
+/baz/zig.adoc
+/baz/zag.adoc
+....
+
+*Link to a topic in the same topic group directory*
+
+----
+xref:<filename>#anchor-id[friendly title]
+----
+
+You must use the `.adoc` file extension. The document processor will correctly link this to the resulting HTML file.
+
+For example, using the above syntax, if you are working on `zig.adoc` and want to link to `zag.adoc`, do it this way:
+
+----
+xref:../zag.adoc#baz-zag[comment]
+----
+
+where `baz-zag` is the anchor ID at the top of the file `zag.adoc`.
+
+*Link to a topic in a different topic group directory*
+
+----
+xref:../dir/<filename>.adoc[friendly title]
+----
+
+For example, if you are working on `bar.adoc` and you want to link to `zig.adoc`, do it this way:
+
+----
+xref:../baz/zig.adoc#baz-zig[see the ZIG manual for more]
+----
+
+[NOTE]
+====
+You must use the .adoc extension in order for the link to work correctly and you must specify an anchor ID.
+====
+
+*Link to a subtopic within a topic file*
+
+To link to a subtopic within a topic file, use the following syntax:
+
+----
+xref:../baz/zig/#subtopic
+----
+
+*Link to a subtopic within the same topic file*
+
+To link to a subtopic within the same topic file, use the following syntax:
+
+----
+xref:subtopic
+----
+
+Note: There is no `#` used when linking to a subtopic within the same topic.
+
+== Sharing Content Between Files
+
+If you want to share content from one topic so that it appears in another topic,
+you can use the `include` directive. See the Asciidoctor documentation for
+details:
+
+http://asciidoctor.org/docs/user-manual/#include-partial
+
+If you find that you need to include content from one topic multiple times into
+another topic, see the following usage:
+
+http://asciidoctor.org/docs/user-manual/#include-multiple
+
+== Writing Concepts
+A _concept_ is a topic (full .adoc file) or section (individual heading within a
+topic) that supports the things that users want to do and should not include
+task information like commands or numbered steps. Consider topic/section titles
+with a verb like "Understanding <concept>" if it is solely concept-based.
+
+== Writing Tasks
+A _task_ is a topic (full .adoc file) or section (individual heading within a
+topic) that supports the things that users want to do and includes procedural
+information like commands and numbered steps. Write tasks in the following
+format.
+
+*Task Title*: Use a verb in the task title (for example, Create or Creating).
+
+Include a paragraph explaining why the user must perform this task. This should be 1-2 sentences maximum.
+
+If applicable, include any gotchas (things that could trip up the user or cause the task to fail).
+
+
+*Before You Begin*
+
+* A bulleted list of pre-requisites that MUST be performed before the user can complete this task. Skip if there isn't any related information.
+
+*Procedure*
+
+. Step 1 - One command per step.
+
+. Step 2 - One command per step.
+
+. Step N
+
+*After You Finish*
+
+You can explain any other tasks that MUST be completed after this task. You can skip this if there are none.
+
+*Related Information*
+
+* A bulleted list of links to related information about this task. Skip if there isn't any related information.
+
+== Images
+If you want to link to an image:
+
+1. Put it in `<topic_dir>/images`
+2. In the topic document, use this format to link to an image:
+
+----
+image::<name_of_image>[image]
+----
+
+You only need to specify `<name_of_image>`. The build mechanism automatically specifies the file path.
+
+=== AsciiDoctor Diagram Extension
+AsciiDoctor provides a set of http://asciidoctor.org/docs/asciidoctor-diagram/[extensions to embed diagrams] written using http://plantuml.sourceforge.net/[PlantUML], http://www.graphviz.org/[Graphviz], http://ditaa.sourceforge.net/[ditaa], or https://github.com/christiangoltz/shaape[Shaape] syntax inside your AsciiDoc documents. The diagram extension generates an SVG, PNG, or TXT file from the source text. The image file that's generated then gets inserted into the rendered document.
+
+[IMPORTANT]
+====
+The AsciiDoctor diagram extension serves a starting point for creating images in OpenShift documentation. In most cases, these images will be professionally enhanced to meet our internal standards and guidelines.
+====
+
+See the http://asciidoctor.org/docs/asciidoctor-diagram/[AsciiDoctor diagram extension] documentation for instructions on how to install and use it.
+
+
+We will mostly use the `ditaa` block in OpenShift documentation. The `png` file from the `ditaa` block is generated in the same directory as the source file with a checksum as the filename. However, you can specify the path of the generated `png` file with the second attribute in the `ditaa` block.
+
+For example, in our case we would want our images in the *topic_dir/_images_* folder of the main topic directory:
+
+----
+....
+[ditaa, "images/name_of_image"]
+....
+----
+
+== Formatting
+
+For all of the system blocks including table delimiters, use four characters. For example:
+
+....
+|=== for tables
+---- for code blocks
+....
+
+
+=== Code Blocks
+Code blocks are used to show examples of command screen outputs, or
+configuration files. When using command blocks, always use the actual values for
+any items that a user would normally replace. Code blocks should represent
+exactly what a customer would see on their screen. If you need to expand or
+provide information on what some of the contents of a screen output or
+configuration file represent, then use callouts to provide that information.
+
+Follow these general guidelines when using code blocks:
+
+* Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
+
+* For all code blocks, you must include an empty line above a code block.
++
+Acceptable:
++
+....
+Lorem ipsum
+
+----
+$ lorem.sh
+----
+....
++
+Not acceptable:
++
+....
+Lorem ipsum
+----
+$ lorem.sh
+----
+....
++
+Without the line spaces, the content is likely to be not parsed correctly.
+
+* It is recommended to include source tags for the programming language used in the code block to enable syntax highlighting. For example, use the source tags
+ `[source, yaml]` or `[source, javascript]`.
++
+NOTE: Do not use `[source, bash]` for `oc` commands or any terminal commands, because it does not render properly in some cases. We will not accept new contributions that contain `[source, bash]`.
++
+....
+Lorem ipsum
+
+----
+$ lorem.sh
+----
+....
+
+* Try to use callouts to provide information on what the output represents when required.
++
+Use this format when embedding callouts into the code block:
++
+[subs=-callouts]
+....
+----
+code example 1 <1>
+code example 2 <2>
+----
+<1> A note about the first example value.
+<2> A note about the second example value.
+....
+
+* For long lines of code that you want to break up among multiple lines, use a
+backslash to show the line break. For example:
++
+----
+$ oc get endpoints --all-namespaces --template \
+    '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
+    {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
+    {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
+----
+
+* If the user must run a command as root, use a number sign, `#`, at the start of the command instead of a dollar sign, `$`. For example:
++
+----
+# sudo ./openshift start
+----
+
+=== Inline Code or Commands
+Do NOT show full commands or command syntax inline within a sentence. The next section covers how to show commands and command syntax.
+
+The only use case for inline commands is general commands and operations, without replaceables and command options. In this case, an inline command is marked up using backticks:
+
+....
+Use the `GET` operation to do x.
+....
+
+This renders as:
+
+Use the `GET` operation to do x.
+
+=== Command Syntax and Examples
+The main distinction between showing command syntax and an example is that a command syntax should just show customers how to use the command without real values. An example, on the other hand, should show the command with actual values with an example output of that command, where applicable.
+
+==== Command Syntax
+To markup command syntax, use the code block and wrap the replaceables in <> with the required command parameters, as shown in the following example. Do NOT use commands or command syntax inline with sentences.
+
+....
+The following command returns a list of objects for the specified object type:
+
+----
+$ oc get <object_type> <object_id>
+----
+....
+
+This would render as follows:
+
+The following command returns a list of objects for the specified object type:
+
+----
+$ oc get <object_type> <object_id>
+----
+
+==== Examples
+As mentioned, an example of a command should use actual values and also show an output of the command, as shown in the following example. In some examples, a heading might not be required.
+
+
+....
+In the following example, the `oc get` operation returns a complete list of services that are currently defined.
+
+.Example Title
+
+----
+$ oc get se
+NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
+docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
+----
+....
+
+This would render as shown:
+
+In the following example the `oc get` operation returns a complete list of services that are currently defined.
+
+.Example Title
+
+----
+$ oc get se
+NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
+docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
+----
+
+=== Lists
+Lists are created as shown in this example:
+
+....
+. Item 1 (2 spaces between the period and the first character)
+
+. Item 2
+
+. Item 3
+....
+
+This will render as such:
+
+. Item 1
+
+. Item 2
+
+. Item 3
+
+If you need to add any text, admonitions, or code blocks you need to add the continuous +, as shown in the example:
+
+....
+. Item 1
++
+----
+some code block
+----
+
+. Item 2
+
+. Item 3
+....
+
+This renders as shown:
+
+. Item 1
++
+----
+some code block
+----
+
+. Item 2
+
+. Item 3
+
+=== Invalid formatting
+
+The following are examples of invalid formatting and some resolutions.
+
+*Problem*
+The following is invalid formatting. It is intended to mark up a literal value, `openshift-*`, in bold highlighting.
+Because of the two asterisks, AsciiDoctor does not know which asterisk is the closing tag.
+
+Travis reports _Opening and ending tag mismatch:_.
+
+----
+ *`openshift-*`*
+----
+
+*Solution*
+Use an escape character for the second asterisk or use double asterisks:
+
+++++
+**`openshift-*`**
+++++
+
+==== Quick Reference
+.User accounts and info
+[option="header"]
+|===
+|Markup in command syntax |Description |Substitute value in Example block
+
+|<username>
+|Name of user account
+|user@example.com
+
+|<password>
+|User password
+|password
+|===
+
+.Projects and applications
+[option="header"]
+|===
+|Markup in command syntax |Description |Substitute value in Example block
+
+|<project>
+|Name of project
+|myproject
+
+|<app>
+|Name of an application
+|myapp
+|===
+
+== Admonitions
+Admonitions such as notes and warnings are formatted as shown:
+
+....
+[ADMONITION]
+====
+Text for admonition
+====
+....
+
+== Quick Markup Reference
+
+|===
+|Convention |Markup |Example rendered output
+
+|Code blocks
+a|....
+Use the following syntax for the `oc` command:
+
+----
+$ oc <action> <object_type> <object_name_or_id>
+----
+....
+
+a|Use the following syntax for the `oc` command:
+
+----
+$ oc <action> <object_type> <object_name_or_id>
+----
+
+|Inline commands, operations, literal values, variables, parameters, settings,
+flags, environment variables, and user input.
+
+In general (when inline within sentences), something that either operates or
+acts on something else, or when referencing some item from a file or code block /
+example.
+a|$$`oc get`$$
+
+$$`GET`$$
+
+$$Set the `upgrade` variable to `true`.$$
+
+$$Answer by typing `Yes` or `No` when prompted.$$
+
+$$Use the `--amend` flag.$$
+
+a|Use the `oc get` command to get a list of services that are currently defined.
+
+The `GET` operation can be used to do something.
+
+Set the `upgrade` variable to `true`.
+
+Answer by typing `Yes` or `No` when prompted.
+
+Use the `--amend` flag.
+
+|System or software variable to be replaced by the user
+a|$$`<project>`$$
+
+$$`<deployment>`$$
+
+a|
+Use the following command to roll back a deployment, specifying the deployment name:
+
+`oc rollback <deployment>`
+
+|System term/item, user names, unique or example names for individual API objects/resources (e.g., a pod named "mypod"), GUI menu items and buttons, daemon, service, or software package.
+
+In general (when inline within sentences), something that can be operated or
+acted upon, or unique or example names for system terms/items in general.
+
+a|$$*system item*$$
+
+$$*daemon*$$
+
+$$*service*$$
+
+$$*software package*$$
+
+a|*cluster-admin* user
+
+*HTTPD*
+
+*NetworkManager*
+
+*RubyGems*
+
+|Filenames or directory paths
+
+If you need to include a variable in the filename or directory path, follow
+the guidance for system or software variables for the variable.
+
+a|$$*_filename_*$$
+
+$$*_directory_*$$
+a|Edit the *_kubeconfig_* file as required and save your changes.
+
+The *_express.conf_* configuration file is located in the *_/usr/share_* directory.
+
+|Emphasis for a term
+|only emphasize $$_first_$$ time
+|only emphasize _first_ time
+
+|Footnotes
+|A footnote is created with the footnote macro. If you plan to reference a footnote more than once, use the ID footnoteref macro. The customer portal does not support spaces in the footnoteref. For example, "dynamic PV" should be "dynamicPV".
+|See link:http://asciidoctor.org/docs/user-manual/#user-footnotes[Footnotes] for the footnote and footnoteref syntax.
+|===

--- a/contributing_to_docs/templates/overview_topic_template.adoc
+++ b/contributing_to_docs/templates/overview_topic_template.adoc
@@ -1,0 +1,32 @@
+[[contributing-to-docs-templates-overview-topic-template]]
+= Overview
+{product-author}
+{product-version}
+:icons: font
+:experimental:
+
+Start with a clear introduction to the topic directory/category of topics and what information customers can expect to find in the included topics
+
+////
+
+////
+
+== Quick Links
+////
+This section is a way to provide quick links to popular topics that we think will be of most interest to our customers. The example below would be in the Overview topic of the Administration Guide, and shows links to the Managing Nodes topic in that topic category. Note that this is just one example to show how we can help customers to find the information they need.  This section may or may not be required. Use the table below as a template and remove this text.
+////
+
+[option="header"]
+|===
+|How do I? |Links to relevant topics
+
+.^|Add, view, or delete nodes in my OpenShift environment
+
+a|link:../admin_guide/manage_nodes.html#adding-nodes[Add a node]
+
+link:../admin_guide/manage_nodes.html#viewing-nodes[View a node]
+
+link:../admin_guide/manage_nodes.html#deleting-nodes[Delete a node]
+
+|Do something else as an admin
+|Link to topic(s)

--- a/contributing_to_docs/templates/rev_history.adoc
+++ b/contributing_to_docs/templates/rev_history.adoc
@@ -1,0 +1,48 @@
+[[contributing-to-docs-templates-rev-history-guide-dirname]]
+= Revision History: Full Guide Name
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+
+// Woe be to the human who edits the following line!  --the ‘do-release’ script
+// do-release: revhist-tables
+== Fri Jan 01 2016
+
+OpenShift Enterprise X.Y.Z release (if publishing timed with a product release).
+
+// tag::<guide_dirname>_fri_jan_01_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../path/to/topic1.html[Full Topic Title]
+|Added
+link:../path/to/topic1.html#section-anchor[Full Section Title] section to
+(include, discuss, detail, etc.) <relevant_reason>.
+
+|link:../path/to/topic2.html.html[Full Topic Title]
+|New topic to (include, discuss, detail, etc.) <relevant_reason>.
+|===
+// end::<guide_dirname>_fri_jan_01_2016[]
+
+== Mon Jan 11 2016
+
+// tag::<guide_dirname>_mon_jan_11_2016[]
+[cols="1,3",options="header"]
+|===
+
+|Affected Topic |Description of Change
+
+|link:../path/to/topic3.html[Full Topic Title]
+|https://bugzilla.redhat.com/show_bug.cgi?id=#####[*BZ #####*]: Updated
+link:../path/to/topic3.html#section-anchor[Full Section Title] section to
+(fix, add, remove, etc.) <relevant_reason>.
+
+|link:../path/to/subcategory/topic4.html[Subcategory Name -> Full Topic Title]
+|Clarify details about
+link:../path/to/subcategory/topic4.html#link-to-relevant-section[this or that].
+|===
+// end::<guide_dirname>_mon_jan_11_2016[]

--- a/contributing_to_docs/templates/topic_template.adoc
+++ b/contributing_to_docs/templates/topic_template.adoc
@@ -1,0 +1,24 @@
+[[contributing-to-docs-templates-topic-template]]
+= Replace with topic title
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+== Overview
+All topics should include an Overview section that introduces the topic. Remove this and add a brief introduction here.
+
+== Section Title
+Another section in the topic.
+
+== Suggested Next Steps 
+[Link to suggested topic]
+[Link to suggested topic]
+
+////
+This would be the last section of a topic that serves as a suggestion to what topics customers can go read next. It may or may not be required.
+////

--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -1,0 +1,301 @@
+[[contributing-to-docs-term-glossary]]
+= OpenShift Glossary of Terms
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+
+NOTE: The guidelines in this branch are specific for OpenShift / OKD 3.x
+documentation. See the
+link:https://github.com/openshift/openshift-docs/tree/enterprise-4.1/contributing_to_docs[`enterprise-4.1` branch]
+for guidelines for OpenShift / OKD 4.x documentation.
+
+toc::[]
+
+This topic provides guidelines for referring to the various components of
+OpenShift and objects of a running OpenShift system in our documentation. The
+goal is to standardize terminology across OpenShift content and be consistent in
+the usage of our terminology when referring to OpenShift components or
+architecture.
+
+[NOTE]
+====
+If you want to add terms or other content to this document, or if anything needs
+to be fixed, send an email to openshift-docs@redhat.com or submit a PR
+on GitHub.
+====
+
+== Usage of OpenShift Terms
+
+=== action
+
+Usage: action
+
+An action consists of _project_, _verb_, and _resource_:
+
+* *Project* is the project containing the resource that is to be acted upon.
+* *Verb* is a get, list, create, or update operation.
+* *Resource* is the API endpoint being accessed. This is distinct from the
+referenced resource itself, which can be a pod, deployment config, build, etc.
+
+''''
+=== apiserver
+
+Usage: apiserver(s) as appropriate
+
+A REST API endpoint for interacting with the system.  New deployments and
+configurations can be created with this endpoint, and the state of the system
+can be interrogated through this endpoint as well.
+
+''''
+=== application
+
+Usage: _application(s)_ as appropriate; italicized
+
+Although the term _application_ is no longer an official noun in OpenShift,
+customers still create and host applications on OpenShift, and using the term
+within certain contexts is acceptable. For example, the term _application_ may
+refer to some combination of an image, a Git repository, or a replication
+controller, and this _application_ may be running PHP, MySQL, Ruby, JBoss, or
+something else.
+
+Do *NOT* use the term _application_ in a topic or section heading.
+
+*Examples of correct usage*
+====
+_OpenShift runs your applications_.
+
+_The new-app command creates a new application from the components you specify._
+
+_My application has two Ruby web services connected to a database backend and a
+RabbitMQ message queue, as well as a python worker framework._
+
+_You can check the health of your application by adding probes to the various
+parts._
+
+_You can host a WordPress application on OpenShift._
+====
+''''
+
+=== authorization
+
+Usage: authorization
+
+An authorization determines whether an _identity_ is allowed to perform any
+action. It consists of _identity_ and _action_.
+
+''''
+
+=== build
+
+Usage: build(s) as appropriate
+
+''''
+
+=== cluster
+
+Usage: cluster
+
+The collection of controllers, pods, and services and related DNS and networking
+routing configuration that are defined on the system.
+
+''''
+=== container
+
+Usage: container(s) as appropriate
+
+''''
+
+=== container group
+
+Usage: container group
+
+''''
+
+=== deployment
+
+Usage: deployment
+
+A deployment is a statement of intent by a user to roll out a new version of a
+config. A replication controller can be used for that and other purposes. All
+deployments are replication controllers, but all replication controllers are not
+deployments.
+
+To avoid confusion, do not refer to an overall OpenShift installation / instance /
+cluster as an "OpenShift deployment".
+
+''''
+=== deployment controller
+
+Usage: deployment controller(s) as appropriate
+
+Kubernetes object that creates a replication controller from a given pod
+template.  If that pod template is modified, the deployment controller creates
+a new replication controller based on the modified pod template and replaces the
+old replication controller with this new one.
+
+''''
+=== Dockerfile
+
+Usage: Dockerfile; wrapped with [filename] markup. See
+link:doc_guidelines.html[Documentation Guidelines] for markup information.
+
+Container engines like Podman, Buildah, and Docker can build images automatically by reading the instructions from a
+Dockerfile. A Dockerfile is a text document that contains all the commands you
+would normally execute manually in order to build a container image.
+
+Source: https://docs.docker.com/reference/builder/
+
+.Examples of correct usage
+====
+Open the [filename]#Dockerfile# and make the following changes.
+
+Create a [filename]#Dockerfile# at the root of your repository.
+====
+
+''''
+=== identity
+
+Usage: identity or identities as appropriate
+
+Both the username and list of groups the user belongs to.
+
+''''
+=== image
+
+Usage: image(s)
+
+''''
+
+=== Kubelet
+
+Usage: Kubelet(s) as appropriate
+
+The agent that controls a Kubernetes node.  Each node runs a Kubelet, which
+handles starting and stopping containers on a node, based on the desired state
+defined by the master.
+
+''''
+=== Kubernetes master
+
+Usage: Kubernetes master(s) as appropriate
+
+The Kubernetes-native equivalent to the link:#project[OpenShift master].
+An OpenShift system runs OpenShift masters, not Kubernetes masters, and
+an OpenShift master provides a superset of the functionality of a Kubernetes
+master, so it is generally preferred to use the term OpenShift master.
+
+''''
+
+=== minion
+
+Usage: Deprecated. Use link:#node[node] instead.
+
+''''
+
+=== node
+
+Usage: node(s) as appropriate
+
+A
+http://docs.okd.io/latest/architecture/infrastructure_components/kubernetes_infrastructure.html#node[node]
+provides the runtime environments for containers.
+
+''''
+
+=== namespace
+
+Usage: namespace
+
+Typically synonymous with link:#project[project] in OpenShift parlance, which is
+preferred.
+
+''''
+
+=== OpenShift CLI
+
+Usage: OpenShift CLI
+
+This is the command line interface of OpenShift v3, previously referred to as
+the client tools in OpenShift v2.
+
+''''
+
+=== OpenShift master
+
+Usage: OpenShift master(s) as appropriate
+
+Provides a REST endpoint for interacting with the system and manages the state
+of the system, ensuring that all containers expected to be running are actually
+running and that other requests such as builds and deployments are serviced.
+New deployments and configurations are created with the REST API, and the state
+of the system can be interrogated through this endpoint as well.  An OpenShift
+master comprises the apiserver, scheduler, and SkyDNS.
+
+''''
+
+=== Options menu
+
+Usage: Options menu; use sparingly; not to be confused with Actions menu, which
+signifies a specific menu seen in the web console.
+
+This describes a menu type commonly called a "kebab", "hamburger", or "overflow"
+menu that does not have hover text or a given name or label in the web console.
+
+''''
+
+=== pod
+
+Usage: pod(s) as appropriate
+
+Kubernetes object that groups related containers that need to share
+network, filesystem, or memory together for placement on a node.  Multiple
+instances of a Pod can run to provide scaling and redundancy.
+
+''''
+
+=== project
+
+Usage: project(s) as appropriate
+
+A http://docs.okd.io/latest/dev_guide/projects.html[project] allows a
+community of users to organize and manage their content in isolation from other
+communities.
+
+''''
+
+=== replication controller
+
+Usage: replication controller(s) as appropriate
+
+Kubernetes object that ensures N (as specified by the user) instances of a given
+Pod are running at all times.
+
+''''
+=== scheduler
+
+Usage: scheduler(s) as appropriate
+
+Component of the Kubernetes master or OpenShift master that manages the state of
+the system, places pods on nodes, and ensures that all containers that are
+expected to be running are actually running.
+
+''''
+=== SkyDNS
+
+Usage: SkyDNS
+
+Component of the Kubernetes master or OpenShift master that provides
+cluster-wide DNS resolution of internal hostnames for services and pods.
+
+''''
+=== Source-to-Image (S2I)
+
+Usage: Source-to-Image for the first time reference; S2I thereafter.
+
+Deprecated abbreviation (do not use): STI
+
+''''

--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -1,0 +1,198 @@
+[[contributing-to-docs-tools-and-setup]]
+= Install and set up the tools and software
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+:linkattrs:
+:description: How to set up and install the tools to contribute
+
+toc::[]
+
+== Create a GitHub account
+Before you can contribute to OpenShift documentation, you must
+https://www.github.com/join[sign up for a GitHub account].
+
+== Set up authentication
+When you have your account set up, follow the instructions to
+https://help.github.com/articles/generating-ssh-keys/[generate and set up SSH
+keys on GitHub] for proper authentication between your workstation and GitHub.
+
+Confirm authentication is working correctly with the following command:
+
+----
+$ ssh -T git@github.com
+----
+
+== Fork and clone the OpenShift documentation repository
+You must fork and set up the OpenShift documentation repository on your
+workstation so that you can create PRs and contribute. These steps only need to
+be performed during initial setup.
+
+1. Fork the https://github.com/openshift/openshift-docs repository into your
+GitHub account from the GitHub UI. You can do this by clicking on *Fork* in the
+upper right-hand corner.
+
+2. On your workstation, clone the forked repository on your workstation with the
+following command. Be sure to change into the directory where you want to clone,
+and replace _<user_name>_ with your actual GitHub username.
++
+----
+$ git clone git@github.com:user_name/openshift-docs.git
+----
+
+3. From your local repository you just cloned, add an upstream pointer back to
+the OpenShift's remote repository, in this case _openshift-docs_.
++
+----
+$ git remote add upstream git@github.com:openshift/openshift-docs.git
+----
+
+This ensures that you are tracking the remote repository to keep your local
+repository in sync with it.
+
+== Install AsciiBinder and dependencies
+When you have the documentation repository cloned and set up, you are ready to
+install the software and tools you will use to create the content. All OpenShift
+documentation is created in AsciiDoc, and is processed with https://github.com/redhataccess/ascii_binder[AsciiBinder],
+which is an http://asciidoctor.org/[AsciiDoctor]-based docs management system.
+
+You can work on a topic file in an editing environment that automatically
+processes and updates the rendered HTML.
+
+=== What you need
+The following are minimum requirements to set up a live editing environment:
+
+* A bash shell environment (Linux and OS X include a bash shell environment out
+of the box, but if you are on Windows you can use http://cygwin.com/[Cygwin])
+* https://www.ruby-lang.org/en/[Ruby]
+* http://www.git-scm.com/[Git]
+* A web browser (Firefox, Chrome, or Safari)
+* An editor that can strip trailing whitespace.
+
+=== Install the required software dependencies on a Linux system
+The following instructions describe how to install all the required tools to do
+live content editing on a Fedora Linux system.
+
+1. Install the _RubyGems_ package with `yum install rubygems`
+2. Install _Ruby_ development packages with `yum install ruby-devel`
+3. Install _gcc_ with `yum install gcc-c++`
+4. Install _redhat-rpm-config_ with `yum install redhat-rpm-config`
+5. Install _make_ with `yum install make`
+6. Install (1.5.6 version of) _asciidoctor-diagram_ with `gem install asciidoctor-diagram --version=1.5.6`
+7. Install the _ascii_binder_ gem with `gem install ascii_binder`
+
+NOTE: If you already have AsciiBinder installed, you may be due for an update. These directions assume that you are using AsciiBinder 0.1.15.1 or newer. To check and update if necessary, simply run `gem update ascii_binder`. Note that you may need root permissions.
+
+=== Initial setup
+After you have confirmed that you meet the minimum system requirements, or if
+you are on a Linux system you have installed the
+link:#install-the-required-software-dependencies-on-a-linux-system[required
+software dependencies], you can perform the initial setup.
+
+[NOTE]
+.ditaa Support
+====
+https://github.com/stathissideris/ditaa[ditaa] requires $JAVA_HOME be set, which requires a JDK
+installed (try e.g. `yum install java-1.8.0-openjdk-devel` and `export
+JAVA_HOME=/usr/lib/jvm/java-1.8.0`).
+====
+
+=== How to use LiveReload
+With the initial setup complete, you are ready to use LiveReload to edit your
+content.
+
+1. From the `openshift-docs` directory, run an initial build:
++
+----
+$ cd openshift-docs
+$ asciibinder build
+----
+2. Open the generated HTML file in your web browser. This will be located in the
+`openshift-docs/_preview/<distro>/<branch>` directory, with the same path and
+filename as the original `.adoc` file you edited, only it will be with the
+`.html` extension.
+3. Run the `watch` utility:
++
+----
+$ asciibinder watch
+----
++
+[TIP]
+This utility will run in the terminal where you started it, so you should leave
+it running and open new terminal windows for other tasks.
+
+4. In your browser, enable the LiveReload plug-in in the same tab where the
+preview file is open; the icon should change color once activated. The following
+message will also display in your terminal window:
++
+----
+[1] guard(main)> 17:29:22 - INFO - Browser connected.
+----
+
+With this setup, a rebuild is automatically generated each time you make a change
+to the source `.adoc` file, and is immediately viewable in the corresponding
+`.html` file.
+
+=== Clean up
+The `.gitignore` file is set up to prevent anything under the `_preview` and
+`_package` directories from being committed. However, you can reset the
+environment manually by running:
+
+----
+$ asciibinder clean
+----
+
+== Next steps
+With the repository and tools set up on your workstation, you can now either
+edit existing content or create new topics.
+
+* link:doc_guidelines.adoc[Review the documentation guidelines] to understand
+some basic guidelines to keep things consistent across our content.
+* link:create_or_edit_content.adoc[Create a local working branch] on your
+workstation to edit existing topics or create new topics.
+
+=== How to deploy to OpenShift
+You can deploy to OpenShift for development. This process will use your github repo to launch the website,
+and therefore your github repo must have all of the upstream branches. `master` is used for site changes,
+so assuming all your work is in `master`, you can remove all remote branches and then push the upstream branches.
+
+
+Removing remote branches and updating with upstream branches (this assumes remote repos called `origin` and `upstream`)
+[WARNING]
+====
+This is a destructive process, make sure that this is purely a development repo, as all local and remote branches will be deleted
+by performing the below commands.
+====
+----
+$ git fetch --all
+$ for branch in $(git branch -r | grep -v "master" | grep "^  origin"); do git push origin --delete $(echo $branch | cut -d '/' -f 2); done
+$ git branch -D $(git branch | grep -v 'master' | xargs)
+$ for branch in $(git branch -r | grep -v "master" | grep "^  upstream"); do git branch --track $(echo $branch | cut -d '/' -f 2) $(echo $branch | tr -d '[:space:]'); done
+$ for branch in $(git branch | grep -v "master"); do git push origin $(echo $branch | tr -d '[:space:]'); done
+----
+
+Deploying the docs site to an OpenShift cluster
+----
+$ oc process -f asciibinder-template.yml -p NAME=docs \
+    -p SOURCE_REPOSITORY_URL=$(git remote get-url origin) \
+    -p SOURCE_REPOSITORY_REF=$(git rev-parse --abbrev-ref HEAD) \
+    -p MEMORY_LIMIT=512Mi -p MEMORY_REQUEST=256Mi \
+    | oc create -f -
+----
+
+[NOTE]
+====
+If the build fails with "Fetch source failed" status, you can
+delete all the created objects and re-run above with an HTTP uri
+as the `SOURCE_REPOSITORY_URL`, or you can
+link:https://docs.okd.io/latest/dev_guide/builds/build_inputs.html#source-secrets-combinations[create a source secret]
+and add it to the stg1 build, `oc set build-secret --source bc/stg1-docs <secret name>`.
+====
+
+
+You can delete all created objects by running
+
+----
+$ oc delete all -l app=docs
+----


### PR DESCRIPTION
@vikram-redhat, I think we should retain the 3.x contribution guide. We changed enough between the 3.x and 4.x stream that it's useful to retain the old information.

What do you think?