### PR TITLE
installation: provide rd.neednet=1 when using Tang disk encryption

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -14,7 +14,8 @@ settings and run `openshift-install` to install a cluster and `oc` to work with 
 for instructions. See link:https://youtu.be/2uLKvB8Z5D0[Securing Automated Decryption New Cryptography and Techniques]
 for a presentation on Tang.
 
-. Add kernel arguments to configure networking when you do the {op-system-first} installations for your cluster. For example, to configure DHCP networking, identify `ip=dhcp`, or set static networking when you add parameters to the kernel command line.
+
+. Add kernel arguments to configure networking when you do the {op-system-first} installations for your cluster. For example, to configure DHCP networking, identify `ip=dhcp`, or set static networking when you add parameters to the kernel command line. For both DHCP and static networking, you also must provide the `rd.neednet=1` kernel argument.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
In BZ#1819215[1] an error was reported that the RHCOS nodes did not
successfully reboot when Tang disk encryption was used.  The root
cause was the missing kernel argument `rd.neednet=1`.

This updates the docs to call out the requirement on that kernel
argument when using Tang for disk encryption.