### PR TITLE
Fix svc cat in TP table

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -1109,17 +1109,17 @@ indicate that the feature is removed from the release or deprecated.
 
 |Service Catalog
 |GA
-|GA
-|--
+|-
+|-
 
 |Template Service Broker
 |GA
-|GA
+|-
 |-
 
 |OpenShift Ansible Service Broker
 |GA
-|GA
+|-
 |-
 
 |Network Policy


### PR DESCRIPTION
4.2 release notes show these are deprecated in 4.2. Fixed table in 4.3 to match.