### PR TITLE
Update ancient SCL reference

### DIFF
--- a/modules/templates-creating-from-console.adoc
+++ b/modules/templates-creating-from-console.adoc
@@ -27,16 +27,16 @@ metadata:
   name: "ruby"
   creationTimestamp: null
 spec:
-  dockerImageRepository: "registry.redhat.io/openshift3/ruby-20-rhel7"
+  dockerImageRepository: "registry.redhat.io/rhscl/ruby-26-rhel7"
   tags:
     -
-      name: "2.0"
+      name: "2.6"
       annotations:
-        description: "Build and run Ruby 2.0 applications"
+        description: "Build and run Ruby 2.6 applications"
         iconClass: "icon-ruby"
         tags: "builder,ruby" <1>
-        supports: "ruby:2.0,ruby"
-        version: "2.0"
+        supports: "ruby:2.6,ruby"
+        version: "2.6"
 ----
 <1> Including *builder* here ensures this `ImageStreamTag` appears in the
 web console as a builder.


### PR DESCRIPTION
ruby-20-rhel7 is long unsupported and precedes multi-arch enablement.