### PR TITLE
Fix nodecount and ES memory per slack

### DIFF
--- a/modules/cluster-logging-about-crd.adoc
+++ b/modules/cluster-logging-about-crd.adoc
@@ -69,13 +69,13 @@ spec:
   logStore:
     type: "elasticsearch"
     elasticsearch:
-      nodeCount: 2
+      nodeCount: 3
       resources:
         limits:
-          memory: 2Gi
+          memory: 16Gi
         requests:
-          cpu: 200m
-          memory: 2Gi
+          cpu: 500m
+          memory: 16Gi
       storage:
         storageClassName: "gp2"
         size: "200G"

--- a/modules/cluster-logging-configuring-node-selector.adoc
+++ b/modules/cluster-logging-configuring-node-selector.adoc
@@ -26,13 +26,13 @@ spec:
     elasticsearch:
       nodeSelector:  <1>
         logging: es
-      nodeCount: 1
+      nodeCount: 3
       resources:
         limits:
-          memory: 2Gi
+          memory: 16Gi
         requests:
-          cpu: 200m
-          memory: 2Gi
+          cpu: 500m
+          memory: 16Gi
       storage:
         size: "20G"
         storageClassName: "gp2"

--- a/modules/cluster-logging-deploying-about.adoc
+++ b/modules/cluster-logging-deploying-about.adoc
@@ -33,9 +33,9 @@ spec:
       resources:
         limits:
           cpu:
-          memory:
+          memory: 16Gi
         requests:
-          cpu: 1
+          cpu: 500m
           memory: 16Gi
       type: "elasticsearch"
   collection:
@@ -161,13 +161,13 @@ spec:
   logStore:
     type: "elasticsearch"
     elasticsearch:
-      nodeCount: 2
+      nodeCount: 3
       resources:
         limits:
-          memory: 2Gi
+          memory: 32Gi
         requests:
-          cpu: 200m
-          memory: 2Gi
+          cpu: 3
+          memory: 32Gi
       storage: {}
       redundancyPolicy: "SingleRedundancy"
   visualization:

--- a/modules/cluster-logging-elasticsearch-limits.adoc
+++ b/modules/cluster-logging-elasticsearch-limits.adoc
@@ -37,10 +37,10 @@ spec:
       elasticsearch:
         resources: <1>
           limits:
-            memory: "16Gi"
+            memory: 16Gi
           requests:
-            cpu: "1"
-            memory: "16Gi"
+            cpu: 500m
+            memory: 16Gi
 ----
 <1> Specify the CPU and memory limits as needed. If you leave these values blank,
 the Elasticsearch Operator sets default values that should be sufficient for most deployments.


### PR DESCRIPTION
Per Slack conversation. Adding to 4.3, as this branch had the most incorrect `nodecount` fields. Will attempt a CP to master and other branches.

https://coreos.slack.com/archives/CB3HXM2QK/p1598278265072800?thread_ts=1597919166.003000&cid=CB3HXM2QK