### PR TITLE
BZ#1828814 Update production env support to include fast channels

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -56,7 +56,7 @@ $ oc get clusterversion -o json|jq ".items[0].spec"
 +
 [IMPORTANT]
 ====
-For production clusters, you must subscribe to a `stable-*` channel.
+For production clusters, you must subscribe to a `stable-\*` or `fast-*` channel.
 ====
 
 . View the available updates and note the version number of the update that


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1828814

This edit matches our recommendations for [upgrading via the web console](https://docs.openshift.com/container-platform/4.4/updating/updating-cluster-between-minor.html#update-upgrading-web_updating-cluster-between-minor) and our [verified KCS article](https://access.redhat.com/solutions/4929571) on upgrade channel support.