### PR TITLE
OSDOCS-1086: Adding shutdown restart to release notes

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -483,6 +483,16 @@ Virtual hosted buckets are now supported to deploy clusters in new or hidden AWS
 
 Builds and imagestream imports will automatically use the pull secret used to install the cluster if a pull secret is not explicitly set. Developers do not need to copy this pull secret into their namespace.
 
+[id="ocp-4-5-backup-restore"]
+=== Backup and restore
+
+[id="ocp-4-5-shutdown-restart"]
+==== Gracefully shutting down and restarting a cluster
+
+You can now gracefully shut down and restart your {product-title} {product-version} cluster. You might need to temporarily shut down your cluster for maintenance reasons, or to save on resource costs.
+
+See xref:../backup_and_restore/graceful-cluster-shutdown.adoc#graceful-shutdown-cluster[Shutting down the cluster gracefully] for more information.
+
 [id="ocp-4-5-disaster-recovery"]
 === Disaster recovery
 


### PR DESCRIPTION
Preview (internal): http://file.rdu.redhat.com/~ahoffer/2020/shutdown-rn/release_notes/ocp-4-5-release-notes.html#ocp-4-5-backup-restore