### PR TITLE
Add tested cluster maximums for major releases

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+
+[id="cluster-maximums-major-releases_{context}"]
+= {product-title} Tested cluster maximums for major releases
+
+Tested Cloud Platforms for {product-title} 3.x: Red Hat OpenStack, Amazon Web Services and Microsoft Azure.
+Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft Azure and Google Cloud Platform.
+
+[options="header",cols="3*"]
+|===
+| Maximum type |3.x tested maximum |4.x tested maximum
+
+| Number of Nodes
+| 2,000
+| 2,000
+
+| Number of Pods footnoteref:[numberofpodsmajorrelease,The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
+| 150,000
+| 150,000
+
+| Number of Pods per node
+| 250
+| 500 footnoteref:[podspernodemajorrelease, This was tested on a cluster with 100 worker nodes with 500 Pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `hostPrefix` of `22` in the `install-config.yaml` file and `maxPods` set to `500` using a custom KubeletConfig. The maximum number of Pods with attached Persistant Volume Claims (PVC) depends on storage backend from where PVC are allocated. In our tests, only OpenShift Container Storage v4 (OCS v4) was able to satisfy the number of Pods per node discussed in this document.]
+
+| Number of Pods per core
+| There is no default value.
+| There is no default value.
+
+| Number of Namespaces footnoteref:[numberofnamepacesmajorrelease, When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.]
+| 10,000
+| 10,000
+
+| Number of Builds
+| 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
+| 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
+
+| Number of Pods per namespace footnoteref:[objectpernamespacemajorrelease,There are
+a number of control loops in the system that must iterate over all objects
+in a given namespace as a reaction to some changes in state. Having a large
+number of objects of a given type in a single namespace can make those loops
+expensive and slow down processing given state changes. The limit assumes that
+the system has enough CPU, memory, and disk to satisfy the application requirements.]
+| 25,000
+| 25,000
+
+| Number of Services footnoteref:[servicesandendpointsmajorrelease,Each Service port and each Service back-end has a corresponding entry in iptables. The number of back-ends of a given Service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| 10,000
+| 10,000
+
+| Number of Services per Namespace
+| 5,000
+| 5,000
+
+| Number of Back-ends per Service
+| 5,000
+| 5,000
+
+| Number of Deployments per Namespace footnoteref:[objectpernamespacemajorrelease]
+| 2,000
+| 2,000
+
+|===

--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -9,43 +9,43 @@
 |===
 | Maximum type |4.1 tested maximum |4.2 tested maximum |4.3 tested maximum |4.4 tested maximum
 
-| Number of nodes
+| Number of Nodes
 | 2,000
 | 2,000
 | 2,000
 | 2,000
 
-| Number of pods footnoteref:[numberofpods,The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.]
+| Number of Pods footnoteref:[numberofpods,The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
 | 150,000
 | 150,000
 | 150,000
 | 150,000
 
-| Number of pods per node
+| Number of Pods per node
 | 250
 | 250
 | 250
-| 500 footnoteref:[podspernode, This was tested on a cluster with 100 worker nodes with 500 pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `hostPrefix` of `22` in the `install-config.yaml` file and `maxPods` set to `500` using a custom KubeletConfig. The maximum number of pods with attached Persistant Volume Claims (PVC) depends on storage backend from where PVC are allocated. In our tests, only OpenShift Container Storage v4 (OCS v4) was able to satisfy the number of pods per node discussed in this document.]
+| 250
 
-| Number of pods per core
+| Number of Pods per core
 | There is no default value.
 | There is no default value.
 | There is no default value.
 | There is no default value.
 
-| Number of namespaces footnoteref:[numberofnamepaces, When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.]
+| Number of Namespaces footnoteref:[numberofnamepaces, When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.]
 | 10,000
 | 10,000
 | 10,000
 | 10,000
 
-| Number of builds
+| Number of Builds
 | 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
 | 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 
-| Number of pods per namespace footnoteref:[objectpernamespace,There are
+| Number of Pods per Namespace footnoteref:[objectpernamespace,There are
 a number of control loops in the system that must iterate over all objects
 in a given namespace as a reaction to some changes in state. Having a large
 number of objects of a given type in a single namespace can make those loops
@@ -56,25 +56,25 @@ the system has enough CPU, memory, and disk to satisfy the application requireme
 | 25,000
 | 25,000
 
-| Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| Number of Services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
 | 10,000
 | 10,000
 | 10,000
 | 10,000
 
-| Number of services per namespace
+| Number of Services per Namespace
 | 5,000
 | 5,000
 | 5,000
 | 5,000
 
-| Number of back-ends per service
+| Number of Back-ends per Service
 | 5,000
 | 5,000
 | 5,000
 | 5,000
 
-| Number of deployments per namespace footnoteref:[objectpernamespace]
+| Number of Deployments per Namespace footnoteref:[objectpernamespace]
 | 2,000
 | 2,000
 | 2,000

--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -15,6 +15,8 @@ format.
 In most cases, exceeding these numbers results in lower overall performance. It
 does not necessarily mean that the cluster will fail.
 
+include::modules/openshift-cluster-maximums-major-releases.adoc[leveloffset=+1]
+
 include::modules/openshift-cluster-maximums.adoc[leveloffset=+1]
 
 include::modules/openshift-cluster-maximums-environment.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit adds information about the cluster maximums tested on
major versions of OpenShift i.e 3.X and 4.X across various cloud
platforms.

Fixes https://github.com/openshift/openshift-docs/issues/20868.