### PR TITLE
CNV-4013 Update documentation to reflect new Virtualization UI

### DIFF
--- a/modules/virt-about-the-vm-dashboard.adoc
+++ b/modules/virt-about-the-vm-dashboard.adoc
@@ -5,10 +5,12 @@
 [id="virt-about-the-vm-dashboard_{context}"]
 = About the Virtual Machines dashboard
 
-Access the *Virtual Machines* dashboard from the {product-title} web console by navigating to the *Workloads* -> *Virtual Machines* page and
-selecting a virtual machine.
+Access virtual machines from the {product-title} web console by navigating
+to the *Workloads* -> *Virtualization* page. The *Workloads* -> *Virtualization* page contains two tabs:
+* *Virtual Machines*
+* *Virtual Machine Templates*
 
-The dashboard includes the following cards:
+The following cards describe each virtual machine:
 
 * *Details* provides identifying information about the virtual machine, including:
 ** Name

--- a/modules/virt-add-boot-order-web.adoc
+++ b/modules/virt-add-boot-order-web.adoc
@@ -10,9 +10,13 @@ Add items to a boot order list by using the web console.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Select a virtual machine to open the *Virtual Machine Overview* screen.
+
+. Click the *Details* tab.
 
 . Click the pencil icon that is located on the right side of *Boot Order*. If a YAML configuration does not exist, or if this is the first time that you are creating a boot order list, the following message displays: *No resource selected. VM will attempt to boot disks from YAML by order of appearance in YAMLv file. Please select a boot source*.
 

--- a/modules/virt-cancelling-vm-migration-web.adoc
+++ b/modules/virt-cancelling-vm-migration-web.adoc
@@ -5,17 +5,21 @@
 [id="virt-cancelling-vm-migration-web_{context}"]
 = Cancelling live migration of a virtual machine instance in the web console
 
-A live migration of the virtual machine instance can be cancelled using the 
-Options menu {kebab} found on each virtual machine in the 
-*Workloads* -> *Virtual Machines* screen, or from the *Actions* menu 
-on the *Virtual Machine Details* screen.
+You can cancel a live migration of the virtual machine instance using the
+Options menu {kebab} found on each virtual machine in the
+*Virtualization* -> *Virtual Machines* tab, or from the *Actions* menu
+available on all tabs in the *Virtual Machine Overview* screen.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. You can cancel the migration from this screen, which makes it easier to perform actions on multiple virtual machines in the one screen, or from the *Virtual Machine Details* screen where you can view comprehensive details of the selected virtual machine:
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. You can cancel the migration from this screen, which makes it easier to
+perform actions on multiple virtual machines, or from the
+*Virtual Machine Overview* screen where you can view comprehensive details
+of the selected virtual machine:
 ** Click the Options menu {kebab} at the end of virtual machine and select
 *Cancel Virtual Machine Migration*.
-** Click the virtual machine name to open the *Virtual Machine Details*
+** Select a virtual machine name to open the *Virtual Machine Overview*
 screen and click *Actions* -> *Cancel Virtual Machine Migration*.
 . Click *Cancel Migration* to cancel the virtual machine live migration.

--- a/modules/virt-connecting-to-the-terminal.adoc
+++ b/modules/virt-connecting-to-the-terminal.adoc
@@ -11,9 +11,9 @@ You can connect to a virtual machine by using the web console.
 
 .  Ensure you are in the correct project. If not, click the *Project*
 list and select the appropriate project.
-.  Click *Workloads* -> *Virtual Machines* to display the virtual
-machines in the project.
-.  Select a virtual machine.
-.  In the *Overview* tab, click the `virt-launcher-<vm-name>` Pod.
+.  Click *Workloads* -> *Virtualization* from the side menu.
+.  Click the *Virtual Machines* tab.
+.  Select a virtual machine to open the *Virtual Machine Overview* screen.
+.  In the *Details* tab, click the `virt-launcher-<vm-name>` Pod.
 .  Click the *Terminal* tab. If the terminal is blank, select the
 terminal and press any key to initiate connection.

--- a/modules/virt-connecting-vnc-console.adoc
+++ b/modules/virt-connecting-vnc-console.adoc
@@ -5,11 +5,12 @@
 [id="virt-connecting-vnc-console_{context}"]
 = Connecting to the VNC console
 
-Connect to the VNC console of a running virtual machine from the *Consoles* tab
-in the *Virtual Machine Details* screen of the web console.
+Connect to the VNC console of a running virtual machine from the *Console* tab
+in the *Virtual Machine Overview* screen of the web console.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. Select a virtual machine.
-. Click *Consoles*. The VNC console opens by default.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+. Click the *Console* tab. The VNC console opens by default.

