### PR TITLE
OSDOCS-953: Adding release notes for oauth-proxy imagestream

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -80,6 +80,11 @@ for details.
 
 For more information, see xref:../authentication/bound-service-account-tokens.adoc#bound-service-account-tokens[Using bound service account tokens].
 
+[id="ocp-4-4-oauth-proxy-imagestream"]
+==== The `oauth-proxy` imagestream is now available
+
+{product-title} 4.4 introduces the `oauth-proxy` imagestream for third party authentication integration. You should no longer use the `oauth-proxy` image from the Red Hat Registry. You should instead use the `openshift/oauth-proxy:v4.4` imagestream if you target {product-title} 4.4 clusters and newer. This guarantees backwards compatibility and allows you to add imagestream triggers to get critical fixes. The `v4.4` tag will be available for at least the next three {product-title} minor releases without breaking changes. Each minor release will also introduce its own tag.
+
 [id="ocp-4-4-kube-apiserver-check-certs-before-tokens"]
 ==== kube-apiserver checks client certificates before tokens
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-953

Preview: http://file.rdu.redhat.com/~ahoffer/2020/OSDOCS-953-rn/release_notes/ocp-4-4-release-notes.html