### PR TITLE
Remove 4.6 content from 4.5 RN

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -127,13 +127,6 @@ following notable technical changes:
 `generate crds` commands so that users can opt-in to `v1` CRDs. The default setting
 is `v1beta1`.
 
-[id="ocp-4-5-ovn-k8s-pod-np-uses-ovs-on-cluster-nodes"]
-==== OVN-Kubernetes Pod network provider now uses OVS installed on cluster nodes
-
-The OVN-Kubernetes Pod network provider now uses the Open vSwitch (OVS) version
-installed on the cluster nodes. Previously, OVS ran in a container on each node,
-managed by a DaemonSet. Using the host OVS eliminates any possible downtime from
-upgrading the containerized version of OVS.
 
 [id="ocp-4-5-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
Removed 4.6 content from the 4.5 RN's.  No QE required. See [Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1843235#c2) for more info.