### PR TITLE
CNV example output and some source-y updates

### DIFF
--- a/modules/virt-accessing-rdp-console.adoc
+++ b/modules/virt-accessing-rdp-console.adoc
@@ -24,6 +24,7 @@ Windows virtual machine.
 . Log in to the {VirtProductName} cluster through the `oc` CLI tool as a user with
 an access token.
 +
+[source,terminal]
 ----
 $ oc login -u <user> https://<cluster.example.com>:8443
 ----
@@ -31,10 +32,12 @@ $ oc login -u <user> https://<cluster.example.com>:8443
 . Use `oc describe vmi` to display the configuration of the running
 Windows virtual machine.
 +
+[source,terminal]
 ----
 $ oc describe vmi <windows-vmi-name>
 ----
 +
+.Example output
 [source,yaml]
 ----
 ...

--- a/modules/virt-accessing-vmi-ssh.adoc
+++ b/modules/virt-accessing-vmi-ssh.adoc
@@ -31,8 +31,14 @@ $ virtctl expose vm <fedora-vm> --port=20022 --target-port=22 --name=fedora-vm-s
 
 . Check the service to find out which port the service acquired:
 +
+[source,terminal]
 ----
 $ oc get svc
+----
+
+.Example output
+[source,terminal]
+----
 NAME            TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)           AGE
 fedora-vm-ssh   NodePort   127.0.0.1      <none>        20022:32551/TCP   6s
 ----
@@ -42,6 +48,7 @@ In this example, the service acquired the `32551` port.
 . Log in to  the virtual machine instance via SSH. Use the `ipAddress` of the
 node and the port that you found in the previous step:
 +
+[source,terminal]
 ----
 $ ssh username@<node_IP_address> -p 32551
 ----

--- a/modules/virt-analyzing-datavolume-conditions-and-events.adoc
+++ b/modules/virt-analyzing-datavolume-conditions-and-events.adoc
@@ -29,6 +29,8 @@ The `Message` indicates which PVC owns the DataVolume.
 long the PVC has been bound (`Age`) and by what resource (`From`),
 in this case `datavolume-controller`:
 +
+.Example output
+[source,terminal]
 ----
 Status:
 	Conditions:
@@ -61,6 +63,8 @@ From this information, you conclude that an import operation was running,
 creating contention for other operations that are
 attempting to access the DataVolume:
 +
+.Example output
+[source,terminal]
 ----
 Status:
 	 Conditions:
@@ -83,6 +87,8 @@ Status:
 to be used, as in the following example. If the DataVolume is not ready to be
 used, the `Status` is `False`:
 +
+.Example output
+[source,terminal]
 ----
 Status:
 	 Conditions:

--- a/modules/virt-attaching-vm-to-sriov-network.adoc
+++ b/modules/virt-attaching-vm-to-sriov-network.adoc
@@ -37,6 +37,7 @@ spec:
 
 . Apply the virtual machine configuration:
 +
+[source,terminal]
 ----
 $ oc apply -f <vm-sriov.yaml> <1>
 ----

--- a/modules/virt-automating-virtual-machine-creation-with-ansible.adoc
+++ b/modules/virt-automating-virtual-machine-creation-with-ansible.adoc
@@ -75,12 +75,15 @@ already exists.
 .  Run the `ansible-playbook` command, using your playbook's file name as the
 only argument:
 +
+[source,terminal]
 ----
 $ ansible-playbook create-vm.yaml
 ----
 
 . Review the output to determine if the play was successful:
 +
+.Example output
+[source,terminal]
 ----
 (...)
 TASK [Create my first VM] ************************************************************************
@@ -94,6 +97,7 @@ localhost                  : ok=2    changed=1    unreachable=0    failed=0    s
 boot the VM now, edit the file so that it includes `state: running` and run the
 playbook again:
 +
+[source,terminal]
 ----
 $ ansible-playbook create-vm.yaml
 ----

--- a/modules/virt-checking-storage-class.adoc
+++ b/modules/virt-checking-storage-class.adoc
@@ -1,5 +1,8 @@
 // Module included in the following assemblies:
+//
 // * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+
+[id="virt-checking-storage-class_{context}"]
 = Checking the default storage class
 
 You must check the default storage class to ensure that it is NFS.
@@ -20,7 +23,7 @@ If more than one default storage class is defined, the VirtualMachineImport CR u
 
 .. Click the Options menu {kebab} of the default storage class and select *Edit Storage Class*.
 .. In the *Details* tab, click the Edit button beside *Annotations*.
