### PR TITLE
Add missing file to migration 3-4 installation

### DIFF
--- a/migration/migrating_3_4/deploying-cam-3-4.adoc
+++ b/migration/migrating_3_4/deploying-cam-3-4.adoc
@@ -22,6 +22,7 @@ After you have installed the Cluster Application Migration Operator on your clus
 
 You can install the Cluster Application Migration Operator with the Operation Lifecycle Manager (OLM) on an {product-title} {product-version} target cluster and manually on an {product-title} 3 source cluster.
 
+include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
 include::modules/migration-installing-cam-operator-ocp-3.adoc[leveloffset=+2]
 :!migrating-3-4:
 


### PR DESCRIPTION
Add missing include file for installing CAM on 4.x target cluster

For 4.2, "migrating 3-4"