### PR TITLE
Rebrand CAM as MTC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1270,12 +1270,12 @@ Topics:
     File: planning-migration-3-to-4
   - Name: Migrating application workloads from OpenShift Container Platform 3.7 to 4.3
     File: migrating-application-workloads-3-to-4
-  - Name: Deploying the Cluster Application Migration tool
-    File: deploying_cam
   - Name: Configuring a replication repository
     File: configuring-replication-repository
-  - Name: Migrating applications with the CAM web console
-    File: migrating-applications-with-cam
+  - Name: Deploying the Migration Toolkit for Containers
+    File: deploying_mtc
+  - Name: Migrating application workloads
+    File: migrating-applications-with-mtc
   - Name: Migrating control plane settings with the Control Plane Migration Assistant
     File: migrating-with-cpma
   - Name: Troubleshooting
@@ -1286,12 +1286,12 @@ Topics:
   Topics:
   - Name: Migrating application workloads from OpenShift Container Platform 4.1 to 4.3
     File: migrating-application-workloads-4_1-to-4
-  - Name: Deploying the Cluster Application Migration tool
-    File: deploying_cam
   - Name: Configuring a replication repository
     File: configuring-replication-repository
-  - Name: Migrating applications with the CAM web console
-    File: migrating-applications-with-cam
+  - Name: Deploying the Migration Toolkit for Containers
+    File: deploying_mtc
+  - Name: Migrating application workloads
+    File: migrating-applications-with-mtc
   - Name: Troubleshooting
     File: troubleshooting
 - Name: Migrating Openshift Container Platform 4.2 to 4.3
@@ -1300,12 +1300,12 @@ Topics:
   Topics:
   - Name: Migrating application workloads from OpenShift Container Platform 4.2 to 4.3
     File: migrating-application-workloads-4_2-to-4
-  - Name: Deploying the Cluster Application Migration tool
-    File: deploying_cam
   - Name: Configuring a replication repository
     File: configuring-replication-repository
-  - Name: Migrating applications with the CAM web console
-    File: migrating-applications-with-cam
+  - Name: Deploying the Migration Toolkit for Containers
+    File: deploying_mtc
+  - Name: Migrating application workloads
+    File: migrating-applications-with-mtc
   - Name: Troubleshooting
     File: troubleshooting
 ---

--- a/migration/migrating_3_4/about-migration.adoc
+++ b/migration/migrating_3_4/about-migration.adoc
@@ -14,5 +14,5 @@ Learn about the differences between {product-title} versions 3 and 4. Prior to t
 
 xref:../../migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc#migrating-application-workloads-3-to-4[Performing your migration]::
 Learn about and use the tools to perform your migration:
-* Cluster Application Migration (CAM) tool to migrate your application workloads
-* Control Plane Migration Assistant (CPMA) to migrate your control plane
+* {mtc-first} to migrate your application workloads
+* Control Plane Migration Assistant (CPMA) to plan your control plane migration

--- a/migration/migrating_3_4/configuring-replication-repository.adoc
+++ b/migration/migrating_3_4/configuring-replication-repository.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
+You must configure an object storage to use as a replication repository. The {mtc-first} copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_3_4/configuring-replication-repository.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
 
 The following storage providers are supported:
 

--- a/migration/migrating_3_4/deploying_mtc.adoc
+++ b/migration/migrating_3_4/deploying_mtc.adoc
@@ -1,0 +1,22 @@
+[id='deploying-mtc_{context}']
+= Deploying the {mtc-first}
+include::modules/common-attributes.adoc[]
+:context: migrating-3-4
+:migrating-3-4:
+
+toc::[]
+
+// To do: Confirm operator name
+Deploying the {mtc-first} requires installing the {mtc-full} Operator on the xref:../../migration/migrating_3_4/deploying_mtc.adoc#installing-mtc-operator-ocp-3_sourcecluster-3-4[{product-title} 3 source] and xref:../../migration/migrating_3_4/deploying_mtc.adoc#installing-mtc-operator-ocp-4_targetcluster-3-4[{product-title} {product-version} target] clusters.
+
+:context: sourcecluster-3-4
+:sourcecluster-3-4:
+include::modules/migration-installing-mtc-operator-ocp-3.adoc[leveloffset=+1]
+:sourcecluster-3-4!:
+
+:context: targetcluster-3-4
+:targetcluster-3-4:
+include::modules/migration-installing-mtc-operator-ocp-4.adoc[leveloffset=+1]
+:targetcluster-3-4!:
+
+:!migrating-3-4:

--- a/migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
+++ b/migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
@@ -6,9 +6,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate application workloads from {product-title} 3.7 (and later) to {product-title} {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
+You can migrate application workloads from {product-title} 3.7 (and later) to {product-title} {product-version} with the {mtc-first}. The {mtc-short} enables you to control the migration and to minimize application downtime.
 
-The CAM tool's web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful application workloads at the granularity of a namespace.
+The {mtc-short}'s web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful application workloads at the granularity of a namespace.
 
 Optionally, you can use the xref:../../migration/migrating_3_4/migrating-with-cpma.adoc#migration-understanding-cpma_{context}[Control Plane Migration Assistant (CPMA)] to assist you in migrating control plane settings.
 
@@ -18,7 +18,7 @@ Before you begin your migration, be sure to review the information on xref:../..
 ====
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
-include::modules/migration-understanding-cam.adoc[leveloffset=+1]
+include::modules/migration-understanding-mtc.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
 
 :!migrating-3-4:

--- a/migration/migrating_3_4/migrating-applications-with-mtc.adoc
+++ b/migration/migrating_3_4/migrating-applications-with-mtc.adoc
@@ -1,0 +1,16 @@
+[id='migrating-applications-with-mtc_{context}']
+= Migrating applications with the {mtc-short} web console
+include::modules/common-attributes.adoc[]
+:context: migrating-3-4
+:migrating-3-4:
+
+toc::[]
+
+include::modules/migration-launching-mtc.adoc[leveloffset=+1]
+include::modules/migration-adding-cluster-to-mtc.adoc[leveloffset=+1]
+include::modules/migration-adding-replication-repository-to-mtc.adoc[leveloffset=+1]
+include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+1]
+include::modules/migration-creating-migration-plan-mtc.adoc[leveloffset=+1]
+include::modules/migration-running-migration-plan-mtc.adoc[leveloffset=+1]
+
+:!migrating-3-4:

