### PR TITLE
BZ1856186-3-11 - Reclaim procedure

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -123,14 +123,62 @@ to policy.
 === Reclaim volumes
 
 The reclaim policy of a `PersistentVolume` tells the cluster what to do with
-the volume after it is released. Volumes reclaim policy can either be `Retain` or `Delete`.
+the volume after it is released. A PV's reclaim policy can be either `Retain` or `Delete`.
 
-`Retain` reclaim policy allows manual reclamation of the resource for those volume plug-ins that support it. `Delete` reclaim policy deletes both the `PersistentVolume` object from {product-title} and the associated storage asset in external infrastructure, such as AWS EBS, GCE PD, or Cinder volume.
+* `Retain` reclaim policy allows manual reclamation of the resource for those volume plug-ins that support it.
+* `Delete` reclaim policy deletes both the `PersistentVolume` object from {product-title} and the associated storage asset in external infrastructure, such as AWS EBS, GCE PD, or Cinder volume.
 
 [NOTE]
 ====
 Dynamically provisioned volumes have a default `ReclaimPolicy` value of `Delete`. Manually provisioned volumes have a default `ReclaimPolicy` value of `Retain`.
 ====
+
+[[changingpolicy]]
+=== Change the reclaim policy
+
+To change the reclaim policy of a PV:
+
+. List the PVs in your cluster:
++
+[source,terminal]
+----
+$ oc get pv
+----
++
+.Example output
+[source-terminal]
+----
+NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
+ pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
+ pvc-b95650f8-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim2    manual                     6s
+ pvc-bb3ca71d-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim3    manual                     3s
+----
+
+. Choose one of your PVs and change its reclaim policy:
++
+[source,terminal]
+----
+$ oc patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+----
+
++
+. Verify that your chosen PV has the right policy:
++
+[source,terminal]
+----
+$ oc get pv
+----
++
+.Example output
+[source-terminal]
+----
+NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
+ pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
+ pvc-b95650f8-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim2    manual                     6s
+ pvc-bb3ca71d-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Retain          Bound     default/claim3    manual                     3s
+----
++
+In the preceding output, the PV bound to claim `default/claim3` now has a `Retain` reclaim policy. The PV will not be automatically deleted when a user deletes claim `default/claim3`.
 
 [[persistent-volumes]]
 == Persistent volumes
@@ -361,7 +409,10 @@ The following table lists current reclaim policies:
 |Reclaim policy |Description
 
 |Retain
-|Manual reclamation
+|Allows manual reclamation.
+
+|Delete
+|Deletes both PV and associated external storage asset.
 
 |===
 


### PR DESCRIPTION
Relates to https://github.com/openshift/openshift-docs/pull/24687 - for enterprise-3.11 only, as reported in [BZ1856186](https://bugzilla.redhat.com/show_bug.cgi?id=1856186). 

In this PR, I also added "Delete" to the `Reclaim policy` table because it was missing. But I did not add "Recycle" because it wasn't already referenced in 3.11 docs, and because it is deprecated.

Preview build: http://file.rdu.redhat.com/bfuru/081120/BZ1856186-3-11/architecture/additional_concepts/storage.html#changingpolicy