### PR TITLE
Add cluster and environment details

### DIFF
--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -44,7 +44,7 @@ AWS cloud platform:
 | 32
 | gp2 
 | 100 
-| 3/25/250/500/2000 footnoteref:[nodescaleaws,Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
+| 3/25/250/500 footnoteref:[nodescaleaws,Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.]
 | us-west-2
 
 |===

--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -19,6 +19,8 @@ include::modules/openshift-cluster-maximums-major-releases.adoc[leveloffset=+1]
 
 include::modules/openshift-cluster-maximums.adoc[leveloffset=+1]
 
+include::modules/openshift-cluster-maximums-environment.adoc[leveloffset=+1]
+
 include::modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc[leveloffset=+1]
 
 include::modules/how-to-plan-your-environment-according-to-application-requirements.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit adds information about the cluster and cloud platform
used for testing the performance and scalability of OCP 4.5.