### PR TITLE
Add recommendation for going beyond 5000 services per ns

### DIFF
--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -69,3 +69,101 @@ do not. Most Java applications and applications that use huge pages are examples
 of applications that would not allow for overcommitment. That memory can not be
 used for other applications. In the example above, the environment would be
 roughly 30 percent overcommitted, a common ratio.
+
+The application Pods can access a service either by using environment variables or DNS. 
+If using environment variables, for each active service the variables are injected by the 
+kubelet when a Pod is run on a node. A cluster-aware DNS server watches the Kubernetes API 
+for new services and creates a set of DNS records for each one. If DNS is enabled throughout 
+your cluster, then all Pods should automatically be able to resolve services by their DNS name. 
+Service discovery using DNS can be used in case you must go beyond 5000 services. When using 
+environment variables for service discovery, the argument list exceeds the allowed length after 
+5000 services in a namespace, then the Pods and deployments will start failing. Disable the service 
+links in the deployment's service specification file to overcome this:
+
+[source, yaml]
+----
+ ---
+    Kind: Template
+    apiVersion: v1
+    metadata:
+      name: deploymentConfigTemplate
+      creationTimestamp:
+      annotations:
+        description: This template will create a deploymentConfig with 1 replica, 4 env vars and a service.
+        tags: ''
+    objects:
+    - kind: DeploymentConfig
+      apiVersion: v1
+      metadata:
+        name: deploymentconfig${IDENTIFIER}
+      spec:
+        template:
+          metadata:
+            labels:
+              name: replicationcontroller${IDENTIFIER}
+          spec:
+            enableServiceLinks: false
+            containers:
+            - name: pause${IDENTIFIER}
+              image: "${IMAGE}"
+              ports:
+              - containerPort: 8080
+                protocol: TCP
+              env:
+              - name: ENVVAR1_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              - name: ENVVAR2_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              - name: ENVVAR3_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              - name: ENVVAR4_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              resources: {}
+              imagePullPolicy: IfNotPresent
+              capabilities: {}
+              securityContext:
+                capabilities: {}
+                privileged: false
+            restartPolicy: Always
+            serviceAccount: ''
+        replicas: 1
+        selector:
+          name: replicationcontroller${IDENTIFIER}
+        triggers:
+        - type: ConfigChange
+        strategy:
+          type: Rolling
+    - kind: Service
+      apiVersion: v1
+      metadata:
+        name: service${IDENTIFIER}
+      spec:
+        selector:
+          name: replicationcontroller${IDENTIFIER}
+        ports:
+        - name: serviceport${IDENTIFIER}
+          protocol: TCP
+          port: 80
+          targetPort: 8080
+        portalIP: ''
+        type: ClusterIP
+        sessionAffinity: None
+      status:
+        loadBalancer: {}
+    parameters:
+    - name: IDENTIFIER
+      description: Number to append to the name of resources
+      value: '1'
+      required: true
+    - name: IMAGE
+      description: Image to use for deploymentConfig
+      value: gcr.io/google-containers/pause-amd64:3.0
+      required: false
+    - name: ENV_VALUE
+      description: Value to use for environment variables
+      generate: expression
+      from: "[A-Za-z0-9]{255}"
+      required: false
+    labels:
+      template: deploymentConfigTemplate
+----

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -44,42 +44,7 @@ AWS cloud platform:
 | 32
 | gp2 
 | 100 
-| 3/25/250/2000 footnoteref:[nodescaleaws,Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
+| 3/25/250/500/2000 footnoteref:[nodescaleaws,Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
 | us-west-2
-
-|===
-
-
-Azure cloud platform:
-
-[options="header",cols="8*"]
-|===
-| Node |Flavor |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/iops |Count |Region
-
-| Master/etcd footnoteref:[masteretcdnodeazure,For a higher IOPs and throughput cap, 1024GB disks are used for master/etcd nodes because etcd is I/O intensive and latency sensitive.]
-| Standard_D8s_v3
-| 8
-| 32
-| Premium SSD
-| 1024 ( P30 )
-| 3
-| centralus
-
-| Infra footnoteref:[infranodesazure,Infra nodes are used to host Monitoring, Ingress and Registry components to make sure they have enough resources to run at large scale.]
-| Standard_D16s_v3 
-| 16
-| 64
-| Premium SSD
-| 1024 ( P30 )
-| 3
-| centralus
-
-| Worker
-| Standard_D4s_v3
-| 4
-| 16
-| Premium SSD
-| 1024 ( P30 )| 3/25/100/110 footnoteref:[nodescaleazure,The cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
-| centralus
 
 |===


### PR DESCRIPTION
This commit:
- Adds information on using DNS instead of relying on environment
  variables for discovery to go beyond 5000 services per namespace
  cluster maximum on OCP 4.5.
- Updates environment details on which the cluster maximums
  have been tested for OCP 4.5.