### PR TITLE
fix headers in assemblies

### DIFF
--- a/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc
@@ -23,7 +23,7 @@ ifdef::openshift-enterprise,openshift-webscale[]
 Note that certain options, such as *Pipelines*, *Event Source*, and *Import Virtual Machines*, are displayed only when the xref:../../pipelines/installing-pipelines.adoc#op-installing-pipelines-operator-in-web-console_installing-pipelines[OpenShift Pipelines], xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#serverless-install-web-console_installing-openshift-serverless[OpenShift Serverless], and xref:../../virt/install/installing-virt-web.adoc#virt-subscribing-to-the-catalog_installing-virt-web[OpenShift Virtualization] Operators are installed, respectively.
 endif::[]
 
-.Prerequisites
+== Prerequisites
 To create applications using the *Developer* perspective ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].

--- a/applications/application_life_cycle_management/odc-editing-applications.adoc
+++ b/applications/application_life_cycle_management/odc-editing-applications.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 You can edit the configuration and the source code of the application you create using the *Topology* view.
 
-.Prerequisites
+== Prerequisites
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to the xref:../../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
 * You have the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create and modify applications in {product-title}.

--- a/applications/application_life_cycle_management/odc-viewing-application-composition-using-topology-view.adoc
+++ b/applications/application_life_cycle_management/odc-viewing-application-composition-using-topology-view.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 The *Topology* view in the *Developer* perspective of the web console provides a visual representation of all the applications within a project, their build status, and the components and services associated with them.
 
-.Prerequisites
+== Prerequisites
 To view your applications in the *Topology* view and interact with them, ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].

--- a/applications/application_life_cycle_management/odc-working-with-helm-charts-using-developer-perspective.adoc
+++ b/applications/application_life_cycle_management/odc-working-with-helm-charts-using-developer-perspective.adoc
@@ -11,7 +11,7 @@ include::modules/helm-understanding-helm.adoc[leveloffset=+1]
 You can use the *Developer* perspective in the web console to select and install a chart from the Helm charts listed in the *Developer Catalog*. You can create a Helm release using these charts, upgrade, rollback, and uninstall the release.
 
 
-.Prerequisites
+== Prerequisites
 
 * You have logged in to the web console and have switched to the xref:../../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
 

--- a/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
+++ b/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 The *Monitoring* view in the *Developer* perspective provides options to monitor your project or application metrics, such as CPU, memory, and bandwidth usage, and network related information.
 
-.Prerequisites
+== Prerequisites
 
 * You have xref:../web_console/web-console.adoc#web-console-overview[logged in to the web console] and have switched to the xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
 * You have xref:../applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed applications on {product-title}].

--- a/backup_and_restore/graceful-cluster-restart.adoc
+++ b/backup_and_restore/graceful-cluster-restart.adoc
@@ -15,7 +15,7 @@ Even though the cluster is expected to be functional after the restart, the clus
 
 If your cluster fails to recover, follow the steps to xref:../backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore to a previous cluster state].
 
-.Prerequisites
+== Prerequisites
 
 * You have xref:../backup_and_restore/graceful-cluster-shutdown.adoc#graceful-shutdown-cluster[gracefully shut down your cluster].
 

--- a/backup_and_restore/graceful-cluster-shutdown.adoc
+++ b/backup_and_restore/graceful-cluster-shutdown.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 This document describes the process to gracefully shut down your cluster. You might need to temporarily shut down your cluster for maintenance reasons, or to save on resource costs.
 
-.Prerequisites
+== Prerequisites
 
 * Take an xref:../backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[etcd backup] prior to shutting down the cluster.
 

--- a/backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -18,7 +18,7 @@ If the control plane certificates are not valid on the member being replaced, th
 If a master node is lost and a new one is created, the etcd cluster Operator handles generating the new TLS certificates and adding the node as an etcd member.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Take an xref:../backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[etcd backup] prior to replacing an unhealthy etcd member.
 

--- a/builds/custom-builds-buildah.adoc
+++ b/builds/custom-builds-buildah.adoc
@@ -24,7 +24,7 @@ to compromise the cluster and therefore should be granted only to users who are
 trusted with administrative privileges on the cluster.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Review how to xref:../builds/securing-builds-by-strategy.adoc#securing-builds-by-strategy[grant custom build permissions].
 

--- a/cli_reference/developer_cli_odo/creating-a-multicomponent-application-with-odo.adoc
+++ b/cli_reference/developer_cli_odo/creating-a-multicomponent-application-with-odo.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 This example describes how to deploy a multicomponent application - a shooter game. The application consists of a front-end Node.js component and a back-end Java component.
 
-.Prerequisites
+== Prerequisites
 
 * `{odo-title}` is installed.
 * You have a running cluster. Developers can use link:https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/[CodeReady Containers (CRC)] to deploy a local cluster quickly.

--- a/cli_reference/developer_cli_odo/creating-a-single-component-application-with-odo.adoc
+++ b/cli_reference/developer_cli_odo/creating-a-single-component-application-with-odo.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 With `{odo-title}`, you can create and deploy applications on  clusters.
 
-.Prerequisites
+== Prerequisites
 
 * `{odo-title}` is installed.
 * You have a running cluster. You can use link:https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/[CodeReady Containers (CRC)] to deploy a local cluster quickly.

--- a/cli_reference/developer_cli_odo/creating-an-application-with-a-database.adoc
+++ b/cli_reference/developer_cli_odo/creating-an-application-with-a-database.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 This example describes how to deploy and connect a database to a front-end application.
 
-.Prerequisites
+== Prerequisites
 
 * `{odo-title}` is installed.
 * `oc` client is installed.

--- a/cli_reference/developer_cli_odo/creating-applications-by-using-devfiles.adoc
+++ b/cli_reference/developer_cli_odo/creating-applications-by-using-devfiles.adoc
@@ -12,7 +12,7 @@ include::modules/developer-cli-odo-about-devfiles-in-odo.adoc[leveloffset=+1]
 
 == Creating a Java application by using a devfile
 
-.Prerequisites
+== Prerequisites
 
 * You have installed `{odo-title}`. 
 * You must know your ingress domain cluster name. Contact your cluster administrator if you do not know it. For example, `apps-crc.testing` is the cluster domain name for https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/[Red Hat CodeReady Containers].

--- a/cli_reference/developer_cli_odo/creating-instances-of-services-managed-by-operators.adoc
+++ b/cli_reference/developer_cli_odo/creating-instances-of-services-managed-by-operators.adoc
@@ -13,7 +13,7 @@ Operators are a method of packaging, deploying, and managing Kubernetes services
 To create services from an Operator, you must ensure that the Operator has valid values defined in its `metadata` to start the requested service. `{odo-title}` uses the `metadata.annotations.alm-examples` YAML file of an Operator to start
 the service. If this YAML has placeholder values or sample values, a service cannot start. You can modify the YAML file and start the service with the modified values. To learn how to modify YAML files and start services from it, go to xref:../../cli_reference/developer_cli_odo/creating-instances-of-services-managed-by-operators.adoc#creating-services-from-yaml-files_creating-instances-of-services-managed-by-operators[Creating services from YAML files].
 
-.Prerequisites
+== Prerequisites
 * Install the `oc` CLI and log into the cluster.
 ** Note that the configuration of the cluster determines the services available to you. To access the Operator services, a cluster administrator must install the respective Operator on the cluster first. To learn more, see xref:../../operators/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Adding Operators to the cluster].
 * Install the `{odo-title}` CLI.

