### PR TITLE
BZ1833239 - Declaring all required registries with 'allowedRegistries'

### DIFF
--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -80,3 +80,8 @@ registries are blocked.
 Only one of `blockedRegistries` or `allowedRegistries` may be set
 
 |===
+
+[WARNING]
+====
+When the `allowedRegistries` parameter is defined, all registries including `registry.redhat.io` and `quay.io` are blocked unless explicitly listed. If using the parameter, declare source registries `registry.redhat.io` and `quay.io` as required by payload images within your environment, to prevent Pod failure. For disconnected clusters, mirror registries should also be added.
+====


### PR DESCRIPTION
Applies to branch/enterprise-4.2, branch/enterprise-4.3 and branch/enterprise-4.4.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1833239.

Preview is at https://bz1833239--ocpdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html.