### PR TITLE
[enterprise-4.5] AWS EFS provisioner was dropped for 4.x

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -218,6 +218,11 @@ In the table, features are marked with the following statuses:
 |-
 |-
 
+|External provisioner for AWS EFS
+|-
+|-
+|-
+
 |====
 
 [id="ocp-4-5-deprecated-features"]
@@ -403,11 +408,6 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 |GA
-
-|External provisioner for AWS EFS
-|TP
-|TP
-|
 
 |Pod Unidler
 |TP


### PR DESCRIPTION
This depends on the status of #22524. It has already been confirmed by QE via email.