### PR TITLE
bug 1840616: kube-scheduler custom policy: do not use GeneralPredicates alongside its representants

### DIFF
--- a/modules/nodes-scheduler-default-about.adoc
+++ b/modules/nodes-scheduler-default-about.adoc
@@ -60,18 +60,15 @@ data:
         "apiVersion" : "v1",
         "predicates" : [
                 {"name" : "MaxGCEPDVolumeCount"},
-                {"name" : "GeneralPredicates"},
+                {"name" : "GeneralPredicates"}, <1>
                 {"name" : "MaxAzureDiskVolumeCount"},
                 {"name" : "MaxCSIVolumeCountPred"},
                 {"name" : "CheckVolumeBinding"},
                 {"name" : "MaxEBSVolumeCount"},
-                {"name" : "PodFitsResources"},
                 {"name" : "MatchInterPodAffinity"},
                 {"name" : "CheckNodeUnschedulable"},
                 {"name" : "NoDiskConflict"},
                 {"name" : "NoVolumeZoneConflict"},
-                {"name" : "MatchNodeSelector"},
-                {"name" : "HostName"},
                 {"name" : "PodToleratesNodeTaints"}
                 ],
         "priorities" : [
@@ -96,13 +93,16 @@ metadata:
   selfLink: /api/v1/namespaces/openshift-config/configmaps/scheduler-policy
   uid: 17ee8865-d927-11e9-b213-02d1e1709840`
 ----
+<1> The `GeneralPredicates` predicate represents the `PodFitsResources`, `HostName`, `PodFitsHostPorts`, and `MatchNodeSelector` predicates.
+Because you are not allowed to configure the same predicate multiple times, the `GeneralPredicates` predicate cannot be used alongside
+any of the four represented predicates.
 
 ////
 .Typical predicate string
 ----
 \n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\"},
 ----
-* `name` is the name of the predicate, such as `labelsPresence`. 
+* `name` is the name of the predicate, such as `labelsPresence`.
 * `label` and `<label>` is the node label:value pair to match to apply the predicate, such `label:rack`.
 * `<condition>` and `<state>` is when the predicate should be applied, such as `presence:true`.
 
@@ -110,7 +110,7 @@ metadata:
 ----
 \n\t{\"name\" : \"<PredicateName>\", \"label\" : \"<label>\",  \"<condition>\" : \"<state>\", \"weight\" : <weight>},
 ----
-* `name` is the name of the priority, such as `labelsPresence`. 
+* `name` is the name of the priority, such as `labelsPresence`.
 * `label` and `<label>` is the node `label:value` pair to match to apply the priority, such `label:rack`.
 * `<condition>` and `<state>` is when the priority should be applied, such as `presence:true`.
 * `weight` and `<weight> is the numerical weight to apply to the priority.

--- a/modules/nodes-scheduler-default-creating.adoc
+++ b/modules/nodes-scheduler-default-creating.adoc
@@ -14,7 +14,7 @@ You can control change the default scheduling behavior by creating a JSON file w
 
 To configure the scheduler policy:
 
-. Create the a JSON file named `policy.cfg` with the desired predicates and priorities. 
+. Create a JSON file named `policy.cfg` with the desired predicates and priorities.
 +
 .Sample scheduler JSON file
 [source,json]
@@ -23,24 +23,28 @@ To configure the scheduler policy:
 "kind" : "Policy",
 "apiVersion" : "v1",
 "predicates" : [ <1>
-        {"name" : "PodFitsHostPorts"},
-        {"name" : "PodFitsResources"},
+        {"name" : "MaxGCEPDVolumeCount"},
+        {"name" : "GeneralPredicates"},
+        {"name" : "MaxAzureDiskVolumeCount"},
+        {"name" : "MaxCSIVolumeCountPred"},
+        {"name" : "CheckVolumeBinding"},
+        {"name" : "MaxEBSVolumeCount"},
+        {"name" : "MatchInterPodAffinity"},
+        {"name" : "CheckNodeUnschedulable"},
         {"name" : "NoDiskConflict"},
         {"name" : "NoVolumeZoneConflict"},
-        {"name" : "MatchNodeSelector"},
-        {"name" : "MaxEBSVolumeCount"},
-        {"name" : "MaxAzureDiskVolumeCount"},
-        {"name" : "checkServiceAffinity"},
-        {"name" : "PodToleratesNodeNoExecuteTaints"},
-        {"name" : "MaxGCEPDVolumeCount"},
-        {"name" : "MatchInterPodAffinity"},
-        {"name" : "PodToleratesNodeTaints"},
-        {"name" : "HostName"}
+        {"name" : "PodToleratesNodeTaints"}
         ],
-"priorities" : [<2>
+"priorities" : [ <2>
         {"name" : "LeastRequestedPriority", "weight" : 1},
         {"name" : "BalancedResourceAllocation", "weight" : 1},
         {"name" : "ServiceSpreadingPriority", "weight" : 1},
+        {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
+        {"name" : "NodeAffinityPriority", "weight" : 1},
+        {"name" : "TaintTolerationPriority", "weight" : 1},
+        {"name" : "ImageLocalityPriority", "weight" : 1},
+        {"name" : "SelectorSpreadPriority", "weight" : 1},
+        {"name" : "InterPodAffinityPriority", "weight" : 1},
         {"name" : "EqualPriority", "weight" : 1}
         ]
 }
@@ -62,53 +66,6 @@ $ oc create configmap -n openshift-config --from-file=policy.cfg scheduler-polic
 
 configmap/scheduler-policy created
 ----
-+
-[source,yaml]
-----
-apiVersion: v1
-data:
-  policy.cfg: |
-    {
-        "kind" : "Policy",
-        "apiVersion" : "v1",
-        "predicates" : [
-                {"name" : "MaxGCEPDVolumeCount"},
-                {"name" : "GeneralPredicates"},
-                {"name" : "MaxAzureDiskVolumeCount"},
-                {"name" : "MaxCSIVolumeCountPred"},
-                {"name" : "CheckVolumeBinding"},
-                {"name" : "MaxEBSVolumeCount"},
-                {"name" : "PodFitsResources"},
-                {"name" : "MatchInterPodAffinity"},
-                {"name" : "CheckNodeUnschedulable"},
-                {"name" : "NoDiskConflict"},
-                {"name" : "NoVolumeZoneConflict"},
-                {"name" : "MatchNodeSelector"},
-                {"name" : "HostName"},
-                {"name" : "PodToleratesNodeTaints"}
-                ],
-        "priorities" : [
-                {"name" : "LeastRequestedPriority", "weight" : 1},
-                {"name" : "BalancedResourceAllocation", "weight" : 1},
-                {"name" : "ServiceSpreadingPriority", "weight" : 1},
-                {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
-                {"name" : "NodeAffinityPriority", "weight" : 1},
-                {"name" : "TaintTolerationPriority", "weight" : 1},
-                {"name" : "ImageLocalityPriority", "weight" : 1},
-                {"name" : "SelectorSpreadPriority", "weight" : 1},
-                {"name" : "InterPodAffinityPriority", "weight" : 1},
-                {"name" : "EqualPriority", "weight" : 1}
-                ]
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: "2019-09-17T08:42:33Z"
-  name: scheduler-policy
-  namespace: openshift-config
-  resourceVersion: "59500"
-  selfLink: /api/v1/namespaces/openshift-config/configmaps/scheduler-policy
-  uid: 17ee8865-d927-11e9-b213-02d1e1709840`
-----
 
 . Edit the Scheduler Operator Custom Resource to add the ConfigMap:
 +
@@ -126,7 +83,7 @@ $ oc patch Scheduler cluster --type='merge' -p '{"spec":{"policy":{"name":"sched
 +
 After making the change to the Scheduler config resource, wait for the `opensift-kube-apiserver` pods to redeploy. This can take several minutes. Until the pods redeploy, new scheduler does not take effect.
 
-. Verify the scheduler policy is configured by viewing the log of a scheduler pod in the `openshift-kube-scheduler` namespace. The following command checks for the predoicates and priorites that are being registered by the scheduler:
+. Verify the scheduler policy is configured by viewing the log of a scheduler pod in the `openshift-kube-scheduler` namespace. The following command checks for the predicates and priorities that are being registered by the scheduler:
 +
 ----
 $ oc logs <scheduler-pod> | grep predicates
@@ -138,6 +95,5 @@ For example:
 ----
 $ oc logs openshift-kube-scheduler-ip-10-0-141-29.ec2.internal | grep predicates
 
-Creating scheduler with fit predicates 'map[MaxGCEPDVolumeCount:{} MaxAzureDiskVolumeCount:{} CheckNodeUnschedulable:{} NoDiskConflict:{} NoVolumeZoneConflict:{} MatchNodeSelector:{} GeneralPredicates:{} MaxCSIVolumeCountPred:{} CheckVolumeBinding:{} MaxEBSVolumeCount:{} PodFitsResources:{} MatchInterPodAffinity:{} HostName:{} PodToleratesNodeTaints:{}]' and priority functions 'map[InterPodAffinityPriority:{} LeastRequestedPriority:{} ServiceSpreadingPriority:{} ImageLocalityPriority:{} SelectorSpreadPriority:{} EqualPriority:{} BalancedResourceAllocation:{} NodePreferAvoidPodsPriority:{} NodeAffinityPriority:{} TaintTolerationPriority:{}]'
+Creating scheduler with fit predicates 'map[MaxGCEPDVolumeCount:{} MaxAzureDiskVolumeCount:{} CheckNodeUnschedulable:{} NoDiskConflict:{} NoVolumeZoneConflict:{} GeneralPredicates:{} MaxCSIVolumeCountPred:{} CheckVolumeBinding:{} MaxEBSVolumeCount:{} MatchInterPodAffinity:{} PodToleratesNodeTaints:{}]' and priority functions 'map[InterPodAffinityPriority:{} LeastRequestedPriority:{} ServiceSpreadingPriority:{} ImageLocalityPriority:{} SelectorSpreadPriority:{} EqualPriority:{} BalancedResourceAllocation:{} NodePreferAvoidPodsPriority:{} NodeAffinityPriority:{} TaintTolerationPriority:{}]'
 ----
-

--- a/modules/nodes-scheduler-default-modifying.adoc
+++ b/modules/nodes-scheduler-default-modifying.adoc
@@ -39,13 +39,10 @@ data:
                 {"name" : "MaxCSIVolumeCountPred"},
                 {"name" : "CheckVolumeBinding"},
                 {"name" : "MaxEBSVolumeCount"},
-                {"name" : "PodFitsResources"},
                 {"name" : "MatchInterPodAffinity"},
                 {"name" : "CheckNodeUnschedulable"},
                 {"name" : "NoDiskConflict"},
                 {"name" : "NoVolumeZoneConflict"},
-                {"name" : "MatchNodeSelector"},
-                {"name" : "HostName"},
                 {"name" : "PodToleratesNodeTaints"}
                 ],
         "priorities" : [ <2>
@@ -76,7 +73,7 @@ It can take a few minutes for the scheduler to restart the pods with the updated
 
 * Change the policies and predicates being used:
 
-. Remove the scheduler policy CongifMap:
+. Remove the scheduler policy ConfigMap:
 +
 ----
 $ oc delete configmap -n openshift-config <name>
@@ -105,26 +102,29 @@ data:
     "kind" : "Policy",
     "apiVersion" : "v1",
     "predicates" : [
-            {"name" : "PodFitsHostPorts"},
-            {"name" : "PodFitsResources"},
+            {"name" : "MaxGCEPDVolumeCount"},
+            {"name" : "GeneralPredicates"},
+            {"name" : "MaxAzureDiskVolumeCount"},
+            {"name" : "MaxCSIVolumeCountPred"},
+            {"name" : "CheckVolumeBinding"},
+            {"name" : "MaxEBSVolumeCount"},
+            {"name" : "MatchInterPodAffinity"},
+            {"name" : "CheckNodeUnschedulable"},
             {"name" : "NoDiskConflict"},
             {"name" : "NoVolumeZoneConflict"},
-            {"name" : "MatchNodeSelector"},
-            {"name" : "MaxEBSVolumeCount"},
-            {"name" : "MaxAzureDiskVolumeCount"},
-            {"name" : "CheckVolumeBinding"},
-            {"name" : "CheckServiceAffinity"},
-            {"name" : "PodToleratesNodeNoExecuteTaints"},
-            {"name" : "MaxGCEPDVolumeCount"},
-            {"name" : "MatchInterPodAffinity"},
-            {"name" : "PodToleratesNodeTaints"},
-            {"name" : "HostName"}
+            {"name" : "PodToleratesNodeTaints"}
             ],
     "priorities" : [
-            {"name" : "LeastRequestedPriority", "weight" : 2},
-            {"name" : "BalancedResourceAllocation", "weight" : 2},
-            {"name" : "ServiceSpreadingPriority", "weight" : 2},
-            {"name" : "EqualPriority", "weight" : 2}
+            {"name" : "LeastRequestedPriority", "weight" : 1},
+            {"name" : "BalancedResourceAllocation", "weight" : 1},
+            {"name" : "ServiceSpreadingPriority", "weight" : 1},
+            {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
+            {"name" : "NodeAffinityPriority", "weight" : 1},
+            {"name" : "TaintTolerationPriority", "weight" : 1},
+            {"name" : "ImageLocalityPriority", "weight" : 1},
+            {"name" : "SelectorSpreadPriority", "weight" : 1},
+            {"name" : "InterPodAffinityPriority", "weight" : 1},
+            {"name" : "EqualPriority", "weight" : 1}
             ]
     }
 ----
@@ -144,4 +144,3 @@ $ oc create configmap -n openshift-config --from-file=policy.cfg scheduler-polic
 
 configmap/scheduler-policy created
 ----
-

--- a/modules/nodes-scheduler-default-priorities.adoc
+++ b/modules/nodes-scheduler-default-priorities.adoc
@@ -155,7 +155,7 @@ For example:
 "apiVersion": "v1",
 "priorities": [
     {
-        "name":"RackSpread", 
+        "name":"RackSpread",
         "weight" : 1,
         "argument": {
             "serviceAntiAffinity": {
@@ -173,9 +173,11 @@ In some situations using `ServiceAntiAffinity` based on custom labels does not s
 See link:https://access.redhat.com/solutions/3432401[this Red Hat Solution].
 ====
 
-*The `labelPreference` parameter gives priority based on the specified label.
+The `labelPreference` parameter gives priority based on the specified label.
 If the label is present on a node, that node is given priority.
 If no label is specified, priority is given to nodes that do not have a label.
+If multiple priorities with the `labelPreference` parameter are set,
+all of the priorities must have the same weight.
 
 [source,json]
 ----


### PR DESCRIPTION
…its representants

Replaces #22521, and targeted against master to get to 4.5 as well.

Preview (internal): http://file.rdu.redhat.com/~ahoffer/2020/predicates-update/nodes/scheduling/nodes-scheduler-default.html#nodes-scheduler-default-about-understanding_nodes-scheduler-default