### PR TITLE
Display ior_enabled parameter

### DIFF
--- a/modules/ossm-cr-gateway.adoc
+++ b/modules/ossm-cr-gateway.adoc
@@ -19,6 +19,7 @@ Here is an example that illustrates the Istio gateway parameters for the `Servic
          autoscaleEnabled: false
          autoscaleMin: 1
          autoscaleMax: 5
+         ior_enabled: true
 ----
 
 
@@ -62,7 +63,9 @@ Here is an example that illustrates the Istio gateway parameters for the `Servic
 |A valid number of allocatable pods based on your environment's configuration.
 |`5`
 
+|
 |`ior_enabled`
 |Controls whether Automatic Route Creation is enabled.
-|false
+|`true`/`false`
+|`false`
 |===


### PR DESCRIPTION
Addresses #22876 

Fixed table formatting error which prevented publication of the ior_enabled row in the parameters table.  Added ior_enabled to the sample YAML.