### PR TITLE
Re-add deleted topicmap entry

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1360,6 +1360,8 @@ Topics:
   Topics:
   - Name: Getting started with Helm on OpenShift Container Platform
     File: getting-started-with-helm-on-openshift-container-platform
+- Name: Knative CLI (kn) for use with OpenShift Serverless
+  File: kn-cli-tools
 - Name: Pipelines CLI (tkn)
   Dir: tkn_cli
   Distros: openshift-enterprise,openshift-webscale,openshift-origin


### PR DESCRIPTION
This entry and the corresponding adoc file were added previously for OCP 4.4. However, this seems to have been accidentally removed when Pipelines tkn was added. Re-adding.