### PR TITLE
Clarify portion of Audit that is removed in TP table

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -1594,7 +1594,7 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 
-|Central Audit
+|Audit Policy
 |-
 |-
 |-


### PR DESCRIPTION
@vikram-redhat this was the last feature in the TP table that needed confirmation for our removal/deprecation specification initiative. We're now all set!

This clarifies the specific portion of central auditing that was removed. Many portions are still GA.