### PR TITLE
BZ-1853459 Updated clipboardJS regex when checking for $ in code blocks

### DIFF
--- a/_javascripts/clipboard.js
+++ b/_javascripts/clipboard.js
@@ -11,7 +11,7 @@ document.querySelectorAll('span.clipboard-button').forEach((copybutton, index) =
 var clipboard = new ClipboardJS('.clipboard-button', {
     text: function(target) {
       const targetId = target.getAttribute('data-clipboard-target').substr(1);
-      const clipboardText = document.getElementById(targetId).innerText.replace(/\$\s/g, "");
+      const clipboardText = document.getElementById(targetId).innerText.replace(/\$[ ]/g, "");
 
       if (clipboardText.slice(0, 2) === "# ") {
         return clipboardText.substr(2);


### PR DESCRIPTION
BZ-1853459 https://bugzilla.redhat.com/show_bug.cgi?id=1853459

@vikram-redhat I updated the regex in clipboard.js to look for only a space `[  ]` after `$` and not `\s`, which  matches a whitespace character (including tabs and line breaks).

I tested the yaml code blocks in the BZ and they are copying correctly now. I also tested several `$ oc ` code blocks, including those that have multiple commands in them. The functionality works as expected. 

Please let me know if you need me to build and link to a local build to test. I made sure to change back the docs.js link from local back to 4.1 before committing.