### PR TITLE
update machine autoscaler cr

### DIFF
--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -29,7 +29,7 @@ which MachineSet this MachineAutoscaler scales, specify or include the name of
 the MachineSet to scale. The MachineSet name takes the following form:
 `<clusterid>-<machineset>-<aws-region-az>`
 <2> Specify the minimum number Machines of the specified type that must remain in the
-specified AWS zone after the ClusterAutoscaler initiates cluster scaling. Do not set this value to `0`.
+specified zone after the ClusterAutoscaler initiates cluster scaling. If running in AWS, GCP, or Azure, this value can be set to `0`. For other providers, do not set this value to `0`. 
 <3> Specify the maximum number Machines of the specified type that the ClusterAutoscaler can deploy in the
 specified AWS zone after it initiates cluster scaling. Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` definition is large enough to allow the MachineAutoScaler to deploy this number of machines.
 <4> In this section, provide values that describe the existing MachineSet to


### PR DESCRIPTION
This change updates the guidance for the minimum number machines to
include the functionality for scaling to zero.