### PR TITLE
Adding toc-title to attributes files

### DIFF
--- a/modules/jaeger-document-attributes.adoc
+++ b/modules/jaeger-document-attributes.adoc
@@ -3,6 +3,7 @@
 // The following are shared by all RH Build of Jaeger documents:
 :toc:
 :toclevels: 4
+:toc-title: 
 :experimental:
 //
 // Product content attributes, that is, substitution variables in the files.

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -3,6 +3,7 @@
 // The following are shared by all RHOSSM documents:
 :toc:
 :toclevels: 4
+:toc-title:
 :experimental:
 //
 // Product content attributes, that is, substitution variables in the files.


### PR DESCRIPTION
Fixes issue of having "Table of Contents" above the mini-tocs.

Cherry pick to 4.3, 4.4, and 4.5.

