### PR TITLE
BZ1826292 - Add proc for configuring block storage in image registry

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -78,6 +78,10 @@ include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -59,6 +59,10 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
 .Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -69,6 +69,10 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
 .Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -53,6 +53,9 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
 
 .Next steps
 

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -69,6 +69,10 @@ include::modules/registry-removed.adoc[leveloffset=+2]
 
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -71,6 +71,10 @@ include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 

--- a/modules/installation-registry-storage-block-recreate-rollout.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+
+[id="installation-registry-storage-block-recreate-rollout_{context}"]
+= Configuring block registry storage for VMware vSphere
+
+To allow the image registry to use block storage types such as vSphere Virtual Machine Disk (VMDK) during upgrades as a cluster administrator, you can use the `Recreate` rollout strategy.
+
+.Procedure
+
+. To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only `1` replica:
++
+----
+$ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
+----
++
+. Provision the PV for the block storage device, and create a PVC for that volume. The requested block volume uses the ReadWriteOnce (RWO) access mode.
++
+. Edit the registry configuration so that it references the correct PVC.

--- a/modules/installation-registry-storage-config.adoc
+++ b/modules/installation-registry-storage-config.adoc
@@ -36,12 +36,12 @@ endif::aws[]
 ifndef::aws[]
 The `image-registry` Operator is not initially available for platforms that do
 not provide default storage. After installation, you must configure your
-registry to use storage so the Registry Operator is made available.
+registry to use storage so that the Registry Operator is made available.
 endif::aws[]
 
-Instructions for both configuring a PersistentVolume, which is required
-for production clusters, and for configuring an empty directory as the storage
-location, which is available for only non-production clusters, are shown.
+Instructions are shown for configuring a PersistentVolume, which is required for production clusters. Where applicable, instructions are shown for configuring an empty directory as the storage location, which is available for only non-production clusters.
+
+Additional instructions are provided for allowing the image registry to use block storage types by using the `Recreate` rollout strategy during upgrades.
 
 ifeval::["{context}" == "installing-aws-user-infra"]
 :!aws:

--- a/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
@@ -14,6 +14,10 @@ include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+1]
 
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
 
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+1]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
 [id="configuring-registry-storage-vsphere-addtl-resources"]
 == Additional resources
 


### PR DESCRIPTION
[BZ1826292](https://bugzilla.redhat.com/show_bug.cgi?id=1826292) - 4.4+. Adds instructions for configuring block storage type in image registry during upgrade for RWO access mode.

Preview links for impacted assemblies:

- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-vsphere.html
- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#installing-vsphere-installer-provisioned-registry
- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html
- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html
- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html
- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations.html
- https://bz1826292--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html