### PR TITLE
Bug 1847439: Bridge CNI does not require a "master" parameter.

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -116,7 +116,6 @@ rawCNIConfig: '{ <1>
   "cniVersion": "0.3.1",
   "name": "work-network",
   "type": "bridge",
-  "master": "eth1",
   "isGateway": true,
   "vlan": 2,
   "ipam": {


### PR DESCRIPTION
The bridge CNI configuration incorrectly assumed a "master" parameter, likely from a copy/paste error.
This causes only confusion for users, but, the effect is inert (doesn't actually cause problems)