### PR TITLE
CNV-3573 clone local volume to different node

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1527,6 +1527,8 @@ Topics:
       File: cnv-uploading-local-disk-images-virtctl
     - Name: Uploading a local disk image to a block storage DataVolume
       File: cnv-uploading-local-disk-images-block
+    - Name: Moving a local virtual machine disk to a different node
+      File: cnv-moving-local-vm-disk-to-different-node
     - Name: Expanding virtual storage by adding blank disk images
       File: cnv-expanding-virtual-storage-with-blank-disk-images
     - Name: Preparing CDI scratch space

--- a/cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-moving-local-vm-disk-to-different-node.adoc
+++ b/cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-moving-local-vm-disk-to-different-node.adoc
@@ -1,0 +1,22 @@
+[id="cnv-moving-local-vm-disk-to-different-node"]
+= Moving a local virtual machine disk to a different node
+include::modules/cnv-document-attributes.adoc[]
+:context: cnv-moving-local-vm-disk-to-different-node
+toc::[]
+
+Virtual machines that use local volume storage can be moved so that they run on a specific node. 
+
+You might want to move the virtual machine to a specific node for the following reasons:
+
+* The current node has limitations to the local storage configuration.
+* The new node is better optimized for the workload of that virtual machine. 
+
+To move a virtual machine that uses local storage, you must clone the underlying volume by using a DataVolume. After the cloning operation is complete, you can xref:../../../cnv/cnv_virtual_machines/cnv-edit-vms.adoc#cnv-edit-vms[edit the virtual machine configuration] so that it uses the new DataVolume, or xref:../../../cnv/cnv_virtual_machines/cnv-edit-vms.adoc#cnv-vm-add-disk_cnv-edit-vms[add the new DataVolume to another virtual machine].
+
+[NOTE]
+====
+Users without the `cluster-admin` role require xref:../../../cnv/cnv_virtual_machines/cnv_cloning_vms/cnv-enabling-user-permissions-to-clone-datavolumes.adoc#cnv-enabling-user-permissions-to-clone-datavolumes[additional user permissions] in order to clone volumes across namespaces.
+====
+
+include::modules/cnv-cloning-local-volume-to-another-node.adoc[leveloffset=+1]
+

--- a/modules/cnv-cloning-local-volume-to-another-node.adoc
+++ b/modules/cnv-cloning-local-volume-to-another-node.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-moving-local-vm-disk-to-different-node.adoc
+
+[id="cnv-cloning-local-volume-to-another-node_{context}"]
+= Cloning a local volume to another node
+
+You can move a virtual machine disk so that it runs on a specific node by cloning the underlying PersistentVolumeClaim (PVC).
+
+To ensure the virtual machine disk is cloned to the correct node, you must either create a new PersistentVolume (PV) or identify one on the correct node.
+Apply a unique label to the PV so that it can be referenced by the DataVolume.
+
+[NOTE]
+====
+The destination PV must be the same size or larger than the source PVC.
+If the destination PV is smaller than the source PVC, the cloning operation fails.
+====
+
+.Prerequisites
+
+* The virtual machine must not be running. Power down the virtual machine before cloning the virtual machine disk. 
+
+.Procedure
+
+. Either create a new local PV on the node, or identify a local PV already on the node:
+
+* Create a local PV that includes the `nodeAffinity.nodeSelectorTerms` parameters. The following manifest creates a `10Gi` local PV on `node01`. 
++
+[source,yaml]
+----
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: <destination-pv> <1>
+  annotations:
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 10Gi <2>
+  local:
+    path: /mnt/local-storage/local/disk1 <3>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - node01 <4>
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local
+  volumeMode: Filesystem
+----
+<1> The name of the PV.
+<2> The size of the PV. You must allocate enough space, or the cloning operation fails. The size must be the same as or larger than the source PVC.
+<3> The mount path on the node.
+<4> The name of the node where you want to create the PV.
+
+* Identify a PV that already exists on the target node. You can identify the node where a PV is provisioned by viewing the `nodeAffinity` field in its configuration:
++
+----
+$ oc get pv <destination-pv> -o yaml
+----
++
+The following snippet shows that the PV is on `node01`:
++
+[source,yaml]
+----
+...
+spec:
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname <1>
+          operator: In
+          values:
+          - node01 <2>
+...
+----
+<1> The `kubernetes.io/hostname` key uses the node host name to select a node.
+<2> The host name of the node. 
+
+. Add a unique label to the PV:
++
+----
+$ oc label pv <destination-pv> node=node01
+----
+
+. Create a DataVolume manifest that references the following:
+
+* The PVC name and namespace of the virtual machine.
+* The label you applied to the PV in the previous step.
+* The size of the destination PV.
++
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: <clone-datavolume> <1>
+spec:
+  source:
+    pvc:
+      name: "<source-vm-disk>" <2>
+      namespace: "<source-namespace>" <3>
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    selector:
+      matchLabels:
+        node: node01 <4>
+    resources:
+      requests:
+        storage: <10Gi> <5>
+----
+<1> The name of the new DataVolume.
+<2> The name of the source PVC. If you do not know the PVC name, you can find it in the virtual machine configuration: `spec.volumes.persistentVolumeClaim.claimName`.
+<3> The namespace where the source PVC exists.
+<4> The label that you applied to the PV in the previous step.
+<5> The size of the destination PV.
+
+. Start the cloning operation by applying the DataVolume manifest to your cluster:
++
+----
+$ oc apply -f <clone-datavolume.yaml>
+----
+
+The DataVolume clones the PVC of the virtual machine into the PV on the specific node.


### PR DESCRIPTION
 New module and assembly to cover moving a VM that uses local storage to a specific node. This process requires the user to label a PV on the destination node and clone the underlying volume of the VM using a DataVolume that references the PV label.

I've included this under 'Virtual Machine Disks' instead of 'Cloning Virtual Machines' because although the process requires cloning, the user ultimately wants to move the virtual machine to a specific node. 