--- a/cli_reference/developer_cli_odo/using_odo_in_a_restricted_environment/creating-and-deploying-a-component-to-the-disconnected-cluster.adoc
+++ b/cli_reference/developer_cli_odo/using_odo_in_a_restricted_environment/creating-and-deploying-a-component-to-the-disconnected-cluster.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 After you push the `init` image to a cluster with a mirrored registry, you must mirror a supported builder image for your application with the `oc` tool, overwrite the mirror registry using the environment variable, and then create your component.
 
-.Prerequisites
+== Prerequisites
 
 * Install `oc` on the client operating system.
 * xref:../../../cli_reference/developer_cli_odo/installing-odo.adoc#installing-odo-on-linux[Install `{odo-title}`] on the client operating system.

--- a/cli_reference/developer_cli_odo/using_odo_in_a_restricted_environment/pushing-the-odo-init-image-to-the-restricted-cluster-registry.adoc
+++ b/cli_reference/developer_cli_odo/using_odo_in_a_restricted_environment/pushing-the-odo-init-image-to-the-restricted-cluster-registry.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 Depending on the configuration of your cluster and your operating system you can either push the `odo` init image to a mirror registry or directly to an internal registry.
 
-.Prerequisites
+== Prerequisites
 
 * Install `oc` on the client operating system.
 * xref:../../../cli_reference/developer_cli_odo/installing-odo.adoc#installing-odo-on-linux[Install `{odo-title}`] on the client operating system.

--- a/cloud_infrastructure_access/dedicated-aws-access.adoc
+++ b/cloud_infrastructure_access/dedicated-aws-access.adoc
@@ -14,7 +14,7 @@ access options.
 [id="dedicated-configuring-aws-access"]
 == Configuring AWS infrastructure access
 
-.Prerequisites
+== Prerequisites
 * An AWS account with IAM permissions.
 
 [id="dedicated-aws-account-creation"]

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -158,7 +158,7 @@ perform this task. This should be 1-2 sentences maximum.
 
 If applicable, include any gotchas (things that could trip up the user or cause the task to fail).
 
-.Prerequisites
+== Prerequisites
 
 * A bulleted list of prerequisites that MUST be performed before the user can complete this task.
 Skip if there isn't any related information.
@@ -171,7 +171,7 @@ Skip if there isn't any related information.
 
 . Step N
 
-.Next steps
+== Next steps
 
 You can explain any other tasks that MUST be completed after this task. You can
 skip this if there are none. Do not include xrefs. If the next steps are closely

--- a/installing/install_config/installing-restricted-networks-preparations.adoc
+++ b/installing/install_config/installing-restricted-networks-preparations.adoc
@@ -53,7 +53,7 @@ include::modules/installation-preparing-restricted-cluster-to-gather-support-dat
 
 include::modules/installation-restricted-network-samples.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 //* TODO need to add the registry secret to the machines, which is different
 

--- a/installing/installing-troubleshooting.adoc
+++ b/installing/installing-troubleshooting.adoc
@@ -8,7 +8,7 @@ toc::[]
 To assist in troubleshooting a failed {product-title} installation, you can
 gather logs from the bootstrap and control plane, or master, machines. You can also get debug information from the installation program.
 
-.Prerequisites
+== Prerequisites
 
 * You attempted to install an {product-title} cluster, and installation failed.
 

--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -18,7 +18,7 @@ include::modules/installation-aws-iam-user.adoc[leveloffset=+1]
 
 include::modules/installation-aws-regions.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * Install an {product-title} cluster:
 ** xref:../../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[Quickly install a cluster] with default options

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -10,7 +10,7 @@ cluster on infrastructure that the installation program provisions on
 Amazon Web Services (AWS). To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -58,7 +58,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_aws/installing-aws-default.adoc
+++ b/installing/installing_aws/installing-aws-default.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 Amazon Web Services (AWS) that uses the default configuration options.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -47,7 +47,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -15,7 +15,7 @@ You must set most of the network configuration parameters during installation,
 and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -73,7 +73,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a private cluster into an existing VPC on Amazon Web Services (AWS). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -61,7 +61,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -13,7 +13,7 @@ CloudFormation templates. You can modify the templates to customize your
 infrastructure or use the information that they contain to create AWS objects
 according to your company's policies.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -132,7 +132,7 @@ include::modules/installation-create-ingress-dns-records.adoc[leveloffset=+1]
 include::modules/installation-aws-user-infra-installation.adoc[leveloffset=+1]
 
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster into an existing Amazon Virtual Private Cloud (VPC) on Amazon Web Services (AWS). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -57,7 +57,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -20,7 +20,7 @@ CloudFormation templates. You can modify the templates to customize your
 infrastructure or use the information that they contain to create AWS objects
 according to your company's policies.
 
-.Prerequisites
+== Prerequisites
 
 * xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your mirror host]
  and obtain the `imageContentSources` data for your version of {product-title}.
@@ -147,7 +147,7 @@ include::modules/installation-create-ingress-dns-records.adoc[leveloffset=+1]
 include::modules/installation-aws-user-infra-installation.adoc[leveloffset=+1]
 
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_azure/installing-azure-account.adoc
+++ b/installing/installing_azure/installing-azure-account.adoc
@@ -29,7 +29,7 @@ include::modules/installation-azure-service-principal.adoc[leveloffset=+1]
 
 include::modules/installation-azure-regions.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * Install an {product-title} cluster on Azure. You can
 xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[install a customized cluster]

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -10,7 +10,7 @@ cluster on infrastructure that the installation program provisions on
 Microsoft Azure. To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -45,7 +45,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_azure/installing-azure-default.adoc
+++ b/installing/installing_azure/installing-azure-default.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 Microsoft Azure that uses the default configuration options.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -34,7 +34,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -15,7 +15,7 @@ You must set most of the network configuration parameters during installation,
 and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -58,7 +58,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a private cluster into an existing Azure Virtual Network (VNet) on Microsoft Azure. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -47,7 +47,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -14,7 +14,7 @@ link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/ove
 model your own. You can also create the required resources through other
 methods; the templates are just an example.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a cluster into an existing Azure Virtual Network (VNet) on Microsoft Azure. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -43,7 +43,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -15,7 +15,7 @@ You must set most of the network configuration parameters during installation,
 and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -79,7 +79,7 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -17,7 +17,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 before you attempt to install an {product-title} cluster in such an environment.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -87,7 +87,7 @@ include::modules/installation-registry-storage-non-production.adoc[leveloffset=+
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -17,7 +17,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 before you attempt to install an {product-title} cluster in such an environment.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
 +
@@ -100,7 +100,7 @@ include::modules/installation-registry-storage-non-production.adoc[leveloffset=+
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -22,7 +22,7 @@ include::modules/installation-gcp-permissions.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-regions.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * Install an {product-title} cluster on GCP. You can
 xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[install a customized cluster]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -10,7 +10,7 @@ cluster on infrastructure that the installation program provisions on
 Google Cloud Platform (GCP). To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -46,7 +46,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-default.adoc
+++ b/installing/installing_gcp/installing-gcp-default.adoc
@@ -9,7 +9,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 Google Cloud Platform (GCP) that uses the default configuration options.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -36,7 +36,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -17,7 +17,7 @@ You must set most of the network configuration parameters during installation,
 and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -61,7 +61,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a private cluster into an existing VPC on Google Cloud Platform (GCP). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -49,7 +49,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -14,7 +14,7 @@ completing these steps or to help model your own. You are also free to create
 the required resources through other methods; the templates are just an
 example.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -137,7 +137,7 @@ include::modules/installation-creating-gcp-shared-vpc-cluster-wide-firewall-rule
 
 include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -14,7 +14,7 @@ completing these steps or to help model your own. You are also free to create
 the required resources through other methods; the templates are just an
 example.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -111,7 +111,7 @@ include::modules/installation-gcp-user-infra-adding-ingress.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster into an existing Virtual Private Cloud (VPC) on Google Cloud Platform (GCP). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
 parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -43,7 +43,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -20,7 +20,7 @@ completing these steps or to help model your own. You are also free to create
 the required resources through other methods; the templates are just an
 example.
 
-.Prerequisites
+== Prerequisites
 
 * xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host]
  and obtain the `imageContentSources` data for your version of {product-title}.
@@ -103,7 +103,7 @@ include::modules/installation-gcp-user-infra-adding-ingress.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -19,7 +19,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 Restricted network installations are not tested or supported on IBM Z in {product-title} {product-version}.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Provision
 xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS]
