### PR TITLE
CNV-5076 Exposing next run configuration to be applied after VM restart

### DIFF
--- a/modules/virt-add-boot-order-web.adoc
+++ b/modules/virt-add-boot-order-web.adoc
@@ -18,10 +18,18 @@ Add items to a boot order list by using the web console.
 
 . Click the *Details* tab.
 
-. Click the pencil icon that is located on the right side of *Boot Order*. If a YAML configuration does not exist, or if this is the first time that you are creating a boot order list, the following message displays: *No resource selected. VM will attempt to boot disks from YAML by order of appearance in YAMLv file. Please select a boot source*.
+. Click the pencil icon that is located on the right side of *Boot Order*. If a YAML configuration does not exist, or if this is the first time that you are creating a boot order list, the following message displays: *No resource selected. VM will attempt to boot from disks by order of appearance in YAML file.*
 
 . Click *Add Source* and select a bootable disk or Network Interface Card (NIC) for the virtual machine.
 
 . Add any additional disks or NICs to the boot order list.
 
 . Click *Save*.
+
+[NOTE]
+====
+If the virtual machine is running, changes to *Boot Order* will not take effect until you restart the virtual machine.
+
+You can view pending changes by clicking *View Pending Changes* on the right side of the *Boot Order* field. The *Pending Changes* banner at the
+top of the page displays a list of all changes that will be applied when the virtual machine restarts.
+====

--- a/modules/virt-add-disk-to-vm.adoc
+++ b/modules/virt-add-disk-to-vm.adoc
@@ -7,13 +7,15 @@
 // and VM templates.
 
 ifeval::["{context}" == "virt-edit-vms"]
+:virt-vm:
 :object: virtual machine
-:object-gui: Virtual Machines
+:object-gui: Virtual Machine
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
+:virt-vm-template:
 :object: virtual machine template
-:object-gui: Virtual Machine Templates
+:object-gui: Virtual Machine Template
 endif::[]
 
 [id="virt-vm-add-disk_{context}"]
@@ -24,22 +26,34 @@ Use this procedure to add a virtual disk to a {object}.
 
 .Procedure
 
