### PR TITLE
updating aro3x link on homepage

### DIFF
--- a/index-commercial.html
+++ b/index-commercial.html
@@ -219,7 +219,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <h2>Azure Red Hat OpenShift</h2>
             <div class="list-group">
               <p class="list-group-item-text">Azure Red Hat OpenShift provides single-tenant, high-availability Kubernetes clusters on Azure, supported by Red Hat and Microsoft.</p>
-              <p><a role="button" class="btn btn-primary" href="aro/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> ARO Docs</a></p>
+              <p><a role="button" class="btn btn-primary" href="aro/3/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> ARO Docs</a></p>
             </div>
           </div>
           <div class="col-sm-3 text-center">


### PR DESCRIPTION
Updating link to 3x aro docs.

https://github.com/openshift/openshift-docs/pull/21121
https://github.com/openshift/openshift-docs/pull/21436