### PR TITLE
BZ1826423 - Add Cinder to available plug-ins table in 4.x docs

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -17,9 +17,9 @@ configured provider's API to create new storage resources:
 |Provisioner plug-in name
 |Notes
 
-//|OpenStack Cinder
-//|`kubernetes.io/cinder`
-//|
+|OpenStack Cinder
+|`kubernetes.io/cinder`
+|
 
 |AWS Elastic Block Store (EBS)
 |`kubernetes.io/aws-ebs`


### PR DESCRIPTION
[BZ 1826423](https://bugzilla.redhat.com/show_bug.cgi?id=1826423)
Adding Cinder to supported plug-in table. This was left out of docs during OCP 3 -> OCP 4 migration.

Preview link: https://bz1826423--ocpdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#available-plug-ins_dynamic-provisioning