### PR TITLE
Add Virtualization GA release note

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -801,18 +801,10 @@ With this update, support for respecting a cluster-wide proxy configuration is a
 [id="ocp-4-5-virtualization-ga"]
 ==== OpenShift Virtualization is now generally available
 
-Red Hat OpenShift Virtualization is now a fully supported and generally
-available feature of {product-title} 4.5. Previously known as container-native
+Red Hat {VirtProductName} is supported to run on {product-title} 4.5. Previously known as container-native
 virtualization, OpenShift Virtualization enables you to bring traditional
 virtual machines (VMs) into {product-title} where they run alongside containers,
 and are managed as native Kubernetes objects.
-
-OpenShift Virtualization version 2.4 is the GA version fully supported for
-{product-title} 4.5. See the
-xref:../virt/virt-2-4-release-notes.adoc#virt-2-4-release-notes[OpenShift Virtualization release notes]
-for more information on the GA release and
-xref:../virt/about-virt.adoc#about-virt[About OpenShift Virtualization] to get
-started.
 
 [id="ocp-4-5-notable-technical-changes"]
 == Notable technical changes

--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -795,6 +795,25 @@ You can now upgrade a Metering Operator to 4.5 from 4.2 through 4.4. Previously,
 
 With this update, support for respecting a cluster-wide proxy configuration is available. Additionally, the upstream repository moved from the operator-framework organization to kube-reporting.
 
+[id="ocp-4-5-virtualization"]
+=== OpenShift Virtualization
+
+[id="ocp-4-5-virtualization-ga"]
+==== OpenShift Virtualization is now generally available
+
+Red Hat OpenShift Virtualization is now a fully supported and generally
+available feature of {product-title} 4.5. Previously known as container-native
+virtualization, OpenShift Virtualization enables you to bring traditional
+virtual machines (VMs) into {product-title} where they run alongside containers,
+and are managed as native Kubernetes objects.
+
+OpenShift Virtualization version 2.4 is the GA version fully supported for
+{product-title} 4.5. See the
+xref:../virt/virt-2-4-release-notes.adoc#virt-2-4-release-notes[OpenShift Virtualization release notes]
+for more information on the GA release and
+xref:../virt/about-virt.adoc#about-virt[About OpenShift Virtualization] to get
+started.
+
 [id="ocp-4-5-notable-technical-changes"]
 == Notable technical changes
 
@@ -1828,6 +1847,11 @@ In the table below, features are marked with the following statuses:
 |-
 |-
 |TP
+
+|OpenShift Virtualization
+|TP
+|TP
+|GA
 
 |====
 


### PR DESCRIPTION
This should be merged when OpenShift Virtualization 2.4 is released. This is scheduled for July 29.