### PR TITLE
Fixup source terminal for admin_guide

### DIFF
--- a/admin_guide/allocating_node_resources.adoc
+++ b/admin_guide/allocating_node_resources.adoc
@@ -49,6 +49,7 @@ on the effects of these settings, see xref:computing-allocated-resources[Computi
 
 You can see which services are controlled by `system-reserved`  with a tool such as libcgroup:
 
+[source,terminal]
 ----
 $ yum install libcgroup-tools 
 $ lscgroup memory:/system.slice
@@ -83,12 +84,14 @@ After setting `kube-reserved` and `system-reserved`:
 
 * Monitor the memory usage of a node for high-water marks:
 +
+[source,terminal]
 ----
 $ ps aux | grep <service-name>
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ ps aux | grep atomic-openshift-node
 
@@ -100,6 +103,7 @@ If this value is close to your `kube-reserved` mark, you can increase the `kube-
 
 * Monitor the memory usage of system services with a tool such as libcgroup:
 +
+[source,terminal]
 ----
 $ yum install libcgroup-tools
 $ cgget -g memory  /system.slice | grep memory.usage_in_bytes
@@ -136,6 +140,7 @@ If `[Allocatable]` is negative, it is set to *0*.
 To see a node's current capacity and allocatable resources, you can run:
 
 ====
+[source,terminal]
 ----
 $ oc get node/<node_name> -o yaml
 ...
@@ -163,6 +168,7 @@ which is accessible at *_<master>/api/v1/nodes/<node>/proxy/stats/summary_*.
 
 For instance, to access the resources from *cluster.node22* node, you can run:
 
+[source,terminal]
 ----
 $ curl <certificate details> https://<master>/api/v1/nodes/cluster.node22/proxy/stats/summary
 {

--- a/admin_guide/assembly_restore-etcd-quorum.adoc
+++ b/admin_guide/assembly_restore-etcd-quorum.adoc
@@ -34,6 +34,7 @@ that the cluster is unhealthy:
 
 * If you use the etcd v2 API, run the following command:
 +
+[source,terminal]
 ----
 # etcd_ctl=2 etcdctl  --cert-file=/etc/origin/master/master.etcd-client.crt  \
           --key-file /etc/origin/master/master.etcd-client.key \
@@ -51,6 +52,7 @@ cluster is unhealthy
 
 * If you use the v3 API, run the following command:
 +
+[source,terminal]
 ----
 # ETCDCTL_API=3 etcdctl --cert=/etc/origin/master/master.etcd-client.crt  \
           --key=/etc/origin/master/master.etcd-client.key \

--- a/admin_guide/building_dependency_trees.adoc
+++ b/admin_guide/building_dependency_trees.adoc
@@ -46,13 +46,17 @@ The following table describes common `build-chain` usage and general syntax:
 |Description |Syntax
 
 |Build the dependency tree for the *latest* tag in `<image-stream>`.
-|----
+|
+[source,terminal]
+----
 $ oc adm build-chain <image-stream>
 ----
 
 |Build the dependency tree for the *v2* tag in DOT format, and visualize it
 using the DOT utility.
-|----
+|
+[source,terminal]
+----
 $ oc adm build-chain <image-stream>:v2 \
     -o dot \
     \| dot -T svg -o deps.svg
@@ -60,7 +64,9 @@ $ oc adm build-chain <image-stream>:v2 \
 
 |Build the dependency tree across all projects for the specified image stream
 tag found the *test* project.
-|----
+|
+[source,terminal]
+----
 $ oc adm build-chain <image-stream>:v1 \
     -n test --all
 ----

--- a/admin_guide/cluster_capacity.adoc
+++ b/admin_guide/cluster_capacity.adoc
@@ -43,6 +43,7 @@ You can run the `hypercc cluster-capacity` analysis tool as a stand-alone utilit
 Install the openshift-enterprise-cluster-capacity RPM package to get the tool.
 To run the tool on the command line:
 
+[source,terminal]
 ----
 $ hypercc cluster-capacity --kubeconfig <path-to-kubeconfig> \
     --podspec <path-to-pod-spec>
@@ -82,6 +83,7 @@ spec:
 You can also add the `--verbose` option to output a detailed description of how
 many pods can be scheduled on each node in the cluster:
 
+[source,terminal]
 ----
 $ hypercc cluster-capacity --kubeconfig <path-to-kubeconfig> \
     --podspec <path-to-pod-spec> --verbose
@@ -117,6 +119,7 @@ the cluster capacity tool as a job involves using a `ConfigMap`.
 
 . Create the cluster role:
 +
+[source,terminal]
 ----
 $ cat << EOF| oc create -f -
 kind: ClusterRole
@@ -132,12 +135,14 @@ EOF
 
 . Create the service account:
 +
+[source,terminal]
 ----
 $ oc create sa cluster-capacity-sa
 ----
 
 . Add the role to the service account:
 +
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user cluster-capacity-role \
     system:serviceaccount:default:cluster-capacity-sa <1>
@@ -175,6 +180,7 @@ spec:
 +
 If you haven't created a `ConfigMap`, create one before creating the job:
 +
+[source,terminal]
 ----
 $ oc create configmap cluster-capacity-configmap \
     --from-file=pod.yaml
@@ -226,6 +232,7 @@ accessed inside the pod as `/test-pod/pod.yaml`.
 
 . Run the cluster capacity image as a job in a pod:
 +
+[source,terminal]
 ----
 $ oc create -f cluster-capacity-job.yaml
 ----
@@ -233,6 +240,7 @@ $ oc create -f cluster-capacity-job.yaml
 . Check the job logs to find the number of pods that can be scheduled in the
  cluster:
 +
+[source,terminal]
 ----
 $ oc logs jobs/cluster-capacity-job
 small-pod pod requirements:

--- a/admin_guide/diagnostics_tool.adoc
+++ b/admin_guide/diagnostics_tool.adoc
@@ -45,6 +45,7 @@ binary to provide diagnostics within an {product-title} server or client.
 To use the diagnostics tool, preferably on a master host and as cluster
 administrator, run:
 
+[source,terminal]
 ----
 # oc adm diagnostics
 ----
@@ -54,6 +55,7 @@ This runs all available diagnostics and skips any that do not apply to the envir
 You can run a specific diagnostics by name or run specific
 diagnostics by name as you work to address issues. For example:
 
+[source,terminal]
 ----
 $ oc adm diagnostics
 ----
@@ -163,6 +165,7 @@ Ansible-deployed cluster ensures that running `oc adm diagnostics` works without
 any flags. If you are not using the default location for the configuration
 files, you must use the `--master-config` and `--node-config` options:
 
+[source,terminal]
 ----
 # oc adm diagnostics --master-config=<file_path> --node-config=<file_path>
 ----
@@ -346,6 +349,7 @@ To run the *openshift-ansible* health checks using the `ansible-playbook`
 command, change to the playbook directory, specify your cluster's inventory file, and run the *_health.yml_*
 playbook:
 
+[source,terminal]
 ----
 $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
@@ -355,6 +359,7 @@ $ ansible-playbook -i <inventory_file> \
 To set variables in the command line, include the `-e` flag with any desired
 variables in `key=value` format. For example:
 
+[source,terminal]
 ----
 $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i <inventory_file> \
@@ -391,6 +396,7 @@ image via the Docker CLI.
 
 Run the following as a non-root user that has privileges to run containers:
 
+[source,terminal]
 ----
 # docker run -u `id -u` \ <1>
     -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa:Z,ro \ <2>

--- a/admin_guide/disabling_features.adoc
+++ b/admin_guide/disabling_features.adoc
@@ -100,6 +100,7 @@ kubernetesMasterConfig:
 
 . Restart the {product-title} master service to apply the changes.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -140,6 +141,7 @@ kubeletArguments:
 
 . Restart the {product-title} service for the changes to take effect:
 +
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node.service
 ----

--- a/admin_guide/encrypting_data.adoc
+++ b/admin_guide/encrypting_data.adoc
@@ -168,6 +168,7 @@ To create a new secret:
 . Generate a 32-byte random key and base64 encode it. For example, on Linux and
 macOS use:
 +
+[source,terminal]
 ----
 $ head -c 32 /dev/urandom | base64
 ----
@@ -183,6 +184,7 @@ from Golang or `random.random()` from Python are not suitable.
 
 . Restart the API server:
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -204,12 +206,14 @@ program to retrieve the contents of your secret.
 
 . Create a new secret called `secret1` in the `default` namespace:
 +
+[source,terminal]
 ----
 $ oc create secret generic secret1 -n default --from-literal=mykey=mydata
 ----
 
 . Using the `etcdctl` command line, read that secret out of etcd:
 +
+[source,terminal]
 ----
 $ ETCDCTL_API=3 etcdctl get /kubernetes.io/secrets/default/secret1 -w fields [...] | grep Value
 ----
@@ -218,6 +222,7 @@ $ ETCDCTL_API=3 etcdctl get /kubernetes.io/secrets/default/secret1 -w fields [..
 +
 The final command will look similar to:
 +
+[source,terminal]
 ----
 $ ETCDCTL_API=3 etcdctl get /kubernetes.io/secrets/default/secret1 -w fields \
 --cacert=/var/lib/origin/openshift.local.config/master/ca.crt \
@@ -231,6 +236,7 @@ indicates the *aescbc* provider has encrypted the resulting data.
 
 . Verify the secret is correctly decrypted when retrieved via the API:
 +
+[source,terminal]
 ----
 $ oc get secret secret1 -n default -o yaml | grep mykey
 ----
@@ -243,6 +249,7 @@ This should match *mykey: bXlkYXRh*.
 Since secrets are encrypted when written, performing an update on a secret will
 encrypt that content.
 
+[source,terminal]
 ----
 $ oc adm migrate storage --include=secrets --confirm
 ----
@@ -270,6 +277,7 @@ on all servers.
 If using a single API server, you can skip this step.
 ====
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -281,6 +289,7 @@ encryption in the configuration.
 . Restart all API servers to ensure each server now encrypts using the new
 key.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -288,6 +297,7 @@ key.
 
 . Run the following to encrypt all existing secrets with the new key:
 +
+[source,terminal]
 ----
 $ oc adm migrate storage --include=secrets --confirm
 ----
@@ -319,6 +329,7 @@ resources:
 
 . Restart all API servers:
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -326,6 +337,7 @@ resources:
 
 . Run the following to force all secrets to be decrypted:
 +
+[source,terminal]
 ----
 $ oc adm migrate storage --include=secrets --confirm
 ----

--- a/admin_guide/high_availability.adoc
+++ b/admin_guide/high_availability.adoc
@@ -241,6 +241,7 @@ start with `OPENSHIFT_HA_*` and they can be changed as needed.
 For example, the command below will create an IP failover configuration on a selection of nodes labeled `router=us-west-ha` (on 4 nodes with 7 virtual IPs monitoring a service
 listening on port 80, such as the router process).
 
+[source,terminal]
 ----
 $ oc adm ipfailover --selector="router=us-west-ha" \
     --virtual-ips="1.2.3.4,10.1.1.100-104,5.6.7.8" \
@@ -252,6 +253,7 @@ $ oc adm ipfailover --selector="router=us-west-ha" \
 You can view what the configuration that would look like
 using one of the supported formats (the example below uses the JSON format):
 
+[source,terminal]
 ----
 $ oc adm ipfailover [<Ip_failover_config_name>] <options> -o json
 ----
@@ -354,6 +356,7 @@ exit 0
 
 . Create the ConfigMap:
 +
+[source,terminal]
 ----
 $ oc create configmap mycustomcheck --from-file=mycheckscript.sh
 ----
@@ -365,7 +368,7 @@ decimal) is typical.
 
 .. Using `oc` commands:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc env dc/ipf-ha-router \
     OPENSHIFT_HA_CHECK_SCRIPT=/etc/keepalive/mycheckscript.sh
@@ -426,7 +429,7 @@ To specify preemption:
 
 .. When creating ipfailover using the `preemption-strategy`:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc adm ipfailover --preempt-strategy=nopreempt \
   ...
@@ -435,7 +438,7 @@ $ oc adm ipfailover --preempt-strategy=nopreempt \
 
 .. Setting the variable using the `oc set env` command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc set env dc/ipf-ha-router \
     --overwrite=true \
@@ -492,6 +495,7 @@ Be careful since every *keepalived* daemon uses the VRRP protocol over multicast
 xref:../admin_guide/high_availability.adoc#ha-vrrp-id-offset[each VIP].
 ====
 
+[source,terminal]
 ----
 $ for node in openshift-node-{5,6,7,8,9}; do   ssh $node <<EOF
 
@@ -618,6 +622,7 @@ link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness
 Kubernetes health checks] must be used to ensure that services are live.
 ====
 
+[source,terminal]
 ----
 # oc adm ipfailover <ipfailover_name> --create \
     ...
@@ -650,6 +655,7 @@ The following example defines a label for nodes that are servicing
 traffic in the US west geography *ha-svc-nodes=geo-us-west*:
 +
 ====
+[source,terminal]
 ----
 $ oc label nodes openshift-node-{5,6,7,8,9} "ha-svc-nodes=geo-us-west"
 ----
@@ -663,6 +669,7 @@ The following example creates a new service account with the name ipfailover in 
 *default* namespace:
 +
 ====
+[source,terminal]
 ----
 $ oc create serviceaccount ipfailover -n default
 ----
@@ -671,6 +678,7 @@ $ oc create serviceaccount ipfailover -n default
 . Add the ipfailover service account in the *default* namespace to the *privileged* SCC:
 +
 ====
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user privileged system:serviceaccount:default:ipfailover
 ----
@@ -689,6 +697,7 @@ The following example runs five instances using the ipfailover service account:
 +
 ifdef::openshift-enterprise[]
 ====
+[source,terminal]
 ----
 $ oc adm router ha-router-us-west --replicas=5 \
     --selector="ha-svc-nodes=geo-us-west" \
@@ -700,6 +709,7 @@ endif::[]
 
 ifdef::openshift-origin[]
 ====
+[source,terminal]
 ----
 $ oc adm router ha-router-us-west --replicas=5 \
     --selector="ha-svc-nodes=geo-us-west" \
@@ -721,6 +731,7 @@ of nodes in the *geo-cache* label. Check that the label matches the one used in
 the first step.
 ====
 +
+[source,terminal]
 ----
 $ oc create -n <namespace> -f ./examples/geo-cache.json
 ----
@@ -743,6 +754,7 @@ The ipfailover command for the *router*:
 +
 ifdef::openshift-enterprise[]
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
@@ -755,6 +767,7 @@ $ oc adm ipfailover ipf-ha-router-us-west \
 endif::[]
 ifdef::openshift-origin[]
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
@@ -776,6 +789,7 @@ offset. In this case, setting a value of `10` means that the
 +
 ifdef::openshift-enterprise[]
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-geo-cache \
     --replicas=5 --watch-port=9736 \
@@ -788,6 +802,7 @@ $ oc adm ipfailover ipf-ha-geo-cache \
 endif::[]
 ifdef::openshift-origin[]
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-geo-cache \
     --replicas=5 --watch-port=9736 \
@@ -819,6 +834,7 @@ Deploy the ipfailover router to monitor postgresql listening on node
 port 32439 and the external IP address, as defined in the *postgresql-ingress*
 service:
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-postgresql \
     --replicas=1 \ <1>
@@ -847,6 +863,7 @@ The following example shows how to dynamically update the deployment strategy an
 +
 ifdef::openshift-enterprise[]
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
@@ -858,6 +875,7 @@ $ oc adm ipfailover ipf-ha-router-us-west \
 endif::[]
 ifdef::openshift-origin[]
 ====
+[source,terminal]
 ----
 $ oc adm ipfailover ipf-ha-router-us-west \
     --replicas=5 --watch-port=80 \
@@ -871,6 +889,7 @@ endif::[]
 . Edit the deployment configuration:
 +
 ====
+[source,terminal]
 ----
 $ oc edit dc/ipf-ha-router-us-west
 ----

--- a/admin_guide/idling_applications.adoc
+++ b/admin_guide/idling_applications.adoc
@@ -45,6 +45,7 @@ multiple services].
 
 Idle a single service with the following command:
 
+[source,terminal]
 ----
 $ oc idle <service>
 ----
@@ -62,6 +63,7 @@ multiple applications in bulk within the same project.
 
 . Idle the services using the `--resource-names-file` option:
 +
+[source,terminal]
 ----
 $ oc idle --resource-names-file <filename>
 ----
@@ -82,6 +84,7 @@ services and traffic passing through routes.
 Applications may be manually unidled by scaling up the resources. For example,
 to scale up a deploymentconfig, run the command:
 
+[source,terminal]
 ----
 $ oc scale --replicas=1 dc <deploymentconfig>
 ----

--- a/admin_guide/image_policy.adoc
+++ b/admin_guide/image_policy.adoc
@@ -272,8 +272,9 @@ $ master-restart controllers
 +
 For example, use the information above, then test like this:
 +
+[source,terminal]
 ----
-oc import-image openshift/image-policy-check:latest --confirm
+$ oc import-image openshift/image-policy-check:latest --confirm
 ----
 
 . Create a pod using this YAML. The pod should be created.

--- a/admin_guide/image_policy.adoc
+++ b/admin_guide/image_policy.adoc
@@ -259,6 +259,7 @@ admissionConfig:
 
 . Restart master services running in control plane static Pods using the `master-restart` command:
 +
+[source,terminal]
 ----
 $ master-restart api
 $ master-restart controllers
@@ -334,6 +335,7 @@ spec:
 . Get the digest from `oc get istag/image-policy-check:latest` and use it for
 `oc annotate images/<digest> images.openshift.io/deny-execution=true`. For example:
 +
+[source,terminal]
 ----
 $ oc annotate images/sha256:09ce3d8b5b63595ffca6636c7daefb1a615a7c0e3f8ea68e5db044a9340d6ba8 images.openshift.io/deny-execution=true
 ----

--- a/admin_guide/image_signatures.adoc
+++ b/admin_guide/image_signatures.adoc
@@ -58,6 +58,7 @@ In order to attach the signature to the image, the user must have the
 ifdef::openshift-origin,openshift-enterprise[]
 Cluster administrators can add this using:
 
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user system:image-signer <user_name>
 ----
@@ -65,6 +66,7 @@ endif::[]
 
 Images may be signed at push time:
 
+[source,terminal]
 ----
 $ atomic push [--sign-by <gpg_key_id>] --type atomic <image>
 ----
@@ -103,6 +105,7 @@ In order to verify the signature of an image, the user must have the
 ifdef::openshift-origin,openshift-enterprise[]
 Cluster administrators can add this using:
 
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user system:image-auditor <user_name>
 ----
@@ -121,6 +124,7 @@ without the `--save` flag first and check the logs for potential issues.
 
 To verify an image signature use the following format:
 
+[source,terminal]
 ----
 $ oc adm verify-image-signature <image> --expected-identity=<pull_spec> [--save] [options]
 ----
@@ -130,6 +134,7 @@ The `<image>` may be found by describing the image stream tag.
 See the following example command output.
 
 .Example Image Signature Verification
+[source,terminal]
 ----
 $ oc describe is nodejs -n openshift
 Name:             nodejs
@@ -162,6 +167,7 @@ For example, to add the CA for *_docker-registry.default.svc_*, transfer the fil
 
 . Copy the CA certificate to the *_/etc/pki/ca-trust/source/anchors/_* directory. For example:
 +
+[source,terminal]
 ----
 # cp </path_to_file>/node-client-ca.crt \
     /etc/pki/ca-trust/source/anchors/
@@ -169,6 +175,7 @@ For example, to add the CA for *_docker-registry.default.svc_*, transfer the fil
 
 . Execute `update-ca-trust` to update the list of trusted CAs:
 +
+[source,terminal]
 ----
 # update-ca-trust
 ----
@@ -198,6 +205,7 @@ to send a JSON payload to the `extensions` endpoint:
 PUT /extensions/v2/<namespace>/<name>/signatures/<digest>
 ----
 
+[source,terminal]
 ----
 $ curl -X PUT --data @signature.json http://<user>:<token>@<registry_endpoint>:5000/extensions/v2/<namespace>/<name>/signatures/sha256:<digest>
 ----
@@ -230,6 +238,7 @@ Registry, you can read the signatures using the following command:
 GET /extensions/v2/<namespace>/<name>/signatures/<digest>
 ----
 
+[source,terminal]
 ----
 $ curl http://<user>:<token>@<registry_endpoint>:5000/extensions/v2/<namespace>/<name>/signatures/sha256:<digest>
 ----

--- a/admin_guide/index.adoc
+++ b/admin_guide/index.adoc
@@ -55,7 +55,7 @@ xref:../architecture/additional_concepts/authorization.adoc#evaluating-authoriza
 names] (e.g., `templates`). To view the details of these roles and their sets of
 verbs and resources, run the following:
 
-[subs="attributes"]
+[source,terminal,subs="attributes"]
 ----
 $ oc describe clusterrole/{cluster-admin-role}
 $ oc describe clusterrole/{project-admin-role}

--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -50,6 +50,7 @@ Complete the following procedure to change the MTU for the nodes in your cluster
 
 ... Run the following command to edit the ConfigMap. Replace `<config_map>` with the name of the ConfigMap to edit.
 +
+[source,terminal]
 ----
 # oc edit cm <config_map> -n openshift-node
 ----
@@ -64,6 +65,7 @@ networkConfig:
 
 .. Remove the SDN interface by running the following command. Replace `<ovs_pod_name>` with the name of the OVS pod.
 +
+[source,terminal]
 ----
 # oc exec <ovs_pod_name> -- ovs-vsctl del-br br0
 ----
@@ -74,6 +76,7 @@ networkConfig:
 
 ... Restart the SDN and OVS pods by running the following commands:
 +
+[source,terminal]
 ----
 # oc delete pod -n openshift-sdn -l=app=ovs
 # oc delete pod -n openshift-sdn -l=app=sdn
@@ -86,6 +89,7 @@ You can generate RSA keys suitable for IPsec by using the {product-title} intern
 
 . Run the following commands to generate the RSA certificates on the master node:
 +
+[source,terminal]
 ----
 # export CA=/etc/origin/master
 
@@ -102,6 +106,7 @@ You can generate RSA keys suitable for IPsec by using the {product-title} intern
 key files into a *_PKCS#12_* file, which is a common file format for multiple
 certificates and keys:
 +
+[source,terminal]
 ----
 # openssl pkcs12 -export \
   -in <hostname>.crt \ <1>
@@ -117,6 +122,7 @@ certificates and keys:
 The `-W` option is left empty because no password is assigned to the *_PKCS#12_*
 file, as it is only temporary.
 +
+[source,terminal]
 ----
 # ipsec initnss
 # pk12util -i <hostname>.p12 -d sql:/etc/ipsec.d -W ""
@@ -219,6 +225,7 @@ be placed into the configuration for every other node.
 
 . Use *openssl* to read this subject from the node's certificate:
 +
+[source,terminal]
 ----
 # openssl x509 \
   -in /path/to/client-certificate -text | \
@@ -280,12 +287,14 @@ to normal cluster deployments.
 . Start the *ipsec* service to load the new configuration and policies,
 and begin encrypting:
 +
+[source,terminal]
 ----
 # systemctl start ipsec
 ----
 
 . Enable the *ipsec* service to start on boot:
 +
+[source,terminal]
 ----
 # systemctl enable ipsec
 ----

--- a/admin_guide/iptables.adoc
+++ b/admin_guide/iptables.adoc
@@ -84,6 +84,7 @@ required by {product-title} and Docker. {product-title} and Docker are not
 notified of the change.
 ====
 
+[source,terminal]
 ----
 # systemctl disable iptables.service
 # systemctl mask iptables.service
@@ -112,6 +113,7 @@ Restarting the Docker service will cause all containers running on the node to
 be stopped and restarted.
 ====
 
+[source,terminal]
 ----
 # systemctl restart iptables.service
 # systemctl restart docker

--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -436,6 +436,7 @@ endif::openshift-dedicated[]
 To apply a limit range to a project, create a limit range
 object definition on your file system to your desired specifications, then run:
 
+[source,terminal]
 ----
 $ oc create -f <limit_range_file> -n <project>
 ----
@@ -452,6 +453,7 @@ You can also use the CLI to view limit range details:
 . First, get the list of limit ranges defined in the project. For example, for a
 project called *demoproject*:
 +
+[source,terminal]
 ----
 $ oc get limits -n demoproject
 NAME              AGE
@@ -461,6 +463,7 @@ resource-limits   6d
 . Then, describe the limit range you are interested in, for example the
 *resource-limits* limit range:
 +
+[source,terminal]
 ----
 $ oc describe limits resource-limits -n demoproject
 Name:                           resource-limits
@@ -482,6 +485,7 @@ openshift.io/ImageStream        openshift.io/image-tags -       10      -       
 
 Remove any active limit range to no longer enforce the limits of a project:
 
+[source,terminal]
 ----
 $ oc delete limits <limit_name>
 ----

--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -346,8 +346,7 @@ $ oc adm manage-node <node1> <node2> --schedulable=false
 
 For example:
 
-[source,terminal]
-[options="nowrap"]
+[source,terminal,options="nowrap"]
 ----
 $ oc adm manage-node node1.example.com --schedulable=false
 ----

--- a/admin_guide/manage_rbac.adoc
+++ b/admin_guide/manage_rbac.adoc
@@ -74,6 +74,7 @@ Authorization] section.
 ifdef::openshift-enterprise,openshift-origin[]
 To view the cluster roles and their associated rule sets:
 
+[source,terminal]
 ----
 $ oc describe clusterrole.rbac
 Name:		admin
@@ -289,6 +290,7 @@ To view the current set of cluster role bindings, which show the users and
 groups that are bound to various roles:
 
 ifdef::openshift-enterprise,openshift-origin[]
+[source,terminal]
 ----
 $ oc describe clusterrolebinding.rbac
 Name:		admin
@@ -496,6 +498,7 @@ Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
 ----
 endif::[]
 ifdef::openshift-dedicated,openshift-aro[]
+[source,terminal]
 ----
 $ oc describe clusterrolebinding.rbac
 ----
@@ -517,6 +520,7 @@ The local role bindings are also viewable.
 To view the current set of local role bindings, which show the users and groups
 that are bound to various roles:
 
+[source,terminal]
 ----
 $ oc describe rolebinding.rbac
 ----
@@ -528,6 +532,7 @@ viewing the local role bindings of another project, if the user already has the
 xref:../architecture/additional_concepts/authorization.adoc#roles[default
 cluster role] in it.
 
+[source,terminal]
 ----
 $ oc describe rolebinding.rbac -n joe-project
 Name:		admin
@@ -657,7 +662,7 @@ endif::[]
 For example, you can add the *admin* role to the *alice* user in *joe-project*
 by running:
 
-[options="nowrap"]
+[source,terminal,options="nowrap"]
 ----
 $ oc adm policy add-role-to-user admin alice -n joe-project
 ----
@@ -665,7 +670,7 @@ $ oc adm policy add-role-to-user admin alice -n joe-project
 
 You can then view the local role bindings and verify the addition in the output:
 
-[options="nowrap"]
+[source,terminal,options="nowrap"]
 ----
 $ oc describe rolebinding.rbac -n joe-project
 Name:		admin
@@ -739,6 +744,7 @@ You can create a local role for a project and then bind it to a user.
 
 . To create a local role for a project, run the following command:
 +
+[source,terminal]
 ----
 $ oc create role <name> --verb=<verb> --resource=<resource> -n <project>
 ----
@@ -752,12 +758,14 @@ In this command, specify:
 For example, to create a local role that allows a user to view pods in the
 `blue` project, run the following command:
 +
+[source,terminal]
 ----
 $ oc create role podview --verb=get --resource=pod -n blue
 ----
 
 . To bind the new role to a user, run the following command:
 
+[source,terminal]
 ----
 $ oc adm policy add-role-to-user podview user2 --role-namespace=blue -n blue
 ----
@@ -767,6 +775,7 @@ $ oc adm policy add-role-to-user podview user2 --role-namespace=blue -n blue
 
 To create a cluster role, run the following command:
 
+[source,terminal]
 ----
 $ oc create clusterrole <name> --verb=<verb> --resource=<resource>
 ----
@@ -780,6 +789,7 @@ In this command, specify:
 For example, to create a cluster role that allows a user to view pods, run the
 following command:
 
+[source,terminal]
 ----
 $ oc create clusterrole podviewonly --verb=get --resource=pod
 ----
@@ -815,6 +825,7 @@ does not modify them:
 
 . Protect each role from reconciliation:
 +
+[source,terminal]
 ----
 $ oc annotate clusterrole.rbac <role_name> --overwrite rbac.authorization.kubernetes.io/autoupdate=false
 ----
@@ -827,6 +838,7 @@ or required permissions after upgrading.
 
 . Generate a default bootstrap policy template file:
 +
+[source,terminal]
 ----
 $ oc adm create-bootstrap-policy-file --filename=policy.json
 ----
@@ -842,12 +854,14 @@ contains only the default policies.
 . Use the policy file to automatically reconcile roles and role bindings that
 are not reconcile protected:
 +
+[source,terminal]
 ----
 $ oc auth reconcile -f policy.json
 ----
 
 . Reconcile security context constraints:
 +
+[source,terminal]
 ----
 # oc adm policy reconcile-sccs \
     --additive-only=true \

--- a/admin_guide/manage_scc.adoc
+++ b/admin_guide/manage_scc.adoc
@@ -46,6 +46,7 @@ endif::openshift-dedicated[]
 
 To get a current list of SCCs:
 
+[source,terminal]
 ----
 $ oc get scc
 
@@ -66,6 +67,7 @@ You can view information about a particular SCC, including which users, service 
 
 For example, to examine the *restricted* SCC:
 
+[source,terminal]
 ----
 $ oc describe scc restricted
 Name:					restricted
@@ -162,6 +164,7 @@ to drop all possible capabilities.
 
 . Then, run `oc create` passing the file to create it:
 +
+[source,terminal]
 ----
 $ oc create -f scc_admin.yaml
 securitycontextconstraints "scc-admin" created
@@ -169,6 +172,7 @@ securitycontextconstraints "scc-admin" created
 
 . Verify that the SCC was created:
 +
+[source,terminal]
 ----
 $ oc get scc scc-admin
 NAME        PRIV      CAPS      SELINUX    RUNASUSER   FSGROUP    SUPGROUP   PRIORITY   READONLYROOTFS   VOLUMES
@@ -180,6 +184,7 @@ scc-admin   true      []        RunAsAny   RunAsAny    RunAsAny   RunAsAny   <no
 
 To delete an SCC:
 
+[source,terminal]
 ----
 $ oc delete scc <scc_name>
 ----
@@ -195,6 +200,7 @@ If you delete a default SCC, it will be regenerated upon restart.
 
 To update an existing SCC:
 
+[source,terminal]
 ----
 $ oc edit scc <scc_name>
 ----
@@ -309,6 +315,7 @@ Deployments, StatefulSets, DaemonSets, etc.
 
 . Run:
 +
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user <scc_name> <user_name>
 $ oc adm policy add-scc-to-group <scc_name> <group_name>
@@ -316,6 +323,7 @@ $ oc adm policy add-scc-to-group <scc_name> <group_name>
 +
 For example, to allow the *e2e-user* access to the *privileged* SCC, run:
 +
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user privileged e2e-user
 ----
@@ -329,12 +337,14 @@ $ oc adm policy add-scc-to-user privileged e2e-user
 First, create a xref:../dev_guide/service_accounts.adoc#dev-guide-service-accounts[service account].
 For example, to create service account `mysvcacct` in project `myproject`:
 
+[source,terminal]
 ----
 $ oc create serviceaccount mysvcacct -n myproject
 ----
 
 Then, add the service account to the `privileged` SCC.
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user privileged system:serviceaccount:myproject:mysvcacct
 ----
@@ -356,6 +366,7 @@ pre-allocated UID, without granting everyone access to the *privileged* SCC:
 
 . Grant all authenticated users access to the *anyuid* SCC:
 +
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-group anyuid system:authenticated
 ----
@@ -374,6 +385,7 @@ Some container images (examples: `postgres` and `redis`) require root access and
 have certain expectations about how volumes are owned.  For these images, add
 the service account to the `anyuid` SCC.
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user anyuid system:serviceaccount:myproject:mysvcacct
 ----
@@ -475,12 +487,14 @@ following actions:
 
 . Set the `*allowHostDirVolumePlugin*` parameter to `true` for the new SCC:
 +
+[source,terminal]
 ----
 $ oc patch scc hostpath -p '{"allowHostDirVolumePlugin": true}'
 ----
 
 . Grant access to this SCC to all users:
 +
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-group hostpath system:authenticated
 ----
@@ -509,12 +523,14 @@ unspecified, run as the `default` service account.
 
 To add an SCC to a user:
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user <scc_name> <user_name>
 ----
 
 To add an SCC to a service account:
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user <scc_name> \
     system:serviceaccount:<serviceaccount_namespace>:<serviceaccount_name>
@@ -523,6 +539,7 @@ $ oc adm policy add-scc-to-user <scc_name> \
 If you are currently in the project to which the service account belongs, you
 can use the `-z` flag and just specify the `<serviceaccount_name>`.
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user <scc_name> -z <serviceaccount_name>
 ----
@@ -537,12 +554,14 @@ namespace it applies to.
 
 To add an SCC to a group:
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-group <scc_name> <group_name>
 ----
 
 To add an SCC to all service accounts in a namespace:
 
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-group <scc_name> \
     system:serviceaccounts:<serviceaccount_namespace>

--- a/admin_guide/manage_users.adoc
+++ b/admin_guide/manage_users.adoc
@@ -49,6 +49,7 @@ xref:../install_config/configuring_authentication.adoc#identity-providers_parame
 provider configuration].
 . Give the new user the desired role:
 +
+[source,terminal]
 ----
 # oc create clusterrolebinding <clusterrolebinding_name> \
   --clusterrole=<role> --user=<user>
@@ -58,6 +59,7 @@ Where the `--clusterrole` option is the desired cluster role. For example, to
 give the new user `cluster-admin` privileges, which gives the user access to
 everything within a cluster:
 +
+[source,terminal]
 ----
 # oc create clusterrolebinding registry-controller \
   --clusterrole=cluster-admin --user=admin
@@ -94,6 +96,7 @@ identification provider: `*user*` and `*identity*`.
 
 To get the current list of users:
 
+[source,terminal]
 ----
 $ oc get user
 NAME      UID                                    FULL NAME   IDENTITIES
@@ -102,6 +105,7 @@ demo     75e4b80c-dbf1-11e5-8dc6-0e81e52cc949               htpasswd_auth:demo
 
 To get the current list of identities:
 
+[source,terminal]
 ----
 $ oc get identity
 NAME                  IDP NAME        IDP USER NAME   USER NAME   USER UID
@@ -135,6 +139,7 @@ create groups.
 
 To create a new group:
 
+[source,terminal]
 ----
 # oc adm groups new <group_name> <user1> <user2>
 ----
@@ -142,6 +147,7 @@ To create a new group:
 For example, to create the `west` groups and in it place the `john` and `betty`
 users:
 
+[source,terminal]
 ----
 # oc adm groups new west john betty
 ----
@@ -149,6 +155,7 @@ users:
 To verify that the group has been created, and list the users associated with
 the group, run the following:
 
+[source,terminal]
 ----
 # oc get groups
 NAME      USERS
@@ -165,24 +172,28 @@ Next steps:
 
 To add a label to a user or group:
 
+[source,terminal]
 ----
 $ oc label user/<user_name> <label_name>=<label_value>
 ----
 
 For example, if the user name is *theuser* and the label is *level=gold*:
 
+[source,terminal]
 ----
 $ oc label user/theuser level=gold
 ----
 
 To remove the label:
 
+[source,terminal]
 ----
 $ oc label user/<user_name> <label_name>-
 ----
 
 To show labels for a user or group:
 
+[source,terminal]
 ----
 $ oc describe user/<user_name>
 ----
@@ -194,6 +205,7 @@ To delete a user:
 
 . Delete the user record:
 +
+[source,terminal]
 ----
 $ oc delete user demo
 user "demo" deleted
@@ -206,6 +218,7 @@ the provider name from the user record in `oc get user`.
 +
 In this example, the identity provider name is *htpasswd_auth*. The command is:
 +
+[source,terminal]
 ----
 # oc delete identity htpasswd_auth:demo
 identity "htpasswd_auth:demo" deleted

--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -46,7 +46,7 @@ endif::openshift-enterprise,openshift-origin[]
 
 To join projects to an existing project network:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc adm pod-network join-projects --to=<project1> <project2> <project3>
 ----
@@ -62,7 +62,7 @@ Alternatively, instead of specifying specific project names, you can use the
 
 To verify the networks you have joined together:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc get netnamespaces
 ----
@@ -75,7 +75,7 @@ same NetID.
 
 To isolate the project network in the cluster and vice versa, run:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc adm pod-network isolate-projects <project1> <project2>
 ----
@@ -92,7 +92,7 @@ Alternatively, instead of specifying specific project names, you can use the
 
 To allow projects to access all pods and services in the cluster and vice versa:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc adm pod-network make-projects-global <project1> <project2>
 ----
@@ -125,12 +125,14 @@ As an {product-title} cluster administrator, you can edit the host name in a
 route even after creation.  You can also create a role to allow specific users
 to do so:
 
+[source,terminal]
 ----
 $ oc create clusterrole route-editor --verb=update --resource=routes.route.openshift.io/custom-host
 ----
 
 You can then bind the new role to a user:
 
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user route-editor user
 ----
@@ -157,7 +159,7 @@ admissionConfig:
 
 . Restart the master services for the changes to take effect:
 +
-[source,bash]
+[source,terminal]
 ----
 $ master-restart api
 $ master-restart controllers
@@ -358,7 +360,7 @@ in your pods.
 
 . Use the JSON file to create an EgressNetworkPolicy object:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc create -f <policy>.json
 ----
@@ -522,14 +524,14 @@ ordinary container.
 
 . Create the pod using the above definition:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc create -f <pod_name>.json
 ----
 +
 To check to see if the pod has been created:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get pod <pod_name>
 ----
@@ -674,7 +676,7 @@ definition directly, because it contains a privileged container.
 
 . Create a file containing the `EGRESS_DESTINATION` data:
 +
-[source,bash]
+[source,terminal]
 ----
 $ cat my-egress-destination.txt
 # Egress routes for Project "Test", version 3
@@ -692,7 +694,7 @@ Note that you can put blank lines and comments into this file
 
 . Create a ConfigMap object from the file:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc delete configmap egress-routes --ignore-not-found
 $ oc create configmap egress-routes \
@@ -1069,14 +1071,14 @@ hosts on the subnet.
 
 . Create the pod using the definition:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc create -f <replication_controller>.json
 ----
 
 . To verify, check to see if the replication controller pod has been created:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc describe rc <replication_controller>
 ----
@@ -1150,7 +1152,7 @@ To enable static source IPs:
 
 . Update the `NetNamespace` with the desired IP:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch netnamespace <project_name> -p '{"egressIPs": ["<IP_address>"]}'
 ----
@@ -1158,7 +1160,7 @@ $ oc patch netnamespace <project_name> -p '{"egressIPs": ["<IP_address>"]}'
 For example, to assign the `MyProject` project to an IP address of
 192.168.1.100:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch netnamespace MyProject -p '{"egressIPs": ["192.168.1.100"]}'
 ----
@@ -1173,7 +1175,7 @@ switch to using the next IP in the list after a short delay.
 field on the `HostSubnet` object on the node host. Include as many IPs as you
 want to assign to that node host:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch hostsubnet <node_name> -p \
   '{"egressIPs": ["<IP_address_1>", "<IP_address_2>"]}'
@@ -1182,7 +1184,7 @@ $ oc patch hostsubnet <node_name> -p \
 For example, to say that `node1` should have the egress IPs 192.168.1.100,
 192.168.1.101, and 192.168.1.102:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch hostsubnet node1 -p \
   '{"egressIPs": ["192.168.1.100", "192.168.1.101", "192.168.1.102"]}'
@@ -1251,7 +1253,7 @@ multiple IP addresses is not supported.
 For example, to assign `project1` to an IP address of 192.168.1.100 and
 `project2` to an IP address of 192.168.1.101:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch netnamespace project1 -p '{"egressIPs": ["192.168.1.100"]}'
 $ oc patch netnamespace project2 -p '{"egressIPs": ["192.168.1.101"]}''
@@ -1260,7 +1262,7 @@ $ oc patch netnamespace project2 -p '{"egressIPs": ["192.168.1.101"]}''
 . Indicate which nodes can host egress IP addresses by
 setting their `egressCIDRs` fields:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch hostsubnet <node_name> -p \
   '{"egressCIDRs": ["<IP_address_range_1>", "<IP_address_range_2>"]}'
@@ -1269,7 +1271,7 @@ $ oc patch hostsubnet <node_name> -p \
 For example, to set `node1` and `node2` to host egress IP addresses
 in the range 192.168.1.0 to 192.168.1.255:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch hostsubnet node1 -p '{"egressCIDRs": ["192.168.1.0/24"]}'
 $ oc patch hostsubnet node2 -p '{"egressCIDRs": ["192.168.1.0/24"]}'
@@ -1293,7 +1295,7 @@ are using the *ovs-multitenant* or *ovs-networkpolicy* plugin, you can enable
 multicast on a per-project basis by setting an annotation on the project's
 corresponding `netnamespace` object:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc annotate netnamespace <namespace> \
     netnamespace.network.openshift.io/multicast-enabled=true
@@ -1301,7 +1303,7 @@ $ oc annotate netnamespace <namespace> \
 
 Disable multicast by removing the annotation:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc annotate netnamespace <namespace> \
     netnamespace.network.openshift.io/multicast-enabled-
@@ -1529,7 +1531,7 @@ procedure, then skip this step. The cluster administrator role is required to
 add labels to namespaces.
 ====
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc label namespace default name=default
 ----
@@ -1569,6 +1571,7 @@ new project is created. To do this:
 ifdef::openshift-dedicated[]
 . Edit the default project template with the following command:
 +
+[source,terminal]
 ----
 $ oc edit template project-request -n dedicated-admin
 ----
@@ -1585,12 +1588,14 @@ procedure, then skip this step. The cluster administrator role is required to
 add labels to namespaces.
 ====
 +
+[source,terminal]
 ----
 $ oc label namespace default name=default
 ----
 
 . Edit the template to include the desired `NetworkPolicy` objects:
 +
+[source,terminal]
 ----
 $ oc edit template project-request -n default
 ----
@@ -1700,12 +1705,14 @@ For example, run the tcpdump tool on each pod while reproducing the behavior tha
 Review the captures on both sides to compare send and receive timestamps to analyze the latency of traffic to/from a pod.
 Latency can occur in {product-title} if a node interface is overloaded with traffic from other pods, storage devices, or the data plane.
 +
+[source,terminal]
 ----
 $ tcpdump -s 0 -i any -w /tmp/dump.pcap host <podip 1> && host <podip 2> <1>
 ----
 +
 <1> `podip` is the IP address for the pod. Run the following command to get the IP address of the pods:
 +
+[source,terminal]
 ----
 # oc get pod <podname> -o wide
 ----
@@ -1714,6 +1721,7 @@ tcpdump generates a file at *_/tmp/dump.pcap_* containing all traffic between th
 before the issue is reproduced and stop the analyzer shortly after the issue is finished reproducing to minimize the size of the file.
 You can also run a packet analyzer between the nodes (eliminating the SDN from the equation) with:
 +
+[source,terminal]
 ----
 # tcpdump -s 0 -i any -w /tmp/dump.pcap port 4789
 ----

--- a/admin_guide/managing_pods.adoc
+++ b/admin_guide/managing_pods.adoc
@@ -26,6 +26,7 @@ storage consumption.
 
 To view the usage statistics:
 
+[source,terminal]
 ----
 $ oc adm top pods
 NAME                         CPU(cores)   MEMORY(bytes)
@@ -36,6 +37,7 @@ heapster-n94r4               3m           37Mi
 
 To view the usage statistics for pods with labels:
 
+[source,terminal]
 ----
 $ oc adm top pod --selector=''
 ----
@@ -116,7 +118,7 @@ seconds. Note that the value of the override must be specified in string form.
 
 ** Run `oc edit` and add the `openshift.io/active-deadline-seconds-override: 1000` annotation in the editor.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc edit namespace <project-name>
 ----
@@ -125,7 +127,7 @@ Or
 +
 ** Use the `oc patch` command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc patch namespace <project_name> -p '{"metadata":{"annotations":{"openshift.io/active-deadline-seconds-override":"1000"}}}'
 ----
@@ -290,6 +292,7 @@ To configure pod access limits:
 . Navigate to the project you want to affect.
 . Create a JSON file for the pod limit policy:
 +
+[source,terminal]
 ----
 # oc create -f <policy>.json
 ----
@@ -383,8 +386,9 @@ annotations. For example, to limit both pod egress and ingress bandwidth to 10M/
 
 . Create the pod using the object definition:
 +
+[source,terminal]
 ----
-oc create -f <file_or_dir_path>
+$ oc create -f <file_or_dir_path>
 ----
 
 [[managing-pods-poddisruptionbudget]]
@@ -432,12 +436,14 @@ be either an integer or a string specifying a percentage (for example, `20%`).
 
 If you created a YAML file with the above object definition, you could add it to project with the following:
 
+[source,terminal]
 ----
 $ oc create -f </path/to/file> -n <project_name>
 ----
 
 You can check for pod disruption budgets across all projects with the following:
 
+[source,terminal]
 ----
 $ oc get poddisruptionbudget --all-namespaces
 

--- a/admin_guide/managing_projects.adoc
+++ b/admin_guide/managing_projects.adoc
@@ -46,6 +46,7 @@ To create your own custom project template:
 
 . Start with the current default project template:
 +
+[source,terminal]
 ----
 $ oc adm create-bootstrap-project-template -o yaml > template.yaml
 ----
@@ -54,6 +55,7 @@ $ oc adm create-bootstrap-project-template -o yaml > template.yaml
 
 . Load the template:
 +
+[source,terminal]
 ----
 $ oc create -f template.yaml -n default
 ----
@@ -71,6 +73,7 @@ endif::openshift-enterprise,openshift-origin[]
 ifdef::openshift-dedicated[]
 Edit the default project template with the following command:
 
+[source,terminal]
 ----
 $ oc edit template project-request -n dedicated-admin
 ----
@@ -79,6 +82,7 @@ If you modify the default project template and want your changes to remain after
 you upgrade, you must update the `openshift.io/overwrite-protect` annotation value
 to `true`.
 
+[source,terminal]
 ----
 $ oc annotate template project-request -n dedicated-admin openshift.io/overwrite-protect=true
 ----
@@ -132,6 +136,7 @@ xref:../admin_guide/manage_rbac.adoc#viewing-cluster-bindings[clusterrolebinding
 Run the following command, then review the subjects in the `self-provisioners`
 section.
 +
+[source,terminal]
 ----
 $ oc  describe clusterrolebinding.rbac self-provisioners
 
@@ -152,6 +157,7 @@ Subjects:
 `self-provisioner` role to the `system:authenticated:oauth` group, run the
 following command:
 +
+[source,terminal]
 ----
 $ oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
 ----
@@ -160,6 +166,7 @@ $ oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
 role to more users, groups, or serviceaccounts than the
 `system:authenticated:oauth` group, run the following command:
 +
+[source,terminal]
 ----
 $ oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth
 ----
@@ -191,6 +198,7 @@ to the role. Automatic updates reset the cluster roles to the default state.
 ** To update the role binding from the command line:
 ... Run the following command:
 +
+[source,terminal]
 ----
 $ oc edit clusterrolebinding.rbac self-provisioners
 ----
@@ -209,6 +217,7 @@ metadata:
 
  ** To update the role binding by using a single command:
 +
+[source,terminal]
 ----
 $ oc patch clusterrolebinding.rbac self-provisioners -p '{ "metadata": { "annotations": { "rbac.authorization.kubernetes.io/autoupdate": "false" } } }'
 ----
@@ -220,6 +229,7 @@ Dedicated admins can prevent an authenticated user group from self-provisioning 
 To remove the `self-provisioner` clusterrole from all authenticated 
 users, the `system:authenticated:oauth` group, run the following command:
 
+[source,terminal]
 ----
 $ oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth
 ----
@@ -260,6 +270,7 @@ projectConfig:
 
 Restart the OpenShift service for the changes to take effect:
 
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -275,6 +286,7 @@ topology with multiple regions, you can use a node selector to restrict specific
 The following creates a new project named `myproject` and dictates that pods be
 deployed onto nodes labeled `user-node` and `east`:
 
+[source,terminal]
 ----
 $ oc adm new-project myproject \
     --node-selector='type=user-node,region=east'
@@ -306,6 +318,7 @@ metadata:
 
 You can also override the default value for an existing project namespace by using the following command:
 
+[source,terminal]
 ----
 # oc patch namespace myproject -p \
     '{"metadata":{"annotations":{"openshift.io/node-selector":"node-role.kubernetes.io/infra=true"}}}'
@@ -402,6 +415,7 @@ labels for users and groups.
 Once your changes are made, restart {product-title} for the changes to take
 effect.
 
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -424,6 +438,7 @@ placed on them because project editors can manipulate those labels.
 
 . Create a service account in the project, if it is does not exist:
 +
+[source,terminal]
 ----
 $ oc create sa <sa_name>
 ----
@@ -431,6 +446,7 @@ $ oc create sa <sa_name>
 . As a user with `cluster-admin` privileges, add the `self-provisioner` cluster
 role to the service account:
 +
+[source,terminal]
 ----
 $ oc adm policy \
     add-cluster-role-to-user self-provisioner \
@@ -460,6 +476,7 @@ admissionConfig:
 . After you save the changes, restart {product-title} for the changes to take
 effect:
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -470,12 +487,14 @@ account and creating a new project.
 
 .. Log in as the service account by using its token:
 +
+[source,terminal]
 ----
 $ oc login --token <token>
 ----
 
 .. Create a new project:
 +
+[source,terminal]
 ----
 $ oc new-project <project_name>
 ----

--- a/admin_guide/monitoring_images.adoc
+++ b/admin_guide/monitoring_images.adoc
@@ -27,6 +27,7 @@ or through a xref:../dev_guide/builds/index.adoc#dev-guide-how-builds-work[build
 
 To view the usage statistics:
 
+[source,terminal]
 ----
 $ oc adm top images
 NAME                 IMAGESTREAMTAG            PARENTS                   USAGE                         METADATA    STORAGE
@@ -53,6 +54,7 @@ You can display usage statistics about `*ImageStreams*`.
 
 To view the usage statistics:
 
+[source,terminal]
 ----
 $ oc adm top imagestreams
 NAME                STORAGE     IMAGES  LAYERS

--- a/admin_guide/multiproject_quota.adoc
+++ b/admin_guide/multiproject_quota.adoc
@@ -26,7 +26,7 @@ You can select projects based on annotation selection, label selection, or
 both. For example, to select projects based on annotations, run the
 following command:
 
-[source,bash]
+[source,terminal]
 ----
 $ oc create clusterquota for-user \
      --project-annotation-selector openshift.io/requester=<user-name> \
@@ -81,9 +81,9 @@ pods and 20 secrets.
 
 Similarly, to select projects based on labels, run this command:
 
-[source,bash]
+[source,terminal]
 ----
-$  oc create clusterresourcequota for-name \ <1>
+$ oc create clusterresourcequota for-name \ <1>
     --project-label-selector=name=frontend \ <2>
     --hard=pods=10 --hard=secrets=20
 ----
@@ -122,14 +122,14 @@ multi-project quota documents that are applied to his or her project. The
 project administrator can do this via the `*AppliedClusterResourceQuota*`
 resource.
 
-[source,bash]
+[source,terminal]
 ----
 $ oc describe AppliedClusterResourceQuota
 ----
 
 produces:
 
-[source,bash]
+[source,terminal]
 ----
 Name:   for-user
 Namespace:  <none>

--- a/admin_guide/node_problem_detector.adoc
+++ b/admin_guide/node_problem_detector.adoc
@@ -276,9 +276,9 @@ To configure the Node Problem Detector, add or remove problem conditions and eve
 
 . Edit the Node Problem Detector configuration map with a text editor.
 +
-[source,bash]
+[source,terminal]
 ----
-oc edit configmap -n openshift-node-problem-detector node-problem-detector
+$ oc edit configmap -n openshift-node-problem-detector node-problem-detector
 ----
 
 . Remove, add, or edit any node conditions or events as needed.

--- a/admin_guide/node_problem_detector.adoc
+++ b/admin_guide/node_problem_detector.adoc
@@ -73,6 +73,7 @@ The Node Problem Detector can detect:
 The following examples show output from the Node Problem Detector watching for kernel deadlock node condition on a specific node. The command
 uses `oc get node` to watch a specific node filtering for a `KernelDeadlock` entry in a log.
 
+[source,terminal]
 ----
 # oc get node <node> -o yaml | grep -B5 KernelDeadlock
 ----
@@ -98,6 +99,7 @@ The following command uses `oc get event` against the *default* project watching
 events listed in the `kernel-monitor.json` section of the
 xref:admin-guide-node-problem-detector-sample[Node Problem Detector configuration map].
 
+[source,terminal]
 ----
 # oc get event -n default --field-selector=source=kernel-monitor --watch
 ----
@@ -158,6 +160,7 @@ You must manually change the parameter to `true` when installing the Node Proble
 If xref:admin-guide-node-problem-detector-verify[the Node Problem Detector is not installed],
 change to the playbook directory and run the *openshift-node-problem-detector/config.yml* playbook to install Node Problem Detector:
 
+[source,terminal]
 ----
 $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
@@ -302,7 +305,7 @@ For example:
 
 . Restart running pods to apply the changes. To restart pods, you can delete all existing pods:
 +
-[source,bash]
+[source,terminal]
 ----
 # oc delete pods -n openshift-node-problem-detector -l name=node-problem-detector
 ----
@@ -336,7 +339,7 @@ To verify that the Node Problem Detector is active:
 
 * Run the following command to get the name of the Problem Node Detector pod:
 +
-[source,bash]
+[source,terminal]
 ----
 # oc get pods -n openshift-node-problem-detector
 
@@ -348,14 +351,14 @@ node-problem-detector-nggjv   1/1       Running   0          1h
 
 * Run the following command to view log information on the Problem Node Detector pod:
 +
-[source,bash]
+[source,terminal]
 ----
 # oc logs -n openshift-node-problem-detector <pod_name>
 ----
 +
 The output should be similar to the following:
 +
-[source,bash]
+[source,terminal]
 ----
 # oc logs -n openshift-node-problem-detector node-problem-detector-c6kng
 I0416 23:22:00.641354       1 log_monitor.go:63] Finish parsing log monitor config file: {WatcherConfig:{Plugin:journald PluginConfig:map[source:kernel] LogPath:/host/log/journal Lookback:5m} BufferSize:10 Source:kernel-monitor DefaultConditions:[{Type:KernelDeadlock Status:false Transition:0001-01-01 00:00:00 +0000 UTC Reason:KernelHasNoDeadlock Message:kernel has no deadlock}]
@@ -363,14 +366,14 @@ I0416 23:22:00.641354       1 log_monitor.go:63] Finish parsing log monitor conf
 
 * Test the Node Problem Detector by simulating an event on the node:
 +
-[source,bash]
+[source,terminal]
 ----
 # echo "kernel: divide error: 0000 [#0] SMP." >> /dev/kmsg
 ----
 
 * Test the Node Problem Detector by simulating a condition on the node:
 +
-[source,bash]
+[source,terminal]
 ----
 # echo "kernel: task docker:7 blocked for more than 300 seconds." >> /dev/kmsg
 ----
@@ -390,7 +393,7 @@ openshift_node_problem_detector_state=absent
 
 . Change to the playbook directory and run the *_config.yml_* Ansible playbook:
 +
-[source,bash]
+[source,terminal]
 ----
 $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
@@ -402,7 +405,7 @@ $ ansible-playbook playbooks/openshift-node-problem-detector/config.yml
 
 To run Node Problem Detector as a standalone system daemon, execute the following command, pointing to the IP address of your access API server:
 
-[source,bash]
+[source,terminal]
 ----
 # oc node-problem-detector --apiserver-override=http://APISERVER_IP:APISERVER_INSECURE_PORT?inClusterConfig=false
 ----

--- a/admin_guide/out_of_resource_handling.adoc
+++ b/admin_guide/out_of_resource_handling.adoc
@@ -75,6 +75,7 @@ in the case of Docker, which storage driver you are using.
 +
 You can limit the read/write layer for the container by setting the `--storage-opt dm.basesize` flag in the Docker daemon. 
 +
+[source,terminal]
 ----
 $ sudo dockerd --storage-opt dm.basesize=50G
 ----
@@ -143,11 +144,13 @@ kubeletArguments:
 Restart the {product-title} service for the changes to take effect:
 
 ifdef::openshift-enterprise[]
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node
 ----
 endif::[]
 ifdef::openshift-origin[]
+[source,terminal]
 ----
 # systemctl restart origin-node
 ----
@@ -383,11 +386,13 @@ For more information, see xref:../admin_guide/allocating_node_resources.adoc#all
 Restart the {product-title} service for the changes to take effect:
 
 ifdef::openshift-enterprise[]
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node
 ----
 endif::[]
 ifdef::openshift-origin[]
+[source,terminal]
 ----
 # systemctl restart origin-node
 ----
@@ -422,11 +427,13 @@ The default choice is intended to allow the system to stabilize, and to prevent 
 . Restart the {product-title} services for the changes to take effect:
 +
 ifdef::openshift-enterprise[]
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node
 ----
 endif::[]
 ifdef::openshift-origin[]
+[source,terminal]
 ----
 # systemctl restart origin-node
 ----

--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -61,6 +61,7 @@ file buffers.
 The `buffer_type` and `buffer_path` are configured in the Fluentd configuration files as
 follows:
 
+[source,terminal]
 ----
 $ egrep "buffer_type|buffer_path" *.conf
 output-es-config.conf:
@@ -425,6 +426,7 @@ unless it runs out of physical memory.
 To ensure this behavior, the node instructs the kernel to always overcommit
 memory:
 
+[source,terminal]
 ----
 $ sysctl -w vm.overcommit_memory=1
 ----
@@ -432,6 +434,7 @@ $ sysctl -w vm.overcommit_memory=1
 The node also instructs the kernel not to panic when it runs out of memory.
 Instead, the kernel OOM killer should kill processes based on priority:
 
+[source,terminal]
 ----
 $ sysctl -w vm.panic_on_oom=0
 ----
@@ -457,6 +460,7 @@ oversubscribed.
 
 To disable swap:
 
+[source,terminal]
 ----
 $ swapoff -a
 ----

--- a/admin_guide/pruning_resources.adoc
+++ b/admin_guide/pruning_resources.adoc
@@ -27,6 +27,7 @@ still taking up disk space.
 == Basic prune operations
 The CLI groups prune operations under a common parent command.
 
+[source,terminal]
 ----
 $ oc adm prune <object_type> <options>
 ----
@@ -44,6 +45,7 @@ This specifies:
 To prune groups records from an external provider, administrators can
 run the following command:
 
+[source,terminal]
 ----
 $ oc adm prune groups --sync-config=path/to/sync/config [<options>]
 ----
@@ -75,12 +77,14 @@ for the structure of this file.
 
 To see the groups that the prune command deletes:
 
+[source,terminal]
 ----
 $ oc adm prune groups --sync-config=ldap-sync-config.yaml
 ----
 
 To perform the prune operation:
 
+[source,terminal]
 ----
 $ oc adm prune groups --sync-config=ldap-sync-config.yaml --confirm
 ----
@@ -92,6 +96,7 @@ $ oc adm prune groups --sync-config=ldap-sync-config.yaml --confirm
 In order to prune deployments that are no longer required by the system due to
 age and status, administrators may run the following command:
 
+[source,terminal]
 ----
 $ oc adm prune deployments [<options>]
 ----
@@ -126,6 +131,7 @@ and hours (`h`).
 
 To see what a pruning operation would delete:
 
+[source,terminal]
 ----
 $ oc adm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m
@@ -133,6 +139,7 @@ $ oc adm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
 
 To actually perform the prune operation:
 
+[source,terminal]
 ----
 $ oc adm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m --confirm
@@ -145,6 +152,7 @@ $ oc adm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
 In order to prune builds that are no longer required by the system due to age
 and status, administrators may run the following command:
 
+[source,terminal]
 ----
 $ oc adm prune builds [<options>]
 ----
@@ -177,6 +185,7 @@ current time. (default `60m`)
 
 To see what a pruning operation would delete:
 
+[source,terminal]
 ----
 $ oc adm prune builds --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m
@@ -184,6 +193,7 @@ $ oc adm prune builds --orphans --keep-complete=5 --keep-failed=1 \
 
 To actually perform the prune operation:
 
+[source,terminal]
 ----
 $ oc adm prune builds --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m --confirm
@@ -202,6 +212,7 @@ by modifying their build configuration.
 In order to prune images that are no longer required by the system due to age,
 status, or exceed limits, administrators may run the following command:
 
+[source,terminal]
 ----
 $ oc adm prune images [<options>]
 ----
@@ -241,6 +252,7 @@ contain pruned layers will be broken, because the pruned layers that have
 metadata in the cache will not be pushed. Therefore it is necessary to clear the
 cache after pruning. This can be accomplished by redeploying the registry:
 
+[source,terminal]
 ----
 $ oc rollout latest dc/docker-registry
 ----
@@ -382,12 +394,14 @@ To see what a pruning operation would delete:
 . Keeping up to three tag revisions, and keeping resources (images, image
 streams and pods) younger than sixty minutes:
 +
+[source,terminal]
 ----
 $ oc adm prune images --keep-tag-revisions=3 --keep-younger-than=60m
 ----
 
 . Pruning every image that exceeds defined limits:
 +
+[source,terminal]
 ----
 $ oc adm prune images --prune-over-size-limit
 ----
@@ -395,6 +409,7 @@ $ oc adm prune images --prune-over-size-limit
 To actually perform the prune operation for the previously mentioned options
 accordingly:
 
+[source,terminal]
 ----
 $ oc adm prune images --keep-tag-revisions=3 --keep-younger-than=60m --confirm
 
@@ -449,6 +464,7 @@ and obsolete image named `sha:abz`. By running the following command in
 namespace `N`, where the image is tagged, you will see the image is tagged three
 times in a single image stream named `myapp`:
 
+[source,terminal]
 ----
 $ image_name="sha:abz"
 $ oc get is -n openshift -o go-template='{{range $isi, $is := .items}}{{range $ti, $tag := $is.status.tags}}{{range $ii, $item := $tag.items}}{{if eq $item.image "'$image_name'"}}{{$is.metadata.name}}:{{$tag.tag}} at position {{$ii}} out of {{len $tag.items}}
@@ -606,6 +622,7 @@ To switch the registry to read-only mode:
 
 .. Set the following environment variable:
 +
+[source,terminal]
 ----
 $ oc set env -n default \
     dc/docker-registry \
@@ -617,6 +634,7 @@ completes; wait for the redeployment to complete before continuing. However, if
 you have disabled these triggers, you must manually redeploy the registry so
 that the new environment variables are picked up:
 +
+[source,terminal]
 ----
 $ oc rollout -n default \
     latest dc/docker-registry
@@ -628,6 +646,7 @@ resources.
 
 .. Get the service account name:
 +
+[source,terminal]
 ----
 $ service_account=$(oc get -n default \
     -o jsonpath=$'system:serviceaccount:{.metadata.namespace}:{.spec.template.spec.serviceAccountName}\n' \
@@ -636,6 +655,7 @@ $ service_account=$(oc get -n default \
 
 .. Add the *system:image-pruner* cluster role to the service account:
 +
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user \
     system:image-pruner \
@@ -646,6 +666,7 @@ $ oc adm policy add-cluster-role-to-user \
 would be removed, run the hard pruner in dry-run mode. No changes are actually
 made:
 +
+[source,terminal]
 ----
 $ oc -n default \
     exec -i -t "$(oc -n default get pods -l deploymentconfig=docker-registry \
@@ -656,6 +677,7 @@ $ oc -n default \
 Alternatively, to get the exact paths for the prune candidates, increase the
 logging level:
 +
+[source,terminal]
 ----
 $ oc -n default \
     exec "$(oc -n default get pods -l deploymentconfig=docker-registry \
@@ -665,6 +687,7 @@ $ oc -n default \
 ----
 +
 .Truncated sample output
+[source,terminal]
 ----
 $ oc exec docker-registry-3-vhndw \
     -- /bin/sh -c 'REGISTRY_LOG_LEVEL=info /usr/bin/dockerregistry -prune=check'
@@ -685,6 +708,7 @@ Use -prune=delete to actually delete the data
 . *Run the hard prune*: Execute the following command inside one
 running instance of *docker-registry* pod to run the hard prune:
 +
+[source,terminal]
 ----
 $ oc -n default \
     exec -i -t "$(oc -n default get pods -l deploymentconfig=docker-registry -o jsonpath=$'{.items[0].metadata.name}\n')" \
@@ -692,6 +716,7 @@ $ oc -n default \
 ----
 +
 .Sample output
+[source,terminal]
 ----
 $ oc exec docker-registry-3-vhndw \
     -- /usr/bin/dockerregistry -prune=delete
@@ -703,6 +728,7 @@ Freed up 2.835 GiB of disk space
 . *Switch the registry back to read-write mode*: After the prune is
 finished, the registry can be switched back to read-write mode by executing:
 +
+[source,terminal]
 ----
 $ oc set env -n default dc/docker-registry REGISTRY_STORAGE_MAINTENANCE_READONLY-
 ----

--- a/admin_guide/quota.adoc
+++ b/admin_guide/quota.adoc
@@ -152,6 +152,7 @@ exceed this value.
 You can configure an object count quota for these standard namespaced resource types using the `count/<resource>.<group>` syntax
 while xref:create-a-quota[creating a quota].
 
+[source,terminal]
 ----
 $ oc create quota <name> --hard=count/<resource>.<group>=<quota> <1>
 ----
@@ -172,6 +173,7 @@ the GPU resource `nvidia.com/gpu`.
 
 . Determine how many GPUs are available on a node in your cluster. For example:
 +
+[source,terminal]
 ----
 # oc describe node ip-172-31-27-209.us-west-2.compute.internal | egrep 'Capacity|Allocatable|gpu'
                     openshift.com/gpu-accelerator=true
@@ -186,6 +188,7 @@ In this example, 2 GPUs are available.
 
 . Set a quota in the namespace `nvidia`. In this example, the quota is `1`:
 +
+[source,terminal]
 ----
 # cat gpu-quota.yaml
 apiVersion: v1
@@ -200,6 +203,7 @@ spec:
 
 . Create the quota:
 +
+[source,terminal]
 ----
 # oc create -f gpu-quota.yaml
 resourcequota/gpu-quota created
@@ -207,6 +211,7 @@ resourcequota/gpu-quota created
 
 . Verify that the namespace has the correct quota set:
 +
+[source,terminal]
 ----
 # oc describe quota gpu-quota -n nvidia
 Name:                    gpu-quota
@@ -218,6 +223,7 @@ requests.nvidia.com/gpu  0     1
 
 . Run a pod that asks for a single GPU:
 +
+[source,terminal]
 ----
 # oc create pod gpu-pod.yaml
 ----
@@ -251,6 +257,7 @@ spec:
 
 . Verify that the pod is running:
 +
+[source,terminal]
 ----
 # oc get pods
 NAME              READY     STATUS      RESTARTS   AGE
@@ -259,6 +266,7 @@ gpu-pod-s46h7     1/1       Running     0          1m
 
 . Verify that the quota `Used` counter is correct:
 +
+[source,terminal]
 ----
 # oc describe quota gpu-quota -n nvidia
 Name:                    gpu-quota
@@ -271,6 +279,7 @@ requests.nvidia.com/gpu  1     1
 . Attempt to create a second GPU pod in the `nvidia` namespace. This is
 technically available on the node because it has 2 GPUs:
 +
+[source,terminal]
 ----
 # oc create -f gpu-pod.yaml
 Error from server (Forbidden): error when creating "gpu-pod.yaml": pods "gpu-pod-f7z2w" is forbidden: exceeded quota: gpu-quota, requested: requests.nvidia.com/gpu=1, used: requests.nvidia.com/gpu=1, limited: requests.nvidia.com/gpu=1
@@ -580,12 +589,14 @@ such as the examples in
 xref:../admin_guide/quota.adoc#sample-resource-quota-definitions[Sample Resource
 Quota Definitions]. Then, create using that file to apply it to a project:
 
+[source,terminal]
 ----
 $ oc create -f <resource_quota_definition> [-n <project_name>]
 ----
 
 For example:
 
+[source,terminal]
 ----
 $ oc create -f core-object-counts.yaml -n demoproject
 ----
@@ -601,12 +612,14 @@ These types of quotas are useful to protect against exhaustion of storage resour
 
 To configure an object count quota for a resource, run the following command:
 
+[source,terminal]
 ----
 $ oc create quota <name> --hard=count/<resource>.<group>=<quota>,count/<resource>.<group>=<quota>
 ----
 
 For example:
 
+[source,terminal]
 ----
 $ oc create quota test --hard=count/deployments.extensions=2,count/replicasets.extensions=4,count/pods=3,count/secrets=4
 resourcequota "test" created
@@ -637,6 +650,7 @@ You can also use the CLI to view quota details:
 called *demoproject*:
 +
 
+[source,terminal]
 ----
 $ oc get quota -n demoproject
 NAME                AGE
@@ -650,6 +664,7 @@ core-object-counts  29m
 *core-object-counts* quota:
 +
 
+[source,terminal]
 ----
 $ oc describe quota core-object-counts -n demoproject
 Name:			core-object-counts
@@ -694,6 +709,7 @@ kubernetesMasterConfig:
 
 After making any changes, restart the master services to apply them.
 
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers

--- a/admin_guide/router.adoc
+++ b/admin_guide/router.adoc
@@ -39,6 +39,7 @@ specify *0* as the stats port number.
 
 ifdef::openshift-enterprise[]
 ====
+[source,terminal]
 ----
 $ oc adm router hap --service-account=router --stats-port=0
 ----
@@ -46,6 +47,7 @@ $ oc adm router hap --service-account=router --stats-port=0
 endif::[]
 ifdef::openshift-origin[]
 ====
+[source,terminal]
 ----
 $ oc adm router hap --service-account=router --stats-port=0
 ----
@@ -59,6 +61,7 @@ Note: HAProxy will still collect and store statistics, it would just _not_
       the HAProxy Router container.
 
 ====
+[source,terminal]
 ----
 $ cmd="echo 'show stat' | socat - UNIX-CONNECT:/var/lib/haproxy/run/haproxy.sock"
 $ routerPod=$(oc get pods --selector="router=router"  \
@@ -104,6 +107,7 @@ any log format string that HAProxy accepts.
 
 To set a running router pod to send messages to a syslog server:
 ====
+[source,terminal]
 ----
 $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=<dest_ip:dest_port>  ROUTER_LOG_LEVEL=<level>
 ----
@@ -112,6 +116,7 @@ $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=<dest_ip:dest_port>  ROUTER_LOG_LEV
 For example, the following sets HAProxy to send logs to 127.0.0.1 with the
 default port *514* and changes the log level to *debug*.
 
+[source,terminal]
 ----
 $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 ----

--- a/admin_guide/scheduling/custom_scheduler.adoc
+++ b/admin_guide/scheduling/custom_scheduler.adoc
@@ -122,24 +122,28 @@ spec:
 
 . Run the following command to create the pod:
 +
+[source,terminal]
 ----
 $ oc create -f <file-name>.yaml
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc create -f custom-scheduler-example.yaml
 ----
 
 . Run the following command to check that the pod was created:
 +
+[source,terminal]
 ----
 $ oc get pod <file-name>
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc get pod custom-scheduler-example
 
@@ -149,12 +153,14 @@ custom-scheduler-example   1/1       Running   0          4m
 
 . Run the following command to check that the custom scheduler scheduled the pod:
 +
+[source,terminal]
 ----
 $ oc describe pod <pod-name>
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc describe pod custom-scheduler-example
 ----

--- a/admin_guide/scheduling/descheduler.adoc
+++ b/admin_guide/scheduling/descheduler.adoc
@@ -105,18 +105,21 @@ rules:
 
 . Create the xref:../../admin_guide/service_accounts.adoc#admin-guide-service-accounts[service account] which will be used to run the job:
 +
+[source,terminal]
 ----
 # oc create sa <file-name>.yaml -n kube-system
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 # oc create sa descheduler-sa.yaml -n kube-system
 ----
 
 . Bind the cluster role to the service account:
 +
+[source,terminal]
 ----
 # oc create clusterrolebinding descheduler-cluster-role-binding \
     --clusterrole=<cluster-role-name> \
@@ -125,6 +128,7 @@ For example:
 +
 For example:
 +
+[source,terminal]
 ----
 # oc create clusterrolebinding descheduler-cluster-role-binding \
     --clusterrole=descheduler-cluster-role \
@@ -253,6 +257,7 @@ strategies:
 
 Create a xref:../../dev_guide/configmaps.adoc#dev-guide-configmaps[configuration map] for the descheduler policy file in the `kube-system` project, so that it can be referenced by the descheduler job.
 
+[source,terminal]
 ----
 # oc create configmap descheduler-policy-configmap \
      -n kube-system --from-file=<path-to-policy-dir/policy.yaml> <1>
@@ -311,12 +316,14 @@ The policy file is mounted as a volume from the configuration map.
 
 To run the descheduler as a job in a pod:
 
+[source,terminal]
 ----
 # oc create -f <file-name>.yaml
 ----
 
 For example:
 
+[source,terminal]
 ----
 # oc create -f descheduler-job.yaml
 ----

--- a/admin_guide/scheduling/node_affinity.adoc
+++ b/admin_guide/scheduling/node_affinity.adoc
@@ -122,6 +122,7 @@ The following steps demonstrate a simple configuration that creates a node and a
 
 . Add a label to a node by editing the node configuration or by using the `oc label node` command:
 +
+[source,terminal]
 ----
 $ oc label node node1 e2e-az-name=e2e-az1
 ----
@@ -153,6 +154,7 @@ spec:
 
 . Create the pod:
 +
+[source,terminal]
 ----
 $ oc create -f e2e-az2.yaml
 ----
@@ -166,6 +168,7 @@ The following steps demonstrate a simple configuration that creates a node and a
 
 . Add a label to a node by editing the node configuration or by executing the `oc label node` command:
 +
+[source,terminal]
 ----
 $ oc label node node1 e2e-az-name=e2e-az3
 ----
@@ -197,6 +200,7 @@ Do not manually edit the `node-config.yaml` file.
 
 . Create the pod.
 +
+[source,terminal]
 ----
 $ oc create -f e2e-az3.yaml
 ----
@@ -213,12 +217,14 @@ The following example demonstrates node affinity for a node and pod with matchin
 
 * The *Node1* node has the label `zone:us`:
 +
+[source,terminal]
 ----
 $ oc label node node1 zone=us
 ----
 
 *  The pod *pod-s1* has the `zone` and `us` key/value pair under a required node affinity rule:
 +
+[source,terminal]
 ----
 $ cat pod-s1.yaml
 apiVersion: v1
@@ -242,6 +248,7 @@ spec:
 
 * Create the pod using the standard command:
 +
+[source,terminal]
 ----
 $ oc create -f pod-s1.yaml
 pod "pod-s1" created
@@ -262,12 +269,14 @@ The following example demonstrates node affinity for a node and pod without matc
 
 * The *Node1* node has the label `zone:emea`:
 +
+[source,terminal]
 ----
 $ oc label node node1 zone=emea
 ----
 
 *  The pod *pod-s1* has the `zone` and `us` key/value pair under a required node affinity rule:
 +
+[source,terminal]
 ----
 $ cat pod-s1.yaml
 apiVersion: v1

--- a/admin_guide/scheduling/node_affinity.adoc
+++ b/admin_guide/scheduling/node_affinity.adoc
@@ -256,8 +256,9 @@ pod "pod-s1" created
 
 * The pod *pod-s1* can be scheduled on *Node1*:
 +
+[source,terminal]
 ----
- oc get pod -o wide
+$ oc get pod -o wide
 NAME     READY     STATUS       RESTARTS   AGE      IP      NODE
 pod-s1   1/1       Running      0          4m       IP1     node1
 ----
@@ -300,9 +301,11 @@ spec:
 
 * The pod *pod-s1* cannot be scheduled on *Node1*:
 +
+[source,terminal]
 ----
-oc describe pod pod-s1
-<---snip--->
+$ oc describe pod pod-s1
+
+...
 Events:
  FirstSeen LastSeen Count From              SubObjectPath  Type                Reason
  --------- -------- ----- ----              -------------  --------            ------

--- a/admin_guide/scheduling/pod_affinity.adoc
+++ b/admin_guide/scheduling/pod_affinity.adoc
@@ -280,9 +280,9 @@ The following example demonstrates pod anti-affinity for pods with matching labe
 
 * The pod *pod-s1* has the label `security:s1`.
 +
-[source,yaml]
+[source,terminal]
 ----
-cat pod-s1.yaml
+$ cat pod-s1.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -297,9 +297,9 @@ spec:
 
 * The pod *pod-s2* has the label selector `security:s1` under `podAntiAffinity`.
 +
-[source,yaml]
+[source,terminal]
 ----
-cat pod-s2.yaml
+$ cat pod-s2.yaml
 apiVersion: v1
 kind: Pod
 metadata:

--- a/admin_guide/scheduling/pod_affinity.adoc
+++ b/admin_guide/scheduling/pod_affinity.adoc
@@ -115,7 +115,7 @@ The following steps demonstrate a simple two-pod configuration that creates pod 
 
 . Create a pod with a specific label in the pod specification:
 +
-[source,yaml]
+[source,terminal]
 ----
 $ cat team4.yaml
 apiVersion: v1
@@ -155,6 +155,7 @@ spec:
 
 . Create the pod.
 +
+[source,terminal]
 ----
 $ oc create -f <pod-spec>.yaml
 ----
@@ -166,7 +167,7 @@ The following steps demonstrate a simple two-pod configuration that creates pod 
 
 . Create a pod with a specific label in the pod specification:
 +
-[source,yaml]
+[source,terminal]
 ----
 $ cat team4.yaml
 apiVersion: v1
@@ -212,6 +213,7 @@ spec:
 
 . Create the pod.
 +
+[source,terminal]
 ----
 $ oc create -f <pod-spec>.yaml
 ----
@@ -228,7 +230,7 @@ The following example demonstrates pod affinity for pods with matching labels an
 
 * The pod *team4* has the label `team:4`.
 +
-[source,yaml]
+[source,terminal]
 ----
 $ cat team4.yaml
 apiVersion: v1
@@ -245,7 +247,7 @@ spec:
 
 * The pod *team4a* has the label selector `team:4` under `podAffinity`.
 +
-[source,yaml]
+[source,terminal]
 ----
 $ cat pod-team4a.yaml
 apiVersion: v1
@@ -328,7 +330,7 @@ The following example demonstrates pod affinity for pods without matching labels
 
 * The pod *pod-s1* has the label `security:s1`.
 +
-[source,yaml]
+[source,terminal]
 ----
 $ cat pod-s1.yaml
 apiVersion: v1
@@ -345,7 +347,7 @@ spec:
 
 * The pod *pod-s2* has the label selector `security:s2`.
 +
-[source,yaml]
+[source,terminal]
 ----
 $ cat pod-s2.yaml
 apiVersion: v1
@@ -370,6 +372,7 @@ spec:
 
 * The pod *pod-s2* is not scheduled unless there is a node with a pod that has the `security:s2` label. If there is no other pod with that label, the new pod remains in a pending state:
 +
+[source,terminal]
 ----
 NAME      READY     STATUS    RESTARTS   AGE       IP        NODE
 pod-s2    0/1       Pending   0          32s       <none>

--- a/admin_guide/scheduling/pod_placement.adoc
+++ b/admin_guide/scheduling/pod_placement.adoc
@@ -65,6 +65,7 @@ admissionConfig:
 
 . Restart {product-title} for the changes to take effect.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -164,6 +165,7 @@ admissionConfig:
 
 . Restart {product-title} for the changes to take effect.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -226,6 +228,7 @@ If a project does not have node selectors specified, the pods associated with th
 
 . Restart {product-title} for the changes to take effect.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -292,6 +295,7 @@ status: {}
 
 . Create the pod in the project:
 +
+[source,terminal]
 ----
 # oc create -f pod.yaml --namespace=ns1
 ----

--- a/admin_guide/scheduling/scheduler.adoc
+++ b/admin_guide/scheduling/scheduler.adoc
@@ -231,6 +231,7 @@ you require.
 
 . Restart the {product-title} for the changes to take effect.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers

--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -97,6 +97,7 @@ For example:
 
 * The node has the following taints:
 +
+[source,terminal]
 ----
 $ oc adm taint nodes node1 key1=value1:NoSchedule
 $ oc adm taint nodes node1 key1=value1:NoExecute
@@ -127,12 +128,14 @@ one of the three that is not tolerated by the pod.
 
 You add a taint to a node using the `oc adm taint` command with the parameters described in the xref:taint-components-table[Taint and toleration components] table:
 
+[source,terminal]
 ----
 $ oc adm taint nodes <node-name> <key>=<value>:<effect>
 ----
 
 For example:
 
+[source,terminal]
 ----
 $ oc adm taint nodes node1 key1=value1:NoExecute
 ----
@@ -213,6 +216,7 @@ admissionConfig:
 
 . Restart OpenShift for the changes to take effect:
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -222,12 +226,14 @@ admissionConfig:
 +
 .. Create a pod:
 +
+[source,terminal]
 ----
 $ oc create -f </path/to/file>
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc create -f hello-pod.yaml
 pod "hello-pod" created
@@ -235,12 +241,14 @@ pod "hello-pod" created
 +
 .. Check the pod tolerations:
 +
+[source,terminal]
 ----
 $ oc describe pod <pod-name> |grep -i toleration
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc describe pod hello-pod |grep -i toleration
 Tolerations:    node.kubernetes.io/not-ready=:Exists:NoExecute for 300s
@@ -279,6 +287,7 @@ Taints: node.kubernetes.io/not-ready:NoExecute
 
 . Restart OpenShift for the changes to take effect:
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers
@@ -339,6 +348,7 @@ To specify dedicated nodes:
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc adm taint nodes node1 dedicated=groupName:NoSchedule
 ----
@@ -358,6 +368,7 @@ To configure a node so that users can use only that node:
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc adm taint nodes node1 dedicated=groupName:NoSchedule
 ----
@@ -378,6 +389,7 @@ To ensure pods are blocked from the specialized hardware:
 
 . Taint the nodes that have the specialized hardware using one of the following commands:
 +
+[source,terminal]
 ----
 $ oc adm taint nodes <node-name> disktype=ssd:NoSchedule
 $ oc adm taint nodes <node-name> disktype=ssd:PreferNoSchedule

--- a/admin_guide/scheduling/taints_tolerations.adoc
+++ b/admin_guide/scheduling/taints_tolerations.adoc
@@ -279,8 +279,9 @@ kubernetesMasterConfig:
 
 . Check that the taint is added to a node:
 +
+[source,terminal]
 ----
-oc describe node $node | grep -i taint
+$ oc describe node $node | grep -i taint
 
 Taints: node.kubernetes.io/not-ready:NoExecute
 ----

--- a/admin_guide/sdn_troubleshooting.adoc
+++ b/admin_guide/sdn_troubleshooting.adoc
@@ -264,6 +264,7 @@ to the node.
 . Make sure that all nodes have the expected IP addresses:
 +
 ====
+[source,terminal]
 ----
 # oc get hostsubnet
 NAME                   HOST                   HOST IP           SUBNET
@@ -281,6 +282,7 @@ use `oc edit hostsubnet` to correct the entries.
 endpoint IPs and node IPs:
 +
 ====
+[source,terminal]
 ----
 # oc get pods --selector=docker-registry \
     --template='{{range .items}}HostIP: {{.status.hostIP}}   PodIP: {{.status.podIP}}{{end}}{{"\n"}}'
@@ -305,6 +307,7 @@ local or virtual network.
 * Check the route the packet takes out of the box to the target address:
 +
 ====
+[source,terminal]
 ----
 # ip route get 192.168.122.202
   192.168.122.202 dev ens3  src 192.168.122.46
@@ -319,6 +322,7 @@ make sure that is the expected interface.
 An alternate result may be the following:
 +
 ====
+[source,terminal]
 ----
 # ip route get 192.168.122.202
   1.2.3.4 via 192.168.122.1 dev ens3  src 192.168.122.46
@@ -404,6 +408,7 @@ You must run the `ovs-vsctl` and `ovs-ofctl` commands on one of the OVS pods.
 
 To list the OVS pods, enter the following command:
 
+[source,terminal]
 ----
 $ oc get pod -n openshift-sdn -l app=ovs
 ----
@@ -411,6 +416,7 @@ $ oc get pod -n openshift-sdn -l app=ovs
 Check the Open vSwitch bridges on both sides.
 Replace `<ovs_pod_name>` with the name of one of the OVS pods.
 
+[source,terminal]
 ----
 $ oc exec -n openshift-sdn <ovs_pod_name> -- ovs-vsctl list-br
 br0
@@ -420,6 +426,7 @@ The previous command should return `br0`.
 
 You can list all of the ports that OVS knows about:
 
+[source,terminal]
 ----
 $ oc exec -n openshift-sdn <ovs_pod_name> -- ovs-ofctl -O OpenFlow13 dump-ports-desc br0
 OFPST_PORT_DESC reply (OF1.3) (xid=0x2):
@@ -447,6 +454,7 @@ be listed as ports.
 
 Next, list the flows that are configured on that bridge:
 
+[source,terminal]
 ----
 $ oc exec -n openshift-sdn <ovs_pod_name> --  ovs-ofctl -O OpenFlow13 dump-flows br0
 ----
@@ -496,6 +504,7 @@ eth0 network MTU in order to pass data to between node hosts.
 . Check the MTU of your network by running the `ip addr` command:
 +
 ====
+[source,terminal]
 ----
 # ip addr
 ---
@@ -515,6 +524,7 @@ The MTU of the above network is 1500.
 the `*mtu*` in the node configuration of the targeted node host:
 +
 ====
+[source,terminal]
 ----
 # $ oc describe configmaps node-config-infra
 ...
@@ -595,6 +605,7 @@ replaced with an `iptables`-only solution.
 As a cluster administrator, run the diagnostics tool to diagnose common network
 issues:
 
+[source,terminal]
 ----
 # oc adm diagnostics NetworkCheck
 ----
@@ -615,6 +626,7 @@ useful debugging information. However, this script is unsupported.
 
 By default, `oc adm diagnostics NetworkCheck` logs errors into *_/tmp/openshift/_*. This can be configured with the `--network-logdir` option:
 
+[source,terminal]
 ----
 # oc adm diagnostics NetworkCheck --network-logdir=<path/to/directory>
 ----
@@ -631,6 +643,7 @@ By default, `oc adm diagnostics NetworkCheck` logs errors into *_/tmp/openshift/
 
 When a pod fails to deploy, check its docker log for a TLS handshake timeout:
 
+[source,terminal]
 ----
 $ docker log <container_id>
 ...

--- a/admin_guide/seccomp.adoc
+++ b/admin_guide/seccomp.adoc
@@ -45,6 +45,7 @@ design document].
 Seccomp is a feature of the Linux kernel. To ensure seccomp is enabled on your
 system, run:
 
+[source,terminal]
 ----
 $ cat /boot/config-`uname -r` | grep CONFIG_SECCOMP=
 CONFIG_SECCOMP=y
@@ -81,11 +82,13 @@ kubeletArguments:
 . Restart the node service to apply the changes:
 +
 ifdef::openshift-enterprise[]
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node
 ----
 endif::[]
 ifdef::openshift-origin[]
+[source,terminal]
 ----
 # systemctl restart origin-node
 ----
@@ -127,11 +130,13 @@ kubeletArguments:
 . Restart the node service to apply the changes:
 +
 ifdef::openshift-enterprise[]
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node
 ----
 endif::[]
 ifdef::openshift-origin[]
+[source,terminal]
 ----
 # systemctl restart origin-node
 ----

--- a/admin_guide/securing_builds.adoc
+++ b/admin_guide/securing_builds.adoc
@@ -78,7 +78,7 @@ privileges, remove the corresponding role from the *system:authenticated* group,
 
 . Apply the `openshift.io/reconcile-protect` annotation
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc edit clusterrolebinding system:build-strategy-docker-binding
 
@@ -106,7 +106,7 @@ userNames:
 
 . Remove the role:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc adm policy remove-cluster-role-from-group system:build-strategy-docker system:authenticated
 ----
@@ -120,6 +120,7 @@ endif::[]
 
 Ensure the build strategy subresources are also removed from these roles:
 
+[source,terminal]
 ----
 $ oc edit clusterrole admin
 $ oc edit clusterrole edit
@@ -156,6 +157,7 @@ To allow only a set of specific users to create builds with a particular strateg
 For example, to add the *system:build-strategy-docker* cluster role to the user *devuser*:
 +
 ====
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user system:build-strategy-docker devuser
 ----
@@ -182,6 +184,7 @@ strategy:
 For example, to add the *system:build-strategy-docker* role within the project *devproject* to the user *devuser*:
 +
 ====
+[source,terminal]
 ----
 $ oc adm policy add-role-to-user system:build-strategy-docker devuser -n devproject
 ----

--- a/admin_guide/service_accounts.adoc
+++ b/admin_guide/service_accounts.adoc
@@ -41,6 +41,7 @@ system:serviceaccount:<project>:<name>
 For example, to add the *view* role to the *robot* service account in the
 *top-secret* project:
 
+[source,terminal]
 ----
 $ oc policy add-role-to-user view system:serviceaccount:top-secret:robot
 ----
@@ -70,6 +71,7 @@ specified project.
 For example, to allow all service accounts in all projects to view resources in
 the *top-secret* project:
 
+[source,terminal]
 ----
 $ oc policy add-role-to-group view system:serviceaccounts -n top-secret
 ----
@@ -77,6 +79,7 @@ $ oc policy add-role-to-group view system:serviceaccounts -n top-secret
 To allow all service accounts in the *managers* project to edit resources in the
 *top-secret* project:
 
+[source,terminal]
 ----
 $ oc policy add-role-to-group edit system:serviceaccounts:managers -n top-secret
 ----
@@ -124,6 +127,7 @@ object type or use the web console.
 
 To get a list of existing service accounts in the current project:
 
+[source,terminal]
 ----
 $ oc get sa
 NAME       SECRETS   AGE
@@ -134,6 +138,7 @@ deployer   2         2d
 
 To create a new service account:
 
+[source,terminal]
 ----
 $ oc create sa robot
 serviceaccount "robot" created
@@ -159,6 +164,7 @@ endif::[]
 
 These can be seen by describing the service account:
 
+[source,terminal]
 ----
 $ oc describe sa robot
 Name:		robot

--- a/admin_guide/sysctls.adoc
+++ b/admin_guide/sysctls.adoc
@@ -35,6 +35,7 @@ process file system. The parameters cover various subsystems, such as:
 More subsystems are described in
 link:https://www.kernel.org/doc/Documentation/sysctl/README[Kernel documentation]. To get a list of all parameters, you can run:
 
+[source,terminal]
 ----
 $ sudo sysctl -a
 ----
@@ -60,6 +61,7 @@ version and distributor.
 To check which *_net.*_* sysctls are namespaced on your system, run the
 following command:
 
+[source,terminal]
 ----
 $ podman run --rm -ti docker.io/fedora \
     /bin/sh -c "dnf install -y findutils && find /proc/sys/ \
@@ -127,10 +129,11 @@ containers, resource shortage, or complete breakage of a node.
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc edit cm node-config-compute -n openshift-node
 
-....
+...
     kubeletArguments:
       allowed-unsafe-sysctls: <1>
       - "net.ipv4.tcp_keepalive_time"
@@ -142,7 +145,7 @@ $ oc edit cm node-config-compute -n openshift-node
 . Create a new SCC that uses the contents of the *restricted* SCC and add the unsafe sysctls:
 +
 ----
-....
+...
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
@@ -155,16 +158,17 @@ allowedUnsafeSysctls: <1>
 - net.ipv4.tcp_keepalive_time
 - net.ipv4.tcp_keepalive_intvl
 - net.ipv4.tcp_keepalive_probes
-....
+...
 metadata:
   name: restricted-sysctls <2>
-....
+...
 ---- 
 <1> Add the unsafe sysctls you want to use.
 <2> Specify a new name for the SCC.
 
 . Grant the new SCC access to your pod ServiceAccount:
 +
+[source,terminal]
 ----
 $ oc adm policy add-scc-to-user restricted-sysctls -z default -n your_project_name
 ----
@@ -174,12 +178,12 @@ $ oc adm policy add-scc-to-user restricted-sysctls -z default -n your_project_na
 ----
 kind: DeploymentConfig
 
-....
+...
   template:
-    ....
+    ...
     spec:
       containers:
-      ....
+      ...
       securityContext:
         sysctls:
         - name: net.ipv4.tcp_keepalive_time
@@ -193,11 +197,13 @@ kind: DeploymentConfig
 . Restart the node service to apply the changes:
 +
 ifdef::openshift-enterprise[]
+[source,terminal]
 ----
 # systemctl restart atomic-openshift-node
 ----
 endif::[]
 ifdef::openshift-origin[]
+[source,terminal]
 ----
 # systemctl restart origin-node
 ----

--- a/admin_guide/tcp_ingress_external_ports.adoc
+++ b/admin_guide/tcp_ingress_external_ports.adoc
@@ -135,13 +135,13 @@ spec:
 
 . Create a LoadBalancer service on your pod:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc create -f loadbalancer.yaml
 ----
 . Check the service for an external IP. For example, for a service named `myservice`:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get svc myservice
 ----
@@ -149,7 +149,7 @@ $ oc get svc myservice
 When your LoadBalancer-type service has an external IP assigned, the output
 displays the IP:
 +
-[source,bash]
+[source,terminal]
 ----
 NAME         CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
 myservice    172.30.74.106   172.29.0.1    3306/TCP    30s
@@ -161,6 +161,7 @@ myservice    172.30.74.106   172.29.0.1    3306/TCP    30s
 Add a static route directing traffic for the ingress CIDR to a node in the
 cluster. For example:
 
+[source,terminal]
 ----
 # route add -net 172.29.0.0/16 gw 10.66.140.17 eth0
 ----
@@ -182,6 +183,7 @@ xref:../admin_guide/tcp_ingress_external_ports.adoc#unique-external-ips-ingress-
 file. When *_master-config.yaml_* changes, the master services must be restarted.
 endif::[]
 
+[source,terminal]
 ----
 # master-restart api
 # master-restart controllers

--- a/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-LC-and-ASG-cluster-auto-scaler.adoc
@@ -20,7 +20,7 @@ the existing cluster when it starts.
 
 . Create the *_bootstrap.kubeconfig_* file by generating it from a master node:
 +
-[source,bash]
+[source,terminal]
 ----
 $ ssh master "sudo oc serviceaccounts create-kubeconfig -n openshift-infra node-bootstrapper" > ~/bootstrap.kubeconfig
 ----
@@ -28,7 +28,7 @@ $ ssh master "sudo oc serviceaccounts create-kubeconfig -n openshift-infra node-
 . Create the *_user-data.txt_* cloud-init file from the *_bootstrap.kubeconfig_*
 file:
 +
-[source,bash]
+[source,terminal]
 ----
 $ cat <<EOF > user-data.txt
 #cloud-config
@@ -62,7 +62,7 @@ EOF
 . Upload a launch configuration template to an AWS S3 bucket.
 . Create the launch configuration by using the AWS CLI:
 +
-[source,bash]
+[source,terminal]
 ----
 $ aws autoscaling create-launch-configuration \
     --launch-configuration-name mycluster-LC \ <1>
@@ -85,7 +85,7 @@ NOTE: If your template is fewer than 16 KB before you encode it, you can provide
 
 . Create the Auto Scaling group by using the AWS CLI:
 +
-[source,bash]
+[source,terminal]
 ----
 $ aws autoscaling create-auto-scaling-group \
       --auto-scaling-group-name mycluster-ASG \ <1>

--- a/admin_guide/topics/creating-primed-images-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/creating-primed-images-cluster-auto-scaler.adoc
@@ -133,6 +133,7 @@ endif::[]
 
 . Run the *_build_ami.yml_* playbook to generate a primed image:
 +
+[source,terminal]
 ----
 # ansible-playbook -i </path/to/inventory/file> \
 ifdef::openshift-enterprise[]

--- a/admin_guide/topics/deploying-cluster-auto-scaler.adoc
+++ b/admin_guide/topics/deploying-cluster-auto-scaler.adoc
@@ -28,6 +28,7 @@ openshift_master_bootstrap_auto_approve=true
 
 .. To obtain the auto-scaler components, change to the playbook directory and run the playbook again:
 +
+[source,terminal]
 ----
 $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook -i </path/to/inventory/file> \
@@ -36,6 +37,7 @@ $ ansible-playbook -i </path/to/inventory/file> \
 
 .. Confirm that the `bootstrap-autoapprover` pod is running:
 +
+[source,terminal]
 ----
 $ oc get pods --all-namespaces | grep bootstrap-autoapprover
 NAMESPACE               NAME                                             READY     STATUS    RESTARTS   AGE
@@ -44,7 +46,7 @@ openshift-infra         bootstrap-autoapprover-0                         1/1    
 
 . Create a namespace for the auto-scaler:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc apply -f - <<EOF
 apiVersion: v1
@@ -58,7 +60,7 @@ EOF
 
 . Create a service account for the auto-scaler:
 +
-[source,shell]
+[source,terminal]
 ----
 $ oc apply -f - <<EOF
 apiVersion: v1
@@ -75,7 +77,7 @@ EOF
 . Create a cluster role to grant the required permissions to the service
 account:
 +
-[source,shell]
+[source,terminal]
 ----
 $ oc apply -n cluster-autoscaler -f - <<EOF
 apiVersion: v1
@@ -152,7 +154,7 @@ EOF
 
 . Create a role for the deployment auto-scaler:
 +
-[source,shell]
+[source,terminal]
 ----
 $ oc apply -n cluster-autoscaler -f - <<EOF
 apiVersion: v1
@@ -192,9 +194,9 @@ EOF
 
 . Create a *_creds_* file to store AWS credentials for the auto-scaler:
 +
-[source,shell]
+[source,terminal]
 ----
-cat <<EOF > creds
+$ cat <<EOF > creds
 [default]
 aws_access_key_id = your-aws-access-key-id
 aws_secret_access_key = your-aws-secret-access-key
@@ -205,7 +207,7 @@ The auto-scaler uses these credentials to launch new instances.
 
 . Create the a secret that contains the AWS credentials:
 +
-[source,shell]
+[source,terminal]
 ----
 $ oc create secret -n cluster-autoscaler generic autoscaler-credentials --from-file=creds
 ----
@@ -215,7 +217,7 @@ The auto-scaler uses this secret to launch instances within AWS.
 . Create and grant cluster-reader role to the `cluster-autoscaler` 
 service account that you created:
 +
-[source,shell]
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user cluster-autoscaler system:serviceaccount:cluster-autoscaler:cluster-autoscaler -n cluster-autoscaler
 
@@ -226,7 +228,7 @@ $ oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:cl
 
 . Deploy the cluster auto-scaler:
 +
-[source,shell]
+[source,terminal]
 ----
 $ oc apply -n cluster-autoscaler -f - <<EOF
 apiVersion: apps/v1

--- a/admin_guide/topics/pod-priority-disable.adoc
+++ b/admin_guide/topics/pod-priority-disable.adoc
@@ -30,6 +30,7 @@ disablePreemption=false
 
 . Restart the {product-title} master service and scheduler to apply the changes.
 +
+[source,terminal]
 ----
 # master-restart api
 # master-restart scheduler

--- a/admin_guide/topics/proc_adding-hosts.adoc
+++ b/admin_guide/topics/proc_adding-hosts.adoc
@@ -48,6 +48,7 @@ maximums] section for the recommended maximum number of nodes.
 . Ensure you have the latest playbooks by updating the *openshift-ansible*
 package:
 +
+[source,terminal]
 ----
 # yum update openshift-ansible
 ----
@@ -118,6 +119,7 @@ registry and router pods cannot be placed anywhere.
 playbook. If your inventory file is located somewhere other than the default of
 *_/etc/ansible/hosts_*, specify the location with the `-i` option:
 +
+[source,terminal]
 ----
 $ cd /usr/share/ansible/openshift-ansible
 $ ansible-playbook [-i /path/to/file] \
@@ -138,12 +140,14 @@ other than the default of *_/etc/ansible/hosts_*, specify the location with the
 `-i` option.
 ** For additional nodes:
 +
+[source,terminal]
 ----
 $ ansible-playbook [-i /path/to/file] \
     playbooks/openshift-node/scaleup.yml
 ----
 ** For additional masters:
 +
+[source,terminal]
 ----
 $ ansible-playbook [-i /path/to/file] \
     playbooks/openshift-master/scaleup.yml
@@ -151,6 +155,7 @@ $ ansible-playbook [-i /path/to/file] \
 +
 . Set the node label to `logging-infra-fluentd=true`, if you deployed the EFK stack in your cluster:
 +
+[source,terminal]
 ----
 # oc label node/new-node.example.com logging-infra-fluentd=true
 ----

--- a/admin_guide/topics/proc_etcd-quorum-single-node-v2-v3.adoc
+++ b/admin_guide/topics/proc_etcd-quorum-single-node-v2-v3.adoc
@@ -18,6 +18,7 @@ remaining etcd node a standalone etcd cluster.
 . On the etcd node that you did not remove from the cluster, stop all etcd services by 
 removing the etcd pod definition:
 +
+[source,terminal]
 ----
 # mkdir -p /etc/origin/node/pods-stopped
 # mv /etc/origin/node/pods/etcd.yaml /etc/origin/node/pods-stopped/
@@ -30,6 +31,7 @@ removing the etcd pod definition:
 These commands create a custom file for the etcd service, which adds the 
 `--force-new-cluster` option to the etcd start command:
 +
+[source,terminal]
 ----
 # mkdir -p /etc/systemd/system/etcd.service.d/
 # echo "[Service]" > /etc/systemd/system/etcd.service.d/temp.conf
@@ -45,6 +47,7 @@ These commands create a custom file for the etcd service, which adds the
 . List the etcd member and confirm that the member list contains only your single
 etcd host:
 +
+[source,terminal]
 ----
 # etcdctl member list
 165201190bf7f217: name=192.168.34.20 peerURLs=http://localhost:2380 clientURLs=https://master-0.example.com:2379 isLeader=true
@@ -54,6 +57,7 @@ etcd host:
 `peerURLs` parameter value to use the IP address where etcd listens for peer 
 communication:
 +
+[source,terminal]
 ----
 # etcdctl member update 165201190bf7f217 https://192.168.34.20:2380 <1>
 ----
@@ -64,6 +68,7 @@ address.
 
 . To verify, check that the IP is in the member list:
 +
+[source,terminal]
 ----
 $ etcdctl2 member list
 5ee217d17301: name=master-0.example.com peerURLs=https://*192.168.55.8*:2380 clientURLs=https://192.168.55.8:2379 isLeader=true

--- a/admin_guide/topics/proc_etcd-quorum-static-pod.adoc
+++ b/admin_guide/topics/proc_etcd-quorum-static-pod.adoc
@@ -23,6 +23,7 @@ mv /etc/origin/node/pods/etcd.yaml .
 
 . Temporarily force a new cluster on the etcd host:
 +
+[source,terminal]
 ----
 $ cp /etc/etcd/etcd.conf etcd.conf.bak
 $ echo "ETCD_FORCE_NEW_CLUSTER=true" >> /etc/etcd/etcd.conf
@@ -30,12 +31,14 @@ $ echo "ETCD_FORCE_NEW_CLUSTER=true" >> /etc/etcd/etcd.conf
 
 . Restart the etcd pod:
 +
+[source,terminal]
 ----
 $ mv etcd.yaml /etc/origin/node/pods/.
 ----
 
 . Stop the etcd pod and remove the `FORCE_NEW_CLUSTER` command:
 +
+[source,terminal]
 ----
 $ mv /etc/origin/node/pods/etcd.yaml .
 $ rm /etc/etcd/etcd.conf
@@ -44,6 +47,7 @@ $ mv etcd.conf.bak /etc/etcd/etcd.conf
 
 . Restart the etcd pod:
 +
+[source,terminal]
 ----
 $ mv etcd.yaml /etc/origin/node/pods/.
 ----

--- a/admin_guide/topics/proc_removing-failed-etcd-member.adoc
+++ b/admin_guide/topics/proc_removing-failed-etcd-member.adoc
@@ -16,6 +16,7 @@ Before you add a new etcd node, remove the failed one.
 
 . From an active etcd host, remove the failed etcd node:
 +
+[source,terminal]
 ----
 # etcdctl -C https://<surviving host IP>:2379 \
   --ca-file=/etc/etcd/ca.crt     \
@@ -31,6 +32,7 @@ Before you add a new etcd node, remove the failed one.
 . Stop the etcd service on the failed etcd member by
 removing the etcd pod definition:
 +
+[source,terminal]
 ----
 # mkdir -p /etc/origin/node/pods-stopped
 # mv /etc/origin/node/pods/* /etc/origin/node/pods-stopped/
@@ -43,6 +45,7 @@ removing the etcd pod definition:
 It is recommended to back up this directory to an off-cluster location before removing the contents. You can remove this backup after a successful restore.
 ====
 +
+[source,terminal]
 ----
 # rm -rf /var/lib/etcd/*
 ----

--- a/admin_guide/topics/testing-auto-scaler.adoc
+++ b/admin_guide/topics/testing-auto-scaler.adoc
@@ -54,7 +54,7 @@ cannot run all of the pods without first increasing the number of compute nodes.
 
 . Create a namespace for the deployment:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc apply -f - <<EOF
 apiVersion: v1
@@ -66,7 +66,7 @@ EOF
 
 . Deploy the configuration:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc apply -n autoscaler-demo -f scale-up.yaml
 ----
@@ -74,7 +74,7 @@ $ oc apply -n autoscaler-demo -f scale-up.yaml
 . View the pods in your namespace:
 .. View the running pods in your namespace:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get pods -n autoscaler-demo | grep Running
 cluster-autoscaler-5485644d46-ggvn5   1/1       Running   0          1d
@@ -90,7 +90,7 @@ scale-up-79684ff956-zwdpr             1/1       Running   0          31s
 ----
 .. View the pending pods in your namespace:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get pods -n autoscaler-demo | grep Pending
 scale-up-79684ff956-5jdnj             0/1       Pending   0          40s
@@ -112,7 +112,7 @@ can several minutes for the nodes have a `Ready` state in the cluster.
 
 . After several minutes, check the list of nodes to see if new nodes are ready:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get nodes
 NAME                            STATUS    ROLES     AGE       VERSION
@@ -126,7 +126,7 @@ ip-172-31-63-234.ec2.internal   Ready     master    1d        v1.11.0+d4cacc0
 
 . When more nodes are ready, view the running pods in your namespace again:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get pods -n autoscaler-demo
 NAME                                  READY     STATUS    RESTARTS   AGE


### PR DESCRIPTION
@codyhoag fyi this is an initial pass on `admin_guide/`, but doesn't yet touch `include` files which in 3.11 can be scattered anywhere.

TODO
- Split commands and output
- Cleanup include files