### PR TITLE
Add generic config details to Storage docs for OSP Manila

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -54,6 +54,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro[]
 - iSCSI
 - Local volume
 - NFS
+- OpenStack Manila
 - Red Hat OpenShift Container Storage
 endif::openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
@@ -152,6 +153,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |iSCSI  | ✅ | ✅ |  -
 |Local volume | ✅ | - |  -
 |NFS  | ✅ | ✅ | ✅
+|OpenStack Manila  | - | - | ✅
 |Red Hat OpenShift Container Storage  | ✅ | - | ✅
 |VMware vSphere | ✅ | - |  -
 endif::[]
@@ -175,7 +177,7 @@ ifdef::openshift-dedicated[]
  * PVs are provisioned with either EBS volumes (AWS) or GCP storage (GCP),
 depending on where the cluster is provisioned.
  * Only RWO access mode is applicable, as EBS volumes and GCE Persistent
-Disks can not be mounted to multiple nodes.
+Disks cannot be mounted to multiple nodes.
  * *emptyDir* has the same lifecycle as the Pod:
    ** *emptyDir* volumes survive container crashes/restarts.
    ** *emptyDir* volumes are deleted when the Pod is deleted.
@@ -184,7 +186,7 @@ endif::[]
 ifdef::openshift-online[]
  * PVs are provisioned with EBS volumes (AWS).
  * Only RWO access mode is applicable, as EBS volumes and GCE Persistent
-Disks can not be mounted to multiple nodes.
+Disks cannot be mounted to multiple nodes.
  * Docker volumes are disabled.
    ** VOLUME directive without a mapped external volume fails to be
 instantiated


### PR DESCRIPTION
[BZ1878186](https://bugzilla.redhat.com/show_bug.cgi?id=1878186) - Customer request via OSP Eng to add OSP Manila file share service config options to generic sections of OCP Storage docs (i.e., Types of PVs, Access modes).

@jsafrane or @gnufied Could either of you PTAL and let me know if these additions make sense and look accurate to you?
@qinpingli PTAL from QE perspective.
Thanks!

Preview links:

- [Types of PVs](https://bz1878186--ocpdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#types-of-persistent-volumes_understanding-persistent-storage)
- [Access modes](https://bz1878186--ocpdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#pv-access-modes_understanding-persistent-storage) (see **Table 2**)