--- a/migration/migrating_4_1_4/configuring-replication-repository.adoc
+++ b/migration/migrating_4_1_4/configuring-replication-repository.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
+You must configure an object storage to use as a replication repository. The {mtc-full} copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_4_1_4/configuring-replication-repository.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
 
 The following storage providers are supported:
 

--- a/migration/migrating_4_1_4/deploying_mtc.adoc
+++ b/migration/migrating_4_1_4/deploying_mtc.adoc
@@ -1,0 +1,21 @@
+[id='deploying-mtc_{context}']
+= Deploying the {mtc-first}
+include::modules/common-attributes.adoc[]
+:context: migrating-4_1-4_x
+:migrating-4_1-4_x:
+
+toc::[]
+
+Deploying the {mtc-first} requires installing the {mtc-operator} on the xref:../../migration/migrating_4_1_4/deploying_mtc.adoc#installing-mtc-operator-ocp-4_sourcecluster-4_1-4_x[{product-title} 4.1 source] and xref:../../migration/migrating_4_1_4/deploying_mtc.adoc#installing-mtc-operator-ocp-4_targetcluster-4_1-4_x[{product-title} {product-version} target] clusters.
+
+:context: sourcecluster-4_1-4_x
+:sourcecluster-4_1-4_x:
+include::modules/migration-installing-mtc-operator-ocp-4.adoc[leveloffset=+1]
+:sourcecluster-4_1-4_x!:
+
+:context: targetcluster-4_1-4_x
+:targetcluster-4_1-4_x:
+include::modules/migration-installing-mtc-operator-ocp-4.adoc[leveloffset=+1]
+:targetcluster-4_1-4_x!:
+
+:!migrating-4_1-4_x:

--- a/migration/migrating_4_1_4/migrating-application-workloads-4_1-to-4.adoc
+++ b/migration/migrating_4_1_4/migrating-application-workloads-4_1-to-4.adoc
@@ -6,12 +6,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate application workloads from {product-title} 4.1 to {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
+You can migrate application workloads from {product-title} 4.1 to {product-version} with the {mtc-first}. The {mtc-short} enables you to control the migration and to minimize application downtime.
 
-The CAM tool's web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
+The {mtc-short}'s web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
-include::modules/migration-understanding-cam.adoc[leveloffset=+1]
+include::modules/migration-understanding-mtc.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
+
 
 :!migrating-4_1-4_x:

--- a/migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+++ b/migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
@@ -1,0 +1,16 @@
+[id='migrating-applications-with-mtc_{context}']
+= Migrating applications with the {mtc-short} web console
+include::modules/common-attributes.adoc[]
+:context: migrating-4_1-4_x
+:migrating-4_1-4_x:
+
+toc::[]
+
+include::modules/migration-launching-mtc.adoc[leveloffset=+1]
+include::modules/migration-adding-cluster-to-mtc.adoc[leveloffset=+1]
+include::modules/migration-adding-replication-repository-to-mtc.adoc[leveloffset=+1]
+include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+1]
+include::modules/migration-creating-migration-plan-mtc.adoc[leveloffset=+1]
+include::modules/migration-running-migration-plan-mtc.adoc[leveloffset=+1]
+
+:!migrating-4_1-4_x:

--- a/migration/migrating_4_2_4/configuring-replication-repository.adoc
+++ b/migration/migrating_4_2_4/configuring-replication-repository.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
+You must configure an object storage to use as a replication repository. The {mtc-full} copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_4_2_4/configuring-replication-repository.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
 
 The following storage providers are supported:
 

--- a/migration/migrating_4_2_4/deploying_mtc.adoc
+++ b/migration/migrating_4_2_4/deploying_mtc.adoc
@@ -1,0 +1,21 @@
+[id='deploying-mtc_{context}']
+= Deploying the {mtc-first}
+include::modules/common-attributes.adoc[]
+:context: migrating-4_2-4_x
+:migrating-4_2-4_x:
+
+toc::[]
+
+Deploying the {mtc-first} requires installing the {mtc-operator} on the xref:../../migration/migrating_4_2_4/deploying_mtc.adoc#installing-mtc-operator-ocp-4_sourcecluster-4_2-4_x[{product-title} 4.2 source] and xref:../../migration/migrating_4_2_4/deploying_mtc.adoc#installing-mtc-operator-ocp-4_targetcluster-4_2-4_x[{product-title} {product-version} target] clusters.
+
+:context: sourcecluster-4_2-4_x
+:sourcecluster-4_2-4_x:
+include::modules/migration-installing-mtc-operator-ocp-4.adoc[leveloffset=+1]
+:sourcecluster-4_2-4_x!:
+
+:context: targetcluster-4_2-4_x
+:targetcluster-4_2-4_x:
+include::modules/migration-installing-mtc-operator-ocp-4.adoc[leveloffset=+1]
+:targetcluster-4_2-4_x!:
+
+:!migrating-4_2-4_x:

