### PR TITLE
Change not allowed namespace name

### DIFF
--- a/modules/nodes-descheduler-configuring-other-settings.adoc
+++ b/modules/nodes-descheduler-configuring-other-settings.adoc
@@ -15,7 +15,7 @@ You can configure additional settings for the descheduler, such as how frequentl
 . Edit the `KubeDescheduler` object:
 +
 ----
-$ oc edit kubedeschedulers.operator.openshift.io cluster -n openshift-kube-descheduler-operator
+$ oc edit kubedeschedulers.operator.openshift.io cluster -n ocp-kube-descheduler-operator
 ----
 
 . Configure additional settings as necessary:
@@ -26,7 +26,7 @@ apiVersion: operator.openshift.io/v1beta1
 kind: KubeDescheduler
 metadata:
   name: cluster
-  namespace: openshift-kube-descheduler-operator
+  namespace: ocp-kube-descheduler-operator
 spec:
   deschedulingIntervalSeconds: 3600 <1>
   flags:

--- a/modules/nodes-descheduler-configuring-strategies.adoc
+++ b/modules/nodes-descheduler-configuring-strategies.adoc
@@ -15,7 +15,7 @@ You can configure which strategies the descheduler uses to evict Pods.
 . Edit the `KubeDescheduler` object:
 +
 ----
-$ oc edit kubedeschedulers.operator.openshift.io cluster -n openshift-kube-descheduler-operator
+$ oc edit kubedeschedulers.operator.openshift.io cluster -n ocp-kube-descheduler-operator
 ----
 
 . Specify one or more strategies in the `spec.strategies` section.
@@ -26,7 +26,7 @@ apiVersion: operator.openshift.io/v1beta1
 kind: KubeDescheduler
 metadata:
   name: cluster
-  namespace: openshift-kube-descheduler-operator
+  namespace: ocp-kube-descheduler-operator
 spec:
   deschedulingIntervalSeconds: 3600
   strategies:

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -17,12 +17,12 @@ The descheduler is not available by default. To enable the descheduler, you must
 . Log in to the {product-title} web console.
 . Create the required namespace for the Kube Descheduler Operator.
 .. Navigate to *Administration* -> *Namespaces* and click *Create Namespace*.
-.. Enter `openshift-kube-descheduler-operator` in the *Name* field and click *Create*.
+.. Enter `ocp-kube-descheduler-operator` in the *Name* field and click *Create*.
 . Install the Kube Descheduler Operator.
 .. Navigate to *Operators* -> *OperatorHub*.
 .. Type *Kube Descheduler Operator* into the filter box.
 .. Select the *Kube Descheduler Operator* and click *Install*.
-.. On the *Create Operator Subscription* page, select *A specific namespace on the cluster*. Select *openshift-kube-descheduler-operator* from the drop-down menu.
+.. On the *Create Operator Subscription* page, select *A specific namespace on the cluster*. Select *ocp-kube-descheduler-operator* from the drop-down menu.
 .. Adjust the values for the *Update Channel* and *Approval Strategy* to the desired values.
 .. Click *Subscribe*.
 . Create a descheduler instance.


### PR DESCRIPTION
Not possible to create namespace name having prefix `openshift- ` or `kube-`
Changing namespace from openshift-kube-descheduler-operator to ocp-kube-descheduler-operator

Error:
Danger alert:An error occurred
project.project.openshift.io "openshift-kube-descheduler-operator" is forbidden: cannot request a project starting with "openshift-"
