### PR TITLE
Changed Subscribe to Install and Create Operator Subscription to Install Options

### DIFF
--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -123,8 +123,8 @@ in the previous section.
 
 .. Choose  *Performance Addon Operator* from the list of available Operators, and then click *Install*.
 
-.. On the *Create Operator Subscription* page, under *A specific namespace on the cluster*
-select *openshift-performance-addon-operator*. Then, click *Subscribe*.
+.. On the *Install Operator* page, under *A specific namespace on the cluster*
+select *openshift-performance-addon-operator*. Then, click *Install*.
 
 . Optional: Verify that the performance-addon-operator installed successfully:
 

--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -35,8 +35,8 @@ production deployments.
 
 .. Choose *Elasticsearch* from the list of available Operators, and click *Install*.
 
-.. On the *Create Operator Subscription* page, under *A specific namespace on the cluster* select *openshift-logging*.
-Then, click *Subscribe*.
+.. On the *Install Operator* page, under *A specific namespace on the cluster* select *openshift-logging*.
+Then, click *Install*.
 
 . Install the Cluster Logging Operator from the OperatorHub:
 
@@ -44,8 +44,8 @@ Then, click *Subscribe*.
 
 .. Choose  *Cluster Logging* from the list of available Operators, and click *Install*.
 
-.. On the *Create Operator Subscription* page, under *A specific namespace on the cluster* select *openshift-logging*.
-Then, click *Subscribe*.
+.. On the *Install Operator* page, under *A specific namespace on the cluster* select *openshift-logging*.
+Then, click *Install*.
 
 . Verify the operator installations:
 

--- a/modules/jaeger-install-elasticsearch.adoc
+++ b/modules/jaeger-install-elasticsearch.adoc
@@ -35,7 +35,7 @@ If you have already installed the Elasticsearch Operator as part of OpenShift cl
 
 . Click *Install*.
 
-. On the *Create Operator Subscription* page, select the *A specific namespace on the cluster* option and then select *openshift-operators-redhat* from the menu.
+. On the *Install Operator* page, select the *A specific namespace on the cluster* option and then select *openshift-operators-redhat* from the menu.
 
 . Select the *Update Channel* that matches your {product-title} installation.  For example, if you are installing on {product-title} version 4.5, select the 4.5 update channel.
 
@@ -46,6 +46,6 @@ If you have already installed the Elasticsearch Operator as part of OpenShift cl
 The Manual approval strategy requires a user with appropriate credentials to approve the Operator install and subscription process.
 ====
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . On the *Installed Operators* page, select the `openshift-operators-redhat` project. Wait until you see that the Elasticsearch Operator shows a status of "InstallSucceeded" before continuing.

--- a/modules/jaeger-install.adoc
+++ b/modules/jaeger-install.adoc
@@ -32,12 +32,12 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 . Click *Install*.
 
-. On the *Create Operator Subscription* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . Select the *stable* Update Channel. This will automatically update Jaeger as new versions are released.  If you select a maintenance channel, for example, *1.17-stable*, you will receive bug fixes and security patches for the length of the support cycle for that version.
 
 * Select an Approval Strategy. You can select *Automatic* or *Manual* updates. If you choose Automatic updates for an installed Operator, when a new version of that Operator is available, the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention. If you select Manual updates, when a newer version of an Operator is available, the OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . On the *Subscription Overview* page, select the `openshift-operators` project. Wait until you see that the Jaeger Operator shows a status of "InstallSucceeded" before continuing.

--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -38,7 +38,7 @@ metadata:
 
 .  Click the Metering card, review the package description, and then click *Install*.
 .  Select an *Update Channel*, *Installation Mode*, and *Approval Strategy*.
-.  Click *Subscribe*.
+.  Click *Install*.
 
 .  Verify that the Metering Operator is installed by switching to the *Operators* -> *Installed Operators* page. The Metering Operator has a *Status* of *Succeeded* when the installation is complete.
 +

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -19,7 +19,7 @@ You can install the OpenShift Container Storage Operator from OperatorHub.
 . Use *Filter by keyword* (in this case, *OCS*) to find the *OpenShift Container Storage Operator*.
 . Select the *OpenShift Container Storage Operator* and click *Install*.
 . Select an *Update Channel*, *Installation Mode*, and *Approval Strategy*.
