### PR TITLE
Task migration from using Resources to using workspaces

### DIFF
--- a/modules/op-about-pipelinerun.adoc
+++ b/modules/op-about-pipelinerun.adoc
@@ -9,7 +9,7 @@ A _PipelineRun_ instantiates a Pipeline for execution with specific inputs, outp
 
 All the Tasks in the Pipeline are executed in the defined sequence until all Tasks are successful or a Task fails. The `status` field tracks and stores the progress of each TaskRun in the PipelineRun for monitoring and auditing purpose.
 
-Here is an example of a PipelineRun to run a Pipeline `build-and-deploy` with relevant resources and parameters:
+The following example shows a PipelineRun to run the `build-and-deploy` Pipeline  with relevant resources and parameters:
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1beta1 <1>
@@ -19,20 +19,21 @@ metadata:
 spec:
   pipelineRef:
     name: build-and-deploy <4>
-  resources: <5>
-  - name: git-repo
-    resourceRef:
-      name: api-repo
-  - name: image
-    resourceRef:
-      name: api-image
-  params: <6>
+  params: <5>
   - name: deployment-name
     value: vote-api
+  - name: git-url
+    value: http://github.com/openshift-pipelines/vote-api.git
+  - name: IMAGE
+    value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api
+  workspaces: <6>
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: source-pvc
 ----
 <1> PipelineRun API version `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `PipelineRun`.
 <3> Unique name to identify this PipelineRun.
 <4> Name of the Pipeline to be run. In this example, `build-and-deploy`.
-<5> Name of the resources which will be required to run the Pipeline `build-and-deploy`.
-<6> Specifies the list of parameters required to run the Pipeline.
+<5> Specifies the list of parameters required to run the Pipeline.
+<6> Workspace used by the PipelineRun.

--- a/modules/op-about-pipelines.adoc
+++ b/modules/op-about-pipelines.adoc
@@ -9,57 +9,91 @@ A _Pipeline_ is a collection of Tasks arranged in a specific order of execution.
 
 A Pipeline definition consists of a number of fields or attributes, which together enable the Pipeline to accomplish a specific goal. Each Pipeline definition must contain at least one Task, which ingests specific inputs and produces specific outputs. The Pipeline definition can also optionally include Conditions, Workspaces, Parameters, or Resources depending on the application requirements.
 
-Here is a code snippet of a Pipeline `build-and-deploy`, which builds an application image from a Git repository using `buildah` ClusterTask:
+The following example shows the `build-and-deploy` Pipeline, which builds an application image from a Git repository using the `buildah` ClusterTask:
 
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1beta1 <1>
 kind: Pipeline <2>
-metadata: <3>
-  name: build-and-deploy
+metadata:
+  name: build-and-deploy <3>
 spec: <4>
-  resources: <5>
-  - name: git-repo
-    type: git
-  - name: image
-    type: image
+  workspaces: <5>
+  - name: shared-workspace
   params: <6>
   - name: deployment-name
     type: string
     description: name of the deployment to be patched
+  - name: git-url
+    type: string
+    description: url of the git repo for the code of deployment
+  - name: git-revision
+    type: string
+    description: revision to be used from repo of the code for deployment
+    default: "release-tech-preview-2"
+  - name: IMAGE
+    type: string
+    description: image to be build from the code
   tasks: <7>
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+      kind: ClusterTask
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+    - name: revision
+      value: $(params.git-revision)
   - name: build-image <8>
     taskRef:
       name: buildah
       kind: ClusterTask
-    resources:
-      inputs:
-      - name: source
-        resource: git-repo
-      outputs:
-      - name: image
-        resource: image
     params:
     - name: TLSVERIFY
       value: "false"
+    - name: IMAGE
+      value: $(params.IMAGE)
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    runAfter:
+    - fetch-repository
   - name: apply-manifests <9>
     taskRef:
       name: apply-manifests
-    resources:
-      inputs:
-      - name: source
-        resource: git-repo
+    workspaces:
+    - name: source
+      workspace: shared-workspace
     runAfter: <10>
     - build-image
-...
+  - name: update-deployment
+    taskRef:
+      name: update-deployment
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: deployment
+      value: $(params.deployment-name)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    runAfter:
+    - apply-manifests
 ----
 <1> Pipeline API version `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `Pipeline`.
 <3> Unique name of this Pipeline.
 <4> Specifies the definition and structure of the Pipeline.
-<5> Set of resources required to run the Tasks specified in the Pipeline.
+<5> Workspaces used across all the Tasks in the Pipeline.
 <6> Parameters used across all the Tasks in the Pipeline.
-<7> Specifies the list of Tasks used in the Pipeline. In this example, two Tasks are specified: `build-image` and `apply-manifests`.
+<7> Specifies the list of Tasks used in the Pipeline.
 <8> Task `build-image`, which uses the `buildah` ClusterTask to build application images from a given Git repository.
 <9> Task `apply-manifests`, which uses a user-defined Task with the same name.
 <10> Specifies the sequence in which Tasks are run in a Pipeline. In this example, the `apply-manifests` Task is run only after the `build-image` Task is completed.