@@ -76,7 +76,7 @@ include::modules/installation-registry-storage-non-production.adoc[leveloffset=+
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a customized cluster on
 {rh-openstack-first}. To customize the installation, modify parameters in the `install-config.yaml` before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -40,7 +40,7 @@ include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 include::modules/installation-osp-configuring-floating-ip.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a customized cluster on
 {rh-openstack-first} that uses Kuryr SDN. To customize the installation, modify parameters in the `install-config.yaml` before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -46,7 +46,7 @@ include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 include::modules/installation-osp-configuring-floating-ip.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_openstack/installing-openstack-installer.adoc
+++ b/installing/installing_openstack/installing-openstack-installer.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 {rh-openstack-first}.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -35,7 +35,7 @@ include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 include::modules/installation-osp-configuring-floating-ip.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_openstack/installing-openstack-troubleshooting.adoc
+++ b/installing/installing_openstack/installing-openstack-troubleshooting.adoc
@@ -11,7 +11,7 @@ In the event of a failure in {product-title} on OpenStack installation, you can 
 
 == View OpenStack instance logs
 
-.Prerequisites
+== Prerequisites
 
 * OpenStack CLI tools are installed
 
@@ -23,7 +23,7 @@ The console logs appear.
 
 == SSH access to an instance
 
-.Prerequisites
+== Prerequisites
 
 * OpenStack CLI tools are installed
 

--- a/installing/installing_openstack/installing-openstack-user-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-user-kuryr.adoc
@@ -10,7 +10,7 @@ In {product-title} version {product-version}, you can install a cluster on
 
 Using your own infrastructure allows you to integrate your cluster with existing infrastructure and modifications. The process requires more labor on your part than installer-provisioned installations, because you must create all {rh-openstack} resources, like Nova servers, Neutron ports, and security groups. However, Red Hat provides Ansible playbooks to help you in the deployment process.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -61,7 +61,7 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 include::modules/installation-osp-verifying-installation.adoc[leveloffset=+1]
 include::modules/installation-osp-configuring-floating-ip.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_openstack/installing-openstack-user.adoc
+++ b/installing/installing_openstack/installing-openstack-user.adoc
@@ -10,7 +10,7 @@ In {product-title} version {product-version}, you can install a cluster on
 
 Using your own infrastructure allows you to integrate your cluster with existing infrastructure and modifications. The process requires more labor on your part than installer-provisioned installations, because you must create all {rh-openstack} resources, like Nova servers, Neutron ports, and security groups. However, Red Hat provides Ansible playbooks to help you in the deployment process.
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -55,7 +55,7 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 include::modules/installation-osp-verifying-installation.adoc[leveloffset=+1]
 include::modules/installation-osp-configuring-floating-ip.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_openstack/uninstalling-openstack-user.adoc
+++ b/installing/installing_openstack/uninstalling-openstack-user.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 You can remove a cluster that you deployed to {rh-openstack-first} on user-provisioned infrastructure.
 
-.Prerequisites
+== Prerequisites
 
 * Have on your machine
 ** A single directory in which you can create files to help you with the removal process

--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -27,7 +27,7 @@ For an alternative to installing a customized cluster, see xref:../../installing
 This installation program is available for Linux and macOS only.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -85,7 +85,7 @@ After the {product-title} cluster initializes, you can perform the following tas
 * Optional: After deployment, add or replace SSH keys using the Machine Config Operator (MCO) in {product-title}.
 * Optional: Remove the `kubeadmin` user. Instead, use the authentication provider to create a user with cluster-admin privileges.
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -20,7 +20,7 @@ For an alternative to installing a default cluster, see xref:../../installing/in
 This installation program is available for Linux and macOS only.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 VMware vSphere infrastructure that you provision in a restricted network.
 
-.Prerequisites
+== Prerequisites
 
 * xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
 +
@@ -85,7 +85,7 @@ For instructions about configuring registry storage so that it references the co
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on your
 VMware vSphere instance by using installer-provisioned infrastructure. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Provision
 xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
@@ -63,7 +63,7 @@ include::modules/installation-registry-storage-block-recreate-rollout.adoc[level
 
 For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -10,7 +10,7 @@ VMware vSphere instance by using installer-provisioned infrastructure with custo
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Provision
 xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
@@ -73,7 +73,7 @@ include::modules/installation-registry-storage-block-recreate-rollout.adoc[level
 
 For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on your
 VMware vSphere instance by using installer-provisioned infrastructure.
 
-.Prerequisites
+== Prerequisites
 
 * Provision
 xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
@@ -57,7 +57,7 @@ include::modules/installation-registry-storage-block-recreate-rollout.adoc[level
 
 For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere].
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -16,7 +16,7 @@ and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
 
 
-.Prerequisites
+== Prerequisites
 
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
@@ -76,7 +76,7 @@ For instructions about configuring registry storage so that it references the co
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -8,7 +8,7 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 VMware vSphere infrastructure that you provision.
 
-.Prerequisites
+== Prerequisites
 
 * Provision
 xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
@@ -78,7 +78,7 @@ For instructions about configuring registry storage so that it references the co
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 
-.Next steps
+== Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can

--- a/jaeger/jaeger_install/rhbjaeger-installation.adoc
+++ b/jaeger/jaeger_install/rhbjaeger-installation.adoc
@@ -12,7 +12,7 @@ You can install Jaeger on {product-title} in either of two ways:
 * If you do not want to install a service mesh, you can use the Jaeger Operator to install the Red Hat build of Jaeger by itself.  To install Jaeger without a service mesh, use the following instructions.
 
 
-.Prerequisites
+== Prerequisites
 
 Before you can install {ProductName}, review the installation activities, and ensure that you meet the prerequisites:
 
@@ -38,6 +38,6 @@ include::modules/jaeger-install-elasticsearch.adoc[leveloffset=+1]
 include::modules/jaeger-install.adoc[leveloffset=+1]
 
 ////
-.Next steps
+== Next steps
 * xref:../../jaeger/jaeger_install/rhbj-deploying.adoc#jaeger-deploying[Deploy {ProductName}].
 ////

--- a/machine_management/applying-autoscaling.adoc
+++ b/machine_management/applying-autoscaling.adoc
@@ -35,7 +35,7 @@ include::modules/cluster-autoscaler-cr.adoc[leveloffset=+2]
 :FeatureName: ClusterAutoscaler
 include::modules/deploying-resource.adoc[leveloffset=+2]
 
-.Next steps
+== Next steps
 
 * After you configure the ClusterAutoscaler, you must configure at least one
 MachineAutoscaler.

--- a/machine_management/manually-scaling-machineset.adoc
+++ b/machine_management/manually-scaling-machineset.adoc
@@ -13,7 +13,7 @@ If you need to modify aspects of a MachineSet outside of scaling,
 see xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a MachineSet].
 ====
 
-.Prerequisites
+== Prerequisites
 
 * If you enabled the cluster-wide proxy and scale up workers not included in `networking.machineNetwork[].cidr` from the installation configuration, you must xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[add the workers to the Proxy object's `noProxy` field] to prevent connection issues.
 

--- a/metering/metering-installing-metering.adoc
+++ b/metering/metering-installing-metering.adoc
@@ -20,7 +20,7 @@ include::modules/metering-install-operator.adoc[leveloffset=+1]
 
 After adding the Metering Operator to your cluster you can install the components of metering by installing the metering stack.
 
-.Prerequisites
+== Prerequisites
 
 * Review the xref:../metering/configuring_metering/metering-about-configuring.adoc#metering-about-configuring[configuration options]
 * Create a MeteringConfig resource. You can begin the following process to generate a default MeteringConfig, then use the examples in the documentation to modify this default file for your specific installation. Review the following topics to create your MeteringConfig resource:

--- a/metering/metering-upgrading-metering.adoc
+++ b/metering/metering-upgrading-metering.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 You can upgrade metering to {product-version} by updating the Metering Operator subscription.
 
-.Prerequisites
+== Prerequisites
 
 *  The cluster is updated to 4.5.
 *  The xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Metering Operator] is installed from OperatorHub.

--- a/metering/metering-usage-examples.adoc
+++ b/metering/metering-usage-examples.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 Use the following example Reports to get started measuring capacity, usage, and utilization in your cluster. These examples showcase the various types of reports metering offers, along with a selection of the predefined queries.
 
-.Prerequisites
+== Prerequisites
 * xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Install Metering]
 * Review the details about xref:../metering/metering-using-metering#using-metering[writing and viewing reports].
 

--- a/metering/metering-using-metering.adoc
+++ b/metering/metering-using-metering.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-.Prerequisites
+== Prerequisites
 
 * xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Install Metering]
 * Review the details about the available options that can be configured for a xref:../metering/reports/metering-about-reports.adoc#metering-about-reports[Report] and how they function.

