### PR TITLE
[cnv] adding empty toc-title var to cnv attributes

### DIFF
--- a/modules/cnv_document_attributes.adoc
+++ b/modules/cnv_document_attributes.adoc
@@ -2,6 +2,7 @@
 //
 // The following are shared by all documents:
 :toc:
+:toc-title:
 :toclevels: 4
 :experimental:
 //


### PR DESCRIPTION
Adding empty `:toc-title:` variable to the CNV-specific attributes file so that the "Table of Contents" header is omitted from CNV assemblies.

@vikram-redhat 