### PR TITLE
node.kubernetes.io/unreachable:NoExecute taint should cause immediate pod eviction

### DIFF
--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -1,13 +1,13 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes-scheduler-taints-tolerations.adoc
+// * nodes/scheduling/nodes-scheduler-taints-tolerations.adoc
 
 [id="nodes-scheduler-taints-tolerations-about_{context}"]
 = Understanding taints and tolerations
 
-A _taint_ allows a node to refuse pod to be scheduled unless that pod has a matching _toleration_.
+A _taint_ allows a node to refuse Pod to be scheduled unless that Pod has a matching _toleration_.
 
-You apply taints to a node through the node specification (`NodeSpec`) and apply tolerations to a pod through the pod specification (`PodSpec`). A taint on a node instructs the node to repel all pods that do not tolerate the taint.
+You apply taints to a node through the node specification (`NodeSpec`) and apply tolerations to a Pod through the Pod specification (`PodSpec`). A taint on a node instructs the node to repel all Pods that do not tolerate the taint.
 
 Taints and tolerations consist of a key, value, and effect. An operator allows you to leave one of these parameters empty.
 
@@ -31,14 +31,14 @@ Taints and tolerations consist of a key, value, and effect. An operator allows y
 [cols="2a,3a"]
 !====
 !`NoSchedule`
-!* New pods that do not match the taint are not scheduled onto that node.
-* Existing pods on the node remain.
+!* New Pods that do not match the taint are not scheduled onto that node.
+* Existing Pods on the node remain.
 !`PreferNoSchedule`
-!* New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to.
-* Existing pods on the node remain.
+!* New Pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to.
+* Existing Pods on the node remain.
 !`NoExecute`
-!* New pods that do not match the taint cannot be scheduled onto that node.
-* Existing pods on the node that do not have a matching toleration  are removed.
+!* New Pods that do not match the taint cannot be scheduled onto that node.
+* Existing Pods on the node that do not have a matching toleration  are removed.
 !====
 
 |`operator`
@@ -68,7 +68,7 @@ The following taints are built into kubernetes:
 
 * `node.kubernetes.io/not-ready`: The node is not ready. This corresponds to the node condition `Ready=False`.
 * `node.kubernetes.io/unreachable`: The node is unreachable from the node controller. This corresponds to the node condition `Ready=Unknown`.
-* `node.kubernetes.io/out-of-disk`: The node has insufficient free space on the node for adding new pods. This corresponds to the node condition `OutOfDisk=True`.
+* `node.kubernetes.io/out-of-disk`: The node has insufficient free space on the node for adding new Pods. This corresponds to the node condition `OutOfDisk=True`.
 * `node.kubernetes.io/memory-pressure`: The node has memory pressure issues. This corresponds to the node condition `MemoryPressure=True`.
 * `node.kubernetes.io/disk-pressure`: The node has disk pressure issues. This corresponds to the node condition `DiskPressure=True`.
 * `node.kubernetes.io/network-unavailable`: The node network is unavailable.
@@ -78,7 +78,7 @@ The following taints are built into kubernetes:
 [id="nodes-scheduler-taints-tolerations-about-seconds_{context}"]
 == Understanding how to use toleration seconds to delay pod evictions
 
-You can specify how long a pod can remain bound to a node before being evicted by specifying the `tolerationSeconds` parameter in the pod specification. If a taint with the `NoExecute` effect is added to a node, any pods that do not tolerate the taint are evicted immediately (pods that do tolerate the taint are not evicted). However, if a pod that to be evicted has the `tolerationSeconds` parameter, the pod is not evicted until that time period expires.
+You can specify how long a Pod can remain bound to a node before being evicted by specifying the `tolerationSeconds` parameter in the Pod specification. If a taint with the `NoExecute` effect is added to a node, any Pods that do not tolerate the taint are evicted immediately (Pods that do tolerate the taint are not evicted). However, if a Pod that to be evicted has the `tolerationSeconds` parameter, the Pod is not evicted until that time period expires.
 
 For example:
 [source, yaml]
@@ -91,19 +91,19 @@ tolerations:
   tolerationSeconds: 3600
 ----
 
-Here, if this pod is running but does not have a matching taint, the pod stays bound to the node for 3,600 seconds and then be evicted. If the taint is removed before that time, the pod is not evicted.
+Here, if this Pod is running but does not have a matching taint, the Pod stays bound to the node for 3,600 seconds and then be evicted. If the taint is removed before that time, the Pod is not evicted.
 
 [id="nodes-scheduler-taints-tolerations-about-multiple_{context}"]
 == Understanding how to use multiple taints
 
-You can put multiple taints on the same node and multiple tolerations on the same pod. {product-title} processes multiple taints and tolerations as follows:
+You can put multiple taints on the same node and multiple tolerations on the same Pod. {product-title} processes multiple taints and tolerations as follows:
 
