### PR TITLE
Modify the tested maximums for OpenShift 4.4 and 4.5

### DIFF
--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -12,15 +12,15 @@
 | Number of Nodes
 | 2,000
 | 2,000
-| 2,000
-| 2,000
+| 250
+| 500
 | 2,000
 
 | Number of Pods footnoteref:[numberofpods,The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
 | 150,000
 | 150,000
-| 150,000
-| 150,000
+| 62,500
+| 62,500
 | 150,000
 
 | Number of Pods per node


### PR DESCRIPTION
This commit modifies the tested cluster maximums for OpenShift 4.4
and 4.5 releases to match with the documented environment information.
Tested maximums reported for major releases ( 3.x and 4.x ) still
stay the same.