-.. Click the Delete button {delete} on the right side of the  `storageclass.kubernetes.io/is-default-class` annotation and then click *Save*.
+.. Click the Delete button {delete} on the right side of the `storageclass.kubernetes.io/is-default-class` annotation and then click *Save*.
 
 . Change an existing NFS storage class to be the default:
 
@@ -38,15 +41,17 @@ If the default storage class is not NFS, you must change the default storage cla
 
 .Procedure
 
-Get the storage classes by entering the following command:
-
+* Get the storage classes by entering the following command:
++
+[source,terminal]
 ----
 $ oc get sc
 ----
 
 The `default` storage class is displayed in the output:
 
-[source,options="nowrap"]
+.Example output
+[source,terminal,options="nowrap"]
 ----
 NAME                PROVISIONER           RECLAIMPOLICY  VOLUMEBINDINGMODE     ALLOWVOLUMEEXPANS
 ...

--- a/modules/virt-cloning-local-volume-to-another-node.adoc
+++ b/modules/virt-cloning-local-volume-to-another-node.adoc
@@ -59,12 +59,14 @@ spec:
 
 * Identify a PV that already exists on the target node. You can identify the node where a PV is provisioned by viewing the `nodeAffinity` field in its configuration:
 +
+[source,terminal]
 ----
 $ oc get pv <destination-pv> -o yaml
 ----
 +
 The following snippet shows that the PV is on `node01`:
 +
+.Example output
 [source,yaml]
 ----
 ...
@@ -84,6 +86,7 @@ spec:
 
 . Add a unique label to the PV:
 +
+[source,terminal]
 ----
 $ oc label pv <destination-pv> node=node01
 ----
@@ -123,6 +126,7 @@ spec:
 
 . Start the cloning operation by applying the DataVolume manifest to your cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f <clone-datavolume.yaml>
 ----

--- a/modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
+++ b/modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
@@ -74,6 +74,7 @@ endif::[]
 
 . Start cloning the PVC by creating the DataVolume:
 +
+[source,terminal]
 ----
 $ oc create -f <cloner-datavolume>.yaml
 ----

--- a/modules/virt-deploying-operator-cli.adoc
+++ b/modules/virt-deploying-operator-cli.adoc
@@ -28,6 +28,7 @@ spec:
 
 . Deploy the {VirtProductName} Operator by running the following command:
 +
+[source,terminal]
 ----
 $ oc apply -f <file name>.yaml
 ----
@@ -36,13 +37,15 @@ $ oc apply -f <file name>.yaml
 
 * Ensure that {VirtProductName} deployed successfully by watching the `PHASE` of the ClusterServiceVersion (CSV) in the `openshift-cnv` namespace. Run the following command:
 +
+[source,terminal]
 ----
 $ watch oc get csv -n openshift-cnv
 ----
 +
 The following output displays if deployment was successful:
 +
-[subs="attributes+"]
+.Example output
+[source,terminal,subs="attributes+"]
 ----
 NAME                                      DISPLAY                    VERSION   REPLACES   PHASE
 kubevirt-hyperconverged-operator.v{HCOVersion}   {VirtProductName}   {HCOVersion}                Succeeded

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
+//
 // * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
-[id='virt-importing-vm-cli_{context}']
+
+[id="virt-importing-vm-cli_{context}"]
 = Importing a Red Hat Virtualization virtual machine with the CLI
 
 You can import a Red Hat Virtualization (RHV) virtual machine with the CLI by creating the Secret and VirtualMachineImport Custom Resources (CRs). The Secret CR stores the RHV Manager credentials and CA certificate. The VirtualMachineImport CR defines the parameters of the VM import process.
@@ -41,6 +43,7 @@ EOF
 <3> Specify the password for `admin@internal`.
 <4> Specify the RHV Manager CA certificate. You can obtain the CA certificate by running the following command:
 +
+[source,terminal]
 ----
 $ openssl s_client -connect :443 -showcerts < /dev/null
 ----
@@ -132,12 +135,14 @@ EOF
 
 . Follow the progress of the virtual machine import to verify that the import was successful:
 +
+[source,terminal]
 ----
 $ oc get vmimports vm-import -n default
 ----
 +
 The output indicating a successful import resembles the following example:
 +
+.Example output
 [source,yaml]
 ----
 apiVersion: v2v.kubevirt.io/v1alpha1

--- a/modules/virt-monitoring-upgrade-status.adoc
+++ b/modules/virt-monitoring-upgrade-status.adoc
@@ -24,12 +24,15 @@ available information.
 
 . Run the following command:
 +
+[source,terminal]
 ----
 $ oc get csv
 ----
 
 . Review the output, checking the `PHASE` field. For example:
 +
