### PR TITLE
CNV - BZ#1816971 - RN for disabled KubeMacPool

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -52,6 +52,11 @@ include::modules/technology-preview.adoc[leveloffset=+2]
 
 == Known issues
 
+* KubeMacPool is disabled in {CNVProductName} {CNVVersion}. This means that a secondary
+interface of a Pod or virtual machine obtains a randomly generated MAC address rather
+than a unique one from a pool. Although rare, randomly assigned MAC addresses can conflict.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1816971[*BZ#1816971*])
+
 // For 2.3: Add new Known Issues above this line (so that we don't mix the new with the old/possibly no longer irrelevant ones)
 // Don't remove: this BZ is probably true for all 2.x releases
 * The `masquerade` binding method for virtual machines cannot be used in clusters with RHEL 7 compute nodes.


### PR DESCRIPTION
Known Issue added for the removal of KubeMacPool for cnv 2.3:
https://bugzilla.redhat.com/show_bug.cgi?id=1816971
