### PR TITLE
CNV - 2-3 versioned rel_notes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1466,7 +1466,7 @@ Topics:
   Dir: cnv_release_notes
   Topics:
   - Name: Container-native virtualization release notes
-    File: cnv-release-notes
+    File: cnv-2-3-release-notes
 - Name: Container-native virtualization installation
   Dir: cnv_install
   Topics:

--- a/cnv/cnv_release_notes/cnv-2-3-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-2-3-release-notes.adoc
@@ -1,4 +1,4 @@
-[id="cnv-release-notes"]
+[id="cnv-2-3-release-notes"]
 = {RN_BookName}
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-release-notes


### PR DESCRIPTION
Changing the 2.3 release notes way from 'master' style to 'version' style to follow OCP approach
#22089 handled master branch
@vikram-redhat 