### PR TITLE
Updating code blocks to guideline format for OPC 4.3

### DIFF
--- a/modules/creating-serverless-apps-kn.adoc
+++ b/modules/creating-serverless-apps-kn.adoc
@@ -15,16 +15,26 @@ The following procedure describes how you can create a basic serverless applicat
 
 . Create the Knative service by entering the following command:
 +
+
+[source,terminal]
 ----
-$ kn service create <SERVICE-NAME> --image <IMAGE> --env <KEY=VALUE>
+$ kn service create <service-name> --image <image> --env <key=value>
 ----
 
++
 .Example command
++
+
+[source,terminal]
 ----
 $ kn service create hello --image docker.io/openshift/hello-openshift --env RESPONSE="Hello Serverless!"
 ----
 
++
 .Example output
++
+
+[source,terminal]
 ----
 Creating service 'hello' in namespace 'default':
 

--- a/modules/serverless-apps-intro.adoc
+++ b/modules/serverless-apps-intro.adoc
@@ -10,6 +10,7 @@ To deploy a serverless application using {ServerlessProductName}, you must creat
 Knative services are Kubernetes services, defined by a route and a configuration, and contained in a YAML file.
 
 .Example Knative service YAML
+
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1

--- a/modules/serverless-config-replicas.adoc
+++ b/modules/serverless-config-replicas.adoc
@@ -32,18 +32,23 @@ image::serving-YAML-HA.png[Knative Serving YAML]
 +
 . Edit the custom resource definition YAML:
 +
+
 .Example YAML
++
+
 [source,yaml]
 ----
 spec:
   high-availability:
     replicas: 3
 ----
+
 +
 [IMPORTANT]
 ====
 Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
 ====
 +
+
 * The default `replicas` value is `2`.
 * Changing the value to `1` will disable HA, or you can increase the number of replicas as required. The example configuration shown specifies a replica count of `3` for all HA controllers.

--- a/modules/serverless-creating-broker.adoc
+++ b/modules/serverless-creating-broker.adoc
@@ -5,39 +5,58 @@
 [id="serverless-creating-broker_{context}"]
 = Creating a broker manually
 
-To create a broker, you must create a `ServiceAccount` for each namespace and give that `ServiceAccount` the required RBAC permissions.
+To create a broker, you must create a service account for each namespace, and give that service account the required RBAC permissions.
 
 .Prerequisites
 * Knative Eventing installed, which includes the `ClusterRole`.
 
 .Procedure
-. Create the `ServiceAccount` objects:
+. Create the `ServiceAccount` objects.
+.. Create the `eventing-broker-ingress` object by entering the following command:
 +
+
+[source,terminal]
 ----
-$ oc -n default create serviceaccount eventing-broker-ingress
-$ oc -n default create serviceaccount eventing-broker-filter
+$ oc -n <namespace> create serviceaccount eventing-broker-ingress
 ----
 
-. Give those objects RBAC permissions:
+.. Create the `eventing-broker-filter` object by entering the following command:
 +
+
+[source,terminal]
+----
+$ oc -n <namespace> create serviceaccount eventing-broker-filter
+----
+
+. Give the objects that you have created RBAC permissions:
++
+[source,terminal]
 ----
 $ oc -n default create rolebinding eventing-broker-ingress \
   --clusterrole=eventing-broker-ingress \
   --serviceaccount=default:eventing-broker-ingress
+----
+
++
+
+[source,terminal]
+----
 $ oc -n default create rolebinding eventing-broker-filter \
   --clusterrole=eventing-broker-filter \
   --serviceaccount=default:eventing-broker-filter
 ----
 
-. Create the broker:
+. Create a broker by creating and applying a YAML file containing the following:
 +
+
+[source,yaml]
 ----
-cat << EOF | oc apply -f -
 apiVersion: eventing.knative.dev/v1beta1
 kind: Broker
 metadata:
   namespace: default
   name: default <1>
-EOF
 ----
+
++
 <1> This example uses the name `default`, but you can replace this with any other valid name.

