### PR TITLE
Add Whereabouts CNI plug-in documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -458,12 +458,14 @@ Topics:
     File: removing-pod
   - Name: Configuring a bridge network
     File: configuring-bridge
-  - Name: Configuring a macvlan network
-    File: configuring-macvlan
-  - Name: Configuring an ipvlan network
-    File: configuring-ipvlan
   - Name: Configuring a host-device network
     File: configuring-host-device
+  - Name: Configuring an ipvlan network
+    File: configuring-ipvlan
+  - Name: Configuring a macvlan network with basic customizations
+    File: configuring-macvlan-basic
+  - Name: Configuring a macvlan network
+    File: configuring-macvlan
   - Name: Editing an additional network
     File: edit-additional-network
   - Name: Removing an additional network

--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -8,9 +8,16 @@
 // Configuring Multus plug-ins using the Cluster Network Operator
 // is nearly identical in each case.
 
+ifeval::["{context}" == "configuring-macvlan-basic"]
+:plugin: macvlan
+:macvlan:
+:yaml:
+endif::[]
+// This is necessary for Whereabouts CNI which is JSON-only
 ifeval::["{context}" == "configuring-macvlan"]
 :plugin: macvlan
-:yaml:
+:macvlan:
+:json:
 endif::[]
 ifeval::["{context}" == "configuring-ipvlan"]
 :plugin: ipvlan
@@ -30,7 +37,7 @@ endif::[]
 
 The Cluster Network Operator (CNO) manages additional network definitions. When
 you specify an additional network to create, the CNO creates the
-NetworkAttachmentDefinition Custom Resource (CR) automatically.
+NetworkAttachmentDefinition custom resource (CR) automatically.
 
 [IMPORTANT]
 ====
@@ -76,7 +83,7 @@ spec:
         type: static
         staticIPAMConfig:
           addresses:
-          - address: 10.1.1.0/24
+          - address: 10.1.1.7
 ----
 endif::yaml[]
 ifdef::json[]
@@ -104,7 +111,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.1/24"
+            "address": "191.168.1.23"
           }
         ]
       }
@@ -153,7 +160,35 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.1/24"
+            "address": "191.168.1.23"
+          }
+        ]
+      }
+    }'
+----
+endif::[]
+ifdef::macvlan+json[]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: '{
+      "cniVersion": "0.3.1",
+      "name": "test-network-1",
+      "type": "{plugin}",
+      "master": "eth1",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "191.168.1.23"
           }
         ]
       }
@@ -164,9 +199,7 @@ endif::[]
 
 . Save your changes and quit the text editor to commit your changes.
 
-. Optional: Confirm that the CNO created the NetworkAttachmentDefinition CR by
-running the following command. There might be a delay before the CNO creates the
-CR.
+. Confirm that the CNO created the NetworkAttachmentDefinition CR by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the CR.
 +
 ----
 $ oc get network-attachment-definitions -n <namespace>
@@ -174,9 +207,15 @@ NAME                 AGE
 test-network-1       14m
 ----
 
-ifeval::["{context}" == "configuring-macvlan"]
+ifeval::["{context}" == "configuring-macvlan-basic"]
+:!macvlan:
 :!plugin:
 :!yaml:
+endif::[]
+ifeval::["{context}" == "configuring-macvlan"]
+:!macvlan:
+:!plugin:
+:!json:
 endif::[]
 ifeval::["{context}" == "configuring-ipvlan"]
 :!plugin:

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -11,84 +11,133 @@
 // for the Macvlan CNI plug-in only. In the future other Multus plug-ins
 // might be managed the same way by the CNO.
 
-ifeval::["{context}" == "configuring-macvlan"]
+ifeval::["{context}" == "configuring-macvlan-basic"]
 :yaml:
 endif::[]
