### PR TITLE
BZ 1822673 - Fixed typo based on feedback

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -59,7 +59,7 @@ in xref:../installing/install_config/installing-customizing.adoc#installing-cust
 [id="installation-about-fips-components-runtimes_{context}"]
 === Runtimes
 
-To ensure that containers know that they are running on a host that has is using FIPS validated / Implementation Under Test cryptography modules, use CRI-O to manage your runtimes. CRI-O supports FIPS-Mode, in that it configures the containers to know that they are running in FIPS mode.
+To ensure that containers know that they are running on a host that is using FIPS validated / Implementation Under Test cryptography modules, use CRI-O to manage your runtimes. CRI-O supports FIPS-Mode, in that it configures the containers to know that they are running in FIPS mode.
 
 [id="installing-fips-mode_{context}"]
 ==  Installing a cluster in FIPS mode


### PR DESCRIPTION
BZ 1822673 [https://bugzilla.redhat.com/show_bug.cgi?id=1822673](https://bugzilla.redhat.com/show_bug.cgi?id=1822673)

Fixed typo as pointed out by the DDF.

Applies to 4.3, 4.4, and 4.5 docs.

@vikram-redhat can you please review? Thanks.