### PR TITLE
CNV-4721 Make CDI work with namespace resource quota

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1588,6 +1588,8 @@ Topics:
     Topics:
     - Name: Configuring local storage for virtual machines
       File: virt-configuring-local-storage-for-vms
+    - Name: Configuring CDI to work with namespaces that have a compute resource quota
+      File: virt-configuring-cdi-for-namespace-resourcequota
     - Name: Uploading local disk images by using the virtctl tool
       File: virt-uploading-local-disk-images-virtctl
     - Name: Uploading a local disk image to a block storage DataVolume

--- a/modules/virt-about-cpu-and-memory-quota-namespace.adoc
+++ b/modules/virt-about-cpu-and-memory-quota-namespace.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-configuring-cdi-for-namespace-resourcequota.adoc
+
+[id="virt-about-cpu-and-memory-quota-namespace_{context}"]
+= About CPU and memory quotas in a namespace
+
+A _resource quota_, defined by the `ResourceQuota` object, imposes restrictions on
+a namespace that limit the total amount of compute resources that can be
+consumed by resources within that namespace.
+
+The `CDIConfig` object defines the user configuration for the Containerized Data Importer (CDI). The CPU and
+memory request and limit values for the `CDIConfig` object are set to a default
+value of 0.
+This ensures that Pods created by CDI that make no compute resource requirements
+are given the default values and are allowed to run in a namespace that is restricted
+with a quota.

--- a/modules/virt-editing-cdi-cpu-and-memory-defaults.adoc
+++ b/modules/virt-editing-cdi-cpu-and-memory-defaults.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-configuring-cdi-for-namespace-resourcequota.adoc
+
+[id="virt-editing-cdi-cpu-and-memory-defaults_{context}"]
+= Editing the `CDIConfig` object to override CPU and memory defaults
+
+Modify the default settings for CPU and memory requests and limits for your
+use case by editing the `spec` attribute of the `CDIConfig` object.
+
+.Prerequisites
+
+* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+
+.Procedure
+
+. Edit the `cdiconfig/config` by running the following command:
++
+----
+$ oc edit cdiconfig/config
+----
+
+. Change the default CPU and memory requests and limits by editing the `spec: podResourceRequirements` property of the `CDIConfig` object:
++
+[source,yaml]
+
+----
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: CDIConfig
+metadata:
+  labels:
+    app: containerized-data-importer
+    cdi.kubevirt.io: ""
+  name: config
+spec:
+    podResourceRequirements:
+    limits:
+      cpu: "4"
+      memory: "1Gi"
+    requests:
+      cpu: "1"
+      memory: "250Mi"
+...
+----
+
+. Save and exit the editor to update the `CDIConfig` object.
+
+.Verification Step
+
+View the `CDIConfig` status and verify your changes by running the following command:
+
+----
+$ oc get cdiconfig config -o yaml
+----

--- a/virt/virtual_machines/virtual_disks/virt-configuring-cdi-for-namespace-resourcequota.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-cdi-for-namespace-resourcequota.adoc
@@ -1,0 +1,15 @@
+[id="virt-configuring-cdi-for-namespace-resourcequota"]
+= Configuring CDI to work with namespaces that have a compute resource quota
+include::modules/virt-document-attributes.adoc[]
+:context: virt-configuring-cdi-for-namespace-resourcequota
+toc::[]
+
+You can use the Containerized Data Importer (CDI) to import, upload, and clone virtual machine disks into namespaces that are subject to CPU and memory resource restrictions.
+
+include::modules/virt-about-cpu-and-memory-quota-namespace.adoc[leveloffset=+1]
+
+include::modules/virt-editing-cdi-cpu-and-memory-defaults.adoc[leveloffset=+1]
+
+== Additional resources
+
+* xref:../../../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Resource quotas per project]


### PR DESCRIPTION
These modules and assembly address [https://issues.redhat.com/browse/CNV-4721](https://issues.redhat.com/browse/CNV-4721).

**Question**: Should the procedure re: overriding default CPU and memory requests/limits include a step to verify the changes by retrieving the CDIConfig status? If yes, what is the `oc` command to check CDIConfig status and what is the expected response?

Applies to Enterprise-4.5

Code review requested from Adam Litke and Alexander Wels (tagged in Jira)
QE review requested from Ying Cui (tagged in Jira)




