### PR TITLE
Update information about imagepruner object

### DIFF
--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -6,12 +6,7 @@
 = Automatically pruning images
 
 Images that are no longer required by the system due to age,
-status, or exceed limits are automatically pruned. Cluster administrators can configure the Pruning Custom Resource, or delete it to disable it.
-
-[NOTE]
-====
-When the Pruning Custom Resource is deleted, the pruning `CronJob` and its related components should also be deleted.
-====
+status, or exceed limits are automatically pruned. Cluster administrators can configure the Pruning Custom Resource, or suspend it.
 
 .Prerequisites
 
@@ -25,20 +20,19 @@ When the Pruning Custom Resource is deleted, the pruning `CronJob` and its relat
 [source,yaml]
 ----
 spec:
-  schedule: "0 0 * * *" <1>
+  schedule: 0 0 * * * <1>
   suspend: false <2>
   keepTagRevisions: 3 <3>
-  keepYoungerThan: 60m <4>
+  keepYoungerThan: 3600000000000 <4>
   resources: {} <5>
   affinity: {} <6>
   nodeSelector: {} <7>
-  tolerations: {} <8>
-  startingDeadlineSeconds: 60 <9>
-  successfulJobsHistoryLimit: 3 <10>
-  failedJobsHistoryLimit: 3 <11>
+  tolerations: [] <8>
+  successfulJobsHistoryLimit: 3 <9>
+  failedJobsHistoryLimit: 3 <10>
 status:
-  observedGeneration: 2 <12>
-  conditions: <13>
+  observedGeneration: 2 <11>
+  conditions: <12>
   - type: Available
     status: "True"
     lastTransitionTime: 2019-10-09T03:13:45
@@ -55,19 +49,18 @@ status:
     reason: Succeeded
     message: "Most recent image pruning job succeeded."
 ----
-<1> `schedule`: `CronJob` formatted schedule, defaults to daily at midnight for new clusters. This is a required field.
-<2> `suspend`: If set to `true`, the `CronJob` running pruning is suspended. This is an optional field, and it defaults to `false`.
-<3> `keepTagRevisions`: The number of revisions per tag to keep. This is an optional field, and it defaults to `3` if not set.
-<4> `keepYoungerThan`: Retain images younger than this duration. This is an optional field, and it defaults `60m` if not set.
+<1> `schedule`: `CronJob` formatted schedule. This is an optional field, default is daily at midnight.
+<2> `suspend`: If set to `true`, the `CronJob` running pruning is suspended. This is an optional field, default is `false`. The initial value on new clusters is `true`.
+<3> `keepTagRevisions`: The number of revisions per tag to keep. This is an optional field, default is `3`. The initial value is `3`.
+<4> `keepYoungerThan`: Retain images younger than this duration in nanoseconds. This is an optional field, default is `3600000000000` (60 minutes).
 <5> `resources`: Standard Pod resource requests and limits. This is an optional field.
 <6> `affinity`: Standard Pod affinity. This is an optional field.
 <7> `nodeSelector`: Standard Pod node selector. This is an optional field.
 <8> `tolerations`: Standard Pod tolerations. This is an optional field.
-<9> `startingDeadlineSeconds`: Start deadline for `CronJob`. This is an optional field.
-<10> `successfulJobsHistoryLimit`: The maximum number of successful jobs to retain. Must be `>= 1` to ensure metrics are reported. Defaults to `3` if not set.
-<11> `failedJobsHistoryLimit`: The maximum number of failed jobs to retain. Must be `>= 1` to ensure metrics are reported. Defaults to `3` if not set.
-<12> `observedGeneration`: The generation observed by the Operator.
-<13> `conditions`: The standard condition objects with the following types:
+<9> `successfulJobsHistoryLimit`: The maximum number of successful jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.
+<10> `failedJobsHistoryLimit`: The maximum number of failed jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.
+<11> `observedGeneration`: The generation observed by the Operator.
+<12> `conditions`: The standard condition objects with the following types:
 * `Available`: Indicates if the pruning job has been created. Reasons can be Ready or Error.
 * `Scheduled`: Indicates if the next pruning job has been scheduled. Reasons can be Scheduled, Suspended, or Error.
 * `Failed`: Indicates if the most recent pruning job failed.
@@ -75,9 +68,9 @@ status:
 
 [IMPORTANT]
 ====
-The Image Registry Operator's behavior for managing the pruner is orthogonal to the `ManagementState` specified on the Image Registry Operator's `ClusterOperator` object. If the image registry Operator is not in the `Managed` state, the image pruner can still be configured and managed by the Pruning Custom Resource.
+The Image Registry Operator's behavior for managing the pruner is orthogonal to the `managementState` specified on the Image Registry Operator's `ClusterOperator` object. If the image registry Operator is not in the `Managed` state, the image pruner can still be configured and managed by the Pruning Custom Resource.
 
-However, the `ManagementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
+However, the `managementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
 * `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.


### PR DESCRIPTION
4.4 has only keepYoungerThan that is an integer in nanoseconds.

https://bugzilla.redhat.com/show_bug.cgi?id=1840973

/assign @bmcelvee 