### PR TITLE
Revert "Revert "[enterprise-4.2] BZ1826423 - Add Cinder to available plug-ins table in 4.x docs""

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -17,9 +17,9 @@ configured provider's API to create new storage resources:
 |Provisioner plug-in name
 |Notes
 
-//|OpenStack Cinder
-//|`kubernetes.io/cinder`
-//|
+|OpenStack Cinder
+|`kubernetes.io/cinder`
+|
 
 |AWS Elastic Block Store (EBS)
 |`kubernetes.io/aws-ebs`


### PR DESCRIPTION
Reverts openshift/openshift-docs#21378
Ugh...4.1 merge should have been reverted, not 4.2. So re-reverting 4.2.