### PR TITLE
Fix non existing image in Serverless eventing

### DIFF
--- a/modules/apiserversource-kn.adoc
+++ b/modules/apiserversource-kn.adoc
@@ -34,7 +34,7 @@ $ kn trigger create event-display-trigger --sink svc:event-display
 . Create events by launching a pod in the default namespace. You can do this by entering the following command:
 +
 ----
-$ oc create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+$ oc create deployment hello-node --image=quay.io/openshift-knative/knative-eventing-sources-event-display
 ----
 
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:

--- a/modules/apiserversource-yaml.adoc
+++ b/modules/apiserversource-yaml.adoc
@@ -148,7 +148,7 @@ $ oc apply --filename trigger.yaml
 . Create events by launching a pod in the default namespace. You can do this by entering the following command:
 +
 ----
-$ oc create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+$ oc create deployment hello-node --image=quay.io/openshift-knative/knative-eventing-sources-event-display
 ----
 
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/23465

This patch fixes non existing image.
Ideally we should use an official image, but we don't have it yet. So use an image in quay.io.

/cc @abrennan89 @matzew 