### PR TITLE
CNV-3893 UI extended with Volume Mode and Access Mode for virtual disks

### DIFF
--- a/modules/virt-about-storage-setting-for-datavolumes.adoc
+++ b/modules/virt-about-storage-setting-for-datavolumes.adoc
@@ -16,7 +16,7 @@ You can also add settings for other storage classes in order to create DataVolum
 You must configure storage settings that are supported by the underlying storage.
 ====
 
-All DataVolumes that you create in the web console use the default storage settings unless you specifya storage class that is also defined in the ConfigMap.
+All DataVolumes that you create in the web console use the default storage settings unless you specify a storage class that is also defined in the ConfigMap.
 
 [id="virt-datavolumes-access-modes_{context}"]
 == Access modes

--- a/modules/virt-add-disk-to-vm.adoc
+++ b/modules/virt-add-disk-to-vm.adoc
@@ -28,6 +28,7 @@ Use this procedure to add a virtual disk to a {object}.
 . Select the *Disks* tab.
 . Click *Add Disks* to open the *Add Disk* window.
 . In the *Add Disk* window, specify *Source*, *Name*, *Size*, *Interface*, and *Storage Class*.
+.. Optional: In the *Advanced* list, specify the *Volume Mode* and *Access Mode* for the virtual disk. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` ConfigMap.
 . Use the drop-down lists and check boxes to edit the disk configuration.
 . Click *OK*.
 

--- a/modules/virt-storage-wizard-fields-web.adoc
+++ b/modules/virt-storage-wizard-fields-web.adoc
@@ -26,3 +26,35 @@
 |The `StorageClass` that is used to create the disk.
 
 |===
+
+[id="virt-storage-wizard-fields-advanced-web_{context}"]
+[discrete]
+== Advanced storage settings
+The following advanced storage settings are available for *Blank*, *URL*, and *Attach Cloned Disk* disks.
+These parameters are optional. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` ConfigMap.
+
+[cols="2a,3a,5a"]
+|===
+|Name | Parameter |  Description
+
+.2+|Volume Mode
+|Filesystem
+|Stores the virtual disk on a filesystem-based volume.
+
+|Block
+|Stores the virtual disk directly on the block volume. Only use `Block` if the underlying storage supports it.
+
+.3+|Access Mode
+|Single User (RWO)
+|The disk can be mounted as read/write by a single node.
+
+|Shared Access (RWX)
+|The disk can be mounted as read/write by many nodes.
+[NOTE]
+====
+This is required for some features, such as live migration of virtual machines between nodes.
+====
+
+|Read Only (ROX)
+|The disk can be mounted as read-only by many nodes.
+|===

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -30,6 +30,9 @@ include::modules/virt-cdrom-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 
+For more information on the `kubevirt-storage-class-defaults` ConfigMap, see xref:../../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[
+Storage defaults for DataVolumes].
+
 include::modules/virt-creating-vm-yaml-web.adoc[leveloffset=+1]
 include::modules/virt-creating-vm.adoc[leveloffset=+1]
 

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -12,5 +12,11 @@ include::modules/virt-editing-vm-web.adoc[leveloffset=+1]
 include::modules/virt-editing-vm-yaml-web.adoc[leveloffset=+1]
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]
 include::modules/virt-add-disk-to-vm.adoc[leveloffset=+1]
+
+For more information on the `kubevirt-storage-class-defaults` ConfigMap, see xref:../../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[
+Storage defaults for DataVolumes].
+
+include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-add-nic-to-vm.adoc[leveloffset=+1]
+include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-edit-cdrom-vm.adoc[leveloffset=+1]


### PR DESCRIPTION
The UI for virtual disks has been extended so users can specify Access Mode and Volume Mode. This has been added to the Wizard Storage Fields and Adding a Virtual Disk to a VM sections, with links to modifying the default settings in the ConfigMap.

[CNV-3893](https://issues.redhat.com/browse/CNV-3893)