### PR TITLE
install/bare_metal: Remove tech preview text from three-node cluster

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -52,13 +52,7 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
-[id="installing-bare-metal-three-node"]
-== Running a three-node cluster
-
-:FeatureName: Three-node cluster
-include::modules/technology-preview.adoc[leveloffset=+2]
-
-include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
+include::modules/installation-three-node-cluster.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -65,13 +65,7 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
-[id="installing-restricted-networks-bare-metal-three-node"]
-== Running a three-node cluster
-
-:FeatureName: Three-node cluster
-include::modules/technology-preview.adoc[leveloffset=+2]
-
-include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
+include::modules/installation-three-node-cluster.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 

--- a/modules/installation-three-node-cluster.adoc
+++ b/modules/installation-three-node-cluster.adoc
@@ -14,7 +14,7 @@
 [id="installation-three-node-cluster_{context}"]
 = Configuring a three-node cluster
 
-You can install and run three-node clusters in {product-title} with no workers. This provides smaller, more resource efficient clusters for cluster administrators and developers to use for deployment, development, and testing.
+You can optionally install and run three-node clusters in {product-title} with no workers. This provides smaller, more resource efficient clusters for cluster administrators and developers to use for deployment, development, and testing.
 
 .Procedure
 


### PR DESCRIPTION
This has always worked but now it's tested and fully supported in 4.5+

/cc @kalexand-rh 