### PR TITLE
OSDOCS-1017 Release Notes 4.5 - Storage

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -122,6 +122,33 @@ for more information.
 
 See xref:../backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-scenario-3-recovering-expired-certs_dr-recovering-expired-certs[Recovering from expired control plane certificates] for more information.
 
+[id="ocp-4-5-storage"]
+=== Storage
+
+[id="ocp-4-5-persistent-storage-csi-ebs"]
+==== Persistent storage using the AWS EBS CSI Driver Operator (Technology Preview)
+
+You can now use the Container Storage Interface (CSI) to deploy the CSI driver you need for provisioning AWS Elastic Block Store (EBS) persistent storage. This Operator is in Technology Preview.
+// Add the following text with link when https://github.com/openshift/openshift-docs/pull/22350 has merged.
+//To enable it, see install instructions in link[AWS Elastic Block Store CSI Driver Operator].
+
+[id="ocp-4-5-persistent-storage-csi-manila"]
+==== Persistent storage using the OpenStack Manila CSI Driver Operator
+
+You can now use CSI to provision a PersistentVolume using the CSI driver for the OpenStack Manila shared file system service.
+// Add the following text with link when https://github.com/openshift/openshift-docs/pull/22199 has merged.
+//To enable it, see install instructions in link[OpenStack Manila CSI Driver Operator].
+
+[id="ocp-4-5-persistent-storage-csi-inline"]
+==== Persistent storage using CSI inline ephemeral volumes (Technology Preview)
+
+You can now use CSI to specify volumes directly in the Pod specification, rather than in a PersistentVolume. This feature is in Technology Preview and is available by default when using CSI drivers. For more information, see xref:../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes].
+
+[id="ocp-4-5-persistent-storage-csi-cloning"]
+==== Persistent storage using CSI volume cloning
+
+Volume cloning using CSI, previously in Technology Preview, is now fully supported in OpenShift Container Platform 4.5. For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-cloning.adoc#persistent-storage-csi-cloning[CSI volume cloning].
+
 [id="ocp-4-5-notable-technical-changes"]
 == Notable technical changes
 
@@ -272,11 +299,6 @@ In the table below, features are marked with the following statuses:
 |TP
 |
 
-|External provisioner for AWS EFS
-|TP
-|TP
-|
-
 |Pod Unidler
 |TP
 |TP
@@ -290,7 +312,7 @@ In the table below, features are marked with the following statuses:
 |Ephemeral Storage Limit/Requests
 |TP
 |TP
-|
+|TP
 
 |Descheduler
 |-
@@ -321,11 +343,6 @@ In the table below, features are marked with the following statuses:
 |TP
 |GA
 |GA
-
-|Raw Block with Cinder
-|TP
-|TP
-|
 
 |Three-node bare metal deployments
 |TP
@@ -362,30 +379,45 @@ In the table below, features are marked with the following statuses:
 |TP
 |
 
+|Raw Block with Cinder
+|TP
+|TP
+|TP
+
+|External provisioner for AWS EFS
+|TP
+|TP
+|TP
+
 |CSI volume snapshots
 |-
 |TP
-|
+|TP
 
 |CSI volume cloning
 |-
 |TP
 |GA
 
+|CSI AWS EBS Driver Operator
+|-
+|-
+|TP
+
+|OpenStack Manila CSI Driver Operator
+|-
+|-
+|GA
+
+|CSI inline ephemeral volumes
+|-
+|-
+|TP
+
 |OpenShift Pipelines
 |-
 |TP
 |
-
-|Manila CSI driver
-|-
-|-
-|TP
-
-|AWS EBS CSI driver
-|-
-|-
-|TP
 
 |====
 


### PR DESCRIPTION
[OSDOCS-1017](https://issues.redhat.com/browse/OSDOCS-1017)
Adds 4.5 OCP Storage features to 4.5 Release Notes:
• CSI AWS EBS Operator (TP)
• CSI Inline Ephemeral Volumes (TP)
• CSI Manila Operator (GA)
• CSI Cloning GA

Also updates the TP tracker table

Preview build: http://file.rdu.redhat.com/bfuru/061120/OSDOCS-1017/release_notes/ocp-4-5-release-notes.html