### PR TITLE
Changed and extended Openshift Container Storage linkls from 4.4 to 4…

### DIFF
--- a/modules/deploy-red-hat-openshift-container-storage.adoc
+++ b/modules/deploy-red-hat-openshift-container-storage.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/storage-configuration.adoc
+
+[options="header",cols="1,1"]
+|===
+
+|If you are looking for Red Hat OpenShift Container Storage information about...
+|See the following Red Hat OpenShift Container Storage documentation:
+
+|What’s new, known issues, notable bug fixes, and Technology Previews
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/4.5_release_notes/[OpenShift Container Storage 4.5 Release Notes]
+
+|Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/planning_your_deployment/index[Planning your  OpenShift Container Storage 4.5 deployment]
+
+|Instructions on preparing to deploy when your environment is not directly connected to the internet
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/preparing_to_deploy_in_a_disconnected_environment/index[Preparing to deploy OpenShift Container Storage 4.5 in a disconnected environment]
+
+|Instructions on deploying OpenShift Container Storage to use an external Red Hat Ceph Storage cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_openshift_container_storage_in_external_mode/index[Deploying OpenShift Container Storage 4.5 in external mode]
+
+|Instructions on deploying OpenShift Container Storage to local storage on bare metal infrastructure
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_openshift_container_storage_using_bare_metal_infrastructure/index[Deploying OpenShift Container Storage 4.5 using bare metal infrastructure]
+
+|Instructions on deploying OpenShift Container Storage on Red Hat OpenShift Container Platform VMWare vSphere clusters
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_openshift_container_storage_on_vmware_vsphere/index[Deploying OpenShift Container Storage 4.5 on VMWare vSphere]
+
+|Instructions on deploying OpenShift Container Storage using Amazon Web Services for local or cloud storage
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_openshift_container_storage_using_amazon_web_services/index[Deploying OpenShift Container Storage 4.5 using Amazon Web Services]
+
+|Instructions on deploying and managing OpenShift Container Storage on existing Red Hat OpenShift Container Platform Google Cloud clusters
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_and_managing_openshift_container_storage_using_google_cloud/index[Deploying and managing OpenShift Container Storage 4.5 using Google Cloud]
+
+|Instructions on deploying and managing OpenShift Container Storage on existing Red Hat OpenShift Container Platform Azure clusters
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_and_managing_openshift_container_storage_using_microsoft_azure/index[Deploying and managing OpenShift Container Storage 4.5 using Microsoft Azure]
+
+|Managing a Red Hat OpenShift Container Storage 4.5 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/managing_openshift_container_storage/index[Managing OpenShift Container Storage 4.5]
+
+|Monitoring a Red Hat OpenShift Container Storage 4.5 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/monitoring_openshift_container_storage/index[Monitoring Red Hat OpenShift Container Storage 4.5]
+
+|Migrating your {product-title} cluster from version 3 to version 4
+|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/migration/index[Migration]
+
+|===

--- a/modules/deploy-red-hat-openshift-container-storage.adoc
+++ b/modules/deploy-red-hat-openshift-container-storage.adoc
@@ -41,6 +41,9 @@
 |Monitoring a Red Hat OpenShift Container Storage 4.5 cluster
 |link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/monitoring_openshift_container_storage/index[Monitoring Red Hat OpenShift Container Storage 4.5]
 
+|Resolve issues encountered during operations
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/troubleshooting_openshift_container_storage/index[Troubleshooting OpenShift Container Storage 4.5]
+
 |Migrating your {product-title} cluster from version 3 to version 4
 |link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/migration/index[Migration]
 

--- a/post_installation_configuration/storage-configuration.adoc
+++ b/post_installation_configuration/storage-configuration.adoc
@@ -70,28 +70,4 @@ include::modules/recommended-configurable-storage-technology.adoc[leveloffset=+1
 // This section is sourced from storage/persistent_storage/persistent-storage-ocs.adoc
 Red Hat OpenShift Container Storage is a provider of agnostic persistent storage for {product-title} supporting file, block, and object storage, either in-house or in hybrid clouds. As a Red Hat storage solution, Red Hat OpenShift Container Storage is completely integrated with {product-title} for deployment, management, and monitoring.
 
-[options="header",cols="1,1"]
-|===
-
-|If you are looking for Red Hat OpenShift Container Storage information about...
-|See the following Red Hat OpenShift Container Storage documentation:
-
-|What’s new, known issues, notable bug fixes, and Technology Previews
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/4.4_release_notes/[Red Hat OpenShift Container Storage 4.4 Release Notes]
-
-|Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/planning_your_deployment/index[Planning your Red Hat OpenShift Container Storage 4.4 deployment]
-
-|Deploying Red Hat OpenShift Container Storage 4.4 on an existing {product-title} cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/deploying_openshift_container_storage/index[Deploying Red Hat OpenShift Container Storage 4.4]
-
-|Managing a Red Hat OpenShift Container Storage 4.4 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/managing_openshift_container_storage/index[Managing Red Hat OpenShift Container Storage 4.4]
-
-|Monitoring a Red Hat OpenShift Container Storage 4.4 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.4/html/monitoring_openshift_container_storage/index[Monitoring Red Hat OpenShift Container Storage 4.4]
-
-|Migrating your {product-title} cluster from version 3 to version 4
-|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.4/html/migration/index[Migration]
-
-|===
+include::modules/deploy-red-hat-openshift-container-storage.adoc[leveloffset=+1]


### PR DESCRIPTION
- Changed and extended Openshift Container Storage links from 4.4 to 4.5, replaces old by new guides and moved table to own doc (modules/deploy-red-hat-openshift-container-storage.adoc)
- This should apply to OCP 4.4, 4.5 and 4.6 until OCS 4.6 is released

@openshift/team-documentation