### PR TITLE
virt-vm-storage: example for building a containerDisk image

### DIFF
--- a/modules/virt-vm-storage-volume-types.adoc
+++ b/modules/virt-vm-storage-volume-types.adoc
@@ -44,9 +44,15 @@ disk.
 |containerDisk
 |References an image, such as a virtual machine disk, that is stored in
 the container image registry. The image is pulled from the registry and
-embedded in a volume when the virtual machine is created. A
-*containerDisk* volume is ephemeral. It is discarded when
+embedded in a volume when the virtual machine is created.
+
+[NOTE]
+====
+A *containerDisk* volume is ephemeral. It is discarded when
 the virtual machine is stopped, restarted, or deleted.
+This means that they are useful *only* for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs.
+====
 
 Container disks are not limited to a single virtual machine and are
 useful for creating large numbers of virtual machine clones that do not
@@ -54,6 +60,17 @@ require persistent storage.
 
 Only RAW and QCOW2 formats are supported disk types for the container
 image registry. QCOW2 is recommended for reduced image size.
+Use the follwing to create your own container disk.
+----
+$ cat > Dockerfile << EOF
+FROM scratch
+ADD --chown=107:107 vm-image.qcow2 /disk/
+EOF
+
+$ podman build -t somerepo/some-container-disk:latest .
+$ podman push somerepo/some-container-disk:latest
+----
+
 
 |emptyDisk
 |Creates an additional sparse QCOW2 disk that is tied to the life-cycle


### PR DESCRIPTION
Document how container disks are created and why they should be used very carefully.

Bug-URL: https://bugzilla.redhat.com/show_bug.cgi?id=1875725
Signed-off-by: Dan Kenigsberg <danken@redhat.com>