### PR TITLE
Trivial: Typos in OLM doc

### DIFF
--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -8,7 +8,7 @@
 The Operator Lifecycle Manager (OLM) is composed of two Operators: the OLM
 Operator and the Catalog Operator.
 
-Each of these Operators are responsible for managing the Custom Resource
+Each of these Operators is responsible for managing the Custom Resource
 Definitions (CRDs) that are the basis for the OLM framework:
 
 .CRDs managed by OLM and Catalog Operators
@@ -46,7 +46,7 @@ object to watch for their Custom Resource (CR) in a list of namespaces or
 cluster-wide.
 |===
 
-Each of these Operators are also responsible for creating resources:
+Each of these Operators is also responsible for creating resources:
 
 .Resources created by OLM and Catalog Operators
 [options="header"]
@@ -75,7 +75,7 @@ cluster.
 The OLM Operator is not concerned with the creation of the required resources;
 users can choose to manually create these resources using the CLI, or users can
 choose to create these resources using the Catalog Operator. This separation of
-concern enables users incremental buy-in in terms of how much of the OLM
+concern allows users incremental buy-in in terms of how much of the OLM
 framework they choose to leverage for their application.
 
 While the OLM Operator is often configured to watch all namespaces, it can also
@@ -100,7 +100,7 @@ required resources they specify. It is also responsible for watching
 CatalogSources for updates to packages in channels and upgrading them
 (optionally automatically) to the latest available versions.
 
-A user that wishes to track a package in a channel creates a Subscription
+A user who wishes to track a package in a channel creates a Subscription
 resource configuring the desired package, channel, and the CatalogSource from
 which to pull updates. When updates are found, an appropriate InstallPlan is
 written into the namespace on behalf of the user.

--- a/modules/olm-upgrades.adoc
+++ b/modules/olm-upgrades.adoc
@@ -5,7 +5,7 @@
 [id="olm-upgrades_{context}"]
 = Operator installation and upgrade workflow in OLM
 
-In the Operator Lifecycle Manager (OLM) ecosystem, the following resource are
+In the Operator Lifecycle Manager (OLM) ecosystem, the following resources are
 used to resolve Operator installations and upgrades:
 
 * ClusterServiceVersion (CSV)


### PR DESCRIPTION
Fixes for typos I noticed while reading the [OLM workflow & architecture](https://docs.openshift.com/container-platform/4.4/operators/understanding_olm/olm-understanding-olm.html) doc