### PR TITLE
Updates to Architecture book code blocks

### DIFF
--- a/architecture/additional_concepts/authentication.adoc
+++ b/architecture/additional_concepts/authentication.adoc
@@ -120,15 +120,17 @@ administering the cluster. For example, running `oc delete nodes --all` fails,
 but running `oc delete nodes --all --as=system:admin` succeeds. You
 can grant a user that permission by running this command:
 
+[source,terminal]
 ----
 $ oc create clusterrolebinding <any_valid_name> --clusterrole=sudoer --user=<username>
 ----
 
 If you need to create a project request on behalf of a user, include the
-`*--as=<user> --as-group=<group1> --as-group=<group2>*` flags in your command.
-Because `*system:authenticated:oauth*` is the only bootstrap group that can
+`--as=<user> --as-group=<group1> --as-group=<group2>` flags in your command.
+Because `system:authenticated:oauth` is the only bootstrap group that can
 create project requests, you must impersonate that group, as shown in the following example:
 
+[source,terminal]
 ----
 $ oc new-project <project> --as=<user> \
 --as-group=system:authenticated --as-group=system:authenticated:oauth
@@ -181,6 +183,7 @@ To register additional clients:
 
 ====
 
+[source,terminal]
 ----
 $ oc create -f <(echo '
 kind: OAuthClient
@@ -217,6 +220,7 @@ When using a service account as an OAuth client:
 * `client_id` is `system:serviceaccount:<serviceaccount_namespace>:<serviceaccount_name>`.
 * `client_secret` can be any of the API tokens for that service account. For example:
 +
+[source,terminal]
 ----
 $ oc sa get-token <serviceaccount_name>
 ----
@@ -236,6 +240,7 @@ Annotation keys must have the prefix
 `serviceaccounts.openshift.io/oauth-redirecturi.` or
 `serviceaccounts.openshift.io/oauth-redirectreference.` such as:
 
+[source,terminal]
 ----
 serviceaccounts.openshift.io/oauth-redirecturi.<name>
 ----
@@ -243,6 +248,7 @@ serviceaccounts.openshift.io/oauth-redirecturi.<name>
 In its simplest form, the annotation can be used to directly specify valid
 redirect URIs. For example:
 
+[source,terminal]
 ----
 "serviceaccounts.openshift.io/oauth-redirecturi.first":  "https://example.com"
 "serviceaccounts.openshift.io/oauth-redirecturi.second": "https://other.com"
@@ -258,6 +264,7 @@ is where dynamic redirect URIs via the
 
 For example:
 
+[source,terminal]
 ----
 "serviceaccounts.openshift.io/oauth-redirectreference.first": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"jenkins\"}}"
 ----
@@ -265,8 +272,8 @@ For example:
 Since the value for this annotation contains serialized JSON data, it is easier
 to see in an expanded format:
 
+[source,json]
 ----
-
 {
   "kind": "OAuthRedirectReference",
   "apiVersion": "v1",
@@ -275,15 +282,14 @@ to see in an expanded format:
     "name": "jenkins"
   }
 }
-
 ----
 
 Now you can see that an `OAuthRedirectReference` allows us to reference the
 route named `jenkins`. Thus, all ingresses for that route will now be considered
-valid.  The full specification for an `OAuthRedirectReference` is:
+valid. The full specification for an `OAuthRedirectReference` is:
 
+[source,json]
 ----
-
 {
   "kind": "OAuthRedirectReference",
   "apiVersion": "v1",
@@ -293,7 +299,6 @@ valid.  The full specification for an `OAuthRedirectReference` is:
     "group": ... <3>
   }
 }
-
 ----
 
 <1> `kind` refers to the type of the object being referenced. Currently, only `route` is supported.
@@ -303,6 +308,7 @@ valid.  The full specification for an `OAuthRedirectReference` is:
 Both annotation prefixes can be combined to override the data provided by the
 reference object. For example:
 
+[source,terminal]
 ----
 "serviceaccounts.openshift.io/oauth-redirecturi.first":  "custompath"
 "serviceaccounts.openshift.io/oauth-redirectreference.first": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"jenkins\"}}"
@@ -335,6 +341,7 @@ Any combination of the above syntax can be combined using the following format:
 
 The same object can be referenced more than once for more flexibility:
 
+[source,terminal]
 ----
 "serviceaccounts.openshift.io/oauth-redirecturi.first":  "custompath"
 "serviceaccounts.openshift.io/oauth-redirectreference.first": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"jenkins\"}}"
@@ -349,6 +356,7 @@ Assuming that the route named `jenkins` has an ingress of
 Static and dynamic annotations can be used at the same time to achieve the
 desired behavior:
 
+[source,terminal]
 ----
 "serviceaccounts.openshift.io/oauth-redirectreference.first": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"jenkins\"}}"
 "serviceaccounts.openshift.io/oauth-redirecturi.second": "https://other.com"
@@ -368,15 +376,27 @@ an *unexpected condition* server error during OAuth, run `oc get events` to view
 
 The following example warns of a service account that is missing a proper OAuth redirect URI:
 
+[source,terminal]
 ----
 $ oc get events | grep ServiceAccount
+----
+
+.Example Output
+[source,terminal]
+----
 1m         1m          1         proxy                    ServiceAccount                                  Warning   NoSAOAuthRedirectURIs   service-account-oauth-client-getter   system:serviceaccount:myproject:proxy has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>
 ----
 
 Running `oc describe sa/<service-account-name>` reports any OAuth events associated with the given service account name.
 
+[source,terminal]
 ----
 $ oc describe sa/proxy | grep -A5 Events
+----
+
+.Example Output
+[source,terminal]
+----
 Events:
   FirstSeen     LastSeen        Count   From                                    SubObjectPath   Type            Reason                  Message
   ---------     --------        -----   ----                                    -------------   --------        ------                  -------
@@ -387,6 +407,7 @@ The following is a list of the possible event errors:
 
 **No redirect URI annotations or an invalid URI is specified**
 
+[source,terminal]
 ----
 Reason                  Message
 NoSAOAuthRedirectURIs   system:serviceaccount:myproject:proxy has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>
@@ -394,6 +415,7 @@ NoSAOAuthRedirectURIs   system:serviceaccount:myproject:proxy has no redirectURI
 
 **Invalid route specified**
 
+[source,terminal]
 ----
 Reason                  Message
 NoSAOAuthRedirectURIs   [routes.route.openshift.io "<name>" not found, system:serviceaccount:myproject:proxy has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]
