### PR TITLE
Fixing long oc install wording

### DIFF
--- a/modules/nodes-cluster-disabling-features-cluster.adoc
+++ b/modules/nodes-cluster-disabling-features-cluster.adoc
@@ -16,7 +16,7 @@ your cluster remains disabled.
 .Prerequisites
 
 * You added a FeatureGate and enabled Technology Preview features.
-* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
+* Install the OpenShift CLI (`oc`).
 * You must log in to the cluster with a user that has the `cluster-admin` role.
 
 .Procedure

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -15,8 +15,7 @@ of the Customer Portal.
 
 .Prerequisites
 
-* Install the version of the OpenShift Command-line Interface (CLI), commonly
-known as `oc`, that matches the version for your updated version.
+* Install the OpenShift CLI (`oc`) that matches the version for your updated version.
 * Log in to the cluster as user with `cluster-admin` privileges.
 * Install the `jq` package.
 


### PR DESCRIPTION
Two more updates for 4.6 that were missed because of the auto cherry pick for #25228 to 4.6.