### PR TITLE
[enterprise-4.3] AWS EFS provisioner was dropped for 4.x

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -1246,9 +1246,9 @@ indicate that the feature is removed from the release or deprecated.
 |GA
 
 |External provisioner for AWS EFS
-|TP
-|TP
-|TP
+|-
+|-
+|-
 
 |Pod Unidler
 |TP


### PR DESCRIPTION
This depends on the status of #22524. It has already been confirmed by QE via email.