### PR TITLE
BZ1876886 - Add EBS max vol note

### DIFF
--- a/modules/storage-persistent-storage-aws-maximum-volumes.adoc
+++ b/modules/storage-persistent-storage-aws-maximum-volumes.adoc
@@ -3,17 +3,13 @@
 // * storage/persistent_storage-aws.adoc
 
 [id="maximum-number-of-ebs-volumes-on-a-node_{context}"]
-= Maximum Number of EBS Volumes on a Node
+= Maximum number of EBS volumes on a node
 
 By default, {product-title} supports a maximum of 39 EBS volumes attached to one
 node. This limit is consistent with the
-link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits[AWS
-volume limits].
+link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits[AWS volume limits]. The volume limit depends on the instance type.
 
-{product-title} can be configured to have a higher limit by setting the
-environment variable `KUBE_MAX_PD_VOLS`. However, AWS requires a particular
-naming scheme
-(link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html[AWS
-Device Naming]) for attached devices, which only supports a maximum of 52
-volumes. This limits the number of volumes that can be attached to a node via
-{product-title} to 52.
+[IMPORTANT]
+====
+As a cluster administrator, you must use either in-tree or Container Storage Interface (CSI) volumes and their respective storage classes, but never both volume types at the same time. The maximum attached EBS volume number is counted separately for in-tree and CSI volumes.
+====


### PR DESCRIPTION
[BZ1876886](https://bugzilla.redhat.com/show_bug.cgi?id=1876886)
Adds note to docs for cloud admins to choose either in-tree or CSI to report correct max vol number in AWS EBS.

@jsafrane and @qinpingli - PTAL and make sure wording and placement both make sense, thanks! Also, please confirm that this applies only to OCP 4.6+?

Also, related to https://bugzilla.redhat.com/show_bug.cgi?id=1794729.