### PR TITLE
Add step to verify kubeapi-server pods after updating API server certificate

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -78,3 +78,23 @@ spec:
         name: <secret>
 ...
 ----
+
+. Check the `kube-apiserver` operator, and verify that a new revision of the Kubernetes API server rolls out.
+It may take a minute for the operator to detect the configuration change and trigger a new deployment.
+While the new revision is rolling out, `PROGRESSING` will report `True`.
++
+[source,terminal]
+----
+$ oc get clusteroperators kube-apiserver
+----
++
+Do not continue to the next step until `PROGRESSING` is listed as `False`, as shown in the following output:
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+NAME             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
+kube-apiserver   {product-version}.0     True        False         False      145m
+----
++
+If `PROGRESSING` is showing `True`, wait a few minutes and try again.


### PR DESCRIPTION
This additional step helps show the reader which pods to monitor for changes, and verify that the API server pods are ready to be tested for the new cert.

I believe this should apply to all OCP 4.x branches.