### PR TITLE
Add infrastructure nodes sizing recommendations

### DIFF
--- a/modules/infrastructure-node-sizing.adoc
+++ b/modules/infrastructure-node-sizing.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+[id="infrastructure-node-sizing_{context}"]
+=  Infrastructure node sizing
+
+The infrastructure node resource requirements depend on the cluster age, nodes, and objects in the cluster, as these factors can lead to an increase in the number of metrics or time series in Prometheus. The following infrastructure node size recommendations are based on the results of cluster maximums and control plane density focused testing.
+
+[options="header",cols="3*"]
+|===
+| Number of worker nodes |CPU cores |Memory (GB)
+
+| 25
+| 4
+| 32
+
+| 100
+| 8
+| 64
+
+| 250
+| 32
+| 192
+
+| 500
+| 32
+| 192
+
+|===
+
+[IMPORTANT]
+====
+These sizing recommendations are based on scale tests, which create a large number of objects across the cluster. These tests include reaching some of the cluster maximums. In the case of 250 and 500 node counts on a {product-title} {product-version} cluster, these maximums are 10000 namespaces with 61000 Pods, 10000 deployments, 181000 secrets, 400 ConfigMaps, and so on. Prometheus is a highly memory intensive application; the resource usage depends on various factors including the number of nodes, objects, the Prometheus metrics scraping interval, metrics or time series, and the age of the cluster. The disk size also depends on the retention period. You must take these factors into consideration and size them accordingly.
+
+The sizing recommendations are applicable only for the infrastructure components which gets installed during the cluster install - Prometheus, Router and Registry. Logging is a day two operation and the recommendations do not take it into account.
+====
+
+[NOTE]
+====
+In {product-title} {product-version}, half of a CPU core (500 millicore) is now reserved by the system by default compared to {product-title} 3.11 and previous versions. This influences the stated sizing recommendations.
+====

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -17,6 +17,16 @@ include::modules/master-node-sizing.adoc[leveloffset=+1]
 
 include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
+include::modules/infrastructure-components.adoc[leveloffset=+1]
+
+include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+1]
+
+include::modules/infrastructure-moving-registry.adoc[leveloffset=+1]
+
+include::modules/infrastructure-moving-router.adoc[leveloffset=+1]
+
+include::modules/infrastructure-node-sizing.adoc[leveloffset=+1]
+
 == Additional resources
 
 * xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[{product-title}


### PR DESCRIPTION
This commit adds information on infrastructure nodes which hosts
Router, Registry, Logging and Monitoring components for various
nodes scale. The data is based on the cluster maximums and density
focuded scale test runs.