### PR TITLE
OSDOCS-1299 - Add Storage section to Troubleshooting guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -363,6 +363,8 @@ Topics:
     File: investigating-pod-issues
   - Name: Troubleshooting the Source-to-Image process
     File: troubleshooting-s2i
+  - Name: Troubleshooting storage issues
+    File: troubleshooting-storage-issues
   - Name: Diagnosing OpenShift CLI (oc) issues
     File: diagnosing-oc-issues
 ---

--- a/modules/storage-multi-attach-error.adoc
+++ b/modules/storage-multi-attach-error.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-storage-issues.adoc
+
+[id="storage-multi-attach-error_{context}"]
+= Resolving multi-attach errors
+
+When a node crashes or shuts down abruptly, the attached ReadWriteOnce (RWO) volume is expected to be unmounted from the node so that it can be used by a Pod scheduled on another node.
+
+However, mounting on a new node is not possible because the failed node is unable to unmount the attached volume.
+
+A multi-attach error is reported:
+
+[source,terminal]
+.Example output
+--
+Unable to attach or mount volumes: unmounted volumes=[sso-mysql-pvol], unattached volumes=[sso-mysql-pvol default-token-x4rzc]: timed out waiting for the condition
+Multi-Attach error for volume "pvc-8837384d-69d7-40b2-b2e6-5df86943eef9" Volume is already used by pod(s) sso-mysql-1-ns6b4
+--
+
+To resolve the multi-attach issue, use one of the following solutions:
+
+* Enable multiple attachments by using RWX volumes.
++
+For most storage solutions, you can use ReadWriteMany (RWX) volumes to prevent multi-attach errors.
++
+* Recover or delete the failed node when using an RWO volume.
++
+For storage that does not support RWX, such as VMware vSphere, RWO volumes must be used instead. However, RWO volumes cannot be mounted on multiple nodes.
++
+If you encounter a multi-attach error message with an RWO volume, you can either recover or delete the failed node to make the volume available to other nodes.

--- a/support/troubleshooting/troubleshooting-storage-issues.adoc
+++ b/support/troubleshooting/troubleshooting-storage-issues.adoc
@@ -1,0 +1,9 @@
+[id="troubleshooting-storage-issues"]
+= Troubleshooting storage issues
+include::modules/common-attributes.adoc[]
+:context: troubleshooting-storage-issues
+
+toc::[]
+
+// Multi-attach error resolution
+include::modules/storage-multi-attach-error.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-1299](https://issues.redhat.com/browse/OSDOCS-1299) and [OSDOCS-1422](https://issues.redhat.com/browse/OSDOCS-1422).

Added first module, based on [BZ-1858369](https://bugzilla.redhat.com/show_bug.cgi?id=1858369) - Multi-attach error. This content exists already in similar form as introduced in https://github.com/openshift/openshift-docs/pull/24437. 

[PREVIEW LINK](https://osdocs-1299--ocpdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-storage-issues.html)