### PR TITLE
OSDOCS-933 - CSI Cloning GA

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-cloning.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-cloning.adoc
@@ -7,10 +7,6 @@ toc::[]
 
 Volume cloning duplicates an existing persistent volume to help protect against data loss in {product-title}. This feature is only available with supported Container Storage Interface (CSI) drivers. You should be familiar with xref:../../storage/understanding-persistent-storage.adoc#persistent-volumes_understanding-persistent-storage[persistent volumes] before you provision a CSI volume clone.
 
-:FeatureName: CSI volume cloning
-
-include::modules/technology-preview.adoc[leveloffset=+0]
-
 include::modules/persistent-storage-csi-cloning-overview.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-cloning-provisioning.adoc[leveloffset=+1]


### PR DESCRIPTION
Work tracked in [OSDOCS-933](https://issues.redhat.com/browse/OSDOCS-933).

Removes TP note from CSI Cloning doc. (In regards to Jira specs for this story, note that the previous 4.4 TP cloning doc mentions a few times that CSI cloning is only available for supported CSI drivers. The procedure for provisioning a cloned PVC remains unchanged.)

Preview build:
https://osdocs-933--ocpdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-cloning.html