### PR TITLE
release_notes/ocp-4-5-release-notes: Update BZ#1791162 -> BZ#1845411

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -607,7 +607,7 @@ In the table below, features are marked with the following statuses:
 [id="ocp-4-5-known-issues"]
 == Known issues
 
-* When upgrading to a new {product-title} z-stream release, connectivity to the API server might be interrupted as nodes are upgraded, causing API requests to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1791162[*BZ#1791162*])
+* When upgrading to a new {product-title} z-stream release, connectivity to the API server might be interrupted as nodes are upgraded, causing API requests to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845411[*BZ#1845411*])
 
 * When upgrading to a new {product-title} z-stream release, connectivity to routers might be interrupted as router pods are updated. For the duration of the upgrade, some applications might not be consistently reachable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809665[*BZ#1809665*])
 


### PR DESCRIPTION
@sttts [linked a bunch of platform-specific fixes from 1791162 and closed it `CURRENTRELEASE`][1].  He then [spun off 1845411][2] as an umbrella tracking the remaining platform-specific issues.  With this pull request, we link to the open tracker from the release notes.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1791162#c27
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1791162#c30