### PR TITLE
machine-config-operator: A few fixes

### DIFF
--- a/modules/machine-config-operator.adoc
+++ b/modules/machine-config-operator.adoc
@@ -8,7 +8,7 @@
 [discrete]
 == Purpose
 
-The Machine Congig Operator manages and applies configuration and updates of the
+The Machine Config Operator manages and applies configuration and updates of the
 base operating system and container runtime, including everything between the
 kernel and kubelet.
 
@@ -21,10 +21,18 @@ control the upgrade for sets of machines individually.
 * machine-config-daemon: Applies new machine configuration during update.
 Validates and verifies the machine's state to the requested machine
 configuration.
-* machine-config: Provides a complete source of machine configuration at
-installation, first start up, and updates for a machine.
+* machine-config-operator: Oversees, handles upgrades and reports status on
+all of the other components above.
 
 [discrete]
 == Project
 
 link:https://github.com/openshift/machine-config-operator[openshift-machine-config-operator]
+
+[discrete]
+== CRDs
+
+* `MachineConfig`
+* `MachineConfigPool`
+* `KubeletConfig`
+* `ContainerRuntimeConfig`


### PR DESCRIPTION
- Fix a typo.
- Clarify the name and purpose of the operator component
- List CRDs as is done for e.g. the machine-api-operator