### PR TITLE
Update SR-IOV runtime configuration procedure

### DIFF
--- a/modules/nw-sriov-add-pod-runtimeconfig.adoc
+++ b/modules/nw-sriov-add-pod-runtimeconfig.adoc
@@ -5,11 +5,11 @@
 [id="nw-sriov-add-pod-runtimeconfig_{context}"]
 = Configuring static MAC and IP addresses on additional SR-IOV networks
 
-You can configure static MAC and IP addresses on an SR-IOV network by specifying Container Network Interface (CNI) runtimeConfig data in a pod annotation.
+You can configure static MAC and IP addresses on an SR-IOV network by specifying Container Network Interface (CNI) runtimeConfig data in a Pod annotation.
 
 .Prerequisites
 
-* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* Install the {product-title} Command-line Interface (CLI), commonly known as `oc`.
 * Log in as a user with `cluster-admin` privileges when creating the SriovNetwork CR.
 
 .Procedure
@@ -77,9 +77,9 @@ spec:
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
 ----
-<1> Replace `<name>` with then name of the SR-IOV network attachment definition CR.
-<2> Specify the `mac` address for the SR-IOV device which is allocated from the resource type defined in the SR-IOV network attachment definition CR.
-<3> Specify the IPv4 and/or IPv6 addresses for the SR-IOV device which is allocated from the resource type defined in the SR-IOV network attachment definition CR.
+<1> Specify the name of the SR-IOV network attachment definition CR.
+<2> Specify the MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR.
+<3> Specify addresses for the SR-IOV device which is allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported.
 
 . Create the sample SR-IOV pod by running the following command:
 +


### PR DESCRIPTION
@zshi-redhat, so I have a question about this:

```yaml
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
	{
		"name": "<name>", <1>
		"mac": "20:04:0f:f1:88:01", <2>
		"ips": ["192.168.10.1/24", "2001::1/64"] <3>
	}
]'
```

Is the above what _Configuring static MAC and IP addresses on additional SR-IOV networks_ is discussing? Is that the _runtimeConfig_?

And `mac` and `ips` can be specified because the the `capabilities` field is defined in the SriovNetwork?

If so, we seem to be duplicating configurations in places, and it could be confusing.

It might be there is an alternate way to present this.