### PR TITLE
CNV-3890 Adding xRef to Importing a VM

### DIFF
--- a/cnv/cnv_virtual_machines/cnv-create-vms.adoc
+++ b/cnv/cnv_virtual_machines/cnv-create-vms.adoc
@@ -10,7 +10,7 @@ Use one of these procedures to create a virtual machine:
 * Running the virtual machine wizard
 * Pasting a pre-configured YAML file with the virtual machine wizard
 * Using the CLI
-* Importing a VMware virtual machine or template with the virtual machine wizard
+* xref:../../cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc#cnv-importing-vmware-vm[Importing a VMware virtual machine or template with the virtual machine wizard]
 
 [WARNING]
 ====


### PR DESCRIPTION
This PR adds an xRef to the Import VM Module to complete the content of the Create VMs assembly.

Test Build: http://file.bos.redhat.com/bgaydos/051320/cnv/cnv_virtual_machines/cnv-create-vms.html

I added the Xref inline in the topic overview, but if this is not what is desired, I can move it further down in the content and link via a heading.

Label Peer-review-needed and merge and pick to Enterprise-4.4, Enterprise-4.5.

Thanks,

Bob