-. Process the taints for which the pod has a matching toleration.
-. The remaining unmatched taints have the indicated effects on the pod:
+. Process the taints for which the Pod has a matching toleration.
+. The remaining unmatched taints have the indicated effects on the Pod:
 +
-* If there is at least one unmatched taint with effect `NoSchedule`, {product-title} cannot schedule a pod onto that node.
-* If there is no unmatched taint with effect `NoSchedule` but there is at least one unmatched taint with effect `PreferNoSchedule`, {product-title} tries to not schedule the pod onto the node.
-* If there is at least one unmatched taint with effect `NoExecute`, {product-title} evicts the pod from the node (if it is already running on the node), or the pod is not scheduled onto the node (if it is not yet running on the node).
+* If there is at least one unmatched taint with effect `NoSchedule`, {product-title} cannot schedule a Pod onto that node.
+* If there is no unmatched taint with effect `NoSchedule` but there is at least one unmatched taint with effect `PreferNoSchedule`, {product-title} tries to not schedule the Pod onto the node.
+* If there is at least one unmatched taint with effect `NoExecute`, {product-title} evicts the Pod from the node (if it is already running on the node), or the Pod is not scheduled onto the node (if it is not yet running on the node).
 +
 ** Pods that do not tolerate the taint are evicted immediately.
 +
@@ -121,7 +121,7 @@ $ oc adm taint nodes node1 key1=value1:NoExecute
 $ oc adm taint nodes node1 key2=value2:NoSchedule
 ----
 
-* The pod has the following tolerations:
+* The Pod has the following tolerations:
 +
 [source, yaml]
 ----
@@ -136,33 +136,34 @@ tolerations:
   effect: "NoExecute"
 ----
 
-In this case, the pod cannot be scheduled onto the node, because there is no toleration matching the third taint. The pod continues running if it is already running on the node when the taint is added, because the third taint is the only
-one of the three that is not tolerated by the pod.
+In this case, the Pod cannot be scheduled onto the node, because there is no toleration matching the third taint. The Pod continues running if it is already running on the node when the taint is added, because the third taint is the only
+one of the three that is not tolerated by the Pod.
 
 [id="nodes-scheduler-taints-tolerations-about-prevent_{context}"]
 == Preventing pod eviction for node problems
 
-{product-title} can be configured to represent *node unreachable* and *node not ready* conditions as taints.  This allows per-pod specification of how long to remain bound to a node that becomes unreachable or not ready, rather than using the default of five minutes.
+The Taint-Based Evictions feature, enabled by default, adds a taint with the `NoExecute` effect to nodes that are not ready or are unreachable. This allows you to specify how long a Pod should remain bound to a node that becomes unreachable or not ready, rather than using the default of five minutes. For example, you might want to allow a Pod on an unreachable node if the workload is safe to remain running while a networking issue resolves.
 
-The Taint-Based Evictions feature is enabled by default. The taints are automatically added by the node controller and the normal logic for evicting pods from `Ready` nodes is disabled.
+If a node enters a not ready state, the node controller adds the `node.kubernetes.io/not-ready:NoExecute` taint to the node. If a node enters an unreachable state, the  the node controller adds the `node.kubernetes.io/unreachable:NoExecute` taint to the node. 
 
-* If a node enters a not ready state, the `node.kubernetes.io/not-ready:NoExecute`  taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
-* If a node enters a not reachable state, the `node.kubernetes.io/unreachable:NoExecute` taint is added and pods cannot be scheduled on the node. Existing pods remain for the toleration seconds period.
+The `NoExecute` taint affects Pods that are already running on the node as follows: 
 
-This feature, in combination with `tolerationSeconds`, allows a pod to specify how long it should stay bound to a node that has one or both of these problems.
+* Pods that do not tolerate the taint are evicted immediately.
+* Pods that tolerate the taint without specifying `tolerationSeconds` in their toleration specification remain bound forever.
+* Pods that tolerate the taint with a specified `tolerationSeconds` remain bound for the specified amount of time.
 
 [id="nodes-scheduler-taints-tolerations-about-taintNodesByCondition_{context}"]
 == Understanding pod scheduling and node conditions (Taint Node by Condition)
 
-{product-title} automatically taints nodes that report conditions such as memory pressure and disk pressure. If a node reports a condition, a taint is added until the condition clears. The taints have the `NoSchedule` effect, which means no pod can be scheduled on the node, unless the pod has a matching toleration. This feature, *Taint Nodes By Condition*, is enabled by default. 
+{product-title} automatically taints nodes that report conditions such as memory pressure and disk pressure. If a node reports a condition, a taint is added until the condition clears. The taints have the `NoSchedule` effect, which means no Pod can be scheduled on the node, unless the Pod has a matching toleration. This feature, *Taint Nodes By Condition*, is enabled by default. 
  
