### PR TITLE
BZ#1878995 Remove warning for running pods on the control plane

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -157,11 +157,6 @@ endif::baremetal,baremetal-restricted[]
 .. Locate the `mastersSchedulable` parameter and set its value to `False`.
 .. Save and exit the file.
 --
-+
-[NOTE]
-====
-Currently, due to a link:https://github.com/kubernetes/kubernetes/issues/65618[Kubernetes limitation], router Pods running on control plane machines will not be reachable by the ingress load balancer. This step might not be required in a future minor version of {product-title}.
-====
 
 ifdef::gcp,aws,azure[]
 ifndef::user-infra-vpc[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1878995