### PR TITLE
CSS code font

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -775,7 +775,6 @@ table > tbody > tr > td > div > div > p > code {
      clear: both;
 }
  *:not(pre) > code {
-     padding: 0;
      white-space: nowrap;
      background-color: #e7e7e7;
      border: 0 solid #dddddd;
@@ -783,6 +782,9 @@ table > tbody > tr > td > div > div > p > code {
      border-radius: 0px;
      text-shadow: none;
      line-height: 1;
+     font-weight: 400; /* normal */
+     vertical-align: baseline;
+     padding: 2px 4px;
 }
  pre code {
      text-shadow: none;


### PR DESCRIPTION
This adjusts the styling for monospaced fonts. Use of the `<style>` tag is merely to demo the change; the actual modification must be made to `_stylesheets/docs.css`.

Example: http://file.bos.redhat.com/jboxman/css-code-font/css-code-font/welcome/index.html

Depends on rebasing against https://github.com/openshift/openshift-docs/pull/21760.

@lbarbeevargas FYI