### PR TITLE
Fixed default limit/requests for fluentd

### DIFF
--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -31,10 +31,9 @@ spec:
       fluentd:
         resources:
           limits: <1>
-            cpu: 250m
-            memory: 1Gi
+            memory: 736Mi
           requests:
-            cpu: 250m
-            memory: 1Gi
+            cpu: 100m
+            memory: 736Mi
 ----
 <1> Specify the CPU and memory limits and requests as needed. The values shown are the default values.

--- a/modules/cluster-logging-cpu-memory.adoc
+++ b/modules/cluster-logging-cpu-memory.adoc
@@ -74,10 +74,10 @@ spec:
       fluentd:
         resources: <4>
           limits:
-            memory: 1Gi
+            memory: 736Mi
           requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 736Mi
 ----
 <1> Specify the CPU and memory limits and requests for the log store as needed. For Elasticsearch, you must adjust both the request value and the limit value.
 <2> Specify the CPU and memory limits and requests for the log visualizater as needed.


### PR DESCRIPTION
From Slack conversation: https://coreos.slack.com/archives/CB3HXM2QK/p1598267663059300?thread_ts=1597919166.003000&cid=CB3HXM2QK