### PR TITLE
Remove CSI spec ref in note

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 The Container Storage Interface (CSI) allows {product-title} to consume
-storage from storage backends that implement the
+storage from storage back ends that implement the
 link:https://github.com/container-storage-interface/spec[CSI interface]
 as persistent storage.
 
@@ -18,9 +18,6 @@ link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage ven
 
 Installation instructions differ by driver, and are found in each driver's
 documentation. Follow the instructions provided by the CSI driver.
-
-{product-title} {product-version} supports version 1.1.0 of the
-link:https://github.com/container-storage-interface/spec[CSI specification].
 ====
 
 include::modules/persistent-storage-csi-architecture.adoc[leveloffset=+1]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/22613
We recently decided to remove the CSI spec reference and link starting in 4.5, so this PR corresponds to that decision. It's not necessary to state which CSI spec version is supported, and it becomes difficult to maintain content OCP content against spec updates.

Preview link: https://remove-csi-spec--ocpdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html