### PR TITLE
modules/understanding-upgrade-channels: Recommend clearing channel

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -21,6 +21,8 @@ ifndef::openshift-origin[]
 * `stable-{product-version}`
 * `eus-4.6` (only available when running 4.6)
 
+If you do not want the Cluster Version Operator to fetch available updates from the upgrade recommendation service, you can use the `oc adm upgrade channel` command in the OpenShift CLI to configure an empty channel. This configuration can be helpful if, for example, a cluster has restricted network access and there is no local, reachable upgrade recommendation service.
+
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 {product-title} {product-version} offers the following upgrade channel:

--- a/updating/updating-cluster-between-minor.adoc
+++ b/updating/updating-cluster-between-minor.adoc
@@ -9,7 +9,7 @@ You can update, or upgrade, an {product-title} cluster between minor versions.
 
 [NOTE]
 ====
-Because of the difficulty of changing update channels by using `oc`, use the web console to change the update channel. It is recommended to complete the update process within the web console. You can follow the steps in xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] to complete the update after you change to a {product-version} channel.
+Use the web console or `oc adm upgrade channel _<channel>_` to change the update channel. You can follow the steps in xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] to complete the update after you change to a {product-version} channel.
 ====
 
 == Prerequisites


### PR DESCRIPTION
I would prefer to configure this by clearing the `upstream` setting, which seems more intuitive for "there is no upstream" to me.  But sadly, it seems that the CVO has been falling back to a default URI when the ClusterVersion upstream is empty since [way][1] [back][2], and that this behavior is [enshrined in the API][3].  Although the channel docs also [talk about defaults][4], the only channel defaulting in the CVO is when creating a ClusterVersion object after the in-cluster copy was (accidentally?) [deleted][4].  So maybe we could talk folks into adjusting the CVO logic to return `NoUpstream` in the empty-upstream case, but at the moment, clearing the channel is the best approach for "the CVO keeps complaining that it can't hit the upstream, and I want to quiet it down" (rhbz#1827378)[5].

[1]: https://github.com/openshift/cluster-version-operator/blame/2c4931dc283c551938be1a00fee290de0b79d99c/pkg/cvo/availableupdates.go#L27-L31
[2]: https://github.com/openshift/cluster-version-operator/commit/ab4d84a021c38fea5e5973287e1f5580928907c1#diff-78f2af341fa49292dd6930f378018867R24
[3]: https://github.com/openshift/api/blame/0422dc17083e9e8df18d029f3f34322e96e9c326/config/v1/types_cluster_version.go#L56-L57
[4]: https://github.com/openshift/api/blame/0422dc17083e9e8df18d029f3f34322e96e9c326/config/v1/types_cluster_version.go#L62-L63
[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1827378