### PR TITLE
fixes incorrect case occurences

### DIFF
--- a/modules/configuration-resource-overview.adoc
+++ b/modules/configuration-resource-overview.adoc
@@ -26,7 +26,7 @@ You can customize the following Configuration Resources:
 |
 
 |Samples
-| * *ManagementState:*
+| * *managementState:*
 ** *Managed.* The operator updates the samples as the configuration dictates.
 ** *Unmanaged.* The operator ignores updates to the samples resource object and
 any imagestreams or templates in the OpenShift namespace.

--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -75,9 +75,9 @@ status:
 
 [IMPORTANT]
 ====
-The Image Registry Operator's behavior for managing the pruner is orthogonal to the `ManagementState` specified on the Image Registry Operator's `ClusterOperator` object. If the image registry Operator is not in the `Managed` state, the image pruner can still be configured and managed by the Pruning Custom Resource.
+The Image Registry Operator's behavior for managing the pruner is orthogonal to the `managementState` specified on the Image Registry Operator's `ClusterOperator` object. If the image registry Operator is not in the `Managed` state, the image pruner can still be configured and managed by the Pruning Custom Resource.
 
-However, the `ManagementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
+However, the `managementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
 * `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.

--- a/modules/registry-change-management-state.adoc
+++ b/modules/registry-change-management-state.adoc
@@ -15,7 +15,7 @@ To start the image registry, you must change the Image Registry Operator configu
 
 .Procedure
 
-* Change `ManagementState` Image Registry Operator configuration from `Removed` to `Managed`. For example:
+* Change `managementState` Image Registry Operator configuration from `Removed` to `Managed`. For example:
 +
 [source,yaml]
 ----

--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -13,7 +13,7 @@ configuration parameters.
 |===
 |Parameter |Description
 
-|`ManagementState`
+|`managementState`
 |`Managed`: The Operator updates the registry as configuration resources
 are updated.
 

--- a/modules/registry-removed.adoc
+++ b/modules/registry-removed.adoc
@@ -21,7 +21,7 @@ Registry Operator bootstraps itself as `Removed`. This allows
 `openshift-installer` to complete installations on these platform types.
 
 After installation, you must edit the Image Registry Operator configuration to
-switch the `ManagementState` from `Removed` to `Managed`.
+switch the `managementState` from `Removed` to `Managed`.
 
 [NOTE]
 ====

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -33,9 +33,9 @@ and workload resources for the registry reside in that namespace.
 
 [IMPORTANT]
 ====
-The Image Registry Operator's behavior for managing the pruner is orthogonal to the `ManagementState` specified on the Image Registry Operator's `ClusterOperator` object. If the image registry operator is not in the `Managed` state, the image pruner can still be configured and managed by the Pruning Custom Resource.
+The Image Registry Operator's behavior for managing the pruner is orthogonal to the `managementState` specified on the Image Registry Operator's `ClusterOperator` object. If the image registry operator is not in the `Managed` state, the image pruner can still be configured and managed by the Pruning Custom Resource.
 
-However, the `ManagementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
+However, the `managementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
 * `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.

--- a/rest_api/operator_apis/config-samples-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/config-samples-operator-openshift-io-v1.adoc
@@ -108,7 +108,7 @@ Type::
 
 | `managementState`
 | `string`
-| managementState reflects the current operational status of the on/off switch for the operator.  This operator compares the ManagementState as part of determining that we are turning the operator back on (i.e. "Managed") when it was previously "Unmanaged".
+| managementState reflects the current operational status of the on/off switch for the operator.  This operator compares the managementState as part of determining that we are turning the operator back on (i.e. "Managed") when it was previously "Unmanaged".
 
 | `samplesRegistry`
 | `string`


### PR DESCRIPTION
`ManagementState` does not exist, instead the parameter is `managementState`. This PR fixes incorrect instances of the parameter.