### PR TITLE
Remove oc run from docs

### DIFF
--- a/modules/cli-developer-troubleshooting.adoc
+++ b/modules/cli-developer-troubleshooting.adoc
@@ -90,12 +90,11 @@ $ oc rsync ~/mydirectory/ python-1-mz2rf:/opt/app-root/src/
 
 == run
 
-Create and run a particular image. By default, this creates a DeploymentConfig
-to manage the created containers.
+Create a Pod running a particular image.
 
-.Example: Start an instance of the `perl` image with three replicas
+.Example: Start a Pod running the `perl` image
 ----
-$ oc run my-test --image=perl --replicas=3
+$ oc run my-test --image=perl
 ----
 
 == wait

--- a/modules/nodes-nodes-jobs-creating-cron.adoc
+++ b/modules/nodes-nodes-jobs-creating-cron.adoc
@@ -56,7 +56,7 @@ all subsequent executions will be suspended.
 <6> The number of failed finished jobs to retain (defaults to 1).
 <7> Job template. This is similar to the job example.
 <8> Sets a label for jobs spawned by this CronJob.
-<9> The restart policy of the pod. This does not apply to the job controller. 
+<9> The restart policy of the pod. This does not apply to the job controller.
 +
 [NOTE]
 ====
@@ -74,15 +74,12 @@ $ oc create -f <file-name>.yaml
 
 [NOTE]
 ====
-You can also create and launch a CronJob from a single command using `oc run`. The following command creates and launches the same CronJob as specified in the previous example:
+You can also create and launch a CronJob from a single command using `oc create cronjob`. The following command creates and launches a CronJob similar to the one specified in the previous example:
 
 ----
-$ oc run pi --image=perl --schedule='*/1 * * * *' \
-    --restart=OnFailure --labels parent="cronjobpi" \
-    --command -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+$ oc create cronjob pi --image=perl --schedule='*/1 * * * *' -- perl -Mbignum=bpi -wle 'print bpi(2000)'
 ----
 
-With `oc run`, the `--schedule` option accepts schedules in link:https://en.wikipedia.org/wiki/Cron[cron format].
+With `oc create cronjob`, the `--schedule` option accepts schedules in link:https://en.wikipedia.org/wiki/Cron[cron format].
 
-When creating a CronJob,  `oc run` only supports the `Never` or `OnFailure` restart policies (`--restart`).
 ====

--- a/modules/nodes-nodes-jobs-creating.adoc
+++ b/modules/nodes-nodes-jobs-creating.adoc
@@ -39,7 +39,7 @@ spec:
 2. Optionally, specify how many successful pod completions are needed to mark a job completed.
 * For non-parallel jobs, leave unset. When unset, defaults to `1`.
 * For parallel jobs with a fixed completion count, specify the number of completions.
-* For parallel jobs with a work queue, leave unset. When unset defaults to the `parallelism` value. 
+* For parallel jobs with a work queue, leave unset. When unset defaults to the `parallelism` value.
 3. Optionally, specify the maximum duration the job can run.
 4. Optionally, specify the number of retries for a job. This field defaults to six.
 5. Specify the template for the pod the controller creates.
@@ -59,10 +59,9 @@ $ oc create -f <file-name>.yaml
 
 [NOTE]
 ====
-You can also create and launch a job from a single command using `oc run`. The following command creates and launches the same job as specified in the previous example:
+You can also create and launch a job from a single command using `oc create job`. The following command creates and launches a job similar to the one specified in the previous example:
 
 ----
-$ oc run pi --image=perl --replicas=1  --restart=OnFailure \
-    --command -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+$ oc create job pi --image=perl -- perl -Mbignum=bpi -wle 'print bpi(2000)'
 ----
 ====


### PR DESCRIPTION
oc run starting from 4.5 is creating only Pods and there is no option to
create any other resource. Users should be using oc create <resource>
commands instead. This update the documentation in all those places
where oc create should be used instead.

Replaces #23288 and #23289.