--- a/modules/op-about-taskrun.adoc
+++ b/modules/op-about-taskrun.adoc
@@ -9,7 +9,7 @@ A _TaskRun_ instantiates a Task for execution with specific inputs, outputs, and
 
 A Task consists of one or more Steps that execute container images, and each container image performs a specific piece of build work. A TaskRun executes the Steps in a Task in the specified order, until all Steps execute successfully or a failure occurs.
 
-Here is an example of a TaskRun to run a Task `apply-manifests` with relevant input parameters:
+The following example shows a TaskRun that runs the `apply-manifests` Task with the relevant input parameters:
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1beta1 <1>
@@ -17,22 +17,18 @@ kind: TaskRun <2>
 metadata:
   name: apply-manifests-taskrun <3>
 spec: <4>
-  resources: <5>
-    inputs:
-    - name: source
-      resourceRef:
-        name: git-resource-name
-  params: <6>
-  - name: manifest_dir
-    value: directory-name
-  taskRef: <7>
-    name: apply-manifests
+  serviceAccountName: pipeline
+  taskRef: <5>
     kind: Task
+    name: apply-manifests
+  workspaces: <6>
+  - name: source
+    persistentVolumeClaim:
+      claimName: source-pvc
 ----
 <1> TaskRun API version `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `TaskRun`.
 <3> Unique name to identify this TaskRun.
-<4> Definition of the TaskRun. For this TaskRun, a set of input resources, parameters, and Tasks are specified.
-<5> Resources required to run the Tasks. For this TaskRun, `git-resource-name` is referred as an input resource.
-<6> List of parameters required to run the Task.
-<7> Name of the Task reference used for this TaskRun. This TaskRun executes the Task `apply-manifests`.
+<4> Definition of the TaskRun. For this TaskRun, the Task and the required workspace are specified.
+<5> Name of the Task reference used for this TaskRun. This TaskRun executes the `apply-manifests` Task.
+<6> Workspace used by the TaskRun.

--- a/modules/op-about-tasks.adoc
+++ b/modules/op-about-tasks.adoc
@@ -5,38 +5,43 @@
 [id="about-tasks_{context}"]
 = Tasks
 
-_Tasks_ are the building blocks of a Pipeline and consist of sequentially executed Steps. Steps are a series of commands that achieve a specific goal, such as building an image.
+_Tasks_ are the building blocks of a Pipeline and consist of sequentially executed Steps. Tasks are reusable and can be used in multiple Pipelines.
 
-Every Task runs as a Pod and each Step runs in its own container within the same Pod. Because Steps run within the same Pod, they have access to the same volumes for caching files, ConfigMaps, and Secrets.
+_Steps_ are a series of commands that achieve a specific goal, such as building an image. Every Task runs as a Pod and each Step runs in its own container within the same Pod. Because Steps run within the same Pod, they have access to the same volumes for caching files, ConfigMaps, and Secrets.
 
-A Task uses `inputs` parameters, such as a Git resource, and `outputs` parameters, such as an image in a registry, to interact with other Tasks. They are reusable and can be used in multiple Pipelines.
-
-Here is an example of a Maven Task with a single Step to build a Maven-based Java application.
+The following example shows the `apply-manifests` Task.
 
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1beta1 <1>
 kind: Task <2>
 metadata:
-  name: maven-build <3>
+  name: apply-manifests <3>
 spec: <4>
-  resources:
-    inputs:
-    - name: workspace-git
-      targetPath: /
-      type: git
+  params:
+  - default: k8s
+    description: The directory in source that contains yaml manifests
+    name: manifest_dir
+    type: string
   steps:
-  - name: build
-    image: maven:3.6.0-jdk-8-slim
+  - args:
+    - |-
+      echo Applying manifests in $(inputs.params.manifest_dir) directory
+      oc apply -f $(inputs.params.manifest_dir)
+      echo -----------------------------------
     command:
-    - /usr/bin/mvn
-    args:
-    - install
+    - /bin/bash
+    - -c
+    image: quay.io/openshift/origin-cli:latest
+    name: apply
+    workingDir: /workspace/source
+  workspaces:
+  - name: source
 ----
 <1> Task API version `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `Task`.
 <3> Unique name of this Task.
-<4> Lists the Task Steps along with input and output resources.
+<4> Lists the parameters and Steps in the Task and the workspace used by the Task.
 
 This Task starts the Pod and runs a container inside that Pod using the `maven:3.6.0-jdk-8-slim` image to run the specified commands. It receives an input directory called `workspace-git` that contains the source code of the application.
 

--- a/modules/op-about-triggers.adoc
+++ b/modules/op-about-triggers.adoc
@@ -2,8 +2,6 @@
 //
 // *openshift_pipelines/creating-applications-with-cicd-pipelines.adoc
 
-
-
 [id="about-triggers_{context}"]
 = Triggers
 
