### PR TITLE
CNV-5230 - specifying cluster version support

### DIFF
--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * virt/about-virt.adoc
+// * virt/virt_release_notes/virt-2-4-release-notes.adoc
+
+[id="virt-supported-cluster-version_{context}"]
+= {VirtProductName} supported cluster version
+
+{VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters.
+

--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -12,7 +12,4 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 // It is included here in the assembly because of the xref ban.
 You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
 
-== {VirtProductName} support
-
-:FeatureName: {VirtProductName}
-include::modules/technology-preview.adoc[leveloffset=+2]
+include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]


### PR DESCRIPTION
Adding version support info to a new topic. This was initially intended for the 'what-you-can-do-with-virt' module for simplicity but it's far more visible as a standalone.
This means that there will need to be a separate PR for the enterprise-4.5 branch to include this in the rel_notes 

https://issues.redhat.com/browse/CNV-5230