### PR TITLE
Add CSI note to IBM Z and LinuxONE errata in OCP 4.3 Release Notes

### DIFF
--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -2119,6 +2119,7 @@ Note the following restrictions for {product-title} on IBM Z and LinuxONE:
 
 * Worker nodes must run Red Hat Enterprise Linux CoreOS.
 * Persistent shared storage must be of type Filesystem: NFS.
+* Other third-party storage vendors might provide Container Storage Interface (CSI)-enabled solutions that are certified to work with {product-title}. Consult OperatorHub on {product-title}, or your storage vendor, for more information.
 * When setting up your z/VM instance for the {product-title} installation you might
 need to temporarily give your worker nodes more virtual CPU capacity or add a third worker node.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822770[*BZ#1822770*])


### PR DESCRIPTION
[OSDOCS-1129](https://issues.redhat.com/browse/OSDOCS-1129)
PM request on behalf of customer to add note about third-party CSI support for IBM Z and LinuxONE in 4.3 Release Notes errata: https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-18-features

Related 4.2 PR: https://github.com/openshift/openshift-docs/pull/22698