### PR TITLE
shifting install TOC

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -257,11 +257,6 @@ Topics:
     File: installing-restricted-networks-vsphere
   - Name: Uninstalling a cluster on vSphere that uses installer-provisioned infrastructure
     File: uninstalling-cluster-vsphere-installer-provisioned
-- Name: Troubleshooting installation issues
-  File: installing-troubleshooting
-- Name: Support for FIPS cryptography
-  File: installing-fips
-  Distros: openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-online
 - Name: Installation configuration
   Dir: install_config
   Topics:
@@ -279,6 +274,11 @@ Topics:
   - Name: Configuring a private cluster
     Distros: openshift-enterprise,openshift-webscale,openshift-origin
     File: configuring-private-cluster
+- Name: Troubleshooting installation issues
+  File: installing-troubleshooting
+- Name: Support for FIPS cryptography
+  File: installing-fips
+  Distros: openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-online    
 ---
 Name: Updating clusters
 Dir: updating
@@ -497,7 +497,7 @@ Topics:
 #  File: configuring-networkpolicy
 - Name: Network policy
   Dir: network_policy
-  Topics: 
+  Topics:
   - Name: About network policy
     File: about-network-policy
   - Name: Creating a network policy


### PR DESCRIPTION
@vikram-redhat, Stephanie asked if it would be possible to reorganize the portal "installing" book so that the troubleshooting assembly wasn't first. I think that this shift should do it. Will you PTAL? 