--- a/mod_docs_guide/getting-started-modular-docs-ocp.adoc
+++ b/mod_docs_guide/getting-started-modular-docs-ocp.adoc
@@ -18,7 +18,7 @@ team and anyone who might be contributing content to it.
 This guide itself has been written using the format of the modular docs
 initiative.
 
-.Prerequisites
+== Prerequisites
 
 * You have read through and familiarized yourself with the
 link:https://redhat-documentation.github.io/modular-docs[Red Hat CCS modular docs guide].

--- a/monitoring/application-monitoring.adoc
+++ b/monitoring/application-monitoring.adoc
@@ -14,6 +14,6 @@ include::modules/monitoring-configuring-cluster-for-application-monitoring.adoc[
 include::modules/monitoring-configuring-monitoring-for-an-application.adoc[leveloffset=+1]
 include::modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * To automatically adjust the number of pods in which the application runs, xref:../monitoring/application-monitoring.adoc#application-monitoring[configure Horizontal Pod Autoscaling for the application.]

--- a/monitoring/cluster_monitoring/about-cluster-monitoring.adoc
+++ b/monitoring/cluster_monitoring/about-cluster-monitoring.adoc
@@ -8,6 +8,6 @@ toc::[]
 include::modules/monitoring-about-cluster-monitoring.adoc[leveloffset=+1]
 include::modules/monitoring-stack-components-and-monitored-targets.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[Configure the monitoring stack.]

--- a/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
@@ -11,7 +11,7 @@ In {product-title} 4, Ansible is not the primary technology to install {product-
 
 This section explains what configuration is supported, shows how to configure the monitoring stack, and demonstrates several common configuration scenarios.
 
-.Prerequisites
+== Prerequisites
 
 * The monitoring stack imposes additional resource requirements. Consult the computing resources recommendations in xref:../../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#scaling-cluster-monitoring-operator[Scaling the Cluster Monitoring Operator] and verify that you have sufficient resources.
 
@@ -37,7 +37,7 @@ Running cluster monitoring with persistent storage means that your metrics are s
 See xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Dedicate sufficient local persistent storage to ensure that the disk does not become full. How much storage you need depends on the number of pods. For information on system requirements for persistent storage, see xref:../../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#prometheus-database-storage-requirements[Prometheus database storage requirements].
 * Make sure you have a persistent volume (PV) ready to be claimed by the persistent volume claim (PVC), one PV for each replica. Because Prometheus has two replicas and Alertmanager has three replicas, you need five PVs to support the entire monitoring stack. The PVs should be available from the Local Storage Operator. This does not apply if you enable dynamically provisioned storage.
@@ -78,7 +78,7 @@ include::modules/monitoring-listing-acting-alerting-rules.adoc[leveloffset=+2]
 
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../monitoring/cluster_monitoring/managing-cluster-alerts.adoc#managing-cluster-alerts[Manage cluster alerts.]
 * Learn about

--- a/monitoring/cluster_monitoring/examining-cluster-metrics.adoc
+++ b/monitoring/cluster_monitoring/examining-cluster-metrics.adoc
@@ -24,6 +24,6 @@ include::modules/technology-preview.adoc[leveloffset=+0]
 
 See the xref:../../monitoring/monitoring-your-own-services.adoc#monitoring-your-own-services[documentation on monitoring your own services]. It includes details on accessing non-cluster metrics as a developer or a privileged user.
 
-.Next steps
+== Next steps
 
 xref:../../monitoring/cluster_monitoring/prometheus-alertmanager-and-grafana.adoc#prometheus-alertmanager-and-grafana[Access the Prometheus, Alertmanager, and Grafana.]

--- a/monitoring/cluster_monitoring/managing-cluster-alerts.adoc
+++ b/monitoring/cluster_monitoring/managing-cluster-alerts.adoc
@@ -29,7 +29,7 @@ include::modules/monitoring-changing-alertmanager-configuration.adoc[leveloffset
 
 * See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#configuring-alertmanager[Configuring Alertmanager] for more information on changing Alertmanager configuration.
 
-.Next steps
+== Next steps
 
 xref:../../monitoring/cluster_monitoring/examining-cluster-metrics.adoc#examining-cluster-metrics[Examine cluster metrics.]
 

--- a/monitoring/configuring-hpa-for-an-application.adoc
+++ b/monitoring/configuring-hpa-for-an-application.adoc
@@ -10,7 +10,7 @@ You can configure Horizontal Pod Autoscaling (HPA) for an application that expor
 :FeatureName: Horizontal Pod Autoscaling for an application
 include::modules/technology-preview.adoc[leveloffset=+0]
 
-.Prerequisites
+== Prerequisites
 
 * Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
 * You must log in to the cluster with a user that has the `cluster-admin` role.

--- a/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
@@ -9,7 +9,7 @@ As a cluster administrator, you can designate an IP address block that is extern
 
 This functionality is generally most useful for clusters installed on bare-metal hardware.
 
-.Prerequisites
+== Prerequisites
 
 * Your network infrastructure must route traffic for the external IP addresses to your cluster.
 

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
@@ -18,7 +18,7 @@ The procedures in this section require prerequisites performed by the cluster
 administrator.
 ====
 
-.Prerequisites
+== Prerequisites
 
 Before starting the following procedures, the administrator must:
 

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc
@@ -17,7 +17,7 @@ The procedures in this section require prerequisites performed by the cluster
 administrator.
 ====
 
-.Prerequisites
+== Prerequisites
 
 Before starting the following procedures, the administrator must:
 

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
@@ -17,7 +17,7 @@ The procedures in this section require prerequisites performed by the cluster
 administrator.
 ====
 
-.Prerequisites
+== Prerequisites
 
 Before starting the following procedures, the administrator must:
 

--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -12,7 +12,7 @@ Production environments can deny direct access to the Internet and instead have 
 The cluster-wide proxy is only supported if you used a user-provisioned infrastructure installation or provide your own networking, such as a virtual private cloud or virual network, for a supported provider.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Review the xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[sites that your cluster requires access to] and determine whether any of them must bypass the proxy. By default, all cluster egress traffic is proxied, including calls to the cloud provider API for the cloud that hosts your cluster. Add sites to the Proxy object's `spec.noProxy` field to bypass the proxy if necessary.
 +

--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -16,7 +16,7 @@ include::modules/technology-preview.adoc[leveloffset=+0]
 :FeatureName: Remote Direct Memory Access (RDMA)
 include::modules/technology-preview.adoc[leveloffset=+0]
 
-.Prerequisites
+== Prerequisites
 
 * Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
 * Log in as a user with `cluster-admin` privileges.

--- a/networking/multiple_networks/configuring-bridge.adoc
+++ b/networking/multiple_networks/configuring-bridge.adoc
@@ -16,6 +16,6 @@ include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-.Next steps
+== Next steps
 
 * xref:../../networking/multiple_networks/attaching-pod.adoc#attaching-pod[Attach a Pod to an additional network].

--- a/networking/multiple_networks/configuring-host-device.adoc
+++ b/networking/multiple_networks/configuring-host-device.adoc
@@ -14,6 +14,6 @@ include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-.Next steps
+== Next steps
 
 * xref:../../networking/multiple_networks/attaching-pod.adoc#attaching-pod[Attach a Pod to an additional network].

--- a/networking/multiple_networks/configuring-ipvlan.adoc
+++ b/networking/multiple_networks/configuring-ipvlan.adoc
@@ -18,6 +18,6 @@ include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-.Next steps
+== Next steps
 
 * xref:../../networking/multiple_networks/attaching-pod.adoc#attaching-pod[Attach a Pod to an additional network].

--- a/networking/multiple_networks/configuring-macvlan-basic.adoc
+++ b/networking/multiple_networks/configuring-macvlan-basic.adoc
@@ -21,6 +21,6 @@ include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-.Next steps
+== Next steps
 
 * xref:../../networking/multiple_networks/attaching-pod.adoc#attaching-pod[Attach a Pod to an additional network].

--- a/networking/multiple_networks/configuring-macvlan.adoc
+++ b/networking/multiple_networks/configuring-macvlan.adoc
@@ -21,6 +21,6 @@ include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-.Next steps
+== Next steps
 
 * xref:../../networking/multiple_networks/attaching-pod.adoc#attaching-pod[Attach a Pod to an additional network].

--- a/networking/openshift_sdn/multitenant-isolation.adoc
+++ b/networking/openshift_sdn/multitenant-isolation.adoc
@@ -20,7 +20,7 @@ accessible, accepting network traffic from Pods and services in all other
 projects. A globally accessible project can access Pods and services in all
 other projects.
 
-.Prerequisites
+== Prerequisites
 
 * You must have a cluster configured to use the OpenShift SDN Container Network
 Interface (CNI) plug-in in multitenant isolation mode.

--- a/openshift_images/cnf-building-and-deploying-a-dpdk-payload.adoc
+++ b/openshift_images/cnf-building-and-deploying-a-dpdk-payload.adoc
@@ -20,7 +20,7 @@ xref:../builds/build-strategies.adoc#build-strategy-s2i_build-strategies[Source-
 The DPDK base image comes preinstalled with DPDK, and with a build tool that can be used to
 create a target image containing the DPDK libraries and the application provided by the user.
 
-.Prerequisites
+== Prerequisites
 
 Before using the S2I tool, ensure that you have the following components installed and configured:
 

--- a/openshift_images/configuring-samples-operator.adoc
+++ b/openshift_images/configuring-samples-operator.adoc
@@ -8,7 +8,7 @@ The Samples Operator, which operates in the OpenShift namespace, installs and
 updates the Red Hat Enterprise Linux (RHEL)-based {product-title} imagestreams
 and {product-title} templates.
 
-.Prerequisites
+== Prerequisites
 * Deploy an {product-title} cluster.
 
 //Add any other prereqs that are always valid before you modify the CRD.

--- a/openshift_images/templates-using-ruby-on-rails.adoc
+++ b/openshift_images/templates-using-ruby-on-rails.adoc
@@ -20,7 +20,7 @@ to your issue. It can also be useful to review your previous steps to ensure
 that all the steps were executed correctly.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Basic Ruby and Rails knowledge.
 * Locally installed version of Ruby 2.0.0+, Rubygems, Bundler.

--- a/pipelines/creating-applications-with-cicd-pipelines.adoc
+++ b/pipelines/creating-applications-with-cicd-pipelines.adoc
@@ -21,7 +21,7 @@ This section uses the `pipelines-tutorial` example to demonstrate the preceding 
 * `apply_manifest` and `update-deployment` Tasks in link:https://github.com/openshift/pipelines-tutorial/tree/release-tech-preview-1[`pipelines-tutorial`] Git repository.
 
 [discrete]
-.Prerequisites
+== Prerequisites
 
 * You have access to an {product-title} cluster.
 

--- a/pipelines/installing-pipelines.adoc
+++ b/pipelines/installing-pipelines.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 // Prerequisites for installing OpenShift Operator
 [discrete]
-.Prerequisites
+== Prerequisites
 
 * You have access to an {product-title} cluster using an account with `cluster-admin` permissions.
 

--- a/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
+++ b/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
@@ -22,7 +22,7 @@ NOTE: The .NET Core runtime is not yet supported by the Pipeline templates.
 ////
 
 [Discrete]
-.Prerequisites
+== Prerequisites
 
 * You have access to an {product-title} cluster and have switched to the xref:../web_console/odc-about-developer-perspective.adoc[Developer perspective] in the web console.
 * You have the xref:../pipelines/installing-pipelines.adoc#installing-pipelines[OpenShift Pipelines Operator installed] in your cluster.

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -20,7 +20,7 @@ to the registry using the `oc login` command. The operations you can perform
 depend on your user permissions, as described in the following sections.
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-.Prerequisites
+== Prerequisites
 
 * You must have configured an identity provider (IDP).
 * For pulling images, for example when using the `podman pull` command,

--- a/serverless/event_sources/knative-event-sources.adoc
+++ b/serverless/event_sources/knative-event-sources.adoc
@@ -16,7 +16,7 @@ xref:../../serverless/knative_eventing/serverless-sinkbinding.adoc#serverless-si
 
 You can create and manage Knative event sources using the **Developer** perspective in the {product-title} web console, the `kn` CLI, or by applying YAML files.
 
-.Prerequisites
+== Prerequisites
 
 * You must have a current installation of xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#serverless-install-web-console_installing-openshift-serverless[{ServerlessProductName}], including Knative Serving and Eventing, in your {product-title} cluster. This can be installed by a cluster administrator.
 * Event sources need a service to use as an event _sink_. The sink is the service or application that events are sent to from the event source.

--- a/serverless/event_sources/serverless-apiserversource.adoc
+++ b/serverless/event_sources/serverless-apiserversource.adoc
@@ -9,7 +9,7 @@ toc::[]
 ApiServerSource is an event source that can be used to connect an event sink, such as a Knative service, to the Kubernetes API server.
 ApiServerSource watches for Kubernetes events and forwards them to the Knative Eventing broker.
 
-.Prerequisites
+== Prerequisites
 
 * You must have a current installation of xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#serverless-install-web-console_installing-openshift-serverless[{ServerlessProductName}], including Knative Serving and Eventing, in your {product-title} cluster. This can be installed by a cluster administrator.
 * Event sources need a service to use as an event _sink_. The sink is the service or application that events are sent to from the event source.

--- a/serverless/event_sources/serverless-kn-source.adoc
+++ b/serverless/event_sources/serverless-kn-source.adoc
@@ -37,6 +37,6 @@ Service 'event-display' created to latest revision 'event-display-sjptv-1' is av
 http://event-display-knative-serving.apps.ci-ln-kf2fv0k-d5d6b.origin-ci-int-aws.dev.rhcloud.com
 ////
 
-.Next steps
+== Next steps
 * See the documentation on xref:../serverless-apiserversource.adoc#serverless-apiserversource[Using ApiServerSource].
 * See the documentation on xref:../serverless-pingsource.adoc#serverless-pingsource[Using PingSource].

--- a/serverless/installing_serverless/installing-knative-eventing.adoc
+++ b/serverless/installing_serverless/installing-knative-eventing.adoc
@@ -18,7 +18,7 @@ This guide provides information about installing Knative Eventing using the defa
 
 include::modules/serverless-create-eventing-namespace.adoc[leveloffset=+1]
 
-.Prerequisites
+== Prerequisites
 * An {product-title} account with cluster administrator access
 * Installed {ServerlessOperatorName}
 * Created the `knative-eventing` namespace

--- a/serverless/installing_serverless/installing-knative-serving.adoc
+++ b/serverless/installing_serverless/installing-knative-serving.adoc
@@ -14,7 +14,7 @@ For more information about configuration options for the KnativeServing custom r
 
 include::modules/serverless-create-serving-namespace.adoc[leveloffset=+1]
 
-.Prerequisites
+== Prerequisites
 * An {product-title} account with cluster administrator access.
 * Installed {ServerlessOperatorName}.
 * Created the `knative-serving` namespace.

--- a/serverless/installing_serverless/removing-openshift-serverless.adoc
+++ b/serverless/installing_serverless/removing-openshift-serverless.adoc
@@ -34,7 +34,7 @@ You can use the following procedure to remove the remaining CRDs.
 Removing the Operator and API CRDs also removes all resources that were defined using them, including Knative services.
 ====
 
-.Prerequisites
+== Prerequisites
 *  You uninstalled Knative Serving and removed the {ServerlessOperatorName}.
 
 .Procedure

--- a/serverless/knative_eventing/serverless-kn-trigger.adoc
+++ b/serverless/knative_eventing/serverless-kn-trigger.adoc
@@ -12,7 +12,7 @@ Using triggers allows you to filter events from a channel or broker, so that sub
 
 The Knative CLI provides a set of `kn trigger` commands that can be used to create and manage triggers.
 
-.Prerequisites
+== Prerequisites
 Before you can use triggers, you will need:
 
 * Knative Eventing and `kn` installed.

--- a/service_mesh/service_mesh_arch/understanding-ossm.adoc
+++ b/service_mesh/service_mesh_arch/understanding-ossm.adoc
@@ -12,6 +12,6 @@ include::modules/ossm-architecture.adoc[leveloffset=+1]
 
 include::modules/ossm-vs-istio.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../service_mesh/service_mesh_install/preparing-ossm-installation.adoc#preparing-ossm-installation[Prepare to install {ProductName}] in your {product-title} environment.

--- a/service_mesh/service_mesh_day_two/configuring-jaeger.adoc
+++ b/service_mesh/service_mesh_day_two/configuring-jaeger.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 This section describes configuration that is performed in the CRD or in the CR file.
 
-.Prerequisites
+== Prerequisites
 
 * Access to an {product-title} cluster with cluster-admin user privileges.
 * Elasticsearch operator has been installed on the cluster

--- a/service_mesh/service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc
+++ b/service_mesh/service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 When you deploy an application into the {ProductShortName}, there are several differences between the behavior of applications in the upstream community version of Istio and the behavior of applications within a {ProductName} installation.
 
-.Prerequisites
+== Prerequisites
 
 * Review xref:../../service_mesh/service_mesh_arch/ossm-vs-community.adoc#ossm-vs-community[Comparing {ProductName} and upstream Istio community installations]
 
@@ -31,6 +31,6 @@ include::modules/ossm-mixer-policy.adoc[leveloffset=+1]
 * Deploy services external to the mesh in separate namespaces that are not in any mesh.
 * Non-mesh services that need to be deployed within a service mesh enlisted namespace should label their deployments `maistra.io/expose-route: "true"`, which ensures {product-title} routes to these services still work.
 
-.Next steps
+== Next steps
 
 * xref:../../service_mesh/service_mesh_day_two/ossm-example-bookinfo.adoc#ossm-bookinfo-tutorial[Deploy Bookinfo] on {ProductName}.

--- a/service_mesh/service_mesh_install/customizing-installation-ossm.adoc
+++ b/service_mesh/service_mesh_install/customizing-installation-ossm.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 You can customize your {ProductName} by modifying the default {ProductShortName} custom resource or by creating a new custom resource.
 
-.Prerequisites
+== Prerequisites
 * An account with the `cluster-admin` role.
 * Completed the xref:../../service_mesh/service_mesh_install/preparing-ossm-installation.adoc#preparing-ossm-installation[Preparing to install {ProductName}] process.
 * Have installed the operators.
@@ -33,6 +33,6 @@ For more information about configuring Elasticsearch with {product-title}, see  
 include::modules/ossm-cr-threescale.adoc[leveloffset=+1]
 
 
-.Next steps
+== Next steps
 
 * xref:../../service_mesh/service_mesh_day_two/prepare-to-deploy-applications-ossm.adoc#deploying-applications-ossm[Prepare to deploy applications] on {ProductName}.

--- a/service_mesh/service_mesh_install/installing-ossm.adoc
+++ b/service_mesh/service_mesh_install/installing-ossm.adoc
@@ -21,7 +21,7 @@ Multi-tenant control plane installations are the default configuration starting 
 The {ProductShortName} documentation uses `istio-system` as the example project, but you may deploy the service mesh to any project.
 ====
 
-.Prerequisites
+== Prerequisites
 * Follow the xref:../../service_mesh/service_mesh_install/preparing-ossm-installation.adoc#preparing-ossm-installation[Preparing to install {ProductName}] process.
 * An account with the `cluster-admin` role.
 
@@ -42,7 +42,7 @@ include::modules/ossm-update-app-sidecar.adoc[leveloffset=+1]
 
 
 
-.Next steps
+== Next steps
 
 * xref:../../service_mesh/service_mesh_install/customizing-installation-ossm.adoc#customize-installation-ossm[Customize the {ProductName} installation].
 

--- a/service_mesh/service_mesh_install/preparing-ossm-installation.adoc
+++ b/service_mesh/service_mesh_install/preparing-ossm-installation.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 Before you can install {ProductName}, review the installation activities, ensure that you meet the prerequisites:
 
-.Prerequisites
+== Prerequisites
 
 * Possess an active {product-title} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
 * Review the xref:../../architecture/architecture-installation.adoc#installation-overview_architecture-installation[{product-title} {product-version} overview].
@@ -33,6 +33,6 @@ include::modules/ossm-installation-activities.adoc[leveloffset=+1]
 Please see xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store] for details on configuring the default Jaeger parameters for Elasticsearch in a production environment.
 ====
 
-.Next steps
+== Next steps
 
 * xref:../../service_mesh/service_mesh_install/installing-ossm.adoc#installing-ossm[Install {ProductName}] in your {product-title} environment.

--- a/service_mesh/service_mesh_support/ossm-collecting-ossm-data.adoc
+++ b/service_mesh/service_mesh_support/ossm-collecting-ossm-data.adoc
@@ -16,7 +16,7 @@ and {ProductName}.
 
 include::modules/about-must-gather.adoc[leveloffset=+1]
 
-.Prerequisites
+== Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
 

--- a/storage/persistent_storage/persistent-storage-efs.adoc
+++ b/storage/persistent_storage/persistent-storage-efs.adoc
@@ -21,7 +21,7 @@ shared across the {product-title} cluster.
 PersistentVolumeClaims are specific to a project or namespace and can be
 requested by users.
 
-.Prerequisites
+== Prerequisites
 * Configure the AWS security groups to allow inbound NFS traffic
 from the EFS volume's security group.
 * Configure the AWS EFS volume to allow incoming SSH traffic from any host.

--- a/storage/persistent_storage/persistent-storage-vsphere.adoc
+++ b/storage/persistent_storage/persistent-storage-vsphere.adoc
@@ -26,7 +26,7 @@ requested by users.
 
 Dynamically provisioning VMware vSphere volumes is the recommended method.
 
-.Prerequisites
+== Prerequisites
 * An {product-title} cluster installed on a VMware vSphere version that meets the requirements for the components that you use. See xref:../../installing/installing_vsphere/installing-vsphere.adoc[Installing a cluster on vSphere] for information about vSphere version support.
 
 You can use either of the following procedures to dynamically provision these volumes using the default StorageClass.

--- a/updating/updating-cluster-between-minor.adoc
+++ b/updating/updating-cluster-between-minor.adoc
@@ -12,7 +12,7 @@ You can update, or upgrade, an {product-title} cluster between minor versions.
 Because of the difficulty of changing update channels by using `oc`, use the web console to change the update channel. It is recommended to complete the update process within the web console. You can follow the steps in xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] to complete the update after you change to a {product-version} channel.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * Have access to the cluster as a user with `admin` privileges.
 See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 You can update, or upgrade, an {product-title} cluster within a minor version by using the OpenShift CLI (`oc`).
 
-.Prerequisites
+== Prerequisites
 
 * Have access to the cluster as a user with `admin` privileges.
 See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].

