### PR TITLE
Add bonding info with bare metal install

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -61,6 +61,8 @@ to use an ISO image or network PXE booting to create the machines.
 
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
+
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -71,6 +71,8 @@ to use an ISO image or network PXE booting to create the machines.
 
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
+
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -84,6 +84,8 @@ to use an ISO image or network PXE booting to create the machines.
 
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
+
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
-// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
 [id="installation-user-infra-machines-iso_{context}"]
 = Creating {op-system-first} machines using an ISO image
@@ -66,22 +66,17 @@ coreos.inst.install_dev=sda <1>
 coreos.inst.image_url=<bare_metal_image_URL> <2>
 coreos.inst.ignition_url=http://example.com/config.ign <3>
 ip=<dhcp or static IP address> <4> <5>
+bond=<bonded_interface> <6>
 ----
 <1> Specify the block device of the system to install to.
 <2> Specify the URL of the RAW image that you uploaded to your server.
 <3> Specify the URL of the Ignition config file for this machine type.
 <4> Set `ip=dhcp` or set an individual static IP address (`ip=`) and DNS server (`nameserver=`) on each node.
-For example, setting
-`ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none nameserver=4.4.4.41` sets:
-* Node's IP address to `10.10.10.2`
-* Gateway address to `10.10.10.254`
-* Netmask to `255.255.255.0`
-* Hostname to `core0.example.com`
-* The DNS server address to `4.4.4.41`
-<5>  If you use multiple network interfaces or DNS servers, you can further customize the IP address configuration in the following ways:
-* If your system has multiple network interfaces, you can add multiple IP address configurations by specifying multiple `ip=` entries.
-* If your system has multiple network interfaces, you can use a combination of DHCP and static IP configurations. You must specify the interface to use, for example `ip=enp1s0:dhcp ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none`.
-* You can provide multiple DNS servers by adding a `nameserver=` entry for each server, such as `nameserver=1.1.1.1 nameserver=8.8.8.8`.
+See _Configuring static networking_ for details.
+<5>  If you use multiple network interfaces or DNS servers, 
+see _Configuring static IP networking_ for details on how to configure them.
+<6> Optionally, you can bond multiple network interfaces to a single interface
+using the `bond=` option, as described in _Configuring static networking_.
 
 . Press Enter to complete the installation. After {op-system} installs, the system
 reboots. After the system reboots, it applies the Ignition config file that you

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing_bare_metal/installing-bare-metal-network-customizations.adoc
+
+[id="installation-user-infra-machines-static-network_{context}"]
+= Static IP address examples for RHCOS kernel parameters
+
+If you install {op-system-first} from an ISO image, you can add kernel arguments
+when you boot that image to configure the node's networking.
+The following table describes and illustrates how to use those kernel arguments.
+
+.Configuring static networking
+[source,adoc]
+|===
+|Description |Examples
+
+a|To configure an IP address, either use DHCP (`ip=dhcp`) or set an individual
+static IP address (`ip=<host_ip>`). Then identify the DNS server IP address (`nameserver=<dns_ip>`) on each node. This example sets: +
+
+* The node's IP address to `10.10.10.2` +
+* The gateway address to `10.10.10.254` +
+* The netmask to `255.255.255.0` +
+* The hostname to `core0.example.com` +
+* The DNS server address to `4.4.4.41`
+
+|`ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none nameserver=4.4.4.41` +
+
+|Specify multiple network interfaces by specifying multiple `ip=` entries.
+|`ip=192.168.122.25 ip=192.168.122.26`
+
+|You can combine DHCP
+and static IP configurations on systems with
+multiple network interfaces.
+|`ip=enp1s0:dhcp ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none`.
+
+|You can provide multiple DNS servers by adding a `nameserver=` entry for each server
+|`nameserver=1.1.1.1 nameserver=8.8.8.8`.
+
+a|Bonding multiple network interfaces to a single interface is optionally supported
+using the `bond=` option.  In these two examples:
+
+* _name_ is the bonding device name (bond0), _network_interfaces_
+represents a comma-separated list of physical (ethernet) interfaces (`em1,em2`),
+and _options_ is a comma-separated list of bonding options.
+* When you
+create a bonded interface using `bond=`, you must specify how the IP address
+is assigned (either with `ip=` or `dhcp`) and other
+information for the bonded interface.
+|The syntax is: `bond=name[:network_interfaces][:options]`
+
+`bond=bond0:em1,em2:mode=active-backup,tx_queues=32,downdelay=5000`
+`ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none`
+
+`bond=bond0:em1,em2:mode=active-backup,tx_queues=32,downdelay=5000`
+`ip=bond0:dhcp`
+|===


### PR DESCRIPTION
This content describes how to set up bonding by adding kernel arguments during a bare metal install.