### PR TITLE
Update 3.11 for `openshift start` / `hyperkube` changes

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -12,19 +12,16 @@ toc::[]
 
 == Customizing master and node configuration after installation
 
-The `openshift start` command and its subcommands (`master` to launch a
-xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master
-server] and `node` to launch a
-xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[node
-server]) take a limited set of arguments that are sufficient for launching
-servers in a development or experimental environment.
+The `openshift start` command (for master servers) and `hyperkube` command (for
+node servers) take a limited set of arguments that are sufficient for launching
+servers in a development or experimental environment. However, these arguments
+are insufficient to describe and control the full set of configuration and
+security options that are necessary in a production environment.
 
-However, these arguments are insufficient to describe and control the full set
-of configuration and security options that are necessary in a production
-environment. You must provide those options in the xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[Master
-host files], at *_/etc/origin/master/master-config.yaml_*
-and the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps]:
-
+You must provide these options in the
+xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#master[master configuration file],
+at *_/etc/origin/master/master-config.yaml_*, and the
+xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps].
 These files define options including overriding the default plug-ins, connecting
 to etcd, automatically creating service accounts, building image names,
 customizing project requests, configuring volume plug-ins, and much more.
@@ -76,7 +73,7 @@ in the configuration files] themselves.
 [NOTE]
 ====
 To modify a node in your cluster, update the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps] as needed.
-Do not manually edit the `node-config.yaml` file.
+Do not manually edit the *_node-config.yaml_* file.
 ====
 
 endif::openshift-origin[]
@@ -290,7 +287,7 @@ xref:../install_config/master_node_configuration.adoc#node-configuration-files[n
 [NOTE]
 ====
 To modify a node in your cluster, update the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps] as needed.
-Do not manually edit the `node-config.yaml` file.
+Do not manually edit the *_node-config.yaml_* file.
 ====
 
 [[master-configuration-files]]
@@ -1069,7 +1066,7 @@ dnsConfig:
 
 |`*MasterClientConnectionOverrides*`
 |Provides overrides to the client connection used to connect to the master.
-This parameter is not supported. To set QPS and burst values, see 
+This parameter is not supported. To set QPS and burst values, see
 xref:#master-node-configuration-node-qps-burst[Setting Node QPS and Burst Values].
 
 |`*MaxRequestsInFlight*`
@@ -1540,7 +1537,7 @@ include::scaling_performance/host_practices.adoc[tag=node-qps-burst]
 | Parameter Name | Description
 
 |`*kube-api-qps*`
-|The QPS rate at which the Kubelet talks to the APIServer. The default is `20`. 
+|The QPS rate at which the Kubelet talks to the APIServer. The default is `20`.
 
 |`*kube-api-burst*`
 |The burst rate at which the Kubelet talks to the APIServer. The default is `40`.
@@ -1566,15 +1563,13 @@ starting with 1.9, the corruption issue is resolved and it is safe to switch to
 parallel pulls.
 ====
 
-====
 [source,yaml]
 ----
 kubeletArguments:
   serialize-image-pulls:
   - "false" <1>
 ----
-<1> Change to true to disable parallel pulls. (This is the default config)
-====
+<1> Change to `true` to disable parallel pulls. This is the default configuration.
 
 [[master-node-configuration-passwords-and-other-data]]
 == Passwords and Other Sensitive Data
@@ -1588,7 +1583,6 @@ or in encrypted files.
 .Environment Variable Example
 [source,yaml]
 ----
-  ...
   bindPassword:
     env: BIND_PASSWORD_ENV_VAR_NAME
 ----
@@ -1596,7 +1590,6 @@ or in encrypted files.
 .External File Example
 [source,yaml]
 ----
-  ...
   bindPassword:
     file: bindPassword.txt
 ----
@@ -1604,7 +1597,6 @@ or in encrypted files.
 .Encrypted External File Example
 [source,yaml]
 ----
-  ...
   bindPassword:
     file: bindPassword.encrypted
     keyFile: bindPassword.key
@@ -1612,7 +1604,6 @@ or in encrypted files.
 
 To create the encrypted file and key file for the above example:
 
-[options="nowrap"]
 ----
 $ oc adm ca encrypt --genkey=bindPassword.key --out=bindPassword.encrypted
 > Data to encrypt: B1ndPass0rd!
@@ -1650,7 +1641,6 @@ is recommended to not make them greater than these values.
 To create configuration files for an all-in-one server (a master and a node on
 the same host) in the specified directory:
 
-[options="nowrap"]
 ----
 $ openshift start --write-config=/openshift.local.config
 ----
@@ -1658,7 +1648,6 @@ $ openshift start --write-config=/openshift.local.config
 To create a xref:master-configuration-files[master configuration file] and
 other required files in the specified directory:
 
-[options="nowrap"]
 ----
 $ openshift start master --write-config=/openshift.local.config/master
 ----
@@ -1666,7 +1655,6 @@ $ openshift start master --write-config=/openshift.local.config/master
 To create a xref:node-configuration-files[node configuration file] and other
 related files in the specified directory:
 
-[options="nowrap"]
 ----
 $ oc adm create-node-config \
     --node-dir=/openshift.local.config/node-<node_hostname> \
@@ -1684,53 +1672,58 @@ comma-delimited list of every host name or IP address you want server
 certificates to be valid for.
 
 [[launching-servers-using-configuration-files]]
