### PR TITLE
Add 4.5 relnote for OLM webhooks

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -352,6 +352,19 @@ To support this feature, OLM now enforces CRD upgrades are safer by ensuring
 existing CRD storage versions are not missing in the upgraded CRD, avoiding
 potential data loss.
 
+[id="ocp-4-5-olm-webhooks"]
+==== Admission webhook support in OLM
+
+Validating and mutating admission webhooks allow Operator authors to intercept,
+modify, and accept or reject resources before they are handled by the Operator
+controller. Operator Lifecycle Manager (OLM) can manage the lifecycle of these
+webhooks when they are shipped alongside your Operator.
+
+////
+See xref:../operators/olm-webhooks.adoc#olm-webhooks[Managing admission webhooks in Operator Lifecycle Manager]
+for more details.
+////
+
 [id="ocp-4-5-operator-api"]
 ==== Read-only Operator API (Technology Preview)
 


### PR DESCRIPTION
Will uncomment the `xref` after https://github.com/openshift/openshift-docs/pull/23396 merges, where this small blurb for the release note has already been peer reviewed.