### PR TITLE
release_notes/ocp-4-5-release-notes: Fix "terminationGracePeriodseconds" -> "terminationGracePeriodSeconds"

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -271,7 +271,7 @@ Helm-based Operator enhancements include:
 [id="ocp-4-5-termination-grace-period-support"]
 ==== terminationGracePeriod parameter support
 
-{product-title} now properly supports the `terminationGracePeriodseconds`
+{product-title} now properly supports the `terminationGracePeriodSeconds`
 parameter with the CRI-O container runtime.
 
 [id="ocp-4-5-deprecated-removed-features"]


### PR DESCRIPTION
Match [the API casing][1].

/assign @mburke5678

[1]: https://github.com/openshift/api/blob/bd35d0abb483082aba103946dec6d6917e4f0985/vendor/k8s.io/api/core/v1/types.go#L2880-L2888