### PR TITLE
Specify a namespace when querying for metering events

### DIFF
--- a/modules/metering-debugging.adoc
+++ b/modules/metering-debugging.adoc
@@ -178,7 +178,7 @@ Alternatively, you can view the logs of the Operator container (replace `-c ansi
 It can be helpful to view the `.status` field of your MeteringConfig custom resource to debug any recent failures. The following command shows status messages with type `Invalid`:
 
 ----
-$ oc get meteringconfig operator-metering -o=jsonpath='{.status.conditions[?(@.type=="Invalid")].message}'
+$ oc -n openshift-metering get meteringconfig operator-metering -o=jsonpath='{.status.conditions[?(@.type=="Invalid")].message}'
 ----
 // $ oc -n openshift-metering get meteringconfig operator-metering -o json | jq '.status'
 
@@ -187,7 +187,7 @@ $ oc get meteringconfig operator-metering -o=jsonpath='{.status.conditions[?(@.t
 Check events that the Metering Operator is generating. This can be helpful during installation or upgrade to debug any resource failures. Sort events by the last timestamp:
 
 ----
-$ oc get events -n openshift-metering --field-selector involvedObject.kind=MeteringConfig --sort-by='.lastTimestamp'
+$ oc -n openshift-metering get events --field-selector involvedObject.kind=MeteringConfig --sort-by='.lastTimestamp'
 ----
 
 The output shows the latest changes in the MeteringConfig resources:


### PR DESCRIPTION
Events are namespace resources, so we should be passing a namespace when querying for events in the openshift-metering namespace.