### PR TITLE
chore(oc login): Adde NOTE admonition to explain usage of HTTP_PROXY env vars

### DIFF
--- a/modules/cli-logging-in.adoc
+++ b/modules/cli-logging-in.adoc
@@ -14,8 +14,8 @@ You can log in to the `oc` CLI to access and manage your cluster.
 
 [NOTE]
 ====
-If you want to access a cluster in the internet that you can only access over an HTTP proxy server, then you can set the `HTTP_PROXY` and `HTTPS_PROXY` variables.
-These environment variables are respected by `oc` so that all communication with the cluster will go through the HTTP proxy.
+To access a cluster that is accessible only over an HTTP proxy server, you can set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables.
+These environment variables are respected by the `oc` CLI so that all communication with the cluster goes through the HTTP proxy.
 ====
 
 .Procedure

--- a/modules/cli-logging-in.adoc
+++ b/modules/cli-logging-in.adoc
@@ -12,6 +12,12 @@ You can log in to the `oc` CLI to access and manage your cluster.
 * You must have access to an {product-title} cluster.
 * You must have installed the CLI.
 
+[NOTE]
+====
+If you want to access a cluster in the internet that you can only access over an HTTP proxy server, then you can set the `HTTP_PROXY` and `HTTPS_PROXY` variables.
+These environment variables are respected by `oc` so that all communication with the cluster will go through the HTTP proxy.
+====
+
 .Procedure
 
 * Log in to the CLI using the `oc login` command and enter the required


### PR DESCRIPTION
Add a short note how a remote cluster can be accessed with `oc` (and other clients) by using an HTTP proxy.

This documentation would also help the OpenShift serverless documentation as the CLI tooling of OpenShift Serverless relies on `oc login` for the authentication.