### PR TITLE
Installer azure gcp command blocks source terminal

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -123,6 +123,8 @@ The cluster requires several firewall rules. If you do not use a shared VPC, the
 
 If you choose to create each rule based on events, you must create firewall rules after you provision the cluster and during the life of the cluster when the console notifies you that rules are missing. Events that are similar to the following event are displayed, and you must add the firewall rules that are required:
 
+.Example output
+[source,terminal]
 ----
 Firewall change required by security admin: `gcloud compute firewall-rules create k8s-fw-a26e631036a3f46cba28f8df67266d55 --network example-network --description "{\"kubernetes.io/service-name\":\"openshift-ingress/router-default\", \"kubernetes.io/service-ip\":\"35.237.236.234\"}\" --allow tcp:443,tcp:80 --source-ranges 0.0.0.0/0 --target-tags exampl-fqzq7-master,exampl-fqzq7-worker --project example-project`
 ----

--- a/modules/admin-credentials-root-secret-formats.adoc
+++ b/modules/admin-credentials-root-secret-formats.adoc
@@ -67,11 +67,13 @@ On Microsoft Azure, the credentials secret format includes two properties that m
 contain the cluster's infrastructure ID, generated randomly for each cluster
 installation. This value can be found after running create manifests:
 
+[source,terminal]
 ----
 $ cat .openshift_install_state.json | jq '."*installconfig.ClusterID".InfraID' -r
 ----
 
 .Example output
+[source,terminal]
 ----
 mycluster-2mpcn
 ----

--- a/modules/installation-azure-create-dns-zones.adoc
+++ b/modules/installation-azure-create-dns-zones.adoc
@@ -31,6 +31,7 @@ sure the installation config you generated earlier reflects that scenario.
 . Create the new public DNS zone in the resource group exported in the
 `BASE_DOMAIN_RESOURCE_GROUP` environment variable:
 +
+[source,terminal]
 ----
 $ az network dns zone create -g ${BASE_DOMAIN_RESOURCE_GROUP} -n ${CLUSTER_NAME}.${BASE_DOMAIN}
 ----
@@ -40,6 +41,7 @@ You can skip this step if you are using a public DNS zone that already exists.
 . Create the private DNS zone in the same resource group as the rest of this
 deployment:
 +
+[source,terminal]
 ----
 $ az network private-dns zone create -g ${RESOURCE_GROUP} -n ${CLUSTER_NAME}.${BASE_DOMAIN}
 ----

