### PR TITLE
CNV - 2-4 versioned rel_notes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1463,7 +1463,7 @@ Topics:
   Dir: cnv_release_notes
   Topics:
   - Name: Container-native virtualization release notes
-    File: cnv-release-notes
+    File: cnv-2-4-release-notes
 - Name: Container-native virtualization installation
   Dir: cnv_install
   Topics:

--- a/cnv/cnv_release_notes/cnv-2-4-release-notes.adoc
+++ b/cnv/cnv_release_notes/cnv-2-4-release-notes.adoc
@@ -1,4 +1,4 @@
-[id="cnv-release-notes"]
+[id="cnv-2-4-release-notes"]
 = {RN_BookName}
 include::modules/cnv-document-attributes.adoc[]
 :context: cnv-release-notes
@@ -13,7 +13,7 @@ include::modules/cnv-what-you-can-do-with-cnv.adoc[leveloffset=+2]
 :FeatureName: {CNVProductNameStart}
 include::modules/technology-preview.adoc[leveloffset=+2]
 
-[id="cnv-2-3-new"]
+[id="cnv-2-4-new"]
 == New and changed features
 
 * {CNVProductNameStart} is certified in Microsoft's Windows Server
@@ -24,7 +24,7 @@ Container Platform 4 on RHEL CoreOS 8_.
 
 * New templates are available that are compatible with Microsoft Windows 10.
 
-[id="cnv-2-3-networking-new"]
+[id="cnv-2-4-networking-new"]
 === Networking
 
 * You can now use {CNVProductName} with either the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#learn-about-ovn-kubernetes[OVN-Kubernetes] or the xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] network provider.
@@ -33,14 +33,14 @@ Container Platform 4 on RHEL CoreOS 8_.
 
 ** For more information, see the xref:../../cnv/cnv_node_network/cnv-observing-node-network-state.adoc#cnv-about-nmstate_cnv-observing-node-network-state[node networking] chapter.
 
-[id="cnv-2-3-storage-new"]
+[id="cnv-2-4-storage-new"]
 === Storage
 
 * You can now import, upload, and clone virtual machine disks into namespaces that are subject to CPU and memory resource restrictions.
 
 * The `virtctl` tool can now monitor server-side upload post-processing asynchronously and more accurately reports the status of xref:../../cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-uploading-local-disk-images-virtctl.adoc#cnv-uploading-local-disk-images-virtctl[virtual machine disk uploads].
 
-[id="cnv-2-3-web-new"]
+[id="cnv-2-4-web-new"]
 === Web console
 
 * You can now view the *Paused* status of a virtual machine in the web console. The web console displays this status on the *Virtual Machines* dashboard and on the *Virtual Machine Details* page. +
@@ -71,7 +71,7 @@ resources, you ensure that your virtual machine's workload runs on CPUs that
 are not used by other processes. This can improve your virtual machine's performance
 and the accuracy of latency predictions.
 
-[id="cnv-2-3-changes"]
+[id="cnv-2-4-changes"]
 == Notable technical changes
 
 * You must deploy {CNVProductName} in a single namespace that is named
@@ -98,7 +98,7 @@ To confirm that uninstallation is paused due to a pending object, view the
 xref:../../cnv/cnv_logging_events_monitoring/cnv-events.adoc#cnv-viewing-vm-events-web_cnv-events[*Events*] tab.
 ====
 
-[id="cnv-2-3-known-issues"]
+[id="cnv-2-4-known-issues"]
 == Known issues
 
 * KubeMacPool is disabled in {CNVProductName} {CNVVersion}. This means that a secondary


### PR DESCRIPTION
Converting CNV release notes from master style to version style, as is the way of the Tiger aka OCP
#22089 handled master branch

@lmandavi re: what I was talking about in the meeting. I've updated the section id's with the next version but otherwise no changes to the release notes, which has been copied over from 2.3 (enterprise4.4) 
@vikram-redhat 