### PR TITLE
Term correction for 4.5 release notes

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -308,9 +308,9 @@ cluster installation by sharing the node's pull secret credentials with the
 {product-title} {product-version} introduces the Vertical Pod Autoscaler Operator (VPA). The VPA reviews the historic and current CPU and memory resources for containers in Pods and can update the resource limits and requests based on the usage values it learns. You create individual custom resources (CR) to instruct the VPA to update all of the Pods associated with a workload object, such as a Deployment, Deployment Config, StatefulSet, Job, DaemonSet, ReplicaSet, or ReplicationController. The VPA helps you to understand the optimal CPU and memory usage for your Pods and can automatically maintain Pod resources through the Pod lifecycle.
 
 [id="ocp-4-5-openstack-anti-affinity"]
-==== Anti-affinity compute node scheduling on {rh-openstack}
+==== Anti-affinity control plane node scheduling on {rh-openstack}
 
-If separate physical hosts are available on an {rh-openstack} deployment, compute nodes will be scheduled across all of them.
+If separate physical hosts are available on an {rh-openstack} deployment, control plane nodes will be scheduled across all of them.
 
 [id="ocp-4-5-cluster-monitoring"]
 === Cluster monitoring


### PR DESCRIPTION
This commit changes "compute" to "control plane" in the high-affinity
OSP scheduling item that's part of the 4.5 RNs.

Could you review, @mandre @pierreprinetti? Check your inboxes for details. :) 

FYI @alimobrem @codyhoag 