### PR TITLE
Updated Istio vs. Service Mesh topics.

### DIFF
--- a/modules/ossm-multitenant.adoc
+++ b/modules/ossm-multitenant.adoc
@@ -1,0 +1,41 @@
+////
+Module included in the following assemblies:
+-ossm-vs-community.adoc
+////
+
+[id="ossm-multitenant-install_{context}"]
+= {ProductName} multitenant installation
+
+Whereas upstream Istio takes a single tenant approach, {ProductName} supports multiple independent control planes within the cluster. {ProductName} uses a multitenant operator to manage the control plane lifecycle.
+
+{ProductName} installs a multitenant control plane by default. You specify the projects that can access the {ProductShortName}, and isolate the {ProductShortName} from other control plane instances.
+
+[id="ossm-mt-vs-clusterwide_{context}"]
+== Multitenancy versus cluster-wide installations
+
+The main difference between a multitenant installation and a cluster-wide installation is the scope of privileges used by the control plane deployments, for example, Galley and Pilot. The components no longer use cluster-scoped Role Based Access Control (RBAC) resource `ClusterRoleBinding`.
+
+Every project in the `ServiceMeshMemberRoll` `members` list will have a `RoleBinding` for each service account associated with the control plane deployment and each control plane deployment will only watch those member projects. Each member project has a `maistra.io/member-of` label added to it, where the `member-of` value is the project containing the control plane installation.
+
+{ProductName} configures each member project to ensure network access between itself, the control plane, and other member projects. The exact configuration differs depending on how OpenShift software-defined networking (SDN) is configured. See About OpenShift SDN for additional details.
+
+If the {product-title} cluster is configured to use the SDN plug-in:
+
+* *`NetworkPolicy`*: {ProductName} creates a `NetworkPolicy` resource in each member project allowing ingress to all pods from the other members and the control plane. If you remove a member from {ProductShortName}, this `NetworkPolicy` resource is deleted from the project.
++
+[NOTE]
+====
+This also restricts ingress to only member projects. If you require ingress from non-member projects, you need to create a `NetworkPolicy` to allow that traffic through.
+====
+
+* *Multitenant*: {ProductName} joins the `NetNamespace` for each member project to the `NetNamespace` of the control plane project (the equivalent of running `oc adm pod-network join-projects --to control-plane-project member-project`). If you remove a member from the {ProductShortName}, its `NetNamespace` is isolated from the control plane (the equivalent of running `oc adm pod-network isolate-projects member-project`).
+
+* *Subnet*: No additional configuration is performed.
+
+[id="ossm-cluster-scoped-resources_{context}"]
+== Cluster scoped resources
+
+Upstream Istio has two cluster scoped resources that it relies on. The `MeshPolicy` and the `ClusterRbacConfig`. These are not compatible with a multitenant cluster and have been replaced as described below.
+
+* _ServiceMeshPolicy_ replaces MeshPolicy for configuration of control-plane-wide authentication policies. This must be created in the same project as the control plane.
+* _ServicemeshRbacConfig_ replaces ClusterRbacConfig for configuration of control-plane-wide role based access control. This must be created in the same project as the control plane.

--- a/modules/ossm-vs-istio-1x.adoc
+++ b/modules/ossm-vs-istio-1x.adoc
@@ -3,42 +3,25 @@ Module included in the following assemblies:
 -service_mesh/v1x/ossm-vs-community.adoc
 ////
 
-[id="ossm-multi-tenant-install-1x_{context}"]
-= {ProductName} control plane
+[id="ossm-vs-istio_{context}"]
+= Differences between Istio and {ProductName}
 
