### PR TITLE
virt: removing problematic xref

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -277,7 +277,7 @@ and point the hostpath provisioner to that partition so it will not interfere wi
 from the Operator Lifecycle Manager (OLM). This issue is caused by the limitations
 associated with using a declarative API to track the state of {VirtProductName}
 Operators. Enabling automatic updates during
-//xref:install/installing-virt.adoc#virt-subscribing-to-the-catalog_installing-virt[installation] (This xref was causing the build to fail. Requires troubleshooting).
+// installation xref temporarily redacted
 decreases the risk of encountering this issue.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1759612[*BZ#1759612*])
 


### PR DESCRIPTION
This cherrypick [build](https://travis-ci.com/github/openshift/openshift-docs/builds/176376113) is broken -- and so is the one for enterprise-4.6 -- because of an incorrect xref in the yet-to-be-published virt 2.4 release notes. I am removing it so that those builds pass. After I merge my cherrypicks, I will open another PR to add the xref back into those branches with the correct path.

PS. I'm going to cherrypick this to enterprise-4.6 because it's a release note.