### PR TITLE
4-6 GCP and Azure non-guaranteed instances

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -37,14 +37,24 @@ Use the sample MachineSet for your cloud.
 
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
 
-AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
-which can save you on costs compared to On-Demand Instance prices. You can
-xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
-by adding SpotMarketOptions to the MachineSet YAML file.
+MachineSets running on AWS support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances].
+You can save on costs by using Spot Instances at a lower price compared to
+On-Demand Instances on AWS. xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-aws[Configure Spot Instances]
+by adding `spotMarketOptions` to the MachineSet YAML file.
 
 include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
 
+MachineSets running on Azure support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Spot VMs].
+You can save on costs by using Spot VMs at a lower price compared to
+standard VMs on Azure. You can xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-azure[configure Spot VMs]
+by adding `spotVMOptions` to the MachineSet YAML file.
+
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
+
+MachineSets running on GCP support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[preemptible VM instances].
+You can save on costs by using preemptible VM instances at a lower price
+compared to normal instances on GCP. You can xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-gcp[configure preemptible VM instances]
+by adding `preemptible` to the MachineSet YAML file.
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -15,3 +15,7 @@ include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/machineset-yaml-azure.adoc[leveloffset=+1]
 
 include::modules/machineset-creating.adoc[leveloffset=+1]
+
+include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
+
+include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -15,3 +15,7 @@ include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+1]
 
 include::modules/machineset-creating.adoc[leveloffset=+1]
+
+include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
+
+include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -1,24 +1,75 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
+// * machine_management/creating_machinesets/creating-machineset-gcp.adoc
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+
+ifeval::["{context}" == "creating-machineset-aws"]
+:aws:
+endif::[]
+ifeval::["{context}" == "creating-machineset-azure"]
+:azure:
+endif::[]
+ifeval::["{context}" == "creating-machineset-gcp"]
+:gcp:
+endif::[]
 
 [id="machineset-creating-non-guaranteed-instance_{context}"]
-= Creating Spot Instances
+ifdef::aws[= Creating Spot Instances by using MachineSets]
+ifdef::azure[= Creating Spot VMs by using MachineSets]
+ifdef::gcp[= Creating preemptible VM instances by using MachineSets]
 
-You can launch a Spot Instance on AWS by adding SpotMarketOptions to your MachineSet YAML file.
+ifdef::aws[You can launch a Spot Instance on AWS by adding `spotMarketOptions` to your MachineSet YAML file.]
+ifdef::azure[You can launch a Spot VM on Azure by adding `spotVMOptions` to your MachineSet YAML file.]
+ifdef::gcp[You can launch a preemptible VM instance on GCP by adding `preemptible` to your MachineSet YAML file.]
 
 .Procedure
 * Add the following line under the `providerSpec` field:
 +
+ifdef::aws[]
 [source,yaml]
 ----
 providerSpec:
   value:
-    spotMarketOptions: {} <1>
+    spotMarketOptions: {}
 ----
-<1> You can optionally set the `maxPrice` for the `spotMarketOptions` field to limit the cost of the Spot Instance, for example `maxPrice: '2.50'`. If the `maxPrice` is set, this value is used as the hourly maximum spot price. If not set, the maximum price defaults to charge up to the On-Demand Instance price.
-
++
+You can optionally set the `spotMarketOptions.maxPrice` field to limit the cost of the Spot Instance. For example you can set `maxPrice: '2.50'`.
++
+If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to charge up to the On-Demand Instance price.
++
 [NOTE]
 ====
 It is strongly recommended to use the default On-Demand price as the `maxPrice` value and to not set the maximum price for Spot Instances.
 ====
+endif::aws[]
+ifdef::azure[]
+[source,yaml]
+----
+providerSpec:
+  value:
+    spotVMOptions: {}
+----
++
+You can optionally set the `spotVMOptions.maxPrice` field to limit the cost of the Spot VM. For example you can set `maxPrice: '0.98765'`.
+If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to `-1` and charges up to the standard VM price.
++
+Azure caps Spot VM prices at the standard price. Azure will not evict an instance due to pricing if the instance is set with the default `maxPrice`.
+However, an instance can still be evicted due to capacity restrictions.
+
+[NOTE]
+====
+It is strongly recommended to use the default standard VM price as the `maxPrice` value and to not set the maximum price for Spot VMs.
+====
+endif::azure[]
+ifdef::gcp[]
+[source,yaml]
+----
+providerSpec:
+  value:
+    preemptible: true
+----
++
+If `preemptible` is set to `true`, the machine is labelled as an `interruptable-instance` after the instance is launched.
+
+endif::gcp[]

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -1,32 +1,95 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
+// * machine_management/creating_machinesets/creating-machineset-gcp.adoc
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+
+ifeval::["{context}" == "creating-machineset-aws"]
+:aws:
+endif::[]
+ifeval::["{context}" == "creating-machineset-azure"]
+:azure:
+endif::[]
+ifeval::["{context}" == "creating-machineset-gcp"]
+:gcp:
+endif::[]
 
 [id="machineset-non-guaranteed-instance_{context}"]
-= MachineSet Spot Instances
-
-You can save on costs by creating an AWS MachineSet that deploys machines as non-guaranteed Spot Instances.
+ifdef::aws[= MachineSets that deploy machines as Spot Instances]
+ifdef::azure[= MachineSets that deploy machines as Spot VMs]
+ifdef::gcp[= MachineSets that deploy machines as preemptible VM instances]
+ifdef::aws[]
+You can save on costs by creating a MachineSet running on AWS that deploys machines as non-guaranteed Spot Instances.
 Spot Instances utilize unused AWS EC2 capacity and are less expensive than On-Demand Instances.
 You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless,
 horizontally scalable workloads.