-. Click *Subscribe*.
+. Click *Install*.
 +
 On the *Installed Operators* page, the *OpenShift Container Storage Operator* appears in the *openshift-storage* project with the status *Succeeded*.
 

--- a/modules/migration-installing-cam-operator-ocp-4.adoc
+++ b/modules/migration-installing-cam-operator-ocp-4.adoc
@@ -50,7 +50,7 @@ ifdef::source-4-1-4[]
 endif::[]
 . Use the *Filter by keyword* field (in this case, `Migration`) to find the *Cluster Application Migration Operator*.
 . Select the *Cluster Application Migration Operator* and click *Install*.
-. On the *Create Operator Subscription* page, click *Subscribe*.
+. On the *Install Operator* page, click *Install*.
 +
 On the *Installed Operators* page, the *Cluster Application Migration Operator* appears in the *openshift-migration* project with the status *Succeeded*.
 

--- a/modules/nodes-cluster-remote-workers-objects.adoc
+++ b/modules/nodes-cluster-remote-workers-objects.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * logging/nodes-cluster-remote-workers.adoc
+
+[id="nodes-cluster-remote-workers-objects_{context}"]
+= About Kubernetes objects and remote worker nodes
+
+
+
+If you are using remote worker nodes, you should consider which objects to use to run your applications. 
+
+Daemonsets::
+Daemonsets are the best approach to managing pods on the edge because they do not typically need rescheduling behavior. The Openshift API will only get status updates if the Node is in communication with the API. If the Node disconnects from the cluster, then the Daemonset Pod within the API will not change state, and will continue in the last state that was reported. For example, if a daemonset pod is in the running state when a node stops communicating then the pod keeps running and is assumed to be running within the API. 
+
+A workload that wants to target all edge workers would likely want to use a daemonset. A daemonset will run a workload on all the matching workers automatically, and an Openshift/Kubernetes Service endpoint can be used to load balance to those daemonset pods. Daemonsets support label and toleration matching so a subset of nodes can be selected to place workloads.
+
+Daemonsets will not re-run after a reboot of the node if they can’t reach the API server. 
+
+Another limitation is for workloads requiring continuous operation. Daemonsets can’t guarantee updates without disruption. Meaning, the old pod is removed first before the new (updated) pod can start and has a non-zero window of disruption.
+
+Static Pods::
+If Pods need to be restarted when a node reboots while network separated from the supervisor cluster, Static Pods can be used. Drawback of static pods  is that they can't use secrets and ConfigMaps. 
+See https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/
+
+Other Types of Kubernetes Objects::
+Replicasets, Deployments, ReplicationControllers are object types that can be used. Using these types will allow the scheduler to reschedule these pods onto other nodes after the 5 minute disconnect of the node. Some workloads can benefit from this, like REST APIs where an administrator might want to guarantee N number of pods are running and accessible.
+
+Having said that, in the case of the Edge Remote Worker node, it may in fact not be desirable for the workload/pod to be scheduled to a different node in the cluster (because of the nature of the Edge workload doing a specific function at that specific edge location).
+
+Persistent Volumes::
+Workloads that require persistent volumes will not be able to migrate to other zones in case of node/network failure.
+
+Tuneables
+Only node-status-update-frequency is configurable via a KubeletConfig [docs].
+node-monitor-grace-period and pod-eviction-timeout that are part of Controller Manager are not configurable at this time.
+<TBD zone config>
+

--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -1,17 +1,16 @@
 // Module included in the following assemblies:
 //
 // * nodes/clusters/nodes-cluster-overcommit.adoc
-// * post_installation_configuration/node-tasks.adoc
 
 [id="nodes-cluster-resource-override-deploy-console_{context}"]
 = Installing the Cluster Resource Override Operator using the web console
 
-You can use the {product-title} web console to install the Cluster Resource Override Operator to help control overcommit in your cluster.
+You can use the {product-title} web console to install the Cluster Resource Override Operator to help control overcommit in your cluster.  
 
 .Prerequisites
 
 * The Cluster Resource Override Operator has no effect if limits have not
-been set on containers. You must specify default limits for a project using a LimitRange
+been set on containers. You must specify default limits for a project using a LimitRange 
 object or configure limits in Pod specs in order for the overrides to apply.
 
 .Procedure
