### PR TITLE
BZ1850510 - Update NFS registry storage docs

### DIFF
--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -26,6 +26,11 @@ ReadWriteMany access mode.
 . To configure your registry to use storage, change the `spec.storage.pvc` in
 the `configs.imageregistry/cluster` resource.
 +
+[NOTE]
+====
+When using shared storage such as NFS, it is strongly recommended to use the `supplementalGroups` strategy, which dictates the allowable supplemental groups for the Security Context, rather than the `fsGroup` ID. Refer to the NFS *Group IDs* documentation for details.
+====
+
 . Verify you do not have a registry Pod:
 +
 ----
@@ -34,13 +39,12 @@ $ oc get pod -n openshift-image-registry
 +
 [NOTE]
 =====
-If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
-If the storage type is `NFS`, and you want to scale up the registry Pod by setting
-`replica>1` you must enable the `no_wdelay` mount option. For example:
-
+* If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
+* If the storage type is `NFS`, you must enable the `no_wdelay` and `root_squash` mount options. For example:
++
 ----
 # cat /etc/exports
-/mnt/data *(rw,sync,no_wdelay,no_root_squash,insecure,fsid=0)
+/mnt/data *(rw,sync,no_wdelay,root_squash,insecure,fsid=0)
 sh-4.2# exportfs -rv
 exporting *:/mnt/data
 ----

--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -34,6 +34,11 @@ a different storage backend, such as `NFS`, to configure the registry storage.
 . To configure your registry to use storage, change the `spec.storage.pvc` in the
 `configs.imageregistry/cluster` resource.
 +
+[NOTE]
+====
+When using shared storage such as NFS, it is strongly recommended to use the `supplementalGroups` strategy, which dictates the allowable supplemental groups for the Security Context, rather than the `fsGroup` ID. Refer to the NFS *Group IDs* documentation for details.
+====
+
 . Verify you do not have a registry Pod:
 +
 ----
@@ -42,13 +47,12 @@ $ oc get pod -n openshift-image-registry
 +
 [NOTE]
 =====
-If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
-If the storage type is `NFS`, and you want to scale up the registry Pod by setting
-`replica>1` you must enable the `no_wdelay` mount option. For example:
-
+* If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
+* If the storage type is `NFS`, you must enable the `no_wdelay` and `root_squash` mount options. For example:
++
 ----
 # cat /etc/exports
-/mnt/data *(rw,sync,no_wdelay,no_root_squash,insecure,fsid=0)
+/mnt/data *(rw,sync,no_wdelay,root_squash,insecure,fsid=0)
 sh-4.2# exportfs -rv
 exporting *:/mnt/data
 ----

--- a/modules/storage-persistent-storage-nfs-group-ids.adoc
+++ b/modules/storage-persistent-storage-nfs-group-ids.adoc
@@ -1,7 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-nfs.adoc
+// * storage/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
 
+[id=storage-persistent-storage-nfs-group-ids_{context}]
 = Group IDs
 
 The recommended way to handle NFS access, assuming it is not an option to
@@ -13,8 +15,7 @@ Pod's `securityContext`.
 
 [NOTE]
 ====
-It is generally preferable to use supplemental group IDs to gain access to
-persistent storage versus using user IDs.
+To gain access to persistent storage, it is generally preferable to use supplemental group IDs versus user IDs.
 ====
 
 Because the group ID on the example target NFS directory

--- a/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
@@ -12,10 +12,12 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+1]
 
 include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+1]
 
+See xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#storage-persistent-storage-nfs-group-ids_persistent-storage-nfs[Group IDs] for additional details about using supplemental groups to handle NFS access.
+
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
 
 
 [id="configuring-registry-storage-baremetal-addtl-resources"]
 == Additional resources
 
-For more details on configuring registry storage for bare metal, see xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].
+For more details about configuring registry storage for bare metal, see xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].

--- a/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
@@ -12,6 +12,8 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+1]
 
+See xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#storage-persistent-storage-nfs-group-ids_persistent-storage-nfs[Group IDs] for additional details about using supplemental groups to handle NFS access.
+
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
 
 include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+1]
@@ -21,4 +23,4 @@ For instructions about configuring registry storage so that it references the co
 [id="configuring-registry-storage-vsphere-addtl-resources"]
 == Additional resources
 
-For more details on configuring registry storage for vSphere, see xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].
+For more details about configuring registry storage for vSphere, see xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].


### PR DESCRIPTION
[BZ1850510](https://bugzilla.redhat.com/show_bug.cgi?id=1850510) - Add link to Group IDs module for recommended info about using supplemental groups for NFS shared storage. And also update NFS example to use `root_squash` and `no_wdelay`. Applies to OCP 4.3+.

Preview links - step 2 note and example now include `root_squash` and supplemental group note is added in step 1: 

- https://bz1850510--ocpdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#registry-configuring-storage-baremetal_configuring-registry-storage-baremetal
- https://bz1850510--ocpdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-vsphere.html#installation-registry-storage-config_configuring-registry-storage-vsphere