### PR TITLE
CNV - Added [source,terminal] tags and Example output headings

### DIFF
--- a/modules/virt-installing-qemu-guest-agent-on-linux-vm.adoc
+++ b/modules/virt-installing-qemu-guest-agent-on-linux-vm.adoc
@@ -5,8 +5,8 @@
 [id="virt-installing-qemu-guest-agent-on-linux-vm_{context}"]
 = Installing QEMU guest agent on a Linux virtual machine
 
-The `qemu-guest-agent` is widely available and available by default in Red Hat 
-virtual machines. Install the agent and start the service 
+The `qemu-guest-agent` is widely available and available by default in Red Hat
+virtual machines. Install the agent and start the service
 
 .Procedure
 
@@ -14,19 +14,21 @@ virtual machines. Install the agent and start the service
 
 . Install the QEMU guest agent on the virtual machine:
 +
+[source,terminal]
 ----
 $ yum install -y qemu-guest-agent
 ----
 
 . Start the QEMU guest agent service:
 +
+[source,terminal]
 ----
 $ systemctl start qemu-guest-agent
 ----
 
 . Ensure the service is persistent:
 +
+[source,terminal]
 ----
 $ systemctl enable qemu-guest-agent
 ----
-

--- a/modules/virt-installing-virtctl-client.adoc
+++ b/modules/virt-installing-virtctl-client.adoc
@@ -11,7 +11,7 @@ Install the `virtctl` client from the `kubevirt-virtctl` package.
 
 * Install the `kubevirt-virtctl` package:
 +
+[source,terminal]
 ----
 # yum install kubevirt-virtctl
 ----
-

--- a/modules/virt-listing-dvs.adoc
+++ b/modules/virt-listing-dvs.adoc
@@ -12,6 +12,7 @@ You can list the DataVolumes in your cluster by using the `oc` command-line inte
 
 * List all DataVolumes by running the following command:
 +
+[source,terminal]
 ----
 $ oc get dvs
 ----

--- a/modules/virt-listing-vmis-cli.adoc
+++ b/modules/virt-listing-vmis-cli.adoc
@@ -12,6 +12,7 @@ You can list all virtual machine instances (VMIs) in your cluster, including sta
 
 * List all VMIs by running the following command:
 +
+[source,terminal]
 ----
 $ oc get vmis
 ----

--- a/modules/virt-monitoring-vm-migration-cli.adoc
+++ b/modules/virt-monitoring-vm-migration-cli.adoc
@@ -12,10 +12,12 @@ of the `VirtualMachineInstance` configuration.
 
 * Use the `oc describe` command on the migrating virtual machine instance:
 +
+[source,terminal]
 ----
 $ oc describe vmi vmi-fedora
 ----
 +
+.Example output
 [source,yaml]
 ----
 ...

--- a/modules/virt-reclaiming-statically-provisioned-persistent-volumes.adoc
+++ b/modules/virt-reclaiming-statically-provisioned-persistent-volumes.adoc
@@ -3,7 +3,7 @@
 // virt/virtual_machines/virtual_disks/virt-reusing-statically-provisioned-persistent-volumes.adoc
 
 [id="virt-reclaiming-statically-provisioned-persistent-volumes_{context}"]
-= Reclaiming statically provisioned persistent volumes 
+= Reclaiming statically provisioned persistent volumes
 
 Reclaim a statically provisioned persistent volume (PV) by unbinding the persistent volume claim (PVC) and deleting the PV. You might also need to manually delete the shared storage.
 
@@ -16,18 +16,21 @@ This procedure provides a general approach that might need to be customized depe
 
 .. Check the reclaim policy of the PV:
 +
+[source,terminal]
 ----
 $ oc get pv <pv_name> -o yaml | grep 'persistentVolumeReclaimPolicy'
 ----
 
 .. If the `persistentVolumeReclaimPolicy` is not set to `Retain`, edit the reclaim policy with the following command:
 +
+[source,terminal]
 ----
 $ oc patch pv <pv_name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 ----
 
 . Ensure that no resources are using the PV:
 +
+[source,terminal]
 ----
 $ oc describe pvc <pvc_name> | grep 'Mounted By:'
 ----
