### PR TITLE
increased options listed for spec maturity and capabilities

### DIFF
--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -23,8 +23,8 @@ generation when a lack of data in any of the required fields is detected.
 ensure uniqueness, for example `app-operator.v0.1.1`.
 
 |`metadata.capabilities`
-|The Operator's capability level according to the Operator maturity model, for
-example `Seamless Upgrades`.
+|The Operator's capability level according to the Operator maturity model.
+Options include `Basic Install`, `Seamless Upgrades`, `Full Lifecycle`, `Deep Insights`, and `Auto Pilot`.
 
 |`spec.displayName`
 |A public name to identify the Operator.
@@ -79,8 +79,9 @@ application being managed, each with a `name` and `url`.
 a `mediatype`.
 
 |`spec.maturity`
-|The level of maturity the software has achieved at this version, for
-example `alpha`, `beta`, `stable`.
+|The level of maturity the software has achieved at this version. Options include
+`planning`, `pre-alpha`, `alpha`, `beta`, `stable`, `mature`, `inactive`, and
+`deprecated`.
 |===
 
 Further details on what data each field above should hold are found in the


### PR DESCRIPTION
Further details added for spec.maturity definition [1] and add spec.capabilities [2].

[1] https://github.com/operator-framework/operator-lifecycle-manager/blob/master/deploy/upstream/manifests/0.13.0/0000_50_olm_03-clusterserviceversion.crd.yaml#L145-L156

[2] https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#required-fields-for-operatorhub