### PR TITLE
Replace OperatorSource with CatalogSource for backing service in Service Binding

### DIFF
--- a/modules/odc-connecting-components.adoc
+++ b/modules/odc-connecting-components.adoc
@@ -53,36 +53,40 @@ Currently, a few specific Operators like the *etcd* and the *PostgresSQL Databas
 
 You can establish a binding connection with Operator-backed components.
 
-This procedure walks through an example of creating a binding connection between a PostgreSQL Database service and a Node.js application. To create a binding connection with a service that is backed by the PostgreSQL Database Operator, you must first add the Red Hat-provided PostgreSQL Database Operator to the OperatorHub using a backing  Operator source, and then install the Operator.
+This procedure walks through an example of creating a binding connection between a PostgreSQL Database service and a Node.js application. To create a binding connection with a service that is backed by the PostgreSQL Database Operator, you must first add the Red Hat-provided PostgreSQL Database Operator to the *OperatorHub* using a `CatalogSource` resource, and then install the Operator.
+The PostreSQL Database Operator then creates and manages the `Database` resource, which exposes the binding information in secrets, config maps, status, and spec attributes.
 
 .Prerequisite
 * Ensure that you have created and deployed a Node.js application using the *Developer* perspective.
 * Ensure that you have installed the *Service Binding Operator* from OperatorHub.
 
 .Procedure
-. Create a backing Operator source that adds the PostgresSQL Operator provided by Red Hat to the OperatorHub. A backing Operator source exposes the binding information in secrets, config maps, status, and spec attributes.
-.. In the *Add* view, click the *YAML* option to see the *Import YAML* screen.
-.. Add the following YAML file to apply the Operator source:
+. Create a `CatalogSource` resource that adds the PostgresSQL Database Operator provided by Red Hat to the *OperatorHub*.
+.. In the *+Add* view, click the *YAML* option to see the *Import YAML* screen.
+.. Add the following YAML file to apply the `CatalogSource` resource:
 +
 [source,yaml]
 ----
-apiVersion: operators.coreos.com/v1
-kind: OperatorSource
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
 metadata:
- name: db-operators
- namespace: openshift-marketplace
+    name: sample-db-operators
+    namespace: openshift-marketplace
 spec:
- type: appregistry
- endpoint: https://quay.io/cnr
- registryNamespace: pmacik
+    sourceType: grpc
+    image: quay.io/redhat-developer/sample-db-operators-olm:v1
+    displayName: Sample DB OLM registry
+    updateStrategy:
+        registryPoll:
+            interval: 30m
 ----
-.. Click *Create* to create the Operator source in your cluster.
-. Install the Red Hat-provided PostgreSQL Database Operator:
+.. Click *Create* to create the `CatalogSource` resource in your cluster.
+. Install the Red Hat-provided *PostgreSQL Database* Operator:
 .. In the *Administrator* perspective of the console, navigate to *Operators -> OperatorHub*.
 .. In the *Database* category, select the *PostgreSQL Database* Operator and install it.
 . Create a database (DB) instance for the application:
-.. Switch to the *Developer* perspective and ensure that you are in the appropriate project.
-.. In the *Add* view, click the *YAML* option to see the *Import YAML* screen.
+.. Switch to the *Developer* perspective and ensure that you are in the appropriate project, for example, `test-project`.
+.. In the *+Add* view, click the *YAML* option to see the *Import YAML* screen.
 .. Add the service instance YAML in the editor and click *Create* to deploy the service. Following is an example of what the service YAML will look like:
 +
 [source,YAML]
@@ -91,7 +95,6 @@ apiVersion: postgresql.baiju.dev/v1alpha1
 kind: Database
 metadata:
  name: db-demo
- namespace: test-project
 spec:
  image: docker.io/postgres
  imageName: postgres


### PR DESCRIPTION
This PR is meant for ocp v4.5+

The docs shows installation of a backing service operator that is done via `OperatorSource`. That is obsolete in v4.5 and removed in v4.6, so this PR updates the docs by replacing the `OperatorSource` with `CatalogSource`.