### PR TITLE
Migration: update OCP versions in navigation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1266,14 +1266,14 @@ Name: Migration
 Dir: migration
 Distros: openshift-enterprise,openshift-webscale,openshift-origin
 Topics:
-- Name: Migrating OpenShift Container Platform 3 to 4
+- Name: Migrating from OpenShift Container Platform 3
   Dir: migrating_3_4
   Topics:
-  - Name: About migrating OpenShift Container Platform 3 to 4
+  - Name: About migrating from OpenShift Container Platform 3 to 4
     File: about-migration
-  - Name: Planning your OpenShift Container Platform 3 to 4 migration
+  - Name: Planning your migration from OpenShift Container Platform 3 to 4
     File: planning-migration-3-to-4
-  - Name: Migrating application workloads from OpenShift Container Platform 3.7 to 4.3
+  - Name: Migration tools and prerequisites
     File: migrating-application-workloads-3-4
   - Name: Deploying the Cluster Application Migration tool
     File: deploying-cam-3-4
@@ -1285,11 +1285,11 @@ Topics:
     File: migrating-with-cpma
   - Name: Troubleshooting
     File: troubleshooting-3-4
-- Name: Migrating OpenShift Container Platform 4.1 to 4.3
+- Name: Migrating from OpenShift Container Platform 4.1
   Dir: migrating_4_1_4
   Distros: openshift-enterprise
   Topics:
-  - Name: Migrating application workloads from OpenShift Container Platform 4.1 to 4.3
+  - Name: Migration tools and prerequisites
     File: migrating-application-workloads-4-1-4
   - Name: Deploying the Cluster Application Migration tool
     File: deploying-cam-4-1-4
@@ -1299,11 +1299,11 @@ Topics:
     File: migrating-applications-with-cam-4-1-4
   - Name: Troubleshooting
     File: troubleshooting-4-1-4
-- Name: Migrating Openshift Container Platform 4.2 to 4.3
+- Name: Migrating from Openshift Container Platform 4.2
   Dir: migrating_4_2_4
   Distros: openshift-enterprise
   Topics:
-  - Name: Migrating application workloads from OpenShift Container Platform 4.2 to 4.3
+  - Name: Migration tools and prerequisites
     File: migrating-application-workloads-4-2-4
   - Name: Deploying the Cluster Application Migration tool
     File: deploying-cam-4-2-4

--- a/migration/migrating_3_4/about-migration.adoc
+++ b/migration/migrating_3_4/about-migration.adoc
@@ -14,5 +14,6 @@ Learn about the differences between {product-title} versions 3 and 4. Prior to t
 
 xref:../../migration/migrating_3_4/migrating-application-workloads-3-4.adoc#migrating-application-workloads-3-4[Performing your migration]::
 Learn about and use the tools to perform your migration:
+
 * Cluster Application Migration (CAM) tool to migrate your application workloads
 * Control Plane Migration Assistant (CPMA) to migrate your control plane

--- a/migration/migrating_3_4/configuring-replication-repository-3-4.adoc
+++ b/migration/migrating_3_4/configuring-replication-repository-3-4.adoc
@@ -6,7 +6,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_3_4/configuring-replication-repository-3-4.adoc#file-system-copy-method_{context}[file system] or the xref:../../migration/migrating_3_4/configuring-replication-repository-3-4.adoc#snapshot-copy-method_{context}[snapshot] data copy method.
+You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster.
+
+The CAM tool supports the xref:../../migration/migrating_3_4/migrating-application-workloads-3-4.adoc#migration-understanding-data-copy-methods_migrating-3-4[file system and snapshot data copy methods] for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
 
 The following storage providers are supported:
 
@@ -19,8 +21,6 @@ The following storage providers are supported:
 The source and target clusters must have network access to the replication repository during migration.
 
 In a restricted environment, you can create an internally hosted replication repository. If you use a proxy server, you must ensure that your replication repository is whitelisted.
-
-include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 
 ifeval::["{product-version}" == "4.2"]
 :FeatureName: Configuring Multi-Cloud Object Gateway as a replication repository for migration

--- a/migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+++ b/migration/migrating_3_4/migrating-application-workloads-3-4.adoc
@@ -1,16 +1,20 @@
 [id="migrating-application-workloads-3-4"]
