### PR TITLE
CNV-4865 KubeMacPool for namespaces

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1574,7 +1574,9 @@ Topics:
       File: virt-installing-qemu-guest-agent
     - Name: Viewing the IP address of NICs on a virtual machine
       File: virt-viewing-ip-of-vm-nic
-# A BETTER NAME THAN 'STORAGE 4 U'
+    - Name: Using a MAC address pool for virtual machines
+      File: virt-using-mac-address-pool-for-vms
+#A BETTER NAME THAN 'STORAGE 4 U'
   - Name: Virtual machine disks
     Dir: virtual_disks
     Topics:

--- a/modules/virt-about-kubemacpool.adoc
+++ b/modules/virt-about-kubemacpool.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_vm_networking/virt-using-mac-address-pool-for-vms.adoc
+
+[id="virt-about-kubemacpool_{context}"]
+= About KubeMacPool
+
+If you enable the KubeMacPool component for a namespace, virtual machine NICs in that namespace are allocated MAC addresses from a MAC address pool.
+This ensures that the NIC is assigned a unique MAC address that does not conflict with the MAC address of another virtual machine.
+
+Virtual machine instances created from that virtual machine retain the assigned MAC address across reboots.
+
+[NOTE]
+====
+KubeMacPool does not handle virtual machine instances created independently from a virtual machine.
+====
+
+KubeMacPool is disabled by default.
+Enable a MAC address pool for a namespace by applying the KubeMacPool label to the namespace.
+

--- a/modules/virt-disabling-mac-address-pool-for-namespace-cli.adoc
+++ b/modules/virt-disabling-mac-address-pool-for-namespace-cli.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_vm_networking/virt-using-mac-address-pool-for-vms.adoc
+
+[id="virt-disabling-mac-address-pool-for-namespace-cli_{context}"]
+= Disabling a MAC address pool for a namespace in the CLI
+
+Disable a MAC address pool for virtual machines in a namespace by removing the `mutatevirtualmachines.kubemacpool.io` label.
+
+.Procedure
+
+* Remove the KubeMacPool label from the namespace.
+The following example removes the KubeMacPool label from two namespaces, `<namespace1>` and `<namespace2>`:
++
+----
+$ oc label namespace <namespace1> <namespace2> mutatevirtualmachines.kubemacpool.io-
+----
+

--- a/modules/virt-enabling-mac-address-pool-for-namespace-cli.adoc
+++ b/modules/virt-enabling-mac-address-pool-for-namespace-cli.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * cnv/cnv_virtual_machines/cnv_vm_networking/virt-using-mac-address-pool-for-vms.adoc
+
+[id="virt-enabling-mac-address-pool-for-namespace-cli_{context}"]
+= Enabling a MAC address pool for a namespace in the CLI
+
+Enable a MAC address pool for virtual machines in a namespace by applying the `mutatevirtualmachines.kubemacpool.io=allocate` label to the namespace.
+
+.Procedure
+
+* Add the KubeMacPool label to the namespace.
+The following example adds the KubeMacPool label to two namespaces, `<namespace1>` and `<namespace2>`:
++
+----
+$ oc label namespace <namespace1> <namespace2> mutatevirtualmachines.kubemacpool.io=allocate
+----
+

--- a/virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc
@@ -1,0 +1,17 @@
+[id="virt-using-mac-address-pool-for-vms"]
+= Using a MAC address pool for virtual machines
+include::modules/virt-document-attributes.adoc[]
+:context: virt-using-mac-address-pool-for-vms
+toc::[]
+
+:FeatureName: KubeMacPool
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+The _KubeMacPool_ component provides a MAC address pool service for virtual machine NICs in designated namespaces. Enable a MAC address pool in a namespace by applying the KubeMacPool label to that namespace.
+
+include::modules/virt-about-kubemacpool.adoc[leveloffset=+1]
+
+include::modules/virt-enabling-mac-address-pool-for-namespace-cli.adoc[leveloffset=+1]
+
+include::modules/virt-disabling-mac-address-pool-for-namespace-cli.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Adding an assembly and 3 modules to cover enabling and disabling KubeMacPool for Pods and VMs in a namespace.
[CNV-4865](https://issues.redhat.com/browse/CNV-4865)

Preview build: https://cnv-4865-kubemacpool--ocpdocs.netlify.app/openshift-enterprise/latest/cnv/cnv_virtual_machines/cnv_vm_networking/virt-using-mac-address-pool-for-vms.html

cherrypick to enterprise-4.5