### PR TITLE
No qcow2 images for ISO installs

### DIFF
--- a/modules/installation-azure-user-infra-uploading-rhcos.adoc
+++ b/modules/installation-azure-user-infra-uploading-rhcos.adoc
@@ -53,6 +53,8 @@ The {op-system} images might not change with every release of {product-title}.
 You must specify an image with the highest version that is
 less than or equal to the {product-title} version that you install. Use the image version
 that matches your {product-title} version if it is available.
+Only use ISO images for this procedure.
+{op-system} qcow2 images are not supported for bare metal installs.
 ====
 
 . Copy the chosen VHD to a blob:

--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -22,6 +22,8 @@ The {op-system} images might not change with every release of {product-title}.
 You must download an image with the highest version that is
 less than or equal to the {product-title} version that you install. Use the image version
 that matches your {product-title} version if it is available.
+Only use ISO images for this procedure.
+{op-system} qcow2 images are not supported for bare metal installs.
 ====
 +
 The file name contains the {product-title} version number in the format

--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -23,6 +23,8 @@ The {op-system} images might not change with every release of {product-title}.
 You must download images with the highest version that is less than or equal
 to the {product-title} version that you install. Use the image versions
 that match your {product-title} version if they are available.
+Only use ISO images for this procedure.
+{op-system} qcow2 images are not supported for bare metal installs.
 ====
 +
 Download the following files:

--- a/modules/installation-osp-creating-image.adoc
+++ b/modules/installation-osp-creating-image.adoc
@@ -23,6 +23,8 @@ The {op-system} images might not change with every release of {product-title}.
 You must download images with the highest version that is less than or equal to
 the {product-title} version that you install. Use the image versions that match
 your {product-title} version if they are available.
+Only use ISO images for this procedure.
+{op-system} qcow2 images are not supported for bare metal installs.
 ====
 
 . Download the _{op-system-first} - OpenStack Image (QCOW)_.

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -35,6 +35,8 @@ The {op-system} images might not change with every release of {product-title}.
 You must download images with the highest version that is less than or equal
 to the {product-title} version that you install. Use the image versions
 that match your {product-title} version if they are available.
+Only use ISO images for this procedure.
+{op-system} qcow2 images are not supported for bare metal installs.
 ====
 +
 The file names contain the {product-title} version number.

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -103,6 +103,8 @@ The {op-system} images might not change with every release of {product-title}.
 You must download an image with the highest version that is
 less than or equal to the {product-title} version that you install. Use the image version
 that matches your {product-title} version if it is available.
+Only use ISO images for this procedure.
+{op-system} qcow2 images are not supported for bare metal installs.
 ====
 +
 The file name contains the {product-title} version number in the format


### PR DESCRIPTION
RHCOS team asked that we add this note to avoid confusion of some users thinking they can do ISO installs with qcow2 images.