### PR TITLE
4-6 Release Notes for metering Report expiration

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -196,6 +196,18 @@ By default, the following network connections are checked:
 ** the internal API load balancer
 ** the external API load balancer
 
+[id="ocp-4-6-operators"]
+=== Operators
+
+[id="ocp-4-6-metering-operator"]
+==== Configuring a retention period of metering Reports
+
+You can now set a retention period on a metering Report. The metering Report custom resource
+has a new `expiration` field. If the `expiration` duration value is set on a Report,
+and no other Reports or ReportQueries depend on the expiring Report, the Metering Operator
+removes the Report from your cluster at the end of its retention period.
+//For more information, see metering ../../metering/reports/metering-about-reports.adoc#metering-expiration_metering-about-reports[Reports expiration].
+
 [id="ocp-4-6-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
4.6 Release Notes for the new metering Report `expiration` field.