--- a/updating/updating-cluster-rhel-compute.adoc
+++ b/updating/updating-cluster-rhel-compute.adoc
@@ -9,7 +9,7 @@ You can update, or upgrade, an {product-title} cluster. If your cluster contains
 Red Hat Enterprise Linux (RHEL) machines, you must perform more steps to update
 those machines.
 
-.Prerequisites
+== Prerequisites
 
 * Have access to the cluster as a user with `admin` privileges.
 See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].

--- a/updating/updating-cluster.adoc
+++ b/updating/updating-cluster.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 You can update, or upgrade, an {product-title} cluster by using the web console.
 
-.Prerequisites
+== Prerequisites
 
 * Have access to the cluster as a user with `admin` privileges.
 See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -11,7 +11,7 @@ A restricted network environment is the one in which your cluster nodes cannot a
 
 If multiple clusters are present within the restricted network, mirror the required release images to a single container image registry and use that registry to update all the clusters.
 
-.Prerequisites
+== Prerequisites
 
 * Have access to the internet to obtain the necessary container images.
 * Have write access to a container registry in the restricted-network environment to push and pull images. The container registry must be compatible with Docker registry API v2.

--- a/virt/install/installing-virt-cli.adoc
+++ b/virt/install/installing-virt-cli.adoc
@@ -8,7 +8,7 @@ Install {VirtProductName} to add virtualization functionality to your {product-t
 cluster. You can subscribe to and deploy the {VirtProductName} Operators by
 using the command line to apply manifests to your cluster.
 
-.Prerequisites
+== Prerequisites
 * Install {product-title} {product-version} on your cluster.
 * Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
 * Log in as a user with `cluster-admin` privileges.

--- a/virt/install/installing-virt-web.adoc
+++ b/virt/install/installing-virt-web.adoc
@@ -11,7 +11,7 @@ You can use the {product-title} {product-version}
 xref:../../web_console/web-console.adoc#web-console-overview_web-console[web console]
 to subscribe to and deploy the {VirtProductName} Operators.
 
-.Prerequisites
+== Prerequisites
 * Install {product-title} {product-version} on your cluster.
 * Log in as a user with `cluster-admin` permissions.
 

--- a/virt/install/uninstalling-virt-cli.adoc
+++ b/virt/install/uninstalling-virt-cli.adoc
@@ -7,7 +7,7 @@ toc::[]
 You can uninstall {VirtProductName} by using the {product-title}
   xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[CLI].
 
-.Prerequisites
+== Prerequisites
 
 * You must have {VirtProductName} {VirtVersion} installed.
 

--- a/virt/install/uninstalling-virt-web.adoc
+++ b/virt/install/uninstalling-virt-web.adoc
@@ -7,7 +7,7 @@ toc::[]
 You can uninstall {VirtProductName} by using the {product-title}
 xref:../../web_console/web-console.adoc#web-console-overview_web-console[web console].
 
-.Prerequisites
+== Prerequisites
 
 * You must have {VirtProductName} {VirtVersion} installed.
 * You must delete all xref:../../virt/virtual_machines/virt-delete-vms.adoc#virt-delete-vm-web_virt-delete-vms[virtual machines],

--- a/virt/live_migration/virt-live-migration.adoc
+++ b/virt/live_migration/virt-live-migration.adoc
@@ -4,7 +4,7 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-live-migration
 toc::[]
 
-.Prerequisites
+== Prerequisites
 * Before using LiveMigration, ensure that the storage class used by the
 virtual machine has a PersistentVolumeClaim (PVC) with a shared
 ReadWriteMany (RWX) access mode.

--- a/virt/virt-using-the-cli-tools.adoc
+++ b/virt/virt-using-the-cli-tools.adoc
@@ -9,7 +9,7 @@ The two primary CLI tools used for managing resources in the cluster are:
 * The {VirtProductName} `virtctl` client
 * The {product-title} `oc` client
 
-.Prerequisites
+== Prerequisites
 
 * You must xref:../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[install the `virtctl` client].
 

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
@@ -10,7 +10,7 @@ operating system or other program without requiring a locally attached
 storage device. For example, you can use it to choose your desired OS
 image from a PXE server when deploying a new host.
 
-.Prerequisites
+== Prerequisites
 
 * A Linux bridge must be xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#attaching-to-multiple-networks[connected].
 

--- a/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc
@@ -9,7 +9,7 @@ dedicated to them in order to improve performance.
 
 include::modules/virt-about-dedicated-resources.adoc[leveloffset=+1]
 
-.Prerequisites
+== Prerequisites
 
 * The
 xref:../../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must

--- a/virt/virtual_machines/advanced_vm_management/virt-using-huge-pages-with-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-using-huge-pages-with-vms.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 You can use huge pages as backing memory for virtual machines in your cluster.
 
-.Prerequisites
+== Prerequisites
 
 * Nodes must have xref:../../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#configuring-huge-pages_huge-pages[pre-allocated huge pages configured].
 

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
@@ -8,7 +8,7 @@ You can clone the PersistentVolumeClaim (PVC) of a virtual machine disk into
 a new block DataVolume by referencing the source PVC in your DataVolume configuration
 file.
 
-.Prerequisites
+== Prerequisites
 
 * Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
 

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
@@ -8,7 +8,7 @@ You can clone the PersistentVolumeClaim (PVC) of a virtual machine disk into
 a new DataVolume by referencing the source PVC in your DataVolume configuration
 file.
 
-.Prerequisites
+== Prerequisites
 
 * Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
 

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
@@ -8,7 +8,7 @@ You can create a new virtual machine by cloning the PersistentVolumeClaim (PVC) 
 an existing VM. By including a `dataVolumeTemplate` in your virtual machine
 configuration file, you create a new DataVolume from the original PVC.
 
-.Prerequisites
+== Prerequisites
 
 * Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
 

--- a/virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc
@@ -12,7 +12,7 @@ user with the `cluster-admin` role must create a new ClusterRole. Bind
 this ClusterRole to a user to enable them to clone virtual machines
 to the destination namespace. 
 
-.Prerequisites
+== Prerequisites
 
 * Only a user with the xref:../../../authentication/using-rbac.adoc#default-roles_using-rbac[`cluster-admin`]
 role can create ClusterRoles.

--- a/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes-block.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes-block.adoc
@@ -19,7 +19,7 @@ The resizing procedure varies based on the operating system that is installed on
 Refer to the operating system documentation for details.
 ====
 
-.Prerequisites 
+== Prerequisites 
 
 * If you require scratch space according to the
 xref:#virt-cdi-supported-operations-matrix_virt-importing-virtual-machine-images-datavolumes-block[CDI supported operations matrix], you must first

--- a/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
@@ -19,7 +19,7 @@ The resizing procedure varies based on the operating system installed on the VM.
 Refer to the operating system documentation for details.
 ====
 
-.Prerequisites
+== Prerequisites
 
 * If the endpoint requires a TLS certificate, the certificate must be
 xref:../../../virt/virtual_machines/importing_vms/virt-tls-certificates-for-dv-imports.adoc#virt-adding-tls-certificates-for-authenticating-dv-imports_virt-tls-certificates-for-dv-imports[included in a ConfigMap]

--- a/virt/virtual_machines/virt-installing-virtio-drivers-on-new-windows-vm.adoc
+++ b/virt/virtual_machines/virt-installing-virtio-drivers-on-new-windows-vm.adoc
@@ -4,7 +4,7 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-installing-virtio-drivers-on-new-windows-vm"
 toc::[]
 
-.Prerequisites
+== Prerequisites
 
 * Windows installation media accessible by the virtual machine, such as
 xref:../../virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc#virt-importing-vm-datavolume_virt-importing-virtual-machine-images-datavolumes[importing an ISO into a data volume]

--- a/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.adoc
@@ -11,7 +11,7 @@ In this workflow, you create a local block device to use as a PersistentVolume,
 associate this block volume with an `upload` DataVolume, and use `virtctl`
 to upload the local disk image into the DataVolume.
 
-.Prerequisites
+== Prerequisites
 
 * xref:../../../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Install]
 the `kubevirt-virtctl` package.

