### PR TITLE
ipam static address must never be a CIDR range

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -190,7 +190,7 @@ You can configure ipam for static IP address assignment:
     "type": "static",
       "addresses": [
         {
-          "address": "191.168.1.1/24"
+          "address": "191.168.1.7"
         }
       ]
   }


### PR DESCRIPTION
Fixed in 4.4, but never happened subsequently.