### PR TITLE
Hugepages allocation at boot time, rather than run time.

### DIFF
--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -5,20 +5,28 @@
 [id="configuring-huge-pages_{context}"]
 = Configuring huge pages
 
-Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the
-Node Tuning Operator to allocate huge pages on a specific node.
+Nodes must pre-allocate huge pages used in an {product-title} cluster.
+There are two ways of reserving huge pages: at boot time and at run time.
+Reserving at boot time increases the possibility of success because the
+memory has not yet been significantly fragmented. The Node Tuning
+Operator currently supports boot time allocation of huge pages on specific nodes.
+
+
+== At boot time
 
 .Procedure
 
-. Label the node so that the Node Tuning Operator knows on which node to apply the
-tuned profile, which describes how many huge pages should be allocated:
+To minimize node reboots, the order of the steps below needs to be followed:
+
+. Label all nodes that need the same hugepages setting by a label.
 +
 ----
-$ oc label node <node_using_hugepages> hugepages=true
+$ oc label node <node_using_hugepages> node-role.kubernetes.io/worker-hp=
 ----
 
-. Create a file with the following content and name it `hugepages_tuning.yaml`:
+. Create a file with the following content and name it `hugepages-tuned-boottime.yaml`:
 +
+[source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
@@ -29,29 +37,117 @@ spec:
   profile: <2>
   - data: |
       [main]
-      summary=Configuration for hugepages
+      summary=Boot time configuration for hugepages
       include=openshift-node
+      [bootloader]
+      cmdline_openshift_node_hugepages=hugepagesz=2M hugepages=50 <3>
+    name: openshift-node-hugepages
 
+  recommend:
+  - machineConfigLabels: <4>
+      machineconfiguration.openshift.io/role: "worker-hp"
+    priority: 30
+    profile: openshift-node-hugepages
+----
+<1> Set the `name` of the Tuned resource to `hugepages`.
+<2> Set the `profile` section to allocate huge pages.
+<3> Note the order of parameters is important as some platforms support hugepages of various sizes.
+<4> Enable MachineConfigPool based matching.
+
+
+. Create the Tuned `hugepages` profile
++
+----
+$ oc create -f hugepages-tuned-boottime.yaml
+----
+
+. Create a file with the following content and name it `hugepages-mcp.yaml`:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-hp
+  labels:
+    worker-hp: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,worker-hp]}
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-hp: ""
+----
+
+. Create the MachineConfigPool:
++
+----
+$ oc create -f hugepages-mcp.yaml
+----
+
+Given enough non-fragmented memory, all the nodes in the `worker-hp`
+MachineConfigPool should now have 50 2Mi hugepages allocated.
+
+----
+$ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages-2Mi}"
+100Mi
+----
+
+[WARNING]
+====
+This functionality is currently only supported on {op-system-first} 8.x worker nodes. On {op-system-base-full} 7.x worker nodes the
+tuned `[bootloader]` plug-in is currently not supported.
+====
+
+////
+For run-time allocation, kubelet changes are needed, see BZ1819719.
+== At run time
+
+.Procedure
+
+. Label the node so that the Node Tuning Operator knows on which node to apply the
+tuned profile, which describes how many huge pages should be allocated:
++
+----
+$ oc label node <node_using_hugepages> hugepages=true
+----
+
+. Create a file with the following content and name it `hugepages-tuned-runtime.yaml`:
++
+[source,yaml]
+----
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: hugepages <1>
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile: <2>
+  - data: |
+      [main]
+      summary=Run time configuration for hugepages
+      include=openshift-node
       [vm]
       transparent_hugepages=never
-
-      [sysctl]
-      vm.nr_hugepages=1024
+      [sysfs]
+      /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages=50
     name: node-hugepages
+
   recommend:
   - match: <3>
     - label: hugepages
     priority: 30
     profile: node-hugepages
 ----
-<1> Set the `name` parameter value to `hugepages`.
+<1> Set the `name` of the Tuned resource to `hugepages`.
 <2> Set the `profile` section to allocate huge pages.
 <3> Set the `match` section to associate the profile to nodes with the `hugepages` label.
 
-. Create the custom `hugepages` tuned profile by using the `hugepages_tuning.yaml` file:
+. Create the custom `hugepages` tuned profile by using the `hugepages-tuned-runtime.yaml` file:
 +
 ----
-$ oc create -f hugepages_tuning.yaml
+$ oc create -f hugepages-tuned-runtime.yaml
 ----
 
 . After creating the profile, the Operator applies the new profile to the correct
@@ -66,3 +162,5 @@ $ oc logs <tuned_pod_on_node_using_hugepages> \
 ----
 2019-08-08 07:20:41,286 INFO     tuned.daemon.daemon: static tuning from profile 'node-hugepages' applied
 ----
+
+////

--- a/modules/how-huge-pages-are-consumed-by-apps.adoc
+++ b/modules/how-huge-pages-are-consumed-by-apps.adoc
@@ -14,6 +14,7 @@ notation using integer values supported on a particular node. For example, if a
 node supports 2048KiB page sizes, it exposes a schedulable resource
 `hugepages-2Mi`. Unlike CPU or memory, huge pages do not support over-commitment.
 
+[source,yaml]
 ----
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
For run time hugepages allocation to work properly, (currently missing) support from the kubelet is needed.  Promote only boot time allocation at this point.