@@ -21,14 +19,14 @@ EventListeners tie the concepts of TriggerBindings and TriggerTemplates together
 
 //image::op-triggers.png[]
 
-Here is a code snippet of the `vote-app-binding` TriggerBinding, which extracts the Git repository information from the received event payload:
+The following example shows a code snippet of the `vote-app-binding` TriggerBinding, which extracts the Git repository information from the received event payload:
 
 [source,yaml]
 ----
 apiVersion: triggers.tekton.dev/v1alpha1 <1>
 kind: TriggerBinding <2>
 metadata:
-  name: vote-app-binding <3>
+  name: vote-app <3>
 spec:
   params: <4>
   - name: git-repo-url
@@ -45,13 +43,13 @@ spec:
 <4> List of parameters which will be extracted from the received event payload and passed to the TriggerTemplate. In this example, the Git repository URL, name, and revision are extracted from the body of the event payload.
 
 
-Here is a code snippet of a `vote-app-template` TriggerTemplate, which creates Pipeline Resources from the Git repository information received from the TriggerBinding:
+The following example shows a code snippet of a `vote-app-template` TriggerTemplate, which creates Pipeline Resources from the Git repository information received from the TriggerBinding:
 [source,yaml]
 ----
 apiVersion: triggers.tekton.dev/v1alpha1 <1>
 kind: TriggerTemplate <2>
 metadata:
-  name: vote-app-template <3>
+  name: vote-app <3>
 spec:
   params: <4>
   - name: git-repo-url
@@ -61,19 +59,29 @@ spec:
     default: master
   - name: git-repo-name
     description: The name of the deployment to be created / patched
+
   resourcetemplates: <5>
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource <6>
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
     metadata:
-      name: $(tt.params.git-repo-name)-git-repo-$(uid)
+      name: build-deploy-$(tt.params.git-repo-name)-$(uid)
     spec:
-      type: git
+      serviceAccountName: pipeline
+      pipelineRef:
+        name: build-and-deploy
       params:
-      - name: revision
-        value: $(tt.params.git-revision)
-      - name: url
+      - name: deployment-name
+        value: $(tt.params.git-repo-name)
+      - name: git-url
         value: $(tt.params.git-repo-url)
-...
+      - name: git-revision
+        value: $(tt.params.git-revision)
+      - name: IMAGE
+        value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/$(tt.params.git-repo-name)
+      workspaces:
+      - name: shared-workspace
+        persistentvolumeclaim:
+          claimName: source-pvc
 ----
 
 <1> TriggerTemplate API version `v1alpha1`.
@@ -81,9 +89,9 @@ spec:
 <3> Unique name to identify this TriggerTemplate.
 <4> Parameters supplied by the TriggerBinding or EventListerner.
 <5> List of Resource templates created for the Pipeline from the parameters received in the TriggerBinding or EventListener.
-<6> A Pipeline Resource of type `git` is created using the parameters `git-repo-name`, `git-repo-url`, and `git-revision`.
 
-Here is an example of an EventListener which uses `vote-app-binding` TriggerBinding and `vote-app-template` TriggerTemplate to process incoming events.
+
+The following example shows an EventListener which uses `vote-app-binding` TriggerBinding and `vote-app-template` TriggerTemplate to process incoming events.
 
 [source,yaml]
 ----
@@ -95,9 +103,9 @@ spec:
   serviceAccountName: pipeline <4>
   triggers:
   - bindings: <5>
-    - name: vote-app-binding
+    - ref: vote-app
     template: <6>
-      name: vote-app-template
+      name: vote-app
 ----
 <1> EventListener API version `v1alpha1`.
 <2> Specifies the type of Kubernetes object. In this example, `EventListener`.

--- a/modules/op-about-workspace.adoc
+++ b/modules/op-about-workspace.adoc
@@ -5,9 +5,14 @@
 [id="about-workspaces_{context}"]
 = Workspaces
 
+[NOTE]
+====
+It is recommended that you use Workspaces instead of PipelineResources in OpenShift Pipelines, as PipelineResources are difficult to debug, limited in scope, and make Tasks less reusable.
+====
+
 Workspaces declare shared storage volumes that a Task in a Pipeline needs at runtime. Instead of specifying the actual location of the volumes, Workspaces enable you to declare the filesystem or parts of the filesystem that would be required at runtime. You must provide the specific location details of the volume that is mounted into that Workspace in a TaskRun or a PipelineRun. This separation of volume declaration from runtime storage volumes makes the Tasks reusable, flexible, and independent of the user environment.
 
-Listed below are the various ways in which you can use Workspaces:
+With Workspaces, you can:
 
 * Store Task inputs and outputs
 * Share data among Tasks
@@ -23,7 +28,7 @@ You can specify Workspaces in the TaskRun or PipelineRun using:
 * A PersistentVolumeClaim from a provided VolumeClaimTemplate
 * An emptyDir that is discarded when the TaskRun completes
 
