### PR TITLE
4.5 relnote for Bundle Format / opm

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -336,6 +336,48 @@ Volume cloning using CSI, previously in Technology Preview, is now fully support
 [id="ocp-4-5-operators"]
 === Operators
 
+[id="ocp-4-5-bundle-format-opm"]
+==== Bundle Format for packaging Operators and `opm` CLI tool
+
+The Bundle Format for Operators is a new packaging format introduced by the
+Operator Framework that is supported starting with {product-title} 4.5. To
+improve scalability and better enable upstream users hosting their own catalogs,
+the Bundle Format specification simplifies the distribution of Operator
+metadata.
+
+[NOTE]
+====
+While the legacy Package Manifest Format is deprecated in {product-title} 4.5,
+it is still supported and Operators provided by Red Hat are currently shipped
+using the Package Manifest Format.
+====
+
+An Operator bundle represents a single version of an Operator and can be
+scaffolded with the Operator SDK. On-disk _bundle manifests_ are containerized
+and shipped as a _bundle image_, a non-runnable container image that stores the
+Kubernetes manifests and Operator metadata. Storage and distribution of the
+bundle image is then managed using existing container tools like `podman` and
+`docker` and container registries like Quay.
+
+See
+xref:../operators/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Packaging formats]
+for more details on the Bundle Format.
+
+The new `opm` CLI tool is also introduced alongside the Bundle Format. The `opm`
+CLI allows you to create and maintain catalogs of Operators from a list of
+bundles, called an index, that are equivalent to a "repository". The result is a
+container image, called an _index image_, which can be stored in a container
+registry and then installed on a cluster.
+
+An index contains a database of pointers to Operator manifest content that can
+be queried via an included API that is served when the container image is run.
+On {product-title}, OLM can use the index image as a catalog by referencing it
+in a CatalogSource, which polls the image at regular intervals to enable
+frequent updates to installed Operators on the cluster.
+
+See xref:../operators/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-bundle-format[Managing custom catalogs]
+for more details on `opm` usage.
+
 [id="ocp-4-5-olm-v1-crd"]
 ==== v1 CRD support in Operator Lifecycle Manager
 


### PR DESCRIPTION
Preview (internal): http://file.rdu.redhat.com/~adellape/070220/45rn_bundle_opm/release_notes/ocp-4-5-release-notes.html#ocp-4-5-bundle-format-opm

Will add proper `xref`s to the fake-links once https://github.com/openshift/openshift-docs/pull/22536 merges.