### PR TITLE
Added a media query for hover on smartphones and touchscreens

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -172,6 +172,12 @@ span.clipboard-button:hover {
 .fa-check {
   color: #73804E;
 }
+
+@media (hover: none) and (pointer: coarse) {
+  .fa-clipboard:hover {
+    color: #404040;
+  }
+}
 /* End ClipboardJS edits */
 
 .fa-inverse:hover {


### PR DESCRIPTION
@vikram-redhat Here is a potential fix for the clipboard CSS on smartphones and touchscreens so that the button isn't stuck on "hover" (gray instead of black) after clicked.

I tested it in chrome dev tools and got good results. I wouldn't know for sure if it works until I can test it live on my phone.

https://medium.com/@ferie/detect-a-touch-device-with-only-css-9f8e30fa1134