### PR TITLE
tkn installation instructions on RHEL using RPM

### DIFF
--- a/cli_reference/tkn_cli/installing-tkn.adoc
+++ b/cli_reference/tkn_cli/installing-tkn.adoc
@@ -13,6 +13,9 @@ You can also find the URL to the latest binaries from the {product-title} web co
 // Install tkn on Linux
 include::modules/op-installing-tkn-on-linux.adoc[leveloffset=+1]
 
+// Install tkn on Linux using RPM
+include::modules/op-installing-tkn-on-linux-using-rpm.adoc[leveloffset=+1]
+
 //Install tkn on Windows
 include::modules/op-installing-tkn-on-windows.adoc[leveloffset=+1]
 

--- a/modules/op-installing-pipelines-operator-using-the-cli.adoc
+++ b/modules/op-installing-pipelines-operator-using-the-cli.adoc
@@ -23,7 +23,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel:  <channel name> <1>
-  name: openshift-pipelines-operator <2>
+  name: openshift-pipelines-operator-rh <2>
   source: redhat-operators <3>
   sourceNamespace: openshift-marketplace <4>
 ----

--- a/modules/op-installing-tkn-on-linux-using-rpm.adoc
+++ b/modules/op-installing-tkn-on-linux-using-rpm.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/tkn_cli/installing-tkn.adoc
+
+[id="installing-tkn-on-linux-using-rpm"]
+
+= Installing {pipelines-title} CLI (tkn) on Linux using an RPM
+
+For {op-system-base-full} version 8, you can install the {pipelines-title} CLI (`tkn`) as an RPM.
+
+.Prerequisites
+
+* You have an active {product-title} subscription on your Red Hat account.
+* You have root or sudo privileges on your local system.
+
+.Procedure
+
+. Register with Red Hat Subscription Manager:
++
+----
+# subscription-manager register
+----
+
+. Pull the latest subscription data:
++
+----
+# subscription-manager refresh
+----
+
+. List the available subscriptions:
++
+----
+# subscription-manager list --available --matches '*pipelines*'
+----
+
+. In the output for the previous command, find the pool ID for your {product-title} subscription and attach the subscription to the registered system:
++
+----
+# subscription-manager attach --pool=<pool_id>
+----
+
+. Enable the repositories required by {pipelines-title}:
++
+----
+# subscription-manager repos --enable="pipelines-1.0-for-rhel-8-x86_64-rpms"
+----
+
+. Install the `openshift-pipelines-client` package:
++
+----
+# yum install openshift-pipelines-client
+----
+
+After you install the CLI, it is available using the `tkn` command:
+
+----
+$ tkn version
+----


### PR DESCRIPTION
This module captures the installation instructions for `tkn` on RHEL  using RPM.

Targeted for OCP 4.4 and 4.5. 

The PR is reviewed and approved by QE. 