### PR TITLE
Rm FeatureGate link from OperatorAPI proc

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -626,8 +626,7 @@ $ oc patch clusterversion version \
     }'
 ----
 
-. Add the `OperatorLifecycleManagerV2=true` xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[FeatureGate]
-to the OLM Operator.
+. Add the `OperatorLifecycleManagerV2=true` feature gate to the OLM Operator.
 
 .. Edit the OLM Operator's Deployment:
 +


### PR DESCRIPTION
Feature doesn't actually use a FeatureGate CR, just adding the flag manually to Deployment. No need for link.