### PR TITLE
Updated docs for  issue#23979

### DIFF
--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -85,10 +85,16 @@ For example, to label a node:
 $ oc label nodes ip-10-0-142-25.ec2.internal type=user-node region=east
 ----
 +
-To label a MachineSet:
+To label a node managed by MachineSet one need to add the label to MachineSet so that label is added to node when it is created:
 +
 ----
-$ oc label MachineSet abc612-msrtw-worker-us-east-1c type=user-node region=east
+$ oc patch MachineSet abcocp-worker-1x2c3 --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"type":"user-node","region":"east"}}]'
+----
++
+There are multiple ways to view if the label is applied correctly to the node, list the node with the label to see if it is applied properly:
++
+----
+$ oc get nodes -l <key>=<value>
 ----
 
 When you create a pod in the namespace, {product-title} adds the appropriate `<key>:<value>` and schedules


### PR DESCRIPTION
The command mentioned in the section adds a label to the MachineSet but does not add the label to the node created specific MachineSet. The new command will add the label to the MachinSet spec.template.spec.metadata.labels so that the nodes created with this MachineSet will have specific labels