### PR TITLE
Add info re: svc cat non-upgradeable after 4.4

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -697,11 +697,16 @@ now deprecated. You should use `machineNetwork.cidr` instead.
 [id="ocp-4-4-service-catalog-deprecated"]
 ==== Service Catalog, Template Service Broker, Ansible Service Broker, and their Operators
 
+[NOTE]
+====
+Service Catalog is not installed by default in {product-title} 4.
+====
+
 Service Catalog, Template Service Broker, Ansible Service Broker, and their
-associated Operators were deprecated in {product-title} 4.2.
+associated Operators were deprecated starting in {product-title} 4.2.
 
 Ansible Service Broker, the Ansible Service Broker Operator, and the following
-APBs have now been removed starting in {product-title} 4.4:
+APBs are now removed in {product-title} 4.4:
 
 * APB base image
 * APB tools container
@@ -715,19 +720,27 @@ The following related APIs have also been removed:
 * `.osb.openshift.io/v1`
 
 Service Catalog and Template Service Broker will be removed in a future
-{product-title} release. If they are enabled in 4.4, the web console warns the
-user that these features are still enabled.
+{product-title} release, as well as the following related API:
 
-The following alerts can be viewed from the *Monitoring* -> *Alerting* page and
-have a *Warning* severity:
+* `.servicecatalog.k8s.io/v1beta1`
+
+If they are enabled in 4.4, the web console warns cluster administrators that
+these features are still enabled. The following alerts can be viewed from the
+*Monitoring* -> *Alerting* page and have a *Warning* severity:
 
 * `ServiceCatalogAPIServerEnabled`
 * `ServiceCatalogControllerManagerEnabled`
 * `TemplateServiceBrokerEnabled`
 
-The following related API will be removed in a future release:
+The `service-catalog-controller-manager` and `service-catalog-apiserver` cluster
+Operators are also now set to `Upgradeable=false` in 4.4. This means that they
+will block future cluster upgrades to the next minor version, for example 4.5,
+if they are still installed at that time. Upgrading to z-stream releases such as
+4.4.z, however, are still permitted in this state.
 
-* `.servicecatalog.k8s.io/v1beta1`
+If Service Catalog is installed, cluster administrators can see
+xref:../applications/service_brokers/uninstalling-service-catalog.adoc#sb-uninstalling-service-catalog[Uninstalling Service Catalog]
+to uninstall it before the next minor version of {product-title} is released.
 
 [id="ocp-4-4-deprecation-of-operatorsources"]
 ==== Deprecation of OperatorSources, CatalogSourceConfigs, and packaging format


### PR DESCRIPTION
Preview (internal): http://file.rdu.redhat.com/~adellape/042620/44_svc_cat_upgradeable/release_notes/ocp-4-4-release-notes.html#ocp-4-4-service-catalog-deprecated