### PR TITLE
Setting OCM Insights integration assembly to Tech Preview

### DIFF
--- a/modules/displaying-potential-issues-with-your-cluster.adoc
+++ b/modules/displaying-potential-issues-with-your-cluster.adoc
@@ -5,7 +5,7 @@
 [id="displaying-potential-issues-with-your-cluster_{context}"]
 = Displaying potential issues with your cluster
 
-This section describes how to display the Insights report in the {cloud-redhat-com}.
+This section describes how to display the Insights report in the {cloud-redhat-com} beta instance.
 
 Note that Insights repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
 
@@ -13,7 +13,7 @@ Note that Insights repeatedly analyzes your cluster and shows the latest results
 
 * Your cluster is registered in the {cloud-redhat-com}.
 * Remote health reporting is enabled, which is the default.
-* You are logged in to the {cloud-redhat-com}.
+* You are logged in to the link:https://cloud.redhat.com/beta/openshift[{cloud-redhat-com} beta instance].
 
 .Procedure
 
@@ -34,4 +34,3 @@ Depending on the result, the tab displays one of the following:
 . If any issues are displayed on the tab, click the *>* icon in front of the entry for further details.
 +
 Depending on the issue, the details can also contain a link to an Red Hat Knowledge Base article. For details and information on how to solve the problem, click *How to remediate this issue*.
-

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -6,5 +6,7 @@ toc::[]
 
 Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report on the *Insights* tab of each cluster in {cloud-redhat-com}.
 
-include::modules/displaying-potential-issues-with-your-cluster.adoc[leveloffset=+1]
+:FeatureName: {cloud-redhat-com} Insights integration
+include::modules/technology-preview.adoc[leveloffset=+0]
 
+include::modules/displaying-potential-issues-with-your-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to master and enterprise-4.5.

The Insights tab is not yet available in OpenShift Cluster Manager (OCM). It is only available in the beta instance of OCM.

Preview is available at https://ocm_insights_integration--ocpdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html