--- a/modules/virt-creating-template-wizard-web.adoc
+++ b/modules/virt-creating-template-wizard-web.adoc
@@ -12,7 +12,8 @@ until you provide values in the required fields.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machine Templates*.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machine Templates* tab.
 . Click *Create Template* and select *New with Wizard*.
 . Fill in all required fields in the *General* step.
 . Click *Next* to progress to the *Networking* screen. A NIC that is named `nic0` is attached by default.
@@ -32,4 +33,4 @@ A *Bootable Disk* is not required for virtual machines provisioned from a *PXE* 
 
 . Click *Create Virtual Machine Template >*. The *Results* screen displays the JSON configuration file for the virtual machine template.
 +
-The template is listed in *Workloads* -> *Virtual Machine Templates*.
+The template is listed in the *Virtual Machine Templates* tab.

--- a/modules/virt-creating-vm-wizard-web.adoc
+++ b/modules/virt-creating-vm-wizard-web.adoc
@@ -21,7 +21,8 @@ A *Bootable Disk* is not required for virtual machines provisioned from a *PXE* 
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
 . Click *Create Virtual Machine* and select *New with Wizard*.
 . Fill in all required fields in the *General* step. Selecting a *Template* automatically fills in these fields.
 . Click *Next* to progress to the *Networking* step. A `nic0` NIC is attached by default.
@@ -32,4 +33,4 @@ A *Bootable Disk* is not required for virtual machines provisioned from a *PXE* 
 .. (Optional) Click the Options menu {kebab} to edit the disk and save your changes.
 . Click *Review and Create*. The *Results* screen displays the JSON configuration file for the virtual machine.
 
-The virtual machine is listed in *Workloads* -> *Virtual Machines*.
+The virtual machine is listed in the *Virtual Machines* tab.

--- a/modules/virt-creating-vm-yaml-web.adoc
+++ b/modules/virt-creating-vm-yaml-web.adoc
@@ -5,7 +5,7 @@
 [id="virt-creating-vm-yaml-web_{context}"]
 = Pasting in a pre-configured YAML file to create a virtual machine
 
-Create a virtual machine by writing or pasting a YAML configuration file in the web console in the *Workloads* -> *Virtual Machines* screen. A valid `example` virtual machine configuration is provided by default whenever you open the YAML edit screen.
+Create a virtual machine by writing or pasting a YAML configuration file. A valid `example` virtual machine configuration is provided by default whenever you open the YAML edit screen.
 
 If your YAML configuration is invalid when you click *Create*, an error message indicates the parameter in which the error occurs. Only one error is shown at a time.
 
@@ -16,11 +16,12 @@ Navigating away from the YAML screen while editing cancels any changes to the co
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
 . Click *Create Virtual Machine* and select *New from YAML*.
 . Write or paste your virtual machine configuration in the editable window.
 .. Alternatively, use the `example` virtual machine provided by default in the YAML screen.
 . (Optional) Click *Download* to download the YAML configuration file in its present state.
 . Click *Create* to create the virtual machine.
 
-The virtual machine is listed in *Workloads* -> *Virtual Machines*.
+The virtual machine is listed in the *Virtual Machines* tab.

--- a/modules/virt-delete-vm-web.adoc
+++ b/modules/virt-delete-vm-web.adoc
@@ -14,7 +14,8 @@ When you delete a virtual machine, the DataVolume it uses is automatically delet
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines* from the side menu.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
 . Click the &#8942; button of the virtual machine that you want to delete and select *Delete Virtual Machine*.
-** Alternatively, click the virtual machine name to open the *Virtual Machine Details* screen and click *Actions* -> *Delete Virtual Machine*.
+** Alternatively, click the virtual machine name to open the *Virtual Machine Overview* screen and click *Actions* -> *Delete Virtual Machine*.
 . In the confirmation pop-up window, click *Delete* to permanently delete the virtual machine.

--- a/modules/virt-deleting-template-web.adoc
+++ b/modules/virt-deleting-template-web.adoc
@@ -9,7 +9,8 @@ Deleting a virtual machine template permanently removes it from the cluster.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machine Templates*.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machine Templates* tab.
 . You can delete the virtual machine template from this pane, which makes it
 easier to perform actions on multiple templates in the one pane, or from the
  *Virtual Machine Template Details* pane where you can view comprehensive

--- a/modules/virt-edit-boot-order-web.adoc
+++ b/modules/virt-edit-boot-order-web.adoc
@@ -9,9 +9,13 @@ Edit the boot order list in the web console.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Select a virtual machine to open the *Virtual Machine Overview* screen.
+
+. Click the *Details* tab.
 
 . Click the pencil icon that is located on the right side of *Boot Order*.
 

