### PR TITLE
Fix callout numbering

### DIFF
--- a/modules/persistent-storage-csi-snapshots-create.adoc
+++ b/modules/persistent-storage-csi-snapshots-create.adoc
@@ -61,17 +61,12 @@ spec:
     persistentVolumeClaimName: myclaim <2>
 ----
 +
-<1> The request for a particular class by the volume snapshot.
-+
-[NOTE]
-====
-If `volumeSnapshotClassName` is empty, then no snapshot is created.
-====
+<1> The request for a particular class by the volume snapshot. If `volumeSnapshotClassName` is empty, then no snapshot is created.
+
 +
 <2> The name of the PersistentVolumeClaim object bound to a persistent volume. This defines what you want to create a snapshot of. Required for dynamically provisioning a snapshot.
 
-+
-* Create the object you saved in the previous step by entering the following command:
+. Create the object you saved in the previous step by entering the following command:
 +
 ----
 $ oc create -f volumesnapshot-dynamic.yaml


### PR DESCRIPTION
Relates to this [PR 22785](https://github.com/openshift/openshift-docs/pull/22785) and this comment:
https://github.com/openshift/openshift-docs/pull/22785#issuecomment-641388987
@bmcelvee Unfortunately, when I add the continuing `+`, it doesn't continue the callout numbering. (Instead, it lists both callouts as #1.) I couldn't figure out a better workaround, and ultimately reverted back to original formatting. I actually think I mucked with this when the original content was created. Will continue to investigate a fix for this.