-ifeval::["{context}" != "configuring-macvlan"]
+ifeval::["{context}" != "configuring-macvlan-basic"]
 :json:
 endif::[]
 
 [id="nw-multus-ipam-object_{context}"]
 = Configuration for ipam CNI plug-in
 
-The IP address management (IPAM) Container Network Interface (CNI) plug-in manages IP address assignment for other CNI plug-ins. You can configure ipam for either static IP address assignment or dynamic IP address assignment by using DHCP. The DHCP server you specify must be reachable from the additional network.
+The ipam Container Network Interface (CNI) plug-in provides IP address management (IPAM) for other CNI plug-ins.
 
 ifdef::json[]
-The following JSON configuration object describes the parameters that you can set.
+You can use the following methods for IP address assignment:
+
+- Static assignment.
+- Dynamic assignment through a DHCP server. The DHCP server you specify must be reachable from the additional network.
+- Dynamic assignment through the Whereabouts IPAM CNI plug-in.
 endif::json[]
 
 ifdef::yaml[]
 The following YAML configuration describes the parameters that you can set.
 endif::yaml[]
 
+////
 IMPORTANT: If you set the `type` parameter to the `DHCP` value, you cannot set
 any other parameters.
+////
 
 ifdef::json[]
-.ipam CNI plug-in JSON configuration object
+[id="nw-multus-static_{context}"]
+== Static IP address assignment configuration
+
+The following JSON describes the configuration for static IP address assignment:
+
+.Static assignment configuration
 [source,json]
 ----
 {
   "ipam": {
-    "type": "<type>", <1>
-    "addresses": [ <2>
+    "type": "static",
+    "addresses": [ <1>
       {
-        "address": "<address>", <3>
-        "gateway": "<gateway>" <4>
+        "address": "<address>", <2>
+        "gateway": "<gateway>" <3>
       }
     ],
-    "routes": [ <5>
+    "routes": [ <4>
       {
-        "dst": "<dst>" <6>
-        "gw": "<gw>" <7>
+        "dst": "<dst>" <5>
+        "gw": "<gw>" <6>
       }
     ],
-    "dns": { <8>
-      "nameservers": ["<nameserver>"], <9>
-      "domain": "<domain>", <10>
-      "search": ["<search_domain>"] <11>
+    "dns": { <7>
+      "nameservers": ["<nameserver>"], <8>
+      "domain": "<domain>", <9>
+      "search": ["<search_domain>"] <10>
     }
   }
 }
 ----
-<1> Specify `static` to configure the plug-in to manage IP address assignment.
-Specify `DHCP` to allow a DHCP server to manage IP address assignment. You
-cannot specify any additional parameters if you specify a value of `DHCP`.
-
-<2> An array describing IP addresses to assign to the virtual interface. Both
+<1> An array describing IP addresses to assign to the virtual interface. Both
 IPv4 and IPv6 IP addresses are supported.
 
-<3> A block of IP addresses that you specify in CIDR format to assign
-to Pods on a worker node, such as `10.1.1.0/24`.
+<2> An IP address that you specify.
 
-<4> The default gateway to route egress network traffic to.
+<3> The default gateway to route egress network traffic to.
 
-<5> An array describing routes to configure inside the Pod.
+<4> An array describing routes to configure inside the Pod.
 
-<6> The IP address range in CIDR format.
+<5> The IP address range in CIDR format.
 
-<7> The gateway where network traffic is routed.
+<6> The gateway where network traffic is routed.
 
-<8> Optional: DNS configuration.
+<7> Optional: DNS configuration.
 
-<9> An of array of one or more IP addresses for to send DNS queries to.
+<8> An of array of one or more IP addresses for to send DNS queries to.
 
-<10> The default domain to append to a host name. For example, if the
+<9> The default domain to append to a host name. For example, if the
 domain is set to `example.com`, a DNS lookup query for `example-host` is
 rewritten as `example-host.example.com`.
 
-<11> An array of domain names to append to an unqualified host name,
+<10> An array of domain names to append to an unqualified host name,
 such as `example-host`, during a DNS lookup query.
+
+[id="nw-multus-dhcp_{context}"]
+== Dynamic IP address assignment configuration
+
+The following JSON describes the configuration for dynamic IP address address assignment with DHCP:
+
+.DHCP assignment configuration
+[source,json]
+----
+{
+  "ipam": {
+    "type": "dhcp"
+  }
+}
+----
+
+[id="nw-multus-whereabouts_{context}"]
+== Dynamic IP address assignment configuration with Whereabouts
+
+The Whereabouts CNI plug-in allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server.
+
+The following JSON describes the configuration for dynamic IP address assignment with Whereabouts:
+
+.Whereabouts assignment configuration
+[source,json]
+----
+{
+  "ipam": {
+    "type": "whereabouts",
+    "range": "<range>", <1>
+    "exclude": ["<exclude_part>, ..."], <2>
+  }
+}
+----
+<1> Specify an IP address and range in CIDR notation. IP addresses are assigned from within this range of addresses.
+<2> Optional: Specify a list of IP addresses and ranges in CIDR notation. IP addresses within an excluded address range are not assigned.
+
+////
+[NOTE]
+=====
+Whereabouts can be used for both IPv4 and IPv6 addresses.
+=====
+////
 
 [id="nw-multus-static-example_{context}"]
 == Static IP address assignment configuration example
@@ -109,8 +158,8 @@ You can configure ipam for static IP address assignment:
 }
 ----
 
-[id="nw-multus-dynamic-example_{context}"]
-== Dynamic IP address assignment configuration example
+[id="nw-multus-dhcp-example_{context}"]
+== Dynamic IP address assignment configuration example using DHCP
 
 You can configure ipam for DHCP:
 
@@ -118,13 +167,33 @@ You can configure ipam for DHCP:
 ----
 {
   "ipam": {
-    "type": "DHCP"
+    "type": "dhcp"
+  }
+}
+----
+
+[id="nw-multus-whereabouts-example_{context}"]
+== Dynamic IP address assignment configuration example using Whereabouts
+
+You can configure ipam to use Whereabouts:
+
+[source,json]
+----
+{
+  "ipam": {
+    "type": "whereabouts",
+    "range": "192.0.2.192/27",
+    "exclude": [
+       "192.0.2.192/30",
+       "192.0.2.196/32"
+    ]
   }
 }
 ----
 endif::json[]
 
-// YAML uses collection and mapping to describe arrays and objects
+// YAML configuration is only relevant to `simpleMacvlanConfig`
+// This is limited by the fields that the CNO accepts
 
 ifdef::yaml[]
 .ipam CNI plug-in YAML configuration object
@@ -168,8 +237,7 @@ ipamConfig:
 <1> A collection of mappings that define IP addresses to assign to the virtual
 interface. Both IPv4 and IPv6 IP addresses are supported.
 
-<2> A block of IP addresses that you specify in CIDR format to assign
-to Pods on a worker node, such as `10.1.1.0/24`.
+<2> An IP address that you specify.
 
 <3> The default gateway to route egress network traffic to.
 
@@ -240,10 +308,9 @@ ipamConfig:
 ----
 endif::yaml[]
 
-
-ifeval::["{context}" == "configuring-macvlan"]
+ifeval::["{context}" == "configuring-macvlan-basic"]
 :!yaml:
 endif::[]
-ifeval::["{context}" != "configuring-macvlan"]
+ifeval::["{context}" != "configuring-macvlan-basic"]
 :!json:
 endif::[]

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -2,9 +2,84 @@
 //
 // * networking/multiple_networks/configuring-macvlan.adoc
 
+ifeval::["{context}" == "configuring-macvlan-basic"]
+:yaml:
+endif::[]
+// This is necessary for Whereabouts CNI which is JSON-only
+ifeval::["{context}" == "configuring-macvlan"]
+:json:
+endif::[]
+
+// Content duplicated because the callouts are identical
+// and must be changed simultaneously if edited. The numbers
+// do not easily line up, so the content is duplicated in each section.
+
 [id="nw-multus-macvlan-object_{context}"]
 = Configuration for macvlan CNI plug-in
 
+ifdef::json[]
+The configuration for an additional network attachment that uses the macvlan
+Container Network Interface (CNI) plug-in is provided in two parts:
+
+* Cluster Network Operator (CNO) configuration
+* CNI plug-in configuration
+
+The CNO configuration specifies the name for the additional network attachment
+and the namespace to create the attachment in. The plug-in
+is configured by a JSON object specified by the `rawCNIConfig` parameter in
+the CNO configuration.
+
+The following YAML describes the configuration parameters for the CNO:
+
+.Cluster Network Operator YAML configuration
+[source,yaml]
+----
+name: <name> <1>
+namespace: <namespace> <2>
+rawCNIConfig: '{ <3>
+  ...
+}'
+type: Raw
+----
+<1> Specify a name for the additional network attachment that you are
+creating. The name must be unique within the specified `namespace`.
+
+<2> Specify the namespace to create the network attachment in. If
+you do not specify a value, then the `default` namespace is used.
+
+<3> Specify the CNI plug-in configuration in JSON format, which
+is based on the following template.
+
+The following object describes the configuration parameters for the macvlan CNI
+plug-in:
+
+.macvlan CNI plug-in JSON configuration object
+[source,json]
+----
+{
+  "cniVersion": "0.3.1",
+  "name": "<name>", <1>
+  "type": "macvlan",
+  "mode": "<mode>", <2>
+  "master": "<master>", <3>
+  "mtu": <mtu>, <4>
+  "ipam": { <5>
+    ...
+  }
+}
+----
+<1> Specify a name for the additional network attachment that you are creating. The name must be unique within the specified `namespace`.
+
+<2> The ethernet interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
+
+<3> Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
+
+<4> Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+
+<5> Specify a configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+endif::json[]
+
+ifdef::yaml[]
 The following YAML describes the configuration parameters for the macvlan
 Container Network Interface (CNI) plug-in:
 
@@ -40,12 +115,14 @@ default value is automatically set by the kernel.
 
 <6> Specify a configuration object for the ipam CNI plug-in. The
 plug-in manages IP address assignment for the attachment definition.
+endif::yaml[]
 
 [id="nw-multus-macvlan-config-example_{context}"]
 == macvlan configuration example
 
 The following example configures an additional network named `macvlan-net`:
 
+ifdef::yaml[]
 [source,yaml]
 ----
 name: macvlan-net
@@ -55,3 +132,30 @@ simpleMacvlanConfig:
   ipamConfig:
     type: DHCP
 ----
+endif::yaml[]
+ifdef::json[]
+[source,yaml]
+----
+name: macvlan-net
+namespace: work-network
+type: Raw
+rawCNIConfig: |-
+  {
+    "cniVersion": "0.3.1",
+    "name": "macvlan-net",
+    "type": "macvlan",
+    "master": "eth1",
+    "mode": "bridge",
+    "ipam": {
+      "type": "dhcp"
+      }
+  }
+----
+endif::json[]
+
+ifeval::["{context}" == "configuring-macvlan-basic"]
+:!yaml:
+endif::[]
+ifeval::["{context}" == "configuring-macvlan"]
+:!json:
+endif::[]

--- a/networking/multiple_networks/configuring-macvlan-basic.adoc
+++ b/networking/multiple_networks/configuring-macvlan-basic.adoc
@@ -1,11 +1,11 @@
-[id="configuring-macvlan"]
-= Configuring a macvlan network
+[id="configuring-macvlan-basic"]
+= Configuring a macvlan network with basic customizations
 include::modules/common-attributes.adoc[]
-:context: configuring-macvlan
+:context: configuring-macvlan-basic
 
 toc::[]
 
-As a cluster administrator, you can configure an additional network for your cluster using the macvlan Container Network Interface (CNI) plug-in with advanced customization.
+As a cluster administrator, you can configure an additional network for your cluster using the macvlan Container Network Interface (CNI) plug-in.
 When a Pod is attached to the network, the plug-in creates a sub-interface from the parent interface on the host.
 A unique hardware mac address is generated for each sub-device.
 
@@ -15,7 +15,7 @@ The unique MAC addresses this plug-in generates for sub-interfaces might not be
 compatible with the security polices of your cloud provider.
 ====
 
-You specify a configuration with a CNI object. This approach allows you to specify additional configuration options that are not available when using a YAML configuration.
+You specify a basic configuration directly in YAML. This approach offers fewer configuration options than by specifying a macvlan configuration by using a CNI object directly in JSON.
 
 include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -51,17 +51,19 @@ networks in your cluster:
  * *bridge*: xref:../../networking/multiple_networks/configuring-bridge.adoc#configuring-bridge[Creating a bridge-based additional network]
  allows Pods on the same host to communicate with each other and the host.
 
-* *host-device*: xref:../../networking/multiple_networks/configuring-host-device.adoc#configuring-host-device[Creating a host-device additional network] allows Pods access to a physical Ethernet network device on the host system.
+* *host-device*: xref:../../networking/multiple_networks/configuring-host-device.adoc#configuring-host-device[Configuring a host-device additional network] allows Pods access to a physical Ethernet network device on the host system.
 
- * *macvlan*: xref:../../networking/multiple_networks/configuring-macvlan.adoc#configuring-macvlan[Creating a macvlan-based additional network]
- allows Pods on a host to communicate with other hosts and Pods on those hosts
- by using a physical network interface. Each Pod that is attached to a macvlan-based
- additional network is provided a unique MAC address.
-
- * *ipvlan*: xref:../../networking/multiple_networks/configuring-ipvlan.adoc#configuring-ipvlan[Creating an ipvlan-based additional network]
+ * *ipvlan*: xref:../../networking/multiple_networks/configuring-ipvlan.adoc#configuring-ipvlan[Configuring an ipvlan-based additional network]
  allows Pods on a host to communicate with other hosts and Pods on those hosts,
  similar to a macvlan-based additional network. Unlike a macvlan-based
  additional network, each Pod shares the same MAC address as the parent physical
  network interface.
 
- * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Creating an SR-IOV based additional network] allows Pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+ * *macvlan*: Creating a macvlan-based additional network allows Pods on a host to communicate with other hosts and Pods on those hosts by using a physical network interface. Each Pod that is attached to a macvlan-based additional network is provided a unique MAC address.
++
+A macvlan additional network can be configured in two ways:
+
+ - xref:../../networking/multiple_networks/configuring-macvlan-basic.adoc#configuring-macvlan-basic[Configuring a macvlan-based additional network with basic customizations]
+ - xref:../../networking/multiple_networks/configuring-macvlan.adoc#configuring-macvlan[Configuring a macvlan-based additional network]
+
+ * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configuring an SR-IOV based additional network] allows Pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.


### PR DESCRIPTION
This supersedes https://github.com/openshift/openshift-docs/pull/20605.

The goal of this PR is to add configuration options for the Whereabouts CNI plug-in. It can be used only through the ipam CNI plug-in as a child object. And the ipam CNI plug-in can be used only within other CNI plug-in configurations.

Because macvlan configuration is an outlier, it does not use `rawCNIConfig`. This adds that approach for macvlan so that it can also use Whereabouts. So macvlan now has two assemblies instead of one.

macvlan previously was configured entirely via YAML. Now it can also be configured via mixed YAML and JSON objects.

So this adds 1 assembly for advanced macvlan to account for this.