### PR TITLE
Update parameter descriptions for kube-proxy

### DIFF
--- a/modules/nw-kube-proxy-config.adoc
+++ b/modules/nw-kube-proxy-config.adoc
@@ -1,13 +1,16 @@
 // Module included in the following assemblies:
-// * networking/configuring-kubeproxy.adoc
+//
+// * networking/openshift_sdn/configuring-kube-proxy.adoc
 
 [id="nw-kube-proxy-config_{context}"]
 = kube-proxy configuration parameters
 
-You can modify the following `kubeProxyConfig` parameters:
+You can modify the following `kubeProxyConfig` parameters.
+
+IMPORTANT: Because of performance improvements introduced in {product-title} 4.3 and greater, adjusting the `iptablesSyncPeriod` parameter is no longer necessary.
 
 .Parameters
-[cols=".^2,.^3,.^3,.^2a",options="header"]
+[cols="30%,30%,30%,10%",options="header"]
 |====
 |Parameter|Description|Values|Default
 
@@ -20,10 +23,10 @@ link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
 
 |`proxyArguments.iptables-min-sync-period`
 |The minimum duration before refreshing `iptables` rules. This parameter ensures
-that the refresh does not happen too frequently.
+that the refresh does not happen too frequently. By default, a refresh starts as soon as a change that affects `iptables` rules occurs.
 |A time interval, such as `30s` or `2m`. Valid suffixes include `s`,
 `m`, and `h` and are described in the
 link:https://golang.org/pkg/time/#ParseDuration[Go time package]
-|`30s`
+|`0s`
 
 |====

--- a/modules/nw-kube-proxy-configuring.adoc
+++ b/modules/nw-kube-proxy-configuring.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
-// * networking/configuring-kubeproxy.adoc
+//
+// * networking/openshift_sdn/configuring-kube-proxy.adoc
 
 [id="nw-kube-proxy-configuring_{context}"]
 = Modifying the kube-proxy configuration
@@ -43,15 +44,14 @@ The syntax is validated by the `oc` command when you save the file and exit the
 editor. If your modifications contain a syntax error, the editor opens the file
 and displays an error message.
 
-. Run the following command to confirm the configuration update:
+. Enter the following command to confirm the configuration update:
 +
 [source,terminal]
 ----
 $ oc get networks.operator.openshift.io -o yaml
 ----
 +
-The command returns output similar to the following example:
-+
+.Example output
 [source,yaml]
 ----
 apiVersion: v1
@@ -77,7 +77,7 @@ items:
 kind: List
 ----
 
-. Optional: Run the following command to confirm that the Cluster Network
+. Optional: Enter the following command to confirm that the Cluster Network
 Operator accepted the configuration change:
 +
 [source,terminal]

--- a/modules/nw-kube-proxy-sync.adoc
+++ b/modules/nw-kube-proxy-sync.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
-// * networking/configuring-kubeproxy.adoc
+//
+// * networking/openshift_sdn/configuring-kube-proxy.adoc
 
 [id="nw-kube-proxy-sync_{context}"]
 = About iptables rules synchronization

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -52,17 +52,17 @@ spec:
     iptablesSyncPeriod: 30s <4>
     proxyArguments:
       iptables-min-sync-period: <5>
-      - 30s
+      - 0s
 ----
 <1> Specified in the `install-config.yaml` file.
 
 <2> Configures the default Container Network Interface (CNI) network provider for the cluster network.
 
-<3> The parameters for this object specify the `kube-proxy` configuration. If
-you do not specify the parameter values, the Network Operator applies the
-displayed default parameter values.
+<3> The parameters for this object specify the `kube-proxy` configuration. If you do not specify the parameter values, the Cluster Network Operator applies the displayed default parameter values. If you are using the OVN-Kubernetes default CNI network provider, the kube-proxy configuration has no effect.
 
 <4> The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
++
+NOTE: Because of performance improvements introduced in {product-title} 4.3 and greater, adjusting the `iptablesSyncPeriod` parameter is no longer necessary.
 
 <5> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
 endif::operator[]
@@ -85,22 +85,20 @@ spec:
     iptablesSyncPeriod: 30s <5>
     proxyArguments:
       iptables-min-sync-period: <6>
-      - 30s
+      - 0s
 ----
 <1> A list specifying the blocks of IP addresses from which Pod IPs are
 allocated and the subnet prefix length assigned to each individual node.
 
-<2> A block of IP addresses for services. The OpenShift SDN Container Network
-Interface (CNI) plug-in supports only a single IP address block for the service
-network.
+<2> A block of IP addresses for services. The OpenShift SDN Container Network Interface (CNI) network provider supports only a single IP address block for the service network.
 
-<3> Configures the default Container Network Interface (CNI) network provider for the cluster network.
+<3> Configures the default CNI network provider for the cluster network.
 
-<4> The parameters for this object specify the Kubernetes network proxy
-(kube-proxy) configuration. If you are using the OVN-Kubernetes network
-provider, the kube-proxy configuration has no effect.
+<4> The parameters for this object specify the Kubernetes network proxy (kube-proxy) configuration. If you are using the OVN-Kubernetes default CNI network provider, the kube-proxy configuration has no effect.
 
 <5> The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
++
+NOTE: Because of performance improvements introduced in {product-title} 4.3 and greater, adjusting the `iptablesSyncPeriod` parameter is no longer necessary.
 
 <6> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
 endif::operator[]
@@ -249,7 +247,7 @@ spec:
     iptablesSyncPeriod: 30s
     proxyArguments:
       iptables-min-sync-period:
-      - 30s
+      - 0s
 ----
 
 ifeval::["{context}" == "cluster-network-operator"]

--- a/networking/openshift_sdn/configuring-kube-proxy.adoc
+++ b/networking/openshift_sdn/configuring-kube-proxy.adoc
@@ -10,5 +10,5 @@ the Cluster Network Operator (CNO). kube-proxy maintains network rules for
 forwarding connections for endpoints associated with services.
 
 include::modules/nw-kube-proxy-sync.adoc[leveloffset=+1]
-include::modules/nw-kube-proxy-configuring.adoc[leveloffset=+1]
 include::modules/nw-kube-proxy-config.adoc[leveloffset=+1]
+include::modules/nw-kube-proxy-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/24676

@danwinship, I found some additional instances of kube-proxy. Previews of the updated content are below:

Previews:

- [Cluster Network Operator configuration - install customization](https://gh-24676--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#nw-operator-cr_installing-aws-network-customizations)
- [CNO overview](https://gh-24676--ocpdocs.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator.html#nw-operator-cr_cluster-network-operator)
- [Configuring kube-proxy](https://gh-24676--ocpdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-kube-proxy.html)

Thanks!