### PR TITLE
Fixing bad link to signalfx article

### DIFF
--- a/modules/cluster-logging-deploy-storage-considerations.adoc
+++ b/modules/cluster-logging-deploy-storage-considerations.adoc
@@ -78,6 +78,5 @@ and becomes RED.
 [NOTE]
 ====
 These low and high watermark values are Elasticsearch defaults in the current release. You can modify these values,
-but you also must apply any modifications to the alerts also. The alerts are based
-on these defaults.
+but you also must apply any modifications to the alerts also. The alerts are based on these defaults.
 ====

--- a/modules/cluster-logging-deploy-storage-considerations.adoc
+++ b/modules/cluster-logging-deploy-storage-considerations.adoc
@@ -12,7 +12,7 @@ is little requirement to use hardware based mirroring RAID variants. RAID 0 can 
 be used to increase overall disk performance.
 ////
 
-A persistent volume is required for each Elasticsearch deployment configuration. On {product-title} this is achieved using
+A persistent volume (PV) is required for each Elasticsearch deployment configuration. On {product-title} this is achieved using
 Persistent Volume Claims.
 
 The Elasticsearch Operator names the PVCs using the Elasticsearch resource name.

--- a/modules/cluster-logging-deploy-storage-considerations.adoc
+++ b/modules/cluster-logging-deploy-storage-considerations.adoc
@@ -69,11 +69,7 @@ calculate per-application throughput and disk space as follows:
 
 Fluentd ships any logs from *systemd journal* and **/var/log/containers/*.log** to Elasticsearch.
 
-Therefore, consider how much data you need in advance and that you are
-aggregating application log data. Some Elasticsearch users have found that it
-is necessary to keep absolute storage consumption around 50% and below 70% at all times. This
-helps to avoid Elasticsearch becoming unresponsive during large merge
-operations.
+Consider how much data you need in advance and that you are aggregating application log data. 
 
 By default, at 85% Elasticsearch stops allocating new data to the node, at 90% Elasticsearch attempts to relocate
 existing shards from that node to other nodes if possible. But if no nodes have free capacity below 85%, Elasticsearch effectively rejects creating new indices


### PR DESCRIPTION
Link to external article expired. Updating to an archived version of the article