### PR TITLE
BZ1839982 FOR 2.4: Updating access mode for LiveMigration

### DIFF
--- a/modules/virt-understanding-live-migration.adoc
+++ b/modules/virt-understanding-live-migration.adoc
@@ -5,16 +5,15 @@
 [id="virt-understanding-live-migration_{context}"]
 = Understanding live migration
 
-Live migration is the process of moving a running virtual machine instance to 
-another node in the cluster without interruption to the virtual workload or 
-access. This can be a manual process, if you select a virtual machine instance 
-to migrate to another node, or an automatic process, if the 
-virtual machine instance has a `LiveMigrate` eviction strategy and the node on 
-which it is running is placed into maintenance. 
+Live migration is the process of moving a running virtual machine instance to
+another node in the cluster without interrupting the virtual workload or access.
+This can be a manual process, if you select virtual machine instance
+to migrate to another node, or an automatic process, if the virtual machine
+instance has a `LiveMigrate` eviction strategy and the node on
+which it is running is placed into maintenance.
 
 [IMPORTANT]
 ====
-Virtual machines must have a PersistentVolumeClaim (PVC) with a shared 
-ReadWriteMany (RWX) access mode to be live migrated.
+Virtual machines must have a PersistentVolumeClaim (PVC)
+with a shared ReadWriteMany (RWX) access mode to be live migrated.
 ====
-

--- a/modules/virt-updating-access-mode-for-live-migration.adoc
+++ b/modules/virt-updating-access-mode-for-live-migration.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-live-migration.adoc
+
+[id="virt-updating-access-mode-for-live-migration_{context}"]
+= Updating access mode for LiveMigration
+
+For LiveMigration to function properly, you must use the
+ReadWriteMany (RWX) access mode. Use this
+procedure to update the access mode, if needed.
+
+.Procedure
+* To set the RWX access mode, run the following `oc patch` command:
++
+----
+$ oc patch -n openshift-cnv \
+    cm kubevirt-storage-class-defaults \
+    -p '{"data":{"'$<STORAGE_CLASS>'.accessMode":"ReadWriteMany"}}'
+----

--- a/virt/live_migration/virt-live-migration.adoc
+++ b/virt/live_migration/virt-live-migration.adoc
@@ -4,7 +4,15 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-live-migration
 toc::[]
 
+.Prerequisites
+* Before using LiveMigration, ensure that the storage class used by the
+virtual machine has a PersistentVolumeClaim (PVC) with a shared
+ReadWriteMany (RWX) access mode.
+See xref:../../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[Storage defaults for DataVolumes]
+to ensure your storage settings are correct.
+
 include::modules/virt-understanding-live-migration.adoc[leveloffset=+1]
+include::modules/virt-updating-access-mode-for-live-migration.adoc[leveloffset=+1]
 
 .Additional resources:
 


### PR DESCRIPTION
Expanding content to include a separate module with prereqs and procedure for changing access mode from RWO to RWX to enable LiveMigration.

This BZ has been code and QE reviewed and approved and went through peer review extensively. 
Steve Bream is recommending it be merged, but feel free to review for suggestions, @adellape 

Requesting peer review from @adellape --- as this is a bug, please fit this in when you can as we can push async to the 2.4 build. 

Please label *peer review needed* and  *enterprise-4.5*

Test Build: See Netify build.

