### PR TITLE
modules/installation-creating-gcp-worker: Drop 'region' from YAML

### DIFF
--- a/modules/installation-creating-gcp-worker.adoc
+++ b/modules/installation-creating-gcp-worker.adoc
@@ -81,27 +81,25 @@ resources:
   type: 06_worker.py
   properties:
     infra_id: '${INFRA_ID}' <2>
-    region: '${REGION}' <3>
-    zone: '${ZONE_0}' <4>
+    zone: '${ZONE_0}' <3>
 
-    compute_subnet: '${COMPUTE_SUBNET}' <5>
-    image: '${CLUSTER_IMAGE}' <6>
-    machine_type: 'n1-standard-4' <7>
+    compute_subnet: '${COMPUTE_SUBNET}' <4>
+    image: '${CLUSTER_IMAGE}' <5>
+    machine_type: 'n1-standard-4' <6>
     root_volume_size: '128'
-    service_account_email: '${WORKER_SERVICE_ACCOUNT_EMAIL}' <8>
+    service_account_email: '${WORKER_SERVICE_ACCOUNT_EMAIL}' <7>
 
-    ignition: '${WORKER_IGNITION}' <9>
+    ignition: '${WORKER_IGNITION}' <8>
 EOF
 ----
 <1> `name` is the name of the worker machine, for example `w-a-0`.
 <2> `infra_id` is the `INFRA_ID` infrastructure name from the extraction step.
-<3> `region` is the region to deploy the cluster into, for example `us-central1`.
-<4> `zone` is the zone to deploy the worker machine into, for example `us-central1-a`.
-<5> `compute_subnet` is the `selfLink` URL to the compute subnet.
-<6> `image` is the `selfLink` URL to the {op-system} image.
-<7> `machine_type` is the machine type of the instance, for example `n1-standard-4`.
-<8> `service_account_email` is the email address for the worker service account created above.
-<9> `ignition` is the contents of the `worker.ign` file.
+<3> `zone` is the zone to deploy the worker machine into, for example `us-central1-a`.
+<4> `compute_subnet` is the `selfLink` URL to the compute subnet.
+<5> `image` is the `selfLink` URL to the {op-system} image.
+<6> `machine_type` is the machine type of the instance, for example `n1-standard-4`.
+<7> `service_account_email` is the email address for the worker service account created above.
+<8> `ignition` is the contents of the `worker.ign` file.
 
 . Optional: If you want to launch additional instances, include additional
 resources of type `06_worker.py` in your `06_worker.yaml` resource definition


### PR DESCRIPTION
The script consuming the YAML landed without `region` consumers in bd08aca0cd (#17043), and still has no consumers for that property.

/assign @adellape