### PR TITLE
Bug 1856348: Samples operator configuration for restricted networks, replaced confusing command

### DIFF
--- a/modules/installation-restricted-network-samples.adoc
+++ b/modules/installation-restricted-network-samples.adoc
@@ -86,7 +86,7 @@ to contain the `hostname` portion of the mirror location defined in the mirror
 configuration:
 +
 ----
-$ oc get configs.samples.operator.openshift.io -n openshift-cluster-samples-operator
+$ oc edit configs.samples.operator.openshift.io -n openshift-cluster-samples-operator
 ----
 +
 [NOTE]


### PR DESCRIPTION
I've replaced `oc get` with `oc edit` on the procedure to setup the samples operator for restricted network since the documentation tells you to modify the resource and the example is confusing for some users.