### PR TITLE
Bug 1874825: Fixed custom MAC CNI example

### DIFF
--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -125,41 +125,42 @@ you do not specify a value, then the `default` namespace is used.
 <3> Specify the CNI plug-in configuration in JSON format, which
 is based on the following template.
 
-The following object describes the configuration parameters for utilizing static MAC address
-and IP address using the macvlan CNI plug-in:
+The following object describes the configuration parameters for utilizing static MAC address and IP address using the macvlan CNI plug-in:
 
 .macvlan CNI plug-in JSON configuration object using static IP and MAC address
 [source,json]
 ----
 {
   "cniVersion": "0.3.1",
-  "plugins": [{ <1>
+  "name": "<name>", <1>
+  "plugins": [{ <2>
       "type": "macvlan",
-      "capabilities": { "ips": true }, <2>
-      "master": "eth0", <3>
+      "capabilities": { "ips": true }, <3>
+      "master": "eth0", <4>
       "mode": "bridge",
       "ipam": {
         "type": "static"
       }
     }, {
-      "capabilities": { "mac": true }, <4>
+      "capabilities": { "mac": true }, <5>
       "type": "tuning"
     }]
 }
 ----
 
-<1> The `plugins` field specifies a configuration list of CNI configurations.
+<1> Specifies the name for the additional network attachment to create. The name must be unique within the specified `namespace`.
 
-<2> The `capabilities` key denotes that a request is being made to enable the static IP functionality of a CNI plug-ins runtime configuration capabilities.
+<2> Specifies an array of CNI plug-in configurations. The first object specifies a macvlan plug-in configuration and the second object specifies a tuning plug-in configuration.
 
-<3> The `master` field is specific to the macvlan plug-in.
+<3> Specifies that a request is made to enable the static IP address functionality of the CNI plug-in runtime configuration capabilities.
 
-<4> Here the `capabilities` key denotes that a request is made to enable the static MAC address functionality of a CNI plug-in.
+<4> Specifies the interface that the macvlan plug-in uses.
 
-The above network attachment may then be referenced in a JSON formatted annotation, along with keys to specify which
-static IP and MAC address will be assigned to a given pod.
+<5> Specifies that a request is made to enable the static MAC address functionality of a CNI plug-in.
 
-Edit the desired pod with:
+The above network attachment can be referenced in a JSON formatted annotation, along with keys to specify which static IP and MAC address will be assigned to a given pod.
+
+Edit the pod with:
 
 [source,terminal]
 ----
@@ -186,14 +187,13 @@ metadata:
 
 <1> Use the `<name>` as provided when creating the `rawCNIConfig` above.
 
-<2> Provide the desired IP address.
+<2> Provide an IP address including the subnet mask.
 
-<3> Provide the desired MAC address.
+<3> Provide the MAC address.
 
 [NOTE]
 ====
-Static IP addresses and MAC addresses do not have to be used at the same time, you may use them
-individually, or together.
+Static IP addresses and MAC addresses do not have to be used at the same time, you may use them individually, or together.
 ====
 
 To verify the IP address and MAC properties of a pod with additional networks, use the `oc` command to execute the ip command within a pod.


### PR DESCRIPTION
This PR fixes wrong CNI JSON configuration that lacks `name` field, used to define a macvlan network with customizable MACs.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1874825