### PR TITLE
CNV GA placeholder reversion + extras

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -1,12 +1,15 @@
 [id="about-virt"]
-= OpenShift Virtualization
+= About {VirtProductName}
 include::modules/virt-document-attributes.adoc[]
 :context: about-virt
 toc::[]
 
-Documentation for OpenShift Virtualization, formerly known as container-native virtualization, will be available for {product-title} 4.5 in the near future.
+Learn about {VirtProductName}'s capabilities and support scope.
 
-In the meantime, the https://docs.openshift.com/container-platform/4.4/cnv/cnv-about-cnv.html[container-native virtualization 2.3 documentation] is available as part of the {product-title} 4.4 documentation.
+include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 
-// Container-native virtualization 2.3 is also supported for use in {product-title} 4.5.
+// This line is attached to the above `virt-what-you-can-do-with-virt` module.
+// It is included here in the assembly because of the xref ban.
+You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
 
+include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]

--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 == About Red Hat {VirtProductName}
 
-Red Hat {VirtProductName} is now a fully supported and generally available feature of {product-title} 4.5. Previously known as container-native virtualization, {VirtProductName} enables you to bring traditional virtual machines (VMs) into {product-title} where they run alongside containers, and are managed as native Kubernetes objects.
+Red Hat {VirtProductName} is supported for use on {product-title} 4.5 clusters. Previously known as container-native virtualization, {VirtProductName} enables you to bring traditional virtual machines (VMs) into {product-title} where they run alongside containers, and are managed as native Kubernetes objects.
 
 //RN-CNV-5460-Branding-Logo
 {VirtProductName} is represented by a new logo:
@@ -117,8 +117,6 @@ single sidebar menu item labeled *Virtualization*. When you click *Virtualizatio
 
 [id="virt-2-4-known-issues"]
 == Known issues
-//https://bugzilla.redhat.com/show_bug.cgi?id=1855067 - Requested doc text for this defect.
-//https://bugzilla.redhat.com/show_bug.cgi?id=1835426 - Requested doc text for this defect.
 //https://bugzilla.redhat.com/show_bug.cig?=id=1959237
 * If you upgrade to {VirtProductName} {VirtVersion}, both older and newer versions of common templates are available for each combination of operating system, workload, and flavor. When you create a virtual machine by using a common template, you must use the newer version of the template. Disregard the older version to avoid issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859237[*BZ#1859237*])
 
@@ -203,4 +201,4 @@ running either `oc adm drain` or `kubectl drain`. Do not run these commands on
 the nodes of any clusters where {VirtProductName} is deployed. The nodes might not
 drain if there are virtual machines running on top of them.
 
-The current solution is to xref:../virt/node_maintenance/virt-setting-node-maintenance.adoc#virt-setting-node-maintenance[put nodes into maintenance].
+** The current solution is to xref:../virt/node_maintenance/virt-setting-node-maintenance.adoc#virt-setting-node-maintenance[put nodes into maintenance].


### PR DESCRIPTION
When CNV 2.4 is ready for GA, this PR reverts the about-virt.adoc assembly to it's usual state (from it's current, temporary plaeholder state) and includes any additional changes for 2.4 that have arisen, such as the support-cluster-version include.

@vikram-redhat @ousleyp 