### PR TITLE
Add --manifests-only to OLM disconnected

### DIFF
--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -59,9 +59,22 @@ This disables the default OperatorSources that are configured by default during
 an {product-title} installation.
 endif::[]
 
-. Mirror the contents of your catalog to your target registry. The following `oc adm catalog mirror`
-command extracts the contents of your custom Operator catalog image to generate
-the manifests required for mirroring and mirrors the images to your registry:
+. The `oc adm catalog mirror` command extracts the contents of your custom
+Operator catalog image to generate the manifests required for mirroring. You can
+choose to either:
++
+--
+* Allow the default behavior of the command to automatically mirror all of the
+image content to your mirror registry after generating manifests, or
+* Add the `--manifests-only` flag to only generate the manifests required for
+mirroring, but do not actually mirror the image content to a registry yet. This
+can be useful for reviewing what will be mirrored, and it allows you to make any
+changes to the mapping list if you only require a subset of the content. You can
+then use that file with the `oc image mirror` command to mirror the modified
+list of images in a later step.
+--
++
+On your workstation with unrestricted network access, run the following command:
 +
 ----
 $ oc adm catalog mirror \
@@ -69,9 +82,8 @@ $ oc adm catalog mirror \
     <registry_host_name>:<port> \
     [-a ${REG_CREDS}] \//<2>
     [--insecure] \//<3>
-    [--filter-by-os="<os>/<arch>"] <4>
-
-mirroring ...
+    [--filter-by-os="<os>/<arch>"] \//<4>
+    [--manifests-only] <5>
 ----
 <1> Specify your Operator catalog image.
 <2> Optional: If required, specify the location of your registry credentials
@@ -82,9 +94,11 @@ the `--insecure` flag.
 architectures and operating systems, you can filter by architecture and
 operating system to mirror only the images that match. Valid values are
 `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<5> Optional: Only generate the manifests required for mirroring and do not actually
+mirror the image content to a registry.
 +
-This command also creates a `<image_name>-manifests/` directory in the current
-directory and generates the following files:
+After running the command, a `<image_name>-manifests/` directory is created in
+the current directory and generates the following files:
 +
 --
 * The `imageContentSourcePolicy.yaml` file defines an ImageContentSourcePolicy
@@ -95,10 +109,26 @@ in the target registry. This file is compatible with the `oc image mirror`
 command and can be used to further customize the mirroring configuration.
 --
 
-. Apply the manifests:
+. If you used the `--manifests-only` flag in the previous step and want to mirror
+only a subset of the content:
+
+.. Modify the list of images in your `mapping.txt` file to your
+specifications.
+
+.. Still on your workstation with unrestricted network access, use your modified
+`mapping.txt` file to mirror the images to your registry using the `oc image
+mirror` command:
 +
 ----
-$ oc apply -f ./redhat-operators-manifests
+$ oc image mirror \
+    [-a ${REG_CREDS}] \
+    -f ./redhat-operators-manifests/mapping.txt
+----
+
+. Apply the ImageContentSourcePolicy:
++
+----
+$ oc apply -f ./redhat-operators-manifests/imageContentSourcePolicy.yaml
 ----
 
 . Create a CatalogSource object that references your catalog image.
@@ -127,24 +157,44 @@ spec:
 $ oc create -f catalogsource.yaml
 ----
 
-. Verify the CatalogSource and package manifest are created successfully:
+. Verify the following resources are created successfully.
+
+.. Check the Pods:
 +
 ----
-# oc get pods -n openshift-marketplace
-NAME READY STATUS RESTARTS AGE
-my-operator-catalog-6njx6 1/1 Running 0 28s
-marketplace-operator-d9f549946-96sgr 1/1 Running 0 26h
-
-# oc get catalogsource -n openshift-marketplace
-NAME DISPLAY TYPE PUBLISHER AGE
-my-operator-catalog My Operator Catalog grpc 5s
-
-# oc get packagemanifest -n openshift-marketplace
-NAME CATALOG AGE
-etcd My Operator Catalog 34s
+$ oc get pods -n openshift-marketplace
 ----
 +
-You can also view them from the *OperatorHub* page in the web console.
+.Example output
+----
+NAME                                    READY   STATUS    RESTARTS  AGE
+my-operator-catalog-6njx6               1/1     Running   0         28s
+marketplace-operator-d9f549946-96sgr    1/1     Running   0         26h
+----
+
+.. Check the CatalogSource:
++
+----
+$ oc get catalogsource -n openshift-marketplace
+----
++
+.Example output
+----
+NAME                  DISPLAY               TYPE PUBLISHER  AGE
+my-operator-catalog   My Operator Catalog   grpc            5s
+----
+
+.. Check the PackageManifest:
++
+----
+$ oc get packagemanifest -n openshift-marketplace
+----
++
+.Example output
+----
+NAME    CATALOG              AGE
+etcd    My Operator Catalog  34s
+----
 
 You can now install the Operators from the *OperatorHub* page on your restricted
-network {product-title} cluster.
+network {product-title} cluster web console.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1222

The main change is updating steps 2 and 3 in the mirroring procedure to include `--manifests-only` usage. Also other minor clean-up throughout the procedure for flow and latest guidelines.

http://file.rdu.redhat.com/~adellape/072120/mapping/operators/olm-restricted-networks.html#olm-restricted-networks-operatorhub_olm-restricted-networks