### PR TITLE
Remove KUBE_MAX_PD_VOLS variable in 4.4

### DIFF
--- a/modules/storage-persistent-storage-aws-maximum-volumes.adoc
+++ b/modules/storage-persistent-storage-aws-maximum-volumes.adoc
@@ -3,17 +3,8 @@
 // * storage/persistent_storage-aws.adoc
 
 [id="maximum-number-of-ebs-volumes-on-a-node_{context}"]
-= Maximum Number of EBS Volumes on a Node
+= Maximum number of EBS volumes on a node
 
 By default, {product-title} supports a maximum of 39 EBS volumes attached to one
 node. This limit is consistent with the
-link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits[AWS
-volume limits].
-
-{product-title} can be configured to have a higher limit by setting the
-environment variable `KUBE_MAX_PD_VOLS`. However, AWS requires a particular
-naming scheme
-(link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html[AWS
-Device Naming]) for attached devices, which only supports a maximum of 52
-volumes. This limits the number of volumes that can be attached to a node via
-{product-title} to 52.
+link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits[AWS volume limits]. The volume limit depends on the instance type.


### PR DESCRIPTION
Relates to https://github.com/openshift/openshift-docs/pull/25348 though without the note because CSI is not supported until 4.5. For 4.4 only. A 4.3 PR makes the same change for OCP 4.3: https://github.com/openshift/openshift-docs/pull/25413

Preview: [Maximum number of EBS volumes on a node](https://bz1794729--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-aws.html#maximum-number-of-ebs-volumes-on-a-node_persistent-storage-aws)