@@ -30,13 +29,13 @@ To install the Cluster Resource Override Operator using the {product-title} web 
 
 .. Choose  *ClusterResourceOverride Operator* from the list of available Operators and click *Install*.
 
-.. On the *Create Operator Subscription* page, make sure *A specific Namespace on the cluster* is selected for *Installation Mode*.
+.. On the *Install Operator* page, make sure *A specific Namespace on the cluster* is selected for *Installation Mode*. 
 
 .. Make sure *clusterresourceoverride-operator* is selected for *Installed Namespace*.
 
 .. Select an *Update Channel* and *Approval Strategy*.
 
-.. Click *Subscribe*.
+.. Click *Install*.
 
 . On the *Installed Operators* page, click *ClusterResourceOverride*.
 
@@ -44,7 +43,6 @@ To install the Cluster Resource Override Operator using the {product-title} web 
 
 .. On the *Create ClusterResourceOverride* page, edit the YAML template to set the overcommit values as needed:
 +
-[source,yaml]
 ----
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
@@ -70,7 +68,6 @@ spec:
 
 .. On the *ClusterResourceOverride Details* age, click *YAML*. The `mutatingWebhookConfigurationRef` section appears when the webhook is called.
 +
-[source,yaml]
 ----
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
@@ -124,6 +121,6 @@ metadata:
 
   labels:
     clusterresourceoverrides.admission.autoscaling.openshift.io: enabled <1>
-----
+---- 
 <1> Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the Namespace.
 ////

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -22,9 +22,9 @@ The descheduler is not available by default. To enable the descheduler, you must
 .. Navigate to *Operators* -> *OperatorHub*.
 .. Type *Kube Descheduler Operator* into the filter box.
 .. Select the *Kube Descheduler Operator* and click *Install*.
-.. On the *Create Operator Subscription* page, select *A specific namespace on the cluster*. Select *openshift-kube-descheduler-operator* from the drop-down menu.
+.. On the *Install Operator* page, select *A specific namespace on the cluster*. Select *openshift-kube-descheduler-operator* from the drop-down menu.
 .. Adjust the values for the *Update Channel* and *Approval Strategy* to the desired values.
-.. Click *Subscribe*.
+.. Click *Install*.
 . Create a descheduler instance.
 .. From the *Operators* -> *Installed Operators* page, click the *Kube Descheduler Operator*.
 .. Select the *Kube Descheduler* tab and click *Create KubeDescheduler*.

--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -13,11 +13,11 @@ You can use the {product-title} web console to install the Vertical Pod Autoscal
 
 . Choose  *VerticalPodAutoscaler* from the list of available Operators, and click *Install*.
 
-. On the *Create Operator Subscription* page, ensure that the *Operator recommended namespace* option
+. On the *Install Operator* page, ensure that the *Operator recommended namespace* option
 is selected. This installs the Operator in the mandatory `openshift-vertical-pod-autoscaler` namespace, which
 is automatically created if it does not exist.
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . Verify the install by listing the VPA Operator components:
 

--- a/modules/nw-ptp-installing-operator.adoc
+++ b/modules/nw-ptp-installing-operator.adoc
@@ -130,7 +130,7 @@ in the previous section.
 
 .. Choose  *PTP Operator* from the list of available Operators, and then click *Install*.
 
-.. On the *Create Operator Subscription* page, under *A specific namespace on the cluster* select *openshift-ptp*. Then, click *Subscribe*.
+.. On the *Install Operator* page, under *A specific namespace on the cluster* select *openshift-ptp*. Then, click *Install*.
 
 . Optional: Verify that the PTP Operator installed successfully:
 

--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -154,9 +154,9 @@ endif::run-level[]
 
 .. Select *SR-IOV Network Operator* from the list of available Operators, and then click *Install*.
 
-.. On the *Create Operator Subscription* page, under *A specific namespace on the cluster*, select *openshift-sriov-network-operator*.
+.. On the *Install Operator* page, under *A specific namespace on the cluster*, select *openshift-sriov-network-operator*.
 
-.. Click *Subscribe*.
+.. Click *Install*.
 
 . Verify that the SR-IOV Network Operator is installed successfully:
 

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -51,7 +51,7 @@ Operators; you must acknowledge the warning before continuing.
 
 . Read the information about the Operator and click *Install*.
 
