### PR TITLE
BZ1782386 - Clarify vSphere infra reqs in OCP 4.2

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -6,24 +6,31 @@
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
-You must install the {product-title} cluster on a VMware vSphere version 6.5
-or 6.7U2 or later instance.
+You must install the {product-title} cluster on a VMware vSphere version that meets the requirements for the components that you use.
 
-VMware recommends using vSphere Version 6.7 U2 or later with your {product-title}
-cluster.
-vSphere 6.7U2 includes:
+If you use a vSphere version 6.5 instance, consider upgrading to 6.7 before you install {product-title}.
 
-* Support for VMware NSX-T
-* Support for vSAN, VMFS and NFS, using the in-tree VCP
+.Minimum supported vSphere version for VMware components
+|===
+|Component | Minimum supported versions |Description
 
-While vSphere 6.5 with Hardware version 13 is supported, {product-title}
-clusters are subject to the following restrictions:
+|Hypervisor
+|vSphere 6.5 with HW version 13
+|This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
-* NSX-T SDN is not supported.
-* You must use another SDN or storage provider that {product-title} supports.
+|Networking (NSX-T)
+|n/a
+|vSphere 6.5 or vSphere 6.7U2+ are required for {product-title}. Because previous versions of vSphere with NSX-T are not currently compatible with {product-title}, NSX-T is not supported. NSX-T certification is in process and will be supported in a future release.
 
-If you use a vSphere version 6.5 instance, consider upgrading to 6.7U2 before
-you install {product-title}.
+|Storage with in-tree drivers
+|vSphere 6.5 or vSphere 6.7
+|This plug-in creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title} and can be used when vSphere CSI drivers are not available.
+
+|Storage with vSphere CSI driver
+|vSphere 6.7U3 and later
+|This plug-in creates vSphere storage by using the standard Container Storage Interface. The vSphere CSI driver is provided and supported by VMware.
+
+|===
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Fix for [BZ1782386](https://bugzilla.redhat.com/show_bug.cgi?id=1782386) to clarify wording and support for NSX-T. This relates closely to PR [19866](https://github.com/openshift/openshift-docs/pull/19866). I've opened this against 4.2 branch only with one small difference from that PR, based on this comment: https://github.com/openshift/openshift-docs/pull/19866#issuecomment-628774240:

line 21 | `vSphere 6.5 or vSphere 6.7U2+ are required` (leaving out `U3` for 6.5 so that we are not updating the min version on older versions that we still support).