### PR TITLE
modules/understanding-upgrade-channels: Fix '{product-stable}' -> '{product-version}' typo

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -139,7 +139,7 @@ the `fast-{product-version}` channel. Although you can switch to the
 You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel
 if your current release is a general availability release. You can always
 switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel, although if the current release was recently promoted to
-`fast-{product-stable}` there can
+`fast-{product-version}` there can
 be a delay of up to a day for the release to be promoted to
 `stable-{product-version}`. If you change to a channel that does not include your
 current release, an alert displays and no updates can be recommended, but you can


### PR DESCRIPTION
Typo is from 1c199f19e0 (#19088).

![Screenshot from 2020-04-21 14-39-44](https://user-images.githubusercontent.com/209920/79916689-03537180-83de-11ea-9aa0-58d9d24626dc.png)
