### PR TITLE
Two spec definitions and empty value for policy in example 'Creating default cluster-wide node selectors'

### DIFF
--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -50,10 +50,13 @@ apiVersion: config.openshift.io/v1
 kind: Scheduler
 metadata:
   name: cluster
-spec: {}
-  policy:
+...
+
 spec:
   defaultNodeSelector: type=user-node,region=east <1>
+  mastersSchedulable: false
+  policy:
+    name: "" 
 ----
 <1> Add a node selector with the appropriate `<key>:<value>` pairs. 
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1847509