### PR TITLE
Fix link

### DIFF
--- a/admin_guide/image_signatures.adoc
+++ b/admin_guide/image_signatures.adoc
@@ -295,4 +295,4 @@ _unverified_ by default and will have to be verified by image administrators.
 ====
 
 For more details about the registries configuration directory, see
-link:https://github.com/containers/image/blob/master/docs/registries.d.md[Registries Configuration Directory].
+link:https://github.com/containers/image/blob/master/docs/containers-registries.d.5.md[Registries Configuration Directory].


### PR DESCRIPTION
Updated link has nearly identical content by comparison:

[Old doc](https://github.com/containers/image/blob/c07087f1f0fba7fc41567062c591abdf06c87085/docs/registries.d.md)
[New doc](https://github.com/containers/image/blob/master/docs/containers-registries.d.5.md)

The doc just seems to have changed names. Updated accordingly.