### PR TITLE
CNV BZ1828744 slirp invalid for nic type

### DIFF
--- a/cnv/cnv_release_notes/cnv-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-release-notes.adoc
@@ -144,6 +144,8 @@ name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822266[*BZ#1822266*])
 *** Create a new custom resource that is named the default `kubevirt-hyperconverged`.
 Then, delete the custom resource that is not named `kubevirt-hyperconverged`.
 
+* The {product-title} 4.4 web console includes *slirp* as an option when you add a NIC to a virtual machine, but *slirp* is not a valid NIC type. Do not select *slirp* when adding a NIC to a virtual machine.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1828744[*BZ#1828744*])
 
 // For 2.3: Add new Known Issues above this line (so that we don't mix the new with the old/possibly no longer irrelevant ones)
 // The following 7 bugs are from the 2.2 release notes but from their bugs they still seem to be relevant for 2.3:


### PR DESCRIPTION
Adding known issue for slirp as not a good choice for NIC type
Preview:
![Screenshot from 2020-04-28 16-54-16](https://user-images.githubusercontent.com/17755748/80502647-32835900-8971-11ea-9b95-a45634163de2.png)
