### PR TITLE
Added 4.6 tested maximums

### DIFF
--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -7,7 +7,7 @@
 
 [options="header",cols="6*"]
 |===
-| Maximum type |4.1 tested maximum |4.2 tested maximum |4.3 tested maximum |4.4 tested maximum |4.5 tested maximum
+| Maximum type |4.1 and 4.2 tested maximum |4.3 tested maximum |4.4 tested maximum |4.5 tested maximum |4.6 tested maximum
 
 | Number of Nodes
 | 2,000
@@ -25,7 +25,7 @@
 
 | Number of Pods per node
 | 250
-| 250
+| 500
 | 500
 | 500
 | 500
@@ -46,7 +46,7 @@
 
 | Number of Builds
 | 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
-| 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
+| 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy


### PR DESCRIPTION
@chaitanyaenr Stubbed out a section for 4.6 cluster maximums. I combined 4.1 and 4.2 columns to trim the table down a bit. I realize these metrics could change, but adding this for now. PTAL. Thanks!