### PR TITLE
Migration upgrade source clusters

### DIFF
--- a/modules/migration-prerequisites.adoc
+++ b/modules/migration-prerequisites.adoc
@@ -7,9 +7,10 @@
 = Migration prerequisites
 
 ifdef::migrating-3-4[]
-* The source cluster must be {product-title} 3.7, 3.9, 3.10, or 3.11.
 * You must have `podman` installed.
+* The source cluster must be {product-title} 3.7, 3.9, 3.10, or 3.11.
 endif::[]
+* You must upgrade the source cluster to the latest z-stream release.
 * You must have `cluster-admin` privileges on all clusters.
 * The source and target clusters must have unrestricted network access to the replication repository.
 * The cluster on which the Migration controller is installed must have unrestricted access to the other clusters.
@@ -32,6 +33,7 @@ The following `imagestreamtags` have been _removed_ from {product-title} _4.2_:
 * `python:3.3`, `python:3.4`
 * `ruby:2.0`, `ruby:2.2`
 
+ifeval::["{product-version}" == "4.4"]
 The following `imagestreamtags` have been _removed_ from {product-title} _4.4_:
 
 * `dotnet: 2.2`
@@ -41,3 +43,4 @@ The following `imagestreamtags` have been _removed_ from {product-title} _4.4_:
 * `perl:5.24`
 * `php: 7.0, 7.1`
 * `redis: 3.2`
+endif::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-265
Source clusters must be upgraded to latest z-stream release.
Added 'ifeval' for imagestream tags so that images removed from 4.4 only appear 4.4 docs.

CP for 4.2, 4.3, 4.4, 4.5.