### PR TITLE
CAM upgrade verification step

### DIFF
--- a/migration/migrating_3_4/deploying-cam-3-4.adoc
+++ b/migration/migrating_3_4/deploying-cam-3-4.adoc
@@ -1,5 +1,5 @@
 [id='deploying-cam-3-4']
-= Deploying the Cluster Application Migration tool
+= Deploying and upgrading the Cluster Application Migration tool
 include::modules/common-attributes.adoc[]
 :context: migrating-3-4
 :migrating-3-4:
@@ -50,4 +50,5 @@ include::modules/migration-installing-cam-operator-ocp-3.adoc[leveloffset=+2]
 :context: migrating-3-4
 :migrating-3-4:
 include::modules/migration-launching-cam.adoc[leveloffset=+1]
+include::modules/migration-upgrading-migration-tool.adoc[leveloffset=+1]
 :!migrating-3-4:

--- a/migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
+++ b/migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
@@ -1,5 +1,5 @@
 [id='deploying-cam-4-1-4']
-= Deploying the Cluster Application Migration tool
+= Deploying and upgrading the Cluster Application Migration tool
 include::modules/common-attributes.adoc[]
 :context: migrating-4-1-4
 :migrating-4-1-4:
@@ -62,4 +62,5 @@ include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
 :context: migrating-4-1-4
 :migrating-4-1-4:
 include::modules/migration-launching-cam.adoc[leveloffset=+1]
+include::modules/migration-upgrading-migration-tool.adoc[leveloffset=+1]
 :!migrating-4-1-4:

--- a/migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
+++ b/migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
@@ -1,5 +1,5 @@
 [id='deploying-cam-4-2-4']
-= Deploying the Cluster Application Migration tool
+= Deploying and upgrading the Cluster Application Migration tool
 include::modules/common-attributes.adoc[]
 :context: migrating-4-2-4
 :migrating-4-2-4:
@@ -61,4 +61,5 @@ include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]
 :context: migrating-4-2-4
 :migrating-4-2-4:
 include::modules/migration-launching-cam.adoc[leveloffset=+1]
+include::modules/migration-upgrading-migration-tool.adoc[leveloffset=+1]
 :!migrating-4-2-4:

--- a/modules/migration-upgrading-migration-tool.adoc
+++ b/modules/migration-upgrading-migration-tool.adoc
@@ -1,0 +1,96 @@
+// Module included in the following assemblies:
+// * migration/migrating_3_4/deploying-cam-3-4.adoc
+// * migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
+// * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
+[id='migration-upgrading-migration-tool_{context}']
+= Upgrading the Cluster Application Migration Tool
+
+You can upgrade your Cluster Application Migration (CAM) tool on your source and target clusters.
+
+If you are upgrading from CAM 1.1 to 1.2, you must update the service account token in the CAM web console.
+
+[id='upgrading-cam-ocp-4_{context}']
+== Upgrading the CAM tool on an {product-title} 4 cluster
+
+You can upgrade the CAM tool on an {product-title} 4 cluster with the Operator Lifecycle Manager.
+
+If you selected the *Automatic* approval option when you subscribed to the Cluster Application Migration Operator, the CAM tool is updated automatically.
+
+The following procedure enables you to change the *Manual* approval option to *Automatic* or to change the release channel.
+
+.Procedure
+
+. In the {product-title} console, navigate to *Operators* > *Installed Operators*.
+. Click *Cluster Application Migration Operator*.
+. In the *Subscription* tab, change the *Approval* option to *Automatic*.
+. Optional: Edit the *Channel*.
++
+Updating the subscription deploys the updated Cluster Application Migration Operator and updates the CAM tool components.
+
+ifdef::migrating-3-4[]
+[id='upgrading-cam-ocp-3_{context}']
+== Upgrading the CAM tool on an {product-title} 3 cluster
+
+You can upgrade the CAM tool on an {product-title} 3 cluster by downloading the latest `operator.yml` file and replacing the existing Cluster Application Migration Operator CR object.
+
+[NOTE]
+====
+If you remove and re-create the namespace, you must update the cluster's service account token in the CAM web console.
+====
+
+.Procedure
+
+. Log in to `registry.redhat.io` with your Red Hat Customer Portal credentials:
++
+----
+$ sudo podman login registry.redhat.io
+----
+
+. Download the latest `operator.yml` file:
++
+----
+$ sudo podman cp $(sudo podman create registry.redhat.io/rhcam-1-2/openshift-migration-rhel7-operator:v1.2):/operator.yml ./
+----
+
+. Log in to your {product-title} 3 cluster.
+
+. Deploy the updated Cluster Application Migration Operator CR object:
++
+----
+$ oc replace -f operator.yml
+----
+
+. Get the Restic Pod:
++
+----
+$ oc get pod -n openshift-migration | grep restic
+----
+
+. Delete the Restic Pod so that the upgrade is applied when it restarts:
++
+----
+$ oc delete pod <restic_pod>
+----
+endif::[]
+
+[id='updating-service-account-token_{context}']
+== Updating the service account token
+
+If you are upgrading from CAM 1.1 to 1.2, you must update the service account token in the CAM web console.
+
+CAM 1.1 uses the `mig` service account, while CAM 1.2 uses the `migration-controller` service account.
+
+.Procedure
+
+. Log in to a cluster and obtain the `migration-controller` service account token:
++
+----
+$ oc sa get-token -n openshift-migration migration-controller
+----
+
+. Log in to the CAM web console and click *Clusters*.
+. Click the Options menu {kebab} of the cluster and select *Edit*.
+. Copy the new token to the *Service account token* field.
+. Click *Update cluster* and then click *Close*.
++
+The service account token is updated for the cluster.


### PR DESCRIPTION
Originally, this was going to be CAM upgrade + verification. However, the engineers need to figure out how to create a mechanism for verifying CAM version on a 3.x cluster. In order not to hold up the upgrade procedure, I am publishing the upgrade without the verification step. The steps have been verified by QE for 4.5. The verification will be in a separate bug and PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1844122

4.5, 4.6