### PR TITLE
Fix build issues

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1407,8 +1407,6 @@ Topics:
     File: template-template-openshift-io-v1
   - Name: 'TemplateInstance [template.openshift.io/v1]'
     File: templateinstance-template-openshift-io-v1
-  - Name: 'Template [template.openshift.io/v1]'
-    File: template-template-openshift-io-v1
 - Name: user.openshift.io
   Dir: user_openshift_io
   Topics:

--- a/api-map.yaml
+++ b/api-map.yaml
@@ -475,11 +475,12 @@
     version: v1
     plural: brokertemplateinstances
     namespaced: false
-  - kind: Template
-    group: template.openshift.io
-    version: v1
-    plural: processedtemplates
-    namespaced: true
+# This collides with Template below
+#  - kind: Template
+#    group: template.openshift.io
+#    version: v1
+#    plural: processedtemplates
+#    namespaced: true
   - kind: TemplateInstance
     group: template.openshift.io
     version: v1

--- a/rest_api/admissionregistration_k8s_io/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1beta1.adoc
+++ b/rest_api/admissionregistration_k8s_io/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1beta1.adoc
@@ -234,13 +234,13 @@ Type::
 
 | `operations`
 | `array (string)`
-| Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.
+| Operations is the operations the admission hook cares about - CREATE, UPDATE, or +++*+++ for all operations. If '*' is present, the length of the slice must be one. Required.
 
 | `resources`
 | `array (string)`
 | Resources is a list of resources this rule applies to.
 
-For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/+++*+++' means all subresources of pods. '+++*+++/scale' means all scale subresources. '+++*+++/+++*+++' means all resources and their subresources.
 
 If wildcard is present, the validation rule will ensure resources do not overlap with each other.
 

--- a/rest_api/admissionregistration_k8s_io/validatingwebhookconfiguration-admissionregistration-k8s-io-v1beta1.adoc
+++ b/rest_api/admissionregistration_k8s_io/validatingwebhookconfiguration-admissionregistration-k8s-io-v1beta1.adoc
@@ -234,13 +234,13 @@ Type::
 
 | `operations`
 | `array (string)`
-| Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.
+| Operations is the operations the admission hook cares about - CREATE, UPDATE, or +++*+++ for all operations. If '*' is present, the length of the slice must be one. Required.
 
 | `resources`
 | `array (string)`
 | Resources is a list of resources this rule applies to.
 
-For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/+++*+++' means all subresources of pods. '+++*+++/scale' means all scale subresources. '+++*+++/+++*+++' means all resources and their subresources.
 
 If wildcard is present, the validation rule will ensure resources do not overlap with each other.
 

--- a/rest_api/authorization_k8s_io/localsubjectaccessreview-authorization-k8s-io-v1.adoc
+++ b/rest_api/authorization_k8s_io/localsubjectaccessreview-authorization-k8s-io-v1.adoc
@@ -143,7 +143,7 @@ Type::
 
 | `group`
 | `string`
-| Group is the API Group of the Resource.  "*" means all.
+| Group is the API Group of the Resource.  "+++*+++"means all.
 
 | `name`
 | `string`
@@ -155,7 +155,7 @@ Type::
 
 | `resource`
 | `string`
-| Resource is one of the existing resource types.  "*" means all.
+| Resource is one of the existing resource types.  "+++*+++"means all.
 
 | `subresource`
 | `string`
@@ -163,11 +163,11 @@ Type::
 
 | `verb`
 | `string`
-| Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+| Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "+++*+++"means all.
 
 | `version`
 | `string`
-| Version is the API Version of the Resource.  "*" means all.
+| Version is the API Version of the Resource.  "+++*+++"means all.
 
 |===
 ..status

--- a/rest_api/authorization_k8s_io/selfsubjectaccessreview-authorization-k8s-io-v1.adoc
+++ b/rest_api/authorization_k8s_io/selfsubjectaccessreview-authorization-k8s-io-v1.adoc
@@ -113,7 +113,7 @@ Type::
 
 | `group`
 | `string`
-| Group is the API Group of the Resource.  "*" means all.
+| Group is the API Group of the Resource.  "+++*+++"means all.
 
 | `name`
 | `string`
@@ -125,7 +125,7 @@ Type::
 
 | `resource`
 | `string`
-| Resource is one of the existing resource types.  "*" means all.
+| Resource is one of the existing resource types.  "+++*+++"means all.
 
 | `subresource`
 | `string`
@@ -133,11 +133,11 @@ Type::
 
 | `verb`
 | `string`
-| Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+| Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "+++*+++"means all.
 
 | `version`
 | `string`
