### PR TITLE
BZ-1851054 Fixed CLI secondary network attachment procedure for 4.4 docs

### DIFF
--- a/modules/cnv-creating-bridge-nad-cli.adoc
+++ b/modules/cnv-creating-bridge-nad-cli.adoc
@@ -30,7 +30,7 @@ metadata:
 spec:
   config: '{
     "cniVersion": "0.3.1",
-    "name": "cnv-bridge-conf", <2>
+    "name": "a-bridge-network", <2>
     "plugins": [
       {
         "type": "cnv-bridge", <3>
@@ -44,7 +44,7 @@ spec:
 ----
 <1> If you add this annotation to your NetworkAttachmentDefinition, your virtual machine instances
 will only run on nodes that have the `br0` bridge connected.
-<2> Required. A name for the configuration.
+<2> Required. A name for the configuration. It is recommended to match the configuration name to the `name` value of the NetworkAttachmentDefinition.
 <3> The actual name of the Container Network Interface (CNI) plug-in that provides
 the network for this NetworkAttachmentDefinition. Do not change this field unless
 you want to use a different CNI.
@@ -56,7 +56,7 @@ $ oc create -f <resource_spec.yaml>
 ----
 
 . Edit the configuration file of a virtual machine or virtual machine instance that you want to connect to the
-bridge network:
+bridge network, for example:
 +
 [source,yaml]
 ----
@@ -64,13 +64,33 @@ apiVersion: v1
 kind: VirtualMachine
 metadata:
   name: example-vm
-  annotations:
-    k8s.v1.cni.cncf.io/networks: a-bridge-network <1>
 spec:
-...
+  domain:
+    devices:
+      interfaces:
+        - masquerade: {}
+          name: default
+        - bridge: {}
+          name: bridge-net <1>
+  ...
+
+  networks:
+    - name: default
+      pod: {}
+    - name: bridge-net <1>
+      multus:
+        networkName: a-bridge-network <2>
+  ...
 ----
-<1> You must substitute the actual `name` value from the
+<1> The `name` value for the bridge interface and network must be the same.
+<2> You must substitute the actual `name` value from the
 NetworkAttachmentDefinition.
++
+[NOTE]
+====
+The virtual machine instance will be connected to both the `default` Pod network and `bridge-net`, which is
+defined by a NetworkAttachmentDefinition named `a-bridge-network`.
+====
 
 . Apply the configuration file to the resource:
 +


### PR DESCRIPTION
BZ-1851054 https://bugzilla.redhat.com/show_bug.cgi?id=1851054

PR implements changes suggested in #23551 for the enterprise-4.4 branch

Fixed CLI procedure to connect VM to secondary network

