### PR TITLE
Remove reference to autoheal in 3.11

### DIFF
--- a/install/running_install.adoc
+++ b/install/running_install.adoc
@@ -515,9 +515,6 @@ The following table lists the playbooks in the order that they must run:
 |Node Problem Detector Install
 |*_{pb-prefix}playbooks/openshift-node-problem-detector/config.yml_*
 
-|Autoheal Install
-|*_{pb-prefix}playbooks/openshift-autoheal/config.yml_*
-
 |Operator Lifecycle Manager (OLM) Install (Technology Preview)
 |*_{pb-prefix}playbooks/olm/config.yml_*
 |===


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1821658
This was not released for 3.11 so should not be documented.