### PR TITLE
CNV 2-4 RN OVN statement

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -7,6 +7,11 @@ toc::[]
 == About {VirtProductName} {VirtVersion}
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+2]
+
+// This line is attached to the above `virt-what-you-can-do-with-virt` module.
+// It is included here in the assembly because of the xref ban.
+You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
+
 //Commented out because for GA release we have special text that covers this info. But going forward, we will want to include the following:
 //include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Noticed that this line wasn't in the 2-4 RN assembly but it should be. This might be because of an earlier mixup whereby the 2.2 release notes were copied into the 2.4 branch. 
It is technically a part of the virt-what-you-can-do-with-virt.adoc module but isn't include because of the xref ban. 
