### PR TITLE
Removing references to 4.0 which doesn't exist

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -65,13 +65,13 @@ the best course of action.
 ====
 
 [[ocp-311-major-changes-in-40]]
-=== Major Changes Coming in Version 4.0
+=== Major Changes Coming in Version 4
 
 {product-title} 3.11 is the last release in the 3.x stream. Large changes to the
-underlying architecture and installation process are coming in version 4.0, and
+underlying architecture and installation process are coming in version 4, and
 many features will be deprecated.
 
-.Features Deprecated in Version 4.0
+.Features Deprecated in Version 4
 [cols="2",options="header"]
 |====
 |Feature |Justification
@@ -103,7 +103,7 @@ many features will be deprecated.
 |Custom Docker Build Strategy on Builder Pods
 |If you want to continue using custom builds, you must replace your Docker
 invocations with Podman and Buildah. The custom build strategy will not be
-removed, but the functionality will change significantly in {product-title} 4.0.
+removed, but the functionality will change significantly in {product-title} 4.
 
 |Cockpit
 |Replaced by Quay.
@@ -115,7 +115,7 @@ removed, but the functionality will change significantly in {product-title} 4.0.
 |CoreDNS will be the default.
 
 |External etcd nodes
-|For 4.0, etcd is on the cluster always.
+|For 4, etcd is on the cluster always.
 
 |CloudForms OpenShift Provider and Podified CloudForms
 |Replaced by built-in management tooling.
@@ -126,11 +126,11 @@ removed, but the functionality will change significantly in {product-title} 4.0.
 
 
 |xref:../upgrading/blue_green_deployments.adoc#upgrading-blue-green-deployments[blue-green-installation method]
-|Ease of upgrade is a core value of 4.0.
+|Ease of upgrade is a core value of 4.
 
 |====
 
-Because of the extent of the changes in {product-title} 4.0, the product
+Because of the extent of the changes in {product-title} 4, the product
 documentation will also undergo significant changes, including the deprecation
 of large amounts of content. New content will be released based on the
 architectural changes and updated use cases.


### PR DESCRIPTION
The 3.11 release notes mention OCP version 4.0, which doesn't exist because we went straight to 4.1. Removing 4.0 references.