-The scheduler checks for these taints on nodes before scheduling pods. If the taint is present, the pod is scheduled on a different node. Because the scheduler checks for taints and not the actual Node conditions, you configure the scheduler to ignore some of these node conditions by adding appropriate Pod tolerations. 
+The scheduler checks for these taints on nodes before scheduling Pods. If the taint is present, the Pod is scheduled on a different node. Because the scheduler checks for taints and not the actual Node conditions, you configure the scheduler to ignore some of these node conditions by adding appropriate Pod tolerations. 
 
 The DaemonSet controller automatically adds the following tolerations to all daemons, to ensure backward compatibility: 
 
 * node.kubernetes.io/memory-pressure
 * node.kubernetes.io/disk-pressure
-* node.kubernetes.io/out-of-disk (only for critical pods)
+* node.kubernetes.io/out-of-disk (only for critical Pods)
 * node.kubernetes.io/unschedulable (1.10 or later)
 * node.kubernetes.io/network-unavailable (host network only)
 
@@ -171,19 +172,19 @@ You can also add arbitrary tolerations to DaemonSets.
 [id="nodes-scheduler-taints-tolerations-about-taintBasedEvictions_{context}"]
 == Understanding evicting pods by condition (Taint-Based Evictions)
 
-The Taint-Based Evictions feature, enabled by default, evicts pods from a node that experiences specific conditions, such as `not-ready` and `unreachable`. 
-When a node experiences one of these conditions, {product-title} automatically adds taints to the node, and starts evicting and rescheduling the pods on different nodes.
+The Taint-Based Evictions feature, enabled by default, evicts Pods from a node that experiences specific conditions, such as `not-ready` and `unreachable`. 
+When a node experiences one of these conditions, {product-title} automatically adds taints to the node, and starts evicting and rescheduling the Pods on different nodes.
 
-Taint Based Evictions has a `NoExecute` effect, where any pod that does not tolerate the taint will be evicted immediately and any pod that does tolerate the taint will never be evicted.
+Taint Based Evictions has a `NoExecute` effect, where any Pod that does not tolerate the taint will be evicted immediately and any Pod that does tolerate the taint will never be evicted.
 
 [NOTE]
 ====
-{product-title} evicts pods in a rate-limited way to prevent massive pod evictions in scenarios such as the master becoming partitioned from the nodes.
+{product-title} evicts Pods in a rate-limited way to prevent massive Pod evictions in scenarios such as the master becoming partitioned from the nodes.
 ====
 
-This feature, in combination with `tolerationSeconds`, allows you to specify how long a pod should stay bound to a node that has a node condition. If the condition still exists after the `tolerationSections` period, the taint remains on the node and the pods are evicted in a rate-limited manner. If the condition clears before the `tolerationSeconds` period, pods are not removed. 
+This feature, in combination with `tolerationSeconds`, allows you to specify how long a Pod should stay bound to a node that has a node condition. If the condition still exists after the `tolerationSections` period, the taint remains on the node and the Pods are evicted in a rate-limited manner. If the condition clears before the `tolerationSeconds` period, Pods are not removed. 
 
-{product-title} automatically adds a toleration for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` with `tolerationSeconds=300`, unless the pod configuration specifies either toleration.
+{product-title} automatically adds a toleration for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` with `tolerationSeconds=300`, unless the Pod configuration specifies either toleration.
 
 [source,yaml]
 ----
@@ -199,13 +200,13 @@ spec
       tolerationSeconds: 300
 ----
 
-These tolerations ensure that the default pod behavior is to remain bound for 5 minutes after one of these node conditions problems is detected. 
+These tolerations ensure that the default Pod behavior is to remain bound for 5 minutes after one of these node conditions problems is detected. 
 
-You can configure these tolerations as needed. For example, if you have an application with a lot of local state you might want to keep the pods bound to node for a longer time in the event of network partition, allowing for the partition to recover and avoiding pod eviction. 
+You can configure these tolerations as needed. For example, if you have an application with a lot of local state you might want to keep the Pods bound to node for a longer time in the event of network partition, allowing for the partition to recover and avoiding Pod eviction. 
 
-DaemonSet pods are created with NoExecute tolerations for the following taints with no tolerationSeconds:
+DaemonSet Pods are created with NoExecute tolerations for the following taints with no tolerationSeconds:
 
 * `node.kubernetes.io/unreachable`
 * `node.kubernetes.io/not-ready`
 
-This ensures that DaemonSet pods are never evicted due to these node conditions, even if the `DefaultTolerationSeconds` admission controller is disabled.
+This ensures that DaemonSet Pods are never evicted due to these node conditions, even if the `DefaultTolerationSeconds` admission controller is disabled.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1848079