### PR TITLE
Add v1beta1 CRD dep notice

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -231,12 +231,12 @@ Volume cloning using CSI, previously in Technology Preview, is now fully support
 === Operator Lifecycle Manager
 
 [id="ocp-4-5-olm-v1-crd"]
-==== v1 CRD support
+==== v1 CRD support in Operator Lifecycle Manager
 
-Operator Lifecycle Manager (OLM) now supports Operators using v1 Custom Resource
-Definitions (CRDs) when loading Operators into catalogs and deploying them on
-cluster. Previously, OLM only supported v1beta1 CRDs; OLM now manages both v1
-and v1beta1 CRDs in the same way.
+Operator Lifecycle Manager (OLM) now supports Operators using v1
+CustomResourceDefinitions (CRDs) when loading Operators into catalogs and
+deploying them on cluster. Previously, OLM only supported v1beta1 CRDs; OLM now
+manages both v1 and v1beta1 CRDs in the same way.
 
 To support this feature, OLM now enforces CRD upgrades are safer by ensuring
 existing CRD storage versions are not missing in the upgraded CRD, avoiding
@@ -327,10 +327,24 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
+|v1beta1 CRDs
+|GA
+|GA
+|DEP
+
 |====
 
 [id="ocp-4-5-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-5-deprecated-v1beta1-crds"]
+==== v1beta1 CRDs
+
+The `apiextensions.k8s.io/v1beta1` API version for CustomResourceDefinitions
+(CRDs) is now deprecated. It will be removed in a future release of
+{product-title}.
+
+See xref:ocp-4-5-olm-v1-crd[v1 CRD support in Operator Lifecycle Manager] for related details.
 
 [id="ocp-4-5-deprecation-of-operatorsources"]
 ==== OperatorSources and CatalogSourceConfigs block cluster upgrades


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1096

Preview (internal): http://file.rdu.redhat.com/~adellape/070120/v1beta1_dep/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-features

FYI @codyhoag @jeana-redhat. Still confirming if the notice should start in 4.5 before merge.