### PR TITLE
Commenting out reference to API docs

### DIFF
--- a/security/container_security/security-container-content.adoc
+++ b/security/container_security/security-container-content.adoc
@@ -24,4 +24,4 @@ include::modules/security-container-content-scanning.adoc[leveloffset=+1]
 include::modules/security-container-content-external-scanning.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../openshift_images/images-understand.adoc#images-imagestream-use_images-understand[Image stream objects]
-* xref:../../rest_api/index.adoc#rest-api[{product-title} {product-version} REST APIs]
+// * xref:../../rest_api/index.adoc#rest-api[{product-title} {product-version} REST APIs]


### PR DESCRIPTION
Commenting out xref to API docs for 4.4, as from #23590. This fixes the 4.4 branch builds failing.