-. On the *Create Operator Subscription* page:
+. On the *Install Operator* page:
 
 .. Select one of the following:
 *** *All namespaces on the cluster (default)* installs the Operator in the default
@@ -69,7 +69,7 @@ endif::[]
 
 .. Select *Automatic* or *Manual* approval strategy, as described earlier.
 
-. Click *Subscribe* to make the Operator available to the selected namespaces on
+. Click *Install* to make the Operator available to the selected namespaces on
 this {product-title} cluster.
 
 .. If you selected a Manual approval strategy, the upgrade status of the

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -26,7 +26,7 @@ endif::[]
 
 . Select the Operator and click *Install*.
 
-. On the *Create Operator Subscription* page, modify the Subscription object's
+. On the *Install Operator* page, modify the Subscription object's
 YAML to include one or more of the following environment variables in the
 `spec` section:
 +
@@ -73,7 +73,7 @@ OLM handles these environment variables as a unit; if at least one of them is
 set, all three are considered overridden and the cluster-wide defaults are not
 used for the subscribed Operator's Deployments.
 
-. Click *Subscribe* to make the Operator available to the selected namespaces.
+. Click *Install* to make the Operator available to the selected namespaces.
 
 . After the Operator's CSV appears in the relevant namespace, you can verify that
 custom proxy environment variables are set in the Deployment. For example, using

--- a/modules/op-installing-pipelines-operator-in-web-console.adoc
+++ b/modules/op-installing-pipelines-operator-in-web-console.adoc
@@ -25,7 +25,7 @@ Ensure that you do not select the *Community* version of the *OpenShift Pipeline
 +
 //image::op-install-subscription.png[]
 
-. On the *Create Operator Subscription* page:
+. On the *Install Operator* page:
 
   .. Select *All namespaces on the cluster (default)* for the *Installation Mode*. This mode installs the Operator in the default `openshift-operators` namespace, which enables the Operator to watch and be made available to all namespaces in the cluster.
 
@@ -34,7 +34,7 @@ Ensure that you do not select the *Community* version of the *OpenShift Pipeline
     *** The *ocp-<4.x>* channel enables installation of the latest stable release of the {pipelines-title} Operator.
     *** The *preview* channel enables installation of the latest preview version of the {pipelines-title} Operator, which may contain features that are not yet available from the 4.x update channel.
 +
-    . Click *Subscribe*. You will see the Operator listed on the *Installed Operators* page.
+    . Click *Install*. You will see the Operator listed on the *Installed Operators* page.
 +
 [NOTE]
 ====

--- a/modules/ossm-operatorhub-install.adoc
+++ b/modules/ossm-operatorhub-install.adoc
@@ -33,7 +33,7 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 . Click *Install*.
 
-. On the *Create Operator Subscription* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . In the Update Channel, select the most current version.
 
@@ -44,7 +44,7 @@ Do not install Community versions of the Operators. Community Operators are not 
 The Manual approval strategy requires a user with appropriate credentials to approve the Operator install and subscription process.
 ====
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . The *Installed Operators* page displays the Elasticsearch Operator's installation progress.
 
@@ -75,7 +75,7 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 . Click *Install*.
 
-. On the *Create Operator Subscription* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . Select the *stable* Update Channel.
 
@@ -86,7 +86,7 @@ Do not install Community versions of the Operators. Community Operators are not 
 The Manual approval strategy requires a user with appropriate credentials to approve the Operator install and subscription process.
 ====
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . The *Installed Operators* page displays the Jaeger Operator's installation progress.
 
@@ -118,7 +118,7 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 . Click *Install*.
 
-. On the *Create Operator Subscription* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . Select the *stable* Update Channel.
 
@@ -129,7 +129,7 @@ Do not install Community versions of the Operators. Community Operators are not 
 The Manual approval strategy requires a user with appropriate credentials to approve the Operator install and subscription process.
 ====
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . The *Installed Operators* page displays the Kiali Operator's installation progress.
 
@@ -154,7 +154,7 @@ The Manual approval strategy requires a user with appropriate credentials to app
 
 . Click the {ProductName} Operator to display information about the Operator.
 
-. On the *Create Operator Subscription* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . Click *Install*.
 
@@ -167,6 +167,6 @@ The Manual approval strategy requires a user with appropriate credentials to app
 The Manual approval strategy requires a user with appropriate credentials to approve the Operator install and subscription process.
 ====
 
