### PR TITLE
Rm errant output from building bundle image

### DIFF
--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -8,15 +8,6 @@
 You can build, push, and validate an Operator bundle image using the Operator
 SDK.
 
-.Example output
-[source,terminal]
-----
-INFO[0000] Unpacked image layers                                 bundle-dir=/tmp/bundle-041168359 container-tool=podman
-INFO[0000] running podman pull                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman
-INFO[0002] running podman save                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman
-INFO[0002] All validation tests have completed successfully      bundle-dir=/tmp/bundle-041168359 container-tool=podman
-----
-
 .Prerequisites
 
 * Operator SDK version 0.17.2


### PR DESCRIPTION
Strange random block introduced via https://github.com/openshift/openshift-docs/pull/24430; not sure how/why it ended up duplicated here. :thinking: 