### PR TITLE
Required key name for NoSchedule taints on master nodes

### DIFF
--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -65,7 +65,7 @@ Taints and tolerations consist of a key, value, and effect.
 [frame=none]
 [cols="2a,3a"]
 !====
-!`NoSchedule`
+!`NoSchedule` ^[1]^
 !* New pods that do not match the taint are not scheduled onto that node.
 * Existing pods on the node remain.
 !`PreferNoSchedule`
@@ -87,6 +87,28 @@ Taints and tolerations consist of a key, value, and effect.
 !====
 
 |===
+[.small]
+--
+1. If you add a `NoSchedule` taint to a master node, the node must have the `node-role.kubernetes.io/master=:NoSchedule` taint, which is added by default.
++
+For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    machine.openshift.io/machine: openshift-machine-api/ci-ln-62s7gtb-f76d1-v8jxv-master-0
+    machineconfiguration.openshift.io/currentConfig: rendered-master-cdc1ab7da414629332cc4c3926e6e59c
+...
+spec:
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+...
+----
+--
 
 A toleration matches a taint:
 

--- a/modules/nodes-scheduler-taints-tolerations-adding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding.adoc
@@ -47,6 +47,8 @@ spec:
         tolerationSeconds: 3600
 ----
 <1> The `Exists` operator does not take a `value`.
++
+This example places a taint on `node1` that has key `key1`, value `value1`, and taint effect `NoExecute`.
 
 . Add a taint to a node by using the following command with the parameters described in the *Taint and toleration components* table:
 +
@@ -63,6 +65,30 @@ $ oc adm taint nodes node1 key1=value1:NoExecute
 ----
 +
 This command places a taint on `node1` that has key `key1`, value `value1`, and effect `NoExecute`.
++
+[NOTE]
+====
+If you add a `NoSchedule` taint to a master node, the node must have the `node-role.kubernetes.io/master=:NoSchedule` taint, which is added by default.
 
+For example:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    machine.openshift.io/machine: openshift-machine-api/ci-ln-62s7gtb-f76d1-v8jxv-master-0
+    machineconfiguration.openshift.io/currentConfig: rendered-master-cdc1ab7da414629332cc4c3926e6e59c
+...
+spec:
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+...
+
+----
+====
++
 The tolerations on the Pod match the taint on the node. A pod with either toleration can be scheduled onto `node1`.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1814325