### PR TITLE
Update container catalog terminology

### DIFF
--- a/architecture/understanding-development.adoc
+++ b/architecture/understanding-development.adoc
@@ -173,7 +173,7 @@ Red Hat Registry. The Red Hat Registry is represented by two locations:
 `registry.access.redhat.com`, which is unauthenticated and deprecated, and
 `registry.redhat.io`, which requires authentication. You can learn about the Red
 Hat and partner images in the Red Hat Registry from the
-link:https://registry.redhat.io/[Red Hat Container Catalog].
+link:https://catalog.redhat.com/software/containers/explore[Container images section of the Red Hat Ecosystem Catalog].
 Besides listing Red Hat container images, it also shows extensive information
 about the contents and quality of those images, including health scores that are
 based on applied security updates.

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -99,9 +99,9 @@ ifdef::openshift-origin[]
 +
 If you do not use the pull secret from the {cloud-redhat-com} site:
 +
-* Red Hat Operators are not available. 
+* Red Hat Operators are not available.
 * The Telemetry and Insights operators do not send data to Red Hat.
-* Content from the link:https://registry.redhat.io/[Red Hat Container Catalog] registry, such as image streams and Operators, are not available. 
+* Content from the link:https://catalog.redhat.com/software/containers/explore[Red Hat Ecosystem Catalog Container images] registry, such as image streams and Operators, are not available.
 endif::openshift-origin[]
 
 ifeval::["{context}" == "installing-ibm-z"]

--- a/modules/registry-authentication-enabled-registry-overview.adoc
+++ b/modules/registry-authentication-enabled-registry-overview.adoc
@@ -5,7 +5,7 @@
 [id="registry-authentication-enabled-registry-overview_{context}"]
 = Authentication enabled Red Hat registry
 
-All container images available through the Red Hat Container Catalog are hosted
+All container images available through the Container images section of the Red Hat Ecosystem Catalog are hosted
 on an image registry, `registry.redhat.io`.
 
 The registry, `registry.redhat.io`, requires authentication for access to

--- a/modules/security-container-content-external-scanning.adoc
+++ b/modules/security-container-content-external-scanning.adoc
@@ -149,15 +149,15 @@ vulnerability summary data and a compliance boolean:
 ----
 
 This example shows the
-link:https://catalog.redhat.com/software/containers/explore[Red Hat Container Catalog]
+link:https://catalog.redhat.com/software/containers/explore[Container images section of the Red Hat Ecosystem Catalog]
 annotation for an image with health index data
 with an external URL for additional details:
 
-.Red Hat Container Catalog annotation
+.Red Hat Ecosystem Catalog annotation
 [source,json]
 ----
 {
-  "name": "Red Hat Container Catalog",
+  "name": "Red Hat Ecosystem Catalog",
   "description": "Container health index",
   "timestamp": "2016-09-08T05:04:46Z",
   "reference": "https://access.redhat.com/errata/RHBA-2016:1566",
@@ -188,7 +188,7 @@ Replace `<image>` with an image digest, for example
 ----
 $ oc annotate image <image> \
     quality.images.openshift.io/vulnerability.redhatcatalog='{ \
-    "name": "Red Hat Container Catalog", \
+    "name": "Red Hat Ecosystem Catalog", \
     "description": "Container health index", \
     "timestamp": "2020-06-01T05:04:46Z", \
     "compliant": null, \
@@ -249,7 +249,7 @@ The following is an example of `PATCH` payload data:
 "metadata": {
   "annotations": {
     "quality.images.openshift.io/vulnerability.redhatcatalog":
-       "{ 'name': 'Red Hat Container Catalog', 'description': 'Container health index', 'timestamp': '2020-06-01T05:04:46Z', 'compliant': null, 'reference': 'https://access.redhat.com/errata/RHBA-2020:2347', 'summary': [{'label': 'Health index', 'data': '4', 'severityIndex': 1, 'reference': null}] }"
+       "{ 'name': 'Red Hat Ecosystem Catalog', 'description': 'Container health index', 'timestamp': '2020-06-01T05:04:46Z', 'compliant': null, 'reference': 'https://access.redhat.com/errata/RHBA-2020:2347', 'summary': [{'label': 'Health index', 'data': '4', 'severityIndex': 1, 'reference': null}] }"
     }
   }
 }

--- a/modules/security-registries-ecosystem.adoc
+++ b/modules/security-registries-ecosystem.adoc
@@ -30,10 +30,10 @@ the Red Hat Ecosystem Catalog. Because containers consume software provided by R
 Hat and the errata process, old, stale containers are insecure whereas new,
 fresh containers are more secure.
 
-To illustrate the age of containers, the Red Hat Container Catalog uses a
+To illustrate the age of containers, the Red Hat Ecosystem Catalog uses a
 grading system. A freshness grade is a measure of the oldest and most severe
 security errata available for an image. "A" is more up to date than "F". See