-= Migrating application workloads from {product-title} 3.7 to {product-version}
+= Migration tools and prerequisites
 include::modules/common-attributes.adoc[]
 :context: migrating-3-4
 :migrating-3-4:
 
 toc::[]
 
-You can migrate application workloads from {product-title} 3.7 (and later) to {product-title} {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
+You can migrate application workloads from {product-title} 3.7, 3.9, 3.10, and 3.11 to {product-title} {product-version} with the Cluster Application Migration (CAM) tool. The CAM tool enables you to control the migration and to minimize application downtime.
 
 The CAM tool's web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful application workloads at the granularity of a namespace.
 
-Optionally, you can use the xref:../../migration/migrating_3_4/migrating-with-cpma.adoc#migration-understanding-cpma_migrating-3-4[Control Plane Migration Assistant (CPMA)] to assist you in migrating control plane settings.
+The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
+
+You can use migration hooks to run Ansible playbooks at certain points during the migration. The hooks are added when you create a migration plan.
+
+The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane. The CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
 
 [IMPORTANT]
 ====
@@ -19,6 +23,7 @@ Before you begin your migration, be sure to review the information on xref:../..
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
+include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
-
+include::modules/migration-understanding-cpma.adoc[leveloffset=+1]
 :!migrating-3-4:

--- a/migration/migrating_3_4/migrating-with-cpma.adoc
+++ b/migration/migrating_3_4/migrating-with-cpma.adoc
@@ -6,8 +6,8 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/migration-understanding-cpma.adoc[leveloffset=+1]
+The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane from {product-title} 3.7 (or later) to {product-version}. The CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
+
 include::modules/migration-installing-cpma.adoc[leveloffset=+1]
 include::modules/migration-using-cpma.adoc[leveloffset=+1]
-
 :!migrating-3-4:

--- a/migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
+++ b/migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
@@ -6,7 +6,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc#file-system-copy-method_migrating-4-1-4[file system] or the xref:../../migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc#snapshot-copy-method_migrating-4-1-4[snapshot] data copy method.
+You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster.
+
+The CAM tool supports the xref:../../migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc#migration-understanding-data-copy-methods_migrating-4-1-4[file system and snapshot data copy methods] for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
 
 The following storage providers are supported:
 
@@ -19,8 +21,6 @@ The following storage providers are supported:
 The source and target clusters must have network access to the replication repository during migration.
 
 In a restricted environment, you can create an internally hosted replication repository. If you use a proxy server, you must ensure that your replication repository is whitelisted.
-
-include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 
 ifeval::["{product-version}" == "4.2"]
 :FeatureName: Configuring Multi-Cloud Object Gateway as a replication repository for migration

--- a/migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
+++ b/migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
@@ -1,5 +1,5 @@
 [id="migrating-application-workloads-4-1-4"]
-= Migrating application workloads from {product-title} 4.1 to {product-version}
+= Migration tools and prerequisites
 include::modules/common-attributes.adoc[]
 :context: migrating-4-1-4
 :migrating-4-1-4:
@@ -10,8 +10,13 @@ You can migrate application workloads from {product-title} 4.1 to {product-versi
 
 The CAM tool's web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
 
+The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
+
+You can use migration hooks to run Ansible playbooks at certain points during the migration. The hooks are added when you create a migration plan.
+
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
+include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
 
 :!migrating-4-1-4:

--- a/migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
+++ b/migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
@@ -6,7 +6,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster, using either the xref:../../migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc#file-system-copy-method_migrating-4-2-4[file system] or the xref:../../migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc#snapshot-copy-method_migrating-4-2-4[snapshot] data copy method.
+You must configure an object storage to use as a replication repository. The Cluster Application Migration tool copies data from the source cluster to the replication repository, and then from the replication repository to the target cluster.
+
+The CAM tool supports the xref:../../migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc#migration-understanding-data-copy-methods_migrating-4-2-4[file system and snapshot data copy methods] for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
 
 The following storage providers are supported:
 
@@ -19,8 +21,6 @@ The following storage providers are supported:
 The source and target clusters must have network access to the replication repository during migration.
 
 In a restricted environment, you can create an internally hosted replication repository. If you use a proxy server, you must ensure that your replication repository is whitelisted.
-
-include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 
 ifeval::["{product-version}" == "4.2"]
 :FeatureName: Configuring Multi-Cloud Object Gateway as a replication repository for migration

--- a/migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
+++ b/migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
@@ -1,5 +1,5 @@
 [id="migrating-application-workloads-4-2-4"]
-= Migrating application workloads from {product-title} 4.2 to {product-version}
+= Migration tools and prerequisites
 include::modules/common-attributes.adoc[]
 :context: migrating-4-2-4
 :migrating-4-2-4:
@@ -10,8 +10,13 @@ You can migrate application workloads from {product-title} 4.2 to {product-versi
 
 The CAM tool's web console and API, based on Kubernetes Custom Resources, enable you to migrate stateful and stateless application workloads at the granularity of a namespace.
 
+The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
+
+You can use migration hooks to run Ansible playbooks at certain points during the migration. The hooks are added when you create a migration plan.
+
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
+include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
 
 :!migrating-4-2-4:

--- a/modules/migration-adding-cluster-to-cam.adoc
+++ b/modules/migration-adding-cluster-to-cam.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id='migration-adding-cluster-to-cam_{context}']
 = Adding a cluster to the CAM web console
 

--- a/modules/migration-adding-replication-repository-to-cam.adoc
+++ b/modules/migration-adding-replication-repository-to-cam.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id='migration-adding-replication-repository-to-cam_{context}']
 = Adding a replication repository to the CAM web console
 

--- a/modules/migration-changing-migration-plan-limits.adoc
+++ b/modules/migration-changing-migration-plan-limits.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id='migration-changing-migration-plan-limits_{context}']
 = Changing migration plan limits for large migrations
 

