### PR TITLE
fix serverless links

### DIFF
--- a/serverless/installing_serverless/installing-openshift-serverless.adoc
+++ b/serverless/installing_serverless/installing-openshift-serverless.adoc
@@ -46,7 +46,7 @@ The following limitations apply to all {ServerlessProductName} deployments:
 For more advanced use-cases such as logging or metering on {product-title}, you must deploy more resources. Recommended requirements for such use-cases are 24 CPUs and 96GB of memory.
 
 If you have high availability (HA) enabled on your cluster, this requires between 0.5 - 1.5 cores and between 200MB - 2GB of memory for each replica of the Knative Serving control plane.
-HA is enabled for some Knative Serving components by default. You can disable HA by following the documentation on xref:../serverless-HA.adoc#serverless-HA[Configuring high availability replicas on {ServerlessProductName}].
+HA is enabled for some Knative Serving components by default. You can disable HA by following the documentation on xref:../../serverless/serverless-HA.adoc#serverless-HA[Configuring high availability replicas on {ServerlessProductName}].
 
 [IMPORTANT]
 ====

--- a/serverless/installing_serverless/serverless-install-config-options.adoc
+++ b/serverless/installing_serverless/serverless-install-config-options.adoc
@@ -72,7 +72,7 @@ High availability (HA) defaults to 2 replicas per controller if no number of rep
 
 You can set this to `1` to disable HA, or add more replicas by setting a higher integer.
 
-For more information about configuring HA, see xref:../serverless-HA.adoc#serverless-HA[High availability on {ServerlessProductName}].
+For more information about configuring HA, see xref:../../serverless/serverless-HA.adoc#serverless-HA[High availability on {ServerlessProductName}].
 
 .Example YAML
 [source,yaml]


### PR DESCRIPTION
@abrennan89 minor fixes - xrefs should go back to the first directory and then back in. See: https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#internal-cross-references