### PR TITLE
Updating to reflect latest

### DIFF
--- a/modules/serverless-creating-broker.adoc
+++ b/modules/serverless-creating-broker.adoc
@@ -5,7 +5,7 @@
 [id="serverless-creating-broker_{context}"]
 = Creating a broker manually
 
-The following sections describe how to create a broker.
+You can manually create a broker for Knative Eventing.
 
 .Prerequisites
 * Knative Eventing installed.

--- a/modules/serverless-creating-broker.adoc
+++ b/modules/serverless-creating-broker.adoc
@@ -11,7 +11,7 @@ You can manually create a broker for Knative Eventing.
 * Knative Eventing installed.
 
 .Procedure
-. Create the broker:
+Create the broker:
 +
 ----
 cat << EOF | oc apply -f -

--- a/modules/serverless-creating-broker.adoc
+++ b/modules/serverless-creating-broker.adoc
@@ -5,30 +5,12 @@
 [id="serverless-creating-broker_{context}"]
 = Creating a broker manually
 
-To create a broker, you must create a `ServiceAccount` for each namespace and give that `ServiceAccount` the required RBAC permissions.
+The following sections describe how to create a broker.
 
 .Prerequisites
-* Knative Eventing installed, which includes the `ClusterRole`.
+* Knative Eventing installed.
 
 .Procedure
-. Create the `ServiceAccount` objects:
-+
-----
-$ oc -n default create serviceaccount eventing-broker-ingress
-$ oc -n default create serviceaccount eventing-broker-filter
-----
-
-. Give those objects RBAC permissions:
-+
-----
-$ oc -n default create rolebinding eventing-broker-ingress \
-  --clusterrole=eventing-broker-ingress \
-  --serviceaccount=default:eventing-broker-ingress
-$ oc -n default create rolebinding eventing-broker-filter \
-  --clusterrole=eventing-broker-filter \
-  --serviceaccount=default:eventing-broker-filter
-----
-
 . Create the broker:
 +
 ----

--- a/modules/serverless-creating-broker.adoc
+++ b/modules/serverless-creating-broker.adoc
@@ -11,10 +11,10 @@ You can manually create a broker for Knative Eventing.
 * Knative Eventing installed.
 
 .Procedure
-Create the broker:
+* Create the broker:
 +
 ----
-cat << EOF | oc apply -f -
+$ cat << EOF | oc apply -f -
 apiVersion: eventing.knative.dev/v1beta1
 kind: Broker
 metadata:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>
/assign @abrennan89 

With the SERVERLESS_1.8.0, we are moving the "default broker implementation" (not the broker that is named `default`), to be the `MTChannelBroker`. The `ChannelBroker` is deprecated, and will be removed in a future version. Upstream has already deleted it.

However, for the user, this means NOT much changes on the CRD. Broker is broker, regardless of implementation.

Howver, creating borkers, is much much simpler now. No more RBAC needed.  Just applying the yamls, like on any other object.

I;ve updated the existing doc.
