### PR TITLE
Fixed references to new table

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -72,11 +72,11 @@ bond=<bonded_interface> <6>
 <2> Specify the URL of the RAW image that you uploaded to your server.
 <3> Specify the URL of the Ignition config file for this machine type.
 <4> Set `ip=dhcp` or set an individual static IP address (`ip=`) and DNS server (`nameserver=`) on each node.
-See _Configuring static networking_ for details.
+See _Static IP address examples for RHCOS kernel parameters_ for details.
 <5>  If you use multiple network interfaces or DNS servers, 
-see _Configuring static IP networking_ for details on how to configure them.
+see _Static IP address examples for RHCOS kernel parameters_ for details on how to configure them.
 <6> Optionally, you can bond multiple network interfaces to a single interface
-using the `bond=` option, as described in _Configuring static networking_.
+using the `bond=` option, as described in _Static IP address examples for RHCOS kernel parameters_.
 
 . Press Enter to complete the installation. After {op-system} installs, the system
 reboots. After the system reboots, it applies the Ignition config file that you

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -11,7 +11,7 @@ If you install {op-system-first} from an ISO image, you can add kernel arguments
 when you boot that image to configure the node's networking.
 The following table describes and illustrates how to use those kernel arguments.
 
-.Configuring static networking
+.Static IP address examples for RHCOS kernel parameters
 [source,adoc]
 |===
 |Description |Examples


### PR DESCRIPTION
I changed the name of the section containing a new table with information about configuring static networking in an ISO install, but I forgot to change a couple of references to that content. This PR attempts to fix that.