### PR TITLE
[enterprise-4.6] openshift-sdn to ovn-kubernetes migration testing feedback (#24445)

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -27,7 +27,7 @@ Perform the migration only when an interruption in service is acceptable.
 +
 [source,terminal]
 ----
-$ oc get Network.config.openshift.io cluster -o yaml
+$ oc get Network.config.openshift.io cluster -o yaml > cluster-openshift-sdn.yaml
 ----
 
 . To enable the migration, set an annotation on the Cluster Network Operator configuration object by entering the following command:
@@ -46,11 +46,11 @@ $ oc patch Network.config.openshift.io cluster \
   --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
 ----
 
-. To confirm the migration disabled the OpenShift SDN default CNI network provider, enter the following command. It might take several moments for all the OpenShift SDN Pods to stop.
+. To confirm the migration disabled the OpenShift SDN default CNI network provider and removed all OpenShift SDN Pods, enter the following command. It might take several moments for all the OpenShift SDN Pods to stop.
 +
 [source,terminal]
 ----
-$ oc get pod -n openshift-sdn --watch
+$ watch oc get pod -n openshift-sdn
 ----
 
 . To complete the migration, reboot each node in your cluster. For example, you could use a bash script similar to the following. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.

--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -42,11 +42,11 @@ $ oc patch Network.config.openshift.io cluster \
 $ oc edit Network.config.openshift.io cluster
 ----
 
-. To confirm that the migration disabled the OVN-Kubernetes default CNI network provider, enter the following command. It might take several moments for all the OVN-Kubernetes Pods to stop.
+. To confirm that the migration disabled the OVN-Kubernetes default CNI network provider and removed all the OVN-Kubernetes Pods, enter the following command. It might take several moments for all the OVN-Kubernetes Pods to stop.
 +
 [source,terminal]
 ----
-$ oc get pod -n openshift-ovn-kubernetes --watch
+$ watch oc get pod -n openshift-ovn-kubernetes
 ----
 
 . To complete the rollback, reboot each node in your cluster. For example, you could use a bash script similar to the following. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.


### PR DESCRIPTION
Update procedure for OVN-Kubernetes migration

Explicitly state success of no lingering openshift-sdn pods
Use watch command rather than the oc  --watch arg,
which offers no indication of completion

Co-authored-by: Vagner Farias <vfarias@redhat.com>