### PR TITLE
Document Operator Management state for NTO.

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -16,7 +16,8 @@ $ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
 
 The default CR is meant for delivering standard node-level tuning for the
-{product-title} platform and any custom changes to the default CR will be
+{product-title} platform and it can only be modified to set the Operator
+Management state. Any other custom changes to the default CR will be
 overwritten by the Operator. For custom tuning, create your own tuned CRs. Newly
 created CRs will be combined with the default CR and custom tuning applied to
 {product-title} nodes based on node or Pod labels and profile priorities.

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -6,17 +6,29 @@
 = Custom tuning specification
 
 The custom resource (CR) for the operator has two major sections. The first
-section, `profile:`, is a list of tuned profiles and their names. The second,
+section, `profile:`, is a list of Tuned profiles and their names. The second,
 `recommend:`, defines the profile selection logic.
 
 Multiple custom tuning specifications can co-exist as multiple CRs in the
 operator's namespace. The existence of new CRs or the deletion of old CRs is
 detected by the Operator. All existing custom tuning specifications are merged
-and appropriate objects for the containerized tuned daemons are updated.
+and appropriate objects for the containerized Tuned daemons are updated.
+
+*Management state*
+
+The Operator Management state is set by adjusting the default Tuned CR.
+By default, the Operator is in the Managed state and the `spec.managementState`
+field is not present in the default Tuned CR. Valid values for the Operator
+Management state are as follows:
+
+  * Managed: the Operator will update its operands as configuration resources are updated
+  * Unmanaged: the Operator will ignore changes to the configuration resources
+  * Removed: the Operator will remove its operands and resources the Operator provisioned
+
 
 *Profile data*
 
-The `profile:` section lists tuned profiles and their names.
+The `profile:` section lists Tuned profiles and their names.
 
 [source, yaml]
 ----
@@ -29,7 +41,7 @@ profile:
 
     [sysctl]
     net.ipv4.ip_forward=1
-    # ... other sysctl's or other tuned daemon plugins supported by the containerized tuned
+    # ... other sysctl's or other Tuned daemon plugins supported by the containerized Tuned
 
 # ...
 
@@ -72,7 +84,7 @@ The individual items of the list:
 <3> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
 <4> An optional list.
 <5> Profile ordering priority. Lower numbers mean higher priority (0 is the highest priority).
-<6> A tuned profile to apply on a match. For example `tuned_profile_1`.
+<6> A Tuned profile to apply on a match. For example `tuned_profile_1`.
 
 `<match>` is an optional list recursively defined as follows:
 
@@ -112,7 +124,7 @@ The `match` item is evaluated first in a short-circuit manner. Therefore, if it 
 ====
 When using MachineConfigPool based matching, it is advised to group nodes with the same
 hardware configuration into the same MachineConfigPool. Not following this practice
-might result in tuned operands calculating conflicting kernel parameters for two or more nodes
+might result in Tuned operands calculating conflicting kernel parameters for two or more nodes
 sharing the same MachineConfigPool.
 ====
 
@@ -136,10 +148,10 @@ sharing the same MachineConfigPool.
   profile: openshift-node
 ----
 
-The CR above is translated for the containerized tuned daemon into its
+The CR above is translated for the containerized Tuned daemon into its
 `recommend.conf` file based on the profile priorities. The profile with the
 highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is
-considered first. The containerized tuned daemon running on a given node looks
+considered first. The containerized Tuned daemon running on a given node looks
 to see if there is a pod running on the same node with the
 `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>`
 section evaluates as `false`. If there is such a pod with the label, in order for
@@ -150,7 +162,7 @@ If the labels for the profile with priority `10` matched,
 `openshift-control-plane-es` profile is applied and no other profile is
 considered. If the node/pod label combination did not match, the second highest
 priority profile (`openshift-control-plane`) is considered. This profile is
-applied if the containerized tuned pod runs on a node with labels
+applied if the containerized Tuned pod runs on a node with labels
 `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
 Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -22,17 +22,17 @@ ifdef::operators[]
 == Purpose
 endif::operators[]
 The Node Tuning Operator helps you manage node-level tuning by orchestrating the
-tuned daemon. The majority of high-performance applications require some level
+Tuned daemon. The majority of high-performance applications require some level
 of kernel tuning. The Node Tuning Operator provides a unified management
 interface to users of node-level sysctls and more flexibility to add custom
-tuning specified by user needs. The Operator manages the containerized tuned
+tuning specified by user needs. The Operator manages the containerized Tuned
 daemon for {product-title} as a Kubernetes DaemonSet. It ensures the custom
-tuning specification is passed to all containerized tuned daemons running in the
+tuning specification is passed to all containerized Tuned daemons running in the
 cluster in the format that the daemons understand. The daemons run on all nodes
 in the cluster, one per node.
 
-Node-level settings applied by the containerized tuned daemon are rolled back on
-an event that triggers a profile change or when the containerized tuned daemon
+Node-level settings applied by the containerized Tuned daemon are rolled back on
+an event that triggers a profile change or when the containerized Tuned daemon
 is terminated gracefully by receiving and handling a termination signal.
 
 The Node Tuning Operator is part of a standard {product-title} installation in


### PR DESCRIPTION
Document the Operator Management state and fix Tuned daemon/profile capitalization.