### PR TITLE
Add references to the OCP availability on IBM Z and IBM Power

### DIFF
--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -71,6 +71,8 @@ user-provisioned infrastructure on the following platforms:
 * {rh-openstack}
 * VMware vSphere
 * Bare metal
+* IBM Z
+* IBM Power
 
 With installations on user-provisioned infrastructure, each machine can have full internet access, you can place your cluster behind a proxy, or you can perform a _restricted network installation_. In a restricted network installation, you can download the images that are required to install a cluster, place them in a mirror registry, and use that data to install your cluster. While you require internet access to pull images for platform containers, with a restricted network installation on vSphere or bare metal infrastructure, your cluster machines do not require direct internet access.
 

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -41,6 +41,8 @@ or using xref:../installing/installing_azure/installing-azure-user-infra.adoc#in
 
 - **xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[Install a cluster on VMware vSphere]**: You can install {product-title} on supported versions of vSphere.
 
+- **Install a cluster on IBM architectures**: You can deploy an {product-title} cluster on xref:../installing/installing_ibm_z/installing-ibm-z.adoc[IBM Z], xref:../installing/installing_ibm_z/installing-ibm-z.adoc[LinuxONE], or xref:../installing/installing_ibm_power/installing-ibm-power.adoc[IBM Power].
+
 - **xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Install a cluster on bare metal]**: If none of the available platform and cloud providers meet your needs, you can install {product-title} on bare metal.
 
 - **Install a cluster on OpenStack Platform**: You can install a cluster on
@@ -62,8 +64,11 @@ user-provisioned infrastructure on
 xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[AWS],
 GCP,
 xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[vSphere],
-or
 xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal]
+xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc[IBM Z],
+xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc[LinuxONE],
+or
+xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc[IBM Power]
 does not have full access to the internet, you can
 xref:../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[mirror the {product-title} installation images]
 and install a cluster in a restricted network.


### PR DESCRIPTION
@chrisnegus Does this change look good to you? It is intended to go into `enterprise-4.3`, `enterprise-4.4`, and later.