### PR TITLE
Product name update - OpenShift Virtualization

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2013,28 +2013,28 @@ Topics:
     File: rhbjaeger-removing
 
 ---
-Name: OpenShift virtualization
+Name: OpenShift Virtualization
 Dir: virt
 Distros: openshift-enterprise,openshift-webscale
 Topics:
-- Name: About OpenShift virtualization
+- Name: About OpenShift Virtualization
   File: about-virt
-- Name: OpenShift virtualization release notes
+- Name: OpenShift Virtualization release notes
   File: virt-2-4-release-notes
-- Name: OpenShift virtualization installation
+- Name: OpenShift Virtualization installation
   Dir: install
   Topics:
-  - Name: Preparing your OpenShift cluster for OpenShift virtualization
+  - Name: Preparing your OpenShift cluster for OpenShift Virtualization
     File: preparing-cluster-for-virt
-  - Name: Installing OpenShift virtualization
+  - Name: Installing OpenShift Virtualization
     File: installing-virt
   - Name: Installing the virtctl client
     File: virt-installing-virtctl
-  - Name: Uninstalling OpenShift virtualization using the web console
+  - Name: Uninstalling OpenShift Virtualization using the web console
     File: uninstalling-virt-web
-  - Name: Uninstalling OpenShift virtualization using the CLI
+  - Name: Uninstalling OpenShift Virtualization using the CLI
     File: uninstalling-virt-cli
-- Name: Upgrading OpenShift virtualization
+- Name: Upgrading OpenShift Virtualization
   File: upgrading-virt
 - Name: Using the CLI tools
   File: virt-using-the-cli-tools
@@ -2100,7 +2100,7 @@ Topics:
   - Name: Virtual machine networking
     Dir: vm_networking
     Topics:
-    - Name: Using the default Pod network with OpenShift virtualization
+    - Name: Using the default Pod network with OpenShift Virtualization
       File: virt-using-the-default-pod-network-with-virt
     - Name: Attaching a virtual machine to multiple networks
       File: virt-attaching-vm-multiple-networks
@@ -2198,7 +2198,7 @@ Topics:
     File: virt-using-dashboard-to-get-cluster-info
   - Name: OpenShift cluster monitoring, logging, and Telemetry
     File: virt-openshift-cluster-monitoring
-  - Name: Collecting OpenShift virtualization data for Red Hat Support
+  - Name: Collecting OpenShift Virtualization data for Red Hat Support
     File: virt-collecting-virt-data
 ---
 # OpenShift Serverless

--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -9,7 +9,7 @@
 // Product content attributes, that is, substitution variables in the files.
 //
 :product-title: OpenShift Container Platform
-:VirtProductName: OpenShift virtualization
+:VirtProductName: OpenShift Virtualization
 :ProductRelease:
 :ProductVersion:
 :VirtVersion: 2.4
@@ -25,6 +25,6 @@
 //     Using the pattern ending in 'BookName' makes it easy to grep for occurrences
 //     throughout the topics
 //
-:Install_BookName: Installing OpenShift virtualization
-:Using_BookName: Using OpenShift virtualization
-:RN_BookName: OpenShift virtualization release notes
+:Install_BookName: Installing OpenShift Virtualization
+:Using_BookName: Using OpenShift Virtualization
+:RN_BookName: OpenShift Virtualization release notes


### PR DESCRIPTION
This PR is for the document attributes file that contains the product name variable associated with OpenShift Virtualization. Per new branding requirements, the word "virtualization" is now "Virtualization".