--- a/modules/migration-configuring-aws-s3.adoc
+++ b/modules/migration-configuring-aws-s3.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/configuring-replication-repository-3-4.adoc
-// migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
-// migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
+// * migration/migrating_3_4/configuring-replication-repository-3-4.adoc
+// * migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
+// * migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
 [id='migration-configuring-aws-s3_{context}']
 = Configuring an AWS S3 storage bucket as a replication repository
 

--- a/modules/migration-configuring-azure.adoc
+++ b/modules/migration-configuring-azure.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/configuring-replication-repository-3-4.adoc
-// migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
-// migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
+// * migration/migrating_3_4/configuring-replication-repository-3-4.adoc
+// * migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
+// * migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
 [id='migration-configuring-azure_{context}']
 = Configuring a Microsoft Azure Blob storage container as a replication repository
 

--- a/modules/migration-configuring-gcp.adoc
+++ b/modules/migration-configuring-gcp.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/configuring-replication-repository-3-4.adoc
-// migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
-// migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
+// * migration/migrating_3_4/configuring-replication-repository-3-4.adoc
+// * migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
+// * migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
 [id='migration-configuring-gcp_{context}']
 = Configuring a Google Cloud Provider storage bucket as a replication repository
 

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/configuring-replication-repository-3-4.adoc
-// migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
-// migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
+// * migration/migrating_3_4/configuring-replication-repository-3-4.adoc
+// * migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
+// * migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
 [id='migration-configuring-mcg_{context}']
 = Configuring a Multi-Cloud Object Gateway storage bucket as a replication repository
 

--- a/modules/migration-creating-ca-bundle.adoc
+++ b/modules/migration-creating-ca-bundle.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id='creating-ca-bundle_{context}']
 = Creating a CA certificate bundle file
 

--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id='migration-creating-migration-plan-cam_{context}']
 = Creating a migration plan in the CAM web console
 

--- a/modules/migration-downloading-logs.adoc
+++ b/modules/migration-downloading-logs.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/troubleshooting-3-4.adoc
-// migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
-// migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
+// * migration/migrating_3_4/troubleshooting-3-4.adoc
+// * migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
+// * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 [id='migration-downloading-logs_{context}']
 = Downloading migration logs
 

--- a/modules/migration-installing-cam-operator-ocp-3.adoc
+++ b/modules/migration-installing-cam-operator-ocp-3.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/deploying-cam-3-4.adoc
+// * migration/migrating_3_4/deploying-cam-3-4.adoc
 [id="migration-installing-cam-operator-ocp-3_{context}"]
 ifdef::migrating-3-4[]
 = Installing the Cluster Application Migration Operator on an {product-title} 3 source cluster

--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/deploying-cam-3-4.adoc
-// migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
-// migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
+// * migration/migrating_3_4/deploying-cam-3-4.adoc
+// * migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
 [id="migration-installing-cam-operator-ocp-4_{context}"]
 ifdef::source-4-1-4[]
 = Installing the Cluster Application Migration Operator on an {product-title} 4.1 source cluster