--- a/modules/virt-editing-template-yaml-web.adoc
+++ b/modules/virt-editing-template-yaml-web.adoc
@@ -19,11 +19,11 @@ Navigating away from the YAML screen while editing cancels any changes to the
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machine Templates*.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machine Templates* tab.
 . Select a template.
 . Click the *YAML* tab to display the editable configuration.
 . Edit the file and click *Save*.
 
 A confirmation message, which includes the updated version number for the object,
 shows the modification has been successful.
-

--- a/modules/virt-editing-vm-web.adoc
+++ b/modules/virt-editing-vm-web.adoc
@@ -4,11 +4,11 @@
 // * virt/vm_templates/virt-editing-vm-template.adoc
 
 // Establishing conditionals so content can be re-used for editing VMs
-// and VM templates. 
+// and VM templates.
 
-// The ifeval statements use the context of the assembly in which the module 
+// The ifeval statements use the context of the assembly in which the module
 // is included to declare 1) an attribute, and 2) the content of the {object}
-// and {object-gui} variables used throughout. We need two variables because 
+// and {object-gui} variables used throughout. We need two variables because
 // the object is lower case, but the gui elements are capitalized.
 
 ifeval::["{context}" == "virt-editing-vm-template"]
@@ -28,18 +28,20 @@ endif::[]
 = Editing a {object} in the web console
 
 Edit select values of a {object} in the *{object-gui} Overview* screen
-of the web console by clicking on the pencil icon next to the relevant field. 
-Other values can be edited using the CLI. 
+of the web console by clicking on the pencil icon next to the relevant field.
+Other values can be edited using the CLI.
 
 .Procedure
 
-. Click *Workloads* -> *{object-gui}s* from the side menu.
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *{object-gui}s* tab.
 . Select a {object} to open the *{object-gui} Overview* screen.
-. Click the pencil icon to make that field editable.
+. Click the *Details* tab.
+. Click the pencil icon to make a field editable.
 . Make the relevant changes and click *Save*.
 
-// Using the attributes we declared earlier, we can have different lines after 
-// the procedure that will be included in the different assemblies. 
+// Using the attributes we declared earlier, we can have different lines after
+// the procedure that will be included in the different assemblies.
 
 ifdef::virt-vm-template[]
 Editing a virtual machine template will not affect virtual machines already created from that template.

--- a/modules/virt-editing-vm-yaml-web.adoc
+++ b/modules/virt-editing-vm-yaml-web.adoc
@@ -19,8 +19,9 @@ Navigating away from the YAML screen while editing cancels any changes to the co
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machine* from the side menu.
-. Select a virtual machine.
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
 . Click the *YAML* tab to display the editable configuration.
 . Optional: You can click *Download* to download the YAML file locally in its current state.
 . Edit the file and click *Save*.

--- a/modules/virt-importing-vmware-vm.adoc
+++ b/modules/virt-importing-vmware-vm.adoc
@@ -22,7 +22,8 @@ If you try to import a virtual machine whose disk size is larger than the availa
 
 .Procedure
 
-. In the {VirtProductName} web console, click *Workloads* -> *Virtual Machines*.
+. In the {VirtProductName} web console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
 . Click *Create Virtual Machine* and select *Import with Wizard*.
 
 . In the *General* screen, perform the following steps:
@@ -75,9 +76,9 @@ If you do not select a storage class, {VirtProductName} uses the default storage
 
 . Review your settings and click *Create Virtual Machine*.
 +
-A *Successfully created virtual machine* message and a list of resources created for the virtual machine are displayed. The powered off virtual machine appears in *Workloads* -> *Virtual Machines*.
+A *Successfully created virtual machine* message and a list of resources created for the virtual machine are displayed. The powered off virtual machine appears in the *Virtual Machines* tab.
 
-. Click *See virtual machine details* to view the dashboard of the imported virtual machine.
+. Click the name of the imported virtual machine to view the *Virtual Machine Overview* screen.
 +
 If an error occurs, perform the following steps:
 

--- a/modules/virt-initiating-vm-migration-web.adoc
+++ b/modules/virt-initiating-vm-migration-web.adoc
@@ -15,13 +15,14 @@ can initiate a virtual machine migration.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
 . You can initiate the migration from this screen, which makes it easier to
 perform actions on multiple virtual machines in the one screen, or from the
