### PR TITLE
adding distro map and homepage button for 4.x ARO docs

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -128,8 +128,11 @@ openshift-aro:
   site_url: https://docs.openshift.com/
   branches:
     enterprise-3.11:
-      name: 'Latest'
-      dir: aro
+      name: '3'
+      dir: aro/3
+    enterprise-4.3:
+      name: '4'
+      dir: aro/4
 openshift-webscale:
   name: OpenShift Container Platform
   author: OpenShift Documentation Project <openshift-docs@redhat.com>


### PR DESCRIPTION
This adds the ARO 4.x docs to the distro map and adds the related button to the docs.openshift.com homepage.

The content for the 4.x ARO docs is in this PR against the enterprise-4.3 branch.
https://github.com/openshift/openshift-docs/pull/21121

@vikram-redhat does this need to be cherrypicked on merge?