### PR TITLE
CNV BZ#1859661 - VMI migration rel_not

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -122,7 +122,30 @@ single sidebar menu item labeled *Virtualization*. When you click *Virtualizatio
 
 [id="virt-2-4-known-issues"]
 == Known issues
+
 * If you enable a MAC address pool for a namespace by applying the KubeMacPool label and using the `io` attribute for virtual machines in that namespace, the `io` attribute configuration is not retained for the VMs. As a workaround, do not use the `io` attribute for VMs. Alternatively, you can disable KubeMacPool for the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1869527[*BZ#1869527*])
+
+* If container-native virtualization 2.3 is installed on your {product-title} 4.4 cluster, upgrading the cluster to version 4.5 may cause a migrating virtual machine instance (VMI) to fail.
+This is because the virt-launcher Pod does not successfully notify the virt-handler Pod that migration has failed.
+The result is that the source VMI `migrationState` is not updated.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1859661[*BZ#1859661*])
++
+** As a workaround, delete the virt-handler Pod on the source node where the VMI is running. This restarts the virt-handler Pod, which updates the VMI status and restarts VMI migration:
++
+. Find the name of the source node where the VMI is running:
++
+[source,terminal]
+----
+$ oc get vmi -o wide 
+----
+
+. Delete the virt-handler Pod on the source node:
++
+[source,terminal]
+----
+$ oc delete pod -n openshift-cnv --selector=kubevirt.io=virt-handler --field-selector=spec.nodeName=<source-node-name> <1>
+----
+<1> Where <source-node-name> is the name of the source node that the VMI is migrating from.
 
 //https://bugzilla.redhat.com/show_bug.cig?=id=1959237
 * If you upgrade to {VirtProductName} {VirtVersion}, both older and newer versions of common templates are available for each combination of operating system, workload, and flavor. When you create a virtual machine by using a common template, you must use the newer version of the template. Disregard the older version to avoid issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859237[*BZ#1859237*])


### PR DESCRIPTION
Adding known issue and workaround for VMI migration bz#1859661 for 2.4

https://bugzilla.redhat.com/show_bug.cgi?id=1859661


No netlify build. This is a screenshot of the local build:
![Screenshot from 2020-08-11 18-34-08](https://user-images.githubusercontent.com/17755748/89923729-50638980-dc01-11ea-9503-958de971467d.png)

