### PR TITLE
Adding auto cert recovery to 4.4.8 release notes

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -2461,6 +2461,16 @@ release:
 
 link:https://access.redhat.com/solutions/5132771[{product-title} 4.4.8 container image list]
 
+[[ocp-4-4-8-features]]
+==== Features
+
+[[ocp-4-4-8-auto-cert-recovery]]
+===== Automatic control plane certificate recovery
+
+{product-title} can now automatically recover from expired control plane certificates. The exception is that you must manually approve pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates.
+
+See xref:../backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-scenario-3-recovering-expired-certs_dr-recovering-expired-certs[Recovering from expired control plane certificates] for more information.
+
 [[ocp-4-4-8-bug-fixes]]
 ==== Bug Fixes
 


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~ahoffer/2020/adding-cert-recovery-to-448/release_notes/ocp-4-4-release-notes.html#ocp-4-4-8-auto-cert-recovery