### PR TITLE
removing and incorrect link

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -28,13 +28,13 @@ ifdef::openshift-aro[]
 
 {product-title} is supported by Red Hat and Microsoft. Use the following table to navigate all the available documentation related to {product-title}.
 
-Documentaiton unique to the {product-title} service (e.g. how to create a cluster, how to get support) is generally found on the Microsoft Azure documentation site; documentation that is common to all OpenShift distributions is generally found on this documentation site.
+Documentation unique to the {product-title} service (e.g. how to create a cluster, how to get support) is generally found on the Microsoft Azure documentation site; documentation that is common to all OpenShift distributions is generally found on this page.
 
 [cols="1,1",options="header"]
 |===
 
 | link:https://docs.microsoft.com/en-us/azure/openshift/[Microsoft Azure documentation]
-| link:https://docs.openshift.com/aro/4/index.html[Red Hat OpenShift documentation]
+| Red Hat OpenShift documentation
 
 a| * Overview of {product-title}
 * Creating a cluster


### PR DESCRIPTION
Removing the incorrect link to the RH docs on the welcome page.

We're just merging to 4.3 now. The plan is to do a bulk merge of ARO 4.3x changes to master in a separate story.