### PR TITLE
VM import requires admin user

### DIFF
--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -5,7 +5,11 @@
 = Prerequisites for importing a virtual machine
 
 ifdef::virt-importing-rhv-vm[]
-Source environment prerequisites::
+Importing a virtual machine from Red Hat Virtualization (RHV) into {VirtProductName} has the following prerequisites.
+
+== Red Hat Virtualization prerequisites
+
+The Red Hat Virtualization (RHV) environment has the following prerequisites for VM import:
 
 * Network:
 
@@ -30,14 +34,18 @@ Source environment prerequisites::
 ** The VM must not be configured for USB devices.
 ** The watchdog model must not be `diag288`.
 
-Target environment prerequisites::
+== {VirtProductName} prerequisites
 
+The {VirtProductName} environment has the following prerequisites for VM import:
+
+* You must be an admin user.
 * The {product-title} storage class must be NFS.
 endif::[]
 
 ifdef::virt-importing-vmware-vm[]
 Importing a virtual machine from VMware vCenter into {VirtProductName} has the following prerequisites:
 
+* You must be an admin user.
 * You must have access to an image registry.
 * You must create a VMware Virtual Disk Development Kit (VDDK) image, push it to an image registry, and add it to the `v2v-vmware` ConfigMap.
 * The VMware virtual machine must be powered off.

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -77,7 +77,7 @@ endif::[]
 ifdef::virt-importing-rhv-vm[]
 * *General* -> *Name*: The VM name is limited to 63 characters. link:https://bugzilla.redhat.com/show_bug.cgi?id=1857165[(*BZ#1857165*)]
 * *General* -> *Description*: Optional description of the VM.
-* *Storage* -> *Storage Class*: The default storage class must be NFS.
+* *Storage* -> *Storage Class*: Select *NFS*.
 * *Networking* -> *Network*: You can select a network from a list of available `NetworkAttachmentDefinition` objects.
 endif::[]
 
@@ -105,7 +105,7 @@ ifdef::virt-importing-vmware-vm[]
 ** *Source*: For example, *Import Disk*.
 ** *Size*
 ** *Interface*
-** *Storage Class*: If you do not select a storage class, the default storage class is used for the VM disk and the v2v-conversion-template disk. The v2v-conversion-template disk is a 2 GB disk that is used as scratch space for copying the VM disk.
+** *Storage Class*: If you do not select a storage class, the default storage class is used for the VM disk and the `v2v-conversion-template` disk. The `v2v-conversion-template` disk is a 2 GB disk that is used as scratch space for copying the VM disk.
 +
 The following storage classes are supported for VMware VM import:
 

--- a/modules/virt-troubleshooting-vm-import.adoc
+++ b/modules/virt-troubleshooting-vm-import.adoc
@@ -96,8 +96,9 @@ You can perform the following actions to fix this problem:
 ** Change the RHV VM operating system to an operating system that exists in the default `vm-import-controller` ConfigMap.
 ** If you created a custom ConfigMap, check the ConfigMap to verify that the RHV VM operating system is mapped to a matching {VirtProductName} common template.
 ** If there is no matching {VirtProductName} common template, create an appropriate VM template in the {VirtProductName} console and then create a custom ConfigMap to map the RHV VM operating system to the new template.
-endif::[]
 
+* The migration will hang at the *Starting Red Hat Virtualization (RHV) controller* message in the {VirtProductName} console if a non-admin user tries to import a VM. Only an admin user has permission to import a VM.
+endif::[]
 endif::[]
 
 ifdef::virt-importing-vmware-vm[]
@@ -120,6 +121,15 @@ Configmaps "vmware-to-kubevirt-os" not found
 This warning does not affect the VMware virtual machine import.
 endif::[]
 
+* The following error message is displayed in the {product-title} console if a non-admin user tries to import a VM:
++
+[source,terminal]
+----
+Could not load ConfigMap vmware-to-kubevirt-os in kube-public namespace
+Restricted Access: configmaps "vmware-to-kubevirt-os" is forbidden: User cannot get resource "configmaps" in API group "" in the namespace "kube-public"
+----
++
+Only an admin user can import a VM.
 endif::[]
 
 ifdef::virt-importing-vmware-vm[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1872318
Error message bug: https://bugzilla.redhat.com/show_bug.cgi?id=1871109

Bug applies to both RHV and VMware VM import.

Changes:

admin user added to prerequisites:
https://rhv-import-requires-admin--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-prerequisites_virt-importing-rhv-vm

error message added to troubleshooting:

https://rhv-import-requires-admin--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#error-messages_virt-importing-rhv-vm

Target version 2.4.1

CP for 4.5, 4.6