### PR TITLE
Include route-override chained CNI plug-in

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -536,6 +536,8 @@ Topics:
     File: edit-additional-network
   - Name: Removing an additional network
     File: remove-additional-network
+  - Name: Overriding a route
+    File: configuring-route-override
   - Name: Configuring PTP
     File: configuring-ptp
 - Name: Hardware networks

--- a/modules/nw-multus-route-override-create.adoc
+++ b/modules/nw-multus-route-override-create.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-route-override.adoc
+
+[id=""]
+= Configuring a route override
+
+.Prerequisites
+
+.Procedure
+
+
+[id="nw-multus-route-override-example_{context}"]
+== Specifying routes using the route-override CNI plugin
+
+In addition to assigning IP addresses to pods, you can also override any routing on a given pod.
+
+The "route-override" CNI plugin is used to accomplish this, and is used as a "chained plugin". To chain
+CNI plugins, you specify a list of CNI configurations. Only some plugins (such as route-override) can
+be utilized in this fashion, and are typically used to add capabilities or alter properties of additional
+network interfaces.
+
+.Route-Override CNI chained CNI plug-in JSON configuration object
+[source,json]
+----
+{
+    "cniVersion": "0.3.0",
+    "name" : "exampleconfiguration",
+    "plugins": [ <1>
+    {
+        "type": "...", <2>
+        "ipam": {
+            "type": "..."
+        }
+    },
+    {
+        "type" : "route-override", <3>
+        "flushroutes" : true, <4>
+        "addroutes": [ <5>
+        {
+            "dst": "192.168.10.0/24", <6>
+            "gw": "10.1.254.254" <7>
+        }],
+        "delroutes": [ <8>
+        {
+            "dst": "192.168.0.0/24"
+        }],
+        "flushgateway": false, <9>
+    }
+    ]
+}
+----
+
+<1> When using chained plugins the `plugins` key should be a list of JSON objects
+<2> The first JSON object in the list will be the primary CNI plugin for the additional network.
+<3> The second JSON object should be set to `"type" : "route-override"` in order to alter routing. Required.
+<4> The `flushroutes` key, when set to true, will remove all existing routes from pods referencing this configuration. Optional.
+<5> The `addroutes` key is a list of JSON objects describing route destinations and gateways to be added. Optional.
+<6> The `dst` field in each `addroutes` object is the destination IP address and subnet mask in CIDR format.
+<7> The `gw` field is the gateway to set for each of the destination CIDR ranges. Optional.
+<8> The `delroutes` key is a list of JSON objects describing which destination routes to delete.
+<9> The `flushgateway` key when set to true, will remove the default gateway. Optional.
+

--- a/networking/multiple_networks/configuring-route-override.adoc
+++ b/networking/multiple_networks/configuring-route-override.adoc
@@ -1,0 +1,19 @@
+[id="configuring-route-override"]
+= Overriding a route
+include::modules/common-attributes.adoc[]
+:context: configuring-route-override
+
+toc::[]
+
+As a cluster administrator, you can override the network routing configuration for a Pod, such as adding or deleting a route, flushing all routes, and flushing the default route.
+
+[IMPORTANT]
+====
+If you misconfigure the routing table for a Pod, it might become unreachable from your cluster.
+====
+
+include::modules/nw-multus-chained.adoc[leveloffset=+1]
+
+include::modules/nw-multus-route-override-object.adoc[leveloffset=+1]
+
+include::modules/nw-multus-route-override-create.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/pull/20605

@dougbtv, `route-override` fits best as a new topic. Once this is complete, it will be included in the TOC.

Will there be additional chained CNI plug-ins? Eventually this may need to morph into more expansive content if so.