### PR TITLE
Errata update for 3.11.232 release

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -3,9 +3,9 @@
 {product-author}
 {product-version}
 :major-tag: v3.11
-:latest-tag: v3.11.219
-:latest-int-tag: v3.11.219
-:latest-registry-console-tag: v3.11.219
+:latest-tag: v3.11.232
+:latest-int-tag: v3.11.232
+:latest-registry-console-tag: v3.11.232
 :data-uri:
 :icons:
 :experimental:

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -3,10 +3,10 @@
 {product-author}
 {product-version}
 ifdef::openshift-enterprise[]
-:latest-tag: v3.11.219
+:latest-tag: v3.11.232
 endif::[]
 ifdef::openshift-origin[]
-:latest-tag: v3.11.219
+:latest-tag: v3.11.232
 endif::[]
 :data-uri:
 :icons:

--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -3269,3 +3269,171 @@ Issued: 2020-05-27
 An update for cri-o is now available for {product-title} 3.11. Details of the
 update are documented in the
 link:https://access.redhat.com/errata/RHSA-2020:2218[RHSA-2020:2218] advisory.
+
+[[ocp-3-11-232]]
+=== RHBA-2020:2477 - {product-title} 3.11.232 bug fix update
+
+Issued: 2020-06-17
+
+{product-title} release 3.11.232 is now available. The list of packages and
+bug fixes included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2020:2477[RHBA-2020:2477] advisory.
+The container images included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2020:2434[RHBA-2020:2434] advisory.
+
+[[ocp-3-11-232-features]]
+==== Features
+
+[[ocp-3-11-232-added-nodejs-jenkins-agent-v10-and-v12]]
+===== Added Node.js Jenkins Agent v10 and v12
+
+The `jenkins-agent-nodejs-10-rhel7` and `jenkins-agent-nodejs-12-rhel7` images
+are now added to {product-title}. These new images allow Jenkins Pipelines to
+be upgraded to use either v10 or v12 of the Node.js Jenkins Agent. The Node.js
+v8 Jenkins Agent is now deprecated, but will continue to be provided. For
+existing clusters, you must manually upgrade the Node.js Jenkins Agent, which
+can be performed on a per namespace basis. Follow these steps to complete the
+manual upgrade:
+
+. Select the project for which you want to upgrade the Jenkins Pipelines:
++
+----
+$ oc project <project_name>
+----
+
+. Import the new Node.js Jenkins Agent image:
++ 
+----
+$ oc import-image nodejs openshift3/jenkins-agent-nodejs-10-rhel7 --from=registry.redhat.io/openshift3/jenkins-agent-nodejs-10-rhel7 --confirm
+----
++
+This command imports the v10 image. If you prefer v12, update the image
+specifications accordingly.
+
+. Overwrite the current Node.js Jenkins Agent with the new one you imported:
++
+----
+$ oc label is nodejs role=jenkins-slave --overwrite
+----
+
+. Verify in the Jenkins log that the new Jenkins Agent template is configured:
++
+----
+$ oc logs -f jenkins-1-<pod>
+----
+
+You can only get technical support for applications using the Node.js v8 Jenkins
+Agent. For software maintenance support, you must upgrade to one of the
+supported images. See xref:../using_images/other_images/jenkins_slaves.adoc#using-images-other-images-jenkins-slaves[Jenkins Agents]
+for more information.
+
+[[ocp-3-11-232-images]]
+==== Images
+
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with
+the following images:
+
+----
+openshift3/ose-ansible:v3.11.232-3
+openshift3/ose-descheduler:v3.11.232-3
+openshift3/ose-node-problem-detector:v3.11.232-3
+openshift3/ose-cluster-monitoring-operator:v3.11.232-3
+openshift3/csi-attacher:v3.11.232-3
+openshift3/csi-livenessprobe:v3.11.232-3
+openshift3/ose-efs-provisioner:v3.11.232-3
+openshift3/prometheus-alertmanager:v3.11.232-3
+openshift3/prometheus:v3.11.232-3
+openshift3/image-inspector:v3.11.232-3
+openshift3/jenkins-agent-nodejs-10-rhel7:v3.11.232-3
+openshift3/jenkins-agent-nodejs-8-rhel7:v3.11.232-3
+openshift3/ose-kube-rbac-proxy:v3.11.232-3
+openshift3/kuryr-cni:v3.11.232-3
+openshift3/ose-logging-elasticsearch5:v3.11.232-4
+openshift3/logging-fluentd:v3.11.232-3
+openshift3/metrics-cassandra:v3.11.232-3
+openshift3/metrics-hawkular-openshift-agent:v3.11.232-3
+openshift3/metrics-schema-installer:v3.11.232-3
+openshift3/apb-tools:v3.11.232-3
+openshift3/ose-docker-builder:v3.11.232-3
+openshift3/ose-cluster-capacity:v3.11.232-3
+openshift3/ose:v3.11.232-3
+openshift3/ose-egress-dns-proxy:v3.11.232-3
+openshift3/ose-haproxy-router:v3.11.232-3
+openshift3/ose-hypershift:v3.11.232-3
+openshift3/mariadb-apb:v3.11.232-3
+openshift3/mediawiki:v3.11.232-3
+openshift3/node:v3.11.232-3
+openshift3/postgresql-apb:v3.11.232-3
+openshift3/ose-docker-registry:v3.11.232-3
+openshift3/ose-tests:v3.11.232-3
+openshift3/local-storage-provisioner:v3.11.232-3
+openshift3/ose-operator-lifecycle-manager:v3.11.232-3
+openshift3/ose-egress-http-proxy:v3.11.232-3
+openshift3/ose-ovn-kubernetes:v3.11.232-3
+openshift3/ose-prometheus-operator:v3.11.232-3
+openshift3/snapshot-controller:v3.11.232-3
+openshift3/ose-template-service-broker:v3.11.232-3
+openshift3/ose-cluster-autoscaler:v3.11.232-3
+openshift3/ose-metrics-server:v3.11.232-3
+openshift3/automation-broker-apb:v3.11.232-3
+openshift3/ose-configmap-reloader:v3.11.232-3
+openshift3/csi-driver-registrar:v3.11.232-3
+openshift3/csi-provisioner:v3.11.232-3
+openshift3/oauth-proxy:v3.11.232-3
+openshift3/prometheus-node-exporter:v3.11.232-3
+openshift3/grafana:v3.11.232-3
+openshift3/jenkins-agent-maven-35-rhel7:v3.11.232-3
+openshift3/jenkins-agent-nodejs-12-rhel7:v3.11.232-3
+openshift3/jenkins-slave-base-rhel7:v3.11.232-3
+openshift3/ose-kube-state-metrics:v3.11.232-3
+openshift3/ose-logging-curator5:v3.11.232-3
+openshift3/ose-logging-eventrouter:v3.11.232-3
+openshift3/ose-logging-kibana5:v3.11.232-3
+openshift3/metrics-hawkular-metrics:v3.11.232-3
+openshift3/metrics-heapster:v3.11.232-3
+openshift3/apb-base:v3.11.232-3
+openshift3/ose-ansible-service-broker:v3.11.232-3
+openshift3/ose-cli:v3.11.232-3
+openshift3/ose-console:v3.11.232-3
+openshift3/ose-deployer:v3.11.232-3
+openshift3/ose-egress-router:v3.11.232-3
+openshift3/ose-hyperkube:v3.11.232-3
+openshift3/ose-keepalived-ipfailover:v3.11.232-3
+openshift3/mediawiki-apb:v3.11.232-3
+openshift3/mysql-apb:v3.11.232-3
+openshift3/ose-pod:v3.11.232-3
+openshift3/ose-recycler:v3.11.232-3
+openshift3/ose-service-catalog:v3.11.232-3
+openshift3/jenkins-2-rhel7:v3.11.232-3
+openshift3/manila-provisioner:v3.11.232-3
+openshift3/ose-web-console:v3.11.232-3
+openshift3/kuryr-controller:v3.11.232-3
+openshift3/ose-prometheus-config-reloader:v3.11.232-3
+openshift3/registry-console:v3.11.232-3
+openshift3/snapshot-provisioner:v3.11.232-3
+----
+
+[[ocp-3-11-232-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest
+release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade
+methods and strategies] for instructions.
+
+[[RHSA-2020-2478]]
+=== RHSA-2020:2478 - Important: {product-title} jenkins-2-plugins security update
+
+Issued: 2020-06-17
+
+An update for jenkins-2-plugins is now available for {product-title} 3.11.
+Details of the update are documented in the
+link:https://access.redhat.com/errata/RHSA-2020:2478[RHSA-2020:2478] advisory.
+
+[[RHSA-2020-2479]]
+=== RHSA-2020:2479 - Moderate: {product-title} atomic-openshift security update
+
+Issued: 2020-06-17
+
+An update for atomic-openshift is now available for {product-title} 3.11.
+Details of the update are documented in the
+link:https://access.redhat.com/errata/RHSA-2020:2479[RHSA-2020:2479] advisory.

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -2,9 +2,9 @@
 = Performing automated in-place cluster upgrades
 {product-author}
 {product-version}
-:latest-tag: v3.11.219
+:latest-tag: v3.11.232
 :latest-short-tag: v3.11
-:latest-int-tag: v3.11.219
+:latest-int-tag: v3.11.232
 ifdef::openshift-enterprise[]
 :pb-prefix: /usr/share/ansible/openshift-ansible/
 endif::[]


### PR DESCRIPTION
Ships 2020-06-17

This includes the new Nodejs Jenkins Agent v10/12 upgrade release note that was previously reviewed/confirmed in #22427. 