### PR TITLE
Always include `name` in CNI configuration

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -114,6 +114,7 @@ namespace: work-network
 type: Raw
 rawCNIConfig: '{ <1>
   "cniVersion": "0.3.1",
+  "name": "work-network",
   "type": "bridge",
   "master": "eth1",
   "isGateway": true,

--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -97,6 +97,7 @@ spec:
     type: Raw
     rawCNIConfig: '{
       "cniVersion": "0.3.1",
+      "name": "test-network-1",
       "type": "{plugin}",
       "master": "eth1",
       "ipam": {
@@ -124,6 +125,7 @@ spec:
     type: Raw
     rawCNIConfig: '{
       "cniVersion": "0.3.1",
+      "name": "test-network-1",
       "type": "{plugin}",
       "device": "eth1"
     }'
@@ -143,6 +145,7 @@ spec:
     type: Raw
     rawCNIConfig: '{
       "cniVersion": "0.3.1",
+      "name": "test-network-1",
       "type": "{plugin}",
       "master": "eth1",
       "mode": "l2",

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -86,6 +86,7 @@ namespace: work-network
 type: Raw
 rawCNIConfig: '{ <1>
   "cniVersion": "0.3.1",
+  "name": "work-network",
   "type": "host-device",
   "device": "eth1"
 }'

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -79,7 +79,7 @@ to Pods on a worker node, such as `10.1.1.0/24`.
 
 <7> The gateway where network traffic is routed.
 
-<8> Optional: The DNS configuration.
+<8> Optional: DNS configuration.
 
 <9> An of array of one or more IP addresses for to send DNS queries to.
 

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -83,6 +83,7 @@ namespace: work-network
 type: Raw
 rawCNIConfig: '{ <1>
   "cniVersion": "0.3.1",
+  "name": "work-network",
   "type": "ipvlan",
   "master": "eth1",
   "mode": "l3",


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1793418

@dougbtv, I think this addresses the problem of the missing `name` value.