### PR TITLE
Adding link to Support policy for unmanaged Operators

### DIFF
--- a/_unused_topics/cluster-logging-collector-log-rotation.adoc
+++ b/_unused_topics/cluster-logging-collector-log-rotation.adoc
@@ -21,7 +21,7 @@ log.4  1Mb
 
 .Prerequisites
 
-Set cluster logging to the unmanaged state.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/_unused_topics/cluster-logging-curator-yaml.adoc
+++ b/_unused_topics/cluster-logging-curator-yaml.adoc
@@ -9,7 +9,7 @@ You can configure Elasticsearch Curator to delete indices.
 
 .Prerequisite
 
-Set cluster logging to the unmanaged state. In managed state, the Cluster Logging Operator reverts changes made to the `logging-curator` configuration map.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/_unused_topics/cluster-logging-fluentd-json.adoc
+++ b/_unused_topics/cluster-logging-fluentd-json.adoc
@@ -23,7 +23,7 @@ The features in this topic should be used by only experienced Fluentd and Elasti
 
 .Prerequisites
 
-Set cluster logging to the unmanaged state.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/logging/config/cluster-logging-collector.adoc
+++ b/logging/config/cluster-logging-collector.adoc
@@ -13,6 +13,8 @@ You can configure log rotation, log location, use an external log aggregator, an
 ====
 You must set cluster logging to Unmanaged state before performing these configurations, unless otherwise noted.
 For more information, see xref:../../logging/config/cluster-logging-management.adoc#cluster-logging-management[Changing the cluster logging management state].
+
+Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades. For more information, see xref:../../architecture/architecture-installation.html#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators].
 ====
 
 // The following include statements pull in the module files that comprise
@@ -28,10 +30,6 @@ include::modules/cluster-logging-collector-limits.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-location.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-overcommit-buffer-chunk.adoc[leveloffset=+1]
-
-include::modules/cluster-logging-collector-json.adoc[leveloffset=+1]
-
-include::modules/cluster-logging-collector-undefined.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-envvar.adoc[leveloffset=+1]
 

--- a/logging/config/cluster-logging-configuring-about.adoc
+++ b/logging/config/cluster-logging-configuring-about.adoc
@@ -11,6 +11,8 @@ After installing cluster logging into your {product-title} cluster, you can make
 ====
 You must set cluster logging to Unmanaged state before performing these configurations, unless otherwise noted.
 For more information, see xref:../../logging/config/cluster-logging-management.adoc#cluster-logging-management[Changing the cluster logging management state].
+
+Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades. For more information, see xref:../../architecture/architecture-installation.html#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators].
 ====
 
 // The following include statements pull in the module files that comprise

--- a/logging/config/cluster-logging-kibana.adoc
+++ b/logging/config/cluster-logging-kibana.adoc
@@ -13,6 +13,8 @@ You can scale Kibana for redundancy and configure the CPU and memory for your Ki
 ====
 You must set cluster logging to Unmanaged state before performing these configurations, unless otherwise noted.
 For more information, see xref:../../logging/config/cluster-logging-management.adoc#cluster-logging-management[Changing the cluster logging management state].
+
+Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades. For more information, see xref:../../architecture/architecture-installation.html#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators].
 ====
 
 // The following include statements pull in the module files that comprise

--- a/logging/config/cluster-logging-management.adoc
+++ b/logging/config/cluster-logging-management.adoc
@@ -8,7 +8,12 @@ toc::[]
 
 In order to modify certain components managed by the Cluster Logging Operator or the Elasticsearch Operator, you must set the operator to the _unmanaged_ state.
 
-In unmanaged state, the operators do not respond to changes in the CRs. The administrator assumes full control of individual component configurations and upgrades when in unmanaged state.
+In unmanaged state, the operators do not respond to changes in the CRs. The administrator assumes full control of individual component configurations and upgrades when in unmanaged state. 
+
+[IMPORTANT]
+====
+Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades. For more information, see xref:../../architecture/architecture-installation.html#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators].
+====
 
 In managed state, the Cluster Logging Operator (CLO) responds to changes in the Cluster Logging Custom Resource (CR) and adjusts the logging deployment accordingly.
 

--- a/modules/cluster-logging-collector-envvar.adoc
+++ b/modules/cluster-logging-collector-envvar.adoc
@@ -13,7 +13,7 @@ available environment variables.
 
 .Prerequisite
 
-Set cluster logging to the unmanaged state.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/modules/cluster-logging-collector-json.adoc
+++ b/modules/cluster-logging-collector-json.adoc
@@ -23,7 +23,7 @@ The features in this topic should be used by only experienced Fluentd and Elasti
 
 .Prerequisites
 
-Set cluster logging to the unmanaged state.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/modules/cluster-logging-collector-log-location.adoc
+++ b/modules/cluster-logging-collector-log-location.adoc
@@ -9,7 +9,7 @@ The log collector writes logs to a specified file or to the default location, `/
 
 .Prerequisite
 
-* Set cluster logging to the unmanaged state.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/modules/cluster-logging-curator-actions.adoc
+++ b/modules/cluster-logging-curator-actions.adoc
@@ -19,7 +19,7 @@ Using the *action* file is recommended only for advanced users as using this fil
 
 * Cluster logging and Elasticsearch must be installed.
 
-* Set cluster logging to the unmanaged state.
+* Set cluster logging to the unmanaged state. Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
 .Procedure
 

--- a/modules/nodes-cluster-overcommit-buffer-chunk.adoc
+++ b/modules/nodes-cluster-overcommit-buffer-chunk.adoc
@@ -16,6 +16,7 @@ Fluentd file buffering stores records in _chunks_. Chunks are stored in _buffers
 ====
 To modify the `FILE_BUFFER_LIMIT` or `BUFFER_SIZE_LIMIT` parameters
 in the Fluentd daemonset as described below, you must set cluster logging to the unmanaged state.
+Operators in an unmanaged state are unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 ====
 
 The Fluentd `buffer_chunk_limit` is determined by the environment variable


### PR DESCRIPTION
Until we decide, if we decide, to remove unmanaged configurations, adding a link to the new _Support policy for unmanaged Operators_ module. 