### PR TITLE
CNV-4562 Handle datavolume volumes mistakenly used as pvc volumes

### DIFF
--- a/modules/virt-vm-storage-volume-types.adoc
+++ b/modules/virt-vm-storage-volume-types.adoc
@@ -30,6 +30,10 @@ PVC.
 DataVolumes build on the *persistentVolumeClaim* disk type by managing the process
 of preparing the virtual machine disk via an import, clone, or upload operation.
 VMs that use this volume type are guaranteed not to start until the volume is ready.
++
+Define DataVolumes with a `type` of *dataVolume*. If another volume type is
+used in error, such as *PersistentVolumeClaim*, a warning will be triggered
+and the virtual machine will fail to start.
 
 *cloudInitNoCloud*::
 Attaches a disk that contains the referenced cloud-init NoCloud data


### PR DESCRIPTION
Please label peer review needed and enterprise-4.5.

Tagging @awels for final code review.
Tagging @qwang1 for QE review.

Test Build: http://file.bos.redhat.com/bgaydos/071920/virt/virtual_machines/virt-create-vms.html#virt-storage-wizard-fields-web_virt-create-vms

In Virtual Machine Storage Types for dataVolume, the following has been added:

_Define DataVolumes with a type of dataVolume. If another volume type is used in error, such as PersistentVolumeClaim, a warning will be triggered and the virtual machine will fail to start._

Peer review may reveal another place to state this information or a better place to state it.

Bob