### PR TITLE
Update registry step

### DIFF
--- a/modules/installation-creating-mirror-registry.adoc
+++ b/modules/installation-creating-mirror-registry.adoc
@@ -110,8 +110,8 @@ OpenSSL documentation.
 ----
 <1> For `<local_registry_host_port>`, specify the port that your mirror registry
 uses to serve content.
-<2> If you are installing on IBM Power, specify
-`docker.io/ibmcom/registry-ppc64le:2.6.2.5` instead.
+<2> If you are installing on IBM Z or Power, specify
+`docker.io/ibmcom/registry:2.6.2.5` instead.
 
 . Open the required ports for your registry:
 +


### PR DESCRIPTION
@openshift/team-documentation
..Shit I must have hit a wrong button I only wanted to update that one file..... 

I've updated step 5 ii so that the sentence applies to both IBM Z and Power. 
`docker.io/ibmcom/registry:2.6.2.5` has been tested by both IBM Z and Power test teams to work. 