### PR TITLE
Updates to the Uninstalling metering documentation

### DIFF
--- a/metering/metering-uninstall.adoc
+++ b/metering/metering-uninstall.adoc
@@ -1,13 +1,31 @@
 :context: metering-uninstall
 [id="metering-uninstall"]
-= Uninstalling Metering
+= Uninstalling metering
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
 You can remove metering from your {product-title} cluster.
 
+[NOTE]
+====
+Metering does not manage or delete Amazon S3 bucket data. After uninstalling metering,
+you must manually clean up S3 buckets that were used to store metering data.
+====
+
+[id="metering-remove"]
+== Removing the Metering Operator from your cluster
+
+Remove the Metering Operator from your cluster by following the documentation on
+xref:../operators/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[deleting Operators from a cluster].
+
+[NOTE]
+====
+Removing the Metering Operator from your cluster does not remove its CustomResourceDefinitions or managed resources. See the following sections on xref:../metering/metering-uninstall.adoc#metering-uninstall_metering-uninstall[Uninstalling a metering namespace]
+and xref:../metering/metering-uninstall.adoc#metering-uninstall-crds_metering-uninstall[Uninstalling metering CustomResourceDefinitions]
+for steps to remove any remaining metering components.
+====
+
 include::modules/metering-uninstall.adoc[leveloffset=+1]
 
-
-
+include::modules/metering-uninstall-crds.adoc[leveloffset=+1]

--- a/metering/reports/metering-storage-locations.adoc
+++ b/metering/reports/metering-storage-locations.adoc
@@ -51,15 +51,16 @@ spec:
 ----
 <1> (optional) The filesystem URL for Presto and Hive to use for the database. This can be an `hdfs://` or `s3a://` filesystem URL.
 
-There are some additonal optional fields that can be specified in the `hive` section:
+There are some additional optional fields that can be specified in the `hive` section:
 
 * (optional) defaultTableProperties:  Contains configuration options for creating tables using Hive.
 * (optional) fileFormat: The file format used for storing files in the filesystem. See the link:https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe[Hive Documentation on File Storage Format] for a list of options and more details.
 * (optional) rowFormat: Controls the link:https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe[ Hive row format]. This controls how Hive serializes and deserializes rows. See the link:https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe[Hive Documentation on Row Formats and SerDe] for more details.
 
 == Default StorageLocation
-If an annotation `storagelocation.metering.openshift.io/is-default` exists and is set to `true` on a StorageLocation resource, then that resource becomes the default storage resource.  Any components with a storage configuration option where StorageLocation is not specified will use the default storage resource. There can only be on default storage resource. If more than one resource with the annotation exists, an error will be logged and the operator will consider there to be no default.
+If an annotation `storagelocation.metering.openshift.io/is-default` exists and is set to `true` on a StorageLocation resource, then that resource becomes the default storage resource.  Any components with a storage configuration option where StorageLocation is not specified will use the default storage resource. There can be only one default storage resource. If more than one resource with the annotation exists, an error is logged because the Operator cannot determine the default.
 
+.Default storage example
 [source,yaml]
 ----
 apiVersion: metering.openshift.io/v1

--- a/modules/metering-reports.adoc
+++ b/modules/metering-reports.adoc
@@ -301,7 +301,7 @@ A simple use case for a roll-up report is to spread the time required to produce
 A custom roll-up report requires a custom report query.
 The ReportQuery template processor provides a function: `reportTableName` that can get the necessary table name from a Report's `metadata.name`.
 
-Below is an snippet taken from a built-in query:
+Below is a snippet taken from a built-in query:
 
 .pod-cpu.yaml
 [source,yaml]

--- a/modules/metering-uninstall-crds.adoc
+++ b/modules/metering-uninstall-crds.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * metering/metering-uninstall.adoc
+
+[id="metering-uninstall-crds_{context}"]
+= Uninstalling metering CustomResourceDefinitions
+
+The metering CustomResourceDefinitions (CRDs) remain in the cluster after the Metering
+Operator is uninstalled and the `openshift-metering` namespace is deleted.
+
+[IMPORTANT]
+====
+Deleting the metering CRDs disrupts any additional metering installations in other namespaces in your cluster.
+Ensure that there are no other metering installations before proceeding.
+====
+
+.Prerequisites
+
+*  The MeteringConfig custom resource in the `openshift-metering` namespace is deleted.
+*  The `openshift-metering` namespace is deleted.
+
+.Procedure
+
+*  Delete the remaining metering CRDs:
++
+[source,terminal]
+----
+$ oc get crd -o name | grep "metering.openshift.io" | xargs oc delete
+----

--- a/modules/metering-uninstall.adoc
+++ b/modules/metering-uninstall.adoc
@@ -3,25 +3,33 @@
 // * metering/metering-uninstall.adoc
 
 [id="metering-uninstall_{context}"]
-= Uninstalling metering from {product-title}
+= Uninstalling a metering namespace
 
-You can remove metering from your cluster.
+Uninstall your metering namespace, for example the `openshift-metering` namespace, by removing the MeteringConfig resource and deleting the `openshift-metering` namespace.
 
 .Prerequisites
 
-* Metering must be installed.
+* The Metering Operator is removed from your cluster.
 
 .Procedure
 
-To remove metering:
+.  Remove all resources created by the Metering Operator:
++
+[source,terminal]
+----
+$ oc --namespace openshift-metering delete meteringconfig --all
+----
 
-. In the {product-title} web console, click *Operators* -> *Installed Operators*.
+.  After the previous step is complete, verify that all Pods in the `openshift-metering` namespace are deleted or are reporting a terminating state:
++
+[source,terminal]
+----
+$ oc --namespace openshift-metering get pods
+----
 
-. Find the Metering Operator and click the {kebab} menu. Select *Uninstall Operator*.
-
-. In the dialog box, click *Remove* to uninstall metering.
-
-[NOTE]
-====
-Metering does not manage or delete any S3 bucket data. If you used Amazon S3 for storage, any S3 buckets used to store metering data must be manually cleaned up.
-====
+.  Delete the `openshift-metering` namespace:
++
+[source,terminal]
+----
+$ oc delete namespace openshift-metering
+----


### PR DESCRIPTION
Updated the _Uninstalling metering_ documentation. Added a new `modules/metering-uninstall-crds.adoc` file. This PR is based on [PR-23823](https://github.com/openshift/openshift-docs/pull/23823).

@timflannagan1 PTAL. Thanks!