--- a/migration/migrating_4_2_4/migrating-application-workloads-4_2-to-4.adoc
+++ b/migration/migrating_4_2_4/migrating-application-workloads-4_2-to-4.adoc
@@ -6,12 +6,12 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate application workloads from {product-title} 4.2 to {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
+You can migrate application workloads from {product-title} 4.2 to {product-version} with the {mtc-first}. The {mtc-short} enables you to control the migration and to minimize application downtime.
 
-The CAM tool's web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
+The {mtc-short}'s web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
-include::modules/migration-understanding-cam.adoc[leveloffset=+1]
+include::modules/migration-understanding-mtc.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
 
 :!migrating-4_2-4_x:

--- a/migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
+++ b/migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
@@ -1,0 +1,15 @@
+[id='migrating-applications-with-mtc_{context}']
+= Migrating applications with the {mtc-short} web console
+include::modules/common-attributes.adoc[]
+:context: migrating-4_2-4_x
+:migrating-4_2-4_x:
+
+toc::[]
+
+include::modules/migration-launching-mtc.adoc[leveloffset=+1]
+include::modules/migration-adding-cluster-to-mtc.adoc[leveloffset=+1]
+include::modules/migration-adding-replication-repository-to-mtc.adoc[leveloffset=+1]
+include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+1]
+include::modules/migration-creating-migration-plan-mtc.adoc[leveloffset=+1]
+include::modules/migration-running-migration-plan-mtc.adoc[leveloffset=+1]
+:!migrating-4_2-4_x:

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -24,3 +24,7 @@ endif::[]
 :cloud-redhat-com: Red Hat OpenShift Cluster Manager
 :rh-virtualization-first: Red Hat Virtualization (RHV)
 :rh-virtualization: RHV
+:mtc-first: Migration Toolkit for Containers (MTC)
+:mtc-full: Migration Toolkit for Containers
+:mtc-short: MTC
+:mtc-operator: MTC Operator

--- a/modules/migration-adding-cluster-to-mtc.adoc
+++ b/modules/migration-adding-cluster-to-mtc.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam.adoc
-[id='migration-adding-cluster-to-cam_{context}']
-= Adding a cluster to the CAM web console
+// migration/migrating_3_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
+[id='migration-adding-cluster-to-mtc_{context}']
+= Adding a cluster to the {mtc-short} web console
 
-You can add a cluster to the CAM web console.
+You can add a source cluster to the {mtc-short} web console.
 
 .Prerequisites
 
@@ -25,7 +25,7 @@ $ oc sa get-token mig -n openshift-migration
 eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtaWciLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlY3JldC5uYW1lIjoibWlnLXRva2VuLWs4dDJyIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Im1pZyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImE1YjFiYWMwLWMxYmYtMTFlOS05Y2NiLTAyOWRmODYwYjMwOCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptaWc6bWlnIn0.xqeeAINK7UXpdRqAtOj70qhBJPeMwmgLomV9iFxr5RoqUgKchZRG2J2rkqmPm6vr7K-cm7ibD1IBpdQJCcVDuoHYsFgV4mp9vgOfn9osSDp2TGikwNz4Az95e81xnjVUmzh-NjDsEpw71DH92iHV_xt2sTwtzftS49LpPW2LjrV0evtNBP_t_RfskdArt5VSv25eORl7zScqfe1CiMkcVbf2UqACQjo3LbkpfN26HAioO2oH0ECPiRzT0Xyh-KwFutJLS9Xgghyw-LD9kPKcE_xbbJ9Y4Rqajh7WdPYuB0Jd9DPVrslmzK-F6cgHHYoZEv0SvLQi-PO0rpDrcjOEQQ
 ----
 
-. Log in to the CAM web console.
+. Log in to the {mtc-short} web console.
 . In the *Clusters* section, click *Add cluster*.
 . Fill in the following fields:
 

--- a/modules/migration-adding-replication-repository-to-mtc.adoc
+++ b/modules/migration-adding-replication-repository-to-mtc.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam.adoc
-[id='migration-adding-replication-repository-to-cam_{context}']
-= Adding a replication repository to the CAM web console
+// migration/migrating_3_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
+[id='migration-adding-replication-repository-to-mtc_{context}']
+= Adding a replication repository to the {mtc-short} web console
 
-You can add an object storage bucket as a replication repository to the CAM web console.
+You can add an object storage bucket as a replication repository to the {mtc-short} web console.
 
 .Prerequisites
 
@@ -14,13 +14,13 @@ You can add an object storage bucket as a replication repository to the CAM web 
 
 .Procedure
 
-. Log in to the CAM web console.
+. Log in to the {mtc-short} web console.
 . In the *Replication repositories* section, click *Add repository*.
 . Select a *Storage provider type* and fill in the following fields:
 
 * *AWS* for AWS S3, MCG, and generic S3 providers:
 
-** *Replication repository name*: Specify the replication repository name in the CAM web console.
+** *Replication repository name*: Specify the replication repository name in the {mtc-short} web console.
 ** *S3 bucket name*: Specify the name of the S3 bucket you created.
 ** *S3 bucket region*: Specify the S3 bucket region. *Required* for AWS S3. *Optional* for other S3 providers.
 ** *S3 endpoint*: Specify the URL of the S3 service, not the bucket, for example, `\https://<s3-storage.apps.cluster.com>`. *Required* for a generic S3 provider. You must use the `https://` prefix.
