### PR TITLE
BZ-1857788 Added note about workaround for VMs using HPP

### DIFF
--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -37,3 +37,12 @@ used to manage the virtual machine process.
 
 * DataVolumes and their associated PersistentVolumeClaims are preserved during
 upgrade.
++
+[IMPORTANT]
+====
+If you have virtual machines running that cannot be live migrated, they might block an {product-title} cluster upgrade.
+This includes virtual machines that use hostpath provisioner storage or SR-IOV network interfaces.
+
+As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster upgrade. Remove the `evictionStrategy: LiveMigrate` field and
+set the `runStrategy` field to `Always`. Learn more about xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[configuring virtual machine eviction strategy].
+====


### PR DESCRIPTION
BZ-1857788 https://bugzilla.redhat.com/show_bug.cgi?id=1857788

Added a note to remove evictionStrategy: LiveMigrate and use runStrategy: Always for VMs using hostpath-provisioner or SR-IOV network interfaces as a workaround for cluster upgrade issue

Preview build: https://bz-1857788--ocpdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#how-openshift-virtualization-upgrades-affect-your-cluster

Tagging @aglitke for SME review
Tagging @rnetser for QE review

Merge/CP to enterprise-4.5 and enterprise-4.6