### PR TITLE
Fix spec.template.metadata.annotations for min and max scale example

### DIFF
--- a/modules/configuring-scale-bounds-knative.adoc
+++ b/modules/configuring-scale-bounds-knative.adoc
@@ -19,8 +19,9 @@ maxScale:: If the `maxScale` annotation is not set, there will be no upper limit
 spec:
   template:
     metadata:
-      autoscaling.knative.dev/minScale: "2"
-      autoscaling.knative.dev/maxScale: "10"
+      annotations:
+        autoscaling.knative.dev/minScale: "2"
+        autoscaling.knative.dev/maxScale: "10"
 ----
 
 Using these annotations in the revision template will propagate this confguration to `PodAutoscaler` objects.


### PR DESCRIPTION
This fixes the scale annotation example to `spec.template.metadata.annotations`.

/cc @ddonahue007 @abrennan89 @markusthoemmes 