### PR TITLE
Updated master node sizing for 4.4

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -21,7 +21,7 @@ The master node resource requirements depend on the number of nodes in the clust
 
 | 250
 | 16
-| 64
+| 96
 
 |===
 


### PR DESCRIPTION
- Updated recommended memory for master node to 96GB based on 4.4
  perfscale data