### PR TITLE
[enterprise-3.11] Fixed http to https in the webhook URL for master API for the example

### DIFF
--- a/dev_guide/builds/triggering_builds.adoc
+++ b/dev_guide/builds/triggering_builds.adoc
@@ -106,7 +106,7 @@ The payload URL is returned as the GitHub Webhook URL by the `oc describe` comma
 (see xref:describe-buildconfig[Displaying Webhook URLs]), and is structured as follows:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/github
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/github
 ----
 
 To configure a GitHub Webhook:
@@ -177,7 +177,7 @@ The payload URL is returned as the GitLab Webhook URL by the `oc describe` comma
 (see xref:describe-buildconfig[Displaying Webhook URLs]), and is structured as follows:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/gitlab
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/gitlab
 ----
 
 To configure a GitLab Webhook:
@@ -221,7 +221,7 @@ The payload URL is returned as the Bitbucket Webhook URL by the `oc describe` co
 (see xref:describe-buildconfig[Displaying Webhook URLs]), and is structured as follows:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/bitbucket
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/bitbucket
 ----
 
 To configure a Bitbucket Webhook:
@@ -269,7 +269,7 @@ To set up the caller, supply the calling system with the URL of the generic
 webhook endpoint for your build:
 
 ----
-http://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/generic
+https://<openshift_api_host:port>/oapi/v1/namespaces/<namespace>/buildconfigs/<name>/webhooks/<secret>/generic
 ----
 
 The caller must invoke the webhook as a `POST` operation.


### PR DESCRIPTION
* Version: OCP3.11
* Description:
   OCP master API supports only HTTPS, not HTTP. But some webhook example URLs are used HTTP.