### PR TITLE
Added real-time kernel support (epic GRPA-1211)

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -21,6 +21,7 @@ configure on your nodes in this way.
 
 
 include::modules/installation-special-config-kargs.adoc[leveloffset=+1]
+include::modules/installation-special-config-rtkernel.adoc[leveloffset=+1]
 include::modules/installation-special-config-kmod.adoc[leveloffset=+1]
 include::modules/installation-special-config-encrypt-disk.adoc[leveloffset=+1]
 include::modules/installation-special-config-encrypt-disk-tpm2.adoc[leveloffset=+2]

--- a/modules/installation-special-config-crony.adoc
+++ b/modules/installation-special-config-crony.adoc
@@ -32,7 +32,7 @@ This example adds the file to `master` nodes. You can change it to `worker` or m
 additional MachineConfig for the `worker` role:
 +
 ----
-$ cat << EOF > ./99_masters-chrony-configuration.yaml
+$ cat << EOF > ./99-masters-chrony-configuration.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:

--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -53,7 +53,7 @@ ewogInVybCI6ICJodHRwczovL3RhbmcuZXhhbXBsZS5jb20iLAogInRocCI6ICJaUk1leTFjR3cwN3ps
 . Replace the “source” in the TPM2 example with the Base64 encoded file for one or both of these examples for worker and/or master nodes:
 +
 ----
-$ cat << EOF > ./99_openshift-worker-tang-encryption.yaml
+$ cat << EOF > ./99-openshift-worker-tang-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -77,7 +77,7 @@ EOF
 
 +
 ----
-$ cat << EOF > ./99_openshift-master-encryption.yaml
+$ cat << EOF > ./99-openshift-master-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -21,7 +21,7 @@ $ ./openshift-install create manifests --dir=<installation_directory>
 disks for those nodes. Here are examples of those two files:
 +
 ----
-$ cat << EOF > ./99_openshift-worker-tpmv2-encryption.yaml
+$ cat << EOF > ./99-openshift-worker-tpmv2-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -44,7 +44,7 @@ EOF
 
 +
 ----
-$ cat << EOF > ./99_openshift-master-tpmv2-encryption.yaml
+$ cat << EOF > ./99-openshift-master-tpmv2-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:

--- a/modules/installation-special-config-kargs.adoc
+++ b/modules/installation-special-config-kargs.adoc
@@ -34,18 +34,18 @@ $ ./openshift-install create manifests --dir=<installation_directory>
 . Decide if you want to add kernel arguments to worker or master nodes.
 
 . In the `openshift` directory, create a file (for example,
-`99_openshift-machineconfig_master-kargs.yaml`) to define a MachineConfig
+`99-openshift-machineconfig-master-kargs.yaml`) to define a MachineConfig
 object to add the kernel settings.
 This example adds a `loglevel=7` kernel argument to master nodes:
 +
 ----
-$ cat << EOF > 99_openshift-machineconfig_master-kargs.yaml
+$ cat << EOF > 99-openshift-machineconfig-master-kargs.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: master
-  name: 99_openshift-machineconfig_master-kargs
+  name: 99-openshift-machineconfig-master-kargs
 spec:
   kernelArguments:
     - 'loglevel=7'

--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -320,14 +320,14 @@ with files you would like to deliver:
 ----
 $ ./filetranspiler/filetranspile -i ./baseconfig.ign \
      -f ${FAKEROOT} --format=yaml --dereference-symlinks \
-     | sed 's/^/     /' | (cat mc-base.yaml -) > 99_simple-kmod.yaml
+     | sed 's/^/     /' | (cat mc-base.yaml -) > 99-simple-kmod.yaml
 ----
 
 . If the cluster is not up yet, generate manifest files and add this file to the
 `openshift` directory. If the cluster is already running, apply the file as follows:
 +
 ----
-$ oc create -f 99_simple-kmod.yaml
+$ oc create -f 99-simple-kmod.yaml
 ----
 +
 Your nodes will start the `kmods-via-containers@simple-kmod.service`

