### PR TITLE
search: fix the "occured" search error typo

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -62,7 +62,7 @@ function hcsearch(searchParams) {
     // GET success
     if (hcsearchresults == "") {
       // success, but no response (response code mismatch)
-      $("#hc-search-result").append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+      $("#hc-search-result").append("<p><strong>An error occurred while retrieving search results. Please try again later.</strong></p>");
       hcSearchIndicator.hide();
     }
     if (!$.isEmptyObject(hcsearchresults.response.result)) { 
@@ -99,7 +99,7 @@ function hcsearch(searchParams) {
     hcSearchIndicator.hide();
   }).fail(function(response) {
     // GET error
-    hcSearchResult.append("<p><strong>An error occured while retrieving search results. Please try again later.</strong></p>");
+    hcSearchResult.append("<p><strong>An error occurred while retrieving search results. Please try again later.</strong></p>");
     hcSearchIndicator.hide();
   });
 }  // function hcsearch()


### PR DESCRIPTION
* Fixes the "occured" typo when the search endpoint is not reachable,
  as reported in the bug 1859259

Signed-off-by: Jiri Fiala <jfiala@redhat.com>