### PR TITLE
CNV-4378 Correcting API version in modules

### DIFF
--- a/modules/cnv-resuming-node-maintenance-cli.adoc
+++ b/modules/cnv-resuming-node-maintenance-cli.adoc
@@ -5,8 +5,8 @@
 [id="cnv-resuming-node-maintenance-cli_{context}"]
 = Resuming a node from maintenance mode in the CLI
 
-Resume a node from maintenance mode and make it schedulable again by deleting 
-the `NodeMaintenance` object for the node. 
+Resume a node from maintenance mode and make it schedulable again by deleting
+the `NodeMaintenance` object for the node.
 
 .Procedure
 
@@ -25,10 +25,10 @@ $ oc describe nodemaintenance <node02-maintenance>
 [source,yaml]
 ----
 Name:         node02-maintenance
-Namespace:    
-Labels:       
-Annotations:  
-API Version:  kubevirt.io/v1alpha1
+Namespace:
+Labels:
+Annotations:
+API Version:  nodemaintenance.kubevirt.io/v1beta1
 Kind:         NodeMaintenance
 ...
 Spec:
@@ -41,4 +41,3 @@ Spec:
 ----
 $ oc delete nodemaintenance <node02-maintenance>
 ----
-

--- a/modules/cnv-setting-node-maintenance-cli.adoc
+++ b/modules/cnv-setting-node-maintenance-cli.adoc
@@ -5,18 +5,18 @@
 [id="cnv-setting-node-maintenance-cli_{context}"]
 = Setting a node to maintenance mode in the CLI
 
-Set a node to maintenance mode by creating a `NodeMaintenance` Custom Resource 
-(CR) object that references the node name and the reason for setting it to 
-maintenance mode.  
+Set a node to maintenance mode by creating a `NodeMaintenance` Custom Resource
+(CR) object that references the node name and the reason for setting it to
+maintenance mode.
 
 .Procedure
 
-. Create the node maintenance CR configuration. This example uses a CR that is 
+. Create the node maintenance CR configuration. This example uses a CR that is
 called `node02-maintenance.yaml`:
 +
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha1
+apiVersion: nodemaintenance.kubevirt.io/v1beta1
 kind: NodeMaintenance
 metadata:
   name: node02-maintenance
@@ -31,7 +31,7 @@ spec:
 $ oc apply -f <node02-maintenance.yaml>
 ----
 
-The node live migrates virtual machine instances that have the 
-`liveMigration` eviction strategy, and taint the node so that it is no longer 
-schedulable. All other pods and virtual machines on the node are deleted and 
+The node live migrates virtual machine instances that have the
+`liveMigration` eviction strategy, and taint the node so that it is no longer
+schedulable. All other pods and virtual machines on the node are deleted and
 recreated on another node.


### PR DESCRIPTION
Identified two modules in which incorrect API version is specified and which is corrected as indicated in Jira story CNV-4378  by @stu-gott 

Test Build: 
http://file.bos.redhat.com/bgaydos/051420/cnv/cnv_node_maintenance/cnv-setting-node-maintenance.html

http://file.bos.redhat.com/bgaydos/051420/cnv/cnv_node_maintenance/cnv-resuming-node.html

Retagging @stu-gott for code review.

Stu,if you need me to contact Karel to get resolution to your question from May 6 in the Jira record? 
 
Thanks
Bob