--- a/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-virtctl.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-virtctl.adoc
@@ -7,7 +7,7 @@ toc::[]
 You can upload a locally stored disk image to a new or existing DataVolume by using the
 `virtctl` command-line utility.
 
-.Prerequisites
+== Prerequisites
 
 * xref:../../../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Install]
 the `kubevirt-virtctl` package.

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -16,7 +16,7 @@ include::modules/virt-networking-glossary.adoc[leveloffset=+1]
 
 == Creating a NetworkAttachmentDefinition
 
-.Prerequisites
+== Prerequisites
 
 * A Linux bridge must be configured and attached on every node. 
 See the xref:../../../virt/node_network/virt-updating-node-network-config.adoc#virt-about-nmstate_virt-updating-node-network-config[node networking] section for more information.

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 You can attach a virtual machine to use a Single Root I/O Virtualization (SR-IOV) network as a secondary network.
 
-.Prerequisites
+== Prerequisites
 
 * You must have xref:../../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[configured an SR-IOV device for virtual machines].
 

--- a/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
+++ b/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
@@ -7,7 +7,7 @@ toc::[]
 You can configure a Single Root I/O Virtualization (SR-IOV) device for virtual machines in your cluster.
 This process is similar but not identical to configuring an SR-IOV device for {product-title}.
 
