### PR TITLE
Update contributor guidlines for object naming conventions

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -697,6 +697,10 @@ Text for admonition
 [id="api-object-formatting"]
 == API object formatting
 
+Use pascal case (uppercase each word) when referring to Kubernetes and OpenShift API objects. Do not use monospace, bold, or italics.
+
+
+
 Use initial capitalization and camel case for Kubernetes/OpenShift API objects
 and do not mark them up unless referring to a specific field or variable name
 from a spec or manifest.


### PR DESCRIPTION
Because this came up again recently, I wanted to propose a formal update to the contribution guidelines. If we can reach a consensus, let's update (if warranted) the guidelines. Outside teams are taking cues from this, so it's important that we can present a unified front on this.

About six months ago we discussed this at some length on Slack; I captured [that conversation](https://docs.google.com/document/d/1wVh-O-njH1we3g4arHuuWhAWIgHJHsSCnUlCZEG-CB4/edit).

We had general agreement that

- we've been inconsistent.
- capitalizing every k8s object name in every situation is odd.
- applying monospace is jarring (and in any case, that violates IBM).

I'd also mention that, at last count, OCP offers over 120 different CRDs, so we cannot easily have a list of how to handle every object individually.

We also have the [CCS terms glossary for OpenShift](https://doc-stage.usersys.redhat.com/documentation/en-us/ccs_internal_documentation/1.0/html-single/glossary_of_terms_and_conventions_for_product_documentation/index#red_hat_openshift).

And [deployments](https://docs.openshift.com/container-platform/4.2/applications/deployments/what-deployments-are.html) illustrations the extent to which the distinction is confounding.

And developers will abbreviate either the object name or the concept, but without further context it's not clear which of these is happening. (persistent volume claim vs. PersistentVolumeClaim resource vs. PVC.)

Oh, and the OCP console uses the resource object name in title case, with spaces, such as _Sriov Network_ for SriovNetwork.

Oh, and as another exciting example: AMQ Streams Operator. This provides at least 9 different CRDs, and resources such as Kafka and KafkaConnectS2I. How to handle these? k8s uses a declarative API. These aren't concepts, exactly, but APIs for bringing up a Kafka cluster or the same, but with S2I support.