-Here is a code snippet of the `build-and-deploy` Pipeline which declares a `shared-workspace` Workspace for the Tasks, `build-image` and `apply-manifests`, defined in the Pipeline.
+The following example shows a code snippet of the `build-and-deploy` Pipeline, which declares a `shared-workspace` Workspace for the `build-image` and `apply-manifests` Tasks as defined in the Pipeline.
 
 [source,yaml]
 ----
@@ -65,8 +70,8 @@ spec:
 <2> Definition of Tasks used in the Pipeline. This snippet defines two Tasks, `build-image` and `apply-manifests`, which share a common Workspace.
 <3> List of Workspaces used in the `build-image` Task. A Task definition can include as many Workspaces as it requires. However, it is recommended that a Task uses at most one writable Workspace.
 <4> Name that uniquely identifies the Workspace used in the Task. This Task uses one Workspace named `source`.
-<5> Name of the Pipeline Workspace used by the Task. Note that the Workspace `source` in turn uses Pipeline Workspace `shared-workspace`.
-<6> List of Workspaces used in `apply-manifests` Task. Note that this Task shares the `source` Workspace with `build-image` Task.
+<5> Name of the Pipeline Workspace used by the Task. Note that the Workspace `source` in turn uses the Pipeline Workspace named `shared-workspace`.
+<6> List of Workspaces used in the `apply-manifests` Task. Note that this Task shares the `source` Workspace with the `build-image` Task.
 
 Here is a code snippet of the `build-deploy-api-pipelinerun` PipelineRun, which uses a PersistentVolumeClaim for defining the storage volume for the `shared-workspace` Workspace used in the `build-and-deploy` Pipeline.
 
@@ -79,10 +84,6 @@ metadata:
 spec:
   pipelineRef:
     name: build-and-deploy
-  resources:
-  - name: image
-    resourceRef:
-      name: api-image
   params:
 ...
 

--- a/modules/op-adding-triggers.adoc
+++ b/modules/op-adding-triggers.adoc
@@ -2,11 +2,10 @@
 //
 // *openshift_pipelines/creating-applications-with-cicd-pipelines.adoc
 
-
 [id="adding-triggers_{context}"]
 = Adding Triggers to a Pipeline
 
-After you have assembled and started the Pipeline for the application, add TriggerBindings, TriggerTemplates, and an EventListener to capture GitHub events.
+Triggers enable Pipelines to respond to external GitHub events, such as push events and pull requests. After you have assembled and started the Pipeline for the application, add TriggerBindings, TriggerTemplates, and an EventListener to capture the GitHub events.
 
 [discrete]
 .Procedure
@@ -37,7 +36,7 @@ $ oc create -f <triggerbinding-yaml-file-name.yaml>
 Alternatively, you can create the `TriggerBinding` directly from the `pipelines-tutorial` Git repository:
 +
 ----
-$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-1/03_triggers/01_binding.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/03_triggers/01_binding.yaml
 ----
 
 . Copy the content of the following sample `TriggerTemplate` YAML file and save it:
@@ -54,33 +53,11 @@ spec:
     description: The git repository url
   - name: git-revision
     description: The git revision
-    default: master
+    default: release-tech-preview-2
   - name: git-repo-name
     description: The name of the deployment to be created / patched
 
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: $(tt.params.git-repo-name)-git-repo-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(tt.params.git-revision)
-      - name: url
-        value: $(tt.params.git-repo-url)
-
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: $(tt.params.git-repo-name)-image-$(uid)
-    spec:
-      type: image
-      params:
-      - name: url
-        value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/$(tt.params.git-repo-name):latest
-
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -89,16 +66,19 @@ spec:
       serviceAccountName: pipeline
       pipelineRef:
         name: build-and-deploy
-      resources:
-      - name: git-repo
-        resourceRef:
-          name: $(tt.params.git-repo-name)-git-repo-$(uid)
-      - name: image
-        resourceRef:
-          name: $(tt.params.git-repo-name)-image-$(uid)
       params:
       - name: deployment-name
         value: $(tt.params.git-repo-name)
+      - name: git-url
+        value: $(tt.params.git-repo-url)
+      - name: git-revision
+        value: $(tt.params.git-revision)
+      - name: IMAGE
+        value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/$(tt.params.git-repo-name)
+      workspaces:
+      - name: shared-workspace
+        persistentvolumeclaim:
+          claimName: source-pvc
 ----
 
 . Create the `TriggerTemplate`:
@@ -110,7 +90,7 @@ $ oc create -f <triggertemplate-yaml-file-name.yaml>
 Alternatively, you can create the `TriggerTemplate` directly from the `pipelines-tutorial` Git repository:
 +
 ----
-$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-1/03_triggers/02_template.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/03_triggers/02_template.yaml
 ----
 
 . Copy the contents of the following sample `EventListener` YAML file and save it:
@@ -139,7 +119,7 @@ $ oc create -f <eventlistener-yaml-file-name.yaml>
 Alternatively, you can create the `EvenListener` directly from the `pipelines-tutorial` Git repository:
 +
 ----
