### PR TITLE
[cnv] adding empty toc-title var to cnv attributes

### DIFF
--- a/modules/cnv-document-attributes.adoc
+++ b/modules/cnv-document-attributes.adoc
@@ -2,6 +2,7 @@
 //
 // The following are shared by all documents:
 :toc:
+:toc-title:
 :toclevels: 4
 :experimental:
 //


### PR DESCRIPTION
Adding empty `:toc-title:` variable to the CNV-specific attributes file so that the "Table of Contents" header is omitted from CNV assemblies.

@vikram-redhat should I cherrypick this to previous versions as well?
(edited to add: this file exists as far back as 3.11, but it was named cnv_document_attributes.adoc in 3.11.)