### PR TITLE
Bug 1880238: [DOCS] Eliminate unclear descriptions on the "Setting Deployment Resources" section

### DIFF
--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -293,18 +293,14 @@ $ oc set triggers --help
 
 [NOTE]
 ====
-This resource is available only if your administrator enabled the ephemeral storage
-technology preview. This feature is disabled by
-default.
+`ephemeral-storage` is available only if your administrator enabled the xref:../../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[ephemeral storage] technology preview. This feature is disabled by default.
 ====
 
-A deployment is completed by a pod that consumes resources (memory, CPU, and ephemeral storage) on a
-node. By default, pods consume unbounded node resources. However, if a project
-specifies default container limits, then pods consume resources up to those
-limits.
+A deployment is completed by a deploy pod that consumes resources (memory, CPU, and ephemeral storage) on a
+worker node like other usual pods. By default, a deploy pod consumes unbounded node resources on the scheduled worker node. Usually, it's no problem, because the deploy pod consumes trivial resources and it runs during short deployment period. However, if a project specifies default container limits, then pods inluding the deploy pod consume resources up to those limits.
 
 You can also limit resource use by specifying resource limits as part of the
-deployment strategy. Deployment resources can be used with the Recreate,
+deployment strategy. Deployment resources for a deploy pod can be used with the Recreate,
 Rolling, or Custom deployment strategies.
 
 In the following example, each of `resources`, `cpu`, `memory`, and `ephemeral-storage` is
@@ -324,8 +320,7 @@ resources:
 <1> `cpu` is in CPU units: `100m` represents 0.1 CPU units (100 * 1e-3).
 <2> `memory` is in bytes: `256Mi` represents 268435456 bytes (256 * 2 ^ 20).
 <3> `ephemeral-storage` is in bytes: `1Gi` represents 1073741824 bytes (2 ^ 30).
-This applies only if your administrator enabled the ephemeral storage technology
-preview.
+This applies only if your administrator enabled the xref:../../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[ephemeral storage] technology preview.
 ====
 
 However, if a quota has been defined for your project, one of the following two


### PR DESCRIPTION
* Version: v3.11
* Reference: [[DOCS] Eliminate unclear descriptions on the "Setting Deployment Resources" section](https://bugzilla.redhat.com/show_bug.cgi?id=1880238)
* Description: Some explanations are not clear and it leads misunderstanding for deployment resources setting.