### PR TITLE
docs: gettings started admin guide

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -13,21 +13,18 @@ ifdef::openshift-origin[]
 toc::[]
 
 == Overview
-{product-title} has multiple installation methods available, each of which allow
-you to quickly get your own {product-title} instance up and running. Depending
-on your environment, you can choose the installation method that works best for
-you.
+{product-title} has installation method which allow you to quickly get your own {product-title} instance up and running.
 
 For deploying a full {product-title} cluster, see the
 xref:../install/index.adoc#install-planning[Installing Clusters] guide.
 
 == Prerequisites
 
-Before choosing an installation method, you must first
+Before continuing with installation, you must first
 xref:../install/prerequisites.adoc#install-config-install-prerequisites[satisfy the prerequisites] on
 your hosts, which includes verifying system and environment requirements and
 installing and configuring the CRI-O or Docker container engines. After ensuring your hosts are properly set
-up, you can continue by choosing one of the following installation methods.
+up, you can continue with installation.
 
 Container engines and {product-title} must run on the Linux operating system. If you want to
 run the server from a Windows or Mac OS X host, start a Linux VM first.
@@ -48,72 +45,12 @@ ifdef::openshift-origin[]
 clouds. For information, see
 xref:../install/running_install.adoc#advanced-cloud-providers[Running Installation Playbooks].
 
-Once you have your cluster nodes provisioned, choose the
-installation method that fits your case the best.
 endif::[]
 
-[[installation-methods]]
-== Installation Methods
+[[installation-method]]
+== Installation Method
 
-Choose one of the following installation methods that works best for you.
-
-=== Method 1: Running in a Container [[running-in-a-docker-container]]
-You can quickly get {product-title} running in a container using images
-from https://hub.docker.com[Docker Hub] on a Linux system. This method is
-supported on Fedora, CentOS, and Red Hat Enterprise Linux (RHEL) hosts only.
-
-[CAUTION]
-====
-{product-title} listens on ports 53, 7001, and 8443. If another service is
-already listening on those ports you must stop that service before launching
-the {product-title} container.
-====
-
-*Installing and Starting an All-in-One Server*
-
-. Launch the server in a container:
-+
-----
-$ sudo docker run -d --name "origin" \
-        --privileged --pid=host --net=host \
-        -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
-        -v /var/lib/docker:/var/lib/docker:rw \
-        -v /var/lib/origin/openshift.local.volumes:/var/lib/origin/openshift.local.volumes:rslave \ <1>
-        openshift/origin start
-----
-<1> `rslave` only works if the Docker version is 1.10 or later and a Red Hat distribution.
-+
-[NOTE]
-====
-If you want to use
-xref:../install_config/aggregate_logging.adoc#install-config-aggregate-logging[{product-title}'s
-aggregated logging], you must add `-v /var/log:/var/log` to the `docker` command
-line. The *origin* container must have access to the host's
-*_var/log/containers/_* and *_/var/log/messages_*.
-====
-+
-This command:
-+
-- starts {product-title} listening on all interfaces on your host (*0.0.0.0:8443*),
-- starts the web console listening on all interfaces at `/console` (*0.0.0.0:8443*),
-- launches an [sysitem]#etcd# server to store persistent data, and
-- launches the Kubernetes system components.
-
-. After the container is started, you can open a console inside the container:
-+
-----
-$ sudo docker exec -it origin bash
-----
-
-If you delete the container, any configuration or stored application definitions
-will also be removed.
-
-*What's Next?*
-
-Now that you have {product-title} successfully running in your environment,
-xref:try-it-out[try it out] by walking through a sample application lifecycle.
-
-=== Method 2: Downloading the Binary [[downloading-the-binary]]
+=== Downloading the Binary [[downloading-the-binary]]
 Red Hat periodically publishes binaries to GitHub, which you can download on the
 {product-title} repository's
 https://github.com/openshift/origin/releases[Releases] page. These are Linux,


### PR DESCRIPTION
Removing section "Run in Container" in 3.11 admin guide as
the openshift-origin image was deprecated in 3.10

Signed-off-by: zerodayz <cerninr@gmail.com>