### PR TITLE
Correct spec.maturity definition and add spec.capabilities

### DIFF
--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -22,6 +22,10 @@ generation when a lack of data in any of the required fields is detected.
 |A unique name for this CSV. Operator version should be included in the name to
 ensure uniqueness, for example `app-operator.v0.1.1`.
 
+|`metadata.capabilities`
+|The Operator's capability level according to the Operator maturity model, for
+example `Seamless Upgrades`.
+
 |`spec.displayName`
 |A public name to identify the Operator.
 
@@ -75,8 +79,8 @@ application being managed, each with a `name` and `url`.
 a `mediatype`.
 
 |`spec.maturity`
-|The Operator's capability level according to the Operator maturity model, for
-example `Seamless Upgrades`.
+|The level of maturity the software has achieved at this version, for
+example `alpha`, `beta`, `stable`.
 |===
 
 Further details on what data each field above should hold are found in the


### PR DESCRIPTION
Correct spec.maturity definition [1] and add spec.capabilities [2].

[1] https://github.com/operator-framework/operator-lifecycle-manager/blob/master/deploy/upstream/manifests/0.13.0/0000_50_olm_03-clusterserviceversion.crd.yaml#L145-L156

[2] https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#required-fields-for-operatorhub

