### PR TITLE
modules/understanding-upgrade-channels: Generalize "-rc" -> "a pre-release version"

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -32,7 +32,7 @@ The `candidate-{product-version}` channel contains candidate builds for a z-stre
 ({product-version}.z) release.
 Release candidates contain all the features of the product but are not supported. Use release candidate versions to test feature acceptance and assist in qualifying the next version
 of {product-title}.
-A release candidate is any build that is available in the candidate channel, including ones that do not contain `-rc` in their names.
+A release candidate is any build that is available in the candidate channel, including ones that do not contain link:https://semver.org/spec/v2.0.0.html#spec-item-9[a pre-release version] such as `-rc` in their names.
 After a version is available in the candidate channel, it goes through more quality checks. If
 it meets the quality standard, it is promoted to the `fast-{product-version}` or `stable-{product-version}` channels.
 Because of this strategy, if a specific release is available in both the `candidate-{product-version}` channel and in the `fast-{product-version}`


### PR DESCRIPTION
And link the SemVer spec so folks can figure out what that means. This allows us to cover `-fc` too, since we may be releasing things like [4.6.0-fc.0][1] going forward.

This would technically apply to all of our releases, but since we are only likely to get FC releases for 4.6 and later, I don't see a need to backport it.

[1]: https://github.com/openshift/cincinnati-graph-data/pull/376