### PR TITLE
Add 'Example output' codeblock title & [source,terminal] to doc_guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -234,11 +234,11 @@ statement] is not necessary. For example, if you were viewing a build for the
 `openshift-enterprise` distro (for any of the distro-defined branches), this
 would render as:
 
-"You can deploy applications on OpenShift Container Platform."
+> You can deploy applications on OpenShift Container Platform.
 
 And for the `openshift-origin` distro:
 
-"You can deploy applications on OKD."
+> You can deploy applications on OKD.
 
 Considering that we use distinct branches to keep content for product versions
 separated, global use of `{product-version}` across all branches is probably
@@ -258,7 +258,7 @@ https://docs.openshift.com/container-platform/3.11/install/example_inventories.h
 
 
 == Links, hyperlinks, and cross references
-Links can be used to cross-reference internal assemblies or send customers to external information resources for further reading.
+Links can be used to cross-reference internal assemblies or send readers to external information resources for further reading.
 
 In OpenShift docs:
 
@@ -305,12 +305,10 @@ the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-the-cli[
 Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
 ----
 
-.Rendered output of cross-referencing:
-====
-Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-the-cli[OpenShift CLI].
-
-Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
-====
+.Rendered output of cross-referencing
+> Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-the-cli[OpenShift CLI].
+>
+> Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
 
 === Links to external websites
 
@@ -435,20 +433,60 @@ For all of the system blocks including table delimiters, use four characters. Fo
 ---- for code blocks
 ....
 
+=== Code blocks, command syntax, and example output
 
-=== Code blocks
-Code blocks are used to show examples of command screen outputs, or
-configuration files. When using command blocks, always use the actual values for
-any items that a user would normally replace. Code blocks should represent
-exactly what a customer would see on their screen. If you must expand or
-provide information on what some of the contents of a screen output or
-configuration file represent, then use callouts to provide that information.
+Code blocks are generally used to show examples of command syntax, example
+screen output, and configuration files.
 
-Follow these general guidelines when using code blocks:
+The main distinction between showing command syntax and a command example is
+that a command syntax shows readers how to use the command without real values.
+An example command, however, shows the command with actual values with an
+example output of that command, where applicable.
+
+For example:
+
+....
+In the following example, the `oc get` operation returns a complete list of services that are currently defined:
+
+[source,terminal]
+----
+$ oc get se
+----
+
+.Example output
+[source,terminal]
+----
+NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
+docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
+----
+....
+
+This renders as:
+
+> In the following example, the `oc get` operation returns a complete list of services that are currently defined:
+>
+> ----
+> $ oc get se
+> ----
+>
+> .Example output
+> ----
+> NAME                LABELS                                    SELECTOR            IP                  PORT
+> kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
+> kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
+> docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
+> ----
+
+The following guidelines go into more detail about specific requirements and
+recommendations when using code blocks:
 
 * Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
 
-* For all code blocks, you must include an empty line above a code block.
+* For all code blocks, you must include an empty line above a code block (unless
+that line is introducing block metadata, such as `[source,terminal]` for syntax
+highlighting).
 +
 Acceptable:
 +
@@ -471,53 +509,101 @@ $ lorem.sh
 +
 Without the line spaces, the content is likely to be not parsed correctly.
 
-* It is recommended to include source tags for the programming language used in the code block to enable syntax highlighting. For example, use the source tags
- `[source,yaml]` or `[source,javascript]`.
-+
-NOTE: Do not use `[source,bash]` for `oc` commands or any terminal commands, because it does not render properly in some cases.
+* Use `[source,terminal]` for `oc` commands or any terminal commands to enable
+syntax highlighting. Any `[source]` metadata must go on the line directly before
+the code block. For example:
 +
 ....
-Lorem ipsum
-
+[source,terminal]
 ----
-$ lorem.sh
+$ oc get nodes
 ----
 ....
-
-* Do not use more than one command per code block. For example, the following must be split up into three separate code blocks.
 +
+If you are also showing a code block for the output of the command, use
+`[source,terminal]` for that code block as well.
+
+* Use source tags for the programming language used in the code block to enable
+syntax highlighting. For example:
+
+** `[source,yaml]`
+** `[source,go]`
+** `[source,javascript]`
+
+* Do not use more than one command per code block. For example, the following must
+be split up into three separate code blocks:
++
+....
 Run the following commands to create templates you can modify:
-+
+
+[source,terminal]
 ----
 $ oc adm create-login-template > login.html
 ----
-+
+
+[source,terminal]
 ----
 $ oc adm create-provider-selection-template > providers.html
 ----
-+
+
+[source,terminal]
 ----
 $ oc adm create-error-template > errors.html
 ----
-+
+....
 
-* Separate a command and its related output into individual code blocks. For example:
+* Separate a command and its related example output into individual code blocks.
+This allows the command to be easily copied using the button on
++++docs.openshift.com+++.
 +
-Use the `oc new-project` command to create a new project.
+In addition, prepend the code block for the output with the title `.Example output`
+to make it consistently clear across the docs when this is being represented. A
+lead-in sentence explaining the example output is optional. For example:
 +
+....
+Use the `oc new-project` command to create a new project:
+
+[source,terminal]
 ----
 $ oc new-project my-project
 ----
 
-+
-The output verifies that a new project was created.
-+
+The output verifies that a new project was created:
 
+.Example output
+[source,terminal]
 ----
 Now using project "my-project" on server "https://openshift.example.com:6443".
 ----
+....
 
-* Try to use callouts to provide information on what the output represents when required.
+* To mark up command syntax, use the code block and wrap any replaceable values in
+angle brackets (`<>`) with the required command parameter, using underscores
+(`_`) between words as necessary for legibility. For example:
++
+....
+The following command returns a list of objects for the specified object type:
+
+[source,terminal]
+----
+$ oc get <object_type> <object_id>
+----
+....
++
+This renders as:
++
+--
+> The following command returns a list of objects for the specified object type:
+>
+> ----
+> $ oc get <object_type> <object_id>
+> ----
+--
++
+NOTE: Avoid using full command syntax inline with sentences.
+
+* If you must provide additional information on what a line of a code block
+represents, use callouts (`<1>`, `<2>`, etc.) to provide that information.
 +
 Use this format when embedding callouts into the code block:
 +
@@ -541,7 +627,7 @@ $ oc get endpoints --all-namespaces --template \
     {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
 ----
 
-* If the user must run a command as root, use a number sign, `#`, at the start of the command instead of a dollar sign, `$`. For example:
+* If the user must run a command as root, use a number sign (`#`) at the start of the command instead of a dollar sign (`$`). For example:
 +
 ----
 # subscription-manager list
@@ -583,65 +669,7 @@ Use the `GET` operation to do x.
 
 This renders as:
 
-Use the `GET` operation to do x.
-
-=== Command Syntax and Examples
-The main distinction between showing command syntax and example is that a command syntax should just show customers how to use the command without real values. An example on the other hand should show the command with actual values with an example output of that command, where applicable.
-
-==== Command syntax
-To markup command syntax, use the code block and wrap the replaceables in <> with the required command parameters, as shown in the following example. Do NOT use commands or command syntax inline with sentences.
-
-....
-The following command returns a list of objects for the specified object type:
-
-----
-$ oc get <object_type> <object_id>
-----
-....
-
-This would render as follows:
-
-The following command returns a list of objects for the specified object type:
-
-----
-$ oc get <object_type> <object_id>
-----
-
-==== Examples
-As mentioned an example of a command should use actual values and also show an output of the command, as shown in the following example. In some a heading may not be required.
-
-[WARNING]
-====
-Do not provide examples which use `jq`. Examples should use a templating engine that is provided with oc, like `jsonpath`. See (https://bugzilla.redhat.com/show_bug.cgi?id=1764726#c6) for more information.
-====
-
-....
-In the following example the `oc get` operation returns a complete list of services that are currently defined.
-
-.Example title
-
-----
-$ oc get se
-NAME                LABELS                                    SELECTOR            IP                  PORT
-kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
-kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
-docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
-----
-....
-
-This would render as shown:
-
-In the following example the `oc get` operation returns a complete list of services that are currently defined.
-
-.Example title
-
-----
-$ oc get se
-NAME                LABELS                                    SELECTOR            IP                  PORT
-kubernetes          component=apiserver,provider=kubernetes   <none>              172.30.17.96        443
-kubernetes-ro       component=apiserver,provider=kubernetes   <none>              172.30.17.77        80
-docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
-----
+> Use the `GET` operation to do x.
 
 === Lists
 Lists are created as shown in this example:
@@ -654,13 +682,11 @@ Lists are created as shown in this example:
 . Item 3
 ....
 
-This will render as such:
+This renders as:
 
-. Item 1
-
-. Item 2
-
-. Item 3
+> . Item 1
+> . Item 2
+> . Item 3
 
 If you must add any text, admonitions, or code blocks you have to add the continuous +, as shown in the example:
 
@@ -676,17 +702,15 @@ some code block
 . Item 3
 ....
 
-This renders as shown:
+This renders as:
 
-. Item 1
-+
-----
-some code block
-----
-
-. Item 2
-
-. Item 3
+> . Item 1
+> +
+> ----
+> some code block
+> ----
+> . Item 2
+> . Item 3
 
 === Footnotes
 
@@ -767,11 +791,11 @@ style and wrap it in a `--` block.
 |===
 |Markup in command syntax |Description |Substitute value in Example block
 
-|<username>
+|`<username>`
 |Name of user account
 |user@example.com
 
-|<password>
+|`<password>`
 |User password
 |password
 |===
@@ -781,11 +805,11 @@ style and wrap it in a `--` block.
 |===
 |Markup in command syntax |Description |Substitute value in Example block
 
-|<project>
+|`<project>`
 |Name of project
 |myproject
 
-|<app>
+|`<app>`
 |Name of an application
 |myapp
 |===
@@ -835,101 +859,144 @@ style guidelines. For example:
 
 |Code blocks
 
-a|Use the following syntax for the `oc` command:
+a|
+....
+Use the following syntax for the `oc` command:
 
 ----
 $ oc <action> <object_type> <object_name_or_id>
 ----
+....
 
-a|Use the following syntax for the `oc` command:
-
-----
-$ oc <action> <object_type> <object_name_or_id>
-----
+a|
+> Use the following syntax for the `oc` command:
+>
+> ----
+> $ oc <action> <object_type> <object_name_or_id>
+> ----
 
 a|Use backticks for all non-GUI "system items", including:
 
 * Inline commands, operations, literal values, variables, parameters, settings,
 flags, environment variables, user input
 * System term/item, user names, unique or example names for individual API
-objects/resources (e.g., a Pod named "mypod"), daemon, service, or software
+objects/resources (e.g., a Pod named `mypod`), daemon, service, or software
 package
 * RPM packages
 * File names or directory paths
 
-a|$$`oc get`$$
-
-$$Set the `upgrade` variable to `true`.$$
-
-$$Use the `--amend` flag.$$
-
-$$Answer by typing `Yes` or `No` when prompted.$$
-
-$$`user_name`$$
-
-$$`service_name`$$
-
-$$`package_name`$$
-
-$$`filename`$$
-
-a|Use the `oc get services` command to get a list of services that are currently defined.
-
-Use the `--amend` flag.
+a|
+....
+`oc get`
 
 Set the `upgrade` variable to `true`.
 
+Use the `--amend` flag.
+
 Answer by typing `Yes` or `No` when prompted.
 
-`cluster-admin` user
+`user_name`
 
-`firewalld` service
+`service_name`
 
-`rubygems` RPM package
+`package_name`
 
-The `express.conf` configuration file is located in the `/usr/share` directory.
+`filename`
+....
+
+a|
+> Use the `oc get services` command to get a list of services that are currently defined.
+>
+> &nbsp;
+>
+> Use the `--amend` flag.
+>
+> &nbsp;
+>
+> Set the `upgrade` variable to `true`.
+>
+> &nbsp;
+>
+> Answer by typing `Yes` or `No` when prompted.
+>
+> &nbsp;
+>
+> `cluster-admin` user
+>
+> &nbsp;
+>
+> `firewalld` service
+>
+> &nbsp;
+>
+> `rubygems` RPM package
+>
+> &nbsp;
+>
+> The `express.conf` configuration file is located in the `/usr/share` directory.
 
 |System or software variable to be replaced by the user
-a|$$`<project>`$$
+a|
+....
+`<project>`
 
-$$`<deployment>`$$
+`<deployment>`
+....
 
-a|Use the following command to roll back a Deployment, specifying the Deployment name:
-
-`oc rollback <deployment>`
+a|
+> Use the following command to roll back a Deployment, specifying the Deployment name:
+>
+> `oc rollback <deployment>`
 
 |Use single asterisks for web console / GUI items (menus, buttons, page titles, etc.).
-Use two characters to form the arrow in a series of menu items, $$->$$.
+Use two characters to form the arrow in a series of menu items (`$$->$$`).
 
-a|Choose $$*Cluster Console*$$ from the list.
-
-Navigate to the $$*Operators* -> *Catalog Sources*$$ page.
-
-Click $$*Create Subscription*$$.
-
-a|Choose *Cluster Console* from the list.
+a|
+....
+Choose *Cluster Console* from the list.
 
 Navigate to the *Operators* -> *Catalog Sources* page.
 
 Click *Create Subscription*.
+....
+
+a|
+> Choose *Cluster Console* from the list.
+>
+> &nbsp;
+>
+> Navigate to the *Operators* -> *Catalog Sources* page.
+>
+> &nbsp;
+>
+> Click *Create Subscription*.
 
 |Use underscores to emphasize the first appearance of a new term.
 
-|An $$_Operator_$$ is a method of packaging, deploying, and managing a Kubernetes application.
+a|
+....
+An _Operator_ is a method of packaging, deploying,
+and managing a Kubernetes application.
+....
 
-|An _Operator_ is a method of packaging, deploying, and managing a Kubernetes application.
+a|
+> An _Operator_ is a method of packaging, deploying, and managing a Kubernetes application.
 
 |Use of single asterisks for general emphasis is allowed but should only be used
 very sparingly. Let the writing, instead of font usage, create the emphasis
 wherever possible.
 
-a|Do $$*not*$$ delete the file.
+a|
+....
+Do *not* delete the file.
+....
 
-a|Do *not* delete the file.
+a|
+> Do *not* delete the file.
 
 |Footnotes
 
-|A footnote is created with the footnote macro. If you plan to reference a footnote more than once, use the ID footnoteref macro. The customer portal does not support spaces in the footnoteref. For example, "dynamic PV" should be "dynamicPV".
+|A footnote is created with the footnote macro. If you plan to reference a footnote more than once, use the ID footnoteref macro. The Customer Portal does not support spaces in the footnoteref. For example, "dynamic PV" should be "dynamicPV".
 
 |See link:http://asciidoctor.org/docs/user-manual/#user-footnotes[Footnotes] for the footnote and footnoteref syntax.
 


### PR DESCRIPTION
* Add guideline for using `.Example output` as a codeblock title.
* Add guideline for using `[source,terminal]` for any command syntax/exmaples/output codeblocks.
* Realized there was some duplicated content about code blocks and command syntax/examples/output in a few spots, so attempted to consolidate them in a logical way.
* Switched to using quotes as a way of more obviously highlight where the rendered output starts and stops.

[Rendered preview](https://github.com/openshift/openshift-docs/blob/6f5ba3c83028080ecc0af1c7696b8ec12753f88c/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output

@openshift/team-documentation PTAL