### PR TITLE
CNV GA placeholder

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -1,18 +1,12 @@
 [id="about-virt"]
-= About {VirtProductName}
+= OpenShift Virtualization
 include::modules/virt-document-attributes.adoc[]
 :context: about-virt
 toc::[]
 
-Learn about {VirtProductName}'s capabilities and support scope.
+Documentation for OpenShift Virtualization, formerly known as container-native virtualization, will be available for {product-title} 4.5 in the near future.
 
-include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
+In the meantime, the https://docs.openshift.com/container-platform/4.4/cnv/cnv-about-cnv.html[container-native virtualization 2.3 documentation] is available as part of the {product-title} 4.4 documentation.
 
-// This line is attached to the above `virt-what-you-can-do-with-virt` module.
-// It is included here in the assembly because of the xref ban.
-You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
+// Container-native virtualization 2.3 is also supported for use in {product-title} 4.5.
 
-== {VirtProductName} support
-
-:FeatureName: {VirtProductName}
-include::modules/technology-preview.adoc[leveloffset=+2]


### PR DESCRIPTION
Replacing content with placeholder content for OCP 4.5 docs pre-CNV 2.4

All virt and cnv links for OCP 4.5 will be redirected to this placeholder text until 2.4 is released, at which time this will be reverted to the previous text. 

@vikram-redhat @aspauldi