### PR TITLE
Revert "[enterprise-4.5] node network config: two more bond modes"

### DIFF
--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -13,8 +13,6 @@ to the cluster.
 {VirtProductName} only supports the following bond modes:
 
 * mode=1 active-backup +
-* mode=2 balance-xor +
-* mode=4 802.3ad +
 * mode=5 balance-tlb +
 * mode=6 balance-alb
 ====


### PR DESCRIPTION
Reverts openshift/openshift-docs#23536