### PR TITLE
document creation of api-int dns record

### DIFF
--- a/modules/installing-rhv-preparing-the-network-environment.adoc
+++ b/modules/installing-rhv-preparing-the-network-environment.adoc
@@ -26,6 +26,7 @@ $ arp 10.35.1.19
 +
 ----
 api.<cluster-name>.<base-domain>   <ip-address> <1>
+api-int.<cluster-name>.<base-domain>   <ip-address> <1>
 *.apps.<cluster-name>.<base-domain>   <ip-address> <2>
 ----
 <1> For `<cluster-name>`, `<base-domain>`, and `<ip-address>`, specify the cluster name, base domain, and static IP address of your {product-title} API.
@@ -35,6 +36,7 @@ For example:
 +
 ----
 api.my-cluster.virtlab.example.com	10.35.1.19
+api-int.my-cluster.virtlab.example.com	10.35.1.19
 *.apps.my-cluster.virtlab.example.com	10.35.1.20
 ----
 +


### PR DESCRIPTION
In order for the installation to complete, the nodes must be able to resolve api-int.<cluster-name>.<base-domain>  as well as api.<cluster-name>.<base-domain>.