### PR TITLE
Cnv bz1875725 containerdisks

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2375,6 +2375,8 @@ Topics:
       File: virt-cloning-a-datavolume-using-smart-cloning
     - Name: Storage defaults for DataVolumes
       File: virt-storage-defaults-for-datavolumes
+    - Name: Using container disks with virtual machines
+      File: virt-using-container-disks-with-vms
     - Name: Preparing CDI scratch space
       File: virt-preparing-cdi-scratch-space
     - Name: Re-using statically provisioned persistent volumes

--- a/modules/virt-about-container-disks.adoc
+++ b/modules/virt-about-container-disks.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+// * virt/virtual_machines/importing_vms/virt-importing-container-disk-with-datavolumes.adoc
+
+[id="virt-about-container-disks_{context}"]
+= About container disks
+
+A container disk is a virtual machine image that is stored as a container image in a container image registry. You can use container disks to deliver the same disk images to multiple virtual machines and to create large numbers of virtual machine clones.
+
+A container disk can either be imported into a persistent volume claim (PVC) by using a DataVolume that is attached to a virtual machine, or attached directly to a virtual machine as an ephemeral `containerDisk` volume.
+
+== Importing a container disk into a PVC by using a DataVolume
+
+Use the Containerized Data Importer (CDI) to import the container disk into a PVC by using a DataVolume. You can then attach the DataVolume to a virtual machine for persistent storage.
+
+== Attaching a container disk to a virtual machine as a `containerDisk` volume
+
+A `containerDisk` volume is ephemeral. It is discarded when the virtual machine is stopped, restarted, or deleted. When a virtual machine with a `containerDisk` volume starts, the container image is pulled from the registry and hosted on the node that is hosting the virtual machine.
+
+Use `containerDisk` volumes for read-only filesystems such as CD-ROMs or for disposable virtual machines.
+
+[IMPORTANT]
+====
+Using `containerDisk` volumes for read-write filesystems is not recommended because the data is temporarily written to local storage on the hosting node. This slows live migration of the virtual machine, such as in the case of node maintenance, because the data must be migrated to the destination node. Additionally, all data is lost if the node loses power or otherwise shuts down unexpectedly.
+====
+

