### PR TITLE
Add MHC timeout documentation

### DIFF
--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -24,18 +24,19 @@ spec:
       machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone> <3>
   unhealthyConditions:
   - type:    "Ready"
-    timeout: "300s"
+    timeout: "300s" <4>
     status: "False"
   - type:    "Ready"
-    timeout: "300s"
+    timeout: "300s" <4>
     status: "Unknown"
-  maxUnhealthy: "40%" <4>
+  maxUnhealthy: "40%" <5>
 ----
 <1> Specify the name of the MachineHealthCheck to deploy.
 <2> Specify a label for the machine pool that you want to check.
 <3> Specify the MachineSet to track in `<cluster_name>-<label>-<zone>`
 format. For example, `prod-node-us-east-1a`.
-<4> Specify the amount of unhealthy machines allowed in the targeted pool of
+<4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the Machine will be remediated. Long timeouts can result in long periods of downtime for the workload on the unhealthy Machine.
+<5> Specify the amount of unhealthy machines allowed in the targeted pool of
 machines. This can be set as a percentage or an integer.
 
 [NOTE]


### PR DESCRIPTION
Currently there's a document field of the MHC CR - `timeout`, but there's no explanation on what that timeout means