### PR TITLE
Release Notes for Storage, Web UI, API

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -73,6 +73,7 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 * You can now configure the *Volume Mode* and *Access Mode* for a virtual disk when you xref:../virt/virtual_machines/virt-edit-vms.adoc#virt-vm-add-disk_virt-edit-vms[add a disk to a virtual machine] in the web console. This is also possible when adding a disk to a xref:../virt/virtual_machines/virt-create-vms.adoc#virt-creating-vm-wizard-web_virt-create-vms[new virtual machine using the wizard].
 
 //CNV-5422 - CNV support for Ceph-based OCS 4.4.
+* Using OpenShift Container Storage (OCS) with {VirtProductName} gives you the benefits of fault-tolerant storage and the ability to live migrate between nodes.
 
 //CNV-5423 - CDI support for namespaces that are restricted by resource quotas.
 * You can now use the Containerized Data Importer (CDI) to import, upload, and clone virtual machine disks into namespaces
@@ -83,13 +84,17 @@ the resource limits applied to CDI worker Pods.
 * The `virtctl` tool can now use a `DataVolume` when uploading virtual machine disks to the cluster. This helps prevent virtual machines
 from being inadvertently started before an upload has completed.
 
-//CNV-5421 - DataVolumes have been enhanced with conditions that make it easier to understand the state of VM disk import, clone, and upload.
+//CNV-5421 - OpenShift Container Storage (OCS) DataVolumes
+* OpenShift Container Storage DataVolumes have been enhanced with conditions and events that make it easier to understand the state of virtual disk imports, clones, and upload operations.
+Conditions and events also simplify troubleshooting.
 
 [id="virt-2-4-web-new"]
 === Web console
 //Placeholder for new content.
 
 //CNV-5275 - Update template designs - virtual machines and virtual machine templates merged under one menu called Virtualization.
+* In the web console, the sidebar items *Virtual Machines* and *Virtual Machine Templates* have been replaced by a
+single sidebar menu item labeled *Virtualization*. When you click *Virtualization*, you have access to two tabs: *Virtual Machines* and *Virtual Machine Templates*.
 
 //CNV-5272 - Configure scheduling directly from CNV UI.
 * You can now configure the scheduling properties of virtual machines by accessing the *Scheduling and resources requirements* section of the *Virtual Machine Details* page. For example, you can view and manage affinity rules, dedicated resources, and tolerations for tainted nodes. You can also search for nodes with labels that match specific key/value pairs by using the *Node Selector*.
@@ -106,6 +111,9 @@ from being inadvertently started before an upload has completed.
 
 //CNV-5371 - Import existing virtual machines from Red Hat Virtualization to OpenShift Virtualization.
 * You can import a single Red Hat Virtualization virtual machine by using the virtual machine wizard or the CLI.
+
+//CNV-5463 - New API Subgroup for Virt
+* Every component in {VirtProductName} now uses its own API subgroup, `<component_name>.kubevirt.io`.
 
 [id="virt-2-4-known-issues"]
 == Known issues
@@ -187,4 +195,5 @@ nodes.
 running either `oc adm drain` or `kubectl drain`. Do not run these commands on
 the nodes of any clusters where {VirtProductName} is deployed. The nodes might not
 drain if there are virtual machines running on top of them.
+
 The current solution is to xref:../virt/node_maintenance/virt-setting-node-maintenance.adoc#virt-setting-node-maintenance[put nodes into maintenance].


### PR DESCRIPTION
This PR contains release notes for the following four stories:

[CNV-5422](https://issues.redhat.com/browse/CNV-5422) - CNV support for Ceph-based OCS 4.4.
* Using OpenShift Container Storage with OpenShift Virtualization allows you to realize the benefits of fault-tolerant storage while retaining the ability to live-migrate between nodes in a cluster. **Code and QE approved**

[CNV-5421](https://issues.redhat.com/browse/CNV-5421) - DataVolumes have been enhanced with conditions that make it easier to understand the state of VM disk import, clone, and upload.
* OpenShift Container Storage (OCS)  DataVolumes have been enhanced with conditions and events that make it easier to understand the state of virtual disk imports, clones, and upload operations.
Conditions and events also simplify troubleshooting.  **Code and QE approved**

[CNV-5275](https://issues.redhat.com/browse/CNV-5275) - Update template designs - virtual machines and virtual machine templates merged under one menu called Virtualization.
* On the Web console, the two sidebar menu items *Virtual Machines* and "Virtual Machine Templates" are replaced by a
single sidebar menu item labeled *Virtualization*. When you click *Virtualization*, you have access to two tabs: *Virtual Machines* and *Virtual Machine Templates*. **Code and QE approved**

[CNV-5463](https://issues.redhat.com/browse/CNV-5463) - New API Subgroup for Virt
* Every component in {VirtProductName} now uses its own API sub-group, `<component_name>.kubevirt.io`. **Code and QE approved**

Test Build: http://file.bos.redhat.com/bgaydos/072320_2/virt/virt-2-4-release-notes.html

Please label *Peer review needed* and *enterprise-4.5* ONLY.

Thanks,
Bob