### PR TITLE
[Suggested Edit] IPSec on Cloud Providers

### DIFF
--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -158,6 +158,7 @@ conn private
 	failureshunt=drop
 	negotiationshunt=hold
 	auto=ondemand
+	encapsulation=yes <2>
 
 conn clear
 	left=%defaultroute
@@ -168,12 +169,7 @@ conn clear
 	priority=100
 ----
 <1> Replace <cert_nickname> with the certificate nickname from step one.
-+
-[IMPORTANT]
-====
-The Amazon/Azure internal cloud network does not route IPsec `ESP` or `AH` packets. These packets need to be encapsulated in `UDP`. While normally the NAT detection takes care of this `ESP` in `UDP` encapsulation, if NAT is not detected, you can force encapsulation by setting `encapsulation=yes`.
-====
-+
+<2> If you do not use NAT, you must include `encapsulation=yes` in the configuration to force encapsulation. The **Amazon** and **Azure** internal cloud networks do not route IPsec `ESP` or `AH` packets. These packets must be encapsulated in `UDP`, and if it is configured, NAT detection configures the `ESP` in `UDP` encapsulation. If you use NAT or if you are not under the Network/Cloud-Provider limitations as described before, omit this parameter and value.
 
 . Tell *libreswan*
 which IP subnets and hosts to apply each policy using policy
@@ -243,18 +239,13 @@ conn <other_node_hostname>
         rightrsasigkey=%cert
         auto=start
         keyingtries=%forever
+	encapsulation=yes <5>	
 ----
 <1> Replace <this_node_ip> with the cluster IP address of this node.
 <2> Replace <this_node_cert_nickname> with the node certificate nickname from step one.
 <3> Replace <other_node_ip> with the cluster IP address of the other node.
 <4> Replace <other_node_cert_full_subject> with the other node's certificate subject from just above. For example: "O=system:nodes,CN=openshift-node-45.example.com".
-
-+
-[IMPORTANT]
-====
-The Amazon/Azure internal cloud network does not route IPsec `ESP` or `AH` packets. These packets need to be encapsulated in `UDP`. While normally the NAT detection takes care of this `ESP` in `UDP` encapsulation, if NAT is not detected, you can force encapsulation by setting `encapsulation=yes`.
-====
-+
+<5> If you do not use NAT, you must include `encapsulation=yes` in the configuration to force encapsulation. The **Amazon** and **Azure** internal cloud networks do not route IPsec `ESP` or `AH` packets. These packets must be encapsulated in `UDP`, and if it is configured, NAT detection configures the `ESP` in `UDP` encapsulation. If you use NAT or if you are not under the Network/Cloud-Provider limitations as described before, omit this parameter and value.
 
 . Place the following in the *_/etc/ipsec.d/openshift-cluster.secrets_* file on each node:
 +

--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -168,6 +168,12 @@ conn clear
 	priority=100
 ----
 <1> Replace <cert_nickname> with the certificate nickname from step one.
++
+[IMPORTANT]
+====
+The Amazon/Azure internal cloud network does not route IPsec `ESP` or `AH` packets. These packets need to be encapsulated in `UDP`. While normally the NAT detection takes care of this `ESP` in `UDP` encapsulation, if NAT is not detected, you can force encapsulation by setting `encapsulation=yes`.
+====
++
 
 . Tell *libreswan*
 which IP subnets and hosts to apply each policy using policy
@@ -242,6 +248,13 @@ conn <other_node_hostname>
 <2> Replace <this_node_cert_nickname> with the node certificate nickname from step one.
 <3> Replace <other_node_ip> with the cluster IP address of the other node.
 <4> Replace <other_node_cert_full_subject> with the other node's certificate subject from just above. For example: "O=system:nodes,CN=openshift-node-45.example.com".
+
++
+[IMPORTANT]
+====
+The Amazon/Azure internal cloud network does not route IPsec `ESP` or `AH` packets. These packets need to be encapsulated in `UDP`. While normally the NAT detection takes care of this `ESP` in `UDP` encapsulation, if NAT is not detected, you can force encapsulation by setting `encapsulation=yes`.
+====
++
 
 . Place the following in the *_/etc/ipsec.d/openshift-cluster.secrets_* file on each node:
 +


### PR DESCRIPTION
The Amazon/Azure internal cloud network does not route IPsec `ESP` or `AH` packets. These packets need to be encapsulated in `UDP`. While normally the NAT detection takes care of this `ESP` in `UDP` encapsulation, if NAT is not detected, you can force encapsulation by setting `encapsulation=yes`.

Libreswan site (example): https://libreswan.org/wiki/Interoperability#ESP_packet_filter