--- a/modules/installation-azure-create-ingress-dns-records.adoc
+++ b/modules/installation-azure-create-ingress-dns-records.adoc
@@ -75,8 +75,14 @@ $ az network private-dns record-set a add-record -g ${RESOURCE_GROUP} -z ${CLUST
 If you prefer to add explicit domains instead of using a wildcard, you can
 create entries for each of the cluster's current Routes:
 
+[source,terminal]
 ----
 $ oc get --all-namespaces -o jsonpath='{range .items[*]}{range .status.ingress[*]}{.host}{"\n"}{end}{end}' routes
+----
+
+.Example output
+[source,terminal]
+----
 oauth-openshift.apps.cluster.basedomain.com
 console-openshift-console.apps.cluster.basedomain.com
 downloads-openshift-console.apps.cluster.basedomain.com

--- a/modules/installation-azure-create-resource-group-and-identity.adoc
+++ b/modules/installation-azure-create-resource-group-and-identity.adoc
@@ -19,12 +19,14 @@ Azure.
 
 . Create the resource group in a supported Azure region:
 +
+[source,terminal]
 ----
 $ az group create --name ${RESOURCE_GROUP} --location ${AZURE_REGION}
 ----
 
 . Create an Azure identity for the resource group:
 +
+[source,terminal]
 ----
 $ az identity create -g ${RESOURCE_GROUP} -n ${INFRA_ID}-identity
 ----
@@ -37,13 +39,19 @@ balancer. You must assign the Azure identity to a role.
 
 .. Export the following variables required by the Azure role assignment:
 +
+[source,terminal]
 ----
 $ export PRINCIPAL_ID=`az identity show -g ${RESOURCE_GROUP} -n ${INFRA_ID}-identity --query principalId --out tsv`
+----
++
+[source,terminal]
+----
 $ export RESOURCE_GROUP_ID=`az group show -g ${RESOURCE_GROUP} --query id --out tsv`
 ----
 
 .. Assign the Contributor role to the identity:
 +
+[source,terminal]
 ----
 $ az role assignment create --assignee "${PRINCIPAL_ID}" --role 'Contributor' --scope "${RESOURCE_GROUP_ID}"
 ----

--- a/modules/installation-azure-service-principal.adoc
+++ b/modules/installation-azure-service-principal.adoc
@@ -20,6 +20,7 @@ to represent it.
 
 . Log in to the Azure CLI:
 +
+[source,terminal]
 ----
 $ az login
 ----
@@ -31,8 +32,14 @@ subscription.
 .. View the list of available accounts and record the `tenantId` value for the
 subscription you want to use for your cluster:
 +
+[source,terminal]
 ----
 $ az account list --refresh
+----
++
+.Example output
+[source,terminal]
+----
 [
   {
     "cloudName": "AzureCloud",
@@ -52,8 +59,14 @@ $ az account list --refresh
 .. View your active account details and confirm that the `tenantId` matches
 the subscription you want to use:
 +
+[source,terminal]
 ----
 $ az account show
+----
++
+.Example output
+[source,terminal]
+----
 {
   "environmentName": "AzureCloud",
   "id": "9bab1460-96d5-40b3-a78e-17b15e978a80",
@@ -72,6 +85,7 @@ correct subscription.
 
 .. If you are not using the right subscription, change the active subscription:
 +
+[source,terminal]
 ----
 $ az account set -s <id> <1>
 ----
@@ -80,9 +94,14 @@ use for `<id>`.
 
 .. If you changed the active subscription, display your account information again:
 +
+[source,terminal]
 ----
 $ az account show
-
+----
++
+.Example output
+[source,terminal]
+----
 {
   "environmentName": "AzureCloud",
   "id": "33212d16-bdf6-45cb-b038-f6565b61edda",
@@ -102,8 +121,15 @@ output. You need these values during {product-title} installation.
 
 . Create the service principal for your account:
 +
+[source,terminal]
 ----
 $ az ad sp create-for-rbac --role Contributor --name <service_principal> <1>
+----
+<1> Replace `<service_principal>` with the name to assign to the service principal.
++
+.Example output
+[source,terminal]
+----
 Changing "<service_principal>" to a valid URI of "http://<service_principal>", which is the required format used for service principal names
 Retrying role assignment creation: 1/36
 Retrying role assignment creation: 2/36
@@ -116,9 +142,7 @@ Retrying role assignment creation: 4/36
   "password": "ac461d78-bf4b-4387-ad16-7e32e328aec6",
   "tenant": "6048c7e9-b2ad-488d-a54e-dc3f6be6a7ee"
 }
-
 ----
-<1> Replace `<service_principal>` with the name to assign to the service principal.
 
 . Record the values of the `appId` and `password` parameters from the previous
 output. You need these values during {product-title} installation.
@@ -129,6 +153,7 @@ permission and the `User Access Administrator` role for the cluster to assign
 credentials for its components.
 .. To assign the `User Access Administrator` role, run the following command:
 +
+[source,terminal]
 ----
 $ az role assignment create --role "User Access Administrator" \
     --assignee-object-id $(az ad sp list --filter "appId eq '<appId>'" \ <1>
@@ -139,15 +164,19 @@ $ az role assignment create --role "User Access Administrator" \
 .. To assign the `Azure Active Directory Graph` permission, run the following
 command:
 +
+[source,terminal]
 ----
 $ az ad app permission add --id <appId> \ <1>
      --api 00000002-0000-0000-c000-000000000000 \
      --api-permissions 824c81eb-e3f8-4ee6-8f6d-de7f50d565b7=Role
-
-     Invoking "az ad app permission grant --id 46d33abc-b8a3-46d8-8c84-f0fd58177435 --api 00000002-0000-0000-c000-000000000000" is needed to make the change effective
-
 ----
 <1> Replace `<appId>` with the `appId` parameter value for your service principal.
++
+.Example output
+[source,terminal]
+----
+Invoking "az ad app permission grant --id 46d33abc-b8a3-46d8-8c84-f0fd58177435 --api 00000002-0000-0000-c000-000000000000" is needed to make the change effective
+----
 +
 For more information about the specific permissions that you grant with this
 command, see the
@@ -157,6 +186,7 @@ Azure Active Directory tenant administrator role, follow the guidelines for
 your organization to request that the tenant administrator approve your
 permissions request.
 +
+[source, terminal]
 ----
 $ az ad app permission grant --id <appId> \ <1>
      --api 00000002-0000-0000-c000-000000000000

--- a/modules/installation-azure-user-infra-completing.adoc
+++ b/modules/installation-azure-user-infra-completing.adoc
@@ -18,9 +18,14 @@ cluster is ready.
 
 * Complete the cluster installation:
 +
+[source,terminal]
 ----
 $ ./openshift-install --dir=<installation_directory> wait-for install-complete <1>
-
+----
++
+.Example output
+[source,terminal]
+----
 INFO Waiting up to 30m0s for the cluster to initialize...
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you

--- a/modules/installation-azure-user-infra-deploying-rhcos.adoc
+++ b/modules/installation-azure-user-infra-deploying-rhcos.adoc
@@ -26,12 +26,14 @@ describes the image storage that your cluster requires.
 
 . Export the {op-system} VHD blob URL as a variable:
 +
+[source,terminal]
 ----
 $ export VHD_BLOB_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} -c vhd -n "rhcos.vhd" -o tsv`
 ----
 
 . Deploy the cluster image:
 +
+[source,terminal]
 ----
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/02_storage.json" \

--- a/modules/installation-azure-user-infra-uploading-rhcos.adoc
+++ b/modules/installation-azure-user-infra-uploading-rhcos.adoc
@@ -20,6 +20,7 @@ are accessible during deployment.
 
 . Create an Azure storage account to store the VHD cluster image:
 +
+[source,terminal]
 ----
 $ az storage account create -g ${RESOURCE_GROUP} --location ${AZURE_REGION} --name ${CLUSTER_NAME}sa --kind Storage --sku Standard_LRS
 ----
@@ -36,6 +37,7 @@ in the Azure documentation.
 
 . Export the storage account key as an environment variable:
 +
+[source,terminal]
 ----
 $ export ACCOUNT_KEY=`az storage account keys list -g ${RESOURCE_GROUP} --account-name ${CLUSTER_NAME}sa --query "[0].value" -o tsv`
 ----
@@ -43,6 +45,7 @@ $ export ACCOUNT_KEY=`az storage account keys list -g ${RESOURCE_GROUP} --accoun
 . Choose the {op-system} version to use and export the URL of its VHD to an
 environment variable:
 +
+[source,terminal]
 ----
 $ export VHD_URL=`curl -s https://raw.githubusercontent.com/openshift/installer/release-4.4/data/data/rhcos.json | jq -r .azure.url`
 ----
@@ -57,8 +60,13 @@ that matches your {product-title} version if it is available.
 
 . Copy the chosen VHD to a blob:
 +
+[source,terminal]
 ----
 $ az storage container create --name vhd --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY}
+----
++
+[source,terminal]
+----
 $ az storage blob copy start --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} --destination-blob "rhcos.vhd" --destination-container vhd --source-uri "${VHD_URL}"
 ----
 +
@@ -75,7 +83,12 @@ done
 
 . Create a blob storage container and upload the generated `bootstrap.ign` file:
 +
+[source,terminal]
 ----
 $ az storage container create --name files --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} --public-access blob
+----
++
+[source,terminal]
+----
 $ az storage blob upload --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} -c "files" -f "<installation_directory>/bootstrap.ign" -n "bootstrap.ign"
 ----

