### PR TITLE
Remove dropped RHSA from 3.11 RNs

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -3070,22 +3070,6 @@ To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest
 release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade
 methods and strategies] for instructions.
 
-[[RHSA-2020-0797]]
-=== RHSA-2020:0797 - Moderate: {product-title} apb-tools-container security update
-
-Issued: 2020-03-18
-
-An update for apb-tools-container is now available for {product-title} 3.11.
-Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:0797[RHSA-2020:0797] advisory.
-
-[[RHSA-2020-0797-upgrading]]
-==== Upgrading
-
-To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest
-release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade
-methods and strategies] for instructions.
-
 [[RHSA-2020-0798]]
 === RHSA-2020:0798 - Moderate: {product-title} mediawiki-apb security update
 


### PR DESCRIPTION
This relates to [this advisory](https://errata.devel.redhat.com/advisory/52420). It never shipped, so we should remove it from the Release Notes.