### PR TITLE
CNV-4657 virtctl web console download

### DIFF
--- a/modules/virt-enabling-virt-repos.adoc
+++ b/modules/virt-enabling-virt-repos.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// install/virt-installing-virtctl.adoc
+// virt/install/virt-installing-virtctl.adoc
 
 [id="virt-enabling-virt-repos_{context}"]
 = Enabling {VirtProductName} repositories

--- a/modules/virt-installing-virtctl-client-web.adoc
+++ b/modules/virt-installing-virtctl-client-web.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// virt/install/virt-installing-virtctl.adoc
+
+[id="virt-installing-virtctl-client-web_{context}"]
+= Installing the `virtctl` client from the web console
+
+You can download the `virtctl` client from the Red Hat Customer Portal, which is linked to in your {VirtProductName} web console in the *Command Line Tools* page.
+
+.Prerequisites
+
+* You must have an activated {product-title} subscription to access the download page on the Customer Portal. 
+
+.Procedure
+
+. Access the Customer Portal by clicking the image:question-circle.png[title="Help"] icon, which is in the upper-right corner of the web console, and selecting *Command Line Tools*. 
+
+. Ensure you have the appropriate version for your cluster selected from the *Version:* list.
+
+. Download the `virtctl` client for your distribution. All downloads are in `tar.gz` format.
+
+. Extract the tarball. The following CLI command extracts it into the same directory as the tarball and is applicable for all distributions:
++
+[source,terminal]
+----
+$ tar -xvf <virtctl-version-distribution.arch>.tar.gz 
+----
+
+. For Linux and macOS:
+
+.. Navigate the extracted folder hierachy and make the `virtctl` binary executable:
++
+[source,terminal]
+----
+$ chmod +x <virtctl-file-name>
+----
+
+.. Move the `virtctl` binary to a directory on your PATH.
+
+... To check your path, run:
++
+[source,terminal]
+----
+$ echo $PATH
+----
+
+. For Windows users:
+
+.. Navigate the extracted folder hierarchy and double-click the `virtctl` executable file to install the client.

--- a/modules/virt-installing-virtctl-client.adoc
+++ b/modules/virt-installing-virtctl-client.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// install/virt-installing-virtctl.adoc
+// virt/install/virt-installing-virtctl.adoc
 
 [id="virt-installing-virtctl-client_{context}"]
 = Installing the `virtctl` client

--- a/virt/install/virt-installing-virtctl.adoc
+++ b/virt/install/virt-installing-virtctl.adoc
@@ -5,13 +5,16 @@ include::modules/virt-document-attributes.adoc[]
 toc::[]
 
 The `virtctl` client is a command-line utility for managing {VirtProductName}
-resources.
+resources. It is available for Linux, macOS, and Windows distributions.
 
-Install the client to your system by enabling the {VirtProductName} repository and
-installing the `kubevirt-virtctl` package.
+You can install the `virtctl` client from the {VirtProductName} web console or by enabling the {VirtProductName} repository and installing the `kubevirt-virtctl` package.
+
+include::modules/virt-installing-virtctl-client-web.adoc[leveloffset=+1]
 
 include::modules/virt-enabling-virt-repos.adoc[leveloffset=+1]
+
 include::modules/virt-installing-virtctl-client.adoc[leveloffset=+1]
 
-See also:
+[id="virt-installing-virtctl-addtl-resources"]
+== Additional resources
 xref:../../virt/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[Using the CLI tools] for {VirtProductName}.


### PR DESCRIPTION
Added module to cover downloading the virtctl client from the web console.
This borrows some existing style elements from serverless and osdk content for consistency.

The current UI directs to the kubevirt github page for downloads. Since this is likely to change, both now and in the future, I've avoided a specific file name for the client with an attempt to lower maintenance costs. 

https://issues.redhat.com/browse/CNV-4657