### PR TITLE
CNV: Storage matrix for VM import

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -1,37 +1,106 @@
 // Module included in the following assemblies:
 //
 // * virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc
+// * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+// * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
 
 [id="virt-features-for-storage-matrix_{context}"]
 = {VirtProductName} storage feature matrix
 
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+The following table describes local and shared persistent storage that support VM import.
+endif::[]
+
 .{VirtProductName} storage feature matrix
+ifdef::virt-features-for-storage[]
 [cols="40%,30%,30%",options="header"]
 |===
-||Virtual machine live migration  |Host-assisted virtual machine disk cloning
+|
+|Virtual machine live migration
+|Host-assisted virtual machine disk cloning
+endif::[]
+ifdef::virt-importing-rhv-vm[]
+[cols="50%,50%",options="header",caption]
+|===
+|
+|RHV VM import
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+[cols="50%,50%",options="header",caption]
+|===
+|
+|VMware VM import
+endif::[]
 
 |OpenShift Container Storage: RBD block-mode volumes
+ifdef::virt-features-for-storage[]
 |Yes
 |Yes
+endif::[]
+ifdef::virt-importing-rhv-vm[]
+ifeval::["{VirtVersion}" == "2.5"]
+|Yes
+endif::[]
+ifeval::["{VirtVersion}" == "2.4"]
+|No
+endif::[]
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+|No
+endif::[]
 
 |{VirtProductName} hostpath provisioner
+ifdef::virt-features-for-storage[]
 |No
 |Yes
-
-|Other multi-node writable storage ^[1]^
-|Yes
-|Yes
-
-|Other single-node writable storage ^[2]^
+endif::[]
+ifdef::virt-importing-rhv-vm[]
 |No
-|Yes
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+|Yes ^[1]^
+endif::[]
+
+|Other multi-node writable storage
+ifdef::virt-features-for-storage[]
+|Yes ^[1]^
+|Yes ^[1]^
+endif::[]
+ifdef::virt-importing-rhv-vm[]
+|Yes ^[1]^
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+|Yes ^[2]^
+endif::[]
+
+|Other single-node writable storage
+ifdef::virt-features-for-storage[]
+|No
+|Yes ^[2]^
+endif::[]
+ifdef::virt-importing-rhv-vm[]
+|Yes ^[2]^
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+|Yes ^[3]^
+endif::[]
 |===
 [.small]
+ifdef::virt-importing-vmware-vm[]
 --
-1. PVCs must request a ReadWriteMany access mode
-2. PVCs must request a ReadWriteOnce access mode
+1. The `v2v-conversion-template` disk use {VirtProductName} hostpath provisioner storage if the VM disk(s) is NFS.
+2. PVCs must request a ReadWriteMany access mode.
+3. PVCs must request a ReadWriteOnce access mode.
 --
+endif::[]
+ifdef::virt-features-for-storage,virt-importing-rhv-vm[]
+--
+1. PVCs must request a ReadWriteMany access mode.
+2. PVCs must request a ReadWriteOnce access mode.
+--
+endif::[]
 
+ifdef::virt-features-for-storage[]
 [NOTE]
 ====
 You cannot live migrate virtual machines that use:
@@ -41,3 +110,4 @@ You cannot live migrate virtual machines that use:
 
 Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
 ====
+endif::[]

--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -37,22 +37,19 @@ The Red Hat Virtualization (RHV) environment has the following prerequisites for
 == {VirtProductName} prerequisites
 
 The {VirtProductName} environment has the following prerequisites for VM import:
-
-* You must be an admin user.
-* The {product-title} storage class must be NFS.
 endif::[]
-
 ifdef::virt-importing-vmware-vm[]
-Importing a virtual machine from VMware vCenter into {VirtProductName} has the following prerequisites:
+Importing a VMware VM into {VirtProductName} has the following prerequisites:
 
-* You must be an admin user.
 * You must have access to an image registry.
 * You must create a VMware Virtual Disk Development Kit (VDDK) image, push it to an image registry, and add it to the `v2v-vmware` ConfigMap.
