### PR TITLE
Fix the command to get csv

### DIFF
--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -231,7 +231,7 @@ The Cluster Logging Operator is installed to the `openshift-logging` Namespace.
 There should be a Cluster Logging Operator in the `openshift-logging` Namespace. The Version number might be different than shown.
 +
 ----
-oc get csv --openshift-logging
+oc get csv -n openshift-logging
 
 NAMESPACE                                               NAME                                         DISPLAY                  VERSION               REPLACES   PHASE
 ...


### PR DESCRIPTION
To get csvs within the openshift-logging namespace, we need to use
`oc get csv -n openshift-logging` format

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>