### PR TITLE
BZ#1823387 Add networking and port info for Azure/GCP UPI

### DIFF
--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -81,6 +81,8 @@ include::modules/installation-arm-vnet.adoc[leveloffset=+2]
 include::modules/installation-azure-user-infra-deploying-rhcos.adoc[leveloffset=+1]
 include::modules/installation-arm-image-storage.adoc[leveloffset=+2]
 
+include::modules/installation-network-user-infra.adoc[leveloffset=+1]
+
 include::modules/installation-creating-azure-dns.adoc[leveloffset=+1]
 include::modules/installation-arm-dns.adoc[leveloffset=+2]
 

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -88,6 +88,8 @@ include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[lev
 include::modules/installation-extracting-infraid.adoc[leveloffset=+2]
 include::modules/installation-user-infra-exporting-common-variables.adoc[leveloffset=+2]
 
+include::modules/installation-network-user-infra.adoc[leveloffset=+1]
+
 include::modules/installation-creating-gcp-lb.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-ext-lb.adoc[leveloffset=+2]
 include::modules/installation-deployment-manager-int-lb.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -64,6 +64,8 @@ include::modules/installation-user-infra-exporting-common-variables.adoc[levelof
 include::modules/installation-creating-gcp-vpc.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-vpc.adoc[leveloffset=+2]
 
+include::modules/installation-network-user-infra.adoc[leveloffset=+1]
+
 include::modules/installation-creating-gcp-lb.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-ext-lb.adoc[leveloffset=+2]
 include::modules/installation-deployment-manager-int-lb.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -63,6 +63,8 @@ include::modules/installation-user-infra-exporting-common-variables.adoc[levelof
 include::modules/installation-creating-gcp-vpc.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-vpc.adoc[leveloffset=+2]
 
+include::modules/installation-network-user-infra.adoc[leveloffset=+1]
+
 include::modules/installation-creating-gcp-lb.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-ext-lb.adoc[leveloffset=+2]
 include::modules/installation-deployment-manager-int-lb.adoc[leveloffset=+2]

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -1,8 +1,12 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_azure/installing-azure-user-infra.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_gcp/installing-gcp-user-infra.adoc
+// * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -47,6 +51,20 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
 endif::[]
+ifeval::["{context}" == "installing-azure-user-infra"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-user-infra"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp"]
+:gcp:
+:restricted:
+endif::[]
+
 
 [id="installation-network-user-infra_{context}"]
 = Networking requirements for user-provisioned infrastructure
@@ -54,6 +72,7 @@ endif::[]
 All the {op-system-first} machines require networking to be configured in `initramfs` during boot
 to fetch their Ignition config files.
 
+ifndef::azure,gcp[]
 ifdef::ibm-z[]
 During the initial boot, the machines require an HTTP or HTTPS server to
 establish a network connection to download their Ignition config files.
@@ -76,6 +95,7 @@ machines. If the API servers and worker nodes are in different zones, you can
 configure a default DNS search zone to allow the API server to resolve the
 node names. Another supported approach is to always refer to hosts by their
 fully-qualified domain names in both the node objects and all DNS requests.
+endif::azure,gcp[]
 
 ifndef::ibm-z[]
 [id="installation-host-names-dhcp-user-infra_{context}"]
@@ -201,6 +221,7 @@ ifdef::vsphere[]
 :!vsphere:
 endif::[]
 
+ifndef::azure,gcp[]
 [discrete]
 == NTP configuration for user-provisioned infrastructure
 
@@ -211,6 +232,7 @@ Each {product-title} node in the cluster must have access to a Network Time Prot
 ifndef::ibm-z[]
 If a DHCP server provides NTP server information, the chrony time service on the {op-system-first} machines read the information and can sync the clock with the NTP servers.
 endif::ibm-z[]
+endif::azure,gcp[]
 
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
@@ -222,5 +244,18 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-azure-user-infra"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-user-infra"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp"]
+:!gcp:
 :!restricted:
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1823387

Previews:
- [Azure UPI](https://deploy-preview-25083--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-network-user-infra_installing-azure-user-infra)
- [GCP UPI](https://deploy-preview-25083--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-network-user-infra_installing-gcp-user-infra)
- [GCP UPI shared VPC](https://deploy-preview-25083--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-network-user-infra_installing-gcp-user-infra-vpc)
- [GCP UPI restricted](https://deploy-preview-25083--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html)