### PR TITLE
BZ-1854318 Fixed codeblock callout text

### DIFF
--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -56,7 +56,7 @@ spec:
 <5> Optional. Human-readable description of the interface.
 <6> The type of interface. This example creates a bond.
 <7> The requested state for the interface after creation.
-<8> Optional. If you do not use `dhcp` you must specify static IP address for the interface.
+<8> Optional. If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
 <9> Enables `ipv4` in this example.
 <10> The driver mode for the bond. This example uses an active backup mode.
 <11> Optional. This example uses miimon to inspect the bond link every 140ms.

--- a/modules/virt-example-bridge-nncp.adoc
+++ b/modules/virt-example-bridge-nncp.adoc
@@ -6,7 +6,7 @@
 = Example: Linux bridge interface NodeNetworkConfigurationPolicy
 
 Create a Linux bridge interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest
-to the cluster. 
+to the cluster.
 
 The following YAML file is an example of a manifest for a Linux bridge interface.
 It includes samples values that you must replace with your own information.
@@ -36,14 +36,14 @@ spec:
           port:
             - name: eth1 <11>
 ----
-<1> Name of the Policy. 
+<1> Name of the Policy.
 <2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
 <4> Name of the interface.
 <5> Optional. Human-readable description of the interface.
 <6> The type of interface. This example creates a bridge.
 <7> The requested state for the interface after creation.
-<8> Optional. If you do not use `dhcp` you must specify static IP address for the interface.
+<8> Optional. If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
 <9> Enables `ipv4` in this example.
 <10> Disables `stp` in this example.
 <11> The node NIC to which the bridge attaches.


### PR DESCRIPTION
BZ-1854318 https://bugzilla.redhat.com/show_bug.cgi?id=1854318

Preview: https://bz-1854318--ocpdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html#virt-example-bridge-nncp_virt-updating-node-network-config

Fixed text for codeblock callout <8> to remove the static IP address requirement for the interface

Applies to 4.5 docs