### PR TITLE
Removed aws billing assembly from the Azure docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1178,6 +1178,7 @@ Topics:
     File: metering-configure-reporting-operator
   - Name: Configuring AWS billing correlation
     File: metering-configure-aws-billing-correlation
+    Distros: openshift-enterprise,openshift-webscale,openshift-origin
 - Name: Reports
   Dir: reports
   Topics:


### PR DESCRIPTION
Removed the "Configuring AWS billing correlation" assembly from the 4.3 `openshift-aro` distro.

Preview is available [here](http://file.bos.redhat.com/lbarbeev/09172020/remove-metering-aws-billing-from-azure-docs/metering/configuring_metering/metering-about-configuring.html). 

The "Configuring AWS billing correlation" assembly was removed from under Metering > Configuring metering.