### PR TITLE
BZ1725731 - Add SSL note for GlusterFS

### DIFF
--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -80,6 +80,14 @@ System Interface [for Unix] (POSIX) permissions and SELinux considerations.
 Understanding the basics of xref:pod_security_context.adoc#install-config-persistent-storage-pod-security-context[Volume Security],
 POSIX permissions, and SELinux is presumed.
 
+[IMPORTANT]
+====
+
+In OpenShift Container Storage 3.11, you must enable SSL encryption to ensure secure access control to persistent volumes.
+
+For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/html-single/operations_guide/index#chap-Documentation-Red_Hat_Gluster_Storage_Container_Native_with_OpenShift_Platform-Enabling_Encryption[Red Hat OpenShift Container Storage 3.11 Operations Guide].
+====
+
 [[considerations-volume-security-posix]]
 ==== POSIX Permissions
 


### PR DESCRIPTION
[BZ 1725731](https://bugzilla.redhat.com/show_bug.cgi?id=1725731)

Adds note for OCS 3.11 to use SSL encryption on PVs. I did not include forward-looking statement about OCS 4, which was described in the BZ, because we should avoid predictions. 

If auto-encryption is already in production in OCS 4, please let me know and I can add a statement that "this functionality is available in OCS 4."

Preview link: http://file.rdu.redhat.com/~bfuru/050120/BZ1725731/BZ1725731/install_config/persistent_storage/persistent_storage_glusterfs.html#considerations-volume-security

@liangxia or @ashmitha7 - Not sure who can provide QE review for this, PTAL?

@pamoedom PTAL?