### PR TITLE
Jim cert clarifications edits

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -2,35 +2,24 @@
 //
 // * security/certificates/api-server.adoc
 
-[id="add-named-api-server_{context}"]
+[id="customize-certificates-api-add-named_{context}"]
 = Add an API server named certificate
 
 The default API server certificate is issued by an internal {product-title}
-cluster CA. You can add additional certificates to the API server to send
-based on the client's requested URL, such as when a reverse proxy or
-load balancer is used.
+cluster CA. You can add one or more alternative certificates that the API
+server will return based on the fully qualified domain name (FQDN) requested by
+the client, for example when a reverse proxy or load balancer is used.
 
 .Prerequisites
 
-* You must have the certificate and key, in the PEM format, for the
-client's URL.
-* The certificate must be issued for the URL used by the client to
-reach the API server.
-* The certificate must have the `subjectAltName` extension for the URL.
-* If a certificate chain is required to certify the server certificate, then the certificate chain must be appended to the server certificate. Certificate files must be Base64 PEM-encoded and typically have a `.crt` or `.pem` extension. For example:
-+
-----
-$ cat server_cert.pem int2ca_cert.pem int1ca_cert.pem rootca_cert.pem>combined_cert.pem
-----
-+
-When combining certificates, the order of the certificates is important. Each following certificate must directly certify the certificate preceding it, for example:
-
-. {product-title} master host server certificate.
-
-. Intermediate CA certificate that certifies the server certificate.
-
-. Root CA certificate that certifies the intermediate CA certificate.
-
+* You must have a certificate for the FQDN and its corresponding private key. Each should be in a separate PEM format file.
+* The private key must be unencrypted. If your key is encrypted, decrypt it
+before importing it into {product-title}.
+* The certificate must include the `subjectAltName` extension showing the FQDN.
+* The certificate file can contain one or more certificates in a chain. The
+certificate for the API server FQDN must be the first certificate in the file.
+It can then be followed with any intermediate certificates, and the file should
+end with the root CA certificate.
 
 [WARNING]
 ====
@@ -41,21 +30,18 @@ cluster in a degraded state.
 
 .Procedure
 
-. Create a secret that contains the certificate and key in the
+. Create a secret that contains the certificate chain and private key in the
 `openshift-config` namespace.
 +
 ----
-$ oc create secret tls <certificate> \//<1>
+$ oc create secret tls <secret> \//<1>
      --cert=</path/to/cert.crt> \//<2>
      --key=</path/to/cert.key> \//<3>
      -n openshift-config
 ----
-<1> `<certificate>` is the name of the secret that will contain
-the certificate.
-<2> `</path/to/cert.crt>` is the path to the certificate on your
-local file system.
-<3> `</path/to/cert.key>` is the path to the private key associated
-with this certificate.
+<1> `<secret>` is the name of the secret that will contain the certificate chain and private key.
+<2> `</path/to/cert.crt>` is the path to the certificate chain on your local file system.
+<3> `</path/to/cert.key>` is the path to the private key associated with this certificate.
 
 . Update the API server to reference the created secret.
 +
@@ -63,13 +49,11 @@ with this certificate.
 $ oc patch apiserver cluster \
      --type=merge -p \
      '{"spec":{"servingCerts": {"namedCertificates":
-     [{"names": ["<hostname>"], //<1>
-     "servingCertificate": {"name": "<certificate>"}}]}}}' <2>
+     [{"names": ["<FQDN>"], //<1>
+     "servingCertificate": {"name": "<secret>"}}]}}}' <2>
 ----
-<1> Replace `<hostname>` with the hostname that the API server
-should provide the certificate for.
-<2> Replace `<certificate>` with the name used for the secret in
-the previous step.
+<1> Replace `<FQDN>` with the FQDN that the API server should provide the certificate for.
+<2> Replace `<secret>` with the name used for the secret in the previous step.
 
 . Examine the `apiserver/cluster` object and confirm the secret is now
 referenced.
@@ -81,8 +65,8 @@ spec:
   servingCerts:
     namedCertificates:
     - names:
-      - <hostname>
+      - <FQDN>
       servingCertificate:
-        name: <certificate>
+        name: <secret>
 ...
 ----

--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -12,21 +12,28 @@ and CLI, will have encryption provided by specified certificate.
 
 .Prerequisites
 
-* You must have a wildcard certificate and its private key,
-both in the PEM format, for use.
-* The certificate must have a `subjectAltName` extension of
+* You must have a wildcard certificate for the fully qualified `.apps` subdomain
+and its corresponding private key. Each should be in a separate PEM format file.
+* The private key must be unencrypted. If your key is encrypted, decrypt it
+before importing it into {product-title}.
+* The certificate must include the `subjectAltName` extension showing
 `*.apps.<clustername>.<domain>`.
+* The certificate file can contain one or more certificates in a chain. The
+wildcard certificate must be the first certificate in the file. It can then be
+followed with any intermediate certificates, and the file should end with the
+root CA certificate.
+* Copy the root CA certificate into an additional PEM format file.
 
 .Procedure
 
-. Create a ConfigMap that includes the certificate authority used to signed the new certificate:
+. Create a ConfigMap that includes only the root CA certificate used to sign the wildcard certificate:
 +
 ----
 $ oc create configmap custom-ca \
      --from-file=ca-bundle.crt=</path/to/example-ca.crt> \//<1>
      -n openshift-config
 ----
-<1> `</path/to/example-ca.crt>` is the path to the certificate authority file on your local file system.
+<1> `</path/to/example-ca.crt>` is the path to the root CA certificate file on your local file system.
 
 . Update the cluster-wide proxy configuration with the newly created ConfigMap:
 +
@@ -36,18 +43,18 @@ $ oc patch proxy/cluster \
      --patch='{"spec":{"trustedCA":{"name":"custom-ca"}}}'
 ----
 
-. Create a secret that contains the wildcard certificate and key:
+. Create a secret that contains the wildcard certificate chain and key:
 +
 ----
-$ oc create secret tls <certificate> \//<1>
+$ oc create secret tls <secret> \//<1>
      --cert=</path/to/cert.crt> \//<2>
      --key=</path/to/cert.key> \//<3>
      -n openshift-ingress
 ----
-<1> `<certificate>` is the name of the secret that will contain
-the certificate and private key.
-<2> `</path/to/cert.crt>` is the path to the certificate on your
-local file system.
+<1> `<secret>` is the name of the secret that will contain the certificate chain
+and private key.
+<2> `</path/to/cert.crt>` is the path to the certificate chain on your local
+file system.
 <3> `</path/to/cert.key>` is the path to the private key associated
 with this certificate.
 
@@ -57,8 +64,8 @@ secret:
 ----
 $ oc patch ingresscontroller.operator default \
      --type=merge -p \
-     '{"spec":{"defaultCertificate": {"name": "<certificate>"}}}' \//<1>
+     '{"spec":{"defaultCertificate": {"name": "<secret>"}}}' \//<1>
      -n openshift-ingress-operator
 ----
-<1> Replace `<certificate>` with the name used for the secret in
+<1> Replace `<secret>` with the name used for the secret in
 the previous step.


### PR DESCRIPTION
- Certificate and key must be in separate files
- Key must be unencrypted
- Certificate chains are fine, specify ordering
- Use to refer to a secret
- Refer to hostname, not URL, for correctness
- Clarify root CA certificate handling

@jim-minter's changes from: https://github.com/openshift/openshift-docs/pull/20867