### PR TITLE
Fixing instances of `a {product-title}`

### DIFF
--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can customize and install a {product-title} cluster on {rh-virtualization-first}, similar to the one shown in the following diagram.
+You can customize and install an {product-title} cluster on {rh-virtualization-first}, similar to the one shown in the following diagram.
 
 image::92_OpenShift_Cluster_Install_RHV_0520.png[Diagram of an {product-title} cluster on a {rh-virtualization} cluster]
 

--- a/jaeger/jaeger_install/rhbjaeger-removing.adoc
+++ b/jaeger/jaeger_install/rhbjaeger-removing.adoc
@@ -5,7 +5,7 @@ include::modules/jaeger-document-attributes.adoc[]
 
 toc::[]
 
-The steps for removing Jaeger from a {product-title} cluster are as follows:
+The steps for removing Jaeger from an {product-title} cluster are as follows:
 
 . Shut down any Jaeger pods.
 . Remove any Jaeger instances.

--- a/modules/installation-gcp-user-infra-config-host-project-vpc.adoc
+++ b/modules/installation-gcp-user-infra-config-host-project-vpc.adoc
@@ -9,7 +9,7 @@ If you use a shared Virtual Private Cloud (VPC) to host your {product-title} clu
 
 [NOTE]
 ====
-If you already have a project that hosts the shared VPC network, review this section to ensure that the project meets all of the requirements to install a {product-title} cluster.
+If you already have a project that hosts the shared VPC network, review this section to ensure that the project meets all of the requirements to install an {product-title} cluster.
 ====
 
 .Procedure

--- a/modules/installation-osp-creating-network-resources.adoc
+++ b/modules/installation-osp-creating-network-resources.adoc
@@ -5,7 +5,7 @@
 [id="installation-osp-creating-network-resources_{context}"]
 = Creating network resources
 
-Create the network resources that a {product-title} on {rh-openstack-first} installation on your own infrastructure requires. To save time, run supplied Ansible playbooks that generate security groups, networks, subnets, routers, and ports.
+Create the network resources that an {product-title} on {rh-openstack-first} installation on your own infrastructure requires. To save time, run supplied Ansible playbooks that generate security groups, networks, subnets, routers, and ports.
 
 .Procedure
 

--- a/modules/installation-osp-default-deployment.adoc
+++ b/modules/installation-osp-default-deployment.adoc
@@ -7,7 +7,7 @@
 [id="installation-osp-default-deployment_{context}"]
 = Resource guidelines for installing {product-title} on {rh-openstack}
 
-To support a {product-title} installation, your {rh-openstack-first} quota must meet the following requirements:
+To support an {product-title} installation, your {rh-openstack-first} quota must meet the following requirements:
 
 .Recommended resources for a default {product-title} cluster on {rh-openstack}
 [options="header"]

--- a/modules/nodes-nodes-working-deleting-bare-metal.adoc
+++ b/modules/nodes-nodes-working-deleting-bare-metal.adoc
@@ -13,7 +13,7 @@ delete local manifest Pods.
 
 .Procedure
 
-Delete a node from a {product-title} cluster running on bare metal by completing
+Delete a node from an {product-title} cluster running on bare metal by completing
 the following steps:
 
 . Mark the node as unschedulable:

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -5,7 +5,7 @@
 [id="olm-creating-catalog-from-index_{context}"]
 = Creating a catalog from an index image
 
-You can create a catalog from an index image and apply it to a {product-title}
+You can create a catalog from an index image and apply it to an {product-title}
 cluster.
 
 .Prerequisites

--- a/modules/olm-csv.adoc
+++ b/modules/olm-csv.adoc
@@ -6,7 +6,7 @@
 = ClusterServiceVersion
 
 A _ClusterServiceVersion_ (CSV) represents a specific version of a running
-Operator on a {product-title} cluster. It is a YAML manifest created from
+Operator on an {product-title} cluster. It is a YAML manifest created from
 Operator metadata that assists Operator Lifecycle Manager (OLM) in running the
 Operator in the cluster.
 

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -11,7 +11,7 @@ ifeval::["{context}" == "olm-managing-custom-catalogs"]
 = Mirroring an Operator catalog image
 
 Cluster administrators can mirror their catalog's content into a registry and
-use a CatalogSource to load the content onto a {product-title} cluster. For this
+use a CatalogSource to load the content onto an {product-title} cluster. For this
 example, the procedure uses a custom `redhat-operators` catalog image previously
 built and pushed to a supported registry.
 endif::[]


### PR DESCRIPTION
Noticed several times where `a {product-title}` was used. Replaced with `an {product-title}`.  Based on master. Will attempt to cherrypick to other branches as allowed.