### PR TITLE
BZ1872658: Clarified definition of maximum-dead-containers-per-contai…

### DIFF
--- a/admin_guide/garbage_collection.adoc
+++ b/admin_guide/garbage_collection.adoc
@@ -43,7 +43,7 @@ default is *0*. Use *0* for no limit. Values for this setting can be
 specified using unit suffixes such as *h* for hour, *m* for minutes, *s* for seconds.
 
 |`*maximum-dead-containers-per-container*`
-|The number of instances to retain per pod container. The default is *1*.
+|The number of old instances to retain per container. The default is *1*.
 
 |`*maximum-dead-containers*`
 |The maximum number of total dead containers in the node. The default is *-1*, which means unlimited.
@@ -96,22 +96,22 @@ endif::[]
 
 Each spin of the garbage collector loop goes through the following steps:
 
-1. Retrieve a list of available containers.
-2. Filter out all containers that are running or are not alive longer than
-the `*minimum-container-ttl-duration*` parameter.
-3. Classify all remaining containers into equivalence classes based on pod and image name membership.
-4. Remove all unidentified containers (containers that are managed by kubelet but their name is malformed).
+1. Retrieves a list of available containers.
+2. Filters out all containers that are running or are not alive longer than
+the `*minimum-container-ttl-duration*` parameter. Containers that are not alive can be in an exited, dead, or terminated state.
+3. Classifies all remaining containers into equivalence classes based on pod and image name membership.
+4. Removes all unidentified containers (containers that are managed by kubelet but their name is malformed).
 5. For each class that contains more containers than the
-`*maximum-dead-containers-per-container*` parameter, sort containers in the class by
+`*maximum-dead-containers-per-container*` parameter, sorts containers in the class by
 creation time.
-6. Start removing containers from the oldest first until the
+6. Starts removing containers from the oldest first until the
 `*maximum-dead-containers-per-container*` parameter is met.
 7. If there are still more containers in the list than the
 `*maximum-dead-containers*` parameter, the collector starts removing containers
 from each class so the number of containers in each one is not greater than the
 average number of containers per class, or
 `<all_remaining_containers>/<number_of_classes>`.
-8. If this is still not enough, sort all containers in the list and start
+8. If this is still not enough, the collector sorts all containers in the list and starts
 removing containers from the oldest first until the `*maximum-dead-containers*`
 criterion is met.
 


### PR DESCRIPTION
…ner and definition of not alive. Also fixed verb tenses to clarify that the collector performs the process, and not the user.

https://bugzilla.redhat.com/show_bug.cgi?id=1872658