--- a/modules/installation-azure-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-azure-user-infra-wait-for-bootstrap.adoc
@@ -24,6 +24,7 @@ the Ignition config files that you generated with the installation program.
 . Change to the directory that contains the installation program and run the
 following command:
 +
+[source,terminal]
 ----
 $ ./openshift-install wait-for bootstrap-complete --dir=<installation_directory> \ <1>
     --log-level info <2>
@@ -38,6 +39,7 @@ has initialized.
 
 . Delete the bootstrap resources:
 +
+[source,terminal]
 ----
 $ az network nsg rule delete -g ${RESOURCE_GROUP} --nsg-name ${INFRA_ID}-nsg --name bootstrap_ssh_in
 $ az vm stop -g ${RESOURCE_GROUP} --name ${INFRA_ID}-bootstrap

--- a/modules/installation-creating-azure-bootstrap.adoc
+++ b/modules/installation-creating-azure-bootstrap.adoc
@@ -33,6 +33,7 @@ describes the bootstrap machine that your cluster requires.
 
 . Export the following variables required by the bootstrap machine deployment:
 +
+[source,terminal]
 ----
 $ export BOOTSTRAP_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} -c "files" -n "bootstrap.ign" -o tsv`
 $ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "2.2.0" --arg url ${BOOTSTRAP_URL} '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 -w0`
@@ -40,6 +41,7 @@ $ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "2.2.0" --arg url ${BOOTSTRAP_URL}
 
 . Create the deployment by using the `az` CLI:
 +
+[source,terminal]
 ----
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/04_bootstrap.json" \

--- a/modules/installation-creating-azure-control-plane.adoc
+++ b/modules/installation-creating-azure-control-plane.adoc
@@ -34,12 +34,14 @@ This template describes the control plane machines that your cluster requires.
 
 . Export the following variable needed by the control plane machine deployment:
 +
+[source,terminal]
 ----
 $ export MASTER_IGNITION=`cat <installation_directory>/master.ign | base64`
 ----
 
 . Create the deployment by using the `az` CLI:
 +
+[source,terminal]
 ----
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/05_masters.json" \
@@ -52,4 +54,3 @@ $ az deployment group create -g ${RESOURCE_GROUP} \
 <2> The SSH RSA public key file as a string.
 <3> The name of the private DNS zone to which the master nodes are attached.
 <4> The base name to be used in resource names; this is usually the cluster’s Infra ID.
-

--- a/modules/installation-creating-azure-dns.adoc
+++ b/modules/installation-creating-azure-dns.adoc
@@ -32,6 +32,7 @@ requires.
 
 . Create the deployment by using the `az` CLI:
 +
+[source,terminal]
 ----
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/03_infra.json" \
@@ -47,12 +48,14 @@ resource group where the public DNS zone exists.
 
 .. Export the following variable:
 +
+[source,terminal]
 ----
 $ export PUBLIC_IP=`az network public-ip list -g ${RESOURCE_GROUP} --query "[?name=='${INFRA_ID}-master-pip'] | [0].ipAddress" -o tsv`
 ----
 
 .. Create the DNS record in a new public zone:
 +
+[source,terminal]
 ----
 $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n api -a ${PUBLIC_IP} --ttl 60
 ----
