### PR TITLE
Fix static IP address examples

### DIFF
--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -76,7 +76,7 @@ spec:
         type: static
         staticIPAMConfig:
           addresses:
-          - address: 10.1.1.0/24
+          - address: 10.1.1.7
 ----
 endif::yaml[]
 ifdef::json[]
@@ -103,7 +103,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.1/24"
+            "address": "191.168.1.7"
           }
         ]
       }
@@ -152,7 +152,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.1/24"
+            "address": "191.168.1.7"
           }
         ]
       }

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -159,7 +159,7 @@ You can configure ipam for static IP address assignment:
     "type": "static",
       "addresses": [
         {
-          "address": "191.168.1.1/24"
+          "address": "191.168.1.7"
         }
       ]
   }
@@ -270,15 +270,15 @@ ipamConfig:
   type: static
   staticIPAMConfig:
     addresses:
-    - address: 198.51.100.11/24
-      gateway: 198.51.100.10
+    - address: 10.51.100.11
+      gateway: 10.51.100.10
     routes:
     - destination: 0.0.0.0/0
-      gateway: 198.51.100.1
+      gateway: 10.51.100.1
     dns:
       nameservers:
-      - 198.51.100.1
-      - 198.51.100.2
+      - 10.51.100.1
+      - 10.51.100.2
       domain: testDNS.example
       search:
       - testdomain1.example


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1812128

This is for 4.4 and 4.3 only. It's already fixed in 4.5+.

@zshi-redhat, this specifies a single static IP address instead of incorrectly using a CIDR range. Can you verify this?

Thanks!