### PR TITLE
Removed stray reference to event routing

### DIFF
--- a/modules/cluster-logging-about-components.adoc
+++ b/modules/cluster-logging-about-components.adoc
@@ -24,7 +24,6 @@ There are currently 5 different types of cluster logging components:
 * collection - This is the component that collects logs from the node, formats them, and stores them in the logStore. The current implementation is Fluentd.
 * visualization - This is the UI component used to view logs, graphs, charts, and so forth. The current implementation is Kibana.
 * curation - This is the component that trims logs by age. The current implementation is Curator.
-* event routing - This is the component forwards {product-title} events to cluster logging. The current implementation is Event Router.
 
 ifndef::cnv-logging[]
 In this document, we may refer to logStore or Elasticsearch, visualization or Kibana, curation or Curator, collection or Fluentd, interchangeably, except where noted.


### PR DESCRIPTION
Removing a stray reference to _event routing_ in 4.3 and 4.4. The text is not in 4.5+. The event router was removed from docs via https://github.com/openshift/openshift-docs/pull/24495