@@ -60,6 +63,7 @@ $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${C
 .. If you are adding the cluster to an existing public zone, you can create the DNS
 record in it instead:
 +
+[source,terminal]
 ----
 $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${BASE_DOMAIN} -n api.${CLUSTER_NAME} -a ${PUBLIC_IP} --ttl 60
 ----

--- a/modules/installation-creating-azure-vnet.adoc
+++ b/modules/installation-creating-azure-vnet.adoc
@@ -31,6 +31,7 @@ VNet that your cluster requires.
 
 . Create the deployment by using the `az` CLI:
 +
+[source,terminal]
 ----
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/01_vnet.json" \
@@ -40,6 +41,7 @@ $ az deployment group create -g ${RESOURCE_GROUP} \
 
 . Link the VNet template to the private DNS zone:
 +
+[source,terminal]
 ----
 $ az network private-dns link vnet create -g ${RESOURCE_GROUP} -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n ${INFRA_ID}-network-link -v "${INFRA_ID}-vnet" -e false
 ----

--- a/modules/installation-creating-azure-worker.adoc
+++ b/modules/installation-creating-azure-worker.adoc
@@ -40,12 +40,14 @@ template describes the worker machines that your cluster requires.
 
 . Export the following variable needed by the worker machine deployment:
 +
+[source,terminal]
 ----
 $ export WORKER_IGNITION=`cat <installation_directory>/worker.ign | base64`
 ----
 
 . Create the deployment by using the `az` CLI:
 +
+[source,terminal]
 ----
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/06_workers.json" \

--- a/modules/installation-creating-gcp-bootstrap.adoc
+++ b/modules/installation-creating-gcp-bootstrap.adoc
@@ -41,6 +41,7 @@ template describes the bootstrap machine that your cluster requires.
 .. Export the control plane subnet location:
 +
 ifndef::shared-vpc[]
+[source,terminal]
 ----
 $ export CONTROL_SUBNET=`gcloud compute networks subnets describe ${INFRA_ID}-master-subnet --region=${REGION} --format json | jq -r .selfLink`
 ----
@@ -48,21 +49,25 @@ endif::shared-vpc[]
 
 .. Export the location of the {op-system-first} image that the installation program requires:
 +
+[source,terminal]
 ----
 $ export CLUSTER_IMAGE=`gcloud compute images describe ${INFRA_ID}-rhcos-image --format json | jq -r .selfLink`
 ----
 
 ifndef::shared-vpc[]
-.. Export each zone that the cluster uses:
+.. Export the three zones that the cluster uses:
 +
+[source,terminal]
 ----
 $ export ZONE_0=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[0] | cut -d "/" -f9`
 ----
 +
+[source,terminal]
 ----
 $ export ZONE_1=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[1] | cut -d "/" -f9`
 ----
 +
+[source,terminal]
 ----
 $ export ZONE_2=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[2] | cut -d "/" -f9`
 ----
@@ -70,6 +75,7 @@ endif::shared-vpc[]
 
 . Create a bucket and upload the `bootstrap.ign` file:
 +
+[source,terminal]
 ----
 $ gsutil mb gs://${INFRA_ID}-bootstrap-ignition
 $ gsutil cp bootstrap.ign gs://${INFRA_ID}-bootstrap-ignition/
@@ -78,6 +84,7 @@ $ gsutil cp bootstrap.ign gs://${INFRA_ID}-bootstrap-ignition/
 . Create a signed URL for the bootstrap instance to use to access the Ignition
 config. Export the URL from the output as a variable:
 +
+[source,terminal]
 ----
 $ export BOOTSTRAP_IGN=`gsutil signurl -d 1h service-account-key.json \
     gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign | grep "^gs:" | awk '{print $5}'`
@@ -85,6 +92,7 @@ $ export BOOTSTRAP_IGN=`gsutil signurl -d 1h service-account-key.json \
 
 . Create a `04_bootstrap.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >04_bootstrap.yaml
 imports:
@@ -118,6 +126,7 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-bootstrap --config 04_bootstrap.yaml
 ----
@@ -126,6 +135,7 @@ ifndef::shared-vpc[]
 . The templates do not manage load balancer membership due to limitations of Deployment
 Manager, so you must add the bootstrap machine manually:
 +
+[source,terminal]
 ----
 $ gcloud compute target-pools add-instances \
     ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_0}" --instances=${INFRA_ID}-bootstrap
@@ -137,12 +147,14 @@ endif::shared-vpc[]
 ifdef::shared-vpc[]
 . Add the bootstrap instance to the internal load balancer instance group:
 +
+[source,terminal]
 ----
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-bootstrap-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
 ----
 
 . Add the bootstrap instance group to the internal load balancer backend service:
 +
+[source,terminal]
 ----
 $ gcloud compute backend-services add-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
 ----

--- a/modules/installation-creating-gcp-control-plane.adoc
+++ b/modules/installation-creating-gcp-control-plane.adoc
@@ -40,6 +40,7 @@ This template describes the control plane machines that your cluster requires.
 
 . Export the following variables needed by the resource definition:
 +
+[source,terminal]
 ----
 $ export MASTER_SERVICE_ACCOUNT_EMAIL=`gcloud iam service-accounts list | grep "^${INFRA_ID}-master-node " | awk '{print $2}'`
 $ export MASTER_IGNITION=`cat master.ign`
@@ -47,6 +48,7 @@ $ export MASTER_IGNITION=`cat master.ign`
 
 . Create a `05_control_plane.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >05_control_plane.yaml
 imports:
@@ -81,6 +83,7 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-control-plane --config 05_control_plane.yaml
 ----
@@ -89,6 +92,7 @@ $ gcloud deployment-manager deployments create ${INFRA_ID}-control-plane --confi
 Manager, so you must add the etcd entries manually:
 +
 ifndef::shared-vpc[]
+[source,terminal]
 ----
 $ export MASTER0_IP=`gcloud compute instances describe ${INFRA_ID}-m-0 --zone ${ZONE_0} --format json | jq -r .networkInterfaces[0].networkIP`
 $ export MASTER1_IP=`gcloud compute instances describe ${INFRA_ID}-m-1 --zone ${ZONE_1} --format json | jq -r .networkInterfaces[0].networkIP`
@@ -107,11 +111,12 @@ $ gcloud dns record-sets transaction execute --zone ${INFRA_ID}-private-zone
 ----
 endif::shared-vpc[]
 ifdef::shared-vpc[]
+[source,terminal]
 ----
 $ export MASTER0_IP=`gcloud compute instances describe ${INFRA_ID}-m-0 --zone ${ZONE_0} --format json | jq -r .networkInterfaces[0].networkIP`
 $ export MASTER1_IP=`gcloud compute instances describe ${INFRA_ID}-m-1 --zone ${ZONE_1} --format json | jq -r .networkInterfaces[0].networkIP`
 $ export MASTER2_IP=`gcloud compute instances describe ${INFRA_ID}-m-2 --zone ${ZONE_2} --format json | jq -r .networkInterfaces[0].networkIP`
-if [ -f transaction.yaml ]; then rm transaction.yaml; fi
+$ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud dns record-sets transaction start --zone ${INFRA_ID}-private-zone --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
 $ gcloud dns record-sets transaction add ${MASTER0_IP} --name etcd-0.${CLUSTER_NAME}.${BASE_DOMAIN}. --ttl 60 --type A --zone ${INFRA_ID}-private-zone --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
 $ gcloud dns record-sets transaction add ${MASTER1_IP} --name etcd-1.${CLUSTER_NAME}.${BASE_DOMAIN}. --ttl 60 --type A --zone ${INFRA_ID}-private-zone --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
@@ -129,6 +134,7 @@ ifndef::shared-vpc[]
 . The templates do not manage load balancer membership due to limitations of Deployment
 Manager, so you must add the control plane machines manually:
 +
+[source,terminal]
 ----
 $ gcloud compute target-pools add-instances ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_0}" --instances=${INFRA_ID}-m-0
 $ gcloud compute target-pools add-instances ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_1}" --instances=${INFRA_ID}-m-1
@@ -144,6 +150,7 @@ ifdef::shared-vpc[]
 Manager, so you must add the control plane machines manually.
 ** For an internal cluster, use the following commands:
 +
+[source,terminal]
 ----
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-m-0
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-instance-group --zone=${ZONE_1} --instances=${INFRA_ID}-m-1
@@ -152,6 +159,7 @@ $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZO
 
 ** For an external cluster, use the following commands:
 +
+[source,terminal]
 ----
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-m-0
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-instance-group --zone=${ZONE_1} --instances=${INFRA_ID}-m-1

--- a/modules/installation-creating-gcp-dns.adoc
+++ b/modules/installation-creating-gcp-dns.adoc
@@ -38,11 +38,13 @@ requires.
 . Export the following variable required by the resource definition:
 +
 ifndef::shared-vpc[]
