### PR TITLE
Related image block is defined to use image as the key

### DIFF
--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -23,9 +23,9 @@ CSV:
 spec:
   relatedImages: <1>
     - name: etcd-operator <2>
-      value: quay.io/etcd-operator/operator@sha256:d134a9865524c29fcf75bbc4469013bc38d8a15cb5f41acfddb6b9e492f556e4 <3>
+      image: quay.io/etcd-operator/operator@sha256:d134a9865524c29fcf75bbc4469013bc38d8a15cb5f41acfddb6b9e492f556e4 <3>
     - name: etcd-image
-      value: quay.io/etcd-operator/etcd@sha256:13348c15263bd8838ec1d5fc4550ede9860fcbb0f843e48cbccec07810eebb68
+      image: quay.io/etcd-operator/etcd@sha256:13348c15263bd8838ec1d5fc4550ede9860fcbb0f843e48cbccec07810eebb68
 ...
 ----
 <1> Create a `relatedImages` section and set the list of related images.


### PR DESCRIPTION
The yaml key for the image pull spec in related images
is not correct it should be `image` not `value`.