### PR TITLE
Updating topicmap, support, and event sources for OCP 4.3

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1693,6 +1693,8 @@ Topics:
 - Name: Event sources
   Dir: event_sources
   Topics:
+  - Name: Getting started with event sources
+    File: knative-event-sources
   - Name: Using the kn CLI to list event sources and event source types
     File: serverless-kn-source
   - Name: Using ApiServerSource

--- a/serverless/event_sources/knative-event-sources.adoc
+++ b/serverless/event_sources/knative-event-sources.adoc
@@ -1,0 +1,32 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="knative-event-sources"]
+= Getting started with event sources
+include::modules/common-attributes.adoc[]
+:context: knative-event-sources
+toc::[]
+
+An event source is a resource object that acts as a link between an event producer and a _sink_. A sink can be a Knative Service, Channel, or Broker that receives Events from an event source.
+
+Currently, {ServerlessProductName} supports the following event source types:
+
+ApiServerSource:: Connects a sink to the Kubernetes API server.
+PingSource:: Periodically sends ping Events with a constant payload. It can be used as a timer.
+
+SinkBinding is also supported, which allows you to connect core Kubernetes resources such as Deployment, Job, or StatefulSet with a sink.
+
+You can create and manage Knative event source using the **Developer** perspective in the web console, the `kn` CLI, or by applying YAML files.
+
+.Prerequisites
+
+* You must have a current installation of xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#serverless-install-web-console_installing-openshift-serverless[{ServerlessProductName}], including Knative Serving and Eventing, in your {product-title} cluster. This can be installed by a cluster administrator.
+
+[id="knative-event-sources-create"]
+== Creating event sources
+
+* Create an xref:../../serverless/event_sources/serverless-apiserversource.adoc#serverless-apiserversource[ApiServerSource].
+* Create an xref:../../serverless/event_sources/serverless-pingsource.adoc#serverless-pingsource[PingSource].
+// add others
+
+[id="knative-event-sources-additional-resources"]
+== Additional resources
+* For more information about Knative Eventing workflows using {ServerlessProductName}, see xref:../../serverless/knative_eventing/serverless-knative-eventing.adoc#serverless-knative-eventing[How Knative Eventing works].

--- a/serverless/knative_eventing/serverless-knative-eventing.adoc
+++ b/serverless/knative_eventing/serverless-knative-eventing.adoc
@@ -15,6 +15,7 @@ Event-driven architecture is based on the concept of decoupled relationships bet
 
 For more information about event-driven architecture, see link:https://www.redhat.com/en/topics/integration/what-is-event-driven-architecture[What is event-driven architecture?]
 
+[id="serverless-knative-eventing-workflows"]
 == Knative Eventing workflows
 
 In a Knative Eventing workflow, _event producers_ send information to an event source about changes to system state. Examples of event producers include a Kafka cluster or the Kubernetes API server.
@@ -31,6 +32,7 @@ Examples of sinks are Knative services and channels. Events can also be sent to:
 * A _broker_, where they can be filtered using _triggers_ before being sent to a sink. Using the broker and trigger together enables an event delivery mechanism that hides the details of event routing from the event producer and event consumer.
 * A _channel_, where Knative services can "subscribe" to receive events of a certain type.
 
+[id="serverless-knative-eventing-additional-resources"]
 == Additional resources
 
 * For more information about brokers, see xref:../knative_eventing/serverless-using-brokers.adoc#serverless-using-brokers[Using brokers].

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -8,8 +8,6 @@ toc::[]
 
 For an overview of {ServerlessProductName} functionality, see xref:../serverless/serverless-getting-started.adoc#serverless-getting-started[Getting started with OpenShift Serverless].
 
-include::modules/serverless-getting-support.adoc[leveloffset=+1]
-
 :FeatureName: Knative Eventing
 include::modules/technology-preview.adoc[leveloffset=+1]
 
@@ -27,5 +25,5 @@ include::modules/serverless-rn-1-5-0.adoc[leveloffset=+1]
 
 * For details about the latest Knative Serving release, see the link:https://github.com/knative/serving/releases[Knative Serving releases page].
 * For details about the latest Knative Serving Operator release, see the link:https://github.com/knative/serving-operator/releases[Knative Serving Operator releases page].
-* For details about the latest Knative CLI release, see the link:https://github.com/knative/client/releases[Knative client releases page].
+* For details about the latest Knative CLI release, see the link:https://github.com/knative/client/releases[Knative CLI releases page].
 * For details about the latest Knative Eventing release, see the link:https://github.com/knative/eventing/releases[Knative Eventing releases page].

--- a/serverless/serverless-support.adoc
+++ b/serverless/serverless-support.adoc
@@ -6,6 +6,11 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/serverless-getting-support.adoc[leveloffset=+1]
+
+[id="serverless-support-gather-info_{context}"]
+== Gathering diagnostic information for support
+
 When opening a support case, it is helpful to provide debugging
 information about your cluster to Red Hat Support.
 
@@ -16,5 +21,5 @@ The `must-gather` tool enables you to collect diagnostic information about your
 For prompt support, supply diagnostic information for both {product-title}
 and {ServerlessProductName}.
 
-include::modules/about-must-gather.adoc[leveloffset=+1]
-include::modules/serverless-about-collecting-data.adoc[leveloffset=+1]
+include::modules/about-must-gather.adoc[leveloffset=+2]
+include::modules/serverless-about-collecting-data.adoc[leveloffset=+2]


### PR DESCRIPTION
Updating OCP 4.3 Serverless docs to align with master topicmap and content.