### PR TITLE
BZ1804489 - Add device path note for local storage

### DIFF
--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -90,4 +90,3 @@ data:
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically and the new storage configuration is applied.
-

--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -7,7 +7,7 @@
 
 Local volumes cannot be created by dynamic provisioning. Instead,
 PersistentVolumes must be created by the Local Storage Operator. This
-provisioner will look for any devices, both filesystem and block volumes,
+provisioner will look for any devices, both file system and block volumes,
 at the paths specified in defined resource.
 
 .Prerequisites
@@ -23,7 +23,7 @@ and paths to the local volumes.
 +
 [NOTE]
 ====
-Do not use different StorageClass names for the same device. Doing so will create multiple PVs.
+Do not use different StorageClass names for the same device. Doing so will create multiple persistent volumes (PV)s.
 ====
 
 +
@@ -50,7 +50,7 @@ spec:
       volumeMode: Filesystem <3>
       fsType: xfs <4>
       devicePaths: <5>
-        - /path/to/device
+        - /path/to/device <6>
 ----
 <1> The namespace where the Local Storage Operator is installed.
 <2> Optional: A node selector containing a list of nodes where the local storage volumes are attached. This
@@ -62,6 +62,7 @@ local volumes.
 <4> The file system that is created when the local volume is mounted for the
 first time.
 <5> The path containing a list of local storage devices to choose from.
+<6> Replace this value with your actual local disks filepath to the LocalVolume resource, such as `/dev/xvdg`. PVs are created for these local disks when the provisioner is deployed successfully.
 +
 .Example: Block
 [source,yaml]
@@ -85,7 +86,7 @@ spec:
     - storageClassName: "localblock-sc"
       volumeMode: Block  <3>
       devicePaths: <4>
-        - /dev/xvdg
+        - /path/to/device <5>
 ----
 <1> The namespace where the Local Storage Operator is installed.
 <2> Optional: A node selector containing a list of nodes where the local storage volumes are attached. This
@@ -95,6 +96,7 @@ on all available nodes.
 <3> The volume mode, either `Filesystem` or `Block`, defining the type of the
 local volumes.
 <4> The path containing a list of local storage devices to choose from.
+<5> Replace this value with your actual local disks filepath to the LocalVolume resource, such as `/dev/xvdg`. PVs are created for these local disks when the provisioner is deployed successfully.
 
 . Create the local volume resource in your {product-title} cluster, specifying
 the file you just created:

--- a/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
@@ -16,7 +16,6 @@ This section explains what configuration is supported, shows how to configure th
 * The monitoring stack imposes additional resource requirements. Consult the computing resources recommendations in xref:../../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#scaling-cluster-monitoring-operator[Scaling the Cluster Monitoring Operator] and verify that you have sufficient resources.
 
 include::modules/monitoring-maintenance-and-support.adoc[leveloffset=+1]
-
 include::modules/monitoring-creating-cluster-monitoring-configmap.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-the-cluster-monitoring-stack.adoc[leveloffset=+1]
 include::modules/monitoring-configurable-monitoring-components.adoc[leveloffset=+1]
@@ -31,7 +30,7 @@ include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[
 [id="configuring-persistent-storage"]
 == Configuring persistent storage
 
-Running cluster monitoring with persistent storage means that your metrics are stored to a Persistent Volume and can survive a pod being restarted or recreated. This is ideal if you require your metrics or alerting data to be guarded from data loss. For production environments, it is highly recommended to configure persistent storage. Because of the high IO demands, it is advantageous to use local storage.
+Running cluster monitoring with persistent storage means that your metrics are stored to a persistent volume (PV) and can survive a pod being restarted or recreated. This is ideal if you require your metrics or alerting data to be guarded from data loss. For production environments, it is highly recommended to configure persistent storage. Because of the high IO demands, it is advantageous to use local storage.
 
 [IMPORTANT]
 ====
@@ -41,7 +40,7 @@ See xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-c
 .Prerequisites
 
 * Dedicate sufficient local persistent storage to ensure that the disk does not become full. How much storage you need depends on the number of pods. For information on system requirements for persistent storage, see xref:../../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#prometheus-database-storage-requirements[Prometheus database storage requirements].
-* Make sure you have a Persistent Volume (PV) ready to be claimed by the Persistent Volume Claim (PVC), one PV for each replica. Since Prometheus has two replicas and Alertmanager has three replicas, you need five PVs to support the entire monitoring stack. The Persistent Volumes should be available from the Local Storage Operator. This does not apply if you enable dynamically provisioned storage.
+* Make sure you have a persistent volume (PV) ready to be claimed by the persistent volume claim (PVC), one PV for each replica. Because Prometheus has two replicas and Alertmanager has three replicas, you need five PVs to support the entire monitoring stack. The PVs should be available from the Local Storage Operator. This does not apply if you enable dynamically provisioned storage.
 * Use the block type of storage.
 * xref:../../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-using-local-volume[Configure local persistent storage.]
 


### PR DESCRIPTION
This is a work in progress attempt to add instructions for configuring an additional storage device to be used by local volumes as described in [BZ1804489](https://bugzilla.redhat.com/show_bug.cgi?id=1804489).

I've made an attempt, as suggested, to adapt the following article for storage rather than network devices: https://access.redhat.com/articles/4731401.

Lacking additional info and technical expertise, I'm not sure if this procedure is even close to meeting the request of providing a working example for RHCOS.

@liangxia or @anpingli Can one of you take a look at this and suggest how the example file and machine-config instructions can be more accurately modified to be used for a storage device?