### PR TITLE
Remove outdated Kuryr + Octavia compatibility notes

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -34,23 +34,13 @@ OpenShift UDP services are not supported.
 same port. Services that expose the same port to different protocols, like TCP
 and UDP, are not supported.
 
-[IMPORTANT]
-====
-The OVN Octavia driver does not support listeners that use different protocols on
-any {rh-openstack} version.
-====
-
 [discrete]
 [id="openstack-go-limitations_{context}"]
 == {rh-openstack} environment limitations
 
 There are limitations when using Kuryr SDN that depend on your deployment environment.
 
-Because of Octavia's lack of support for the UDP protocol and multiple listeners, Kuryr forces Pods to use TCP
-for DNS resolution if:
-
-* The {rh-openstack} version is earlier than 16
-* The OVN Octavia driver is used
+Because of Octavia's lack of support for the UDP protocol and multiple listeners, if the {rh-openstack} version is earlier than 16, Kuryr forces Pods to use TCP for DNS resolution.
 
 In Go versions 1.12 and earlier, applications that are compiled with CGO support disabled use UDP only. In this case,
 the native Go resolver does not recognize the `use-vc` option in `resolv.conf`, which controls whether TCP is forced for DNS resolution.


### PR DESCRIPTION
This PR resolves #23711. 

QE should be covered already by https://github.com/openshift/openshift-docs/pull/21488 and https://github.com/openshift/openshift-docs/pull/22878.