+[source,terminal]
 ----
-$ export CLUSTER_NETWORK=`gcloud compute networks describe ${INFRA_ID}-network --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink` 
+$ export CLUSTER_NETWORK=`gcloud compute networks describe ${INFRA_ID}-network --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
 ----
 endif::shared-vpc[]
 ifdef::shared-vpc[]
+[source,terminal]
 ----
 $ export CLUSTER_NETWORK=`gcloud compute networks describe ${HOST_PROJECT_NETWORK} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
 ----
@@ -52,6 +54,7 @@ endif::shared-vpc[]
 
 . Create a `02_infra.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >02_infra.yaml
 imports:
@@ -75,6 +78,7 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-infra --config 02_infra.yaml
 ----
@@ -84,12 +88,14 @@ Manager, so you must create them manually:
 
 .. Export the following variable:
 +
+[source,terminal]
 ----
 $ export CLUSTER_IP=`gcloud compute addresses describe ${INFRA_ID}-cluster-public-ip --region=${REGION} --format json | jq -r .address`
 ----
 
 .. Add external DNS entries:
 +
+[source,terminal]
 ----
 $ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud dns record-sets transaction start --zone ${BASE_DOMAIN_ZONE_NAME}
@@ -99,6 +105,7 @@ $ gcloud dns record-sets transaction execute --zone ${BASE_DOMAIN_ZONE_NAME}
 
 .. Add internal DNS entries:
 +
+[source,terminal]
 ----
 $ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud dns record-sets transaction start --zone ${INFRA_ID}-private-zone

--- a/modules/installation-creating-gcp-firewall-rules-vpc.adoc
+++ b/modules/installation-creating-gcp-firewall-rules-vpc.adoc
@@ -32,6 +32,7 @@ template describes the security groups that your cluster requires.
 
 . Create a `03_firewall.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >03_firewall.yaml
 imports:
@@ -54,6 +55,7 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-firewall --config 03_firewall.yaml --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
 ----

--- a/modules/installation-creating-gcp-iam-shared-vpc.adoc
+++ b/modules/installation-creating-gcp-iam-shared-vpc.adoc
@@ -32,6 +32,7 @@ template describes the IAM roles that your cluster requires.
 
 . Create a `03_iam.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >03_iam.yaml
 imports:
@@ -47,18 +48,21 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-iam --config 03_iam.yaml
 ----
 
 . Export the variable for the master service account:
 +
+[source,terminal]
 ----
 $ export MASTER_SA=`gcloud iam service-accounts list | grep "^${INFRA_ID}-master-node " | awk '{print $2}'`
 ----
 
 . Export the variable for the master service account:
 +
+[source,terminal]
 ----
 $ export WORKER_SA=`gcloud iam service-accounts list | grep "^${INFRA_ID}-worker-node " | awk '{print $2}'`
 ----
@@ -67,30 +71,35 @@ $ export WORKER_SA=`gcloud iam service-accounts list | grep "^${INFRA_ID}-worker
 
 .. Grant the `networkViewer` role of the project that hosts your shared VPC to the master service account:
 +
+[source,terminal]
 ----
 $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} projects add-iam-policy-binding ${HOST_PROJECT} --member "serviceAccount:${MASTER_SA}" --role "roles/compute.networkViewer"
 ----
 
 .. Grant the `networkUser` role to the master service account for the control plane subnet:
 +
+[source,terminal]
 ----
 $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} compute networks subnets add-iam-policy-binding "${HOST_PROJECT_CONTROL_SUBNET}" --member "serviceAccount:${MASTER_SA}" --role "roles/compute.networkUser" --region ${REGION}
 ----
 
 .. Grant the `networkUser` role to the worker service account for the control plane subnet:
 +
+[source,terminal]
 ----
 $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} compute networks subnets add-iam-policy-binding "${HOST_PROJECT_CONTROL_SUBNET}" --member "serviceAccount:${WORKER_SA}" --role "roles/compute.networkUser" --region ${REGION}
 ----
 
 .. Grant the `networkUser` role to the master service account for the compute subnet:
 +
+[source,terminal]
 ----
 $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} compute networks subnets add-iam-policy-binding "${HOST_PROJECT_COMPUTE_SUBNET}" --member "serviceAccount:${MASTER_SA}" --role "roles/compute.networkUser" --region ${REGION}
 ----
 
 .. Grant the `networkUser` role to the worker service account for the compute subnet:
 +
+[source,terminal]
 ----
 $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} compute networks subnets add-iam-policy-binding "${HOST_PROJECT_COMPUTE_SUBNET}" --member "serviceAccount:${WORKER_SA}" --role "roles/compute.networkUser" --region ${REGION}
 ----
@@ -98,6 +107,7 @@ $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} compute net
 . The templates do not create the policy bindings due to limitations of Deployment
 Manager, so you must create them manually:
 +
+[source,terminal]
 ----
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SA}" --role "roles/compute.instanceAdmin"
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SA}" --role "roles/compute.networkAdmin"
@@ -111,6 +121,7 @@ $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccoun
 
 . Create a service account key and store it locally for later use:
 +
+[source,terminal]
 ----
 $ gcloud iam service-accounts keys create service-account-key.json --iam-account=${MASTER_SA}
 ----

--- a/modules/installation-creating-gcp-lb.adoc
+++ b/modules/installation-creating-gcp-lb.adoc
@@ -39,26 +39,31 @@ requires.
 
 .. Export the cluster network location:
 +
+[source,terminal]
 ----
 $ export CLUSTER_NETWORK=`gcloud compute networks describe ${HOST_PROJECT_NETWORK} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
 ----
 
 .. Export the control plane subnet location:
 +
+[source,terminal]
 ----
 $ export CONTROL_SUBNET=`gcloud compute networks subnets describe ${HOST_PROJECT_CONTROL_SUBNET} --region=${REGION} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
 ----
 
