### PR TITLE
Remove Pipelines bug fixes because it's in DP for 4.3

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -696,13 +696,6 @@ Podman containers on CRI-O restore so that they are no longer deleted from
 storage upon startup.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1758500[*BZ#1758500*])
 
-*Developer Console*
-
-* An invalid property was introduced into the Pipeline Operator during an upgrade.
-As a result, Pipelines could no longer start from the UI. The property is now
-updated to use a valid specification. As a result, Pipelines start from the UI
-again. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1763725[*BZ#1763725*])
-
 *Etcd*
 
 * Etcd would become overloaded with a large number of objects, causing the
@@ -1648,13 +1641,6 @@ TCP and UDP ports 30000-32767. This caused newly introduced OVN Networking
 components to not work properly in clusters lacking these security group rules.
 Now security group rules are available to allow the aforementioned
 bi-directional traffic support. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1779469[*BZ#1779469*])
-
-* The OpenShift Pipeline Operator v0.9.x+ did not work with UI code after the
-removal of an API reference. The `serviceAccount` field in Pipeline Runs was
-replaced with the `serviceAccountName` field, but was still being used by the
-Operator. This caused pipelines created in {product-title} to not create
-Pipeline Runs correctly. The API references have been fixed, and pipelines  work
-again with the OpenShift Pipeline Operator v0.9.x+. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1788201[*BZ#1788201*])
 
 * Previously, users would be given a _Restricted Access_ error when trying to
 access the *Installed Operators* page in the web console. This happened because


### PR DESCRIPTION
FYI @Preeticp as we discussed earlier.

This removes Pipelines bug fixes from 4.3 RNs. Pipelines is Developer Preview for 4.3, so we should ignore these bug summaries