### PR TITLE
Revert "[enterprise-4.2] BZ1826423 - Add Cinder to available plug-ins table in 4.x docs"

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -17,9 +17,9 @@ configured provider's API to create new storage resources:
 |Provisioner plug-in name
 |Notes
 
-|OpenStack Cinder
-|`kubernetes.io/cinder`
-|
+//|OpenStack Cinder
+//|`kubernetes.io/cinder`
+//|
 
 |AWS Elastic Block Store (EBS)
 |`kubernetes.io/aws-ebs`


### PR DESCRIPTION
Reverts openshift/openshift-docs#21364
Request was to add OpenStack Cinder support in OCP 4.x tables. But we did not test/support OpenStack Cinder in 4.1: https://docs.google.com/document/d/1YkTNoWzUs1V8QA-o7bw1BpksoPaLTu3Lr8S1gc7yy_c/edit#heading=h.p9052tipfzbz