### PR TITLE
[OSP] Remove duplicative statement from resource requirements

### DIFF
--- a/modules/installation-osp-default-kuryr-deployment.adoc
+++ b/modules/installation-osp-default-kuryr-deployment.adoc
@@ -62,9 +62,6 @@ If you are using
 {rh-openstack} version 15 or earlier, or the `ovn-octavia driver`, each load balancer
 has a security group with the user project.
 
-* Swift space requirements vary depending on the size of the bootstrap Ignition
-file and image registry.
-
 * The quota does not account for load balancer resources (such as VM
 resources), but you must consider these resources when you decide the
 {rh-openstack} deployment's size. The default installation will have more than


### PR DESCRIPTION
This commit removes a note from the OSP Kuryr resource requirements list
that duplicates (in a dated way*) the IMPORTANT admonition above it.

[BZ - 1853294](https://bugzilla.redhat.com/show_bug.cgi?id=1853294)

\* Swift is no longer used for bootstrap Ignition files