### PR TITLE
BZ-1857790 Added note about live migration of VMs using HPP

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -31,3 +31,13 @@
 1. PVCs must request a ReadWriteMany access mode
 2. PVCs must request a ReadWriteOnce access mode
 --
+
+[NOTE]
+====
+You cannot live migrate virtual machines that use:
+
+* A storage class with ReadWriteOnce (RWO) access mode
+* Passthrough features such as SRI-OV and GPU
+
+Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
+====


### PR DESCRIPTION
BZ-1857790 https://bugzilla.redhat.com/show_bug.cgi?id=1857790

Added an explicit note about live migration of VMs created from common templates and using HPP or another storage class with RWO access mode as well as passthrough features such as SRI-OV and GPU.

Preivew build: https://bz-1857790--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-features-for-storage.html#virt-features-for-storage-matrix_virt-features-for-storage

Tagging @aglitke for SME review
Tagging @rnetser for QE review

Merge/CP to enterprise-4.5 and enterprise-4.6