### PR TITLE
Updating TOC heading for usability.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2113,7 +2113,7 @@ Topics:
   Topics:
   - Name: Installing Jaeger
     File: rhbjaeger-installation
-  - Name: Deploying Jaeger
+  - Name: Configuring Jaeger
     File: rhbjaeger-deploying
   - Name: Upgrading Jaeger
     File: rhbjaeger-updating

--- a/jaeger/jaeger_install/rhbjaeger-deploying.adoc
+++ b/jaeger/jaeger_install/rhbjaeger-deploying.adoc
@@ -1,5 +1,5 @@
 [id="deploying-jaeger"]
-= Deploying Jaeger
+= Configuring and Deploying Jaeger
 include::modules/jaeger-document-attributes.adoc[]
 :context: jaeger-deploying
 


### PR DESCRIPTION
Changing the heading in the TOC from "Deploying Jaeger" to "Configuring Jaeger" to improve usability.