### PR TITLE
CNV - BZ#1875383 rel_note for terminationGracePeriod

### DIFF
--- a/virt/virt-2-4-release-notes.adoc
+++ b/virt/virt-2-4-release-notes.adoc
@@ -147,8 +147,22 @@ $ oc delete pod -n openshift-cnv --selector=kubevirt.io=virt-handler --field-sel
 ----
 <1> Where <source-node-name> is the name of the source node that the VMI is migrating from.
 
-//https://bugzilla.redhat.com/show_bug.cig?=id=1959237
-* If you upgrade to {VirtProductName} {VirtVersion}, both older and newer versions of common templates are available for each combination of operating system, workload, and flavor. When you create a virtual machine by using a common template, you must use the newer version of the template. Disregard the older version to avoid issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859237[*BZ#1859237*])
+* Common templates in previous versions of {VirtProductName} had a default `spec.terminationGracePeriodSeconds` value of `0`. Virtual machines created from these older common templates can encounter disk issues from being forcefully terminated. +
+If you upgrade to {VirtProductName} {VirtVersion}, both older and newer versions of common templates are available for each combination of operating system, workload, and flavor. When you create a virtual machine by using a common template, you must use the newer version of the template. Disregard the older version to avoid issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859235[*BZ#1859235*])
+
+** To verify if a virtual machine is affected by this bug, run the following command in the namespace of the virtual machine to determine the `spec.terminationGracePeriodSeconds` value:
++
+[source,terminal]
+----
+$ oc get vm <virtual-machine-name> -o yaml | grep "terminationGracePeriodSeconds"
+----
+
+** If the virtual machine has a `terminationGracePeriodSeconds` value of `0`, patch the virtual machine config with a `spec.terminationGracePeriodSeconds` value of `180` for Linux virtual machines, or a value of `3600` for Windows virtual machines.
++
+[source,terminal]
+----
+$ oc patch vm <virtual-machine-name> --type merge -p '{"spec":{"template":{"spec":{"terminationGracePeriodSeconds":180}}}}'
+----
 
 * Running virtual machines that cannot be live migrated might block an {product-title} cluster upgrade. This includes virtual machines that use hostpath-provisioner storage or SR-IOV network interfaces.
 As a workaround, you can reconfigure the virtual machines so that they can be powered off during a cluster upgrade. In the `spec` section of the virtual machine configuration file:


### PR DESCRIPTION
Added steps to an existing release note (regardless of what the diff says) to verify and patch a virtual machine if it has been created from an older template with terminationGracePeriod: 0. Also changed the bz id to reference the dev bz

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1875383
(Bug is targeted for 2.4.2 but it can be merged when ready because it's also valid for 2.4.1)

Build: https://cnv-bz1875383-grace-period--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-4-release-notes.html#virt-2-4-known-issues
(3rd known issue from top)