### PR TITLE
CNV BZ#1859231 remove ipam from cnv sriov 

### DIFF
--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -57,8 +57,8 @@ spec:
   networkNamespace: <target_namespace> <4>
   vlan: <vlan> <5>
   spoofChk: "<spoof_check>" <6>
-  ipam: {} <7>
 ifdef::ocp-sriov-net[]
+  ipam: {} <7>
   linkState: <link_state> <8>
   maxTxRate: <max_tx_rate> <9>
   minTxRate: <min_rx_rate> <10>
@@ -78,16 +78,8 @@ endif::ocp-sriov-net[]
 ====
 You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
 ====
-ifdef::virt-sriov-net[]
-<7> An IPAM configuration is not supported with vfio-pci devices, however you must include an empty `ipam: {}` parameter for the SriovNetwork CR to be created. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1859231[BZ#1859231].
-endif::virt-sriov-net[]
 ifdef::ocp-sriov-net[]
 <7> A configuration object for the IPAM CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
-+
-[IMPORTANT]
-====
-If you do not specify an IPAM configuration, you need to include an empty `ipam: {}` parameter for the SriovNetwork CR to be created. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1859231[BZ#1859231].
-====
 <8> Optional: Replace `<link_state>` with the link state of virtual function (VF). Allowed value are `enable`, `disable` and `auto`.
 <9> Optional: Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
 <10> Optional: Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.


### PR DESCRIPTION
Now that [BZ#1859231](https://bugzilla.redhat.com/show_bug.cgi?id=1859231) is pushed, removing ipam from the cnv sriov manifest (as it doesn't work with cnv config because vfio-pci) and removing the admonitions re the ipam bz

CNV doc: https://cnv-sriov-remove-ipam--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.html#nw-sriov-network-attachment_virt-defining-an-sriov-network
OCP doc: https://cnv-sriov-remove-ipam--ocpdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-net-attach.html#nw-sriov-network-attachment_configuring-sriov-net-attach

@jboxman - can you please give this a sanity check for ocp docs
