### PR TITLE
BZ1856186 - Add manual reclaim procedure to 4.x docs

### DIFF
--- a/modules/storage-persistent-storage-reclaim-manual.adoc
+++ b/modules/storage-persistent-storage-reclaim-manual.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * storage/understanding-persistent-storage.adoc
+
+[id="reclaim-manual_{context}"]
+= Reclaiming a PersistentVolume manually
+
+When a PersistentVolumeClaim (PVC) is deleted, the PersistentVolume (PV) still exists and is considered "released". However, the PV is not yet available for another claim because the previous claimant's data remains on the volume.
+
+.Procedure
+To manually reclaim the PV as a cluster administrator:
+
+. Delete the PV.
++
+[source,terminal]
+----
+$ oc delete <pv-name>
+----
++
+The associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume, still exists after the PV is deleted.
+
+. Clean up the data on the associated storage asset.
+
+. Delete the associated storage asset. Alternately, to reuse the same storage asset, create a new PV with the storage asset definition.
+
+The reclaimed PV is now available for use by another PVC.

--- a/storage/understanding-persistent-storage.adoc
+++ b/storage/understanding-persistent-storage.adoc
@@ -8,6 +8,8 @@ include::modules/storage-persistent-storage-overview.adoc[leveloffset=+1]
 
 include::modules/storage-persistent-storage-lifecycle.adoc[leveloffset=+1]
 
+include::modules/storage-persistent-storage-reclaim-manual.adoc[leveloffset=+2]
+
 include::modules/storage-persistent-storage-reclaim.adoc[leveloffset=+2]
 
 include::modules/storage-persistent-storage-pv.adoc[leveloffset=+1]


### PR DESCRIPTION
Another addition to address [BZ1856186](https://bugzilla.redhat.com/show_bug.cgi?id=1856186) - this one is to describe how to manually reclaim storage as detailed [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain).

https://github.com/openshift/openshift-docs/pull/24778 addresses the same issue but in 3.11 docs.

[Preview build link](https://bz1856186--ocpdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#reclaim-manual_understanding-persistent-storage)

@chao007 PTAL