### PR TITLE
Add --filter-by-os for catalog build + mirror

### DIFF
--- a/modules/olm-arch-os-support.adoc
+++ b/modules/olm-arch-os-support.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-generating-csvs.adoc
+
+[id="olm-arch-os-support_{context}"]
+= Architecture and operating system support for Operators
+
+The following strings are supported in Operator Lifecycle Manager (OLM) on
+{product-title} when labeling or filtering Operators that support multiple
+architectures and operating systems:
+
+.Architectures supported on {product-title}
+[options="header"]
+|===
+|Architecture |String
+
+|AMD64
+|`amd64`
+
+|64-bit PowerPC little-endian
+|`ppc64le`
+
+|IBM Z
+|`s390x`
+|===
+
+.Operating systems supported on {product-title}
+[options="header"]
+|===
+|Operating system |String
+
+|Linux
+|`linux`
+
+|z/OS
+|`zos`
+|===
+
+[NOTE]
+====
+Different versions of {product-title} and other Kubernetes-based distributions
+might support a different set of architectures and operating systems.
+====

--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -69,20 +69,26 @@ link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
-    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.3 \//<2>
-    --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<3>
-    [-a ${REG_CREDS}] \//<4>
-    [--insecure] <5>
+    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.4 \//<2>
+    --filter-by-os="linux/amd64" \//<3>
+    --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<4>
+    [-a ${REG_CREDS}] \//<5>
+    [--insecure] <6>
 
 INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
 ...
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v1
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
-<3> Name your catalog image and include a tag, for example, `v1`.
-<4> Optional: If required, specify the location of your registry credentials file.
-<5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<2> Set `--from` to the `ose-operator-registry` base image using the tag that
+matches the target {product-title} cluster major and minor version.
+<3> Set `--filter-by-os` to the operating system and architecture to use for the
+base image, which must match the target {product-title} cluster. Valid values
+are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<4> Name your catalog image and include a tag, for example, `v1`.
+<5> Optional: If required, specify the location of your registry credentials file.
+<6> Optional: If you do not want to configure trust for the target registry, add the
+`--insecure` flag.
 +
 Sometimes invalid manifests are accidentally introduced into Red Hat's catalogs;
 when this happens, you might see some errors:

--- a/modules/olm-enabling-operator-for-multi-arch.adoc
+++ b/modules/olm-enabling-operator-for-multi-arch.adoc
@@ -32,41 +32,8 @@ additional architecture for an Operator in the non-default channel is possible,
 but that architecture is not available for filtering in the PackageManifest API.
 ====
 
-.Architectures supported on {product-title}
-[options="header"]
-|===
-|Architecture |String
-
-|AMD64
-|`amd64`
-
-|64-bit PowerPC little-endian
-|`ppc64le`
-
-|IBM Z
-|`s390x`
-|===
-
-.Operating systems supported on {product-title}
-[options="header"]
-|===
-|Operating system |String
-
-|Linux
-|`linux`
-
-|z/OS
-|`zos`
-|===
-
-[NOTE]
-====
-Different versions of {product-title} and other Kubernetes-based distributions might
-support a different set of architectures and operating systems.
-====
-
 If a CSV does not include an `os` label, it is treated as if it has the
-following by default:
+following Linux support label by default:
 
 [source,yaml]
 ----
@@ -75,7 +42,7 @@ labels:
 ----
 
 If a CSV does not include an `arch` label, it is treated as if it has the
-following by default:
+following AMD64 support label by default:
 
 [source,yaml]
 ----

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -54,13 +54,20 @@ $ oc adm catalog mirror \
     <registry_host_name>:<port>/olm/redhat-operators:v1 \//<1>
     <registry_host_name>:<port> \
     [-a ${REG_CREDS}] \//<2>
-    [--insecure] <3>
+    [--insecure] \//<3>
+    [--filter-by-os="<os>/<arch>"] <4>
 
 mirroring ...
 ----
 <1> Specify your Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials file.
