### PR TITLE
BZ1872278 - Clarify vSphere Reg Storage RWO Docs

### DIFF
--- a/modules/installation-registry-storage-block-recreate-rollout.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout.adoc
@@ -14,6 +14,11 @@
 
 To allow the image registry to use block storage types such as vSphere Virtual Machine Disk (VMDK) during upgrades as a cluster administrator, you can use the `Recreate` rollout strategy.
 
+[IMPORTANT]
+====
+Block storage volumes are not recommended for use with image registry on production clusters. An installation where the registry is configured on block storage is not highly available because the registry cannot have more than one replica.
+====
+
 .Procedure
 
 . To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only `1` replica:

--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -17,14 +17,13 @@ registry to use storage.
 
 * Cluster administrator permissions.
 * A cluster on VMware vSphere.
-* Provision persistent storage
-for your cluster. To deploy a private image registry, your storage must provide
+* Provision persistent storage for your cluster. To deploy a private image registry, your storage must provide
 ReadWriteMany access mode.
 +
 [IMPORTANT]
 ====
 vSphere volumes do not support the `ReadWriteMany` access mode. You must use
-a different storage backend, such as `NFS`, to configure the registry storage.
+a different storage backend, such as object storage, to configure the registry storage for high-availability.
 ====
 +
 * Must have "100Gi" capacity.


### PR DESCRIPTION
[BZ1872278](https://bugzilla.redhat.com/show_bug.cgi?id=1872278)
Since 4.4, OCP supports RWO, which means vSphere volumes can be used for image registry storage, although they are not recommended for production clusters because they cannot have more than 1 replica, and thus, are not highly available.

Also, replaces NFS with object storage as example for storage backend config of registry.
**Cc:** @bmcelvee 