### PR TITLE
CNV OVN naughty xref 

### DIFF
--- a/modules/virt-what-you-can-do-with-virt.adoc
+++ b/modules/virt-what-you-can-do-with-virt.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virt-about-virt.adoc
+// * virt/about-virt.adoc
 // * virt/virt_release_notes/virt-2-4-release-notes.adoc
 
 [id="virt-what-you-can-do-with-virt_{context}"]
@@ -21,4 +21,5 @@ custom resources to enable virtualization tasks. These tasks include:
 An enhanced web console provides a graphical portal to manage these virtualized
 resources alongside the {product-title} cluster containers and infrastructure.
 
-You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#learn-about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] network provider.
+// A line about support for OVN and OpenShiftSDN network providers has been moved to the `about-virt` assembly due to xrefs.
+// If you are re-using this module, you might also want to include that line in your assembly.

--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -1,12 +1,16 @@
-[id="virt-about-virt"]
+[id="about-virt"]
 = About {VirtProductName}
 include::modules/virt-document-attributes.adoc[]
-:context: virt-about-virt
+:context: about-virt
 toc::[]
 
 Learn about {VirtProductName}'s capabilities and support scope.
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
+
+// This line is attached to the above `virt-what-you-can-do-with-virt` module.
+// It is included here in the assembly because of the xref ban.
+You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#learn-about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] network provider.
 
 == {VirtProductName} support
 


### PR DESCRIPTION
Moving out a line about supported network providers from the 'what-you-can-do-with-virt' module and into the 'about-virt' assembly due to the xref ban in modules. Included comments in both to inform future writers looking to re-use the `wycdwv` module.

@vikram-redhat 