### PR TITLE
Add Marketplace doc to 4.4

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -866,6 +866,9 @@ Topics:
 - Name: Pruning objects to reclaim resources
   File: pruning-objects
   Distros: openshift-origin,openshift-enterprise,openshift-webscale
+- Name: The Red Hat Marketplace
+  File: red-hat-marketplace
+  Distros: openshift-origin,openshift-enterprise,openshift-webscale
 ---
 Name: Machine management
 Dir: machine_management

--- a/applications/red-hat-marketplace.adoc
+++ b/applications/red-hat-marketplace.adoc
@@ -1,0 +1,10 @@
+[id="red-hat-marketplace"]
+= The Red Hat Marketplace
+include::modules/common-attributes.adoc[]
+:context: red-hat-marketplace
+
+toc::[]
+
+{product-title} cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started[Red Hat Marketplace] to manage software on {product-title}, provide developers with self-service access to deploy application instances, and correlate application usage against a quota.
+
+include::modules/red-hat-marketplace-features.adoc[leveloffset=+1]

--- a/applications/red-hat-marketplace.adoc
+++ b/applications/red-hat-marketplace.adoc
@@ -5,6 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started[Red Hat Marketplace] to manage software on {product-title}, provide developers with self-service access to deploy application instances, and correlate application usage against a quota.
+The link:https://marketplace.redhat.com[Red Hat® Marketplace] is an open cloud marketplace that makes it easy to discover and access certified software for container-based environments in public clouds and on-prem.
 
 include::modules/red-hat-marketplace-features.adoc[leveloffset=+1]

--- a/applications/red-hat-marketplace.adoc
+++ b/applications/red-hat-marketplace.adoc
@@ -5,6 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The link:https://marketplace.redhat.com[Red Hat® Marketplace] is an open cloud marketplace that makes it easy to discover and access certified software for container-based environments in public clouds and on-prem.
+The link:https://marketplace.redhat.com[Red Hat® Marketplace] is an open cloud marketplace that makes it easy to discover and access certified software for container-based environments that run on public clouds and on-premesis.
 
 include::modules/red-hat-marketplace-features.adoc[leveloffset=+1]

--- a/applications/red-hat-marketplace.adoc
+++ b/applications/red-hat-marketplace.adoc
@@ -1,0 +1,10 @@
+[id="red-hat-marketplace"]
+= The Red Hat Marketplace
+include::modules/common-attributes.adoc[]
+:context: red-hat-marketplace
+
+toc::[]
+
+The link:https://marketplace.redhat.com[Red Hat® Marketplace] is an open cloud marketplace that makes it easy to discover and access certified software for container-based environments in public clouds and on-prem.
+
+include::modules/red-hat-marketplace-features.adoc[leveloffset=+1]

--- a/applications/using-marketplace.adoc
+++ b/applications/using-marketplace.adoc
@@ -1,0 +1,34 @@
+[id="using-marketplace"]
+= Using Red Hat Marketplace
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+{product-title} cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started
+[Red Hat Marketplace] to manage software on {product-title}, provide developers with self-service access to deploy application instances, and correlate application usage against a quota.
+
+== Connecting {product-title} clusters to the Marketplace
+
+You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Additional users can be added through the Marketplace for the Procurement department to access this data.
+
+A Marketplace Operator is installed to install the image registry secret, manage the on-cluster catalog and report application usage during the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process].
+
+== Installing applications
+
+Cluster administrators can browse and link:https://marketplace.redhat.com/en-us/documentation/operators[install Marketplace applications] from within OperatorHub in {product-title} or at the link:https://marketplace.redhat.com[Marketplace web application].
+
+After applications are installed, access them in the web console under *Installed Operators*.
+
+== Deploying an instance of an application
+
+Applications that you install from the Marketplace can be used in the Administrator and Developer perspectives of the web console.
+
+=== Using the Developer perspective
+
+Developers using the {product-title} cluster don’t have to concern themselves with Operator installation or usage tracking of applications. Newly installed capabilities are immediately available for use within the Developer perspective’s catalog. 
+
+For example, once a database Operator is installed, a developer can create an instance from the catalog within their Project. Usage of the database is collected and reported in aggregate to the cluster administrator.
+
+=== Using the Administrator perspective
+
+{product-title} users can launch applications instances by browsing available CRDs within the *Installed Operators* list.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -5,35 +5,42 @@
 [id="red-hat-marketplace-features_{context}"]
 = Red Hat Marketplace features
 
-{product-title} cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started[Red Hat Marketplace] to manage software on {product-title}, provide developers with self-service access to deploy application instances, and correlate application usage against a quota.
+Cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started[Red Hat Marketplace] to manage software on {product-title}, give developers self-service access to deploy application instances, and correlate application usage against a quota.
 
 [id="marketplace-clusters_{context}"]
 == Connect {product-title} clusters to the Marketplace
 
