### PR TITLE
CNV-5286, CNV-5285 - Added rel_notes for networking stories 

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -58,9 +58,11 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 === Networking
 //Placeholder for new content.
 
-#CNV-5286 - SR-IOV Networking to provide a basic fast datapath option
+//CNV-5286 - SR-IOV Networking (no xref yet, PR not merged)
+* {VirtProductName} is now integrated with the {product-title} xref:../networking/hardware_networks/about-sriov.adoc#about-sriov[Single Root I/O Virtualization (SR-IOV) Operator]. You can now xref:../virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc#virt-attaching-vm-to-sriov-network[attach virtual machines to SR-IOV networks] in your cluster. 
 
-#CNV-5285 - MAC pool support was reintroduced to OpenShift virtualization. It is disabled by default and can be enabled per namespace.
+//CNV-5285 - MAC pool support 
+* xref:../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-using-mac-address-pool-for-vms[MAC address pool] is now supported in {VirtProductName}. It is disabled by default in the cluster and can be enabled per namespace.
 
 [id="virt-2-4-storage-new"]
 === Storage


### PR DESCRIPTION
Three networking release notes for three networking epics: 

https://issues.redhat.com/browse/CNV-5285 - KubeMacPool
https://issues.redhat.com/browse/CNV-5286 - SR-IOV

This PR won't get an automatic build. Screenshot of the build: 
![Screenshot from 2020-07-16 13-33-16](https://user-images.githubusercontent.com/17755748/87666489-ffc75080-c768-11ea-9622-6d62da0118f0.png)

(edit: Removed CNV-5263 and updated screenshot)