### PR TITLE
Remove timeline text from delay

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -69,7 +69,7 @@ You can use the `fast-{product-version}` channel to upgrade from a previous mino
 
 While the `fast-{product-version}` channel contains releases as soon
 as their errata are published, releases are added to the `stable-{product-version}` channel
-after a delay of several hours to a day. During this delay, data is collected from Red Hat SRE teams, Red Hat support services, and pre-production and production environments that participate in connected customer program about the stability of the release.
+after a delay. During this delay, data is collected from Red Hat SRE teams, Red Hat support services, and pre-production and production environments that participate in connected customer program about the stability of the release.
 
 You can use the `stable-{product-version}` channel to upgrade from a previous minor version of
 {product-title}.


### PR DESCRIPTION
Removed timeline text from doc per [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1841927).