+endif::aws[]
+ifdef::azure[]
+You can save on costs by creating a MachineSet running on Azure that deploys machines as non-guaranteed Spot VMs.
+Spot VMs utilize unused Azure capacity and are less expensive than standard VMs.
+You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless,
+horizontally scalable workloads.
+endif::azure[]
+ifdef::gcp[]
+You can save on costs by creating a MachineSet running on GCP that deploys machines as non-guaranteed preemptible VM instances.
+Preemptible VM instances utilize excess Compute Engine capacity and are less expensive than normal instances.
+You can use preemptible VM instances for workloads that can tolerate interruptions, such as batch or stateless,
+horizontally scalable workloads.
+endif::gcp[]
 
 [IMPORTANT]
 ====
-It is strongly recommended that control plane machines are not created on Spot Instances
+It is strongly recommended that control plane machines are not created on
+ifdef::aws[Spot Instances]
+ifdef::azure[Spot VMs]
+ifdef::gcp[preemptible VM instances]
 due to the increased likelihood of the instance being terminated. Manual intervention is
 required to replace a terminated control plane node.
 ====
 
+ifdef::aws[]
 AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to
-the user when an interruption occurs. The {product-title} begins to remove the workloads
+the user when an interruption occurs. {product-title} begins to remove the workloads
 from the affected instances when AWS issues the termination warning.
 
-Interruptions can occur when using Spot Instances if:
+Interruptions can occur when using Spot Instances for the following reasons:
 
-* The instance price exceeds your maximum price.
-* The demand for Spot Instances increases.
-* The supply of Spot Instances decreases.
+* The instance price exceeds your maximum price
+* The demand for Spot Instances increases
+* The supply of Spot Instances decreases
 
 When AWS terminates an instance, a termination handler running on the Spot Instance
 node deletes the machine resource. To satisfy the MachineSet `replicas` quantity, the
-MachineSet creates a new machine that then requests a new Spot Instance.
+MachineSet creates a machine that requests a Spot Instance.
+endif::aws[]
+ifdef::azure[]
+Azure can terminate a Spot VM at any time. Azure gives a 30-second warning to
+the user when an interruption occurs. {product-title} begins to remove the workloads
+from the affected instances when Azure issues the termination warning.
+
+Interruptions can occur when using Spot VMs for the following reasons:
+
+* The instance price exceeds your maximum price
+* The supply of Spot VMs decreases
+* Azure needs capacity back
+
+
+When Azure terminates an instance, a termination handler running on the Spot VM
+node deletes the machine resource. To satisfy the MachineSet `replicas` quantity, the
+MachineSet creates a machine that requests a Spot VM.
+endif::azure[]
+ifdef::gcp[]
+GCP Compute Engine can terminate a preemptible VM instance at any time. Compute Engine sends a preemption notice to the user indicating that an interruption will occur in 30 seconds.
+{product-title} begins to remove the workloads from the affected instances when Compute Engine issues the preemption notice. An ACPI G3 Mechanical Off signal is sent to the operating
+system after 30 seconds if the instance is not stopped. The preemptible VM instance is then transitioned to a `TERMINATED` state by Compute Engine.
+
+Interruptions can occur when using preemptible VM instances for the following reasons:
+
+* There is a system or maintenance event
+* The supply of preemptible VM instances decreases
+* The instance reaches the end of the allotted 24-hour period for preemptible VM instances
+
+When GCP terminates an instance, a termination handler running on the preemptible VM instance
+node deletes the machine resource. To satisfy the MachineSet `replicas` quantity, the
+MachineSet creates a machine that requests a preemptible VM instance.
+endif::gcp[]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -46,13 +46,24 @@ Use the sample MachineSet for your cloud.
 
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
 
-AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
-which can save you on costs compared to On-Demand Instance prices. You can
-xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
-by adding SpotMarketOptions to the MachineSet YAML file.
+MachineSets running on AWS support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances].
+You can save on costs by using Spot Instances at a lower price compared to
+On-Demand Instances on AWS. xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-aws[Configure Spot Instances]
+by adding `spotMarketOptions` to the MachineSet YAML file.
 
 include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
+
+MachineSets running on Azure support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Spot VMs].
+You can save on costs by using Spot VMs at a lower price compared to
+standard VMs on Azure. You can xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-azure[configure Spot VMs]
+by adding `spotVMOptions` to the MachineSet YAML file.
+
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
+
+MachineSets running on GCP support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[preemptible VM instances].
+You can save on costs by using preemptible VM instances at a lower price
+compared to normal instances on GCP. You can xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-gcp[configure preemptible VM instances]
+by adding `preemptible` to the MachineSet YAML file.
 
 include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
 include::modules/cluster-autoscaler-cr.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR covers both GCP and Azure non-guaranteed [spot/preemptible VM] instances support added in 4.6.

4.6 GCP machine API support for Preemptible VM instances - [OSDOCS-1285](https://issues.redhat.com/browse/OSDOCS-1285)

4.6 Azure machine API spot instances support - [OSDOCS-1286](https://issues.redhat.com/browse/OSDOCS-1286)

This work relates to 4.5 AWS Spot Instances - [PR-24678](https://github.com/openshift/openshift-docs/pull/24678)