### PR TITLE
Updating the guidance to remove the wordy version of installing CLI p…

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -337,13 +337,10 @@ allowed for use across all distribution documentation:
 
 Usage: OpenShift CLI (`oc`)
 
-The `oc` tool is the command line interface of OpenShift 3 and 4.
+The `oc` tool is the command-line interface of OpenShift 3 and 4.
 
 When referencing as a prerequisite for a procedure module, use the following
-construction: Install the OpenShift Command-line Interface (CLI), commonly known
-as `oc`.
-
-When referencing in overview text, use: OpenShift CLI (`oc`).
+construction: Install the OpenShift CLI (`oc`).
 
 ''''
 === OpenShift master


### PR DESCRIPTION
…rereq

@openshift/team-documentation PTAL. I'm updating the guidance we have on the wording for installing the CLI as a prereq. We discussed this last year that the wording used some places of "Install the OpenShift Command-line Interface (CLI), commonly known as `oc`." was overkill. I'm going to open a separate PR to update all existing instances of this to simply "Install the OpenShift CLI (`oc`)."