### PR TITLE
Serverless advanced install doc updates

### DIFF
--- a/modules/knative-serving-advanced-config.adoc
+++ b/modules/knative-serving-advanced-config.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+// * /serverless/installing_serverless/serverless-install-config-options.adoc
+
+[id="knative-serving-advanced-config_{context}"]
+= Knative Serving supported installation configuration options
+
+This guide provides information for cluster administrators about advanced installation configuration options for Knative Serving.
+
+[IMPORTANT]
+====
+Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
+====
+
+image::serving-form-view.png[Create Knative Serving form in web console Administrator Perspective]
+
+[id="knative-serving-controller-custom-certs_{context}"]
+== Controller Custom Certs
+
+If your registry uses a self-signed certificate, you must enable tag-to-digest resolution by creating a ConfigMap or Secret.
+The {ServerlessOperatorName} then automatically configures Knative Serving controller access to the registry.
+
+To enable tag-to-digest resolution, the Knative Serving controller requires access to the container registry.
+
+[IMPORTANT]
+====
+The ConfigMap or Secret must reside in the same namespace as the Knative Serving CustomResourceDefinition (CRD).
+====
+
+The following example triggers the {ServerlessOperatorName} to:
+
+. Create and mount a volume containing the certificate in the controller.
+. Set the required environment variable properly.
+
+.Example YAML
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  controller-custom-certs:
+    name: certs
+    type: ConfigMap
+----
+
+The following example uses a certificate in a ConfigMap named `certs` in the `knative-serving` namespace.
+
+The supported types are `ConfigMap` and `Secret`.
+
+If no controller custom cert  is specified, this defaults to the `config-service-ca` ConfigMap.
+
+.Example default YAML
+[source,yaml]
+----
+spec:
+  controller-custom-certs:
+    name: config-service-ca
+    type: ConfigMap
+----
+
+[id="knative-serving-high-availability_{context}"]
+== High availability
+
+High availability (HA) defaults to `2` replicas per controller if no number of replicas is specified.
+
+You can set this to `1` to disable HA, or add more replicas by setting a higher integer.
+
+.Example YAML
+[source,yaml]
+----
+spec:
+  high-availability:
+    replicas: 2
+----

--- a/serverless/installing_serverless/serverless-install-config-options.adoc
+++ b/serverless/installing_serverless/serverless-install-config-options.adoc
@@ -6,82 +6,10 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide provides information for cluster administrators about advanced installation configuration options for Knative Serving and Knative Eventing.
+This guide provides information for cluster administrators about advanced installation configuration options for {ServerlessProductName} components.
 
-The YAML configuration is shown by default when you are creating the Knative Serving or Knative Eventing custom resource definitions. However, you can access the form view by selecting *Edit Form* in the top right corner of the *Create Knative Serving* or *Create Knative Eventing* pages.
-
-[IMPORTANT]
-====
-Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
-====
-
-== Knative Serving supported installation configuration options
-
-image::serving-form-view.png[Create Knative Serving form]
-
-=== Controller Custom Certs
-
-If your registry uses a self-signed certificate, you must enable tag-to-digest resolution by creating a ConfigMap or Secret.
-The {ServerlessOperatorName} then automatically configures Knative Serving controller access to the registry.
-
-To enable tag-to-digest resolution, the Knative Serving controller requires access to the container registry.
-
-[IMPORTANT]
-====
-The ConfigMap or Secret must reside in the same namespace as the Knative Serving custom resource definition.
-====
-
-The following example triggers the {ServerlessOperatorName} to:
-
-. Create and mount a volume containing the certificate in the controller.
-. Set the required environment variable properly.
-
-.Example YAML
-[source,yaml]
-----
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: knative-serving
-spec:
-  controller-custom-certs:
-    name: certs
-    type: ConfigMap
-----
-
-The following example uses a certificate in a ConfigMap named `certs` in the `knative-serving` namespace.
-
-You can also configure controller custom certs using the form view.
-The supported types are `ConfigMap` and `Secret`.
-
-If no controller custom cert  is specified, this defaults to the `config-service-ca` ConfigMap.
-
-.Example default YAML
-[source,yaml]
-----
-spec:
-  controller-custom-certs:
-    name: config-service-ca
-    type: ConfigMap
-----
-
-=== High availability
-
-High availability (HA) defaults to 2 replicas per controller if no number of replicas is specified.
-
-You can set this to `1` to disable HA, or add more replicas by setting a higher integer.
-
-For more information about configuring HA, see xref:../../serverless/serverless-HA.adoc#serverless-HA[High availability on {ServerlessProductName}].
-
-.Example YAML
-[source,yaml]
-----
-spec:
-  high-availability:
-    replicas: 2
-----
+include::modules/knative-serving-advanced-config.adoc[leveloffset=+1]
 
 // == Knative Eventing supported installation configuration options
-
 // image::eventing-form-view.png[Create Knative Eventing form]
+// TODO: Add when there's more information for eventing.


### PR DESCRIPTION
- Updated advanced install config to remove mention of YAML as default. Split serving into module.
