### PR TITLE
Add OSP platform support matrix note to UPI assemblies

### DIFF
--- a/installing/installing_openstack/installing-openstack-user-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-user-kuryr.adoc
@@ -14,6 +14,7 @@ Using your own infrastructure allows you to integrate your cluster with existing
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
 * Have an {rh-openstack} account where you want to install {product-title}
 

--- a/installing/installing_openstack/installing-openstack-user.adoc
+++ b/installing/installing_openstack/installing-openstack-user.adoc
@@ -14,6 +14,7 @@ Using your own infrastructure allows you to integrate your cluster with existing
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
 * Have an {rh-openstack} account where you want to install {product-title}
 


### PR DESCRIPTION
Repeats #20830 (already reviewed) on remaining ShiftStack installation assemblies