### PR TITLE
Removing SRIOV ipam release note

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -156,11 +156,6 @@ As a workaround, you can reconfigure the virtual machines so that they can be po
 ** Remove the `evictionStrategy: LiveMigrate` field. See xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[Configuring virtual machine eviction strategy] for more information on how to configure eviction strategy.
 ** Set the `runStrategy` field to `Always`.
 
-
-* If you do not specify an IPAM configuration in the SriovNetwork configuration, the NetworkAttachmentDefinition is not created.
-As a workaround, you must include an empty `ipam: {}` parameter in the SriovNetwork configuration.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1859231[*BZ#1859231*])
-
 * For unknown reasons, memory consumption for the `containerDisk` volume type might gradually increase until it exceeds the memory limit. To resolve this issue, restart the VM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855067[*BZ#1855067*])
 
 * Sometimes, when attempting to edit the subscription channel of the *{VirtProductName} Operator* in the web console, clicking the


### PR DESCRIPTION
[BZ#1859231](https://bugzilla.redhat.com/show_bug.cgi?id=1859231) is pushed, removing release note from cnv docs (ocp docs already handled in #24992)