### PR TITLE
Updated code block guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -484,6 +484,39 @@ $ lorem.sh
 ----
 ....
 
+* Do not use more than one command per code block. For example, the following must be split up into three separate code blocks.
++
+Run the following commands to create templates you can modify:
++
+----
+$ oc adm create-login-template > login.html
+----
++
+----
+$ oc adm create-provider-selection-template > providers.html
+----
++
+----
+$ oc adm create-error-template > errors.html
+----
++
+
+* Separate a command and its related output into individual code blocks. For example:
++
+Use the `oc new-project` command to create a new project.
++
+----
+$ oc new-project my-project
+----
+
++
+The output verifies that a new project was created.
++
+
+----
+Now using project "my-project" on server "https://openshift.example.com:6443".
+----
+
 * Try to use callouts to provide information on what the output represents when required.
 +
 Use this format when embedding callouts into the code block:


### PR DESCRIPTION
@openshift/team-documentation PTAL, thank you!

Updated the docs guidelines regarding code blocks after team discussions around the new click-to-copy button and standardizing how we write codes blocks.