### PR TITLE
Separating command and output for 4.5 Monitoring book

### DIFF
--- a/modules/configuring-hpa-based-on-application-metrics.adoc
+++ b/modules/configuring-hpa-based-on-application-metrics.adoc
@@ -41,6 +41,7 @@ spec:
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy.yaml
 ----

--- a/modules/monitoring-accessing-alerting-rules-for-all-namespaces.adoc
+++ b/modules/monitoring-accessing-alerting-rules-for-all-namespaces.adoc
@@ -21,12 +21,14 @@ In a future release, the route to the Thanos Ruler UI will be deprecated in favo
 
 . List routes for the `openshift-user-workload-monitoring` namespace:
 +
+[source,terminal]
 ----
 $ oc -n openshift-user-workload-monitoring get routes
 ----
 +
 The output shows the URL for the Thanos Ruler UI:
 +
+[source,terminal]
 ----
 NAME           HOST/PORT
 ...

--- a/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
+++ b/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
@@ -15,12 +15,14 @@ You can list existing alerting rules for your project.
 
 . To list alerting rules in <project>, run:
 +
+[source,terminal]
 ----
 $ oc -n <project> get prometheusrule
 ----
 
 . To list the configuration of an alerting rule, run:
 +
+[source,terminal]
 ----
 $ oc -n <project> get prometheusrule <rule> -oyaml
 ----

--- a/modules/monitoring-accessing-metrics-of-all-services-as-a-cluster-administrator.adoc
+++ b/modules/monitoring-accessing-metrics-of-all-services-as-a-cluster-administrator.adoc
@@ -42,12 +42,14 @@ In a future release, the route to the Thanos Querier UI will be deprecated in fa
 --
 . List routes for the `openshift-monitoring` namespace:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get routes
 ----
 +
 The output shows the URL for the Thanos Querier UI:
 +
+[source,terminal]
 ----
 NAME                HOST/PORT
 ...

--- a/modules/monitoring-accessing-prometheus-alertmanager-grafana-directly.adoc
+++ b/modules/monitoring-accessing-prometheus-alertmanager-grafana-directly.adoc
@@ -20,8 +20,14 @@ The Alertmanager UI accessed in this procedure is the old interface for Alertman
 
 . Run:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get routes
+----
++
+.Example output
+[source,terminal]
+----
 NAME                HOST/PORT                                                     ...
 alertmanager-main   alertmanager-main-openshift-monitoring.apps._url_.openshift.com ...
 grafana             grafana-openshift-monitoring.apps._url_.openshift.com           ...
@@ -37,4 +43,3 @@ https://alertmanager-main-openshift-monitoring.apps._url_.openshift.com
 ----
 
 . Navigate to the address using a web browser and authenticate.
-

--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -15,6 +15,7 @@ You can overwrite the default Alertmanager configuration by editing the `alertma
 
 . Print the currently active Alertmanager configuration into file `alertmanager.yaml`:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .data "alertmanager.yaml" }}' |base64 -d > alertmanager.yaml
 ----
@@ -85,6 +86,7 @@ With this configuration, alerts of `critical` severity fired by the `example-app
 +
 . Apply the new configuration in the file:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring create secret generic alertmanager-main --from-file=alertmanager.yaml --dry-run -o=yaml |  oc -n openshift-monitoring replace secret --filename=-
 ----

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -15,6 +15,7 @@ You can assign tolerations to any of the monitoring stack components to enable m
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -15,6 +15,7 @@ Using the external labels feature of Prometheus, you can attach additional custo
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -15,6 +15,7 @@ For the Prometheus or Alertmanager to use a persistent volume (PV), you first mu
 
 . Edit the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-configuring-monitoring-for-an-application.adoc
+++ b/modules/monitoring-configuring-monitoring-for-an-application.adoc
@@ -84,15 +84,16 @@ spec:
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy.yaml
 ----
 
 . Forward a port to the Prometheus UI. In this example, port 9090 is used:
 +
+[source,terminal]
 ----
 $ oc port-forward -n openshift-user-workload-monitoring svc/prometheus-operated 9090
 ----
 
 . Navigate to the Prometheus UI at http://localhost:9090/targets to see the sample application being monitored.
-

--- a/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
@@ -15,6 +15,7 @@ You can configure the Prometheus Cluster Monitoring stack using ConfigMaps. Conf
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
@@ -60,4 +61,3 @@ data:
 Here, *prometheusK8s* defines the Prometheus component and the following lines define its configuration.
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically.
-

--- a/modules/monitoring-creating-alerting-rules.adoc
+++ b/modules/monitoring-creating-alerting-rules.adoc
@@ -55,6 +55,7 @@ Additionally, you cannot create alerting rules for the `openshift-*` core OpenSh
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f example-app-alerting-rule.yaml
 ----

