### PR TITLE
BZ 1851760: cloning between volume modes

### DIFF
--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
@@ -8,6 +8,13 @@ You can clone the PersistentVolumeClaim (PVC) of a virtual machine disk into
 a new block DataVolume by referencing the source PVC in your DataVolume configuration
 file.
 
+[WARNING]
+====
+Cloning operations between different volume modes are not supported. The `volumeMode` values must match in both the source and target specifications.
+
+For example, if you attempt to clone from a PersistentVolume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`, the operation fails with an error message.
+====
+
 == Prerequisites
 
 * Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
@@ -8,6 +8,13 @@ You can clone the PersistentVolumeClaim (PVC) of a virtual machine disk into
 a new DataVolume by referencing the source PVC in your DataVolume configuration
 file.
 
+[WARNING]
+====
+Cloning operations between different volume modes are not supported. The `volumeMode` values must match in both the source and target specifications.
+
+For example, if you attempt to clone from a PersistentVolume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`, the operation fails with an error message.
+====
+
 == Prerequisites
 
 * Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
@@ -8,6 +8,13 @@ You can create a new virtual machine by cloning the PersistentVolumeClaim (PVC) 
 an existing VM. By including a `dataVolumeTemplate` in your virtual machine
 configuration file, you create a new DataVolume from the original PVC.
 
+[WARNING]
+====
+Cloning operations between different volume modes are not supported. The `volumeMode` values must match in both the source and target specifications.
+
+For example, if you attempt to clone from a PersistentVolume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`, the operation fails with an error message.
+====
+
 == Prerequisites
 
 * Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1851760

Preview build: https://cloning-volume-modes--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.html

enterprise-4.5, 4.6