### PR TITLE
BZ-1823977: Updating command to approval all pending CSRs

### DIFF
--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -27,7 +27,6 @@ these CSRs are approved or, if necessary, approve them yourself.
 .Prerequisites
 
 * You added machines to your cluster.
-* Install the `jq` package.
 
 .Procedure
 
@@ -102,11 +101,10 @@ $ oc adm certificate approve <csr_name> <1>
 ----
 <1> `<csr_name>` is the name of a CSR from the list of current CSRs.
 
-** If all the CSRs are valid, approve them all by running the following
-command:
+** To approve all pending CSRs, run the following command:
 +
 ----
-$ oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' | xargs oc adm certificate approve
+$ oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' | xargs oc adm certificate approve
 ----
 
 ifeval::["{context}" == "installing-ibm-z"]


### PR DESCRIPTION
Apply change from https://bugzilla.redhat.com/show_bug.cgi?id=1823977 to 4.x. Command accomplishes the same thing, but this one doesn't require the jq package to be installed.