### PR TITLE
Version updates for all images for 4.5 docs

### DIFF
--- a/modules/images-other-jenkins-agent-images.adoc
+++ b/modules/images-other-jenkins-agent-images.adoc
@@ -11,11 +11,11 @@ The {product-title} Jenkins agent images are available on `quay.io` or
 Jenkins images are available through the Red Hat Registry:
 
 ----
-$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.3.0>
-$ docker pull registry.redhat.io/openshift4/jenkins-agent-nodejs-10-rhel7:<v4.3.0>
-$ docker pull registry.redhat.io/openshift4/jenkins-agent-nodejs-12-rhel7:<v4.3.0>
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-maven:<v4.3.0>
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-base:<v4.3.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.5.0>
+$ docker pull registry.redhat.io/openshift4/jenkins-agent-nodejs-10-rhel7:<v4.5.0>
+$ docker pull registry.redhat.io/openshift4/jenkins-agent-nodejs-12-rhel7:<v4.5.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-maven:<v4.5.0>
+$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-base:<v4.5.0>
 ----
 
 To use these images, you can either access them directly from `quay.io` or


### PR DESCRIPTION
This PR updates the versions for all images in 4.5 docs. Similar to:
- https://github.com/openshift/openshift-docs/pull/22426 for 4.3
- https://github.com/openshift/openshift-docs/pull/22516 for 4.2