### PR TITLE
Include SR-IOV device discovery in only one assembly

### DIFF
--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -65,7 +65,6 @@ can be disabled by editting default SriovOperatorConfig CR.
 ====
 
 include::modules/nw-sriov-supported-devices.adoc[leveloffset=+2]
-include::modules/nw-sriov-device-discovery.adoc[leveloffset=+2]
 include::modules/nw-sriov-example-vf-function-in-pod.adoc[leveloffset=+2]
 
 .Next steps


### PR DESCRIPTION
This module is included in two places. This one makes the least sense.

- https://docs.openshift.com/container-platform/4.4/networking/hardware_networks/about-sriov.html#discover-sr-iov-devices_about-sriov (deleted)
- https://docs.openshift.com/container-platform/4.4/networking/hardware_networks/configuring-sriov-device.html#discover-sr-iov-devices_configuring-sriov-device

cc @zshi-redhat 