### PR TITLE
Do not instruct to create an empty configmap for monitoring operator

### DIFF
--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -3,36 +3,26 @@
 // * monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
 
 [id="creating-cluster-monitoring-configmap_{context}"]
-= Creating cluster monitoring ConfigMap
+= Creating a cluster monitoring ConfigMap
 
-To configure the Prometheus Cluster Monitoring stack, you must create the cluster monitoring ConfigMap.
+To configure the {product-title} monitoring stack, you must create the cluster monitoring ConfigMap.
 
 .Prerequisites
 
-* An installed `oc` CLI tool
-* Administrative privileges for the cluster
+* You have access to the cluster as a user with the cluster-admin role.
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
 . Check whether the `cluster-monitoring-config` ConfigMap object exists:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get configmap cluster-monitoring-config
 ----
 
-. If it does not exist, create it:
-+
-----
-$ oc -n openshift-monitoring create configmap cluster-monitoring-config
-----
-
-. Start editing the `cluster-monitoring-config` ConfigMap:
-+
-----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
-----
-
-. Create the `data` section if it does not exist yet:
+. If the ConfigMap does not exist:
+.. Create the following YAML manifest. In this example the file is called `cluster-monitoring-config.yaml`:
 +
 [source,yaml]
 ----
@@ -43,4 +33,11 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
+----
++
+.. Apply the configuration to create the ConfigMap:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
 ----


### PR DESCRIPTION
Since this PR has been merged in `cluster-monitoring-operator`  https://github.com/openshift/cluster-monitoring-operator/pull/731 creating config map without `config.yaml` will immediately cause the operator to go to Degraded state. Even though the next step mitigates this state, it takes few minutes for operator to get back to healthy state. We should not instruct our customers to run commands that create damage. If the person following instructions as they currently are and left process in the mid-way or just copy pastes commands from here and there will leave their cluster in unupgradeable state.

```
$ oc get co monitoring
NAME         VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.4.17    True        False         False      96m
$ oc -n openshift-monitoring create configmap cluster-monitoring-config
configmap/cluster-monitoring-config created
$ oc get co monitoring
NAME         VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.4.17    False       False         True       2s
$ oc -n openshift-monitoring delete configmap cluster-monitoring-config
configmap "cluster-monitoring-config" deleted
$ oc get co monitoring
NAME         VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.4.17    False       True          True       52s
```

operator logs:
```
I0825 02:38:17.125769       1 operator.go:299] Updating ClusterOperator status to failed. Err: the Cluster Monitoring ConfigMap doesn't contain a 'config.yaml' key
E0825 02:38:17.150089       1 operator.go:273] Syncing "openshift-monitoring/cluster-monitoring-config" failed
E0825 02:38:17.150119       1 operator.go:274] sync "openshift-monitoring/cluster-monitoring-config" failed: the Cluster Monitoring ConfigMap doesn't contain a 'config.yaml' key
```

