### PR TITLE
update nodejs version

### DIFF
--- a/using_images/other_images/jenkins_slaves.adoc
+++ b/using_images/other_images/jenkins_slaves.adoc
@@ -28,7 +28,7 @@ The first is a link:https://github.com/openshift/jenkins/tree/master/slave-base[
 Two more images that extend the base image are also provided:
 
 * link:https://github.com/openshift/jenkins/tree/master/agent-maven-3.5[Maven v3.5 image]
-* link:https://github.com/openshift/jenkins/tree/master/agent-nodejs-12[Node.js v12 image]
+* link:https://github.com/openshift/jenkins/tree/master/agent-nodejs-10[Node.js v10 image] and link:https://github.com/openshift/jenkins/tree/master/agent-nodejs-12[Node.js v12 image]
 
 The Maven and Node.js Jenkins agent images provide Dockerfiles for both CentOS
 and RHEL that you can reference when building new agent images. Also note the
@@ -58,6 +58,7 @@ $ docker pull registry.redhat.io/openshift3/jenkins-slave-base-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-maven-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-nodejs-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-agent-maven-35-rhel7
+$ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-10-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-12-rhel7
 ----
 endif::[]
@@ -74,6 +75,7 @@ $ docker pull registry.redhat.io/openshift3/jenkins-slave-base-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-maven-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-nodejs-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-agent-maven-35-rhel7
+$ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-10-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-12-rhel7
 ----
 
@@ -86,6 +88,7 @@ $ docker pull openshift/jenkins-slave-base-centos7
 $ docker pull openshift/jenkins-slave-maven-centos7
 $ docker pull openshift/jenkins-slave-nodejs-centos7
 $ docker pull openshift/jenkins-agent-maven-35-centos7
+$ docker pull openshift/jenkins-agent-nodejs-10-centos7
 $ docker pull openshift/jenkins-agent-nodejs-12-centos7
 ----
 

--- a/using_images/other_images/jenkins_slaves.adoc
+++ b/using_images/other_images/jenkins_slaves.adoc
@@ -28,7 +28,7 @@ The first is a link:https://github.com/openshift/jenkins/tree/master/slave-base[
 Two more images that extend the base image are also provided:
 
 * link:https://github.com/openshift/jenkins/tree/master/agent-maven-3.5[Maven v3.5 image]
-* link:https://github.com/openshift/jenkins/tree/master/agent-nodejs-8[Node.js v8 image]
+* link:https://github.com/openshift/jenkins/tree/master/agent-nodejs-12[Node.js v12 image]
 
 The Maven and Node.js Jenkins agent images provide Dockerfiles for both CentOS
 and RHEL that you can reference when building new agent images. Also note the
@@ -58,7 +58,7 @@ $ docker pull registry.redhat.io/openshift3/jenkins-slave-base-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-maven-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-nodejs-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-agent-maven-35-rhel7
-$ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-8-rhel7
+$ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-12-rhel7
 ----
 endif::[]
 
@@ -74,7 +74,7 @@ $ docker pull registry.redhat.io/openshift3/jenkins-slave-base-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-maven-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-slave-nodejs-rhel7
 $ docker pull registry.redhat.io/openshift3/jenkins-agent-maven-35-rhel7
-$ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-8-rhel7
+$ docker pull registry.redhat.io/openshift3/jenkins-agent-nodejs-12-rhel7
 ----
 
 *CentOS 7 Based Images*
@@ -86,7 +86,7 @@ $ docker pull openshift/jenkins-slave-base-centos7
 $ docker pull openshift/jenkins-slave-maven-centos7
 $ docker pull openshift/jenkins-slave-nodejs-centos7
 $ docker pull openshift/jenkins-agent-maven-35-centos7
-$ docker pull openshift/jenkins-agent-nodejs-8-centos7
+$ docker pull openshift/jenkins-agent-nodejs-12-centos7
 ----
 
 To use these images, you can either access them directly from these registries


### PR DESCRIPTION
This PR updates the node.js version from 8 to 12 in the 3.11 version of docs.