### PR TITLE
Add info about environment used for scale testing

### DIFF
--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+
+[id="cluster-maximums-environment_{context}"]
+= {product-title} environment and configuration on which the cluster maximums are tested
+
+AWS cloud platform:
+
+[options="header",cols="8*"]
+|===
+| Node |Flavor |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOS |Count |Region
+
+| Master/etcd footnoteref:[masteretcdnodeaws, io1 disks with 3000 IOPS are used for master/etcd nodes as etcd is I/O intensive and latency sensitive.]
+| r5.4xlarge
+| 16
+| 128
+| io1 
+| 220 / 3000
+| 3
+| us-west-2
+
+| Infra footnoteref:[infranodesaws,Infra nodes are used to host Monitoring, Ingress and Registry components to make sure they have enough resources to run at large scale.]
+| m5.12xlarge
+| 48
+| 192
+| gp2 
+| 100 
+| 3
+| us-west-2
+
+| Workload footnoteref:[workloadnode, Workload node is dedicated to run performance and scalability workload generators.]
+| m5.4xlarge
+| 16
+| 64
+| gp2 
+| 500 footnoteref:[disksize, Larger disk size is used so that there is enough space to store the large amounts of data that is collected during the performance and scalability test run.]
+| 1
+| us-west-2
+
+| Worker
+| m5.2xlarge 
+| 8
+| 32
+| gp2 
+| 100 
+| 3/25/250/2000 footnoteref:[nodescaleaws, Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
+| us-west-2
+
+|===
+
+
+Azure cloud platform:
+
+[options="header",cols="8*"]
+|===
+| Node |Flavor |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/iops |Count |Region
+
+| Master/etcd footnoteref:[masteretcdnodeazure, For a higher IOPs and throughput cap, 1024GB disks are used for master/etcd nodes because etcd is I/O intensive and latency sensitive.]
+| Standard_D8s_v3
+| 8
+| 32
+| Premium SSD
+| 1024 ( P30 )
+| 3
+| centralus
+
+| Infra footnoteref:[infranodesazure,Infra nodes are used to host Monitoring, Ingress and Registry components to make sure they have enough resources to run at large scale.]
+| Standard_D16s_v3 
+| 16
+| 64
+| Premium SSD
+| 1024 ( P30 )
+| 3
+| centralus
+
+| Worker
+| Standard_D4s_v3
+| 4
+| 16
+| Premium SSD
+| 1024 ( P30 )| 3/25/100/110 footnoteref:[nodescaleazure, The cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
+| centralus
+
+|===

--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -17,6 +17,8 @@ does not necessarily mean that the cluster will fail.
 
 include::modules/openshift-cluster-maximums.adoc[leveloffset=+1]
 
+include::modules/openshift-cluster-maximums-environment.adoc[leveloffset=+1]
+
 include::modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc[leveloffset=+1]
 
 include::modules/how-to-plan-your-environment-according-to-application-requirements.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit:
- Adds details about the environment including cloud platform used
  for running the performance and scale tests as well as info about
  the cluster configuration like instance types, CPU, memory, disk,
  node count e.t.c.
- Adds info on why we went with particular configuration as well as
  pointers to the docs wherever required.