### PR TITLE
CNV-4562 Handle datavolume volumes mistakenly used as pvc volumes

### DIFF
--- a/modules/virt-importing-vm-datavolume.adoc
+++ b/modules/virt-importing-vm-datavolume.adoc
@@ -92,7 +92,7 @@ spec:
               bus: virtio
             name: datavolumedisk1
         machine:
-          type: ""
+          type: "" <4>
         resources:
           requests:
             memory: 64M
@@ -106,6 +106,7 @@ status: {}
 <1> The `HTTP` source of the image you want to import.
 <2> The `secretRef` parameter is optional.
 <3> The `certConfigMap` is required for communicating with servers that use self-signed certificates or certificates not signed by the system CA bundle. The referenced ConfigMap must be in the same namespace as the DataVolume.
+<4> Specify `type: dataVolume` or `type: ""`. If you specify any other value for `type`, such as `persistentVolumeClaim`, a warning is displayed, and the virtual machine does not start.
 
 . Create the virtual machine:
 +

--- a/modules/virt-vm-storage-volume-types.adoc
+++ b/modules/virt-vm-storage-volume-types.adoc
@@ -27,9 +27,13 @@ recommended method for importing existing virtual machines into
 PVC.
 
 *dataVolume*::
-DataVolumes build on the *persistentVolumeClaim* disk type by managing the process
+DataVolumes build on the `persistentVolumeClaim` disk type by managing the process
 of preparing the virtual machine disk via an import, clone, or upload operation.
 VMs that use this volume type are guaranteed not to start until the volume is ready.
++
+Specify `type: dataVolume` or `type: ""`. If you specify any other value for
+`type`, such as `persistentVolumeClaim`, a warning is displayed, and the virtual
+machine does not start.
 
 *cloudInitNoCloud*::
 Attaches a disk that contains the referenced cloud-init NoCloud data


### PR DESCRIPTION
Please label *peer review needed* and *enterprise-4.5* , *enterprise-4.6*.

This PR carries over edits from https://github.com/openshift/openshift-docs/pull/23943. 

Test Build: See Netify link below

In Virtual Machine Storage Types for dataVolume, the following has been added:

Define DataVolumes with a type of dataVolume. If another volume type is used in error, such as PersistentVolumeClaim, a warning will be triggered and the virtual machine will fail to start.

Peer review may reveal another place to state this information or a better place to state it.

Bob