### PR TITLE
Bug 1873448: Ensure proper tagging of compute node ports

### DIFF
--- a/modules/installation-osp-creating-compute-machines.adoc
+++ b/modules/installation-osp-creating-compute-machines.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_openstack/installing-openstack-user.adoc
+// * installing/installing_openstack/installing-openstack-user-kuryr.adoc
 
 [id="installation-osp-creating-compute-machines_{context}"]
 = Creating compute machines

--- a/modules/installation-osp-creating-compute-machines.adoc
+++ b/modules/installation-osp-creating-compute-machines.adoc
@@ -47,7 +47,7 @@ After standing up the control plane, create compute machines.
 
   - name: 'Set Compute ports tag'
     command:
-      cmd: "openstack port set --tag {{ [cluster_id_tag] }} {{ item.1 }}-{{ item.0 }}"
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
 
   - name: 'List the Compute Trunks'


### PR DESCRIPTION
Wrong tagging of compute node parent ports make kuryr not able
to find the precreated ports, thus breaking the kuryr ports pool
functionality