### PR TITLE
CNV-5230 cluster version for 4.5 branch

### DIFF
--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * virt/about-virt.adoc
+// * virt/virt_release_notes/virt-2-4-release-notes.adoc
+
+[id="virt-supported-cluster-version_{context}"]
+= {VirtProductName} supported cluster version
+
+{VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters.
+

--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -7,6 +7,8 @@ toc::[]
 == About {VirtProductName} {VirtVersion}
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+2]
+//Commented out because for GA release we have special text that covers this info. But going forward, we will want to include the following:
+//include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 
 [id="virt-2-4-new"]
 == New and changed features


### PR DESCRIPTION
Adding cluster version module to 4.5 repo and the 4.5 release notes. Still needs to be added to the 'about-virt.adoc' assembly but that will have to be in another PR as that assembly is currently under embargo for this branch due to difference between OCP 4.5 release and CNV 2.4
For GA, the release note include this content in a special one-time message, so it is commented out, however it will be needed for subsequent releases (expect this file to be cloned to 4.6 branch after GA).