### PR TITLE
Fix invalid admonition type in ShiftStack Kuryr limitations

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -54,7 +54,7 @@ To ensure that TCP forcing is allowed, compile applications either with the envi
 
 In Go versions 1.13 and later, TCP is used automatically if DNS resolution using UDP fails.
 
-[INFO]
+[NOTE]
 ====
 musl-based containers, including Alpine-based containers, do not support the `use-vc` option.
 ====


### PR DESCRIPTION
Resolves #21207 