### PR TITLE
OSDOCS-963 - CSI AWS EBS Operator (TP)

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -620,6 +620,8 @@ Topics:
     File: persistent-storage-csi-cloning
   - Name: OpenStack Manila CSI Driver Operator
     File: persistent-storage-csi-manila
+  - Name: AWS Elastic Block Store CSI Driver Operator
+    File: persistent-storage-csi-ebs
 - Name: Expanding persistent volumes
   File: expanding-persistent-volumes
   Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated

--- a/modules/persistent-storage-csi-ebs-operator-install-driver.adoc
+++ b/modules/persistent-storage-csi-ebs-operator-install-driver.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+
+[id="persistent-storage-csi-ebs-operator-install-driver_{context}"]
+= Installing the AWS Elastic Block Store CSI driver
+
+The AWS Elastic Block Store (EBS) Container Storage Interface (CSI) driver is a custom resource (CR) that enables you to create and mount AWS EBS persistent volumes.
+
+The driver is not installed in {product-title} by default, and must be installed after the AWS EBS CSI Driver Operator has been installed.
+
+.Prerequisites
+
+* The AWS EBS CSI Driver Operator has been installed.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+To install the AWS EBS CSI driver from the web console, complete the following steps:
+
+. Log in to the {product-title} web console.
+
+. Navigate to *Operators* -> *Installed Operators*.
+
+. Locate the *AWS EBS CSI Driver Operator* from the list and click on the Operator link.
+
+. Create the driver:
+.. From the *Details* tab, click *Create Instance*.
+
+.. Optional: Select *YAML view* to make modifications, such as adding notations, to the driver object template.
+
+.. Click *Create* to finalize.
++
+[IMPORTANT]
+====
+Renaming the cluster and specifying a certain namespace are not supported functions.
+====

--- a/modules/persistent-storage-csi-ebs-operator-install.adoc
+++ b/modules/persistent-storage-csi-ebs-operator-install.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+
+[id="persistent-storage-csi-ebs-operator-install_{context}"]
+= Installing the AWS Elastic Block Store CSI Driver Operator
+
+The AWS Elastic Block Store (EBS) Container Storage Interface (CSI) Driver Operator enables the replacement of the existing AWS EBS in-tree storage plug-in.
+
+[IMPORTANT]
+====
+AWS EBS CSI Driver Operator is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production.
+====
+
+Installing the AWS EBS CSI Driver Operator provides the CSI driver that allows you to use CSI volumes with the `PersistentVolumeClaims`, `PersistentVolumes`, and `StorageClasses` API objects in {product-title}. It also deploys the StorageClass that you can use to create persistent volume claims (PVCs).
+
+The AWS EBS CSI Driver Operator is not installed in {product-title} by default. Use the following procedure to install and configure this Operator to enable the AWS EBS CSI driver in your cluster.
+
+.Prerequisites
+* Access to the {product-title} web console.
+
+.Procedure
+To install the AWS EBS CSI Driver Operator from the web console:
+
+. Log in to the web console.
+
+. Navigate to *Operators* -> *OperatorHub*.
+
+. To locate the AWS EBS CSI Driver Operator, type *AWS EBS CSI* into the filter box.
+
+. Click *Install*.
+
+. On the *Install Operator* page, be sure that *All namespaces on the cluster (default)* is selected. Select *openshift-aws-ebs-csi-driver-operator* from the *Installed Namespace* drop-down menu.
+
+. Adjust the values for *Update Channel* and *Approval Strategy* to the values that you want.
+
+. Click *Install*.
+
+Once finished, the AWS EBS CSI Driver Operator is listed in the *Installed Operators* section of the web console.

--- a/modules/persistent-storage-csi-ebs-operator-uninstall.adoc
+++ b/modules/persistent-storage-csi-ebs-operator-uninstall.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+
+[id="persistent-storage-csi-ebs-operator-uninstall_{context}"]
+= Uninstalling the AWS Elastic Block Store CSI Driver Operator
+
+Before you uninstall the AWS EBS CSI Driver Operator, you must delete all persistent volume claims (PVCs) that are in use by the Operator.
+
+.Prerequisites
+* Access to the {product-title} web console.
+
+.Procedure
+To uninstall the AWS EBS CSI Driver Operator from the web console:
+
+. Log in to the web console.
+
+. Navigate to *Storage* -> *Persistent Volume Claims*.
+
+. Select any PVCs that are in use by the AWS EBS CSI Driver Operator and click *Delete*.
+
+. From the *Operators* -> *Installed Operators* page, scroll or type *AWS EBS CSI* into the *Filter by name* field to find the Operator. Then, click on it.
+
+. On the right-hand side of the *Installed Operators* details page, select *Uninstall Operator* from the *Actions* drop-down menu.
+
+. When prompted by the *Uninstall Operator* window, click the *Uninstall* button to remove the Operator from the namespace. Any applications deployed by the Operator on the cluster will need to be cleaned up manually.
+
+Once finished, the AWS EBS CSI Driver Operator is no longer listed in the *Installed Operators* section of the web console.

