### PR TITLE
RN-CNV-5439 TLS certificate rotation

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -18,6 +18,9 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+2]
 
 //CNV-5371 - Import existing virtual machines from Red Hat Virtualization to OpenShift Virtualization.
 
+//CNV-5439 - TLS certificates
+{VirtProductName} rotates and renews TLS certificates at regular intervals. This automatic process does not disrupt any operations.
+
 [id="virt-2-4-networking-new"]
 === Networking
 //Placeholder for new content.


### PR DESCRIPTION
This PR is for the Release Note Jira story https://issues.redhat.com/browse/CNV-5439 and contains the proposed write-up for the 2.4 release notes concerning TLS certificate rotation. 