### PR TITLE
Add Uninstalling Service Catalog

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -840,8 +840,10 @@ Topics:
   Dir: service_brokers
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
   Topics:
-  - Name: Installing the service catalog
+  - Name: Installing Service Catalog
     File: installing-service-catalog
+  - Name: Uninstalling Service Catalog
+    File: uninstalling-service-catalog
   - Name: Installing the Template Service Broker
     File: installing-template-service-broker
   - Name: Uninstalling the Template Service Broker

--- a/applications/service_brokers/installing-service-catalog.adoc
+++ b/applications/service_brokers/installing-service-catalog.adoc
@@ -1,5 +1,5 @@
 [id="sb-installing-service-catalog"]
-= Installing the service catalog
+= Installing Service Catalog
 include::modules/common-attributes.adoc[]
 :context: sb-installing-service-catalog
 
@@ -7,13 +7,23 @@ toc::[]
 
 [IMPORTANT]
 ====
-The service catalog is deprecated in {product-title} 4. Equivalent and better
+Service Catalog is deprecated in {product-title} 4. Equivalent and better
 functionality is present in the Operator Framework and Operator Lifecycle
 Manager (OLM).
 ====
 
-// About the service catalog
+[IMPORTANT]
+====
+Starting in {product-title} 4.4, the `service-catalog-controller-manager` and
+`service-catalog-apiserver` cluster Operators are now set to
+`Upgradeable=false`. This means that they will block future cluster upgrades to
+the next minor version, for example 4.5, if they are still installed at that
+time. Upgrading to z-stream releases such as 4.4.z, however, are still permitted
+in this state.
+====
+
+// About Service Catalog
 include::modules/sb-about-service-catalog.adoc[leveloffset=+1]
 
-// Installing service catalog
+// Installing Service Catalog
 include::modules/sb-install-service-catalog.adoc[leveloffset=+1]

--- a/applications/service_brokers/installing-template-service-broker.adoc
+++ b/applications/service_brokers/installing-template-service-broker.adoc
@@ -23,10 +23,6 @@ xref:../../openshift_images/configuring-samples-operator.adoc#configuring-sample
 for details.
 ====
 
-.Prerequisites
-
-* xref:../../applications/service_brokers/installing-service-catalog.adoc#sb-install-service-catalog_sb-installing-service-catalog[Install the service catalog]
-
 // About the service {tsb-name}
 include::modules/sb-about-template-service-broker.adoc[leveloffset=+1]
 

--- a/applications/service_brokers/uninstalling-service-catalog.adoc
+++ b/applications/service_brokers/uninstalling-service-catalog.adoc
@@ -1,0 +1,23 @@
+[id="sb-uninstalling-service-catalog"]
+= Uninstalling Service Catalog
+include::modules/common-attributes.adoc[]
+:context: sb-uninstalling-service-catalog
+
+toc::[]
+
+[IMPORTANT]
+====
+Starting in {product-title} 4.4, the `service-catalog-controller-manager` and
+`service-catalog-apiserver` cluster Operators are now set to
+`Upgradeable=false`. This means that they will block future cluster upgrades to
+the next minor version, for example 4.5, if they are still installed at that
+time. Upgrading to z-stream releases such as 4.4.z, however, are still permitted
+in this state.
+====
+
+You can uninstall Service Catalog if you have installed it previously. Service
+Catalog must be removed before the cluster can upgrade to future minor versions
+of {product-title}.
+
+// Uninstalling Service Catalog
+include::modules/sb-uninstall-service-catalog.adoc[leveloffset=+1]

--- a/modules/sb-about-service-catalog.adoc
+++ b/modules/sb-about-service-catalog.adoc
@@ -3,28 +3,30 @@
 // * applications/service_brokers/installing-service-catalog.adoc
 
 [id="sb-about-service-catalog_{context}"]
-= About the service catalog
+= About Service Catalog
 
 When developing microservices-based applications to run on cloud native
 platforms, there are many ways to provision different resources and share their
 coordinates, credentials, and configuration, depending on the service
 provider and the platform.
 
-To give developers a more seamless experience, {product-title} includes a
-_service catalog_, an implementation of the
-link:https://openservicebrokerapi.org/[Open Service Broker API] (OSB API) for
-Kubernetes. This allows users to connect any of their applications deployed in
-{product-title} to a wide variety of service brokers.
+To give developers a more seamless experience, {product-title} includes _Service Catalog_,
+an implementation of the link:https://openservicebrokerapi.org/[Open Service Broker API]
+(OSB API) for Kubernetes. This allows users to connect any of their applications
+deployed in {product-title} to a wide variety of service brokers.
 
-The service catalog allows cluster administrators to integrate multiple
-platforms using a single API specification. The {product-title} web console
-displays the cluster service classes offered by service brokers in the service
-catalog, allowing users to discover and instantiate those services for use with
-their applications.
+Service Catalog allows cluster administrators to integrate multiple platforms
+using a single API specification. The {product-title} web console displays the
+cluster service classes offered by service brokers in Service Catalog, allowing
+users to discover and instantiate those services for use with their
+applications.
 
 As a result, service users benefit from ease and consistency of use across
 different types of services from different providers, while service providers
 benefit from having one integration point that gives them access to multiple
 platforms.
 
-The service catalog is not installed by default in {product-title} 4.
+[IMPORTANT]
+====
+Service Catalog is not installed by default in {product-title} 4.
+====

--- a/modules/sb-about-template-service-broker.adoc
+++ b/modules/sb-about-template-service-broker.adoc
@@ -5,7 +5,7 @@
 [id="sb-about-template-service-broker_{context}"]
 = About the {tsb-name}
 
