### PR TITLE
BZ1850510 - Update all_squash mount options

### DIFF
--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -41,7 +41,7 @@ $ oc get pod -n openshift-image-registry
 [NOTE]
 =====
 * If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
-* If the storage type is `NFS`, you must enable the `no_wdelay` and `root_squash` mount options. For example:
+* If the storage type is `NFS`, you must enable the `no_wdelay` and `all_squash` mount options. For example:
 +
 [source,terminal]
 ----
@@ -51,7 +51,7 @@ $ oc get pod -n openshift-image-registry
 .Example output
 [source,terminal]
 ----
-/mnt/data *(rw,sync,no_wdelay,root_squash,insecure,fsid=0)
+/mnt/data *(rw,sync,no_wdelay,all_squash,insecure,fsid=0)
 ----
 +
 [source,terminal]

--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -49,7 +49,7 @@ $ oc get pod -n openshift-image-registry
 [NOTE]
 =====
 * If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
-* If the storage type is `NFS`, you must enable the `no_wdelay` and `root_squash` mount options. For example:
+* If the storage type is `NFS`, you must enable the `no_wdelay` and `all_squash` mount options. For example:
 +
 [source,terminal]
 ----
@@ -59,7 +59,7 @@ $ oc get pod -n openshift-image-registry
 .Example output
 [source,terminal]
 ----
-/mnt/data *(rw,sync,no_wdelay,root_squash,insecure,fsid=0)
+/mnt/data *(rw,sync,no_wdelay,all_squash,insecure,fsid=0)
 ----
 +
 [source,terminal]


### PR DESCRIPTION
[BZ1850510](https://bugzilla.redhat.com/show_bug.cgi?id=1850510) - This is an update to https://github.com/openshift/openshift-docs/pull/24276 and is in response to a new comment by the requestor that `root_squash` should be `all_squash` (https://bugzilla.redhat.com/show_bug.cgi?id=1850510#c19).

@huffmanca - PTAL. I'm not sure how I would address Alex's other option besides `all_squash`: 
> or the image_registry need to be adjusted in some way with a group which is dynamic in a sense that on a container restart/recreation will be modified.
Do you think changing to `all_squash` is a sufficient recommendation in this NFS note?

@qinpingli - PTAL for QE.