### PR TITLE
Add --binary-image to opm docs

### DIFF
--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -20,10 +20,12 @@ You can create an index image using the `opm` CLI.
 ----
 $ opm index add \
     --bundles quay.io/<namespace>/test-operator:v0.1.0 \//<1>
-    --tag quay.io/<namespace>/test-catalog:latest <2>
+    --tag quay.io/<namespace>/test-catalog:latest \//<2>
+    [--binary-image <registry_base_image>] <3>
 ----
-<1> The bundle image to add to the index.
+<1> Comma-separated list of bundle images to add to the index.
 <2> The image tag that you want the index image to have.
+<3> Optional: An alternative registry base image to use for serving the catalog.
 
 . Push the index image to a registry:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1828811

Preview: https://binary_image--ocpdocs.netlify.app/openshift-enterprise/latest/operators/olm-managing-custom-catalogs.html#olm-creating-index-image_olm-managing-custom-catalogs