### PR TITLE
modules/installation-mirror-repository: Drop unnecessary 'export'

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -32,12 +32,12 @@ to determine the version of {product-title} that you want to install and determi
 . Set the required environment variables:
 +
 ----
-$ export OCP_RELEASE=<release_version> <1>
-$ export LOCAL_REGISTRY='<local_registry_host_name>:<local_registry_host_port>' <2>
-$ export LOCAL_REPOSITORY='<repository_name>' <3>
-$ export PRODUCT_REPO='openshift-release-dev' <4>
-$ export LOCAL_SECRET_JSON='<path_to_pull_secret>' <5>
-$ export RELEASE_NAME="ocp-release" <6>
+$ OCP_RELEASE=<release_version> <1>
+$ LOCAL_REGISTRY='<local_registry_host_name>:<local_registry_host_port>' <2>
+$ LOCAL_REPOSITORY='<repository_name>' <3>
+$ PRODUCT_REPO='openshift-release-dev' <4>
+$ LOCAL_SECRET_JSON='<path_to_pull_secret>' <5>
+$ RELEASE_NAME="ocp-release" <6>
 ----
 <1> For `<release_version>`, specify the tag that corresponds to the version of {product-title} to
 install for your architecture, such as `4.4.0-x86_64`.


### PR DESCRIPTION
The export landed with the module in ced98c67ad (#16678).  But these are local variables that we expand when calling the mirror command.  The mirror command receives them from its command line arguments; we don't need [`export`][1] to expose them in the mirror command's environment as well.

/assign @kalexand-rh

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#export