### PR TITLE
Change some wording about resources that need to be provided by UPI

### DIFF
--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -179,7 +179,7 @@ the cluster to the infrastructure that you provided.
 If you do not use infrastructure that the installation program provisioned, you must manage
 and maintain the cluster resources yourself, including:
 
-* The control plane and compute machines that make up the cluster
+* The underlying infrastructure for the control plane and compute machines that make up the cluster
 * Load balancers
 * Cluster networking, including the DNS records and required subnets
 * Storage for the cluster infrastructure and applications


### PR DESCRIPTION
Adjusting "The control plane and compute machines that make up the cluster" with "The underlying compute infrastructure" as this wording seems to make more accurate.