### PR TITLE
Add TP for PTP

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -292,7 +292,7 @@ In the table below, features are marked with the following statuses:
 |Precision Time Protocol (PTP)
 |TP
 |TP
-|
+|TP
 
 |CRI-O for runtime Pods
 |GA


### PR DESCRIPTION
@codyhoag, this is TP in 4.5 as well.

Also,

> PTP is a time protocol supported on OpenShift, PTP-Operator and linuxptp-daemon are two components built for this feature. PTP-Operator manages linuxptp-daemon.

So I wonder if this should be PTP Operator or some such? But we already have PTP in the table, so we'd need to change it in past version as well I suspect?

Thanks.