-{ProductName} installs a multi-tenant control plane by default. You specify the projects that can access the {ProductShortName}, and isolate the {ProductShortName} from other control plane instances.
+An installation of {ProductName} differs from an installation of Istio in multiple ways. The modifications to {ProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on OpenShift.
 
-[id="ossm-mt-vs-clusterwide_{context}"]
-= Multi-tenancy in {ProductName} versus cluster-wide installations
+[id="ossm-cli-tool_{context}"]
+== Command line tool
 
-The main difference between a multi-tenant installation and a cluster-wide installation is the scope of privileges used by the control plane deployments, for example, Galley and Pilot. The components no longer use cluster-scoped Role Based Access Control (RBAC) resource `ClusterRoleBinding`, but rely on project-scoped `RoleBinding`.
-
-Every project in the `members` list will have a `RoleBinding` for each service account associated with a control plane deployment and each control plane deployment will only watch those member projects. Each member project has a `maistra.io/member-of` label added to it, where the `member-of` value is the project containing the control plane installation.
-
-{ProductName} configures each member project to ensure network access between itself, the control plane, and other member projects. The exact configuration differs depending on how OpenShift software-defined networking (SDN) is configured. See About OpenShift SDN for additional details.
-
-If the {product-title} cluster is configured to use the SDN plug-in:
-
-* *`NetworkPolicy`*: {ProductName} creates a `NetworkPolicy` resource in each member project allowing ingress to all pods from the other members and the control plane. If you remove a member from {ProductShortName}, this `NetworkPolicy` resource is deleted from the project.
-+
-[NOTE]
-====
-This also restricts ingress to only member projects. If ingress from non-member projects is required, you need to create a `NetworkPolicy` to allow that traffic through.
-====
-
-* *Multitenant*: {ProductName} joins the `NetNamespace` for each member project to the `NetNamespace` of the control plane project (the equivalent of running `oc adm pod-network join-projects --to control-plane-project member-project`). If you remove a member from the {ProductShortName}, its `NetNamespace` is isolated from the control plane (the equivalent of running `oc adm pod-network isolate-projects member-project`).
-
-* *Subnet*: No additional configuration is performed.
+The command line tool for {ProductName} is oc.  {ProductName}  does not support istioctl.
 
 [id="ossm-automatic-injection_{context}"]
-= Automatic injection
+== Automatic injection
 
 The upstream Istio community installation automatically injects the sidecar into pods within the projects you have labeled.
 
-{ProductName} does not automatically inject the sidecar to any pods, but requires you to specify the `sidecar.istio.io/inject` annotation as illustrated in the Automatic sidecar injection section.
+{ProductName} does not automatically inject the sidecar to any pods, but requires you to opt in to injection using an annotation without labeling projects. This method requires fewer privileges and does not conflict with other OpenShift capabilities such as builder pods. To enable automatic injection you specify the `sidecar.istio.io/inject` annotation as described in the Automatic sidecar injection section.
 
 [id="ossm-rbac_{context}"]
-= Istio Role Based Access Control features
+== Istio Role Based Access Control features
 
 Istio Role Based Access Control (RBAC) provides a mechanism you can use to control access to a service. You can identify subjects by user name or by specifying a set of properties and apply access controls accordingly.
 
@@ -47,7 +30,6 @@ The upstream Istio community installation includes options to perform exact head
 {ProductName} extends the ability to match request headers by using a regular expression. Specify a property key of `request.regex.headers` with a regular expression.
 
 .Upstream Istio community matching request headers example
-
 [source,yaml]
 ----
 apiVersion: "rbac.istio.io/v1alpha1"
@@ -63,7 +45,6 @@ spec:
 ----
 
 .{ProductName} matching request headers by using regular expressions
-
 [source,yaml]
 ----
 apiVersion: "rbac.istio.io/v1alpha1"
@@ -80,40 +61,45 @@ spec:
 
 
 [id="ossm-openssl_{context}"]
-= OpenSSL
+== OpenSSL
 
 {ProductName} replaces BoringSSL with OpenSSL. OpenSSL is a software library that contains an open source implementation of the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols. The {ProductName} Proxy binary dynamically links the OpenSSL libraries (libssl and libcrypto) from the underlying Red Hat Enterprise Linux operating system.
 
+[id="ossm-component-modifications_{context}"]
+== Component modifications
+
+* A _maistra-version_ label has been added to all resources.
+* All Ingress resources have been converted to OpenShift Route resources.
+* Grafana, Tracing (Jaeger), and Kiali are enabled by default and exposed through OpenShift routes.
+* Godebug has been removed from all templates
+* The `istio-multi` ServiceAccount and ClusterRoleBinding have been removed, as well as the `istio-reader` ClusterRole.
+
+[id="ossm-envoy-sds-ca_{context}"]
+== Envoy, Secret Discovery Service, and certificates
+
+* {ProductName} does not support QUIC-based services.
+* Deployment of TLS certificates using the Secret Discovery Service (SDS) functionality of Istio is not currently supported in {ProductName}. The Istio implementation depends on a nodeagent container that uses hostPath mounts.
 
 [id="ossm-cni_{context}"]
-= The Istio Container Network Interface (CNI) plug-in
+== Istio Container Network Interface (CNI) plug-in
 
 {ProductName} includes CNI plug-in, which provides you with an alternate way to configure application pod networking. The CNI plug-in replaces the `init-container` network configuration eliminating the need to grant service accounts and projects access to Security Context Constraints (SCCs) with elevated privileges.
 
-The Istio CNI plugin is enabled through Multus CNI. The Istio operator creates a
-`NetworkAttachmentDefinition` object in each project that is part of the mesh.
-This object is referenced in the `k8s.v1.cni.cncf.io/networks` annotation, which
-is added to a pod during injection.
+[id="ossm-routes-gateways_{context}"]
+== Routes for Istio Gateways
 
-== Using Istio CNI with other Multus CNI plugins
+OpenShift routes for Istio Gateways are automatically managed in {ProductName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
-By default, if a pod contains an existing `k8s.v1.cni.cncf.io/networks` annotation, such as when using Multus CNI to add a macvlan network to the pod, the value of the annotation is overwritten. To preserve the value and instead append Istio CNI to the end, the field `spec.istio.sidecarInjectorWebhook.injectPodRedirectAnnot` must be set to `true` in the `ServiceMeshControlPlane` object as shown in the following example.
+A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information see the "Automatic route creation" section.
 
-----
-kind: ServiceMeshControlPlane
-...
-spec:
-  istio:
-    sidecarInjectorWebhook:
-      injectPodRedirectAnnot: true
-...
-----
+[id="ossm-catch-all-domains_{context}"]
+=== Catch-all domains
+Catch-all domains ("\*") are not supported. If one is found in the Gateway definition, {ProductName} _will_ create the route, but will rely on OpenShift to create a default hostname. This means that the newly created route will __not__ be a catch all ("*") route, instead it will have a hostname in the form `<route-name>[-<project>].<suffix>`. Refer to the OpenShift documentation for more information about how default hostnames work and how a cluster administrator can customize it.
 
-The link:https://intel.github.io/multus-cni/doc/how-to-use.html#lauch-pod-with-json-annotation[JSON form] support was
-introduced in {ProductName} version 1.1.5. In previous {ProductName} versions, only the link:https://intel.github.io/multus-cni/doc/how-to-use.html#lauch-pod-with-text-annotation-with-interface-name[text form]
-of the `k8s.v1.cni.cncf.io/networks` annotation was supported.
+[id="ossm-subdomains_{context}"]
+=== Subdomains
+Subdomains (e.g.: "*.domain.com") are supported. However this ability doesn't come enabled by default in OpenShift. This means that {ProductName} _will_ create the route with the subdomain, but it will only be in effect if OpenShift is configured to enable it.
 
-= Envoy, Secret Discovery Service, and Certificates
-
-* {ProductName} does not support QUIC-based services.
-* Deployment of TLS certificates using the Secret Discovery Service (SDS) functionality of Istio is not currently supported in {ProductName}. The Istio implementation depends on a node agent container that uses hostPath mounts.
+[id="ossm-tls_{context}"]
+=== Transport layer security
+Transport Layer Security (TLS) is supported. This means that, if the Gateway contains a `tls` section, the OpenShift Route will be configured to support TLS.

--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -3,42 +3,25 @@ Module included in the following assemblies:
 -service_mesh/v2x/ossm-vs-community.adoc
 ////
 
-[id="ossm-multi-tenant-install_{context}"]
-= {ProductName} control plane
+[id="ossm-vs-istio_{context}"]
+= Differences between Istio and {ProductName}
 
-{ProductName} installs a multi-tenant control plane by default. You specify the projects that can access the {ProductShortName}, and isolate the {ProductShortName} from other control plane instances.
+An installation of {ProductName} differs from an installation of Istio in multiple ways. The modifications to {ProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on OpenShift.
 
-[id="ossm-mt-vs-clusterwide_{context}"]
-= Multi-tenancy in {ProductName} versus cluster-wide installations
+[id="ossm-cli-tool_{context}"]
+== Command line tool
 
-The main difference between a multi-tenant installation and a cluster-wide installation is the scope of privileges used by the control plane deployments, for example, Galley and Pilot. The components no longer use cluster-scoped Role Based Access Control (RBAC) resource `ClusterRoleBinding`, but rely on project-scoped `RoleBinding`.
-
-Every project in the `members` list will have a `RoleBinding` for each service account associated with a control plane deployment and each control plane deployment will only watch those member projects. Each member project has a `maistra.io/member-of` label added to it, where the `member-of` value is the project containing the control plane installation.
-
-{ProductName} configures each member project to ensure network access between itself, the control plane, and other member projects. The exact configuration differs depending on how OpenShift software-defined networking (SDN) is configured. See About OpenShift SDN for additional details.
-
-If the {product-title} cluster is configured to use the SDN plug-in:
-
-* *`NetworkPolicy`*: {ProductName} creates a `NetworkPolicy` resource in each member project allowing ingress to all pods from the other members and the control plane. If you remove a member from {ProductShortName}, this `NetworkPolicy` resource is deleted from the project.
-+
-[NOTE]
-====
-This also restricts ingress to only member projects. If ingress from non-member projects is required, you need to create a `NetworkPolicy` to allow that traffic through.
-====
-
-* *Multitenant*: {ProductName} joins the `NetNamespace` for each member project to the `NetNamespace` of the control plane project (the equivalent of running `oc adm pod-network join-projects --to control-plane-project member-project`). If you remove a member from the {ProductShortName}, its `NetNamespace` is isolated from the control plane (the equivalent of running `oc adm pod-network isolate-projects member-project`).
-
-* *Subnet*: No additional configuration is performed.
+The command line tool for {ProductName} is oc.  {ProductName}  does not support istioctl.
 
 [id="ossm-automatic-injection_{context}"]
-= Automatic injection
+== Automatic injection
 
 The upstream Istio community installation automatically injects the sidecar into pods within the projects you have labeled.
 
-{ProductName} does not automatically inject the sidecar to any pods, but requires you to specify the `sidecar.istio.io/inject` annotation as illustrated in the Automatic sidecar injection section.
+{ProductName} does not automatically inject the sidecar to any pods, but requires you to opt in to injection using an annotation without labeling projects. This method requires fewer privileges and does not conflict with other OpenShift capabilities such as builder pods. To enable automatic injection you specify the `sidecar.istio.io/inject` annotation as described in the Automatic sidecar injection section.
 
 [id="ossm-rbac_{context}"]
-= Istio Role Based Access Control features
+== Istio Role Based Access Control features
 
 Istio Role Based Access Control (RBAC) provides a mechanism you can use to control access to a service. You can identify subjects by user name or by specifying a set of properties and apply access controls accordingly.
 
@@ -47,7 +30,6 @@ The upstream Istio community installation includes options to perform exact head
 {ProductName} extends the ability to match request headers by using a regular expression. Specify a property key of `request.regex.headers` with a regular expression.
 
 .Upstream Istio community matching request headers example
-
 [source,yaml]
 ----
 apiVersion: "rbac.istio.io/v1alpha1"
@@ -63,7 +45,6 @@ spec:
 ----
 
 .{ProductName} matching request headers by using regular expressions
-
 [source,yaml]
 ----
 apiVersion: "rbac.istio.io/v1alpha1"
@@ -80,40 +61,45 @@ spec:
 
 
 [id="ossm-openssl_{context}"]
-= OpenSSL
+== OpenSSL
 
 {ProductName} replaces BoringSSL with OpenSSL. OpenSSL is a software library that contains an open source implementation of the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols. The {ProductName} Proxy binary dynamically links the OpenSSL libraries (libssl and libcrypto) from the underlying Red Hat Enterprise Linux operating system.
 
+[id="ossm-component-modifications_{context}"]
+== Component modifications
+
+* A _maistra-version_ label has been added to all resources.
+* All Ingress resources have been converted to OpenShift Route resources.
+* Grafana, Tracing (Jaeger), and Kiali are enabled by default and exposed through OpenShift routes.
+* Godebug has been removed from all templates
+* The `istio-multi` ServiceAccount and ClusterRoleBinding have been removed, as well as the `istio-reader` ClusterRole.
+
+[id="ossm-envoy-sds-ca_{context}"]
+== Envoy, Secret Discovery Service, and certificates
+
+* {ProductName} does not support QUIC-based services.
+* Deployment of TLS certificates using the Secret Discovery Service (SDS) functionality of Istio is not currently supported in {ProductName}. The Istio implementation depends on a nodeagent container that uses hostPath mounts.
 
 [id="ossm-cni_{context}"]
-= The Istio Container Network Interface (CNI) plug-in
+== Istio Container Network Interface (CNI) plug-in
 
 {ProductName} includes CNI plug-in, which provides you with an alternate way to configure application pod networking. The CNI plug-in replaces the `init-container` network configuration eliminating the need to grant service accounts and projects access to Security Context Constraints (SCCs) with elevated privileges.
 
-The Istio CNI plugin is enabled through Multus CNI. The Istio operator creates a
-`NetworkAttachmentDefinition` object in each project that is part of the mesh.
-This object is referenced in the `k8s.v1.cni.cncf.io/networks` annotation, which
-is added to a pod during injection.
+[id="ossm-routes-gateways_{context}"]
+== Routes for Istio Gateways
 
-== Using Istio CNI with other Multus CNI plugins
+OpenShift routes for Istio Gateways are automatically managed in {ProductName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
-By default, if a pod contains an existing `k8s.v1.cni.cncf.io/networks` annotation, such as when using Multus CNI to add a macvlan network to the pod, the value of the annotation is overwritten. To preserve the value and instead append Istio CNI to the end, the field `spec.istio.sidecarInjectorWebhook.injectPodRedirectAnnot` must be set to `true` in the `ServiceMeshControlPlane` object as shown in the following example.
+A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information see the "Automatic route creation" section.
 
-----
-kind: ServiceMeshControlPlane
-...
-spec:
-  istio:
-    sidecarInjectorWebhook:
-      injectPodRedirectAnnot: true
-...
-----
+[id="ossm-catch-all-domains_{context}"]
+=== Catch-all domains
+Catch-all domains ("\*") are not supported. If one is found in the Gateway definition, {ProductName} _will_ create the route, but will rely on OpenShift to create a default hostname. This means that the newly created route will __not__ be a catch all ("*") route, instead it will have a hostname in the form `<route-name>[-<project>].<suffix>`. Refer to the OpenShift documentation for more information about how default hostnames work and how a cluster administrator can customize it.
 
-The link:https://intel.github.io/multus-cni/doc/how-to-use.html#lauch-pod-with-json-annotation[JSON form] support was
-introduced in {ProductName} version 1.1.5. In previous {ProductName} versions, only the link:https://intel.github.io/multus-cni/doc/how-to-use.html#lauch-pod-with-text-annotation-with-interface-name[text form]
-of the `k8s.v1.cni.cncf.io/networks` annotation was supported.
+[id="ossm-subdomains_{context}"]
+=== Subdomains
+Subdomains (e.g.: "*.domain.com") are supported. However this ability doesn't come enabled by default in OpenShift. This means that {ProductName} _will_ create the route with the subdomain, but it will only be in effect if OpenShift is configured to enable it.
 
-= Envoy, Secret Discovery Service, and Certificates
-
-* {ProductName} does not support QUIC-based services.
-* Deployment of TLS certificates using the Secret Discovery Service (SDS) functionality of Istio is not currently supported in {ProductName}. The Istio implementation depends on a node agent container that uses hostPath mounts.
+[id="ossm-tls_{context}"]
+=== Transport layer security
+Transport Layer Security (TLS) is supported. This means that, if the Gateway contains a `tls` section, the OpenShift Route will be configured to support TLS.

--- a/service_mesh/v1x/ossm-vs-community.adoc
+++ b/service_mesh/v1x/ossm-vs-community.adoc
@@ -11,6 +11,8 @@ The current release of {ProductName} differs from the current upstream Istio com
 
 // The following include statements pull in the module files that comprise the assembly.
 
+include::modules/ossm-multitenant.adoc[leveloffset=+1]
+
 include::modules/ossm-vs-istio-1x.adoc[leveloffset=+1]
 
 include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]

--- a/service_mesh/v2x/ossm-vs-community.adoc
+++ b/service_mesh/v2x/ossm-vs-community.adoc
@@ -11,8 +11,10 @@ The current release of {ProductName} differs from the current upstream Istio com
 
 // The following include statements pull in the module files that comprise the assembly.
 
+include::modules/ossm-multitenant.adoc[leveloffset=+1]
+
 include::modules/ossm-vs-istio.adoc[leveloffset=+1]
 
-include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]
+include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+2]
 
-include::modules/ossm-jaeger-service-mesh.adoc[leveloffset=+1]
+include::modules/ossm-jaeger-service-mesh.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR updates the ossm vs Istio topic to match the differences listed on Maistra.io.  

- I also split out the Multitenancy content into a separate module.

- The ossm vs Istio topic was published twice, so I removed it from the Service Mesh overview assembly.

- Addresses BZ1803820

- Addresses BZ1807736

- Addresses OSSMDOC-103