### PR TITLE
Put tech preview notification below section heading

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -52,8 +52,11 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+[id="installing-bare-metal-three-node"]
+== Running a three-node cluster
+
 :FeatureName: Three-node cluster
-include::modules/technology-preview.adoc[leveloffset=+1]
+include::modules/technology-preview.adoc[leveloffset=+2]
 
 include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -65,8 +65,11 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+[id="installing-restricted-networks-bare-metal-three-node"]
+== Running a three-node cluster
+
 :FeatureName: Three-node cluster
-include::modules/technology-preview.adoc[leveloffset=+1]
+include::modules/technology-preview.adoc[leveloffset=+2]
 
 include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 

--- a/modules/installation-three-node-cluster.adoc
+++ b/modules/installation-three-node-cluster.adoc
@@ -12,7 +12,7 @@
 // * installing/installing_ibm_z/installing-ibm-z.adoc [Eventually]
 
 [id="installation-three-node-cluster_{context}"]
-= Running a three-node cluster
+= Configuring a three-node cluster
 
 You can install and run three-node clusters in {product-title} with no workers. This provides smaller, more resource efficient clusters for cluster administrators and developers to use for deployment, development, and testing.
 


### PR DESCRIPTION
While looking up the documentation on three-node bare metal clusters,
I missed the tech preview note because it is displayed above the
three-node cluster section heading.  I think it would be more clear if
it was displayed within the section.