-You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Additional users can be added through the Marketplace for the Procurement department to access this data.
+You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Additional users can be added
+// (NOTE: added to what?) 
+through the Marketplace for the Procurement department to access this data.
 
-A Marketplace Operator is installed to install the image registry secret, manage the on-cluster catalog and report application usage during the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process].
+During the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process], a
+a Marketplace Operator is installed that updates the image registry secret, manages the catalog, and reports application usage.
 
 [id="marketplace-install-applications_{context}"]
 == Install applications
 
-Cluster administrators can browse and link:https://marketplace.redhat.com/en-us/documentation/operators[install Marketplace applications] from within OperatorHub in {product-title} or at the link:https://marketplace.redhat.com[Marketplace web application].
+Cluster administrators can link:https://marketplace.redhat.com/en-us/documentation/operators[install Marketplace applications] from within OperatorHub in {product-title}, or at the link:https://marketplace.redhat.com[Marketplace web application].
 
-After applications are installed, access them in the web console under *Installed Operators*.
+Access installed applications from the web console under *Installed Operators*.
 
 [id="marketplace-deploy_{context}"]
-== Deploy an instance of an application
+== Deploy applications from different perspectives
 
-Applications that you install from the Marketplace can be used in the Administrator and Developer perspectives of the web console.
+Deploy Marketplace applications from the web console's Administrator and Developer perspectives.
 
 [discrete]
 === The Developer perspective
 
-Developers using the {product-title} cluster don’t have to concern themselves with Operator installation or usage tracking of applications. Newly installed capabilities are immediately available for use within the Developer perspective’s catalog. 
+Access newly installed capabilities from the Developer perspective’s catalog.
 
-For example, once a database Operator is installed, a developer can create an instance from the catalog within their Project. Usage of the database is collected and reported in aggregate to the cluster administrator.
+For example, after a database Operator is installed, a developer can create an instance from the catalog within their Project. Database usage is aggregated and reported to the cluster administrator.
+
+This perspective does not include Operator installation and application usage tracking.
 
 [discrete]
 === The Administrator perspective
 
-{product-title} users can launch applications instances by browsing available CRDs within the *Installed Operators* list.
+The Administrator perspective includes information about Operator installation and application usage.
+
+{product-title} administrators can launch application instances by browsing custom resource definitions (CRDs) within the *Installed Operators* list.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * applications/red-hat-marketplace.adoc
+
+[id="red-hat-marketplace-features_{context}"]
+= Red Hat Marketplace features
+
+Cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started[Red Hat Marketplace] to manage software on {product-title}, give developers self-service access to deploy application instances, and correlate application usage against a quota.
+
+[id="marketplace-clusters_{context}"]
+== Connect {product-title} clusters to the Marketplace
+
+You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Users that you add by using the Marketplace have their product usage tracked and billed to your organization.
+
+During the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process],
+a Marketplace Operator is installed that updates the image registry secret, manages the catalog, and reports application usage.
+
+[id="marketplace-install-applications_{context}"]
+== Install applications
+
+Cluster administrators can link:https://marketplace.redhat.com/en-us/documentation/operators[install Marketplace applications] from within OperatorHub in {product-title}, or at the link:https://marketplace.redhat.com[Marketplace web application].
+
+Access installed applications from the web console under *Installed Operators*.
+
+[id="marketplace-deploy_{context}"]
+== Deploy applications from different perspectives
+
+Deploy Marketplace applications from the web console's Administrator and Developer perspectives.
+
+[discrete]
+=== The Developer perspective
+
+Access newly installed capabilities from the Developer perspective’s catalog.
+
+For example, after a database Operator is installed, a developer can create an instance from the catalog within their Project. Database usage is aggregated and reported to the cluster administrator.
+
+This perspective does not include Operator installation and application usage tracking.
+
+[discrete]
+=== The Administrator perspective
+
+The Administrator perspective includes information about Operator installation and application usage.
+
+{product-title} administrators can launch application instances by browsing custom resource definitions (CRDs) within the *Installed Operators* list.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -10,9 +10,7 @@ Cluster administrators can use link:https://marketplace.redhat.com/en-us/documen
 [id="marketplace-clusters_{context}"]
 == Connect {product-title} clusters to the Marketplace
 
-You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Additional users can be added
-// (NOTE: added to what?) 
-through the Marketplace for the Procurement department to access this data.
+You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Users that you add by using the Marketplace have their product usage tracked and billed.
 
 During the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process], a
 a Marketplace Operator is installed that updates the image registry secret, manages the catalog, and reports application usage.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -30,7 +30,7 @@ You can deploy Marketplace applications from the web console's Administrator and
 [discrete]
 === The Developer perspective
 
-Developers can access newly installed capabilities from the Developer perspective’s catalog.
+Developers can access newly installed capabilities by using the Developer perspective.
 
 For example, after a database Operator is installed, a developer can create an instance from the catalog within their project. Database usage is aggregated and reported to the cluster administrator.
 
