### PR TITLE
Separating Metering code block commands and output

### DIFF
--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -122,12 +122,15 @@ You can verify the metering node selectors by performing any of the following ch
 .Procedure
 .  Check all pods in the `openshift-metering` namespace:
 +
+[source,terminal]
 ----
 $ oc --namespace openshift-metering get pods -o wide
 ----
 +
-The output shows the `NODE` and corresponding `IP` for each Pod running in the `openshift-metering` namespace:
+The output shows the `NODE` and corresponding `IP` for each Pod running in the `openshift-metering` namespace.
 +
+.Example output
+[source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE     IP            NODE                                         NOMINATED NODE   READINESS GATES
 hive-metastore-0                      1/2     Running   0          4m33s   10.129.2.26   ip-10-0-210-167.us-east-2.compute.internal   <none>           <none>
@@ -140,10 +143,13 @@ reporting-operator-869b854c78-8g2x5   1/2     Running   0          7h27m   10.12
 +
 .  Compare the nodes in the `openshift-metering` namespace to each node `NAME` in your cluster:
 +
+[source,terminal]
 ----
 $ oc get nodes
 ----
 +
+.Example output
+[source,terminal]
 ----
 NAME                                         STATUS   ROLES    AGE   VERSION
 ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.18.3+6025c28
@@ -161,6 +167,7 @@ ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.18.3+602
 .Procedure
 * Check the cluster-wide Scheduler object for the `spec.defaultNodeSelector` field, which shows where Pods are scheduled by default:
 +
+[source,terminal]
 ----
 $ oc get schedulers.config.openshift.io cluster -o yaml
 ----

--- a/metering/metering-upgrading-metering.adoc
+++ b/metering/metering-upgrading-metering.adoc
@@ -65,12 +65,13 @@ You can verify the metering upgrade by performing any of the following checks:
 .Procedure (CLI)
 *  Check the Metering Operator CSV:
 +
+[source,terminal]
 ----
 $ oc get csv | grep metering
 ----
 +
-In the following example, the 4.5 Metering Operator upgrade is successful and replaces the 4.4 metering installation:
-+
+.Example output for metering upgrade from 4.4 to 4.5
+[source,terminal]
 ----
 NAME                                        DISPLAY                  VERSION                 REPLACES                               PHASE
 metering-operator.4.5.0-202007012112.p0     Metering                 4.5.0-202007012112.p0   metering-operator.4.4.0-202005252114   Succeeded
@@ -91,11 +92,12 @@ Many Pods rely on other components to function before they themselves can be con
 .Procedure (CLI)
 *  Check that all required Pods in the `openshift-metering` namespace are created:
 +
+[source,terminal]
 ----
 $ oc -n openshift-metering get pods
 ----
-+
-The output shows that all Pods are created in the `Ready` column:
+.Example output
+[source,terminal]
 +
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE
@@ -109,12 +111,15 @@ reporting-operator-5588964bf8-x2tkn   2/2     Running   0          2m40s
 
 *  Verify that the `ReportDataSources` are importing new data, indicated by a valid timestamp in the `NEWEST METRIC` column. This might take several minutes. Filter out the "-raw" `ReportDataSources`, which do not import data:
 +
+[source,terminal]
 ----
 $ oc get reportdatasources -n openshift-metering | grep -v raw
 ----
 +
-Timestamps in the `NEWEST METRIC` column indicate that `ReportDataSources` are beginning to import new data:
+Timestamps in the `NEWEST METRIC` column indicate that `ReportDataSources` are beginning to import new data.
 +
+.Example output
+[source,terminal]
 ----
 NAME                                         EARLIEST METRIC        NEWEST METRIC          IMPORT START           IMPORT END             LAST IMPORT TIME       AGE
 node-allocatable-cpu-cores                   2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:44Z   23h

--- a/modules/metering-debugging.adoc
+++ b/modules/metering-debugging.adoc
@@ -14,8 +14,9 @@ All of the commands in this section assume you have installed metering through O
 
 [id="metering-get-reporting-operator-logs_{context}"]
 == Get reporting operator logs
-The command below will follow the logs of the `reporting-operator`.
+Use the command below to follow the logs of the `reporting-operator`:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering logs -f "$(oc -n openshift-metering get pods -l app=reporting-operator -o name | cut -c 5-)" -c reporting-operator
 ----
@@ -24,18 +25,23 @@ $ oc -n openshift-metering logs -f "$(oc -n openshift-metering get pods -l app=r
 == Query Presto using presto-cli
 The following command opens an interactive presto-cli session where you can query Presto. This session runs in the same container as Presto and launches an additional Java instance, which can create memory limits for the Pod. If this occurs, you should increase the memory request and limits of the Presto Pod.
 
-By default, Presto is configured to communicate using TLS. You must to run the following command to run Presto queries:
+By default, Presto is configured to communicate using TLS. You must use the following command to run Presto queries:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering exec -it "$(oc -n openshift-metering get pods -l app=presto,presto=coordinator -o name | cut -d/ -f2)"  -- /usr/local/bin/presto-cli --server https://presto:8080 --catalog hive --schema default --user root --keystore-path /opt/presto/tls/keystore.pem
 ----
 
 Once you run this command, a prompt appears where you can run queries. Use the `show tables from metering;` query to view the list of tables:
 
-[source]
+[source,terminal]
 ----
 $ presto:default> show tables from metering;
+----
 
+.Example output
+[source,terminal]
+----
                                  Table
 
  datasource_your_namespace_cluster_cpu_capacity_raw
@@ -83,15 +89,21 @@ presto:default>
 == Query Hive using beeline
 The following opens an interactive beeline session where you can query Hive. This session runs in the same container as Hive and launches an additional Java instance, which can create memory limits for the Pod. If this occurs, you should increase the memory request and limits of the Hive Pod.
 
+[source,terminal]
 ----
 $ oc -n openshift-metering exec -it $(oc -n openshift-metering get pods -l app=hive,hive=server -o name | cut -d/ -f2) -c hiveserver2 -- beeline -u 'jdbc:hive2://127.0.0.1:10000/default;auth=noSasl'
 ----
 
 Once you run this command, a prompt appears where you can run queries. Use the `show tables;` query to view the list of tables:
 
-[source]
+[source,terminal]
 ----
 $ 0: jdbc:hive2://127.0.0.1:10000/default> show tables from metering;
+----
+
+.Example output
+[source,terminal]
+----
 +----------------------------------------------------+
 |                      tab_name                      |
 +----------------------------------------------------+
@@ -134,39 +146,43 @@ $ 0: jdbc:hive2://127.0.0.1:10000/default> show tables from metering;
 
 [id="metering-port-forward-hive-web-ui_{context}"]
 == Port-forward to the Hive web UI
-Run the following command:
+Run the following command to port-forward to the Hive web UI:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering port-forward hive-server-0 10002
 ----
+
 You can now open http://127.0.0.1:10002 in your browser window to view the Hive web interface.
 
 [id="metering-port-forward-hdfs_{context}"]
-== Port-forward to hdfs
-To the namenode:
+== Port-forward to HDFS
+Run the following command to port-forward to the HDFS namenode:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering port-forward hdfs-namenode-0 9870
 ----
 
 You can now open http://127.0.0.1:9870 in your browser window to view the HDFS web interface.
 
-To the first datanode:
+Run the following command to port-forward to the first HDFS datanode:
 
+[source,terminal]
 ----
-$ oc -n openshift-metering port-forward hdfs-datanode-0 9864
+$ oc -n openshift-metering port-forward hdfs-datanode-0 9864 <1>
 ----
-
-To check other datanodes, run the above command, replacing `hdfs-datanode-0` with the Pod you want to view information on.
+<1> To check other datanodes, replace `hdfs-datanode-0` with the Pod you want to view information on.
 
 [id="metering-ansible-operator_{context}"]
 == Metering Ansible Operator
 Metering uses the Ansible Operator to watch and reconcile resources in a cluster environment. When debugging a failed metering installation, it can be helpful to view the Ansible logs or status of your MeteringConfig custom resource.
 
 [id="metering-accessing-ansible-logs_{context}"]
-=== Accessing ansible logs
-In the default installation, the metering Operator is deployed as a Pod. In this case, we can check the logs of the ansible container within this Pod:
+=== Accessing Ansible logs
+In the default installation, the Metering Operator is deployed as a Pod. In this case, you can check the logs of the Ansible container within this Pod:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering logs $(oc -n openshift-metering get pods -l app=metering-operator -o name | cut -d/ -f2) -c ansible
 ----
@@ -177,6 +193,7 @@ Alternatively, you can view the logs of the Operator container (replace `-c ansi
 === Checking the MeteringConfig Status
 It can be helpful to view the `.status` field of your MeteringConfig custom resource to debug any recent failures. The following command shows status messages with type `Invalid`:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering get meteringconfig operator-metering -o=jsonpath='{.status.conditions[?(@.type=="Invalid")].message}'
 ----
@@ -186,12 +203,13 @@ $ oc -n openshift-metering get meteringconfig operator-metering -o=jsonpath='{.s
 === Checking MeteringConfig Events
 Check events that the Metering Operator is generating. This can be helpful during installation or upgrade to debug any resource failures. Sort events by the last timestamp:
 
+[source,terminal]
 ----
 $ oc -n openshift-metering get events --field-selector involvedObject.kind=MeteringConfig --sort-by='.lastTimestamp'
 ----
 
-The output shows the latest changes in the MeteringConfig resources:
-
+.Example output with latest changes in the MeteringConfig resources
+[source,terminal]
 ----
 LAST SEEN   TYPE     REASON        OBJECT                             MESSAGE
 4m40s       Normal   Validating    meteringconfig/operator-metering   Validating the user-provided configuration

--- a/modules/metering-exposing-the-reporting-api.adoc
+++ b/modules/metering-exposing-the-reporting-api.adoc
@@ -18,9 +18,9 @@ By default, the reporting API is secured with TLS and authentication. This is do
 
 In order to access the reporting API, the metering operator exposes a route. Once that route has been installed, you can run the following command to get the route's hostname.
 
-[source]
+[source,terminal]
 ----
-METERING_ROUTE_HOSTNAME=$(oc -n openshift-metering get routes metering -o json | jq -r '.status.ingress[].host')
+$ METERING_ROUTE_HOSTNAME=$(oc -n openshift-metering get routes metering -o json | jq -r '.status.ingress[].host')
 ----
 
 Next, set up authentication using either a service account token or basic authentication with a username/password.
@@ -29,9 +29,9 @@ Next, set up authentication using either a service account token or basic authen
 === Authenticate using a service account token
 With this method, you use the token in the reporting Operator's service account, and pass that bearer token to the Authorization header in the following command:
 
-[source]
+[source,terminal]
 ----
-TOKEN=$(oc -n openshift-metering serviceaccounts get-token reporting-operator)
+$ TOKEN=$(oc -n openshift-metering serviceaccounts get-token reporting-operator)
 curl -H "Authorization: Bearer $TOKEN" -k "https://$METERING_ROUTE_HOSTNAME/api/v1/reports/get?name=[Report Name]&namespace=openshift-metering&format=[Format]"
 ----
 
@@ -43,9 +43,9 @@ We are able to do basic authentication using a username and password combination
 
 Once you have specified the above in your MeteringConfig, you can run the following command:
 
-[source]
+[source,terminal]
 ----
-curl -u testuser:password123 -k "https://$METERING_ROUTE_HOSTNAME/api/v1/reports/get?name=[Report Name]&namespace=openshift-metering&format=[Format]"
+$ curl -u testuser:password123 -k "https://$METERING_ROUTE_HOSTNAME/api/v1/reports/get?name=[Report Name]&namespace=openshift-metering&format=[Format]"
 ----
 
 Be sure to replace `testuser:password123` with a valid username and password combination.
@@ -69,7 +69,7 @@ You need to set `reporting-operator.spec.authProxy.enabled` and `reporting-opera
 
 You can generate a 32-character random string using the following command.
 
-[source]
+[source,terminal]
 ----
 $ openssl rand -base64 32 | head -c32; echo.
 ----

--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -76,12 +76,14 @@ metadata:
 
 .  Create the namespace object:
 +
+[source,terminal]
 ----
 $ oc create -f <file-name>.yaml
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc create -f openshift-metering.yaml
 ----

--- a/modules/metering-install-verify.adoc
+++ b/modules/metering-install-verify.adoc
@@ -19,13 +19,13 @@ You can verify the metering installation by performing any of the following chec
 .Procedure (CLI)
 *  Check the Metering Operator CSV in the `openshift-metering` namespace:
 +
+[source,terminal]
 ----
 $ oc --namespace openshift-metering get csv
 ----
 +
-In the following example, the {product-version} Metering Operator installation is successful:
-+
-[subs="attributes+"]
+.Example output
+[source,terminal,subs="attributes+"]
 ----
 NAME                                           DISPLAY                  VERSION                 REPLACES   PHASE
 elasticsearch-operator.{product-version}.0-202006231303.p0   Elasticsearch Operator   {product-version}.0-202006231303.p0              Succeeded
@@ -47,12 +47,13 @@ Many Pods rely on other components to function before they themselves can be con
 .Procedure (CLI)
 *  Check that all required Pods in the `openshift-metering` namespace are created:
 +
+[source,terminal]
 ----
 $ oc -n openshift-metering get pods
 ----
 +
-The output shows that all Pods are created in the `Ready` column:
-+
+.Example output
+[source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE
 hive-metastore-0                      2/2     Running   0          3m28s
@@ -65,12 +66,14 @@ reporting-operator-5588964bf8-x2tkn   2/2     Running   0          2m40s
 
 *  Verify that the `ReportDataSources` are beginning to import data, indicated by a valid timestamp in the `EARLIEST METRIC` column. This might take several minutes. Filter out the "-raw" `ReportDataSources`, which do not import data:
 +
+[source,terminal]
 ----
 $ oc get reportdatasources -n openshift-metering | grep -v raw
 ----
 +
+.Example output
+[source,terminal]
 ----
-$ oc get reportdatasources -n openshift-metering | grep -v raw
 NAME                                         EARLIEST METRIC        NEWEST METRIC          IMPORT START           IMPORT END             LAST IMPORT TIME       AGE
 node-allocatable-cpu-cores                   2019-08-05T16:52:00Z   2019-08-05T18:52:00Z   2019-08-05T16:52:00Z   2019-08-05T18:52:00Z   2019-08-05T18:54:45Z   9m50s
 node-allocatable-memory-bytes                2019-08-05T16:51:00Z   2019-08-05T18:51:00Z   2019-08-05T16:51:00Z   2019-08-05T18:51:00Z   2019-08-05T18:54:45Z   9m50s

--- a/modules/metering-reports.adoc
+++ b/modules/metering-reports.adoc
@@ -8,16 +8,16 @@ The Report custom resource is used to manage the execution and status of reports
 Metering produces reports derived from usage data sources, which can be used in further analysis and filtering.
 
 A single Report resource represents a job that manages a database table and updates it with new information according to a schedule. The Report exposes the data in that table via the reporting-operator HTTP API.
-Reports with a `spec.schedule` field set are always running and track what time periods it has collected data for. This ensures that if metering is shutdown or unavailable for an extended period of time, it will backfill the data starting where it left off.
-If the schedule is unset, then the Report will run once for the time specified by the `reportingStart` and `reportingEnd`.
+Reports with a `spec.schedule` field set are always running and track what time periods it has collected data for. This ensures that if metering is shutdown or unavailable for an extended period of time, it backfills the data starting where it left off.
+If the schedule is unset, then the Report runs once for the time specified by the `reportingStart` and `reportingEnd`.
 By default, reports wait for ReportDataSources to have fully imported any data covered in the reporting period.
-If the Report has a schedule, it will wait to run until the data in the period currently being processed has finished importing.
+If the Report has a schedule, it waits to run until the data in the period currently being processed has finished importing.
 
 [id="metering-example-report-with-schedule_{context}"]
 == Example Report with a Schedule
 
-The following example Report will contain information on every Pod's CPU requests, and will run every hour, adding the last hours worth of data each time it runs.
-
+The following example Report contains information on every Pod's CPU requests, and runs every hour, adding the last hours worth of data each time it runs.
+[source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
 kind: Report
@@ -36,9 +36,9 @@ spec:
 [id="metering-example-report-without-schedule_{context}"]
 == Example Report without a Schedule (Run-Once)
 
-The following example Report will contain information on every Pod's CPU requests for all of July.
+The following example Report contains information on every Pod's CPU requests for all of July.
 After completion, it does not run again.
-
+[source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
 kind: Report
@@ -58,10 +58,14 @@ The report query controls the schema of the report as well as how the results ar
 
 *`query` is a required field.*
 
-Use the `oc` CLI to obtain a list of available ReportQuery objects:
-
+Use the following command to list available ReportQuery objects:
+[source,terminal]
 ----
 $ oc -n openshift-metering get reportqueries
+----
+.Example output
+[source,terminal]
+----
 NAME                                         AGE
 cluster-cpu-capacity                         23m
 cluster-cpu-capacity-raw                     23m
@@ -122,16 +126,15 @@ ReportQueries with the `-raw` suffix are used by other ReportQueries to build mo
 
 The `aws-ec2-billing-data` report is used by other queries, and should not be used as a standalone report. The `aws-ec2-cluster-cost` report provides a total cost based on the nodes included in the cluster, and the sum of their costs for the time period being reported on.
 
-For a complete list of fields, use the `oc` CLI to get the ReportQuery as YAML, and check the `spec.columns` field:
+Use the following command to get the ReportQuery as YAML, and check the `spec.columns` field. For example, run:
 
-For example, run:
-
+[source,terminal]
 ----
 $ oc -n openshift-metering get reportqueries namespace-memory-request -o yaml
 ----
 
-You should see output like:
-
+.Example output
+[source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
 kind: ReportQuery
@@ -163,7 +166,7 @@ The main fields in the `schedule` section are `period`, and then depending on th
 
 For example, if `period` is set to `weekly`, you can add a `weekly` field to the `spec.schedule` block.
 The following example will run once a week on Wednesday, at 1 PM (hour 13 in the day).
-
+[source,yaml]
 ----
 ...
   schedule:
@@ -221,8 +224,9 @@ One important thing to understand is that this will result in the reporting-oper
 This could be thousands of queries if the period is less than daily and the `reportingStart` is more than a few months back.
 If `reportingStart` is left unset, the Report will run at the next full reportingPeriod after the time the report is created.
 
-As an example of how to use this field, if you had data already collected dating back to January 1st, 2019, which you wanted to be included in your Report, you could create a report with the following values:
+As an example of how to use this field, if you had data already collected dating back to January 1st, 2019, which you want to include in your Report, you can create a report with the following values:
 
+[source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
 kind: Report
@@ -243,8 +247,8 @@ The value of this field will cause the Report to stop running on its schedule af
 Because a schedule will most likely not align with reportingEnd, the last period in the schedule will be shortened to end at the specified reportingEnd time.
 If left unset, then the Report will run forever, or until a `reportingEnd` is set on the Report.
 
-For example, if you wanted to create a report that runs once a week for the month of July:
-
+For example, if you want to create a report that runs once a week for the month of July:
+[source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
 kind: Report
@@ -261,11 +265,11 @@ spec:
 [id="metering-runImmediately_{context}"]
 == runImmediately
 
-When `runImmediately` is set to `true`, the report will be run immediately. This behavior ensures that the report is immediately processed and queued without requiring additional scheduling parameters. 
+When `runImmediately` is set to `true`, the report runs immediately. This behavior ensures that the report is immediately processed and queued without requiring additional scheduling parameters.
 
 [NOTE]
 ====
-When `runImmediately` is set to `true` you must set a `reportingEnd` and `reportingStart` value. 
+When `runImmediately` is set to `true` you must set a `reportingEnd` and `reportingStart` value.
 ====
 
 [id="metering-inputs_{context}"]
@@ -275,15 +279,16 @@ The `spec.inputs` field of a Report can be used to override or set values define
 
 It is a list of name-value pairs:
 
+[source,yaml]
 ----
 spec:
   inputs:
-  - name: "NamespaceCPUUsageReportName"
-    value: "namespace-cpu-usage-hourly"
+  - name: "NamespaceCPUUsageReportName" <1>
+    value: "namespace-cpu-usage-hourly" <2>
 ----
 
-The `name` of an input must exist in the ReportQuery's `inputs` list.
-The `value` of the input must be the correct type for the input's `type`.
+<1> The `name` of an input must exist in the ReportQuery's `inputs` list.
+<2> The `value` of the input must be the correct type for the input's `type`.
 
 // TODO(chance): include modules/metering-reportquery-inputs.adoc module
 
@@ -298,8 +303,9 @@ The ReportQuery template processor provides a function: `reportTableName` that c
 
 Below is an snippet taken from a built-in query:
 
+.pod-cpu.yaml
+[source,yaml]
 ----
-# Taken from pod-cpu.yaml
 spec:
 ...
   inputs:
@@ -323,8 +329,9 @@ spec:
 ...
 ----
 
+.Example `aggregated-report.yaml` roll-up report
+[source,yaml]
 ----
-# aggregated-report.yaml
 spec:
   query: "namespace-cpu-usage"
   inputs:
@@ -344,4 +351,3 @@ The `status` field of a Report currently has two fields:
 
 * `conditions`: Conditions is a list of conditions, each of which have a `type`, `status`, `reason`, and `message` field. Possible values of a condition's `type` field are `Running` and `Failure`, indicating the current state of the scheduled report. The `reason` indicates why its `condition` is in its current state with the `status` being either `true`, `false` or, `unknown`. The `message` provides a human readable indicating why the condition is in the current state. For detailed information on the `reason` values see link:https://github.com/operator-framework/operator-metering/blob/master/pkg/apis/metering/v1/util/report_util.go#L10[`pkg/apis/metering/v1/util/report_util.go`].
 * `lastReportTime`: Indicates the time Metering has collected data up to.
-

--- a/modules/metering-store-data-in-azure.adoc
+++ b/modules/metering-store-data-in-azure.adoc
@@ -42,7 +42,7 @@ data:
 
 You can use the following command to create the secret.
 
-[source]
+[source,terminal]
 ----
-oc create secret -n openshift-metering generic your-azure-secret --from-literal=azure-storage-account-name=your-storage-account-name --from-literal=azure-secret-access-key=your-secret-key
+$ oc create secret -n openshift-metering generic your-azure-secret --from-literal=azure-storage-account-name=your-storage-account-name --from-literal=azure-secret-access-key=your-secret-key
 ----

--- a/modules/metering-store-data-in-gcp.adoc
+++ b/modules/metering-store-data-in-gcp.adoc
@@ -39,7 +39,7 @@ data:
 
 You can use the following command to create the secret.
 
-[source]
+[source,terminal]
 ----
-oc create secret -n openshift-metering generic your-gcs-secret --from-file gcs-service-account.json=/path/to/your/service-account-key.json
+$ oc create secret -n openshift-metering generic your-gcs-secret --from-file gcs-service-account.json=/path/to/your/service-account-key.json
 ----

--- a/modules/metering-store-data-in-s3.adoc
+++ b/modules/metering-store-data-in-s3.adoc
@@ -64,9 +64,9 @@ This command automatically base64 encodes your `aws-access-key-id` and `aws-secr
 
 ====
 
-[source]
+[source,terminal]
 ----
-oc create secret -n openshift-metering generic your-aws-secret --from-literal=aws-access-key-id=your-access-key  --from-literal=aws-secret-access-key=your-secret-key
+$ oc create secret -n openshift-metering generic your-aws-secret --from-literal=aws-access-key-id=your-access-key  --from-literal=aws-secret-access-key=your-secret-key
 ----
 
 The `aws-access-key-id` and `aws-secret-access-key` credentials must have read and write access to the bucket. For an example of an IAM policy granting the required permissions, see the `aws/read-write.json` file below.

--- a/modules/metering-viewing-report-results.adoc
+++ b/modules/metering-viewing-report-results.adoc
@@ -16,38 +16,55 @@ Reports can be retrieved as `JSON`, `CSV`, or `Tabular` formats.
 
 . Change to the `openshift-metering` project:
 +
+[source,terminal]
 ----
 $ oc project openshift-metering
 ----
 
 . Query the reporting API for results:
 
-.. Get the route to the `reporting-api`:
+.. Create a variable for the metering `reporting-api` route then get the route:
 +
+[source,terminal]
 ----
 $ meteringRoute="$(oc get routes metering -o jsonpath='{.spec.host}')"
+----
++
+[source,terminal]
+----
 $ echo "$meteringRoute"
 ----
 
 .. Get the token of your current user to be used in the request:
 +
+[source,terminal]
 ----
 $ token="$(oc whoami -t)"
 ----
 
-
-.. To get the results, use `curl` to make a request to the reporting API for your report:
+.. Set `reportName` to the name of the Report you created:
 +
+[source,terminal]
 ----
-$ reportName=namespace-cpu-request-2019 <1>
-$ reportFormat=csv <2>
+$ reportName=namespace-cpu-request-2019
+----
+
+.. Set `reportFormat` to one of `csv`, `json`, or `tabular` to specify the output format of the API response:
++
+[source,terminal]
+----
+$ reportFormat=csv
+----
+
+.. To get the results, use `curl` to make a request to the reporting API for your Report:
++
+[source,terminal]
+----
 $ curl --insecure -H "Authorization: Bearer ${token}" "https://${meteringRoute}/api/v1/reports/get?name=${reportName}&namespace=openshift-metering&format=$reportFormat"
 ----
-<1> Set `reportName` to the name of the `Report` you created.
-<2> Set `reportFormat` to one of `csv`, `json`, or `tabular` to specify the output format of the API response.
 +
-The response should look similar to the following (example output is with `reportName=namespace-cpu-request-2019` and `reportFormat=csv`):
-+
+.Example output with `reportName=namespace-cpu-request-2019` and `reportFormat=csv`
+[source,terminal]
 ----
 period_start,period_end,namespace,pod_request_cpu_core_seconds
 2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-apiserver,11745.000000

--- a/modules/metering-writing-reports.adoc
+++ b/modules/metering-writing-reports.adoc
@@ -16,6 +16,7 @@ To write a Report, you must define a Report resource in a YAML file, specify the
 
 . Change to the `openshift-metering` project:
 +
+[source,terminal]
 ----
 $ oc project openshift-metering
 ----
@@ -24,6 +25,7 @@ $ oc project openshift-metering
 +
 .. Create a YAML file with the following content:
 +
+[source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
 kind: Report
@@ -42,18 +44,28 @@ spec:
 
 .. Run the following command to create the Report:
 +
+[source,terminal]
 ----
 $ oc create -f <file-name>.yaml
-
+----
++
+.Example output
+[source,terminal]
+----
 report.metering.openshift.io/namespace-cpu-request-2019 created
 ----
 +
 
 . You can list Reports and their `Running` status with the following command:
 +
+[source,terminal]
 ----
 $ oc get reports
-
+----
++
+.Example output
+[source,terminal]
+----
 NAME                         QUERY                   SCHEDULE   RUNNING    FAILED   LAST REPORT TIME       AGE
 namespace-cpu-request-2019   namespace-cpu-request              Finished            2019-12-30T23:59:59Z   26s
 ----


### PR DESCRIPTION
Separated code block commands from their output. Added `[source,terminal]` to code blocks where applicable. Also tweaked some sentences along the way to shift from future to present tense.