### PR TITLE
Virt: fixing xref in the release notes

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -277,7 +277,7 @@ and point the hostpath provisioner to that partition so it will not interfere wi
 from the Operator Lifecycle Manager (OLM). This issue is caused by the limitations
 associated with using a declarative API to track the state of {VirtProductName}
 Operators. Enabling automatic updates during
-// installation xref temporarily redacted
+xref:../virt/install/installing-virt-web.adoc#virt-subscribing-to-the-catalog_installing-virt-web[installation]
 decreases the risk of encountering this issue.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1759612[*BZ#1759612*])
 


### PR DESCRIPTION
FYI @lmandavi - please see https://github.com/openshift/openshift-docs/pull/23959 for context.

Cherrypicking to 4.6 because this is a release note, and release notes are weird.