### PR TITLE
Removing note on @type:copy added to 4.3 and 4.4 in error

### DIFF
--- a/modules/cluster-logging-collector-fluentd.adoc
+++ b/modules/cluster-logging-collector-fluentd.adoc
@@ -7,11 +7,6 @@
 
 You can use the Fluentd *forward* plug-ins to send a copy of your logs to an external log aggregator, instead of the default Elasticsearch.
 
-[NOTE]
-====
-You can configure {product-title} to send logs to both the internal Elasticsearch instance and an outside log aggregator using the '@type copy' plug-in within the Fluentd `output-application` configuration file. Specific instructions for this configuration are beyond the scope of this documentation.
-==== 
-
 In this documentation, the {product-title} cluster is called the _sender_ and the external aggregator is called the _receiver_.
 
 [NOTE]


### PR DESCRIPTION
Added note to logging docs in error. Functionality was removed in 4.3+. Might still exist in 4.1 and 4.2
https://github.com/openshift/openshift-docs/pull/20175