### PR TITLE
User must select masquerade network type.

### DIFF
--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -92,7 +92,7 @@ ifdef::virt-importing-vmware-vm[]
 ** *Name*
 ** *Model*
 ** *Network*
-** *Type*
+** *Type*: You must select the `masquerade` binding method.
 ** *MAC Address*
 
 * *Storage*:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1860002

CP for 4.5 only. Not needed for 4.6 (CNV 2.5)