### PR TITLE
CNV5972 - updating v1alpha API refs to v1beta

### DIFF
--- a/modules/virt-cloning-local-volume-to-another-node.adoc
+++ b/modules/virt-cloning-local-volume-to-another-node.adoc
@@ -99,7 +99,7 @@ $ oc label pv <destination-pv> node=node01
 +
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: <clone-datavolume> <1>

--- a/modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
+++ b/modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
@@ -44,7 +44,7 @@ For example:
 +
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: <cloner-datavolume> <1>

--- a/modules/virt-creating-an-upload-dv.adoc
+++ b/modules/virt-creating-an-upload-dv.adoc
@@ -15,7 +15,7 @@ local disk images.
 
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: <upload-datavolume> <1>

--- a/modules/virt-creating-blank-disk-datavolumes.adoc
+++ b/modules/virt-creating-blank-disk-datavolumes.adoc
@@ -20,7 +20,7 @@ customizing and deploying a DataVolume configuration file.
 
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: blank-image-datavolume

--- a/modules/virt-defining-storageclass-in-cdi-configuration.adoc
+++ b/modules/virt-defining-storageclass-in-cdi-configuration.adoc
@@ -20,7 +20,7 @@ $ oc edit cdiconfig/config
 +
 [source,yaml]
 ----
-API Version:  cdi.kubevirt.io/v1alpha1
+API Version:  cdi.kubevirt.io/v1beta1
 kind: CDIConfig
 metadata:
   name: config

--- a/modules/virt-deploying-operator-cli.adoc
+++ b/modules/virt-deploying-operator-cli.adoc
@@ -17,7 +17,7 @@ You can deploy the {VirtProductName} Operator by using the `oc` CLI.
 +
 [source,yaml]
 ----
-apiVersion: hco.kubevirt.io/v1alpha1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/modules/virt-editing-cdi-cpu-and-memory-defaults.adoc
+++ b/modules/virt-editing-cdi-cpu-and-memory-defaults.adoc
@@ -26,7 +26,7 @@ $ oc edit cdiconfig/config
 [source,yaml]
 
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: CDIConfig
 metadata:
   labels:

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -53,7 +53,7 @@ $ openssl s_client -connect :443 -showcerts < /dev/null
 [source,yaml]
 ----
 $ cat <<EOF | kubectl create -f -
-apiVersion: v2v.kubevirt.io/v1alpha1
+apiVersion: v2v.kubevirt.io/v1beta1
 kind: ResourceMapping
 metadata:
   name: resourcemapping-example
@@ -84,7 +84,7 @@ EOF
 [source,yaml]
 ----
 $ cat <<EOF | oc create -f -
-apiVersion: v2v.kubevirt.io/v1alpha1
+apiVersion: v2v.kubevirt.io/v1beta1
 kind: VirtualMachineImport
 metadata:
   name: vm-import

--- a/modules/virt-importing-vm-to-block-pv.adoc
+++ b/modules/virt-importing-vm-to-block-pv.adoc
@@ -53,7 +53,7 @@ you want to import and `volumeMode: Block` so that an available block PV is used
 +
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: <import-pv-datavolume> <1>

--- a/modules/virt-template-blank-disk-datavolume.adoc
+++ b/modules/virt-template-blank-disk-datavolume.adoc
@@ -8,7 +8,7 @@
 *blank-image-datavolume.yaml*
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: blank-image-datavolume

--- a/modules/virt-template-datavolume-clone.adoc
+++ b/modules/virt-template-datavolume-clone.adoc
@@ -8,7 +8,7 @@
 *example-clone-dv.yaml*
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: "example-clone-dv"

--- a/modules/virt-template-datavolume-import.adoc
+++ b/modules/virt-template-datavolume-import.adoc
@@ -8,7 +8,7 @@
 *example-import-dv.yaml*
 [source,yaml]
 ----
-apiVersion: cdi.kubevirt.io/v1alpha1
+apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
   name: "example-import-dv"

--- a/modules/virt-using-hostpath-provisioner.adoc
+++ b/modules/virt-using-hostpath-provisioner.adoc
@@ -41,7 +41,7 @@ where you want the hostpath provisioner to create PVs. For example:
 +
 [source,yaml]
 ----
-apiVersion: hostpathprovisioner.kubevirt.io/v1alpha1
+apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
 kind: HostPathProvisioner
 metadata:
   name: hostpath-provisioner


### PR DESCRIPTION
All v1alpha[0-9] references in virt docs changed to v1beta1

Searched all modules included in virt docs (in case there was a cnv API reference in OCP doc); came up clean. 

https://issues.redhat.com/browse/CNV-5972