-. Click *Subscribe*.
+. Click *Install*.
 
 . The *Installed Operators* page displays the {ProductName} Operator's installation progress.

--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -48,11 +48,11 @@ To install the Local Storage Operator from the web console, follow these steps:
 
 . Click *Install*.
 
-. On the *Create Operator Subscription* page, select *A specific namespace on the cluster*. Select *local-storage* from the drop-down menu.
+. On the *Install Operator* page, select *A specific namespace on the cluster*. Select *local-storage* from the drop-down menu.
 
 . Adjust the values for *Update Channel* and *Approval Strategy* to the values that you want.
 
-. Click *Subscribe*.
+. Click *Install*.
 
 Once finished, the Local Storage Operator will be listed in the *Installed Operators* section of the web console.
 

--- a/modules/security-pod-scan-cso.adoc
+++ b/modules/security-pod-scan-cso.adoc
@@ -21,9 +21,9 @@ as described here.
 . Select the *Container Security* Operator, then select *Install*
 to go to the Create Operator Subscription page.
 
-. Check the settings. All namespaces and automatic approval strategy are selected, by default
+. Check the settings. All namespaces and automatic approval strategy are selected, by default.
 
-. Select *Subscribe*. The *Container Security* Operator appears after a few moments on the *Installed Operators* screen.
+. Select *Install*. The *Container Security* Operator appears after a few moments on the *Installed Operators* screen.
 
 . Optionally, you can add custom certificates to the CSO. In this example, create a certificate
 named `quay.crt` in the current directory. Then run the following command to add the cert to the CSO:

--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -18,7 +18,7 @@ image::serverless-search.png[{ServerlessOperatorName} in the {product-title} web
 +
 image::serverless-operator.png[{ServerlessOperatorName} information]
 
-. On the *Create Operator Subscription* page:
+. On the *Install Operator* page:
 +
 image::serverless-create-sub.png[Create Operator Subscription page]
 
@@ -27,7 +27,7 @@ image::serverless-create-sub.png[Create Operator Subscription page]
 .. Select the *4.4* channel as the *Update Channel*. The *4.4* channel will enable installation of the latest stable release of the {ServerlessOperatorName}.
 // ... The *preview-4.4* channel enables installation of the latest preview version of the {ServerlessOperatorName}, which may contain features that are not yet available from the *4.4* update channel.
 .. Select *Automatic* or *Manual* approval strategy.
-. Click *Subscribe* to make the Operator available to the selected namespaces on this {product-title} cluster.
+. Click *Install* to make the Operator available to the selected namespaces on this {product-title} cluster.
 . From the *Catalog* → *Operator Management* page, you can monitor the {ServerlessOperatorName} subscription’s installation and upgrade progress.
 .. If you selected a *Manual* approval strategy, the subscription’s upgrade status will remain *Upgrading* until you review and approve its install plan. After approving on the *Install Plan* page, the subscription upgrade status moves to *Up to date*.
 .. If you selected an *Automatic* approval strategy, the upgrade status should resolve to *Up to date* without intervention.

--- a/modules/virt-subscribing-to-the-catalog.adoc
+++ b/modules/virt-subscribing-to-the-catalog.adoc
@@ -20,7 +20,7 @@ Operators.
 
 . Read the information about the Operator and click *Install*.
 
-. On the *Create Operator Subscription* page:
+. On the *Install Operator* page:
 
 .. For *Installed Namespace*, ensure that the *Operator recommended namespace* option
 is selected. This installs the Operator in the mandatory `openshift-cnv` namespace, which
@@ -37,7 +37,7 @@ is selected.
 {VirtProductName} automatically updates when a new z-stream release is
 available.
 
-. Click *Subscribe* to make the Operator available to the `openshift-cnv` namespace.
+. Click *Install* to make the Operator available to the `openshift-cnv` namespace.
 +
 On the *Installed Operators* screen, the *Status* displays *Succeeded* when
 {VirtProductName} finishes installation.


### PR DESCRIPTION
When researching https://github.com/openshift/openshift-docs/issues/25539 I saw that there were multiple instances where we still reference the *Subscribe* button in the Operators Web UI. In 4.5, this button was changed to *Install*.
Also, the *Create Operator Subscription* page was changed to *Install Operator* in 4.5.