### PR TITLE
cnf: fix the subscription name

### DIFF
--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -85,7 +85,7 @@ metadata:
   namespace: openshift-performance-addon-operator
 spec:
   channel: <channel> <1>
-  name: openshift-performance-addon-operator
+  name: performance-addon-operator
   source: redhat-operators <2>
   sourceNamespace: openshift-marketplace
 ----


### PR DESCRIPTION
The `name` field in the Subscription object need to refer
to an existing package. Fix by dropping the `openshift-` prefix.

Signed-off-by: Francesco Romani <fromani@redhat.com>