### PR TITLE
Node Tuning Operator chapter review wrt k8s guidelines.

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -18,7 +18,7 @@ $ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
 The default CR is meant for delivering standard node-level tuning for the
 {product-title} platform and it can only be modified to set the Operator
 Management state. Any other custom changes to the default CR will be
-overwritten by the Operator. For custom tuning, create your own tuned CRs. Newly
+overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly
 created CRs will be combined with the default CR and custom tuning applied to
 {product-title} nodes based on node or Pod labels and profile priorities.
 
@@ -26,7 +26,7 @@ created CRs will be combined with the default CR and custom tuning applied to
 ====
 While in certain situations the support for Pod labels can be a convenient way
 of automatically delivering required tuning, this practice is discouraged and
-strongly advised against, especially in large-scale clusters. The default tuned
+strongly advised against, especially in large-scale clusters. The default Tuned
 CR ships without Pod label matching. If a custom profile is created with Pod
 label matching, then the functionality will be enabled at that time. The Pod
 label functionality might be deprecated in future versions of the Node Tuning

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -3,13 +3,13 @@
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
 [id="verifying-tuned-profiles-are-applied_{context}"]
-=  Verifying that the tuned profiles are applied
+=  Verifying that the Tuned profiles are applied
 
-Use this procedure to check which tuned profiles are applied on every node.
+Use this procedure to check which Tuned profiles are applied on every node.
 
 .Procedure
 
-. Check which tuned Pods are running on each node:
+. Check which Tuned Pods are running on each node:
 +
 ----
 $ oc get pods -n openshift-cluster-node-tuning-operator -o wide

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -8,7 +8,7 @@
 The following CR applies custom node-level tuning for
 {product-title} nodes with label
 `tuned.openshift.io/ingress-node-label` set to any value.
-As an administrator, use the following command to create a custom tuned CR.
+As an administrator, use the following command to create a custom Tuned CR.
 
 .Example
 
@@ -39,7 +39,7 @@ _EOF_
 
 [IMPORTANT]
 ====
-Custom profile writers are strongly encouraged to include the default tuned
+Custom profile writers are strongly encouraged to include the default Tuned
 daemon profiles shipped within the default Tuned CR. The example above uses the
 default `openshift-control-plane` profile to accomplish this.
 ====

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -96,8 +96,8 @@ The individual items of the list:
   <match> <4>
 ----
 <1> Node or Pod label name.
-<2> Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
-<3> Optional node or pod type ("node" or "pod"). If omitted, "node" is assumed.
+<2> Optional node or Pod label value. If omitted, the presence of `<label_name>` is enough to match.
+<3> Optional object type ("node" or "pod"). If omitted, "node" is assumed.
 <4> An optional `<match>` list.
 
 If `<match>` is not omitted, all nested `<match>` sections must also evaluate to
@@ -152,17 +152,17 @@ The CR above is translated for the containerized Tuned daemon into its
 `recommend.conf` file based on the profile priorities. The profile with the
 highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is
 considered first. The containerized Tuned daemon running on a given node looks
-to see if there is a pod running on the same node with the
+to see if there is a Pod running on the same node with the
 `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>`
-section evaluates as `false`. If there is such a pod with the label, in order for
+section evaluates as `false`. If there is such a Pod with the label, in order for
 the `<match>` section to evaluate to `true`, the node label also needs to be
 `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
 If the labels for the profile with priority `10` matched,
 `openshift-control-plane-es` profile is applied and no other profile is
-considered. If the node/pod label combination did not match, the second highest
+considered. If the node/Pod label combination did not match, the second highest
 priority profile (`openshift-control-plane`) is considered. This profile is
-applied if the containerized Tuned pod runs on a node with labels
+applied if the containerized Tuned Pod runs on a node with labels
 `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
 Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks
@@ -197,7 +197,7 @@ spec:
     profile: openshift-node-custom
 ----
 
-To minimize node reboots, label the target Nodes with
+To minimize node reboots, label the target nodes with
 a label the MachineConfigPool's `nodeSelector` will match, then create the
 Tuned CR above and finally create the custom MachineConfigPool itself.
 


### PR DESCRIPTION
Review of the Node Tuning Operato based on k8s Documentation Style Guide.
https://kubernetes.io/docs/contribute/style/style-guide/

Also changing `s|tuned|Tuned|` where appropriate based on discussion with the BaseOS/tuned developers.
