### PR TITLE
BZ1842514 - Default volumesnapshotclass is not supported in 4.4

### DIFF
--- a/modules/persistent-storage-csi-snapshots-create.adoc
+++ b/modules/persistent-storage-csi-snapshots-create.adoc
@@ -33,13 +33,10 @@ apiVersion: snapshot.storage.k8s.io
 kind: VolumeSnapshotClass <1>
 metadata:
   name: csi-hostpath-snap
-  annotations:
-    snapshot.storage.kubernetes.io/is-default-class: "true" <2>
 driver: hostpath.csi.k8s.io
 deletionPolicy: Delete
 ----
 <1> Allows you to specify different attributes belonging to a VolumeSnapshot.
-<2> Optional. This annotation can be used to create a default VolumeSnapshotClass. This object will be used when VolumeSnapshot does not specify any explicit volumeSnapshotClassName.
 
 +
 . Create the object you saved in the previous step by entering the following command:
@@ -63,12 +60,12 @@ spec:
   source:
     persistentVolumeClaimName: myclaim <2>
 ----
-
-<1> The request for a particular class by the volume snapshot. If the parameter is not specified, the default class is used.
++
+<1> The request for a particular class by the volume snapshot.
 +
 [NOTE]
 ====
-If no default class is set and `volumeSnapshotClassName` is empty, then no snapshot is created.
+If `volumeSnapshotClassName` is empty, then no snapshot is created.
 ====
 +
 <2> The name of the PersistentVolumeClaim object bound to a persistent volume. This defines what you want to create a snapshot of. Required for dynamically provisioning a snapshot.


### PR DESCRIPTION
[BZ1842514](https://bugzilla.redhat.com/show_bug.cgi?id=1842514) - Removes notes about default volumestorageclass in `enterprise-4.4` branch only, as default volumesnaphsotclass isn't supported.

@qinpingli PTAL