-.. Export each zone that the cluster uses:
+.. Export the three zones that the cluster uses:
 +
+[source,terminal]
 ----
 $ export ZONE_0=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[0] | cut -d "/" -f9`
 ----
 +
+[source,terminal]
 ----
 $ export ZONE_1=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[1] | cut -d "/" -f9`
 ----
 +
+[source,terminal]
 ----
 $ export ZONE_2=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[2] | cut -d "/" -f9`
 ----
@@ -66,6 +71,7 @@ $ export ZONE_2=`gcloud compute regions describe ${REGION} --format=json | jq -r
 . Create a `02_lb.yaml` resource definition file:
 ** For an internal cluster, run the following command:
 +
+[source,terminal]
 ----
 $ cat <<EOF >02_lb.yaml
 imports:
@@ -92,6 +98,7 @@ EOF
 
 ** For an external cluster, run the following command:
 +
+[source,terminal]
 ----
 $ cat <<EOF >02_lb.yaml
 imports:
@@ -123,18 +130,21 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-lb --config 02_lb.yaml
 ----
 
 . Export the cluster IP address:
 +
+[source,terminal]
 ----
 $ export CLUSTER_IP=$(gcloud compute addresses describe ${INFRA_ID}-cluster-ip --region=${REGION} --format json | jq -r .address)
 ----
 
 . For an external cluster, also export the cluster public IP address:
 +
+[source,terminal]
 ----
 $ export CLUSTER_PUBLIC_IP=$(gcloud compute addresses describe ${INFRA_ID}-cluster-public-ip --region=${REGION} --format json | jq -r .address)
 ----

--- a/modules/installation-creating-gcp-private-dns.adoc
+++ b/modules/installation-creating-gcp-private-dns.adoc
@@ -32,6 +32,7 @@ requires.
 
 . Create a `02_dns.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >02_dns.yaml
 imports:
@@ -52,6 +53,7 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-dns --config 02_dns.yaml --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
 ----
@@ -61,6 +63,7 @@ Manager, so you must create them manually:
 
 .. Add the internal DNS entries:
 +
+[source,terminal]
 ----
 $ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud dns record-sets transaction start --zone ${INFRA_ID}-private-zone --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
@@ -71,6 +74,7 @@ $ gcloud dns record-sets transaction execute --zone ${INFRA_ID}-private-zone --p
 
 .. For an external cluster, also add the external DNS entries:
 +
+[source,terminal]
 ----
 $ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT} dns record-sets transaction start --zone ${BASE_DOMAIN_ZONE_NAME}

--- a/modules/installation-creating-gcp-security.adoc
+++ b/modules/installation-creating-gcp-security.adoc
@@ -32,6 +32,7 @@ template describes the security groups and roles that your cluster requires.
 
 . Export the following variables required by the resource definition:
 +
+[source,terminal]
 ----
 $ export MASTER_NAT_IP=`gcloud compute addresses describe ${INFRA_ID}-master-nat-ip --region ${REGION} --format json | jq -r .address`
 $ export WORKER_NAT_IP=`gcloud compute addresses describe ${INFRA_ID}-worker-nat-ip --region ${REGION} --format json | jq -r .address`
@@ -39,6 +40,7 @@ $ export WORKER_NAT_IP=`gcloud compute addresses describe ${INFRA_ID}-worker-nat
 
 . Create a `03_security.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >03_security.yaml
 imports:
@@ -67,18 +69,21 @@ EOF
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-security --config 03_security.yaml
 ----
 
 . Export the variable for the master service account:
 +
+[source,terminal]
 ----
 $ export MASTER_SA=${INFRA_ID}-m@${PROJECT_NAME}.iam.gserviceaccount.com
 ----
 
 . Export the variable for the master service account:
 +
+[source,terminal]
 ----
 $ export WORKER_SA=${INFRA_ID}-w@${PROJECT_NAME}.iam.gserviceaccount.com
 ----
@@ -86,6 +91,7 @@ $ export WORKER_SA=${INFRA_ID}-w@${PROJECT_NAME}.iam.gserviceaccount.com
 . The templates do not create the policy bindings due to limitations of Deployment
 Manager, so you must create them manually:
 +
+[source,terminal]
 ----
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SA}" --role "roles/compute.instanceAdmin"
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SA}" --role "roles/compute.networkAdmin"
@@ -99,6 +105,7 @@ $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccoun
 
 . Create a service account key and store it locally for later use:
 +
+[source,terminal]
 ----
 $ gcloud iam service-accounts keys create service-account-key.json --iam-account=${MASTER_SA}
 ----

--- a/modules/installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules.adoc
+++ b/modules/installation-creating-gcp-shared-vpc-cluster-wide-firewall-rules.adoc
@@ -21,6 +21,7 @@ If you do not choose to create firewall rules based on cluster events, you must 
 
 . Add a single firewall rule to allow the Google Cloud Engine health checks to access all of the services. This rule enables the ingress load balancers to determine the health status of their instances.
 +
+[source,terminal]
 ----
 $ gcloud compute firewall-rules create --allow='tcp:30000-32767,udp:30000-32767' --network="${CLUSTER_NETWORK}" --source-ranges='130.211.0.0/22,35.191.0.0/16,209.85.152.0/22,209.85.204.0/22' --target-tags="${INFRA_ID}-master,${INFRA_ID}-worker" ${INFRA_ID}-ingress-hc --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT}
 ----
@@ -30,11 +31,13 @@ $ gcloud compute firewall-rules create --allow='tcp:30000-32767,udp:30000-32767'
 --
 ** For an external cluster:
 +
+[source,terminal]
 ----
 $ gcloud compute firewall-rules create --allow='tcp:80,tcp:443' --network="${CLUSTER_NETWORK}" --source-ranges="0.0.0.0/0" --target-tags="${INFRA_ID}-master,${INFRA_ID}-worker" ${INFRA_ID}-ingress --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT}
 ----
 ** For a private cluster:
 +
+[source,terminal]
 ----
 $ gcloud compute firewall-rules create --allow='tcp:80,tcp:443' --network="${CLUSTER_NETWORK}" --source-ranges=${NETWORK_CIDR} --target-tags="${INFRA_ID}-master,${INFRA_ID}-worker" ${INFRA_ID}-ingress --account=${HOST_PROJECT_ACCOUNT} --project=${HOST_PROJECT}
 ----

--- a/modules/installation-creating-gcp-vpc.adoc
+++ b/modules/installation-creating-gcp-vpc.adoc
@@ -41,30 +41,35 @@ ifdef::shared-vpc[]
 
 .. Export the control plane CIDR:
 +
+[source,terminal]
 ----
 $ export MASTER_SUBNET_CIDR='10.0.0.0/19'
 ----
 
 .. Export the compute CIDR:
 +
+[source,terminal]
 ----
 $ export WORKER_SUBNET_CIDR='10.0.32.0/19'
 ----
 
 .. Export the region to deploy the VPC network and cluster to:
 +
+[source,terminal]
 ----
 $ export REGION='<region>'
 ----
 
 . Export the variable for the ID of the project that hosts the shared VPC:
 +
+[source,terminal]
 ----
 $ export HOST_PROJECT=<host_project>
 ----
 
 . Export the variable for the email of the service account that belongs to host project:
 +
+[source,terminal]
 ----
 $ export HOST_PROJECT_ACCOUNT=<host_service_account_email>
 ----
@@ -72,6 +77,7 @@ endif::shared-vpc[]
 
 . Create a `01_vpc.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >01_vpc.yaml
 imports:
