### PR TITLE
Add ExternalIP configuration

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -638,6 +638,9 @@ Topics:
   - Name: Overview
     File: overview-traffic
     Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  - Name: Configuring ExternalIPs for services
+    File: configuring-externalip
+    Distros: openshift-enterprise,openshift-webscale,openshift-origin
   - Name: Configuring ingress cluster traffic using an Ingress Controller
     File: configuring-ingress-cluster-traffic-ingress-controller
   - Name: Configuring ingress cluster traffic using a load balancer

--- a/modules/nw-externalip-about.adoc
+++ b/modules/nw-externalip-about.adoc
@@ -1,0 +1,179 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+
+[id="nw-externalip-about_{context}"]
+= About ExternalIP
+
+For non-cloud environments, {product-title} supports the assignment of external IP addresses to a Service `spec.externalIPs` field through the *ExternalIP* facility.
+This exposes an additional virtual IP address, assigned to the Service, that can be outside the service network defined for the cluster.
+A Service configured with an external IP functions similarly to a Service with `type=NodePort`, allowing you to direct traffic to a local node for load balancing.
+
+You must configure your networking infrastructure to ensure that the external IP address blocks that you define are routed to the cluster.
+
+{product-title} extends the ExternalIP functionality in Kubernetes by adding the following capabilities:
+
+- Restrictions on the use of external IP addresses through a configurable policy
+- Allocation of an external IP address automatically to a Service upon request
+
+By default, only a user with `cluster-admin` privileges can create a Service with `spec.externalIPs[]` set to IP addresses defined within an external IP address block.
+
+[CAUTION]
+====
+Disabled by default, use of ExternalIP functionality can be a security risk, because in-cluster traffic to an external IP address is directed to that Service.
+This could allow cluster users to intercept sensitive traffic destined for external resources.
+====
+
+[IMPORTANT]
+====
+This feature is supported only in non-cloud deployments.
+For cloud deployments, use the load balancer services for automatic deployment of a cloud load balancer to target the endpoints of a service.
+====
+
+You can assign an external IP address in the following ways:
+
+Automatic assignment of an external IP::
+{product-title} automatically assigns an IP address from the `autoAssignCIDRs` CIDR block to the `spec.externalIPs[]` array when you create a Service with `spec.type=LoadBalancer` set.
+In this case, {product-title} implements a non-cloud version of the load balancer Service type and assigns IP addresses to the services.
+Automatic assignment is disabled by default and must be configured by a cluster administrator as described in the following section.
+
+Manual assignment of an external IP::
+{product-title} uses the IP addresses assigned to the `spec.externalIPs[]` array when you create a Service. You cannot specify an IP address that is already in use by another Service.
+
+[id="configuration-externalip_{context}"]
+== Configuration for ExternalIP
+
+Use of an external IP address in {product-title} is governed by the following fields in the `Network.config.openshift.io` CR named `cluster`:
+
+* `spec.externalIP.autoAssignCIDRs` defines an IP address block used by the load balancer when choosing an external IP address for the service. {product-title} supports only a single IP address block for automatic assignment. This can be simpler than having to manage the port space of a limited number of shared IP addresses when manually assigning ExternalIPs to services. If automatic assignment is enabled, a Service with `spec.type=LoadBalancer` is allocated an external IP address.
+* `spec.externalIP.policy` defines the permissible IP address blocks when manually specifying an IP address. {product-title} does not apply policy rules to IP address blocks defined by `spec.externalIP.autoAssignCIDRs`.
+
+If routed correctly, external traffic from the configured external IP address block can reach service endpoints through any TCP or UDP port that the service exposes.
+
+[CAUTION]
+====
+You must ensure that the IP address block you assign terminates at one or more nodes in your cluster.
+====
+
+{product-title} supports both the automatic and manual assignment of IP
+addresses, and each address is guaranteed to be assigned to a maximum of one
+service. This ensures that each service can expose its chosen ports regardless
+of the ports exposed by other services.
+
+[NOTE]
+====
+To use IP address blocks defined by `autoAssignCIDRs` in {product-title}, you must configure the necessary IP address assignment and routing for your host network.
+====
+
+The following YAML describes a Service with an external IP configured:
+
+.Example Service object with `spec.externalIPs[]` set
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-service
+spec:
+  clusterIP: 172.30.163.110
+  externalIPs:
+  - 192.168.132.253
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: highport
+    nodePort: 31903
+    port: 30102
+    protocol: TCP
+    targetPort: 30102
+  selector:
+    app: web
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 192.168.132.253
+----
+
+[id="restrictions-on-ip-assignment_{context}"]
+== Restrictions on the assignment of an external IP address
+
+As a cluster administrator, you can specify IP address blocks to allow and to reject.
+
+You configure IP address policy with a `policy` object defined by specifying the `spec.ExternalIP.policy` field.
+The policy object has the following shape:
+
+[source,json]
+----
+{
+  "policy": {
+    "allowedCIDRs": [],
+    "rejectedCIDRs": []
+  }
+}
+----
+
+When configuring policy restrictions, the following rules apply:
+
+- If `policy={}` is set, then creating a Service with `spec.ExternalIPs[]` set will fail. This is the default for {product-title}.
+- If `policy=null` is set, then creating a Service with `spec.ExternalIPs[]` set to any IP address is allowed.
+- If `policy` is set and either `policy.allowedCIDRs[]` or `policy.rejectedCIDRs[]` is set, the following rules apply:
+
+* If `allowedCIDRs[]` and `rejectedCIDRs[]` are both set, then `rejectedCIDRs[]` has precedence over `allowedCIDRs[]`.
+* If `allowedCIDRs[]` is set, creating a Service with `spec.ExternalIPs[]` will succeed only if the specified IP addresses are allowed.
+* If `rejectedCIDRs[]` is set, creating a Service with `spec.ExternalIPs[]` will succeed only if the specified IP addresses are not rejected.
+
+[id="example-policy-objects_{context}"]
+== Example policy objects
+
+The examples that follow demonstrate several different policy configurations.
+
+- In the following example, the policy prevents {product-title} from creating any Service with an external IP address specified:
++
+.Example policy to reject any value specified for Service `spec.externalIPs[]`
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  externalIP:
+    policy: {}
+  ...
+----
+
+- In the following example, both the `allowedCIDRs` and `rejectedCIDRs` fields are set.
++
+.Example policy that includes both allowed and rejected CIDR blocks
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  externalIP:
+    policy:
+      allowedCIDRs:
+      - 172.16.66.10/23
+      rejectedCIDRs:
+      - 172.16.66.10/24
+  ...
+----
+
+- In the following example, `policy` is set to `null`.
+If set to `null`, when inspecting the configuration object by entering `oc get networks.config.openshift.io -o yaml`, the `policy` field will not appear in the output.
++
+.Example policy to allow any value specified for Service `spec.externalIPs[]`
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  externalIP:
+    policy: null
+  ...
+----

