### PR TITLE
BZ1858002 - Update OCS link in OCP 4.5 docs

### DIFF
--- a/storage/persistent_storage/persistent-storage-ocs.adoc
+++ b/storage/persistent_storage/persistent-storage-ocs.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 Red Hat OpenShift Container Storage is a provider of agnostic persistent storage for {product-title} supporting file, block, and object storage, either in-house or in hybrid clouds. As a Red Hat storage solution, Red Hat OpenShift Container Storage is completely integrated with {product-title} for deployment, management, and monitoring.
 
-Red Hat OpenShift Container Storage provides its own documentation library. The complete set of Red Hat OpenShift Container Storage documentation identified below is available at https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.3/
+Red Hat OpenShift Container Storage provides its own documentation library. The complete set of Red Hat OpenShift Container Storage documentation identified below is available at https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/
 
 [options="header",cols="1,1"]
 |===
@@ -15,21 +15,24 @@ Red Hat OpenShift Container Storage provides its own documentation library. The 
 |See the following Red Hat OpenShift Container Storage documentation:
 
 |What’s new, known issues, notable bug fixes, and Technology Previews
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.3/html/4.3_release_notes/[Red Hat OpenShift Container Storage 4.3 Release Notes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/4.4_release_notes/[Red Hat OpenShift Container Storage 4.4 Release Notes]
 
 |Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.3/html/planning_your_deployment/index[Planning your Red Hat OpenShift Container Storage 4.3 deployment]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/planning_your_deployment/index[Planning your Red Hat OpenShift Container Storage 4.4 deployment]
 
-|Deploying Red Hat OpenShift Container Storage 4.3 on an existing {product-title} cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.3/html/deploying_openshift_container_storage/index[Deploying Red Hat OpenShift Container Storage 4.3]
+|Deploying Red Hat OpenShift Container Storage 4.4 on an existing {product-title} cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/deploying_openshift_container_storage/index[Deploying Red Hat OpenShift Container Storage 4.4]
 
-|Managing a Red Hat OpenShift Container Storage 4.3 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.3/html/managing_openshift_container_storage/index[Managing Red Hat OpenShift Container Storage 4.3]
+|Managing a Red Hat OpenShift Container Storage 4.4 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/managing_openshift_container_storage/index[Managing Red Hat OpenShift Container Storage 4.4]
 
-|Monitoring a Red Hat OpenShift Container Storage 4.3 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.3/html/monitoring_openshift_container_storage/index[Monitoring Red Hat OpenShift Container Storage 4.3]
+|Monitoring a Red Hat OpenShift Container Storage 4.4 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/monitoring_openshift_container_storage/index[Monitoring Red Hat OpenShift Container Storage 4.4]
+
+|How to troubleshoot errors and issues in OpenShift Container Storage
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/troubleshooting_openshift_container_storage/[Troubleshooting OpenShift Container Storage]
 
 |Migrating your {product-title} cluster from version 3 to version 4
-|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/migration/index[Migration]
+|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/migration/index[Migration]
 
 |===


### PR DESCRIPTION
[BZ 1858002](https://bugzilla.redhat.com/show_bug.cgi?id=1858002)
This updates "Persistent storage using Red Hat OpenShift Container Storage" topic in OCP 4.5 with latest OCS doc URLs per BZ.

Upon approval, merge to master, CP to 4.5, 4.6 only.

@qinpingli PTAL for QE approval