### PR TITLE
Backport of Upgrading metering feature and docs to 4-4-13

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1233,6 +1233,8 @@ Topics:
   File: metering-about-metering
 - Name: Installing metering
   File: metering-installing-metering
+- Name: Upgrading metering
+  File: metering-upgrading-metering
 - Name: Configuring metering
   Dir: configuring_metering
   Topics:

--- a/metering/metering-upgrading-metering.adoc
+++ b/metering/metering-upgrading-metering.adoc
@@ -1,0 +1,145 @@
+[id="upgrading-metering"]
+= Upgrading metering
+include::modules/common-attributes.adoc[]
+:context: upgrading-metering
+
+toc::[]
+
+You can upgrade metering to {product-version} by updating the Metering Operator subscription.
+
+[NOTE]
+====
+Upgrading the Metering Operator is supported for {product-title} 4.4.13 and later.
+====
+
+.Prerequisites
+
+*  The cluster is updated to {product-version}.
+*  The xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Metering Operator] is installed from OperatorHub.
++
+[NOTE]
+====
+You must upgrade the Metering Operator to {product-version} manually. Metering does not upgrade automatically if you selected the "Automatic" *Approval Strategy* in a previous installation.
+====
+*  The xref:../metering/configuring_metering/metering-about-configuring.adoc#metering-about-configuring[MeteringConfig] is configured.
+*  The xref:../metering/metering-installing-metering.adoc#metering-install-metering-stack_installing-metering[metering stack] is installed.
+*  Ensure that metering status is healthy by checking that all Pods are ready.
+
+[IMPORTANT]
+====
+Potential data loss can occur if you modify your metering storage configuration after installing or upgrading metering.
+====
+
+.Procedure
+
+.  Click *Operators* -> *Installed Operators* from the web console.
+
+.  Select the `openshift-metering` project.
+
+.  Click *Metering Operator*.
+
+.  Click *Subscription* -> *Channel*.
+
+.  In the *Change Subscription Update Channel* window, select *{product-version}* and click *Save*.
++
+[NOTE]
+====
+Wait several seconds to allow the subscription to update before proceeding to the next step.
+====
+.  Click *Operators* -> *Installed Operators*.
++
+The Metering Operator is shown as {product-version}. For example:
++
+[subs="attributes+"]
+----
+Metering
+{product-version}.0-202007012112.p0 provided by Red Hat, Inc
+----
+
+.Verification
+You can verify the metering upgrade by performing any of the following checks:
+
+*  Check the Metering Operator ClusterServiceVersion (CSV) for the new metering version. This can be done through either the web console or CLI.
++
+--
+.Procedure (UI)
+  .  Navigate to *Operators* -> *Installed Operators* in the metering namespace.
+  .  Click *Metering Operator*.
+  .  Click *Subscription* for *Subscription Details*.
+  .  Check the *Installed Version* for the upgraded metering version. The *Starting Version* shows the metering version prior to upgrading.
+
+.Procedure (CLI)
+*  Check the Metering Operator CSV:
++
+----
+$ oc get csv | grep metering
+----
++
+In the following example, the 4.4 Metering Operator upgrade is successful and replaces the 4.3 metering installation:
++
+----
+NAME                                        DISPLAY                  VERSION                 REPLACES                               PHASE
+metering-operator.4.4.0-202007012112.p0     Metering                 4.4.0-202007012112.p0   metering-operator.4.3.0-202005252114   Succeeded
+----
+--
+
+*  Check that all required Pods in the `openshift-metering` namespace are created. This can be done through either the web console or CLI.
++
+--
+[NOTE]
+====
+Many Pods rely on other components to function before they themselves can be considered ready. Some Pods may restart if other Pods take too long to start. This is to be expected during the Metering Operator upgrade.
+====
+
+.Procedure (UI)
+*  Navigate to *Workloads* -> *Pods* in the metering namespace and verify that Pods are being created. This can take several minutes after upgrading the metering stack.
+
+.Procedure (CLI)
+*  Check that all required Pods in the `openshift-metering` namespace are created:
++
+----
+$ oc -n openshift-metering get pods
+----
++
+The output shows that all Pods are created in the `Ready` column:
++
+----
+NAME                                  READY   STATUS    RESTARTS   AGE
+hive-metastore-0                      2/2     Running   0          3m28s
+hive-server-0                         3/3     Running   0          3m28s
+metering-operator-68dd64cfb6-2k7d9    2/2     Running   0          5m17s
+presto-coordinator-0                  2/2     Running   0          3m9s
+reporting-operator-5588964bf8-x2tkn   2/2     Running   0          2m40s
+----
+--
+
+*  Verify that the `ReportDataSources` are importing new data, indicated by a valid timestamp in the `NEWEST METRIC` column. This might take several minutes. Filter out the "-raw" `ReportDataSources`, which do not import data:
++
+----
+$ oc get reportdatasources -n openshift-metering | grep -v raw
+----
++
+Timestamps in the `NEWEST METRIC` column indicate that `ReportDataSources` are beginning to import new data:
++
+----
+NAME                                         EARLIEST METRIC        NEWEST METRIC          IMPORT START           IMPORT END             LAST IMPORT TIME       AGE
+node-allocatable-cpu-cores                   2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:44Z   23h
+node-allocatable-memory-bytes                2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:07Z   23h
+node-capacity-cpu-cores                      2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:52Z   23h
+node-capacity-memory-bytes                   2020-05-18T21:10:00Z   2020-05-19T19:57:00Z   2020-05-18T19:10:00Z   2020-05-19T19:57:00Z   2020-05-19T19:57:03Z   23h
+persistentvolumeclaim-capacity-bytes         2020-05-18T21:09:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:46Z   23h
+persistentvolumeclaim-phase                  2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:36Z   23h
+persistentvolumeclaim-request-bytes          2020-05-18T21:10:00Z   2020-05-19T19:57:00Z   2020-05-18T19:10:00Z   2020-05-19T19:57:00Z   2020-05-19T19:57:03Z   23h
+persistentvolumeclaim-usage-bytes            2020-05-18T21:09:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:02Z   23h
+pod-limit-cpu-cores                          2020-05-18T21:10:00Z   2020-05-19T19:57:00Z   2020-05-18T19:10:00Z   2020-05-19T19:57:00Z   2020-05-19T19:57:02Z   23h
+pod-limit-memory-bytes                       2020-05-18T21:10:00Z   2020-05-19T19:58:00Z   2020-05-18T19:11:00Z   2020-05-19T19:58:00Z   2020-05-19T19:59:06Z   23h
+pod-persistentvolumeclaim-request-info       2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:07Z   23h
+pod-request-cpu-cores                        2020-05-18T21:10:00Z   2020-05-19T19:58:00Z   2020-05-18T19:11:00Z   2020-05-19T19:58:00Z   2020-05-19T19:58:57Z   23h
+pod-request-memory-bytes                     2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:55:32Z   23h
+pod-usage-cpu-cores                          2020-05-18T21:09:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:54:55Z   23h
+pod-usage-memory-bytes                       2020-05-18T21:08:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:55:00Z   23h
+report-ns-pvc-usage                                                                                                                                             5h36m
+report-ns-pvc-usage-hourly
+----
+
+After all Pods are ready and you have verified that new data is being imported, metering continues to collect data and report on your cluster. Review a previously xref:../metering/reports/metering-about-reports.adoc#metering-example-report-with-schedule_metering-about-reports[scheduled Report] or create a xref:../metering/reports/metering-about-reports.adoc#metering-example-report-without-schedule_metering-about-reports[Run-Once metering Report] to confirm the metering upgrade.

--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -3205,6 +3205,16 @@ release:
 
 link:https://access.redhat.com/solutions/5222701[{product-title} 4.4.13 container image list]
 
+[[ocp-4-4-13-features]]
+==== Features
+
+[[ocp-4-4-13-upgrading-metering]]
+===== Upgrading the Metering Operator
+
+You can now upgrade the Metering Operator, whereas you previously had to uninstall
+your current metering installation and then reinstall the new version of the Metering Operator.
+For more information, see xref:../metering/metering-upgrading-metering.adoc#upgrading-metering[Upgrading metering].
+
 [[ocp-4-4-13-upgrading]]
 ==== Upgrading
 


### PR DESCRIPTION
The _Upgrading metering_ feature GAed in 4.5. This feature was backported to 4.4.13. 

@timflannagan1 PTAL. Thank you!