### PR TITLE
RN-Bug-1853331 virt-who in the subscription manager

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -44,6 +44,11 @@ The SVVP Certification applies to:
 //CNV-5438 - svirt-support-for-cnv
 * This release features significant security enhancements. {VirtProductName} now supports SELinux with Mandatory Access Control (MAC) for isolating virtual machines (VMs). Previously, all VMs were managed by using privileged xref:../security/container_security/security-platform.adoc#security-deployment-sccs_security-platform[Security Context Constraints (SCC)]. Now, you can use less privileged custom SCCs for VMs and limit the use of privileged SCCs to infrastructure containers in the cluster.
 
+//Bug 1853331 Guest Subscriptions
+* You can now enable access to your Red Hat Enterprise Linux entitlement for RHEL virtual machines. Configure the `virt-who` daemon to report the running VMs in your {product-title} cluster. This gives the link:https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/introduction_to_red_hat_subscription_management_workflows/index[Red Hat Subscription Manager] in the RHEL VM access to your entitlements.
+
+
+
 //CNV-4572-Guest-OS
 [id="virt-guest-os-new"]
 === Supported guest operating systems
@@ -142,7 +147,7 @@ $ oc edit -n openshift template <common-template-name>
     terminationGracePeriodSeconds: 30 <1>
 ...
 ----
-<1> The time in seconds that the virtual machine is granted to shut down before it is terminated. The time is dependent on how long the operating system requires to gracefully shut down. Some operating systems may require longer if they perform extensive updates during shutdown or reboot. 
+<1> The time in seconds that the virtual machine is granted to shut down before it is terminated. The time is dependent on how long the operating system requires to gracefully shut down. Some operating systems may require longer if they perform extensive updates during shutdown or reboot.
 
 * Running virtual machines that cannot be live migrated might block an {product-title} cluster upgrade. This includes virtual machines that use hostpath-provisioner storage or SR-IOV network interfaces.
 As a workaround, you can reconfigure the virtual machines so that they can be powered off during a cluster upgrade. In the `spec` section of the virtual machine configuration file:


### PR DESCRIPTION
This PR was created for https://bugzilla.redhat.com/show_bug.cgi?id=1853331 to address the need to mention in the 2.4.1 release notes that virt-who can be configured to report running VMs to an OCP cluster. 
This is a brief release note write-up for the z stream release. It was determined that comprehensive coverage of this topic can be evaluated in the future release. 

SME reviews by @pelauter @danken @pkliczewski. 
CC @sgordon.