### PR TITLE
Removed tag causing verification step to appear twice

### DIFF
--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -84,7 +84,7 @@ endif::[]
 
 . Click *Create*.
 
-ifdef::migrating-3-4,sourcecluster-4_1-4_x,sourcecluster-4_2-4_x[]
+ifdef::sourcecluster-4_1-4_x,sourcecluster-4_2-4_x[]
 . Click *Workloads* -> *Pods* to verify that the Restic and Velero Pods are running.
 endif::[]
 ifdef::targetcluster-3-4,targetcluster-4_2-4_x,targetcluster-4_1-4_x[]


### PR DESCRIPTION
Removed tag that caused verification step to appear twice in CAM operator installation on 4.x target cluster
CP for all 4.x versions