-*Virtual Machine Details* screen where you can view comprehensive details of the
+*Virtual Machine Overview* screen where you can view comprehensive details of the
 selected virtual machine:
 ** Click the Options menu {kebab} at the end of virtual machine and select
 *Migrate Virtual Machine*.
-** Click the virtual machine name to open the *Virtual Machine Details*
+** Click the virtual machine name to open the *Virtual Machine Overview*
 screen and click *Actions* -> *Migrate Virtual Machine*.
 . Click *Migrate* to migrate the virtual machine to another node.

--- a/modules/virt-monitoring-vm-migration-web.adoc
+++ b/modules/virt-monitoring-vm-migration-web.adoc
@@ -5,11 +5,12 @@
 [id="virt-monitoring-vm-migration-web_{context}"]
 = Monitoring live migration of a virtual machine instance in the web console
 
-For the duration of the migration, the virtual machine has a status of 
-*Migrating*. This status is displayed in the *Virtual Machines* list or in the 
-*Virtual Machine Details* screen for the migrating virtual machine. 
+For the duration of the migration, the virtual machine has a status of
+*Migrating*. This status is displayed in the *Virtual Machines* tab or in the
+*Virtual Machine Overview* screen for the migrating virtual machine.
 
 .Procedure
 
-* In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.

--- a/modules/virt-remove-boot-order-item-web.adoc
+++ b/modules/virt-remove-boot-order-item-web.adoc
@@ -11,9 +11,13 @@ Remove items from a boot order list by using the web console.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines* from the side menu.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Select a virtual machine to open the *Virtual Machine Overview* screen.
+
+. Click the *Details* tab.
 
 . Click the pencil icon that is located on the right side of *Boot Order*.
 

--- a/modules/virt-restarting-vm-web.adoc
+++ b/modules/virt-restarting-vm-web.adoc
@@ -14,7 +14,9 @@ To avoid errors, do not restart a virtual machine while it has a status of *Impo
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines*.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Find the row that contains the virtual machine that you want to restart.
 
@@ -27,7 +29,7 @@ To avoid errors, do not restart a virtual machine while it has a status of *Impo
 * To view comprehensive information about the selected virtual machine before
 you restart it:
 
-.. Access the *Virtual Machine Details* page by clicking the name of the virtual
+.. Access the *Virtual Machine Overview* screen by clicking the name of the virtual
 machine.
 
 .. Click *Actions*.

--- a/modules/virt-starting-vm-web.adoc
+++ b/modules/virt-starting-vm-web.adoc
@@ -9,7 +9,9 @@ You can start a virtual machine from the web console.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines*.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Find the row that contains the virtual machine that you want to start.
 
@@ -22,7 +24,7 @@ You can start a virtual machine from the web console.
 * To view comprehensive information about the selected virtual machine before
 you start it:
 
-.. Access the *Virtual Machine Details* page by clicking the name of the virtual
+.. Access the *Virtual Machine Overview* screen by clicking the name of the virtual
 machine.
 
 .. Click *Actions*.

--- a/modules/virt-stopping-vm-web.adoc
+++ b/modules/virt-stopping-vm-web.adoc
@@ -9,7 +9,9 @@ You can stop a virtual machine from the web console.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines*.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Find the row that contains the virtual machine that you want to stop.
 
@@ -22,7 +24,7 @@ You can stop a virtual machine from the web console.
 * To view comprehensive information about the selected virtual machine before
 you stop it:
 
-.. Access the *Virtual Machine Details* page by clicking the name of the virtual
+.. Access the *Virtual Machine Overview* screen by clicking the name of the virtual
 machine.
 
 .. Click *Actions*.

--- a/modules/virt-unpausing-vm-web.adoc
+++ b/modules/virt-unpausing-vm-web.adoc
@@ -18,7 +18,9 @@ You can pause virtual machines by using the `virtctl` client.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines*.
+. Click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
 
 . Find the row that contains the virtual machine that you want to unpause.
 
@@ -31,7 +33,7 @@ You can pause virtual machines by using the `virtctl` client.
 * To view comprehensive information about the selected virtual machine before
 you unpause it:
 
-.. Access the *Virtual Machine Details* page by clicking the name of the virtual
+.. Access the *Virtual Machine Overview* screen by clicking the name of the virtual
 machine.
 
 .. Click the pencil icon that is located on the right side of *Status*.

--- a/modules/virt-viewing-virtual-machine-logs-web.adoc
+++ b/modules/virt-viewing-virtual-machine-logs-web.adoc
@@ -9,8 +9,9 @@ Get virtual machine logs from the associated virtual machine launcher Pod.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. Click the virtual machine to open the *Virtual Machine Details* panel.
-. In the *Overview* tab, click the `virt-launcher-<name>` Pod in the *POD* 
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+. In the *Details* tab, click the `virt-launcher-<name>` Pod in the *Pod*
 section.
 . Click *Logs*.