--- a/modules/nw-externalip-configuring.adoc
+++ b/modules/nw-externalip-configuring.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+
+[id="nw-externalip-configuring_{context}"]
+= Configure external IP address blocks for your cluster
+
+As a cluster administrator, you can configure the following ExternalIP settings:
+
+- An ExternalIP address block used by {product-title} to automatically populate the `spec.clusterIP` field for a Service.
+- A policy object to restrict what IP addresses may be manually assigned to the `spec.clusterIP` array of a Service.
+
+.Prerequisites
+
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Optional: To display the current external IP configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc describe networks.config cluster
+----
+
+. To edit the configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc edit networks.config cluster
+----
+
+. Modify the ExternalIP configuration, as in the following example:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  ...
+  externalIP: <1>
+  ...
+----
+<1> Specify the configuration for the `externalIP` stanza.
+
+. To confirm the updated ExternalIP configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc get networks.config cluster -o go-template='{{.spec.externalIP}}{{"\n"}}'
+----

--- a/modules/nw-externalip-object.adoc
+++ b/modules/nw-externalip-object.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+
+[id="nw-externalip-object_{context}"]
+= ExternalIP address block configuration
+
+The configuration for ExternalIP address blocks is defined by a Network custom resource (CR) named `cluster`. The Network CR is part of the `config.openshift.io` API group.
+
+[IMPORTANT]
+====
+During cluster installation, the Cluster Version Operator (CVO) automatically creates a Network CR named `cluster`.
+Creating any other CR objects of this type is not supported.
+====
+
+The following YAML describes the ExternalIP configuration:
+
+.Network.config.openshift.io CR named `cluster`
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  externalIP:
+    autoAssignCIDRs: [] <1>
+    policy: <2>
+      ...
+----
+<1> Defines the IP address block in CIDR format that is available for automatic assignment of external IP addresses to a Service.
+Only a single IP address range is allowed.
+
+<2> Defines restrictions on manual assignment of an IP address to a Service.
+If no restrictions are defined, specifying the `spec.externalIP` field in a Service is not allowed.
+By default, no restrictions are defined.
+
+The following YAML describes the fields for the `policy` stanza:
+
+.Network.config.openshift.io `policy` stanza
+[source,yaml]
+----
+policy:
+  allowedCIDRs: [] <1>
+  rejectedCIDRs: [] <2>
+----
+<1> A list of allowed IP address ranges in CIDR format.
+<2> A list of rejected IP address ranges in CIDR format.
+
+[discrete]
+== Example external IP configurations
+
+Several possible configurations for external IP address pools are displayed in the following examples:
+
+- The following YAML describes a configuration that enables automatically assigned external IP addresses:
++
+.Example configuration with `spec.externalIP.autoAssignCIDRs` set
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  ...
+  externalIP:
+    autoAssignCIDRs:
+    - 192.168.132.254/29
+----
+
+- The following YAML configures policy rules for the allowed and rejected CIDR ranges:
++
+.Example configuration with `spec.externalIP.policy` set
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  ...
+  externalIP:
+    policy:
+      allowedCIDRs:
+      - 192.168.132.0/29
+      - 192.168.132.8/29
+      rejectedCIDRs:
+      - 192.168.132.7/32
+----

