### PR TITLE
Fix special char '#' issues in bug fix docs

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1488,10 +1488,10 @@ level=error msg="＼"aws＼" produced an unexpected new value for was present, b
 * With this release, an update to a library that is used by the web console resolved performance and display issues on some views.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1796658[*BZ#1796658*])
 
-* Select links in the mast head had an href value of '#' with an OnClick
+* Select links in the mast head had an href value of `\#` with an OnClick
 handler containing the target destination. As a result, those links have the
-option to open in a new tab, however the '#' resolved to the dashboard instead
-of the intended target destination. Now, any links with an href of '#' are
+option to open in a new tab, however the `#` resolved to the dashboard instead
+of the intended target destination. Now, any links with an href of `#` are
 updated to a button element so the *Open Link In New Tab* option is not
 available. Links that have the *Open Link In New Tab* option show the correct
 URL.


### PR DESCRIPTION
I've been having some weird issues with the `#` char getting by Travis CI (previous issues mentioned in https://github.com/openshift/openshift-docs/pull/23503#issuecomment-654593647). To push this through during the bug fix chaos, I resorted to using `'#'` instead of our backticks. This got by our build, but did not publish correctly on docs.openshift.com.

I have included a backslash to escape the first instance of `#`, which now seems to get us by the build and publish successfully. Preview here: http://file.rdu.redhat.com/~choag/071320/rn-fix-4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-bug-fixes