### PR TITLE
CNV-5020 FOR 2.4: virtctl expose documentation should specify need to be in project

### DIFF
--- a/modules/virt-accessing-vmi-ssh.adoc
+++ b/modules/virt-accessing-vmi-ssh.adoc
@@ -14,6 +14,7 @@ the `fedora-vm-ssh` service that forwards port 22 of the `<fedora-vm>` virtual
 machine to a port on the node:
 
 .Prerequisites
+* You must be in the same project as the virtual machine instance.
 * The virtual machine instance you want to access must be connected
 to the default Pod network by using the `masquerade` binding method.
 * The virtual machine instance you want to access must be running.


### PR DESCRIPTION
Adding requested prereq to module.

See Jira story link below for content details.

Tagging @aburdenthehand to review peer review changes.

Test Build: http://file.bos.redhat.com/bgaydos/061820_5/virt/virtual_machines/virt-accessing-vm-consoles.html

Label: Peer Review Needed and enterprise-4.5. Another PR (https://github.com/openshift/openshift-docs/pull/22534) handles this change for enterprise-4.4.

Bob 