### PR TITLE
Reword the legacy log forward deprecation wording

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1088,7 +1088,7 @@ Topics:
     File: cluster-logging-collector
   - Name: Using tolerations to control cluster logging pod placement
     File: cluster-logging-tolerations
-  - Name: Forwarding cluster logs using Log Forwarding
+  - Name: Forwarding cluster logs using the Log Forwarding API
     File: cluster-logging-log-forwarding
   - Name: Fowarding cluster logs using Fluentd plug-ins
     File: cluster-logging-external

--- a/logging/config/cluster-logging-external.adoc
+++ b/logging/config/cluster-logging-external.adoc
@@ -11,11 +11,11 @@ toc::[]
 
 * *Sending logs using syslog*. You can use the Fluentd *syslog* plug-in to send logs to another logging collector using the syslog protocol (RFC 3164). Many logging collectors such as Fluentd, Rsyslog, and others support this protocol.
 
-You can use the xref:../../logging/config/cluster-logging-log-forwarding.adoc#cluster-logging-log-forwarding[log forwarding feature], which can be easier to configure than the plug-ins. The log forwarding feature is currently in Technology Preview.
+Alternatively, you can use the xref:../../logging/config/cluster-logging-log-forwarding.adoc#cluster-logging-log-forwarding[Log Forwarding API], which can be easier to configure than the plug-ins. The Log Forwarding API is currently in Technology Preview.
 
 [IMPORTANT]
 ====
-Changes that are introduced by the new log forwarding feature modified the support for the Fluentd *syslog* plug-in starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap, as described below, to configure a Fluentd plug-in. 
+Changes that are introduced by the Log Forwarding API modified the support for the Fluentd *syslog* plug-in starting with the {product-title} 4.3 release. In {product-title} 4.3, you create a ConfigMap, as described below, to configure a Fluentd plug-in. 
 ==== 
 
 // The following include statements pull in the module files that comprise

--- a/logging/config/cluster-logging-log-forwarding.adoc
+++ b/logging/config/cluster-logging-log-forwarding.adoc
@@ -1,21 +1,21 @@
 :context: cluster-logging-log-forwarding
 [id="cluster-logging-log-forwarding"]
-= Forwarding cluster logs using Log Forwarding
+= Forwarding cluster logs using the Log Forwarding API
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
 
-The cluster logging *Log Forwarding* feature enables administrators to configure custom pipelines to send your container and node logs to specific endpoints within or outside of your cluster. You can send logs by type to the internal {product-title} Elasticsearch instance and/or remote destinations not managed by {product-title} cluster logging, such as your existing logging service, an external Elasticsearch cluster, external log aggregation solutions, or a Security Information and Event Management (SIEM) system.
+The cluster logging *Log Forwarding* API enables administrators to configure custom pipelines to send your container and node logs to specific endpoints within or outside of your cluster. You can send logs by type to the internal {product-title} Elasticsearch instance and/or remote destinations not managed by {product-title} cluster logging, such as your existing logging service, an external Elasticsearch cluster, external log aggregation solutions, or a Security Information and Event Management (SIEM) system.
 
-:FeatureName: Log Forwarding
+:FeatureName: The Log Forwarding API
 include::modules/technology-preview.adoc[leveloffset=+1]
 
-Log Forwarding provides an easier way to forward logs to specific endpoints inside or outside your {product-title} cluster than using the xref:../../logging/config/cluster-logging-external.adoc#cluster-logging-external[Fluentd plugins].
+Log forwarding using the API provides an easier way to forward logs to specific endpoints inside or outside your {product-title} cluster than using the xref:../../logging/config/cluster-logging-external.adoc#cluster-logging-external[Fluentd plugins].
 
 [NOTE]
 ====
-The Log Forwarding feature is optional. If you do not want to forward logs and use only the internal {product-title} Elasticsearch instance, do not configure the Log Forwarding feature. 
+Using the Log Forwarding API is optional. If you want to forward logs to only the internal {product-title} Elasticsearch instance, do not configure log forwarding using the Log Forwarding API. 
 ====
 
 You can send different types of logs to different systems allowing you to control who in your organization can access each type. Optional TLS support ensures that you can send logs using secure communication as required by your organization.

--- a/modules/cluster-logging-collector-fluentd.adoc
+++ b/modules/cluster-logging-collector-fluentd.adoc
@@ -11,7 +11,7 @@ In this documentation, the {product-title} cluster is called the _sender_ and th
 
 [NOTE]
 ====
-This legacy out_forward method is deprecated and will be replaced by the new Log Forwarding feature in a future release.
+This legacy out_forward method is deprecated and will be replaced by the Log Forwarding API in a future release.
 ====
 
 ifdef::openshift-origin[]

--- a/modules/cluster-logging-collector-fluentd.adoc
+++ b/modules/cluster-logging-collector-fluentd.adoc
@@ -11,7 +11,7 @@ In this documentation, the {product-title} cluster is called the _sender_ and th
 
 [NOTE]
 ====
