### PR TITLE
Bug 1804083: Explains requirements for deploying RHEL compute node

### DIFF
--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -52,8 +52,8 @@ link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index
 and the `disk.enableUUID=true` attribute must be set.
 
 * Each system must be able to access the cluster's API
-endpoints by using DNS resolvable host names. Any network security access control that is in place must allow the system access to the
-cluster's API service endpoints. 
+endpoints by using DNS-resolvable host names. Any network security access control that is in place must allow the system access to the
+cluster's API service endpoints.
 
 [id="csr-management-rhel_{context}"]
 == Certificate signing requests management

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -51,6 +51,10 @@ be configured according to its
 link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[storage guidelines]
 and the `disk.enableUUID=true` attribute must be set.
 
+* Each system must be able to access the cluster's API
+endpoints by using DNS resolvable host names. Any network security access control that is in place must allow the system access to the
+cluster's API service endpoints. 
+
 [id="csr-management-rhel_{context}"]
 == Certificate signing requests management
 


### PR DESCRIPTION
Misconfiguratoin of DNS and netwrok control access will cause the
addition of rhel compute node to fail.

DNS configuration and network control access are under the control of the user
and their state can not be predicted.
In order to prevent the failures, it falls on the users shoulders to verify
that DNS and control access are correctly configured to allow the needed access.
The access maybe easily tested prior to installation.