### PR TITLE
Rm proxy override module

### DIFF
--- a/operators/olm-adding-operators-to-cluster.adoc
+++ b/operators/olm-adding-operators-to-cluster.adoc
@@ -15,9 +15,4 @@ include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../operators/understanding_olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-about_olm-understanding-operatorgroups[About OperatorGroups]
-
-include::modules/olm-overriding-proxy-settings.adoc[leveloffset=+1]
-.Additional resources
-
-* xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy]
 endif::[]


### PR DESCRIPTION
After moving the module in https://github.com/openshift/openshift-docs/pull/22131, forgot to remove it from the old assembly, so doing so here.