### PR TITLE
CNV-4978 virt-launcher security

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2054,6 +2054,8 @@ Topics:
     File: uninstalling-virt-cli
 - Name: Upgrading OpenShift Virtualization
   File: upgrading-virt
+- Name: Additional security privileges granted for kubevirt-controller and virt-launcher 
+  File: virt-additional-security-privileges-controller-and-launcher
 - Name: Using the CLI tools
   File: virt-using-the-cli-tools
 - Name: Virtual machines

--- a/modules/virt-additional-scc-for-kubevirt-controller.adoc
+++ b/modules/virt-additional-scc-for-kubevirt-controller.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * virt/virt-additional-security-privileges-controller-and-launcher.adoc
+
+[id="virt-additional-scc-for-kubevirt-controller_{context}"]
+= Additional {product-title} Security Context Constraints and Linux capabilities for the `kubevirt-controller` service account
+
+Security Context Constraints (SCCs) control permissions for Pods. These permissions include actions that a Pod, a collection of containers, can perform and what resources it can access. You can use SCCs to define a set of conditions that a Pod must run with in order to be accepted into the system.
+
+The `kubevirt-controller` is a cluster controller that creates the virt-launcher Pods for virtual machines in the cluster. These virt-launcher Pods are granted permissions by the `kubevirt-controller` service account.
+
+== Additional SCCs granted to the `kubevirt-controller` service account
+
+The `kubevirt-controller` service account is granted additional SCCs and Linux capabilities so that it can create virt-launcher Pods with the appropriate permissions. These extended permissions allow virtual machines to take advantage of {VirtProductName} features that are beyond the scope of typical Pods. 
+
+The `kubevirt-controller` service account is granted the following SCCs:
+
+* `scc.AllowHostDirVolumePlugin = true` +
+This allows virtual machines to use the hostPath volume plug-in.
+
+* `scc.AllowPrivilegedContainer = false` +
+This ensures the virt-launcher Pod is not run as a privileged container.
+
+* `scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "NET_RAW", "SYS_NICE"}` +
+This provides the following additional Linux capabilities
+`NET_ADMIN`,
+`NET_RAW`, and
+`SYS_NICE`.
+
+== Viewing the SCC and RBAC definitions for the `kubevirt-controller`
+
+You can view the `SecurityContextConstraint` definition for the `kubevirt-controller` by using the `oc` tool:
+
+----
+$ oc get scc kubevirt-controller -o yaml
+----
+
+You can view the RBAC definition for the `kubevirt-controller` clusterrole by using the `oc` tool:
+
+----
+$ oc get clusterrole kubevirt-controller -o yaml
+----
+

--- a/modules/virt-extended-selinux-policies-for-virt-launcher.adoc
+++ b/modules/virt-extended-selinux-policies-for-virt-launcher.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * virt/virt-additional-security-privileges-controller-and-launcher.adoc
+
+[id="virt-extended-selinux-policies-for-virt-launcher_{context}"]
+= Extended SELinux policies for virt-launcher Pods
+
+The `container_t` SELinux policy for virt-launcher Pods is extended with the following rules:
+
+* `allow process self (tun_socket (relabelfrom relabelto attach_queue))`
+* `allow process sysfs_t (file (write))`
+* `allow process hugetlbfs_t (dir (add_name create write remove_name rmdir setattr))`
+* `allow process hugetlbfs_t (file (create unlink))`
+
+These rules enable the following virtualization features:
+
+* Relabel and attach queues to its own TUN sockets, which is required to support network multi-queue. Multi-queue enables network performance to scale as the number of available vCPUs increases.
+
+* Allows virt-launcher Pods to write information to sysfs (`/sys`) files, which is required to enable Single Root I/O Virtualization (SR-IOV).
+
+* Read/write `hugetlbfs` entries, which is required to support huge pages. Huge pages are a method of managing large amounts of memory by increasing the memory page size.
+

--- a/virt/virt-additional-security-privileges-controller-and-launcher.adoc
+++ b/virt/virt-additional-security-privileges-controller-and-launcher.adoc
@@ -1,0 +1,24 @@
+[id="virt-additional-security-privileges-controller-and-launcher"]
+= Additional security privileges granted for kubevirt-controller and virt-launcher
+include::modules/virt-document-attributes.adoc[]
+:context: virt-additional-security-privileges-controller-and-launcher
+toc::[]
+
+The `kubevirt-controller` and virt-launcher Pods are granted some SELinux policies and Security Context Constraints privileges that are in addition to typical Pod owners. These privileges enable virtual machines to use {VirtProductName} features.
+
+include::modules/virt-extended-selinux-policies-for-virt-launcher.adoc[leveloffset=+1]
+
+include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+1]
+
+== Additional resources
+
+* The Red Hat Enterprise Linux Virtualization Tuning and Optimization Guide has more information on link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/sect-virtualization_tuning_optimization_guide-networking-techniques#mult[network multi-queue]
+and
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/sect-virtualization_tuning_optimization_guide-memory-tuning#sect-Virtualization_Tuning_Optimization_Guide-Memory-Huge_Pages[huge pages].
+
+* The `capabilities` man page has more information on the Linux capabilities.
+
+* The `sysfs(5)` man page has more information on sysfs.
+
+* The {product-title} Authentication guide has more information on
+xref:../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Security Context Constraints].


### PR DESCRIPTION
New assembly and two concept modules to cover the additional security privileges that are given to the kubevirt-controller and in turn the virt-launcher Pods. 
https://issues.redhat.com/browse/CNV-4978

I believe these privileges are temporary until a restricted SCC is in place. As such, I didn't think it was worth breaking the second module (kubevirt-controller SCCs) into separate modules, which would have required what I see as a redundant expansion of the 'viewing scc..' part. Given the situation, I think it makes sense for them to be one module. 

enterprise-4.5 only 