--- a/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
@@ -1,0 +1,41 @@
+[id="persistent-storage-csi-ebs"]
+= AWS Elastic Block Store CSI Driver Operator
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-csi-ebs
+
+toc::[]
+
+== Overview
+
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic Block Store (EBS).
+
+Familiarity with link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/[PVs], link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[persistent volume claims (PVCs)], link:http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html[dynamic
+provisioning], and link:https://kubernetes.io/docs/admin/authorization/rbac/[RBAC authorization] is recommended.
+
+Before PVCs can be created, you must install the AWS EBS CSI Driver Operator. The Operator provides a default StorageClass that you can use to create PVCs. You also have the option to create the EBS StorageClass as described in xref:../../storage/persistent_storage/persistent-storage-aws.adoc#persistent-storage-aws[Persistent Storage Using AWS Elastic Block Store].
+
+After the Operator is installed, you must also create the AWS EBS CSI custom resource (CR) that is required in the {product-title} cluster.
+
+:FeatureName: AWS EBS CSI Driver Operator
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+== About CSI
+Storage vendors have traditionally provided storage drivers as part of Kubernetes. With the implementation of the Container Storage Interface (CSI), third-party providers can instead deliver storage plug-ins using a standard interface without ever having to change the core Kubernetes code.
+
+CSI Operators give {product-title} users storage options, such as volume snapshots, that are not possible with in-tree volume plug-ins.
+
+[IMPORTANT]
+====
+{product-title} defaults to using an in-tree, or non-CSI, driver to provision AWS EBS storage. This in-tree driver will be removed in a subsequent update of {product-title}. Volumes provisioned using the existing in-tree driver are planned for migration to the CSI driver at that time.
+====
+
+For information about dynamically provisioning AWS EBS persistent volumes in {product-title}, see xref:../../storage/persistent_storage/persistent-storage-aws.adoc#persistent-storage-aws[Persistent Storage Using AWS Elastic Block Store].
+
+include::modules/persistent-storage-csi-ebs-operator-install.adoc[leveloffset=+1]
+include::modules/persistent-storage-csi-ebs-operator-install-driver.adoc[leveloffset=+1]
+include::modules/persistent-storage-csi-ebs-operator-uninstall.adoc[leveloffset=+1]
+//include::modules/persistent-storage-csi-ebs-operator-install-driver.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../../storage/persistent_storage/persistent-storage-aws.adoc#persistent-storage-aws[Persistent Storage Using AWS Elastic Block Store]
+* xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]

--- a/storage/persistent_storage/persistent-storage-aws.adoc
+++ b/storage/persistent_storage/persistent-storage-aws.adoc
@@ -1,4 +1,4 @@
-[id="persistent-storage-using-aws-ebs"]
+[id="persistent-storage-aws"]
 = Persistent Storage Using AWS Elastic Block Store
 include::modules/common-attributes.adoc[]
 :context: persistent-storage-aws
@@ -26,12 +26,15 @@ storage provider.
 
 .Additional References
 
+* xref:../../storage/container_storage_interface/persistent-storage-csi-ebs.adoc#persistent-storage-csi-ebs[AWS Elastic Block Store CSI Driver Operator]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html[Amazon
 EC2]
 
 // Defining attributes required by the next module
 :StorageClass: EBS
 :Provisioner: kubernetes.io/aws-ebs
+
+include::modules/persistent-storage-csi-ebs-operator-install.adoc[leveloffset=+1]
 
 include::modules/storage-create-storage-class.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Work tracked in docs epic [OSDOCS-963](https://issues.redhat.com/browse/OSDOCS-963).

Preview links:

- *AWS Elastic Block Store CSI driver Operator*

https://osdocs-963--ocpdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ebs.html

^ Includes overview of CSI and note that we still support in-tree. Procedure describes how to install the Operator from console or CLI. 

**Note:** I wasn't able to 100% verify the steps because I couldn't locate AWS EBS driver Operator on 4.5 cluster-bot branch.

- *Persistent Storage Using AWS Elastic Block Store*

https://osdocs-963--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-aws.html

^ Added Install Operator procedure from console or CLI. 

**Note:** I wasn't able to 100% verify these steps because I couldn't locate AWS EBS Operator on 4.5 cluster-bot branch.