### PR TITLE
Release Notes 4.6 - Service CA bundle removal

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -169,6 +169,16 @@ In the table, features are marked with the following statuses:
 [id="ocp-4-6-removed-features"]
 === Removed features
 
+[id="ocp-4-6-service-ca-bundle-removal"]
+==== Service CA bundle removal
+
+The `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` file
+previously deprecated in {product-title} 4.1 has been removed. The
+aforementioned file was used by Pods to consume the service-serving CA bundle.
+If you were still using this file in previous versions of {product-title}, you
+must migrate to obtaining the CA bundle from a ConfigMap annotated with
+`service.beta.openshift.io/inject-cabundle=true`.
+
 [id="ocp-4-6-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~choag/083120/rn-4.6-service-ca-removal/release_notes/ocp-4-6-release-notes.html#ocp-4-6-service-ca-bundle-removal