### PR TITLE
BZ1847502 - Replace Cassandra

### DIFF
--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -64,8 +64,8 @@ A scaled registry is an {product-title} registry where three or more pod replica
 [IMPORTANT]
 ====
 Testing shows issues with using the NFS server on RHEL as storage backend for
-the container image registry. This includes the OpenShift Container Registry and Quay, Cassandra
-for metrics storage, and Elasticsearch for logging storage. Therefore, using NFS
+the container image registry. This includes the OpenShift Container Registry and Quay, Prometheus
+for monitoring storage, and Elasticsearch for logging storage. Therefore, using NFS
 to back PVs used by core services is not recommended.
 
 Other NFS implementations on the marketplace might not have these issues.


### PR DESCRIPTION
Per [BZ1847502](https://bugzilla.redhat.com/show_bug.cgi?id=1847502), updating Cassandra -> Prometheus. Applies to 4.2+.

Preview link: https://bz1847502--ocpdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimizing-storage.html#specific-application-storage-recommendations

**Cc:** @rh-max FYI

@qinpingli PTAL