### PR TITLE
remove claimed restriction about https proxy urls

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -75,8 +75,7 @@ additionalTrustBundle: | <4>
 URL scheme must be `http`. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpProxy` value.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster. If
 this field is not specified, then `httpProxy` is used for both HTTP and HTTPS
-connections. The URL scheme must be `http`; `https` is currently not
-supported.
+connections.
 If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpsProxy` value.
 <3> A comma-separated list of destination domain names, domains, IP addresses, or
 other network CIDRs to exclude proxying. Preface a domain with `.` to include

--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -97,8 +97,7 @@ spec:
 URL scheme must be `http`.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster. If
 this is not specified, then `httpProxy` is used for both HTTP and HTTPS
-connections. The URL scheme must be `http`; `https` is currently not
-supported.
+connections.
 <3> A comma-separated list of destination domain names, domains, IP addresses or
 other network CIDRs to exclude proxying. Preface a domain with `.` to include
 all subdomains of that domain. Use `*` to bypass proxy for all destinations.


### PR DESCRIPTION
as far as i know this works (it's why we allow you to configure proxy CAs).  https proxies do not work with builds for purposes of source retrieval, due to a limitation in the git version we use.  That limitation will be going away in 4.6.  It's possible that restriction is where this line came from, i'm not sure.

So maybe it's worth noting that restriction in the build docs explicitly, or we just let it go knowing that the problem is going away sooner than later anyway.