### PR TITLE
Remove SCTP from 4.4.0 release notes

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -169,6 +169,7 @@ Developer Catalog.
 [id="ocp-4-4-networking"]
 === Networking
 
+////
 [id="ocp-4-4-sctp-on-ocp"]
 ==== Stream Control Transmission Protocol (SCTP) on {product-title}
 
@@ -177,6 +178,7 @@ When enabled, you can use SCTP as a protocol with both Pods and Services.
 
 //For more information, see
 //../networking/using-sctp.adoc#using-sctp[Using SCTP].
+////
 
 [id="ocp-4-4-storage"]
 === Storage


### PR DESCRIPTION
@codyhoag, this feature won't land until 4.4.z; Should I comment this out or delete it?

Thanks!