@@ -39,6 +39,6 @@ This perspective does not include Operator installation and application usage tr
 [discrete]
 === The Administrator perspective
 
-The Administrator perspective includes information about Operator installation and application usage.
+Cluster administrators can access Operator installation and application usage information from the Administrator perspective.
 
-Cluster administrators can launch application instances by browsing custom resource definitions (CRDs) within the *Installed Operators* list.
+They can also launch application instances by browsing custom resource definitions (CRDs) in the *Installed Operators* list.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -30,7 +30,7 @@ You can deploy Marketplace applications from the web console's Administrator and
 [discrete]
 === The Developer perspective
 
-You can access newly installed capabilities from the Developer perspective’s catalog.
+Developers can access newly installed capabilities from the Developer perspective’s catalog.
 
 For example, after a database Operator is installed, a developer can create an instance from the catalog within their project. Database usage is aggregated and reported to the cluster administrator.
 

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -5,7 +5,7 @@
 [id="red-hat-marketplace-features_{context}"]
 = Red Hat Marketplace features
 
-Test
+{product-title} cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started[Red Hat Marketplace] to manage software on {product-title}, provide developers with self-service access to deploy application instances, and correlate application usage against a quota.
 
 [id="marketplace-clusters_{context}"]
 == Connect {product-title} clusters to the Marketplace

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -1,34 +1,39 @@
-[id="using-marketplace"]
-= Using Red Hat Marketplace
-include::modules/common-attributes.adoc[]
+// Module included in the following assemblies:
+//
+// * applications/red-hat-marketplace.adoc
 
-toc::[]
+[id="red-hat-marketplace-features_{context}"]
+= Red Hat Marketplace features
 
-{product-title} cluster administrators can use link:https://marketplace.redhat.com/en-us/documentation/getting-started
-[Red Hat Marketplace] to manage software on {product-title}, provide developers with self-service access to deploy application instances, and correlate application usage against a quota.
+Test
 
-== Connecting {product-title} clusters to the Marketplace
+[id="marketplace-clusters_{context}"]
+== Connect {product-title} clusters to the Marketplace
 
 You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Additional users can be added through the Marketplace for the Procurement department to access this data.
 
 A Marketplace Operator is installed to install the image registry secret, manage the on-cluster catalog and report application usage during the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process].
 
-== Installing applications
+[id="marketplace-install-applications_{context}"]
+== Install applications
 
 Cluster administrators can browse and link:https://marketplace.redhat.com/en-us/documentation/operators[install Marketplace applications] from within OperatorHub in {product-title} or at the link:https://marketplace.redhat.com[Marketplace web application].
 
 After applications are installed, access them in the web console under *Installed Operators*.
 
-== Deploying an instance of an application
+[id="marketplace-deploy_{context}"]
+== Deploy an instance of an application
 
 Applications that you install from the Marketplace can be used in the Administrator and Developer perspectives of the web console.
 
-=== Using the Developer perspective
+[discrete]
+=== The Developer perspective
 
 Developers using the {product-title} cluster don’t have to concern themselves with Operator installation or usage tracking of applications. Newly installed capabilities are immediately available for use within the Developer perspective’s catalog. 
 
 For example, once a database Operator is installed, a developer can create an instance from the catalog within their Project. Usage of the database is collected and reported in aggregate to the cluster administrator.
 
-=== Using the Administrator perspective
+[discrete]
+=== The Administrator perspective
 
 {product-title} users can launch applications instances by browsing available CRDs within the *Installed Operators* list.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -12,7 +12,7 @@ Cluster administrators can use link:https://marketplace.redhat.com/en-us/documen
 
 You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Users that you add by using the Marketplace have their product usage tracked and billed to your organization.
 
-During the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process], a
+During the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process],
 a Marketplace Operator is installed that updates the image registry secret, manages the catalog, and reports application usage.
 
 [id="marketplace-install-applications_{context}"]

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -10,7 +10,7 @@ Cluster administrators can use link:https://marketplace.redhat.com/en-us/documen
 [id="marketplace-clusters_{context}"]
 == Connect {product-title} clusters to the Marketplace
 
-You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Users that you add by using the Marketplace have their product usage tracked and billed.
+You can install a common set of applications on {product-title} clusters that you connect to the Marketplace. You can also use the Marketplace to track cluster usage against your subscriptions or quota. Users that you add by using the Marketplace have their product usage tracked and billed to your organization.
 
 During the link:https://marketplace.redhat.com/en-us/documentation/clusters[cluster connection process], a
 a Marketplace Operator is installed that updates the image registry secret, manages the catalog, and reports application usage.


### PR DESCRIPTION
Add s a simple doc about Red Hat Marketplace that is mostly links out to external content at marketplace.redhat.com. This location is currently behind a whitelist but I can show you that content if required.

I am happy to make changes or have someone take over this PR if that is easier.

cc: @maxwelldb 