### PR TITLE
Fix olm-metrics

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -750,6 +750,8 @@ Topics:
     File: olm-understanding-dependency-resolution
   - Name: OperatorGroups
     File: olm-understanding-operatorgroups
+  - Name: Metrics
+    File: olm-understanding-metrics
 - Name: Understanding OperatorHub
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
   File: olm-understanding-operatorhub
@@ -2152,7 +2154,7 @@ Topics:
       File: virt-attaching-vm-multiple-networks
     - Name: Configuring an SR-IOV network device for virtual machines
       File: virt-configuring-sriov-device-for-vms
-    - Name: Defining an SR-IOV network 
+    - Name: Defining an SR-IOV network
       File: virt-defining-an-sriov-network
     - Name: Attaching a virtual machine to an SR-IOV network
       File: virt-attaching-vm-to-sriov-network

--- a/modules/olm-metrics.adoc
+++ b/modules/olm-metrics.adoc
@@ -17,9 +17,10 @@ by the Prometheus-based {product-title} cluster monitoring stack.
 |Number of CatalogSources.
 
 |`csv_abnormal`
-|When reconciling a CSV, present whenever a CSV version is in any state other
-than `Succeeded`. Includes the `name`, `namespace`, `phase`, `reason`, and
-`version` labels. A Prometheus alert is created when this metric is present.
+|When reconciling a ClusterServiceVersion (CSV), present whenever a CSV version
+is in any state other than `Succeeded`, for example when it is not installed.
+Includes the `name`, `namespace`, `phase`, `reason`, and `version` labels. A
+Prometheus alert is created when this metric is present.
 
 |`csv_count`
 |Number of CSVs successfully registered.
@@ -30,7 +31,7 @@ state (value `1`) or not (value `0`). Includes the `name`, `namespace`, and
 `version` labels.
 
 |`csv_upgrade_count`
-|Monotonic count of CatalogSources.
+|Monotonic count of CSV upgrades.
 
 |`install_plan_count`
 |Number of InstallPlans.

--- a/operators/understanding_olm/olm-understanding-metrics.adoc
+++ b/operators/understanding_olm/olm-understanding-metrics.adoc
@@ -1,0 +1,8 @@
+[id="olm-understanding-metrics"]
+= Operator Lifecycle Manager metrics
+include::modules/common-attributes.adoc[]
+:context: olm-understanding-metrics
+
+toc::[]
+
+include::modules/olm-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/22480

Preview (internal): http://file.rdu.redhat.com/~adellape/072820/update_olm_metrics/operators/understanding_olm/olm-understanding-metrics.html

- Adds `olm-metrics` module back into build, as it was left out of the 4.5 OLM docs re-structure.
- Create `olm-understanding-metrics` assembly for `olm-metrics` module, instead of being part of `olm-understanding-olm` assembly as it was previously.
- Fix typo in `csv_upgrade_count` description per https://github.com/openshift/openshift-docs/issues/22480 (the other cited parameters had already been added per other work, after the issue was opened).