### PR TITLE
BZ1848733 - Add note about LocalVolume editing behavior

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -105,8 +105,7 @@ the file you just created:
 $ oc create -f <local-volume>.yaml
 ----
 
-. Verify the provisioner was created, and the corresponding DaemonSets were
-created:
+. Verify that the provisioner was created, and that the corresponding DaemonSets were created:
 +
 ----
 $ oc get all -n local-storage
@@ -135,7 +134,7 @@ replicaset.apps/local-storage-operator-54564d9988   1         1         1       
 ----
 +
 Note the desired and current number of DaemonSet processes. If the desired
-count is `0`, it indicates the label selectors were invalid.
+count is `0`, it indicates that the label selectors were invalid.
 
 . Verify that the PersistentVolumes were created:
 +
@@ -147,3 +146,8 @@ local-pv-1cec77cf   100Gi      RWO            Delete           Available        
 local-pv-2ef7cd2a   100Gi      RWO            Delete           Available           local-sc                82m
 local-pv-3fa1c73    100Gi      RWO            Delete           Available           local-sc                48m
 ----
+
+[IMPORTANT]
+====
+Editing the LocalVolume object does not change the `fsType` or `volumeMode` of existing PersistentVolumes because doing so might result in a destructive operation.
+====


### PR DESCRIPTION
As described in [BZ1848733](https://bugzilla.redhat.com/show_bug.cgi?id=1848733), this PR adds a note in the LocalVolume provisioning procedure about expected behavior when editing the object. Applies to 4.3+. 

Preview: https://bz1848733--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-volume-cr_persistent-storage-local