-| Version is the API Version of the Resource.  "*" means all.
+| Version is the API Version of the Resource.  "+++*+++"means all.
 
 |===
 ..status

--- a/rest_api/authorization_k8s_io/selfsubjectrulesreview-authorization-k8s-io-v1.adoc
+++ b/rest_api/authorization_k8s_io/selfsubjectrulesreview-authorization-k8s-io-v1.adoc
@@ -141,11 +141,11 @@ Required::
 
 | `nonResourceURLs`
 | `array (string)`
-| NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  "*" means all.
+| NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  "+++*+++"means all.
 
 | `verbs`
 | `array (string)`
-| Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+| Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "+++*+++"means all.
 
 |===
 ..status.resourceRules
@@ -176,20 +176,20 @@ Required::
 
 | `apiGroups`
 | `array (string)`
-| APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.  "*" means all.
+| APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.  "+++*+++"means all.
 
 | `resourceNames`
 | `array (string)`
-| ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.  "*" means all.
+| ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.  "+++*+++"means all.
 
 | `resources`
 | `array (string)`
-| Resources is a list of resources this rule applies to.  "*" means all in the specified apiGroups.
- "*/foo" represents the subresource 'foo' for all resources in the specified apiGroups.
+| Resources is a list of resources this rule applies to.  "+++*+++"means all in the specified apiGroups.
+ "+++*+++/foo" represents the subresource 'foo' for all resources in the specified apiGroups.
 
 | `verbs`
 | `array (string)`
-| Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+| Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "+++*+++"means all.
 
 |===
 

--- a/rest_api/authorization_k8s_io/subjectaccessreview-authorization-k8s-io-v1.adoc
+++ b/rest_api/authorization_k8s_io/subjectaccessreview-authorization-k8s-io-v1.adoc
@@ -143,7 +143,7 @@ Type::
 
 | `group`
 | `string`
-| Group is the API Group of the Resource.  "*" means all.
+| Group is the API Group of the Resource.  "+++*+++"means all.
 
 | `name`
 | `string`
@@ -155,7 +155,7 @@ Type::
 
 | `resource`
 | `string`
-| Resource is one of the existing resource types.  "*" means all.
+| Resource is one of the existing resource types.  "+++*+++"means all.
 
 | `subresource`
 | `string`
@@ -163,11 +163,11 @@ Type::
 
 | `verb`
 | `string`
-| Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+| Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "+++*+++"means all.
 
 | `version`
 | `string`
-| Version is the API Version of the Resource.  "*" means all.
+| Version is the API Version of the Resource.  "+++*+++"means all.
 
 |===
 ..status

--- a/rest_api/autoscaling/horizontalpodautoscaler-autoscaling-v1.adoc
+++ b/rest_api/autoscaling/horizontalpodautoscaler-autoscaling-v1.adoc
@@ -106,7 +106,7 @@ Required::
 
 | `kind`
 | `string`
-| Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+| Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
 
 | `name`
 | `string`

--- a/rest_api/core/core-index.adoc
+++ b/rest_api/core/core-index.adoc
@@ -147,7 +147,7 @@ Type::
 == ServiceAccount [core/v1]
 
 Description::
-  ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
+  ServiceAccount binds together: +++*+++ a name, understood by users, and perhaps by peripheral systems, for an identity +++*+++ a principal that can be authenticated and authorized +++*+++ a set of secrets
 
 Type::
   `object`

--- a/rest_api/core/serviceaccount-core-v1.adoc
+++ b/rest_api/core/serviceaccount-core-v1.adoc
@@ -15,7 +15,7 @@ toc::[]
 
 
 Description::
-  ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
+  ServiceAccount binds together: +++*+++ a name, understood by users, and perhaps by peripheral systems, for an identity +++*+++ a principal that can be authenticated and authorized +++*+++ a set of secrets
 
 Type::
   `object`

--- a/rest_api/oauth_openshift_io/oauthclient-oauth-openshift-io-v1.adoc
+++ b/rest_api/oauth_openshift_io/oauthclient-oauth-openshift-io-v1.adoc
@@ -137,11 +137,11 @@ Required::
 
 | `namespaces`
 | `array (string)`
-| Namespaces is the list of namespaces that can be referenced.  * means any of them (including *)
+| Namespaces is the list of namespaces that can be referenced.  +++*+++ means any of them (including *)
 
 | `roleNames`
 | `array (string)`
-| RoleNames is the list of cluster roles that can referenced.  * means anything
+| RoleNames is the list of cluster roles that can referenced.  +++*+++ means anything
 
 |===
 

--- a/rest_api/objects/index.adoc
+++ b/rest_api/objects/index.adoc
@@ -4916,7 +4916,7 @@ Type::
 
 
 
