### PR TITLE
[enterprise-4.4]Node Tuning Operator chapter review wrt k8s guidelines.

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -16,14 +16,15 @@ $ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
 
 The default CR is meant for delivering standard node-level tuning for the
-{product-title} platform and any custom changes to the default CR will be
-overwritten by the Operator. For custom tuning, create your own tuned CRs. Newly
+{product-title} platform and it can only be modified to set the Operator
+Management state. Any other custom changes to the default CR will be
+overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly
 created CRs will be combined with the default CR and custom tuning applied to
 {product-title} nodes based on node or Pod labels and profile priorities.
 
 While in certain situations the support for Pod labels can be a convenient way
 of automatically delivering required tuning, this practice is discouraged and
-strongly advised against, especially in large-scale clusters. The default tuned
+strongly advised against, especially in large-scale clusters. The default Tuned
 CR ships without Pod label matching. If a custom profile is created with Pod
 label matching, then the functionality will be enabled at that time. The Pod
 label functionality might be deprecated in future versions of the Node Tuning

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -3,13 +3,13 @@
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
 [id="verifying-tuned-profiles-are-applied_{context}"]
-=  Verifying that the tuned profiles are applied
+=  Verifying that the Tuned profiles are applied
 
-Use this procedure to check which tuned profiles are applied on every node.
+Use this procedure to check which Tuned profiles are applied on every node.
 
 .Procedure
 
-. Check which tuned Pods are running on each node:
+. Check which Tuned Pods are running on each node:
 +
 ----
 $ oc get pods -n openshift-cluster-node-tuning-operator -o wide

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -8,7 +8,7 @@
 The following CR applies custom node-level tuning for
 {product-title} nodes with label
 `tuned.openshift.io/ingress-node-label` set to any value.
-As an administrator, use the following command to create a custom tuned CR.
+As an administrator, use the following command to create a custom Tuned CR.
 
 .Example
 
@@ -37,6 +37,9 @@ spec:
 _EOF_
 ----
 
-Custom profile writers are strongly encouraged to include the default tuned
+[IMPORTANT]
+====
+Custom profile writers are strongly encouraged to include the default Tuned
 daemon profiles shipped within the default Tuned CR. The example above uses the
 default `openshift-control-plane` profile to accomplish this.
+====


### PR DESCRIPTION
Review of the Node Tuning Operato based on k8s Documentation Style Guide.
https://kubernetes.io/docs/contribute/style/style-guide/

Manual cherrypick of https://github.com/openshift/openshift-docs/pull/24447