### PR TITLE
BZ1861315 [Doc] Missing commands in virtctl documentation

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -29,11 +29,17 @@ $ virtctl image-upload -h
 |Stop a virtual machine.
 
 |`virtctl pause vm\|vmi <object_name>`
-| Pause a virtual machine or virtual machine instance. The machine state is kept
+|Pause a virtual machine or virtual machine instance. The machine state is kept
 in memory.
 
 |`virtctl unpause vm\|vmi <object_name>`
-| Unpause a virtual machine or virtual machine instance.
+|Unpause a virtual machine or virtual machine instance.
+
+|`virtctl migrate <vm_name>`
+|Migrate a virtual machine.
+
+|`virtctl rename <vm_name> <new_vm_name>`
+|Rename a stopped virtual machine.
 
 |`virtctl restart <vm_name>`
 |Restart a virtual machine.
@@ -54,4 +60,10 @@ the specified port of the node.
 
 |`virtctl image-upload dv <datavolume_name> --size=<datavolume_size> --image-path=</path/to/image>`
 |Upload a virtual machine image to a new DataVolume.
+
+|`virtctl version`
+|Display the client and server version information.
+
+|`virtctl help`
+|Display a descriptive list of `virtctl` commands.
 |===


### PR DESCRIPTION
As requested, added the following `virtctl` commands to Table 1:

- Help
- Migrate
- Rename
- Version

See Netify link for test build: https://bz1861315--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virt-using-the-cli-tools.html

Tagging Israel Pinto in BZ (https://bugzilla.redhat.com/show_bug.cgi?id=1861315) for QE sign-off and putting **ON_QA**. Bug is **VERIFIED**.

Please peer review and merge/pick to *enterprise-4.5* and *enterprise-4.6*