### PR TITLE
Understanding Buffer Chunk Limiting for Fluentd documentation is missing the prerequisite section

### DIFF
--- a/modules/nodes-cluster-overcommit-buffer-chunk.adoc
+++ b/modules/nodes-cluster-overcommit-buffer-chunk.adoc
@@ -12,6 +12,12 @@ to switch to file buffering to reduce memory usage and prevent data loss.
 
 Fluentd file buffering stores records in _chunks_. Chunks are stored in _buffers_.
 
+[NOTE]
+====
+To modify the `FILE_BUFFER_LIMIT` or `BUFFER_SIZE_LIMIT` parameters
+in the Fluentd daemonset as described below, you must set cluster logging to the unmanaged state.
+====
+
 The Fluentd `buffer_chunk_limit` is determined by the environment variable
 `BUFFER_SIZE_LIMIT`, which has the default value `8m`. The file buffer size per
 output is determined by the environment variable `FILE_BUFFER_LIMIT`, which has


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1827182