-<3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<2> Optional: If required, specify the location of your registry credentials
+file.
+<3> Optional: If you do not want to configure trust for the target registry, add
+the `--insecure` flag.
+<4> Optional: Because the catalog might reference images that support multiple
+architectures and operating systems, you can filter by architecture and
+operating system to mirror only the images that match. Valid values are
+`linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 +
 This command also creates a `<image_name>-manifests/` directory in the current
 directory and generates the following files:

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -56,20 +56,27 @@ link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
-    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.3 \//<2>
-    --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<3>
-    [-a ${REG_CREDS}] \//<4>
-    [--insecure] <5>
+    --from=registry.redhat.io/openshift4/ose-operator-registry:v4.4 \//<2>
+    --filter-by-os="linux/amd64" \//<3>
+    --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<4>
+    [-a ${REG_CREDS}] \//<5>
+    [--insecure] <6>
 
 INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
 ...
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v2
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
-<3> Name your catalog image and include a tag, for example, `v2` because it is the updated catalog.
-<4> Optional: If required, specify the location of your registry credentials file.
-<5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<2> Set `--from` to the `ose-operator-registry` base image using the tag that
+matches the target {product-title} cluster major and minor version.
+<3> Set `--filter-by-os` to the operating system and architecture to use for the
+base image, which must match the target {product-title} cluster. Valid values
+are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<4> Name your catalog image and include a tag, for example, `v2` because it is the
+updated catalog.
+<5> Optional: If required, specify the location of your registry credentials file.
+<6> Optional: If you do not want to configure trust for the target registry, add the
+`--insecure` flag.
 
 . Mirror the contents of your catalog to your target registry. The following
 `oc adm catalog mirror` command extracts the contents of your custom Operator
@@ -81,13 +88,20 @@ $ oc adm catalog mirror \
     <registry_host_name>:<port>/olm/redhat-operators:v2 \//<1>
     <registry_host_name>:<port> \
     [-a ${REG_CREDS}] \//<2>
-    [--insecure] <3>
+    [--insecure] \//<3>
+    [--filter-by-os="<os>/<arch>"] <4>
 
 mirroring ...
 ----
 <1> Specify your new Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials file.
-<3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<2> Optional: If required, specify the location of your registry credentials
+file.
+<3> Optional: If you do not want to configure trust for the target registry, add
+the `--insecure` flag.
+<4> Optional: Because the catalog might reference images that support multiple
+architectures and operating systems, you can filter by architecture and
+operating system to mirror only the images that match. Valid values are
+`linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 
 . Apply the newly generated manifests:
 +

--- a/operators/olm-restricted-networks.adoc
+++ b/operators/olm-restricted-networks.adoc
@@ -40,5 +40,13 @@ include::modules/olm-building-operator-catalog-image.adoc[leveloffset=+1]
 * xref:../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Creating a mirror registry for installation in a restricted network]
 
 include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+.Additional resources
+
+* xref:../operators/operator_sdk/osdk-generating-csvs.adoc#olm-arch-os-support_osdk-generating-csvs[Architecture and operating system support for Operators]
+
 include::modules/olm-updating-operator-catalog-image.adoc[leveloffset=+1]
+.Additional resources
+
+* xref:../operators/operator_sdk/osdk-generating-csvs.adoc#olm-arch-os-support_osdk-generating-csvs[Architecture and operating system support for Operators]
+
 include::modules/olm-testing-operator-catalog-image.adoc[leveloffset=+1]

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -54,6 +54,8 @@ include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]
 - See the link:https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list[Image Manifest V 2, Schema 2]
 specification for more information on manifest lists.
 
+include::modules/olm-arch-os-support.adoc[leveloffset=+2]
+
 include::modules/osdk-suggested-namespace.adoc[leveloffset=+1]
 include::modules/osdk-crds.adoc[leveloffset=+1]
 include::modules/osdk-owned-crds.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1128

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1831698

Preview (internal):

* [Building an Operator catalog image](http://file.rdu.redhat.com/~adellape/060320/filter-by-os/operators/olm-restricted-networks.html#olm-building-operator-catalog-image_olm-restricted-networks) (step 2)
* [Configuring OperatorHub for restricted networks](http://file.rdu.redhat.com/~adellape/060320/filter-by-os/operators/olm-restricted-networks.html#olm-restricted-networks-operatorhub_olm-restricted-networks) (step 2)
* [Updating an Operator catalog image](http://file.rdu.redhat.com/~adellape/060320/filter-by-os/operators/olm-restricted-networks.html#olm-updating-operator-catalog-image_olm-restricted-networks) (steps 2 & 3)