### PR TITLE
add subdomains to auto route creation

### DIFF
--- a/service_mesh/service_mesh_day_two/ossm-auto-route.adoc
+++ b/service_mesh/service_mesh_day_two/ossm-auto-route.adoc
@@ -30,6 +30,11 @@ spec:
 
 For more information, see xref:../../service_mesh/service_mesh_install/customizing-installation-ossm.adoc#ossm-cr-gateway_customizing-installation-ossm[Istio gateway configuration].
 
+[id="ossm-auto-route-subdomains_{context}"]
+== Subdomains	
+
+{ProductName} creates the route with the subdomain, but {product-title} must be configured to enable it. Subdomains, for example `*.domain.com`, are supported but not by default. Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
+
 If the following gateway is created:
 
 ----


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/OSSMDOC-59

The wildcard documentation has been added to the 4.5 branch https://issues.redhat.com/browse/OSDOCS-1003
in this PR 
https://github.com/openshift/openshift-docs/pull/21974. So, we're ready to add this paragraph back to the OSSM docs.

This should only be cherrypicked to 4.5.