### PR TITLE
Add note about restrictions svc of LB type with Kuryr

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -11,7 +11,10 @@ Using {product-title} with Kuryr SDN has several known limitations.
 [id="openstack-general-limitations_{context}"]
 == {rh-openstack} general limitations
 
-{product-title} with Kuryr SDN does not support NodePort services.
+{product-title} with Kuryr SDN does not support NodePort services. Also, if
+the machines subnet is not connected to a router or it's connected, but
+the router has no external gateway set, Kuryr cannot create floating IPs
+for LoadBalancer services.
 
 [discrete]
 [id="openstack-version-limitations_{context}"]

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -11,10 +11,11 @@ Using {product-title} with Kuryr SDN has several known limitations.
 [id="openstack-general-limitations_{context}"]
 == {rh-openstack} general limitations
 
-{product-title} with Kuryr SDN does not support NodePort services. Also, if
-the machines subnet is not connected to a router or it's connected, but
-the router has no external gateway set, Kuryr cannot create floating IPs
-for LoadBalancer services.
+{product-title} with Kuryr SDN does not support NodePort services. 
+
+If the machines subnet is not connected to a router, or if the
+subnet is connected, but the router has no external gateway set,
+Kuryr cannot create floating IPs for LoadBalancer services.
 
 [discrete]
 [id="openstack-version-limitations_{context}"]


### PR DESCRIPTION
When Kuryr is used creation of Services with Load Balancer type
are restricted to when a Router and External Connectivity exists
on the Cluster.