@@ -32,13 +32,13 @@ You can add an object storage bucket as a replication repository to the CAM web 
 
 * *GCP*:
 
-** *Replication repository name*: Specify the replication repository name in the CAM web console.
+** *Replication repository name*: Specify the replication repository name in the {mtc-short} web console.
 ** *GCP bucket name*: Specify the name of the GCP bucket.
 ** *GCP credential JSON blob*: Specify the string in the `credentials-velero` file.
 
 * *Azure*:
 
-** *Replication repository name*: Specify the replication repository name in the CAM web console.
+** *Replication repository name*: Specify the replication repository name in the {mtc-short} web console.
 ** *Azure resource group*: Specify the resource group of the Azure Blob storage.
 ** *Azure storage account name*: Specify the Azure Blob storage account name.
 ** *Azure credentials - INI file contents*: Specify the string in the `credentials-velero` file.

--- a/modules/migration-changing-migration-plan-limits.adoc
+++ b/modules/migration-changing-migration-plan-limits.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam.adoc
+// migration/migrating_3_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
 [id='migration-changing-migration-plan-limits_{context}']
 = Changing migration plan limits for large migrations
 
@@ -17,15 +17,15 @@ A single migration plan has the following default limits:
 
 * 10 namespaces
 +
-If this limit is exceeded, the CAM web console displays a *Namespace limit exceeded* error and you cannot create a migration plan.
+If this limit is exceeded, the {mtc-short} web console displays a *Namespace limit exceeded* error and you cannot create a migration plan.
 
 * 100 Pods
 +
-If the Pod limit is exceeded, the CAM web console displays a warning message similar to the following example: *Plan has been validated with warning condition(s). See warning message. Pod limit: 100 exceeded, found: 104*.
+If the Pod limit is exceeded, the {mtc-short} web console displays a warning message similar to the following example: *Plan has been validated with warning condition(s). See warning message. Pod limit: 100 exceeded, found: 104*.
 
 * 100 persistent volumes
 +
-If the persistent volume limit is exceeded, the CAM web console displays a similar warning message.
+If the persistent volume limit is exceeded, the {mtc-short} web console displays a similar warning message.
 
 .Procedure
 

--- a/modules/migration-configuring-aws-s3.adoc
+++ b/modules/migration-configuring-aws-s3.adoc
@@ -24,8 +24,8 @@ You can configure an AWS S3 storage bucket as a replication repository.
 +
 ----
 $ aws s3api create-bucket \
-    --bucket <bucket_name> \ <1>
-    --region <bucket_region> <2>
+  --bucket <bucket_name> \ <1>
+  --region <bucket_region> <2>
 ----
 <1> Specify your S3 bucket name.
 <2> Specify your S3 bucket region, for example, `us-east-1`.
@@ -126,12 +126,12 @@ $ aws iam put-user-policy \
 $ aws iam create-access-key --user-name velero
 {
   "AccessKey": {
-        "UserName": "velero",
-        "Status": "Active",
-        "CreateDate": "2017-07-31T22:24:41.576Z",
-        "SecretAccessKey": <AWS_SECRET_ACCESS_KEY>, <1>
-        "AccessKeyId": <AWS_ACCESS_KEY_ID> <1>
+    "UserName": "velero",
+    "Status": "Active",
+    "CreateDate": "2017-07-31T22:24:41.576Z",
+    "SecretAccessKey": <AWS_SECRET_ACCESS_KEY>, <1>
+    "AccessKeyId": <AWS_ACCESS_KEY_ID> <1>
     }
 }
 ----
-<1> Record the `AWS_SECRET_ACCESS_KEY` and the `AWS_ACCESS_KEY_ID` for adding the AWS repository to the CAM web console.
+<1> Record the `AWS_SECRET_ACCESS_KEY` and the `AWS_ACCESS_KEY_ID` for adding the AWS repository to the {mtc-short} web console.

--- a/modules/migration-configuring-azure.adoc
+++ b/modules/migration-configuring-azure.adoc
@@ -71,8 +71,17 @@ $ az storage container create \
 +
 ----
 $ AZURE_SUBSCRIPTION_ID=`az account list --query '[?isDefault].id' -o tsv`
+----
++
+----
 $ AZURE_TENANT_ID=`az account list --query '[?isDefault].tenantId' -o tsv`
+----
++
+----
 $ AZURE_CLIENT_SECRET=`az ad sp create-for-rbac --name "velero" --role "Contributor" --query 'password' -o tsv`
+----
++
+----
 $ AZURE_CLIENT_ID=`az ad sp list --display-name "velero" --query '[0].appId' -o tsv`
 ----
 

--- a/modules/migration-configuring-gcp.adoc
+++ b/modules/migration-configuring-gcp.adoc
@@ -53,7 +53,7 @@ $ PROJECT_ID=$(gcloud config get-value project)
 +
 ----
 $ gcloud iam service-accounts create velero \
-    --display-name "Velero Storage"
+  --display-name "Velero Storage"
 ----
 
 . Set the `SERVICE_ACCOUNT_EMAIL` variable to the service account's email address:
@@ -64,30 +64,42 @@ $ SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts list \
   --format 'value(email)')
 ----
 
