### PR TITLE
CNV - Bug 1872418 - Removed unneeded table captions for Domain Settings and V…

### DIFF
--- a/modules/virt-creating-vm.adoc
+++ b/modules/virt-creating-vm.adoc
@@ -32,6 +32,7 @@ ReplicaSet is not currently supported in {VirtProductName}.
 
 
 
+[caption=]
 .Domain settings
 |===
 |Setting | Description
@@ -46,6 +47,7 @@ ReplicaSet is not currently supported in {VirtProductName}.
 |The name of the volume that is referenced. Must match the name of a volume.
 |===
 
+[caption=]
 .Volume settings
 |===
 |Setting | Description


### PR DESCRIPTION
This PR addresses a minor issue raised in Bug 1872418 (https://bugzilla.redhat.com/show_bug.cgi?id=1872418).

Removed unneeded table captions for Volume Settings and Domain Settings tables in the "Using the CLI to create a virtual machine" subprocedure within Virtual Machines > Creating virtual machines

Peer review needed  Merge/CP to branch/enterprise-4.5 and branch/enterprise-4.6

Preview build https://bz1872418--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#virt-creating-vm_virt-create-vms
@aburdenthehand 