### PR TITLE
node network config: two more bond modes

### DIFF
--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -13,6 +13,8 @@ to the cluster.
 {VirtProductName} only supports the following bond modes:
 
 * mode=1 active-backup +
+* mode=2 balance-xor +
+* mode=4 802.3ad +
 * mode=5 balance-tlb +
 * mode=6 balance-alb
 ====


### PR DESCRIPTION
bond modes 2 and 4 are now supported, too.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>