### PR TITLE
Add a note about crio preferring upstream over local registry if reachable

### DIFF
--- a/installing/install_config/installing-restricted-networks-preparations.adoc
+++ b/installing/install_config/installing-restricted-networks-preparations.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. Installations on a restricted network are supported on only infrastructure that you provision, not infrastructure that the installer provisions.
 
-You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content. You will have to block your cluster from reaching the upstream registry in an unrestricted network. If your cluster can reach the upstream registry it will still prefer it over your local mirror.
+You can also create a mirror that contains the required container images in unrestricted networks to ensure your clusters use only container images that satisfy your organizational controls on external content. You must block your cluster from reaching the upstream registry in an unrestricted network. If your cluster can reach the upstream registry, it uses the images from that registry instead of the local mirror.
 
 [IMPORTANT]
 ====

--- a/installing/install_config/installing-restricted-networks-preparations.adoc
+++ b/installing/install_config/installing-restricted-networks-preparations.adoc
@@ -5,7 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. Installations on a restricted network are supported on only infrastructure that you provision, not infrastructure that the installer provisions. You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content.
+Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. Installations on a restricted network are supported on only infrastructure that you provision, not infrastructure that the installer provisions.
+
+You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content. You will have to block your cluster from reaching the upstream registry in an unrestricted network. If your cluster can reach the upstream registry it will still prefer it over your local mirror.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
If crio can reach the upstream registry it will still prefer it over the local registry. For my environment I just blocked quay.io via dns blacklist during openshift-install 