### PR TITLE
BZ1839982 FOR 2.3: Updating access mode for LiveMigration

### DIFF
--- a/cnv/cnv_live_migration/cnv-live-migration.adoc
+++ b/cnv/cnv_live_migration/cnv-live-migration.adoc
@@ -4,7 +4,15 @@ include::modules/cnv-document-attributes.adoc[]
 :context: cnv-live-migration
 toc::[]
 
+.Prerequisites
+* Before using LiveMigration, ensure that the storage class used by the
+virtual machine has a PersistentVolumeClaim (PVC) with a shared
+ReadWriteMany (RWX) access mode.
+See xref:../../cnv/cnv_virtual_machines/cnv_virtual_disks/cnv-storage-defaults-for-datavolumes.adoc#cnv-storage-defaults-for-datavolumes[Storage defaults for DataVolumes]
+to ensure your storage settings are correct.
+
 include::modules/cnv-understanding-live-migration.adoc[leveloffset=+1]
+include::modules/cnv-updating-access-mode-for-live-migration.adoc[leveloffset=+1]
 
 .Additional resources:
 

--- a/modules/cnv-understanding-live-migration.adoc
+++ b/modules/cnv-understanding-live-migration.adoc
@@ -5,16 +5,15 @@
 [id="cnv-understanding-live-migration_{context}"]
 = Understanding live migration
 
-Live migration is the process of moving a running virtual machine instance to 
-another node in the cluster without interruption to the virtual workload or 
-access. This can be a manual process, if you select a virtual machine instance 
-to migrate to another node, or an automatic process, if the 
-virtual machine instance has a `LiveMigrate` eviction strategy and the node on 
-which it is running is placed into maintenance. 
+Live migration is the process of moving a running virtual machine instance to
+another node in the cluster without interrupting the virtual workload or access.
+This can be a manual process, if you select virtual machine instance
+to migrate to another node, or an automatic process, if the virtual machine
+instance has a `LiveMigrate` eviction strategy and the node on
+which it is running is placed into maintenance.
 
 [IMPORTANT]
 ====
-Virtual machines must have a PersistentVolumeClaim (PVC) with a shared 
-ReadWriteMany (RWX) access mode to be live migrated.
+Virtual machines must have a PersistentVolumeClaim (PVC)
+with a shared ReadWriteMany (RWX) access mode to be live migrated.
 ====
-

--- a/modules/cnv-updating-access-mode-for-live-migration.adoc
+++ b/modules/cnv-updating-access-mode-for-live-migration.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * cnv/live_migration/cnv-live-migration.adoc
+
+[id="cnv-updating-access-mode-for-live-migration_{context}"]
+= Updating access mode for LiveMigration
+
+For LiveMigration to function properly, you must use the
+ReadWriteMany (RWX) access mode. Use this
+procedure to update the access mode, if needed.
+
+.Procedure
+* To set the RWX access mode, run the following `oc patch` command:
++
+----
+$ oc patch -n openshift-cnv \
+    cm kubevirt-storage-class-defaults \
+        -p '{"data":{"'$<STORAGE_CLASS>'.accessMode":"ReadWriteMany"}}'
+----


### PR DESCRIPTION
This PR is for the 2.3 repo. 

Please label **peer review needed** and **enterprise-4.4**.

Test Build: http://file.bos.redhat.com/bgaydos/071320_2/cnv/cnv_live_migration/cnv-live-migration.html

Once content approved for this PR I will update https://github.com/openshift/openshift-docs/pull/22789 with same content for 2.4 repo.

Bob