-. Grant permissions to the service account:
+. Create role permissions for the service account:
 +
 ----
 $ ROLE_PERMISSIONS=(
-    compute.disks.get
-    compute.disks.create
-    compute.disks.createSnapshot
-    compute.snapshots.get
-    compute.snapshots.create
-    compute.snapshots.useReadOnly
-    compute.snapshots.delete
-    compute.zones.get
+  compute.disks.get
+  compute.disks.create
+  compute.disks.createSnapshot
+  compute.snapshots.get
+  compute.snapshots.create
+  compute.snapshots.useReadOnly
+  compute.snapshots.delete
+  compute.zones.get
 )
+----
 
-gcloud iam roles create velero.server \
-    --project $PROJECT_ID \
-    --title "Velero Server" \
-    --permissions "$(IFS=","; echo "${ROLE_PERMISSIONS[*]}")"
+. Create a custom role for the service account:
++
+----
+$ gcloud iam roles create velero.server \
+  --project $PROJECT_ID \
+  --title "Velero Server" \
+  --permissions "$(IFS=","; echo "${ROLE_PERMISSIONS[*]}")"
+----
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-    --member serviceAccount:$SERVICE_ACCOUNT_EMAIL \
-    --role projects/$PROJECT_ID/roles/velero.server
+. Assign the custom role to the service account:
++
+----
+$ gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member serviceAccount:$SERVICE_ACCOUNT_EMAIL \
+  --role projects/$PROJECT_ID/roles/velero.server
+----
 
-gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://${BUCKET}
+. Grant GCP resource access to the service account:
++
+----
+$ gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://${BUCKET}
 ----
 
 . Save the service account's keys to the `credentials-velero` file in the current directory:

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -135,7 +135,7 @@ spec:
   additionalConfig:
     bucketclass: mcg-pv-pool-bc
 ----
-<1> Record the bucket name for adding the replication repository to the CAM web console.
+<1> Record the bucket name for adding the replication repository to the {mtc-short} web console.
 
 . Create the `ObjectBucketClaim` object:
 +
@@ -151,7 +151,7 @@ $ watch -n 30 'oc get -n openshift-storage objectbucketclaim migstorage -o yaml'
 +
 This process can take five to ten minutes.
 
-. Obtain and record the following values, which are required when you add the replication repository to the CAM web console:
+. Obtain and record the following values, which are required when you add the replication repository to the {mtc-short} web console:
 
 * S3 endpoint:
 +

--- a/modules/migration-creating-migration-plan-mtc.adoc
+++ b/modules/migration-creating-migration-plan-mtc.adoc
@@ -1,25 +1,25 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam.adoc
-[id='migration-creating-migration-plan-cam_{context}']
-= Creating a migration plan in the CAM web console
+// migration/migrating_3_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
+[id='migration-creating-migration-plan-mtc_{context}']
+= Creating a migration plan in the {mtc-short} web console
 
-You can create a migration plan in the CAM web console.
+You can create a migration plan in the {mtc-short} web console.
 
 .Prerequisites
 
-* The CAM web console must contain the following:
+* The {mtc-short} web console must contain the following:
 ** Source cluster
-** Target cluster, which is added automatically during the CAM tool installation
+** Target cluster, which is added automatically during the {mtc-short} installation
 ** Replication repository
 
 * If you use snapshots to copy data, the source and target clusters must be running on the same cloud provider (AWS, GCP, or Azure) and in the same region.
 
 .Procedure
 
-. Log in to the CAM web console.
+. Log in to the {mtc-short} web console.
 . In the *Plans* section, click *Add plan*.
 . Enter the *Plan name* and click *Next*.
 +

--- a/modules/migration-downloading-logs.adoc
+++ b/modules/migration-downloading-logs.adoc
@@ -6,11 +6,11 @@
 [id='migration-downloading-logs_{context}']
 = Downloading migration logs
 
-You can download the Velero, Restic, and Migration controller logs in the CAM web console to troubleshoot a failed migration.
+You can download the Velero, Restic, and Migration controller logs in the {mtc-short} web console to troubleshoot a failed migration.
 
 .Procedure
 
-. Log in to the CAM console.
+. Log in to the {mtc-short} console.
 . Click *Plans* to view the list of migration plans.
 . Click the *Options* menu {kebab} of a specific migration plan and select *Logs*.
 . Click *Download Logs* to download the logs of the Migration controller, Velero, and Restic for all clusters.
@@ -18,7 +18,7 @@ You can download the Velero, Restic, and Migration controller logs in the CAM we
 
 .. Specify the log options:
 
-* *Cluster*: Select the source, target, or CAM host cluster.
+* *Cluster*: Select the source, target, or {mtc-short} host cluster.
 * *Log source*: Select *Velero*, *Restic*, or *Controller*.
 * *Pod source*: Select the Pod name, for example, `controller-manager-78c469849c-v6wcf`
 +

--- a/modules/migration-installing-mtc-operator-ocp-3.adoc
+++ b/modules/migration-installing-mtc-operator-ocp-3.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/deploying_cam.adoc
-[id="installing-cam-operator-ocp-3_{context}"]
-= Installing the Cluster Application Migration Operator on an {product-title} 3 source cluster
+// migration/migrating_3_4/deploying_mtc.adoc
+[id="installing-mtc-operator-ocp-3_{context}"]
+= Installing the {mtc-operator} on an {product-title} 3 source cluster
 
 You can install the Cluster Application Migration Operator manually on an {product-title} 3 source cluster because {product-title} 3 does not support the Operator Lifecycle Manager.
 
