### PR TITLE
Known issue fixed in 4.5.8

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1993,10 +1993,6 @@ must prefix any custom MachineConfig file with a differing priority of `98-`
 instead of `99-`.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826150[*BZ#1826150*])
 
-* If you do not specify an IPAM configuration in the SriovNetwork configuration, the NetworkAttachmentDefinition is not created.
-As a workaround, you must include an empty `ipam: {}` parameter in the SriovNetwork configuration.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1859231[*BZ#1859231*])
-
 * Git clone operations that go through an HTTPS proxy fail. Non-TLS (HTTP)
 proxies can be used successfully.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1750650[*BZ#1750650*])


### PR DESCRIPTION
This known issue is fixed in the upcoming 4.5.8 z-stream release ([BZ#1859231](https://bugzilla.redhat.com/show_bug.cgi?id=1859231)). Ships 2020-09-08