### PR TITLE
BZ1844942 - Amending procedure to define explicit resource quotas

### DIFF
--- a/applications/quotas/quotas-setting-per-project.adoc
+++ b/applications/quotas/quotas-setting-per-project.adoc
@@ -23,6 +23,4 @@ include::modules/quotas-creating-a-quota.adoc[leveloffset=+1]
 include::modules/quotas-creating-object-count-quotas.adoc[leveloffset=+2]
 include::modules/setting-resource-quota-for-extended-resources.adoc[leveloffset=+2]
 include::modules/quotas-viewing-quotas.adoc[leveloffset=+1]
-
-// This is not configurable in 4.1 right now - removing
-// include::modules/quotas-requiring-explicit-quota.adoc[leveloffset=+1]
+include::modules/quotas-requiring-explicit-quota.adoc[leveloffset=+1]

--- a/modules/quotas-requiring-explicit-quota.adoc
+++ b/modules/quotas-requiring-explicit-quota.adoc
@@ -4,48 +4,131 @@
 
 // NOTE: This is currently not configurable in 4.1, removing from 4.1 docs.
 
-[id="quota-requiring-explicit-quota_{context}"]
-= Requiring explicit quota to consume a resource
+[id="configuring-explicit-resource-quotas_{context}"]
+= Configuring explicit resource quotas
 
-If a resource is not managed by quota, a user has no restriction on the amount
-of resource that can be consumed.  For example, if there is no quota on storage
-related to the gold storage class, the amount of gold storage a project can
-create is unbounded.
+Configure explicit resource quotas in a project request template to apply specific resource quotas in new projects.
 
-For high-cost compute or storage resources, administrators might want to require
-an explicit quota be granted in order to consume a resource.  For example, if a
-project was not explicitly given quota for storage related to the gold storage
-class, users of that project would not be able to create any storage of that
-type.
+.Prerequisites
+
+* Access to the cluster as a user with the cluster-admin role.
+
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
 
 .Procedure
 
-To require explicit quota to consume a particular resource:
-
-. Add the following stanza to the master configuration:
+. Add a resource quota definition to a project request template:
++
+** If a project request template does not exist in a cluster:
+.. Create a bootstrap project template and output it to a file called `template.yaml`:
++
+----
+$ oc adm create-bootstrap-project-template -o yaml > template.yaml
+----
++
+.. Add a resource quota definition to `template.yaml`. The following example defines a resource quota named 'storage-consumption'. The definition must be added before the `parameters:` section in the template:
 +
 [source,yaml]
 ----
-admissionConfig:
-  pluginConfig:
-    ResourceQuota:
-      configuration:
-        apiVersion: resourcequota.admission.k8s.io/v1alpha1
-        kind: Configuration
-        limitedResources:
-        - resource: persistentvolumeclaims <1>
-        matchContains:
-        - gold.storageclass.storage.k8s.io/requests.storage <2>
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: storage-consumption
+  spec:
+    hard:
+      persistentvolumeclaims: "10" <1>
+      requests.storage: "50Gi" <2>
+      gold.storageclass.storage.k8s.io/requests.storage: "10Gi" <3>
+      silver.storageclass.storage.k8s.io/requests.storage: "20Gi" <4>
+      silver.storageclass.storage.k8s.io/persistentvolumeclaims: "5" <5>
+      bronze.storageclass.storage.k8s.io/requests.storage: "0" <6>
+      bronze.storageclass.storage.k8s.io/persistentvolumeclaims: "0" <7>
 ----
-<1> The group/resource to whose consumption is limited by default.
-<2> The name of the resource tracked by quota associated with the group/resource to
-limit by default.
+<1> The total number of persistent volume claims in a project.
+<2> Across all persistent volume claims in a project, the sum of storage requested cannot exceed this value.
+<3> Across all persistent volume claims in a project, the sum of storage requested in the gold storage class cannot exceed this value.
+<4> Across all persistent volume claims in a project, the sum of storage requested in the silver storage class cannot exceed this value.
+<5> Across all persistent volume claims in a project, the total number of claims in the silver storage class cannot exceed this value.
+<6> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value. When this value is set to `0`, the bronze storage class cannot request storage.
+<7> Across all persistent volume claims in a project, the sum of storage requested in the bronze storage class cannot exceed this value. When this value is set to `0`, the bronze storage class cannot create claims.
 +
-In the above example, the quota system intercepts every operation that
-creates or updates a `PersistentVolumeClaim`. It checks what resources understood
-by quota would be consumed, and if there is no covering quota for those resources
-in the project, the request is denied.
+.. Create a project request template from the modified `template.yaml` file in the `openshift-config` namespace:
 +
-In this example, if a user creates a `PersistentVolumeClaim` that uses storage
-associated with the gold storage class, and there is no matching quota in the
-project, the request is denied.
+----
+$ oc create -f template.yaml -n openshift-config
+----
++
+[NOTE]
+====
+To include the configuration as a `kubectl.kubernetes.io/last-applied-configuration` annotation, add the `--save-config` option to the `oc create` command.
+====
++
+By default, the template is called `project-request`.
++
+** If a project request template already exists within a cluster:
++
+[NOTE]
+====
+If you declaratively or imperatively manage objects within your cluster by using configuration files, edit the existing project request template through those files instead.
+====
++
+.. List templates in the `openshift-config` namespace:
++
+----
+$ oc get templates -n openshift-config
+----
++
+.. Edit an existing project request template:
++
+----
+$ oc edit template <project_request_template> -n openshift-config
+----
++
+.. Add a resource quota definition, such as the preceding 'storage-consumption' example, into the existing template. The definition must be added before the `parameters:` section in the template.
+
+. If you created a project request template, reference it in the cluster's project configuration resource:
+.. Access the project configuration resource for editing:
++
+** By using the web console:
+... Navigate to the *Administration* -> *Cluster Settings* page.
+... Click *Global Configuration* to view all configuration resources.
+... Find the entry for *Project* and click *Edit YAML*.
++
+** By using the CLI:
+... Edit the `project.config.openshift.io/cluster` resource:
++
+----
+$ oc edit project.config.openshift.io/cluster
+----
++
+.. Update the `spec` section of the project configuration resource to include the `projectRequestTemplate` and `name` parameters. The following example references the default project request template name `project-request`:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Project
+metadata:
+  ...
+spec:
+  projectRequestTemplate:
+    name: project-request
+----
+
+. Verify that the resource quota is applied when projects are created:
+.. Create a project:
++
+----
+$ oc new-project <project_name>
+----
++
+.. List the project's resource quotas:
++
+----
+$ oc get resourcequotas
+----
++
+.. Describe the resource quota in detail:
++
+----
+$ oc describe resourcequotas <resource_quota_name>
+----


### PR DESCRIPTION
Applies to 4.2 onward.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1844942.

A preview is available at https://bz1844942--ocpdocs.netlify.app/openshift-enterprise/latest/applications/quotas/quotas-setting-per-project.html#configuring-explicit-resource-quotas_quotas-setting-per-project.