@@ -105,11 +111,13 @@ endif::shared-vpc[]
 . Create the deployment by using the `gcloud` CLI:
 +
 ifndef::shared-vpc[]
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-vpc --config 01_vpc.yaml
 ----
 endif::shared-vpc[]
 ifdef::shared-vpc[]
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create <vpc_deployment_name> --config 01_vpc.yaml --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} <1>
 ----
@@ -118,16 +126,19 @@ $ gcloud deployment-manager deployments create <vpc_deployment_name> --config 01
 . Export the VPC variable that other components require:
 .. Export the name of the host project network:
 +
+[source,terminal]
 ----
 $ export HOST_PROJECT_NETWORK=<vpc_network>
 ----
 .. Export the name of the host project control plane subnet:
 +
+[source,terminal]
 ----
 $ export HOST_PROJECT_CONTROL_SUBNET=<control_plane_subnet>
 ----
 .. Export the name of the host project compute subnet:
 +
+[source,terminal]
 ----
 $ export HOST_PROJECT_COMPUTE_SUBNET=<compute_subnet>
 ----

--- a/modules/installation-creating-gcp-worker.adoc
+++ b/modules/installation-creating-gcp-worker.adoc
@@ -47,11 +47,13 @@ template describes the worker machines that your cluster requires.
 .. Export the subnet that hosts the compute machines:
 +
 ifndef::shared-vpc[]
+[source,terminal]
 ----
 $ export COMPUTE_SUBNET=`gcloud compute networks subnets describe ${INFRA_ID}-worker-subnet --region=${REGION} --format json | jq -r .selfLink`
 ----
 endif::shared-vpc[]
 ifdef::shared-vpc[]