-
 == Launching Servers Using Configuration Files
-Once you have modified the master and/or node configuration files to your
+
+After you have modified the master and node configuration files to your
 specifications, you can use them when launching servers by specifying them as an
-argument. Keep in mind that if you specify a configuration file, none of the
-other command line options you pass are respected.
+argument. If you specify a configuration file, none of the other command line
+options you pass are respected.
 
 [NOTE]
 ====
 To modify a node in your cluster, update the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps] as needed.
-Do not manually edit the `node-config.yaml` file.
+Do not manually edit the *_node-config.yaml_* file.
 ====
 
-To launch an all-in-one server using a master configuration and a node
-configuration file:
-
-[options="nowrap"]
+. Launch a master server using a master configuration file:
++
 ----
-$ openshift start --master-config=/openshift.local.config/master/master-config.yaml --node-config=/openshift.local.config/node-<node_hostname>/node-config.yaml
-----
-
-To launch a master server using a master configuration file:
-
-[options="nowrap"]
-----
-$ openshift start master --config=/openshift.local.config/master/master-config.yaml
+$ openshift start master \
+    --config=/openshift.local.config/master/master-config.yaml
 ----
 
-To launch a node server using a node configuration file:
-
-[options="nowrap"]
+. Start the network proxy and SDN plug-ins using a node configuration file and a
+*_node.kubeconfig_* file:
++
 ----
-$ openshift start node --config=/openshift.local.config/node-<node_hostname>/node-config.yaml
+$ openshift start network \
+    --config=/openshift.local.config/node-<node_hostname>/node-config.yaml \
+    --kubeconfig=/openshift.local.config/node-<node_hostname>/node.kubeconfig
+----
+
+. Launch a node server using a node configuration file:
++
+----
+$ hyperkube kubelet \
+    $(/usr/bin/openshift-node-config \
+    --config=/openshift.local.config/node-<node_hostname>/node-config.yaml)
 ----
 
 [[master-node-view-logs]]
 == Viewing Master and Node Logs
 
-{product-title} collects log messages for debugging, using the `systemd-journald.service` for nodes and a script, called `master-logs`, for masters.
+{product-title} collects log messages for debugging, using the
+`systemd-journald.service` for nodes and a script, called `master-logs`, for
+masters.
 
 [NOTE]
 ====
-The number of lines displayed in the web console is hard-coded at 5000 and cannot be changed. 
-To see the entire log, use the CLI.
+The number of lines displayed in the web console is hard-coded at 5000 and
+cannot be changed. To see the entire log, use the CLI.
 ====
 
-The logging uses five log message severities based on Kubernetes logging conventions, as follows:
+The logging uses five log message severities based on Kubernetes logging
+conventions, as follows:
 
 .Log Level Options
 [cols="3a,6a",options="header"]
@@ -1784,11 +1777,17 @@ master-logs api api 2> file
 [[master-node-config-logging-levels]]
 === Configuring Logging Levels
 
-You can control which INFO messages are logged by setting the `DEBUG_LOGLEVEL` option in the in xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration files] or the */etc/origin/master/master.env* file. Configuring the logs to collect all messages can lead to large logs that are difficult to interpret and can take up excessive space. Only collect all messages when you need to debug your cluster.
+You can control which INFO messages are logged by setting the `DEBUG_LOGLEVEL`
+option in the *_/etc/origin/master/master.env_* file for the master or
+*_/etc/sysconfig/atomic-openshift-node_* file for the nodes. Configuring the
+logs to collect all messages can lead to large logs that are difficult to
+interpret and can take up excessive space. Only collect all messages when you
+need to debug your cluster.
 
 [NOTE]
 ====
-Messages with FATAL, ERROR, WARNING, and some INFO severities appear in the logs regardless of the log configuration.
+Messages with FATAL, ERROR, WARNING, and some INFO severities appear in the logs
+regardless of the log configuration.
 ====
 
 To change the logging level:
@@ -1968,7 +1967,6 @@ I1022 15:12:00.248697       1 store.go:1391] Monitoring deploymentconfigs.apps.o
 W1022 15:12:00.256861       1 swagger.go:38] No API exists for predefined swagger description /oapi/v1
 W1022 15:12:00.258106       1 swagger.go:38] No API exists for predefined swagger description /api/v1
 ----
-
 
 [[master-node-config-restart-services]]
 == Restarting master and node services


### PR DESCRIPTION
Reopening https://github.com/openshift/openshift-docs/pull/18691 against `enterprise-3.11` branch.

Original description:

Fixes https://github.com/openshift/openshift-docs/issues/11751.

Per https://github.com/openshift/origin/releases/tag/v3.11.0:

> * server: The openshift start node functionality and openshift start have been removed - the Kubelet must now be started directly https://github.com/openshift/origin/pull/20344, https://github.com/openshift/origin/pull/20717
>   * By using the Kubelet directly we make nodes easier to manage and more consistent with the upstream.
>   * Future releases will remove other parts of openshift start master.

Preview (internal):

* http://file.rdu.redhat.com/~adellape/041720/startnode311_2/install_config/master_node_configuration.html#customizing-master-and-node-configuration-after-installation
* http://file.rdu.redhat.com/~adellape/041720/startnode311_2/install_config/master_node_configuration.html#launching-servers-using-configuration-files