### PR TITLE
[enterprise-4.x] Fixed http to https in the webhook URL for master API  for the example

### DIFF
--- a/modules/builds-using-bitbucket-webhooks.adoc
+++ b/modules/builds-using-bitbucket-webhooks.adoc
@@ -23,7 +23,7 @@ command (see Displaying Webhook URLs), and is
 structured as follows:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/bitbucket
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/bitbucket
 ----
 
 .Procedure

--- a/modules/builds-using-generic-webhooks.adoc
+++ b/modules/builds-using-generic-webhooks.adoc
@@ -27,7 +27,7 @@ generic:
 webhook endpoint for your build:
 +
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/generic
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/generic
 ----
 +
 The caller must invoke the webhook as a `POST` operation.

--- a/modules/builds-using-github-webhooks.adoc
+++ b/modules/builds-using-github-webhooks.adoc
@@ -34,7 +34,7 @@ command (see Displaying Webhook URLs), and is
 structured as follows:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/github
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/github
 ----
 
 .Prerequisites

--- a/modules/builds-using-gitlab-webhooks.adoc
+++ b/modules/builds-using-gitlab-webhooks.adoc
@@ -22,7 +22,7 @@ The payload URL is returned as the GitLab Webhook URL by the `oc describe` comma
 (see Displaying Webhook URLs), and is structured as follows:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/gitlab
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/gitlab
 ----
 
 .Procedure


### PR DESCRIPTION
*  Version: OCP4.x
* Description:
  OCP master API supports only HTTPS, not HTTP. But some webhook example URLs are used HTTP. 