### PR TITLE
Bug 1827550: Add the empty node selector namespace annotation when installing Metering.

### DIFF
--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -82,22 +82,25 @@ spec:
   reporting-operator:
     spec:
       nodeSelector:
-        "node-role.kubernetes.io/infra": "true"
+        "node-role.kubernetes.io/infra": "" <1>
 
   presto:
     spec:
       coordinator:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": "" <1>
       worker:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": "" <1>
   hive:
     spec:
       metastore:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": "" <1>
       server:
         nodeSelector:
-          "node-role.kubernetes.io/infra": "true"
+          "node-role.kubernetes.io/infra": "" <1>
 ----
+
+// note: this was mirrored from the cluster-logging-operator's node-selector description
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.

--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -8,11 +8,41 @@
 
 .Procedure
 
+
+
+. Create a Namespace for the Metering Operator:
+
+.. Create a Namespace object YAML file (for example, `metering-namespace.yaml`) for the Metering Operator:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-metering <1>
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+----
+<1> Set the name to `openshift-metering`. No other namespace is supported.
+
+.. Create the Namespace:
++
+----
+$ oc create -f <file-name>.yaml
+----
++
+For example:
++
+----
+$ oc create -f metering-namespace.yaml
+----
 . In the {product-title} web console,  click *Operators* -> *OperatorHub*, and filter for `metering` to find the
 Metering Operator.
-
 . Click the Metering card, review the package description, and then click *Install*.
-. Select an *Update Channel*, *Installation Mode*, and *Approval Strategy*.
+. Select the Operator recommended namespace, *openshift-metering*.
+. Select an *Update Channel* and *Approval Strategy*.
 . Click *Subscribe*.
 
 . On the *Installed Operators* screen, the *Status* displays *Succeeded* when the Metering Operator finishes installation. Click the name of the Operator in the first column to view the *Operator Details* page.


### PR DESCRIPTION
The metering-operator recently had a BZ filed where the `defaultNodeSelector`, if configured, in the cluster-wide Pod Scheduler object would inject that node selector to all of the Pods in the metering stack. In the case where a user configured a MeteringConfig custom resource to place each of the metering-operator's operands on a specific set of node selectors, this could potentially collide with the cluster-wide default set of node selectors.

If we add this empty openshift.io/node-selector namespace annotation, it will override the cluster-wide default node selector configuration.