### PR TITLE
Update oc installation to include instructions by OS

### DIFF
--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -38,25 +38,87 @@ of the commands in {product-title} {product-version}. Download and
 install the new version of `oc`.
 ====
 
+[id="on-linux_{context}"]
+== On Linux
+
 .Procedure
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system
-. Download `oc.tar.gz`
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
-. From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type and
-click *Download Command-line Tools*.
+. From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type.
+. In the Command-line interface section, select *Linux* from the dropdown menu and click *Download command-line tools*.
 endif::[]
-. Click the folder for your operating system and architecture and click the
-compressed file.
+. Unpack the archive:
 +
-[NOTE]
-====
-You can install `oc` on Linux, Windows, or macOS.
-====
-. Save the file to your file system.
-. Extract the compressed file.
-. Place it in a directory that is on your `PATH`.
+----
+$ tar xvzf <file>
+----
+. Place the `oc` binary in a directory that is on your `PATH`.
+. To check your `PATH`, run:
++
+----
+$ echo $PATH
+----
+
+[id="on-windows-78_{context}"]
+== On Windows 7/8
+
+.Procedure
+ifdef::openshift-origin[]
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.tar.gz`.
+endif::[]
+ifndef::openshift-origin[]
+. From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type.
+. In the Command-line interface section, select *Windows* from the dropdown menu and click *Download command-line tools*.
+endif::[]
+. Unzip the archive with a ZIP program and save the `.exe` file in a directory of your preference.
+. Right click *Start* and click *Control Panel*.
+. Select *System and Security* and then click *System*.
+. From the menu on the left, select *Advanced systems settings* and click *Environment Variables* at the bottom.
+. Select *Path* from the *Variable* section and click *Edit*.
+. Click *New* and type the path to the folder with the `.exe` file into the field or click *Browse* and select the directory, and click *OK*.
+
+[id="on-windows-10_{context}"]
+== On Windows 10
+
+.Procedure
+ifdef::openshift-origin[]
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.tar.gz`.
+endif::[]
+ifndef::openshift-origin[]
+. From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type.
+. In the Command-line interface section, select *Windows* from the dropdown menu and click *Download command-line tools*.
+endif::[]
+. Unzip the archive with a ZIP program and save the `.exe` file in a directory of your preference.
+. Click *Search* and type `env` or `environment`.
+. Select *Edit environment variables for your account*.
+. Select *Path* from the *Variable* section and click *Edit*.
+. Click *New* and type the path to the directory with the `.exe` file into the field or click *Browse* and select the directory, and click *OK*.
+
+[id="on-macos_{context}"]
+== On MacOS
+
+.Procedure
+ifdef::openshift-origin[]
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.tar.gz`.
+endif::[]
+ifndef::openshift-origin[]
+. From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type.
+. In the Command-line interface section, select *MacOS* from the dropdown menu and click *Download command-line tools*.
+endif::[]
+. Unpack and unzip the archive.
+. Move the `oc` binary to a directory on your PATH.
+. To check your `PATH`, open a terminal window and run:
++
+----
+$ echo $PATH
+----
+
 
 After you install the CLI, it is available using the `oc` command:
 


### PR DESCRIPTION
Added operating system-specific instructions for installing the oc CLI. This brings the oc installation docs more in line with the others like odo, helm, and tkn.

Also made minor edits to the existing instructions to match what's displayed on the Infrastructure Provider page.

@bergerhoffer Tagging you per our email discussion from last week. Please let me know if any changes are needed.