### PR TITLE
Harmonizing Swift table removal in OSP docs

### DIFF
--- a/modules/installation-osp-default-deployment.adoc
+++ b/modules/installation-osp-default-deployment.adoc
@@ -29,7 +29,7 @@ A cluster might function with fewer than recommended resources, but its performa
 
 [IMPORTANT]
 ====
-If OpenStack Object Storage (Swift) is available and operated by a user account with the `swiftoperator` role, it is used as the default backend for the {product-title} image registry. In this case, the volume storage requirement is 175GB. Swift space requirements vary depending on the size of the image registry.
+If OpenStack Object Storage (Swift) is available and operated by a user account with the `swiftoperator` role, it is used as the default backend for the {product-title} image registry. In this case, the volume storage requirement is 175 GB. Swift space requirements vary depending on the size of the image registry.
 ====
 
 [NOTE]

--- a/modules/installation-osp-default-kuryr-deployment.adoc
+++ b/modules/installation-osp-default-kuryr-deployment.adoc
@@ -33,22 +33,11 @@ Use the following quota to satisfy a default cluster's minimum requirements:
 |Load balancer pools     | 500 - 1 needed per Service-exposed port
 |==============================================================================================
 
+A cluster might function with fewer than recommended resources, but its performance is not guaranteed.
+
 [IMPORTANT]
 ====
-If OpenStack Object Storage (Swift) is available, it is used as the default backend for the {product-title} image registry. In this case, the volume storage requirement is 175GB.
-
-.Recommend Swift resources
-[options="header"]
-|======================================
-|Resource              | Value
-|Swift containers      | 2
-|Swift objects         | 1
-|Swift available space | 10 MB or more
-|======================================
-
-Swift space requirements vary depending on the size of the bootstrap Ignition file and image registry.
-
-A cluster might function with fewer than recommended resources, but its performance is not guaranteed.
+If OpenStack Object Storage (Swift) is available and operated by a user account with the `swiftoperator` role, it is used as the default backend for the {product-title} image registry. In this case, the volume storage requirement is 175 GB. Swift space requirements vary depending on the size of the image registry.
 ====
 
 A cluster might function with fewer than recommended resources, but its


### PR DESCRIPTION
This table was not removed from the Kuryr deployment req module in #20420--only the standard one. 

This PR corrects that mistake. 