### PR TITLE
Stronger wording for /readyz config

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -162,7 +162,7 @@ balancer after the bootstrap machine initializes the cluster control plane.
 +
 [NOTE]
 ====
-The load balancer should be configured to take a maximum of 30 seconds from the
+The load balancer must be configured to take a maximum of 30 seconds from the
 time the API server turns off the `/readyz` endpoint to the removal of the API
 server instance from the pool. Within the time frame after `/readyz` returns an
 error or becomes healthy, the endpoint must have been removed or added. Probing


### PR DESCRIPTION
This addresses a post-merge recommendation for stronger wording by the SME in #21336.

Trivial fix; no reviews necessary.