### PR TITLE
[enterprise-4.3] CNV - BZ#1818068 removing supplmentary NAD example 

### DIFF
--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -8,6 +8,11 @@
 As a network administrator, you can configure a NetworkAttachmentDefinition
 of type `cnv-bridge` to provide Layer-2 networking to Pods and virtual machines.
 
+[NOTE]
+====
+The NetworkAttachmentDefinition must be in the same namespace as the Pod or virtual machine.
+====
+
 .Prerequisites
 
 * {CNVProductNameStart} 2.0 or newer
@@ -75,19 +80,6 @@ spec:
 ----
 <1> You must substitute the actual `name` value from the
 NetworkAttachmentDefinition.
-+
-In this example, the NetworkAttachmentDefinition and Pod are in the same
-namespace.
-+
-To specify a different namespace, use the following syntax:
-+
-[source,yaml]
-----
-...
-  annotations:
-    k8s.v1.cni.cncf.io/networks: <namespace>/a-bridge-network
-...
-----
 
 . Apply the configuration file to the resource:
 +


### PR DESCRIPTION
Manual cherrypick from #20880 
As per BZ#1818068, removing the supplementary example for adding NAD outside of namepsace. This is not possible.