### PR TITLE
BZ1731320 - Add XFS extend and grow instructions 

### DIFF
--- a/day_two_guide/topics/increasing_docker_storage.adoc
+++ b/day_two_guide/topics/increasing_docker_storage.adoc
@@ -103,12 +103,59 @@ volumes associated with container storage:
 +
 ----
 # docker-storage-setup
+----
++
+.. For *thin pool* setups, you should see the following output and can proceed to the next step:
++
+----
 INFO: Volume group backing root filesystem could not be determined
 INFO: Device /dev/xvdb is already partitioned and is part of volume group docker_vol
 INFO: Device node /dev/xvdd1 exists.
   Physical volume "/dev/xvdd1" successfully created.
   Volume group "docker_vol" successfully extended
 ----
++
+.. For *XFS* setups that use the Overlay2 file system, the increase shown in the previous output will not be visible.
++
+You must perform the following steps to extend and grow the XFS storage:
++
+... Run the `lvextend` command to grow the logical volume to use of all the available space in the volume group:
++
+----
+# lvextend -r -l +100%FREE /dev/mapper/docker_vol-dockerlv
+----
++
+[NOTE]
+====
+If the requirement is to use lesser space, choose the `FREE` percentage accordingly.
+====
++
+... Run the `xfs_growfs` command to grow the file system to use the available space:
++
+----
+# xfs_growfs /dev/mapper/docker_vol-dockerlv
+----
++
+[NOTE]
+====
+XFS file systems cannot be shrunk.
+====
++
+... Run the `docker-storage-setup` command again:
++
+----
+# docker-storage-setup
+----
++
+You should now see the extended volume groups and logical volumes in the output.
++
+----
+INFO: Device /dev/vdb is already partitioned and is part of volume group docker_vg
+INFO: Found an already configured thin pool /dev/mapper/docker_vg-docker--pool in /etc/sysconfig/docker-storage
+INFO: Device node /dev/mapper/docker_vg-docker--pool exists.
+  Logical volume docker_vg/docker-pool changed.
+----
++
 
 . Start the Docker services:
 +


### PR DESCRIPTION
[BZ 1731320](https://bugzilla.redhat.com/show_bug.cgi?id=1731320)
Adds additional steps that describe how to extend volume group and grow file system in Docker Tasks (OCP 3.11).

Preview build link: 
http://file.rdu.redhat.com/~bfuru/050120/BZ1731320/BZ1731320/day_two_guide/docker_tasks.html#increasing-storage

@liangxia or @qinpingli - PTAL and confirm these instructions are valid.