+.Example output
+[source,terminal]
 ----
 VERSION  REPLACES                                        PHASE
 2.2.1    kubevirt-hyperconverged-operator.v2.2.0         Installing
@@ -39,6 +42,7 @@ VERSION  REPLACES                                        PHASE
 . Optional: Monitor the aggregated status of all {VirtProductName} component
 conditions by running the following command:
 +
+[source,terminal]
 ----
 $ oc get hco -n openshift-cnv kubevirt-hyperconverged \
 -o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
@@ -46,6 +50,8 @@ $ oc get hco -n openshift-cnv kubevirt-hyperconverged \
 +
 A successful upgrade results in the following output:
 +
+.Example output
+[source,terminal]
 ----
 ReconcileComplete  True  Reconcile completed successfully
 Available          True  Reconcile completed successfully

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -55,6 +55,7 @@ access port with the requested VLAN.
 . Create the NetworkAttachmentDefinition object by using the file you created
 in the previous step:
 +
+[source,terminal]
 ----
 $ oc create -f pxe-net-conf.yaml
 ----
@@ -71,6 +72,7 @@ Ensure that `bootOrder` is set to `1` so that the interface boots first.
 In this example, the interface is connected to a network called
 `<pxe-net>`:
 +
+[source,yaml]
 ----
 interfaces:
 - masquerade: {}
@@ -91,6 +93,7 @@ after operating system provisioning.
 +
 Set the disk `bootOrder` value to `2`:
 +
+[source,yaml]
 ----
 devices:
   disks:
@@ -104,6 +107,7 @@ devices:
 NetworkAttachmentDefinition. In this scenario, `<pxe-net>` is connected
 to the NetworkAttachmentDefinition called `<pxe-net-conf>`:
 +
+[source,yaml]
 ----
 networks:
 - name: default
@@ -115,13 +119,20 @@ networks:
 
 . Create the virtual machine instance:
 +
+[source,terminal]
 ----
 $ oc create -f vmi-pxe-boot.yaml
+----
+
+.Example output
+[source,terminal]
+----
   virtualmachineinstance.kubevirt.io "vmi-pxe-boot" created
 ----
 
 . Wait for the virtual machine instance to run:
 +
+[source,terminal]
 ----
 $ oc get vmi vmi-pxe-boot -o yaml | grep -i phase
   phase: Running
@@ -129,6 +140,7 @@ $ oc get vmi vmi-pxe-boot -o yaml | grep -i phase
 
 . View the virtual machine instance using VNC:
 +
+[source,terminal]
 ----
 $ virtctl vnc vmi-pxe-boot
 ----
@@ -137,6 +149,7 @@ $ virtctl vnc vmi-pxe-boot
 
 . Log in to the virtual machine instance:
 +
+[source,terminal]
 ----
 $ virtctl console vmi-pxe-boot
 ----
@@ -146,8 +159,14 @@ connected to the bridge has the specified MAC address. In this
 case, we used `eth1` for the PXE boot, without an IP address. The other
 interface, `eth0`, got an IP address from {product-title}.
 +
+[source,terminal]
 ----
 $ ip addr
+----
+
+.Example output
+[source,terminal]
+----
 ...
 3. eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether de:00:00:00:00:de brd ff:ff:ff:ff:ff:ff

--- a/modules/virt-troubleshooting-incorrect-policy-config.adoc
+++ b/modules/virt-troubleshooting-incorrect-policy-config.adoc
@@ -41,22 +41,28 @@ spec:
             - name: ens01
 ----
 +
+[source,terminal]
 ----
 $ oc apply -f ens01-bridge-testfail.yaml
 ----
 +
+.Example output
+[source,terminal]
 ----
 nodenetworkconfigurationpolicy.nmstate.io/ens01-bridge-testfail created
 ----
 
 . Verify the status of the Policy by running the following command:
 +
+[source,terminal]
 ----
 $ oc get nncp
 ----
 +
 The output shows that the Policy failed:
 +
+.Example output
+[source,terminal]
 ----
 NAME                    STATUS
 ens01-bridge-testfail   FailedToConfigure
@@ -66,15 +72,17 @@ However the Policy status alone does not indicate if it failed on all nodes or a
 
 . List the Enactments to see if the Policy was successful on any of the nodes. If the Policy failed for only a subset it suggests the problem is with specific node configuration; if the Policy failed on all nodes it suggest the problem is with the Policy.
 +
+[source,terminal]
 ----
 $ oc get nnce
 ----
 +
 The output shows that the Policy failed on all nodes:
 +
+.Example output
+[source,terminal]
 ----
 NAME                                   STATUS
