### PR TITLE
Add CSI note to IBM Z errata in OCP 4.2 Release Notes

### DIFF
--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1822,6 +1822,7 @@ Note the following restrictions for {product-title} on IBM System Z:
 ** The Multus plug-in.
 * Worker nodes must run Red Hat Enterprise Linux CoreOS.
 * Persistent storage must be of type Filesystem: NFS.
+* Other third-party storage vendors might provide Container Storage Interface (CSI)-enabled solutions that are certified to work with {product-title}. Consult OperatorHub on {product-title}, or your storage vendor, for more information.
 * These features are available for {product-title} on IBM System Z for
 {product-version}, but not for {product-title} {product-version} on x86:
 ** HyperPAV enabled in IBM System Z or the virtual machine for FICON-attached ECKD storage.


### PR DESCRIPTION
[OSDOCS-1129](https://issues.redhat.com/browse/OSDOCS-1129)
PM request on behalf of customer to add note about third-party CSI support for IBM Z in 4.2 Release Notes errata: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-10-features

Related 4.3 PR: https://github.com/openshift/openshift-docs/pull/22699