### PR TITLE
[enterprise-4.4] AWS EFS provisioner was dropped for 4.x

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -615,6 +615,11 @@ In the table, features are marked with the following statuses:
 |-
 |-
 
+|External provisioner for AWS EFS
+|-
+|-
+|-
+
 |====
 
 [id="ocp-4-4-deprecated-features"]
@@ -1854,11 +1859,6 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 |GA
-
-|External provisioner for AWS EFS
-|TP
-|TP
-|TP
 
 |Pod Unidler
 |TP


### PR DESCRIPTION
This depends on the status of #22524. It has already been confirmed by QE via email.