### PR TITLE
[WIP] Nodejs Jenkins Agent upgrade release note 3.11

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -3233,3 +3233,49 @@ link:https://access.redhat.com/errata/RHBA-2020:1551[RHBA-2020:1551] advisory.
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest
 release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade
 methods and strategies] for instructions.
+
+[[ocp-3-11-x-features]]
+==== Features
+
+[[ocp-3-11-x-added-nodejs-jenkins-agent-v10-and-v12]]
+===== Added Node.js Jenkins Agent v10 and v12
+
+The `jenkins-agent-nodejs-10-rhel7` and `jenkins-agent-nodejs-12-rhel7` images
+are now added to {product-title}. These new images allow Jenkins Pipelines to
+be upgraded to use either v10 or v12 of the Node.js Jenkins Agent. The Node.js
+v8 Jenkins Agent is now deprecated, but will continue to be provided. For
+existing clusters, you must manually upgrade the Node.js Jenkins Agent, which
+can be performed on a per namespace basis. Follow these steps to complete the
+manual upgrade:
+
+. Select the project for which you want to upgrade the Jenkins Pipelines:
++
+----
+$ oc project <project_name>
+----
+
+. Import the new Node.js Jenkins Agent image:
++ 
+----
+$ oc import-image nodejs openshift3/jenkins-agent-nodejs-10-rhel7 --from=registry.redhat.io/openshift3/jenkins-agent-nodejs-10-rhel7 --confirm
+----
++
+This command imports the v10 image. If you prefer v12, update the image
+specifications accordingly.
+
+. Overwrite the current Node.js Jenkins Agent with the new one you imported:
++
+----
+$ oc label is nodejs role=jenkins-slave --overwrite
+----
+
+. Verify in the Jenkins log that the new Jenkins Agent template is configured:
++
+----
+$ oc logs -f jenkins-1-<pod>
+----
+
+You can only get technical support for applications using the Node.js v8 Jenkins
+Agent. For software maintenance support, you must upgrade to one of the
+supported images. See xref:../using_images/other_images/jenkins_slaves.adoc#using-images-other-images-jenkins-slaves[Jenkins Agents]
+for more information.


### PR DESCRIPTION
This is a sample for the release note we'll add for the 3.11 z-stream release describing the upcoming additional two Nodejs Jenkins Agent images. This PR is for review purposes only.

Preview: http://file.rdu.redhat.com/~choag/052720/nodejs-image-test/release_notes/ocp_3_11_release_notes.html#ocp-3-11-x-added-nodejs-jenkins-agent-v10-and-v12