### PR TITLE
BZ1822871 - Add static as option for vSphere volume provisioning

### DIFF
--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -93,7 +93,7 @@ value must match the number of control plane machines that you deploy.
 <7> The fully-qualified host name or IP address of the vCenter server.
 <8> The name of the user for accessing the server. This user must have at least
 the roles and privileges that are required for
-link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html[dynamic persistent volume provisioning]
+link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html[static or dynamic persistent volume provisioning]
 in vSphere.
 <9> The password associated with the vSphere user.
 <10> The vSphere datacenter.


### PR DESCRIPTION
[BZ 1822871](https://bugzilla.redhat.com/show_bug.cgi?id=1822871) - This PR adds static provisioning as an option to satisfy provisioning permissions requirement in 4.x docs.

In [3.11 docs](https://docs.openshift.com/container-platform/3.11/install_config/configuring_vsphere.html#vsphere-permissions), we note that dynamic provisioning is the recommended practice, but static provisioning roles and privileges are also documented

@jsafrane, @liangxia, or @qinpingli  - Can you confirm if static provisioning is still an option in OCP 4, or should I check with vSphere QE/Eng?

Preview build link here: https://bz1822871--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-config-yaml_installing-vsphere