@@ -36,6 +39,7 @@ Remove any resources that use the PVC before continuing.
 
 . Delete the PVC to release the PV:
 +
+[source,terminal]
 ----
 $ oc delete pvc <pvc_name>
 ----
@@ -43,18 +47,21 @@ $ oc delete pvc <pvc_name>
 . Optional: Export the PV configuration to a YAML file. If you manually remove the shared storage later in this procedure, you can refer to this configuration.
 You can also use `spec` parameters in this file as the basis to create a new PV with the same storage configuration after you reclaim the PV:
 +
+[source,terminal]
 ----
 $ oc get pv <pv_name> -o yaml > <file_name>.yaml
 ----
 
 . Delete the PV:
 +
+[source,terminal]
 ----
 $ oc delete pv <pv_name>
 ----
 
 . Optional: Depending on the storage type, you might need to remove the contents of the shared storage folder:
 +
+[source,terminal]
 ----
 $ rm -rf <path_to_share_storage>
 ----
@@ -66,7 +73,7 @@ $ rm -rf <path_to_share_storage>
 To avoid possible conflict, it is good practice to give the new PV object a different name than the one that you deleted.
 ====
 +
+[source,terminal]
 ----
 $ oc create -f <new_pv_name>.yaml
 ----
-

--- a/modules/virt-refreshing-certificates.adoc
+++ b/modules/virt-refreshing-certificates.adoc
@@ -5,7 +5,7 @@
 [id="virt-refreshing-certificates_{context}"]
 = Refreshing TLS certificates
 
-To refresh the TLS certificates for {VirtProductName}, download and run the `rotate-certs` script. This script is available from the `kubevirt/hyperconverged-cluster-operator` repository on GitHub. 
+To refresh the TLS certificates for {VirtProductName}, download and run the `rotate-certs` script. This script is available from the `kubevirt/hyperconverged-cluster-operator` repository on GitHub.
 
 [IMPORTANT]
 ====
@@ -18,28 +18,30 @@ When refreshing the certificates, the following operations are impacted:
 
 .Prerequisites
 
-* Ensure that you are logged in to the cluster as a user with `cluster-admin` privileges. 
+* Ensure that you are logged in to the cluster as a user with `cluster-admin` privileges.
 The script uses your active session to the cluster to refresh certificates in the `openshift-cnv` namespace.
 
 .Procedure
 
 . Download the `rotate-certs.sh` script from GitHub:
 +
+[source,terminal]
 ----
 $ curl -O https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/tools/rotate-certs.sh
 ----
 
 . Ensure the script is executable:
 +
+[source,terminal]
 ----
 $ chmod +x rotate-certs.sh
 ----
 
 . Run the script:
 +
+[source,terminal]
 ----
 $ ./rotate-certs.sh -n openshift-cnv
 ----
 
 The TLS certificates are refreshed and valid for one year.
-

--- a/modules/virt-removing-interface-from-nodes.adoc
+++ b/modules/virt-removing-interface-from-nodes.adoc
@@ -34,15 +34,15 @@ spec:
         type: linux-bridge
         state: absent <4>
 ----
-<1> Name of the Policy. 
+<1> Name of the Policy.
 <2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses the `node-role.kubernetes.io/worker: ""` node selector to select all worker nodes in the cluster.
 <4> Changing the state to `absent` removes the interface.
 
 . Update the  Policy on the node and remove the interface:
 +
+[source,terminal]
 ----
 $ oc apply -f <br1-eth1-policy.yaml> <1>
 ----
 <1> File name of the Policy manifest.
-

--- a/modules/virt-removing-virtio-disk-from-vm.adoc
+++ b/modules/virt-removing-virtio-disk-from-vm.adoc
@@ -15,10 +15,12 @@ Remove the `container-native-virtualization/virtio-win` container disk from the 
 .Procedure
 . Edit the configuration file and remove the `disk` and the `volume`.
 +
+[source,terminal]
 ----
 $ oc edit vm <vm-name>
 ----
 +
+
 [source,yaml]
 ----
 spec:

--- a/modules/virt-restoring-node-network-configuration.adoc
+++ b/modules/virt-restoring-node-network-configuration.adoc
@@ -30,9 +30,8 @@ spec:
 
 . Apply the manifest to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f <eth1.yaml> <1>
 ----
 <1> File name of the Policy manifest.
