### PR TITLE
Update to cluster loader image pull spec to use public registry

### DIFF
--- a/modules/installing-cluster-loader.adoc
+++ b/modules/installing-cluster-loader.adoc
@@ -10,5 +10,5 @@
 . To pull the container image, run:
 +
 ----
-$ sudo podman pull registry.svc.ci.openshift.org/ocp/4.5:tests
+$ sudo podman pull quay.io/openshift/origin-tests:4.5
 ----

--- a/modules/running-cluster-loader.adoc
+++ b/modules/running-cluster-loader.adoc
@@ -18,7 +18,7 @@ template builds and waits for them to complete:
 +
 ----
 $ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z -i \
-registry.svc.ci.openshift.org/ocp/4.5:tests /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
+quay.io/openshift/origin-tests:4.5 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
 openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the \
 cluster [Suite:openshift]"'
 ----
@@ -29,7 +29,7 @@ setting the environment variable for `VIPERCONFIG`:
 ----
 $ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z \
 -v ${LOCAL_CONFIG_FILE_PATH}:/root/configs/:z \
--i registry.svc.ci.openshift.org/ocp/4.5:tests \
+-i quay.io/openshift/origin-tests:4.5 \
 /bin/bash -c 'KUBECONFIG=/root/.kube/config VIPERCONFIG=/root/configs/test.yaml \
 openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should \
 load the cluster [Suite:openshift]"'


### PR DESCRIPTION
Issue affects the following to versions where this regressed from 4.2:
- [enterprise-4.4] Issue in file scalability_and_performance/using-cluster-loader.adoc
- [enterprise-4.3] Issue in file scalability_and_performance/using-cluster-loader.adoc

Updated cluster loader image pull spec to use the publicly available image hosted in Quay.io instead of the registry on openshift.org. I verified I could pull the public images. Please update ASAP, thanks!!!
