### PR TITLE
Update PTP Operator installation

### DIFF
--- a/modules/nw-ptp-installing-operator.adoc
+++ b/modules/nw-ptp-installing-operator.adoc
@@ -30,7 +30,8 @@ kind: Namespace
 metadata:
   name: openshift-ptp
   labels:
-    openshift.io/run-level: "1"
+    name: openshift-ptp
+    openshift.io/cluster-monitoring: "true"
 ----
 
 .. Create the namespace by running the following command:
@@ -65,8 +66,6 @@ step.
 +
 ----
 $ oc get packagemanifest ptp-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
-
-4.4
 ----
 
 .. Create the following Subscription CR and save the YAML in the `ptp-sub.yaml` file:
@@ -144,4 +143,3 @@ the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors
 under *Status*.
 * Go to the *Workloads* -> *Pods* page and check the logs for Pods in the
 `openshift-ptp` project.
-

--- a/networking/multiple_networks/configuring-ptp.adoc
+++ b/networking/multiple_networks/configuring-ptp.adoc
@@ -11,14 +11,12 @@ include::modules/technology-preview.adoc[leveloffset=+1]
 [id="about-using-ptp-hardware"]
 == About PTP hardware on {product-title}
 
-{product-title} includes the capability to use PTP hardware on your nodes.
+{product-title} includes the capability to use Precision Time Protocol (PTP)hardware on your nodes.
 You can configure linuxptp services on nodes with PTP capable hardware.
 
-You can use the {product-title} console to install PTP by deploying the
-PTP Operator. The PTP Operator creates and manages the linuxptp services.
-The Operator provides following features:
+You can use the {product-title} console to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the linuxptp services. The Operator provides following features:
 
-* Discover the PTP capable device in cluster.
+* Discover the PTP capable devices in cluster.
 * Manage configuration of linuxptp services.
 
 include::modules/nw-ptp-installing-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/19847#issuecomment-635720660

This clips the `4.5` version from the output, so it is version agnostic. This output varies with each release of OCP. Another option might be to include the output and state that it is only an example, but if someone doesn't read closely and uses that value, installation might fail.

cc @huiran0826 