### PR TITLE
CNV Adding KubeVirtVersion variable

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -13,6 +13,7 @@
 :ProductRelease:
 :ProductVersion:
 :VirtVersion: 2.4
+:KubeVirtVersion: v0.29.0
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/virt-vm-storage-volume-types.adoc
+++ b/modules/virt-vm-storage-volume-types.adoc
@@ -5,9 +5,7 @@
 [id="virt-vm-storage-volume-types_{context}"]
 = Virtual machine storage volume types
 
-Virtual machine storage volume types are listed, as well as domain and volume settings. See the
-https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinespec[kubevirt
-API Reference] for a definitive list of virtual machine settings.
+Virtual machine storage volume types are listed, as well as domain and volume settings.
 
 [horizontal]
 *ephemeral*::

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -37,6 +37,11 @@ include::modules/virt-creating-vm.adoc[leveloffset=+1]
 
 include::modules/virt-vm-storage-volume-types.adoc[leveloffset=+1]
 
-See the
-https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinespec[kubevirt
-API Reference] for a definitive list of virtual machine settings.
+== Additional resources
+
+The `VirtualMachineSpec` definition in the link:https://kubevirt.io/api-reference/{KubeVirtVersion}/definitions.html#_v1_virtualmachinespec[KubeVirt {KubeVirtVersion} API Reference] provides broader context for the parameters and hierarchy of the virtual machine specification.
+
+[NOTE]
+====
+The KubeVirt API Reference is the upstream project reference and might contain parameters that are not supported in {VirtProductName}. 
+====


### PR DESCRIPTION
PM and eng recommended we re-phrase the 'definitive' part of the API reference and link to the specific version instead of master. This is declared as a variable in the doc-attributes file, as suggested in #21981 

Also removed the duplicate link. Moved the API reference link to the create-vm assembly under the heading 'Additional resources' and added a note to call out that options in upstream are not supported.

The "KubeVirtVersion: will need to be added to the pre-flight checklist to ensure it is updated prior to release