### PR TITLE
Update oc installation to include instructions by OS

### DIFF
--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -28,8 +28,8 @@
 [id="cli-installing-cli_{context}"]
 = Installing the CLI by downloading the binary
 
-You can install the CLI in order to interact with {product-title} using a
-command-line interface.
+You can install the OpenShift CLI (`oc`) in order to interact with {product-title} from a
+command-line interface. You can install `oc` on Linux, Windows, or macOS.
 
 [IMPORTANT]
 ====
@@ -38,25 +38,96 @@ of the commands in {product-title} {product-version}. Download and
 install the new version of `oc`.
 ====
 
+[id="cli-installing-cli-on-linux_{context}"]
+== Installing the CLI on Linux
+
+You can install the OpenShift CLI (`oc`) binary on Linux by using the following procedure.
+
 .Procedure
+
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system
-. Download `oc.tar.gz`
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
-. From the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site, navigate to the page for your installation type and
-click *Download Command-line Tools*.
+. Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
+. Select your infrastructure provider, and, if applicable, your installation type.
+. In the *Command-line interface* section, select *Linux* from the drop-down menu and click *Download command-line tools*.
 endif::[]
-. Click the folder for your operating system and architecture and click the
-compressed file.
+. Unpack the archive:
 +
-[NOTE]
-====
-You can install `oc` on Linux, Windows, or macOS.
-====
-. Save the file to your file system.
-. Extract the compressed file.
-. Place it in a directory that is on your `PATH`.
+----
+$ tar xvzf <file>
+----
+. Place the `oc` binary in a directory that is on your `PATH`.
++
+To check your `PATH`, execute the following command:
++
+----
+$ echo $PATH
+----
+
+After you install the CLI, it is available using the `oc` command:
+
+----
+$ oc <command>
+----
+
+[id="cli-installing-cli-on-windows_{context}"]
+== Installing the CLI on Windows
+
+You can install the OpenShift CLI (`oc`) binary on Windows by using the following procedure.
+
+.Procedure
+
+ifdef::openshift-origin[]
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.zip`.
+endif::[]
+ifndef::openshift-origin[]
+. Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
+. Select your infrastructure provider, and, if applicable, your installation type.
+. In the *Command-line interface* section, select *Windows* from the drop-down menu and click *Download command-line tools*.
+endif::[]
+. Unzip the archive with a ZIP program.
+. Move the `oc` binary to a directory that is on your `PATH`.
++
+To check your `PATH`, open the command prompt and execute the following command:
++
+----
+C:\> path
+----
+
+After you install the CLI, it is available using the `oc` command:
+
+----
+C:\> oc <command>
+----
+
+[id="cli-installing-cli-on-macos_{context}"]
+== Installing the CLI on macOS
+
+You can install the OpenShift CLI (`oc`) binary on macOS by using the following procedure.
+
+.Procedure
+
+ifdef::openshift-origin[]
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Download `oc.tar.gz`.
+endif::[]
+ifndef::openshift-origin[]
+. Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
+. Select your infrastructure provider, and, if applicable, your installation type.
+. In the *Command-line interface* section, select *MacOS* from the drop-down menu and click *Download command-line tools*.
+endif::[]
+. Unpack and unzip the archive.
+. Move the `oc` binary to a directory on your PATH.
++
+To check your `PATH`, open a terminal and execute the following command:
++
+----
+$ echo $PATH
+----
 
 After you install the CLI, it is available using the `oc` command:
 


### PR DESCRIPTION
Preview:

* https://pr-21346-updates--ocpdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands (OCP)
* https://pr-21346-updates--ocpdocs.netlify.app/openshift-origin/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands (OKD)

Replaces #21346.