### PR TITLE
[enterprise-4.3] Use same Distros for ExternalIP

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -541,7 +541,7 @@ Topics:
     Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro
   - Name: Configuring ingress cluster traffic using a service external IP
     File: configuring-ingress-cluster-traffic-service-external-ip
-    Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro
+    Distros: openshift-enterprise,openshift-webscale,openshift-origin
   - Name: Configuring ingress cluster traffic using a NodePort
     File: configuring-ingress-cluster-traffic-nodeport
     Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro


### PR DESCRIPTION
@lamek, is this just for 4.3? I didn't notice this elsewhere.

Thanks.