### PR TITLE
Correct the typo of OCP version for upgrading to 4.6 release

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -14,7 +14,7 @@ recommending the appropriate release versions for cluster upgrade. By controllin
 the pace of upgrades, these upgrade channels allow you to choose an upgrade
 strategy. Upgrade channels are tied to a minor version of
 {product-title}. For instance, {product-title} {product-version}
-upgrade channels will never include an upgrade to a 4.5 release. This strategy ensures that
+upgrade channels will never include an upgrade to a 4.7 release. This strategy ensures that
 administrators explicitly decide to upgrade to the next minor version of
 {product-title}. Upgrade channels control only release selection and do not impact the version of the cluster that you install; the `openshift-install`
 binary file for a specific version of {product-title} always installs that version.


### PR DESCRIPTION
There was a typo about the upgrade channels in "1.3. OpenShift Container Platform upgrade channels and releases".