-. From the *{object-gui}* tab, select your {object}.
-. Select the *Disks* tab.
-. Click *Add Disks* to open the *Add Disk* window.
-. In the *Add Disk* window, specify *Source*, *Name*, *Size*, *Interface*, and *Storage Class*.
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *{object-gui}s* tab.
+. Select a {object} to open the *{object-gui} Overview* screen.
+. Click the *Disks* tab.
+. Click *Add Disk* to open the *Add Disk* window.
+. In the *Add Disk* window, specify the *Source*, *Name*, *Size*, *Interface*, *Type*, and *Storage Class*.
 .. Optional: In the *Advanced* list, specify the *Volume Mode* and *Access Mode* for the virtual disk. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` ConfigMap.
-. Use the drop-down lists and check boxes to edit the disk configuration.
-. Click *OK*.
+. Click *Add*.
+
+ifdef::virt-vm[]
+[NOTE]
+====
+If the {object} is running, the new disk is in the *pending restart* state and will not be attached until you restart the {object}.
+
+The *Pending Changes* banner at the top of the page displays a list of all changes that will be applied when the {object} restarts.
+====
+endif::virt-vm[]
 
 // Unsetting all conditionals used in module
 
 ifeval::["{context}" == "virt-edit-vms"]
+:virt-vm!:
 :object!:
 :object-gui!:
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
+:virt-vm-template!:
 :object!:
 :object-gui!:
 endif::[]

--- a/modules/virt-add-nic-to-vm.adoc
+++ b/modules/virt-add-nic-to-vm.adoc
@@ -4,13 +4,15 @@
 // * virt/vm_templates/virt-editing-vm-template.adoc
 
 ifeval::["{context}" == "virt-edit-vms"]
+:virt-vm:
 :object: virtual machine
-:object-gui: Virtual Machines
+:object-gui: Virtual Machine
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
+:virt-vm-template:
 :object: virtual machine template
-:object-gui: Virtual Machine Templates
+:object-gui: Virtual Machine Template
 endif::[]
 
 [id="virt-vm-add-nic_{context}"]
@@ -21,36 +23,34 @@ Use this procedure to add a network interface to a {object}.
 
 .Procedure
 
-. From the *{object-gui}* tab, select the {object}.
-. Select the *Network Interfaces* tab.
+. Click *Workloads* -> *Virtualization* from the side menu.
+. Click the *{object-gui}s* tab.
+. Select a {object} to open the *{object-gui} Overview* screen.
+. Click the *Network Interfaces* tab.
 . Click *Add Network Interface*.
 . In the *Add Network Interface* window, specify the *Name*, *Model*, *Network*, *Type*,
 and *MAC Address* of the network interface.
-. Click *Add* to add the network interface.
-. Restart the virtual machine to enable access.
-. Edit the drop-down lists and check boxes to configure the network
-interface.
-. Click *Save Changes*.
-. Click *OK*.
+. Click *Add*.
 
-The new network interface displays at the top of the *Create Network Interface* list
-until the user restarts it.
+ifdef::virt-vm[]
+[NOTE]
+====
+If the {object} is running, the new network interface is in the *pending restart* state and changes will not take effect until you restart the {object}.
 
-The new network interface has a `Pending VM restart` Link State until you
-restart the virtual machine. Hover over the Link State to display more
-detailed information.
-
-The *Link State* is set to *Up* by default when the network interface card
-is defined on the virtual machine and connected to the network.
+The *Pending Changes* banner at the top of the page displays a list of all changes that will be applied when the {object} restarts.
+====
+endif::virt-vm[]
 
 // Scrubbing all conditionals used in module
 
 ifeval::["{context}" == "virt-edit-vms"]
+:virt-vm!:
 :object!:
 :object-gui!:
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
+:virt-vm-template!:
 :object!:
 :object-gui!:
 endif::[]

--- a/modules/virt-adding-secret-configmap-service-account-to-vm.adoc
+++ b/modules/virt-adding-secret-configmap-service-account-to-vm.adoc
@@ -12,19 +12,18 @@ Add a secret, ConfigMap, or service account to a virtual machine by using the {p
 
 * The secret, ConfigMap, or service account that you want to add must exist in the same namespace as the target virtual machine.
 
-* The virtual machine must be powered off.
-
 .Procedure
 
-. From the side menu, click *Virtualization*.
+. Click *Workloads* -> *Virtualization* from the side menu.
 
-. Click the *Virtual Machine* tab.
+. Click the *Virtual Machines* tab.
 
-. Select a virtual machine to open its *Virtual Machine Overview* page.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
 
 . Click the *Environment* tab.
 
-. Click *Select a resource* and select a secret, ConfigMap, or service account from the list.
+. Click *Select a resource* and select a secret, ConfigMap, or service account from the list. A six character serial number is automatically
+generated for the selected resource.
 
 . Click *Save*.
 
@@ -32,9 +31,14 @@ Add a secret, ConfigMap, or service account to a virtual machine by using the {p
 
 [NOTE]
 ====
-You can reset the form to the last saved state by clicking *Reload*.
-====
+.. You can reset the form to the last saved state by clicking *Reload*.
 
+.. The *Environment* resources are added to the virtual machine as disks. You can mount the secret, ConfigMap, or service account as you would mount any other disk.
+
+.. If the virtual machine is running, changes will not take effect until you restart the virtual machine. The newly added resources are marked as pending changes
+for both the *Environment* and *Disks* tab in the *Pending Changes* banner at the top of the page.
+
+====
 
 .Verification steps
 
@@ -42,5 +46,10 @@ You can reset the form to the last saved state by clicking *Reload*.
 
 . Check to ensure that the secret, ConfigMap, or service account is included in the list of disks.
 
-. Optional. Start the virtual machine by clicking *Actions* -> *Start Virtual Machine*.
+. Optional. Choose the appropriate method to apply your changes:
+
+.. If the virtual machine is running, restart the virtual machine by clicking *Actions* -> *Restart Virtual Machine*.
+
+.. If the virtual machine is stopped, start the virtual machine by clicking *Actions* -> *Start Virtual Machine*.
+
 You can now mount the secret, ConfigMap, or service account as you would mount any other disk.

--- a/modules/virt-edit-boot-order-web.adoc
+++ b/modules/virt-edit-boot-order-web.adoc
@@ -26,3 +26,11 @@ Edit the boot order list in the web console.
 * If you use a screen reader, press the Up Arrow key or Down Arrow key to move the item in the boot order list. Then, press the *Tab* key to drop the item in a location of your choice.
 
 . Click *Save*.
+
+[NOTE]
+====
+If the virtual machine is running, changes to the boot order list will not take effect until you restart the virtual machine.
+
+You can view pending changes by clicking *View Pending Changes* on the right side of the *Boot Order* field. The *Pending Changes* banner
+at the top of the page displays a list of all changes that will be applied when the virtual machine restarts.
+====

--- a/modules/virt-editing-vm-web.adoc
+++ b/modules/virt-editing-vm-web.adoc
@@ -47,7 +47,13 @@ ifdef::virt-vm-template[]
 Editing a virtual machine template will not affect virtual machines already created from that template.
 endif::virt-vm-template[]
 ifdef::virt-vm[]
-If the {object} is running, changes will not take effect until you reboot the {object}.
+[NOTE]
+====
+If the {object} is running, changes to *Boot Order* or *Flavor* will not take effect until you restart the {object}.
+
+You can view pending changes by clicking *View Pending Changes* on the right side of the relevant field. The *Pending Changes* banner at the
+top of the page displays a list of all changes that will be applied when the {object} restarts.
+====
 endif::virt-vm[]
 
 // Unsetting the attributes/variables used in the module or else they will stay active

--- a/modules/virt-remove-boot-order-item-web.adoc
+++ b/modules/virt-remove-boot-order-item-web.adoc
@@ -21,4 +21,12 @@ Remove items from a boot order list by using the web console.
 
 . Click the pencil icon that is located on the right side of *Boot Order*.
 
-. Click the *Remove* icon next to the item. The item is removed from the boot order list and saved in the list of available boot sources. If you remove all items from the boot order list, the following message displays: *No resource selected. VM will attempt to boot disks from YAML by order of appearance in YAML file. Please select a boot source.*
+. Click the *Remove* icon {delete} next to the item. The item is removed from the boot order list and saved in the list of available boot sources. If you remove all items from the boot order list, the following message displays: *No resource selected. VM will attempt to boot from disks by order of appearance in YAML file.*
+
+[NOTE]
+====
+If the virtual machine is running, changes to *Boot Order* will not take effect until you restart the virtual machine.
+
+You can view pending changes by clicking *View Pending Changes* on the right side of the *Boot Order* field. The *Pending Changes* banner at the
+top of the page displays a list of all changes that will be applied when the virtual machine restarts.
+====

--- a/modules/virt-removing-secret-configmap-service-account-vm.adoc
+++ b/modules/virt-removing-secret-configmap-service-account-vm.adoc
@@ -13,19 +13,17 @@ Remove a secret, ConfigMap, or service account from a virtual machine by using t
 * You must have at least one secret, ConfigMap, or service account
 that is attached to a virtual machine.
 
-* The virtual machine must be powered off.
-
 .Procedure
 
-. From the side menu, click *Virtualization*.
+. Click *Workloads* -> *Virtualization* from the side menu.
 
-. Click the *Virtual Machine* tab.
+. Click the *Virtual Machines* tab.
 
-. Select a virtual machine to open its *Virtual Machine Overview* page.
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
 
 . Click the *Environment* tab.
 
-. Find the item that you want to delete in the list, and click the *Delete* button {delete} on the right side of the item.
+. Find the item that you want to delete in the list, and click the *Remove* button {delete} on the right side of the item.
 
 . Click *Save*.
 


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/CNV-5076 

If the virtual machine is running, changes to select fields in the UI will be displayed as pending changes and take effect after the virtual machine is restarted. Added a note about this feature in the following existing modules:

- **Details tab** (Preview build: https://cnv-5076--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms.html#virt-editing-vm-web_virt-edit-vms)

- **Boot Order** (Preview build: https://cnv-5076--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-boot-order.html)

- **Network Interfaces tab** (Preview build: https://cnv-5076--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms.html#virt-vm-add-nic_virt-edit-vms)

- **Disks tab** (Preview build: https://cnv-5076--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms.html#virt-vm-add-disk_virt-edit-vms)

- **Environment tab** (Preview build: https://cnv-5076--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-managing-configmaps-secrets-service-accounts.html#virt-adding-secret-configmap-service-account-to-vm_virt-managing-configmaps-secrets-service-accounts)

Code review requested from Tomas Jelinek and Ido Rosenzwig (tagged in Jira)
QE review requested from Nelly Credi and Guohua Ouyang (tagged in Jira)

Peer review needed
Merge/CP to branch/enterprise-4.6