### PR TITLE
chore(oc login): Adde NOTE admonition to explain usage of HTTP_PROXY …

### DIFF
--- a/modules/cli-logging-in.adoc
+++ b/modules/cli-logging-in.adoc
@@ -12,6 +12,12 @@ You can log in to the `oc` CLI to access and manage your cluster.
 * You must have access to an {product-title} cluster.
 * You must have installed the CLI.
 
+[NOTE]
+====
+To access a cluster that is accessible only over an HTTP proxy server, you can set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables.
+These environment variables are respected by the `oc` CLI so that all communication with the cluster goes through the HTTP proxy.
+====
+
 .Procedure
 
 * Log in to the CLI using the `oc login` command and enter the required


### PR DESCRIPTION
…vars.

Add a short note how a remote cluster can be accessed with `oc` (and other clients) by using an HTTP proxy.

Replaces #21327 - just to squash the commits.