-utput
 master-1.ens01-bridge-testfail         FailedToConfigure
 master-2.ens01-bridge-testfail         FailedToConfigure
 master-3.ens01-bridge-testfail         FailedToConfigure
@@ -85,12 +93,15 @@ worker-3.ens01-bridge-testfail         FailedToConfigure
 
 . View one of the failed Enactments and look at the traceback. The following command uses the output tool `jsonpath` to filter the output:
 +
+[source,terminal]
 ----
 $ oc get nnce worker-1.ens01-bridge-testfail -o jsonpath='{.status.conditions[?(@.type=="Failing")].message}'
 ----
 +
 This command returns a large traceback that has been edited for brevity:
 +
+.Example output
+[source,terminal]
 ----
 error reconciling NodeNetworkConfigurationPolicy at desired state apply: , failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1' ''
 ...
@@ -185,6 +196,7 @@ $ oc get nns master-1 -o yaml
 +
 The output shows that the interface name on the nodes is `ens1` but the failed Policy incorrectly uses `ens01`:
 +
+.Example output
 [source,yaml]
 ----
    - ipv4:
@@ -196,6 +208,7 @@ The output shows that the interface name on the nodes is `ens1` but the failed P
 
 . Correct the error by editing the existing Policy:
 +
+[source,terminal]
 ----
 $ oc edit nncp ens01-bridge-testfail
 ----
@@ -211,10 +224,13 @@ Save the Policy to apply the correction.
 
 . Check the status of the Policy to ensure it updated successfully:
 +
+[source,terminal]
 ----
 $ oc get nncp
 ----
 +
+.Example output
+[source,terminal]
 ----
 NAME                    STATUS
 ens01-bridge-testfail   SuccessfullyConfigured

--- a/modules/virt-updating-imported-vm-network-name.adoc
+++ b/modules/virt-updating-imported-vm-network-name.adoc
@@ -13,6 +13,7 @@ You must update the NIC name of a virtual machine imported from VMware to confor
 . Go to the `/etc/sysconfig/network-scripts` directory.
 . Change the network configuration file name to `ifcfg-eth0`:
 +
+[source,terminal]
 ----
 $ mv vmnic0 ifcfg-eth0 <1>
 ----
@@ -20,6 +21,7 @@ $ mv vmnic0 ifcfg-eth0 <1>
 
 . Update the `NAME` and `DEVICE` parameters in the network configuration file:
 +
+[source,terminal]
 ----
 NAME=eth0
 DEVICE=eth0
@@ -27,6 +29,7 @@ DEVICE=eth0
 
 . Restart the network:
 +
+[source,terminal]
 ----
 $ systemctl restart network
 ----

--- a/modules/virt-upgrading-virt.adoc
+++ b/modules/virt-upgrading-virt.adoc
@@ -31,6 +31,7 @@ version number to open the *Change Subscription Update Channel* window.
 . Check the status of the upgrade by navigating to *Operators* -> *Installed Operators*.
 You can also check the status by running the following `oc` command:
 +
+[source,terminal]
 ----
 $ oc get csv -n openshift-cnv
 ----

--- a/modules/virt-uploading-local-disk-image-dv.adoc
+++ b/modules/virt-uploading-local-disk-image-dv.adoc
@@ -35,6 +35,7 @@ procedure. The size must be greater than or equal to the size of the disk image.
 Specify the parameters that you identified in the previous step.
 For example:
 +
+[source,terminal]
 ----
 $ virtctl image-upload dv <datavolume_name> \ <1>
 --size=<datavolume_size> \ <2>
@@ -57,6 +58,7 @@ the upload endpoint is *not* verified.
 . Optional. To verify that a DataVolume was created, view all DataVolume objects
 by running the following command:
 +
+[source,terminal]
 ----
 $ oc get dvs
 ----

--- a/modules/virt-uploading-local-disk-image-pvc.adoc
+++ b/modules/virt-uploading-local-disk-image-pvc.adoc
@@ -26,6 +26,7 @@ certificate.
 . Run the `virtctl image-upload` command to upload your VM image.
 You must specify the PVC name, PVC size, and file location. For example:
 +
+[source,terminal]
 ----
 $ virtctl image-upload --pvc-name=<upload-fedora-pvc> --pvc-size=<2Gi> --image-path=</images/fedora.qcow2>
 ----
@@ -39,6 +40,7 @@ the upload endpoint is *not* verified.
 
 . To verify that the PVC was created, view all PVC objects:
 +
+[source,terminal]
 ----
 $ oc get pvc
 ----

