### PR TITLE
Added tags example for Azure MachineSet yaml

### DIFF
--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -75,8 +75,8 @@ spec:
           sshPrivateKey: ""
           sshPublicKey: ""
           tags:
-            tag1: value1
-            tag2: value2
+            - name: kubernetes.io/cluster/<infrastructureID> <1>
+              value: owned
           subnet: <infrastructureID>-<role>-subnet <1> <2>
           userDataSecret:
             name: <role>-user-data <2>

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -74,6 +74,9 @@ spec:
           resourceGroup: <infrastructureID>-rg <1>
           sshPrivateKey: ""
           sshPublicKey: ""
+          tags:
+            tag1: value1
+            tag2: value2
           subnet: <infrastructureID>-<role>-subnet <1> <2>
           userDataSecret:
             name: <role>-user-data <2>


### PR DESCRIPTION
I've added the `tags` key to the yaml example for the document "[Creating a MachineSet in Azure](https://docs.openshift.com/container-platform/4.3/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)", since it was supported and missing.