--- a/modules/migration-installing-cpma.adoc
+++ b/modules/migration-installing-cpma.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
+// * migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
 [id='migration-installing-cpma_{context}']
 = Installing the Control Plane Migration Assistant
 

--- a/modules/migration-known-issues.adoc
+++ b/modules/migration-known-issues.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/troubleshooting-3-4.adoc
-// migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
-// migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
+// * migration/migrating_3_4/troubleshooting-3-4.adoc
+// * migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
+// * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 [id='migration-known-issues_{context}']
 = Known issues
 

--- a/modules/migration-launching-cam.adoc
+++ b/modules/migration-launching-cam.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id="migration-launching-cam_{context}"]
 = Launching the CAM web console
 

--- a/modules/migration-manually-rolling-back-migration.adoc
+++ b/modules/migration-manually-rolling-back-migration.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
-// migration/migrating_3_4/troubleshooting-3-4.adoc
-// migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
-// migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
+// * migration/migrating_3_4/troubleshooting-3-4.adoc
+// * migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
+// * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 [id='migration-manually-rolling-back-migration_{context}']
 = Manually rolling back a migration
 

--- a/modules/migration-prerequisites.adoc
+++ b/modules/migration-prerequisites.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-application-workloads-3-4.adoc
-// migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+// * migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
 [id='migration-prerequisites_{context}']
 = Migration prerequisites
 
@@ -13,37 +13,31 @@ endif::[]
 * You must have `cluster-admin` privileges on all clusters.
 * The source and target clusters must have unrestricted network access to the replication repository.
 * The cluster on which the Migration controller is installed must have unrestricted access to the other clusters.
-ifdef::migrating-3-4,migrating-4-1-4,migrating-4-2-4[]
 * If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
 +
 If the required images are not present, you must update the `imagestreamtags` references to use an available version that is compatible with your application. If the `imagestreamtags` cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to reference them.
-endif::[]
-ifdef::migrating-3-4,migrating-4-2-4[]
-+
-The following `imagestreamtags` have been _removed_ from {product-title} 4.2:
 
-** `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
-** `dotnet-runtime:2.0`
-** `mariadb:10.1`
-** `mongodb:2.4`, `mongodb:2.6`
-** `mysql:5.5`, `mysql:5.6`
-** `nginx:1.8`
-** `nodejs:0.10`, `nodejs:4`, `nodejs:6`
-** `perl:5.16`, `perl:5.20`
-** `php:5.5`, `php:5.6`
-** `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
-** `python:3.3`, `python:3.4`
-** `ruby:2.0`, `ruby:2.2`
-endif::[]
-ifdef::migrating-3-4,migrating-4-1-4,migrating-4-2-4[]
-+
-The following `imagestreamtags` have been _removed_ from {product-title} 4.4:
+The following `imagestreamtags` have been _removed_ from {product-title} _4.2_:
 
-** `dotnet: 2.2`
-** `dotnet-runtime: 2.2`
-** `nginx: 1.12`
-** `nodejs: 8, 8-RHOAR, 10-SCL`
-** `perl:5.24`
-** `php: 7.0, 7.1`
-** `redis: 3.2`
-endif::[]
+* `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
+* `dotnet-runtime:2.0`
+* `mariadb:10.1`
+* `mongodb:2.4`, `mongodb:2.6`
+* `mysql:5.5`, `mysql:5.6`
+* `nginx:1.8`
+* `nodejs:0.10`, `nodejs:4`, `nodejs:6`
+* `perl:5.16`, `perl:5.20`
+* `php:5.5`, `php:5.6`
+* `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
+* `python:3.3`, `python:3.4`
+* `ruby:2.0`, `ruby:2.2`
+
+The following `imagestreamtags` have been _removed_ from {product-title} _4.4_:
+
+* `dotnet: 2.2`
+* `dotnet-runtime: 2.2`
+* `nginx: 1.12`
+* `nodejs: 8, 8-RHOAR, 10-SCL`
+* `perl:5.24`
+* `php: 7.0, 7.1`
+* `redis: 3.2`

--- a/modules/migration-restic-errors.adoc
+++ b/modules/migration-restic-errors.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/troubleshooting-3-4.adoc
-// migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
-// migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
+// * migration/migrating_3_4/troubleshooting-3-4.adoc
+// * migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
+// * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 [id='migration-restic-errors_{context}']
 = Error messages
 

