### PR TITLE
OSDOCS-1038: Adding new descheduler policy to release notes

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -62,7 +62,16 @@ link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShif
 This release adds improvements related to the following components and concepts.
 
 
+[id="ocp-4-5-nodes"]
+=== Nodes
 
+[id="ocp-4-5-descheduler-policy"]
+==== New descheduler strategy is available (Technology Preview)
+
+The descheduler now allows you to configure the `RemovePodsHavingTooManyRestarts` strategy. This strategy ensures that Pods that have been restarted too many times are removed from nodes.
+
+See xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler-strategies_nodes-descheduler[Descheduler strategies]
+for more information.
 
 [id="ocp-4-5-notable-technical-changes"]
 == Notable technical changes


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~ahoffer/2020/OSDOCS-1038-rn/release_notes/ocp-4-5-release-notes.html#ocp-4-5-nodes