--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -16,18 +16,21 @@ To configure the Prometheus Cluster Monitoring stack, you must create the cluste
 
 . Check whether the `cluster-monitoring-config` ConfigMap object exists:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get configmap cluster-monitoring-config
 ----
 
 . If it does not exist, create it:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring create configmap cluster-monitoring-config
 ----
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-deploying-a-sample-service.adoc
+++ b/modules/monitoring-deploying-a-sample-service.adoc
@@ -64,6 +64,7 @@ This configuration deploys a service named `prometheus-example-app` in the `ns1`
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f prometheus-example-app.yaml
 ----
@@ -72,8 +73,14 @@ It will take some time to deploy the service.
 
 . You can check that the service is running:
 +
+[source,terminal]
 ----
 $ oc -n ns1 get pod
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                      READY     STATUS    RESTARTS   AGE
 prometheus-example-app-7857545cb7-sbgwq   1/1       Running   0          81m
 ----

--- a/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
+++ b/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
@@ -15,6 +15,7 @@ You can enable monitoring your own services by setting the `techPreviewUserWorkl
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
@@ -37,8 +38,14 @@ data:
 
 . Optional: You can check that the `prometheus-user-workload` Pods were created:
 +
+[source,terminal]
 ----
 $ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                   READY   STATUS        RESTARTS   AGE
 prometheus-operator-6f7b748d5b-t7nbg   2/2     Running       0          3h
 prometheus-user-workload-0             5/5     Running       1          3h

--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -176,8 +176,14 @@ spec:
 
 . Show the Prometheus Adapter image to use:
 +
+[source,terminal]
 ----
-$ kubectl get -n openshift-monitoring deploy/prometheus-adapter -o jsonpath="{..image}"
+$ oc get -n openshift-monitoring deploy/prometheus-adapter -o jsonpath="{..image}"
+----
++
+.Example output
+[source,terminal]
+----
 quay.io/openshift-release-dev/ocp-v4.3-art-dev@sha256:76db3c86554ad7f581ba33844d6a6ebc891236f7db64f2d290c3135ba81c264c
 ----
 
@@ -241,6 +247,7 @@ spec:
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy.yaml
 ----

--- a/modules/monitoring-granting-user-permissions-using-cli.adoc
+++ b/modules/monitoring-granting-user-permissions-using-cli.adoc
@@ -16,6 +16,7 @@ This procedure shows how to grant users permissions for monitoring their own ser
 
 * Run this command to assign <role> to <user> in <namespace>:
 +
+[source,terminal]
 ----
 $ oc policy add-role-to-user <role> <user> -n <namespace>
 ----

--- a/modules/monitoring-listing-acting-alerting-rules.adoc
+++ b/modules/monitoring-listing-acting-alerting-rules.adoc
@@ -11,14 +11,21 @@ You can list the alerting rules that currently apply to the cluster.
 
 . Configure the necessary port forwarding:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring port-forward svc/prometheus-operated 9090
 ----
 
 . Fetch the JSON object containing acting alerting rules and their properties:
 +
+[source,terminal]
 ----
 $ curl -s http://localhost:9090/api/v1/rules | jq '[.data.groups[].rules[] | select(.type=="alerting")]'
+----
++
+.Example output
+[source,terminal]
+----
 [
   {
     "name": "ClusterOperatorDown",

--- a/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
@@ -15,6 +15,7 @@ By default, the Prometheus Cluster Monitoring stack configures the retention tim
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
@@ -52,4 +53,3 @@ data:
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically.
-

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -15,6 +15,7 @@ You can move any of the monitoring stack components to specific nodes.
 
 . Start editing the `cluster-monitoring-config` ConfigMap:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-removing-alerting-rules.adoc
+++ b/modules/monitoring-removing-alerting-rules.adoc
@@ -15,6 +15,7 @@ You can remove an alerting rule.
 
 * To remove rule <foo> in <namespace>, run:
 +
+[source,terminal]
 ----
 $ oc -n <namespace> delete prometheusrule <foo>
 ----

--- a/modules/monitoring-setting-up-metrics-collection.adoc
+++ b/modules/monitoring-setting-up-metrics-collection.adoc
@@ -42,6 +42,7 @@ This configuration makes OpenShift Monitoring scrape the metrics exposed by the 
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f example-app-service-monitor.yaml
 ----
@@ -50,8 +51,14 @@ It will take some time to deploy the ServiceMonitor.
 
 . You can check that the ServiceMonitor is running:
 +
+[source,terminal]
 ----
 $ oc -n ns1 get servicemonitor
+----
++
+.Example output
+[source,terminal]
+----
 NAME                         AGE
 prometheus-example-monitor   81m
 ----


### PR DESCRIPTION
Applies to branch/enterprise-4.5 only.

This PR is not being merged to master or cherry picked to branch/enterprise-4.6 yet, because I have another unsubmitted PR to come which includes significant restructuring to the Monitoring book for 4.6.

This PR has been created after closing out https://github.com/openshift/openshift-docs/pull/24499.