### PR TITLE
[logging-docs] Added notice about non-community operator

### DIFF
--- a/logging/cluster-logging-deploying.adoc
+++ b/logging/cluster-logging-deploying.adoc
@@ -17,6 +17,12 @@ The process for deploying cluster logging to {product-title} involves:
 
 * Installing the Elasticsearch Operator and Cluster Logging Operator using the {product-title} xref:../logging/cluster-logging-deploying.adoc#cluster-logging-deploy-console_cluster-logging-deploying[web console] or xref:../logging/cluster-logging-deploying.adoc#cluster-logging-deploy-cli_cluster-logging-deploying[CLI].
 
+[IMPORTANT]
+====
+The cluster logging operator is not yet part of the OKD community operators, 
+so you will need to enable the https://github.com/openshift/okd/blob/master/FAQ.md#how-can-i-enable-the-non-community-red-hat-operators[Red Hat operators].
+====
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other


### PR DESCRIPTION
Added a notice about the need to enable non-community operators so people know the cluster logging install will not work out of the box. Also included link to the faq explaining how to do this.

Should fix openshift/okd#295