### PR TITLE
Broken Link to Red Hat Security Guide

### DIFF
--- a/security/container_content.adoc
+++ b/security/container_content.adoc
@@ -49,7 +49,7 @@ all of your approved and deployed images.
 RHEL provides a pluggable API to support multiple scanners. You can also use Red
 Hat CloudForms with OpenSCAP to scan container images for security issues. See
 the
-link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/chap-Compliance_and_Vulnerability_Scanning.html[Red Hat Enterprise Linux Security Guide] for general information on OpenSCAP in
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/security_guide/index#scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening[Red Hat Enterprise Linux Security Guide] for general information on OpenSCAP in
 RHEL, and the
 link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html-single/policies_and_profiles_guide/#openscap[Red Hat CloudForms Policies and Profiles Guide] for specifics on OpenSCAP
 integration.


### PR DESCRIPTION
The existing link https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/chap-Compliance_and_Vulnerability_Scanning.html is broken and has been replaced with https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/security_guide/index#scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening