### PR TITLE
Bug 1868133: modules/installation-azure-config: update example to reflect accurate recommendations

### DIFF
--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -38,7 +38,7 @@ controlPlane: <2>
   platform:
     azure:
       osDisk:
-        diskSizeGB: 512 <5>
+        diskSizeGB: 1024 <5>
       type: Standard_D8s_v3
   replicas: 3
 compute: <2>
@@ -102,7 +102,7 @@ endif::private[]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger virtual machine types, such as `Standard_D8s_v3`, for your machines if you disable simultaneous multithreading.
 ====
-<5> You can specify the size of the disk to use in GB.
+<5> You can specify the size of the disk to use in GB. Minimum recommendation for master nodes is 1024 GB.
 //To configure faster storage for etcd, especially for larger clusters, set the
 //storage type as `io1` and set `iops` to `2000`.
 <6> Specify a list of zones to deploy your machines to. For high availability, specify at least two zones.


### PR DESCRIPTION
We have bumped our defaults for IPI and UPI to 1TB of osDisk but docs still reflect 512GB example.

ref: https://docs.google.com/document/d/1yPpakMC1OSOWeeM4m_bHDuLECLPXrpq5ow2C9HEcs1A/edit#heading=h.cv1evtd7ynmr
