### PR TITLE
Added another two item to the list of information Insights Operator collects

### DIFF
--- a/modules/insights-operator-what-information-is-collected.adoc
+++ b/modules/insights-operator-what-information-is-collected.adoc
@@ -19,5 +19,7 @@ Primary information collected by the Insights Operator includes:
 * Events for all name spaces listed as "related objects" for Degraded operator
 * Anonymized certificate signing requests (CSR) and information about the validity of certificates
 * Configuration settings stored in `ConfigMap` objects in the `openshift-config` name space
+* The image pruner configuration, as well as how often {product-title} prunes images and the status of pruning jobs.
+* The image registry configuration, such as where {product-title} stores images.
 
 The Insights Operator does not collect identifying information such as user names, passwords, certificates, or the names or addresses of user resources.


### PR DESCRIPTION
@openshift/team-documentation
This update applies to OpenShift 4.5.