### PR TITLE
Changes in NTO for 4.4

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -20,3 +20,11 @@ the {product-title} platform and any custom changes to the default CR will be
 overwritten by the Operator. For custom tuning, create your own tuned CRs.
 Newly created CRs will be combined with the default CR and custom tuning
 applied to {product-title} nodes based on node/pod labels and profile priorities.
+
+While in certain situations the support for pod labels can be a convenient
+way of automatically delivering required tuning, this practice is discouraged
+and strongly advised against especially in large-scale clusters. The default
+tuned CR ships without pod label matching. If a custom profile is created
+with pod label matching the functionality will be enabled at that time.
+The pod label functionality may be deprecated in the future versions of the
+Node Tuning Operator.

--- a/modules/cluster-node-tuning-operator-default-profiles-set.adoc
+++ b/modules/cluster-node-tuning-operator-default-profiles-set.adoc
@@ -8,7 +8,7 @@
 The following are the default profiles set on a cluster.
 
 ----
-apiVersion: tuned.openshift.io/v1alpha1
+apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
   name: default
@@ -20,28 +20,36 @@ spec:
       [main]
       summary=Optimize systems running OpenShift (parent profile)
       include=${f:virt_check:virtual-guest:throughput-performance}
+
       [selinux]
       avc_cache_threshold=8192
+
       [net]
       nf_conntrack_hashsize=131072
+
       [sysctl]
       net.ipv4.ip_forward=1
-      kernel.pid_max=>131072
+      kernel.pid_max=>4194304
       net.netfilter.nf_conntrack_max=1048576
+      net.ipv4.conf.all.arp_announce=2
       net.ipv4.neigh.default.gc_thresh1=8192
       net.ipv4.neigh.default.gc_thresh2=32768
       net.ipv4.neigh.default.gc_thresh3=65536
       net.ipv6.neigh.default.gc_thresh1=8192
       net.ipv6.neigh.default.gc_thresh2=32768
       net.ipv6.neigh.default.gc_thresh3=65536
+      vm.max_map_count=262144
+
       [sysfs]
       /sys/module/nvme_core/parameters/io_timeout=4294967295
       /sys/module/nvme_core/parameters/max_retries=10
+
   - name: "openshift-control-plane"
     data: |
       [main]
       summary=Optimize systems running OpenShift control plane
       include=openshift
+
       [sysctl]
       # ktune sysctl settings, maximizing i/o throughput
       #
@@ -57,44 +65,19 @@ spec:
       # Preemption granularity when tasks wake up.  Lower the value to
       # improve wake-up latency and throughput for latency critical tasks.
       kernel.sched_wakeup_granularity_ns=4000000
+
   - name: "openshift-node"
     data: |
       [main]
       summary=Optimize systems running OpenShift nodes
       include=openshift
+
       [sysctl]
       net.ipv4.tcp_fastopen=3
       fs.inotify.max_user_watches=65536
-  - name: "openshift-control-plane-es"
-    data: |
-      [main]
-      summary=Optimize systems running ES on OpenShift control-plane
-      include=openshift-control-plane
-      [sysctl]
-      vm.max_map_count=262144
-  - name: "openshift-node-es"
-    data: |
-      [main]
-      summary=Optimize systems running ES on OpenShift nodes
-      include=openshift-node
-      [sysctl]
-      vm.max_map_count=262144
+      fs.inotify.max_user_instances=8192
+
   recommend:
-  - profile: "openshift-control-plane-es"
-    priority: 10
-    match:
-    - label: "tuned.openshift.io/elasticsearch"
-      type: "pod"
-      match:
-      - label: "node-role.kubernetes.io/master"
-      - label: "node-role.kubernetes.io/infra"
-
-  - profile: "openshift-node-es"
-    priority: 20
-    match:
-    - label: "tuned.openshift.io/elasticsearch"
-      type: "pod"
-
   - profile: "openshift-control-plane"
     priority: 30
     match:
@@ -102,5 +85,5 @@ spec:
     - label: "node-role.kubernetes.io/infra"
 
   - profile: "openshift-node"
-priority: 40
+    priority: 40
 ----

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -6,8 +6,8 @@
 = Custom tuning example
 
 The following CR applies custom node-level tuning for
-{product-title} nodes that run an ingress pod with label
-`tuned.openshift.io/ingress-pod-label=ingress-pod-label-value`.
+{product-title} nodes with label
+`tuned.openshift.io/ingress-node-label` set to any value.
 As an administrator, use the following command to create a custom tuned CR.
 
 .Example
@@ -31,10 +31,12 @@ spec:
     name: openshift-ingress
   recommend:
   - match:
-    - label: tuned.openshift.io/ingress-pod-label
-      value: "ingress-pod-label-value"
-      type: pod
+    - label: tuned.openshift.io/ingress-node-label
     priority: 10
     profile: openshift-ingress
 _EOF_
 ----
+
+Note that custom profile writers are strongly encouraged to include the default tuned daemon profiles
+shipped within the default Tuned CR.  The example above uses the default `openshift-control-plane`
+profile to do just that.

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -14,9 +14,6 @@ include::modules/accessing-an-example-cluster-node-tuning-operator-specification
 
 include::modules/cluster-node-tuning-operator-default-profiles-set.adoc[leveloffset=+1]
 
-:FeatureName: Custom profiles for custom tuning specification
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 include::modules/custom-tuning-specification.adoc[leveloffset=+1]
 
 include::modules/custom-tuning-example.adoc[leveloffset=+1]


### PR DESCRIPTION
  - Lifting custom profiles functionality from technology preview.
  - Warning to users not to use the pod label functionality on large scale clusters.
  - Updated the default Tuned CR to reflect the reality.
  - A note to custom profile writers to include the default openshift profiles when
    creating their own.