### PR TITLE
Odo correction for no additional server in understanding docs

### DIFF
--- a/cli_reference/developer_cli_odo/understanding-odo.adoc
+++ b/cli_reference/developer_cli_odo/understanding-odo.adoc
@@ -16,7 +16,7 @@ Existing tools such as `oc` are more operations-focused and require a deep under
 `{odo-title}` is designed to be simple and concise with the following key features:
 
 * Simple syntax and design centered around concepts familiar to developers, such as projects, applications, and components.
-* Completely client based. No server is required within the cluster for deployment.
+* Completely client based. No additional server other than {product-title} is required for deployment.
 * Official support for Node.js and Java components.
 * Partial compatibility with languages and frameworks such as Ruby, Perl, PHP, and Python.
 * Detects changes to local code and deploys it to the cluster automatically, giving instant feedback to validate changes in real time.


### PR DESCRIPTION
Based on user feedback, updates the documentation to suggest that there
is no need for an **additional** server other than OpenShift / the
cluster you're using. Rather than saying there is *no server required*.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>