### PR TITLE
Removing source,terminal for now

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -26,14 +26,12 @@ You can check whether the proxy is enabled by reviewing the output of `oc get pr
 
 . Start a debug session for a master node:
 +
-[source,terminal]
 ----
 $ oc debug node/<node_name>
 ----
 
 . Change your root directory to the host:
 +
-[source,terminal]
 ----
 sh-4.2# chroot /host
 ----

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -61,7 +61,6 @@ The output of this command should be empty. If it is not empty, wait a few minut
 
 .. Verify that the Kubernetes API server Pods are stopped.
 +
-[source,terminal]
 ----
 [core@ip-10-0-154-194 ~]$ sudo crictl ps | grep kube-apiserver
 ----


### PR DESCRIPTION
Just removing the source,terminal formatting that came in from a cherry pick, since we're not ready for it in 4.4 yet.