### PR TITLE
BZ 1858995 - update AWS EBS storage assembly

### DIFF
--- a/storage/persistent_storage/persistent-storage-aws.adoc
+++ b/storage/persistent_storage/persistent-storage-aws.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 {product-title} supports AWS Elastic Block Store volumes (EBS). You can
-provision your {product-title} cluster with persistent storage using AWS EC2.
+provision your {product-title} cluster with persistent storage by using link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html[Amazon EC2].
 Some familiarity with Kubernetes and AWS is assumed.
 
 The Kubernetes persistent volume framework allows administrators to provision a
@@ -24,17 +24,13 @@ High-availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====
 
-.Additional References
+== Additional References
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-ebs.adoc#persistent-storage-csi-ebs[AWS Elastic Block Store CSI Driver Operator]
-* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html[Amazon
-EC2]
+* See xref:../../storage/container_storage_interface/persistent-storage-csi-ebs.adoc#persistent-storage-csi-ebs[AWS Elastic Block Store CSI Driver Operator] for information about accessing additional storage options, such as volume snapshots, that are not possible with in-tree volume plug-ins.
 
 // Defining attributes required by the next module
 :StorageClass: EBS
 :Provisioner: kubernetes.io/aws-ebs
-
-include::modules/persistent-storage-csi-ebs-operator-install.adoc[leveloffset=+1]
 
 include::modules/storage-create-storage-class.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[BZ 1858995](https://bugzilla.redhat.com/show_bug.cgi?id=1858995) - Fixes confusion in [AWS EBS storage docs](https://docs.openshift.com/container-platform/4.5/storage/persistent_storage/persistent-storage-aws.html) where the CSI Driver Operator install procedure was included in 4.5. This PR eliminates the `Install Operator` module and adds a description to the link in the `Additional resources` section.

@duanwei33 - PTAL for QE

@openshift/team-documentation - PTAL for peer review

Review link is available here: https://1858995--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-aws.html