### PR TITLE
Remove instruction to create empty config map for monitoring operator

### DIFF
--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -21,11 +21,16 @@ To configure the Prometheus Cluster Monitoring stack, you must create the cluste
 $ oc -n openshift-monitoring get configmap cluster-monitoring-config
 ----
 
-. If it does not exist, create it:
-+
-[source,terminal]
+. If it does not exist, create one by applying the following manifest:
+[source,yaml]
 ----
-$ oc -n openshift-monitoring create configmap cluster-monitoring-config
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
 ----
 
 . Start editing the `cluster-monitoring-config` ConfigMap:


### PR DESCRIPTION

Since this PR has been merged in `cluster-monitoring-operator`  https://github.com/openshift/cluster-monitoring-operator/pull/731 creating config map without `config.yaml` will immediately cause the operator to go to Degraded state. Even though the next step mitigates this state, it takes few minutes for operator to get back to healthy state. We should not instruct our customers to the workflows that create damage.

```
$ oc get co monitoring
NAME         VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.4.17    True        False         False      96m
$ oc -n openshift-monitoring create configmap cluster-monitoring-config
configmap/cluster-monitoring-config created
$ oc get co monitoring
NAME         VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.4.17    False       False         True       2s
$ oc -n openshift-monitoring delete configmap cluster-monitoring-config
configmap "cluster-monitoring-config" deleted
$ oc get co monitoring
NAME         VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.4.17    False       True          True       52s
```

operator logs:
```
I0825 02:38:17.125769       1 operator.go:299] Updating ClusterOperator status to failed. Err: the Cluster Monitoring ConfigMap doesn't contain a 'config.yaml' key
E0825 02:38:17.150089       1 operator.go:273] Syncing "openshift-monitoring/cluster-monitoring-config" failed
E0825 02:38:17.150119       1 operator.go:274] sync "openshift-monitoring/cluster-monitoring-config" failed: the Cluster Monitoring ConfigMap doesn't contain a 'config.yaml' key
```

