### PR TITLE
SR-IOV Network Operator does not provide a DHCP DaemonSet

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -17,6 +17,9 @@ endif::[]
 ifeval::["{context}" != "configuring-macvlan-basic"]
 :json:
 endif::[]
+ifeval::["{context}" == "configuring-sriov-net-attach"]
+:sr-iov:
+endif::[]
 
 [id="nw-multus-ipam-object_{context}"]
 = Configuration for ipam CNI plug-in
@@ -99,7 +102,43 @@ such as `example-host`, during a DNS lookup query.
 [id="nw-multus-dhcp_{context}"]
 == Dynamic IP address assignment configuration
 
-The following JSON describes the configuration for dynamic IP address assignment with DHCP:
+The following JSON describes the configuration for dynamic IP address address assignment with DHCP.
+
+.Renewal of DHCP leases
+[IMPORTANT]
+====
+A Pod obtains its original DHCP lease when it is created. The lease must be periodically renewed by a minimal DHCP server deployment running on the cluster.
+
+ifdef::sr-iov[]
+The SR-IOV Network Operator does not create a DHCP server deployment; The Cluster Network Operator is responsible for creating the minimal DHCP server deployment.
+endif::sr-iov[]
+
+To trigger the deployment of the DHCP server, you must create a shim network attachment by editing the Cluster Network Operator configuration, as in the following example:
+
+.Example shim network attachment definition
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  ...
+  additionalNetworks:
+  - name: dhcp-shim
+    namespace: default
+    rawCNIConfig: |-
+    {
+      "name": "dhcp-shim",
+      "cniVersion": "0.3.1",
+      "type": "bridge",
+      "master": "ens5",
+      "ipam": {
+        "type": "dhcp"
+      }
+    }
+----
+====
 
 .DHCP assignment configuration
 [source,json]
@@ -313,4 +352,7 @@ ifeval::["{context}" == "configuring-macvlan-basic"]
 endif::[]
 ifeval::["{context}" != "configuring-macvlan-basic"]
 :!json:
+endif::[]
+ifeval::["{context}" == "configuring-sriov-net-attach"]
+:!sr-iov:
 endif::[]


### PR DESCRIPTION
This adds a new note, with a conditional for SR-IOV Network Operator, explaining how DHCP leases are renewed.