### PR TITLE
Set text-transform: none in CSS

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -467,6 +467,7 @@ span.clipboard-button:hover {
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   position: relative;
+  text-transform: none;
 }
 
 h2 > a.anchor, h3 > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor {


### PR DESCRIPTION
`h3` headings were getting transformed to `uppercase`, which can distort the intended syntax.

Before:
![transform](https://user-images.githubusercontent.com/3442316/85180984-1352ca80-b242-11ea-9853-a87ba4dc7146.png)

After:
![notransform](https://user-images.githubusercontent.com/3442316/85181206-8bb98b80-b242-11ea-92fa-9abe982272ac.png)

