### PR TITLE
CNV+OCP rel_not SRIOV bz1859231

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1927,6 +1927,10 @@ must prefix any custom MachineConfig file with a differing priority of `98-`
 instead of `99-`.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826150[*BZ#1826150*])
 
+* If you do not specify an IPAM configuration in the SriovNetwork configuration, the NetworkAttachmentDefinition is not created.
+As a workaround, you must include an empty `ipam: {}` parameter in the SriovNetwork configuration.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1859231[*BZ#1859231*])
+
 [id="ocp-4-5-asynchronous-errata-updates"]
 == Asynchronous errata updates
 

--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -103,6 +103,10 @@ from being inadvertently started before an upload has completed.
 //https://bugzilla.redhat.com/show_bug.cgi?id=1855067 - Requested doc text for this defect.
 //https://bugzilla.redhat.com/show_bug.cgi?id=1835426 - Requested doc text for this defect.
 
+* If you do not specify an IPAM configuration in the SriovNetwork configuration, the NetworkAttachmentDefinition is not created.
+As a workaround, you must include an empty `ipam: {}` parameter in the SriovNetwork configuration.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1859231[*BZ#1859231*])
+
 * KubeMacPool is disabled in {VirtProductName} {VirtVersion}. This means that a secondary
 interface of a Pod or virtual machine obtains a randomly generated MAC address rather
 than a unique one from a pool. Although rare, randomly assigned MAC addresses can conflict.


### PR DESCRIPTION
New Known Issue that impacts the SRIOV operator. Adding RN for both virt and OCP.
(This RN was brought to my attention on the virt SRIOV docs PR #23160)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1859231

No preview build but hopefully screenshot of local build will suffice:
Virt:
![Screenshot from 2020-07-23 13-19-08](https://user-images.githubusercontent.com/17755748/88281233-9787ea00-cce7-11ea-8bfa-fe2654fabdd4.png)

OCP: 
![Screenshot from 2020-07-23 13-22-23](https://user-images.githubusercontent.com/17755748/88281249-9f478e80-cce7-11ea-8755-e5c94d93a16f.png)

FYI @lmandavi @vikram-redhat 