### PR TITLE
CAM 1.2 cannot migrate 4.4 namespaces with imagestreams

### DIFF
--- a/modules/migration-known-issues.adoc
+++ b/modules/migration-known-issues.adoc
@@ -31,3 +31,7 @@ ifdef::migrating-3-4[]
 
 * If you cannot install CAM 1.2 on an {product-title} 3 cluster, download the current `operator.yml` file, which fixes this problem. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843059[*BZ#1843059*])
 endif::[]
+
+ifdef::migrating-4-2-4[]
+* In the current release (CAM 1.2), you cannot migrate a namespace that contains imagestreams from {product-title} 4.4 or later. The following error message is displayed in the Velero Pod log: `Error restoring nametags`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1848561[*BZ#1848561*])
+endif::[]


### PR DESCRIPTION
Intended to resolve:
https://bugzilla.redhat.com/show_bug.cgi?id=1848561
https://bugzilla.redhat.com/show_bug.cgi?id=1848562
Known issue: Known Issue -- In CAM 1.2, cannot migrate namespace that contains imagestreams from OpenShift Container Platform 4.4+

CP 4.4, 4.5