### PR TITLE
Deprecated CLI command deletion and rpm update

### DIFF
--- a/modules/op-installing-tkn-on-linux-using-rpm.adoc
+++ b/modules/op-installing-tkn-on-linux-using-rpm.adoc
@@ -47,7 +47,7 @@ For {op-system-base-full} version 8, you can install the {pipelines-title} CLI (
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.0-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="pipelines-1.1-for-rhel-8-x86_64-rpms"
 ----
 
 . Install the `openshift-pipelines-client` package:

--- a/modules/op-installing-tkn-on-linux.adoc
+++ b/modules/op-installing-tkn-on-linux.adoc
@@ -10,7 +10,7 @@ For Linux distributions, you can download the CLI directly as a `tar.gz` archive
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.9.0/tkn-linux-amd64-0.9.0.tar.gz[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.11.0/tkn-linux-amd64-0.11.0.tar.gz[CLI].
 
 . Unpack the archive:
 +

--- a/modules/op-installing-tkn-on-macos.adoc
+++ b/modules/op-installing-tkn-on-macos.adoc
@@ -10,7 +10,7 @@ For macOS, the `tkn` CLI is provided as a `tar.gz` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.9.0/tkn-macos-amd64-0.9.0.tar.gz[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.11.0/tkn-macos-amd64-0.11.0.tar.gz[CLI].
 
 . Unpack and unzip the archive.
 

--- a/modules/op-installing-tkn-on-windows.adoc
+++ b/modules/op-installing-tkn-on-windows.adoc
@@ -10,7 +10,7 @@ For Windows, the `tkn` CLI is provided as a `zip` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.9.0/tkn-windows-amd64-0.9.0.zip[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.11.0/tkn-windows-amd64-0.11.0.zip[CLI].
 
 . Unzip the archive with a ZIP program.
 

--- a/modules/op-tkn-pipeline-management.adoc
+++ b/modules/op-tkn-pipeline-management.adoc
@@ -14,15 +14,6 @@ Manage Pipelines.
 $ tkn pipeline --help
 ----
 
-== pipeline create
-Create a Pipeline.
-
-.Example: Create a Pipeline defined by the `mypipeline.yaml` file in a namespace
-[source,terminal]
------
-$ tkn pipeline create -f mypipeline.yaml -n myspace
------
-
 == pipeline delete
 
 Delete a Pipeline.

--- a/modules/op-tkn-pipeline-resource-management.adoc
+++ b/modules/op-tkn-pipeline-resource-management.adoc
@@ -17,11 +17,12 @@ $ tkn resource -h
 == resource create
 Create a Pipeline Resource.
 
-.Example: Create Pipeline Resource defined by the `myresource.yaml` file in a namespace
+.Example: Create a Pipeline Resource in a namespace
 [source,terminal]
 ----
-$ tkn resource create -f myresource.yaml -n myspace
+$ tkn resource create -n myspace
 ----
+This is an interactive command that asks for input on the name of the Resource, type of the Resource, and the values based on the type of the Resource.
 
 == resource delete
 Delete a Pipeline Resource.

--- a/modules/op-tkn-task-management.adoc
+++ b/modules/op-tkn-task-management.adoc
@@ -14,15 +14,6 @@ Manage Tasks.
 $ tkn task -h
 ----
 
-== task create
-Create a Task.
-
-.Example: Create a Task defined by the `mytask.yaml` file in a namespace
-[source,terminal]
-----
-$ tkn task create -f mytask.yaml -n myspace
-----
-
 == task delete
 Delete a Task.
 


### PR DESCRIPTION
- This PR deletes redundant commands and modifies another one.
- It also updates the RPM and CLI links for installation
- It has been reviewed by SME and QE
- It needs to be merged to 4.5 and 4.6