### PR TITLE
OSDOCS-1172: Adding release notes for token inactivity timeout

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -59,6 +59,13 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-6-security"]
 === Security
 
+[id="ocp-4-6-oauth-token-inactivity-timeout"]
+==== Configure OAuth token inactivity timeout
+
+You can now configure OAuth tokens to expire after a certain amount of time that they have been inactive. By default, there is no token inactivity timeout set. You can configure the timeout for the internal OAuth server and for OAuth clients.
+
+See xref:../authentication/configuring-internal-oauth.adoc#oauth-token-inactivity-timeout_configuring-internal-oauth[Configuring token inactivity timeout for the internal OAuth server] and xref:../authentication/configuring-oauth-clients.adoc#oauth-token-inactivity-timeout_configuring-oauth-clients[Configuring token inactivity timeout for an OAuth client] for more information.
+
 [id="ocp-4-6-oauth-token-storage"]
 ==== Secure OAuth token storage format
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1172

PR: https://osdocs-1172-rn--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-security