-The _{tsb-name}_ gives the service catalog visibility into the
+The _{tsb-name}_ gives Service Catalog visibility into the
 default Instant App and Quickstart templates that have shipped with
 {product-title} since its initial release. The {tsb-name} can also
 make available as a service anything for which an {product-title} template has
@@ -15,4 +15,7 @@ By default, the {tsb-name} shows objects that are globally
 available from the `openshift` project. It can also be configured to watch any
 other project that a cluster administrator chooses.
 
+[IMPORTANT]
+====
 The {tsb-name} is not installed by default in {product-title} 4.
+====

--- a/modules/sb-install-service-catalog.adoc
+++ b/modules/sb-install-service-catalog.adoc
@@ -3,20 +3,20 @@
 // * applications/service_brokers/installing-service-catalog.adoc
 
 [id="sb-install-service-catalog_{context}"]
-= Installing service catalog
+= Installing Service Catalog
 
 If you plan on using any of the services from the {tsb-name}, you must install
-the service catalog by completing the following steps.
+Service Catalog by completing the following steps.
 
-The custom resources for the service catalog's API server and controller manager
+The custom resources for Service Catalog's API server and controller manager
 are created by default in {product-title}, but initially have a
-`managementState` of `Removed`. To install the service catalog, you must change
+`managementState` of `Removed`. To install Service Catalog, you must change
 the `managementState` for these resources to `Managed`.
 
 .Procedure
 
-. Enable the service catalog API server.
-.. Use the following command to edit the service catalog API server resource.
+. Enable Service Catalog's API server.
+.. Use the following command to edit Service Catalog's API server resource.
 +
 ----
 $ oc edit servicecatalogapiservers
@@ -31,12 +31,12 @@ spec:
 ----
 .. Save the file to apply the changes.
 +
-The Operator installs the service catalog API server component. As of
+The Operator installs Service Catalog's API server component. As of
 {product-title} 4, this component is installed into the
 `openshift-service-catalog-apiserver` namespace.
 
-. Enable the service catalog controller manager.
-.. Use the following command to edit the service catalog controller manager resource.
+. Enable Service Catalog's controller manager.
+.. Use the following command to edit Service Catalog's controller manager resource.
 +
 ----
 $ oc edit servicecatalogcontrollermanagers
@@ -51,6 +51,9 @@ spec:
 ----
 .. Save the file to apply the changes.
 +
-The Operator installs the service catalog controller manager component. As of
+The Operator installs Service Catalog's controller manager component. As of
 {product-title} 4, this component is installed into the
 `openshift-service-catalog-controller-manager` namespace.
+
+. Verify that the installation is completed successfully by checking that *Service Catalog*
+appears in the left navigation of the web console.

--- a/modules/sb-install-tsb-operator.adoc
+++ b/modules/sb-install-tsb-operator.adoc
@@ -7,7 +7,7 @@
 
 .Prerequisites
 
-* You have installed the service catalog.
+* Service Catalog is installed.
 
 .Procedure
 

--- a/modules/sb-start-tsb.adoc
+++ b/modules/sb-start-tsb.adoc
@@ -10,8 +10,8 @@ After you have installed the {tsb-name} Operator, you can start the
 
 .Prerequisites
 
-* You have installed the service catalog.
-* You have installed the {tsb-name} Operator.
+* Service Catalog is installed.
+* The {tsb-name} Operator is installed.
 
 .Procedure
 
@@ -54,7 +54,7 @@ project, verify that the Pod that starts with `apiserver-` has a status of
 ** From the *Service Catalog* -> *Broker Management* -> *Service Brokers* page, verify
 that the *template-service-broker* service broker has a status of *Ready*.
 
-* Service catalog controller manager Pod logs
+* Service Catalog controller manager Pod logs
 ** From the *Workloads* -> *Pods* page for the
 *openshift-service-catalog-controller-manager* project, review the logs for
 each of the Pods and verify that you see a log entry with the message

--- a/modules/sb-uninstall-service-catalog.adoc
+++ b/modules/sb-uninstall-service-catalog.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * applications/service_brokers/uninstalling-service-catalog.adoc
+
+[id="sb-uninstall-service-catalog_{context}"]
+= Uninstalling Service Catalog
+
+If Service Catalog is installed, cluster administrators can uninstall it by
+using the following procedure.
+
+[WARNING]
+====
+Uninstalling Service Catalog will impact any service brokers and provisioned
+services from those brokers, such as the {tsb-name}, in your cluster.
+====
+
+.Prerequisites
+
+* Service Catalog is installed.
+
+.Procedure
+
+. Using an account with `cluster-admin` privileges, edit the
+`servicecatalogcontrollermanagers` resource:
++
+----
+$ oc edit servicecatalogcontrollermanagers
+----
+
+. Change the `managementState` parameter from `Managed` back to the default
+`Removed`, and save your changes.
+
+. Edit the `servicecatalogapiservers` resource:
++
+----
+$ oc edit servicecatalogapiservers
+----
+
+. Change the `managementState` parameter from `Managed` back to the default
+`Removed`, and save your changes.
+
+. Verify that the removal is completed successfully by checking that *Service Catalog*
+is removed from the left navigation of the web console.


### PR DESCRIPTION
Preview (internal): http://file.rdu.redhat.com/~adellape/042720/uninstall-svccat/applications/service_brokers/uninstalling-service-catalog.html

Also syncs up on "the service catalog" -> "Service Catalog", as has been in the last few release notes.

Link in 4.4 release note update PR depends on this target being available (https://github.com/openshift/openshift-docs/pull/21538).