### PR TITLE
Remove step for not installing CAM operator on target cluster

### DIFF
--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -69,18 +69,6 @@ spec:
   [...]
 ----
 endif::[]
-ifdef::targetcluster-3-4,targetcluster-4_2-4_x,targetcluster-4_1-4_x[]
-. If you do not want to install the CAM tool on the target cluster, update the `migration_controller` and `migration_ui` parameters in the `spec` stanza:
-+
-[source,yaml]
-----
-spec:
-  [...]
-  migration_controller: false
-  migration_ui: false
-  [...]
-----
-endif::[]
 
 . Click *Create*.
 


### PR DESCRIPTION
Removed step for configuring CAM operator **not** to be installed on 4.0 target cluster.
CP for 4.2, 4.3, 4.4  (if possible).