### PR TITLE
Removed Top Consumers and Cluster Capacity cards reference

### DIFF
--- a/modules/virt-about-the-overview-dashboard.adoc
+++ b/modules/virt-about-the-overview-dashboard.adoc
@@ -30,11 +30,6 @@ endif::virt-cluster[]
 ifdef::virt-cluster[]
 * *Cluster Health* summarizes the current health of the cluster as a whole, including relevant alerts and descriptions. If {VirtProductName} is installed, the overall health of {VirtProductName} is diagnosed as well. If more than one subsystem is present, click *See All* to view the status of each subsystem.
 endif::virt-cluster[]
-* *Cluster Capacity* charts help administrators understand when additional resources are required in the cluster. The charts contain an inner ring that displays current consumption, while an outer ring displays thresholds configured for the resource, including information about:
-** CPU time
-** Memory allocation
-** Storage consumed
-** Network resources consumed
 * *Cluster Utilization* shows the capacity of various resources over a specified period of time, to help administrators understand the scale and frequency of high resource consumption.
 * *Events* lists messages related to recent activity in the cluster, such as Pod creation or virtual machine migration to another host.
 

--- a/modules/virt-about-the-overview-dashboard.adoc
+++ b/modules/virt-about-the-overview-dashboard.adoc
@@ -37,7 +37,6 @@ endif::virt-cluster[]
 ** Network resources consumed
 * *Cluster Utilization* shows the capacity of various resources over a specified period of time, to help administrators understand the scale and frequency of high resource consumption.
 * *Events* lists messages related to recent activity in the cluster, such as Pod creation or virtual machine migration to another host.
-* *Top Consumers* helps administrators understand how cluster resources are consumed. Click on a resource to jump to a detailed page listing Pods and nodes that consume the largest amount of the specified cluster resource (CPU, memory, or storage).
 
 ifeval::["{context}" == "virt-using-dashboard-to-get-cluster-info"]
 :!virt-cluster:


### PR DESCRIPTION
I've removed the Top Consumers and Cluster Capacity card references from the documentation since those was removed back in 4.3 in 
https://github.com/openshift/console/pull/3102.