### PR TITLE
Remove tech preview for odo debugging

### DIFF
--- a/cli_reference/developer_cli_odo/debugging-applications-in-odo.adoc
+++ b/cli_reference/developer_cli_odo/debugging-applications-in-odo.adoc
@@ -5,9 +5,6 @@ include::modules/common-attributes.adoc[]
 :context: debugging-applications-in-odo
 toc::[]
 
-:FeatureName: Interactive debugging in {odo-title}
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 With `{odo-title}`, you can attach a debugger to remotely debug your application. This feature is only supported for NodeJS and Java components.
 
 Components created with `{odo-title}` run in the debug mode by default.  A debugger agent runs on the component, on a specific port. To start debugging your application, you must start port forwarding and attach the local debugger bundled in your Integrated development environment (IDE).


### PR DESCRIPTION
`odo debug` is out of tech preview now.

Closes https://github.com/openshift/odo/issues/3869

Signed-off-by: Charlie Drage <charlie@charliedrage.com>