### PR TITLE
Update CRI-O GitHub markdown URLs

### DIFF
--- a/security/deployment.adoc
+++ b/security/deployment.adoc
@@ -117,7 +117,7 @@ For specific instructions on configuring a host, see
 xref:../install/host_preparation.adoc#enabling-image-signature-support[Enabling Image Signature Support].
 See the section below for details on xref:security-deployment-signature-transports[Signature Transports].
 For more details on image signature policy, see the
-link:https://github.com/containers/image/blob/master/docs/policy.json.md[Signature verification policy file format] source code documentation.
+link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/containers-policy.json.md[Signature verification policy file format] source code documentation.
 
 [[security-deployment-signature-transports]]
 === Signature Transports
@@ -139,7 +139,7 @@ Signatures that use the `docker` transport type are served by local file or web
 server. These signatures are more flexible: you can serve images from any 
 container image registry and use an independent server to deliver binary
 signatures. According to the
-link:https://github.com/containers/image/blob/master/docs/signature-protocols.md[Signature access protocols],
+link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/signature-protocols.md[Signature access protocols],
 you access the signatures for each image directly; the root of the server
 directory does not display its file structure.
 
@@ -165,8 +165,8 @@ restart is required since policy and *_registries.d_* files are dynamically
 loaded by the container runtime.
 
 For more details, see the
-link:https://github.com/containers/image/blob/master/docs/registries.d.md[Registries Configuration Directory] or
-link:https://github.com/containers/image/blob/master/docs/signature-protocols.md[Signature access protocols] source code documentation.
+link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/containers-registries.d.md[Registries Configuration Directory] or
+link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/signature-protocols.md[Signature access protocols] source code documentation.
 
 [discrete]
 [[security-deployment-further-reading-2]]
@@ -179,9 +179,9 @@ link:https://github.com/containers/image/blob/master/docs/signature-protocols.md
 ** link:https://access.redhat.com/articles/2750891[Container Image Signing Integration Guide]
 
 - _Source Code Reference_
-** link:https://github.com/containers/image/blob/master/docs/policy.json.md[Image signing policy]
-** link:https://github.com/containers/image/blob/master/docs/signature-protocols.md[Signature transports]
-** link:https://github.com/containers/image/blob/master/docs/atomic-signature.md[Signature format]
+** link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/containers-policy.json.md[Image signing policy]
+** link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/signature-protocols.md[Signature transports]
+** link:https://github.com/containers/image/blob/cri-o-release-1.11/docs/atomic-signature.md[Signature format]
 
 [[security-deployment-secrets-configmaps]]
 == Secrets and ConfigMaps


### PR DESCRIPTION
The release notes for OCP 3.11 indicate that CRI-O 1.11 is used, so these links now point to 3.11; Prior links were all broken.