### PR TITLE
reorder macvlan CNI explanation correctly

### DIFF
--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -70,9 +70,9 @@ plug-in:
 ----
 <1> Specify a name for the additional network attachment that you are creating. The name must be unique within the specified `namespace`.
 
-<2> The ethernet interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
+<2> Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
 
-<3> Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
+<3> The ethernet interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
 
 <4> Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 


### PR DESCRIPTION
the order of master and mode was reversed.