-link:https://access.redhat.com/articles/2803031[Container Health Index grades as used inside the Red Hat Container Catalog] for more details on this grading system.
+link:https://access.redhat.com/articles/2803031[Container Health Index grades as used inside the Red Hat Ecosystem Catalog] for more details on this grading system.
 
 Refer to the link:https://access.redhat.com/security/[Red Hat Product Security Center]
 for details on security updates and vulnerabilities related to Red Hat software.

--- a/modules/virt-adding-virtio-drivers-vm-yaml.adoc
+++ b/modules/virt-adding-virtio-drivers-vm-yaml.adoc
@@ -10,7 +10,7 @@
 
 {VirtProductName} distributes VirtIO drivers for Microsoft Windows as a
 container disk, which is available from the
-link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Container Catalog].
+link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Ecosystem Catalog].
 To install these drivers to a Windows virtual machine, attach the
 `container-native-virtualization/virtio-win` container disk to the virtual machine as a SATA CD drive
 in the virtual machine configuration file.
@@ -18,7 +18,7 @@ in the virtual machine configuration file.
 .Prerequisites
 
 * Download the `container-native-virtualization/virtio-win` container disk from the
-link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Container Catalog].
+link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Ecosystem Catalog].
 This is not mandatory, because the container disk will be downloaded from the Red Hat registry
 if it not already present in the cluster, but it can reduce installation time.
 

--- a/modules/virt-understanding-virtio-drivers.adoc
+++ b/modules/virt-understanding-virtio-drivers.adoc
@@ -11,7 +11,7 @@
 VirtIO drivers are paravirtualized device drivers required for Microsoft Windows
  virtual machines to run in {VirtProductName}. The supported drivers are
 available in the `container-native-virtualization/virtio-win` container disk of the
-link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Container Catalog].
+link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Ecosystem Catalog].
 
 The `container-native-virtualization/virtio-win` container disk must be attached to the virtual machine as a
 SATA CD drive to enable driver installation. You can install VirtIO drivers during

--- a/openshift_images/using_images/using-images-overview.adoc
+++ b/openshift_images/using_images/using-images-overview.adoc
@@ -20,9 +20,7 @@ repositories on the Red Hat Registry but suffixed with a `-openshift`. For
 example, `registry.redhat.io/jboss-eap-6/eap64-openshift` is the name of the
 JBoss EAP image.
 
-All Red Hat supported images covered in this section are described in the Red Hat
-Container Catalog. For every version of each image, you can find details on its
-contents and usage. Browse or search for the image that interests you.
+All Red Hat supported images covered in this section are described in the link:https://catalog.redhat.com/software/containers/explore[Container images section of the Red Hat Ecosystem Catalog]. For every version of each image, you can find details on its contents and usage. Browse or search for the image that interests you.
 
 [IMPORTANT]
 ====

--- a/welcome/oce_about.adoc
+++ b/welcome/oce_about.adoc
@@ -134,7 +134,7 @@ and both cluster-level and tenant-level Prometheus monitoring metrics and events
 
 === Maintained and curated content
 With an {oce} subscription, you receive access to the {product-title} entitled
-content from the Red Hat Container Catalog and Red Hat Connect ISV marketplace.
+content from the Red Hat Ecosystem Catalog and Red Hat Connect ISV marketplace.
 You can access all maintained and curated content that the {product-title}
 eco-system offers either for free, such as the Red Hat Software Collections,
 or through additional purchases. The Kubernetes service broker, service catalog,
@@ -291,7 +291,7 @@ h| Yes
 h| Yes
 
 .3+|
-| Red Hat Container Catalog access
+| Red Hat Ecosystem Catalog access
 | Yes
 | Yes
 

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -152,7 +152,7 @@ and cluster-level Prometheus monitoring metrics and events.
 
 === Maintained and curated content
 With an {oke} subscription, you receive access to the {product-title}
-content from the Red Hat Container Catalog and Red Hat Connect ISV marketplace.
+content from the Red Hat Ecosystem Catalog and Red Hat Connect ISV marketplace.
 You can access all maintained and curated content that the {product-title}
 eco-system offers.
 


### PR DESCRIPTION
This PR is intended to update the appropriate Red Hat Container Catalog terminology to reflect the change to Red Hat Ecosystem Catalog. 

Previews: 
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/architecture/understanding-development.html
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/registry/registry-options.html
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/security/container_security/security-container-content.html
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/security/container_security/security-registries.html
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-installing-virtio-drivers-on-existing-windows-vm.html
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-installing-virtio-drivers-on-new-windows-vm.html
https://deploy-preview-24205--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/using_images/using-images-overview.html

This is a terminology update only. No QE review required.  