### PR TITLE
Noting auto cert recovery was introduced in 4.4.8

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -488,7 +488,7 @@ Builds and imagestream imports will automatically use the pull secret used to in
 [id="ocp-4-5-auto-cert-recovery"]
 ==== Automatic control plane certificate recovery
 
-{product-title} can now automatically recover from expired control plane certificates. The exception is that you must manually approve pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates.
+First introduced in {product-title} 4.4.8, {product-title} can now automatically recover from expired control plane certificates. The exception is that you must manually approve pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates.
 
 See xref:../backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-scenario-3-recovering-expired-certs_dr-recovering-expired-certs[Recovering from expired control plane certificates] for more information.
 


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~ahoffer/2020/adjust-45-cert-recovery/release_notes/ocp-4-5-release-notes.html#ocp-4-5-disaster-recovery