### PR TITLE
Bug 1878581: [DOCS] Update etcd image version tag to 3.2.28

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -326,7 +326,7 @@ $ docker pull registry.redhat.io/openshift3/postgresql-apb:<tag>
 $ docker pull registry.redhat.io/openshift3/registry-console:<tag>
 $ docker pull registry.redhat.io/openshift3/snapshot-controller:<tag>
 $ docker pull registry.redhat.io/openshift3/snapshot-provisioner:<tag>
-$ docker pull registry.redhat.io/rhel7/etcd:3.2.26
+$ docker pull registry.redhat.io/rhel7/etcd:3.2.28
 ----
 
 . For on-premise installations on x86_64 servers, pull the following image.
@@ -538,7 +538,7 @@ $ docker save -o ose3-images.tar \
     registry.redhat.io/openshift3/registry-console \
     registry.redhat.io/openshift3/snapshot-controller \
     registry.redhat.io/openshift3/snapshot-provisioner \
-    registry.redhat.io/rhel7/etcd:3.2.22 \
+    registry.redhat.io/rhel7/etcd:3.2.28 \
 ----
 +
 ** For on-premise installations on IBM POWER8 or IBM POWER9 servers, run the following command:
@@ -598,7 +598,7 @@ $ docker save -o ose3-images.tar \
     registry.redhat.io/openshift3/registry-console \
     registry.redhat.io/openshift3/snapshot-controller \
     registry.redhat.io/openshift3/snapshot-provisioner \
-    registry.redhat.io/rhel7/etcd:3.2.22 \
+    registry.redhat.io/rhel7/etcd:3.2.28 \
 ----
 --
 
@@ -766,7 +766,7 @@ to tag the etcd image:
 +
 [source,bash]
 ----
-$ docker tag registry.redhat.io/rhel7/etcd:3.2.22 registry.example.com/rhel7/etcd:3.2.22
+$ docker tag registry.redhat.io/rhel7/etcd:3.2.28 registry.example.com/rhel7/etcd:3.2.28
 ----
 
 . Push each image into the registry. For example, to push the {product-title}
@@ -842,7 +842,7 @@ openshift_examples_modify_imagestreams=true
 +
 ----
 oreg_url=satellite.example.com/oreg-prod-openshift3_ose-<component>:<version> <1>
-osm_etcd_image=satellite.example.com/oreg-prod-rhel7_etcd:3.2.22 <2>
+osm_etcd_image=satellite.example.com/oreg-prod-rhel7_etcd:3.2.28 <2>
 openshift_examples_modify_imagestreams=true
 ----
 <1> Specify both the `ose` component name and version number.


### PR DESCRIPTION
* Version: v3.11
* Description: Default etcd version tag has been changed from 3.2.22, 3.2.26 to 3.2.28 by [Bug 1828433 - Update etcd to 3.2.28](https://bugzilla.redhat.com/show_bug.cgi?id=1828433)
* Reference: [Bug 1878581 - [DOCS] Update etcd image version tag to 3.2.28](https://bugzilla.redhat.com/show_bug.cgi?id=1878581)