@@ -45,7 +45,7 @@ $ sudo podman cp $(sudo podman create registry.redhat.io/rhcam-1-2/openshift-mig
 $ oc run test --image registry.redhat.io/ubi8 --command sleep infinity
 ----
 
-. Create the Cluster Application Migration Operator CR object:
+. Create the {mtc-operator} CR object:
 +
 ----
 $ oc create -f operator.yml
@@ -62,7 +62,7 @@ rolebindings.rbac.authorization.k8s.io "system:image-builders" already exists <1
 Error from server (AlreadyExists): error when creating "./operator.yml":
 rolebindings.rbac.authorization.k8s.io "system:image-pullers" already exists <1>
 ----
-<1> You can ignore the `Error from server (AlreadyExists)` messages. They are caused by the Cluster Application Migration Operator creating resources for earlier versions of {product-title} 3 that are provided in later releases.
+<1> You can ignore the `Error from server (AlreadyExists)` messages. They are caused by the {mtc-operator} creating resources for earlier versions of {product-title} 3 that are provided in later releases.
 
 . Create the Migration controller CR object:
 +

--- a/modules/migration-installing-mtc-operator-ocp-4.adoc
+++ b/modules/migration-installing-mtc-operator-ocp-4.adoc
@@ -1,24 +1,24 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/deploying_cam.adoc
-// migration/migrating_4_1_4/deploying_cam.adoc
-// migration/migrating_4_2_4/deploying_cam.adoc
-[id="installing-cam-operator-ocp-4_{context}"]
+// migration/migrating_3_4/deploying_mtc.adoc
+// migration/migrating_4_1_4/deploying_mtc.adoc
+// migration/migrating_4_2_4/deploying_mtc.adoc
+[id="installing-mtc-operator-ocp-4_{context}"]
 ifdef::sourcecluster-4_1-4_x[]
-= Installing the Cluster Application Migration Operator on an {product-title} 4.1 source cluster
+= Installing the {mtc-operator} on an {product-title} 4.1 source cluster
 
-You can install the Cluster Application Migration Operator on an {product-title} 4.1 source cluster with OLM.
+You can install the {mtc-operator} on an {product-title} 4.1 source cluster with OLM.
 endif::[]
 ifdef::sourcecluster-4_2-4_x[]
-= Installing the Cluster Application Migration Operator on an {product-title} 4.2 source cluster
+= Installing the {mtc-operator} on an {product-title} 4.2 source cluster
 
-You can install the Cluster Application Migration Operator on an {product-title} 4.2 source cluster with OLM.
+You can install the {mtc-operator} on an {product-title} 4.2 source cluster with OLM.
 endif::[]
 
 ifdef::targetcluster-3-4,targetcluster-4_2-4_x,targetcluster-4_1-4_x[]
-= Installing the Cluster Application Migration Operator on an {product-title} {product-version} target cluster
+= Installing the {mtc-operator} on an {product-title} {product-version} target cluster
 
-You can install the Cluster Application Migration Operator on an {product-title} {product-version} target cluster with OLM.
+You can install the {mtc-operator} on an {product-title} {product-version} target cluster with OLM.
 
 The Cluster Application Migration Operator installs the CAM tool on the target cluster by default.
 endif::[]
@@ -31,12 +31,12 @@ endif::[]
 ifdef::sourcecluster-4_1-4_x[]
 . In the {product-title} web console, click *Catalog* -> *OperatorHub*.
 endif::[]
-. Use the *Filter by keyword* field (in this case, `Migration`) to find the *Cluster Application Migration Operator*.
-. Select the *Cluster Application Migration Operator* and click *Install*.
+. Use the *Filter by keyword* field (in this case, `Migration`) to find the *{mtc-operator}*.
+. Select the *{mtc-operator}* and click *Install*.
 . On the *Create Operator Subscription* page, select the `openshift-migration` namespace, and specify an approval strategy.
 . Click *Subscribe*.
 +
-On the *Installed Operators* page, the *Cluster Application Migration Operator* appears in the *openshift-migration* project with the status *InstallSucceeded*.
+On the *Installed Operators* page, the *{mtc-operator}* appears in the *openshift-migration* project with the status *InstallSucceeded*.
 
 . Under *Provided APIs*, click *View 12 more...*.
 . Click *Create New* -> *MigrationController*.

--- a/modules/migration-known-issues.adoc
+++ b/modules/migration-known-issues.adoc
@@ -8,7 +8,7 @@
 
 This release has the following known issues:
 
-* During migration, the Cluster Application Migration (CAM) tool preserves the following namespace annotations:
+* During migration, the {mtc-first} preserves the following namespace annotations:
 
 ** `openshift.io/sa.scc.mcs`
 ** `openshift.io/sa.scc.supplemental-groups`
@@ -16,16 +16,12 @@ This release has the following known issues:
 +
 These annotations preserve the UID range, ensuring that the containers retain their file system permissions on the target cluster. There is a risk that the migrated UIDs could duplicate UIDs within an existing or future namespace on the target cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1748440[*BZ#1748440*])
 
-* If an AWS bucket is added to the CAM web console and then deleted, its status remains `True` because the MigStorage CR is not updated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1738564[*BZ#1738564*])
+* If an AWS bucket is added to the {mtc-short} web console and then deleted, its status remains `True` because the MigStorage CR is not updated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1738564[*BZ#1738564*])
 
-* Most cluster-scoped resources are not yet handled by the CAM tool. If your applications require cluster-scoped resources, you may have to create them manually on the target cluster.
+* Most cluster-scoped resources are not yet handled by the {mtc-short}. If your applications require cluster-scoped resources, you may have to create them manually on the target cluster.
 
 * If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
 
 * If a large migration fails because Restic times out, you can increase the `restic_timeout` parameter value (default: `1h`) in the Migration controller CR.
 
 * If you select the data verification option for PVs that are migrated with the filesystem copy method, performance is significantly slower. Velero generates a checksum for each file and checks it when the file is restored.
-
-ifdef::migrating-3-4[]
-* In the current release (CAM 1.2), you cannot migrate from {product-title} 3.7 to 4.4 because certain API `GroupVersionKinds` (GVKs) that are used by the source cluster are deprecated. You can manually update the GVKs after migration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1817251[*BZ#1817251*])
-endif::[]

--- a/modules/migration-launching-mtc.adoc
+++ b/modules/migration-launching-mtc.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// migration/migrating_3_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
+[id="migration-launching-mtc_{context}"]
+= Launching the {mtc-short} web console
+
+You can launch the {mtc-short} web console that is installed on the target cluster.
+
+.Procedure
+
+. Log in to the target cluster.
+. Obtain the {mtc-short} web console URL:
++
+----
+$ oc get -n openshift-migration route/migration -o go-template='(?i}//{{ .spec.host }}(:|\z){{ println }}' | sed 's,\.,\\.,g'
+----
+
+. Launch a browser and navigate to the {mtc-short} web console.
++
+[NOTE]
+====
+If you try to access the {mtc-short} web console immediately after installing the {mtc-operator}, the console may not load because the Operator is still configuring the cluster. Wait a few minutes and retry.
+====
+
+. If you are using self-signed CA certificates, you will be prompted to accept the CA certificate of the source cluster's API server. The web page will guide you through the process of accepting the remaining certificates.
+
+. Log in with your {product-title} *username* and *password*.

--- a/modules/migration-restic-timeout.adoc
+++ b/modules/migration-restic-timeout.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// migration/migrating_3_4/troubleshooting.adoc
+// migration/migrating_4_1_4/troubleshooting.adoc
+// migration/migrating_4_2_4/troubleshooting.adoc
+[id='migration-restic-timeout_{context}']
+= Restic timeout error
+
+If a migration fails because Restic times out, the following error appears in the Velero log:
+
+----
+level=error msg="Error backing up item" backup=velero/monitoring error="timed out waiting for all PodVolumeBackups to complete" error.file="/go/src/github.com/heptio/velero/pkg/restic/backupper.go:165" error.function="github.com/heptio/velero/pkg/restic.(*backupper).BackupPodVolumes" group=v1
+----
+
+The default value of `restic_timeout` is one hour. You can increase this for large migrations, keeping in mind that a higher value may delay the return of error messages.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Operators* -> *Installed Operators*.
+. Click *{mtc-operator}*.
+. In the *MigrationController* tab, click *migration-controller*.
+. In the *YAML* tab, update the following parameter value:
++
+[source,yaml]
+----
+spec:
+  restic_timeout: 1h <1>
+----
+<1> Valid units are `h` (hours), `m` (minutes), and `s` (seconds), for example, `3h30m15s`.
+
+. Click *Save*.

--- a/modules/migration-running-migration-plan-mtc.adoc
+++ b/modules/migration-running-migration-plan-mtc.adoc
@@ -1,25 +1,25 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam.adoc
-[id='migration-running-migration-plan-cam_{context}']
-= Running a migration plan in the CAM web console
+// migration/migrating_3_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_1_4/migrating-applications-with-mtc.adoc
+// migration/migrating_4_2_4/migrating-applications-with-mtc.adoc
+[id='migration-running-migration-plan-mtc_{context}']
+= Running a migration plan in the {mtc-short} web console
 
-You can stage or migrate applications and data with the migration plan you created in the CAM web console.
+You can stage or migrate applications and data with the migration plan you created in the {mtc-short} web console.
 
 .Prerequisites
 
-The CAM web console must contain the following:
+The {mtc-short} web console must contain the following:
 
 * Source cluster
-* Target cluster, which is added automatically during the CAM tool installation
+* Target cluster, which is added automatically during the {mtc-short} installation
 * Replication repository
 * Valid migration plan
 
 .Procedure
 
-. Log in to the CAM web console on the target cluster.
+. Log in to the {mtc-short} web console on the target cluster.
 . Select a migration plan.
 . Click *Stage* to copy data from the source cluster to the target cluster without stopping the application.
 +

--- a/modules/migration-understanding-data-copy-methods.adoc
+++ b/modules/migration-understanding-data-copy-methods.adoc
@@ -6,12 +6,12 @@
 [id='migration-understanding-data-copy-methods_{context}']
 = Understanding the data copy methods for migration
 
-The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
+The {mtc-first} supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
 
 [id='file-system-copy-method_{context}']
 == File system copy method
 
-The CAM tool copies data files from the source cluster to the replication repository, and from there to the target cluster.
+The {mtc-short} copies data files from the source cluster to the replication repository, and from there to the target cluster.
 
 [cols="1,1", options="header"]
 .File system copy method summary
@@ -27,7 +27,7 @@ a|* Slower than the snapshot copy method
 [id='snapshot-copy-method_{context}']
 == Snapshot copy method
 
-The CAM tool copies a snapshot of the source cluster's data to a cloud provider's object storage, configured as a replication repository. The data is restored on the target cluster.
+The {mtc-short} copies a snapshot of the source cluster's data to a cloud provider's object storage, configured as a replication repository. The data is restored on the target cluster.
 
 AWS, Google Cloud Provider, and Microsoft Azure support the snapshot copy method.
 

--- a/modules/migration-understanding-mtc.adoc
+++ b/modules/migration-understanding-mtc.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
+// migration/migrating_4_1_4/migrating-application-workloads-4_1-to-4.adoc
+// migration/migrating_4_2_4/migrating-application-workloads-4_2-to-4.adoc
+[id='migration-understanding-mtc_{context}']
+= Understanding the {mtc-full}
+
+The {mtc-first} enables you to migrate Kubernetes resources, persistent volume data, and internal container images from an {product-title} source cluster to an {product-title} {product-version} target cluster, using the {mtc-short} web console or the Kubernetes API.
+
+Migrating an application with the {mtc-short} web console involves the following steps:
+
+. Install the {mtc-operator} on all clusters.
++
+[NOTE]
+====
+The {mtc-operator} installs the {mtc-short} web console and the Migration controller on the target cluster by default. You can configure the Migration controller to install the {mtc-short} on another cluster.
+====
+
+. Configure the replication repository, an intermediate object storage that the {mtc-short} uses to migrate data.
+. Add the source cluster to the {mtc-short} web console.
+. Add the replication repository to the {mtc-short} web console.
+. Create a migration plan, with one of the following data migration options:
+
+* *Copy*: The {mtc-short} copies the data from the source cluster to the replication repository, and from the replication repository to the target cluster.
++
+image::migration-PV-copy.png[]
+
+* *Move*: The {mtc-short} unmounts a remote volume (for example, NFS) from the source cluster, creates a PV resource on the target cluster pointing to the remote volume, and then mounts the remote volume on the target cluster. Applications running on the target cluster use the same remote volume that the source cluster was using. The remote volume must be accessible to the source and target clusters.
++
+[NOTE]
+====
+Although the replication repository does not appear in this diagram, it is required for the actual migration.
+====
++
+image::migration-PV-move.png[]
+
+. Run the migration plan, with one of the following options:
+
+* *Stage* (optional) copies data to the target cluster without stopping the application.
++
+Staging can be run multiple times so that most of the data is copied to the target before migration. This minimizes the actual migration time and application downtime.
+
+* *Migrate* stops the application on the source cluster and recreates its resources on the target cluster. Optionally, you can migrate the workload without stopping the application.
+
+image::OCP_3_to_4_App_migration.png[]

--- a/modules/migration-viewing-migration-crs.adoc
+++ b/modules/migration-viewing-migration-crs.adoc
@@ -6,15 +6,15 @@
 [id='migration-viewing-migration-crs_{context}']
 = Viewing migration Custom Resources
 
-The Cluster Application Migration (CAM) tool creates the following Custom Resources (CRs):
+The {mtc-first} creates the following CRs for migration:
 
 image::migration-architecture.png[migration architecture diagram]
 
-image:darkcircle-1.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migcluster_types.go[MigCluster] (configuration, CAM cluster): Cluster definition
+image:darkcircle-1.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migcluster_types.go[MigCluster] (configuration, {mtc-short} cluster): Cluster definition
 
-image:darkcircle-2.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migstorage_types.go[MigStorage] (configuration, CAM cluster): Storage definition
+image:darkcircle-2.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migstorage_types.go[MigStorage] (configuration, {mtc-short} cluster): Storage definition
 
-image:darkcircle-3.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migplan_types.go[MigPlan] (configuration, CAM cluster): Migration plan
+image:darkcircle-3.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migplan_types.go[MigPlan] (configuration, {mtc-short} cluster): Migration plan
 
 The MigPlan CR describes the source and target clusters, repository, and namespace(s) being migrated. It is associated with 0, 1, or many MigMigration CRs.
 
@@ -23,11 +23,11 @@ The MigPlan CR describes the source and target clusters, repository, and namespa
 Deleting a MigPlan CR deletes the associated MigMigration CRs.
 ====
 
-image:darkcircle-4.png[20,20] link:https://github.com/heptio/velero/blob/master/pkg/apis/velero/v1/backup_storage_location.go[BackupStorageLocation] (configuration, CAM cluster): Location of Velero backup objects
+image:darkcircle-4.png[20,20] link:https://github.com/heptio/velero/blob/master/pkg/apis/velero/v1/backup_storage_location.go[BackupStorageLocation] (configuration, {mtc-short} cluster): Location of Velero backup objects
 
-image:darkcircle-5.png[20,20] link:https://github.com/heptio/velero/blob/master/pkg/apis/velero/v1/volume_snapshot_location.go[VolumeSnapshotLocation] (configuration, CAM cluster): Location of Velero volume snapshots
+image:darkcircle-5.png[20,20] link:https://github.com/heptio/velero/blob/master/pkg/apis/velero/v1/volume_snapshot_location.go[VolumeSnapshotLocation] (configuration, {mtc-short} cluster): Location of Velero volume snapshots
 
-image:darkcircle-6.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migmigration_types.go[MigMigration] (action, CAM cluster): Migration, created during migration
+image:darkcircle-6.png[20,20] link:https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migmigration_types.go[MigMigration] (action, {mtc-short} cluster): Migration, created during migration
 
 A MigMigration CR is created every time you stage or migrate data. Each MigMigration CR is associated with a MigPlan CR.
 


### PR DESCRIPTION
Change "Cluster Application Migration" tool (CAM) to "Migration Toolkit for Containers". This does not affect CPMA.

CP to 4.2, 4.3, 4.4, 4.5.