### PR TITLE
Added section for AWS MachineSet spot instances

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -37,6 +37,11 @@ Use the sample MachineSet for your cloud.
 
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
 
+AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
+which can save you costs compared to On-Demand Instance prices. You can
+xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
+by adding SpotMarketOptions to the MachineSet YAML file.
+
 include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
 
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -15,3 +15,7 @@ include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/machineset-yaml-aws.adoc[leveloffset=+1]
 
 include::modules/machineset-creating.adoc[leveloffset=+1]
+
+include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
+
+include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+[id="machineset-creating-non-guaranteed-instance_{context}"]
+= Creating Spot Instances
+
+You can launch a Spot Instance on AWS by adding SpotMarketOptions to your MachineSet YAML file.
+
+.Procedure
+* Add the following line under the `providerSpec` field:
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    spotMarketOptions: {} <1>
+----
+<1> You can optionally set the `maxPrice` for the `spotMarketOptions` field to limit the cost of the Spot Instance, for example `maxPrice: '2.50'`. If the `maxPrice` is set, this value is used as the hourly maximum spot price. If not set, the maximum price defaults to charge up to the On-Demand Instance price.
+
+[NOTE]
+====
+It is strongly recommended to use the default On-Demand price as the `maxPrice` value and to not set the maximum price for Spot Instances.
+====

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+[id="machineset-non-guaranteed-instance_{context}"]
+= MachineSet Spot Instances
+
+You can save costs by creating an AWS MachineSet that deploys machines as non-guaranteed Spot Instances.
+Spot Instances utilize unused AWS EC2 capacity and are less expensive than On-Demand Instances.
+You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless,
+horizontally scalable workloads.
+
+[IMPORTANT]
+====
+It is strongly recommended that control plane machines are not created on Spot Instances
+due to the increased likelihood of the instance being terminated. Manual intervention is
+required to replace a terminated control plane node.
+====
+
+AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to
+the user when an interruption occurs. The {product-title} begins to remove the workloads
+from the affected instances when AWS issues the termination warning.
+
+Interruptions can occur when using Spot Instances if:
+
+* The instance price exceeds your maximum price.
+* The demand for Spot Instances increases.
+* The supply of Spot Instances decreases.
+
+If AWS does not have capacity, the Machine Health Checker (MHC) can remove the machine.
+The MHC also remediates a machine that fails if a request for a Spot Instance is not
+satisfied when a machine is created. AWS does not replace a Spot Instance when the instance is terminated.


### PR DESCRIPTION
BZ-1860905: https://bugzilla.redhat.com/show_bug.cgi?id=1860905

@enxebre or @joelspeed PTAL. A few questions for SME review:

- Should this information also be included here: https://docs.openshift.com/container-platform/4.5/machine_management/creating-infrastructure-machinesets.html ?
- Does information regarding "a SpotMarketOptions needs to be added to the RunInstancesInput" need to be included in the customer-facing docs? https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/spot-instances.md#aws
- Is there any additional information that is missing?