### PR TITLE
CNV 4080 4079 4075

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -27,10 +27,13 @@ include::modules/technology-preview.adoc[leveloffset=+2]
 // CNV-4134 virtctl upload
 
 // CNV-4080 VMI exposed in UI
+* You can view and manage virtual machine instances that are independent of virtual machines within the virtual machine lists.
 
 // CNV-4079 CD-ROM added to VM wizard
+* {CNVProductNameStart} enables you to configure a CD-ROM in the virtual machine wizard.  You can select the type of CD-ROM configuration from a drop-down list:  *Container*, *URL* or *Attach Disk*. You can also edit CD-ROM configurations in the *Virtual Machine Details* page.
 
 // CNV-4075 VM boot order
+* The boot order list is now available in the *Virtual Machine Details*. You can add items, remove items, and modify the boot order list.
 
 // CNV-4076 UI view/config dedicated resources
 


### PR DESCRIPTION
This PR is for the new content created for the CNV 2.3 Release Notes. In the section "New and changed features" I have added three paragraphs for three new features:

--VMI exposed in UI
https://issues.redhat.com/browse/CNV-4080

--CD-ROM added to VM Wizard 
https://issues.redhat.com/browse/CNV-4079

--VM boot order (CNV-4075)
https://issues.redhat.com/browse/CNV-4075
