### PR TITLE
CNV - JIRA story CNV-4333 Adding fslist, guestosinfo, and userlist commands to ands to Virtctl commands table in Virtual client commands subsection of Using the CLI tools section

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -66,4 +66,13 @@ the specified port of the node.
 
 |`virtctl help`
 |Display a descriptive list of `virtctl` commands.
+
+|`virtctl fslist <vmi_name>`
+|Return a full list of file systems available on the guest machine.
+
+|`virtctl guestosinfo <vmi_name>`
+|Return guest agent information about the operating system.
+
+|`virtctl userlist <vmi_name>`
+|Return a full list of logged-in users on the guest machine.
 |===


### PR DESCRIPTION
This PR address JIRA story CNV-4333 (https://issues.redhat.com/browse/CNV-4333).

Added fslist, guestosinfo, and userlist commands to Virtctl commands table in 'Virtual client commands' subsection of "Using the CLI tools" section.

Preview link - https://cnv4333--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virt-using-the-cli-tools.html#virt-virtctl-commands_virt-using-the-cli-tools