--- a/modules/serverless-inmemorychannel.adoc
+++ b/modules/serverless-inmemorychannel.adoc
@@ -32,6 +32,7 @@ data:
 
 * Create a generic Channel custom object.
 +
+
 [source,yaml]
 ----
 apiVersion: messaging.knative.dev/v1
@@ -40,9 +41,11 @@ metadata:
   name: example-channel
   namespace: default
 ----
+
 +
 When the Channel object is created, a mutating admission webhook adds a set of `spec.channelTemplate` properties for the Channel object based on the default channel implementation.
 +
+
 [source,yaml]
 ----
 apiVersion: messaging.knative.dev/v1

--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -16,21 +16,28 @@ To configure Jaeger for use with {ServerlessProductName}, you will need:
 
 .Procedure
 
-. Create and apply the Jaeger custom resource:
+. Create and apply a Jaeger custom resource YAML file that contains the following sample YAML:
 +
+
+.Jaeger custom resource YAML
++
+
+[source,terminal]
 ----
-$ cat <<EOF | oc apply -f -
 apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: jaeger
   namespace: default
-EOF
 ----
 
 . Enable tracing for Knative Serving, by editing the `KnativeServing` resource and adding a YAML configuration for tracing.
 +
+
 .Tracing YAML example
++
+
+[source,yaml]
 ----
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
@@ -55,11 +62,22 @@ spec:
 
 Access the Jaeger web console to see tracing data. You can access the Jaeger web console by using the `jaeger` route.
 
-. Get the `jaeger` route's hostname:
+. Get the `jaeger` route's hostname by entering the following command:
 +
+
+[source,terminal]
 ----
 $ oc get route jaeger
+----
+
++
+.Example output
++
+
+[source,terminal]
+----
 NAME     HOST/PORT                         PATH   SERVICES       PORT    TERMINATION   WILDCARD
 jaeger   jaeger-default.apps.example.com          jaeger-query   <all>   reencrypt     None
 ----
+
 . Open the endpoint address in your browser to view the console.

--- a/modules/serverless-list-source.adoc
+++ b/modules/serverless-list-source.adoc
@@ -5,11 +5,17 @@
 [id="serverless-list-source_{context}"]
 = Listing available event sources using `kn`
 
-You can list available event sources by using the following command:
+* List available event sources by entering the following command:
++
+
+[source,terminal]
 ----
 $ kn source list
 ----
-Here is an example output:
+
+.Example output
+
+[source,terminal]
 ----
 NAME   TYPE              RESOURCE                               SINK         READY
 a1     ApiServerSource   apiserversources.sources.knative.dev   svc:eshow2   True
@@ -20,11 +26,18 @@ p1     PingSource        pingsources.sources.knative.dev        svc:eshow1   Tru
 == Listing event sources of a specific type only
 
 You can list event sources of a specific type only, by using the `--type` flag.
-For example, to list all event sources of type `PingSource`:
+
+* List available event sources of type `PingSource` by entering the following command:
++
+
+[source,terminal]
 ----
 $ kn source list --type PingSource
 ----
-Here is an example output:
+
+.Example output
+
+[source,terminal]
 ----
 NAME   TYPE              RESOURCE                               SINK         READY
 p1     PingSource        pingsources.sources.knative.dev        svc:eshow1   True

--- a/modules/serverless-metering-queries.adoc
+++ b/modules/serverless-metering-queries.adoc
@@ -9,6 +9,7 @@ The following `ReportQuery` resources reference the example `DataSources` provid
 == Query for CPU usage in Knative Serving
 
 .YAML file
