### PR TITLE
BZ1832115 - Update optional step for LSO node selector

### DIFF
--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -19,16 +19,18 @@ The Local Storage Operator is not installed in {product-title} by default. Use t
 $ oc new-project local-storage
 ----
 
-. Optional: Allow local storage creation on infrastructure nodes.
+. Optional: Allow local storage creation on master and infrastructure nodes.
 +
-You might want to use the Local Storage Operator to create volumes on infrastructure nodes in support of components such as logging and monitoring.
+You might want to use the Local Storage Operator to create volumes on master and infrastructure nodes, and not just worker nodes, to support components such as logging and monitoring.
 +
-You must adjust the default node selector so that the Local Storage Operator includes the infrastructure nodes, and not just worker nodes.
-+
-To block the Local Storage Operator from inheriting the cluster-wide default selector, enter the following command:
+To allow local storage creation on master and infrastructure nodes, add a toleration to the DaemonSet by entering the following commands:
 +
 ----
-$ oc annotate project local-storage openshift.io/node-selector=''
+$ oc patch ds local-storage-local-diskmaker -n local-storage -p '{"spec": {"template": {"spec": {"tolerations":[{"operator": "Exists"}]}}}}'
+----
++
+----
+$ oc patch ds local-storage-local-provisioner -n local-storage -p '{"spec": {"template": {"spec": {"tolerations":[{"operator": "Exists"}]}}}}'
 ----
 
 .From the UI


### PR DESCRIPTION
[BZ1832115](https://bugzilla.redhat.com/show_bug.cgi?id=1832115) - This is an update to https://github.com/openshift/openshift-docs/pull/20762 based on QE findings in 4.x, where a toleration must be added for node selector to include master and infra nodes.

Applies to 4.2, 4.3, 4.4, 4.5.

Preview build link: https://bz1832115--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-storage-install_persistent-storage-local