### PR TITLE
solve bug 1826189

### DIFF
--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -9,4 +9,4 @@ You can use the `oc adm must-gather` CLI command to collect information about yo
 
 To collect {ProductName} data with `must-gather`, you must specify the {ProductName} image: 
 
-`oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7:1.1.0`.
+`oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7:latest`.


### PR DESCRIPTION
currently doc is referring to "oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7:1" which fails since it is no valid image tag.
Change to :latest