--- a/modules/migration-running-migration-plan-cam.adoc
+++ b/modules/migration-running-migration-plan-cam.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
-// migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+// * migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 [id='migration-running-migration-plan-cam_{context}']
 = Running a migration plan in the CAM web console
 

--- a/modules/migration-understanding-cam.adoc
+++ b/modules/migration-understanding-cam.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/migrating-application-workloads-3-4.adoc
-// migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+// * migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
 [id='migration-understanding-cam_{context}']
-= Understanding the Cluster Application Migration tool
+= About the Cluster Application Migration tool
 
 The Cluster Application Migration (CAM) tool enables you to migrate Kubernetes resources, persistent volume data, and internal container images from an {product-title} source cluster to an {product-title} {product-version} target cluster, using the CAM web console or the Kubernetes API.
 

--- a/modules/migration-understanding-cpma.adoc
+++ b/modules/migration-understanding-cpma.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
-// migration/migrating_3-4/migrating-application-workloads-3-to-4.adoc
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
 [id='migration-understanding-cpma_{context}']
-= Understanding the Control Plane Migration Assistant
+= About the Control Plane Migration Assistant
 
-The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane from {product-title} 3.7 (or later) to {product-title} {product-version}. The CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
+The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane from {product-title} 3.7 (or later) to {product-version}. The CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
 
 Because {product-title} 3 and 4 have significant configuration differences, not all parameters are processed. The CPMA can generate a report that describes whether features are supported fully, partially, or not at all.
 

--- a/modules/migration-understanding-data-copy-methods.adoc
+++ b/modules/migration-understanding-data-copy-methods.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/configuring-replication-repository-3-4.adoc
-// migration/migrating_4_1_4/configuring-replication-repository-4-1-4.adoc
-// migration/migrating_4_2_4/configuring-replication-repository-4-2-4.adoc
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+// * migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
 [id='migration-understanding-data-copy-methods_{context}']
-= Understanding the data copy methods for migration
+= About data copy methods
 
 The CAM tool supports the file system and snapshot data copy methods for migrating data from the source cluster to the target cluster. You can select a method that is suited for your environment and is supported by your storage provider.
 

--- a/modules/migration-understanding-migration-hooks.adoc
+++ b/modules/migration-understanding-migration-hooks.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
-// migration/migrating_3_4/migrating-application-workloads-3-4.adoc
-// migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
-// migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
-= Understanding migration hooks
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+// * migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc
+// * migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc
+[id='migration-understanding-migration-hooks_{context}']
+= About migration hooks
 
 You can use migration hooks to run Ansible playbooks at certain points during the migration. The hooks are added when you create a migration plan.
 

--- a/modules/migration-updating-deprecated-gvks.adoc
+++ b/modules/migration-updating-deprecated-gvks.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// migration/migrating_3_4/troubleshooting-3-4.adoc
+// * migration/migrating_3_4/troubleshooting-3-4.adoc
 // for CAM 1.2/4.4 only
 [id='migration-gvk-incompatibility_{context}']
 = Updating deprecated API `GroupVersionKinds`

--- a/modules/migration-using-cpma.adoc
+++ b/modules/migration-using-cpma.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
 [id='migration-using-cpma_{context}']
 = Using the Control Plane Migration Assistant
 

--- a/modules/migration-viewing-migration-crs.adoc
+++ b/modules/migration-viewing-migration-crs.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// migration/migrating_3_4/troubleshooting-3-4.adoc
-// migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
-// migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
+// * migration/migrating_3_4/troubleshooting-3-4.adoc
+// * migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
+// * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 [id='migration-viewing-migration-crs_{context}']
 = Viewing migration Custom Resources
 


### PR DESCRIPTION
Removed target names from topic_map.yml to reduce maintenance.
Renamed "Migrating application workloads" to "Migration tools and prerequisites" because it was more accurate. Links added to [Redirects Register](https://docs.google.com/spreadsheets/d/1KH2_p54Fr2KRFTUGzQdpqExox7iL9RM4_yiPNQpArjk/edit#gid=0).

Moved "About data copy methods" to "Migration tools and prerequisites". No redirect needed.

CP for 4.2, 4.3, 4.4, 4.5.