### PR TITLE
update docs after changes to hive secrets

### DIFF
--- a/modules/metering-use-mysql-or-postgresql-for-hive.adoc
+++ b/modules/metering-use-mysql-or-postgresql-for-hive.adoc
@@ -3,11 +3,35 @@
 // * monitoring/cluster_monitoring/metering-configure-hive-metastore.adoc
 
 [id="metering-use-mysql-or-postgresql-for-hive_{context}"]
-= Use MySQL or PostgreSQL for the Hive metastore
+= Using MySQL or PostgreSQL for the Hive metastore
 
 The default installation of metering configures Hive to use an embedded Java database called Derby. This is unsuited for larger environments and can be replaced with either a MySQL or PostgreSQL database. Use the following example configuration files if your deployment requires a MySQL or PostgreSQL database for Hive.
 
-There are 4 configuration options you can use to control the database used by Hive metastore: url, driver, username, and password.
+There are three configuration options you can use to control the database used by Hive metastore: `url`, `driver`, and `secretName`.
+
+Create your MySQL or Postgres instance with a username and password. Then create a secret by using the OpenShift CLI or a YAML file. The secretName you create for this secret must map to the spec.hive.spec.config.db.secretName field in the MeteringConfig resource.
+
+To create a secret in Openshift CLI you can use the following command:
+
+[source,terminal]
+----
+$ oc --namespace openshift-metering create secret generic <YOUR_SECRETNAME> --from-literal=username=<YOUR_DATABASE_USERNAME> --from-literal=password=<YOUR_DATABASE_PASSWORD>
+----
+
+To create a secret by using a YAML file, use the following example file:
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <YOUR_SECRETNAME> <1>
+data:
+  username: <BASE64_ENCODED_DATABASE_USERNAME> <2>
+  password: <BASE64_ENCODED_DATABASE_PASSWORD> <3>
+----
+<1> The name of the secret.
+<2> Base64 encoded database username.
+<3> Base64 encoded database password.
 
 Use the example configuration file below to use a MySQL database for Hive:
 
@@ -23,9 +47,9 @@ spec:
         db:
           url: "jdbc:mysql://mysql.example.com:3306/hive_metastore"
           driver: "com.mysql.jdbc.Driver"
-          username: "REPLACEME"
-          password: "REPLACEME"
+          secretName: "REPLACEME" <1>
 ----
+<1> The name of the secret containing the base64-encrypted username and password database credentials.
 
 You can pass additional JDBC parameters using the `spec.hive.config.url`. For more details see the https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html[MySQL Connector/J documentation].
 


### PR DESCRIPTION
After updating the method to create a mysql secret, this doc change reflects the new key in the Metering CR.
This effects version 4.6 and up.