### PR TITLE
Fix inconsistency between deployment and replication

### DIFF
--- a/applications/deployments/what-deployments-are.adoc
+++ b/applications/deployments/what-deployments-are.adoc
@@ -37,7 +37,7 @@ xref:../../dev_guide/pod_autoscaling.adoc#dev-guide-pod-autoscaling[autoscaling]
 == Building blocks of a deployment
 
 Deployments and DeploymentConfigs are enabled by the use of native Kubernetes
-API objects ReplicationControllers and ReplicaSets, respectively, as their
+API objects ReplicaSets and ReplicationControllers, respectively, as their
 building blocks.
 
 Users do not have to manipulate ReplicationControllers, ReplicaSets, or Pods


### PR DESCRIPTION
This document says:

> DeploymentConfigs involve one or more ReplicationControllers ... Similarly, Deployments involve one or more ReplicaSets ...

> Deployments and DeploymentConfigs are enabled by the use of native Kubernetes API objects ReplicationControllers and ReplicaSets, respectively, as their building blocks.

The first says that Deployments build on top of ReplicaSet but the second says Deployments build on top of ReplicationContoller. They can't both be right.

The document also says, later on:

> Only use ReplicaSets if you require custom update orchestration or do not require updates at all. Otherwise, use Deployments.

> Building on ReplicationControllers, OpenShift Container Platform adds expanded support for the software development and deployment lifecycle with the concept of DeploymentConfigs.

Fix the one description that is inconsistent with others.