### PR TITLE
Remove RHV VM Q35 prerequisite for importing into CNV

### DIFF
--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -25,14 +25,6 @@ Source environment prerequisites::
 
 ** If the VM uses GPU resources, the nodes providing the GPUs must be configured.
 ** The VM must not be configured for vGPU resources.
-** The BIOS type must be `Q35 Chipset with Legacy BIOS`.
-** The custom emulated machine must be `Q35`.
-+
-[NOTE]
-====
-Virtual machines created with RHV 4.4 emulate the Intel Q35 chipset by default. However, you must update older virtual machines in the RHV 4.4 cluster.
-====
-
 ** The VM must not have snapshots with disks in an `illegal` state.
 ** The VM must not have been created with {product-title} and subsequently added to RHV.
 ** The VM must not be configured for USB devices.

--- a/modules/virt-troubleshooting-vm-import.adoc
+++ b/modules/virt-troubleshooting-vm-import.adoc
@@ -66,13 +66,6 @@ endif::[]
 ifdef::virt-importing-rhv-vm[]
 The following error messages might appear:
 
-* The following error message is displayed in the VM Import Controller Pod log if the system settings of the VM do not emulate the Intel Q35 chipset:
-+
-----
-The virtual machine could not be imported.
-MappingRulesVerificationFailed: VM uses unsupported bios type: i440fx_sea_bios
-----
-
 * The following error message is displayed in the VM Import Controller Pod log if the target VM name exceeds 63 characters link:https://bugzilla.redhat.com/show_bug.cgi?id=1857165[(*BZ#1857165*)]:
 +
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1868073

For CNV 2.5 (Oct 26)
= OCP 4.6

CP 4.6