### PR TITLE
Add note about assembly headers

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -128,62 +128,41 @@ ID. For example:
 == Managing authorization policies
 ----
 
+== Writing assemblies
+An _assembly_ is a collection of modules that describes how to accomplish a user story.
+
+For more information about forming assemblies, see the
+link:https://redhat-documentation.github.io/modular-docs/#forming-assemblies[Red Hat modular docs reference guide] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc[assembly template].
+
+[NOTE]
+====
+For `Prerequisites`, `Next steps`, and `Additional resources` headings, use `==` formatting in assembly files. Do not use `.Prerequisites`, `.Next steps`, or `.Additional information`, as this syntax should only be used within module files to suppress TOC formatting.
+====
+
 == Writing concepts
 A _concept_ contains information to support the tasks that users want to do and
 must not include task information like commands or numbered steps. In most
 cases, create your concepts as individual modules and include them in
-appropriate assemblies. Avoid using gerunds in concept titles. "About <concept>"
+appropriate assemblies.
+
+Avoid using gerunds in concept titles. "About <concept>"
 is a common concept module title.
 
-For more information about writing concepts, see the
-link:https://redhat-documentation.github.io/modular-docs/[Red Hat modular docs reference guide].
+For more information about creating concept modules, see the
+link:https://redhat-documentation.github.io/modular-docs/#creating-concept-modules[Red Hat modular docs reference guide] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc[concept template].
 
-== Writing tasks
-A _task_ contains the steps that users follow to complete a process. Tasks
-contain ordered steps and explicit commands. In most cases, create your tasks
-as individual modules and include them in appropriate assemblies.
+== Writing procedures
+A _procedure_ contains the steps that users follow to complete a process or task. Procedures contain ordered steps and explicit commands. In most cases, create your procedures as individual modules and include them in appropriate assemblies.
 
-[IMPORTANT]
+Use a gerund in the procedure title, such as "Creating".
+
+For more information about writing procedures, see the
+link:https://redhat-documentation.github.io/modular-docs/#creating-procedure-modules[Red Hat modular docs reference guide] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure template].
+
+[NOTE]
 ====
-Use a verb in the task title (for example, Creating).
+When needed, use `.Prerequisites`, `.Next steps`, or `.Additional information` syntax to suppress TOC formatting within a module. Do not use `==` headings or xrefs in modules.
 ====
-
-Task modules take the following form:
-
-----
-<module_metadata>
-
-After the module file metadata, include a paragraph explaining why the user must
-perform this task. This should be 1-2 sentences maximum.
-
-If applicable, include any gotchas (things that could trip up the user or cause the task to fail).
-
-== Prerequisites
-
-* A bulleted list of prerequisites that MUST be performed before the user can complete this task.
-Skip if there isn't any related information.
-
-.Procedure
-
-. Step 1 - One command per step.
-
-. Step 2 - One command per step.
-
-. Step N
-
-== Next steps
-
-You can explain any other tasks that MUST be completed after this task. You can
-skip this if there are none. Do not include xrefs. If the next steps are closely
-related to the task, you might be able to include their modules in the assembly.
-
-.Related information
-
-* A bulleted list of links to related information about this task. Skip if there isn't any related information.
-----
-
-For more information about writing tasks, see the
-link:https://redhat-documentation.github.io/modular-docs/[Red Hat modular docs reference guide].
 
 == Product name & version
 


### PR DESCRIPTION
Updating guidance about "Next steps" and "Prerequisites" formatting, as described in https://github.com/openshift/openshift-docs/pull/25032 and specifically in Andrea's comment: https://github.com/openshift/openshift-docs/pull/25032#issuecomment-681087488

The purpose is to give guidance that `.` should be used in modules to avoid rendering of a TOC inside the module. I did not update the guidance for "Related information" (or change it to "Additional information", although this seems to be more common) because the guidelines don't show an example of using `==` for this. But maybe it should?

@openshift/team-documentation @vikram-redhat @bergerhoffer PTAL

