### PR TITLE
Fix multicast SDN example.

### DIFF
--- a/modules/nw-enabling-multicast.adoc
+++ b/modules/nw-enabling-multicast.adoc
@@ -121,7 +121,7 @@ $ CIDR=$(oc get Network.config.openshift.io cluster \
 [source,terminal]
 ----
 $ oc exec msender -i -t -- \
-    /bin/bash -c "echo | socat STDIO UDP4-DATAGRAM:224.1.0.1:30102,range=$CIDR"
+    /bin/bash -c "echo | socat STDIO UDP4-DATAGRAM:224.1.0.1:30102,range=$CIDR,ip-multicast-ttl=64"
 ----
 +
 If multicast is working, the previous command returns the following output:


### PR DESCRIPTION
In case of ovn-kubernetes, if the multicast receiver and sender PODs are
on different nodes, the multicast traffic is routed. Change the example
to reflect that the TTL of test packets should be changed from the
default value of 1.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>