### PR TITLE
Correcting parameter in RN known issue for BZ1810461

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -2048,7 +2048,7 @@ $ systemctl reboot
 
 * When using a self-signed {rh-openstack-first} 16 cluster, you cannot pull from
 or push to an internal image registry. As a workaround, you must set
-`spec.disableRedirect` to  `true` in the `configs.imageregistry/cluster` resource.
+`spec.disableRedirect` to `true` in the `configs.imageregistry/cluster` resource.
 This allows the client to pull the image layers from the image registry rather
 than from links directly from Swift.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1810461[*BZ#1810461*])

--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -2048,7 +2048,7 @@ $ systemctl reboot
 
 * When using a self-signed {rh-openstack-first} 16 cluster, you cannot pull from
 or push to an internal image registry. As a workaround, you must set
-`spec.disableRedirects = true` in the `configs.imageregistry/cluster` resource.
+`spec.disableRedirect` to  `true` in the `configs.imageregistry/cluster` resource.
 This allows the client to pull the image layers from the image registry rather
 than from links directly from Swift.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1810461[*BZ#1810461*])


### PR DESCRIPTION
From @Fedosin, this RN has a typo in it: 

> hi! we have a typo in the release notes: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-known-issues for BZ#1810461
>
> it says
> `spec.disableRedirects = true`
> 
> but the parameter is called disableRedirect

Source: https://github.com/openshift/api/blob/master/imageregistry/v1/types.go#L58