### PR TITLE
Do not use extensions API group in specs

### DIFF
--- a/modules/migration-manually-rolling-back-migration.adoc
+++ b/modules/migration-manually-rolling-back-migration.adoc
@@ -33,7 +33,7 @@ $ oc delete <resource_type>
 +
 [source,yaml]
 ----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hello-daemonset

--- a/modules/nodes-pods-daemonsets-creating.adoc
+++ b/modules/nodes-pods-daemonsets-creating.adoc
@@ -29,7 +29,7 @@ To create a daemonset:
 +
 [source,yaml]
 ----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hello-daemonset

--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -11,7 +11,7 @@ The following annotates an example NetworkPolicy object:
 [source,yaml]
 ----
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-27107 <1>
 spec:
@@ -26,7 +26,6 @@ spec:
     ports: <4>
     - protocol: TCP
       port: 27017
-
 ----
 <1> The `name` of the NetworkPolicy object.
 <2> A selector describing the Pods the policy applies to. The policy object can


### PR DESCRIPTION
The `extensions` API group is no longer appropriate to use. (https://github.com/openshift/origin/pull/24537)