### PR TITLE
CCXDEV-2501: Remove Tech Preview admonition from "Using Insights to identify issues with your cluster"

### DIFF
--- a/modules/displaying-potential-issues-with-your-cluster.adoc
+++ b/modules/displaying-potential-issues-with-your-cluster.adoc
@@ -5,7 +5,7 @@
 [id="displaying-potential-issues-with-your-cluster_{context}"]
 = Displaying potential issues with your cluster
 
-This section describes how to display the Insights report in the {cloud-redhat-com} beta instance.
+This section describes how to display the Insights report in the {cloud-redhat-com}.
 
 Note that Insights repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
 
@@ -13,7 +13,7 @@ Note that Insights repeatedly analyzes your cluster and shows the latest results
 
 * Your cluster is registered in the {cloud-redhat-com}.
 * Remote health reporting is enabled, which is the default.
-* You are logged in to the link:https://cloud.redhat.com/beta/openshift[{cloud-redhat-com} beta instance].
+* You are logged in to the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}].
 
 .Procedure
 

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -6,7 +6,4 @@ toc::[]
 
 Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report on the *Insights* tab of each cluster in {cloud-redhat-com}.
 
-:FeatureName: {cloud-redhat-com} Insights integration
-include::modules/technology-preview.adoc[leveloffset=+0]
-
 include::modules/displaying-potential-issues-with-your-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
The Insights tab is now available on the official OpenShift Cluster Manager (non-beta) instance.
Please apply this change to master, enterprise-4-5, and enterprise-4.6

@openshift/team-documentation