### PR TITLE
Small fix to 'oc convert' for deprecated GVKs

### DIFF
--- a/modules/migration-updating-deprecated-gvks.adoc
+++ b/modules/migration-updating-deprecated-gvks.adoc
@@ -106,13 +106,13 @@ $ tar -xfv <backup_local_dir>/<backup_name>.tar.gz -C <backup_local_dir>
 . Run `oc convert` in offline mode on each deprecated GVK:
 +
 ----
-$ oc convert <backup_local_dir>/resources/<gvk>.yaml <1>
+$ oc convert <backup_local_dir>/resources/<gvk>.json <1>
 ----
 <1> Specify the deprecated GVK.
 
 . Create the converted GVK on the target cluster:
 +
 ----
-$ oc create -f <gvk>.yaml <1>
+$ oc create -f <gvk>.json <1>
 ----
 <1> Specify the converted GVK.


### PR DESCRIPTION
oc convert is run on json files, not yaml

CP for 4.4, 4.5