### PR TITLE
Change v1alpha1 to v1 in Serverless docs code samples

### DIFF
--- a/modules/knative-serving-concurrent-autoscaling-requests.adoc
+++ b/modules/knative-serving-concurrent-autoscaling-requests.adoc
@@ -11,7 +11,7 @@ Here is an example of `target` being used in a revision template:
 
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: myapp
@@ -28,7 +28,7 @@ spec:
 Here is an example of `containerConcurrency` being used in a revision template:
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: myapp


### PR DESCRIPTION
Should apply for OCP 4.3, 4.4 and 4.5.