+[source,terminal]
 ----
 $ export COMPUTE_SUBNET=$(gcloud compute networks subnets describe ${HOST_PROJECT_COMPUTE_SUBNET} --region=${REGION} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink)`
 ----
@@ -59,18 +61,21 @@ endif::shared-vpc[]
 
 .. Export the email address for your service account:
 +
+[source,terminal]
 ----
 $ export WORKER_SERVICE_ACCOUNT_EMAIL=`gcloud iam service-accounts list | grep "^${INFRA_ID}-worker-node " | awk '{print $2}'`
 ----
 
 .. Export the location of the compute machine Ignition config file:
 +
+[source,terminal]
 ----
 $ export WORKER_IGNITION=`cat worker.ign`
 ----
 
 . Create a `06_worker.yaml` resource definition file:
 +
+[source,terminal]
 ----
 $ cat <<EOF >06_worker.yaml
 imports:
@@ -107,6 +112,7 @@ file.
 
 . Create the deployment by using the `gcloud` CLI:
 +
+[source,terminal]
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-worker --config 06_worker.yaml
 ----

--- a/modules/installation-gcp-user-infra-adding-ingress.adoc
+++ b/modules/installation-gcp-user-infra-adding-ingress.adoc
@@ -38,8 +38,14 @@ generating Ignition configs.
 
 . Wait for the Ingress router to create a load balancer and populate the `EXTERNAL-IP` field:
 +
+[source,terminal]
 ----
 $ oc -n openshift-ingress get service router-default
+----
++
+.Example output
+[source,terminal]
+----
 NAME             TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                      AGE
 router-default   LoadBalancer   172.30.18.154   35.233.157.184   80:32288/TCP,443:31215/TCP   98
 ----
@@ -48,11 +54,13 @@ router-default   LoadBalancer   172.30.18.154   35.233.157.184   80:32288/TCP,44
 ** To use A records:
 ... Export the variable for the router IP address:
 +
+[source,terminal]
 ----
 $ export ROUTER_IP=`oc -n openshift-ingress get service router-default --no-headers | awk '{print $4}'`
 ----
 ... Add the A record to the private zones:
 +
+[source,terminal]
 ----
 $ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud dns record-sets transaction start --zone ${INFRA_ID}-private-zone --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
@@ -61,6 +69,7 @@ $ gcloud dns record-sets transaction execute --zone ${INFRA_ID}-private-zone --p
 ----
 ... For an external cluster, also add the A record to the public zones:
 +
+[source,terminal]
 ----
 $ if [ -f transaction.yaml ]; then rm transaction.yaml; fi
 $ gcloud dns record-sets transaction start --zone ${BASE_DOMAIN_ZONE_NAME} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT}
@@ -71,8 +80,14 @@ $ gcloud dns record-sets transaction execute --zone ${BASE_DOMAIN_ZONE_NAME} --p
 ** To add explicit domains instead of using a wildcard,
 create entries for each of the cluster's current routes:
 +
+[source,terminal]
 ----
 $ oc get --all-namespaces -o jsonpath='{range .items[*]}{range .status.ingress[*]}{.host}{"\n"}{end}{end}' routes
+----
++
+.Example output
+[source,terminal]
+----
 oauth-openshift.apps.your.cluster.domain.example.com
 console-openshift-console.apps.your.cluster.domain.example.com
 downloads-openshift-console.apps.your.cluster.domain.example.com

--- a/modules/installation-gcp-user-infra-completing.adoc
+++ b/modules/installation-gcp-user-infra-completing.adoc
@@ -19,9 +19,14 @@ cluster is ready.
 
 . Complete the cluster installation:
 +
+[source,terminal]
 ----
 $ ./openshift-install --dir=<installation_directory> wait-for install-complete <1>
-
+----
++
+.Example output
+[source,terminal]
+----
 INFO Waiting up to 30m0s for the cluster to initialize...
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you
@@ -37,8 +42,14 @@ The Ignition config files that the installation program generates contain certif
 --
 .. Run the following command to view the current cluster version and status:
 +
+[source,terminal]
 ----
 $ oc get clusterversion
+----
++
+.Example output
+[source,terminal]
+----
 NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
 version             False       True          24m     Working towards 4.5.4: 99% complete
 ----
@@ -46,8 +57,14 @@ version             False       True          24m     Working towards 4.5.4: 99%
 .. Run the following command to view the Operators managed on the control plane by
 the Cluster Version Operator (CVO):
 +
+[source,terminal]
 ----
 $ oc get clusteroperators
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
 authentication                             4.5.4     True        False         False      7m56s
 cloud-credential                           4.5.4     True        False         False      31m
@@ -83,8 +100,14 @@ storage                                    4.5.4     True        False         F
 
 .. Run the following command to view your cluster Pods:
 +
+[source,terminal]
 ----
 $ oc get pods --all-namespaces
+----
++
+.Example output
+[source,terminal]
+----
 NAMESPACE                                               NAME                                                                READY     STATUS      RESTARTS   AGE
 kube-system                                             etcd-member-ip-10-0-3-111.us-east-2.compute.internal                1/1       Running     0          35m
 kube-system                                             etcd-member-ip-10-0-3-239.us-east-2.compute.internal                1/1       Running     0          37m

--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -34,11 +34,13 @@ endif::openshift-origin[]
 
 . Export the following variable:
 +
+[source,terminal]
 ----
 $ export IMAGE_SOURCE=<downloaded_image_file_path>
 ----
 . Create the cluster image:
 +
+[source,terminal]
 ----
 $ gcloud compute images create "${INFRA_ID}-rhcos-image" \
     --source-uri="${IMAGE_SOURCE}"

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -30,6 +30,7 @@ installation program.
 . Change to the directory that contains the installation program and run the
 following command:
 +
+[source,terminal]
 ----
 $ ./openshift-install wait-for bootstrap-complete --dir=<installation_directory> \ <1>
     --log-level info <2>
@@ -45,6 +46,7 @@ has initialized.
 . Delete the bootstrap resources:
 ifndef::shared-vpc[]
 +
+[source,terminal]
 ----
 $ gcloud compute target-pools remove-instances ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_0}" --instances=${INFRA_ID}-bootstrap
 $ gcloud compute target-pools remove-instances ${INFRA_ID}-ign-target-pool --instances-zone="${ZONE_0}" --instances=${INFRA_ID}-bootstrap
@@ -55,6 +57,7 @@ $ gcloud deployment-manager deployments delete ${INFRA_ID}-bootstrap
 endif::shared-vpc[]
 ifdef::shared-vpc[]
 +
+[source,terminal]
 ----
 $ gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
 $ gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign

--- a/modules/installation-user-infra-exporting-common-variables-arm-templates.adoc
+++ b/modules/installation-user-infra-exporting-common-variables-arm-templates.adoc
@@ -24,6 +24,7 @@ detailed in their related procedures.
 . Export common variables found in the `install-config.yaml` to be used by the
 provided ARM templates:
 +
+[source,terminal]
 ----
 $ export CLUSTER_NAME=<cluster_name><1>
 $ export AZURE_REGION=<azure_region><2>
@@ -39,6 +40,7 @@ $ export BASE_DOMAIN_RESOURCE_GROUP=<base_domain_resource_group><5>
 +
 For example:
 +
+[source,terminal]
 ----
 $ export CLUSTER_NAME=test-cluster
 $ export AZURE_REGION=centralus

--- a/modules/installation-user-infra-exporting-common-variables.adoc
+++ b/modules/installation-user-infra-exporting-common-variables.adoc
@@ -53,6 +53,7 @@ variables, which are detailed in their related procedures.
 templates:
 +
 ifndef::shared-vpc[]
+[source,terminal]
 ----
 $ export BASE_DOMAIN='<base_domain>'
 $ export BASE_DOMAIN_ZONE_NAME='<base_domain_zone_name>'
@@ -71,6 +72,7 @@ endif::shared-vpc[]
 //you need some of these variables for the VPC, and you do that
 
 ifdef::shared-vpc[]
+[source,terminal]
 ----
 $ export BASE_DOMAIN='<base_domain>' <1>
 $ export BASE_DOMAIN_ZONE_NAME='<base_domain_zone_name>' <1>

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -211,6 +211,7 @@ ifdef::user-infra-vpc[]
 --
 The contents of the `<installation_directory>/manifests/cloud-provider-config.yaml` resemble the following example:
 +
+[source,yaml]
 ----
 config: |+
   [global]


### PR DESCRIPTION
This PR contains the addition of `[source,terminal]` to the appropriate code blocks. Output was also separated from its associated command. 

I reverted changes previously made to code blocks with multiple commands. I had separated out the commands into their own code blocks, which caused there to be too many commands per step. See [PR-24544 ](https://github.com/openshift/openshift-docs/pull/24544).