### PR TITLE
Adding multiarch docs for Operator SDK

### DIFF
--- a/modules/olm-enabling-operator-for-multi-arch.adoc
+++ b/modules/olm-enabling-operator-for-multi-arch.adoc
@@ -1,0 +1,112 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-generating-csvs.adoc
+
+[id="olm-enabling-operator-for-multi-arch_{context}"]
+= Enabling your Operator for multiple architectures and operating systems
+
+Operator Lifecycle Manager (OLM) assumes that all Operators run on Linux hosts.
+However, as an Operator author, you can specify whether your Operator supports
+managing workloads on other architectures, if worker nodes are available in the
+{product-title} cluster.
+
+If your Operator supports variants other than AMD64 and Linux, you can add
+labels to the CSV that provides the Operator to list the supported variants.
+Labels indicating supported architectures and operating systems are defined by
+the following:
+
+[source,yaml]
+----
+labels:
+    operatorframework.io/arch.<arch>: supported <1>
+    operatorframework.io/os.<os>: supported <2>
+----
+<1> Set `<arch>` to a supported string.
+<2> Set `<os>` to a supported string.
+
+[NOTE]
+====
+Only the labels on the channel head of the default channel are considered for
+filtering PackageManifests by label. This means, for example, that providing an
+additional architecture for an Operator in the non-default channel is possible,
+but that architecture is not available for filtering in the PackageManifest API.
+====
+
+.Architectures supported on {product-title}
+[options="header"]
+|===
+|Architecture |String
+
+|AMD64
+|`amd64`
+
+|64-bit PowerPC little-endian
+|`ppc64le`
+
+|IBM Z
+|`s390x`
+|===
+
+.Operating systems supported on {product-title}
+[options="header"]
+|===
+|Operating system |String
+
+|Linux
+|`linux`
+
+|z/OS
+|`zos`
+|===
+
+[NOTE]
+====
+Different versions of {product-title} and other Kubernetes-based distributions might
+support a different set of architectures and operating systems.
+====
+
+If a CSV does not include an `os` label, it is treated as if it has the
+following by default:
+
+[source,yaml]
+----
+labels:
+    operatorframework.io/os.linux: supported
+----
+
+If a CSV does not include an `arch` label, it is treated as if it has the
+following by default:
+
+[source,yaml]
+----
+labels:
+    operatorframework.io/arch.amd64: supported
+----
+
+If an Operator supports multiple node architectures or operating systems, you
+can add multiple labels, as well.
+
+.Prerequisites
+
+* An Operator project with a CSV.
+* To support listing multiple architectures and operating systems, your Operator
+image referenced in the CSV must be a manifest list image.
+* For the Operator to work properly in restricted network, or disconnected,
+environments, the image referenced must also be specified using a digest (SHA)
+and not by a tag.
+
+.Procedure
+
+* Add a label in your CSV's `metadata.labels` for each supported architecture and
+operating system that your Operator supports:
++
+[source,yaml]
+----
+labels:
+  operatorframework.io/arch.s390x: supported
+  operatorframework.io/os.zos: supported
+  operatorframework.io/os.linux: supported <1>
+  operatorframework.io/arch.amd64: supported <1>
+----
+<1> After you add a new architecture or operating system, you must also now include
+the default `os.linux` and `arch.amd64` variants explicitly.

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -48,6 +48,12 @@ include::modules/osdk-manually-defined-csv-fields.adoc[leveloffset=+1]
 
 include::modules/osdk-generating-a-csv.adoc[leveloffset=+1]
 include::modules/olm-enabling-operator-restricted-network.adoc[leveloffset=+1]
+include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]
+.Additional resources
+
+- See the link:https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list[Image Manifest V 2, Schema 2]
+specification for more information on manifest lists.
+
 include::modules/osdk-suggested-namespace.adoc[leveloffset=+1]
 include::modules/osdk-crds.adoc[leveloffset=+1]
 include::modules/osdk-owned-crds.adoc[leveloffset=+2]


### PR DESCRIPTION
Building on https://github.com/openshift/openshift-docs/pull/22002. 

Preview (internal): http://file.rdu.redhat.com/~adellape/051220/multiarch/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-multi-arch_osdk-generating-csvs

@shawn-hurley PTAL
@emmajiafan PTAL for QE review