### PR TITLE
CNV-5274 - Rel_Note storage settings for virtual disks

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -37,6 +37,7 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+2]
 //Placeholder for new content.
 
 //CNV-5274 - Customize accessMode and volumeMode when creating VM disks.
+* You can now configure the *Volume Mode* and *Access Mode* for a virtual disk when you xref:../virt/virtual_machines/virt-edit-vms.adoc#virt-vm-add-disk_virt-edit-vms[add a disk to a virtual machine] in the web console. This is also possible when adding a disk to a xref:../virt/virtual_machines/virt-create-vms.adoc#virt-creating-vm-wizard-web_virt-create-vms[new virtual machine using the wizard].
 
 //CNV-5422 - CNV support for Ceph-based OCS 4.4.
 


### PR DESCRIPTION
Adding storage RN for [CNV-5274](https://issues.redhat.com/browse/CNV-5274) - storage settings for virtual disks in the UI

This PR won't get an automatic build. Hopefully this screenshot suffices:
![Screenshot from 2020-07-15 19-12-53](https://user-images.githubusercontent.com/17755748/87575191-d3abc100-c6cf-11ea-9d8d-b6f0cda2658c.png)

The Feature PR (#23792) is not merged but it adds to existing content so the xrefs in this rel_note work as expected. 