### PR TITLE
BZ-1880925: Adding step to navigate to /home/core

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -38,6 +38,12 @@ $ oc debug node/<node_name>
 sh-4.2# chroot /host
 ----
 
+. Change to the `/home/core` directory:
++
+----
+sh-4.4# cd /home/core
+----
+
 . If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
 
 . Run the `etcd-snapshot-backup.sh` script and pass in the location to save the backup to.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1880925

Preview: https://bz-1880925--ocpdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/backing-up-etcd.html#backing-up-etcd-data_backup-etcd