### PR TITLE
CNV - change wording and version for VM api ref link

### DIFF
--- a/cnv/cnv_virtual_machines/cnv-create-vms.adoc
+++ b/cnv/cnv_virtual_machines/cnv-create-vms.adoc
@@ -37,6 +37,12 @@ include::modules/cnv-creating-vm.adoc[leveloffset=+1]
 
 include::modules/cnv-vm-storage-volume-types.adoc[leveloffset=+1]
 
-See the
-https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinespec[kubevirt
-API Reference] for a definitive list of virtual machine settings.
+== Additional resources
+
+The `VirtualMachineSpec` definition in the link:https://kubevirt.io/api-reference/v0.26.5/definitions.html#_v1_virtualmachinespec[KubeVirt v.0.26.5 API Reference] provides broader context for the parameters and hierarchy of the virtual machine specification.
+
+[NOTE]
+====
+The KubeVirt API Reference is the upstream project reference and might contain parameters that are not supported in {CNVProductName}. 
+====
+

--- a/modules/cnv-vm-storage-volume-types.adoc
+++ b/modules/cnv-vm-storage-volume-types.adoc
@@ -5,9 +5,7 @@
 [id="cnv-vm-storage-volume-types_{context}"]
 = Virtual machine storage volume types
 
-Virtual machine storage volume types are listed, as well as domain and volume settings. See the
-https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinespec[kubevirt
-API Reference] for a definitive list of virtual machine settings.
+Virtual machine storage volume types are listed, as well as domain and volume settings. 
 
 [horizontal]
 *ephemeral*::


### PR DESCRIPTION
PM and eng recommended we re-phrase the 'definitive' part of the API reference and link to the specific version instead of master.

Also removed the duplicate link.