### PR TITLE
Fix footnotes in 3.11 Arch TLS support

### DIFF
--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -220,14 +220,14 @@ suites enabled.
 |Unsupported
 
 |TLS 1.0
-|No footnoteref:tlsconfig[Disabled by default, but can be enabled in the server configuration.]
-|No footnoteref:tlsconfig[]
-|Maybe footnoteref:otherclient[Some internal clients, such as the LDAP client.]
+|No ^[1]^
+|No ^[1]^
+|Maybe ^[2]^
 
 |TLS 1.1
-|No footnoteref:tlsconfig[]
-|No footnoteref:tlsconfig[]
-|Maybe footnoteref:otherclient[]
+|No ^[1]^
+|No ^[1]^
+|Maybe ^[2]^
 
 |TLS 1.2
 |*Yes*
@@ -235,10 +235,16 @@ suites enabled.
 |*Yes*
 
 |TLS 1.3
-|N/A footnoteref:tls13[TLS 1.3 is still under development.]
-|N/A footnoteref:tls13[]
-|N/A footnoteref:tls13[]
+|N/A ^[3]^
+|N/A ^[3]^
+|N/A ^[3]^
 |===
+[.small]
+--
+1. Disabled by default, but can be enabled in the server configuration.
+2. Some internal clients, such as the LDAP client.
+3. TLS 1.3 is still under development.
+--
 
 The following list of enabled cipher suites of {product-title}'s server and `oc`
 client are sorted in preferred order:


### PR DESCRIPTION
Prevew (internal):

http://file.rdu.redhat.com/~adellape/072420/311_footnotes/architecture/#arch-index-how-is-it-secured-tls