-.Prerequisites
+== Prerequisites
 * You must have xref:../../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Operator.]
 
 * You must have xref:../../../networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[configured the SR-IOV Operator.]
@@ -15,7 +15,7 @@ This process is similar but not identical to configuring an SR-IOV device for {p
 include::modules/nw-sriov-device-discovery.adoc[leveloffset=+1]
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../../virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc#virt-defining-an-sriov-network[Configuring an SR-IOV network attachment for virtual machines]
 

--- a/virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc
+++ b/virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc
@@ -8,13 +8,13 @@ You can create a network attachment for a Single Root I/O Virtualization (SR-IOV
 
 After the network is defined, you can attach virtual machines to the SR-IOV network.
 
-.Prerequisites
+== Prerequisites
 
 * You must have xref:../../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[configured an SR-IOV device for virtual machines].
 
 include::modules/nw-sriov-network-attachment.adoc[leveloffset=+1]
 
-.Next steps
+== Next steps
 
 * xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc#virt-attaching-vm-to-sriov-network[Attaching a virtual machine to an SR-IOV network.]
 

--- a/virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc
+++ b/virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc
@@ -8,7 +8,7 @@ The QEMU guest agent is a daemon that runs on the virtual machine. The agent
 passes network information on the virtual machine, notably the IP address of
 additional networks, to the host.
 
-.Prerequisites
+== Prerequisites
 
 * Verify that the guest agent is installed and running by entering the following command:
 +

--- a/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
+++ b/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 The QEMU guest agent runs on the virtual machine and passes the IP address of attached NICs to the host, allowing you to view the IP address from both the web console and the `oc` client.
 
-.Prerequisites
+== Prerequisites
 
 . Verify that the guest agent is installed and running by entering the following command:
 +

--- a/virt/vm_templates/virt-dedicated-resources-vm-template.adoc
+++ b/virt/vm_templates/virt-dedicated-resources-vm-template.adoc
@@ -9,7 +9,7 @@ dedicated to them in order to improve performance.
 
 include::modules/virt-about-dedicated-resources.adoc[leveloffset=+1]
 
-.Prerequisites
+== Prerequisites
 
 * The
 xref:../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must

--- a/web_console/configuring-web-console.adoc
+++ b/web_console/configuring-web-console.adoc
@@ -7,7 +7,7 @@ toc::[]
 You can modify the {product-title} web console to set a logout redirect URL
 or disable the console.
 
-.Prerequisites
+== Prerequisites
 
 * Deploy an {product-title} cluster.
 

--- a/web_console/disabling-web-console.adoc
+++ b/web_console/disabling-web-console.adoc
@@ -6,7 +6,7 @@ toc::[]
 
 You can disable the {product-title} web console.
 
-.Prerequisites
+== Prerequisites
 
 * Deploy an {product-title} cluster.
 

--- a/web_console/odc-about-developer-perspective.adoc
+++ b/web_console/odc-about-developer-perspective.adoc
@@ -14,7 +14,7 @@ The *Developer* perspective provides workflows specific to developer use cases, 
 * Integrate serverless capabilities (Technology Preview).
 * Create workspaces to edit your application code using Eclipse Che.
 
-.Prerequisites
+== Prerequisites
 
 To access the *Developer* perspective, ensure that you have logged in to the web console.
 

--- a/web_console/web-console.adoc
+++ b/web_console/web-console.adoc
@@ -9,7 +9,7 @@ The {product-title} web console is a user interface accessible from a web browse
 Developers can use the web console to visualize, browse, and manage the contents
 of projects.
 
-.Prerequisites
+== Prerequisites
 
 * JavaScript must be enabled to use the web console. For the best experience, use
 a web browser that supports


### PR DESCRIPTION
@openshift/team-documentation PTAL

FYI - 
@Preeticp @apinnick @aburdenthehand @ousleyp @bgaydosrh @lmandavi @abrennan89 @JStickler @neal-timpe 

This changes 

`.Prerequisites` to `== Prerequisites`

and 

`.Next Steps` to `== Next steps`

so that the rendering of the content is correct for TOC on docs.openshift.com and the portal. 

This is counter to what the mod docs guidelines templates currently say, but we have an AI to get those templates fixed. In the meantime, we are going ahead with this change.

As an example of what it looks like now:
https://docs.openshift.com/container-platform/4.5/installing/installing_aws/installing-aws-default.html

And what it will look like with this change:
https://fixheaders--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-default.html