--- a/modules/installation-special-config-rtkernel.adoc
+++ b/modules/installation-special-config-rtkernel.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-special-config.adoc
+
+[id="installation-special-config-rtkernel_{context}"]
+
+= Adding a real-time kernel to nodes (during installation)
+
+Some {product-title} workloads require a high degree of determinism.
+While Linux is not a real-time operating system, the Linux real-time
+kernel includes a preemptive scheduler that provides the operating
+system with real-time characteristics.
+
+If your {product-title} workloads require these real-time characteristics,
+you can set up your compute (worker) and/or master machines to use the
+Linux real-time kernel when you first install the cluster. To do this,
+create a MachineConfig object and inject that object into the set of manifest
+files used by Ignition during cluster setup, as described in the following
+procedure.
+
+[NOTE]
+====
+This procedure is fully supported with bare metal installations using
+systems that are certified for Red Hat Enterprise Linux for Real Time 8.
+Real time support in OpenShift is also limited to specific subscriptions.
+====
+
+.Prerequisites
+* For a bare metal installation of {product-title}, prepare masters and workers
+* Use at least {product-title} version 4.4
+
+.Procedure
+
+. Generate the Kubernetes manifests for the cluster:
++
+----
+$ ./openshift-install create manifests --dir=<installation_directory>
+----
+
+. Decide if you want to add the real-time kernel to worker or master nodes.
+
+. In the `openshift` directory, create a file (for example,
+`01-worker-realtime.yaml.yaml`) to define a MachineConfig
+object that applies a real-time kernel to the selected nodes (worker
+nodes in this case):
++
+----
+$ cat << EOF > 01-worker-realtime.yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker"
+  name: 01-worker-realtime
+spec:
+  kernelType: realtime
+EOF
+----
++
+You can change `worker` to `master` to add kernel arguments to master nodes instead.
+Create a separate YAML file to add to both master and worker nodes.
+
+. Create the cluster.  You can now continue on to create the {product-title} cluster.
++
+----
+$ ./openshift-install create cluster --dir=<installation_directory>
+----
+
+. Check the real-time kernel: Once the cluster comes up, log in to the cluster
+and run the following commands to make sure that the real-time kernel has
+replaced the regular kernel for the set of worker or master nodes you
+configured:
++
+----
+$ oc get nodes
+NAME                                        STATUS  ROLES    AGE   VERSION
+ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.17.1
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.17.1
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.17.1
+ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.17.1
+ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.17.1
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.17.1
+
+$ oc debug node/ip-10-0-143-147.us-east-2.compute.internal
+Starting pod/ip-10-0-143-147us-east-2computeinternal-debug ...
+To use host binaries, run `chroot /host`
+
+sh-4.4# uname -a
+Linux <worker_node> 4.18.0-147.3.1.rt24.96.el8_1.x86_64 #1 SMP PREEMPT RT
+        Wed Nov 27 18:29:55 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
+----

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-special-config.adoc
+
+[id="nodes-nodes-rtkernel-arguments_{context}"]
+
+= Adding a real-time kernel to nodes (after installation)
+
+Some {product-title} workloads require a high degree of determinism.
+While Linux is not a real-time operating system, the Linux real-time
+kernel includes a preemptive scheduler that provides the operating
+system with real-time characteristics.
+
+If your {product-title} workloads require these real-time characteristics,
+you can switch your compute (worker) and/or master machines to the Linux
+real-time kernel. For {product-title}, {product-version} you can make this
+switch using a MachineConfig object. Although making the change is as simple
+as changing a MachineConfig `kernelType` setting to `realtime`, there are a few
+other considerations before making the change:
+
+[NOTE]
+====
+This procedure is fully supported with bare metal installations using
+systems that are certified for Red Hat Enterprise Linux for Real Time 8.
+Real time support in OpenShift is also limited to specific subscriptions.
+====
+
+.Prerequisites
+* Have a running {product-title} cluster (version 4.4 or later)
+* Log in to the cluster as a user with administrative privileges
+
+.Procedure
+
+. Create a MachineConfig for the real-time kernel: Create a yaml file
+(for example, `01-worker-realtime.yaml.yaml`) that contains a MachineConfig
+object  for the `realtime` kernelType. THis example tells the cluster to
+use a real-time kernel for all worker nodes:
++
+----
+$ cat << EOF > 01-worker-realtime.yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker"
+  name: 01-worker-realtime
+spec:
+  kernelType: realtime
+EOF
+----
++
+You can change `worker` to `master` to add kernel arguments to master nodes instead.
+Create a separate YAML file to add to both master and worker nodes.
+
+. Add the MachineConfig to the cluster.  Type the following to add the MachineConfig
+to the cluster:
++
+----
+$ oc create -f 01-worker-realtime.yaml
+----
+
+. Check the real-time kernel: Once each impacted node reboots, log in to the cluster
+and run the following commands to make sure that the real-time kernel has
+replaced the regular kernel for the set of worker or master nodes you
+configured:
++
+----
+$ oc get nodes
+NAME                                        STATUS  ROLES    AGE   VERSION
+ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.17.1
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.17.1
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.17.1
+ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.17.1
+ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.17.1
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.17.1
+
+$ oc debug node/ip-10-0-143-147.us-east-2.compute.internal
+Starting pod/ip-10-0-143-147us-east-2computeinternal-debug ...
+To use host binaries, run `chroot /host`
+
+sh-4.4# uname -a
+Linux <worker_node> 4.18.0-147.3.1.rt24.96.el8_1.x86_64 #1 SMP PREEMPT RT
+        Wed Nov 27 18:29:55 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
+----
++
+The kernel name contains `rt` and text “PREEMPT RT” indicates that this is a real-time kernel.
+
+. To go back to the regular kernel, just delete the MachineConfig object:
++
+----
+$ oc delete -f 01-worker-realtime.yaml
+----

--- a/nodes/nodes/nodes-nodes-working.adoc
+++ b/nodes/nodes/nodes-nodes-working.adoc
@@ -27,6 +27,8 @@ include::modules/nodes-nodes-working-deleting.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
 
+include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+1]
+
 == Additional resources
 
 For more information on scaling your cluster using a MachineSet,


### PR DESCRIPTION
New docs for adding a real-time kernel during install or day-2. In testing, I realized the MachineConfigs no longer support underscores in their names (_), so I fixed that and other MachineConfigs in other parts of the docs.