### PR TITLE
BZ1856186 - Reclaim procedure

### DIFF
--- a/modules/storage-persistent-storage-lifecycle.adoc
+++ b/modules/storage-persistent-storage-lifecycle.adoc
@@ -73,7 +73,7 @@ If a user deletes a PVC that is in active use by a Pod, the PVC is not removed i
 endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 
 [id="releasing_{context}"]
-== Release volumes
+== Release a PersistentVolume
 
 When you are finished with a volume, you can delete the PVC object from
 the API, which allows reclamation of the resource. The volume is
@@ -82,13 +82,14 @@ for another claim. The previous claimant's data remains on the volume and
 must be handled according to policy.
 
 [id="reclaiming_{context}"]
-== Reclaim volumes
+== Reclaim policy for PersistentVolumes
 
-The reclaim policy of a `PersistentVolume` tells the cluster what to do with the volume after it is released. Volumes reclaim policy can either be
+The reclaim policy of a PersistentVolume tells the cluster what to do with the volume after it is released. A volume's reclaim policy can be
 `Retain`, `Recycle`, or `Delete`.
 
 * `Retain` reclaim policy allows manual reclamation of the resource for
 those volume plug-ins that support it.
+
 * `Recycle` reclaim policy recycles the volume back into the pool of
 unbound persistent volumes once it is released from its claim.
 

--- a/modules/storage-persistent-storage-reclaim.adoc
+++ b/modules/storage-persistent-storage-reclaim.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * storage/understanding-persistent-storage.adoc
+
+[id="reclaim-policy_{context}"]
+= Changing the reclaim policy of a PersistentVolume
+
+To change the reclaim policy of a PersistentVolume:
+
+. List the PersistentVolumes in your cluster:
++
+[source,terminal]
+----
+$ oc get pv
+----
++
+.Example output
+[source-terminal]
+----
+NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
+ pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
+ pvc-b95650f8-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim2    manual                     6s
+ pvc-bb3ca71d-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim3    manual                     3s
+----
+
+. Choose one of your PersistentVolumes and change its reclaim policy:
++
+[source,terminal]
+----
+$ oc patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+----
+
++
+. Verify that your chosen PersistentVolume has the right policy:
++
+[source,terminal]
+----
+$ oc get pv
+----
++
+.Example output
+[source-terminal]
+----
+NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
+ pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
+ pvc-b95650f8-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim2    manual                     6s
+ pvc-bb3ca71d-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Retain          Bound     default/claim3    manual                     3s
+----
++
+In the preceding output, the volume bound to claim `default/claim3` now has a `Retain` reclaim policy. The volume will not be automatically deleted when a user deletes claim `default/claim3`.

--- a/storage/understanding-persistent-storage.adoc
+++ b/storage/understanding-persistent-storage.adoc
@@ -8,6 +8,8 @@ include::modules/storage-persistent-storage-overview.adoc[leveloffset=+1]
 
 include::modules/storage-persistent-storage-lifecycle.adoc[leveloffset=+1]
 
+include::modules/storage-persistent-storage-reclaim.adoc[leveloffset=+2]
+
 include::modules/storage-persistent-storage-pv.adoc[leveloffset=+1]
 
 include::modules/storage-persistent-storage-pvc.adoc[leveloffset=+1]


### PR DESCRIPTION
[BZ1856186](https://bugzilla.redhat.com/show_bug.cgi?id=1856186) - adds a new module within "Lifecycle" that offers instructions for how to change the reclaim policy to `Retain`, as described in upstream: https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/

Preview link: https://bz1856186--ocpdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#reclaim-policy_understanding-persistent-storage

An update to `enterprise-3.11` branch is addressed in https://github.com/openshift/openshift-docs/pull/24713.