### PR TITLE
Fixing broken link. BZ 1842533.

### DIFF
--- a/modules/installation-osp-verifying-external-network.adoc
+++ b/modules/installation-osp-verifying-external-network.adoc
@@ -54,7 +54,7 @@ $ openstack network list --long -c ID -c Name -c "Router Type"
 +--------------------------------------+----------------+-------------+
 ----
 
-A network with an External router type appears in the network list. If at least one does not, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux_OpenStack_Platform/4/html/Installation_and_Configuration_Guide/Configuring_a_Provider_Network1.html[Create an external network].
+A network with an External router type appears in the network list. If at least one does not, see link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/director_installation_and_usage/performing-overcloud-post-installation-tasks#creating-a-default-floating-ip-network[Creating a default floating IP network] and link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/director_installation_and_usage/performing-overcloud-post-installation-tasks#creating-a-default-provider-network[Creating a default provider network].
 
 ifdef::osp-custom,osp-kuryr[]
 [IMPORTANT]


### PR DESCRIPTION
This PR fixes a broken link found in https://bugzilla.redhat.com/show_bug.cgi?id=1842533. 

That link has also become two--one for each external network creation section in the RHOSP docs. 

