### PR TITLE
Add opsrc/csc conversion procedure and update dep notice

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -499,8 +499,8 @@ In the table, features are marked with the following statuses:
 * *DEP*: _Deprecated_
 * *-*: _Removed_
 
-.Deprecated and Removed Features Tracker
-[cols="4",options="header"]
+.Deprecated and removed features tracker
+[cols="3,1,1,1",options="header"]
 |====
 |Feature |OCP 4.2 |OCP 4.3 |OCP 4.4
 
@@ -518,6 +518,21 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 |-
+
+|OperatorSources
+|DEP
+|DEP
+|DEP
+
+|CatalogSourceConfigs
+|DEP
+|DEP
+|DEP
+
+|Operator Framework packaging format v1
+|GA
+|GA
+|DEP
 
 |System Containers for Docker, CRI-O
 |-
@@ -639,7 +654,6 @@ to uninstall it before the next minor version of {product-title} is released.
 [id="ocp-4-4-deprecation-of-operatorsources"]
 ==== Deprecation of OperatorSources, CatalogSourceConfigs, and packaging format
 
-[id="ocp-4-4-marketplace-apis-deprecated"]
 OperatorSources and CatalogSourceConfigs are deprecated from OperatorHub. The
 following related APIs will be removed in a future release:
 
@@ -647,14 +661,101 @@ following related APIs will be removed in a future release:
 * `catalogsourceconfigs.operators.coreos.com/v2`
 * `catalogsourceconfigs.operators.coreos.com/v1`
 
-The Operator Framework's current packaging format is also being deprecated in a
-future release, to be replaced by a new bundle format. As a result, the
-following command will also be deprecated at that time:
-
-* `oc adm catalog build`
+The Operator Framework's current packaging format is also deprecated in this
+release, to be replaced by a new bundle format in a future release. As a result,
+the `oc adm catalog build` command, which builds catalogs in the older format,
+is also deprecated.
 
 For more information on the upcoming new Operator bundle format and Operator
 Package Manager CLI (`opm`), see the link:https://docs.okd.io/latest/operators/understanding_olm/olm-understanding-olm.html#olm-new-bundle-opm_olm-understanding-olm[upstream OKD documentation].
+
+[id="ocp-4-4-marketplace-apis-deprecated"]
+===== Converting custom OperatorSources and CatalogSourceConfigs
+
+If there are any custom OperatorSources or CatalogSourceConfigs objects present
+on the cluster in {product-title} 4.4, the `marketplace` cluster Operator now
+sets an `Upgradeable=false` condition and issues a *Warning* alert. This means
+that it will block future cluster upgrades to the next minor version, for
+example 4.5, if they are still installed at that time. Upgrades to z-stream
+releases such as 4.4.z, however, are still permitted in this state.
+
+Cluster administrators can convert custom OperatorSources or
+CatalogSourceConfigs to using CatalogSources directly to clear this alert:
+
+.Procedure
+
+. Remove your custom OperatorSources or CatalogSourceConfigs objects.
+
+.. Search for OperatorSources or CatalogSourceConfigs objects across all
+namespaces:
++
+----
+$ oc get opsrc --all-namespaces
+$ oc get csc --all-namespaces
+----
+
+.. Remove all custom objects from all relevant namespaces:
++
+----
+$ oc delete opsrc <custom_opsrc_name> -n <namespace>
+$ oc delete csc <custom_csc_name> -n <namespace>
+----
++
+[IMPORTANT]
+====
+Do not remove the default OperatorSources in the `openshift-marketplace`
+namespace, although they are bootstrapped if accidentally removed.
+====
+
+. Use the procedure as described in
+xref:../operators/olm-restricted-networks.adoc#olm-building-operator-catalog-image_olm-restricted-networks[Building an Operator catalog image]
+from the restricted network documentation to create and push a new catalog
+image, making the following changes at the `oc adm catalog build` command step:
++
+--
+* Change `--appregistry-org` to your namespace on the App Registry instance, for
+example on link:https://quay.io[Quay.io].
+* Change `--to` to your image repository tag, which is applied to the built
+catalog image and pushed.
+--
++
+For example:
++
+----
+$ oc adm catalog build \
+    --appregistry-org <namespace> \
+    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.4 \
+    --to=quay.io/<namespace>/<catalog_name>:<tag> \
+    [-a ${REG_CREDS}]
+----
++
+[NOTE]
+====
+The `oc adm catalog build` command is deprecated; however, deprecated features
+are still supported.
+====
+
+. Apply a CatalogSource to your cluster that references your new catalog image:
++
+----
+cat <<EOF | oc apply -f -
+
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: my-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/<namespace>/<catalog_name>:<tag> <1>
+  displayName: My Operator Catalog
+  updateStrategy:
+    registryPoll: <2>
+      interval: 30m
+EOF
+----
+<1> Specify your custom Operator catalog image.
+<2> CatalogSources can now automatically check for new versions to keep up to date.
 
 [id="ocp-4-4-removed-features"]
 === Removed features
@@ -1583,8 +1684,8 @@ In the table below, features are marked with the following statuses:
 * *GA*: _General Availability_
 * *-*: _Not Available_
 
-.Technology Preview Tracker
-[cols="4",options="header"]
+.Technology Preview tracker
+[cols="4,1,1,1",options="header"]
 |====
 |Feature |OCP 4.2 |OCP 4.3 |OCP 4.4
 


### PR DESCRIPTION
Preview (internal): 

* Updated deprecation notice and added conversion steps - http://file.rdu.redhat.com/~adellape/042820/44_catalogbuild/release_notes/ocp-4-4-release-notes.html#ocp-4-4-deprecation-of-operatorsources
* Added to deprecated/removed features table - http://file.rdu.redhat.com/~adellape/042820/44_catalogbuild/release_notes/ocp-4-4-release-notes.html#ocp-4-4-deprecated-removed-features