### PR TITLE
Release notes for OSSM 1.1.1

### DIFF
--- a/modules/jaeger-rn-known-issues.adoc
+++ b/modules/jaeger-rn-known-issues.adoc
@@ -22,4 +22,6 @@ These limitations exist in Jaeger:
 
 These are the known issues in Jaeger:
 
-* link:https://issues.redhat.com/browse/TRACING-809[TRACING-809] Jaeger Ingester is incompatible with Kafka 2.3. When there are two or more instances of the Jaeger Ingester and enough traffic it will continuously generate rebalancing messages in the logs.  This is due to a regression in Kafka 2.3 that was fixed in Kafka 2.3.1.  For more information, see https://github.com/jaegertracing/jaeger/issues/1819[Jaegertracing-1819].
+* link:https://issues.redhat.com/browse/TRACING-1166[TRACING-1166] It is not currently possible to use the Jaeger streaming strategy within a disconnected environment. When a Kafka cluster is being provisioned, it results in a error: `Failed to pull image registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076`.
+
+* link:https://issues.redhat.com/browse/TRACING-809[TRACING-809] Jaeger Ingester is incompatible with Kafka 2.3. When there are two or more instances of the Jaeger Ingester and enough traffic it will continuously generate rebalancing messages in the logs. This is due to a regression in Kafka 2.3 that was fixed in Kafka 2.3.1.  For more information, see https://github.com/jaegertracing/jaeger/issues/1819[Jaegertracing-1819].

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -11,7 +11,7 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 1.1.0
+:ProductVersion: 1.1.1
 :MaistraVersion: 1.1
 :product-build:
 :DownloadURL: registry.redhat.io

--- a/modules/ossm-member-roll-create.adoc
+++ b/modules/ossm-member-roll-create.adoc
@@ -27,7 +27,7 @@ Follow this procedure to add one or more projects to the {ProductShortName} memb
 
 .Procedure
 
-. If you don't already have projects for your mesh, or you're starting from scratch, create a project. It must be different from `istio-system`.
+. If you don't already have projects for your mesh, or you are starting from scratch, create a project. It must be different from `istio-system`.
 
 .. Navigate to *Home* -> *Projects*.
 

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -48,6 +48,8 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-kiali_{context}"]
 == Kiali fixed issues
 
+* link:https://issues.jboss.org/browse/KIALI-3239[KIALI-3239] If a Kiali Operator pod has failed with a status of “Evicted” it blocks the Kiali operator from deploying. The workaround is to delete the Evicted pod and redeploy the Kiali operator.
+
 * link:https://issues.jboss.org/browse/KIALI-3096[KIALI-3096] Runtime metrics fail in {ProductShortName}. There is an OAuth filter between the {ProductShortname} and Prometheus, requiring a bearer token to be passed to Prometheus before access will be granted. Kiali has been updated to use this token when communicating to the Prometheus server, but the application metrics are currently failing with 403 errors.
 
 * link:https://issues.jboss.org/browse/KIALI-3070[KIALI-3070] This bug only affects custom dashboards, not the default dashboards. When you select labels in metrics settings and refresh the page, your selections are retained in the menu but your selections are not displayed on the charts.

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -19,8 +19,6 @@ These limitations exist in {ProductName}:
 
 * Graph layout - The layout for the Kiali graph can render differently, depending on your application architecture and the data to display (number of graph nodes and their interactions). Because it is difficult if not impossible to create a single layout that renders nicely for every situation, Kiali offers a choice of several different layouts. To choose a different layout, you can choose a different *Layout Schema* from the *Graph Settings* menu.
 
-* {ProductName} does not support installation on a restricted network.
-
 [id="ossm-rn-known-issues-ossm_{context}"]
 == {ProductShortName} known issues
 
@@ -57,8 +55,6 @@ If the `istio-operator` pod is evicted while deploying the control pane, delete 
 These are the known issues in Kiali:
 
 * link:https://issues.jboss.org/browse/KIALI-3262[KIALI-3262] In the Kiali console, when you click on Distributed Tracing in the navigation or on a Traces tab, you are asked to accept the certificate, and then asked to provide your OpenShift login credentials. This happens due to an issue with how the framework displays the Trace pages in the Console. The Workaround is to open the URL for the Jaeger console in another browser window and log in. Then you can view the embedded tracing pages in the Kiali console.
-
-* link:https://issues.jboss.org/browse/KIALI-3239[KIALI-3239] If a Kiali Operator pod has failed with a status of “Evicted” it blocks the Kiali operator from deploying. The workaround is to delete the Evicted pod and redeploy the Kiali operator.
 
 * link:https://issues.jboss.org/browse/KIALI-3118[KIALI-3118] After changes to the ServiceMeshMemberRoll, for example adding or removing projects, the Kiali pod restarts and then displays errors on the Graph page while the Kiali pod is restarting.
 

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -35,6 +35,10 @@ Result – If changed, describe the current user experience
 |1.0.0
 |===
 
+== New features {ProductName} 1.1.1
+
+This release of {ProductName} adds support for a disconnected installation.
+
 == New features {ProductName} 1.1.0
 
 This release of {ProductName} adds support for Istio 1.4.6 and Jaeger 1.17.1.

--- a/service_mesh/service_mesh_install/updating-ossm.adoc
+++ b/service_mesh/service_mesh_install/updating-ossm.adoc
@@ -4,7 +4,7 @@ include::modules/ossm-document-attributes.adoc[]
 :context: installing-ossm
 toc::[]
 
-If you're updating from {ProductName} 1.0 to 1.1, you must update the `ServiceMeshControlPlane` resource to update the control plane components to the new version. 
+If you are updating from {ProductName} 1.0 to 1.1, you must update the `ServiceMeshControlPlane` resource to update the control plane components to the new version. 
 
 . In the web console, click the {ProductName} operator.
 

--- a/service_mesh/service_mesh_support/ossm-collecting-ossm-data.adoc
+++ b/service_mesh/service_mesh_support/ossm-collecting-ossm-data.adoc
@@ -16,4 +16,9 @@ and {ProductName}.
 
 include::modules/about-must-gather.adoc[leveloffset=+1]
 
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+* The {product-title} CLI (`oc`) installed.
+
 include::modules/ossm-about-collecting-ossm-data.adoc[leveloffset=+1]


### PR DESCRIPTION
Release notes for version 1.1.1 and disconnected installation.

When this is ready, cherrypick to 4.2, 4.3, and 4.4. 

Update 5/1: it has been added to 4.3. Do not cherry pick to 4.3. 