### PR TITLE
Removing username password login limitation for OIDC IDPs

### DIFF
--- a/modules/identity-provider-add.adoc
+++ b/modules/identity-provider-add.adoc
@@ -12,15 +12,17 @@
 // * authentication/identity_providers/configuring-google-identity-provider.adoc
 // * authentication/identity_providers/configuring-oidc-identity-provider.adoc
 
-// OIDC, GitHub, and Google IDPs do not support username/password login commands
-ifeval::["{context}" == "configuring-oidc-identity-provider"]
-:no-username-password-login:
-endif::[]
+// GitHub and Google IDPs do not support username/password login commands
 ifeval::["{context}" == "configuring-github-identity-provider"]
 :no-username-password-login:
 endif::[]
 ifeval::["{context}" == "configuring-google-identity-provider"]
 :no-username-password-login:
+endif::[]
+// Only some OIDC IDPs support username/password login commands
+ifeval::["{context}" == "configuring-oidc-identity-provider"]
+:no-username-password-login:
+:oidc:
 endif::[]
 
 [id="add-identity-provider_{context}"]
@@ -73,7 +75,13 @@ $ oc login --token=<token>
 +
 [NOTE]
 ====
+ifdef::oidc[]
+Some OpenID Connect identity providers support logging in with a user name and password.
+endif::oidc[]
+
+ifndef::oidc[]
 This identity provider does not support logging in with a user name and password.
+endif::oidc[]
 ====
 endif::no-username-password-login[]
 
@@ -89,6 +97,7 @@ ifeval::["{context}" == "configuring-google-identity-provider"]
 endif::[]
 ifeval::["{context}" == "configuring-oidc-identity-provider"]
 :!no-username-password-login:
+:!oidc:
 endif::[]
 ifeval::["{context}" == "configuring-github-identity-provider"]
 :!no-username-password-login:


### PR DESCRIPTION
Preparation for https://bugzilla.redhat.com/show_bug.cgi?id=1727983.

Preview: https://remove-oidc-limitation--ocpdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-oidc-identity-provider.html#add-identity-provider_configuring-oidc-identity-provider