### PR TITLE
Add HPA for memory to tech preview list

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -517,6 +517,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 
+|HPA for memory utilization
+|TP
+|TP
+|TP
+
 |Machine health checks
 |TP
 |GA


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1849470 raised the realization that the HPA for Memory Utilization feature is not listed as Tech Preview in the 4.x release notes. The feature is TP according to Joel Smith in a provate Slack conversation.