### PR TITLE
LogForwarding endpoint must be an node name or FQDN, not an IP Address

### DIFF
--- a/modules/cluster-logging-collector-log-forward-configure.adoc
+++ b/modules/cluster-logging-collector-log-forward-configure.adoc
@@ -60,8 +60,8 @@ spec:
 <4> Add one or more endpoints:
 * Specify the type of output, either `elasticseach` or `forward`.
 * Enter a name for the output.
-* Enter the endpoint, either the server name or FQDN.
-* Optionally, enter the name of the secret required by the endpoint for TLS communication. The secret must exist in the openshift-logging project. For the default Elastiscearch logstore, use `fluentd` as the secret name.
+* Enter the endpoint, either the server name, FQDN, or IP address. If the cluster-wide proxy using the CIDR annotation is enabled, the endpoint must be a server name or FQDN, not an IP Address. For the internal {product-title} Elasticsearch instance, specify `elasticsearch.openshift-logging.svc:9200`.
+* Optional: Enter the name of the secret required by the endpoint for TLS communication. The secret must exist in the `openshift-logging` project.
 * Specify `insecure: true` if the endpoint does not use a secret, resulting in insecure communication.
 <5> Add one or more pipelines:
 * Enter a name for the pipeline

--- a/modules/cluster-logging-log-forwarding-about.adoc
+++ b/modules/cluster-logging-log-forwarding-about.adoc
@@ -18,8 +18,13 @@ An _output_ is the destination for log data and a _pipeline_ defines simple rout
 
 An output can be either:
 
-* `elasticsearch` to forward logs to an external Elasticsearch v5.x cluster, specified by server name or FQDN, and/or the internal {product-title} Elasticsearch instance. 
-* `forward` to forward logs to an external log aggregation solution. This option uses the Fluentd *forward* plug-ins.
+* `elasticsearch` to forward logs to an external Elasticsearch v5.x cluster and/or the internal {product-title} Elasticsearch instance. 
+* `forward` to forward logs to an external log aggregation solution. This option uses the Fluentd *forward* plug-ins. 
+
+[NOTE]
+====
+The endpoint must be a server name or FQDN, not an IP Address, if the cluster-wide proxy using the CIDR annotation is enabled.
+====
 
 A _pipeline_ associates the source of the data to an output. The source of the data is one of the following:
 
@@ -92,7 +97,7 @@ spec:
 <3> Configuration for the outputs.
 <4> A name to describe the output.
 <5> The type of output, either `elasticsearch` or `forward`.
-<6> The log forwarding endpoint, either the server name or FQDN. For the internal {product-title} Elasticsearch instance, specify `elasticsearch.openshift-logging.svc:9200`.
+* Enter the endpoint, either the server name, FQDN, or IP address. If the cluster-wide proxy using the CIDR annotation is enabled, the endpoint must be a server name or FQDN, not an IP Address. For the internal {product-title} Elasticsearch instance, specify `elasticsearch.openshift-logging.svc:9200`.
 <7> Optional name of the secret required by the endpoint for TLS communication. The secret must exist in the `openshift-logging` project.
 <8> Optional setting if the endpoint does not use a secret, resulting in insecure communication. 
 <9> Configuration for the pipelines.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1831552