### PR TITLE
Fix output of clusterrolebinding system:build-strategy-docker-binding

### DIFF
--- a/modules/builds-disabling-build-strategy-globally.adoc
+++ b/modules/builds-disabling-build-strategy-globally.adoc
@@ -21,9 +21,7 @@ strategy.
 ----
 $ oc edit clusterrolebinding system:build-strategy-docker-binding
 
-apiVersion: v1
-groupNames:
-- system:authenticated
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
@@ -31,15 +29,16 @@ metadata:
   creationTimestamp: 2018-08-10T01:24:14Z
   name: system:build-strategy-docker-binding
   resourceVersion: "225"
-  selfLink: /oapi/v1/clusterrolebindings/system%3Abuild-strategy-docker-binding
+  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/system%3Abuild-strategy-docker-binding
   uid: 17b1f3d4-9c3c-11e8-be62-0800277d20bf
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: system:build-strategy-docker
 subjects:
-- kind: SystemGroup
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
   name: system:authenticated
-userNames:
-- system:serviceaccount:management-infra:management-admin
 ----
 <1> Change the `rbac.authorization.kubernetes.io/autoupdate` annotation's value to `"false"`. 
 . Remove the role:


### PR DESCRIPTION
```bash
$ oc version
Client Version: 4.3.14-202004180552-4fb2d4d
Server Version: 4.3.13
Kubernetes Version: v1.16.2

$ oc edit clusterrolebinding system:build-strategy-docker-binding
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    rbac.authorization.kubernetes.io/autoupdate: "true"
  creationTimestamp: "2020-04-21T10:50:13Z"
  name: system:build-strategy-docker-binding
  resourceVersion: "6512"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/system%3Abuild-strategy-docker-binding
  uid: ae6929e1-2ab3-4a4b-aa2a-a392d48c59e3
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:build-strategy-docker
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: Group
  name: system:authenticated
```