--- a/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
@@ -1,0 +1,25 @@
+[id="configuring-externalip"]
+= Configuring ExternalIPs for services
+include::modules/common-attributes.adoc[]
+:context: configuring-externalip
+
+toc::[]
+
+As a cluster administrator, you can designate an IP address block that is external to the cluster that can send traffic to services in the cluster.
+
+This functionality is generally most useful for clusters installed on bare-metal hardware.
+
+.Prerequisites
+
+* Your network infrastructure must route traffic for the external IP addresses to your cluster.
+
+include::modules/nw-externalip-about.adoc[leveloffset=1]
+
+include::modules/nw-externalip-object.adoc[leveloffset=1]
+
+include::modules/nw-externalip-configuring.adoc[leveloffset=1]
+
+[id="configuring-externalip-next-steps"]
+== Next steps
+
+* xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc#configuring-ingress-cluster-traffic-service-external-ip[Configuring ingress cluster traffic for a service external IP]

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc
@@ -1,19 +1,22 @@
 [id="configuring-ingress-cluster-traffic-service-external-ip"]
-= Configuring ingress cluster traffic using a service external IP
+= Configuring ingress cluster traffic for a service external IP
 include::modules/common-attributes.adoc[]
 :context: configuring-ingress-cluster-traffic-service-external-ip
 
 toc::[]
 
 You can attach an external IP address to a Service so that it is available to traffic outside the cluster.
-This is generally useful only for a cluster installed on bare-metal hardware.
+This is generally useful only for a cluster installed on bare metal hardware.
 The external network infrastructure must be configured correctly to route traffic to the Service.
 
 [id="configuring-ingress-cluster-traffic-service-external-ip-prerequisites"]
 == Prerequisites
 
-// This will be replaced with WIP https://github.com/openshift/openshift-docs/pull/21388
-
-* Your cluster is configured with ExternalIPs enabled. For more information, read link:https://access.redhat.com/solutions/4550681[How to define IP address pools for external IP services and bare metal LoadBalancer services].
+* Your cluster is configured with ExternalIPs enabled. For more information, read xref:../../networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc#configuring-externalip[Configuring ExternalIPs for services].
 
 include::modules/nw-service-externalip-create.adoc[leveloffset=+1]
+
+[id="configuring-ingress-cluster-traffic-service-external-ip-additional-resources"]
+== Additional resources
+
+* xref:../../networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc#configuring-externalip[Configuring ExternalIPs for services]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-536

This PR adds longstanding absent `ExternalIP` configuration. An update to the ingress configuration documentation that utilizes this functionality will follow under a separate cover.