### PR TITLE
Specify 'fluentd' secret name instead of elasticsearch in LogForwarding example

### DIFF
--- a/modules/cluster-logging-collector-log-forward-configure.adoc
+++ b/modules/cluster-logging-collector-log-forward-configure.adoc
@@ -29,7 +29,7 @@ spec:
      type: "elasticsearch"
      endpoint: elasticsearch.openshift-logging.svc:9200
      secret:
-        name: elasticsearch
+        name: fluentd
    - name: elasticsearch-insecure
      type: "elasticsearch"
      endpoint: elasticsearch-insecure.svc.messaging.cluster.local
@@ -61,7 +61,7 @@ spec:
 * Specify the type of output, either `elasticseach` or `forward`.
 * Enter a name for the output.
 * Enter the endpoint, either the server name or FQDN.
-* Optionally, enter the name of the secret required by the endpoint for TLS communication. The secret must exist in the openshift-logging project.
+* Optionally, enter the name of the secret required by the endpoint for TLS communication. The secret must exist in the openshift-logging project. For the default Elastiscearch logstore, use `fluentd` as the secret name.
 * Specify `insecure: true` if the endpoint does not use a secret, resulting in insecure communication.
 <5> Add one or more pipelines:
 * Enter a name for the pipeline


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1835708