### PR TITLE
BZ1856186 - Add manual reclaim procedure to 3.11 docs

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -133,6 +133,29 @@ the volume after it is released. A PV's reclaim policy can be either `Retain` or
 Dynamically provisioned volumes have a default `ReclaimPolicy` value of `Delete`. Manually provisioned volumes have a default `ReclaimPolicy` value of `Retain`.
 ====
 
+
+[[reclaimmanual]]
+=== Reclaim a PersistentVolume Manually
+
+When a PersistentVolumeClaim is deleted, the PersistentVolume still exists and is considered "released". However, the PV is not yet available for another claim because the previous claimant's data remains on the volume.
+
+To manually reclaim the PV as a cluster administrator:
+
+. Delete the PV.
++
+[source,terminal]
+----
+$ oc delete <pv-name>
+----
++
+The associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume, still exists after the PV is deleted.
+
+. Clean up the data on the associated storage asset.
+
+. Delete the associated storage asset. Alternately, to reuse the same storage asset, create a new PV with the storage asset definition.
+
+The reclaimed PV is now available for use by another PVC.
+
 [[changingpolicy]]
 === Change the reclaim policy
 


### PR DESCRIPTION
Another addition to address [BZ1856186](https://bugzilla.redhat.com/show_bug.cgi?id=1856186) - this one is to describe how to manually reclaim storage as detailed [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain).

[3.11 Preview link](http://file.rdu.redhat.com/bfuru/081220/BZ1856186-3-11/architecture/additional_concepts/storage.html#reclaimmanual)

This relates to https://github.com/openshift/openshift-docs/pull/24776, which addresses the same issue but in 4.x docs.

@chao007 PTAL