### PR TITLE
Standardize navigation capitalization to match OpenShift

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1383,36 +1383,36 @@ Name: Service Mesh
 Dir: service_mesh
 Distros: openshift-enterprise,openshift-webscale
 Topics:
-- Name: Service Mesh Release Notes
+- Name: Service Mesh release notes
   File: servicemesh-release-notes
-- Name: Service Mesh Architecture
+- Name: Service Mesh architecture
   Dir: service_mesh_arch
   Topics:
-  - Name: Understanding service mesh
+  - Name: Understanding Service Mesh
     File: understanding-ossm
   - Name: Understanding Kiali
     File: ossm-kiali
   - Name: Understanding Jaeger
     File: ossm-jaeger
-  - Name: Comparing service mesh and Istio
+  - Name: Comparing Service Mesh and Istio
     File: ossm-vs-community
-- Name: Service Mesh Installation
+- Name: Service Mesh installation
   Dir: service_mesh_install
   Topics:
-  - Name: Preparing to install service mesh
+  - Name: Preparing to install Service Mesh
     File: preparing-ossm-installation
-  - Name: Installing service mesh
+  - Name: Installing Service Mesh
     File: installing-ossm
   - Name: Customizing the installation
     File: customizing-installation-ossm
-  - Name: Updating service mesh
+  - Name: Updating Service Mesh
     File: updating-ossm
-  - Name: Removing service mesh
+  - Name: Removing Service Mesh
     File: removing-ossm
 - Name: Day Two
   Dir: service_mesh_day_two
   Topics:
-  - Name: Deploying applications on service mesh
+  - Name: Deploying applications on Service Mesh
     File: prepare-to-deploy-applications-ossm
   - Name: Configuring Jaeger
     File: configuring-jaeger
@@ -1424,7 +1424,7 @@ Topics:
     File: ossm-tutorial-jaeger-tracing
   - Name: Automatic route creation
     File: ossm-auto-route
-- Name: Service mesh user guide
+- Name: Service Mesh user guide
   Dir: service_mesh_user_guide
   Topics:
   - Name: Traffic management
@@ -1436,7 +1436,7 @@ Topics:
 - Name: Support
   Dir: service_mesh_support
   Topics:
-  - Name: Collecting service mesh data for support
+  - Name: Collecting Service Mesh data for support
     File: ossm-collecting-ossm-data
 - Name: 3scale adapter
   Dir: threescale_adapter
@@ -1449,14 +1449,14 @@ Name: Jaeger
 Dir: jaeger
 Distros: openshift-enterprise
 Topics:
-- Name: Jaeger Release Notes
+- Name: Jaeger release notes
   File: rhbjaeger-release-notes
-- Name: Jaeger Architecture
+- Name: Jaeger architecture
   Dir: jaeger_arch
   Topics:
   - Name: Jaeger architecture
     File: rhbjaeger-architecture
-- Name: Jaeger Installation
+- Name: Jaeger installation
   Dir: jaeger_install
   Topics:
   - Name: Installing Jaeger


### PR DESCRIPTION
Navigation capitalization in topic map switched from title case to sentence case (with product names capitalized) to conform with OpenShift standards.