-This legacy out_forward method is deprecated and will be removed in a future release.
+This legacy out_forward method is deprecated and will be replaced by the new Log Forwarding feature in a future release.
 ====
 
 ifdef::openshift-origin[]

--- a/modules/cluster-logging-log-forwarding-about.adoc
+++ b/modules/cluster-logging-log-forwarding-about.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-log-forwarding-about_{context}"]
 = Understanding cluster log forwarding
 
-The {product-title} cluster log forwarding feature uses a combination of _outputs_ and _pipelines_ defined in the Log Forwarding Custom Resource to send logs to specific endpoints inside and outside of your {product-title} cluster. 
+Forwarding cluster logs using the Log Forwarding API requires a combination of _outputs_ and _pipelines_ defined in the Log Forwarding Custom Resource to send logs to specific endpoints inside and outside of your {product-title} cluster. 
 
 [NOTE]
 ====
@@ -31,7 +31,7 @@ Note the following:
 
 * An output supports TLS communication using a secret. Secrets must have keys of: *tls.crt*, *tls.key*, and *ca-bundler.crt* which point to the respective certificates for which they represent. Secrets must have the key *shared_key* for use when using forward in a secure manner.
 
-* You are responsible to create and maintain any additional configurations that external destinations might require, such as keys and secrets, service accounts, port opening, or global proxy configuration.
+* You are responsible for creating and maintaining any additional configurations that external destinations might require, such as keys and secrets, service accounts, port opening, or global proxy configuration.
 
 The following example creates three outputs: 
 

--- a/modules/cluster-logging-log-forwarding-configure.adoc
+++ b/modules/cluster-logging-log-forwarding-configure.adoc
@@ -3,7 +3,7 @@
 // * logging/cluster-logging-log-forwarding.adoc
 
 [id="cluster-logging-log-forwarding-configure_{context}"]
-= Configuring the Log Forwarding feature
+= Configuring log forwarding using the Log Forwarding API
 
 To configure the Log Forwarding, edit the Cluster Logging Custom Resource (CR) to add the `clusterlogging.openshift.io/logforwardingtechpreview: enabled` annotation and create a Log Forwarding Custom Resource to specify the outputs, pipelines, and enable log forwarding.
 
@@ -11,7 +11,7 @@ If you enable Log Forwarding, you should define a pipeline all for three source 
 
 .Procedure
 
-To configure the log forwarding feature:
+To configure log forwarding using the API:
 
 . Edit the Cluster Logging Custom Resource (CR) in the `openshift-logging` project:
 +
@@ -39,7 +39,7 @@ spec:
       type: "fluentd"
       fluentd: {}
 ----
-<1> Enables and disables the Log Forwarding feature. Set to `enabled` to use log forwarding. To use the only the {product-title} Elasticsearch instance, set to disabled or do not add the annotation.
+<1> Enables and disables the Log Forwarding API. Set to `enabled` to use log forwarding. To use the only the {product-title} Elasticsearch instance, set to disabled or do not add the annotation.
 <2> The `spec.collection` block must be defined in the Cluster Logging CR for log forwarding to work.
 
 . Create the Log Forwarding Custom Resource:
@@ -84,8 +84,8 @@ spec:
      - secureforward-offcluster
 ----
 <1> The name of the log forwarding CR must be `instance`.
-<2> The namespace for the log forwarding CR must be `openshift-logging`.
-<3> Set to `enabled` to enable log forwarding.
+<2> The `namespace` for the log forwarding CR must be `openshift-logging`.
+<3> Set to `true` disable the default log forwarding behavior. 
 <4> Add one or more endpoints:
 * Specify the type of output, either `elasticseach` or `forward`.
 * Enter a name for the output.
@@ -174,20 +174,6 @@ spec:
         - fluentd-created-by-user
 ----
 
-The following Log Forwarding custom resource sends all logs to the internal {product-title} Elaticsearch instance, which is the default log forwarding method.
-
-.Sample custom resource to use the default log forwarding
-
-[source,yaml]
-----
-apiVersion: logging.openshift.io/v1alpha1
-kind: LogForwarding
-metadata:
-  name: instance
-  namespace: openshift-logging
-spec:
-  disableDefaultForwarding: false
-----
 ////
 The following Log Forwarding custom resource contains an incorrectly defined source type, `logs.app-logs`. The `status` block shows that the associated pipeline, `app-pipeline`, is dropped resulting in application logs not being stored.
 


### PR DESCRIPTION
From @sichvoge in Slack conversation:
_i think the statement needs some improvements. it’s actually not the first time that someone asks for more clarification. maybe we should say something along the lines that the legacy mechanism will be replaced by the new log forwarding API._

https://coreos.slack.com/archives/CB3HXM2QK/p1587387926482800