### PR TITLE
cnv 2.5: Remove HPP storage workaround and v2v disk

### DIFF
--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -77,15 +77,15 @@ endif::[]
 ifdef::virt-importing-rhv-vm[]
 * *General* -> *Name*: The VM name is limited to 63 characters. link:https://bugzilla.redhat.com/show_bug.cgi?id=1857165[(*BZ#1857165*)]
 * *General* -> *Description*: Optional description of the VM.
-ifeval::["{VirtVersion}" == "2.4"]
+ifeval::["{VirtVersion}" < "2.5"]
 * *Storage* -> *Storage Class*: Select *NFS*.
 endif::[]
-ifeval::["{VirtVersion}" == "2.5"]
+ifeval::["{VirtVersion}" >= "2.5"]
 * *Storage* -> *Storage Class*: Select *NFS* or *ocs-storagecluster-ceph-rbd*.
 endif::[]
 * *Networking* -> *Network*: You can select a network from a list of available `NetworkAttachmentDefinition` objects.
 
-ifeval::["{VirtVersion}" == "2.5"]
+ifeval::["{VirtVersion}" >= "2.5"]
 . If you are using RBD block-mode volume storage, configure the volume mode of the disk:
 .. Click *Edit* and then click *Storage*.
 .. Select *Edit* from the Options menu {kebab} of the VM disk.
@@ -118,9 +118,8 @@ ifdef::virt-importing-vmware-vm[]
 ** *Source*: For example, *Import Disk*.
 ** *Size*
 ** *Interface*
-** *Storage Class*: If you do not select a storage class, the default storage class is used for the VM disk and the `v2v-conversion-template` disk. The `v2v-conversion-template` disk is a 2 GB disk that is used as scratch space for copying the VM disk.
-+
-The following storage classes are supported for VMware VM import:
+ifeval::["{VirtVersion}" < "2.5"]
+** *Storage Class*: The following storage classes are supported for VMware VM import:
 
 *** VM disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
 *** `v2v-conversion-template` disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
@@ -129,6 +128,10 @@ _or_
 
 *** VM disk: *NFS*
 *** `v2v-conversion-template` disk: *hostpath-provisioner (HPP)*
+endif::[]
+ifeval::["{VirtVersion}" >= "2.5"]
+** *Storage Class*: Select *NFS* or *ocs-storagecluster-ceph-rbd (ceph-rbd)*.
+endif::[]
 +
 Other storage classes might work, but they are not officially supported.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1874784

CP for 4.5 and 4.6.