### PR TITLE
Add command line block for command line

### DIFF
--- a/service_mesh/service_mesh_install/updating-ossm.adoc
+++ b/service_mesh/service_mesh_install/updating-ossm.adoc
@@ -28,7 +28,10 @@ This new configuration option is called `overload.global_downstream_max_connecti
 +
 . Create a secret from the `bootstrap-override.json` file, replacing <SMCPnamespace> with the namespace where you created the service mesh control plane (SMCP):
 +
+[source,terminal]
+----
 $  oc create secret generic -n <SMCPnamespace> gateway-bootstrap --from-file=bootstrap-override.json
+----
 +
 . Update the SMCP configuration to activate the override.
 
@@ -53,7 +56,10 @@ spec:
 
 . To set the new configuration option, create a secret that has the desired value for the `overload.global_downstream_max_connections` setting.  The following example uses a value of `10000`:
 +
+[source,terminal]
+----
 $  oc create secret generic -n <SMCPnamespace> gateway-settings --from-literal=overload.global_downstream_max_connections=10000
+----
 +
 
 . Update the SMCP again to mount the secret in the location where Envoy is looking for runtime configuration:


### PR DESCRIPTION
Please refer to https://docs.openshift.com/container-platform/4.5/service_mesh/service_mesh_install/updating-ossm.html

The `$ oc create` command is not in the command line block.

![sample](https://user-images.githubusercontent.com/2138339/92840806-7f496700-f41c-11ea-8a4a-13141892fc69.png)
