### PR TITLE
Bug 1833239: [DOCS] Add warning message about blocking all RH registry when configuring "allowedRegistries"

### DIFF
--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -77,6 +77,11 @@ registries are allowed.
 `allowedRegistries`: Whitelisted for image pull and push actions. All other
 registries are blocked.
 
+[IMPORTANT]
+====
+If you configure `allowedRegistries`, you may consider to add `registry.redhat.io` and `quay.io` either. Those registries will be blocked without the additional configuration.
+====
+
 Only one of `blockedRegistries` or `allowedRegistries` may be set
 
 |===


### PR DESCRIPTION
* Versions: OCP4.4, and other OCP4.x either

* Descriptions:
  `allowedRegistries` can block Red Hat registries without specific configurations about that. And it's big impact on running OCP4 cluster, so we should warn about that in advance on the docs.

* Reference: [[DOCS] Add warning message about blocking all RH registry when configuring "allowedRegistries"](https://bugzilla.redhat.com/show_bug.cgi?id=1833239)