### PR TITLE
BZ-1845226: Updating the output for the etcd cluster operator's status

### DIFF
--- a/modules/restore-identify-unhealthy-etcd-member.adoc
+++ b/modules/restore-identify-unhealthy-etcd-member.adoc
@@ -22,17 +22,7 @@ $ oc get etcd -o=jsonpath='{range .items[0].status.conditions[?(@.type=="EtcdMem
 . Review the output:
 +
 ----
-ip-10-0-164-97.ec2.internal,ip-10-0-154-204.ec2.internal members are available,  have not started, ip-10-0-131-183.ec2.internal are unhealthy,  are unknown
-----
-+
-In this example, `ip-10-0-131-183.ec2.internal are unhealthy` indicates that the `ip-10-0-131-183.ec2.internal` etcd member is unhealthy.
-
-////
-Once https://github.com/openshift/cluster-etcd-operator/pull/307 merges for 4.4, use this output:
-
-----
 2 of 3 members are available, ip-10-0-131-183.ec2.internal is unhealthy
 ----
 +
 This example output shows that the `ip-10-0-131-183.ec2.internal` etcd member is unhealthy.
-////


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1845226