-[id="persistentvolumeclaim-core-v1"]
+[id="persistentvolumeclaim-core-v1-index"]
 == PersistentVolumeClaim [core/v1]
 
 

--- a/rest_api/policy/podsecuritypolicy-policy-v1beta1.adoc
+++ b/rest_api/policy/podsecuritypolicy-policy-v1beta1.adoc
@@ -90,9 +90,9 @@ Required::
 
 | `allowedUnsafeSysctls`
 | `array (string)`
-| allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+| allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "+++*+++ " in which case it is considered as a prefix of allowed sysctls. Single +++*+++ means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
 
-Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+Examples: e.g. "foo/+++*+++ " allows "foo/bar", "foo/baz", etc. e.g. "foo.+++*+++ " allows "foo.bar", "foo.baz", etc.
 
 | `defaultAddCapabilities`
 | `array (string)`
@@ -104,9 +104,9 @@ Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "fo
 
 | `forbiddenSysctls`
 | `array (string)`
-| forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+| forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "+++*+++"in which case it is considered as a prefix of forbidden sysctls. Single +++*+++ means all sysctls are forbidden.
 
-Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+Examples: e.g. "foo/+++*+++" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*+++*+++" forbids "foo.bar", "foo.baz", etc.
 
 | `fsGroup`
 | `object`

--- a/rest_api/route_openshift_io/route-route-openshift-io-v1.adoc
+++ b/rest_api/route_openshift_io/route-route-openshift-io-v1.adoc
@@ -203,7 +203,7 @@ Required::
 | `string`
 | insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.
 
-* Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.
+* Allow - traffic is sent to the server on the insecure port (default) +++*+++ Disable - no traffic is allowed on the insecure port. +++*+++ Redirect - clients are redirected to the secure port.
 
 | `key`
 | `string`

--- a/rest_api/security_openshift_io/securitycontextconstraints-security-openshift-io-v1.adoc
+++ b/rest_api/security_openshift_io/securitycontextconstraints-security-openshift-io-v1.adoc
@@ -83,9 +83,9 @@ Required::
 
 | `.allowedUnsafeSysctls`
 | `array (string)`
-| AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+| AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "+++*+++"in which case it is considered as a prefix of allowed sysctls. Single +++*+++ means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
 
-Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+Examples: e.g. "foo/+++*+++" allows "foo/bar", "foo/baz", etc. e.g. "foo.*+++*+++" allows "foo.bar", "foo.baz", etc.
 
 | `.apiVersion`
 | `string`
@@ -101,9 +101,9 @@ Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "fo
 
 | `.forbiddenSysctls`
 | `array (string)`
-| ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+| ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "+++*+++"in which case it is considered as a prefix of forbidden sysctls. Single +++*+++ means all sysctls are forbidden.
 
-Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+Examples: e.g. "foo/+++*+++" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*+++*+++" forbids "foo.bar", "foo.baz", etc.
 
 | `.fsGroup`
 | `object`


### PR DESCRIPTION
Not sure how this passed Travis. Or does that not run for 3.11?

Requires extensive manual repairs due several factors.

@vikram-redhat, so the OpenAPI spec for 3.11 gives me a sad. It might be possible to deduce why some resources are excluded, but meanwhile the build won't go because of missing `xref`. I can remove these for now, however:

```
Transforming the AsciiDoc content to DocBook XML...
Unknown ID or title "binarybuildsource-build-openshift-io-v1", used as an internal cross reference
Unknown ID or title "dockerstrategyoptions-build-openshift-io-v1", used as an internal cross reference
Unknown ID or title "sourcerevision-build-openshift-io-v1", used as an internal cross reference
Unknown ID or title "sourcestrategyoptions-build-openshift-io-v1", used as an internal cross reference
Unknown ID or title "buildtriggercause-build-openshift-io-v1", used as an internal cross reference
Unknown ID or title "preconditions-meta-v1", used as an internal cross reference
Unknown ID or title "deploymentconfigrollbackspec-apps-openshift-io-v1", used as an internal cross reference
Unknown ID or title "imagelayerdata-image-openshift-io-v1", used as an internal cross reference
Unknown ID or title "imageblobreferences-image-openshift-io-v1", used as an internal cross reference
Unknown ID or title "scalespec-autoscaling-v1", used as an internal cross reference
Unknown ID or title "scalestatus-autoscaling-v1", used as an internal cross reference
Unknown ID or title "scalespec-extensions-v1beta1", used as an internal cross reference
Unknown ID or title "scalestatus-extensions-v1beta1", used as an internal cross reference
Unknown ID or title "podsecuritypolicylist-policy-v1beta1", used as an internal cross reference
```

It's still probably more correct than what we had before.