### PR TITLE
remove line about namespaced clusterrole

### DIFF
--- a/rest_api/role_apis/clusterrolebinding-authorization-openshift-io-v1.adoc
+++ b/rest_api/role_apis/clusterrolebinding-authorization-openshift-io-v1.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 
 Description::
-  ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace. It adds who information via (Users and Groups) OR Subjects and namespace information by which namespace it exists in. ClusterRoleBindings in a given namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces).
+  ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace. It adds who information via (Users and Groups) OR Subjects and namespace information by which namespace it exists in. 
 
 Type::
   `object`


### PR DESCRIPTION
it is incorrect. clusterroles are always cluster global.

Signed-off-by: Yuval Kashtan <yuvalkashtan@gmail.com>