### PR TITLE
Logging rework buffer chunk

### DIFF
--- a/logging/config/cluster-logging-collector.adoc
+++ b/logging/config/cluster-logging-collector.adoc
@@ -29,7 +29,7 @@ include::modules/cluster-logging-collector-limits.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-log-location.adoc[leveloffset=+1]
 
-include::modules/nodes-cluster-overcommit-buffer-chunk.adoc[leveloffset=+1]
+include::modules/cluster-logging-collector-chunk.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-envvar.adoc[leveloffset=+1]
 

--- a/modules/cluster-logging-collector-chunk.adoc
+++ b/modules/cluster-logging-collector-chunk.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * config/cluster-logging-collector.adoc
+
+[id="cluster-logging-collector-chunk_{context}"]
+= Configuring Buffer Chunk Limiting for Fluentd
+
+If the Fluentd log collector is unable to keep up with a high number of logs, 
+Fluentd performs file buffering to reduce memory usage and prevent data loss.
+
+Fluentd file buffering stores records in _chunks_. Chunks are stored in _buffers_.
+
+You can tune file buffering in your cluster by editing environment variables
+in the Fluentd Daemonset:
+
+[NOTE]
+====
+To modify the `FILE_BUFFER_LIMIT` or `BUFFER_SIZE_LIMIT` parameters
+in the Fluentd Daemonset, you must set cluster logging to the unmanaged state.
+Operators in an unmanaged state are unsupported and the cluster administrator 
+assumes full control of the individual component configurations and upgrades.
+====
+
+* *BUFFER_SIZE_LIMIT*. This parameter determines the maximum size of each chunk 
+file before Fluentd creates a new chunk. The default is `8M`. 
+This parameter sets the Fluentd `chunk_limit_size` variable.
++
+A high `BUFFER_SIZE_LIMIT` can collect more records per chunk file. However, 
+bigger records take longer to be sent to the logstore. 
+
+* *FILE_BUFFER_LIMIT*. This parameter determines the file buffer size per logging output.
+This value is only a request based on the available space on the node where a Fluentd pod is scheduled.
+{product-title} does not allow Fluentd to exceed the node capacity. The default is `256Mi`.
++
+A high `FILE_BUFFER_LIMIT` could translate to a higher `BUFFER_QUEUE_LIMIT` based the number of outputs. 
+However, if the node's space is under pressure, Fluentd can fail.
++
+By default, the `number_of_outputs` is `1` if all the logs are sent to a single resource, and is incremented by `1` for each 
+additional resource. You might have multiple outputs if you use the Log Forwarding API, the Fluentd *Forward* protocol, or 
+syslog protocol to forward logs to external locations.
++
+The permanent volume size must be larger than `FILE_BUFFER_LIMIT` multiplied by the
+number of outputs.
+
+* *BUFFER_QUEUE_LIMIT*. This parameter is the maximum number of buffer chunks allowed.
+The `BUFFER_QUEUE_LIMIT` parameter is not directly tunable. {product-title} calculates this value 
+based on the number of logging outputs, the chunk size, and the filesystem space available. 
+The default is `32` chunks. To change the `BUFFER_QUEUE_LIMIT`, you must change the value of `FILE_BUFFER_LIMIT`.
+The `BUFFER_QUEUE_LIMIT` parameter sets the Fluentd `queue_limit_length` parameter.
++
+{product-title} calculates the `BUFFER_QUEUE_LIMIT` as `(FILE_BUFFER_LIMIT / (number_of_outputs * BUFFER_SIZE_LIMIT))`.
++
+Using the default set of values, the value of `BUFFER_QUEUE_LIMIT` is 32:
+
+** `FILE_BUFFER_LIMIT = 256Mi`
+** `number_of_outputs = 1`
+** `BUFFER_SIZE_LIMIT = 8Mi`
+
+{product-title} uses the Fluentd link:https://docs.fluentd.org/buffer/file[*file* buffer plug-in]
+to configure how the chunks are stored. You can see the location of the buffer file
+using the following command:
+
+----
+$ oc get cm fluentd -o json | jq -r '.data."fluent.conf"'
+----
+
+----
+<buffer>
+   @type file <1>
+   path '/var/lib/flunetd/retry-elasticseach' <2>
+----
+<1> The Fluentd *file* buffer plugin. Do not change this value. 
+<2> The path where buffer chunks are stored.
+
+.Prerequisite
+
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state 
+are unsupported and the cluster administrator assumes full control of the individual 
+component configurations and upgrades.
+
+.Procedure
+
+To configure Buffer Chunk Limiting:
+
+. Edit either of the following parameters in the `fluentd` Daemonset.  
++
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      containers:
+          env:
+          - name: FILE_BUFFER_LIMIT <1>
+            value: "256"
+          - name: BUFFER_SIZE_LIMIT <2>
+            value: 8Mi
+----
+<1> Specify the Fluentd file buffer size per output. 
+<2> Specify the maximum size of each Fluentd buffer chunk.


### PR DESCRIPTION
When working on https://bugzilla.redhat.com/show_bug.cgi?id=1827182, it seemed that the section on tuning buffer chunks [1] is confusing and could be better organized. 
In researching, Peri of the logging team discovered changes in the code in 4.3+. 
The changes in this PR will be applied to 4.3+ and possibly modified for 4.1 and 4.2.

[1] https://docs.openshift.com/container-platform/4.3/nodes/clusters/nodes-cluster-overcommit.html#understandin-fluentd-buffering_nodes-cluster-overcommit