### PR TITLE
Add 4.6 Storage Release Notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -203,17 +203,29 @@ By default, the following network connections are checked:
 ** the internal API load balancer
 ** the external API load balancer
 
-[id="ocp-4-6-operators"]
-=== Operators
+[id="ocp-4-6-storage"]
+=== Storage
 
-[id="ocp-4-6-metering-operator"]
-==== Configuring a retention period of metering Reports
+[id="ocp-4-6-csi-driver-cso"]
+==== CSI drivers now managed by the Cluster Storage Operator
+The Container Storage Interface (CSI) Driver Operators and drivers for xref:../storage/container_storage_interface/persistent-storage-csi-ebs.adoc#persistent-storage-csi-ebs[AWS Elastic Block Store (EBS)], xref:../storage/container_storage_interface/persistent-storage-csi-ovirt.adoc#persistent-storage-csi-ovirt[Red Hat Virtualization (oVirt)], and xref:../storage/container_storage_interface/persistent-storage-csi-manila.adoc#persistent-storage-csi-manila[OpenStack Manila shared file system service] are now managed by the Cluster Storage Operator in {product-title}.
 
-You can now set a retention period on a metering Report. The metering Report custom resource
-has a new `expiration` field. If the `expiration` duration value is set on a Report,
-and no other Reports or ReportQueries depend on the expiring Report, the Metering Operator
-removes the Report from your cluster at the end of its retention period.
-//For more information, see metering ../../metering/reports/metering-about-reports.adoc#metering-expiration_metering-about-reports[Reports expiration].
+For AWS EBS and oVirt, this feature installs the CSI Driver Operator and driver in the `openshift-cluster-csi-drivers` namespace by default. For Manila, the CSI Driver Operator is installed in `openshift-cluster-csi-drivers` and the driver is installed in the `openshift-manila-csi-driver` namespace.
+
+[IMPORTANT]
+====
+If you installed a CSI Driver Operator and driver on an {product-title} 4.5 cluster:
+
+* The AWS EBS CSI Driver Operator and driver must be uninstalled before you update to a newer version of {product-title}.
+* The OpenStack Manila CSI Driver Operator is no longer available in Operator Lifecycle Manager (OLM). It has been automatically converted by the Cluster Version Operator.
+====
+
+[id="ocp-4-6-lso-automation"]
+==== Automatic device discovery and provisioning with the Local Storage Operator
+The Local Storage Operator now has the ability to:
+
+* Automatically discover a list of available disks in a cluster. You can select a list of nodes, or all nodes, for auto-discovery to be continuously applied to.
+* Automatically provision local persistent volumes from attached devices. Appropriate devices are filtered and persistent volumes are provisioned based on the filtered devices.
 
 [id="ocp-4-6-notable-technical-changes"]
 == Notable technical changes
@@ -431,17 +443,22 @@ In the table below, features are marked with the following statuses:
 |CSI AWS EBS Driver Operator
 |-
 |TP
-|
+|TP
 
 |OpenStack Manila CSI Driver Operator
 |-
 |GA
 |GA
 
+|Red Hat Virtualization (oVirt) CSI Driver Operator
+|-
+|-
+|GA
+
 |CSI inline ephemeral volumes
 |-
 |TP
-|
+|TP
 
 |OpenShift Pipelines
 |TP


### PR DESCRIPTION
4.6 Storage Release Notes (https://issues.redhat.com/browse/OSDOCS-1414) for the following features:

- cluster-storage-operator managing CSI driver operator instead of OLM	(https://issues.redhat.com/browse/STOR-380). 
Documented in https://issues.redhat.com/browse/OSDOCS-1176.

- Allow local-storage-operator to continuously make inventory of local disks (https://issues.redhat.com/browse/STOR-404). Documented in https://issues.redhat.com/browse/OSDOCS-1178.

- Allow local-storage-operator to auto-provision PVs from available devices on a node (https://issues.redhat.com/browse/STOR-317). Documented in https://issues.redhat.com/browse/OSDOCS-1177.

**[PREVIEW LINK](https://osdocs-1414--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-storage)**