### PR TITLE
BZ1694185 - Adding note about CA certificates specific to first master.

### DIFF
--- a/day_two_guide/topics/proc_backing-up-master.adoc
+++ b/day_two_guide/topics/proc_backing-up-master.adoc
@@ -63,6 +63,11 @@ on only the first master listed in the Ansible host inventory. If you
 deprecate the first master host, copy the `/etc/origin/master/ca.serial.txt`
 file to the rest of master hosts before the process.
 ====
++
+[IMPORTANT]
+====
+In {product-title} {product-version} clusters running multiple masters, one of the master nodes includes additional CA certificates in `/etc/origin/master`, `/etc/etcd/ca` and `/etc/etcd/generated_certs`. These are required for application node and etcd node scale-up operations and would need to be restored on another master node should the originating master become permanently unavailable. These directories are included by default within the backup procedures documented here.
+====
 
 . Other important files that need to be considered when planning a backup
 include:


### PR DESCRIPTION
Applies to branch/enterprise-3.11.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1694185.

Preview available at http://file.fab.redhat.com/~pneedle/environment_backup.html.