-* The VMware virtual machine must be powered off.
+* The VMware virtual machine must be powered off during import.
 * There must be sufficient storage space for the imported disk.
 +
 [WARNING]
 ====
-If you try to import a virtual machine whose disk size is larger than the available storage space, the operation cannot complete. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage backend.
+If you try to import a virtual machine with a disk that is larger than the available storage space, the operation cannot complete. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage backend.
 ====
 endif::[]
+* You must be an admin user.
+* The local and shared persistent storage must support VM import.

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -72,13 +72,26 @@ ifdef::virt-importing-rhv-vm[]
 . Optional: You can select *Start virtual machine on creation*.
 endif::[]
 
-. Optional: Click *Edit* to update the following settings:
+. Click *Edit* to update the following settings:
 
 ifdef::virt-importing-rhv-vm[]
 * *General* -> *Name*: The VM name is limited to 63 characters. link:https://bugzilla.redhat.com/show_bug.cgi?id=1857165[(*BZ#1857165*)]
 * *General* -> *Description*: Optional description of the VM.
+ifeval::["{VirtVersion}" == "2.4"]
 * *Storage* -> *Storage Class*: Select *NFS*.
+endif::[]
+ifeval::["{VirtVersion}" == "2.5"]
+* *Storage* -> *Storage Class*: Select *NFS* or *ocs-storagecluster-ceph-rbd*.
+endif::[]
 * *Networking* -> *Network*: You can select a network from a list of available `NetworkAttachmentDefinition` objects.
+
+ifeval::["{VirtVersion}" == "2.5"]
+. If you are using RBD block-mode volume storage, configure the volume mode of the disk:
+.. Click *Edit* and then click *Storage*.
+.. Select *Edit* from the Options menu {kebab} of the VM disk.
+.. Click *Advanced* to display the advanced options.
+.. Select *Block* from the *Volume Mode* list.
+endif::[]
 endif::[]
 
 ifdef::virt-importing-vmware-vm[]
@@ -110,12 +123,12 @@ ifdef::virt-importing-vmware-vm[]
 The following storage classes are supported for VMware VM import:
 
 *** VM disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
-*** v2v-conversion-template disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
+*** `v2v-conversion-template` disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
 +
 _or_
 
 *** VM disk: *NFS*
-*** v2v-conversion-template disk: *hostpath-provisioner (HPP)*
+*** `v2v-conversion-template` disk: *hostpath-provisioner (HPP)*
 +
 Other storage classes might work, but they are not officially supported.
 

--- a/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
@@ -9,6 +9,9 @@ You can import a single Red Hat Virtualization (RHV) virtual machine into your {
 
 include::modules/virt-importing-vm-prerequisites.adoc[leveloffset=+1]
 
+[discrete]
+include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+2]
+
 ifeval::["{VirtVersion}" == "2.4"]
 include::modules/virt-checking-storage-class.adoc[leveloffset=+1]
 

--- a/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
@@ -13,6 +13,9 @@ The import process uses the VMware Virtual Disk Development Kit (VDDK) to copy t
 
 include::modules/virt-importing-vm-prerequisites.adoc[leveloffset=+1]
 
+[discrete]
+include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+2]
+
 == Configuring an image registry for the VDDK image
 
 You can configure either an internal {product-title} image registry or a secure external image registry for the VDDK image.

--- a/virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc
@@ -2,9 +2,11 @@
 = Storage features
 include::modules/virt-document-attributes.adoc[]
 :context: virt-features-for-storage
+:virt-features-for-storage:
 toc::[]
 
 Use the following table to determine feature availability for local and shared
 persistent storage in {VirtProductName}.
 
 include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
+:virt-features-for-storage!:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1874792

CP for 4.5, 4.6

Preview links:

https://cnv-vm-import-storage-matrix--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-features-for-storage-matrix_virt-importing-rhv-vm

https://cnv-vm-import-storage-matrix--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html#virt-features-for-storage-matrix_virt-importing-vmware-vm

The updated wizard procedure is tagged for 2.5, so the added step will not appear in the preview build.