-$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-1/03_triggers/03_event_listener.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/03_triggers/03_event_listener.yaml
 ----
 
 . Expose the EventListener service as an {product-title} route to make it publicly accessible:

--- a/modules/op-assembling-a-pipeline.adoc
+++ b/modules/op-assembling-a-pipeline.adoc
@@ -5,7 +5,9 @@
 [id="assembling-a-pipeline_{context}"]
 = Assembling a Pipeline
 
-A Pipeline represents a CI/CD flow and is defined by the Tasks to be executed. It specifies how the Tasks interact with each other and their order of execution using the `inputs` , `outputs`, and `runAfter` parameters. It is designed to be generic and reusable in multiple applications and environments.
+A Pipeline represents a CI/CD flow and is defined by the Tasks to be executed. It is designed to be generic and reusable in multiple applications and environments.
+
+A Pipeline specifies how the Tasks interact with each other and their order of execution using the `from` and `runAfter` parameters. It uses the `workspaces` field to specify one or more volumes that each Task in the Pipeline requires during execution.
 
 In this section, you will create a Pipeline that takes the source code of the application from GitHub and then builds and deploys it on {product-title}.
 
@@ -16,10 +18,10 @@ In this section, you will create a Pipeline that takes the source code of the ap
 
 The Pipeline performs the following tasks for the back-end application `vote-api` and front-end application `vote-ui`:
 
-* Clones the source code of the application from the Git repositories `api-repo` and `ui-repo`.
-* Builds the container images `api-image` and `ui-image` using the `buildah` ClusterTask.
-* Pushes the `api-image` and `ui-image` images to the internal image registry.
-* Deploys the new images on {product-title} using the `apply-manifests` and `update-deployment` Tasks.
+* Clones the source code of the application from the Git repository by referring to the `git-url` and `git-revision` parameters.
+* Builds the container image using the `buildah` ClusterTask.
+* Pushes the image to the internal image registry by referring to the `image` parameter.
+* Deploys the new image on {product-title} by using the `apply-manifests` and `update-deployment` Tasks.
 
 [discrete]
 .Procedure
@@ -33,54 +35,77 @@ kind: Pipeline
 metadata:
   name: build-and-deploy
 spec:
-  resources:
-  - name: git-repo
-    type: git
-  - name: image
-    type: image
+  workspaces:
+  - name: shared-workspace
   params:
   - name: deployment-name
     type: string
     description: name of the deployment to be patched
+  - name: git-url
+    type: string
+    description: url of the git repo for the code of deployment
+  - name: git-revision
+    type: string
+    description: revision to be used from repo of the code for deployment
+    default: "release-tech-preview-2"
+  - name: IMAGE
+    type: string
+    description: image to be build from the code
   tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+      kind: ClusterTask
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+    - name: revision
+      value: $(params.git-revision)
   - name: build-image
     taskRef:
       name: buildah
       kind: ClusterTask
-    resources:
-      inputs:
-      - name: source
-        resource: git-repo
-      outputs:
-      - name: image
-        resource: image
     params:
     - name: TLSVERIFY
       value: "false"
+    - name: IMAGE
+      value: $(params.IMAGE)
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    runAfter:
+    - fetch-repository
   - name: apply-manifests
     taskRef:
       name: apply-manifests
-    resources:
-      inputs:
-      - name: source
-        resource: git-repo
+    workspaces:
+    - name: source
+      workspace: shared-workspace
     runAfter:
     - build-image
   - name: update-deployment
     taskRef:
       name: update-deployment
-    resources:
-      inputs:
-      - name: image
-        resource: image
+    workspaces:
+    - name: source
+      workspace: shared-workspace
     params:
     - name: deployment
       value: $(params.deployment-name)
+    - name: IMAGE
+      value: $(params.IMAGE)
     runAfter:
     - apply-manifests
 ----
 +
-Notice that the Pipeline definition abstracts away the specifics of the Git source repository and image registries to be used during the Pipeline execution.
+The Pipeline definition abstracts away the specifics of the Git source repository and image registries. These details are added as `params` when a Pipeline is triggered and executed.
 
 . Create the Pipeline:
 +
@@ -91,7 +116,7 @@ $ oc create -f <pipeline-yaml-file-name.yaml>
 Alternatively, you can also execute the YAML file directly from the Git repository:
 +
 ----
-$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-1/01_pipeline/04_pipeline.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/01_pipeline/04_pipeline.yaml
 ----
 
 . Use the `tkn pipeline list` command to verify that the Pipeline is added to the application:

--- a/modules/op-creating-pipeline-tasks.adoc
+++ b/modules/op-creating-pipeline-tasks.adoc
@@ -11,8 +11,8 @@
 . Install the `apply-manifests` and `update-deployment` Tasks from the `pipelines-tutorial` repository, which contains a list of reusable Tasks for Pipelines:
 +
 ----
