### PR TITLE
added Red Hat OpenShift on IBM Cloud docset

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -24,7 +24,7 @@
 ---
 Name: Welcome
 Dir: welcome
-Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online,openshift-aro
+Distros: openshift-*,partner-*
 Topics:
 - Name: Welcome
   File: index
@@ -644,6 +644,7 @@ Topics:
 ---
 Name: Operators
 Dir: operators
+Distros: openshift-*
 Topics:
 - Name: Understanding Operators
   File: olm-what-operators-are
@@ -1379,6 +1380,7 @@ Topics:
 ---
 Name: OpenShift REST APIs
 Dir: rest_api
+Distros: openshift-*
 Topics:
 - Name: API endpoints
   File: index

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -8,10 +8,14 @@ Welcome to the {product-title} {product-version} documentation, where you can
 find information to help you learn about {product-title} and start
 exploring its features.
 
+ifndef::partner-roks[]
+
 To navigate the {product-title} {product-version} documentation, you can either
 
 * Use the left navigation bar to browse the documentation or
 * Select the activity that interests you from the contents of this Welcome page
+
+endif::partner-roks[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 You can start with an **xref:../architecture/architecture.adoc#architecture-overview-architecture[Introduction to {product-title}]**
@@ -44,7 +48,7 @@ a| * Overview of {product-title}
 a| * Overview of OpenShift architecture
 * Release Notes
 * Developing on OpenShift
-* Managing your cluster 
+* Managing your cluster
 |===
 
 == Available Regions
@@ -85,6 +89,35 @@ a| * Overview of OpenShift architecture
 
 |===
 endif::[]
+
+ifdef::partner-roks[]
+
+{product-title} is supported by Red Hat and IBM. Use the following table to navigate all the available documentation related to {product-title}.
+
+Documentation unique to the {product-title} service (e.g. how to create a cluster, how to get support) is generally found on the IBM documentation site; documentation that is common to all OpenShift distributions is generally found on this page.
+
+[cols="1,1",options="header"]
+|===
+
+| link:https://cloud.ibm.com/docs/openshift[IBM Cloud documentation]
+| link:https://docs.openshift.com/container-platform/latest/welcome/index.html[Red Hat OpenShift documentation]
+
+a| * Overview of {product-title}
+* Creating a cluster
+* Getting support
+* How-to guides and tutorials
+* CLI reference
+a| * Overview of OpenShift architecture
+* Release Notes
+* Developing on OpenShift
+* Managing your cluster
+|===
+
+== Available Regions
+
+{product-title} is currently available in the link:https://cloud.ibm.com/docs/containers?topic=containers-regions-and-zones#locations[following regions].
+
+endif::partner-roks[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Cluster installer activities
@@ -144,6 +177,7 @@ Internet access is still required to access the cloud APIs and installation medi
   Install Red Hat OpenShift Container Storage on existing worker nodes to provide agnostic persistent storage for {product-title}.
 endif::[]
 
+ifndef::partner-roks[]
 == Developer activities
 Ultimately, {product-title} is a platform for developing and deploying containerized applications. As an application developer, {product-title} documentation will help you:
 
@@ -193,6 +227,7 @@ xref:../operators/operator_sdk/osdk-helm.adoc#osdk-helm[Helm], or configure xref
 
 - **Use xref:../applications/service_brokers/installing-template-service-broker.adoc#sb-about-template-service-broker-sb-installing-tsb[Template Service Broker] or xref:../applications/service_brokers/installing-ansible-service-broker.adoc#sb-about-ansible-service-broker-sb-installing-asb[OpenShift Ansible Broker] applications**: Service brokers are a mechanism for provisioning applications outside of an {product-title} environment.
 endif::[]
+endif::partner-roks[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Cluster administrator activities


### PR DESCRIPTION
@openshift/team-documentation in preparation for the new distro partner-roks, updating the _topic_map.yml for the enterprise-4.3 branch.

Note the use of openshift-*,partner-* for the welcome page. partner-roks, only has the welcome page available and no other docs.

PR to add the distro to the master branch: https://github.com/openshift/openshift-docs/pull/24693

@lamek - we should move to changing our distro tags for service delivery docs (openshift-aro, openshift-moa) to using the partner- prefix instead of openshift- prefix, as it allows us to avoid tags like this:

openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online,openshift-aro,openshift-moa

and replace with:
openshift-*,partner-*