### PR TITLE
rhv-download-rhcos-image: simplify download procedure

### DIFF
--- a/modules/installing-rhv-downloading-rhcos-image.adoc
+++ b/modules/installing-rhv-downloading-rhcos-image.adoc
@@ -20,22 +20,14 @@ IMPORTANT: Do not substitute the {op-system} image specified by these instructio
 $ mkdir rhcos
 $ cd rhcos
 ----
-
-. In a browser, go to link:https://github.com/openshift/installer/blob/release-4.4/data/data/rhcos.json[].
-. In `rhcos.json`, find `baseURI` and copy its value.
-. On the Manager, start a `wget` command and paste the value of `baseURI` but *do not press kbd:[Enter]*. For example:
++
+Find the URL of the latest {op-system} image and download it
 +
 ----
-$ wget https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4/44.81.202003062006-0/x86_64/
-----
-. In `rhcos.json` document, find `openstack` and copy the value of `path`.
-. On the Manager, paste the value of `path`. For example:
-+
-----
-$ wget https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4/44.81.202003062006-0/x86_64/rhcos-44.81.202003062006-0-openstack.x86_64.qcow2.gz
+$ RHCOS_QCOW=$(wget -q -O - https://raw.githubusercontent.com/openshift/installer/release-4.4/data/data/rhcos.json | jq -r '.baseURI+.images.openstack.path')
+$ wget $RHCOS_QCOW
 ----
 +
-. Press kbd:[Enter] and wait for `wget` to finish downloading the {op-system} image.
 . Unzip the {op-system} image. For example:
 +
 ----


### PR DESCRIPTION
I was fooled by the partial build of the `wget` command line, as I did not
notice the request not to press Enter. This patch builds the QCOW URL in
one go with less user involvement

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

/cc @rgolangh @rolfedh 