### PR TITLE
Bug 1679130, clarified that the CRI-O packages are automatically installed

### DIFF
--- a/modules/crio_get.adoc
+++ b/modules/crio_get.adoc
@@ -100,6 +100,8 @@ ocp-crio01 openshift_node_group_name='node-config-all-in-one-crio'
 ocp-docker01 openshift_node_group_name='node-config-all-in-one'
 ```
 
+This will automatically install the necessary CRI-O packages.
+
 The resulting {product-title} configuration will be running the CRI-O container engine on
 the nodes of your {product-title} installation.
 Use the `oc` command to check the status of the nodes and identify the nodes running CRI-O:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1679130