### PR TITLE
Added documentation about Insights tab (CCXDEV-1285)

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -307,6 +307,8 @@ Topics:
     File: showing-data-collected-by-remote-health-monitoring
   - Name: Opting out of remote health reporting
     File: opting-out-of-remote-health-reporting
+  - Name: Using Insights to identify issues with your cluster
+    File: using-insights-to-identify-issues-with-your-cluster
 ---
 Name: Web console
 Dir: web_console

--- a/modules/displaying-potential-issues-with-your-cluster.adoc
+++ b/modules/displaying-potential-issues-with-your-cluster.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+
+[id="displaying-potential-issues-with-your-cluster_{context}"]
+= Displaying potential issues with your cluster
+
+This section describes how to display the Insights report in the {cloud-redhat-com}.
+
+Note that Insights repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
+
+.Prerequisites
+
+* Your cluster is registered in the {cloud-redhat-com}.
+* Remote health reporting is enabled, which is the default.
+* You are logged in to the {cloud-redhat-com}.
+
+.Procedure
+
+. Click the *Clusters* menu in the left pane.
+
+. Click the cluster's name to display the details of the cluster.
+
+. Open the *Insights* tab of the cluster.
++
+Depending on the result, the tab displays one of the following:
++
+* *Your cluster passed all health checks*, if Insights did not identify any issues.
+
+* A list of issues Insights has detected, prioritized by risk (low, moderate, important, and critical).
+
+* *No health checks to display*, if Insights has not yet analyzed the cluster. The analysis starts shortly after the cluster has been installed and connected to the internet.
+
+. If any issues are displayed on the tab, click the *>* icon in front of the entry for further details.
++
+Depending on the issue, the details can also contain a link to an Red Hat Knowledge Base article. For details and information on how to solve the problem, click *How to remediate this issue*.
+

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -1,0 +1,10 @@
+[id="using-insights-to-identify-issues-with-your-cluster"]
+= Using Insights to identify issues with your cluster
+include::modules/common-attributes.adoc[]
+:context: using-insights-to-identify-issues-with-your-cluster
+toc::[]
+
+Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report on the *Insights* tab of each cluster in {cloud-redhat-com}.
+
+include::modules/displaying-potential-issues-with-your-cluster.adoc[leveloffset=+1]
+


### PR DESCRIPTION
This update adds documentation about the Insights tab on cloud.redhat.com to the "Support" section of the docs.

This doc enhancement is for OpenShift 4.5.

@openshift/team-documentation