### PR TITLE
Bugzilla doc text for 4.5.2 release

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1837,13 +1837,6 @@ In the table below, features are marked with the following statuses:
 [id="ocp-4-5-known-issues"]
 == Known issues
 
-* Installations of and upgrades to {product-title} 4.5.1 fail on nodes with
-Secure Boot configured. For clusters configured with Secure Boot, one node from
-both the control plane and compute Machine Config Pools fails to reboot, which
-causes the Machine Config Operator (MCO) to be degraded. The cluster
-subsequently fails to upgrade.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1856501[*BZ#1856501*])
-
 * When upgrading to a new {product-title} z-stream release, connectivity to the API server might be interrupted as nodes are upgraded, causing API requests to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845411[*BZ#1845411*])
 
 * When upgrading to a new {product-title} z-stream release, connectivity to routers might be interrupted as router Pods are updated. For the duration of the upgrade, some applications might not be consistently reachable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809665[*BZ#1809665*])
@@ -1966,15 +1959,15 @@ xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster]
 properly.
 ====
 
-[[rhba-2020-2409]]
+[[RHBA-2020-2409]]
 === RHBA-2020:2409 - {product-title} 4.5 image release and bug fix advisory
 
 Issued: 2020-07-13
 
 {product-title} release 4.5 is now available. The list of container images and
-bug fixes includes in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2020:2409[RHBA-2020:2409] advisory.
-The RPM packages included in the update are provided by the
+bug fixes included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2020:2409[RHBA-2020:2409]
+advisory. The RPM packages included in the update are provided by the
 link:https://access.redhat.com/errata/RHBA-2020:2408[RHBA-2020:2408] advisory.
 
 Space precluded documenting all of the container images for this release in the
@@ -2000,3 +1993,30 @@ Issued: 2020-07-13
 A package update is now available for {product-title} 4.5. Details of the update
 are documented in the
 link:https://access.redhat.com/errata/RHSA-2020:2413[RHSA-2020:2413] advisory.
+
+[[RHBA-2020-2909]]
+=== RHBA-2020:2909 - {product-title} 4.5 image release and bug fix advisory
+
+Issued: 2020-07-16
+
+{product-title} release 4.5.2 is now available. The list of container images and
+bug fixes included in the update are documented in the
+link:https://access.redhat.com/errata/RHBA-2020:2909[RHBA-2020:2909] advisory.
+The RPM packages included in the update are provided by the
+link:https://access.redhat.com/errata/RHBA-2020:2908[RHBA-2020:2908] advisory.
+
+Space precluded documenting all of the container images for this release in the
+advisory. See the following article for notes on the container images in this
+release:
+
+link:https://access.redhat.com/solutions/5225291[{product-title} 4.5.2 container image list]
+
+[[RHBA-2020-2909-bug-fixes]]
+==== Bug Fixes
+
+* Upgrades to {product-title} 4.5.1 failed on nodes with Secure Boot configured.
+For clusters configured with Secure Boot, one node from both the control plane
+and compute Machine Config Pools failed to reboot, which caused the Machine
+Config Operator (MCO) to be degraded. The cluster subsequently failed to
+upgrade. The issue is not present in this release.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1856501[*BZ#1856501*])


### PR DESCRIPTION
- Updated 4.5 release info to mention 4.5.2 and point to corresponding advisory
- Removed 4.5.1 Known Issue BZ1856501
- Made changes to 4.5.1 text to indicate 4.5.2 is the GA release
- Added 4.5.2 RN text and links