-$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-1/01_pipeline/01_apply_manifest_task.yaml
-$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-1/01_pipeline/02_update_deployment_task.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/01_pipeline/01_apply_manifest_task.yaml
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/01_pipeline/02_update_deployment_task.yaml
 ----
 
 . Use the `tkn task list` command to list the Tasks you created:
@@ -45,32 +45,7 @@ The output lists the Operator-installed ClusterTasks:
 ----
 NAME                       DESCRIPTION   AGE
 buildah                                  1 day ago
-buildah-v0-11-3                          1 day ago
 git-clone                                1 day ago
-jib-maven                                1 day ago
-kn                                       1 day ago
-maven                                    1 day ago
-openshift-client                         1 day ago
-openshift-client-v0-11-3                 1 day ago
-s2i                                      1 day ago
-s2i-dotnet-3                             1 day ago
-s2i-dotnet-3-v0-11-3                     1 day ago
-s2i-go                                   1 day ago
-s2i-go-v0-11-3                           1 day ago
-s2i-java-11                              1 day ago
-s2i-java-11-v0-11-3                      1 day ago
-s2i-java-8                               1 day ago
-s2i-java-8-v0-11-3                       1 day ago
-s2i-nodejs                               1 day ago
-s2i-nodejs-v0-11-3                       1 day ago
-s2i-perl                                 1 day ago
-s2i-perl-v0-11-3                         1 day ago
 s2i-php                                  1 day ago
-s2i-php-v0-11-3                          1 day ago
-s2i-python-3                             1 day ago
-s2i-python-3-v0-11-3                     1 day ago
-s2i-ruby                                 1 day ago
-s2i-ruby-v0-11-3                         1 day ago
-s2i-v0-11-3                              1 day ago
 tkn                                      1 day ago
 ----

--- a/modules/op-pipelines-concepts.adoc
+++ b/modules/op-pipelines-concepts.adoc
@@ -15,8 +15,6 @@ PipelineRun:: A PipelineRun is the running instance of a Pipeline. A PipelineRun
 
 TaskRun:: A TaskRun is automatically created by a PipelineRun for each Task in a Pipeline. It is the result of running an instance of a Task in a Pipeline. It can also be manually created if a Task runs outside of a Pipeline.
 
-PipelineResource:: A PipelineResource is an object that is used as an input and output for Pipeline Tasks. For example, if an input is a Git repository and an output is a container image built from that Git repository, these are both classified as PipelineResources. PipelineResources currently support Git resources, Image resources, Cluster resources, Storage Resources and CloudEvent resources.
-
 Workspace:: A Workspace is a storage volume that a Task requires at runtime to receive input or provide output. A Task or Pipeline declares the Workspace, and a TaskRun or PipelineRun provides the actual location of the storage volume, which mounts on the declared Workspace. This makes the Task flexible, reusable, and allows the Workspaces to be shared across multiple Tasks.
 
 Trigger:: A Trigger captures an external event, such as a Git pull request and processes the event payload to extract key pieces of information. This extracted information is then mapped to a set of predefined parameters, which trigger a series of tasks that may involve creation and deployment of Kubernetes resources. You can use Triggers along with Pipelines to create full-fledged CI/CD systems where the execution is defined entirely through Kubernetes resources.

--- a/modules/op-release-notes-1-1.adoc
+++ b/modules/op-release-notes-1-1.adoc
@@ -17,6 +17,8 @@
 In addition to the fixes and stability improvements, here is a highlight of what’s new in OpenShift Pipelines 1.1.
 
 === Pipelines
+
+* Workspaces can now be used instead of PipelineResources. It is recommended that you use Workspaces in OpenShift Pipelines, as PipelineResources are difficult to debug, limited in scope, and make Tasks less reusable. For more details on Workspaces, see Understanding OpenShift Pipelines.
 * Workspace support for VolumeClaimTemplates has been added:
 ** The VolumeClaimTemplate for a PipelineRun and TaskRun can now be added as a volume source for Workspaces. The tekton-controller then creates a PersistentVolumeClaim (PVC) using the template that is seen as a PVC for all TaskRuns in the Pipeline. Thus you do not need to define the PVC configuration every time it binds a workspace that spans multiple tasks.
 ** Support to find the name of the PersistentVolumeClaim when a VolumeClaimTemplate is used as a volume source is now available using variable substitution.

--- a/modules/op-running-a-pipeline.adoc
+++ b/modules/op-running-a-pipeline.adoc
@@ -2,8 +2,6 @@
 //
 // // *openshift_pipelines/creating-applications-with-cicd-pipelines.adoc
 
-
-
 [id="running-a-pipeline_{context}"]
 = Running a Pipeline
 
@@ -15,7 +13,7 @@ A PipelineRun starts a Pipeline and ties it to the Git and image resources that 
 . Start the Pipeline for the back-end application:
 +
 ----
