### PR TITLE
Logging add must gather

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1282,6 +1282,8 @@ Topics:
     File: cluster-logging-troubleshooting-visualizer
   - Name: Troubleshooting the log curator
     File: cluster-logging-troubleshooting-curator
+  - Name: Collecting logging data for Red Hat Support
+    File: cluster-logging-must-gather
 - Name: Uninstalling cluster logging
   File: cluster-logging-uninstall
 - Name: Exported fields

--- a/logging/troubleshooting/cluster-logging-must-gather.adoc
+++ b/logging/troubleshooting/cluster-logging-must-gather.adoc
@@ -1,0 +1,27 @@
+[id="cluster-logging-must-gather"]
+= Collecting logging data for Red Hat Support
+include::modules/ossm-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+
+
+toc::[]
+
+When opening a support case, it is helpful to provide debugging information about your cluster to Red Hat Support.
+
+The xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[`must-gather` tool] enables you to collect diagnostic information for project-level resources, cluster-level resources, and each of the cluster logging components.
+
+For prompt support, supply diagnostic information for both {product-title} and cluster logging.
+
+[NOTE]
+====
+Do not use the `hack/logging-dump.sh` script. The script is no longer supported and does not collect data.
+====
+
+include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+1]
+
+[id="cluster-logging-must-gather-prereqs"]
+== Prerequisites
+
+* Cluster logging and Elasticsearch must be installed.
+
+include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+1]

--- a/modules/cluster-logging-must-gather-about.adoc
+++ b/modules/cluster-logging-must-gather-about.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * logging/troubleshooting/cluster-logging-must-gather.adoc
+
+[id="about-must-gather_{context}"]
+= About the must-gather tool
+
+The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues.
+
+For your cluster logging environment, `must-gather` collects the following information:
+
+* project-level resources, including pods, configuration maps, service accounts, roles, role bindings, and events at the project level
+* cluster-level resources, including nodes, roles, and role bindings at the cluster level
+* cluster logging resources in the `openshift-logging` and `openshift-operators-redhat` namespaces, including health status for the log collector, the log store, the curator, and the log visualizer
+
+When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
+
+
+

--- a/modules/cluster-logging-must-gather-collecting.adoc
+++ b/modules/cluster-logging-must-gather-collecting.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * logging/troubleshooting/cluster-logging-must-gather.adoc
+
+[id="cluster-logging-must-gather-collecting_{context}"]
+= Collecting cluster logging data
+
+You can use the `oc adm must-gather` CLI command to collect information about your cluster logging environment. 
+
+.Procedure
+
+To collect cluster logging information with `must-gather`:
+
+. Navigate to the directory where you want to store the `must-gather` information.
+
+. Run the `oc adm must-gather` command against the cluster logging image: 
++
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm must-gather --image=$(oc -n openshift-logging get deployment.apps/cluster-logging-operator -o jsonpath='{.spec.template.spec.containers[?(@.name == "cluster-logging-operator")].image}')
+----
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm must-gather --image=quay.io/openshift/origin-cluster-logging-operator
+----
+endif::openshift-origin[]
++
+The `must-gather` tool creates a new directory that starts with `must-gather.local` within the current directory. For example:
+`must-gather.local.4157245944708210408`.
+
+. Create a compressed file from the `must-gather` directory that was just created. For example, on a computer that uses a Linux operating system, run the following command:
++
+[source,terminal]
+----
+$ tar -cvaf must-gather.tar.gz must-gather.local.4157245944708210408
+----
+
+. Attach the compressed file to your support case on the link:https://access.redhat.com/[Red Hat Customer Portal].

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -44,6 +44,9 @@ ifndef::openshift-origin[]
 |`registry.redhat.io/ocs4/ocs-must-gather-rhel8`
 |Data collection for Red Hat OpenShift Container Storage.
 
+|`registry.redhat.io/openshift4/ose-cluster-logging-operator`
+|Data collection for Red Hat OpenShift cluster logging.
+
 |===
 
 endif::openshift-origin[]
@@ -69,6 +72,9 @@ ifdef::openshift-origin[]
 
 |`quay.io/ocs-dev/ocs-must-gather`
 |Data collection for OpenShift Container Storage.
+
+|`quay.io/openshift/origin-cluster-logging-operator`
+|Data collection for Red Hat OpenShift cluster logging.
 
 |===
 
@@ -105,7 +111,13 @@ $ oc adm must-gather \
 ----
 <1> The default {product-title} must-gather image
 <2> The must-gather image for {VirtProductName}
-
++
+For cluster logging, run the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather --image=$(oc -n openshift-logging get deployment.apps/cluster-logging-operator -o jsonpath='{.spec.template.spec.containers[?(@.name == "cluster-logging-operator")].image}')
+----
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-When opening a support case, it is often helpful to provide debugging
+When opening a support case, it is helpful to provide debugging
 information about your cluster to Red Hat Support.
 
 It is recommended to provide:


### PR DESCRIPTION
The must-gather feature for cluster logging is not in the docs. This PR adds the images to the must-gather image list and new sections, based on the [Service Mesh must-gather docs](https://docs.openshift.com/container-platform/4.5/service_mesh/service_mesh_support/ossm-collecting-ossm-data.html).
See also: https://github.com/openshift/origin-aggregated-logging/pull/1979