### PR TITLE
KI and Manual Workaround for Buildah ClusterTask in Pipelines 1.0

### DIFF
--- a/modules/op-release-notes-1-0.adoc
+++ b/modules/op-release-notes-1-0.adoc
@@ -72,6 +72,45 @@ For this release, use flags `disable-home-env-overwrite` and `disable-working-di
 == Known issues
 * If you are upgrading from an older version of {pipelines-title}, you must delete your existing deployments before upgrading to {pipelines-title} version 1.0. To delete an existing deployment, you must first delete Custom Resources and then uninstall the {pipelines-title} Operator. For more details, see the uninstalling {pipelines-title} section.
 * Submitting the same `v1alpha1` Tasks more than once results in an error. Use `oc replace` instead of `oc apply` when re-submitting a `v1alpha1` Task.
+* The `buildah` ClusterTask does not work when a new user is added to a container.
++
+When the Operator is installed, the `--storage-driver` flag for the `buildah` ClusterTask is not specified, therefore the flag is set to its default value. In some cases, this causes the storage driver to be set incorrectly. When a new user is added, the incorrect storage-driver results in the failure of the `buildah` ClusterTask with the following error:
++
+----
+useradd: /etc/passwd.8: lock file already used
+useradd: cannot lock /etc/passwd; try again later.
+----
++
+As a workaround, manually set the `--storage-driver` flag value to `overlay` in the `buildah-task.yaml` file:
++
+. Login to your cluster as a `cluster-admin`:
++
+----
+$ oc login -u <login> -p <password> https://openshift.example.com:6443
+----
+. Use the `oc edit` command to edit `buildah` ClusterTask:
++
+----
+$ oc edit clustertask buildah
+----
++
+The current version of the `buildah` clustertask YAML file opens in the editor set by your `EDITOR` environment variable.
+. Under the `steps` field, locate the following `command` field:
++
+----
+ command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
+----
+
+. Replace the `command` field with the following:
++
+----
+ command: ['buildah', '--storage-driver=overlay', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--no-cache', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
+----
+. Save the file and exit.
+
+
++
+Alternatively, you can also modify the `buildah` ClusterTask YAML file directly on the web console by navigating to *Pipelines* -> *Cluster Tasks* -> *buildah*. Select *Edit Cluster Task* from the *Actions* menu and replace the `command` field as shown in the previous procedure.
 
 [id="fixed-issues-1-0_{context}"]
 == Fixed issues


### PR DESCRIPTION
This PR documents the KI and workaround for the Buildah cluster task which fails in Pipelines TP version 1.0 .

JIRA: https://issues.redhat.com/browse/RHDEVDOCS-1922

