### PR TITLE
OSDOCS-1398: Updated etcd backup procedures to use oc debug

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -14,26 +14,37 @@ Only save a backup from a single master host. Do not take a backup from each mas
 
 .Prerequisites
 
-* SSH access to a master host.
-
-.Procedure
-
-. Access a master host.
-
-. If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have checked whether the cluster-wide proxy is enabled.
 +
 [TIP]
 ====
 You can check whether the proxy is enabled by reviewing the output of `oc get proxy cluster -o yaml`. The proxy is enabled if the `httpProxy`, `httpsProxy`, and `noProxy` fields have values set.
 ====
 
-. Run the `cluster-backup.sh` script and pass in the location to save the backup to.
-+
-Be sure to pass in the `-E` flag to `sudo` so that environment variables are properly passed to the script.
+.Procedure
+
+. Start a debug session for a master node:
 +
 [source,terminal]
 ----
-$ sudo -E /usr/local/bin/cluster-backup.sh ./assets/backup
+$ oc debug node/<node_name>
+----
+
+. Change your root directory to the host:
++
+[source,terminal]
+----
+sh-4.2# chroot /host
+----
+
+. If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
+
+. Run the `cluster-backup.sh` script and pass in the location to save the backup to.
++
+[source,terminal]
+----
+sh-4.4# /usr/local/bin/cluster-backup.sh /home/core/assets/backup
 ----
 +
 .Example script output
@@ -46,11 +57,11 @@ found latest kube-apiserver-pod: /etc/kubernetes/static-pod-resources/kube-apise
 found latest kube-controller-manager-pod: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-8
 found latest kube-scheduler-pod: /etc/kubernetes/static-pod-resources/kube-scheduler-pod-6
 found latest etcd-pod: /etc/kubernetes/static-pod-resources/etcd-pod-2
-Snapshot saved at /var/home/core/assets/backup/snapshot_2020-03-18_220218.db
-snapshot db and kube resources are successfully saved to /var/home/core/assets/backup
+Snapshot saved at /home/core/assets/backup/snapshot_2020-03-18_220218.db
+snapshot db and kube resources are successfully saved to /home/core/assets/backup
 ----
 +
-In this example, two files are created in the `./assets/backup/` directory on the master host:
+In this example, two files are created in the `/home/core/assets/backup/` directory on the master host:
 
 * `snapshot_<datetimestamp>.db`: This file is the etcd snapshot.
 * `static_kuberesources_<datetimestamp>.tar.gz`: This file contains the resources for the static Pods. If etcd encryption is enabled, it also contains the encryption keys for the etcd snapshot.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1398

Preview: https://osdocs-1398--ocpdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/backing-up-etcd.html#backing-up-etcd-data_backup-etcd