### PR TITLE
no base64 encoding allowed in additionalTrustedCA

### DIFF
--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -60,8 +60,8 @@ administrators will have the appropriate permissions.
 should be trusted during `ImageStream import`, `pod image pull`,
 `openshift-image-registry pullthrough`, and builds. The namespace for this ConfigMap is
 `openshift-config`. The format of the ConfigMap is to use the registry hostname
-as the key, and the base64-encoded certificate as the value, for each additional
-registry CA to trust.
+as the key, and the PEM certificate as the value, for each additional registry CA to
+trust.
 <4> `registrySources`: Contains configuration that determines how the container
 runtime should treat individual registries when accessing images for builds and
 pods. For instance, whether or not to allow insecure access. It does not contain


### PR DESCRIPTION
Just struggled with this until I foudnd out that the value shall be a pure unencoded PEM certificate.

Just like suggested in [Setting up additional trusted certificate authorities for builds](https://docs.openshift.com/container-platform/4.3/builds/setting-up-trusted-ca.html):

> The ConfigMap must be created in the openshift-config namespace.
>   - domain is the key in the ConfigMap; value is the PEM-encoded certificate.
>     - Each CA must be associated with a domain. The domain format is hostname[..port].

Applies to all 4.* releases.