### PR TITLE
Break apart command codeblocks from example output in Operators guide

### DIFF
--- a/modules/building-memcached-operator-using-osdk.adoc
+++ b/modules/building-memcached-operator-using-osdk.adoc
@@ -28,10 +28,23 @@ or above to support the `apps/v1beta2` API group), for example {product-title} {
 +
 Use the CLI to create a new `memcached-operator` project:
 +
+[source,terminal]
 ----
 $ mkdir -p $GOPATH/src/github.com/example-inc/
+----
++
+[source,terminal]
+----
 $ cd $GOPATH/src/github.com/example-inc/
+----
++
+[source,terminal]
+----
 $ operator-sdk new memcached-operator
+----
++
+[source,terminal]
+----
 $ cd memcached-operator
 ----
 
@@ -40,6 +53,7 @@ $ cd memcached-operator
 .. Use the CLI to add a new CRD API called `Memcached`, with `APIVersion` set to
 `cache.example.com/v1apha1` and `Kind` set to `Memcached`:
 +
+[source,terminal]
 ----
 $ operator-sdk add api \
     --api-version=cache.example.com/v1alpha1 \
@@ -66,6 +80,7 @@ type MemcachedStatus struct {
 .. After modifying the `*_types.go` file, always run the following command to
 update the generated code for that resource type:
 +
+[source,terminal]
 ----
 $ operator-sdk generate k8s
 ----
@@ -106,6 +121,7 @@ If you add any custom validations, run the following command to update the
 OpenAPI validation section in the CRD's
 `deploy/crds/cache.example.com_memcacheds_crd.yaml` file:
 +
+[source,terminal]
 ----
 $ operator-sdk generate crds
 ----
@@ -129,6 +145,7 @@ spec:
 .. Add a new Controller to the project to watch and reconcile the Memcached
 resource:
 +
+[source,terminal]
 ----
 $ operator-sdk add controller \
     --api-version=cache.example.com/v1alpha1 \
@@ -163,6 +180,7 @@ The first watch is for the Memcached type as the primary resource. For each Add,
 Update, or Delete event, the reconcile loop is sent a reconcile `Request` (a
 `<namespace>:<name>` key) for that Memcached object:
 +
+[source,go]
 ----
 err := c.Watch(
   &source.Kind{Type: &cachev1alpha1.Memcached{}}, &handler.EnqueueRequestForObject{})
@@ -173,6 +191,7 @@ reconcile `Request` for the owner of the Deployment. In this case, this is the
 Memcached object for which the Deployment was created. This allows the
 controller to watch Deployments as a secondary resource:
 +
+[source,go]
 ----
 err := c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
@@ -185,6 +204,7 @@ implements the reconcile loop. The reconcile loop is passed the `Request`
 argument which is a `<namespace>:<name>` key used to lookup the primary resource
 object, Memcached, from the cache:
 +
+[source,go]
 ----
 func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error) {
   // Lookup the Memcached instance for this reconcile request
@@ -197,6 +217,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 Based on the return value of `Reconcile()` the reconcile `Request` may be
 requeued and the loop may be triggered again:
 +
+[source,go]
 ----
 // Reconcile successful - don't requeue
 return reconcile.Result{}, nil
@@ -212,6 +233,7 @@ return reconcile.Result{Requeue: true}, nil
 .. Before running the Operator, the CRD must be registered with the Kubernetes API
 server:
 +
+[source,terminal]
 ----
 $ oc create \
     -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
@@ -230,6 +252,7 @@ Choose one of the following methods.
 
 .... Build the `memcached-operator` image and push it to a registry:
 +
+[source,terminal]
 ----
 $ operator-sdk build quay.io/example/memcached-operator:v0.0.1
 ----
@@ -237,6 +260,7 @@ $ operator-sdk build quay.io/example/memcached-operator:v0.0.1
 .... The Deployment manifest is generated at `deploy/operator.yaml`. Update the
 Deployment image as follows since the default is just a placeholder:
 +
+[source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ----
@@ -248,23 +272,43 @@ link:https://quay.io/new/[create a new public image] repository named
 
 .... Push the image to the registry:
 +
+[source,terminal]
 ----
 $ podman push quay.io/example/memcached-operator:v0.0.1
 ----
 
 .... Setup RBAC and deploy `memcached-operator`:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/operator.yaml
 ----
 
 .... Verify that `memcached-operator` is up and running:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator       1         1         1            1           1m
 ----
@@ -276,6 +320,7 @@ This method is preferred during development cycle to deploy and test faster.
 Run the Operator locally with the default Kubernetes configuration file present
 at `$HOME/.kube/config`:
 +
+[source,terminal]
 ----
 $ operator-sdk run --local --namespace=default
 ----
@@ -287,24 +332,43 @@ You can use a specific `kubeconfig` using the flag
 Memcached CR.
 
 .. Create the example `Memcached` CR that was generated at
-`deploy/crds/cache_v1alpha1_memcached_cr.yaml`:
+`deploy/crds/cache_v1alpha1_memcached_cr.yaml`.
+
+.. View the file:
 +
+[source,terminal]
 ----
 $ cat deploy/crds/cache_v1alpha1_memcached_cr.yaml
+----
++
+.Example output
+[source,terminal]
+----
 apiVersion: "cache.example.com/v1alpha1"
 kind: "Memcached"
 metadata:
   name: "example-memcached"
 spec:
   size: 3
+----
 
+.. Create the object:
++
+[source,terminal]
+----
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
 .. Ensure that `memcached-operator` creates the Deployment for the CR:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator       1         1         1            1           2m
 example-memcached        3         3         3            3           1m
@@ -313,15 +377,29 @@ example-memcached        3         3         3            3           1m
 .. Check the Pods and CR status to confirm the status is updated with the
 `memcached` Pod names:
 +
+[source,terminal]
 ----
 $ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                  READY     STATUS    RESTARTS   AGE
 example-memcached-6fd7c98d8-7dqdr     1/1       Running   0          1m
 example-memcached-6fd7c98d8-g5k7v     1/1       Running   0          1m
 example-memcached-6fd7c98d8-m7vn7     1/1       Running   0          1m
 memcached-operator-7cc7cfdf86-vvjqk   1/1       Running   0          2m
-
+----
++
+[source,terminal]
+----
 $ oc get memcached/example-memcached -o yaml
+----
++
+.Example output
+[source,terminal]
+----
 apiVersion: cache.example.com/v1alpha1
 kind: Memcached
 metadata:
@@ -347,8 +425,14 @@ updating the size of the deployment.
 
 .. Change the `spec.size` field in the `memcached` CR from `3` to `4`:
 +
+[source,terminal]
 ----
 $ cat deploy/crds/cache_v1alpha1_memcached_cr.yaml
+----
++
+.Example output
+[source,terminal]
+----
 apiVersion: "cache.example.com/v1alpha1"
 kind: "Memcached"
 metadata:
@@ -359,26 +443,54 @@ spec:
 
 .. Apply the change:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
 .. Confirm that the Operator changes the Deployment size:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 example-memcached    4         4         4            4           5m
 ----
 
 . *Clean up the resources:*
 +
+[source,terminal]
 ----
 $ oc delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/operator.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/service_account.yaml
 ----
 

--- a/modules/cluster-authentication-operator.adoc
+++ b/modules/cluster-authentication-operator.adoc
@@ -11,6 +11,7 @@
 The Cluster Authentication Operator installs and maintains the Authentication
 Custom Resource in a cluster and can be viewed with:
 
+[source,terminal]
 ----
 $ oc get clusteroperator authentication -o yaml
 ----

--- a/modules/cluster-monitoring-operator.adoc
+++ b/modules/cluster-monitoring-operator.adoc
@@ -39,6 +39,7 @@ link:https://github.com/openshift/cluster-monitoring-operator[openshift-monitori
 [discrete]
 == Configuration objects
 
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit cm cluster-monitoring-config
 ----

--- a/modules/cluster-openshift-controller-manager-operators.adoc
+++ b/modules/cluster-openshift-controller-manager-operators.adoc
@@ -10,6 +10,7 @@
 
 The OpenShift Controller Manager Operator installs and maintains the `OpenShiftControllerManager` Custom Resource in a cluster and can be viewed with:
 
+[source,terminal]
 ----
 $ oc get clusteroperator openshift-controller-manager -o yaml
 ----
@@ -17,6 +18,7 @@ $ oc get clusteroperator openshift-controller-manager -o yaml
 The Custom Resource Definition `openshiftcontrollermanagers.operator.openshift.io`
 can be viewed in a cluster with:
 
+[source,terminal]
 ----
 $ oc get crd openshiftcontrollermanagers.operator.openshift.io -o yaml
 ----

--- a/modules/crd-creating-aggregated-cluster-roles.adoc
+++ b/modules/crd-creating-aggregated-cluster-roles.adoc
@@ -78,6 +78,7 @@ and only read permission to the `view` role.
 
 . Create the cluster role:
 +
+[source,terminal]
 ----
 $ oc create -f <file_name>.yaml
 ----

--- a/modules/crd-creating-crds.adoc
+++ b/modules/crd-creating-crds.adoc
@@ -54,18 +54,21 @@ By default, a CRD is cluster-scoped and available to all projects.
 
 . Create the CRD object:
 +
+[source,terminal]
 ----
 $ oc create -f <file_name>.yaml
 ----
 +
 A new RESTful API endpoint is created at:
 +
+[source,terminal]
 ----
 /apis/<spec:group>/<spec:version>/<scope>/*/<names-plural>/...
 ----
 +
 For example, using the example file, the following endpoint is created:
 +
+[source,terminal]
 ----
 /apis/stable.example.com/v1/namespaces/*/crontabs/...
 ----

--- a/modules/crd-creating-custom-resources-from-file.adoc
+++ b/modules/crd-creating-custom-resources-from-file.adoc
@@ -53,6 +53,7 @@ that must be completed before the object can be deleted.
 
 . After you create the file, create the object:
 +
+[source,terminal]
 ----
 $ oc create -f <file_name>.yaml
 ----

--- a/modules/crd-inspecting-custom-resources.adoc
+++ b/modules/crd-inspecting-custom-resources.adoc
@@ -6,9 +6,9 @@
 // * operators/crds/extending-api-with-crds.adoc
 
 [id="crd-inspecting-custom-resources_{context}"]
-= Inspecting Custom Resources
+= Inspecting custom resources
 
-You can inspect Custom Resource (CR) objects that exist in your cluster using
+You can inspect custom resource (CR) objects that exist in your cluster using
 the CLI.
 
 .Prerequisites
@@ -19,15 +19,21 @@ the CLI.
 
 . To get information on a specific `Kind` of a CR, run:
 +
+[source,terminal]
 ----
 $ oc get <kind>
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc get crontab
-
+----
++
+.Example output
+[source,terminal]
+----
 NAME                 KIND
 my-new-cron-object   CronTab.v1.stable.example.com
 ----
@@ -35,21 +41,38 @@ my-new-cron-object   CronTab.v1.stable.example.com
 Resource names are not case-sensitive, and you can use either the singular or
 plural forms defined in the CRD, as well as any short name. For example:
 +
+[source,terminal]
 ----
 $ oc get crontabs
+----
++
+[source,terminal]
+----
 $ oc get crontab
+----
++
+[source,terminal]
+----
 $ oc get ct
 ----
 
 . You can also view the raw YAML data for a CR:
 +
+[source,terminal]
 ----
 $ oc get <kind> -o yaml
 ----
 +
+For example:
++
+[source,terminal]
 ----
 $ oc get ct -o yaml
-
+----
++
+.Example output
+[source,terminal]
+----
 apiVersion: v1
 items:
 - apiVersion: stable.example.com/v1

--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -31,6 +31,7 @@ link:https://github.com/openshift/cluster-ingress-operator[openshift-ingress-ope
 ** Instance Name: default
 ** View Command:
 +
+[source,terminal]
 ----
 $ oc get clusteringresses.ingress.openshift.io -n openshift-ingress-operator default -o yaml
 ----
@@ -41,6 +42,7 @@ $ oc get clusteringresses.ingress.openshift.io -n openshift-ingress-operator def
 The Ingress Operator sets up the router in the `openshift-ingress` project and
 creates the deployment for the router:
 
+[source,terminal]
 ----
 $ oc get deployment -n openshift-ingress
 ----
@@ -53,8 +55,13 @@ the following example, ingress controllers managed by the Ingress Operator will
 run in v4-only mode because only one cluster network exists and the network is a
 v4 `cidr`:
 
+[source,terminal]
 ----
 $ oc get network/cluster -o jsonpath='{.status.clusterNetwork[*]}'
+----
 
+.Example output
+[source,terminal]
+----
 map[cidr:10.128.0.0/14 hostPrefix:23]
 ----

--- a/modules/kube-apiserver-operator.adoc
+++ b/modules/kube-apiserver-operator.adoc
@@ -29,6 +29,7 @@ link:https://github.com/openshift/cluster-kube-apiserver-operator[openshift-kube
 [discrete]
 == Configuration objects
 
+[source,terminal]
 ----
 $ oc edit kubeapiserver
 ----

--- a/modules/managing-memcached-operator-using-olm.adoc
+++ b/modules/managing-memcached-operator-using-olm.adoc
@@ -33,6 +33,7 @@ application, in this case Memcached, as a whole. It is defined by a
 From the `memcached-operator/` directory that was created when you built the
 Memcached Operator, generate the CSV manifest:
 +
+[source,terminal]
 ----
 $ operator-sdk generate csv --csv-version 0.0.1
 ----
@@ -65,6 +66,7 @@ directory by the Operator SDK when you built the Memcached Operator.
 
 .. Apply the Operator's CSV manifest to the specified namespace in the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy/olm-catalog/memcached-operator/0.0.1/memcached-operator.v0.0.1.clusterserviceversion.yaml
 ----
@@ -76,10 +78,23 @@ it does not yet meet the requirements specified in the manifest.
 permissions to the Operator, and the Custom Resource Definition (CRD) to create
 the Memcached type that the Operator manages:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/crds/cache.example.com_memcacheds_crd.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role_binding.yaml
 ----
 +
@@ -96,10 +111,11 @@ resource has the kind `Memcached`. Native Kubernetes RBAC also applies to
 each Operator.
 +
 Creating instances of Memcached in this namespace will now trigger the Memcached
-Operator to instantiate pods running the memcached server that are managed by
+Operator to instantiate Pods running the memcached server that are managed by
 the Operator. The more `CustomResources` you create, the more unique instances
 of Memcached are managed by the Memcached Operator running in this namespace.
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc apply -f -
 apiVersion: "cache.example.com/v1alpha1"
@@ -109,7 +125,10 @@ metadata:
 spec:
   size: 1
 EOF
-
+----
++
+[source,terminal]
+----
 $ cat <<EOF | oc apply -f -
 apiVersion: "cache.example.com/v1alpha1"
 kind: "Memcached"
@@ -118,18 +137,39 @@ metadata:
 spec:
   size: 1
 EOF
-
+----
++
+[source,terminal]
+----
 $ oc get Memcached
+----
++
+.Example output
+[source,terminal]
+----
 NAME                      AGE
 memcached-for-drupal      22s
 memcached-for-wordpress   27s
-
+----
++
+[source,terminal]
+----
 $ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                       READY     STATUS    RESTARTS   AGE
 memcached-app-operator-66b5777b79-pnsfj    1/1       Running   0          14m
 memcached-for-drupal-5476487c46-qbd66      1/1       Running   0          3s
 memcached-for-wordpress-65b75fd8c9-7b9x7   1/1       Running   0          8s
 ----
+
+////
+This procedure no longer works. The original CSV that was linked 404'd now, but
+the newer one doesn't have a replaces field. Removing the step until a working
+replacement is developed.
 
 . *Update an application.*
 +
@@ -140,16 +180,37 @@ ownership moved to the new Operator without fear of any programs stopping
 execution. It is up to the Operators themselves to execute any data migrations
 required to upgrade resources to run under a new version of the Operator.
 +
-The following command demonstrates applying a new
-link:https://github.com/operator-framework/getting-started/blob/master/memcachedoperator.0.0.2.csv.yaml[Operator manifest file]
-using a new version of the Operator and shows that the pods remain executing:
+The following commands demonstrate applying a new Operator manifest file using a
+new version of the Operator and shows that the Pods remain executing:
+
+.. Download the manifest:
 +
+[source,terminal]
 ----
-$ curl -Lo memcachedoperator.0.0.2.csv.yaml https://raw.githubusercontent.com/operator-framework/getting-started/master/memcachedoperator.0.0.2.csv.yaml
-$ oc apply -f memcachedoperator.0.0.2.csv.yaml
+$ curl -Lo memcachedoperator.0.18.1.csv.yaml \
+    https://raw.githubusercontent.com/operator-framework/operator-sdk-samples/master/go/memcached-operator/deploy/olm-catalog/memcached-operator/manifests/memcached-operator.clusterserviceversion.yaml
+----
+
+.. Create the object:
++
+[source,terminal]
+----
+$ oc apply -f memcachedoperator.0.18.1.csv.yaml
+----
+
+.. View the Pods:
++
+[source,terminal]
+----
 $ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                       READY     STATUS    RESTARTS   AGE
 memcached-app-operator-66b5777b79-pnsfj    1/1       Running   0          3s
 memcached-for-drupal-5476487c46-qbd66      1/1       Running   0          14m
 memcached-for-wordpress-65b75fd8c9-7b9x7   1/1       Running   0          14m
 ----
+////

--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operators/olm-restricted-networks.adoc
+// * operators/olm-managing-custom-catalogs.adoc
 // * migration/migrating_3_4/deploying-cam-3-4.adoc
 // * migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
@@ -29,12 +30,7 @@ to both your network and the internet.
 .Prerequisites
 
 
-* A Linux workstation with unrestricted network access
-ifeval::["{context}" == "olm-restricted-networks"]
-footnoteref:[BZ1771329,The
-`oc adm catalog` command is currently only supported on Linux.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1771329[*BZ#1771329*])]
-endif::[]
+* Workstation with unrestricted network access
 * `oc` version 4.3.5+
 * `podman` version 1.4.4+
 * Access to mirror registry that supports
@@ -43,6 +39,7 @@ link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 variable to the file path of your registry credentials for use in later steps.
 For example, for the `podman` CLI:
 +
+[source,terminal]
 ----
 $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 ----
@@ -52,6 +49,7 @@ $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 . On the workstation with unrestricted network access, authenticate with the
 target mirror registry:
 +
+[source,terminal]
 ----
 $ podman login <registry_host_name>
 ----
@@ -59,6 +57,7 @@ $ podman login <registry_host_name>
 Also authenticate with `registry.redhat.io` so that the base image can be pulled
 during the build:
 +
+[source,terminal]
 ----
 $ podman login registry.redhat.io
 ----
@@ -66,6 +65,7 @@ $ podman login registry.redhat.io
 . Build a catalog image based on the `redhat-operators` catalog from
 link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 +
+[source,terminal]
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
@@ -74,10 +74,6 @@ $ oc adm catalog build \
     --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<4>
     [-a ${REG_CREDS}] \//<5>
     [--insecure] <6>
-
-INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
-...
-Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v1
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
 <2> Set `--from` to the `ose-operator-registry` base image using the tag that
@@ -90,9 +86,19 @@ are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 <6> Optional: If you do not want to configure trust for the target registry, add the
 `--insecure` flag.
 +
+.Example output
+[source,terminal]
+----
+INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
+...
+Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v1
+----
++
 Sometimes invalid manifests are accidentally introduced into Red Hat's catalogs;
 when this happens, you might see some errors:
 +
+.Example output with errors
+[source,terminal]
 ----
 ...
 INFO[0014] directory                                     dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605 file=4.2 load=package

--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * operators/understanding_olm/olm-packaging-formats.adoc
+// * operators/understanding_olm/olm-packaging-format.adoc
 // * operators/operator_sdk/osdk-managing-bundle-images.adoc
 
 [id="olm-bundle-format_{context}"]
@@ -43,6 +43,7 @@ and typically the CRDs that define the owned APIs of the CSV in its `manifest/`
 directory, though additional objects may be included:
 
 .Example Bundle Format layout
+[source,terminal]
 ----
 etcd
 ├── manifests

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -16,6 +16,7 @@ cluster.
 
 . Apply a CatalogSource to your cluster that references your index image:
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc apply -f -
 
@@ -38,9 +39,24 @@ EOF
 
 . Verify using the {product-title} web console or CLI that the catalog loaded
 successfully and that packages are available. For example, using the CLI:
+
+.. Check the Pods:
 +
+[source,terminal]
 ----
 $ oc get pods -n openshift-marketplace
+----
+
+.. Check the CatalogSource:
++
+[source,terminal]
+----
 $ oc get catalogsource -n openshift-marketplace
+----
+
+.. Check the PackageManifest:
++
+[source,terminal]
+----
 $ oc get packagemanifests -n openshift-marketplace
 ----

--- a/modules/olm-creating-etcd-cluster-from-operator.adoc
+++ b/modules/olm-creating-etcd-cluster-from-operator.adoc
@@ -27,16 +27,14 @@ launch and manage the software provided by the Operator.
 ====
 You can get this list from the CLI using:
 
+[source,terminal]
 ----
 $ oc get csv
 ----
 ====
 
 . On the *Installed Operators* page, click *Copied*, and then click the etcd
-Operator to view more details and available actions:
-+
-.etcd Operator overview
-image::etcd-operator-overview.png[]
+Operator to view more details and available actions.
 +
 As shown under *Provided APIs*, this Operator makes available three new resource
 types, including one for an *etcd Cluster* (the `EtcdCluster` resource). These
@@ -55,9 +53,6 @@ Services, and other components of the new etcd cluster.
 . Click the *Resources* tab to see that your project now contains a number of
 resources created and configured automatically by the Operator.
 +
-.etcd Operator resources
-image::etcd-operator-resources.png[]
-+
 Verify that a Kubernetes service has been created that allows you to access the
 database from other Pods in your project.
 
@@ -67,6 +62,7 @@ that have already been created in the project, in a self-service manner, just
 like a cloud service. If you want to enable additional users with this ability,
 project administrators can add the role using the following command:
 +
+[source,terminal]
 ----
 $ oc policy add-role-to-user edit <user> -n <target_project>
 ----

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -17,6 +17,7 @@ You can create an index image using the `opm` CLI.
 
 . Start a new index:
 +
+[source,terminal]
 ----
 $ opm index add \
     --bundles quay.io/<namespace>/test-operator:v0.1.0 \//<1>
@@ -27,6 +28,7 @@ $ opm index add \
 
 . Push the index image to a registry:
 +
+[source,terminal]
 ----
 $ podman push quay.io/<namespace>/test-catalog:latest
 ----

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * operators/olm-deleting-operators-to-cluster.adoc
+// * operators/olm-deleting-operators-from-a-cluster.adoc
 
 [id="olm-deleting-operator-from-a-cluster-using-cli_{context}"]
 = Deleting Operators from a cluster using the CLI
@@ -24,22 +24,40 @@ endif::[]
 . Check the current version of the subscribed Operator (for example, `jaeger`)
 in the `currentCSV` field:
 +
+[source,terminal]
 ----
 $ oc get subscription jaeger -n openshift-operators -o yaml | grep currentCSV
+----
++
+.Example output
+[source,terminal]
+----
   currentCSV: jaeger-operator.v1.8.2
 ----
 
 . Delete the Operator's Subscription (for example, `jaeger`):
 +
+[source,terminal]
 ----
 $ oc delete subscription jaeger -n openshift-operators
+----
++
+.Example output
+[source,terminal]
+----
 subscription.operators.coreos.com "jaeger" deleted
 ----
 
 . Delete the CSV for the Operator in the target namespace using the `currentCSV`
 value from the previous step:
 +
+[source,terminal]
 ----
 $ oc delete clusterserviceversion jaeger-operator.v1.8.2 -n openshift-operators
+----
++
+.Example output
+[source,terminal]
+----
 clusterserviceversion.operators.coreos.com "jaeger-operator.v1.8.2" deleted
 ----

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * operators/olm-deleting-operators-to-cluster.adoc
+// * operators/olm-deleting-operators-from-a-cluster.adoc
 
 [id="olm-deleting-operators-from-a-cluster-using-web-console_{context}"]
 = Deleting Operators from a cluster using the web console
@@ -26,11 +26,15 @@ the *Filter by name* to find the Operator you want. Then, click on it.
 . On the right-hand side of the *Operator Details* page, select *Uninstall
 Operator* from the *Actions* drop-down menu.
 +
-An *Uninstall Operator?* dialog box is displayed, reminding you that *Removing
-the operator will not remove any of its custom resource definitions or managed
-resources. If your operator has deployed applications on the cluster or
+An *Uninstall Operator?* dialog box is displayed, reminding you that:
++
+[.small]
+--
+*Removing the Operator will not remove any of its custom resource definitions or
+managed resources. If your Operator has deployed applications on the cluster or
 configured off-cluster resources, these will continue to run and need to be
 cleaned up manually.*
+--
 +
 The Operator, any Operator deployments, and Pods are removed by this action. Any
 resources managed by the Operator, including CRDs and CRs are not removed. The

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -20,11 +20,13 @@ permissions.
 
 . View the list of Operators available to the cluster from OperatorHub:
 +
+[source,terminal]
 ----
 $ oc get packagemanifests -n openshift-marketplace
 ----
 +
 .Example output
+[source,terminal]
 ----
 NAME                               CATALOG               AGE
 3scale-operator                    Red Hat Operators     91m
@@ -46,6 +48,7 @@ Note the CatalogSource for your desired Operator.
 . Inspect your desired Operator to verify its supported InstallModes and available
 Channels:
 +
+[source,terminal]
 ----
 $ oc describe packagemanifests <operator_name> -n openshift-marketplace
 ----
@@ -87,6 +90,7 @@ spec:
 
 .. Create the OperatorGroup object:
 +
+[source,terminal]
 ----
 $ oc apply -f operatorgroup.yaml
 ----
@@ -118,6 +122,7 @@ OperatorHub CatalogSources.
 
 . Create the Subscription object:
 +
+[source,terminal]
 ----
 $ oc apply -f sub.yaml
 ----

--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -17,12 +17,14 @@ ifdef::openshift-enterprise,openshift-webscale[]
 . Set the `REG_CREDS` environment variable to the file path of your registry
 credentials for use in later steps. For example, for the `podman` CLI:
 +
+[source,terminal]
 ----
 $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 ----
 
 . Authenticate with `registry.redhat.io`:
 +
+[source,terminal]
 ----
 $ podman login registry.redhat.io
 ----
@@ -31,6 +33,7 @@ endif::[]
 . Extract the `opm` binary from the Operator Registry image and copy it to your
 local file system:
 +
+[source,terminal]
 ifdef::openshift-origin[]
 ----
 $ oc image extract quay.io/openshift/origin-operator-registry:4.5.0 \
@@ -50,23 +53,27 @@ endif::[]
 
 . Make the binary executable:
 +
+[source,terminal]
 ----
 $ chmod +x ./opm
 ----
 
 . Place the file anywhere in your `PATH`, such as `/usr/local/bin/`.
 +
+[source,terminal]
 ----
 $ sudo mv ./opm /usr/local/bin/
 ----
 
 . Verify that the client was installed correctly:
 +
+[source,terminal]
 ----
 $ opm version
 ----
 +
 .Example output
+[source,terminal]
 ----
 Version: version.Version{OpmVersion:"1.12.3", GitCommit:"", BuildDate:"2020-07-01T23:18:58Z", GoOs:"linux", GoArch:"amd64"}
 ----

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -79,9 +79,16 @@ used for the subscribed Operator's Deployments.
 custom proxy environment variables are set in the Deployment. For example, using
 the CLI:
 +
+[source,terminal]
 ----
-$ oc get deployment -n openshift-operators etcd-operator -o yaml | grep -i "PROXY" -A 2
-
+$ oc get deployment -n openshift-operators \
+    etcd-operator -o yaml \
+    | grep -i "PROXY" -A 2
+----
++
+.Example output
+[source,terminal]
+----
         - name: HTTP_PROXY
           value: test_http
         - name: HTTPS_PROXY

--- a/modules/olm-package-manifest-format.adoc
+++ b/modules/olm-package-manifest-format.adoc
@@ -16,6 +16,7 @@ that define the owned APIs of the CSV, though additional objects may be
 included. All versions of the Operator are nested in a single directory:
 
 .Example Package Manifest Format layout
+[source,terminal]
 ----
 etcd
 ├── 0.6.1

--- a/modules/olm-policy-scoping-operator-install.adoc
+++ b/modules/olm-policy-scoping-operator-install.adoc
@@ -15,6 +15,7 @@ designated namespace.
 
 . Create a new namespace:
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc create -f -
 apiVersion: v1
@@ -27,6 +28,7 @@ EOF
 . Allocate permissions that you want the Operator(s) to be confined to. This
 involves creating a new service account, relevant Role(s), and RoleBinding(s).
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc create -f -
 apiVersion: v1
@@ -41,6 +43,7 @@ The following example grants the service account permissions to do anything in
 the designated namespace for simplicity. In a production environment, you should
 create a more fine-grained set of permissions:
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc create -f -
 apiVersion: rbac.authorization.k8s.io/v1
@@ -74,6 +77,7 @@ the designated namespace to ensure that its tenancy is confined to it. In
 addition, OperatorGroups allow a user to specify a service account. Specify the
 ServiceAccount created in the previous step:
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1
@@ -93,6 +97,7 @@ and therefore to the service account specified.
 
 . Create a Subscription in the designated namespace to install an Operator:
 +
+[source,terminal]
 ----
 $ cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1alpha1

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -27,10 +27,7 @@ endif::[]
 
 .Prerequisites
 
-* A Linux workstation with unrestricted network access
-ifeval::["{context}" == "olm-restricted-networks"]
-footnoteref:[BZ1771329]
-endif::[]
+* Workstation with unrestricted network access
 * A custom Operator catalog image pushed to a supported registry
 * `oc` version 4.3.5+
 * `podman` version 1.4.4+
@@ -40,6 +37,7 @@ link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 variable to the file path of your registry credentials for use in later steps.
 For example, for the `podman` CLI:
 +
+[source,terminal]
 ----
 $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 ----
@@ -50,6 +48,7 @@ ifeval::["{context}" == "olm-restricted-networks"]
 . Disable the default OperatorSources by adding `disableAllDefaultSources: true`
 to the spec:
 +
+[source,terminal]
 ----
 $ oc patch OperatorHub cluster --type json \
     -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
@@ -76,6 +75,7 @@ list of images in a later step.
 +
 On your workstation with unrestricted network access, run the following command:
 +
+[source,terminal]
 ----
 $ oc adm catalog mirror \
     <registry_host_name>:<port>/olm/redhat-operators:v1 \//<1>
@@ -119,6 +119,7 @@ specifications.
 `mapping.txt` file to mirror the images to your registry using the `oc image
 mirror` command:
 +
+[source,terminal]
 ----
 $ oc image mirror \
     [-a ${REG_CREDS}] \
@@ -127,6 +128,7 @@ $ oc image mirror \
 
 . Apply the ImageContentSourcePolicy:
 +
+[source,terminal]
 ----
 $ oc apply -f ./redhat-operators-manifests/imageContentSourcePolicy.yaml
 ----
@@ -153,6 +155,7 @@ spec:
 
 .. Use the file to create the CatalogSource object:
 +
+[source,terminal]
 ----
 $ oc create -f catalogsource.yaml
 ----
@@ -161,11 +164,13 @@ $ oc create -f catalogsource.yaml
 
 .. Check the Pods:
 +
+[source,terminal]
 ----
 $ oc get pods -n openshift-marketplace
 ----
 +
 .Example output
+[source,terminal]
 ----
 NAME                                    READY   STATUS    RESTARTS  AGE
 my-operator-catalog-6njx6               1/1     Running   0         28s
@@ -174,11 +179,13 @@ marketplace-operator-d9f549946-96sgr    1/1     Running   0         26h
 
 .. Check the CatalogSource:
 +
+[source,terminal]
 ----
 $ oc get catalogsource -n openshift-marketplace
 ----
 +
 .Example output
+[source,terminal]
 ----
 NAME                  DISPLAY               TYPE PUBLISHER  AGE
 my-operator-catalog   My Operator Catalog   grpc            5s
@@ -186,11 +193,13 @@ my-operator-catalog   My Operator Catalog   grpc            5s
 
 .. Check the PackageManifest:
 +
+[source,terminal]
 ----
 $ oc get packagemanifest -n openshift-marketplace
 ----
 +
 .Example output
+[source,terminal]
 ----
 NAME    CATALOG              AGE
 etcd    My Operator Catalog  34s

--- a/modules/olm-status-viewing-cli.adoc
+++ b/modules/olm-status-viewing-cli.adoc
@@ -17,18 +17,22 @@ You can view Operator Subscription status using the CLI.
 
 . List Operator Subscriptions:
 +
+[source,terminal]
 ----
-$  oc get subs -n <operator_namespace>
+$ oc get subs -n <operator_namespace>
 ----
 
 . Use the `oc describe` command to inspect a Subscription resource:
 +
+[source,terminal]
 ----
 $ oc describe sub <subscription_name> -n <operator_namespace>
 ----
 
 . In the command output, find the `Conditions` section:
 +
+.Example output
+[source,terminal]
 ----
 Conditions:
    Last Transition Time:  2019-07-29T13:42:57Z
@@ -40,5 +44,8 @@ Conditions:
 
 [NOTE]
 ====
-Default {product-title} cluster Operators are managed by the Cluster Version Operator (CVO) and they do not have a Subscription object. Application Operators are managed by Operator Lifecycle Manager (OLM) and they have a Subscription object.
+Default {product-title} cluster Operators are managed by the Cluster Version
+Operator (CVO) and they do not have a Subscription object. Application Operators
+are managed by Operator Lifecycle Manager (OLM) and they have a Subscription
+object.
 ====

--- a/modules/olm-testing-operator-catalog-image.adoc
+++ b/modules/olm-testing-operator-catalog-image.adoc
@@ -24,12 +24,14 @@ link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 
 . Pull the Operator catalog image:
 +
+[source,terminal]
 ----
 $ podman pull <registry_host_name>:<port>/olm/redhat-operators:v1
 ----
 
 . Run the image:
 +
+[source,terminal]
 ----
 $ podman run -p 50051:50051 \
     -it <registry_host_name>:<port>/olm/redhat-operators:v1
@@ -37,8 +39,14 @@ $ podman run -p 50051:50051 \
 
 . Query the running image for available packages using `grpcurl`:
 +
+[source,terminal]
 ----
 $ grpcurl -plaintext localhost:50051 api.Registry/ListPackages
+----
++
+.Example output
+[source,terminal]
+----
 {
   "name": "3scale-operator"
 }
@@ -52,8 +60,14 @@ $ grpcurl -plaintext localhost:50051 api.Registry/ListPackages
 
 . Get the latest Operator bundle in a channel:
 +
+[source,terminal]
 ----
 $  grpcurl -plaintext -d '{"pkgName":"kiali-ossm","channelName":"stable"}' localhost:50051 api.Registry/GetBundleForChannel
+----
++
+.Example output
+[source,terminal]
+----
 {
   "csvName": "kiali-operator.v1.0.7",
   "packageName": "kiali-ossm",
@@ -63,11 +77,16 @@ $  grpcurl -plaintext -d '{"pkgName":"kiali-ossm","channelName":"stable"}' local
 
 . Get the digest of the image:
 +
+[source,terminal]
 ----
 $ podman inspect \
     --format='{{index .RepoDigests 0}}' \
     <registry_host_name>:<port>/olm/redhat-operators:v1
-
+----
++
+.Example output
+[source,terminal]
+----
 example_registry:5000/olm/redhat-operators@sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3
 ----
 

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -18,6 +18,7 @@ You can update an existing index image using the `opm` CLI.
 
 . Update the existing index:
 +
+[source,terminal]
 ----
 $ opm index add \
     --bundles quay.io/<namespace>/another-operator:v1 \//<1>
@@ -30,6 +31,7 @@ $ opm index add \
 
 . Push the updated index image:
 +
+[source,terminal]
 ----
 $ podman push quay.io/<namespace>/test-catalog:latest
 ----
@@ -37,6 +39,7 @@ $ podman push quay.io/<namespace>/test-catalog:latest
 . After OLM polls the index image at its regular interval, verify that the new
 packages are successfully added:
 +
+[source,terminal]
 ----
 $ oc get packagemanifests -n openshift-marketplace
 ----

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operators/olm-restricted-networks.adoc
+// * operators/olm-managing-custom-catalogs.adoc
 
 [id="olm-updating-operator-catalog-image_{context}"]
 = Updating an Operator catalog image
@@ -17,10 +18,7 @@ image is already configured for use with OperatorHub.
 
 .Prerequisites
 
-* A Linux workstation with unrestricted network access
-ifeval::["{context}" == "olm-restricted-networks"]
-footnoteref:[BZ1771329]
-endif::[]
+* Workstation with unrestricted network access
 * `oc` version 4.3.5+
 * `podman` version 1.4.4+
 * Access to mirror registry that supports
@@ -30,6 +28,7 @@ link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 variable to the file path of your registry credentials for use in later steps.
 For example, for the `podman` CLI:
 +
+[source,terminal]
 ----
 $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 ----
@@ -39,6 +38,7 @@ $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 . On the workstation with unrestricted network access, authenticate with the
 target mirror registry:
 +
+[source,terminal]
 ----
 $ podman login <registry_host_name>
 ----
@@ -46,6 +46,7 @@ $ podman login <registry_host_name>
 Also authenticate with `registry.redhat.io` so that the base image can be pulled
 during the build:
 +
+[source,terminal]
 ----
 $ podman login registry.redhat.io
 ----
@@ -53,6 +54,7 @@ $ podman login registry.redhat.io
 . Build a new catalog image based on the `redhat-operators` catalog from
 link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
 +
+[source,terminal]
 ----
 $ oc adm catalog build \
     --appregistry-org redhat-operators \//<1>
@@ -61,10 +63,6 @@ $ oc adm catalog build \
     --to=<registry_host_name>:<port>/olm/redhat-operators:v2 \//<4>
     [-a ${REG_CREDS}] \//<5>
     [--insecure] <6>
-
-INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
-...
-Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v2
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
 <2> Set `--from` to the `ose-operator-registry` base image using the tag that
@@ -77,12 +75,21 @@ updated catalog.
 <5> Optional: If required, specify the location of your registry credentials file.
 <6> Optional: If you do not want to configure trust for the target registry, add the
 `--insecure` flag.
++
+.Example output
+[source,terminal]
+----
+INFO[0013] loading Bundles                               dir=/var/folders/st/9cskxqs53ll3wdn434vw4cd80000gn/T/300666084/manifests-829192605
+...
+Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v2
+----
 
 . Mirror the contents of your catalog to your target registry. The following
 `oc adm catalog mirror` command extracts the contents of your custom Operator
 catalog image to generate the manifests required for mirroring and mirrors the
 images to your registry:
 +
+[source,terminal]
 ----
 $ oc adm catalog mirror \
     <registry_host_name>:<port>/olm/redhat-operators:v2 \//<1>
@@ -90,8 +97,6 @@ $ oc adm catalog mirror \
     [-a ${REG_CREDS}] \//<2>
     [--insecure] \//<3>
     [--filter-by-os="<os>/<arch>"] <4>
-
-mirroring ...
 ----
 <1> Specify your new Operator catalog image.
 <2> Optional: If required, specify the location of your registry credentials
@@ -105,6 +110,7 @@ operating system to mirror only the images that match. Valid values are
 
 . Apply the newly generated manifests:
 +
+[source,terminal]
 ----
 $ oc apply -f ./redhat-operators-manifests
 ----
@@ -139,6 +145,7 @@ spec:
 
 ... Use the updated file to replace the CatalogSource object:
 +
+[source,terminal]
 ----
 $ oc replace -f catalogsource.yaml
 ----
@@ -146,6 +153,7 @@ $ oc replace -f catalogsource.yaml
 .. Alternatively, edit the CatalogSource using the following command and reference
 your new catalog image in the `spec.image` parameter:
 +
+[source,terminal]
 ----
 $ oc edit catalogsource <catalog_source_name> -n openshift-marketplace
 ----

--- a/modules/olm-upgrades.adoc
+++ b/modules/olm-upgrades.adoc
@@ -49,9 +49,7 @@ graph of updates:
 .OLM's graph of available channel updates
 image::olm-replaces.png[]
 
-For example:
-
-.Channels in a package
+.Example channels in a package
 [source,yaml]
 ----
 packageName: example
@@ -111,9 +109,7 @@ By shipping a new catalog and adding a _skipped_ release, OLM is ensured that it
 can always get a single unique update regardless of the cluster state and
 whether it has seen the bad update yet.
 
-For example:
-
-.CSV with skipped release
+.Example CSV with skipped release
 [source,yml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -148,6 +144,7 @@ Creating the New CatalogSource as described requires publishing CSVs that `repla
 one Operator, but can `skip` several. This can be accomplished using the
 `skipRange` annotation:
 
+[source,yaml]
 ----
 olm.skipRange: <semver_range>
 ----
@@ -169,9 +166,7 @@ criteria for skipping are met.
 . The next Operator that replaces the current one in any source visible to the
 Subscription.
 
-For example:
-
-.CSV with skipRange
+. Example CSV with `skipRange`
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1

--- a/modules/osdk-ansible-k8s-module-inside-operator.adoc
+++ b/modules/osdk-ansible-k8s-module-inside-operator.adoc
@@ -51,17 +51,36 @@ out the existing line:
 (RBAC) definitions for the Custom Resource (CR) `Foo`. The `operator-sdk`
 command autogenerates these files inside of the `deploy/` directory:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/crds/foo_v1alpha1_foo_crd.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role_binding.yaml
 ----
 
 . Run the `run --local` command:
 +
+[source,terminal]
 ----
 $ operator-sdk run --local
+----
++
+.Example output
+[source,terminal]
+----
 [...]
 INFO[0000] Starting to serve on 127.0.0.1:8888
 INFO[0000] Watching foo.example.com/v1alpha1, Foo, default
@@ -85,14 +104,21 @@ This is why it is important to set sane defaults for the Operator.
 . Create a CR instance of `Foo` with the default variable `state` set to
 `present`:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/cr.yaml
 ----
 
 . Check that the namespace `test` was created:
 +
+[source,terminal]
 ----
 $ oc get namespace
+----
++
+.Example output
+[source,terminal]
+----
 NAME          STATUS    AGE
 default       Active    28d
 kube-public   Active    28d
@@ -114,10 +140,19 @@ spec:
 
 . Apply the changes and confirm that the namespace is deleted:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy/cr.yaml
-
+----
++
+[source,terminal]
+----
 $ oc get namespace
+----
++
+.Example output
+[source,terminal]
+----
 NAME          STATUS    AGE
 default       Active    28d
 kube-public   Active    28d
@@ -136,8 +171,13 @@ use.
 
 . Build the `foo-operator` image and push it to a registry:
 +
+[source,terminal]
 ----
 $ operator-sdk build quay.io/example/foo-operator:v0.0.1
+----
++
+[source,terminal]
+----
 $ podman push quay.io/example/foo-operator:v0.0.1
 ----
 
@@ -146,36 +186,63 @@ Deployment image in this file must be modified from the placeholder
 `REPLACE_IMAGE` to the previously-built image. To do so, run the following
 command:
 +
+[source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
 ----
 +
 If you are performing these steps on OSX, use the following command instead:
 +
+[source,terminal]
 ----
 $ sed -i "" 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
 . Deploy the `foo-operator`:
 +
+[source,terminal]
 ----
-$ oc create -f deploy/crds/foo_v1alpha1_foo_crd.yaml # if CRD doesn't exist already
+$ oc create -f deploy/crds/foo_v1alpha1_foo_crd.yaml <1>
+----
+<1> Only required if the CRD does not exist already.
++
+[source,terminal]
+----
 $ oc create -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/operator.yaml
 ----
 
 . Verify that the `foo-operator` is up and running:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 foo-operator       1         1         1            1           1m
 ----
 
 . You can now view the Ansible logs for the `foo-operator`:
 +
+[source,terminal]
 ----
 $ oc logs deployment/foo-operator
 ----

--- a/modules/osdk-ansible-k8s-module-installing.adoc
+++ b/modules/osdk-ansible-k8s-module-installing.adoc
@@ -11,6 +11,7 @@ To install the `k8s` Ansible module on your local workstation:
 
 . Install Ansible 2.9+:
 +
+[source,terminal]
 ----
 $ sudo yum install ansible
 ----
@@ -19,7 +20,12 @@ $ sudo yum install ansible
 link:https://github.com/openshift/openshift-restclient-python[OpenShift python client]
 package using `pip`:
 +
+[source,terminal]
 ----
 $ sudo pip install openshift
+----
++
+[source,terminal]
+----
 $ sudo pip install kubernetes
 ----

--- a/modules/osdk-ansible-k8s-module-testing-locally.adoc
+++ b/modules/osdk-ansible-k8s-module-testing-locally.adoc
@@ -12,14 +12,23 @@ local machine as opposed to running and rebuilding the Operator each time.
 
 . Install the `community.kubernetes` collection:
 +
+[source,terminal]
 ----
 $ ansible-galaxy collection install community.kubernetes
 ----
 
 . Initialize a new Ansible-based Operator project:
 +
+[source,terminal]
 ----
-$ operator-sdk new --type ansible --kind Foo --api-version foo.example.com/v1alpha1 foo-operator
+$ operator-sdk new --type ansible \
+    --kind Foo \
+    --api-version foo.example.com/v1alpha1 foo-operator
+----
++
+.Example output
+[source,terminal]
+----
 Create foo-operator/tmp/init/galaxy-init.sh
 Create foo-operator/tmp/build/Dockerfile
 Create foo-operator/tmp/build/test-framework/Dockerfile
@@ -36,6 +45,7 @@ Initialized empty Git repository in /home/dymurray/go/src/github.com/dymurray/op
 Run git init done
 ----
 +
+[source,terminal]
 ----
 $ cd foo-operator
 ----
@@ -75,8 +85,14 @@ includes the `foo` role:
 
 . Run the playbook:
 +
+[source,terminal]
 ----
 $ ansible-playbook playbook.yml
+----
++
+.Example output
+[source,terminal]
+----
  [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
 
 PLAY [localhost] ***************************************************************************
@@ -93,8 +109,14 @@ localhost                  : ok=2    changed=1    unreachable=0    failed=0
 
 . Check that the namespace was created:
 +
+[source,terminal]
 ----
 $ oc get namespace
+----
++
+.Example output
+[source,terminal]
+----
 NAME          STATUS    AGE
 default       Active    28d
 kube-public   Active    28d
@@ -104,8 +126,14 @@ test          Active    3s
 
 . Rerun the playbook setting `state` to `absent`:
 +
+[source,terminal]
 ----
 $ ansible-playbook playbook.yml --extra-vars state=absent
+----
++
+.Example output
+[source,terminal]
+----
  [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
 
 PLAY [localhost] ***************************************************************************
@@ -122,8 +150,14 @@ localhost                  : ok=2    changed=1    unreachable=0    failed=0
 
 . Check that the namespace was deleted:
 +
+[source,terminal]
 ----
 $ oc get namespace
+----
++
+.Example output
+[source,terminal]
+----
 NAME          STATUS    AGE
 default       Active    28d
 kube-public   Active    28d

--- a/modules/osdk-ansible-managing-cr-status.adoc
+++ b/modules/osdk-ansible-managing-cr-status.adoc
@@ -3,7 +3,7 @@
 // * operators/operator_sdk/osdk-ansible.adoc
 
 [id="osdk-ansible-managing-cr-status_{context}"]
-= Managing Custom Resource status using the operator_sdk.util Ansible collection
+= Managing Custom Resource status using the `operator_sdk.util` Ansible collection
 
 Ansible-based Operators automatically update Custom Resource (CR)
 link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresources]
@@ -35,7 +35,7 @@ status:
 
 Ansible-based Operators also allow Operator authors to supply custom status
 values with the `k8s_status` Ansible module, which is included in the
-link:https://galaxy.ansible.com/operator_sdk/util[operator_sdk util collection].
+link:https://galaxy.ansible.com/operator_sdk/util[`operator_sdk.util` collection].
 This allows the author to update the `status` from within Ansible with any
 key-value pair as desired.
 
@@ -58,9 +58,9 @@ with a `manageStatus` field set to `false`:
   manageStatus: false
 ----
 
-. Then, use the `operator_sdk.util.k8s_status` Ansible module to update the
-subresource. For example, to update with key `foo` and value `bar`,
-`operator_sdk.util` can be used as shown:
+. Use the `operator_sdk.util.k8s_status` Ansible module to update the subresource.
+For example, to update with key `foo` and value `bar`, `operator_sdk.util` can
+be used as shown:
 +
 [source,yaml]
 ----
@@ -72,16 +72,18 @@ subresource. For example, to update with key `foo` and value `bar`,
     status:
       foo: bar
 ----
-
-Collections can also be declared in the role's `meta/main.yml`, which is
++
+Collections can also be declared in the `meta/main.yml` for the role, which is
 included for new scaffolded Ansible Operators.
++
 [source,yaml]
 ----
 collections:
   - operator_sdk.util
 ----
-
-Declaring collections in the role meta allows you to invoke the `k8s_status` module directly:
++
+Declaring collections in the role meta allows you to invoke the `k8s_status`
+module directly:
 +
 [source,yaml]
 ----

--- a/modules/osdk-architecture.adoc
+++ b/modules/osdk-architecture.adoc
@@ -51,6 +51,7 @@ defined under `pkg/apis/` and runs all controllers under `pkg/controller/`.
 
 The manager can restrict the namespace that all controllers watch for resources:
 
+[source,go]
 ----
 mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
 ----
@@ -58,6 +59,7 @@ mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
 By default, this is the namespace that the Operator is running in. To watch all
 namespaces, you can leave the namespace option empty:
 
+[source,go]
 ----
 mgr, err := manager.New(cfg, manager.Options{Namespace: ""})
 ----

--- a/modules/osdk-building-ansible-operator.adoc
+++ b/modules/osdk-building-ansible-operator.adoc
@@ -29,11 +29,16 @@ isolation for failures and monitoring, and differing API definitions.
 To create a new Ansible-based, namespace-scoped `memcached-operator` project and
 change to its directory, use the following commands:
 +
+[source,terminal]
 ----
 $ operator-sdk new memcached-operator \
     --api-version=cache.example.com/v1alpha1 \
     --kind=Memcached \
     --type=ansible
+----
++
+[source,terminal]
+----
 $ cd memcached-operator
 ----
 +
@@ -174,6 +179,7 @@ Before running the Operator, Kubernetes needs to know about the new Custom
 Resource Definition (CRD) the Operator will be watching. Deploy the `Memcached`
 CRD:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 ----
@@ -194,8 +200,13 @@ method for production use.
 
 ... Build the `memcached-operator` image and push it to a registry:
 +
+[source,terminal]
 ----
 $ operator-sdk build quay.io/example/memcached-operator:v0.0.1
+----
++
+[source,terminal]
+----
 $ podman push quay.io/example/memcached-operator:v0.0.1
 ----
 
@@ -203,23 +214,42 @@ $ podman push quay.io/example/memcached-operator:v0.0.1
 deployment image in this file needs to be modified from the placeholder
 `REPLACE_IMAGE` to the previous built image. To do this, run:
 +
+[source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
 ... Deploy the `memcached-operator`:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/operator.yaml
 ----
 
 ... Verify that the `memcached-operator` is up and running:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+[source,terminal]
+----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator       1         1         1            1           1m
 ----
@@ -238,12 +268,14 @@ path (for example `/etc/ansible/roles`).
 ... To run the Operator locally with the default Kubernetes configuration file
 present at `$HOME/.kube/config`:
 +
+[source,terminal]
 ----
 $ operator-sdk run --local
 ----
 +
 To run the Operator locally with a provided Kubernetes configuration file:
 +
+[source,terminal]
 ----
 $ operator-sdk run --local --kubeconfig=config
 ----
@@ -253,22 +285,37 @@ $ operator-sdk run --local --kubeconfig=config
 .. Modify the `deploy/crds/cache_v1alpha1_memcached_cr.yaml` file as shown and
 create a `Memcached` CR:
 +
+[source,terminal]
 ----
 $ cat deploy/crds/cache_v1alpha1_memcached_cr.yaml
+----
++
+.Example output
+[source,yaml]
+----
 apiVersion: "cache.example.com/v1alpha1"
 kind: "Memcached"
 metadata:
   name: "example-memcached"
 spec:
   size: 3
-
+----
++
+[source,terminal]
+----
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
 .. Ensure that the `memcached-operator` creates the Deployment for the CR:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator       1         1         1            1           2m
 example-memcached        3         3         3            3           1m
@@ -276,8 +323,13 @@ example-memcached        3         3         3            3           1m
 
 .. Check the Pods to confirm three replicas were created:
 +
+[source,terminal]
 ----
 $ oc get pods
+----
++
+[source,terminal]
+----
 NAME                                  READY     STATUS    RESTARTS   AGE
 example-memcached-6fd7c98d8-7dqdr     1/1       Running   0          1m
 example-memcached-6fd7c98d8-g5k7v     1/1       Running   0          1m
@@ -290,33 +342,69 @@ memcached-operator-7cc7cfdf86-vvjqk   1/1       Running   0          2m
 .. Change the `spec.size` field in the `memcached` CR from `3` to `4` and apply the
 change:
 +
+[source,terminal]
 ----
 $ cat deploy/crds/cache_v1alpha1_memcached_cr.yaml
+----
++
+.Example output
+[source,yaml]
+----
 apiVersion: "cache.example.com/v1alpha1"
 kind: "Memcached"
 metadata:
   name: "example-memcached"
 spec:
   size: 4
-
+----
++
+[source,terminal]
+----
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
 .. Confirm that the Operator changes the Deployment size:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 example-memcached    4         4         4            4           5m
 ----
 
 . *Clean up the resources:*
 +
+[source,terminal]
 ----
 $ oc delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/operator.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
 ----

--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -8,6 +8,15 @@
 You can build, push, and validate an Operator bundle image using the Operator
 SDK.
 
+.Example output
+[source,terminal]
+----
+INFO[0000] Unpacked image layers                                 bundle-dir=/tmp/bundle-041168359 container-tool=podman
+INFO[0000] running podman pull                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman
+INFO[0002] running podman save                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman
+INFO[0002] All validation tests have completed successfully      bundle-dir=/tmp/bundle-041168359 container-tool=podman
+----
+
 .Prerequisites
 
 * Operator SDK version 0.17.2
@@ -18,6 +27,7 @@ SDK.
 
 . From your Operator project directory, build the bundle image using the Operator SDK:
 +
+[source,terminal]
 ----
 $ operator-sdk bundle create \
     quay.io/<namespace>/test-operator:v0.1.0 \//<1>
@@ -36,18 +46,21 @@ location with the `--directory` flag.
 
 . Log in to the registry where you want to push the bundle image. For example:
 +
+[source,terminal]
 ----
 $ podman login quay.io
 ----
 
 . Push the bundle image to the registry:
 +
+[source,terminal]
 ----
 $ podman push quay.io/<namespace>/test-operator:v0.1.0
 ----
 
 . Validate the bundle image in the remote registry:
 +
+[source,terminal]
 ----
 $ operator-sdk bundle validate \
     quay.io/<namespace>/test-operator:v0.1.0 \
@@ -55,6 +68,7 @@ $ operator-sdk bundle validate \
 ----
 +
 .Example output
+[source,terminal]
 ----
 INFO[0000] Unpacked image layers                                 bundle-dir=/tmp/bundle-041168359 container-tool=podman
 INFO[0000] running podman pull                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman

--- a/modules/osdk-building-helm-operator.adoc
+++ b/modules/osdk-building-helm-operator.adoc
@@ -33,11 +33,16 @@ isolation for failures and monitoring, and differing API definitions.
 To create a new Helm-based, namespace-scoped `nginx-operator` project, use the
 following command:
 +
+[source,terminal]
 ----
 $ operator-sdk new nginx-operator \
   --api-version=example.com/v1alpha1 \
   --kind=Nginx \
   --type=helm
+----
++
+[source,terminal]
+----
 $ cd nginx-operator
 ----
 +
@@ -131,6 +136,7 @@ file, just like the `helm install -f ./overrides.yaml` command works.
 Before running the Operator, Kubernetes needs to know about the new custom
 resource definition (CRD) the operator will be watching. Deploy the following CRD:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/crds/example_v1alpha1_nginx_crd.yaml
 ----
@@ -151,8 +157,13 @@ method for production use.
 
 ... Build the `nginx-operator` image and push it to a registry:
 +
+[source,terminal]
 ----
 $ operator-sdk build quay.io/example/nginx-operator:v0.0.1
+----
++
+[source,terminal]
+----
 $ podman push quay.io/example/nginx-operator:v0.0.1
 ----
 
@@ -160,23 +171,43 @@ $ podman push quay.io/example/nginx-operator:v0.0.1
 deployment image in this file needs to be modified from the placeholder
 `REPLACE_IMAGE` to the previous built image. To do this, run:
 +
+[source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/nginx-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
 ... Deploy the `nginx-operator`:
 +
+[source,terminal]
 ----
 $ oc create -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc create -f deploy/operator.yaml
 ----
 
 ... Verify that the `nginx-operator` is up and running:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 nginx-operator       1         1         1            1           1m
 ----
@@ -192,20 +223,27 @@ looks in your local file system for this path.
 
 ... Create a symlink at this location to point to your Helm chart's path:
 +
+[source,terminal]
 ----
 $ sudo mkdir -p /opt/helm/helm-charts
+----
++
+[source,terminal]
+----
 $ sudo ln -s $PWD/helm-charts/nginx /opt/helm/helm-charts/nginx
 ----
 
 ... To run the Operator locally with the default Kubernetes configuration file
 present at `$HOME/.kube/config`:
 +
+[source,terminal]
 ----
 $ operator-sdk run --local
 ----
 +
 To run the Operator locally with a provided Kubernetes configuration file:
 +
+[source,terminal]
 ----
 $ operator-sdk run --local --kubeconfig=<path_to_config>
 ----
@@ -214,22 +252,35 @@ $ operator-sdk run --local --kubeconfig=<path_to_config>
 +
 Apply the `Nginx` CR that you modified earlier:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy/crds/example.com_v1alpha1_nginx_cr.yaml
 ----
 +
 Ensure that the `nginx-operator` creates the Deployment for the CR:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                           DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 example-nginx-b9phnoz9spckcrua7ihrbkrt1        2         2         2            2           1m
 ----
 +
 Check the Pods to confirm two replicas were created:
 +
+[source,terminal]
 ----
 $ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                                      READY     STATUS    RESTARTS   AGE
 example-nginx-b9phnoz9spckcrua7ihrbkrt1-f8f9c875d-fjcr9   1/1       Running   0          1m
 example-nginx-b9phnoz9spckcrua7ihrbkrt1-f8f9c875d-ljbzl   1/1       Running   0          1m
@@ -237,8 +288,14 @@ example-nginx-b9phnoz9spckcrua7ihrbkrt1-f8f9c875d-ljbzl   1/1       Running   0 
 +
 Check that the Service port is set to `8080`:
 +
+[source,terminal]
 ----
 $ oc get service
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                      TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
 example-nginx-b9phnoz9spckcrua7ihrbkrt1   ClusterIP   10.96.26.3   <none>        8080/TCP   1m
 ----
@@ -248,41 +305,83 @@ example-nginx-b9phnoz9spckcrua7ihrbkrt1   ClusterIP   10.96.26.3   <none>       
 Change the `spec.replicaCount` field from `2` to `3`, remove the `spec.service`
 field, and apply the change:
 +
+[source,terminal]
 ----
 $ cat deploy/crds/example.com_v1alpha1_nginx_cr.yaml
+----
++
+.Example output
+[source,yaml]
+----
 apiVersion: "example.com/v1alpha1"
 kind: "Nginx"
 metadata:
   name: "example-nginx"
 spec:
   replicaCount: 3
-
+----
++
+[source,terminal]
+----
 $ oc apply -f deploy/crds/example.com_v1alpha1_nginx_cr.yaml
 ----
 +
 Confirm that the Operator changes the Deployment size:
 +
+[source,terminal]
 ----
 $ oc get deployment
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                           DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 example-nginx-b9phnoz9spckcrua7ihrbkrt1        3         3         3            3           1m
 ----
 +
 Check that the Service port is set to the default `80`:
 +
+[source,terminal]
 ----
 $ oc get service
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                      TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)  AGE
 example-nginx-b9phnoz9spckcrua7ihrbkrt1   ClusterIP   10.96.26.3   <none>        80/TCP   1m
 ----
 
 . *Clean up the resources:*
 +
+[source,terminal]
 ----
 $ oc delete -f deploy/crds/example.com_v1alpha1_nginx_cr.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/operator.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/role_binding.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/role.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/service_account.yaml
+----
++
+[source,terminal]
+----
 $ oc delete -f deploy/crds/example_v1alpha1_nginx_crd.yaml
 ----

--- a/modules/osdk-cli-reference-add.adoc
+++ b/modules/osdk-cli-reference-add.adoc
@@ -46,9 +46,16 @@ Operator application.
 |CRD `Kind` (e.g., `AppService`).
 |===
 
-.Example `add api` output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk add api --api-version app.example.com/v1alpha1 --kind AppService
+----
+
+.Example output
+[source,terminal]
+----
 Create pkg/apis/app/v1alpha1/appservice_types.go
 Create pkg/apis/addtoscheme_app_v1alpha1.go
 Create pkg/apis/app/v1alpha1/register.go
@@ -57,25 +64,46 @@ Create deploy/crds/app_v1alpha1_appservice_cr.yaml
 Create deploy/crds/app_v1alpha1_appservice_crd.yaml
 Running code-generation for Custom Resource (CR) group versions: [app:v1alpha1]
 Generating deepcopy funcs
+----
 
+[source,terminal]
+----
 $ tree pkg/apis
+----
+
+.Example output
+[source,terminal]
+----
 pkg/apis/
 ├── addtoscheme_app_appservice.go
 ├── apis.go
 └── app
-	└── v1alpha1
-		├── doc.go
-		├── register.go
-		├── types.go
+    └── v1alpha1
+        ├── doc.go
+        ├── register.go
+        └── types.go
 ----
 
-.Example `add controller` output
+[source,terminal]
 ----
 $ operator-sdk add controller --api-version app.example.com/v1alpha1 --kind AppService
+----
+
+.Example output
+[source,terminal]
+----
 Create pkg/controller/appservice/appservice_controller.go
 Create pkg/controller/add_appservice.go
+----
 
+[source,terminal]
+----
 $ tree pkg/controller
+----
+
+.Example output
+[source,terminal]
+----
 pkg/controller/
 ├── add_appservice.go
 ├── appservice
@@ -83,9 +111,14 @@ pkg/controller/
 └── controller.go
 ----
 
-.Example `add crd` output
+[source,terminal]
 ----
 $ operator-sdk add crd --api-version app.example.com/v1alpha1 --kind AppService
+----
+
+.Example output
+[source,terminal]
+----
 Generating Custom Resource Definition (CRD) files
 Create deploy/crds/app_v1alpha1_appservice_crd.yaml
 Create deploy/crds/app_v1alpha1_appservice_cr.yaml

--- a/modules/osdk-cli-reference-build.adoc
+++ b/modules/osdk-cli-reference-build.adoc
@@ -36,10 +36,16 @@ If `--enable-tests` is set, the `build` command also builds the testing binary,
 adds it to the container image, and generates a `deploy/test-pod.yaml` file that
 allows a user to run the tests as a Pod on a cluster.
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk build quay.io/example/operator:v0.0.1
+----
 
+.Example output
+[source,terminal]
+----
 building example-operator...
 
 building container quay.io/example/operator:v0.0.1...

--- a/modules/osdk-cli-reference-completion.adoc
+++ b/modules/osdk-cli-reference-completion.adoc
@@ -25,10 +25,16 @@ issuing CLI commands quicker and easier.
 |Usage help output.
 |===
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk completion bash
+----
 
+.Example output
+[source,terminal]
+----
 # bash completion for operator-sdk                         -*- shell-script -*-
 ...
 # ex: ts=4 sw=4 et filetype=sh

--- a/modules/osdk-cli-reference-generate.adoc
+++ b/modules/osdk-cli-reference-generate.adoc
@@ -27,10 +27,21 @@ The `generate crds` subcommand generates CRDs or updates them if they exist, und
 |Help for `generate crds`
 |===
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk generate crds
+----
+
+[source,terminal]
+----
 $ tree deploy/crds
+----
+
+.Example output
+[source,terminal]
+----
 ├── deploy/crds/app.example.com_v1alpha1_appservice_cr.yaml
 └── deploy/crds/app.example.com_appservices_crd.yaml
 ----
@@ -74,9 +85,16 @@ latest CRD manifests.
 
 |===
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk generate csv --csv-version 0.1.0 --update-crds
+----
+
+.Example output
+[source,terminal]
+----
 INFO[0000] Generating CSV manifest version 0.1.0
 INFO[0000] Fill in the following required fields in file deploy/olm-catalog/operator-name/0.1.0/operator-name.v0.1.0.clusterserviceversion.yaml:
 	spec.keywords
@@ -100,19 +118,42 @@ This command must be run every time the API (`spec` and `status`) for a custom
 resource type is updated.
 ====
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ tree pkg/apis/app/v1alpha1/
+----
+
+.Example output
+[source,terminal]
+----
 pkg/apis/app/v1alpha1/
 ├── appservice_types.go
 ├── doc.go
-├── register.go
+└── register.go
+----
 
+[source,terminal]
+----
 $ operator-sdk generate k8s
+----
+
+.Example output
+[source,terminal]
+----
 Running code-generation for Custom Resource (CR) group versions: [app:v1alpha1]
 Generating deepcopy funcs
+----
 
+[source,terminal]
+----
 $ tree pkg/apis/app/v1alpha1/
+----
+
+.Example output
+[source,terminal]
+----
 pkg/apis/app/v1alpha1/
 ├── appservice_types.go
 ├── doc.go

--- a/modules/osdk-cli-reference-new.adoc
+++ b/modules/osdk-cli-reference-new.adoc
@@ -59,13 +59,25 @@ modules.
 ====
 
 .Example usage for Go project
+
+[source,terminal]
 ----
 $ mkdir $GOPATH/src/github.com/example.com/
+----
+
+[source,terminal]
+----
 $ cd $GOPATH/src/github.com/example.com/
+----
+
+[source,terminal]
+----
 $ operator-sdk new app-operator
 ----
 
 .Example usage for Ansible project
+
+[source,terminal]
 ----
 $ operator-sdk new app-operator \
     --type=ansible \

--- a/modules/osdk-cli-reference-print-deps.adoc
+++ b/modules/osdk-cli-reference-print-deps.adoc
@@ -13,9 +13,16 @@ versions required by Operators. It prints in columnar format by default.
 |Print packages and versions in `Gopkg.toml` format.
 |===
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk print-deps --as-file
+----
+
+.Example output
+[source,terminal]
+----
 required = [
   "k8s.io/code-generator/cmd/defaulter-gen",
   "k8s.io/code-generator/cmd/deepcopy-gen",

--- a/modules/osdk-cli-reference-run.adoc
+++ b/modules/osdk-cli-reference-run.adoc
@@ -38,7 +38,9 @@ The `--local` flag launches the Operator on the local machine by building
 the Operator binary with the ability to access a Kubernetes cluster using a
 `kubeconfig` file.
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk run --local \
   --kubeconfig "mycluster.kubecfg" \
@@ -51,6 +53,7 @@ environment variable, and passes in flags for the Operator. To use the Operator
 flags, your Operator must know how to handle the option. For example, for an
 Operator that understands the `resync-interval` flag:
 
+[source,terminal]
 ----
 $ operator-sdk run --local --operator-flags "--resync-interval 10"
 ----
@@ -59,6 +62,7 @@ If you are planning on using a different namespace than the default, use the
 `--namespace` flag to change where the Operator is watching for Custom Resources
 (CRs) to be created:
 
+[source,terminal]
 ----
 $ operator-sdk run --local --namespace "testing"
 ----

--- a/modules/osdk-cli-reference-test.adoc
+++ b/modules/osdk-cli-reference-test.adoc
@@ -5,8 +5,8 @@ The `operator-sdk test` command can test the Operator locally.
 
 == local
 
-The `local` subcommand runs Go tests built using the Operator SDK's test
-framework locally.
+The `local` subcommand runs Go tests built using the test framework of the
+Operator SDK locally.
 
 .`test local` arguments
 [options="header",cols="1,3"]
@@ -54,10 +54,15 @@ manifest.
 |Usage help output.
 |===
 
-.Example output
+For example:
+
+[source,terminal]
 ----
 $ operator-sdk test local ./test/e2e/
+----
 
-# Output:
+.Example output
+[source,terminal]
+----
 ok  	github.com/operator-framework/operator-sdk-samples/memcached-operator/test/e2e	20.410s
 ----

--- a/modules/osdk-generating-a-csv.adoc
+++ b/modules/osdk-generating-a-csv.adoc
@@ -15,6 +15,7 @@
 
 . Generate the CSV:
 +
+[source,terminal]
 ----
 $ operator-sdk generate csv --csv-version <version>
 ----

--- a/modules/osdk-helm-chart-support.adoc
+++ b/modules/osdk-helm-chart-support.adoc
@@ -31,6 +31,7 @@ trail.
 
 For an example of a simple CR called `Tomcat`:
 
+[source,yaml]
 ----
 apiVersion: apache.org/v1alpha1
 kind: Tomcat
@@ -43,6 +44,7 @@ spec:
 The `replicaCount` value, `2` in this case, is propagated into the chart's
 templates where following is used:
 
+[source,yaml]
 ----
 {{ .Values.replicaCount }}
 ----
@@ -51,6 +53,7 @@ After an Operator is built and deployed, you can deploy a new instance of an app
 by creating a new instance of a CR, or list the different instances running in
 all environments using the `oc` command:
 
+[source,terminal]
 ----
 $ oc get Tomcats --all-namespaces
 ----

--- a/modules/osdk-how-csv-gen-works.adoc
+++ b/modules/osdk-how-csv-gen-works.adoc
@@ -9,6 +9,7 @@ An Operator project's `deploy/` directory is the standard location for all
 manifests required to deploy an Operator. The Operator SDK can use data from
 manifests in `deploy/` to write a CSV. The following command:
 
+[source,terminal]
 ----
 $ operator-sdk generate csv --csv-version <version>
 ----

--- a/modules/osdk-installing-cli.adoc
+++ b/modules/osdk-installing-cli.adoc
@@ -42,8 +42,9 @@ endif::[]
 
 . Set the release version variable:
 +
+[source,terminal]
 ----
-RELEASE_VERSION=v0.17.2
+$ RELEASE_VERSION=v0.17.2
 ----
 
 . Download the release binary.
@@ -51,12 +52,14 @@ RELEASE_VERSION=v0.17.2
 --
 * For Linux:
 +
+[source,terminal]
 ----
 $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 ----
 
 * For macOS:
 +
+[source,terminal]
 ----
 $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
 ----
@@ -69,12 +72,14 @@ $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download
 --
 * For Linux:
 +
+[source,terminal]
 ----
 $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
 ----
 
 * For macOS:
 +
+[source,terminal]
 ----
 $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
 ----
@@ -86,22 +91,25 @@ the following command to verify the binary:
 --
 * For Linux:
 +
+[source,terminal]
 ----
 $ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
 ----
 
 * For macOS:
 +
+[source,terminal]
 ----
 $ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
 ----
 --
 +
-If you do not have the maintainer's public key on your workstation, you will
-get the following error:
+If you do not have the public key of the maintainer on your workstation, you
+will get the following error:
 +
+.Example output with error
+[source,terminal]
 ----
-$ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
 $ gpg: assuming signed data in 'operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin'
 $ gpg: Signature made Fri Apr  5 20:03:22 2019 CEST
 $ gpg:                using RSA key <key_id> <1>
@@ -112,6 +120,7 @@ $ gpg: Can't check signature: No public key
 To download the key, run the following command, replacing `<key_id>` with the RSA
 key string provided in the output of the previous command:
 +
+[source,terminal]
 ----
 $ gpg [--keyserver keys.gnupg.net] --recv-key "<key_id>" <1>
 ----
@@ -123,23 +132,42 @@ $ gpg [--keyserver keys.gnupg.net] --recv-key "<key_id>" <1>
 --
 * For Linux:
 +
+[source,terminal]
 ----
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+----
++
+[source,terminal]
+----
 $ sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk
+----
++
+[source,terminal]
+----
 $ rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 ----
 
 * For macOS:
 +
+[source,terminal]
 ----
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
+----
++
+[source,terminal]
+----
 $ sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/operator-sdk
+----
++
+[source,terminal]
+----
 $ rm operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
 ----
 --
 
 . Verify that the CLI tool was installed correctly:
 +
+[source,terminal]
 ----
 $ operator-sdk version
 ----
@@ -166,12 +194,14 @@ endif::[]
 
 . Install the SDK CLI using the `brew` command:
 +
+[source,terminal]
 ----
 $ brew install operator-sdk
 ----
 
 . Verify that the CLI tool was installed correctly:
 +
+[source,terminal]
 ----
 $ operator-sdk version
 ----
@@ -199,23 +229,42 @@ endif::[]
 
 . Clone the `operator-sdk` repository:
 +
+[source,terminal]
 ----
 $ mkdir -p $GOPATH/src/github.com/operator-framework
+----
++
+[source,terminal]
+----
 $ cd $GOPATH/src/github.com/operator-framework
+----
++
+[source,terminal]
+----
 $ git clone https://github.com/operator-framework/operator-sdk
+----
++
+[source,terminal]
+----
 $ cd operator-sdk
 ----
 
 . Check out the desired release branch:
 +
+[source,terminal]
 ----
 $ git checkout master
 ----
 
 . Compile and install the SDK CLI:
 +
+[source,terminal]
 ----
 $ make dep
+----
++
+[source,terminal]
+----
 $ make install
 ----
 +
@@ -223,6 +272,7 @@ This installs the CLI binary `operator-sdk` at *_$GOPATH/bin_*.
 
 . Verify that the CLI tool was installed correctly:
 +
+[source,terminal]
 ----
 $ operator-sdk version
 ----

--- a/modules/osdk-monitoring-prometheus-metrics-helper.adoc
+++ b/modules/osdk-monitoring-prometheus-metrics-helper.adoc
@@ -13,7 +13,8 @@ function exposes general metrics about the running program:
 func ExposeMetricsPort(ctx context.Context, port int32) (*v1.Service, error)
 ----
 
-These metrics are inherited from the `controller-runtime` library API. By default, the metrics are served on `0.0.0.0:8383/metrics`.
+These metrics are inherited from the `controller-runtime` library API. By
+default, the metrics are served on `0.0.0.0:8383/metrics`.
 
 A Service object is created with the metrics port exposed, which can be then
 accessed by Prometheus. The Service object is garbage collected when the leader

--- a/modules/osdk-running-scorecard.adoc
+++ b/modules/osdk-running-scorecard.adoc
@@ -33,6 +33,7 @@ This is required for the scorecard proxy to work correctly.
 . Create the namespace defined in the RBAC files (`role_binding`).
 . Run the scorecard from the root directory of your Operator project:
 +
+[source,terminal]
 ----
 $ operator-sdk scorecard
 ----

--- a/modules/osdk-scorecard-olm.adoc
+++ b/modules/osdk-scorecard-olm.adoc
@@ -20,10 +20,11 @@ one of the following methods.
 --
 * *Manual method:*
 
-..  Create a proxy server secret containing a local Kubeconfig:
+..  Create a proxy server Secret containing a local Kubeconfig.
 
 ... Generate a user name using the scorecard proxy's namespaced owner reference.
 +
+[source,terminal]
 ----
 $ echo '{"apiVersion":"","kind":"","name":"scorecard","uid":"","Namespace":"'<namespace>'"}' | base64 -w 0 <1>
 ----
@@ -58,11 +59,12 @@ users:
 
 ... Encode the `Config` as base64:
 +
+[source,terminal]
 ----
 $ cat scorecard-config.yaml | base64 -w 0
 ----
 
-... Create a `Secret` manifest `scorecard-secret.yaml`:
+... Create a Secret manifest `scorecard-secret.yaml`:
 +
 [source,yaml]
 ----
@@ -77,13 +79,14 @@ data:
 <1> Replace `<namespace>` with the namespace your Operator will deploy in.
 <2> Replace `<kubeconfig_base64>` with the `Config` encoded as base64.
 
-... Apply the secret:
+... Apply the Secret:
 +
+[source,terminal]
 ----
 $ oc apply -f scorecard-secret.yaml
 ----
 
-... Insert a volume referring to the `Secret` into the Operator's Deployment:
+... Insert a volume referring to the Secret into the Deployment for the Operator:
 +
 [source,yaml]
 ----
@@ -178,20 +181,59 @@ spec:
 The
 link:https://github.com/operator-framework/community-operators[`community-operators`]
 repository has several bash functions that can perform the previous steps in the
-procedure for you:
+procedure for you.
+
+.. Run the following `curl` command:
 +
+[source,terminal]
 ----
 $ curl -Lo csv-manifest-modifiers.sh \
     https://raw.githubusercontent.com/operator-framework/community-operators/master/scripts/lib/file
+----
+
+.. Source the `csv-manifest-modifiers.sh` file:
++
+[source,terminal]
+----
 $ . ./csv-manifest-modifiers.sh
+----
+
+.. Create the Kubeconfig Secret file:
++
+[source,terminal]
+----
 $ create_kubeconfig_secret_file scorecard-secret.yaml "<namespace>" <1>
-$ oc apply -f scorecard-secret.yaml
-$ insert_kubeconfig_volume "<csv_file>" <2>
-$ insert_kubeconfig_secret_mount "<csv_file>"
-$ insert_proxy_container "<csv_file>" "quay.io/operator-framework/scorecard-proxy:master"
 ----
 <1> Replace `<namespace>` with the namespace your Operator will deploy in.
-<2> Replace `<csv_file>` with the path to your Operator's CSV manifest.
+
+.. Apply the Secret:
++
+[source,terminal]
+----
+$ oc apply -f scorecard-secret.yaml
+----
+
+.. Insert the Kubeconfig volume:
++
+[source,terminal]
+----
+$ insert_kubeconfig_volume "<csv_file>" <1>
+----
+<1> Replace `<csv_file>` with the path to your Operator's CSV manifest.
+
+.. Insert the Kubeconfig Secret mount:
++
+[source,terminal]
+----
+$ insert_kubeconfig_secret_mount "<csv_file>"
+----
+
+.. Insert the proxy container:
++
+[source,terminal]
+----
+$ insert_proxy_container "<csv_file>" "quay.io/operator-framework/scorecard-proxy:master"
+----
 --
 
 . After inserting the proxy container, follow the steps in the _Getting started with the Operator SDK_
@@ -205,6 +247,7 @@ and `olm-deployed` options are set.
 `csv-path: <csv_manifest_path>` and `olm-deployed` options set in your scorecard
 configuration file:
 +
+[source,terminal]
 ----
 $ operator-sdk scorecard
 ----

--- a/modules/osdk-scorecard-tests.adoc
+++ b/modules/osdk-scorecard-tests.adoc
@@ -13,8 +13,13 @@ testing environment.
 Each test has a short name that uniquely identifies the test. This is useful
 when selecting a specific test or tests to run. For example:
 
+[source,terminal]
 ----
 $ operator-sdk scorecard -o text --selector=test=checkspectest
+----
+
+[source,terminal]
+----
 $ operator-sdk scorecard -o text --selector='test in (checkspectest,checkstatustest)'
 ----
 

--- a/operators/operator_sdk/osdk-cli-reference.adoc
+++ b/operators/operator_sdk/osdk-cli-reference.adoc
@@ -7,6 +7,7 @@ toc::[]
 
 This guide documents the Operator SDK CLI commands and their syntax:
 
+[source,terminal]
 ----
 $ operator-sdk <command> [<subcommand>] [<argument>] [<flags>]
 ----

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -29,6 +29,7 @@ The CSV version is the same as the Operator's, and a new CSV is generated when
 upgrading Operator versions. Operator authors can use the `--csv-version` flag
 to have their Operators' state encapsulated in a CSV with the supplied semantic version:
 
+[source,terminal]
 ----
 $ operator-sdk generate csv --csv-version <version>
 ----


### PR DESCRIPTION
Also add `[source,terminal]` where relevant.

Preview: http://file.rdu.redhat.com/~adellape/080320/example_output_operators/operators/olm-managing-custom-catalogs.html#olm-installing-opm_olm-managing-custom-catalogs