### PR TITLE
nodes/nodes/nodes-nodes-machine-config-daemon-metrics: Internal must-gather link

### DIFF
--- a/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.adoc
+++ b/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.adoc
@@ -10,4 +10,4 @@ include::modules/machine-config-daemon-metrics.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../monitoring/cluster_monitoring/about-cluster-monitoring.adoc[the documentation on the Prometheus Cluster Monitoring stack].
-* See link:https://github.com/openshift/must-gather[the repository of the must-gather tool].
+* See xref:../../support/gathering-cluster-data.adoc[the documentation on gathering data about your cluster].


### PR DESCRIPTION
We have internal must-gather docs, so use them instead of pointing out to whatever happens to be on GitHub.  The link landed pointing at GitHub in 5a705959d2 (#18787).