### PR TITLE
OSDOCS-1082: Bumping kube version to 1.18

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -24,7 +24,7 @@ compliance, and governance requirements.
 
 Red Hat {product-title}
 (link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234]) is now
-available. This release uses link:https://v1-17.docs.kubernetes.io/docs/setup/release/notes/[Kubernetes 1.17] with CRI-O runtime. New features, changes, and known issues that pertain to
+available. This release uses link:https://v1-18.docs.kubernetes.io/docs/setup/release/notes/[Kubernetes 1.18] with CRI-O runtime. New features, changes, and known issues that pertain to
 {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.4.0 as the GA version and,


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~ahoffer/2020/OSDOCS-1082-kube-rn/release_notes/ocp-4-5-release-notes.html