### PR TITLE
BZ1858369 - Document multi-attach error for RWO failed node

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -137,8 +137,8 @@ the Pods that use these volumes are deleted.
 .Supported access modes for PVs
 [cols=",^v,^v,^v", width="100%",options="header"]
 |===
-|Volume Plug-in  |ReadWriteOnce  |ReadOnlyMany  |ReadWriteMany
-|AWS EBS  | ✅ | - |  -
+|Volume Plug-in  |ReadWriteOnce ^[1]^  |ReadOnlyMany  |ReadWriteMany
+|AWS EBS ^[2]^ | ✅ | - |  -
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |Azure File | ✅ | ✅ | ✅
 |Azure Disk | ✅ | - | -
@@ -155,14 +155,14 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |Red Hat OpenShift Container Storage  | ✅ | - | ✅
 |VMware vSphere | ✅ | - |  -
 endif::[]
+
 |===
-
-[NOTE]
-====
-Use a recreate deployment strategy for Pods that rely on AWS EBS.
+[.small]
+--
+1. ReadWriteOnce (RWO) volumes cannot be mounted on multiple nodes. If a node fails, the system does not allow the attached RWO volume to be mounted on a new node because it is already assigned to the failed node. If you encounter a multi-attach error message as a result, you can either recover or delete the failed node to make the volume available to other nodes. 
+2. Use a recreate deployment strategy for Pods that rely on AWS EBS.
 // GCE Persistent Disks, or Openstack Cinder PVs.
-====
-
+--
 
 ifdef::openshift-dedicated,openshift-online[]
 [id="pv-restrictions_{context}"]


### PR DESCRIPTION
[BZ1858369](https://bugzilla.redhat.com/show_bug.cgi?id=1858369) - Adds a note to supported access modes table in OCP Storage docs that explains the reason for a multi-attach error with RWO volumes. Applies to OCP 4.3+.

Also changed note about using recreate strategy for AWS EBS from admonition style to footnote style for consistency and readability.

@gnufied or @jsafrane - PTAL for technical accuracy

@qinpingli or @wzheng1 - PTAL for QE

PREVIEW: https://bz1858369--ocpdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#pv-access-modes_understanding-persistent-storage