### PR TITLE
bz1846644 updated k8s_status procedures

### DIFF
--- a/modules/osdk-ansible-custom-resource-files.adoc
+++ b/modules/osdk-ansible-custom-resource-files.adoc
@@ -33,8 +33,8 @@ default.
 
 |`status`
 |Summarizes the current state of the object. For Ansible-based Operators, the
-link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource[`status` subresource]
-is enabled for CRDs and managed by the `k8s_status` Ansible module by default,
+link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresource]
+is enabled for CRDs and managed by the `operator_sdk.util.k8s_status` Ansible module by default,
 which includes `condition` information to the CR's `status`.
 
 |`annotations`

--- a/modules/osdk-ansible-managing-cr-status.adoc
+++ b/modules/osdk-ansible-managing-cr-status.adoc
@@ -3,10 +3,10 @@
 // * operators/operator_sdk/osdk-ansible.adoc
 
 [id="osdk-ansible-managing-cr-status_{context}"]
-= Managing Custom Resource status using the k8s_status Ansible module
+= Managing Custom Resource status using the operator_sdk.util Ansible collection
 
 Ansible-based Operators automatically update Custom Resource (CR)
-link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource[`status` subresources]
+link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresources]
 with generic information about the previous Ansible run. This includes the
 number of successful and failed tasks and relevant error messages as shown:
 
@@ -34,10 +34,10 @@ status:
 ----
 
 Ansible-based Operators also allow Operator authors to supply custom status
-values with the
-link:https://github.com/fabianvf/ansible-k8s-status-module[`k8s_status`] Ansible
-module. This allows the author to update the `status` from within Ansible with
-any key-value pair as desired.
+values with the `k8s_status` Ansible module, which is included in the
+link:https://galaxy.ansible.com/operator_sdk/util[operator_sdk util collection].
+This allows the author to update the `status` from within Ansible with any
+key-value pair as desired.
 
 By default, Ansible-based Operators always include the generic Ansible
 run output as shown above. If you would prefer your application did _not_ update
@@ -54,17 +54,17 @@ with a `manageStatus` field set to `false`:
 - version: v1
   group: api.example.com
   kind: Foo
-  role: /opt/ansible/roles/Foo
+  role: Foo
   manageStatus: false
 ----
 
-. Then, use the `k8s_status` Ansible module to update the subresource. For
-example, to update with key `foo` and value `bar`, `k8s_status` can be used as
-shown:
+. Then, use the `operator_sdk.util.k8s_status` Ansible module to update the
+subresource. For example, to update with key `foo` and value `bar`,
+`operator_sdk.util` can be used as shown:
 +
 [source,yaml]
 ----
-- k8s_status:
+- operator_sdk.util.k8s_status:
   api_version: app.example.com/v1
   kind: Foo
   name: "{{ meta.name }}"
@@ -73,34 +73,26 @@ shown:
     foo: bar
 ----
 
+Collections can also be declared in the role's `meta/main.yml`, which is
+included for new scaffolded Ansible Operators.
+[source,yaml]
+----
+collections:
+  - operator_sdk.util
+----
+
+Declaring collections in the role meta allows you to invoke the `k8s_status` module directly:
++
+[source,yaml]
+----
+k8s_status:
+  <snip>
+  status:
+    foo: bar
+----
+
 .Additional resources
 
 - For more details about user-driven status management from Ansible-based
 Operators, see the
-link:https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/ansible-operator-status.md[Ansible Operator Status Proposal].
-
-[id="osdk-ansible-managing-cr-status-locally_{context}"]
-== Using the k8s_status Ansible module when testing locally
-
-If your Operator takes advantage of the `k8s_status` Ansible module and you want
-to test the Operator locally with the `operator-sdk run --local` command, you must
-install the module in a location that Ansible expects. This is done with the
-`library` configuration option for Ansible.
-
-For this example, assume the user is placing third-party Ansible modules in the
-`/usr/share/ansible/library/` directory.
-
-.Procedure
-
-. To install the `k8s_status` module, set the `ansible.cfg` file to search in
-the `/usr/share/ansible/library/` directory for installed Ansible modules:
-+
-----
-$ echo "library=/usr/share/ansible/library/" >> /etc/ansible/ansible.cfg
-----
-
-. Add the `k8s_status.py` file to the `/usr/share/ansible/library/` directory:
-+
-----
-$ wget https://raw.githubusercontent.com/openshift/ocp-release-operator-sdk/master/library/k8s_status.py -O /usr/share/ansible/library/k8s_status.py
-----
+link:https://github.com/operator-framework/operator-sdk/blob/master/proposals/ansible-operator-status.md[Ansible-based Operator Status Proposal for Operator SDK].


### PR DESCRIPTION
Bug:
https://github.com/sheriff-rh/openshift-docs/pull/new/bz1846644

Starting in Operator SDK 0.14.x, the Ansible module `k8s_status` was extracted and is now provided by the `operator_sdk.util` Ansible collection. As such, these changes apply to enterprise-4.4+. 

Updates include: 
* several broken/moved link fixes
* updated procedures regarding the new `operator_sdk.util` collection to access the `k8s_status` module features

These changes were imported from SDK docs: 
https://sdk.operatorframework.io/docs/ansible/development-tips/#custom-resource-status-management

Build preview: 
https://bz1846644--ocpdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-ansible.html#osdk-ansible-managing-cr-status_osdk-ansible

@adellape  FYI
@jianzhangbjz  PTAL, thanks. 