### PR TITLE
kube-scheduler custom policy: do not use GeneralPredicates alongside …

### DIFF
--- a/modules/nodes-scheduler-default-about.adoc
+++ b/modules/nodes-scheduler-default-about.adoc
@@ -65,13 +65,10 @@ data:
                 {"name" : "MaxCSIVolumeCountPred"},
                 {"name" : "CheckVolumeBinding"},
                 {"name" : "MaxEBSVolumeCount"},
-                {"name" : "PodFitsResources"},
                 {"name" : "MatchInterPodAffinity"},
                 {"name" : "CheckNodeUnschedulable"},
                 {"name" : "NoDiskConflict"},
                 {"name" : "NoVolumeZoneConflict"},
-                {"name" : "MatchNodeSelector"},
-                {"name" : "HostName"},
                 {"name" : "PodToleratesNodeTaints"}
                 ],
         "priorities" : [
@@ -97,12 +94,16 @@ metadata:
   uid: 17ee8865-d927-11e9-b213-02d1e1709840`
 ----
 
+`GeneralPredicates` predicate represents `PodFitsResources`, `HostName`, `PodFitsHostPorts` and `MatchNodeSelector` predicates.
+Since it is not allowed to configure the same predicate multiple times, `GeneralPredicates` predicate can not be used alongside
+any of the four represented predicates.
+
 ////
 .Typical predicate string
 ----
 \n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\"},
 ----
-* `name` is the name of the predicate, such as `labelsPresence`. 
+* `name` is the name of the predicate, such as `labelsPresence`.
 * `label` and `<label>` is the node label:value pair to match to apply the predicate, such `label:rack`.
 * `<condition>` and `<state>` is when the predicate should be applied, such as `presence:true`.
 
@@ -110,7 +111,7 @@ metadata:
 ----
 \n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\", \"weight\" : <weight>},
 ----
-* `name` is the name of the priority, such as `labelsPresence`. 
+* `name` is the name of the priority, such as `labelsPresence`.
 * `label` and `<label>` is the node `label:value` pair to match to apply the priority, such `label:rack`.
 * `<condition>` and `<state>` is when the priority should be applied, such as `presence:true`.
 * `weight` and `<weight> is the numerical weight to apply to the priority.

--- a/modules/nodes-scheduler-default-creating.adoc
+++ b/modules/nodes-scheduler-default-creating.adoc
@@ -14,7 +14,7 @@ You can control change the default scheduling behavior by creating a JSON file w
 
 To configure the scheduler policy:
 
-. Create the a JSON file named `policy.cfg` with the desired predicates and priorities. 
+. Create the a JSON file named `policy.cfg` with the desired predicates and priorities.
 +
 .Sample scheduler JSON file
 [source,json]
@@ -78,13 +78,10 @@ data:
                 {"name" : "MaxCSIVolumeCountPred"},
                 {"name" : "CheckVolumeBinding"},
                 {"name" : "MaxEBSVolumeCount"},
-                {"name" : "PodFitsResources"},
                 {"name" : "MatchInterPodAffinity"},
                 {"name" : "CheckNodeUnschedulable"},
                 {"name" : "NoDiskConflict"},
                 {"name" : "NoVolumeZoneConflict"},
-                {"name" : "MatchNodeSelector"},
-                {"name" : "HostName"},
                 {"name" : "PodToleratesNodeTaints"}
                 ],
         "priorities" : [
@@ -140,4 +137,3 @@ $ oc logs openshift-kube-scheduler-ip-10-0-141-29.ec2.internal | grep predicates
 
 Creating scheduler with fit predicates 'map[MaxGCEPDVolumeCount:{} MaxAzureDiskVolumeCount:{} CheckNodeUnschedulable:{} NoDiskConflict:{} NoVolumeZoneConflict:{} MatchNodeSelector:{} GeneralPredicates:{} MaxCSIVolumeCountPred:{} CheckVolumeBinding:{} MaxEBSVolumeCount:{} PodFitsResources:{} MatchInterPodAffinity:{} HostName:{} PodToleratesNodeTaints:{}]' and priority functions 'map[InterPodAffinityPriority:{} LeastRequestedPriority:{} ServiceSpreadingPriority:{} ImageLocalityPriority:{} SelectorSpreadPriority:{} EqualPriority:{} BalancedResourceAllocation:{} NodePreferAvoidPodsPriority:{} NodeAffinityPriority:{} TaintTolerationPriority:{}]'
 ----
-

--- a/modules/nodes-scheduler-default-modifying.adoc
+++ b/modules/nodes-scheduler-default-modifying.adoc
@@ -39,13 +39,10 @@ data:
                 {"name" : "MaxCSIVolumeCountPred"},
                 {"name" : "CheckVolumeBinding"},
                 {"name" : "MaxEBSVolumeCount"},
-                {"name" : "PodFitsResources"},
                 {"name" : "MatchInterPodAffinity"},
                 {"name" : "CheckNodeUnschedulable"},
                 {"name" : "NoDiskConflict"},
                 {"name" : "NoVolumeZoneConflict"},
-                {"name" : "MatchNodeSelector"},
-                {"name" : "HostName"},
                 {"name" : "PodToleratesNodeTaints"}
                 ],
         "priorities" : [ <2>
@@ -144,4 +141,3 @@ $ oc create configmap -n openshift-config --from-file=policy.cfg scheduler-polic
 
 configmap/scheduler-policy created
 ----
-

--- a/modules/nodes-scheduler-default-priorities.adoc
+++ b/modules/nodes-scheduler-default-priorities.adoc
@@ -176,6 +176,8 @@ See link:https://access.redhat.com/solutions/3432401[this Red Hat Solution].
 *The `labelPreference` parameter gives priority based on the specified label.
 If the label is present on a node, that node is given priority.
 If no label is specified, priority is given to nodes that do not have a label.
+In case multiple priorities with `labelPreference` parameter are set,
+all of the priorities have to have the same weight.
 
 [source,json]
 ----


### PR DESCRIPTION
 `GeneralPredicates` predicate represents `PodFitsResources`, `HostName`, `PodFitsHostPorts` and `MatchNodeSelector` predicates. Since it is not allowed to configure the same predicate multiple times, `GeneralPredicates` predicate can not be used alongside any of the four represented predicates.

Also, all priorities with `labelPreference` parameter have to have the same weight.