### PR TITLE
BZ1835077 - Fix file system path note

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -50,7 +50,7 @@ spec:
       volumeMode: Filesystem <3>
       fsType: xfs <4>
       devicePaths: <5>
-        - /path/to/device <6>
+        - /path/to/filesystem <6>
 ----
 <1> The namespace where the Local Storage Operator is installed.
 <2> Optional: A node selector containing a list of nodes where the local storage volumes are attached. This
@@ -62,7 +62,7 @@ local volumes.
 <4> The file system that is created when the local volume is mounted for the
 first time.
 <5> The path containing a list of local storage devices to choose from.
-<6> Replace this value with your actual local disks filepath to the LocalVolume resource, such as `/dev/xvdg`. PVs are created for these local disks when the provisioner is deployed successfully.
+<6> Replace this value with your actual local file system path to the LocalVolume resource, such as `/etc/motd`. PVs are created for these local file systems when the provisioner is deployed successfully.
 +
 .Example: Block
 [source,yaml]


### PR DESCRIPTION
[BZ1835077](https://bugzilla.redhat.com/show_bug.cgi?id=1835077)
Updates the filesystem annotation and description to match filesystem path, rather than block device path.
This is an update to [PR 21894](https://github.com/openshift/openshift-docs/pull/21894).

Preview link here:
https://bz1835077--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-volume-cr_persistent-storage-local