-
-

--- a/modules/virt-resuming-node-maintenance-cli.adoc
+++ b/modules/virt-resuming-node-maintenance-cli.adoc
@@ -12,16 +12,19 @@ the `NodeMaintenance` object for the node.
 
 . Find the `NodeMaintenance` object:
 +
+[source,terminal]
 ----
 $ oc get nodemaintenance
 ----
 
 . Optional: Insepct the `NodeMaintenance` object to ensure it is associated with the correct node:
 +
+[source,terminal]
 ----
 $ oc describe nodemaintenance <node02-maintenance>
 ----
 +
+.Example output
 [source,yaml]
 ----
 Name:         node02-maintenance
@@ -38,6 +41,7 @@ Spec:
 
 . Delete the `NodeMaintenance` object:
 +
+[source,terminal]
 ----
 $ oc delete nodemaintenance <node02-maintenance>
 ----

--- a/modules/virt-setting-node-maintenance-cli.adoc
+++ b/modules/virt-setting-node-maintenance-cli.adoc
@@ -27,6 +27,7 @@ spec:
 
 . Create the `NodeMaintenance` object in the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f <node02-maintenance.yaml>
 ----

--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -44,6 +44,7 @@ spec:
 
 . Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects for {VirtProductName} by running the following command:
 +
+[source,terminal]
 ----
 $ oc apply -f <file name>.yaml
 ----

--- a/modules/virt-troubleshooting-vm-import.adoc
+++ b/modules/virt-troubleshooting-vm-import.adoc
@@ -14,14 +14,21 @@ You can check the V2V Conversion Pod log for errors.
 
 . Obtain the V2V Conversion Pod name by running the following command:
 +
+[source,terminal]
 ----
 $ oc get pods -n <project> | grep v2v <1>
-kubevirt-v2v-conversion-f66f7d-zqkz7            1/1     Running     0          4h49m
 ----
 <1> Specify the project of your imported virtual machine.
 
+.Example output
+[source,terminal]
+----
+kubevirt-v2v-conversion-f66f7d-zqkz7            1/1     Running     0          4h49m
+----
+
 . Obtain the V2V Conversion Pod log by running the following command:
 +
+[source,terminal]
 ----
 $ oc logs kubevirt-v2v-conversion-f66f7d-zqkz7 -f -n <project>
 ----
@@ -33,14 +40,21 @@ You can check the VM Import Controller Pod log for errors.
 
 . Obtain the VM Import Controller Pod name by running the following command:
 +
+[source,terminal]
 ----
 $ oc get pods -n <project> | grep import <1>
-vm-import-controller-f66f7d-zqkz7            1/1     Running     0          4h49m
 ----
 <1> Specify the project of your imported virtual machine.
 
+.Example output
+[source,terminal]
+----
+vm-import-controller-f66f7d-zqkz7            1/1     Running     0          4h49m
+----
+
 . Obtain the VM Import Controller Pod log by running the following command:
 +
+[source,terminal]
 ----
 $ oc logs vm-import-controller-f66f7d-zqkz7 -f -n <project>
 ----
@@ -120,6 +134,7 @@ endif::[]
 
 * If you enter the wrong credentials for the RHV Manager, the Manager might lock the admin user account because the `vm-import-operator` tries repeatedly to connect to the RHV API. To unlock the account, log in to the Manager and enter the following command:
 +
+[source,terminal]
 ----
 $ ovirt-aaa-jdbc-tool user unlock admin
 ----

--- a/modules/virt-updating-access-mode-for-live-migration.adoc
+++ b/modules/virt-updating-access-mode-for-live-migration.adoc
@@ -12,6 +12,7 @@ procedure to update the access mode, if needed.
 .Procedure
 * To set the RWX access mode, run the following `oc patch` command:
 +
+[source,terminal]
 ----
 $ oc patch -n openshift-cnv \
     cm kubevirt-storage-class-defaults \


### PR DESCRIPTION
Added [source,terminal] tags for terminal code block syntax highlighting and Example output headings to separate the output where applicable.

Merge/CP to branch/enterprise-4.5 and branch/enterprise-4.6.