### PR TITLE
BZ-1854318 Fixed codeblock callout text (PR for 4.4 docs)

### DIFF
--- a/modules/cnv-example-bond-nncp.adoc
+++ b/modules/cnv-example-bond-nncp.adoc
@@ -6,7 +6,7 @@
 = Example: Bond interface NodeNetworkConfigurationPolicy
 
 Create a bond interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest
-to the cluster. 
+to the cluster.
 
 [NOTE]
 ====
@@ -43,20 +43,20 @@ spec:
         options:
           miimon: '140' <11>
         slaves: <12>
-        - eth1 
+        - eth1
         - eth2
       mtu: 1450 <13>
 ----
-<1> Name of the Policy. 
+<1> Name of the Policy.
 <2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
 <4> Name of the interface.
 <5> Optional. Human-readable description of the interface.
-<6> The type of interface. This example creates a bond. 
+<6> The type of interface. This example creates a bond.
 <7> The requested state for the interface after creation.
-<8> Optional. If you do not use `dhcp` you must specify static IP address for the interface.
+<8> Optional. If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
 <9> Enables `ipv4` in this example.
 <10> The driver mode for the bond. This example uses an active backup mode.
 <11> Optional. This example uses miimon to inspect the bond link every 140ms.
-<12> The subordinate node NICs in the bond. 
-<13> Optional. The maximum transmission unit (MTU) for the bond. If not specified, this value is set to `1500` by default. 
+<12> The subordinate node NICs in the bond.
+<13> Optional. The maximum transmission unit (MTU) for the bond. If not specified, this value is set to `1500` by default.

--- a/modules/cnv-example-bridge-nncp.adoc
+++ b/modules/cnv-example-bridge-nncp.adoc
@@ -6,7 +6,7 @@
 = Example: Linux bridge interface NodeNetworkConfigurationPolicy
 
 Create a Linux bridge interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest
-to the cluster. 
+to the cluster.
 
 The following YAML file is an example of a manifest for a Linux bridge interface.
 It includes samples values that you must replace with your own information.
@@ -36,14 +36,14 @@ spec:
           port:
             - name: eth1 <11>
 ----
-<1> Name of the Policy. 
+<1> Name of the Policy.
 <2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
 <4> Name of the interface.
 <5> Optional. Human-readable description of the interface.
 <6> The type of interface. This example creates a bridge.
 <7> The requested state for the interface after creation.
-<8> Optional. If you do not use `dhcp` you must specify static IP address for the interface.
+<8> Optional. If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
 <9> Enables `ipv4` in this example.
 <10> Disables `stp` in this example.
 <11> The node NIC to which the bridge attaches.


### PR DESCRIPTION
BZ-1854318 https://bugzilla.redhat.com/show_bug.cgi?id=1854318

This PR implements the same changes suggested in #23951 for 4.4 docs. Separate PR required due to file name prefix change (cnv -> virt)

Fixed text for codeblock callout <8> to remove the static IP address requirement for the interface