--- a/modules/virt-using-hostpath-provisioner.adoc
+++ b/modules/virt-using-hostpath-provisioner.adoc
@@ -16,6 +16,7 @@ that the hostpath provisioner creates.
 * Apply the SELinux context `container_file_t` to the PV
 backing directory on each node. For example:
 +
+[source,terminal]
 ----
 $ sudo chcon -t container_file_t -R </path/to/backing/directory>
 ----
@@ -30,6 +31,7 @@ by using a MachineConfig manifest instead.
 
 . Create the HostPathProvisioner custom resource file. For example:
 +
+[source,terminal]
 ----
 $ touch hostpathprovisioner_cr.yaml
 ----
@@ -62,6 +64,7 @@ it for you. If you did not apply the `container_file_t` SELinux context, this ca
 
 . Create the custom resource in the `openshift-cnv` namespace:
 +
+[source,terminal]
 ----
 $ oc create -f hostpathprovisioner_cr.yaml -n openshift-cnv
 ----

--- a/modules/virt-viewing-namespace-events-cli.adoc
+++ b/modules/virt-viewing-namespace-events-cli.adoc
@@ -11,6 +11,7 @@ Use the {product-title} client to get the events for a namespace.
 
 * In the namespace, use the `oc get` command:
 +
+[source,terminal]
 ----
 $ oc get events
 ----

--- a/modules/virt-viewing-network-state-of-node.adoc
+++ b/modules/virt-viewing-network-state-of-node.adoc
@@ -11,16 +11,19 @@ A `NodeNetworkState` object exists on every node in the cluster. This object is 
 
 . List all the `NodeNetworkState` objects in the cluster:
 +
+[source,terminal]
 ----
 $ oc get nns
 ----
 
 . Inspect a `NodeNetworkState` to view the network on that node. The output in this example has been redacted for clarity:
 +
+[source,terminal]
 ----
 $ oc get nns node01 -o yaml
 ----
 +
+.Example output
 [source,yaml]
 ----
 apiVersion: nmstate.io/v1alpha1

--- a/modules/virt-viewing-resource-events-cli.adoc
+++ b/modules/virt-viewing-resource-events-cli.adoc
@@ -14,9 +14,18 @@ Events are included in the resource description, which you can get using the
 how to get the events for a virtual machine, a virtual machine instance, and the 
 virt-launcher Pod for a virtual machine:
 +
+[source,terminal]
 ----
 $ oc describe vm <vm>
+----
++
+[source,terminal]
+----
 $ oc describe vmi <vmi>
+----
++
+[source,terminal]
+----
 $ oc describe pod virt-launcher-<name>
 ----
 

--- a/modules/virt-viewing-virtual-machine-logs-cli.adoc
+++ b/modules/virt-viewing-virtual-machine-logs-cli.adoc
@@ -9,8 +9,9 @@ Get virtual machine logs from the virtual machine launcher Pod.
 
 .Procedure
 
-* User the following command:
+* Use the following command:
 +
+[source,terminal]
 ----
 $ oc logs <virt-launcher-name>
 ----

--- a/modules/virt-viewing-vmi-ip-cli.adoc
+++ b/modules/virt-viewing-vmi-ip-cli.adoc
@@ -14,10 +14,14 @@ machine, or by running `oc get vmi <vmi_name> -o yaml`.
 
 * Use the `oc describe` command to display the virtual machine interface configuration:
 +
-[source]
+[source,terminal]
 ----
 $ oc describe vmi <vmi_name>
-
+----
++
+.Example output
+[source,yaml]
+----
 ...
 Interfaces:
    Interface Name:  eth0

--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -7,14 +7,14 @@
 
 The `virtctl` client is a command-line utility for managing {VirtProductName}
 resources. The following table contains the `virtctl` commands used throughout
-the {VirtProductName} documentation. +
-[NOTE]
-====
+the {VirtProductName} documentation.
+
 To view a list of options that you can use with a command, run it with the `-h` or `--help` flag. For example:
++
+[source,terminal]
 ----
 $ virtctl image-upload -h
 ----
-====
 
 .`virtctl` client commands
 

--- a/modules/virt-vm-rdp-console-web.adoc
+++ b/modules/virt-vm-rdp-console-web.adoc
@@ -33,6 +33,7 @@ Windows virtual machine.
 . Open an RDP client and reference the `console.rdp` file. For example, using
 *remmina*:
 +
+[source,terminal]
 ----
 $ remmina --connect /path/to/console.rdp
 ----


### PR DESCRIPTION
- Adding Example output heading to example output, and separating output from commands where applicable. 
- In these files I've added '[source,terminal]' tags to terminal commands (but have not undertaken this for all modules). 
- Also fixing some module metadata and adding/correcting module IDs.