+
 [source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
@@ -64,6 +65,7 @@ spec:
 == Query for memory usage in Knative Serving
 
 .YAML file
+
 [source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
@@ -117,11 +119,20 @@ spec:
 
 [id="applying-queries-knative_{context}"]
 == Applying Queries for Knative Serving metering
-You can apply the `ReportQuery` by using the following command:
+
+. Apply the `ReportQuery` by entering the following command:
++
+
+[source,terminal]
 ----
 $ oc apply -f <query-name>.yaml
 ----
-.Example
+
++
+.Example command
++
+
+[source,terminal]
 ----
 $ oc apply -f knative-service-memory-usage.yaml
 ----

--- a/modules/serverless-metering-reports.adoc
+++ b/modules/serverless-metering-reports.adoc
@@ -8,6 +8,7 @@ You can run metering reports against Knative Serving by creating `Report` resour
 Before you run a report, you must modify the input parameter within the `Report` resource to specify the start and end dates of the reporting period.
 
 .YAML file
+
 [source,yaml]
 ----
 apiVersion: metering.openshift.io/v1
@@ -27,14 +28,29 @@ runImmediately: true
 
 [id="reports-metering-serverless-run_{context}"]
 == Running a metering report
-Once you have provided the input parameters, you can run the report using the command:
+
+. Run the report by entering the following command:
++
+
+[source,terminal]
 ----
 $ oc apply -f <report-name>.yml
 ----
-You can then check the report as shown in the following example:
-----
-$ kubectl get report
 
+. You can then check the report by entering the following command:
++
+
+[source,terminal]
+----
+$ oc get report
+----
+
++
+.Example output
++
+
+[source,terminal]
+----
 NAME                        QUERY                       SCHEDULE   RUNNING    FAILED   LAST REPORT TIME       AGE
 knative-service-cpu-usage   knative-service-cpu-usage              Finished            2019-06-30T23:59:59Z   10h
 ----

--- a/modules/serverless-pingsource-kn.adoc
+++ b/modules/serverless-pingsource-kn.adoc
@@ -17,13 +17,17 @@ The following sections describe how to create, verify and remove a basic PingSou
 . To verify that the PingSource is working, create a simple Knative
 service that dumps incoming messages to the service's logs:
 +
+
+[source,terminal]
 ----
 $ kn service create event-display \
-    --image quay.io/openshift-knative/knative-eventing-sources-event-display:v0.13.2
+    --image quay.io/openshift-knative/knative-eventing-sources-event-display:latest
 ----
 
 . For each set of ping events that you want to request, create a PingSource in the same namespace as the event consumer:
 +
+
+[source,terminal]
 ----
 $ kn source ping create test-ping-source \
     --schedule "*/2 * * * *" \
@@ -33,12 +37,17 @@ $ kn source ping create test-ping-source \
 
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:
 +
+
+[source,terminal]
 ----
 $ kn source ping describe test-ping-source
 ----
+
 +
-The output should be similar to:
+.Example output
 +
+
+[source,terminal]
 ----
 Name:         test-ping-source
 Namespace:    default
@@ -71,18 +80,25 @@ The example shown in this guide creates a PingSource that sends a message every 
 
 . Watch for new pods created:
 +
+
+[source,terminal]
 ----
 $ watch oc get pods
 ----
 
 . Cancel watching the pods using Ctrl+C, then look at the logs of the created pod:
 +
+
+[source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
+
 +
-The logs should contain lines similar to the following:
+.Example output
 +
+
+[source,terminal]
 ----
 ☁️  cloudevents.Event
 Validation: valid
@@ -102,8 +118,18 @@ Data,
 [id="pingsource-remove-kn_{context}"]
 == Remove the PingSource
 
-You can delete the PingSource and the service that you created by entering the following commands:
+. Delete the PingSource:
++
+
+[source,terminal]
 ----
 $ kn delete pingsources.sources.knative.dev test-ping-source
+----
+
+. Delete the `event-display` service:
++
+
+[source,terminal]
+-----
 $ kn delete service.serving.knative.dev event-display
 ----

--- a/modules/serverless-pingsource-yaml.adoc
+++ b/modules/serverless-pingsource-yaml.adoc
@@ -24,6 +24,8 @@ If you change the names of the YAML files from those used in the examples, you m
 service that dumps incoming messages to the service's logs.
 .. Copy the example YAML into a file named `service.yaml`:
 +
+
+[source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -35,8 +37,11 @@ spec:
       containers:
         - image: quay.io/openshift-knative/knative-eventing-sources-event-display:v0.13.2
 ----
+
 .. Create the service:
 +
+
+[source,terminal]
 ----
 $ oc apply --filename service.yaml
 ----
@@ -44,6 +49,8 @@ $ oc apply --filename service.yaml
 . For each set of ping events that you want to request, create a PingSource in the same namespace as the event consumer.
 .. Copy the example YAML into a file named `ping-source.yaml`:
 +
+
+[source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha2
 kind: PingSource
@@ -58,20 +65,28 @@ spec:
       kind: Service
       name: event-display
 ----
+
 .. Create the PingSource:
 +
+
+[source,terminal]
 ----
 $ oc apply --filename ping-source.yaml
 ----
 
-. Check that the controller is mapped correctly by entering the following command and inspecting the output:
+. Check that the controller is mapped correctly by entering the following command:
 +
+
+[source,terminal]
 ----
 $ oc get pingsource.sources.knative.dev test-ping-source -oyaml
 ----
+
 +
-The output should be similar to:
+.Example output
 +
+
+[source,terminal]
 ----
 apiVersion: sources.knative.dev/v1alpha2
 kind: PingSource
@@ -106,18 +121,25 @@ The example shown in this guide creates a PingSource that sends a message every 
 
 . Watch for new pods created:
 +
+
+[source,terminal]
 ----
 $ watch oc get pods
 ----
 
 . Cancel watching the pods using Ctrl+C, then look at the logs of the created pod:
 +
+
+[source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
+
 +
-The logs should contain lines similar to the following:
+.Example output
 +
+
+[source,terminal]
 ----
 ☁️  cloudevents.Event
 Validation: valid
@@ -137,8 +159,18 @@ Data,
 [id="pingsource-remove-yaml_{context}"]
 == Remove the PingSource
 
-You can delete the PingSource and the service that you created by entering the following commands:
+. Delete the service by entering the following command:
++
+
+[source,terminal]
 ----
 $ oc delete --filename service.yaml
+----
+
+. Delete the PingSource by entering the following command:
++
+
+[source,terminal]
+----
 $ oc delete --filename ping-source.yaml
 ----

--- a/modules/serverless-rn-1-6-0.adoc
+++ b/modules/serverless-rn-1-6-0.adoc
@@ -22,6 +22,8 @@ This change causes commands without a fully qualified APIGroup and kind, such as
 
 After upgrading to {ServerlessProductName} 1.6.0, you must remove the old CRD to fix this issue.
 You can remove the old CRD by entering the following command:
+
+[source,terminal]
 ----
 $ oc delete crd knativeservings.serving.knative.dev
 ----
@@ -63,6 +65,8 @@ To prevent {ServerlessProductName} from being visible in the {product-title} web
 +
 Cluster administrators can remove these CRDs by entering the following command:
 +
+
+[source,terminal]
 ----
 $ oc get crd -oname | grep -E '(serving|internal).knative.dev' | xargs oc delete
 ----

--- a/modules/serverless-rn-1-7-0.adoc
+++ b/modules/serverless-rn-1-7-0.adoc
@@ -34,9 +34,12 @@ You can disable HA for these components by completing the procedure in the _Conf
 * In previous versions, requesting KnativeServing custom resources (CRs) without specifying an API group, for example, `oc get knativeserving -n knative-serving`, occasionally caused errors. This issue is fixed in {ServerlessProductName} 1.7.0.
 * In previous versions, the Knative Serving controller was not notified when a new service CA certificate was generated due to service CA certificate rotation. New revisions created after a service CA certificate rotation were failing with the error:
 +
+
+[source,terminal]
 ----
 Revision "foo-1" failed with message: Unable to fetch image "image-registry.openshift-image-registry.svc:5000/eap/eap-app": failed to resolve image to digest: failed to fetch image information: Get https://image-registry.openshift-image-registry.svc:5000/v2/: x509: certificate signed by unknown authority.
 ----
+
 +
 The {ServerlessOperatorName} now restarts the Knative Serving controller whenever a new service CA certificate is generated, which ensures that the controller is always configured to use the current service CA certificate. For more information, see the {product-title} documentation on _Securing service traffic using service serving certificate secrets_ under _Authentication_.
 

--- a/modules/serverless-sinkbinding-kn.adoc
+++ b/modules/serverless-sinkbinding-kn.adoc
@@ -16,12 +16,16 @@ This guide describes the steps required to create, manage, and delete a SinkBind
 
 . To check that SinkBinding is set up correctly, create a Knative event display service, or event sink, that dumps incoming messages to its log:
 +
+
+[source,terminal]
 ----
 $ kn service create event-display --image quay.io/openshift-knative/knative-eventing-sources-event-display:v0.13.2
 ----
 
 . Create a SinkBinding that directs events to the service:
 +
+
+[source,terminal]
 ----
 $ kn source binding create bind-heartbeat --subject Job:batch/v1:app=heartbeat-cron --sink svc:event-display
 ----
@@ -29,6 +33,8 @@ $ kn source binding create bind-heartbeat --subject Job:batch/v1:app=heartbeat-c
 . Create a CronJob.
 .. Create a file named `heartbeats-cronjob.yaml` and copy the following sample code into it:
 +
+
+[source,yaml]
 ----
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -63,20 +69,28 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
 ----
+
 .. After you have created the `heartbeats-cronjob.yaml` file, apply it by entering:
 +
+
+[source,terminal]
 ----
 $ oc apply --filename heartbeats-cronjob.yaml
 ----
 
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:
 +
+
+[source,terminal]
 ----
 $ kn source binding describe bind-heartbeat
 ----
+
 +
-The output should be similar to:
+.Example output
 +
+
+[source,terminal]
 ----
 Name:         bind-heartbeat
 Namespace:    demo-2
@@ -99,13 +113,25 @@ Conditions:
 
 You can verify that the Kubernetes events were sent to the Knative event sink by looking at the message dumper function logs.
 
-You can view the message dumper function logs by entering:
+* View the message dumper function logs by entering the following commands:
++
+
+[source,terminal]
 ----
 $ oc get pods
+----
++
+
+[source,terminal]
+----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 
-The logs should contain lines similar to the following:
++
+.Example output
++
+
+[source,terminal]
 ----
 ☁️  cloudevents.Event
 Validation: valid

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -16,6 +16,8 @@ This guide describes the steps required to create, manage, and delete a SinkBind
 . To check that SinkBinding is set up correctly, create a Knative event display service, or event sink, that dumps incoming messages to its log.
 .. Copy the following sample YAML into a file named `service.yaml`:
 +
+
+[source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -27,15 +29,20 @@ spec:
       containers:
         - image: quay.io/openshift-knative/knative-eventing-sources-event-display:v0.13.2
 ----
+
 .. After you have created the `service.yaml` file, apply it by entering:
 +
+
+[source,terminal]
 ----
-$ oc apply --filename service.yaml
+$ oc apply -f service.yaml
 ----
 
 . Create a SinkBinding that directs events to the service.
 .. Create a file named `sinkbinding.yaml` and copy the following sample code into it:
 +
+
+[source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha1
 kind: SinkBinding
@@ -55,17 +62,23 @@ spec:
       kind: Service
       name: event-display
 ----
+
 +
 <1> In this example, any Job with the label `app: heartbeat-cron` will be bound to the event sink.
+
 .. After you have created the `sinkbinding.yaml` file, apply it by entering:
 +
+
+[source,terminal]
 ----
-$ oc apply --filename sinkbinding.yaml
+$ oc apply -f sinkbinding.yaml
 ----
 
 . Create a CronJob.
 .. Create a file named `heartbeats-cronjob.yaml` and copy the following sample code into it:
 +
+
+[source,yaml]
 ----
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -100,20 +113,28 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
 ----
+
 .. After you have created the `heartbeats-cronjob.yaml` file, apply it by entering:
 +
+
+[source,terminal]
 ----
-$ oc apply --filename heartbeats-cronjob.yaml
+$ oc apply -f heartbeats-cronjob.yaml
 ----
 
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:
 +
+
+[source,terminal]
 ----
 $ oc get sinkbindings.sources.knative.dev bind-heartbeat -oyaml
 ----
+
 +
-The output should be similar to:
+.Example output
 +
+
+[source,terminal]
 ----
 spec:
   sink:
@@ -135,13 +156,26 @@ spec:
 
 You can verify that the Kubernetes events were sent to the Knative event sink by looking at the message dumper function logs.
 
-You can view the message dumper function logs by entering:
+. View the message dumper function logs by entering the following commands:
++
+
+[source,terminal]
 ----
 $ oc get pods
+----
+
++
+
+[source,terminal]
+----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 
-The logs should contain lines similar to the following:
++
+.Example output
++
+
+[source,terminal]
 ----
 ☁️  cloudevents.Event
 Validation: valid

--- a/modules/serverless-workflow-basic.adoc
+++ b/modules/serverless-workflow-basic.adoc
@@ -13,12 +13,17 @@ You can use this guide as a reference to perform create, read, update, and delet
 
 . Create a service in the `default` namespace from an image:
 +
+
+[source,terminal]
 ----
 $ kn service create hello --image docker.io/openshift/hello-openshift --env RESPONSE="Hello Serverless!"
 ----
+
 +
 .Example output
 +
+
+[source,terminal]
 ----
 Creating service 'hello' in namespace 'default':
 
@@ -34,11 +39,17 @@ http://hello-default.apps-crc.testing
 
 . List the service:
 +
+
+[source,terminal]
 ----
 $ kn service list
 ----
+
 +
 .Example output
++
+
+[source,terminal]
 ----
 NAME    URL                                     LATEST          AGE     CONDITIONS   READY   REASON
 hello   http://hello-default.apps-crc.testing   hello-gsdks-1   8m35s   3 OK / 3     True
@@ -46,24 +57,34 @@ hello   http://hello-default.apps-crc.testing   hello-gsdks-1   8m35s   3 OK / 3
 
 . Check if the service is working by using the `curl` service endpoint command:
 +
+
+[source,terminal]
 ----
 $ curl http://hello-default.apps-crc.testing
 ----
+
 +
 .Example output
 +
+
+[source,terminal]
 ----
 Hello Serverless!
 ----
 
 . Update the service:
 +
+
+[source,terminal]
 ----
 $ kn service update hello --env RESPONSE="Hello OpenShift!"
 ----
+
 +
 .Example output
 +
+
+[source,terminal]
 ----
 Updating Service 'hello' in namespace 'default':
 
@@ -79,12 +100,17 @@ The service's environment variable `RESPONSE` is now set to "Hello OpenShift!".
 
 . Describe the service.
 +
+
+[source,terminal]
 ----
 $ kn service describe hello
 ----
+
 +
 .Example output
 +
+
+[source,terminal]
 ----
 Name:       hello
 Namespace:  default
@@ -104,24 +130,34 @@ Conditions:
 
 . Delete the service:
 +
+
+[source,terminal]
 ----
 $ kn service delete hello
 ----
+
 +
 .Example output
 +
+
+[source,terminal]
 ----
 Service 'hello' successfully deleted in namespace 'default'.
 ----
+
+. Verify that the `hello` service is deleted by attempting to `list` it:
 +
-Verify that the `hello` service is deleted by attempting to `list` it:
-+
+
+[source,terminal]
 ----
 $ kn service list hello
 ----
+
 +
 .Example output
 +
+
+[source,terminal]
 ----
 No services found.
 ----


### PR DESCRIPTION
- Updating code blocks in-keeping with new OCP docs guidelines.
- Updating images from specific version to `latest.