### PR TITLE
Adding missing information on AWS Spot Instances

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -38,7 +38,7 @@ Use the sample MachineSet for your cloud.
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
 
 AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
-which can save you costs compared to On-Demand Instance prices. You can
+which can save you on costs compared to On-Demand Instance prices. You can
 xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
 by adding SpotMarketOptions to the MachineSet YAML file.
 

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -5,7 +5,7 @@
 [id="machineset-non-guaranteed-instance_{context}"]
 = MachineSet Spot Instances
 
-You can save costs by creating an AWS MachineSet that deploys machines as non-guaranteed Spot Instances.
+You can save on costs by creating an AWS MachineSet that deploys machines as non-guaranteed Spot Instances.
 Spot Instances utilize unused AWS EC2 capacity and are less expensive than On-Demand Instances.
 You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless,
 horizontally scalable workloads.
@@ -27,6 +27,6 @@ Interruptions can occur when using Spot Instances if:
 * The demand for Spot Instances increases.
 * The supply of Spot Instances decreases.
 
-If AWS does not have capacity, the Machine Health Checker (MHC) can remove the machine.
-The MHC also remediates a machine that fails if a request for a Spot Instance is not
-satisfied when a machine is created. AWS does not replace a Spot Instance when the instance is terminated.
+When AWS terminates an instance, a termination handler running on the Spot Instance
+node deletes the machine resource. To satisfy the MachineSet `replicas` quantity, the
+MachineSet creates a new machine that then requests a new Spot Instance.

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -45,6 +45,12 @@ include::modules/machineset-creating.adoc[leveloffset=+3]
 Use the sample MachineSet for your cloud.
 
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
+
+AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
+which can save you on costs compared to On-Demand Instance prices. You can
+xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
+by adding SpotMarketOptions to the MachineSet YAML file.
+
 include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
 


### PR DESCRIPTION
Information regarding termination handlers and MachineSet replicas was missing from the original [PR-24678](https://github.com/openshift/openshift-docs/pull/24678), which added content on AWS Spot Instances to 4.5. This PR adds the missing information.