### PR TITLE
updating/updating-restricted-network-cluster: Add "signature" to heading

### DIFF
--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -34,8 +34,8 @@ include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+1]
 
 include::modules/update-mirror-repository.adoc[leveloffset=+1]
 
-[id="updating-restricted-network-image-configmap"]
-== Creating the image ConfigMap
+[id="updating-restricted-network-image-signature-configmap"]
+== Creating the image signature ConfigMap
 
 Before you update your cluster, you must manually create a ConfigMap that contains the signatures of the release images that you use. This signature allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
 


### PR DESCRIPTION
The ConfigMap contains a signature (or signatures) for the release image, not an image itself.  This also matches a number of existing references:

```console
$ git --no-pager grep -i 'image signature configmap' modules
modules/update-configuring-image-signature.adoc:= Creating an image signature ConfigMap manually
modules/update-configuring-image-signature.adoc:Create and apply the image signature ConfigMap to the cluster that you want to update.
modules/update-oc-configmap-signature-verification.adoc:. Apply the the mirrored release image signature ConfigMap to the connected cluster:
modules/update-restricted.adoc:* You applied the release image signature ConfigMap for the new release to your cluster.
modules/update-restricted.adoc:* You obtained the sha256 sum value for the release from the image signature ConfigMap.
modules/update-restricted.adoc:<1> The `<sha256_sum_value>` value is the sha256 sum value for the release from the image signature ConfigMap, for example, `@sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`
```

I'm not sure if there's a way to preserve the previous anchor for folks who may have existing links, so I'm just changing the anchor to keep up with the header here.

/assign @kalexand-rh