### PR TITLE
Bug 1873907: [DOCS] not existing API is specified to the "Policy" manifest of the ServiceMesh

### DIFF
--- a/modules/ossm-security-mtls.adoc
+++ b/modules/ossm-security-mtls.adoc
@@ -33,7 +33,7 @@ You can also configure mTLS for individual services or namespaces by creating a 
 
 [source,yaml]
 ----
-apiVersion: "authentication.maistra.io/v1"
+apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
   name: "default"


### PR DESCRIPTION
* Version: v4.3 ~ v4.5+
* Description: Correct an apiVersion of the "Policy" with "authentication.istio.io/v1alpha1".
* Reference: [[DOCS] not existing API is specified to the "Policy" manifest of the ServiceMesh](https://bugzilla.redhat.com/show_bug.cgi?id=1873907)