-$ tkn pipeline start build-and-deploy -r git-repo=api-repo -r image=api-image -p deployment-name=vote-api
+$ tkn pipeline start build-and-deploy -w name=shared-workspace,claimName=source-pvc -p deployment-name=vote-api -p git-url=http://github.com/openshift-pipelines/vote-api.git -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api
 ----
 +
 Note the PipelineRun ID returned in the command output.
@@ -28,7 +26,7 @@ $ tkn pipelinerun logs <pipelinerun ID> -f
 . Start the Pipeline for the front-end application:
 +
 ----
-$ tkn pipeline start build-and-deploy -r git-repo=ui-repo -r image=ui-image -p deployment-name=vote-ui
+$ tkn pipeline start build-and-deploy -w name=shared-workspace,claimName=source-pvc -p deployment-name=vote-api -p git-url=http://github.com/openshift-pipelines/vote-ui.git -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui
 ----
 +
 Note the PipelineRun ID returned in the command output.

--- a/modules/op-specifying-pvc-as-volumesource-in-workspaces.adoc
+++ b/modules/op-specifying-pvc-as-volumesource-in-workspaces.adoc
@@ -1,0 +1,41 @@
+// This module is included in the following assembly:
+//
+//  *openshift_pipelines/creating-applications-with-cicd-pipelines.adoc
+
+[id="specifying-pvc-as-volumesource-in-workspaces_{context}"]
+= Specifying PersistentVolumeClaims as VolumeSource in Workspaces
+
+Workspaces help Tasks share data, and allow you to specify one or more volumes that each Task in the Pipeline requires during execution.
+
+In this section, you will create a PersistentVolumeClaim to provide data storage and bind it to the Workspace. This PersistentVolumeClaim provides the volumes or filesystem required for the Pipeline execution.
+
+[discrete]
+.Procedure
+
+. Copy and save the contents of the following sample PersistentVolumeClaim YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+----
++
+. Create the PersistentVolumeClaim, specifying the file you just created:
++
+----
+$ oc create -f <PersistentVolumeClaim-yaml-file-name.yaml>
+----
++
+Alternatively, you can execute the YAML file directly from the Git repository:
++
+----
+$ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/release-tech-preview-2/01_pipeline/03_persistent_volume_claim.yaml
+----

--- a/modules/op-triggering-a-pipelinerun.adoc
+++ b/modules/op-triggering-a-pipelinerun.adoc
@@ -7,20 +7,20 @@
 
 Whenever a `push` event occurs in the Git repository, the configured Webhook sends an event payload to the publicly exposed EventListener service route. The EventListener service of the application processes the payload, and passes it to the relevant TriggerBindings and TriggerTemplates pair. The TriggerBinding extracts the parameters and the TriggerTemplate uses these parameters to create resources. This may rebuild and redeploy the application.
 
-In this section, you will push an empty commit to the front-end `vote-api` repository, which will trigger the PipelineRun.
+In this section, you push an empty commit to the front-end `vote-ui` repository, which then triggers the PipelineRun.
 
 [discrete]
 .Procedure
 
-. From the terminal, clone your forked Git repository `vote-api`:
+. From the terminal, clone your forked Git repository `vote-ui`:
 +
 ----
-$ git clone git@github.com:<your GitHub ID>/vote-api.git -b release-tech-preview-1
+$ git clone git@github.com:<your GitHub ID>/vote-ui.git -b release-tech-preview-2
 ----
 . Push an empty commit:
 +
 ----
-$ git commit -m "empty-commit" --allow-empty && git push origin release-tech-preview-1
+$ git commit -m "empty-commit" --allow-empty && git push origin release-tech-preview-2
 ----
 . Check if the PipelineRun was triggered:
 +

--- a/pipelines/creating-applications-with-cicd-pipelines.adoc
+++ b/pipelines/creating-applications-with-cicd-pipelines.adoc
@@ -10,37 +10,33 @@ With {pipelines-title}, you can create a customized CI/CD solution to build, tes
 To create a full-fledged, self-serving CI/CD Pipeline for an application, you must perform the following tasks:
 
 * Create custom Tasks, or install existing reusable Tasks.
-* Create a Pipeline and PipelineResources to define the delivery Pipeline for your application.
+* Create and define the delivery Pipeline for your application.
+* Create a PersistentVolumeClaim attached to the Workspace to provide the volume or filesystem for Pipeline execution.
 * Create a PipelineRun to instantiate and invoke the Pipeline.
 * Add Triggers to capture any events in the source repository.
 
 This section uses the `pipelines-tutorial` example to demonstrate the preceding tasks. The example uses a simple application which consists of:
 
