### PR TITLE
CNV - Bug 1872582 - Correcting misspelled word indicies under Elasticsearch…

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -345,7 +345,7 @@ Cluster logging in {product-title} {product-version} now uses Elasticsearch 6.8.
 
 The new Elasticsearch version introduces a new Elasticsearch data model. With the new data model, data is no longer indexed by type (infrastructure and application) and project. Data is only indexed by type:
 
-* The application logs that were previously in the *project-* indicies in {product-title} 4.4 are in a set of indices prefixed with *app-*.
+* The application logs that were previously in the *project-* indices in {product-title} 4.4 are in a set of indices prefixed with *app-*.
 * The infrastructure logs that were previously in the *.operations-* indices are now in the *infra-* indices.
 * The audit logs are stored in the *audit-* indices.
 


### PR DESCRIPTION
This PR addresses a minor issue raised in Bug 1872582 (https://bugzilla.redhat.com/show_bug.cgi?id=1872582)

Corrected misspelled word 'indicies' to "indices" under "Elasticsearch version upgrade" subheading of OCP 4.5 release notes

Peer review needed