### PR TITLE
Add release notes entry for SR-IOV InfiniBand support

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -298,7 +298,6 @@ Partial Tuned real-time profile support became available in {product-title} 4.4.
 Now, the real-time profiles are fully compatible with what the real-time
 profiles do in Tuned on {op-system-base-full}.
 
-
 [id="ocp-4-6-networking"]
 === Networking
 
@@ -312,6 +311,12 @@ For this release, OpenShift SDN remains the default Pod network provider.
 ==== Expand node service port range
 
 The node service port range is expandable beyond the default range of `30000-32767`. You can use this expanded range in your `Service` objects. For more information, refer to xref:../networking/configuring-node-port-service-range.adoc#configuring-node-port-service-range[Configuring the node port service range].
+
+[id="ocp-4-6-sr-iov-infiniband-devices"]
+==== SR-IOV Network Operator InfiniBand device support
+
+The Single Root I/O Virtualization (SR-IOV) Network Operator now supports InfiniBand (IB) network devices.
+// For more information on configuring an IB network device for your cluster, refer to xref::../networking/hardware_networks/...[This link].
 
 [id="ocp-4-6-pod-network-connectivity-checks"]
 ==== Pod network connectivity checks


### PR DESCRIPTION
This adds a RN entry for OCP 4.6.

@zshi-redhat, do we have any specific additional information we want to include in the release notes for InfiniBand support? I'm going to link to the content for configuring these devices, once it's merged.

Thanks.