### PR TITLE
CNV - bz#1861322 - vm wizard admonition

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -120,6 +120,7 @@ single sidebar menu item labeled *Virtualization*. When you click *Virtualizatio
 //https://bugzilla.redhat.com/show_bug.cig?=id=1959237
 * If you upgrade to {VirtProductName} {VirtVersion}, both older and newer versions of common templates are available for each combination of operating system, workload, and flavor. When you create a virtual machine by using a common template, you must use the newer version of the template. Disregard the older version to avoid issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859237[*BZ#1859237*])
 
+[id="virt-2-4-bz1861297"]
 * When creating virtual machines by using common-templates or the virtual machine wizard, the default `terminationGracePeriodSeconds` value is set to `0` (force stop).
 This can result in virtual disk failure and can put the virtual workload at risk.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861297[*BZ#1861297*])

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -19,6 +19,13 @@ Instead, create a new namespace or use an existing namespace without the
 `openshift` prefix.
 ====
 
+[IMPORTANT]
+====
+When creating virtual machines by using common-templates or the virtual machine wizard, the default `terminationGracePeriodSeconds` value is set to `0`, which forces the virtual machine to terminate when rebooted or shut down.
+Failure to shutdown gracefully can result in virtual disk failure and can put the virtual workload at risk. +
+See the xref:../../virt/virt-2-4-release-notes.adoc#virt-2-4-bz1861297[OpenShift Virtualization release notes] for more information and for the current workaround.
+====
+
 include::modules/virt-creating-vm-wizard-web.adoc[leveloffset=+1]
 
 Refer to the virtual machine wizard fields section when running the web console wizard.


### PR DESCRIPTION
Adding ID to specific (existing) known issue, and important admonition (recommended by QE) to the procedure that xrefs to the workaround

https://bugzilla.redhat.com/show_bug.cgi?id=1861322
https://bugzilla.redhat.com/show_bug.cgi?id=1861297 <-- we can remove these once the dev bz is merged.

This PR will not have a netlify build but hopefully this screenshot will suffice: 
![Screenshot from 2020-08-06 13-55-00](https://user-images.githubusercontent.com/17755748/89529611-4ef32500-d7ed-11ea-9af2-2ca194629a35.png)
The link goes directly to the known issue so users can access the workaround.