### PR TITLE
Remove duplicated pullSecret parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -418,26 +418,6 @@ The first item in `networking.machineNetwork` must match the value of `machinesS
 If you deploy to a custom subnet, you cannot specify an external DNS server to the {product-title} installer. Instead, link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/subnet[add DNS to the subnet in {rh-openstack}].
 
 |A UUID as a string, for example `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
-
-|`pullSecret`
-|Get this pull secret from link:https://cloud.redhat.com/openshift/install/pull-secret[] to authenticate downloading container images for {product-title} components from services such as Quay.io.
-|
-[source,json]
-----
-{
-   "auths":{
-      "cloud.openshift.com":{
-         "auth":"b3Blb=",
-         "email":"you@example.com"
-      },
-      "quay.io":{
-         "auth":"b3Blb=",
-         "email":"you@example.com"
-      }
-   }
-}
-----
-
 |====
 
 


### PR DESCRIPTION
Fixes #25589. This duplicated parameter seems like the result of a bad merge resolution at some point in the past. 