### PR TITLE
Hide downstream RN from OKD build

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -34,7 +34,7 @@ Topics:
 - Name: Legal notice
   File: legal-notice
 ---
-Name: What's New?
+Name: What's new?
 Dir: whats_new
 Distros: openshift-origin
 Topics:
@@ -67,7 +67,7 @@ Topics:
 ---
 Name: Release notes
 Dir: release_notes
-Distros: openshift-enterprise,openshift-webscale,openshift-origin
+Distros: openshift-enterprise,openshift-webscale
 Topics:
 - Name: OpenShift Container Platform 4.4 release notes
   File: ocp-4-4-release-notes

--- a/whats_new/index.adoc
+++ b/whats_new/index.adoc
@@ -1,20 +1,13 @@
 :context: whats-new-index
 [id="whats-new-index"]
-= What's new
+= What's new?
 include::modules/common-attributes.adoc[]
-
 
 toc::[]
 
-
-
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
+See the link:https://github.com/openshift/okd/releases[*Releases*] page in the
+*openshift/okd* project repository for information on the latest OKD releases.
 
 include::modules/whats-new-features.adoc[leveloffset=+1]
 
 include::modules/whats-new-deprecated.adoc[leveloffset=+1]
-
-


### PR DESCRIPTION
The stub file for OCP's downstream release notes were showing up in the OKD docs, so hiding that from the build.

Also syncs up some sentence case formatting and adds a link to the latest OKD release info.

Preview build (internal): http://file.rdu.redhat.com/~adellape/041720/rm_rn_okd/whats_new/