### PR TITLE
Bridge CNI should not have a "master" parameter.

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -133,7 +133,6 @@ spec:
       "name": "dhcp-shim",
       "cniVersion": "0.3.1",
       "type": "bridge",
-      "master": "ens5",
       "ipam": {
         "type": "dhcp"
       }


### PR DESCRIPTION
This removes the "master" parameter from the DHCP example which uses bridge.