### PR TITLE
changed path for bookinfo samples

### DIFF
--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -10,5 +10,5 @@ You can use the `oc adm must-gather` CLI command to collect information about yo
 To collect {ProductName} data with `must-gather`, you must specify the {ProductName} image: 
 
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7:1.1.0
+$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7
 ----

--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -9,4 +9,6 @@ You can use the `oc adm must-gather` CLI command to collect information about yo
 
 To collect {ProductName} data with `must-gather`, you must specify the {ProductName} image: 
 
-`oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7:1.1.0`.
+----
+$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7:1.1.0
+----

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -12,6 +12,7 @@
 :ProductShortName: Service Mesh
 :ProductRelease:
 :ProductVersion: 1.1.0
+:MaistraVersion: 1.1
 :product-build:
 :DownloadURL: registry.redhat.io
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/ossm-tutorial-bookinfo-adding-destination-rules.adoc
+++ b/modules/ossm-tutorial-bookinfo-adding-destination-rules.adoc
@@ -14,12 +14,12 @@ Before you can use the Bookinfo application, you have to add default destination
 ** If you did not enable mutual TLS:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/networking/destination-rule-all.yaml
 ----
 
 ** If you enabled mutual TLS:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all-mtls.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/networking/destination-rule-all-mtls.yaml
 ----
 

--- a/modules/ossm-tutorial-bookinfo-adding-destination-rules.adoc
+++ b/modules/ossm-tutorial-bookinfo-adding-destination-rules.adoc
@@ -14,12 +14,12 @@ Before you can use the Bookinfo application, you have to add default destination
 ** If you did not enable mutual TLS:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/networking/destination-rule-all.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-{MaistraVersion}/samples/bookinfo/networking/destination-rule-all.yaml
 ----
 
 ** If you enabled mutual TLS:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/networking/destination-rule-all-mtls.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-{MaistraVersion}/samples/bookinfo/networking/destination-rule-all-mtls.yaml
 ----
 

--- a/modules/ossm-tutorial-bookinfo-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-install.adoc
@@ -78,13 +78,13 @@ $ oc -n <control plane project> patch --type='json' smmr default -p '[{"op": "ad
 . From the CLI, deploy the Bookinfo application in the _`bookinfo`_ project by applying the `bookinfo.yaml` file:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/platform/kube/bookinfo.yaml
 ----
 
 . Create the ingress gateway by applying the `bookinfo-gateway.yaml` file:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo-gateway.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/networking/bookinfo-gateway.yaml
 ----
 
 . Set the value for the `GATEWAY_URL` parameter:

--- a/modules/ossm-tutorial-bookinfo-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-install.adoc
@@ -78,13 +78,13 @@ $ oc -n <control plane project> patch --type='json' smmr default -p '[{"op": "ad
 . From the CLI, deploy the Bookinfo application in the _`bookinfo`_ project by applying the `bookinfo.yaml` file:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/platform/kube/bookinfo.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-{MaistraVersion}/samples/bookinfo/platform/kube/bookinfo.yaml
 ----
 
 . Create the ingress gateway by applying the `bookinfo-gateway.yaml` file:
 +
 ----
-$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-1.1/samples/bookinfo/networking/bookinfo-gateway.yaml
+$ oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/istio/maistra-{MaistraVersion}/samples/bookinfo/networking/bookinfo-gateway.yaml
 ----
 
 . Set the value for the `GATEWAY_URL` parameter:


### PR DESCRIPTION
In response to https://issues.redhat.com/browse/OSSMDOC-60, which incorporates 

https://github.com/Maistra/maistra.github.io/pull/121
and MAISTRA-1219