--- a/modules/virt-preparing-container-disk-for-vms.adoc
+++ b/modules/virt-preparing-container-disk-for-vms.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+
+[id="virt-preparing-container-disk-for-vms_{context}"]
+= Preparing a container disk for virtual machines
+
+You must build a container disk with a virtual machine image and push it to a container registry before it can used with a virtual machine. You can then either import the container disk into a PVC using a DataVolume and attach it to a virtual machine, or you can attach the container disk directly to a virtual machine as an ephemeral `containerDisk` volume.
+
+.Prerequisites
+
+* For RHEL users: You have root or sudo privileges on your local system to install `podman`.
+
+* The virtual machine image must be either QCOW2 or RAW format.
+
+.Procedure
+
+. Install `podman` if it is not already installed:
++
+[source,terminal]
+----
+$ sudo yum install podman -y
+----
+
+. Create a Dockerfile to build the virtual machine image into a container image. The virtual machine image must be owned by QEMU, which has a UID of `107`, and placed in the `/disk/` directory inside the container. Permissions for the `/disk/` directory must then be set to `0440`.
++
+The following example uses the Red Hat Universal Base Image (UBI) to handle these configuration changes in the first stage, and uses the minimal `scratch` image in the second stage to store the result:
++
+[source,terminal]
+----
+$ cat > Dockerfile << EOF
+FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
+ADD --chown=107:107 <vm_image>.qcow2 /disk/ <1>
+RUN chmod 0440 /disk/*
+
+FROM scratch
+COPY --from=builder /disk/* /disk/
+EOF
+----
+<1> Where <vm_image> is the virtual machine image in either QCOW2 or RAW format. +
+To use a remote virtual machine image, replace `<vm_image>.qcow2` with the complete url for the remote image.
+
+. Build and tag the container:
++
+[source,terminal]
+----
+$ podman build -t <registry>/<container_disk_name>:latest .
+----
+
+. Push the container image to the registry:
++
+[source,terminal]
+----
+$ podman push <registry>/<container_disk_name>:latest
+----

--- a/modules/virt-vm-storage-volume-types.adoc
+++ b/modules/virt-vm-storage-volume-types.adoc
@@ -5,63 +5,40 @@
 [id="virt-vm-storage-volume-types_{context}"]
 = Virtual machine storage volume types
 
+[cols="1a,1a"]
 |===
 |Storage volume type |Description
 
 |ephemeral
-|A local copy-on-write (COW) image that uses a network volume as a
-read-only backing store. The backing volume
-must be a *PersistentVolumeClaim*. The ephemeral image is created when
-the virtual machine starts and stores all writes locally. The ephemeral
-image is discarded when the virtual machine is stopped, restarted, or
-deleted. The backing volume (PVC) is not mutated in any way.
+|A local copy-on-write (COW) image that uses a network volume as a read-only backing store. The backing volume must be a *PersistentVolumeClaim*. The ephemeral image is created when the virtual machine starts and stores all writes locally. The ephemeral image is discarded when the virtual machine is stopped, restarted, or deleted. The backing volume (PVC) is not mutated in any way.
 
 |persistentVolumeClaim
-|Attaches an available PV to a virtual machine. Attaching a PV allows for the
-virtual machine data to persist between sessions.
+|Attaches an available PV to a virtual machine. Attaching a PV allows for the virtual machine data to persist between sessions.
 
-Importing an existing virtual machine disk into a PVC by using
-CDI and attaching the PVC to a virtual machine instance is the
-recommended method for importing existing virtual machines into
-{product-title}. There are some requirements for the disk to be used within a
-PVC.
+Importing an existing virtual machine disk into a PVC by using CDI and attaching the PVC to a virtual machine instance is the recommended method for importing existing virtual machines into {product-title}. There are some requirements for the disk to be used within a PVC.
 
 |dataVolume
-|DataVolumes build on the `persistentVolumeClaim` disk type by managing the process
-of preparing the virtual machine disk via an import, clone, or upload operation.
-VMs that use this volume type are guaranteed not to start until the volume is ready.
+|DataVolumes build on the `persistentVolumeClaim` disk type by managing the process of preparing the virtual machine disk via an import, clone, or upload operation. VMs that use this volume type are guaranteed not to start until the volume is ready.
 
-Specify `type: dataVolume` or `type: ""`. If you specify any other value for
-`type`, such as `persistentVolumeClaim`, a warning is displayed, and the virtual
-machine does not start.
+Specify `type: dataVolume` or `type: ""`. If you specify any other value for `type`, such as `persistentVolumeClaim`, a warning is displayed, and the virtual machine does not start.
 
 |cloudInitNoCloud
-|Attaches a disk that contains the referenced cloud-init NoCloud data
-source, providing user data and metadata to the virtual machine.
-A cloud-init installation is required inside the virtual machine
-disk.
+|Attaches a disk that contains the referenced cloud-init NoCloud data source, providing user data and metadata to the virtual machine. A cloud-init installation is required inside the virtual machine disk.
 
 |containerDisk
-|References an image, such as a virtual machine disk, that is stored in
-the container image registry. The image is pulled from the registry and
-embedded in a volume when the virtual machine is created. A
-*containerDisk* volume is ephemeral. It is discarded when
-the virtual machine is stopped, restarted, or deleted.
+|References an image, such as a virtual machine disk, that is stored in the container image registry. The image is pulled from the registry and attached to the virtual machine as a disk when the virtual machine is launched.
 
-Container disks are not limited to a single virtual machine and are
-useful for creating large numbers of virtual machine clones that do not
-require persistent storage.
+A `containerDisk` volume is not limited to a single virtual machine and is useful for creating large numbers of virtual machine clones that do not require persistent storage.
 
-Only RAW and QCOW2 formats are supported disk types for the container
-image registry. QCOW2 is recommended for reduced image size.
+Only RAW and QCOW2 formats are supported disk types for the container image registry. QCOW2 is recommended for reduced image size.
+
+[NOTE]
+====
+A `containerDisk` volume is ephemeral. It is discarded when the virtual machine is stopped, restarted, or deleted. A `containerDisk` volume is useful for read-only filesystems such as CD-ROMs or for disposable virtual machines.
+====
 
 |emptyDisk
-|Creates an additional sparse QCOW2 disk that is tied to the life-cycle
-of the virtual machine interface. The data survives guest-initiated
-reboots in the virtual machine but is discarded when the virtual machine
-stops or is restarted from the web console. The empty disk is used to
-store application dependencies and data that otherwise exceeds the
-limited temporary file system of an ephemeral disk.
+|Creates an additional sparse QCOW2 disk that is tied to the life-cycle of the virtual machine interface. The data survives guest-initiated reboots in the virtual machine but is discarded when the virtual machine stops or is restarted from the web console. The empty disk is used to store application dependencies and data that otherwise exceeds the limited temporary file system of an ephemeral disk.
 
 The disk *capacity* size must also be provided.
 

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -50,5 +50,6 @@ include::modules/virt-about-runstrategies-vms.adoc[leveloffset=+1]
 The KubeVirt API Reference is the upstream project reference and might contain parameters that are not supported in {VirtProductName}.
 ====
 
+* xref:../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-using-container-disks-with-vms[Prepare a container disk] before adding it to a virtual machine as a `containerDisk` volume. 
 * See xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[Deploying machine health checks] for further details on deploying and enabling machine health checks.
 * See xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Installer-provisioned infrastructure overview] for further details on installer-provisioned infrastructure.

--- a/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
@@ -1,0 +1,15 @@
+[id="virt-using-container-disks-with-vms"]
+= Using container disks with virtual machines
+include::modules/virt-document-attributes.adoc[]
+:context: virt-using-container-disks-with-vms
+toc::[]
+
+You can build a virtual machine image into a container disk and store it in your container registry. You can then import the container disk into persistent storage for a virtual machine or attach it directly to the virtual machine for ephemeral storage.
+
+include::modules/virt-about-container-disks.adoc[leveloffset=+1]
+include::modules/virt-preparing-container-disk-for-vms.adoc[leveloffset=+1]
+
+== Next steps
+
+* xref:../../../virt/virtual_machines/virt-create-vms.adoc#virt-create-vms[Create a virtual machine] that uses
+a containerDisk volume for ephemeral storage.


### PR DESCRIPTION
Adding a procedure to cover [BZ#1875725](https://bugzilla.redhat.com/show_bug.cgi?id=1875725) request for how to create a containerDisk. Since this doesn't belong anywhere it needed a new assembly, which also required a concept to cover containerDisk volumes. 
Also moved a para re: ephemeral nature of containerDisks into an adomintion in the storage type table to increase visibility and added the new assembly to the 'Additional resources' section of 'creating vms'

Additional info taken from https://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=containerdisk

New assembly: https://cnv-bz1875725-containerdisk--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-using-containerdisk-volumes.html
Updated storage types table: https://cnv-bz1875725-containerdisk--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#virt-vm-storage-volume-types_virt-create-vms

@fabiand and @dankenigsberg please review.
Note that the new assembly is under 'Advanced virtual machine management' rather than 'Virtual machine disks' due to the concerns Fabian had raised earlier. 