### PR TITLE
[enterprise-4.3] modules: Specify a namespace when querying for metering events.

### DIFF
--- a/modules/metering-debugging.adoc
+++ b/modules/metering-debugging.adoc
@@ -182,9 +182,9 @@ Alternatively, you can view the logs of the Operator container (replace `-c ansi
 
 [id="metering-checking-meteringconfig-status_{context}"]
 === Checking the MeteringConfig Status
-It can be helpful to view the `.status` field of your MeteringConfig custom resource to debug any recent failures. You can do this with the following command:
+It can be helpful to view the `.status` field of your MeteringConfig custom resource to debug any recent failures. The following command shows status messages with type `Invalid`:
 
 [source]
 ----
-$ oc -n openshift-metering get meteringconfig operator-metering -o json | jq '.status'
+$ oc -n openshift-metering get meteringconfig operator-metering -o=jsonpath='{.status.conditions[?(@.type=="Invalid")].message}'
 ----


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/24943

I'm including the improvement from 4.5+ to no longer use the `jq` package.