### PR TITLE
[enterprise-4.2] Enable schema1 support in configured registries

### DIFF
--- a/modules/installation-creating-mirror-registry.adoc
+++ b/modules/installation-creating-mirror-registry.adoc
@@ -101,6 +101,7 @@ OpenSSL documentation.
      -v /opt/registry/certs:/certs:z \
      -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
      -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+     -e REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true \
      -d docker.io/library/registry:2
 ----
 <1> For `<local_registry_host_port>`, specify the port that your mirror registry


### PR DESCRIPTION
Many historically-published images in Quay.io use the schema1 format,
and both (oc image mirror) and (podman push) fail when pushing schema1
images to registries that reject schema1 (and even if they didn't fail,
the push would modify the manifest digest, which is inconsistent with
our disconnected operation design and the general desire to use
manifest digests for iamge references).

Signed-off-by: Miloslav Trmač <mitr@redhat.com>

From https://github.com/openshift/openshift-docs/pull/22158