### PR TITLE
networking/configuring-a-custom-pki: Link back to builds trusted-CA config

### DIFF
--- a/networking/configuring-a-custom-pki.adoc
+++ b/networking/configuring-a-custom-pki.adoc
@@ -40,6 +40,12 @@ The `trustedCA` field is a reference to a `ConfigMap` containing the custom
 certificate and key pair used by the cluster component.
 ====
 
+== Alternatives for additional trust
+
+Cluster components may provide alternative mechanisms for configuring additional trust, for situations when a proxy is not needed:
+
+* xref:../builds/setting-up-trusted-ca.adoc[Builds]
+
 include::modules/installation-configure-proxy.adoc[leveloffset=+1]
 
 include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]


### PR DESCRIPTION
Reciprocating the builds -> proxy link from 1fdd604b88 (#18207), so folks who think "I need to add X.509 trust" and land on the "custom PKI" section can see "oh, I'm not using a proxy, I guess I should configure the build tooling directly..." and head over.  Also, we're likely to have a number of additional cluster components that have their own custom CA injection mechanisms, and this new section gives us a convenient list we can extend.