### PR TITLE
CNV - updating 'HCOVersion' attribute

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -25,11 +25,11 @@ ifdef::from-main-support-section[]
 ifndef::openshift-origin[]
 
 .Supported must-gather images
-[cols="2,2",options="header"]
+[cols="2,2",options="header",subs="attributes+"]
 |===
 |Image |Purpose
 
-|`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v2.4.0`
+|`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v{HCOVersion}`
 |Data collection for {VirtProductName}.
 
 |`registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8`
@@ -97,11 +97,11 @@ ifndef::openshift-origin[]
 arguments. For example, the following command gathers both the default cluster
 data and information specific to {VirtProductName}:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ oc adm must-gather \
  --image-stream=openshift/must-gather \ <1>
- --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v2.4.0 <2>
+ --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v{HCOVersion} <2>
 ----
 <1> The default {product-title} must-gather image
 <2> The must-gather image for {VirtProductName}

--- a/modules/virt-about-collecting-virt-data.adoc
+++ b/modules/virt-about-collecting-virt-data.adoc
@@ -19,4 +19,4 @@ resources
 
 To collect {VirtProductName} data with `must-gather`, you must specify the
 {VirtProductName} image:
-`--image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v2.4.0`.
+`--image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v{HCOVersion}`.

--- a/modules/virt-deleting-virt-cli.adoc
+++ b/modules/virt-deleting-virt-cli.adoc
@@ -51,7 +51,7 @@ $ oc delete csv ${CSV_NAME} -n openshift-cnv
 {VirtProductName} is uninstalled when a confirmation message indicates that the CSV was deleted successfully:
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-clusterserviceversion.operators.coreos.com "kubevirt-hyperconverged-operator.v2.4.0" deleted
+clusterserviceversion.operators.coreos.com "kubevirt-hyperconverged-operator.v{HCOVersion}" deleted
 ----

--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.4
 :KubeVirtVersion: v0.30.5
-:HCOVersion: 2.4.0
+:HCOVersion: 2.4.1
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -1,6 +1,7 @@
 [id="gathering-cluster-data"]
 = Gathering data about your cluster
 include::modules/common-attributes.adoc[]
+include::modules/virt-document-attributes.adoc[]
 :context: gathering-cluster-data
 
 toc::[]


### PR DESCRIPTION
Updating the HCOVersion attribute ahead of 2.4.1. Also taking the opportunity to update hardcoded instances with the HCOVersion attribute - the knock-on effect being adding the virt-attributes file tot he OCP gathering data assembly, and the subs="attributes+" powerglove for relevant codeblocks and table

@ousleyp 