@@ -401,6 +423,7 @@ NoSAOAuthRedirectURIs   [routes.route.openshift.io "<name>" not found, system:se
 
 **Invalid reference type specified**
 
+[source,terminal]
 ----
 Reason                  Message
 NoSAOAuthRedirectURIs   [no kind "<name>" is registered for version "v1", system:serviceaccount:myproject:proxy has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]
@@ -408,6 +431,7 @@ NoSAOAuthRedirectURIs   [no kind "<name>" is registered for version "v1", system
 
 **Missing SA tokens**
 
+[source,terminal]
 ----
 Reason                  Message
 NoSAOAuthTokens         system:serviceaccount:myproject:proxy has no tokens
@@ -421,12 +445,14 @@ The following steps represent one way a user could get into a broken state and h
 
 .. Create YAML for a proxy service account object and ensure it uses the route `proxy`:
 +
+[source,terminal]
 ----
-vi serviceaccount.yaml
+$ vi serviceaccount.yaml
 ----
 +
 Add the following sample code:
 +
+[source,yaml]
 ----
 apiVersion: v1
 kind: ServiceAccount
@@ -438,12 +464,14 @@ metadata:
 
 .. Create YAML for a route object to create a secure connection to the proxy:
 +
+[source,terminal]
 ----
-vi route.yaml
+$ vi route.yaml
 ----
 +
 Add the following sample code:
 +
+[source,yaml]
 ----
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -471,13 +499,14 @@ spec:
 
 .. Create a YAML for a deployment configuration to launch a proxy as a sidecar:
 +
+[source,terminal]
 ----
-vi proxysidecar.yaml
+$ vi proxysidecar.yaml
 ----
 +
 Add the following sample code:
 +
-[subs="replacements, +attributes"]
+[source,yaml,subs="replacements,+attributes"]
 ----
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -526,16 +555,26 @@ endif::[]
           secretName: proxy-tls
 ----
 +
-.. Create the objects
+.. Create the three objects:
 +
+[source,terminal]
 ----
-oc create -f serviceaccount.yaml
-oc create -f route.yaml
-oc create -f proxysidecar.yaml
+$ oc create -f serviceaccount.yaml
+----
++
+[source,terminal]
+----
+$ oc create -f route.yaml
+----
++
+[source,terminal]
+----
+$ oc create -f proxysidecar.yaml
 ----
 
 . Run `oc edit sa/proxy` to edit the service account and change the `serviceaccounts.openshift.io/oauth-redirectreference` annotation to point to a Route that does not exist.
 +
+[source,yaml]
 ----
 apiVersion: v1
 imagePullSecrets:
@@ -549,15 +588,21 @@ metadata:
 
 . Review the OAuth log for the service to locate the server error:
 +
+[source,terminal]
 ----
 The authorization server encountered an unexpected condition that prevented it from fulfilling the request.
 ----
 
 . Run `oc get events` to view the `ServiceAccount` event:
 +
+[source,terminal]
 ----
-oc get events | grep ServiceAccount
-
+$ oc get events | grep ServiceAccount
+----
++
+.Example Output
+[source,terminal]
+----
 23m        23m         1         proxy                    ServiceAccount                                  Warning   NoSAOAuthRedirectURIs   service-account-oauth-client-getter   [routes.route.openshift.io "notexist" not found, system:serviceaccount:myproject:proxy has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]
 ----
 
@@ -609,6 +654,7 @@ Thus, any application running inside the cluster can issue a `GET` request to
 *_\https://openshift.default.svc/.well-known/oauth-authorization-server_* to fetch
 the following information:
 
+[source,json]
 ----
 {
   "issuer": "https://<master>", <1>
@@ -676,7 +722,7 @@ OAuth authorization flows.
 Run the following command to request an OAuth token by using the authorization code
 grant method:
 
-[source,bash]
+[source,terminal]
 ----
 $ curl -H "X-Remote-User: <username>" \
      --cacert /etc/origin/master/ca.crt \
@@ -703,11 +749,16 @@ responses from `/oauth/authorize`, and how they should be handled:
 
 To request an OAuth token using the implicit grant flow:
 
-[source,bash]
+[source,terminal]
 ----
 $ curl -u <username>:<password>
 'https://<master-address>:8443/oauth/authorize?client_id=openshift-challenging-client&response_type=token' -skv / <1>
 / -H "X-CSRF-Token: xxx" <2>
+----
+
+.Example Output
+[source,terminal]
+----
 *   Trying 10.64.33.43...
 * Connected to 10.64.33.43 (10.64.33.43) port 8443 (#0)
 * found 148 certificates in /etc/ssl/certs/ca-certificates.crt
@@ -755,20 +806,23 @@ set to `token`.
 `access_token=gzTwOq_mVJ7ovHliHBTgRQEEXa1aCZD9lnj7lSw3ekQ`.
 
 To view only the OAuth token value, run the following command:
-[source,bash]
+[source,terminal]
 ----
-$ curl -u <username>:<password>
-'https://<master-address>:8443/oauth/authorize?client_id=openshift-challenging-client&response_type=token' <1>
+$ curl -u <username>:<password> /
+'https://<master-address>:8443/oauth/authorize?client_id=openshift-challenging-client&response_type=token' / <1>
 -skv -H "X-CSRF-Token: xxx" --stderr - |  grep -oP "access_token=\K[^&]*" <2>
-
-hvqxe5aMlAzvbqfM2WWw3D6tR0R2jCQGKx0viZBxwmc
 ----
 <1> `client-id` is set to `openshift-challenging-client` and `response-type` is
 set to `token`.
 <2> Set `X-CSRF-Token` header to a non-empty value.
 
-You can also use the `Code Grant` method to request a token
+.Example Output
+[source,terminal]
+----
+hvqxe5aMlAzvbqfM2WWw3D6tR0R2jCQGKx0viZBxwmc
+----
 
+You can also use the `Code Grant` method to request a token.
 
 ifdef::openshift-enterprise,openshift-origin[]
 

--- a/architecture/additional_concepts/authorization.adoc
+++ b/architecture/additional_concepts/authorization.adoc
@@ -74,11 +74,13 @@ the CLI].
 For example, consider the following excerpt that shows the rule sets
 for the *admin* and *basic-user* xref:roles[default cluster roles]:
 
-[options="nowrap"]
+[source,terminal]
 ----
 $ oc describe clusterrole.rbac admin basic-user
 ----
 
+.Example Output
+[source,terminal]
 ----
 Name:		admin
 Labels:		<none>
@@ -248,11 +250,13 @@ PolicyRule:
 The following excerpt from viewing local role bindings shows the above roles bound
 to various users and groups:
 
-[options="nowrap"]
+[source,terminal]
 ----
-oc describe rolebinding.rbac admin basic-user -n alice-project
+$ oc describe rolebinding.rbac admin basic-user -n alice-project
 ----
 
+.Example Output
+[source,terminal]
 ----
 Name:		admin
 Labels:		<none>
@@ -479,8 +483,9 @@ when you upgrade {product-title}.
 To update custom roles and permissions, it is strongly recommended to use
 the following command:
 
+[source,terminal]
 ----
-# oc auth reconcile -f <file> <1>
+$ oc auth reconcile -f <file> <1>
 ----
 <1> `<file>` is the absolute path to the xref:../../admin_guide/custom_resource_definitions.adoc#creating-aggregated-cluster-role-crd_admin-guide-custom-resources[roles and permissions] to apply.
 
@@ -548,8 +553,14 @@ ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
 Seven SCCs are added to the cluster by default, and are viewable by cluster
 administrators using the CLI:
 
+[source,terminal]
 ----
 $ oc get scc
+----
+
+.Example Output
+[source,terminal]
+----
 NAME               PRIV      CAPS      SELINUX     RUNASUSER          FSGROUP     SUPGROUP    PRIORITY   READONLYROOTFS   VOLUMES
 anyuid             false     []        MustRunAs   RunAsAny           RunAsAny    RunAsAny    10         false            [configMap downwardAPI emptyDir persistentVolumeClaim secret]
 hostaccess         false     []        MustRunAs   MustRunAsRange     MustRunAs   RunAsAny    <none>     false            [configMap downwardAPI emptyDir hostPath persistentVolumeClaim secret]
@@ -582,8 +593,14 @@ endif::openshift-dedicated[]
 The definition for each SCC is also viewable by cluster administrators using the
 CLI. For example, for the privileged SCC:
 
+[source,terminal]
 ----
-# oc get -o yaml --export scc/privileged
+$ oc get -o yaml --export scc/privileged
+----
+
+.Example Output
+[source,yaml]
+----
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true
@@ -1047,6 +1064,7 @@ From within your {product-title} project, you can determine what verbs you
 can perform against all namespace-scoped resources (including third-party
 resources). Run:
 
+[source,terminal]
 ----
 $ oc policy can-i --list --loglevel=8
 ----
@@ -1056,6 +1074,7 @@ information.
 
 To receive information back in a user-readable format, run:
 
+[source,terminal]
 ----
 $ oc policy can-i --list
 ----
@@ -1064,6 +1083,7 @@ The output will provide a full list.
 
 To determine if you can perform specific xref:action[verbs], run:
 
+[source,terminal]
 ----
 $ oc policy can-i <verb> <resource>
 ----
@@ -1071,6 +1091,7 @@ $ oc policy can-i <verb> <resource>
 xref:../../admin_guide/scoped_tokens.adoc#admin-guide-scoped-tokens-user-scopes[User
 scopes] can provide more information about a given scope. For example:
 
+[source,terminal]
 ----
 $ oc policy can-i <verb> <resource> --scopes=user:info
 ----

--- a/architecture/additional_concepts/dynamic_admission_controllers.adoc
+++ b/architecture/additional_concepts/dynamic_admission_controllers.adoc
@@ -14,29 +14,29 @@ toc::[]
 
 == Overview
 
-In addition to the default xref:../../architecture/additional_concepts/admission_controllers.html#architecture-additional-concepts-admission-controllers[admission controllers], 
-you can use _admission webhooks_ as part of the admission chain. 
+In addition to the default xref:../../architecture/additional_concepts/admission_controllers.html#architecture-additional-concepts-admission-controllers[admission controllers],
+you can use _admission webhooks_ as part of the admission chain.
 
-Admission webhooks call webhook servers to either mutate pods upon creation, such as to inject labels, 
-or to validate specific aspects of the pod configuration during the admission process.  
+Admission webhooks call webhook servers to either mutate pods upon creation, such as to inject labels,
+or to validate specific aspects of the pod configuration during the admission process.
 
-Admission webhooks intercept requests to the master API prior to the persistence of a resource, but after the request is authenticated and authorized. 
+Admission webhooks intercept requests to the master API prior to the persistence of a resource, but after the request is authenticated and authorized.
 
-//// 
+////
 do not document initializers PR-7789
 There are two general types of dynamic admission controllers available in {product-title}:
 
 * xref:architecture-additional-concepts-dynamic-admission-initializer[Initializers]. A user-customized controller that performs specific pre-initialization tasks.
 * xref:architecture-additional-concepts-dynamic-admission-webhooks[External Admission Webhooks]. HTTPS callbacks that receive admission requests and performs specific tasks.
 ////
- 
 
-//// 
+
+////
 do not document initializers PR-7789
 [[architecture-additional-concepts-dynamic-admission-initializer]]
 == Initializers
 
-An *Initializer* is a user-customized controller, known as *initializer controllers*, 
+An *Initializer* is a user-customized controller, known as *initializer controllers*,
 that performs a list of pre-initialization tasks, stored in every object's metadata
 (for example, *AddMyCorporatePolicySidecar*). Initializers are allowed to make mutations to objects.
 
@@ -50,8 +50,8 @@ The initializer feature is an alpha feature and may change in a future release o
 After an initializer has performed its assigned task, {product-title} removes the intializer from
 the pre-initialization list. The list is called *metadata.initializers.pending*.
 
-For example, an inititalizer, *AddContainertoPod*, sends a patch that inserts a container in a pod. After the pod is inserted, 
-*AddContainertoPod* removes its name from `metadata.initializers.pending`. 
+For example, an inititalizer, *AddContainertoPod*, sends a patch that inserts a container in a pod. After the pod is inserted,
+*AddContainertoPod* removes its name from `metadata.initializers.pending`.
 
 Objects which have a non-empty initializer list are considered _uninitialized_,
 and are not visible in the API unless specifically requested by using the query parameter,
@@ -63,13 +63,13 @@ Initializers are useful for administrators to force policies, such as an (xref:.
 [NOTE]
 ====
 If your use case does not involve mutating objects, consider using
-xref:architecture-additional-concepts-dynamic-admission-webhooks[external admission webhooks], 
+xref:architecture-additional-concepts-dynamic-admission-webhooks[external admission webhooks],
 for better performance.
 ====
 
-As an {product-title} object is being created, the object is considered uninitialized. 
+As an {product-title} object is being created, the object is considered uninitialized.
 Uninitialized object are checked against all existing
-xref:architecture-additional-concepts-dynamic-admission-initializer-config[`initializerConfiguration` objects]. 
+xref:architecture-additional-concepts-dynamic-admission-initializer-config[`initializerConfiguration` objects].
 All matching `spec.initializers[].name` are appended to the new object's
 `metadata.initializers.pending` field.
 
@@ -107,7 +107,7 @@ metadata:
 Setting the pending initializers to empty on the metadata allows it to bypass the initializer.
 
 
-Limit the scope of objects to be initialized to the smallest subset possible using an InitializerConfiguration. 
+Limit the scope of objects to be initialized to the smallest subset possible using an InitializerConfiguration.
 
 Examples:
 
@@ -191,14 +191,14 @@ Ensure that all expansions of the `<apiGroup, apiVersions, resources>` tuple
 in a `rule` are valid. If they are not, separate them in different `rules`.
 +
 After you create the `initializerConfiguration`, the system will take a few
-seconds to honor the new configuration. 
+seconds to honor the new configuration.
 
-. {product-title} appends the name of the initializer configuration object, here  `podimage.example.com`, 
-to the `metadata.initializers.pending` field of any newly created pods. 
+. {product-title} appends the name of the initializer configuration object, here  `podimage.example.com`,
+to the `metadata.initializers.pending` field of any newly created pods.
 
 . An initializer controller should list and watch for uninitialized objects, by
 using the query parameter `includeUninitialized=true`. If using client-go, just
-set 
+set
 [listOptions.includeUninitialized](https://github.com/kubernetes/kubernetes/blob/v1.7.0-rc.1/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L315)
 to true.
 
@@ -214,11 +214,11 @@ There are two types of admission webhook objects you can configure:
 
 * xref:admission-webhooks-m[Mutating admission webhooks] allow for the use of mutating webhooks to modify resource content before it is persisted.
 
-* xref:admission-webhooks-v[Validating admission webhooks] allow for the use of validating webhooks to enforce custom admission policies.   
+* xref:admission-webhooks-v[Validating admission webhooks] allow for the use of validating webhooks to enforce custom admission policies.
 
 Configuring the webhooks and external webhook servers is beyond the scope of this document. However, the webhooks must adhere to an
 https://github.com/kubernetes/kubernetes/blob/v1.10.0-beta.1/staging/src/k8s.io/api/admission/v1beta1/types.go#L28[interface]
-in order to work properly with {product-title}. 
+in order to work properly with {product-title}.
 
 [IMPORTANT]
 ====
@@ -235,20 +235,20 @@ https://access.redhat.com/support/offerings/techpreview/.
 endif::[]
 ====
 
-When an object is instantiated, {product-title} makes an API call to admit the object. During the admission process, a _mutating admission controller_ 
-can invoke webhooks to perform tasks, such as injecting affinity labels. At the end of the admissions process, 
-a _validating admission controller_ can invoke webhooks to make sure the object is configured properly, such as verifying affinity labels. 
+When an object is instantiated, {product-title} makes an API call to admit the object. During the admission process, a _mutating admission controller_
+can invoke webhooks to perform tasks, such as injecting affinity labels. At the end of the admissions process,
+a _validating admission controller_ can invoke webhooks to make sure the object is configured properly, such as verifying affinity labels.
 If the validation passes, {product-title} schedules the object as configured.
 
-When the API request comes in, the mutating or validating admission controller 
-uses the list of external webhooks in the configuration and calls them in parallel: 
+When the API request comes in, the mutating or validating admission controller
+uses the list of external webhooks in the configuration and calls them in parallel:
 
-* If *all* of the webhooks approve the request, the admission chain continues. 
+* If *all* of the webhooks approve the request, the admission chain continues.
 
 * If *any* of the webhooks deny the request, the admission request is denied, and
-the reason for doing so is based on the _first_ webhook denial reason. 
+the reason for doing so is based on the _first_ webhook denial reason.
 +
-If more than one webhook denies the admission request, 
+If more than one webhook denies the admission request,
 only the first will be returned to the user.
 
 * If there is an error encountered when calling a
@@ -257,7 +257,7 @@ webhook, that request is either denied or the webhook is ignored.
 The communication between the admission controller and the webhook server needs to be
 secured using  TLS. Generate a CA certificate and use the certificate to sign the server certificate
 used by your webhook server. The PEM-formatted CA certificate is supplied
-to the admission controller using a mechanism, such as 
+to the admission controller using a mechanism, such as
 xref:../../dev_guide/secrets.adoc#service-serving-certificate-secrets[Service Serving Certificate Secrets].
 
 The following diagram illustrates this process with two admission webhooks that call multiple webhooks.
@@ -267,36 +267,36 @@ image::api-server-pipeline.png["API admission stage", align="center"]
 A simple example use case for admission webhooks is syntactical validation
 of resources. For example, you have an infrastructure that requires all pods to
 have a common set of labels, and you do not want any pod to be
-persisted if the pod does not have those labels. You could write a webhook to inject these labels 
+persisted if the pod does not have those labels. You could write a webhook to inject these labels
 and another webhook to verify that the labels are present.
 The {product-title} will then schedule pod that have the labels and pass validation
 and reject pods that do not pass due to missing labels.
 
 Some common use-cases include:
 
-* Mutating resources to inject side-car containers into pods. 
-* Restricting projects to block some resources from a project. 
+* Mutating resources to inject side-car containers into pods.
+* Restricting projects to block some resources from a project.
 * Custom resource validation to perform complex validation on dependent fields.
 
 === Types of Admission Webhooks
 
-Cluster administrators can include _mutating admission webhooks_ or _validating admission webhooks_ 
+Cluster administrators can include _mutating admission webhooks_ or _validating admission webhooks_
 in the admission chain of the API server.
 
 [[admission-webhooks-m]]
-*Mutating admission webhooks* are invoked during the mutation phase of the admission process, which allows modification of the resource content before it is persisted.  
-One example of a mutating admission webhook is the 
+*Mutating admission webhooks* are invoked during the mutation phase of the admission process, which allows modification of the resource content before it is persisted.
+One example of a mutating admission webhook is the
 ifdef::openshift-enterprise,openshift-origin[]
-xref:../../admin_guide/scheduling/pod_placement.adoc#constraining-pod-placement-nodeselector[Pod Node Selector] 
+xref:../../admin_guide/scheduling/pod_placement.adoc#constraining-pod-placement-nodeselector[Pod Node Selector]
 endif::openshift-enterprise,openshift-origin[]
 ifdef::openshift-online,openshift-dedicated[]
 Pod Node Selector
 endif::openshift-online,openshift-dedicated[]
-feature, 
-which uses an annotation on a namespace to find a label selector and add it to the pod specification. 
+feature,
+which uses an annotation on a namespace to find a label selector and add it to the pod specification.
 
 [[architecture-additional-concepts-dynamic-admission-webhooks-ex-m]]
-.Sample mutating admission webhook configuration:
+.Sample Mutating Admission Webhook Configuration
 
 [source,yaml]
 ----
@@ -333,23 +333,23 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 <7> The webhook URL used for admission requests.
 <8> A PEM-encoded CA certificate that signs the server certificate used by the webhook server.
 <9> Rules that define when the API server should use this controller.
-<10> The operation(s) that triggers the API server to call this controller: 
+<10> The operation(s) that triggers the API server to call this controller:
 * create
 * update
 * delete
 * connect
-<11> Specifies how the policy should proceed if the webhook admission server is unavailable. 
-Either `Ignore` (allow/fail open) or `Fail` (block/fail closed). 
+<11> Specifies how the policy should proceed if the webhook admission server is unavailable.
+Either `Ignore` (allow/fail open) or `Fail` (block/fail closed).
 
 [[admission-webhooks-v]]
-*Validating admission webhooks* are invoked during the validation phase of the admission process. 
-This phase allows the enforcement of invariants on particular API resources 
-to ensure that the resource does not change again. The Pod Node Selector is also an example of a validation admission, 
-by ensuring that all `nodeSelector` fields are constrained by the node selector restrictions on the project. 
+*Validating admission webhooks* are invoked during the validation phase of the admission process.
+This phase allows the enforcement of invariants on particular API resources
+to ensure that the resource does not change again. The Pod Node Selector is also an example of a validation admission,
+by ensuring that all `nodeSelector` fields are constrained by the node selector restrictions on the project.
 
 [[architecture-additional-concepts-dynamic-admission-webhooks-ex-v]]
 //http://blog.kubernetes.io/2018/01/extensible-admission-is-beta.html
-.Sample validating admission webhook configuration:
+.Sample Validating Admission Webhook Configuration
 
 [source,yaml]
 ----
@@ -386,33 +386,34 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 <7> The webhook URL used for admission requests.
 <8> A PEM-encoded CA certificate that signs the server certificate used by the webhook server.
 <9> Rules that define when the API server should use this controller.
-<10> The operation that triggers the API server to call this controller. 
+<10> The operation that triggers the API server to call this controller.
 * create
 * update
 * delete
 * connect
-<11> Specifies how the policy should proceed if the webhook admission server is unavailable. 
-Either `Ignore` (allow/fail open) or `Fail` (block/fail closed). 
+<11> Specifies how the policy should proceed if the webhook admission server is unavailable.
+Either `Ignore` (allow/fail open) or `Fail` (block/fail closed).
 
 [NOTE]
 ====
 Fail open can result in unpredictable behavior for all clients.
 ====
- 
+
 [[architecture-additional-concepts-dynamic-admission-webhooks-writing]]
 === Create the Admission Webhook
 
 First deploy the external webhook server and ensure
-it is working properly. Otherwise, depending whether the webhook is configured as `fail open` or 
-`fail closed`, operations will be unconditionally accepted or rejected. 
+it is working properly. Otherwise, depending whether the webhook is configured as `fail open` or
+`fail closed`, operations will be unconditionally accepted or rejected.
 
-. Configure a xref:architecture-additional-concepts-dynamic-admission-webhooks-ex-m[mutating] 
+. Configure a xref:architecture-additional-concepts-dynamic-admission-webhooks-ex-m[mutating]
 or xref:architecture-additional-concepts-dynamic-admission-webhooks-ex-v[validating] admission webhook object in a YAML file.
 
 . Run the following command to create the object:
 +
+[source,terminal]
 ----
-oc create -f <file-name>.yaml
+$ oc create -f <file-name>.yaml
 ----
 +
 After you create the admission webhook object, {product-title} takes a few
@@ -437,8 +438,9 @@ spec:
 
 . Run the following command to create the object:
 +
+[source,terminal]
 ----
-oc create -f <file-name>.yaml
+$ oc create -f <file-name>.yaml
 ----
 
 . Add the admission webhook name to pods you want controlled by the webhook:
@@ -460,19 +462,19 @@ spec:
        - containerPort: 8000
 ----
 +
-<1> Label to trigger the webhook. 
+<1> Label to trigger the webhook.
 
 [NOTE]
 ====
-See the link:https://github.com/openshift/kubernetes-namespace-reservation[kubernetes-namespace-reservation projects] 
-for an end-to-end example of how to build your own secure and portable webhook admission server 
+See the link:https://github.com/openshift/kubernetes-namespace-reservation[kubernetes-namespace-reservation projects]
+for an end-to-end example of how to build your own secure and portable webhook admission server
 and link:https://github.com/openshift/generic-admission-server[generic-admission-apiserver] for the library.
 ====
 
 [[architecture-additional-concepts-dynamic-admission-webhooks-examples]]
 === Admission Webhook Example
 
-The following is an example admission webhook that will not allow 
+The following is an example admission webhook that will not allow
 link:https://github.com/openshift/kubernetes-namespace-reservation[namespace creation if the namespace is reserved]:
 
 [source,yaml]
@@ -487,10 +489,10 @@ apiVersion: admissionregistration.k8s.io/v1beta1
       service:
         namespace: default
         name: webhooks
-       path: /apis/admission.online.openshift.io/v1beta1/namespacereservations 
-      caBundle: KUBE_CA_HERE 
-    rules: 
-    - operations: 
+       path: /apis/admission.online.openshift.io/v1beta1/namespacereservations
+      caBundle: KUBE_CA_HERE
+    rules:
+    - operations:
       - CREATE
       apiGroups:
       - ""
@@ -521,7 +523,7 @@ spec:
 - containerPort: 8000
 ----
 
-The following is the front-end service for the webhook: 
+The following is the front-end service for the webhook:
 
 [source,yaml]
 ----

--- a/architecture/additional_concepts/ephemeral-storage.adoc
+++ b/architecture/additional_concepts/ephemeral-storage.adoc
@@ -95,12 +95,13 @@ You can use `/bin/df` as a tool to monitor ephemeral storage usage on the volume
 
 Use the `df -h` command to show the human-readable values of used and available space in `/var/lib`:
 
+[source,terminal]
 ----
 $ df -h /var/lib
 ----
 
-The output shows the ephemeral storage usage in `/var/lib`:
-
+.Example Output
+[source,terminal]
 ----
 Filesystem  Size  Used Avail Use% Mounted on
 /dev/sda1    69G   32G   34G  49% /

--- a/architecture/additional_concepts/other_api_objects.adoc
+++ b/architecture/additional_concepts/other_api_objects.adoc
@@ -16,13 +16,13 @@ ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicate
 
 A limit range provides a mechanism to enforce min/max limits placed on resources
 in a Kubernetes
-xref:../core_concepts/projects_and_users.adoc#namespaces[namespace]. 
+xref:../core_concepts/projects_and_users.adoc#namespaces[namespace].
 
 By adding a limit range to your namespace, you can enforce the minimum and
 maximum amount of CPU and Memory consumed by an individual pod or container.
 
 For CPU and Memory limits, if you specify a `max` value, but do not specify a
-`min` limit in the LimitRange object, the resource can consume CPU/memory 
+`min` limit in the LimitRange object, the resource can consume CPU/memory
 resources greater than `max` value`.
 
 == ResourceQuota
@@ -73,7 +73,7 @@ A _custom resource_ is an extension of the Kubernetes API that extends the API o
 introduce your own API into a project or a cluster.
 
 ifdef::openshift-enterprise,openshift-origin[]
-  See xref:../../admin_guide/custom_resource_definitions.adoc#admin-guide-custom-resources[Extend the Kubernetes API with Custom Resources].
+See xref:../../admin_guide/custom_resource_definitions.adoc#admin-guide-custom-resources[Extend the Kubernetes API with Custom Resources].
 
 endif::openshift-enterprise,openshift-origin[]
 

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -169,7 +169,7 @@ $ oc get pv
 ----
 +
 .Example Output
-[source-terminal]
+[source,terminal]
 ----
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
  pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
@@ -193,7 +193,7 @@ $ oc get pv
 ----
 +
 .Example Output
-[source-terminal]
+[source,terminal]
 ----
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
  pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
@@ -697,6 +697,7 @@ size for the PVC, and click *Create*.
 popular applications and frameworks. These are listed in the catalog when using
 the web console and are viewable from CLI by viewing the output of:
 
+[source,terminal]
 ----
 $ oc get templates -n openshift
 ----
@@ -710,6 +711,7 @@ use the MongoDB template with a PVC in us-east-2b:
 
 .  Copy the template to a file:
 +
+[source,terminal]
 ----
 $ oc get template -n openshift mongodb-persistent -o yaml --export > mongodb-persistent.yml
 ----
@@ -749,6 +751,7 @@ Now that you have an updated template, you can use it from the CLI or web consol
 From the CLI, you can pass in the required parameters to `oc process` and
 create them.
 
+[source,terminal]
 ----
 $ oc process -f mongodb-export.yml \
 STORAGE_CLASS_NAME=gp2-encrypted-us-east-2b | oc create -f
@@ -816,6 +819,7 @@ enable the feature gates for master(s), add `feature-gates` to
 `apiServerArguments` and `controllerArguments`. To enable the feature gates for
 node(s), add `feature-gates` to `kubeletArguments`. For example:
 
+[source,yaml]
 ----
 kubeletArguments:
    feature-gates:

--- a/architecture/core_concepts/builds_and_image_streams.adoc
+++ b/architecture/core_concepts/builds_and_image_streams.adoc
@@ -201,8 +201,14 @@ The image stream metadata is stored in the etcd instance along with other cluste
 
 The following image stream contains two tags: `34` which points to a Python v3.4 image and `35` which points to a Python v3.5 image:
 
+[source,terminal]
 ----
-oc describe is python
+$ oc describe is python
+----
+
+.Example Output
+[source,terminal]
+----
 Name:			python
 Namespace:		imagestream
 Created:		25 hours ago
@@ -262,6 +268,7 @@ Docker repository::
 A collection of related container images and tags identifying them.
 For example, the OpenShift Jenkins images are in a Docker repository:
 +
+[source,text]
 ----
 docker.io/openshift/jenkins-2-centos7
 ----
@@ -270,6 +277,7 @@ Container registry::
 A content server that can store and service images from Docker repositories.
 For example:
 +
+[source,text]
 ----
 registry.redhat.io
 ----
@@ -280,6 +288,7 @@ container image::
 container image tag::
 A label applied to a container image in a repository that distinguishes a specific image. For example, here *3.6.0* is a tag:
 
+[source,text]
 ----
 docker.io/openshift/jenkins-2-centos7:3.6.0
 ----
@@ -292,6 +301,7 @@ A container image tag can be updated to point to new container image content at 
 container image ID::
 A SHA (Secure Hash Algorithm) code that can be used to pull an image. For example:
 
+[source,text]
 ----
 docker.io/openshift/jenkins-2-centos7@sha256:ab312bda324
 ----
@@ -394,6 +404,7 @@ image stream image object in any image stream definition that you use to create 
 
 The image stream image consists of the image stream name and image ID from the repository, delimited by an `@` sign:
 
+[source,text]
 ----
 <image-stream-name>@<image-id>
 ----
@@ -401,6 +412,7 @@ The image stream image consists of the image stream name and image ID from the r
 To refer to the image in the
 xref:image-stream-object-definition[image stream object example above], the image stream image looks like:
 
+[source,text]
 ----
 origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d
 ----
@@ -456,6 +468,7 @@ You can create your own image stream tags for your own needs. See the xref:../..
 
 The image stream tag is composed of the name of the image stream and a tag, separated by a colon:
 
+[source,text]
 ----
 <image stream name>:<tag>
 ----
@@ -465,6 +478,7 @@ For example, to refer to the
 in the  xref:image-stream-object-definition[image stream object example above], the image stream tag
 would be:
 
+[source,text]
 ----
 origin-ruby-sample:latest
 ----
@@ -637,15 +651,21 @@ image streams, see xref:../../dev_guide/managing_images.adoc#dev-guide-managing-
 To get general information about the image stream and detailed information about all the tags it is pointing to,
 use the following command:
 
+[source,terminal]
 ----
-oc describe is/<image-name>
+$ oc describe is/<image-name>
 ----
 
 For example:
 
+[source,terminal]
 ----
-oc describe is/python
+$ oc describe is/python
+----
 
+.Example Output
+[source,terminal]
+----
 Name:			python
 Namespace:		default
 Created:		About a minute ago
@@ -665,15 +685,21 @@ Tags:			1
 
 To get all the information available about particular image stream tag:
 
+[source,terminal]
 ----
-oc describe istag/<image-stream>:<tag-name>
+$ oc describe istag/<image-stream>:<tag-name>
 ----
 
 For example:
 
+[source,terminal]
 ----
-oc describe istag/python:latest
+$ oc describe istag/python:latest
+----
 
+.Example Output
+[source,terminal]
+----
 Image Name:	sha256:49c18358df82f4577386404991c51a9559f243e0b1bdc366df25
 Docker Image:	centos/python-35-centos7@sha256:49c18358df82f4577386404991c51a9559f243e0b1bdc366df25
 Name:		sha256:49c18358df82f4577386404991c51a9559f243e0b1bdc366df25
@@ -700,23 +726,34 @@ More information is output than shown.
 
 To add a tag that points to one of the existing tags, you can use the `oc tag` command:
 
+[source,terminal]
 ----
 oc tag <image-name:tag> <image-name:tag>
 ----
 
 For example:
 
+[source,terminal]
 ----
-oc tag python:3.5 python:latest
+$ oc tag python:3.5 python:latest
+----
 
+.Example Output
+[source,terminal]
+----
 Tag python:latest set to python@sha256:49c18358df82f4577386404991c51a9559f243e0b1bdc366df25.
 ----
 
 Use the `oc describe` command to confirm the image stream has two tags, one (`3.5`) pointing at the external container image and another tag (`latest`) pointing to the same image because it was created based on the first tag.
 
+[source,terminal]
 ----
-oc describe is/python
+$ oc describe is/python
+----
 
+.Example Output
+[source,terminal]
+----
 Name:			python
 Namespace:		default
 Created:		5 minutes ago
@@ -745,14 +782,21 @@ latest
 
 Use the `oc tag` command for all tag-related operations, such as adding tags pointing to internal or external images:
 
+[source,terminal]
 ----
-oc tag <repositiory/image> <image-name:tag>
+$ oc tag <repositiory/image> <image-name:tag>
 ----
 
 For example, this command maps the `docker.io/python:3.6.0` image to the `3.6` tag in the `python` image stream.
 
+[source,terminal]
 ----
-oc tag docker.io/python:3.6.0 python:3.6
+$ oc tag docker.io/python:3.6.0 python:3.6
+----
+
+.Example Output
+[source,terminal]
+----
 Tag python:3.6 set to docker.io/python:3.6.0.
 ----
 
@@ -764,14 +808,21 @@ See xref:../../dev_guide/managing_images.adoc#private-registries[Importing Image
 
 To update a tag to reflect another tag in an image stream:
 
+[source,terminal]
 ----
-oc tag <image-name:tag> <image-name:latest>
+$ oc tag <image-name:tag> <image-name:latest>
 ----
 
 For example, the following updates the `latest` tag to reflect the `3.6` tag in an image stream:
 
+[source,terminal]
 ----
-oc tag python:3.6 python:latest
+$ oc tag python:3.6 python:latest
+----
+
+.Example Output
+[source,terminal]
+----
 Tag python:latest set to python@sha256:438208801c4806548460b27bd1fbcb7bb188273d13871ab43f.
 ----
 
@@ -779,15 +830,21 @@ Tag python:latest set to python@sha256:438208801c4806548460b27bd1fbcb7bb188273d1
 
 To remove old tags from an image stream:
 
+[source,terminal]
 ----
-oc tag -d <image-name:tag>
+$ oc tag -d <image-name:tag>
 ----
 
 For example:
 
+[source,terminal]
 ----
-oc tag -d python:3.5
+$ oc tag -d python:3.5
+----
 
+.Example Output
+[source,terminal]
+----
 Deleted tag default/python:3.5.
 ----
 
@@ -797,15 +854,21 @@ Deleted tag default/python:3.5.
 
 When working with an external container image registry, to periodically re-import an image (such as, to get latest security updates), use the `--scheduled` flag:
 
+[source,terminal]
 ----
-oc tag <repositiory/image> <image-name:tag> --scheduled
+$ oc tag <repositiory/image> <image-name:tag> --scheduled
 ----
 
 For example:
 
+[source,terminal]
 ----
-oc tag docker.io/python:3.6.0 python:3.6 --scheduled
+$ oc tag docker.io/python:3.6.0 python:3.6 --scheduled
+----
 
+.Example Output
+[source,terminal]
+----
 Tag python:3.6 set to import docker.io/python:3.6.0 periodically.
 ----
 
@@ -813,6 +876,7 @@ This command causes {product-title} to periodically update this particular image
 
 To remove the periodic check, re-run above command but omit the `--scheduled` flag. This will reset its behavior to default.
 
+[source,terminal]
 ----
-oc tag <repositiory/image> <image-name:tag>
+$ oc tag <repositiory/image> <image-name:tag>
 ----

--- a/architecture/core_concepts/deployments.adoc
+++ b/architecture/core_concepts/deployments.adoc
@@ -14,8 +14,7 @@ toc::[]
 [[replication-controllers]]
 == Replication controllers
 
-A
-https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/[replication
+A link:https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/[replication
 controller] ensures that a specified number of replicas of a pod are running at
 all times. If pods exit or are deleted, the replication controller acts to
 instantiate more up to the defined number. Likewise, if there are more running

--- a/architecture/core_concepts/pods_and_services.adoc
+++ b/architecture/core_concepts/pods_and_services.adoc
@@ -64,7 +64,6 @@ which are discussed in other topics and thus only briefly mentioned here:
 
 [[example-pod-definition]]
 .Pod Object Definition (YAML)
-====
 
 [source,yaml]
 ----
@@ -116,8 +115,6 @@ spec:
     secret:
       secretName: default-token-br6yz
 ----
-
-====
 
 <1> Pods can be "tagged" with one or more xref:labels[labels], which can then
 be used to select and manage groups of pods in a single operation. The labels
@@ -229,7 +226,6 @@ See the Kubernetes documentation for some link:https://kubernetes.io/docs/concep
 The following example outlines a simple pod which has two init containers. The first init container waits for `myservice` and the second waits for `mydb`. Once both containers succeed, the Pod starts.
 
 .Sample Init Container Pod Object Definition (YAML)
-====
 
 [source,yaml]
 ----
@@ -252,8 +248,6 @@ spec:
     image: busybox
     command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
 ----
-
-====
 
 <1> Specifies the `myservice` container.
 <2> Specifies the `mydb` container.
@@ -295,7 +289,6 @@ Like pods, services are REST objects. The following
 example shows the definition of a service for the pod defined above:
 
 .Service Object Definition (YAML)
-====
 
 [source,yaml]
 ----
@@ -323,7 +316,6 @@ pods in the same namespace. The maximum name length is 63 characters.
 of internal IPs.
 <4> Port the service listens on.
 <5> Port on the backing pods to which the service forwards connections.
-====
 
 The link:http://kubernetes.io/docs/user-guide/services/[Kubernetes
 documentation] has more information on services.
@@ -334,23 +326,21 @@ ifdef::openshift-enterprise,openshift-origin[]
 
 In addition to the cluster's internal IP addresses, the user can configure IP addresses that are external to the cluster. The administrator is responsible for ensuring that traffic arrives at a node with this IP.
 
-The externalIPs must be selected by the cluster adminitrators from the
+The externalIPs must be selected by the cluster administrators from the
 *externalIPNetworkCIDRs* range configured in
 xref:../../admin_guide/tcp_ingress_external_ports.adoc#unique-external-ips-ingress-traffic-configure-cluster[*_master-config.yaml_*]
 file. When *_master-config.yaml_* is changed, the master services must be
 restarted.
 
 .Sample externalIPNetworkCIDR /etc/origin/master/master-config.yaml
-====
+[source,yaml]
 ----
 networkConfig:
   externalIPNetworkCIDRs:
   - 192.0.1.0.0/24
 ----
-====
 
 .Service externalIPs Definition (JSON)
-====
 
 [source,json]
 ----
@@ -381,7 +371,6 @@ networkConfig:
 
 <1> List of external IP addresses on which the *port* is exposed. This list is in addition to the internal IP address list.
 
-====
 endif::[]
 
 ifdef::openshift-origin,openshift-enterprise[]
@@ -406,12 +395,11 @@ addresses.
 ====
 
 .Sample ingressIPNetworkCIDR /etc/origin/master/master-config.yaml
-====
+[source,yaml]
 ----
 networkConfig:
   ingressIPNetworkCIDR: 172.29.0.0/16
 ----
-====
 
 endif::[]
 
@@ -426,12 +414,11 @@ The selected port will be reported in the service configuration, under  `spec.po
 To specify a custom port just place the port number in the nodePort field. The custom port number must be in the configured range for nodePorts. When '*master-config.yaml*' is changed the master services must be restarted.
 
 .Sample servicesNodePortRange /etc/origin/master/master-config.yaml
-====
+[source,yaml]
 ----
 kubernetesMasterConfig:
   servicesNodePortRange: ""
 ----
-====
 
 The service will be visible as both the `<NodeIP>:spec.ports[].nodePort`
 and `spec.clusterIp:spec.ports[].port`
@@ -503,10 +490,15 @@ do not declare the `ClusterIP` address. To create a headless service, add the
 
 For example, for a group of pods that you want to be a part of the same cluster or service.
 
-.List of pods
-[source,bash]
+.List of Pods
+[source,terminal]
 ----
 $ oc get pods -o wide
+----
+
+.Example Output
+[source,terminal]
+----
 NAME               READY  STATUS    RESTARTS   AGE    IP            NODE
 frontend-1-287hw   1/1    Running   0          7m     172.17.0.3    node_1
 frontend-1-68km5   1/1    Running   0          7m     172.17.0.6    node_1
@@ -514,7 +506,7 @@ frontend-1-68km5   1/1    Running   0          7m     172.17.0.6    node_1
 
 You can define the headless service as:
 
-.Headless service definition
+.Headless Service Definition
 [source,yaml]
 ----
 apiVersion: v1
@@ -545,9 +537,14 @@ status:
 
 Also, headless service does not have any IP address of its own.
 
-[source,bash]
+[source,terminal]
 ----
 $ oc get svc
+----
+
+.Example Output
+[source,terminal]
+----
 NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
 frontend            ClusterIP   172.30.232.77    <none>        5432/TCP   12m
 frontend-headless   ClusterIP   None             <none>        5432/TCP   10m
@@ -563,16 +560,26 @@ grouped by the service.
 
 When you look up the DNS `A` record for a standard service, you get the loadbalanced IP of the service.
 
-[source,bash]
+[source,terminal]
 ----
 $ dig frontend.test A +search +short
+----
+
+.Example Output
+[source,terminal]
+----
 172.30.232.77
 ----
 
 But for a headless service, you get the list of IPs of individual pods.
-[source,bash]
+[source,terminal]
 ----
 $ dig frontend-headless.test A +search +short
+----
+
+.Example Output
+[source,terminal]
+----
 172.17.0.3
 172.17.0.6
 ----
@@ -609,18 +616,12 @@ configurations] of a particular application can be grouped.
 
 Labels are simple key/value pairs, as in the following example:
 
-====
-
 [source,yaml]
 ----
 labels:
   key1: value1
   key2: value2
 ----
-
-====
-
-
 
 Consider:
 

--- a/architecture/core_concepts/projects_and_users.adoc
+++ b/architecture/core_concepts/projects_and_users.adoc
@@ -74,8 +74,7 @@ Namespaces provide a unique scope for:
 Most objects in the system are scoped by namespace, but some are
 excepted and have no namespace, including nodes and users.
 
-The
-https://kubernetes.io/docs/tasks/administer-cluster/namespaces/[Kubernetes
+The link:https://kubernetes.io/docs/tasks/administer-cluster/namespaces/[Kubernetes
 documentation] has more information on namespaces.
 
 [[projects]]

--- a/architecture/infrastructure_components/kubernetes_infrastructure.adoc
+++ b/architecture/infrastructure_components/kubernetes_infrastructure.adoc
@@ -132,12 +132,14 @@ These pods have the following `hostPath` volumes defined:
 
 The set of operations you can do on the static pods is limited. For example:
 
+[source,terminal]
 ----
 $ oc logs master-api-<hostname> -n kube-system
 ----
 
 returns the standard output from the API server. However:
 
+[source,terminal]
 ----
 $ oc delete pod master-api-<hostname> -n kube-system
 ----
@@ -161,18 +163,21 @@ To restart control plane services running in control plane static pods, use the
 
 To restart the master API:
 
+[source,terminal]
 ----
 # master-restart api
 ----
 
 To restart the controllers:
 
+[source,terminal]
 ----
 # master-restart controllers
 ----
 
 To restart etcd:
 
+[source,terminal]
 ----
 # master-restart etcd
 ----
@@ -184,9 +189,18 @@ To restart etcd:
 To view logs for control plane services running in control plane static pods,
 use the `master-logs` command for the respective component:
 
+[source,terminal]
 ----
 # master-logs api api
+----
+
+[source,terminal]
+----
 # master-logs controllers controllers
+----
+
+[source,terminal]
+----
 # master-logs etcd etcd
 ----
 endif::[]
@@ -414,9 +428,14 @@ bootstrapping:
 --
 - The *system:node-bootstrapper* cluster role is used for creating certificate signing requests (CSRs) during node bootstrapping:
 +
+[source,terminal]
 ----
-# oc describe clusterrole.authorization.openshift.io/system:node-bootstrapper
-
+$ oc describe clusterrole.authorization.openshift.io/system:node-bootstrapper
+----
++
+.Example Output
+[source,terminal]
+----
 Name:			system:node-bootstrapper
 Created:		17 hours ago
 Labels:			kubernetes.io/bootstrapping=rbac-defaults
@@ -429,9 +448,14 @@ Verbs			Non-Resource URLs	Resource Names	API Groups		Resources
 - The following *node-bootstrapper* service account is created in the
 *openshift-infra* project:
 +
+[source,terminal]
 ----
-# oc describe sa node-bootstrapper -n openshift-infra
-
+$ oc describe sa node-bootstrapper -n openshift-infra
+----
++
+.Example Output
+[source,terminal]
+----
 Name:                node-bootstrapper
 Namespace:           openshift-infra
 Labels:              <none>
@@ -447,9 +471,14 @@ Events:              <none>
 - The following *system:node-bootstrapper* cluster role binding is for the node
 bootstrapper cluster role and service account:
 +
+[source,terminal]
 ----
-# oc describe clusterrolebindings system:node-bootstrapper
-
+$ oc describe clusterrolebindings system:node-bootstrapper
+----
++
+.Example Output
+[source,terminal]
+----
 Name:			system:node-bootstrapper
 Created:		17 hours ago
 Labels:			<none>
@@ -478,6 +507,7 @@ are:
 .. The *_/etc/origin/master/bootstrap.kubeconfig_* is created when the installer
 uses the *node-bootstrapper* service account as follows:
 +
+[source,terminal]
 ----
 $ oc --config=/etc/origin/master/admin.kubeconfig \
     serviceaccounts create-kubeconfig node-bootstrapper \
@@ -493,6 +523,7 @@ node host.
 .. The *_/etc/origin/master/bootstrap.kubeconfig_* is then passed to kubelet using
 the flag `--bootstrap-kubeconfig` as follows:
 +
+[source,terminal]
 ----
 --bootstrap-kubeconfig=/etc/origin/node/bootstrap.kubeconfig
 ----
@@ -507,8 +538,14 @@ certificate signing controller). If approved, the kubelet client and server
 certificates are created in the *_/etc/origin/node/ceritificates_* directory.
 For example:
 +
+[source,terminal]
 ----
 # ls -al /etc/origin/node/certificates/
+----
++
+.Example Output
+[source,terminal]
+----
 total 12
 drwxr-xr-x. 2 root root  212 Jun 18 21:56 .
 drwx------. 4 root root  213 Jun 19 15:18 ..
@@ -581,6 +618,7 @@ modified directly.
 For example, for a node that is in the *node-config-compute* group, edit the
 ConfigMap using:
 
+[source,terminal]
 ----
 $ oc edit cm node-config-compute -n openshift-node
 ----

--- a/architecture/infrastructure_components/web_console.adoc
+++ b/architecture/infrastructure_components/web_console.adoc
@@ -55,6 +55,7 @@ The `corsAllowedOrigins` parameter is controlled by the configuration field. No
 pinning or escaping is done to the value. The following is an example of how you
 can pin a host name and escape dots:
 
+[source,terminal]
 ----
 corsAllowedOrigins:
 - (?i)//my\.subdomain\.domain\.com(:|\z)

--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -126,6 +126,7 @@ setting is `false`.
 
 The option can be set when the router is created or added later.
 
+[source,terminal]
 ----
 $ oc adm router --strict-sni
 ----
@@ -162,6 +163,7 @@ the `ROUTER_CIPHERS` environment variable with the values `modern`,
 separated ciphers can be provided. The ciphers must be from the set displayed
 by:
 
+[source,terminal]
 ----
 openssl ciphers
 ----
@@ -187,7 +189,6 @@ delete your older route, your claim to the host name will no longer be in effect
 The other namespace now claims the host name and your claim is lost.
 
 .A Route with a Specified Host:
-====
 
 [source,yaml]
 ----
@@ -202,10 +203,8 @@ spec:
     name: service-name
 ----
 <1> Specifies the externally-reachable host name used to expose a service.
-====
 
 .A Route Without a Host:
-====
 
 [source,yaml]
 ----
@@ -218,12 +217,12 @@ spec:
     kind: Service
     name: service-name
 ----
-====
 
 If a host name is not provided as part of the route definition, then
 {product-title} automatically generates one for you. The generated host name
 is of the form:
 
+[source,terminal]
 ----
 <route-name>[-<namespace>].<suffix>
 ----
@@ -233,14 +232,14 @@ above configuration of a route without a host added to a namespace
 *mynamespace*:
 
 .Generated Host Name
-====
 
+[source,terminal]
 ----
 no-route-hostname-mynamespace.router.default.svc.cluster.local <1>
 ----
 <1> The generated host name suffix is the default routing subdomain
 *router.default.svc.cluster.local*.
-====
+
 
 A cluster administrator can also
 ifdef::openshift-enterprise,openshift-origin[]
@@ -261,7 +260,6 @@ xref:passthrough-termination[passthrough], and
 xref:re-encryption-termination[re-encryption] termination.
 
 .Unsecured Route Object YAML Definition
-====
 
 [source,yaml]
 ----
@@ -275,8 +273,6 @@ spec:
     kind: Service
     name: service-name
 ----
-
-====
 
 Unsecured routes are simplest to configure, as they require no key
 or certificates, but secured routes offer security for connections to
@@ -319,7 +315,6 @@ The following table shows example routes and their accessibility:
 |===
 
 .An Unsecured Route with a Path:
-====
 
 [source,yaml]
 ----
@@ -336,7 +331,6 @@ spec:
 ----
 
 <1> The path is the only added attribute for a path-based route.
-====
 
 [NOTE]
 ====
@@ -378,7 +372,6 @@ endif::openshift-dedicated,openshift-aro,openshift-online[]
 will be used for TLS termination.
 
 .A Secured Route Using Edge Termination
-====
 
 [source,yaml]
 ----
@@ -411,7 +404,6 @@ spec:
 <3> The `*key*` field is the contents of the PEM format key file.
 <4> The `*certificate*` field is the contents of the PEM format certificate file.
 <5> An optional CA certificate may be required to establish a certificate chain for validation.
-====
 
 Because TLS is terminated at the router, connections from the router to
 the endpoints over the internal network are not encrypted.
@@ -427,7 +419,6 @@ secure scheme but serve the assets (example images, stylesheets and
 javascript) via the insecure scheme.
 
 .A Secured Route Using Edge Termination Allowing HTTP Traffic
-====
 
 [source,yaml]
 ----
@@ -448,10 +439,8 @@ spec:
 <1> The name of the object, which is limited to 63 characters.
 <2> The `*termination*` field is `edge` for edge termination.
 <3> The insecure policy to allow requests sent on an insecure scheme `HTTP`.
-====
 
 .A Secured Route Using Edge Termination Redirecting HTTP Traffic to HTTPS
-====
 
 [source,yaml]
 ----
@@ -472,7 +461,6 @@ spec:
 <1> The name of the object, which is limited to 63 characters.
 <2> The `*termination*` field is `edge` for edge termination.
 <3> The insecure policy to redirect requests sent on an insecure scheme `HTTP` to a secure scheme `HTTPS`.
-====
 
 [[passthrough-termination]]
 *Passthrough Termination*
@@ -482,7 +470,6 @@ destination without the router providing TLS termination. Therefore no
 key or certificate is required.
 
 .A Secured Route Using Passthrough Termination
-====
 [source,yaml]
 ----
 apiVersion: v1
@@ -499,7 +486,6 @@ spec:
 ----
 <1> The name of the object, which is limited to 63 characters.
 <2> The `*termination*` field is set to `passthrough`. No other encryption fields are needed.
-====
 
 The destination pod is responsible for serving certificates for the
 traffic at the endpoint. This is currently the only method that can support
@@ -522,7 +508,6 @@ checks to determine the authenticity of the host.
 
 
 .A Secured Route Using Re-Encrypt Termination
-====
 
 [source,yaml]
 ----
@@ -552,7 +537,6 @@ termination.
 <3> Required for re-encryption. `*destinationCACertificate*`
 specifies a CA certificate to validate the endpoint certificate, securing the
 connection from the router to the destination pods. If the service is using a service signing certificate, or the administrator has specified a default CA certificate for the router and the service has a certificate signed by that CA, this field can be omitted.
-====
 
 If the `*destinationCACertificate*` field is left empty, the router
 automatically leverages the certificate authority that is generated for service
@@ -616,7 +600,7 @@ and "-". The default is the hashed internal key name for the route. |
 |===
 
 .A Route Setting Custom Timeout
-====
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -628,7 +612,6 @@ metadata:
 ----
 <1> Specifies the new timeout with HAProxy supported units (us, ms, s, m, h, d).
 If unit not provided, ms is the default.
-====
 
 [NOTE]
 ====
@@ -652,6 +635,7 @@ source IP's. Alternatively, use `oc annotate route <name>`.
 
 Allow only one specific IP address:
 
+[source,yaml]
 ----
 metadata:
   annotations:
@@ -660,6 +644,7 @@ metadata:
 
 Allow several IP addresses:
 
+[source,yaml]
 ----
 metadata:
   annotations:
@@ -668,6 +653,7 @@ metadata:
 
 Allow an IP CIDR network:
 
+[source,yaml]
 ----
 metadata:
   annotations:
@@ -676,6 +662,7 @@ metadata:
 
 Allow mixed IP addresses and IP CIDR networks:
 
+[source,yaml]
 ----
 metadata:
   annotations:
@@ -696,7 +683,7 @@ xref:../../install_config/router/default_haproxy_router.adoc#using-wildcard-rout
 
 
 .A Route Specifying a Subdomain WildcardPolicy
-====
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -712,7 +699,6 @@ spec:
 <2> Specifies that the externally reachable host name should allow all hosts
     in the subdomain `example.com`. `*.example.com` is the subdomain for host
     name `wildcard.example.com` to reach the exposed service.
-====
 
 [[route-status-field]]
 == Route Status
@@ -746,62 +732,137 @@ restrictive, and ensures that the router only admits routes with hosts that
 belong to that list.
 
 For example, to deny the `[{asterisk}.]open.header.test`, `[{asterisk}.]openshift.org` and
-`[{asterisk}.]block.it` routes for the `myrouter` route:
+`[{asterisk}.]block.it` routes for the `myrouter` route, run the following two commands:
 
+[source,terminal]
 ----
 $ oc adm router myrouter ...
+----
+
+[source,terminal]
+----
 $ oc set env dc/myrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it"
 ----
 
 This means that `myrouter` will admit the following based on the route's name:
 
+[source,terminal]
 ----
 $ oc expose service/<name> --hostname="foo.header.test"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.allow.it"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.openshift.test"
 ----
 
 However, `myrouter` will deny the following:
 
+[source,terminal]
 ----
 $ oc expose service/<name> --hostname="open.header.test"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.open.header.test"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="block.it"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="franco.baresi.block.it"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="openshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="api.openshift.org"
 ----
 
-Alternatively, to block any routes where the host name is _not_ set to `[{asterisk}.]stickshift.org` or `[{asterisk}.]kates.net`:
+Alternatively, to block any routes where the host name is _not_ set to `[{asterisk}.]stickshift.org` or `[{asterisk}.]kates.net`, run the following two commands:
 
+[source,terminal]
 ----
 $ oc adm router myrouter ...
+----
+
+[source,terminal]
+----
 $ oc set env dc/myrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net"
 ----
 
 This means that the `myrouter` router will admit:
 
+[source,terminal]
 ----
 $ oc expose service/<name> --hostname="stickshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.stickshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="kates.net"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="api.kates.net"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="erno.r.kube.kates.net"
 ----
 
 However, `myrouter` will deny the following:
 
+[source,terminal]
 ----
 $ oc expose service/<name> --hostname="www.open.header.test"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="drive.ottomatic.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.wayless.com"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.deny.it"
 ----
 
-To implement both scenarios, run:
+To implement both scenarios, run the following two commands:
 
+[source,terminal]
 ----
 $ oc adm router adrouter ...
+----
+
+[source,terminal]
+----
 $ oc set env dc/adrouter ROUTER_ALLOWED_DOMAINS="okd.io, kates.net" \
     ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net"
 ----
@@ -812,22 +873,60 @@ This will allow any routes where the host name is set to `[{asterisk}.]openshift
 
 Therefore, the following will be denied:
 
+[source,terminal]
 ----
 $ oc expose service/<name> --hostname="www.open.header.test"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="ops.openshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="log.ops.openshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="www.block.it"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="metrics.kates.net"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="int.metrics.kates.net"
 ----
 
 However, the following will be allowed:
 
+[source,terminal]
 ----
 $ oc expose service/<name> --hostname="openshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="api.openshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="m.api.openshift.org"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="kates.net"
+----
+
+[source,terminal]
+----
 $ oc expose service/<name> --hostname="api.kates.net"
 ----
 
@@ -952,10 +1051,14 @@ is in the same namespace or other namespace since the exact host+path is already
 This feature can be set during router creation or by setting an environment
 variable in the router's deployment configuration.
 
+.Set During Router Creation
+[source,terminal]
 ----
 $ oc adm router ... --disable-namespace-ownership-check=true
 ----
 
+.Set Environment Variable in Router Deployment Configuration
+[source,terminal]
 ----
 $ oc set env dc/router ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK=true
 ----

--- a/architecture/service_catalog/aws_broker.adoc
+++ b/architecture/service_catalog/aws_broker.adoc
@@ -12,7 +12,7 @@
 toc::[]
 {nbsp} +
 
-The _AWS Service Broker_ provides access to Amazon Web Services (AWS) through the {product-title} service catalog. AWS services and componenets can be configured and viewed 
+The _AWS Service Broker_ provides access to Amazon Web Services (AWS) through the {product-title} service catalog. AWS services and components can be configured and viewed
 in both the {product-title} web console and the AWS dashboards.
 
 .Example AWS services in the {product-title} service catalog
@@ -26,4 +26,3 @@ in the *Amazon Web Services - Labs* docs repository.
 The AWS Service Broker is supported and qualified on {product-title}. It is offered directly from Amazon as a download and as such, many components of this service broker solution are supported directly by Amazon for the most recent two versions with a lag of two months after a new {product-title} release.
 Red Hat provides support for the installation and troubleshooting of the OpenShift cluster and service catalog issues.
 ====
-

--- a/architecture/service_catalog/index.adoc
+++ b/architecture/service_catalog/index.adoc
@@ -121,6 +121,7 @@ the `authInfo` section, which contains the data used to authenticate with the
 cluster service broker.
 +
 .Example `ClusterServiceBroker` Resource
+[source,yaml]
 ----
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
@@ -153,6 +154,7 @@ of the service catalog and OSB API.
 ====
 +
 .Example `ClusterServiceClass` Resource
+[source,yaml]
 ----
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceClass
@@ -177,6 +179,7 @@ connects to the appropriate cluster service broker and instructs it to provision
 the service instance.
 +
 .Example `ServiceInstance` Resource
+[source,yaml]
 ----
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceInstance
@@ -206,6 +209,7 @@ containing connection details and credentials for the service instance. Such
 secrets can be mounted into pods as usual.
 +
 .Example `ServiceBinding` Resource
+[source,yaml]
 ----
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
@@ -229,6 +233,7 @@ in the service binding request. For parameters that need more security, place
 them in a secret and reference them using `parametersFrom`.
 +
 .Example Service Binding Resource Referencing a Secret
+[source,yaml]
 ----
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding

--- a/architecture/service_catalog/service_catalog_cli.adoc
+++ b/architecture/service_catalog/service_catalog_cli.adoc
@@ -34,7 +34,7 @@ You can install `svcat` as an RPM by using Red Hat Subscription Management
 (RHSM) if you have an active OpenShift Enterprise subscription on your Red Hat
 account:
 
-[source]
+[source,terminal]
 ----
 # yum install atomic-enterprise-service-catalog-svcat
 ----
@@ -44,7 +44,7 @@ account:
 *Google Compute Engine*
 For Google Cloud Platform, run the following command to setup firewall rules to allow incoming traffic:
 
-[source,bash]
+[source,terminal]
 ----
 $ gcloud compute firewall-rules create allow-service-catalog-secure --allow tcp:30443 --description "Allow incoming traffic on 30443 port."
 ----
@@ -65,9 +65,14 @@ about brokers deployed in the service catalog.
 [[service-catalog-cli-find-broker]]
 ==== Find brokers
 To view all the brokers installed on the cluster:
-[source,bash]
+[source,terminal]
 ----
 $ svcat get brokers
+----
+
+.Example Output
+[source,terminal]
+----
            NAME                                                        URL                                              STATUS
 +-------------------------+-------------------------------------------------------------------------------------------+--------+
   ansible-service-broker    https://asb.openshift-ansible-service-broker.svc:1338/ansible-service-broker                Ready
@@ -77,18 +82,28 @@ $ svcat get brokers
 [[service-catalog-cli-sync-broker]]
 ==== Sync broker catalog
 To refresh the catalog metadata from the broker:
-[source,bash]
+[source,terminal]
 ----
 $ svcat sync broker ansible-service-broker
+----
+
+.Example Output
+[source,terminal]
+----
 Synchronization requested for broker: ansible-service-broker
 ----
 
 [[service-catalog-cli-view-broker]]
 ==== View broker details
 To view the details of the broker:
-[source,bash]
+[source,terminal]
 ----
 $ svcat describe broker ansible-service-broker
+----
+
+.Example Output
+[source,terminal]
+----
   Name:     ansible-service-broker
   URL:      https://openshift-automation-service-broker.openshift-automation-service-broker.svc:1338/openshift-automation-service-broker/
   Status:   Ready - Successfully fetched catalog entries from broker @ 2018-06-07 00:32:59 +0000 UTC
@@ -105,9 +120,14 @@ the broker’s services.
 [[service-catalog-cli-view-serviceclass]]
 ==== View service classes
 To view the available ClusterServiceClass resources:
-[source,bash]
+[source,terminal]
 ----
 $ svcat get classes
+----
+
+.Example Output
+[source,terminal]
+----
         NAME                   DESCRIPTION
 +-------------------+--------------------------------+
   rh-mediawiki-apb    Mediawiki apb implementation
@@ -121,9 +141,14 @@ $ svcat get classes
 ----
 
 To view details of a service class:
-[source,bash]
+[source,terminal]
 ----
 $ svcat describe class rh-postgresql-apb
+----
+
+.Example Output
+[source,terminal]
+----
   Name:          rh-postgresql-apb
   Description:   SCL PostgreSQL apb implementation
   UUID:          d5915e05b253df421efe6e41fb6a66ba
@@ -143,9 +168,14 @@ Plans:
 [[service-catalog-cli-view-serviceplans]]
 ==== View service plans
 To view the ClusterServicePlan resources available in the cluster:
-[source,bash]
+[source,terminal]
 ----
 $ svcat get plans
+----
+
+.Example Output
+[source,terminal]
+----
    NAME           CLASS                  DESCRIPTION
 +---------+-------------------+--------------------------------+
   default   rh-mediawiki-apb    An APB that deploys MediaWiki
@@ -169,9 +199,14 @@ $ svcat get plans
 ----
 
 View details of a plan:
-[source,bash]
+[source,terminal]
 ----
 $ svcat describe plan rh-postgresql-apb/dev
+----
+
+.Example Output
+[source,terminal]
+----
   Name:          dev
   Description:   A single DB server with no storage
   UUID:          9783fc2e859f9179833a7dd003baa841
@@ -253,7 +288,7 @@ Service instances must be created inside an OpenShift namespace.
 
 . Create a new project.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc new-project <project-name> <1>
 ----
@@ -261,9 +296,15 @@ $ oc new-project <project-name> <1>
 
 . Create service instance using the command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ svcat provision postgresql-instance --class rh-postgresql-apb --plan dev --params-json  '{"postgresql_database":"admin","postgresql_password":"admin","postgresql_user":"admin","postgresql_version":"9.6"}' -n szh-project
+----
++
+.Example Output
+
+[source,terminal]
+----
   Name:        postgresql-instance
   Namespace:   szh-project
   Status:
@@ -280,9 +321,14 @@ Parameters:
 [[service-catalog-cli-view-serviceinstance]]
 ===== View service instance details
 To view service instance details:
-[source,bash]
+[source,terminal]
 ----
 $ svcat get instance
+----
+
+.Example Output
+[source,terminal]
+----
          NAME            NAMESPACE          CLASS         PLAN   STATUS
 +---------------------+-------------+-------------------+------+--------+
   postgresql-instance   szh-project   rh-postgresql-apb   dev    Ready
@@ -302,9 +348,14 @@ project.
 
 Create the service binding using the command:
 
-[source,bash]
+[source,terminal]
 ----
 $ svcat bind postgresql-instance --name mediawiki-postgresql-binding
+----
+
+.Example Output
+[source,terminal]
+----
   Name:        mediawiki-postgresql-binding
   Namespace:   szh-project
   Status:
@@ -318,9 +369,14 @@ Parameters:
 ===== View service binding details
 . To view service binding details:
 +
-[source,bash]
+[source,terminal]
 ----
 $ svcat get bindings
+----
++
+.Example Output
+[source,terminal]
+----
               NAME                NAMESPACE         INSTANCE         STATUS
 +------------------------------+-------------+---------------------+--------+
   mediawiki-postgresql-binding   szh-project   postgresql-instance   Ready
@@ -328,9 +384,14 @@ $ svcat get bindings
 
 . Verify the instance details after binding the service:
 +
-[source,bash]
+[source,terminal]
 ----
 $ svcat describe instance postgresql-instance
+----
++
+.Example Output
+[source,terminal]
+----
   Name:        postgresql-instance
   Namespace:   szh-project
   Status:      Ready - The instance was provisioned successfully @ 2018-06-05 08:42:55 +0000 UTC
@@ -358,9 +419,9 @@ and deprovision the service instances.
 [[service-catalog-cli-delete-servicebindings]]
 === Deleting service bindings
 
-. To delete all service bindings, associated with a service instance:
+. To delete all service bindings associated with a service instance:
 +
-[source,bash]
+[source,terminal]
 ----
 $ svcat unbind -n <project-name> <1>
   \ <instance-name> <2>
@@ -371,12 +432,27 @@ $ svcat unbind -n <project-name> <1>
 +
 For example:
 +
-[source,bash]
+[source,terminal]
 ----
 $ svcat unbind -n szh-project postgresql-instance
+----
++
+.Example Output
+[source,terminal]
+----
 deleted mediawiki-postgresql-binding
+----
 
+.  Verify that all service bindings are deleted:
++
+[source,terminal]
+----
 $ svcat get bindings
+----
++
+.Example Output
+[source,terminal]
+----
   NAME   NAMESPACE   INSTANCE   STATUS
 +------+-----------+----------+--------+
 
@@ -390,9 +466,14 @@ Running this command deletes all service bindings for the instance. For deleting
 
 . Verify that the associated secret is deleted.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get secret -n szh-project
+----
++
+.Example Output
+[source,terminal]
+----
 NAME                       TYPE                                  DATA      AGE
 builder-dockercfg-jxk48    kubernetes.io/dockercfg               1         9m
 builder-token-92jrf        kubernetes.io/service-account-token   4         9m
@@ -408,38 +489,74 @@ deployer-token-xfr7c       kubernetes.io/service-account-token   4         9m
 [[service-catalog-cli-delete-serviceinstance]]
 === Deleting service instances
 
-Deprovision the service instance:
-
-[source,bash]
+. To deprovision the service instance:
++
+[source,terminal]
 ----
 $ svcat deprovision postgresql-instance
+----
++
+.Example Output
+[source,terminal]
+----
 deleted postgresql-instance
+----
 
+. Verify the instance is deleted:
++
+[source,terminal]
+----
 $ svcat get instance
+----
++
+.Example Output
+[source,terminal]
+----
   NAME   NAMESPACE   CLASS   PLAN   STATUS
 +------+-----------+-------+------+--------+
+
 ----
 
 [[service-catalog-cli-delete-servicebrokers]]
 === Deleting service brokers
 . To remove broker services for the service catalog, delete the `ClusterServiceBroker` resource:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc delete clusterservicebrokers template-service-broker
+----
++
+.Example Output
+[source,terminal]
+----
 clusterservicebroker "template-service-broker" deleted
+----
 
+. To view all the brokers installed on the cluster:
++
+[source,terminal]
+----
 $ svcat get brokers
+----
++
+.Example Output
+[source,terminal]
+----
            NAME                                                        URL                                              STATUS
 +-------------------------+-------------------------------------------------------------------------------------------+--------+
   ansible-service-broker    https://asb.openshift-ansible-service-broker.svc:1338/ansible-service-broker                Ready
 ----
 
-. View the `ClusterServiceClass` resources for the broker, to verify that the broker is removed:
+. View the `ClusterServiceClass` resources for the broker to verify that the broker is removed:
 +
-[source,bash]
+[source,terminal]
 ----
 $ svcat get classes
+----
++
+.Example Output
+[source,terminal]
+----
   NAME   DESCRIPTION
 +------+-------------+
 

--- a/architecture/topics/flannel.adoc
+++ b/architecture/topics/flannel.adoc
@@ -1,4 +1,4 @@
-*flannel* is a virtual networking layer designed specifically for containers. 
+*flannel* is a virtual networking layer designed specifically for containers.
 {product-title} can use it for networking containers instead of the default
 software-defined networking (SDN) components. This is useful if running
 {product-title} within a cloud provider platform that also relies on SDN,
@@ -27,20 +27,18 @@ image::flannel.png[Flannel Communication]
 
 *Node 1* would contain the following routes:
 
-====
+[source,text]
 ----
 default via 192.168.0.100 dev eth0 proto static metric 100
-10.1.15.0/24 dev docker0 proto kernel scope link src 10.1.15.1 
+10.1.15.0/24 dev docker0 proto kernel scope link src 10.1.15.1
 10.1.20.0/24 via 192.168.0.200 dev eth0
 ----
-====
 
 *Node 2* would contain the following routes:
 
-====
+[source,text]
 ----
 default via 192.168.0.200 dev eth0 proto static metric 100
-10.1.20.0/24 dev docker0 proto kernel scope link src 10.1.20.1 
+10.1.20.0/24 dev docker0 proto kernel scope link src 10.1.20.1
 10.1.15.0/24 via 192.168.0.100 dev eth0
 ----
-====

--- a/architecture/topics/openshift_dns.adoc
+++ b/architecture/topics/openshift_dns.adoc
@@ -19,6 +19,7 @@ DNS queries for services. The master listens to port 53 by default.
 When the node starts, the following message indicates the Kubelet is correctly
 resolved to the master:
 
+[source,terminal]
 ----
 0308 19:51:03.118430    4484 node.go:197] Started Kubelet for node
 openshiftdev.local, server at 0.0.0.0:10250

--- a/architecture/topics/packet_flow.adoc
+++ b/architecture/topics/packet_flow.adoc
@@ -7,7 +7,7 @@ is named *vethB*.
 [NOTE]
 ====
 If the Docker service's use of peer virtual Ethernet devices is not already familiar to you,
-see https://docs.docker.com/engine/userguide/networking/dockernetworks/[Docker's advanced networking
+see link:https://docs.docker.com/engine/userguide/networking/dockernetworks/[Docker's advanced networking
 documentation].
 ====
 

--- a/architecture/topics/router_environment_variables.adoc
+++ b/architecture/topics/router_environment_variables.adoc
@@ -4,12 +4,14 @@ For all the items outlined in this section, you can set environment variables in
 the *deployment config* for the router to alter its configuration, or use the
 `oc set env` command:
 
+[source,terminal]
 ----
 $ oc set env <object_type>/<object_name> KEY1=VALUE1 KEY2=VALUE2
 ----
 
 For example:
 
+[source,terminal]
 ----
 $ oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug
 ----


### PR DESCRIPTION
Added `[source,terminal]` to appropriate code blocks and separated commands from their output in the 3.11 Architecture book.