### PR TITLE
Imagestream tags

### DIFF
--- a/migration/migrating_3_4/migrating-applications-with-cam.adoc
+++ b/migration/migrating_3_4/migrating-applications-with-cam.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate application workloads by adding your clusters and replication repository to the CAM web console. Then you can create and run a migration plan.
+You can migrate application workloads by adding your clusters and replication repository to the CAM web console. Then, you can create and run a migration plan.
 
 If your cluster or replication repository are secured with self-signed certificates, you can create a CA certificate bundle file or disable SSL verification.
 

--- a/migration/migrating_4_1_4/migrating-applications-with-cam.adoc
+++ b/migration/migrating_4_1_4/migrating-applications-with-cam.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate application workloads by adding your clusters and replication repository to the CAM web console. Then you can create and run a migration plan.
+You can migrate application workloads by adding your clusters and replication repository to the CAM web console. Then, you can create and run a migration plan.
 
 If your cluster or replication repository are secured with self-signed certificates, you can create a CA certificate bundle file or disable SSL verification.
 

--- a/migration/migrating_4_2_4/migrating-applications-with-cam.adoc
+++ b/migration/migrating_4_2_4/migrating-applications-with-cam.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate application workloads by adding your clusters and replication repository to the CAM web console. Then you can create and run a migration plan.
+You can migrate application workloads by adding your clusters and replication repository to the CAM web console. Then, you can create and run a migration plan.
 
 If your cluster or replication repository are secured with self-signed certificates, you can create a CA certificate bundle file or disable SSL verification.
 

--- a/modules/migration-creating-ca-bundle.adoc
+++ b/modules/migration-creating-ca-bundle.adoc
@@ -5,7 +5,7 @@
 [id='creating-ca-bundle_{context}']
 = Creating a CA certificate bundle file
 
-If you use a self-signed certificate to secure a cluster or a replication repository, certificate verification may fail with the following error message: `Certificate signed by unknown authority`.
+If you use a self-signed certificate to secure a cluster or a replication repository, certificate verification might fail with the following error message: `Certificate signed by unknown authority`.
 
 You can create a custom CA certificate bundle file and upload it in the CAM web console when you add a cluster or a replication repository.
 

--- a/modules/migration-prerequisites.adoc
+++ b/modules/migration-prerequisites.adoc
@@ -13,12 +13,14 @@ endif::[]
 * You must have `cluster-admin` privileges on all clusters.
 * The source and target clusters must have unrestricted network access to the replication repository.
 * The cluster on which the Migration controller is installed must have unrestricted access to the other clusters.
-ifdef::migrating-3-4,migrating-4_1-4_x[]
+ifdef::migrating-3-4,migrating-4_1-4_x,migrating-4_2-4_x[]
 * If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
 +
 If the required images are not present, you must update the `imagestreamtags` references to use an available version that is compatible with your application. If the `imagestreamtags` cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to reference them.
+endif::[]
+ifdef::migrating-3-4,migrating-4_1-4_x[]
 +
-The following `imagestreamtags` have been _removed_ from {product-title} {product-version}:
+The following `imagestreamtags` have been _removed_ from {product-title} 4.2:
 
 ** `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
 ** `dotnet-runtime:2.0`
@@ -32,4 +34,16 @@ The following `imagestreamtags` have been _removed_ from {product-title} {produc
 ** `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
 ** `python:3.3`, `python:3.4`
 ** `ruby:2.0`, `ruby:2.2`
+endif::[]
+ifdef::migrating-3-4,migrating-4_1-4_x,migrating-4_2-4_x[]
++
+The following `imagestreamtags` have been _removed_ from {product-title} 4.4:
+
+** `dotnet: 2.2`
+** `dotnet-runtime: 2.2`
+** `nginx: 1.12`
+** `nodejs: 8, 8-RHOAR, 10-SCL`
+** `perl:5.24`
+** `php: 7.0, 7.1`
+** `redis: 3.2`
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1818790

CP for 4.2, 4.3, 4.4, 4.5

Changed sections:

https://imagestream-tags--ocpdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/migrating-application-workloads-3-to-4.html#migration-prerequisites_migrating-3-4

https://imagestream-tags--ocpdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_1_4/migrating-application-workloads-4_1-to-4.html#migration-prerequisites_migrating-4_1-4_x

https://imagestream-tags--ocpdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_2_4/migrating-application-workloads-4_2-to-4.html#migration-prerequisites_migrating-4_2-4_x