### PR TITLE
Bugzilla doc text for 4.2.34 release

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -2366,4 +2366,45 @@ Issued: 2020-05-13
 
 An update for oproglottis/gpgme is now available for
 {product-title} 4.2. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:1526[RHSA-2020:2027] advisory.
+link:https://access.redhat.com/errata/RHSA-2020:2027[RHSA-2020:2027] advisory.
+
+[[ocp-4-2-34]]
+=== RHBA-2020:2307 - {product-title} 4.2.34 Bug Fix Update
+
+Issued: 2020-06-03
+
+{product-title} release 4.2.34 is now available. The list of packages included in
+the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2020:2302[RHBA-2020:2302] advisory.
+The container images and bug fixes included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2020:2307[RHBA-2020:2307] advisory.
+
+Space precluded documenting all of the container images for this release in the
+advisory. See the following article for notes on the container images in this
+release:
+
+link:https://access.redhat.com/solutions/5127251[{product-title} 4.2.34 container image list]
+
+[[ocp-4-2-34-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.2 cluster to this latest release, see
+xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+
+[[RHSA-2020-2305]]
+=== RHSA-2020:2305 - Moderate: {product-title} 4.2 security update
+
+Issued: 2020-06-03
+
+An update for openshift-enterprise-apb-tools-container is now available for
+{product-title} 4.2. Details of the update are documented in the
+link:https://access.redhat.com/errata/RHSA-2020:2305[RHSA-2020:2305] advisory.
+
+[[RHSA-2020-2306]]
+=== RHSA-2020:2306 - Moderate: {product-title} 4.2 security update
+
+Issued: 2020-06-03
+
+An update for ose-openshift-apiserver-container is now available for
+{product-title} 4.2. Details of the update are documented in the
+link:https://access.redhat.com/errata/RHSA-2020:2306[RHSA-2020:2306] advisory.


### PR DESCRIPTION
Links to standard release resources, list of security fixes. Also found and fixed a typo in a link from the previous release (line 2369).