### PR TITLE
Update cluster-logging-visualizer.adoc

### DIFF
--- a/logging/viewing/cluster-logging-visualizer.adoc
+++ b/logging/viewing/cluster-logging-visualizer.adoc
@@ -14,7 +14,7 @@ Using the log visualizer, you can:
 * Create and view custom dashboards using the *Dashboard* tab.
 
 Use and configuration of the Kibana interface is beyond the scope of this documentation. For more information,
-on using the interface, see the link:https://www.elastic.co/guide/en/kibana/5.6/connect-to-elasticsearch.html[Kibana documentation]. 
+on using the interface, see the link:https://www.elastic.co/guide/en/kibana/6.8/connect-to-elasticsearch.html[Kibana documentation]. 
 
 
 // The following include statements pull in the module files that comprise


### PR DESCRIPTION
The URL for the Kibana documentation points to version 5.6, which is EOL.  OpenShift 4.5 appears to be using Kibana 6.8.