### PR TITLE
[OCPCLOUD-853] Expand and update MachineHealthCheck documentation

### DIFF
--- a/machine_management/deploying-machine-health-checks.adoc
+++ b/machine_management/deploying-machine-health-checks.adoc
@@ -10,6 +10,10 @@ include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-health-checks-about.adoc[leveloffset=+1]
 
+.Additional resources
+
+* See xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-short-circuiting_deploying-machine-health-checks[Short-circuiting machine health check remediation] for more information about short circuiting
+
 include::modules/machine-health-checks-resource.adoc[leveloffset=+1]
 
 include::modules/machine-health-checks-creating.adoc[leveloffset=+1]

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -6,11 +6,12 @@
 [id="machine-health-checks-about_{context}"]
 = About machine health checks
 
-Machine health checks automatically repair unhealthy machines in a particular machine pool.
+You can define conditions under which machines in a cluster are considered unhealthy by using a `MachineHealthCheck` resource.
+Machines matching the conditions are automatically remediated.
 
-To monitor machine health, create a `MachineHealthCheck` custom resource (CR) that includes a label for the set of machines to monitor and a condition to check, such as staying in the `NotReady` status for 15 minutes or displaying a permanent condition in the node-problem-detector. 
+To monitor machine health, create a `MachineHealthCheck` custom resource (CR) that includes a label for the set of machines to monitor and a condition to check, such as staying in the `NotReady` status for 15 minutes or displaying a permanent condition in the node-problem-detector.
 
-The controller that observes a `MachineHealthCheck` CR checks for the condition that you defined. If a machine fails the health check, the machine is automatically deleted and a new one is created to take its place. When a machine is deleted, you see a `machine deleted` event. 
+The controller that observes a `MachineHealthCheck` CR checks for the condition that you defined. If a machine fails the health check, the machine is automatically deleted and a new one is created to take its place. When a machine is deleted, you see a `machine deleted` event.
 
 [NOTE]
 ====
@@ -31,3 +32,14 @@ To limit the disruptive impact of machine deletions, the controller drains and d
 ====
 
 To stop the check, remove the custom resource.
+
+[id="machine-health-checks-limitations_{context}"]
+== Limitations when deploying machine health checks
+
+There are limitations to consider before deploying a machine health check:
+
+* Only machines owned by a machine set are remediated by a machine health check.
+* Control plane machines are not currently supported and are not remediated if they are unhealthy.
+* If the node for a machine is removed from the cluster, a machine health check considers the machine to be unhealthy and remediates it immediately.
+* If the corresponding node for a machine does not join the cluster after the `nodeStartupTimeout`, the machine is remediated.
+* A machine is remediated immediately if the `Machine` resource phase is `Failed`.

--- a/modules/machine-health-checks-creating.adoc
+++ b/modules/machine-health-checks-creating.adoc
@@ -6,7 +6,8 @@
 [id="machine-health-checks-creating_{context}"]
 = Creating a `MachineHealthCheck` resource
 
-You can create a `MachineHealthCheck` resource for all machine pools in your cluster except the `master` pool.
+You can create a `MachineHealthCheck` resource for all `MachineSets` in your cluster.
+You should not create a `MachineHealthCheck` resource that targets control plane machines.
 
 .Prerequisites
 

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -31,14 +31,61 @@ spec:
     timeout: "300s" <4>
     status: "Unknown"
   maxUnhealthy: "40%" <5>
+  nodeStartupTimeout: "10m" <6>
 ----
 <1> Specify the name of the machine health check to deploy.
 <2> Specify a label for the machine pool that you want to check.
 <3> Specify the machine set to track in `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
-<4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for the workload on the unhealthy machine.
-<5> Specify the amount of unhealthy machines allowed in the targeted pool of machines. This can be set as a percentage or an integer.
+<4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
+<5> Specify the amount of unhealthy machines allowed in the targeted pool. This can be set as a percentage or an integer.
+<6> Specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
 
 [NOTE]
 ====
 The `matchLabels` are examples only; you must map your machine groups based on your specific needs.
+====
+
+[id="machine-health-checks-short-circuiting_{context}"]
+== Short-circuiting machine health check remediation
+
+Short circuiting ensures that machine health checks remediate machines only when the cluster is healthy.
+Short-circuiting is configured through the `maxUnhealthy` field in the `MachineHealthCheck` resource.
+
+If the user defines a value for the `maxUnhealthy` field,
+before remediating any machines, the `MachineHealthCheck` compares the value of `maxUnhealthy`
+with the number of machines within its target pool that it has determined to be unhealthy.
+Remediation is not performed if the number of unhealthy machines exceeds the `maxUnhealthy` limit.
+
+[IMPORTANT]
+====
+If `maxUnhealthy` is not set, the value defaults to `100%` and the machines are remediated regardless of the state of the cluster.
+====
+
+The `maxUnhealthy` field can be set as either an integer or percentage.
+There are different remediation implementations depending on the `maxUnhealthy` value.
+
+=== Setting `maxUnhealthy` by using an absolute value
+
+If `maxUnhealthy` is set to `2`:
+
+* Remediation will be performed if 2 or fewer nodes are unhealthy
+* Remediation will not be performed if 3 or more nodes are unhealthy
+
+These values are independent of how many machines are being checked by the machine health check.
+
+=== Setting `maxUnhealthy` by using percentages
+
+If `maxUnhealthy` is set to `40%` and there are 25 machines being checked:
+
+* Remediation will be performed if 10 or fewer nodes are unhealthy
+* Remediation will not be performed if 11 or more nodes are unhealthy
+
+If `maxUnhealthy` is set to `40%` and there are 6 machines being checked:
+
+* Remediation will be performed if 2 or fewer nodes are unhealthy
+* Remediation will not be performed if 3 or more nodes are unhealthy
+
+[NOTE]
+====
+The allowed number of machines is rounded down when the percentage of `maxUnhealthy` machines that are checked is not a whole number.
 ====


### PR DESCRIPTION
This PR updates and expands on the context given for users to configure MachineHealthChecks within their clusters.

This document is accurate for MHC in 4.5 but can also be backported to previous versions if the `nodeStartupTimeout` is removed from the example MHC.