### PR TITLE
Fix unnecessary code block in Using SinkBinding

### DIFF
--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -5,7 +5,7 @@
 [id="serverless-sinkbinding-yaml_{context}"]
 = Using SinkBinding with the YAML method
 
- This guide describes the steps required to create, manage, and delete a SinkBinding instance using YAML files.
+This guide describes the steps required to create, manage, and delete a SinkBinding instance using YAML files.
 
 .Prerequisites
 


### PR DESCRIPTION
This patch removes unnecessary code block by removing white space.

Please refer to:

https://docs.openshift.com/container-platform/4.4/serverless/knative_eventing/serverless-sinkbinding.html#serverless-sinkbinding-yaml_serverless-sinkbinding

and find `This guide describes the steps required to create, manage, and delete a SinkBinding instance using YAML files.`. It must be a wrong code block.

/cc @abrennan89 