-* A front-end interface `vote-ui`, with the source code in link:https://github.com/openshift-pipelines/vote-ui/tree/release-tech-preview-1[`ui-repo`] Git repository.
-* A back-end interface `vote-api`, with the source code in link:https://github.com/openshift-pipelines/vote-api/tree/release-tech-preview-1[`api-repo`]  Git repository.
-* `apply_manifest` and `update-deployment` Tasks in link:https://github.com/openshift/pipelines-tutorial/tree/release-tech-preview-1[`pipelines-tutorial`] Git repository.
+* A front-end interface, `vote-ui`, with the source code in the link:https://github.com/openshift-pipelines/vote-ui/tree/release-tech-preview-2[`ui-repo`] Git repository.
+* A back-end interface, `vote-api`, with the source code in the link:https://github.com/openshift-pipelines/vote-api/tree/release-tech-preview-2[`api-repo`]  Git repository.
+* The `apply_manifest` and `update-deployment` Tasks in the link:https://github.com/openshift/pipelines-tutorial/tree/release-tech-preview-2[`pipelines-tutorial`] Git repository.
 
-[discrete]
 == Prerequisites
 
 * You have access to an {product-title} cluster.
-
 * You have installed xref:../pipelines/installing-pipelines.adoc#installing-pipelines[OpenShift Pipelines] using the {pipelines-title} Operator listed in the OpenShift OperatorHub. Once installed, it is applicable to the entire cluster.
-
 * You have installed xref:../cli_reference/tkn_cli/installing-tkn.adoc#installing-tkn[OpenShift Pipelines CLI].
-
-* You have forked the front-end link:https://github.com/openshift-pipelines/vote-ui/tree/release-tech-preview-1[`ui-repo`] and back-end link:https://github.com/openshift-pipelines/vote-api/tree/release-tech-preview-1[`api-repo`] Git repositories using your GitHub ID.
-
-* You have Administrator access to your repositories.
+* You have forked the front-end link:https://github.com/openshift-pipelines/vote-ui/tree/release-tech-preview-2[`ui-repo`] and back-end link:https://github.com/openshift-pipelines/vote-api/tree/release-tech-preview-2[`api-repo`] Git repositories using your GitHub ID, and have Administrator access to these repositories.
+* Optional: You have cloned the link:https://github.com/openshift/pipelines-tutorial/tree/release-tech-preview-2[`pipelines-tutorial`] Git repository.
 
 
 include::modules/op-creating-project-and-checking-pipeline-service-account.adoc[leveloffset=+1]
 
 include::modules/op-creating-pipeline-tasks.adoc[leveloffset=+1]
 
-include::modules/op-defining-and-creating-pipelineresources.adoc[leveloffset=+1]
-
 include::modules/op-assembling-a-pipeline.adoc[leveloffset=+1]
+
+include::modules/op-specifying-pvc-as-volumesource-in-workspaces.adoc[leveloffset=+1]
 
 include::modules/op-running-a-pipeline.adoc[leveloffset=+1]
 
@@ -51,7 +47,7 @@ include::modules/op-creating-webhooks.adoc[leveloffset=+1]
 include::modules/op-triggering-a-pipelinerun.adoc[leveloffset=+1]
 
 [id="pipeline-addtl-resources"]
-.Additional resources
+== Additional resources
 
 * For more details on pipelines in the *Developer* perspective, see the xref:../pipelines/working-with-pipelines-using-the-developer-perspective.adoc#working-with-pipelines-using-the-developer-perspective[working with Pipelines in the *Developer* perspective] section.
 * To learn more about Security Context Constraints (SCCs), see xref:../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing Security Context Constraints] section.

--- a/pipelines/understanding-openshift-pipelines.adoc
+++ b/pipelines/understanding-openshift-pipelines.adoc
@@ -27,7 +27,7 @@ include::modules/op-pipelines-concepts.adoc[leveloffset=+1]
 
 [id="op-detailed-concepts"]
 == Detailed OpenShift Pipeline Concepts
-Given below is a detailed view of the various Pipeline concepts.
+This guide provides a detailed view of the various Pipeline concepts.
 
 //About Tasks
 include::modules/op-about-tasks.adoc[leveloffset=+2]
@@ -43,7 +43,7 @@ include::modules/op-about-workspace.adoc[leveloffset=+2]
 include::modules/op-about-triggers.adoc[leveloffset=+2]
 
 
-.Additional resources
+== Additional resources
 
 * For information on installing Pipelines, see xref:../pipelines/installing-pipelines.adoc#installing-pipelines[Installing OpenShift Pipelines].
 * For more details on creating custom CI/CD solutions, see xref:../pipelines/creating-applications-with-cicd-pipelines.adoc#creating-applications-with-cicd-pipelines[Creating applications with CI/CD Pipelines].


### PR DESCRIPTION
This PR fixes: 

 - https://issues.redhat.com/browse/RHDEVDOCS-2081
 - https://issues.redhat.com/browse/RHDEVDOCS-1693
 - https://issues.redhat.com/browse/RHDEVDOCS-2109

 The YAML files in the creating workflow and Understanding conceptual docs have been updated to reflect the migration from Resources to Workspaces. Notes for migration added. 
New module for pvc volumes added.
This also fixes the bug of adding cloning the tutorial repo to the Prerequisites in the Creating flow.

- This has been reviewed by the QE 
- This needs to be merged to 4.5 and 4.6