### PR TITLE
CNV-4990 - VMs to use masq mode ipv6

### DIFF
--- a/modules/virt-configuring-masquerade-mode-dual-stack.adoc
+++ b/modules/virt-configuring-masquerade-mode-dual-stack.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+
+[id="virt-configuring-masquerade-mode-dual-stack_{context}"]
+= Configuring masquerade mode with dual-stack (IPv4 and IPv6)
+
+You can configure a new virtual machine to use both IPv6 and IPv4 on the default pod network by using cloud-init.
+
+The IPv6 network address must be statically set to `fd10:0:2::2/120` with a default gateway of `fd10:0:2::1` in the virtual machine configuration. These are used by the virt-launcher pod to route IPv6 traffic to the virtual machine and are not used externally.
+
+When the virtual machine is running, incoming and outgoing traffic for the virtual machine is routed to both the IPv4 address and the unique IPv6 address of the virt-launcher pod. The virt-launcher pod then routes the IPv4 traffic to the DHCP address of the virtual machine, and the IPv6 traffic to the statically set IPv6 address of the virtual machine.
+
+.Prerequisites
+
+* The {product-title} cluster must use the OVN-Kubernetes Container Network Interface (CNI) network provider configured for dual-stack.
+
+.Procedure
+
+. In a new virtual machine configuration, include an interface with `masquerade` and configure the IPv6 address and default gateway by using cloud-init.
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  name: example-vm-ipv6
+...
+          interfaces:
+            - name: red
+              masquerade: {} <1>
+              ports:
+                - port: 80 <2>
+      networks:
+      - name: red
+        pod: {}
+      volumes:
+      - cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              eth0:
+                dhcp4: true
+                addresses: [ fd10:0:2::2/120 ] <3>
+                gateway6: fd10:0:2::1 <4>
+----
+<1> Connect using masquerade mode.
+<2> Allows incoming traffic on port 80 to the virtual machine.
+<3> You must use the IPv6 address `fd10:0:2::2/120`.
+<4> You must use the gateway `fd10:0:2::1`.
+
+. Create the virtual machine in the namespace:
++
+[source,terminal]
+----
+$ oc create -f example-vm-ipv6.yaml
+----
+
+.Verification
+
+* To verify that IPv6 has been configured, start the virtual machine and view the interface status of the virtual machine instance to ensure it has an IPv6 address:
+
+[source,terminal]
+----
+$ oc get vmi <vmi-name> -o jsonpath="{.status.interfaces[*].ipAddresses}"
+----

--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -13,6 +13,8 @@ xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-net
 
 include::modules/virt-configuring-masquerade-mode-cli.adoc[leveloffset=+1]
 
+include::modules/virt-configuring-masquerade-mode-dual-stack.adoc[leveloffset=+1]
+
 [id="virt-selecting-binding-method"]
 == Selecting binding method
 


### PR DESCRIPTION
Adding a new module that covers how to configure a VM to use masq mode with ipv6

Newer story: [CNV-4990](https://issues.redhat.com/browse/CNV-4990)
u/s doc: https://kubevirt.io/user-guide/#/creation/interfaces-and-networks?id=masquerade-ipv6-support

Build link:
https://cnv-4864-ipv6-masq--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-configuring-masquerade-mode-ipv6_virt-using-the-default-pod-network-with-virt