### PR TITLE
Remove 'openshift-migration' namespace from 4.4 cluster

### DIFF
--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -25,14 +25,11 @@ endif::[]
 
 .Procedure
 
-. In the {product-title} web console, click *Administration* -> *Namespaces*.
-. Click *Create Namespace*.
-. Enter `openshift-migration` in the *Name* field and click *Create*.
 ifdef::targetcluster-3-4,targetcluster-4_2-4_x,sourcecluster-4_2-4_x,targetcluster-4_1-4_x[]
-. Click *Operators* -> *OperatorHub*.
+. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 endif::[]
 ifdef::sourcecluster-4_1-4_x[]
-. Click *Catalog* -> *OperatorHub*.
+. In the {product-title} web console, click *Catalog* -> *OperatorHub*.
 endif::[]
 . Use the *Filter by keyword* field (in this case, `Migration`) to find the *Cluster Application Migration Operator*.
 . Select the *Cluster Application Migration Operator* and click *Install*.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1833107

4.4 does not require creation of 'openshift-migration' namespace.

CP for 4.4, 4.5