### PR TITLE
BZ1644819 - Update GlusterFS upgrade steps

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -733,16 +733,26 @@ other nodes in their class (`app` versus `infra`), one at a time.
 
 . Upgrade the {product-title} nodes running GlusterFS one at a time.
 
-.. Add a label to the node you want to upgrade:
+.. Add a label to the node you want to upgrade so that only one node is upgraded at a time:
 +
 ----
 $ oc label node <node_name> type=upgrade
 ----
++
 
-.. To run the upgrade playbook on a single node,
+.. Do not terminate the GlusterFS pod you want to restart.
+
+.. To run the upgrade playbook on a single GlusterFS node,
 use `-e openshift_upgrade_nodes_label="type=upgrade"`.
++
+[NOTE]
+====
+The GlusterFS pod should not be terminated.
+====
 
 .. Wait for the GlusterFS pod to respawn and appear.
+
+.. Run basic health checks after each pod restart to ensure they pass.
 
 .. `oc rsh` into the pod and verify all volumes are healed:
 +
@@ -760,7 +770,6 @@ A volume is considered healed when `Number of entries` for that volume is `0`.
 ----
 $ oc label node <node_name> type-
 ----
-
 
 [[upgrading-optional-components]]
 == Upgrading optional components


### PR DESCRIPTION
[BZ 1644819](https://bugzilla.redhat.com/show_bug.cgi?id=1644819) - This PR adds a couple of clarifying steps based on customer and Support feedback in which the user must pass GlusterFS health checks upon pod restart before they upgrade the next node (I think).

@jatanmalde @gpei PTAL?
Preview build link updated 5/8/20: http://file.rdu.redhat.com/bfuru/050820/BZ1644819/upgrading/automated_upgrades.html#special-considerations-for-glusterfs