### PR TITLE
CNV-3944_3 - Document how to recycle NFS PVs

### DIFF
--- a/modules/virt-about-reclaiming-persistent-volumes.adoc
+++ b/modules/virt-about-reclaiming-persistent-volumes.adoc
@@ -10,5 +10,7 @@ When you reclaim a persistent volume (PV), you unbind the PV from a persistent v
 and delete the data in the network share. Finally, you bind the PV to a new PVC to
 prepare the volume for reuse.
 
-Kubernetes no longer recommends setting the Storage Class `reclaimPolicy`
-to `recycle` for persistent volume reclamation.
+[IMPORTANT]
+====
+The `Recycle` reclaim policy is deprecated in {product-title} 4.
+====

--- a/modules/virt-reclaiming-persistent-volumes-for-binding-to-a-new-persistent-volume.adoc
+++ b/modules/virt-reclaiming-persistent-volumes-for-binding-to-a-new-persistent-volume.adoc
@@ -9,7 +9,7 @@
 Use this procedure to reclaim a statically-provisioned persistent volume for reuse.
 
 .Procedure
-. Export the PV configuration for future use:
+. Export the PV configuration for future use, and edit the YAML file if needed:
 +
 ----
 $ oc get pv <pv_name> -o yaml > <file_name>.yaml
@@ -21,8 +21,8 @@ you want to reclaim. Save the output for future reference.
 ----
 $ oc describe pv <pv_name>
 ----
-. Review the `storageClass` object. Verify that the Storage Class `reclaimPolicy` is set to `delete`.
-If it is not, create a new `storageClass` object with `reclaimPolicy` set to `delete`.
+. Review the `StorageClass` object. Verify that the Storage Class `reclaimPolicy` is set to `delete`.
+If it is not, create a new `StorageClass` object with `reclaimPolicy` set to `delete`.
 
 . Enter the following command to verify that no other resources
 are using the persistent volume claim:


### PR DESCRIPTION
This PR contains the following changes recommended by Ying Cui of QE:

====================================================
1- In doc [1] you provided, here are small comments from my perspective.

"Kubernetes no longer recommends setting the Storage Class reclaimPolicy to recycle for persistent volume reclamation." -- It is downstream doc,  that is not ok we mention k8s stuff in d/s doc. let's rephrase this part, FYI OCP doc:  https://docs.openshift.com/container-platform/4.5/storage/understanding-persistent-storage.html

2- storageClass, should be StorageClass(100% match kinds)

3- $ oc get pv <pv_name> -o yaml > pv.yaml

should be "$ oc get pv <pv_name> -o yaml > <file_name>.yaml", and edit <file_name>.yaml file. 
===================================================

Please label *enterprise-4.5* and *enterprise-4.6*

Thanks

Bob 