### PR TITLE
updated online documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -895,7 +895,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Storage Classes
   File: storage_classes
-  Distros: openshift-online,openshift-dedicated,openshift-aro
+  Distros: openshift-dedicated,openshift-aro
 - Name: Selector and Label Volume Binding
   File: selector_label_volume_binding
   Distros: openshift-online,openshift-dedicated,openshift-aro

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -468,7 +468,7 @@ spec:
   storageClassName: gold
 
 ----
-
+ifdef::openshift-origin,openshift-enterprise,openshift-aro,openshift-dedicated[]
 [[pvc-storage-class]]
 === Storage classes
 
@@ -483,7 +483,7 @@ The cluster administrator can also set a default storage class for all PVCs.
 When a default storage class is configured, the PVC must explicitly ask for
 `StorageClass` or `storageClassName` annotations set to `""` to be bound to a
 PV without a storage class.
-
+endif::[]
 [[pvc-access-modes]]
 === Access modes
 


### PR DESCRIPTION
Updated openshift-online branch in regards to storage class information. 

Removed the following page: 
https://docs.openshift.com/online/pro/dev_guide/storage_classes.html

Removed the following section: 
https://docs.openshift.com/online/pro/architecture/additional_concepts/storage.html#pvc-storage-class