### PR TITLE
BZ-1829099 Added link to subscription watch

### DIFF
--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -39,17 +39,19 @@ ifndef::openshift-origin[]
 
 In {product-title} {product-version}, you require access to the internet to
 ifndef::restricted[]
-install and
+install
 endif::restricted[]
 ifdef::restricted[]
-obtain the images that you require to install the cluster and to
+obtain the images that are necessary to install
 endif::restricted[]
-entitle your cluster.
-The Telemetry service, which runs by default to provide metrics about cluster health and the success of updates, also requires internet access. If your cluster is connected to the internet, Telemetry runs automatically, and your cluster is registered to the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}]. From there, you can allocate entitlements to your cluster.
+your cluster.
+The Telemetry service, which runs by default to provide metrics about cluster health and the success of updates, also requires internet access. If your cluster is connected to the internet, Telemetry runs automatically, and your cluster is registered to the link:https://cloud.redhat.com/openshift[{cloud-redhat-com} (OCM)].
+
+Once you confirm that your {cloud-redhat-com} inventory is correct, either maintained automatically by Telemetry or manually using OCM, link:https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-to-select-datacollection-tool_assembly-requirements-and-your-responsibilities-ctxt#red_hat_openshift[use subscription watch] to track your {product-title} subscriptions at the account or multi-cluster level.
 
 You must have internet access to:
 
-* Access the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}] page to download the installation program and perform subscription management and entitlement. If the cluster has internet access and you do not disable Telemetry, that service automatically entitles your cluster. If the Telemetry service cannot entitle your cluster, you must manually entitle it on the link:https://cloud.redhat.com/openshift/register[Cluster registration] page.
+* Access the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}] page to download the installation program and perform subscription management. If the cluster has internet access and you do not disable Telemetry, that service automatically entitles your cluster.
 * Access link:http://quay.io[Quay.io] to obtain the packages that are required to install your cluster.
 * Obtain the packages that are required to perform cluster updates.
 ifdef::openshift-enterprise,openshift-webscale[]


### PR DESCRIPTION
BZ-1829099 https://bugzilla.redhat.com/show_bug.cgi?id=1829099

This update is for 4.2 and later. There are a number of assemblies/sections of the docs that include the `cluster-entitlements.adoc` module. I need confirmation on where this content should be included/excluded.

Does "subscription watch" need to be capitalized when used like this (i.e., Subscription Watch)?