--- a/modules/virt-viewing-vm-events-web.adoc
+++ b/modules/virt-viewing-vm-events-web.adoc
@@ -5,15 +5,15 @@
 [id="virt-viewing-vm-events-web_{context}"]
 = Viewing the events for a virtual machine in the web console
 
-You can view the stream events for a running a virtual machine from the 
-*Virtual Machine Details* panel of the web console.
+You can view the stream events for a running a virtual machine from the
+*Virtual Machine Overview* panel of the web console.
 
 The &#9646;&#9646; button pauses the events stream. +
-The &#9654; button continues a paused events stream. 
+The &#9654; button continues a paused events stream.
 
 .Procedure
 
-. Click *Workloads* -> *Virtual Machines* from the side menu.
-. Select a Virtual Machine.
-. Click *Events* to view all events for the virtual machine. 
-
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+. Click *Events* to view all events for the virtual machine.

--- a/modules/virt-viewing-vmi-ip-web.adoc
+++ b/modules/virt-viewing-vmi-ip-web.adoc
@@ -9,7 +9,8 @@ The IP information displays in the *Virtual Machine Overview* screen for the vir
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. Click the virtual machine name to open the *Virtual Machine Overview* screen.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine name to open the *Virtual Machine Overview* screen.
 
-The information for each attached NIC is displayed under *IP ADDRESSES*.
+The information for each attached NIC is displayed under *IP Address*.

--- a/modules/virt-vm-create-nic-web.adoc
+++ b/modules/virt-vm-create-nic-web.adoc
@@ -9,9 +9,10 @@ Create and attach additional NICs to a virtual machine from the web console.
 
 .Procedure
 
-. In the correct project in the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. Select a virtual machine.
+. In the correct project in the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
 . Click *Network Interfaces* to display the NICs already attached to the virtual machine.
-. Click *Create Network Interface* to create a new slot in the list.
+. Click *Add Network Interface* to create a new slot in the list.
 . Fill in the *Name*, *Model*, *Network*, *Type*, and *MAC Address* for the new NIC.
-. Click the *&#10003;* button to save and attach the NIC to the virtual machine.
+. Click the *Add* button to save and attach the NIC to the virtual machine.

--- a/modules/virt-vm-rdp-console-web.adoc
+++ b/modules/virt-vm-rdp-console-web.adoc
@@ -23,13 +23,14 @@ Windows virtual machine.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. Select a Windows virtual machine.
-. Click the *Consoles* tab.
-. Click the *Consoles* list and select *Desktop Viewer*.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a Windows virtual machine to open the *Virtual Machine Overview* screen.
+. Click the *Console* tab.
+. In the *Console* list, select *Desktop Viewer*.
 . In the *Network Interface* list, select the layer-2 NIC.
 . Click *Launch Remote Desktop* to download the `console.rdp` file.
-. Open an RDP client and reference the `console.rdp` file. For example, using 
+. Open an RDP client and reference the `console.rdp` file. For example, using
 *remmina*:
 +
 ----

--- a/modules/virt-vm-serial-console-web.adoc
+++ b/modules/virt-vm-serial-console-web.adoc
@@ -5,12 +5,13 @@
 [id="virt-vm-serial-console-web_{context}"]
 = Connecting to the serial console
 
-Connect to the *Serial Console* of a running virtual machine from the *Consoles*
-tab in the *Virtual Machine Details* screen of the web console.
+Connect to the *Serial Console* of a running virtual machine from the *Console*
+tab in the *Virtual Machine Overview* screen of the web console.
 
 .Procedure
 
-. In the {VirtProductName} console, click *Workloads* -> *Virtual Machines*.
-. Select a virtual machine.
-. Click *Consoles*. The VNC console opens by default.
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+. Click *Console*. The VNC console opens by default.
 . Click the *VNC Console* drop-down list and select *Serial Console*.


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/CNV-4013 and completes the work started in https://github.com/openshift/openshift-docs/pull/23196.

The web console UI has changed to say Workloads -> Virtualization. Clicking Virtualization opens up the Virtual Machines and Virtual Machine Templates tab. 

Updated 28 modules to reflect this change. The openshift-docs/modules/virt-deleting-vmis-web.adoc module in [Andrew's list](https://issues.redhat.com/browse/CNV-4013?focusedCommentId=14205963&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14205963) is currently not being used in the docs.

Tagged Guohua Ouyang for QE review

Applies to 4.5 docs