### PR TITLE
4.5.x Changes to log forward API for 4.5

### DIFF
--- a/modules/cluster-logging-collector-log-forward.adoc
+++ b/modules/cluster-logging-collector-log-forward.adoc
@@ -7,21 +7,6 @@
 
 The Log Forwarding API enables you to configure custom pipelines to send container and node logs to specific endpoints within or outside of your cluster. You can send logs by type to the internal {product-title} Elasticsearch instance and to remote destinations not managed by {product-title} cluster logging, such as an existing logging service, an external Elasticsearch cluster, external log aggregation solutions, or a Security Information and Event Management (SIEM) system.
 
-[IMPORTANT]
-====
-The Log Fowarding API is currently a Technology Preview feature.
-ifdef::openshift-enterprise,openshift-webscale[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
-Technology Preview features support scope] for more information.
-endif::[]
-====
-
 You can send different types of logs to different systems allowing you to control who in your organization can access each type. Optional TLS support ensures that you can send logs using secure communication as required by your organization.
 
 [NOTE]


### PR DESCRIPTION


https://issues.redhat.com/browse/LOG-561

FUTURE consideration for 4.5.z w/ LF GA: We should try and maybe have a general section for introducing the LF API and then move into “Send logs to an external syslog server”, “Send logs to an external Kafka”, “Send logs to an external Graylog using syslog”, etc. This is more about having some nice use cases we know customers may be interested in based on RFEs.
https://docs.google.com/document/d/1Ca04KEUW8-J1z_LuesiD_QivDSFMGTAqiJuft2aI_jw/edit?usp=sharing