### PR TITLE
Add tested cluster maximums for OCP 3.x

### DIFF
--- a/scaling_performance/cluster_maximums.adoc
+++ b/scaling_performance/cluster_maximums.adoc
@@ -20,6 +20,56 @@ stated thresholds, including the etcd version or storage data format.
 In most cases, exceeding these numbers results in lower overall performance.
 It does not necessarily mean that the cluster will fail.
 
+Tested Cloud Platforms for {product-title} 3.x: Red Hat OpenStack, Amazon Web Services and Microsoft Azure.
+
+[[scaling-performance-major-release-cluster-maximums]]
+== {product-title} Tested Cluster Maximums for major release
+
+[options="header",cols="2*"]
+|===
+| Maximum Type |3.x Tested Maximum
+
+| Number of Nodes
+| 2,000
+
+| Number of Pods footnoteref:[numberofpodsmajorrelease,The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
+| 150,000
+
+| Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per node]
+| 250
+
+| Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[pods per core]
+| There is no default value.
+
+| Number of Namespaces
+| 10,000
+
+| Number of Builds: Pipeline Strategy
+| 10,000 (Default pod RAM 512Mi)
+
+| Number of Pods per Namespace footnoteref:[objectpernamespacemajorrelease,There are
+a number of control loops in the system that need to iterate over all objects
+in a given namespace as a reaction to some changes in state. Having a large
+number of objects of a given type in a single namespace can make those loops
+expensive and slow down processing given state changes. The maximum
+assumes that the system has enough CPU, memory, and disk to satisfy the
+application requirements.]
+| 25,000
+
+| Number of Services footnoteref:[servicesandendpointsmajorrelease,Each Service port and each Service back-end has a corresponding entry in iptables. The number of back-ends of a given Service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| 10,000
+
+| Number of Services per Namespace
+| 5,000
+
+| Number of Back-ends per Service
+| 5,000
+
+| Number of Deployments per Namespace footnoteref:[objectpernamespacemajorrelease]
+| 2,000
+
+|===
+
 [[scaling-performance-current-cluster-maximums]]
 == {product-title} Tested Cluster Maximums
 
@@ -27,13 +77,13 @@ It does not necessarily mean that the cluster will fail.
 |===
 | Maximum Type |3.7 Tested Maximum |3.9 Tested Maximum |3.10 Tested Maximum |3.11 Tested Maximum
 
-| Number of nodes
+| Number of Nodes
 | 2,000
 | 2,000
 | 2,000
 | 2,000
 
-| Number of pods footnoteref:[numberofpods,The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.]
+| Number of Pods footnoteref:[numberofpods,The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
 | 120,000
 | 120,000
 | 150,000
@@ -51,20 +101,20 @@ It does not necessarily mean that the cluster will fail.
 | There is no default value.
 | There is no default value.
 
-| Number of namespaces
+| Number of Namespaces
 | 10,000
 | 10,000
 | 10,000
 | 10,000
 
 
-| Number of builds: Pipeline Strategy
+| Number of Builds: Pipeline Strategy
 | N/A
 | 10,000 (Default pod RAM 512Mi)
 | 10,000 (Default pod RAM 512Mi)
 | 10,000 (Default pod RAM 512Mi)
 
-| Number of pods per namespace footnoteref:[objectpernamespace,There are
+| Number of Pods per Namespace footnoteref:[objectpernamespace,There are
 a number of control loops in the system that need to iterate over all objects
 in a given namespace as a reaction to some changes in state. Having a large
 number of objects of a given type in a single namespace can make those loops
@@ -76,25 +126,25 @@ application requirements.]
 | 3,000
 | 25,000
 
-| Number of services footnoteref:[servicesandendpoints,Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| Number of Services footnoteref:[servicesandendpoints,Each Service port and each Service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
 | 10,000
 | 10,000
 | 10,000
 | 10,000
 
-| Number of services per namespace
+| Number of Services per Namespace
 | N/A
 | N/A
 | 5,000
 | 5,000
 
-| Number of back-ends per service
+| Number of Back-ends per Service
 | 5,000
 | 5,000
 | 5,000
 | 5,000
 
-| Number of deployments per namespace footnoteref:[objectpernamespace]
+| Number of Deployments per Namespace footnoteref:[objectpernamespace]
 | 2,000
 | 2,000
 | 2,000


### PR DESCRIPTION
This commit adds information about the cluster maximums tested on
major version i.e OpenShift 3.x across various cloud platforms.

Fixes https://github.com/openshift/openshift-docs/issues/20868.