### PR TITLE
CNV - BZ#1861297 removing timeout note/rel_not

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -150,30 +150,6 @@ $ oc delete pod -n openshift-cnv --selector=kubevirt.io=virt-handler --field-sel
 //https://bugzilla.redhat.com/show_bug.cig?=id=1959237
 * If you upgrade to {VirtProductName} {VirtVersion}, both older and newer versions of common templates are available for each combination of operating system, workload, and flavor. When you create a virtual machine by using a common template, you must use the newer version of the template. Disregard the older version to avoid issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859237[*BZ#1859237*])
 
-[id="virt-2-4-bz1861297"]
-* When creating virtual machines by using common-templates or the virtual machine wizard, the default `terminationGracePeriodSeconds` value is set to `0` (force stop).
-This can result in virtual disk failure and can put the virtual workload at risk.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1861297[*BZ#1861297*])
-
-** As a workaround, update the `spec.terminationGracePeriodSeconds` value in the common-templates before creating a virtual machine from that common-template:
-+
-. Edit the common template by running the following command:
-+
-----
-$ oc edit -n openshift template <common-template-name>
-----
-
-. Update the `spec.terminationGracePeriodSeconds` value:
-+
-[source,yaml]
-----
-...
-  spec:
-    terminationGracePeriodSeconds: 30 <1>
-...
-----
-<1> The time in seconds that the virtual machine is granted to shut down before it is terminated. The time is dependent on how long the operating system requires to gracefully shut down. Some operating systems may require longer if they perform extensive updates during shutdown or reboot.
-
 * Running virtual machines that cannot be live migrated might block an {product-title} cluster upgrade. This includes virtual machines that use hostpath-provisioner storage or SR-IOV network interfaces.
 As a workaround, you can reconfigure the virtual machines so that they can be powered off during a cluster upgrade. In the `spec` section of the virtual machine configuration file:
 +

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -19,13 +19,6 @@ Instead, create a new namespace or use an existing namespace without the
 `openshift` prefix.
 ====
 
-[IMPORTANT]
-====
-When creating virtual machines by using common-templates or the virtual machine wizard, the default `terminationGracePeriodSeconds` value is set to `0`, which forces the virtual machine to terminate when rebooted or shut down.
-Failure to shutdown gracefully can result in virtual disk failure and can put the virtual workload at risk. +
-See the xref:../../virt/virt-2-4-release-notes.adoc#virt-2-4-bz1861297[OpenShift Virtualization release notes] for more information and for the current workaround.
-====
-
 include::modules/virt-creating-vm-wizard-web.adoc[leveloffset=+1]
 
 Refer to the virtual machine wizard fields section when running the web console wizard.


### PR DESCRIPTION
BZ#1861297 has now been verified ahead of 2.4.1. Removing the release note and admonition from the docs

https://bugzilla.redhat.com/show_bug.cgi?id=1861297

@rnetser 