### PR TITLE
[WIP] Nodejs Jenkins Agent upgrade release note 4.x

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -2342,3 +2342,47 @@ After this one-time manual restart, subsequent upgrades and rotations will
 ensure restart before the service CA expires without requiring manual
 intervention.
 ====
+
+[[ocp-4-4-x-features]]
+==== Features
+
+[[ocp-4-4-x-added-nodejs-jenkins-agent-v10-and-v12]]
+===== Added Node.js Jenkins Agent v10 and v12
+
+The `jenkins-agent-nodejs-10-rhel7` and `jenkins-agent-nodejs-12-rhel7` images
+are now added to {product-title}. These new images allow Jenkins Pipelines to
+be upgraded to use either v10 or v12 of the Node.js Jenkins Agent. The Node.js
+v8 Jenkins Agent is now deprecated, but will continue to be provided. For
+existing clusters, you must manually upgrade the Node.js Jenkins Agent, which
+can be performed on a per namespace basis. Follow these steps to complete the
+manual upgrade:
+
+. Select the project for which you want to upgrade the Jenkins Pipelines:
++
+----
+$ oc project <project_name>
+----
+
+. Import the new Node.js Jenkins Agent image:
++ 
+----
+$ oc import-image nodejs openshift4/jenkins-agent-nodejs-10-rhel7 --from=registry.redhat.io/openshift4/jenkins-agent-nodejs-10-rhel7 --confirm
+----
++
+This command imports the v10 image. If you prefer v12, update the image
+specifications accordingly.
+
+. Overwrite the current Node.js Jenkins Agent with the new one you imported:
++
+----
+$ oc label is nodejs role=jenkins-slave --overwrite
+----
+
+. Verify in the Jenkins log that the new Jenkins Agent template is configured:
++
+----
+$ oc logs -f jenkins-1-<pod>
+----
+
+See xref:../openshift_images/using_images/images-other-jenkins-agent.adoc#images-other-jenkins-agent[Jenkins agent]
+for more information.


### PR DESCRIPTION
This is a sample for the release note we'll add for the 4.2-4.4 z-stream releases describing the upcoming additional two Nodejs Jenkins Agent images. This PR is for review purposes only.

Preview: http://file.rdu.redhat.com/~choag/052720/nodejs-image-test-4.x/release_notes/ocp-4-4-release-notes.html#ocp-4-4-x-added-nodejs-jenkins-agent-v10-and-v12