### PR TITLE
Repeat admin prereq removal from ShiftStack assemblies

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -15,8 +15,6 @@ xref:../../architecture/architecture-installation.adoc#architecture-installation
 processes.
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
-* Have access to a {rh-openstack} administrator's account
-
 * Have metadata service enabled in {rh-openstack}
 
 include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
@@ -18,8 +18,6 @@ xref:../../architecture/architecture-installation.adoc#architecture-installation
 processes.
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
-* Have access to an {rh-openstack} administrator's account
-
 include::modules/installation-osp-about-kuryr.adoc[leveloffset=+1]
 include::modules/installation-osp-default-kuryr-deployment.adoc[leveloffset=+1]
 include::modules/installation-osp-kuryr-increase-quota.adoc[leveloffset=+2]


### PR DESCRIPTION
For whatever reason, installer-custom and installer-custom-kuryr assemblies were left out of https://github.com/openshift/openshift-docs/pull/20759. The 4.4 branch represents the correct state of things; 4.2 and 4.3 don't. This PR brings them into alignment. 